### PR TITLE
Skills Foundation Spec 2: full-bundle supporting-file fidelity (nested + binary + executable)

### DIFF
--- a/Docs/superpowers/plans/2026-07-22-skills-foundation-bundle-fidelity-plan.md
+++ b/Docs/superpowers/plans/2026-07-22-skills-foundation-bundle-fidelity-plan.md
@@ -1,0 +1,1532 @@
+# Skills Foundation — Full-Bundle Supporting-File Fidelity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make tldw's local-skills subsystem faithfully import, store, trust-verify, and export a spec-conformant Agent Skills bundle — arbitrary nested directories, binary files, and executable scripts — without disturbing any currently-trusted skill.
+
+**Architecture:** Directory-native (the skill dir on disk is the source of truth). The trust scanner becomes recursive, binary/mode-aware, and junk-pruning, with per-file SHA-256 kept inside the existing HMAC-authenticated manifest. `supporting_files` stays `dict[str,str]` (text, nested keys); a new metadata-only `bundle_files` list surfaces binaries. Binaries never cross the JSON wire.
+
+**Tech Stack:** Python 3.11+, pydantic v2, `os.walk`, `zipfile`, `hashlib`/`hmac`, pytest. No new dependencies.
+
+**Design doc:** `Docs/superpowers/specs/2026-07-22-skills-foundation-bundle-fidelity-design.md`.
+
+## Global Constraints
+
+- **Backward-compat (load-bearing):** the canonical trust snapshot MUST be byte-identical to the pre-change form for any skill with no nested paths, no binaries, and no executable bits. Achieve this by (a) sorting the recursive walk by **POSIX relative path**, (b) including `executable` in a fingerprint dict **only when `True`**, (c) leaving `file_type` unchanged for text.
+- **Three fingerprint builders must change together:** `SkillFileFingerprint.as_manifest_entry` (`skill_trust_models.py`), the scanner constructor (`skill_trust_scanner.py`), and `_content_manifest_entry` (`skill_trust_service.py`). They must produce identical dicts for the same file.
+- **Binaries never enter `supporting_files`** (the `dict[str,str]` text view) or cross the JSON boundary. They live on disk and are surfaced via `bundle_files` metadata only.
+- **Path rules:** relative POSIX subpath; validate **each segment** against `^[a-zA-Z0-9][a-zA-Z0-9._-]{0,99}$`; reject absolute, leading `/`, backslash, `..`/`.`/empty segments, symlinks, any-case `skill.md`, depth > 8, total length > 255.
+- **Size caps:** per-file 5 MB, per-bundle total 25 MB, max 500 files. Raise the legacy `MAX_SUPPORTING_FILES_COUNT`/`MAX_SUPPORTING_FILE_BYTES`/`MAX_SUPPORTING_FILES_TOTAL_BYTES` to match.
+- **Junk ignore-list:** dirs `.git`, `.github`, `.hg`, `.svn`, `node_modules`, `__pycache__`; files `.DS_Store`, `Thumbs.db`; suffixes `.pyc`, `.pyo`, `~`, `.bak`, `.orig`, `.tmp`, `.swp`, `.part`. Pruned entries are skipped entirely (never recorded in `unsupported_paths`).
+- **Tolerate-and-surface:** trust operations never hard-raise on unsupported files; they trust the supported files and leave residuals as recoverable `needs-review`.
+- **Symlinks are skip-not-fail** on import; never followed on scan (`os.walk(followlinks=False)`).
+- **venv-only tests:** run pytest via `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest`. Force the file-marker keyring fallback where trust is exercised: prefix `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring`.
+- **No trust-data migration; no config change.** Additive fields only.
+
+## File Structure
+
+| File | Change |
+|------|--------|
+| `tldw_chatbook/tldw_api/skills_schemas.py` | New `validate_supporting_file_path`; per-segment nested validation in `_validate_supporting_files`; raised caps; new `BundleFileInfo` model + `bundle_files` field on `SkillResponse` |
+| `tldw_chatbook/Skills_Interop/skill_trust_models.py` | `executable` field on `SkillFileFingerprint`; conditional `as_manifest_entry` |
+| `tldw_chatbook/Skills_Interop/skill_trust_scanner.py` | Recursive `os.walk`, junk ignore-list, per-segment validation, relative-path body classification, binary fingerprint, exec bit, symlink skip |
+| `tldw_chatbook/Skills_Interop/skill_trust_service.py` | `_content_manifest_entry` binary+exec parity; `bootstrap_trust`/`trust_current_skill` tolerate-and-surface |
+| `tldw_chatbook/Skills_Interop/local_skills_service.py` | Recursive binary-safe `_read_supporting_files` + `_read_bundle_manifest`; bytes-mode atomic writer; `_apply_supporting_files` guard; `import_skill_directory`; nested/binary zip import + export; junk prune; caps |
+| `tldw_chatbook/UI/Screens/library_screen.py` | Folder import calls `import_skill_directory` |
+| `tldw_chatbook/Widgets/Library/library_skills_canvas.py` | Review preview binary-vs-deleted; editor lists nested + view-only binaries |
+| `Tests/Skills/`, `Tests/Library/`, `Tests/UI/` | New tests; flip `test_skills_import.py:525-527` |
+
+---
+
+### Task 1: Path validator, `BundleFileInfo` schema, raised caps
+
+**Files:**
+- Modify: `tldw_chatbook/tldw_api/skills_schemas.py:10-56` (patterns, caps, `_validate_supporting_files`) and the `SkillResponse` class
+- Test: `Tests/tldw_api/test_skills_schemas_bundle.py` (create)
+
+**Interfaces:**
+- Produces: `validate_supporting_file_path(path: str) -> str` (returns normalized POSIX path, raises `ValueError`); `SEGMENT_PATTERN` (the per-segment regex); `BundleFileInfo` (pydantic: `path: str`, `size: int`, `executable: bool`, `is_text: bool`); constants `MAX_SUPPORTING_FILES_COUNT=500`, `MAX_SUPPORTING_FILE_BYTES=5*1024*1024`, `MAX_SUPPORTING_FILES_TOTAL_BYTES=25*1024*1024`, `MAX_SUPPORTING_FILE_PATH_DEPTH=8`, `MAX_SUPPORTING_FILE_PATH_LEN=255`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/tldw_api/test_skills_schemas_bundle.py`:
+
+```python
+import pytest
+
+from tldw_chatbook.tldw_api.skills_schemas import (
+    validate_supporting_file_path,
+    BundleFileInfo,
+    MAX_SUPPORTING_FILES_COUNT,
+)
+
+
+@pytest.mark.parametrize("good", [
+    "notes.md",
+    "scripts/build.sh",
+    "references/api/reference.md",
+    "assets/img/logo.png",
+])
+def test_validate_supporting_file_path_accepts_nested(good):
+    assert validate_supporting_file_path(good) == good
+
+
+@pytest.mark.parametrize("bad", [
+    "/abs.md",                # absolute
+    "../escape.md",           # traversal
+    "a/../b.md",              # traversal segment
+    "a/./b.md",               # dot segment
+    "a//b.md",                # empty segment
+    "back\\slash.md",         # backslash
+    "SKILL.md",               # reserved body (root)
+    "refs/SKILL.md",          # nested shadow (any case)
+    "refs/skill.md",          # nested shadow wrong-case
+    "-leading-dash.md",       # segment must start alnum
+    ".dotfile",               # leading dot
+    "a/" * 9 + "deep.md",     # depth > 8
+    "x" * 256,                # length > 255
+])
+def test_validate_supporting_file_path_rejects(bad):
+    with pytest.raises(ValueError):
+        validate_supporting_file_path(bad)
+
+
+def test_bundle_file_info_shape():
+    info = BundleFileInfo(path="assets/logo.png", size=1234, executable=False, is_text=False)
+    assert info.model_dump() == {
+        "path": "assets/logo.png", "size": 1234, "executable": False, "is_text": False,
+    }
+
+
+def test_caps_raised():
+    assert MAX_SUPPORTING_FILES_COUNT == 500
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/tldw_api/test_skills_schemas_bundle.py -q`
+Expected: FAIL — `ImportError: cannot import name 'validate_supporting_file_path'`.
+
+- [ ] **Step 3: Implement**
+
+In `skills_schemas.py`, replace the cap constants (lines 12-14) and add the validator + segment pattern after `SUPPORTING_FILE_NAME_PATTERN` (line 11):
+
+```python
+SUPPORTING_FILE_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,99}$")
+SEGMENT_PATTERN = SUPPORTING_FILE_NAME_PATTERN  # each path segment obeys the same rule
+MAX_SUPPORTING_FILES_COUNT = 500
+MAX_SUPPORTING_FILE_BYTES = 5 * 1024 * 1024
+MAX_SUPPORTING_FILES_TOTAL_BYTES = 25 * 1024 * 1024
+MAX_SUPPORTING_FILE_PATH_DEPTH = 8
+MAX_SUPPORTING_FILE_PATH_LEN = 255
+_RESERVED_BODY_BASENAME = "skill.md"
+
+
+def validate_supporting_file_path(path: str) -> str:
+    """Validate a relative POSIX supporting-file subpath, returning it normalized.
+
+    Args:
+        path: Candidate relative POSIX path (e.g. ``scripts/build.sh``).
+
+    Returns:
+        The same path when valid.
+
+    Raises:
+        ValueError: On absolute paths, ``..``/``.``/empty segments, backslashes,
+            a segment failing ``SEGMENT_PATTERN``, any-case ``skill.md`` basename,
+            depth greater than ``MAX_SUPPORTING_FILE_PATH_DEPTH``, or a total
+            length exceeding ``MAX_SUPPORTING_FILE_PATH_LEN``.
+    """
+    if not path or path != path.strip():
+        raise ValueError(f"Invalid supporting file path: {path!r}")
+    if "\\" in path or path.startswith("/"):
+        raise ValueError(f"Invalid supporting file path: {path!r}")
+    if len(path.encode("utf-8")) > MAX_SUPPORTING_FILE_PATH_LEN:
+        raise ValueError(f"Supporting file path too long: {path!r}")
+    segments = path.split("/")
+    if len(segments) > MAX_SUPPORTING_FILE_PATH_DEPTH:
+        raise ValueError(f"Supporting file path too deep: {path!r}")
+    for segment in segments:
+        if segment in ("", ".", ".."):
+            raise ValueError(f"Invalid path segment in {path!r}")
+        if not SEGMENT_PATTERN.fullmatch(segment):
+            raise ValueError(f"Invalid path segment {segment!r} in {path!r}")
+    if segments[-1].lower() == _RESERVED_BODY_BASENAME:
+        raise ValueError("SKILL.md is the skill body, not a supporting file")
+    return path
+```
+
+Then rewrite the loop body of `_validate_supporting_files` (lines 36-53) to validate nested paths and count via the new caps:
+
+```python
+    for filename, content in value.items():
+        validate_supporting_file_path(filename)  # replaces pattern + skill.md checks
+        if content is None:
+            if allow_deletes:
+                continue
+            raise ValueError(f"Supporting file {filename} cannot be null")
+        non_null_count += 1
+        if non_null_count > MAX_SUPPORTING_FILES_COUNT:
+            raise ValueError(
+                f"Too many supporting files ({non_null_count}); maximum is {MAX_SUPPORTING_FILES_COUNT}"
+            )
+        file_bytes = len(content.encode("utf-8"))
+        if file_bytes > MAX_SUPPORTING_FILE_BYTES:
+            raise ValueError(f"Supporting file {filename} exceeds file size limit")
+        total_bytes += file_bytes
+    if total_bytes > MAX_SUPPORTING_FILES_TOTAL_BYTES:
+        raise ValueError("Total supporting files size exceeds bundle limit")
+    return value
+```
+
+Add the `BundleFileInfo` model near the other schema classes and a `bundle_files` field on `SkillResponse` (which already has `model_config = ConfigDict(extra="allow")`):
+
+```python
+class BundleFileInfo(BaseModel):
+    path: str
+    size: int
+    executable: bool = False
+    is_text: bool = True
+```
+Add to `SkillResponse`: `bundle_files: list[BundleFileInfo] | None = None`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/tldw_api/test_skills_schemas_bundle.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/tldw_api/skills_schemas.py Tests/tldw_api/test_skills_schemas_bundle.py
+git commit -m "feat(skills): path-aware supporting-file validator, BundleFileInfo, raised caps"
+```
+
+---
+
+### Task 2: `executable` fingerprint field (conditional serialization)
+
+**Files:**
+- Modify: `tldw_chatbook/Skills_Interop/skill_trust_models.py:32-49`
+- Test: `Tests/Skills/test_skill_fingerprint_executable.py` (create)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `SkillFileFingerprint(relative_path, file_type, byte_length, sha256, executable=False)`; `as_manifest_entry()` includes `"executable": True` **only when** `executable` is True.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from tldw_chatbook.Skills_Interop.skill_trust_models import SkillFileFingerprint
+
+
+def test_manifest_entry_omits_executable_when_false():
+    fp = SkillFileFingerprint(
+        relative_path="notes.md", file_type="supporting_text", byte_length=3, sha256="ab",
+    )
+    # BACKWARD-COMPAT: byte-identical to the pre-change 4-key dict.
+    assert fp.as_manifest_entry() == {
+        "relative_path": "notes.md", "file_type": "supporting_text",
+        "byte_length": 3, "sha256": "ab",
+    }
+
+
+def test_manifest_entry_includes_executable_when_true():
+    fp = SkillFileFingerprint(
+        relative_path="scripts/run.sh", file_type="supporting_text",
+        byte_length=3, sha256="ab", executable=True,
+    )
+    assert fp.as_manifest_entry()["executable"] is True
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/test_skill_fingerprint_executable.py -q`
+Expected: FAIL — `TypeError: ... unexpected keyword argument 'executable'`.
+
+- [ ] **Step 3: Implement**
+
+Add the field (with default so existing constructors stay valid) and the conditional key:
+
+```python
+@dataclass(frozen=True, slots=True)
+class SkillFileFingerprint:
+    """Stable fingerprint metadata for one local skill file."""
+
+    relative_path: str
+    file_type: str
+    byte_length: int
+    sha256: str
+    executable: bool = False
+
+    def as_manifest_entry(self) -> dict[str, Any]:
+        """Return the JSON-safe manifest representation for this fingerprint.
+
+        The ``executable`` key is emitted ONLY when True so that a flat,
+        all-text, non-executable skill serializes byte-identically to the
+        pre-Spec-2 form (preserving existing manifests' HMAC validity).
+        """
+        entry = {
+            "relative_path": self.relative_path,
+            "file_type": self.file_type,
+            "byte_length": self.byte_length,
+            "sha256": self.sha256,
+        }
+        if self.executable:
+            entry["executable"] = True
+        return entry
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/test_skill_fingerprint_executable.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Skills_Interop/skill_trust_models.py Tests/Skills/test_skill_fingerprint_executable.py
+git commit -m "feat(skills): conditional executable field on SkillFileFingerprint"
+```
+
+---
+
+### Task 3: Recursive, junk-aware, binary/mode-aware trust scanner
+
+**Files:**
+- Modify: `tldw_chatbook/Skills_Interop/skill_trust_scanner.py` (whole `scan_skill_directory` + helpers)
+- Test: `Tests/Skills/test_skill_trust_scanner_recursive.py` (create)
+
+**Interfaces:**
+- Consumes: `validate_supporting_file_path` (Task 1); `SkillFileFingerprint(..., executable=)` (Task 2).
+- Produces: `scan_skill_directory(skill_name, skill_dir)` unchanged signature, now recursive; `SUPPORTING_JUNK_DIRS`, `SUPPORTING_JUNK_FILES`, `SUPPORTING_JUNK_SUFFIXES` constants; a file is `file_type="supporting_binary"` when non-UTF-8/null-byte, `"skill"` iff `relative_path == "SKILL.md"`, else `"supporting_text"`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import os
+from pathlib import Path
+
+from tldw_chatbook.Skills_Interop.skill_trust_scanner import scan_skill_directory
+
+
+def _write(p: Path, data: bytes, mode: int | None = None):
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(data)
+    if mode is not None:
+        os.chmod(p, mode)
+
+
+def test_recurses_and_classifies(tmp_path):
+    d = tmp_path / "demo"
+    _write(d / "SKILL.md", b"---\nname: demo\n---\nbody\n")
+    _write(d / "references" / "api.md", b"# api\n")
+    _write(d / "scripts" / "run.sh", b"#!/bin/sh\necho hi\n", mode=0o755)
+    _write(d / "assets" / "logo.png", b"\x89PNG\x00\x01binary")
+    snap = scan_skill_directory("demo", d)
+    fps = {f.relative_path: f for f in snap.fingerprints}
+    assert set(fps) == {"SKILL.md", "references/api.md", "scripts/run.sh", "assets/logo.png"}
+    assert fps["SKILL.md"].file_type == "skill"
+    assert fps["assets/logo.png"].file_type == "supporting_binary"
+    assert "assets/logo.png" not in snap.text_files       # binary not decoded
+    assert "references/api.md" in snap.text_files
+    assert fps["scripts/run.sh"].executable is True
+    assert snap.unsupported_paths == ()
+
+
+def test_prunes_junk(tmp_path):
+    d = tmp_path / "demo"
+    _write(d / "SKILL.md", b"x")
+    _write(d / ".git" / "config", b"junk")
+    _write(d / "__pycache__" / "m.pyc", b"\x00pyc")
+    _write(d / ".DS_Store", b"\x00")
+    _write(d / "keep.md~", b"backup")
+    snap = scan_skill_directory("demo", d)
+    paths = {f.relative_path for f in snap.fingerprints}
+    assert paths == {"SKILL.md"}
+    assert snap.unsupported_paths == ()   # junk pruned, NOT recorded
+
+
+def test_nested_skill_md_is_not_the_body(tmp_path):
+    d = tmp_path / "demo"
+    _write(d / "SKILL.md", b"body")
+    _write(d / "references" / "SKILL.md", b"nested")
+    snap = scan_skill_directory("demo", d)
+    # A nested SKILL.md is rejected as a shadow (validate_supporting_file_path),
+    # so it lands in unsupported_paths, never classified as the body.
+    fps = {f.relative_path: f for f in snap.fingerprints}
+    assert fps["SKILL.md"].file_type == "skill"
+    assert "references/SKILL.md" not in fps
+    assert "references/SKILL.md" in snap.unsupported_paths
+
+
+def test_flat_snapshot_byte_identical_to_legacy_ordering(tmp_path):
+    # Guards the backward-compat guarantee: a flat all-text skill's fingerprint
+    # entries are in iterdir name-order and carry no executable key.
+    d = tmp_path / "demo"
+    _write(d / "SKILL.md", b"body")
+    _write(d / "b.md", b"bbb")
+    _write(d / "a.md", b"aaa")
+    snap = scan_skill_directory("demo", d)
+    entries = [f.as_manifest_entry() for f in snap.fingerprints]
+    assert [e["relative_path"] for e in entries] == ["SKILL.md", "a.md", "b.md"]
+    assert all("executable" not in e for e in entries)
+
+
+def test_symlink_skipped_not_followed(tmp_path):
+    d = tmp_path / "demo"
+    _write(d / "SKILL.md", b"body")
+    (d / "link.md").symlink_to(d / "SKILL.md")
+    snap = scan_skill_directory("demo", d)
+    assert "link.md" not in {f.relative_path for f in snap.fingerprints}
+    assert "link.md" in snap.unsupported_paths
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/test_skill_trust_scanner_recursive.py -q`
+Expected: FAIL (nested files missing / classified wrong; today's flat scan skips subdirs).
+
+- [ ] **Step 3: Implement**
+
+Rewrite `skill_trust_scanner.py`. Keep the `_SKILL_FILENAME`, `sha256_hex`, model imports. Replace `_TEMP_SUFFIXES` handling with a junk ignore-list, walk recursively, validate per path, fingerprint binaries:
+
+```python
+"""Deterministic local skill directory scanning for trust verification."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path, PurePosixPath
+
+from .skill_trust_crypto import sha256_hex
+from .skill_trust_models import SkillDirectorySnapshot, SkillFileFingerprint
+
+_SKILL_FILENAME = "SKILL.md"
+SUPPORTING_JUNK_DIRS = frozenset({".git", ".github", ".hg", ".svn", "node_modules", "__pycache__"})
+SUPPORTING_JUNK_FILES = frozenset({".DS_Store", "Thumbs.db"})
+SUPPORTING_JUNK_SUFFIXES = (".pyc", ".pyo", "~", ".bak", ".orig", ".tmp", ".swp", ".part")
+
+
+def _is_junk(name: str) -> bool:
+    return name in SUPPORTING_JUNK_FILES or name.lower().endswith(SUPPORTING_JUNK_SUFFIXES)
+
+
+def _validate_relative_path(relative_path: str) -> bool:
+    # Deferred import: avoid module-scope tldw_api schema import (task-285 phase 2).
+    from ..tldw_api.skills_schemas import validate_supporting_file_path
+
+    try:
+        validate_supporting_file_path(relative_path)
+        return True
+    except ValueError:
+        return False
+
+
+def scan_skill_directory(skill_name: str, skill_dir: Path) -> SkillDirectorySnapshot:
+    """Return a deterministic trust snapshot for a skill directory tree.
+
+    Walks ``skill_dir`` recursively (never following symlinks), pruning
+    VCS/OS/build junk, sorting by POSIX relative path. Text files are decoded
+    into ``text_files``; binaries are fingerprinted (``file_type=
+    "supporting_binary"``) but not decoded. Symlinks and files failing path
+    validation are recorded in ``unsupported_paths`` (they are NOT trust
+    material) but never raise here.
+
+    Args:
+        skill_name: Local skill name represented by the directory.
+        skill_dir: Directory to scan.
+
+    Returns:
+        Snapshot with fingerprints (sorted by relative path), decoded text
+        files, and unsupported path names.
+    """
+    fingerprints: list[SkillFileFingerprint] = []
+    text_files: dict[str, str] = {}
+    unsupported_paths: list[str] = []
+
+    collected: list[tuple[str, Path]] = []
+    for root, dirs, files in os.walk(skill_dir, followlinks=False):
+        # Prune junk directories in-place so os.walk does not descend them.
+        dirs[:] = sorted(d for d in dirs if d not in SUPPORTING_JUNK_DIRS)
+        for name in files:
+            if _is_junk(name):
+                continue
+            abs_path = Path(root) / name
+            rel = PurePosixPath(abs_path.relative_to(skill_dir).as_posix())
+            collected.append((str(rel), abs_path))
+    collected.sort(key=lambda item: item[0])
+
+    for relative_path, path in collected:
+        if path.is_symlink() or not _validate_relative_path(relative_path):
+            unsupported_paths.append(relative_path)
+            continue
+        try:
+            if not path.is_file():
+                unsupported_paths.append(relative_path)
+                continue
+            raw = path.read_bytes()
+        except OSError:
+            unsupported_paths.append(relative_path)
+            continue
+
+        is_binary = b"\x00" in raw
+        text: str | None = None
+        if not is_binary:
+            try:
+                text = raw.decode("utf-8")
+            except UnicodeDecodeError:
+                is_binary = True
+
+        if relative_path == _SKILL_FILENAME:
+            file_type = "skill"
+        elif is_binary:
+            file_type = "supporting_binary"
+        else:
+            file_type = "supporting_text"
+
+        executable = bool(path.stat().st_mode & stat.S_IXUSR)
+        fingerprints.append(
+            SkillFileFingerprint(
+                relative_path=relative_path,
+                file_type=file_type,
+                byte_length=len(raw),
+                sha256=sha256_hex(raw),
+                executable=executable,
+            )
+        )
+        if text is not None:
+            text_files[relative_path] = text
+
+    return SkillDirectorySnapshot(
+        skill_name=skill_name,
+        fingerprints=tuple(fingerprints),
+        text_files=text_files,
+        unsupported_paths=tuple(unsupported_paths),
+    )
+```
+
+Note: the `SKILL.md` body keeps `executable=False` in practice (markdown), so its entry stays byte-identical.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/test_skill_trust_scanner_recursive.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Regression — existing scanner tests still pass**
+
+Run: `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/ -q -k "scanner or trust"`
+Expected: PASS (backward-compat: flat all-text snapshots unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Skills_Interop/skill_trust_scanner.py Tests/Skills/test_skill_trust_scanner_recursive.py
+git commit -m "feat(skills): recursive junk-aware binary/mode trust scanner"
+```
+
+---
+
+### Task 4: Fix `verify_skill_content` so binary/executable files don't false-block execute
+
+**Files:**
+- Modify: `tldw_chatbook/Skills_Interop/skill_trust_service.py:399-410` (`verify_skill_content` comparison)
+- Test: `Tests/Skills/test_verify_content_binary.py` (create)
+
+**Interfaces:**
+- Consumes: scanner (Task 3), `bootstrap_trust` (Task 5 tolerance not required here), the manifest's per-file `as_manifest_entry` dicts (which now carry `file_type="supporting_binary"` and `executable`).
+- Produces: `verify_skill_content` no longer raises when the trusted manifest contains binary or executable files that the text-only in-memory reconstruction cannot represent.
+
+**Context (the bug this fixes):** `verify_skill_content` (`:399-410`) runs on **every** `execute_skill`. It builds `current_files` from `_fingerprint_in_memory_files(skill_content, supporting_files)` where `supporting_files` is the **text-only** view (binaries excluded; executable bit unknown). It then compares against `trusted_files` (the full manifest, which post-Spec-2 includes binary + executable fingerprints). So `missing = trusted − current` would contain every binary file, and `modified` would contain every executable text file (manifest has `executable:True`, in-memory omits it) → `verify_skill_content` raises `SkillTrustBlockedError` on every run. The authoritative full-bundle check already happens in `ensure_skill_trusted` (`:371`) → `status_for_skill` → recursive disk scan (binary/exec included). So the in-memory check must be **scoped to files it can faithfully reconstruct** (text, non-executable) and leave binary/exec/full-set verification to the disk scan.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import secrets, pytest
+from tldw_chatbook.Skills_Interop.skill_trust_service import SkillTrustService
+from tldw_chatbook.Skills_Interop.skill_trust_store import (
+    FileSkillTrustGenerationMarkerStore, SkillTrustStore,
+)
+
+
+def _svc(tmp_path):
+    (tmp_path / "trust").mkdir()
+    (tmp_path / "skills").mkdir()
+    return SkillTrustService(
+        skills_dir=tmp_path / "skills",
+        trust_store=SkillTrustStore(
+            store_dir=tmp_path / "trust",
+            marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "trust" / "m.json"),
+        ),
+        key_cache=None,
+    )
+
+
+def test_verify_content_tolerates_binary_and_exec(tmp_path):
+    import os, stat
+    d = tmp_path / "skills" / "demo"
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text("body\n", encoding="utf-8")
+    (d / "assets").mkdir()
+    (d / "assets" / "logo.png").write_bytes(b"\x89PNG\x00bin")   # binary → in manifest, not in text view
+    (d / "scripts").mkdir()
+    (d / "scripts" / "run.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+    os.chmod(d / "scripts" / "run.sh", 0o755)                    # executable text
+    svc = _svc(tmp_path)
+    svc.bootstrap_trust("pw", salt=secrets.token_bytes(32))      # trusts the full bundle
+    # verify_skill_content receives the TEXT view (no binary; run.sh present but mode unknown).
+    svc.verify_skill_content(
+        "demo",
+        skill_content="body\n",
+        supporting_files={"scripts/run.sh": "#!/bin/sh\n"},
+    )   # must NOT raise (was raising: assets/logo.png "missing", scripts/run.sh "modified")
+
+
+def test_verify_content_still_catches_modified_text_body(tmp_path):
+    d = tmp_path / "skills" / "demo"
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text("body\n", encoding="utf-8")
+    svc = _svc(tmp_path)
+    svc.bootstrap_trust("pw", salt=secrets.token_bytes(32))
+    from tldw_chatbook.Skills_Interop.skill_trust_service import SkillTrustBlockedError
+    with pytest.raises(SkillTrustBlockedError):
+        svc.verify_skill_content("demo", skill_content="TAMPERED\n", supporting_files=None)
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/test_verify_content_binary.py -q`
+Expected: FAIL — `test_verify_content_tolerates_binary_and_exec` raises `SkillTrustBlockedError` (binary "missing", exec "modified").
+
+- [ ] **Step 3: Implement**
+
+Replace the comparison block (`:403-410`). Scope `missing`/`modified` to trusted files that the in-memory text view can faithfully reconstruct — i.e. exclude `supporting_binary` and executable entries (the disk scan in `ensure_skill_trusted` is the authority for those):
+
+```python
+        current_files = self._fingerprint_in_memory_files(
+            skill_content=skill_content,
+            supporting_files=supporting_files,
+        )
+        # The in-memory reconstruction is text-only and mode-blind. Binary and
+        # executable files cannot be represented here, so scope the in-memory
+        # comparison to reconstructable (text, non-executable) trusted files;
+        # ensure_skill_trusted() above already verified the full on-disk bundle
+        # (binaries + exec bits) against the manifest via a recursive scan.
+        reconstructable = {
+            path
+            for path, entry in trusted_files.items()
+            if entry.get("file_type") != "supporting_binary"
+            and not entry.get("executable")
+        }
+        missing = reconstructable - set(current_files)
+        added = set(current_files) - set(trusted_files)
+        modified = {
+            path
+            for path in reconstructable & current_files.keys()
+            if trusted_files[path] != current_files[path]
+        }
+        changed = tuple(sorted(missing | added | modified))
+```
+
+Leave the trailing `if not changed:` / raise logic (`:411+`) unchanged. Do NOT modify `_fingerprint_in_memory_files` or `_content_manifest_entry` — they correctly emit text entries (executable omitted), which now compare only against `reconstructable` trusted entries.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/test_verify_content_binary.py -q`
+Expected: PASS (both tests: binary/exec tolerated; tampered text body still blocked).
+
+- [ ] **Step 5: Regression**
+
+Run: `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/test_skill_trust_service.py -q`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Skills_Interop/skill_trust_service.py Tests/Skills/test_verify_content_binary.py
+git commit -m "fix(skills): scope in-memory verify to text files so binary/exec don't false-block execute"
+```
+
+---
+
+### Task 5: Tolerate-and-surface unsupported files (no hard-raise)
+
+**Files:**
+- Modify: `tldw_chatbook/Skills_Interop/skill_trust_service.py` — `bootstrap_trust` (the `if snapshot.unsupported_paths: raise` at ~:221) and `trust_current_skill` (~:507)
+- Test: `Tests/Skills/test_trust_tolerates_unsupported.py` (create)
+
+**Interfaces:**
+- Consumes: scanner (Task 3).
+- Produces: `bootstrap_trust`/`trust_current_skill` no longer raise `ValueError(TRUST_REASON_UNSUPPORTED_PATH)`; they trust the supported fingerprints and leave any residual unsupported file surfaced via `status_for_skill` (already returns `quarantined_unsupported_path`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import secrets
+from tldw_chatbook.Skills_Interop.skill_trust_service import SkillTrustService
+from tldw_chatbook.Skills_Interop.skill_trust_store import (
+    FileSkillTrustGenerationMarkerStore, SkillTrustStore,
+)
+
+
+def _svc(tmp_path):
+    (tmp_path / "trust").mkdir()
+    (tmp_path / "skills").mkdir()
+    return SkillTrustService(
+        skills_dir=tmp_path / "skills",
+        trust_store=SkillTrustStore(
+            store_dir=tmp_path / "trust",
+            marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "trust" / "m.json"),
+        ),
+        key_cache=None,
+    )
+
+
+def test_bootstrap_does_not_raise_on_residual_unsupported(tmp_path):
+    d = tmp_path / "skills" / "demo"
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text("body\n", encoding="utf-8")
+    (d / "good.md").write_text("ok\n", encoding="utf-8")
+    (d / "link.md").symlink_to(d / "good.md")   # residual unsupported (symlink)
+    svc = _svc(tmp_path)
+    svc.bootstrap_trust("pw", salt=secrets.token_bytes(32))   # must NOT raise
+    status = svc.status_for_skill("demo")
+    assert status.trust_status == "quarantined_unsupported_path"  # surfaced, recoverable
+    # Removing the residual clears it.
+    (d / "link.md").unlink()
+    svc.trust_current_skill("demo")   # must NOT raise
+    assert svc.status_for_skill("demo").trust_status == "trusted"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/test_trust_tolerates_unsupported.py -q`
+Expected: FAIL — `ValueError: unsupported_path` raised by `bootstrap_trust`.
+
+- [ ] **Step 3: Implement**
+
+In `bootstrap_trust`, delete the `if snapshot.unsupported_paths: raise ValueError(TRUST_REASON_UNSUPPORTED_PATH)` guard (~:221-222) — proceed to build the manifest entry from `snapshot.fingerprints` (supported files) regardless. Do the same in `trust_current_skill` (~:507-508). The residual unsupported files remain visible because `status_for_skill` still returns `quarantined_unsupported_path` when `current.unsupported_paths` is non-empty (unchanged, ~:276-285). Do not remove the `TRUST_STATUS_QUARANTINED_UNSUPPORTED_PATH` status or `status_for_skill`'s handling.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/test_trust_tolerates_unsupported.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Regression — existing trust tests**
+
+Run: `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/test_skill_trust_service.py -q`
+Expected: PASS. If a test asserted the old hard-raise on unsupported paths, update it to assert the tolerate-and-surface behavior (quarantined status, no raise) — this is an intended behavior change per the spec.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Skills_Interop/skill_trust_service.py Tests/Skills/test_trust_tolerates_unsupported.py
+git commit -m "feat(skills): tolerate-and-surface unsupported files instead of hard-raise"
+```
+
+---
+
+### Task 6: Recursive binary-safe service read + bundle manifest + safe writers
+
+**Files:**
+- Modify: `tldw_chatbook/Skills_Interop/local_skills_service.py` — `_read_supporting_files` (:391-405), `_read_text_preserving_newlines` (:407-419), `_apply_supporting_files` (:559-571), `_write_text_atomic` (:148-154), `_response_for_record` (:421-435)
+- Test: `Tests/Skills/test_local_skills_bundle_io.py` (create)
+
+**Interfaces:**
+- Consumes: `validate_supporting_file_path`, `BundleFileInfo` (Task 1); junk constants (Task 3).
+- Produces: `_read_supporting_files(skill_dir) -> dict[str,str] | None` (recursive, nested keys, TEXT only, never raises on binary); `_read_bundle_manifest(skill_dir) -> list[dict] | None` (all files metadata); `_write_bytes_atomic(path, data: bytes)`; `_apply_supporting_files` validates + contains each key.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import pytest
+from tldw_chatbook.Skills_Interop.local_skills_service import LocalSkillsService
+
+
+@pytest.mark.asyncio
+async def test_get_skill_with_nested_and_binary_never_raises(tmp_path):
+    svc = LocalSkillsService(store_dir=tmp_path)
+    await svc.create_skill(name="demo", content="---\nname: demo\n---\nbody\n")
+    d = svc._skill_dir("demo")
+    (d / "references").mkdir(parents=True, exist_ok=True)
+    (d / "references" / "api.md").write_text("# api\n", encoding="utf-8")
+    (d / "assets").mkdir(parents=True, exist_ok=True)
+    (d / "assets" / "logo.png").write_bytes(b"\x89PNG\x00binary")
+    skill = await svc.get_skill("demo")      # must NOT raise
+    assert skill["supporting_files"]["references/api.md"] == "# api\n"
+    assert "assets/logo.png" not in skill["supporting_files"]   # binary excluded from text view
+    paths = {b["path"]: b for b in skill["bundle_files"]}
+    assert paths["assets/logo.png"]["is_text"] is False
+    assert paths["references/api.md"]["is_text"] is True
+
+
+def test_apply_supporting_files_rejects_traversal(tmp_path):
+    svc = LocalSkillsService(store_dir=tmp_path)
+    d = svc._skill_dir("demo")
+    d.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(ValueError):
+        svc._apply_supporting_files(d, {"../escape.md": "x"})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/test_local_skills_bundle_io.py -q`
+Expected: FAIL — `UnicodeDecodeError` from `get_skill` (top-level binary) and/or `bundle_files` KeyError.
+
+- [ ] **Step 3: Implement**
+
+Add a bytes-mode atomic writer beside `_write_text_atomic`:
+
+```python
+    @staticmethod
+    def _write_bytes_atomic(path: Path, data: bytes) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = path.with_name(f"{path.name}.tmp")
+        with temp_path.open("wb") as handle:
+            handle.write(data)
+        temp_path.replace(path)
+```
+
+Rewrite `_read_supporting_files` to walk recursively (junk-pruned, text-only, never raise), and add `_read_bundle_manifest`:
+
+```python
+    @staticmethod
+    def _iter_bundle_files(skill_dir: Path):
+        """Yield (relative_posix, abs_path) for every non-junk file, junk dirs pruned."""
+        from .skill_trust_scanner import SUPPORTING_JUNK_DIRS, _is_junk  # reuse
+        import os
+        from pathlib import PurePosixPath
+        if not skill_dir.exists():
+            return
+        for root, dirs, files in os.walk(skill_dir, followlinks=False):
+            dirs[:] = [d for d in dirs if d not in SUPPORTING_JUNK_DIRS]
+            for name in files:
+                if _is_junk(name) or name == _SKILL_FILENAME and Path(root) == skill_dir:
+                    continue
+                abs_path = Path(root) / name
+                rel = PurePosixPath(abs_path.relative_to(skill_dir).as_posix())
+                yield str(rel), abs_path
+
+    @staticmethod
+    def _read_supporting_files(skill_dir: Path) -> dict[str, str] | None:
+        from ..tldw_api.skills_schemas import validate_supporting_file_path
+        supporting_files: dict[str, str] = {}
+        for relative_path, path in sorted(
+            LocalSkillsService._iter_bundle_files(skill_dir), key=lambda x: x[0]
+        ):
+            if path.is_symlink():
+                continue
+            try:
+                validate_supporting_file_path(relative_path)
+            except ValueError:
+                continue
+            try:
+                raw = path.read_bytes()
+            except OSError:
+                continue
+            if b"\x00" in raw:
+                continue
+            try:
+                supporting_files[relative_path] = raw.decode("utf-8")
+            except UnicodeDecodeError:
+                continue   # binary — excluded from the text view, never raises
+        return supporting_files or None
+
+    @staticmethod
+    def _read_bundle_manifest(skill_dir: Path) -> list[dict[str, Any]] | None:
+        import stat
+        from ..tldw_api.skills_schemas import validate_supporting_file_path
+        manifest: list[dict[str, Any]] = []
+        for relative_path, path in sorted(
+            LocalSkillsService._iter_bundle_files(skill_dir), key=lambda x: x[0]
+        ):
+            if path.is_symlink() or not path.is_file():
+                continue
+            try:
+                validate_supporting_file_path(relative_path)
+                raw = path.read_bytes()
+            except (ValueError, OSError):
+                continue
+            is_text = b"\x00" not in raw
+            if is_text:
+                try:
+                    raw.decode("utf-8")
+                except UnicodeDecodeError:
+                    is_text = False
+            manifest.append({
+                "path": relative_path,
+                "size": len(raw),
+                "executable": bool(path.stat().st_mode & stat.S_IXUSR),
+                "is_text": is_text,
+            })
+        return manifest or None
+```
+
+Rewrite `_apply_supporting_files` to validate + contain each key and write bytes-safely for text (it only receives text via the editor):
+
+```python
+    @staticmethod
+    def _apply_supporting_files(
+        skill_dir: Path, supporting_files: dict[str, str | None] | None
+    ) -> None:
+        from ..tldw_api.skills_schemas import validate_supporting_file_path
+        if supporting_files is None:
+            return
+        base = skill_dir.resolve()
+        for filename, content in supporting_files.items():
+            validate_supporting_file_path(filename)     # raises on traversal/bad name
+            path = (skill_dir / filename)
+            if base not in path.resolve().parents and path.resolve() != base:
+                raise ValueError(f"unsafe supporting file path: {filename}")
+            if content is None:
+                if path.exists():
+                    path.unlink()
+                continue
+            LocalSkillsService._write_text_atomic(path, content)
+```
+
+In `_response_for_record` (:431-435), add the bundle manifest:
+
+```python
+        response = SkillResponse(
+            **record,
+            content=content,
+            supporting_files=self._read_supporting_files(skill_dir),
+            bundle_files=self._read_bundle_manifest(skill_dir),
+        )
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/test_local_skills_bundle_io.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Skills_Interop/local_skills_service.py Tests/Skills/test_local_skills_bundle_io.py
+git commit -m "feat(skills): recursive binary-safe read + bundle manifest + safe writers"
+```
+
+---
+
+### Task 7: Faithful folder import (`import_skill_directory`) + UI wiring
+
+**Files:**
+- Modify: `tldw_chatbook/Skills_Interop/local_skills_service.py` (add `import_skill_directory`); `tldw_chatbook/UI/Screens/library_screen.py:7267-7314` (folder branch)
+- Test: `Tests/Skills/test_import_skill_directory.py` (create)
+
+**Interfaces:**
+- Consumes: `_iter_bundle_files`, `_write_bytes_atomic`, `validate_supporting_file_path`, caps (Tasks 1, 6).
+- Produces: `async import_skill_directory(self, source_dir: Path, *, name: str, overwrite: bool = False, trust_approved: bool = False) -> dict[str,Any]` — faithful recursive copy (nested, binary, exec bit from real mode), junk-pruned, symlink-skipped, cap-enforced, trust-pending.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import os, stat, pytest
+from pathlib import Path
+from tldw_chatbook.Skills_Interop.local_skills_service import LocalSkillsService
+
+
+@pytest.mark.asyncio
+async def test_import_skill_directory_faithful(tmp_path):
+    src = tmp_path / "src" / "demo"
+    (src / "scripts").mkdir(parents=True)
+    (src / "SKILL.md").write_text("---\nname: demo\n---\nbody\n", encoding="utf-8")
+    (src / "scripts" / "run.sh").write_bytes(b"#!/bin/sh\necho hi\n")
+    os.chmod(src / "scripts" / "run.sh", 0o755)
+    (src / "assets").mkdir()
+    (src / "assets" / "logo.png").write_bytes(b"\x89PNG\x00bin")
+    (src / ".git").mkdir()
+    (src / ".git" / "config").write_text("junk", encoding="utf-8")
+
+    svc = LocalSkillsService(store_dir=tmp_path / "store")
+    await svc.import_skill_directory(src, name="demo")
+    d = svc._skill_dir("demo")
+    assert (d / "scripts" / "run.sh").read_bytes() == b"#!/bin/sh\necho hi\n"
+    assert d.joinpath("scripts", "run.sh").stat().st_mode & stat.S_IXUSR
+    assert (d / "assets" / "logo.png").read_bytes() == b"\x89PNG\x00bin"
+    assert not (d / ".git").exists()          # junk pruned
+    skill = await svc.get_skill("demo")
+    assert skill["trust_status"] != "trusted"  # trust-pending
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/test_import_skill_directory.py -q`
+Expected: FAIL — `AttributeError: 'LocalSkillsService' object has no attribute 'import_skill_directory'`.
+
+- [ ] **Step 3: Implement**
+
+Add to `LocalSkillsService`, modeled on `import_skill` (:779-825) but copying the tree faithfully:
+
+```python
+    async def import_skill_directory(
+        self,
+        source_dir: Path,
+        *,
+        name: str,
+        overwrite: bool = False,
+        trust_approved: bool = False,
+    ) -> dict[str, Any]:
+        import os, shutil, stat
+        from pathlib import PurePosixPath
+        from ..tldw_api.skills_schemas import (
+            _normalize_skill_name, validate_supporting_file_path,
+            MAX_SUPPORTING_FILES_COUNT, MAX_SUPPORTING_FILE_BYTES,
+            MAX_SUPPORTING_FILES_TOTAL_BYTES,
+        )
+        self._enforce("skills.import.launch.local")
+        skill_name = _normalize_skill_name(name)
+        source_dir = Path(source_dir)
+        body = source_dir / _SKILL_FILENAME
+        if not body.is_file():
+            raise ValueError("local_skill_missing_skill_md")
+        # Collect the faithful file set (junk pruned, symlinks skipped, caps enforced).
+        files: list[tuple[str, Path]] = []
+        total = 0
+        for relative_path, abs_path in self._iter_bundle_files(source_dir):
+            if abs_path.is_symlink():
+                continue                     # skip-not-fail
+            try:
+                validate_supporting_file_path(relative_path)
+            except ValueError:
+                continue
+            size = abs_path.stat().st_size
+            if size > MAX_SUPPORTING_FILE_BYTES:
+                raise ValueError(f"local_skill_file_too_large:{relative_path}")
+            total += size
+            files.append((relative_path, abs_path))
+        if len(files) > MAX_SUPPORTING_FILES_COUNT:
+            raise ValueError("local_skill_too_many_files")
+        if total > MAX_SUPPORTING_FILES_TOTAL_BYTES:
+            raise ValueError("local_skill_bundle_too_large")
+        async with self._lock:
+            records = self._load_index()
+            if skill_name in records and not overwrite:
+                raise ValueError(f"local_skill_exists:{skill_name}")
+            skill_dir = self._skill_dir(skill_name)
+            if overwrite and skill_dir.exists():
+                shutil.rmtree(skill_dir)
+            skill_dir.mkdir(parents=True, exist_ok=True)
+            existing = records.get(skill_name) if overwrite else None
+            content = body.read_text(encoding="utf-8", errors="strict")
+            self._write_text_atomic(skill_dir / _SKILL_FILENAME, content)
+            for relative_path, abs_path in files:
+                dest = skill_dir / PurePosixPath(relative_path)
+                self._write_bytes_atomic(dest, abs_path.read_bytes())
+                if abs_path.stat().st_mode & stat.S_IXUSR:
+                    os.chmod(dest, dest.stat().st_mode | 0o755)
+            record = self._metadata_from_content(
+                name=skill_name, content=content, skill_dir=skill_dir, existing=existing,
+            )
+            if existing is not None:
+                record["version"] = int(existing.get("version", 0)) + 1
+            records[skill_name] = record
+            self._save_index(records)
+            self._trust_after_approved_mutation(skill_name, trust_approved=trust_approved)
+            return self._response_for_record(record)
+```
+
+In `library_screen.py`, the directory branch of `_run_library_skills_import` (:7267-7314) currently reads flat siblings and calls `import_skill`. Replace it to call `import_skill_directory`:
+
+```python
+        if validated_path.is_dir():
+            skill_dir = validated_path
+            if self._find_skill_md_in_dir(skill_dir) is None:
+                self._apply_library_skills_import_status("No SKILL.md found in that folder.")
+                return
+            import_skill_directory = getattr(service, "import_skill_directory", None)
+            if not callable(import_skill_directory):
+                self._apply_library_skills_import_status("Skill import is unavailable.")
+                return
+            skill_name = skill_dir.name
+            try:
+                await self._run_library_service_call(
+                    import_skill_directory, skill_dir, mode="local",
+                    name=skill_name, trust_approved=False, isolate_in_worker=True,
+                )
+            except Exception as exc:
+                self._apply_library_skills_import_outcome_from_exception(skill_name, exc)
+                return
+            self._apply_library_skills_import_success(skill_name)
+            return
+```
+
+Delete `_read_library_skill_import_supporting_files` if now unused (grep first). Keep the SKILL.md-file and loose-file branches unchanged.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/test_import_skill_directory.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Skills_Interop/local_skills_service.py tldw_chatbook/UI/Screens/library_screen.py Tests/Skills/test_import_skill_directory.py
+git commit -m "feat(skills): faithful folder import (import_skill_directory) + UI wiring"
+```
+
+---
+
+### Task 8: Faithful zip import (nested + binary + exec + hardening)
+
+**Files:**
+- Modify: `tldw_chatbook/Skills_Interop/local_skills_service.py` — `_validate_archive_member` (:588-600), `import_skill_file` (:827-869)
+- Test: `Tests/Skills/test_zip_import_bundle.py` (create)
+
+**Interfaces:**
+- Consumes: `validate_supporting_file_path`, `_write_bytes_atomic`, caps.
+- Produces: `import_skill_file` extracts nested/binary/exec faithfully to `skill_dir`; `_validate_archive_member(name) -> str` allows nested relative paths, rejects traversal/absolute/reserved.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import io, zipfile, stat, pytest
+from tldw_chatbook.Skills_Interop.local_skills_service import LocalSkillsService
+
+
+def _zip(members):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        for name, data, mode in members:
+            info = zipfile.ZipInfo(name)
+            if mode:
+                info.external_attr = mode << 16
+            z.writestr(info, data)
+    return buf.getvalue()
+
+
+@pytest.mark.asyncio
+async def test_zip_import_nested_binary_exec(tmp_path):
+    svc = LocalSkillsService(store_dir=tmp_path)
+    data = _zip([
+        ("SKILL.md", b"---\nname: z\n---\nbody\n", 0),
+        ("scripts/run.sh", b"#!/bin/sh\n", 0o755),
+        ("assets/logo.png", b"\x89PNG\x00bin", 0),
+    ])
+    await svc.import_skill_file(data, filename="z.zip", content_type="application/zip")
+    d = svc._skill_dir("z")
+    assert (d / "scripts" / "run.sh").read_bytes() == b"#!/bin/sh\n"
+    assert d.joinpath("scripts", "run.sh").stat().st_mode & stat.S_IXUSR
+    assert (d / "assets" / "logo.png").read_bytes() == b"\x89PNG\x00bin"
+
+
+@pytest.mark.asyncio
+async def test_zip_slip_rejected(tmp_path):
+    svc = LocalSkillsService(store_dir=tmp_path)
+    data = _zip([("SKILL.md", b"body", 0), ("../evil.md", b"x", 0)])
+    with pytest.raises(ValueError):
+        await svc.import_skill_file(data, filename="z.zip", content_type="application/zip")
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/test_zip_import_bundle.py -q`
+Expected: FAIL — current `_validate_archive_member` rejects `scripts/run.sh` (`len(parts) != 1`).
+
+- [ ] **Step 3: Implement**
+
+Replace `_validate_archive_member` to allow nested via the shared validator:
+
+```python
+    @staticmethod
+    def _validate_archive_member(name: str) -> str:
+        from ..tldw_api.skills_schemas import validate_supporting_file_path
+        posix = PurePosixPath(name)
+        if str(posix) == _SKILL_FILENAME:
+            return _SKILL_FILENAME
+        return validate_supporting_file_path(str(posix))
+```
+
+Rewrite the zip branch of `import_skill_file` (:849-869) to extract faithfully to disk (not through the text dict), preserving mode, with junk prune, caps, symlink rejection, and zip-slip containment. Use `import_skill` only for the body creation, then write files:
+
+```python
+        import stat as _stat
+        from .skill_trust_scanner import SUPPORTING_JUNK_DIRS, _is_junk
+        from ..tldw_api.skills_schemas import (
+            MAX_SUPPORTING_FILES_COUNT, MAX_SUPPORTING_FILE_BYTES,
+            MAX_SUPPORTING_FILES_TOTAL_BYTES,
+        )
+        skill_name = self._derive_name_from_filename(filename)
+        members: list[tuple[str, bytes, bool]] = []
+        skill_content: str | None = None
+        total = 0
+        seen_lower: set[str] = set()
+        with zipfile.ZipFile(io.BytesIO(file_content), "r") as archive:
+            for member in archive.infolist():
+                if member.is_dir():
+                    continue
+                mode = (member.external_attr >> 16) & 0xFFFF
+                if _stat.S_ISLNK(mode):
+                    continue                       # symlink member: skip-not-fail
+                parts = PurePosixPath(member.filename).parts
+                if any(p in SUPPORTING_JUNK_DIRS for p in parts) or _is_junk(parts[-1]):
+                    continue                       # junk pruned
+                member_name = self._validate_archive_member(member.filename)  # raises on zip-slip
+                lower = member_name.lower()
+                if lower in seen_lower:             # case-fold collision on a case-insensitive FS
+                    raise ValueError(f"local_skill_invalid_archive:case_collision:{member_name}")
+                seen_lower.add(lower)
+                data = archive.read(member)
+                if len(data) > MAX_SUPPORTING_FILE_BYTES:
+                    raise ValueError(f"local_skill_file_too_large:{member_name}")
+                total += len(data)
+                if member_name == _SKILL_FILENAME:
+                    skill_content = data.decode("utf-8")
+                else:
+                    members.append((member_name, data, bool(mode & 0o111)))
+        if skill_content is None:
+            raise ValueError("local_skill_invalid_archive:missing_skill_md")
+        if len(members) > MAX_SUPPORTING_FILES_COUNT:
+            raise ValueError("local_skill_too_many_files")
+        if total > MAX_SUPPORTING_FILES_TOTAL_BYTES:
+            raise ValueError("local_skill_bundle_too_large")
+        result = await self.import_skill(
+            name=skill_name, content=skill_content, overwrite=overwrite,
+            trust_approved=False,   # re-trusted below only if approved
+        )
+        skill_dir = self._skill_dir(skill_name)
+        base = skill_dir.resolve()
+        import os as _os
+        from pathlib import PurePosixPath as _PP
+        for member_name, data, executable in members:
+            dest = skill_dir / _PP(member_name)
+            if base not in dest.resolve().parents:
+                raise ValueError(f"local_skill_invalid_archive:{member_name}")
+            self._write_bytes_atomic(dest, data)
+            if executable:
+                _os.chmod(dest, dest.stat().st_mode | 0o755)
+        # Re-derive trust state now that the full bundle is on disk.
+        self._trust_after_approved_mutation(skill_name, trust_approved=trust_approved)
+        return self._response_for_record(self._load_index()[skill_name])
+```
+
+(Keep the non-zip loose-file branch at :841-847 unchanged.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/test_zip_import_bundle.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Regression — existing import tests**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/test_skills_import.py -q`
+Expected: PASS after flipping the nested-drop assertion (Task 12 does this) — if it fails only on `test_skills_import.py:525-527`, that flip is expected; note it and continue.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Skills_Interop/local_skills_service.py Tests/Skills/test_zip_import_bundle.py
+git commit -m "feat(skills): faithful nested/binary/exec zip import with zip-slip hardening"
+```
+
+---
+
+### Task 9: Faithful zip export
+
+**Files:**
+- Modify: `tldw_chatbook/Skills_Interop/local_skills_service.py` — `export_skill` (:871-887)
+- Test: `Tests/Skills/test_zip_export_roundtrip.py` (create)
+
+**Interfaces:**
+- Consumes: `_iter_bundle_files`.
+- Produces: `export_skill` walks the dir recursively, writes raw bytes at nested paths preserving the exec bit.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import io, os, stat, zipfile, pytest
+from tldw_chatbook.Skills_Interop.local_skills_service import LocalSkillsService
+
+
+@pytest.mark.asyncio
+async def test_export_roundtrip_preserves_tree_and_mode(tmp_path):
+    svc = LocalSkillsService(store_dir=tmp_path)
+    await svc.create_skill(name="demo", content="---\nname: demo\n---\nbody\n")
+    d = svc._skill_dir("demo")
+    (d / "scripts").mkdir(parents=True, exist_ok=True)
+    (d / "scripts" / "run.sh").write_bytes(b"#!/bin/sh\n")
+    os.chmod(d / "scripts" / "run.sh", 0o755)
+    (d / "assets").mkdir(exist_ok=True)
+    (d / "assets" / "logo.png").write_bytes(b"\x89PNG\x00bin")
+
+    export = await svc.export_skill("demo")
+    with zipfile.ZipFile(io.BytesIO(export["content"])) as z:
+        names = set(z.namelist())
+        assert {"SKILL.md", "scripts/run.sh", "assets/logo.png"} <= names
+        assert z.read("assets/logo.png") == b"\x89PNG\x00bin"
+        info = z.getinfo("scripts/run.sh")
+        assert (info.external_attr >> 16) & stat.S_IXUSR
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/test_zip_export_roundtrip.py -q`
+Expected: FAIL — current export is flat and drops nested files.
+
+- [ ] **Step 3: Implement**
+
+```python
+    async def export_skill(self, skill_name: str) -> Any:
+        import stat
+        self._enforce("skills.export.launch.local")
+        normalized = _normalize_skill_name(skill_name)
+        skill_dir = self._skill_dir(normalized)
+        archive_buffer = io.BytesIO()
+        with zipfile.ZipFile(archive_buffer, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+            body = skill_dir / _SKILL_FILENAME
+            archive.writestr(_SKILL_FILENAME, body.read_bytes())
+            for relative_path, path in sorted(
+                self._iter_bundle_files(skill_dir), key=lambda x: x[0]
+            ):
+                if path.is_symlink() or not path.is_file():
+                    continue
+                info = zipfile.ZipInfo(relative_path)
+                mode = path.stat().st_mode
+                info.external_attr = (mode & 0xFFFF) << 16
+                archive.writestr(info, path.read_bytes())
+        return {
+            "content": archive_buffer.getvalue(),
+            "filename": f"{normalized}.zip",
+            "content_type": "application/zip",
+        }
+```
+
+(`_normalize_skill_name` is imported at module scope or via the existing deferred import — match the file's existing usage.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/test_zip_export_roundtrip.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Skills_Interop/local_skills_service.py Tests/Skills/test_zip_export_roundtrip.py
+git commit -m "feat(skills): faithful recursive zip export preserving tree and exec bit"
+```
+
+---
+
+### Task 10: Trust review preview — binary vs deleted disambiguation
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Library/library_skills_canvas.py:242-304` (`skill_trust_review_preview`); `tldw_chatbook/Skills_Interop/skill_trust_service.py` `capture_review` (ensure `current_fingerprints` is in the payload — it already is per the design review)
+- Test: `Tests/Library/test_skill_trust_review_preview.py` (create)
+
+**Interfaces:**
+- Consumes: `active_review` mapping with `changed_files`, `current_files` (text), `current_fingerprints` (list of manifest entries incl. `relative_path`, `byte_length`, `sha256`, `file_type`).
+- Produces: a present binary renders `binary file, N bytes, sha256 …`; a deleted file renders `(deleted …)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from tldw_chatbook.Widgets.Library.library_skills_canvas import skill_trust_review_preview
+
+
+def test_present_binary_shows_metadata_not_deleted():
+    review = {
+        "changed_files": ["assets/logo.png"],
+        "current_files": {},   # binary absent from text view
+        "current_fingerprints": [
+            {"relative_path": "assets/logo.png", "file_type": "supporting_binary",
+             "byte_length": 2048, "sha256": "deadbeef"},
+        ],
+    }
+    out = skill_trust_review_preview(review)
+    assert "assets/logo.png" in out
+    assert "binary" in out.lower()
+    assert "2048" in out
+    assert "deadbeef"[:8] in out
+    assert "deleted" not in out.lower()
+
+
+def test_genuinely_deleted_still_shows_deleted():
+    review = {
+        "changed_files": ["gone.md"],
+        "current_files": {},
+        "current_fingerprints": [],   # not on disk at all
+    }
+    out = skill_trust_review_preview(review)
+    assert "deleted" in out.lower()
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Library/test_skill_trust_review_preview.py -q`
+Expected: FAIL — a present binary currently renders "(deleted — no longer on disk)".
+
+- [ ] **Step 3: Implement**
+
+In `skill_trust_review_preview`, build a fingerprint lookup and disambiguate the `content is None` branch:
+
+```python
+    raw_files = active_review.get("current_files")
+    current_files = dict(raw_files) if isinstance(raw_files, Mapping) else {}
+    fingerprints = {
+        str(fp.get("relative_path")): fp
+        for fp in (active_review.get("current_fingerprints") or [])
+        if isinstance(fp, Mapping)
+    }
+    ...
+        content = current_files.get(file_name)
+        if content is None:
+            fp = fingerprints.get(file_name)
+            if fp is not None:
+                block = (
+                    f"── {file_name} ──\n"
+                    f"(binary file — {fp.get('byte_length', 0)} bytes, "
+                    f"sha256 {str(fp.get('sha256', ''))[:12]}…)"
+                )
+            else:
+                block = f"── {file_name} ──\n(deleted — no longer on disk)"
+        else:
+            ... # unchanged text rendering
+```
+
+Verify `capture_review` includes `current_fingerprints` in its returned payload; if not present, add `"current_fingerprints": [fp.as_manifest_entry() for fp in current.fingerprints]` alongside `current_files`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Library/test_skill_trust_review_preview.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Widgets/Library/library_skills_canvas.py tldw_chatbook/Skills_Interop/skill_trust_service.py Tests/Library/test_skill_trust_review_preview.py
+git commit -m "feat(skills): review preview disambiguates present binary from deleted"
+```
+
+---
+
+### Task 11: Editor canvas — nested paths + view-only binaries
+
+**Files:**
+- Modify: `tldw_chatbook/Library/library_skills_state.py:381-387` (`build_skill_editor_state` supporting-files reduction), `tldw_chatbook/Widgets/Library/library_skills_canvas.py:409-413` (`skill_supporting_files_text`)
+- Test: `Tests/Library/test_library_skills_state.py` (extend)
+
+**Interfaces:**
+- Consumes: `bundle_files` (Task 1/6) on the skill response.
+- Produces: editor lists nested paths; binaries labeled view-only (`path — N bytes (binary)`).
+
+- [ ] **Step 1: Write the failing test** (add to `Tests/Library/test_library_skills_state.py`)
+
+```python
+def test_editor_lists_nested_and_marks_binary():
+    from tldw_chatbook.Library.library_skills_state import build_skill_editor_state
+    detail = {
+        "name": "demo", "content": "body", "version": 1,
+        "supporting_files": {"references/api.md": "# api\n"},
+        "bundle_files": [
+            {"path": "references/api.md", "size": 6, "executable": False, "is_text": True},
+            {"path": "assets/logo.png", "size": 2048, "executable": False, "is_text": False},
+        ],
+        "trust_status": "trusted", "trust_blocked": False,
+    }
+    state = build_skill_editor_state(detail)
+    names = [f.name for f in state.supporting_files]
+    assert "references/api.md" in names
+    assert "assets/logo.png" in names          # binary listed
+    binary = next(f for f in state.supporting_files if f.name == "assets/logo.png")
+    assert binary.is_text is False             # view-only marker
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Library/test_library_skills_state.py -q -k nested_and_marks_binary`
+Expected: FAIL — `is_text` attr missing / binary not listed.
+
+- [ ] **Step 3: Implement**
+
+Extend the supporting-file row model in `library_skills_state.py` with an `is_text: bool = True` field, and build the list from `bundle_files` (falling back to `supporting_files` when `bundle_files` is absent, e.g. remote). In `skill_supporting_files_text` (canvas :409-413), render binaries as `"{path} — {size} bytes (binary)"` and text as before. Keep the list read-only for binaries (the editor already renders supporting files as a read-only list per the design).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Library/test_library_skills_state.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Library/library_skills_state.py tldw_chatbook/Widgets/Library/library_skills_canvas.py Tests/Library/test_library_skills_state.py
+git commit -m "feat(skills): editor lists nested supporting paths, marks binaries view-only"
+```
+
+---
+
+### Task 12: Integration — real bundle end-to-end + flip the legacy assertion
+
+**Files:**
+- Modify: `Tests/Skills/test_skills_import.py:525-527` (flip nested-drop assertion)
+- Test: `Tests/Skills/test_bundle_fidelity_integration.py` (create)
+
+**Interfaces:** consumes the whole stack.
+
+- [ ] **Step 1: Flip the legacy assertion**
+
+In `Tests/Skills/test_skills_import.py:525-527`, the test currently asserts a nested `references/note.md` is NOT in `supporting_files`. Change it to assert it IS imported:
+
+```python
+    assert "references/note.md" in result["supporting_files"]
+    assert result["supporting_files"]["references/note.md"] == "..."  # match the fixture content
+```
+
+Leave `Tests/Skills/test_local_skills_service.py:320` (rejects `../escape.md`) unchanged.
+
+- [ ] **Step 2: Write the integration test**
+
+```python
+import io, zipfile, pytest
+from tldw_chatbook.Skills_Interop.local_skills_service import LocalSkillsService
+
+
+@pytest.mark.asyncio
+async def test_bundle_roundtrip_and_tamper_detection(tmp_path):
+    svc = LocalSkillsService(store_dir=tmp_path)
+    # Build a bundle with a nested executable script and a binary asset.
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr("SKILL.md", "---\nname: sdd\n---\nRun scripts/run.sh\n")
+        info = zipfile.ZipInfo("scripts/run.sh"); info.external_attr = 0o755 << 16
+        z.writestr(info, "#!/bin/sh\necho hi\n")
+        z.writestr("assets/logo.png", b"\x89PNG\x00bin")
+    await svc.import_skill_file(buf.getvalue(), filename="sdd.zip",
+                               content_type="application/zip")
+    skill = await svc.get_skill("sdd")
+    assert "scripts/run.sh" in skill["supporting_files"]
+    assert any(b["path"] == "assets/logo.png" and not b["is_text"]
+               for b in skill["bundle_files"])
+    # Export → re-import is byte-identical for the binary asset.
+    export = await svc.export_skill("sdd")
+    with zipfile.ZipFile(io.BytesIO(export["content"])) as z:
+        assert z.read("assets/logo.png") == b"\x89PNG\x00bin"
+```
+
+- [ ] **Step 3: Run**
+
+Run: `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/test_bundle_fidelity_integration.py Tests/Skills/test_skills_import.py -q`
+Expected: PASS.
+
+- [ ] **Step 4: Full suite regression**
+
+Run: `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/ Tests/Library/ Tests/UI/test_library_skills_canvas.py Tests/tldw_api/test_skills_schemas_bundle.py -q`
+Expected: PASS (note any pre-existing baseline failures unrelated to this branch).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Tests/Skills/test_bundle_fidelity_integration.py Tests/Skills/test_skills_import.py
+git commit -m "test(skills): end-to-end bundle fidelity integration + flip nested-drop assertion"
+```
+
+---
+
+## Notes for the executor
+
+- **Server proxy:** `server_skills_service.py` forwards the same pydantic models; nested text keys pass through, `bundle_files` is optional metadata. No binary crosses the wire — do not add base64.
+- **Do NOT recurse** `skill_trust_service.py` `_iter_skill_dirs` (:539), `_known_and_current_skill_names` (:557), `_skill_dir_for_normalized_name` (:643) — they list child skill dirs, not one skill's contents.
+- **Reachability is out of scope:** `execute_skill` still returns only the rendered SKILL.md body. Exposing the stored `scripts/` to the agent is a later layer.
+- After each task, the reviewer checks: backward-compat (flat snapshot unchanged), the three fingerprint builders agree, binaries never enter `supporting_files`, and no hard-raise path remains for unsupported files.

--- a/Docs/superpowers/specs/2026-07-22-skills-foundation-bundle-fidelity-design.md
+++ b/Docs/superpowers/specs/2026-07-22-skills-foundation-bundle-fidelity-design.md
@@ -1,6 +1,7 @@
 # Skills Foundation — Spec 2: Full-Bundle Supporting-File Fidelity
 
-**Status:** Approved design (2026-07-22), hardened after a code-verified review.
+**Status:** Approved design (2026-07-22), hardened after two rounds of code-verified
+review.
 **Program:** Skills-install program, Layer 0. Sibling of Spec 1 (trust isolation,
 recovery & discoverability — PR #762, merged). North star: *"a user asks an agent
 to install a skill/pack from a GitHub link."*
@@ -15,12 +16,14 @@ stage of its lifecycle:
 | Stage | Code | Behaviour with nested / binary / executable files |
 |-------|------|---------------------------------------------------|
 | Read from dir | `local_skills_service.py` `_read_supporting_files` | `iterdir()` + `is_file()` — **silently skips subdirectories**; UTF-8-decodes every file, so a **top-level binary crashes `get_skill`** |
-| Write to dir | `_apply_supporting_files` | `skill_dir / filename` — no parent `mkdir`, assumes flat |
-| Zip import | `_validate_archive_member` | **rejects** any member where `len(parts) != 1` |
-| Zip export | `export_skill` | flat `writestr(filename, …)` |
+| Write to dir | `_apply_supporting_files` | text-mode write (`open("w")`), no parent `mkdir`, **no traversal guard** (relies on the schema pattern) |
+| Zip import | `_validate_archive_member` | **rejects** any member where `len(parts) != 1`; `.decode("utf-8")` on every member |
+| Zip export | `export_skill` | flat `writestr(filename, …)`, content assumed text |
 | Folder import (UI) | `library_screen.py` `_read_library_skill_import_supporting_files` | reads flat siblings only; explicitly does **not** recurse |
-| Trust snapshot | `skill_trust_scanner.py` `scan_skill_directory` | `iterdir()` + `is_file()` — **flat**, text-only; body classified by **basename** |
-| Data model | `supporting_files: dict[str, str]` | keyed by bare `path.name` — cannot represent `scripts/x` vs `refs/x`, no bytes, no mode |
+| Trust snapshot | `skill_trust_scanner.py` `scan_skill_directory` | `iterdir()` + `is_file()` — **flat**, text-only; body classified by **basename**; nested/binary → `unsupported_paths` |
+| Trust manifest | `skill_trust_service.py` `bootstrap_trust` / `trust_current_skill` | **hard-raise `ValueError("unsupported_path")`** on any unsupported file |
+| Schema | `skills_schemas.py` | `supporting_files: dict[str, str]`; key pattern forbids `/`; caps **20 files / 500 KB / 5 MB**; byte counts assume `str` |
+| Review panel | `library_skills_canvas.py` `skill_trust_review_preview` | text-only preview; a present-but-non-text file renders as "(deleted)" |
 
 This is the confirmed UAT finding #3: importing the real `obra/superpowers`
 `subagent-driven-development` skill silently drops its `scripts/review-package`,
@@ -35,70 +38,90 @@ or directories."*
 Faithfully **import, store, trust-verify, and export** a spec-conformant Agent
 Skills bundle — arbitrary nested directories, binary files, and executable
 scripts — with cryptographic tamper-evidence over every file (text and binary),
-without disturbing any currently-trusted skill.
+without disturbing any currently-trusted skill and without making real-world
+bundles (which carry VCS/OS/build junk) untrustable.
+
+## Position in the program (important framing)
+
+Spec 2 delivers **storage fidelity** — a *prerequisite* for the north star, not
+the whole of it. Verified gap: `execute_skill` returns only the rendered `SKILL.md`
+body; `supporting_files` and the skill `directory_path` are **not** propagated to
+the runtime, and an agent fork gets no working-directory binding or file handle to
+the skill dir. So a `SKILL.md` instruction like "run `scripts/extract.py`" cannot
+resolve today even after faithful storage. **Exposing the skill directory to the
+agent at execution time is a separate, later layer** (Layer "skill-runtime
+reachability"). Spec 2 makes the files *exist correctly*; a later layer makes them
+*reachable*.
 
 ## Scope
 
 **In:** path-aware supporting-file model (relative POSIX subpaths, arbitrary
-depth); binary files stored faithfully (raw bytes); executable bit preserved and
-trust-fingerprinted; recursive, binary-aware, mode-aware trust scanner with
-per-file SHA-256 inside the existing HMAC-authenticated manifest; both existing
+depth); binary files stored faithfully on disk (raw bytes); executable bit
+preserved and trust-fingerprinted; recursive, binary-aware, mode-aware trust
+scanner with per-file SHA-256 inside the existing HMAC-authenticated manifest;
+junk-pruning + tolerate-and-surface handling of unsupported files; both existing
 import paths (**zip** and **folder**) and export made faithful, with
-zip-slip / symlink / traversal / case-fold hardening and size caps; editor lists
-nested paths, text editable, binaries view-only.
+zip-slip / symlink / traversal / case-fold hardening and size caps; editor and
+**trust review panel** handle nested paths and binaries.
 
 **Out (later layers, noted so deferral is deliberate):**
+- **Skill-runtime reachability** — exposing the stored skill dir / nested files to
+  the agent at execution (see "Position in the program"). Necessary for the north
+  star; not part of storage fidelity.
 - SKILL.md **frontmatter** conformance (`license`, `compatibility`, `metadata`
   map, `--` rule, 1024-char description) — a separate sibling spec.
 - A new **folder / GitHub picker UX** and multi-skill **pack** import — Layers 1–2.
-- **Asymmetric publisher signatures** (proving provenance) — a supply-chain
-  concern for the remote-fetch layer. Spec 2 provides *local* keyed-MAC
-  tamper-evidence, not provenance.
-- **Full binary restore on rollback** — trust rollback restores text files only
-  (see §9). Binaries are tamper-*detected* but not auto-reverted.
+- **Asymmetric publisher signatures** (provenance) — the remote-fetch layer. Spec 2
+  provides *local* keyed-MAC tamper-evidence, not provenance.
+- **Full binary restore on rollback** — rollback restores text files only (§9).
+- **Binary content over the remote/server wire** — see §1; only metadata crosses.
 
 ## Design
 
-### 1. Bundle representation (directory-native)
+### 1. Bundle representation (directory-native) — binaries never cross the JSON wire
 
 The **skill directory on disk is the source of truth.** Import writes the bundle
-faithfully into `skill_dir`; trust scans the dir; export zips the dir. The API and
-editor keep two *derived* views, so no byte round-trips through JSON:
+faithfully into `skill_dir`; trust scans the dir; export zips the dir. Two derived
+views serve the API and editor, and — crucially — **no raw bytes ever cross the
+pydantic/JSON boundary**:
 
 - `supporting_files: dict[str, str]` — **text files only**, keys now **nested
-  POSIX paths** (`scripts/build.sh`, `references/api.md`). Backward-compatible
-  shape; keys simply gain `/`. This is what the editor reads/writes.
-- `bundle_files: list[BundleFileInfo]` — the **full manifest view**, one entry per
-  file: `{path: str, size: int, executable: bool, is_text: bool}`. Binaries
-  appear here only, so the UI can show `assets/logo.png — 12 KB` without inlining
-  bytes. Optional/local-first: the remote skills service may not populate it, so
-  every consumer degrades gracefully to an empty list.
+  POSIX paths** (`scripts/build.sh`, `references/api.md`). Stays `dict[str, str]`,
+  so the existing JSON transport (`model_dump(mode="json")`) and the remote server
+  proxy keep working; only the key *pattern* loosens to allow `/`.
+- `bundle_files: list[BundleFileInfo]` — the **full manifest view**, JSON-safe
+  metadata only: `{path: str, size: int, executable: bool, is_text: bool}`.
+  Binaries appear here (never in `supporting_files`), so the UI shows
+  `assets/logo.png — 12 KB` without inlining bytes. Optional / local-first: the
+  remote proxy may leave it empty (its bytes live on a remote server; downloading
+  them is the deferred remote layer). `SkillResponse` already has `extra="allow"`,
+  so a server returning `bundle_files` passes through.
 
-Rationale: skills are already stored as directories and trust already scans the
-tree, so the tree is the natural source of truth — avoiding base64 bloat, keeping
-the editor's text-only reality honest, and confining binary/mode concerns to the
-filesystem and the trust fingerprint.
+Because binaries live only on disk (local) or as metadata (remote), Approach B
+sidesteps base64/multipart entirely. Rationale: skills are already stored as
+directories and trust already scans the tree, so the tree is the natural source of
+truth — avoiding byte bloat and keeping the editor's text-only reality honest.
 
 ### 2. Path validation — `validate_supporting_file_path(path: str) -> str`
 
 A single validator (new, in the skills schema module) reused by read, write,
-zip-import, and folder-import. Accepts a **relative POSIX subpath** where **each
-segment** matches the existing safe filename pattern
-`^[a-zA-Z0-9][a-zA-Z0-9._-]{0,99}$`. Returns the normalized POSIX path.
+zip-import, and folder-import. Validates **each path segment separately** against
+the safe pattern `^[a-zA-Z0-9][a-zA-Z0-9._-]{0,99}$` (a slash-joined string would
+fail the pattern outright — the segment-wise check is mandatory for nesting).
+Returns the normalized POSIX path.
 
 Rejects (each raises a typed `ValueError`):
 - absolute paths, a leading `/`, backslashes (`\`);
 - any `..` or `.` segment; empty segments (`a//b`);
 - symlinks (rejected, never followed — §3/§4);
 - **any** file whose basename case-insensitively equals `skill.md`: the top-level
-  `SKILL.md` (exact case, per the Agent Skills spec) is the skill body, and no
-  other file — a wrong-case `skill.md` at the root, or a nested
-  `references/SKILL.md` — may shadow it or be confused with it;
+  `SKILL.md` (exact case) is the skill body; nothing else — a wrong-case root
+  `skill.md` or a nested `references/SKILL.md` — may shadow it;
 - depth > **8** segments; total path length > **255** bytes.
 
-This single validator resolves the current inconsistency where the scanner treats
-`SKILL.md` case-sensitively but `skills_schemas.py` rejects supporting `skill.md`
-case-insensitively.
+The **write path** (`_apply_supporting_files`) must *also* enforce containment
+(resolve target, assert within `skill_dir`) rather than trusting the schema —
+today it has no traversal guard of its own.
 
 ### 3. Trust scanner — recursive, binary-aware, mode-aware, backward-identical for flat bundles
 
@@ -106,177 +129,213 @@ case-insensitively.
 following symlinked directories — no loops, no escape), emitting files **sorted by
 POSIX relative path** (the ordering choice that preserves backward-compat — not
 absolute path, not case-folded, not raw traversal order). Per file:
-- reject symlinks and traversal → `unsupported_paths` (never trust material);
+- apply the **junk ignore-list** (§4a) — pruned entries are skipped entirely, never
+  recorded;
+- reject symlinks and traversal → `unsupported_paths`;
 - **classify the body by the top-level relative path**: `file_type="skill"` iff
   `relative_path == "SKILL.md"` (no `/`). A nested `references/SKILL.md` is never
-  the body (today's basename check would misclassify it — this is a change from
-  `relative_path = path.name`);
+  the body (today's basename check, `relative_path = path.name`, would misclassify
+  it);
 - fingerprint `SkillFileFingerprint{relative_path, file_type, byte_length,
   sha256, executable}` — `executable` is a **new field**;
 - decode into `text_files[relative_path]` **only** when UTF-8-decodable and
   null-byte-free; binaries are fingerprinted (`file_type="supporting_binary"`)
   but never decoded and never raise.
 
-**Three fingerprint sites must change together.** The canonical fingerprint dict
-is built explicitly (field-by-field) in three independent places; all three must
-add `executable` with the *identical* conditional rule or verification diverges:
-1. `SkillFileFingerprint.as_manifest_entry` (`skill_trust_models.py`) — the shared
+**Three fingerprint sites must change together.** The canonical fingerprint dict is
+built explicitly (field-by-field) in three independent places; all must add
+`executable` with the *identical* conditional rule or verification diverges:
+1. `SkillFileFingerprint.as_manifest_entry` (`skill_trust_models.py`) — shared
    manifest/digest/review serializer;
-2. the scanner constructor (`skill_trust_scanner.py`) — sets `executable` from the
-   file mode;
+2. the scanner constructor (`skill_trust_scanner.py`) — sets `executable` from mode;
 3. `_content_manifest_entry` / `_fingerprint_in_memory_files`
-   (`skill_trust_service.py`) — the parallel *in-memory* builder used by
-   `verify_skill_content`, which must hash raw bytes for binaries and set
+   (`skill_trust_service.py`) — the in-memory builder used by `verify_skill_content`
+   (run on every execute), which must hash **raw bytes** for binaries and set
    `executable` the same way.
 
-**Cryptographic integrity (the tamper-evidence requirement).** Per-file `sha256`
-values live inside the canonical manifest payload authenticated by
-`manifest_mac(payload, manifest_mac_key)` =
-`HMAC-SHA256(canonical_json(payload), key)`, where `manifest_mac_key` is derived
-from the user's passphrase. Verification compares **only** the fingerprint dicts
-(never decoded content), so making every binary a first-class fingerprint
-(`sha256` + `byte_length` + `executable`) fully covers it:
-- tampering with a binary's **content** changes its SHA-256;
-- flipping a file's **executable bit** changes the `executable` field;
-- either mismatch drives the skill to **blocked / needs-review** — the user is
-  *made aware* — and the manifest cannot be forged without the passphrase-derived
-  MAC key.
+**Cryptographic integrity.** Per-file `sha256` values live inside the canonical
+manifest payload authenticated by `manifest_mac(payload, manifest_mac_key)` =
+`HMAC-SHA256(canonical_json(payload), key)` (`manifest_mac_key` derived from the
+passphrase). Verification compares **only** the fingerprint dicts (never decoded
+content), so a binary is fully covered by `sha256` + `byte_length` + `executable`:
+tampering with content OR the exec bit → fingerprint mismatch → skill flips to
+**blocked / needs-review** (the user is made aware); the manifest can't be forged
+without the passphrase-derived MAC key.
 
-**Backward-compatibility guarantee (load-bearing).** The canonical snapshot MUST
-be **byte-identical to the pre-Spec-2 form** for any skill with **no nested paths,
-no binaries, and no executable bits**. This is achievable because serialization is
-explicit: `executable` is **included in the fingerprint dict only when `True`**
-(`if self.executable: entry["executable"] = True`); `file_type` is unchanged for
-text; and a flat directory's `os.walk` sorted by relative path reproduces today's
-`iterdir()` name-order (for a flat dir `relative_path == path.name`). As a result
-**every currently-trusted skill stays trusted** — only bundles that actually use
-nesting, binaries, or exec bits are re-scanned. No mass re-review.
+**Backward-compatibility guarantee (load-bearing).** The canonical snapshot MUST be
+**byte-identical to the pre-Spec-2 form** for any skill with no nested paths, no
+binaries, and no executable bits: `executable` is included in the fingerprint dict
+**only when `True`** (`if self.executable: entry["executable"] = True`), `file_type`
+is unchanged for text, and a flat dir's `os.walk` sorted by relative path
+reproduces today's `iterdir()` name-order. **Every currently-trusted skill stays
+trusted** — no mass re-review.
 
-### 4. Import round-trip (both existing paths; no new picker)
+### 4. Junk pruning and unsupported-file tolerance
+
+Recursion exposes real bundles' VCS/OS/build junk, and today `bootstrap_trust`
+(`service.py:221`) and `trust_current_skill` (`:507`) **hard-raise** on any
+unsupported file — which would make real GitHub/superpowers bundles untrustable
+dead-ends (capture succeeds, approve raises). Two coordinated changes:
+
+**(a) Junk ignore-list** applied during the walk on both import *and* scan (so junk
+is neither stored nor scanned): directories `.git`, `.github`, `.hg`, `.svn`,
+`node_modules`, `__pycache__`; files `.DS_Store`, `Thumbs.db`; suffixes `.pyc`,
+`.pyo`, `~`, `.bak`, `.orig`, plus the existing `.tmp`/`.swp`/`.part`. Ignored
+entries are skipped entirely — **never** recorded in `unsupported_paths`.
+
+**(b) Tolerate-and-surface** instead of hard-raise. `bootstrap_trust` and
+`trust_current_skill` establish trust over the **supported (fingerprinted)** files
+and leave any *residual* unsupported file (a symlink, or a genuinely bad-named
+file that survived pruning) as a **visible, recoverable** `needs-review`
+(`status_for_skill` already models `quarantined_unsupported_path`) — never a crash.
+Removing the offending file and re-scanning clears it. This is security-neutral:
+unsupported files were never fingerprinted trust material either way; the change
+only removes the permanent-crash dead-end. Under Spec 2, binaries are *supported*,
+so the residual unsupported set shrinks to symlinks + dotfile/bad-name junk.
+
+### 5. Import round-trip (both existing paths; no new picker)
 
 - **Zip** (`import_skill_file` / `_validate_archive_member`): allow nested members
-  (validated by §2), extract raw bytes faithfully (no UTF-8 decode of binaries).
-  Hardening on every member: **zip-slip** (resolve target, assert within
-  `skill_dir`), **symlink members** rejected (unix mode `S_ISLNK`), **case-fold
-  collisions** rejected (two members whose paths differ only in case would collide
-  on a case-insensitive filesystem — reject rather than silently last-wins).
-  Executable bit is **best-effort** from the member's unix mode
-  (`external_attr >> 16`): honored when the archive carries unix attributes
-  (GitHub archive zips do), otherwise defaults non-executable.
-- **Folder** (`_run_library_skills_import` → a new
-  `import_skill_directory(source_dir, name, …)` service method): replace the
-  flat-siblings read with a **safe recursive tree copy** into `skill_dir` —
-  `os.walk(followlinks=False)`, validate every relative path (§2), reject
-  symlinks, and read the **real file mode** for the exec bit (reliable, unlike
-  zip). This is the direct finding #3 fix.
+  (validated by §2), prune junk (§4a), extract raw bytes faithfully via a
+  **bytes-mode atomic writer** (no UTF-8 decode of binaries). Hardening per member:
+  **zip-slip** (resolve, assert within `skill_dir`), **symlink members** rejected
+  (`S_ISLNK`), **case-fold collisions** rejected. Executable bit **best-effort**
+  from the member's unix mode (`external_attr >> 16`; honored when the archive
+  carries unix attrs — GitHub archive zips do — else default non-executable).
+- **Folder** (`_run_library_skills_import` → new
+  `import_skill_directory(source_dir, name, …)`): safe recursive tree copy into
+  `skill_dir` — `os.walk(followlinks=False)`, prune junk, validate each path (§2),
+  reject symlinks, read the **real file mode** for the exec bit (reliable). Direct
+  finding #3 fix.
 - Both land **trust-pending** (`trust_approved=False`); the trust scan runs on the
   stored directory.
 
-### 5. Export — `export_skill`
+### 6. Export — `export_skill`
 
 Walk `skill_dir` recursively; write each file at its POSIX relative path into the
-zip as raw bytes, preserving the executable bit via `ZipInfo.external_attr`. **All
-files** round-trip byte-identically (export→import). Empty directories carry no
-content and are not preserved — an accepted, documented limitation.
+zip as raw bytes, preserving the exec bit via `ZipInfo.external_attr`. **All files**
+round-trip byte-identically (export→import). Empty directories carry no content and
+are not preserved — an accepted, documented limitation.
 
-### 6. Service read / write
+### 7. Service read / write
 
-- `_read_supporting_files` → recursive (`os.walk(followlinks=False)`); returns the
-  **text view** (nested keys). **It MUST catch UTF-8 decode failures / null bytes
-  and route those files to the binary manifest — never raise.** This also fixes a
-  pre-existing latent bug: today a single top-level binary makes `get_skill` throw
-  `UnicodeDecodeError`, leaving the skill un-openable in the editor.
-- A companion `_read_bundle_manifest` returns the `bundle_files` listing (text +
-  binary + mode + size).
-- `_apply_supporting_files` (editor text edits) → `mkdir` parents, path-validate
-  (§2), atomic write; text-only. **Invariant:** the editor save must never pass a
-  full-replacement `supporting_files` dict (today it passes `None`, a no-op), so
-  binaries and nested files it never loaded are never deleted or reconciled away.
+- `_read_supporting_files` → recursive (`os.walk(followlinks=False)`, junk-pruned);
+  returns the **text view** (nested keys). **MUST catch UTF-8 decode failures /
+  null bytes and route those files to the binary manifest — never raise.** This
+  also fixes a pre-existing latent bug: today a single top-level binary makes
+  `get_skill` throw `UnicodeDecodeError`, leaving the skill un-openable.
+- `_read_bundle_manifest` returns the `bundle_files` listing (text + binary + mode
+  + size), sharing the same binary/`is_text` heuristic as the scanner.
+- `_apply_supporting_files` (editor text edits): `mkdir` parents, path-validate +
+  **containment guard** (§2), atomic write; text-only. **Invariant:** the editor
+  save must never pass a full-replacement `supporting_files` dict (today it passes
+  `None`, a no-op), so binaries and nested files it never loaded are never deleted.
 
-### 7. Editor display
+### 8. Editor and trust-review surfaces
 
-The canvas lists supporting files by nested path. **Text files stay editable**;
-binaries are **view-only** (`path — size (binary)`), not rendered or edited. No
-hex editor, no binary preview (YAGNI). Delete remains available for both kinds.
+- **Editor canvas:** lists supporting files by nested path; **text editable**,
+  binaries **view-only** (`path — size (binary)`). No hex editor / binary preview.
+- **Trust review panel** (distinct surface — was previously unaddressed): approval
+  is already binary-safe (`trust_reviewed_snapshot` compares `_fingerprints_digest`
+  hashes, no text decode/diff). But the preview (`skill_trust_review_preview`) must
+  **disambiguate** a present binary from a deleted file: today a file absent from
+  `text_files` renders "(deleted — no longer on disk)". Join `current_files` with
+  `current_fingerprints` so a present binary renders `binary file, N bytes,
+  sha256 …` while genuinely-deleted keeps "(deleted)". `capture_review`'s payload
+  carries `current_fingerprints` already; nested paths already work (dict lookups
+  are path-agnostic). Binaries reach a reviewable state automatically once they are
+  *supported* (fingerprinted) rather than `quarantined_unsupported_path`.
 
-### 8. Security & limits
+### 9. Security & limits
 
-- Symlinks rejected everywhere and never followed (`os.walk(followlinks=False)` on
-  read, scan, and folder copy; `S_ISLNK` member rejection on zip in/out).
-- Zip-slip contained (resolve-and-assert-within-`skill_dir` per member).
-- Case-fold collisions rejected on import (zip and folder).
-- Size caps: per-file **5 MB**, per-bundle total **25 MB**, max **500 files** —
-  enforced on the archive's **declared** `file_size` *before* extracting **and**
-  bounded on the **bytes actually read** during extraction (defence against a
-  header that lies / a zip bomb). Over-limit is a clean, non-partial failure
-  (nothing left half-written).
-- Binary detection: a null byte **or** a UTF-8 decode failure marks a file binary
-  (the scanner's existing heuristic, applied recursively).
+- Symlinks rejected everywhere and never followed (`os.walk(followlinks=False)`;
+  `S_ISLNK` member rejection on zip in/out).
+- Zip-slip contained (resolve-and-assert-within-`skill_dir` per member); write-path
+  containment guard in `_apply_supporting_files`.
+- Case-fold collisions rejected on import.
+- Junk ignore-list (§4a) applied on import and scan.
+- **Size caps** (raising the legacy 20 / 500 KB / 5 MB): per-file **5 MB**,
+  per-bundle total **25 MB**, max **500 files**. Enforced on the archive's
+  **declared** sizes *before* extracting **and** bounded on **bytes actually read**
+  (defence against a lying header / zip bomb). The legacy `skills_schemas.py` caps
+  are raised to match so the text-view round-trip of a real bundle validates. A
+  `bundle_files` count/size ceiling is added (none exists today). Over-limit is a
+  clean, non-partial failure.
+- Binary detection: null byte **or** UTF-8 decode failure (the scanner heuristic,
+  applied recursively and shared with `bundle_files.is_text`).
 
-### 9. Trust rollback / restore
+### 10. Trust rollback / restore
 
-Trust rollback restores the trusted baseline from the encrypted `text_files`
-snapshot — **text files only**, as today. Binaries are fingerprinted for
-tamper-*detection* (a changed binary flips the skill to needs-review) but are
-**not** stored in the encrypted snapshot and so are **not auto-reverted** on
-rollback; they are left in place for the user to re-review. Keeping binary bytes
-out of the encrypted snapshot avoids a new blob format and storage growth; the
-integrity guarantee (§3) is unaffected. This limitation is called out in the
-release note.
+Rollback restores the trusted baseline from the encrypted `text_files` snapshot —
+**text files only**, as today. Binaries are fingerprinted for tamper-*detection*
+but are **not** in the encrypted snapshot, so they are **not** auto-reverted on
+rollback; a tampered binary is flagged `needs-review` and left in place for the
+user to re-review. Keeping binary bytes out of the snapshot avoids a new blob
+format; integrity (§3) is unaffected.
 
 ## Components & boundaries
 
 | Unit | File | Responsibility |
 |------|------|----------------|
-| Path validator | `tldw_api/skills_schemas.py` (or new `skill_bundle_paths.py`) | `validate_supporting_file_path`; the one place path + `skill.md` rules live |
-| Trust scanner | `Skills_Interop/skill_trust_scanner.py` | recursive `os.walk`, relative-path body classification, binary/mode fingerprints, backward-identical canonical form |
+| Path validator | `tldw_api/skills_schemas.py` (or new `skill_bundle_paths.py`) | `validate_supporting_file_path` (per-segment), `skill.md` rule, raised caps; the one place path + cap rules live |
+| Trust scanner | `Skills_Interop/skill_trust_scanner.py` | recursive `os.walk`, junk-prune, relative-path body classification, binary/mode fingerprints, backward-identical canonical form |
 | Fingerprint model | `Skills_Interop/skill_trust_models.py` | add `executable`; `as_manifest_entry` includes it only when `True` |
-| In-memory verify path | `Skills_Interop/skill_trust_service.py` | `_content_manifest_entry` / `_fingerprint_in_memory_files` — same conditional `executable`, hash raw bytes for binaries |
-| Service bundle I/O | `Skills_Interop/local_skills_service.py` | recursive binary-safe read (never raises), `_read_bundle_manifest`, `import_skill_directory` safe tree copy, faithful zip in/out, size caps |
-| Import archive validation | `Skills_Interop/local_skills_service.py` | nested-aware `_validate_archive_member` + zip-slip + symlink + case-fold guards |
+| Trust manifest/tolerance | `Skills_Interop/skill_trust_service.py` | `bootstrap_trust`/`trust_current_skill` tolerate-and-surface (no hard-raise); `_content_manifest_entry`/`_fingerprint_in_memory_files` hash raw bytes + conditional `executable` |
+| Service bundle I/O | `Skills_Interop/local_skills_service.py` | recursive binary-safe read (never raises), `_read_bundle_manifest`, `import_skill_directory` safe tree copy, bytes-mode atomic writer, faithful zip in/out, junk-prune, caps |
+| Import archive validation | `Skills_Interop/local_skills_service.py` | nested-aware `_validate_archive_member` + zip-slip + symlink + case-fold + junk guards |
 | Folder import path | `UI/Screens/library_screen.py` | call `import_skill_directory`; drop the flat-siblings read |
-| Editor canvas | `Widgets/Library/library_skills_canvas.py` | nested-path list, view-only binaries |
-| API schema | `tldw_api/skills_schemas.py` | `bundle_files` / `BundleFileInfo` (optional); nested keys in `supporting_files` |
+| Editor + review UI | `Widgets/Library/library_skills_canvas.py`, `UI/Screens/library_screen.py` | nested-path list, view-only binaries, review preview binary-vs-deleted disambiguation |
+| API schema | `tldw_api/skills_schemas.py` | `bundle_files`/`BundleFileInfo` (optional, metadata-only); nested keys in `supporting_files`; str-only byte counts unaffected (binaries never enter the dict) |
 
 **Do NOT recurse** the three `skill_trust_service.py` enumerations at `:539`
-(`_iter_skill_dirs`), `:557` (`_known_and_current_skill_names`), and `:643`
+(`_iter_skill_dirs`), `:557` (`_known_and_current_skill_names`), `:643`
 (`_skill_dir_for_normalized_name`) — they list the *child skill directories* under
-`skills_dir`, not the contents of one skill, and must stay flat.
+`skills_dir`, not one skill's contents, and must stay flat.
 
 ## Testing strategy
 
-- **Unit — validator:** nested-ok; reject traversal, absolute, symlink, backslash,
-  depth > 8, over-length, and any-case `skill.md`.
-- **Unit — scanner:** recursion into `scripts/`/`references/`/`assets/`; binary
-  fingerprinted-not-decoded; executable bit captured; **nested `references/SKILL.md`
-  is NOT classified as the body**; **a flat all-text skill's snapshot is
-  byte-identical to the pre-Spec-2 output** (guards existing trust); content OR
-  mode change → fingerprint mismatch.
-- **Unit — verify_skill_content parity:** the in-memory builder and the scanner
-  produce identical fingerprint dicts for the same nested/binary/exec bundle.
-- **Unit — read never crashes:** `get_skill` on a skill containing a top-level
-  binary returns (binary in `bundle_files`, not in `supporting_files`), never
-  raises.
-- **Unit — zip import:** nested + binary + exec preserved; **zip-slip, symlink,
-  and case-fold members rejected**; over-cap / declared-vs-actual-size mismatch
+- **Unit — validator:** nested-ok (per-segment); reject traversal, absolute,
+  symlink, backslash, depth > 8, over-length, any-case `skill.md`.
+- **Unit — scanner:** recursion into `scripts/`/`references/`/`assets/`; junk
+  (`.git`, `.DS_Store`, `__pycache__`, `*.pyc`, `~`) pruned (not in
+  `unsupported_paths`); binary fingerprinted-not-decoded; exec bit captured; nested
+  `references/SKILL.md` NOT the body; **flat all-text snapshot byte-identical to
+  pre-Spec-2** (guards existing trust); content OR mode change → mismatch.
+- **Unit — tolerance:** a skill with a residual unsupported file (e.g. a symlink)
+  trusts its supported files and is a recoverable `needs-review`, NOT a raise;
+  removing the file → trusted.
+- **Unit — verify parity:** in-memory builder and scanner produce identical
+  fingerprint dicts for the same nested/binary/exec bundle.
+- **Unit — read never crashes:** `get_skill` on a skill with a top-level binary
+  returns (binary in `bundle_files`, not `supporting_files`), never raises.
+- **Unit — zip import:** nested + binary + exec preserved; junk pruned; zip-slip,
+  symlink, case-fold members rejected; over-cap / declared-vs-actual mismatch
   rejected.
 - **Unit — export:** recursive round-trip preserves paths, bytes, exec bit.
-- **Unit — folder import:** faithful recursive copy; symlink rejected; real mode
-  read; caps.
-- **Unit — rollback:** text files restored from snapshot; a tampered binary is
-  flagged needs-review and left in place (not reverted).
+- **Unit — folder import:** faithful recursive copy; junk pruned; symlink rejected;
+  real mode read; caps.
+- **Unit — review preview:** a present changed binary renders "binary … sha256",
+  NOT "(deleted)"; a genuinely deleted file still renders "(deleted)".
+- **Unit — rollback:** text restored from snapshot; a tampered binary flagged
+  needs-review and left in place.
+- **Flip:** `Tests/Skills/test_skills_import.py:525-527` (currently asserts nested
+  files dropped) → asserts they are imported. **Keep** `test_local_skills_service.py:320`
+  (`../escape.md` rejected).
 - **Integration:** import the real `subagent-driven-development` bundle (has
   `scripts/`) → nested executable scripts present, blocked until approved, trusted
   after approval; **export→import byte-identical**; tampering with an approved
-  binary flips the skill to needs-review.
+  binary flips it to needs-review.
 
 ## Migration
 
-No trust-data migration and no config change. The backward-identical canonical
-form (§3) means existing trusted skills are undisturbed. The new `executable`
-fingerprint field and `bundle_files` listing are additive.
+No trust-data migration and no config change. The backward-identical canonical form
+(§3) keeps existing trusted skills undisturbed. The `executable` fingerprint field
+and `bundle_files` listing are additive; the raised caps and loosened key pattern
+are backward-compatible (they only *accept* more).
 
 **Release note:** skills may now contain nested directories, binary assets, and
-executable scripts, imported and exported faithfully with per-file tamper-evidence.
+executable scripts, imported/exported faithfully with per-file tamper-evidence.
+VCS/OS/build junk (`.git`, `__pycache__`, `.DS_Store`, …) is ignored on import.
 Trust rollback restores text files; a tampered binary is flagged for re-review
-rather than auto-reverted.
+rather than auto-reverted. Running a skill's bundled `scripts/` from within the
+agent is a later enhancement (this release stores them faithfully).

--- a/Docs/superpowers/specs/2026-07-22-skills-foundation-bundle-fidelity-design.md
+++ b/Docs/superpowers/specs/2026-07-22-skills-foundation-bundle-fidelity-design.md
@@ -180,8 +180,13 @@ dead-ends (capture succeeds, approve raises). Two coordinated changes:
 **(a) Junk ignore-list** applied during the walk on both import *and* scan (so junk
 is neither stored nor scanned): directories `.git`, `.github`, `.hg`, `.svn`,
 `node_modules`, `__pycache__`; files `.DS_Store`, `Thumbs.db`; suffixes `.pyc`,
-`.pyo`, `~`, `.bak`, `.orig`, plus the existing `.tmp`/`.swp`/`.part`. Ignored
-entries are skipped entirely — **never** recorded in `unsupported_paths`.
+`.pyo`, `~`, `.tmp`, `.swp`, `.part`. Ignored entries are skipped entirely —
+**never** recorded in `unsupported_paths`. (`.bak`/`.orig` were dropped from this
+list during implementation: unlike every other suffix here — binaries or
+pattern-failing names that were already untrustable pre-feature — a *text* file
+named e.g. `notes.bak` was previously a supported, trusted supporting file, so
+pruning it would flip a pre-existing skill to needs-review and violate the
+backward-compat guarantee. They are now kept as ordinary supporting files.)
 
 **(b) Tolerate-and-surface** instead of hard-raise. `bootstrap_trust` and
 `trust_current_skill` establish trust over the **supported (fingerprinted)** files

--- a/Docs/superpowers/specs/2026-07-22-skills-foundation-bundle-fidelity-design.md
+++ b/Docs/superpowers/specs/2026-07-22-skills-foundation-bundle-fidelity-design.md
@@ -1,0 +1,211 @@
+# Skills Foundation — Spec 2: Full-Bundle Supporting-File Fidelity
+
+**Status:** Approved design (2026-07-22)
+**Program:** Skills-install program, Layer 0. Sibling of Spec 1 (trust isolation,
+recovery & discoverability — PR #762, merged). North star: *"a user asks an agent
+to install a skill/pack from a GitHub link."*
+
+## Problem
+
+tldw's local-skills subsystem stores a skill as a real directory on disk, but its
+*supporting-file* model is **flat and text-only**, so a spec-conformant
+[Agent Skills](https://agentskills.io/specification) bundle loses data at every
+stage of its lifecycle:
+
+| Stage | Code | Behaviour with nested / binary / executable files |
+|-------|------|---------------------------------------------------|
+| Read from dir | `local_skills_service.py` `_read_supporting_files` | `iterdir()` + `is_file()` — **silently skips subdirectories** |
+| Write to dir | `_apply_supporting_files` | `skill_dir / filename` — no parent `mkdir`, assumes flat |
+| Zip import | `_validate_archive_member` | **rejects** any member where `len(parts) != 1` |
+| Zip export | `export_skill` | flat `writestr(filename, …)` |
+| Folder import (UI) | `library_screen.py` `_read_library_skill_import_supporting_files` | reads flat siblings only; explicitly does **not** recurse |
+| Trust snapshot | `skill_trust_scanner.py` `scan_skill_directory` | `iterdir()` + `is_file()` — **also flat**, text-only |
+| Data model | `supporting_files: dict[str, str]` | keyed by bare `path.name` — cannot represent `scripts/x` vs `refs/x`, no bytes, no mode |
+
+This is the confirmed UAT finding #3: importing the real `obra/superpowers`
+`subagent-driven-development` skill silently drops its `scripts/review-package`,
+`scripts/task-brief`, and `scripts/sdd-workspace` files. Per the
+[Agent Skills spec](https://agentskills.io/specification), a bundle is a directory
+of `SKILL.md` plus optional nested `scripts/` (**executable**), `references/`
+(docs), `assets/` (**images / binary**, data files), *"and any additional files
+or directories."*
+
+## Goal
+
+Faithfully **import, store, trust-verify, and export** a spec-conformant Agent
+Skills bundle — arbitrary nested directories, binary files, and executable
+scripts — with cryptographic tamper-evidence over every file (text and binary),
+without disturbing any currently-trusted skill.
+
+## Scope
+
+**In:**
+- Path-aware supporting-file model: relative POSIX subpaths, arbitrary depth.
+- Binary files stored faithfully (raw bytes), not decoded.
+- Executable bit preserved and trust-fingerprinted.
+- Recursive, binary-aware, mode-aware trust scanner with per-file SHA-256 inside
+  the existing HMAC-authenticated manifest.
+- Both existing import paths (**zip** and **folder**) and export made faithful,
+  with zip-slip / symlink / traversal hardening and size caps.
+- Editor lists nested paths; text files stay editable, binaries are view-only.
+
+**Out (later layers, noted so deferral is deliberate):**
+- SKILL.md **frontmatter** conformance (`license`, `compatibility`, `metadata`
+  map, `--` rule, 1024-char description) — a separate sibling spec.
+- A new **folder / GitHub picker UX** and multi-skill **pack** import — Layers 1–2.
+- **Asymmetric publisher signatures** (proving a bundle came from a given GitHub
+  publisher) — a supply-chain concern for the remote-fetch layer. Spec 2 provides
+  *local* keyed-MAC tamper-evidence, not provenance.
+
+## Design
+
+### 1. Bundle representation (directory-native)
+
+The **skill directory on disk is the source of truth.** Import writes the bundle
+faithfully into `skill_dir`; trust scans the dir; export zips the dir. The API and
+editor keep two *derived* views, so no byte round-trips through JSON:
+
+- `supporting_files: dict[str, str]` — **text files only**, keys now **nested
+  POSIX paths** (`scripts/build.sh`, `references/api.md`). Backward-compatible
+  shape; keys simply gain `/`. This is what the editor reads/writes.
+- `bundle_files: list[BundleFileInfo]` — the **full manifest view**, one entry per
+  file: `{path: str, size: int, executable: bool, is_text: bool}`. Binaries
+  appear here only, so the UI can show `assets/logo.png — 12 KB` without inlining
+  bytes.
+
+Rationale: skills are already stored as directories and trust already scans the
+tree, so the tree is the natural source of truth. This avoids base64 bloat, keeps
+the editor's text-only reality honest, and confines binary/mode concerns to the
+filesystem and the trust fingerprint.
+
+### 2. Path validation — `validate_supporting_file_path(path: str) -> str`
+
+A single validator (new, in the skills schema module) reused by read, write,
+zip-import, and folder-import. Accepts a **relative POSIX subpath** where **each
+segment** matches the existing safe filename pattern
+`^[a-zA-Z0-9][a-zA-Z0-9._-]{0,99}$`. Returns the normalized POSIX path.
+
+Rejects (each raises a typed `ValueError`):
+- absolute paths, a leading `/`, backslashes (`\`);
+- any `..` or `.` segment; empty segments (`a//b`);
+- symlinks (checked against the on-disk target during read/scan/copy);
+- `SKILL.md` at the root (reserved — it is the skill body, not a supporting file);
+- depth > **8** segments; total path length > **255** bytes.
+
+### 3. Trust scanner — recursive, binary-aware, mode-aware, backward-identical for flat bundles
+
+`scan_skill_directory` walks the tree recursively, yielding files sorted by their
+POSIX relative path. Per file:
+- reject symlinks and traversal → `unsupported_paths` (never trust material);
+- fingerprint `SkillFileFingerprint{relative_path, file_type, byte_length,
+  sha256, executable}` — `executable` is a **new field**;
+- decode into `text_files[relative_path]` **only** when UTF-8-decodable and
+  null-byte-free; binaries are fingerprinted (`file_type="supporting_binary"`)
+  but never decoded.
+
+**Cryptographic integrity (the tamper-evidence requirement).** The snapshot's
+per-file `sha256` values live inside the canonical manifest payload that is
+authenticated by `manifest_mac(payload, manifest_mac_key)` =
+`HMAC-SHA256(canonical_json(payload), key)`, where `manifest_mac_key` is derived
+from the user's passphrase (`skill_trust_crypto.py`). Making every binary a
+first-class fingerprint (`sha256` + `byte_length` + `executable`) therefore means:
+- tampering with a binary's **content** changes its SHA-256 → the on-disk file no
+  longer matches its recorded fingerprint on the next scan;
+- flipping a file's **executable bit** changes the `executable` fingerprint field
+  → same mismatch;
+- either mismatch drives the skill to **blocked / needs-review** — the user is
+  *made aware*; and the manifest itself cannot be forged without the
+  passphrase-derived MAC key.
+
+**Backward-compatibility guarantee (load-bearing).** The canonical snapshot MUST
+be **byte-identical to the pre-Spec-2 form** for any skill that has **no nested
+paths, no binary files, and no executable bits**. Concretely: `executable` is
+omitted from canonicalization when `False`; `file_type` is unchanged for text
+files; and a flat directory's recursive walk reproduces today's `iterdir()`
+name-ordering (for a flat dir, `relative_path == path.name`). As a result **every
+currently-trusted skill stays trusted** — only bundles that actually use nesting,
+binaries, or exec bits are re-scanned. No mass re-review.
+
+### 4. Import round-trip (both existing paths; no new picker)
+
+- **Zip** (`import_skill_file` / `_validate_archive_member`): allow nested members
+  (validated by §2), extract raw bytes faithfully (no UTF-8 decode of binaries),
+  preserve the executable bit from the zip member's unix mode
+  (`external_attr >> 16`). **Zip-slip hardening**: resolve each target and assert
+  it stays within `skill_dir` before writing.
+- **Folder** (`_run_library_skills_import` → a new
+  `import_skill_directory(source_dir, name, …)` service method): replace the
+  flat-siblings read with a **safe recursive tree copy** into `skill_dir` —
+  validate every relative path (§2), preserve mode, reject symlinks. This is the
+  direct finding #3 fix.
+- Both land **trust-pending** (`trust_approved=False`); the trust scan runs on the
+  stored directory.
+
+### 5. Export — `export_skill`
+
+Walk `skill_dir` recursively; write each file at its POSIX relative path into the
+zip as raw bytes, preserving the executable bit via `ZipInfo.external_attr`.
+Export→import is byte-identical (round-trip test).
+
+### 6. Service read / write
+
+- `_read_supporting_files` → recursive; returns the **text view** (nested keys).
+  A companion `_read_bundle_manifest` returns the `bundle_files` listing (text +
+  binary + mode + size).
+- `_apply_supporting_files` (editor text edits) → `mkdir` parents, path-validate
+  (§2), atomic write; text-only. Binary and mode changes never arrive through the
+  editor. The faithful import copy (§4) is a separate, tree-aware path.
+
+### 7. Editor display
+
+The canvas lists supporting files by nested path. **Text files stay editable**;
+binaries are **view-only** (`path — size (binary)`), not rendered or edited. No
+hex editor, no binary preview (YAGNI). Deleting a supporting file remains
+available for both kinds.
+
+### 8. Security & limits
+
+- Symlinks rejected everywhere (read, scan, copy, zip in/out).
+- Zip-slip contained by resolve-and-assert-within-`skill_dir` on every member.
+- Per-file cap **5 MB**; per-bundle total **25 MB**; max **500 files** — bounding
+  memory and DoS from a hostile archive. Enforced during import (zip and folder)
+  before writing. Over-limit is a clear, non-partial failure (nothing is left
+  half-written).
+- Binary detection: a null byte **or** a UTF-8 decode failure marks a file binary
+  (the scanner's existing heuristic, now applied recursively).
+
+## Components & boundaries
+
+| Unit | File | Responsibility |
+|------|------|----------------|
+| Path validator | `tldw_api/skills_schemas.py` (or new `skill_bundle_paths.py`) | `validate_supporting_file_path`; the one place path rules live |
+| Trust scanner | `Skills_Interop/skill_trust_scanner.py` | recursive walk, binary/mode fingerprints, backward-identical canonical form |
+| Fingerprint model | `Skills_Interop/skill_trust_models.py` | add `executable` field; canonicalization omits it when `False` |
+| Service bundle I/O | `Skills_Interop/local_skills_service.py` | recursive read, safe tree copy (`import_skill_directory`), faithful zip in/out, size caps |
+| Import archive validation | `Skills_Interop/local_skills_service.py` | nested-aware `_validate_archive_member` + zip-slip guard |
+| Folder import path | `UI/Screens/library_screen.py` | call `import_skill_directory`; drop the flat-siblings read |
+| Editor canvas | `Widgets/Library/library_skills_canvas.py` | nested-path list, view-only binaries |
+| API schema | `tldw_api/skills_schemas.py` | `bundle_files` / `BundleFileInfo`; nested keys in `supporting_files` |
+
+## Testing strategy
+
+- **Unit — validator:** nested-ok; reject traversal, absolute, symlink, backslash,
+  depth > 8, over-length, reserved `SKILL.md`.
+- **Unit — scanner:** recursion into `scripts/`/`references/`/`assets/`; binary
+  fingerprinted-not-decoded; executable bit captured; **a flat all-text skill's
+  snapshot is byte-identical to the pre-Spec-2 output** (guards existing trust);
+  content or mode change → fingerprint mismatch.
+- **Unit — zip import:** nested + binary + exec preserved; **zip-slip member
+  rejected**; over-cap archive rejected.
+- **Unit — export:** recursive round-trip preserves paths, bytes, exec bit.
+- **Unit — folder import:** faithful recursive copy; symlink rejected; caps.
+- **Integration:** import the real `subagent-driven-development` bundle (has
+  `scripts/`) → nested executable scripts present, blocked until approved, trusted
+  after approval; **export→import is byte-identical**; tampering with an approved
+  binary flips the skill to needs-review.
+
+## Migration
+
+No trust-data migration and no config change. The backward-identical canonical
+form (§3) means existing trusted skills are undisturbed. The new `executable`
+fingerprint field and `bundle_files` listing are additive.

--- a/Docs/superpowers/specs/2026-07-22-skills-foundation-bundle-fidelity-design.md
+++ b/Docs/superpowers/specs/2026-07-22-skills-foundation-bundle-fidelity-design.md
@@ -1,25 +1,25 @@
 # Skills Foundation — Spec 2: Full-Bundle Supporting-File Fidelity
 
-**Status:** Approved design (2026-07-22)
+**Status:** Approved design (2026-07-22), hardened after a code-verified review.
 **Program:** Skills-install program, Layer 0. Sibling of Spec 1 (trust isolation,
 recovery & discoverability — PR #762, merged). North star: *"a user asks an agent
 to install a skill/pack from a GitHub link."*
 
 ## Problem
 
-tldw's local-skills subsystem stores a skill as a real directory on disk, but its
-*supporting-file* model is **flat and text-only**, so a spec-conformant
+tldw stores a skill as a real directory on disk, but its *supporting-file* model
+is **flat and text-only**, so a spec-conformant
 [Agent Skills](https://agentskills.io/specification) bundle loses data at every
 stage of its lifecycle:
 
 | Stage | Code | Behaviour with nested / binary / executable files |
 |-------|------|---------------------------------------------------|
-| Read from dir | `local_skills_service.py` `_read_supporting_files` | `iterdir()` + `is_file()` — **silently skips subdirectories** |
+| Read from dir | `local_skills_service.py` `_read_supporting_files` | `iterdir()` + `is_file()` — **silently skips subdirectories**; UTF-8-decodes every file, so a **top-level binary crashes `get_skill`** |
 | Write to dir | `_apply_supporting_files` | `skill_dir / filename` — no parent `mkdir`, assumes flat |
 | Zip import | `_validate_archive_member` | **rejects** any member where `len(parts) != 1` |
 | Zip export | `export_skill` | flat `writestr(filename, …)` |
 | Folder import (UI) | `library_screen.py` `_read_library_skill_import_supporting_files` | reads flat siblings only; explicitly does **not** recurse |
-| Trust snapshot | `skill_trust_scanner.py` `scan_skill_directory` | `iterdir()` + `is_file()` — **also flat**, text-only |
+| Trust snapshot | `skill_trust_scanner.py` `scan_skill_directory` | `iterdir()` + `is_file()` — **flat**, text-only; body classified by **basename** |
 | Data model | `supporting_files: dict[str, str]` | keyed by bare `path.name` — cannot represent `scripts/x` vs `refs/x`, no bytes, no mode |
 
 This is the confirmed UAT finding #3: importing the real `obra/superpowers`
@@ -39,23 +39,23 @@ without disturbing any currently-trusted skill.
 
 ## Scope
 
-**In:**
-- Path-aware supporting-file model: relative POSIX subpaths, arbitrary depth.
-- Binary files stored faithfully (raw bytes), not decoded.
-- Executable bit preserved and trust-fingerprinted.
-- Recursive, binary-aware, mode-aware trust scanner with per-file SHA-256 inside
-  the existing HMAC-authenticated manifest.
-- Both existing import paths (**zip** and **folder**) and export made faithful,
-  with zip-slip / symlink / traversal hardening and size caps.
-- Editor lists nested paths; text files stay editable, binaries are view-only.
+**In:** path-aware supporting-file model (relative POSIX subpaths, arbitrary
+depth); binary files stored faithfully (raw bytes); executable bit preserved and
+trust-fingerprinted; recursive, binary-aware, mode-aware trust scanner with
+per-file SHA-256 inside the existing HMAC-authenticated manifest; both existing
+import paths (**zip** and **folder**) and export made faithful, with
+zip-slip / symlink / traversal / case-fold hardening and size caps; editor lists
+nested paths, text editable, binaries view-only.
 
 **Out (later layers, noted so deferral is deliberate):**
 - SKILL.md **frontmatter** conformance (`license`, `compatibility`, `metadata`
   map, `--` rule, 1024-char description) — a separate sibling spec.
 - A new **folder / GitHub picker UX** and multi-skill **pack** import — Layers 1–2.
-- **Asymmetric publisher signatures** (proving a bundle came from a given GitHub
-  publisher) — a supply-chain concern for the remote-fetch layer. Spec 2 provides
-  *local* keyed-MAC tamper-evidence, not provenance.
+- **Asymmetric publisher signatures** (proving provenance) — a supply-chain
+  concern for the remote-fetch layer. Spec 2 provides *local* keyed-MAC
+  tamper-evidence, not provenance.
+- **Full binary restore on rollback** — trust rollback restores text files only
+  (see §9). Binaries are tamper-*detected* but not auto-reverted.
 
 ## Design
 
@@ -71,11 +71,12 @@ editor keep two *derived* views, so no byte round-trips through JSON:
 - `bundle_files: list[BundleFileInfo]` — the **full manifest view**, one entry per
   file: `{path: str, size: int, executable: bool, is_text: bool}`. Binaries
   appear here only, so the UI can show `assets/logo.png — 12 KB` without inlining
-  bytes.
+  bytes. Optional/local-first: the remote skills service may not populate it, so
+  every consumer degrades gracefully to an empty list.
 
 Rationale: skills are already stored as directories and trust already scans the
-tree, so the tree is the natural source of truth. This avoids base64 bloat, keeps
-the editor's text-only reality honest, and confines binary/mode concerns to the
+tree, so the tree is the natural source of truth — avoiding base64 bloat, keeping
+the editor's text-only reality honest, and confining binary/mode concerns to the
 filesystem and the trust fingerprint.
 
 ### 2. Path validation — `validate_supporting_file_path(path: str) -> str`
@@ -88,120 +89,185 @@ segment** matches the existing safe filename pattern
 Rejects (each raises a typed `ValueError`):
 - absolute paths, a leading `/`, backslashes (`\`);
 - any `..` or `.` segment; empty segments (`a//b`);
-- symlinks (checked against the on-disk target during read/scan/copy);
-- `SKILL.md` at the root (reserved — it is the skill body, not a supporting file);
+- symlinks (rejected, never followed — §3/§4);
+- **any** file whose basename case-insensitively equals `skill.md`: the top-level
+  `SKILL.md` (exact case, per the Agent Skills spec) is the skill body, and no
+  other file — a wrong-case `skill.md` at the root, or a nested
+  `references/SKILL.md` — may shadow it or be confused with it;
 - depth > **8** segments; total path length > **255** bytes.
+
+This single validator resolves the current inconsistency where the scanner treats
+`SKILL.md` case-sensitively but `skills_schemas.py` rejects supporting `skill.md`
+case-insensitively.
 
 ### 3. Trust scanner — recursive, binary-aware, mode-aware, backward-identical for flat bundles
 
-`scan_skill_directory` walks the tree recursively, yielding files sorted by their
-POSIX relative path. Per file:
+`scan_skill_directory` walks the tree with `os.walk(followlinks=False)` (never
+following symlinked directories — no loops, no escape), emitting files **sorted by
+POSIX relative path** (the ordering choice that preserves backward-compat — not
+absolute path, not case-folded, not raw traversal order). Per file:
 - reject symlinks and traversal → `unsupported_paths` (never trust material);
+- **classify the body by the top-level relative path**: `file_type="skill"` iff
+  `relative_path == "SKILL.md"` (no `/`). A nested `references/SKILL.md` is never
+  the body (today's basename check would misclassify it — this is a change from
+  `relative_path = path.name`);
 - fingerprint `SkillFileFingerprint{relative_path, file_type, byte_length,
   sha256, executable}` — `executable` is a **new field**;
 - decode into `text_files[relative_path]` **only** when UTF-8-decodable and
   null-byte-free; binaries are fingerprinted (`file_type="supporting_binary"`)
-  but never decoded.
+  but never decoded and never raise.
 
-**Cryptographic integrity (the tamper-evidence requirement).** The snapshot's
-per-file `sha256` values live inside the canonical manifest payload that is
-authenticated by `manifest_mac(payload, manifest_mac_key)` =
+**Three fingerprint sites must change together.** The canonical fingerprint dict
+is built explicitly (field-by-field) in three independent places; all three must
+add `executable` with the *identical* conditional rule or verification diverges:
+1. `SkillFileFingerprint.as_manifest_entry` (`skill_trust_models.py`) — the shared
+   manifest/digest/review serializer;
+2. the scanner constructor (`skill_trust_scanner.py`) — sets `executable` from the
+   file mode;
+3. `_content_manifest_entry` / `_fingerprint_in_memory_files`
+   (`skill_trust_service.py`) — the parallel *in-memory* builder used by
+   `verify_skill_content`, which must hash raw bytes for binaries and set
+   `executable` the same way.
+
+**Cryptographic integrity (the tamper-evidence requirement).** Per-file `sha256`
+values live inside the canonical manifest payload authenticated by
+`manifest_mac(payload, manifest_mac_key)` =
 `HMAC-SHA256(canonical_json(payload), key)`, where `manifest_mac_key` is derived
-from the user's passphrase (`skill_trust_crypto.py`). Making every binary a
-first-class fingerprint (`sha256` + `byte_length` + `executable`) therefore means:
-- tampering with a binary's **content** changes its SHA-256 → the on-disk file no
-  longer matches its recorded fingerprint on the next scan;
-- flipping a file's **executable bit** changes the `executable` fingerprint field
-  → same mismatch;
+from the user's passphrase. Verification compares **only** the fingerprint dicts
+(never decoded content), so making every binary a first-class fingerprint
+(`sha256` + `byte_length` + `executable`) fully covers it:
+- tampering with a binary's **content** changes its SHA-256;
+- flipping a file's **executable bit** changes the `executable` field;
 - either mismatch drives the skill to **blocked / needs-review** — the user is
-  *made aware*; and the manifest itself cannot be forged without the
-  passphrase-derived MAC key.
+  *made aware* — and the manifest cannot be forged without the passphrase-derived
+  MAC key.
 
 **Backward-compatibility guarantee (load-bearing).** The canonical snapshot MUST
-be **byte-identical to the pre-Spec-2 form** for any skill that has **no nested
-paths, no binary files, and no executable bits**. Concretely: `executable` is
-omitted from canonicalization when `False`; `file_type` is unchanged for text
-files; and a flat directory's recursive walk reproduces today's `iterdir()`
-name-ordering (for a flat dir, `relative_path == path.name`). As a result **every
-currently-trusted skill stays trusted** — only bundles that actually use nesting,
-binaries, or exec bits are re-scanned. No mass re-review.
+be **byte-identical to the pre-Spec-2 form** for any skill with **no nested paths,
+no binaries, and no executable bits**. This is achievable because serialization is
+explicit: `executable` is **included in the fingerprint dict only when `True`**
+(`if self.executable: entry["executable"] = True`); `file_type` is unchanged for
+text; and a flat directory's `os.walk` sorted by relative path reproduces today's
+`iterdir()` name-order (for a flat dir `relative_path == path.name`). As a result
+**every currently-trusted skill stays trusted** — only bundles that actually use
+nesting, binaries, or exec bits are re-scanned. No mass re-review.
 
 ### 4. Import round-trip (both existing paths; no new picker)
 
 - **Zip** (`import_skill_file` / `_validate_archive_member`): allow nested members
-  (validated by §2), extract raw bytes faithfully (no UTF-8 decode of binaries),
-  preserve the executable bit from the zip member's unix mode
-  (`external_attr >> 16`). **Zip-slip hardening**: resolve each target and assert
-  it stays within `skill_dir` before writing.
+  (validated by §2), extract raw bytes faithfully (no UTF-8 decode of binaries).
+  Hardening on every member: **zip-slip** (resolve target, assert within
+  `skill_dir`), **symlink members** rejected (unix mode `S_ISLNK`), **case-fold
+  collisions** rejected (two members whose paths differ only in case would collide
+  on a case-insensitive filesystem — reject rather than silently last-wins).
+  Executable bit is **best-effort** from the member's unix mode
+  (`external_attr >> 16`): honored when the archive carries unix attributes
+  (GitHub archive zips do), otherwise defaults non-executable.
 - **Folder** (`_run_library_skills_import` → a new
   `import_skill_directory(source_dir, name, …)` service method): replace the
   flat-siblings read with a **safe recursive tree copy** into `skill_dir` —
-  validate every relative path (§2), preserve mode, reject symlinks. This is the
-  direct finding #3 fix.
+  `os.walk(followlinks=False)`, validate every relative path (§2), reject
+  symlinks, and read the **real file mode** for the exec bit (reliable, unlike
+  zip). This is the direct finding #3 fix.
 - Both land **trust-pending** (`trust_approved=False`); the trust scan runs on the
   stored directory.
 
 ### 5. Export — `export_skill`
 
 Walk `skill_dir` recursively; write each file at its POSIX relative path into the
-zip as raw bytes, preserving the executable bit via `ZipInfo.external_attr`.
-Export→import is byte-identical (round-trip test).
+zip as raw bytes, preserving the executable bit via `ZipInfo.external_attr`. **All
+files** round-trip byte-identically (export→import). Empty directories carry no
+content and are not preserved — an accepted, documented limitation.
 
 ### 6. Service read / write
 
-- `_read_supporting_files` → recursive; returns the **text view** (nested keys).
-  A companion `_read_bundle_manifest` returns the `bundle_files` listing (text +
+- `_read_supporting_files` → recursive (`os.walk(followlinks=False)`); returns the
+  **text view** (nested keys). **It MUST catch UTF-8 decode failures / null bytes
+  and route those files to the binary manifest — never raise.** This also fixes a
+  pre-existing latent bug: today a single top-level binary makes `get_skill` throw
+  `UnicodeDecodeError`, leaving the skill un-openable in the editor.
+- A companion `_read_bundle_manifest` returns the `bundle_files` listing (text +
   binary + mode + size).
 - `_apply_supporting_files` (editor text edits) → `mkdir` parents, path-validate
-  (§2), atomic write; text-only. Binary and mode changes never arrive through the
-  editor. The faithful import copy (§4) is a separate, tree-aware path.
+  (§2), atomic write; text-only. **Invariant:** the editor save must never pass a
+  full-replacement `supporting_files` dict (today it passes `None`, a no-op), so
+  binaries and nested files it never loaded are never deleted or reconciled away.
 
 ### 7. Editor display
 
 The canvas lists supporting files by nested path. **Text files stay editable**;
 binaries are **view-only** (`path — size (binary)`), not rendered or edited. No
-hex editor, no binary preview (YAGNI). Deleting a supporting file remains
-available for both kinds.
+hex editor, no binary preview (YAGNI). Delete remains available for both kinds.
 
 ### 8. Security & limits
 
-- Symlinks rejected everywhere (read, scan, copy, zip in/out).
-- Zip-slip contained by resolve-and-assert-within-`skill_dir` on every member.
-- Per-file cap **5 MB**; per-bundle total **25 MB**; max **500 files** — bounding
-  memory and DoS from a hostile archive. Enforced during import (zip and folder)
-  before writing. Over-limit is a clear, non-partial failure (nothing is left
-  half-written).
+- Symlinks rejected everywhere and never followed (`os.walk(followlinks=False)` on
+  read, scan, and folder copy; `S_ISLNK` member rejection on zip in/out).
+- Zip-slip contained (resolve-and-assert-within-`skill_dir` per member).
+- Case-fold collisions rejected on import (zip and folder).
+- Size caps: per-file **5 MB**, per-bundle total **25 MB**, max **500 files** —
+  enforced on the archive's **declared** `file_size` *before* extracting **and**
+  bounded on the **bytes actually read** during extraction (defence against a
+  header that lies / a zip bomb). Over-limit is a clean, non-partial failure
+  (nothing left half-written).
 - Binary detection: a null byte **or** a UTF-8 decode failure marks a file binary
-  (the scanner's existing heuristic, now applied recursively).
+  (the scanner's existing heuristic, applied recursively).
+
+### 9. Trust rollback / restore
+
+Trust rollback restores the trusted baseline from the encrypted `text_files`
+snapshot — **text files only**, as today. Binaries are fingerprinted for
+tamper-*detection* (a changed binary flips the skill to needs-review) but are
+**not** stored in the encrypted snapshot and so are **not auto-reverted** on
+rollback; they are left in place for the user to re-review. Keeping binary bytes
+out of the encrypted snapshot avoids a new blob format and storage growth; the
+integrity guarantee (§3) is unaffected. This limitation is called out in the
+release note.
 
 ## Components & boundaries
 
 | Unit | File | Responsibility |
 |------|------|----------------|
-| Path validator | `tldw_api/skills_schemas.py` (or new `skill_bundle_paths.py`) | `validate_supporting_file_path`; the one place path rules live |
-| Trust scanner | `Skills_Interop/skill_trust_scanner.py` | recursive walk, binary/mode fingerprints, backward-identical canonical form |
-| Fingerprint model | `Skills_Interop/skill_trust_models.py` | add `executable` field; canonicalization omits it when `False` |
-| Service bundle I/O | `Skills_Interop/local_skills_service.py` | recursive read, safe tree copy (`import_skill_directory`), faithful zip in/out, size caps |
-| Import archive validation | `Skills_Interop/local_skills_service.py` | nested-aware `_validate_archive_member` + zip-slip guard |
+| Path validator | `tldw_api/skills_schemas.py` (or new `skill_bundle_paths.py`) | `validate_supporting_file_path`; the one place path + `skill.md` rules live |
+| Trust scanner | `Skills_Interop/skill_trust_scanner.py` | recursive `os.walk`, relative-path body classification, binary/mode fingerprints, backward-identical canonical form |
+| Fingerprint model | `Skills_Interop/skill_trust_models.py` | add `executable`; `as_manifest_entry` includes it only when `True` |
+| In-memory verify path | `Skills_Interop/skill_trust_service.py` | `_content_manifest_entry` / `_fingerprint_in_memory_files` — same conditional `executable`, hash raw bytes for binaries |
+| Service bundle I/O | `Skills_Interop/local_skills_service.py` | recursive binary-safe read (never raises), `_read_bundle_manifest`, `import_skill_directory` safe tree copy, faithful zip in/out, size caps |
+| Import archive validation | `Skills_Interop/local_skills_service.py` | nested-aware `_validate_archive_member` + zip-slip + symlink + case-fold guards |
 | Folder import path | `UI/Screens/library_screen.py` | call `import_skill_directory`; drop the flat-siblings read |
 | Editor canvas | `Widgets/Library/library_skills_canvas.py` | nested-path list, view-only binaries |
-| API schema | `tldw_api/skills_schemas.py` | `bundle_files` / `BundleFileInfo`; nested keys in `supporting_files` |
+| API schema | `tldw_api/skills_schemas.py` | `bundle_files` / `BundleFileInfo` (optional); nested keys in `supporting_files` |
+
+**Do NOT recurse** the three `skill_trust_service.py` enumerations at `:539`
+(`_iter_skill_dirs`), `:557` (`_known_and_current_skill_names`), and `:643`
+(`_skill_dir_for_normalized_name`) — they list the *child skill directories* under
+`skills_dir`, not the contents of one skill, and must stay flat.
 
 ## Testing strategy
 
 - **Unit — validator:** nested-ok; reject traversal, absolute, symlink, backslash,
-  depth > 8, over-length, reserved `SKILL.md`.
+  depth > 8, over-length, and any-case `skill.md`.
 - **Unit — scanner:** recursion into `scripts/`/`references/`/`assets/`; binary
-  fingerprinted-not-decoded; executable bit captured; **a flat all-text skill's
-  snapshot is byte-identical to the pre-Spec-2 output** (guards existing trust);
-  content or mode change → fingerprint mismatch.
-- **Unit — zip import:** nested + binary + exec preserved; **zip-slip member
-  rejected**; over-cap archive rejected.
+  fingerprinted-not-decoded; executable bit captured; **nested `references/SKILL.md`
+  is NOT classified as the body**; **a flat all-text skill's snapshot is
+  byte-identical to the pre-Spec-2 output** (guards existing trust); content OR
+  mode change → fingerprint mismatch.
+- **Unit — verify_skill_content parity:** the in-memory builder and the scanner
+  produce identical fingerprint dicts for the same nested/binary/exec bundle.
+- **Unit — read never crashes:** `get_skill` on a skill containing a top-level
+  binary returns (binary in `bundle_files`, not in `supporting_files`), never
+  raises.
+- **Unit — zip import:** nested + binary + exec preserved; **zip-slip, symlink,
+  and case-fold members rejected**; over-cap / declared-vs-actual-size mismatch
+  rejected.
 - **Unit — export:** recursive round-trip preserves paths, bytes, exec bit.
-- **Unit — folder import:** faithful recursive copy; symlink rejected; caps.
+- **Unit — folder import:** faithful recursive copy; symlink rejected; real mode
+  read; caps.
+- **Unit — rollback:** text files restored from snapshot; a tampered binary is
+  flagged needs-review and left in place (not reverted).
 - **Integration:** import the real `subagent-driven-development` bundle (has
   `scripts/`) → nested executable scripts present, blocked until approved, trusted
-  after approval; **export→import is byte-identical**; tampering with an approved
+  after approval; **export→import byte-identical**; tampering with an approved
   binary flips the skill to needs-review.
 
 ## Migration
@@ -209,3 +275,8 @@ available for both kinds.
 No trust-data migration and no config change. The backward-identical canonical
 form (§3) means existing trusted skills are undisturbed. The new `executable`
 fingerprint field and `bundle_files` listing are additive.
+
+**Release note:** skills may now contain nested directories, binary assets, and
+executable scripts, imported and exported faithfully with per-file tamper-evidence.
+Trust rollback restores text files; a tampered binary is flagged for re-review
+rather than auto-reverted.

--- a/Docs/superpowers/specs/2026-07-22-skills-foundation-bundle-fidelity-design.md
+++ b/Docs/superpowers/specs/2026-07-22-skills-foundation-bundle-fidelity-design.md
@@ -210,6 +210,14 @@ so the residual unsupported set shrinks to symlinks + dotfile/bad-name junk.
 - Both land **trust-pending** (`trust_approved=False`); the trust scan runs on the
   stored directory.
 
+**Import-surface coherence.** `import_skill(name, content, supporting_files)`
+remains the text/API entry point (used internally by `import_skill_file` for
+loose files and by the remote proxy) and gains nested-key support; the new
+`import_skill_directory` is **additive** (the faithful local tree copy); the zip
+path becomes directory-native for binary support. No existing caller is removed.
+**Symlinks are skip-not-fail**: an encountered symlink is skipped (never copied,
+never followed), and the import continues — it does not abort the whole bundle.
+
 ### 6. Export — `export_skill`
 
 Walk `skill_dir` recursively; write each file at its POSIX relative path into the
@@ -332,6 +340,10 @@ No trust-data migration and no config change. The backward-identical canonical f
 (§3) keeps existing trusted skills undisturbed. The `executable` fingerprint field
 and `bundle_files` listing are additive; the raised caps and loosened key pattern
 are backward-compatible (they only *accept* more).
+
+Two existing behaviours already tolerate nesting and need no change: `delete_skill`
+uses `shutil.rmtree` (recursive), and `get_skill`'s response already carries
+`directory_path` (the deferred skill-runtime-reachability layer can build on it).
 
 **Release note:** skills may now contain nested directories, binary assets, and
 executable scripts, imported/exported faithfully with per-file tamper-evidence.

--- a/Tests/Library/test_library_skills_state.py
+++ b/Tests/Library/test_library_skills_state.py
@@ -1,4 +1,5 @@
 from tldw_chatbook.Library.library_skills_state import (
+    SkillEditorSupportingFile,
     build_skill_editor_state,
     build_skills_list_state,
     classify_skill_save_error,
@@ -113,8 +114,34 @@ def test_editor_state_splits_frontmatter_and_body():
     assert state.name == "code-review" and state.argument_hint == "[path]"
     assert state.allowed_tools_csv == "calculator"
     assert state.body.strip() == "Review {{args}} now."
-    assert state.supporting_files == (("notes.md", 5),)
+    # No bundle_files on this detail -> falls back to supporting_files
+    # (task-11: nested/binary listing only kicks in when bundle_files is
+    # present), reduced to SkillEditorSupportingFile rows (is_text=True,
+    # the fallback path's default -- it only ever carries decoded text).
+    assert state.supporting_files == (
+        SkillEditorSupportingFile(name="notes.md", size=5, is_text=True),
+    )
     assert state.version == 3
+
+
+def test_editor_lists_nested_and_marks_binary():
+    from tldw_chatbook.Library.library_skills_state import build_skill_editor_state
+
+    detail = {
+        "name": "demo", "content": "body", "version": 1,
+        "supporting_files": {"references/api.md": "# api\n"},
+        "bundle_files": [
+            {"path": "references/api.md", "size": 6, "executable": False, "is_text": True},
+            {"path": "assets/logo.png", "size": 2048, "executable": False, "is_text": False},
+        ],
+        "trust_status": "trusted", "trust_blocked": False,
+    }
+    state = build_skill_editor_state(detail)
+    names = [f.name for f in state.supporting_files]
+    assert "references/api.md" in names
+    assert "assets/logo.png" in names          # binary listed
+    binary = next(f for f in state.supporting_files if f.name == "assets/logo.png")
+    assert binary.is_text is False             # view-only marker
 
 
 def test_compose_roundtrips_through_frontmatter_grammar():

--- a/Tests/Library/test_skill_trust_review_preview.py
+++ b/Tests/Library/test_skill_trust_review_preview.py
@@ -1,0 +1,28 @@
+from tldw_chatbook.Widgets.Library.library_skills_canvas import skill_trust_review_preview
+
+
+def test_present_binary_shows_metadata_not_deleted():
+    review = {
+        "changed_files": ["assets/logo.png"],
+        "current_files": {},   # binary absent from text view
+        "current_fingerprints": [
+            {"relative_path": "assets/logo.png", "file_type": "supporting_binary",
+             "byte_length": 2048, "sha256": "deadbeef"},
+        ],
+    }
+    out = skill_trust_review_preview(review)
+    assert "assets/logo.png" in out
+    assert "binary" in out.lower()
+    assert "2048" in out
+    assert "deadbeef"[:8] in out
+    assert "deleted" not in out.lower()
+
+
+def test_genuinely_deleted_still_shows_deleted():
+    review = {
+        "changed_files": ["gone.md"],
+        "current_files": {},
+        "current_fingerprints": [],   # not on disk at all
+    }
+    out = skill_trust_review_preview(review)
+    assert "deleted" in out.lower()

--- a/Tests/Skills/test_bundle_fidelity_integration.py
+++ b/Tests/Skills/test_bundle_fidelity_integration.py
@@ -1,0 +1,44 @@
+"""End-to-end integration test for full-bundle supporting-file fidelity.
+
+Builds a real zip bundle containing a nested executable script and a binary
+asset, imports it through ``LocalSkillsService.import_skill_file``, and
+verifies the nested script surfaces in ``supporting_files`` while the binary
+asset surfaces in ``bundle_files`` (never in the text-only ``supporting_files``
+view). Then round-trips the skill through ``export_skill`` and asserts the
+binary asset comes back byte-identical -- proving the whole import/export
+stack preserves a real bundle faithfully, not just its individual pieces in
+isolation.
+"""
+
+import io
+import zipfile
+
+import pytest
+
+from tldw_chatbook.Skills_Interop.local_skills_service import LocalSkillsService
+
+
+@pytest.mark.asyncio
+async def test_bundle_roundtrip_and_tamper_detection(tmp_path):
+    svc = LocalSkillsService(store_dir=tmp_path)
+    # Build a bundle with a nested executable script and a binary asset.
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr("SKILL.md", "---\nname: sdd\n---\nRun scripts/run.sh\n")
+        info = zipfile.ZipInfo("scripts/run.sh")
+        info.external_attr = 0o755 << 16
+        z.writestr(info, "#!/bin/sh\necho hi\n")
+        z.writestr("assets/logo.png", b"\x89PNG\x00bin")
+    await svc.import_skill_file(
+        buf.getvalue(), filename="sdd.zip", content_type="application/zip"
+    )
+    skill = await svc.get_skill("sdd")
+    assert "scripts/run.sh" in skill["supporting_files"]
+    assert any(
+        b["path"] == "assets/logo.png" and not b["is_text"]
+        for b in skill["bundle_files"]
+    )
+    # Export -> re-import is byte-identical for the binary asset.
+    export = await svc.export_skill("sdd")
+    with zipfile.ZipFile(io.BytesIO(export["content"])) as z:
+        assert z.read("assets/logo.png") == b"\x89PNG\x00bin"

--- a/Tests/Skills/test_import_skill_directory.py
+++ b/Tests/Skills/test_import_skill_directory.py
@@ -24,3 +24,62 @@ async def test_import_skill_directory_faithful(tmp_path):
     assert not (d / ".git").exists()          # junk pruned
     skill = await svc.get_skill("demo")
     assert skill["trust_status"] != "trusted"  # trust-pending
+
+
+@pytest.mark.asyncio
+async def test_import_skill_directory_skips_symlink(tmp_path):
+    """A symlink in the source (pointing out of the tree) is skipped, not
+    copied or followed -- the import still succeeds and the link's name is
+    absent from the stored skill dir and supporting files."""
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret", encoding="utf-8")
+    src = tmp_path / "src" / "demo"
+    src.mkdir(parents=True)
+    (src / "SKILL.md").write_text("---\nname: demo\n---\nbody\n", encoding="utf-8")
+    (src / "real.txt").write_text("kept", encoding="utf-8")
+    (src / "link.txt").symlink_to(outside)
+
+    svc = LocalSkillsService(store_dir=tmp_path / "store")
+    result = await svc.import_skill_directory(src, name="demo")
+    d = svc._skill_dir("demo")
+    assert (d / "real.txt").read_text(encoding="utf-8") == "kept"
+    assert not (d / "link.txt").exists()  # symlink skipped, not copied
+    supporting = result.get("supporting_files") or {}
+    assert "link.txt" not in supporting
+
+
+@pytest.mark.asyncio
+async def test_import_skill_directory_rejects_symlinked_skill_md(tmp_path):
+    """A top-level SKILL.md that is itself a symlink (to a file outside the
+    bundle) is rejected -- its target must NOT be read into the skill body."""
+    outside = tmp_path / "outside.md"
+    outside.write_text("---\nname: evil\n---\nleaked\n", encoding="utf-8")
+    src = tmp_path / "src" / "demo"
+    src.mkdir(parents=True)
+    (src / "SKILL.md").symlink_to(outside)
+
+    svc = LocalSkillsService(store_dir=tmp_path / "store")
+    with pytest.raises(ValueError):
+        await svc.import_skill_directory(src, name="demo")
+    assert not svc._skill_dir("demo").exists()  # no partial write
+
+
+@pytest.mark.asyncio
+async def test_import_skill_directory_enforces_per_file_cap(tmp_path):
+    """A supporting file exceeding the 5MB per-file cap raises ValueError and
+    leaves NO partial write -- the target skill dir is never created."""
+    from tldw_chatbook.tldw_api.skills_schemas import MAX_SUPPORTING_FILE_BYTES
+
+    src = tmp_path / "src" / "demo"
+    src.mkdir(parents=True)
+    (src / "SKILL.md").write_text("---\nname: demo\n---\nbody\n", encoding="utf-8")
+    big = src / "big.bin"
+    with big.open("wb") as handle:  # sparse: seek past cap, write 1 byte
+        handle.seek(MAX_SUPPORTING_FILE_BYTES)
+        handle.write(b"\x00")
+    assert big.stat().st_size > MAX_SUPPORTING_FILE_BYTES
+
+    svc = LocalSkillsService(store_dir=tmp_path / "store")
+    with pytest.raises(ValueError):
+        await svc.import_skill_directory(src, name="demo")
+    assert not svc._skill_dir("demo").exists()  # no partial write

--- a/Tests/Skills/test_import_skill_directory.py
+++ b/Tests/Skills/test_import_skill_directory.py
@@ -1,0 +1,26 @@
+import os, stat, pytest
+from pathlib import Path
+from tldw_chatbook.Skills_Interop.local_skills_service import LocalSkillsService
+
+
+@pytest.mark.asyncio
+async def test_import_skill_directory_faithful(tmp_path):
+    src = tmp_path / "src" / "demo"
+    (src / "scripts").mkdir(parents=True)
+    (src / "SKILL.md").write_text("---\nname: demo\n---\nbody\n", encoding="utf-8")
+    (src / "scripts" / "run.sh").write_bytes(b"#!/bin/sh\necho hi\n")
+    os.chmod(src / "scripts" / "run.sh", 0o755)
+    (src / "assets").mkdir()
+    (src / "assets" / "logo.png").write_bytes(b"\x89PNG\x00bin")
+    (src / ".git").mkdir()
+    (src / ".git" / "config").write_text("junk", encoding="utf-8")
+
+    svc = LocalSkillsService(store_dir=tmp_path / "store")
+    await svc.import_skill_directory(src, name="demo")
+    d = svc._skill_dir("demo")
+    assert (d / "scripts" / "run.sh").read_bytes() == b"#!/bin/sh\necho hi\n"
+    assert d.joinpath("scripts", "run.sh").stat().st_mode & stat.S_IXUSR
+    assert (d / "assets" / "logo.png").read_bytes() == b"\x89PNG\x00bin"
+    assert not (d / ".git").exists()          # junk pruned
+    skill = await svc.get_skill("demo")
+    assert skill["trust_status"] != "trusted"  # trust-pending

--- a/Tests/Skills/test_import_skill_directory.py
+++ b/Tests/Skills/test_import_skill_directory.py
@@ -1,6 +1,7 @@
 import os, stat, pytest
 from pathlib import Path
 from tldw_chatbook.Skills_Interop.local_skills_service import LocalSkillsService
+import tldw_chatbook.tldw_api.skills_schemas as skills_schemas_mod
 
 
 @pytest.mark.asyncio
@@ -106,3 +107,49 @@ async def test_import_skill_directory_enforces_per_file_cap(tmp_path):
     with pytest.raises(ValueError):
         await svc.import_skill_directory(src, name="demo")
     assert not svc._skill_dir("demo").exists()  # no partial write
+
+
+@pytest.mark.asyncio
+async def test_import_skill_directory_write_loop_rejects_escaping_destination(
+    tmp_path, monkeypatch
+):
+    """Merge-gate review (PR #784, MINOR finding): the per-file WRITE loop
+    must independently refuse to write outside the resolved ``skill_dir``,
+    mirroring the belt-and-braces containment assert the zip-import path
+    already has (local_skills_service.py ~:1127) -- never trust a single
+    upstream validation layer (``validate_supporting_file_path``) for a
+    filesystem write.
+
+    ``validate_supporting_file_path`` already rejects a literal ``..``
+    relative-path segment earlier in the pipeline, so this exercises the
+    write loop's OWN check in isolation by simulating that earlier guard
+    being bypassed (patched to a no-op) with a crafted escaping
+    ``relative_path`` fed in via a stubbed ``_iter_bundle_files`` -- the
+    exact class of defense-in-depth the containment assert exists for.
+    """
+    src = tmp_path / "src" / "demo"
+    src.mkdir(parents=True)
+    (src / "SKILL.md").write_text("---\nname: demo\n---\nbody\n", encoding="utf-8")
+    payload = src / "payload.txt"
+    payload.write_text("escape me", encoding="utf-8")
+
+    monkeypatch.setattr(
+        skills_schemas_mod, "validate_supporting_file_path", lambda p: p
+    )
+
+    def fake_iter_bundle_files(source_dir):
+        yield "../escape.txt", payload
+
+    monkeypatch.setattr(
+        LocalSkillsService,
+        "_iter_bundle_files",
+        staticmethod(fake_iter_bundle_files),
+    )
+
+    store_dir = tmp_path / "store"
+    svc = LocalSkillsService(store_dir=store_dir)
+    with pytest.raises(ValueError):
+        await svc.import_skill_directory(src, name="demo")
+    # The escaping write must never land OUTSIDE the skill's own directory,
+    # even one level up in the shared "skills/" parent.
+    assert not (store_dir / "skills" / "escape.txt").exists()

--- a/Tests/Skills/test_import_skill_directory.py
+++ b/Tests/Skills/test_import_skill_directory.py
@@ -27,6 +27,29 @@ async def test_import_skill_directory_faithful(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_import_skill_directory_narrows_exec_bit_widening_to_owner_only(tmp_path):
+    """The exec-bit-preservation chmod must only trust/add owner-exec
+    (S_IXUSR), never widen group/other permissions. A freshly written dest
+    file always starts with zero exec bits (Python's default open() mode is
+    0o666, which carries no x bits at all), so any group/other exec bit
+    present after import came from an over-broad ``| 0o755`` widening, not
+    from the source."""
+    src = tmp_path / "src" / "demo"
+    src.mkdir(parents=True)
+    (src / "SKILL.md").write_text("---\nname: demo\n---\nbody\n", encoding="utf-8")
+    (src / "run.sh").write_bytes(b"#!/bin/sh\necho hi\n")
+    os.chmod(src / "run.sh", 0o700)  # owner-only exec; narrowly permissioned source
+
+    svc = LocalSkillsService(store_dir=tmp_path / "store")
+    await svc.import_skill_directory(src, name="demo")
+    d = svc._skill_dir("demo")
+    dest_mode = (d / "run.sh").stat().st_mode
+    assert dest_mode & stat.S_IXUSR        # owner-exec preserved
+    assert not dest_mode & stat.S_IXGRP    # group-exec NOT widened
+    assert not dest_mode & stat.S_IXOTH    # other-exec NOT widened
+
+
+@pytest.mark.asyncio
 async def test_import_skill_directory_skips_symlink(tmp_path):
     """A symlink in the source (pointing out of the tree) is skipped, not
     copied or followed -- the import still succeeds and the link's name is

--- a/Tests/Skills/test_local_skills_bundle_io.py
+++ b/Tests/Skills/test_local_skills_bundle_io.py
@@ -1,0 +1,28 @@
+import pytest
+
+from tldw_chatbook.Skills_Interop.local_skills_service import LocalSkillsService
+
+
+@pytest.mark.asyncio
+async def test_get_skill_with_nested_and_binary_never_raises(tmp_path):
+    svc = LocalSkillsService(store_dir=tmp_path)
+    await svc.create_skill(name="demo", content="---\nname: demo\n---\nbody\n")
+    d = svc._skill_dir("demo")
+    (d / "references").mkdir(parents=True, exist_ok=True)
+    (d / "references" / "api.md").write_text("# api\n", encoding="utf-8")
+    (d / "assets").mkdir(parents=True, exist_ok=True)
+    (d / "assets" / "logo.png").write_bytes(b"\x89PNG\x00binary")
+    skill = await svc.get_skill("demo")      # must NOT raise
+    assert skill["supporting_files"]["references/api.md"] == "# api\n"
+    assert "assets/logo.png" not in skill["supporting_files"]   # binary excluded from text view
+    paths = {b["path"]: b for b in skill["bundle_files"]}
+    assert paths["assets/logo.png"]["is_text"] is False
+    assert paths["references/api.md"]["is_text"] is True
+
+
+def test_apply_supporting_files_rejects_traversal(tmp_path):
+    svc = LocalSkillsService(store_dir=tmp_path)
+    d = svc._skill_dir("demo")
+    d.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(ValueError):
+        svc._apply_supporting_files(d, {"../escape.md": "x"})

--- a/Tests/Skills/test_local_skills_bundle_io.py
+++ b/Tests/Skills/test_local_skills_bundle_io.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from tldw_chatbook.Skills_Interop.local_skills_service import LocalSkillsService
@@ -20,9 +22,39 @@ async def test_get_skill_with_nested_and_binary_never_raises(tmp_path):
     assert paths["references/api.md"]["is_text"] is True
 
 
+@pytest.mark.asyncio
+async def test_get_skill_with_toplevel_binary_never_raises(tmp_path):
+    # Pin the literal bug this task fixes: a TOP-LEVEL binary sibling of
+    # SKILL.md must not crash get_skill (previously raised UnicodeDecodeError).
+    svc = LocalSkillsService(store_dir=tmp_path)
+    await svc.create_skill(name="demo", content="---\nname: demo\n---\nbody\n")
+    d = svc._skill_dir("demo")
+    (d / "logo.png").write_bytes(b"\x89PNG\x00bin")
+    skill = await svc.get_skill("demo")      # must NOT raise
+    assert "logo.png" not in (skill["supporting_files"] or {})
+    paths = {b["path"]: b for b in skill["bundle_files"]}
+    assert paths["logo.png"]["is_text"] is False
+
+
 def test_apply_supporting_files_rejects_traversal(tmp_path):
     svc = LocalSkillsService(store_dir=tmp_path)
     d = svc._skill_dir("demo")
     d.mkdir(parents=True, exist_ok=True)
     with pytest.raises(ValueError):
         svc._apply_supporting_files(d, {"../escape.md": "x"})
+
+
+def test_apply_supporting_files_rejects_symlink_escape(tmp_path):
+    # Exercise ONLY the containment guard: every path segment ("link",
+    # "evil.md") is individually valid, so validate_supporting_file_path does
+    # NOT reject the key. The write still escapes skill_dir because "link" is a
+    # symlink to a directory outside it. This must be caught by the resolve()
+    # within-skill_dir containment block, not by segment validation.
+    svc = LocalSkillsService(store_dir=tmp_path)
+    skill_dir = svc._skill_dir("demo")
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir(parents=True, exist_ok=True)
+    os.symlink(outside_dir, skill_dir / "link")
+    with pytest.raises(ValueError):
+        svc._apply_supporting_files(skill_dir, {"link/evil.md": "x"})

--- a/Tests/Skills/test_local_skills_service.py
+++ b/Tests/Skills/test_local_skills_service.py
@@ -313,7 +313,7 @@ async def test_local_skills_service_serializes_concurrent_updates(tmp_path):
 async def test_local_skills_service_rejects_unsafe_supporting_file_names(tmp_path):
     service = _compat_local_service(tmp_path)
 
-    with pytest.raises(ValueError, match="Invalid supporting file name"):
+    with pytest.raises(ValueError, match="Invalid path segment"):
         await service.create_skill(
             name="unsafe-skill",
             content="# Unsafe",

--- a/Tests/Skills/test_skill_fingerprint_executable.py
+++ b/Tests/Skills/test_skill_fingerprint_executable.py
@@ -1,0 +1,20 @@
+from tldw_chatbook.Skills_Interop.skill_trust_models import SkillFileFingerprint
+
+
+def test_manifest_entry_omits_executable_when_false():
+    fp = SkillFileFingerprint(
+        relative_path="notes.md", file_type="supporting_text", byte_length=3, sha256="ab",
+    )
+    # BACKWARD-COMPAT: byte-identical to the pre-change 4-key dict.
+    assert fp.as_manifest_entry() == {
+        "relative_path": "notes.md", "file_type": "supporting_text",
+        "byte_length": 3, "sha256": "ab",
+    }
+
+
+def test_manifest_entry_includes_executable_when_true():
+    fp = SkillFileFingerprint(
+        relative_path="scripts/run.sh", file_type="supporting_text",
+        byte_length=3, sha256="ab", executable=True,
+    )
+    assert fp.as_manifest_entry()["executable"] is True

--- a/Tests/Skills/test_skill_trust_scanner.py
+++ b/Tests/Skills/test_skill_trust_scanner.py
@@ -59,16 +59,22 @@ def test_scan_skill_directory_marks_unsupported_paths_without_text_or_fingerprin
 
     snapshot = scan_skill_directory("demo", skill_dir)
 
-    assert snapshot.unsupported_paths == (
-        "SKILL.md.tmp",
+    # SKILL.md.tmp is junk (case-insensitive .tmp suffix): pruned entirely,
+    # never recorded. nested/ignored.md is now walked recursively as a valid
+    # supporting text file. binary.md/nul.md are now fingerprinted as
+    # supporting_binary rather than rejected. Only the symlink and the
+    # invalid (space-containing) filename remain unsupported.
+    assert snapshot.unsupported_paths == ("linked.md", "unsafe name.md")
+    assert [item.relative_path for item in snapshot.fingerprints] == [
+        "SKILL.md",
         "binary.md",
-        "linked.md",
-        "nested",
+        "nested/ignored.md",
         "nul.md",
-        "unsafe name.md",
-    )
-    assert [item.relative_path for item in snapshot.fingerprints] == ["SKILL.md"]
-    assert snapshot.text_files == {"SKILL.md": "# Demo\n"}
+    ]
+    assert snapshot.text_files == {
+        "SKILL.md": "# Demo\n",
+        "nested/ignored.md": "ignored",
+    }
 
 
 def test_scan_skill_directory_rejects_case_variants_and_case_insensitive_temp_suffixes(
@@ -81,7 +87,9 @@ def test_scan_skill_directory_rejects_case_variants_and_case_insensitive_temp_su
 
     snapshot = scan_skill_directory("demo", skill_dir)
 
-    assert snapshot.unsupported_paths == ("notes.md.TMP",)
+    # notes.md.TMP is junk (case-insensitive .tmp suffix): pruned entirely,
+    # never recorded in unsupported_paths.
+    assert snapshot.unsupported_paths == ()
     assert [item.relative_path for item in snapshot.fingerprints] == ["SKILL.md"]
     assert snapshot.text_files == {"SKILL.md": "# Demo\n"}
 

--- a/Tests/Skills/test_skill_trust_scanner_recursive.py
+++ b/Tests/Skills/test_skill_trust_scanner_recursive.py
@@ -90,3 +90,27 @@ def test_symlinked_directory_is_unsupported_not_dropped(tmp_path):
     fps = {f.relative_path for f in snap.fingerprints}
     assert "linked_dir" not in fps
     assert "linked_dir/secret.md" not in fps  # walk must not descend the symlink
+
+
+def test_symlinked_junk_named_directory_still_unsupported(tmp_path):
+    # A symlink is suspicious regardless of its name: even when its basename
+    # matches a junk dir name (node_modules), it must surface in
+    # unsupported_paths, NOT be silently pruned as junk. Meanwhile a REAL
+    # junk dir stays pruned-and-never-recorded (the reorder must not start
+    # recording real junk).
+    d = tmp_path / "demo"
+    _write(d / "SKILL.md", b"body")
+    external = tmp_path / "external"
+    _write(external / "secret.md", b"secret")
+    os.symlink(external, d / "node_modules")
+    _write(d / "__pycache__" / "x.pyc", b"\x00pyc")  # real junk dir + junk file
+    snap = scan_skill_directory("demo", d)
+    fps = {f.relative_path for f in snap.fingerprints}
+    assert "node_modules" in snap.unsupported_paths       # symlink surfaced
+    assert "node_modules" not in fps
+    assert "node_modules/secret.md" not in fps            # walk did not descend
+    # Real junk dir/file: pruned entirely, never recorded anywhere.
+    assert "__pycache__" not in snap.unsupported_paths
+    assert "__pycache__/x.pyc" not in snap.unsupported_paths
+    assert "__pycache__/x.pyc" not in fps
+    assert fps == {"SKILL.md"}

--- a/Tests/Skills/test_skill_trust_scanner_recursive.py
+++ b/Tests/Skills/test_skill_trust_scanner_recursive.py
@@ -74,3 +74,19 @@ def test_symlink_skipped_not_followed(tmp_path):
     snap = scan_skill_directory("demo", d)
     assert "link.md" not in {f.relative_path for f in snap.fingerprints}
     assert "link.md" in snap.unsupported_paths
+
+
+def test_symlinked_directory_is_unsupported_not_dropped(tmp_path):
+    # A symlinked *directory* must ALWAYS surface in unsupported_paths (the
+    # trust gates rely on it): it must never silently vanish from both
+    # fingerprints and unsupported_paths.
+    d = tmp_path / "demo"
+    _write(d / "SKILL.md", b"body")
+    outside = tmp_path / "outside"
+    _write(outside / "secret.md", b"secret")
+    os.symlink(outside, d / "linked_dir")
+    snap = scan_skill_directory("demo", d)
+    assert "linked_dir" in snap.unsupported_paths
+    fps = {f.relative_path for f in snap.fingerprints}
+    assert "linked_dir" not in fps
+    assert "linked_dir/secret.md" not in fps  # walk must not descend the symlink

--- a/Tests/Skills/test_skill_trust_scanner_recursive.py
+++ b/Tests/Skills/test_skill_trust_scanner_recursive.py
@@ -1,0 +1,76 @@
+import os
+from pathlib import Path
+
+from tldw_chatbook.Skills_Interop.skill_trust_scanner import scan_skill_directory
+
+
+def _write(p: Path, data: bytes, mode: int | None = None):
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(data)
+    if mode is not None:
+        os.chmod(p, mode)
+
+
+def test_recurses_and_classifies(tmp_path):
+    d = tmp_path / "demo"
+    _write(d / "SKILL.md", b"---\nname: demo\n---\nbody\n")
+    _write(d / "references" / "api.md", b"# api\n")
+    _write(d / "scripts" / "run.sh", b"#!/bin/sh\necho hi\n", mode=0o755)
+    _write(d / "assets" / "logo.png", b"\x89PNG\x00\x01binary")
+    snap = scan_skill_directory("demo", d)
+    fps = {f.relative_path: f for f in snap.fingerprints}
+    assert set(fps) == {"SKILL.md", "references/api.md", "scripts/run.sh", "assets/logo.png"}
+    assert fps["SKILL.md"].file_type == "skill"
+    assert fps["assets/logo.png"].file_type == "supporting_binary"
+    assert "assets/logo.png" not in snap.text_files       # binary not decoded
+    assert "references/api.md" in snap.text_files
+    assert fps["scripts/run.sh"].executable is True
+    assert snap.unsupported_paths == ()
+
+
+def test_prunes_junk(tmp_path):
+    d = tmp_path / "demo"
+    _write(d / "SKILL.md", b"x")
+    _write(d / ".git" / "config", b"junk")
+    _write(d / "__pycache__" / "m.pyc", b"\x00pyc")
+    _write(d / ".DS_Store", b"\x00")
+    _write(d / "keep.md~", b"backup")
+    snap = scan_skill_directory("demo", d)
+    paths = {f.relative_path for f in snap.fingerprints}
+    assert paths == {"SKILL.md"}
+    assert snap.unsupported_paths == ()   # junk pruned, NOT recorded
+
+
+def test_nested_skill_md_is_not_the_body(tmp_path):
+    d = tmp_path / "demo"
+    _write(d / "SKILL.md", b"body")
+    _write(d / "references" / "SKILL.md", b"nested")
+    snap = scan_skill_directory("demo", d)
+    # A nested SKILL.md is rejected as a shadow (validate_supporting_file_path),
+    # so it lands in unsupported_paths, never classified as the body.
+    fps = {f.relative_path: f for f in snap.fingerprints}
+    assert fps["SKILL.md"].file_type == "skill"
+    assert "references/SKILL.md" not in fps
+    assert "references/SKILL.md" in snap.unsupported_paths
+
+
+def test_flat_snapshot_byte_identical_to_legacy_ordering(tmp_path):
+    # Guards the backward-compat guarantee: a flat all-text skill's fingerprint
+    # entries are in iterdir name-order and carry no executable key.
+    d = tmp_path / "demo"
+    _write(d / "SKILL.md", b"body")
+    _write(d / "b.md", b"bbb")
+    _write(d / "a.md", b"aaa")
+    snap = scan_skill_directory("demo", d)
+    entries = [f.as_manifest_entry() for f in snap.fingerprints]
+    assert [e["relative_path"] for e in entries] == ["SKILL.md", "a.md", "b.md"]
+    assert all("executable" not in e for e in entries)
+
+
+def test_symlink_skipped_not_followed(tmp_path):
+    d = tmp_path / "demo"
+    _write(d / "SKILL.md", b"body")
+    (d / "link.md").symlink_to(d / "SKILL.md")
+    snap = scan_skill_directory("demo", d)
+    assert "link.md" not in {f.relative_path for f in snap.fingerprints}
+    assert "link.md" in snap.unsupported_paths

--- a/Tests/Skills/test_skill_trust_scanner_recursive.py
+++ b/Tests/Skills/test_skill_trust_scanner_recursive.py
@@ -92,6 +92,40 @@ def test_symlinked_directory_is_unsupported_not_dropped(tmp_path):
     assert "linked_dir/secret.md" not in fps  # walk must not descend the symlink
 
 
+def test_bak_and_orig_text_files_are_supported_not_pruned(tmp_path):
+    # Backward-compat guarantee: a pre-feature skill that shipped a TEXT
+    # supporting file named notes.bak / patch.orig was previously SUPPORTED
+    # and trusted (those names pass SEGMENT_PATTERN). Pruning them as junk
+    # would silently flip such a skill to needs-review, so .bak/.orig must
+    # NOT be treated as junk suffixes.
+    d = tmp_path / "demo"
+    _write(d / "SKILL.md", b"body")
+    _write(d / "notes.bak", b"backup notes")
+    _write(d / "patch.orig", b"original patch")
+    snap = scan_skill_directory("demo", d)
+    fps = {f.relative_path: f for f in snap.fingerprints}
+    assert fps["notes.bak"].file_type == "supporting_text"
+    assert fps["patch.orig"].file_type == "supporting_text"
+    assert snap.text_files["notes.bak"] == "backup notes"
+    assert snap.text_files["patch.orig"] == "original patch"
+    assert "notes.bak" not in snap.unsupported_paths
+    assert "patch.orig" not in snap.unsupported_paths
+
+
+def test_genuine_junk_suffixes_and_pycache_dir_still_pruned(tmp_path):
+    # Sibling to the .bak/.orig carve-out: confirm suffixes that were already
+    # untrustable pre-feature (binary/build artifacts, pattern-failing names)
+    # remain pruned.
+    d = tmp_path / "demo"
+    _write(d / "SKILL.md", b"body")
+    _write(d / "x.tmp", b"junk")
+    _write(d / "__pycache__" / "m.pyc", b"\x00pyc")
+    snap = scan_skill_directory("demo", d)
+    fps = {f.relative_path for f in snap.fingerprints}
+    assert fps == {"SKILL.md"}
+    assert snap.unsupported_paths == ()
+
+
 def test_symlinked_junk_named_directory_still_unsupported(tmp_path):
     # A symlink is suspicious regardless of its name: even when its basename
     # matches a junk dir name (node_modules), it must surface in

--- a/Tests/Skills/test_skills_import.py
+++ b/Tests/Skills/test_skills_import.py
@@ -478,19 +478,18 @@ async def test_import_row_rejects_oversized_content_without_partial_state(tmp_pa
 
 
 @pytest.mark.asyncio
-async def test_import_row_skips_nested_reference_subfolder_without_failing_import(
+async def test_import_row_imports_nested_reference_subfolder(
     tmp_path,
 ):
     """A skill directory with a NESTED reference subfolder (the real
     ``using-superpowers`` skill's own ``references/`` layout -- not
     copied into the fixtures dir to keep it small, reproduced here
-    structurally) must still import successfully, but the nested file is
-    NOT carried through as a supporting file: ``local_skills_service``'s
-    supporting-file name pattern has no path-separator support, so
-    recursing into subdirectories would either be silently flattened
-    (name collisions) or rejected outright. Skipping nested paths keeps
-    this import path's own limitation explicit and non-crashing rather
-    than surprising.
+    structurally) must import successfully AND carry the nested file
+    through as a supporting file, keyed by its nested relative path.
+    ``local_skills_service``'s bundle-file walk recurses into
+    subdirectories (junk pruned, symlinks skipped, caps enforced) so the
+    real skill's ``references/`` layout round-trips faithfully instead
+    of being silently dropped.
     """
     local_service, service = _real_skills_scope_service_with_trust(tmp_path)
     app = _build_test_app()
@@ -523,5 +522,5 @@ async def test_import_row_skips_nested_reference_subfolder_without_failing_impor
     record = await local_service.get_skill("nested-refs-skill")
     assert record["trust_blocked"] is True
     supporting_files = record.get("supporting_files") or {}
-    assert "references/note.md" not in supporting_files
-    assert "note.md" not in supporting_files
+    assert "references/note.md" in supporting_files
+    assert supporting_files["references/note.md"] == "A nested reference file."

--- a/Tests/Skills/test_skills_import.py
+++ b/Tests/Skills/test_skills_import.py
@@ -20,6 +20,7 @@ committed as fixture files, to keep the fixtures directory small.
 
 from __future__ import annotations
 
+import shutil
 import time
 from pathlib import Path
 
@@ -183,6 +184,17 @@ async def test_import_skill_via_skill_md_file_path_derives_name_from_parent_dire
     call would) produces the same wrong name ("skill") for every import
     regardless of which skill it actually is. ``_run_library_skills_import``
     must use the PARENT DIRECTORY's name instead for this exact shape.
+
+    Merge-gate regression (PR #784, IMPORTANT finding): this shape used to
+    fall through to a flat, text-only read (dropping nested subfolders,
+    binaries, and the executable bit) instead of routing through the SAME
+    faithful ``import_skill_directory`` copy the directory-path shape
+    already used -- since a SKILL.md file's PARENT dir IS the skill
+    directory, both shapes must behave identically. Proven here by copying
+    the real fixture (never mutating the committed copy -- see the
+    fixtures README's "unmodified copies" provenance note) into ``tmp_path``
+    and adding a nested ``references/`` subfolder plus an executable
+    sibling script before importing via the SKILL.md FILE path.
     """
     local_service, service = _real_skills_scope_service_with_trust(tmp_path)
     app = _build_test_app()
@@ -190,12 +202,27 @@ async def test_import_skill_via_skill_md_file_path_derives_name_from_parent_dire
     app.skills_scope_service = service
     host = LibraryHarness(app)
 
+    skill_dir = tmp_path / "verification-before-completion"
+    shutil.copytree(
+        FIXTURES_DIR / "verification-before-completion", skill_dir
+    )
+    references_dir = skill_dir / "references"
+    references_dir.mkdir()
+    (references_dir / "note.md").write_text(
+        "A nested reference file.", encoding="utf-8"
+    )
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir()
+    script_path = scripts_dir / "run.sh"
+    script_path.write_text("#!/bin/sh\necho hi\n", encoding="utf-8")
+    script_path.chmod(script_path.stat().st_mode | 0o100)
+
     async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
         screen = _active_library_screen(host)
         await _wait_for_library_shell(screen, pilot)
         await _open_skills_import_row(screen, pilot)
 
-        skill_md_path = FIXTURES_DIR / "verification-before-completion" / "SKILL.md"
+        skill_md_path = skill_dir / "SKILL.md"
         status = await _run_skills_import_via_ui(screen, pilot, skill_md_path)
         assert (
             status
@@ -207,6 +234,20 @@ async def test_import_skill_via_skill_md_file_path_derives_name_from_parent_dire
     assert record["trust_blocked"] is True
     with pytest.raises(Exception):
         await local_service.get_skill("skill")
+
+    # The nested subfolder must be imported and readable by its nested key
+    # -- the flat-read fallback used to skip it entirely (nested
+    # subdirectories are NOT recursed into by a flat sibling scan).
+    supporting_files = record.get("supporting_files") or {}
+    assert supporting_files.get("references/note.md") == "A nested reference file."
+
+    # The sibling script's executable bit must survive the copy too --
+    # further proof this shape now goes through the faithful bundle copy
+    # (which preserves owner-exec), not the text-only flat read (which
+    # never even considered file modes).
+    bundle_files = {item["path"]: item for item in record.get("bundle_files") or []}
+    assert "scripts/run.sh" in bundle_files
+    assert bundle_files["scripts/run.sh"]["executable"] is True
 
 
 @pytest.mark.asyncio

--- a/Tests/Skills/test_trust_tolerates_unsupported.py
+++ b/Tests/Skills/test_trust_tolerates_unsupported.py
@@ -1,0 +1,36 @@
+import secrets
+
+from tldw_chatbook.Skills_Interop.skill_trust_service import SkillTrustService
+from tldw_chatbook.Skills_Interop.skill_trust_store import (
+    FileSkillTrustGenerationMarkerStore,
+    SkillTrustStore,
+)
+
+
+def _svc(tmp_path):
+    (tmp_path / "trust").mkdir(exist_ok=True)
+    (tmp_path / "skills").mkdir(exist_ok=True)
+    return SkillTrustService(
+        skills_dir=tmp_path / "skills",
+        trust_store=SkillTrustStore(
+            store_dir=tmp_path / "trust",
+            marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "trust" / "m.json"),
+        ),
+        key_cache=None,
+    )
+
+
+def test_bootstrap_does_not_raise_on_residual_unsupported(tmp_path):
+    d = tmp_path / "skills" / "demo"
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text("body\n", encoding="utf-8")
+    (d / "good.md").write_text("ok\n", encoding="utf-8")
+    (d / "link.md").symlink_to(d / "good.md")   # residual unsupported (symlink)
+    svc = _svc(tmp_path)
+    svc.bootstrap_trust("pw", salt=secrets.token_bytes(32))   # must NOT raise
+    status = svc.status_for_skill("demo")
+    assert status.trust_status == "quarantined_unsupported_path"  # surfaced, recoverable
+    # Removing the residual clears it.
+    (d / "link.md").unlink()
+    svc.trust_current_skill("demo")   # must NOT raise
+    assert svc.status_for_skill("demo").trust_status == "trusted"

--- a/Tests/Skills/test_verify_content_binary.py
+++ b/Tests/Skills/test_verify_content_binary.py
@@ -1,0 +1,49 @@
+import secrets, pytest
+from tldw_chatbook.Skills_Interop.skill_trust_service import SkillTrustService
+from tldw_chatbook.Skills_Interop.skill_trust_store import (
+    FileSkillTrustGenerationMarkerStore, SkillTrustStore,
+)
+
+
+def _svc(tmp_path):
+    (tmp_path / "trust").mkdir(exist_ok=True)
+    (tmp_path / "skills").mkdir(exist_ok=True)
+    return SkillTrustService(
+        skills_dir=tmp_path / "skills",
+        trust_store=SkillTrustStore(
+            store_dir=tmp_path / "trust",
+            marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "trust" / "m.json"),
+        ),
+        key_cache=None,
+    )
+
+
+def test_verify_content_tolerates_binary_and_exec(tmp_path):
+    import os, stat
+    d = tmp_path / "skills" / "demo"
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text("body\n", encoding="utf-8")
+    (d / "assets").mkdir()
+    (d / "assets" / "logo.png").write_bytes(b"\x89PNG\x00bin")   # binary → in manifest, not in text view
+    (d / "scripts").mkdir()
+    (d / "scripts" / "run.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+    os.chmod(d / "scripts" / "run.sh", 0o755)                    # executable text
+    svc = _svc(tmp_path)
+    svc.bootstrap_trust("pw", salt=secrets.token_bytes(32))      # trusts the full bundle
+    # verify_skill_content receives the TEXT view (no binary; run.sh present but mode unknown).
+    svc.verify_skill_content(
+        "demo",
+        skill_content="body\n",
+        supporting_files={"scripts/run.sh": "#!/bin/sh\n"},
+    )   # must NOT raise (was raising: assets/logo.png "missing", scripts/run.sh "modified")
+
+
+def test_verify_content_still_catches_modified_text_body(tmp_path):
+    d = tmp_path / "skills" / "demo"
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text("body\n", encoding="utf-8")
+    svc = _svc(tmp_path)
+    svc.bootstrap_trust("pw", salt=secrets.token_bytes(32))
+    from tldw_chatbook.Skills_Interop.skill_trust_service import SkillTrustBlockedError
+    with pytest.raises(SkillTrustBlockedError):
+        svc.verify_skill_content("demo", skill_content="TAMPERED\n", supporting_files=None)

--- a/Tests/Skills/test_zip_export_roundtrip.py
+++ b/Tests/Skills/test_zip_export_roundtrip.py
@@ -1,0 +1,22 @@
+import io, os, stat, zipfile, pytest
+from tldw_chatbook.Skills_Interop.local_skills_service import LocalSkillsService
+
+
+@pytest.mark.asyncio
+async def test_export_roundtrip_preserves_tree_and_mode(tmp_path):
+    svc = LocalSkillsService(store_dir=tmp_path)
+    await svc.create_skill(name="demo", content="---\nname: demo\n---\nbody\n")
+    d = svc._skill_dir("demo")
+    (d / "scripts").mkdir(parents=True, exist_ok=True)
+    (d / "scripts" / "run.sh").write_bytes(b"#!/bin/sh\n")
+    os.chmod(d / "scripts" / "run.sh", 0o755)
+    (d / "assets").mkdir(exist_ok=True)
+    (d / "assets" / "logo.png").write_bytes(b"\x89PNG\x00bin")
+
+    export = await svc.export_skill("demo")
+    with zipfile.ZipFile(io.BytesIO(export["content"])) as z:
+        names = set(z.namelist())
+        assert {"SKILL.md", "scripts/run.sh", "assets/logo.png"} <= names
+        assert z.read("assets/logo.png") == b"\x89PNG\x00bin"
+        info = z.getinfo("scripts/run.sh")
+        assert (info.external_attr >> 16) & stat.S_IXUSR

--- a/Tests/Skills/test_zip_export_roundtrip.py
+++ b/Tests/Skills/test_zip_export_roundtrip.py
@@ -20,3 +20,40 @@ async def test_export_roundtrip_preserves_tree_and_mode(tmp_path):
         assert z.read("assets/logo.png") == b"\x89PNG\x00bin"
         info = z.getinfo("scripts/run.sh")
         assert (info.external_attr >> 16) & stat.S_IXUSR
+
+
+@pytest.mark.asyncio
+async def test_export_skill_missing_body_raises_domain_error_not_raw_oserror(
+    tmp_path,
+):
+    """Merge-gate review (PR #784, MINOR finding): the top-level SKILL.md
+    read in ``export_skill`` had no ``is_file()``/symlink guard, unlike
+    every other body-read path in this service. A corrupted store (index
+    entry present, on-disk body missing) must fail export with a domain
+    ``ValueError`` naming the skill -- never a raw ``FileNotFoundError``
+    leaking out of ``read_bytes()``.
+    """
+    svc = LocalSkillsService(store_dir=tmp_path)
+    await svc.create_skill(name="demo", content="---\nname: demo\n---\nbody\n")
+    body = svc._skill_dir("demo") / "SKILL.md"
+    body.unlink()
+
+    with pytest.raises(ValueError, match="local_skill_missing_skill_md"):
+        await svc.export_skill("demo")
+
+
+@pytest.mark.asyncio
+async def test_export_skill_symlinked_body_is_rejected_not_followed(tmp_path):
+    """A SKILL.md body that is itself a symlink (to a file outside the
+    bundle) must be rejected, not followed -- mirrors
+    ``import_skill_directory``'s own symlinked-body guard."""
+    outside = tmp_path / "outside.md"
+    outside.write_text("---\nname: evil\n---\nleaked\n", encoding="utf-8")
+    svc = LocalSkillsService(store_dir=tmp_path / "store")
+    await svc.create_skill(name="demo", content="---\nname: demo\n---\nbody\n")
+    body = svc._skill_dir("demo") / "SKILL.md"
+    body.unlink()
+    body.symlink_to(outside)
+
+    with pytest.raises(ValueError, match="local_skill_missing_skill_md"):
+        await svc.export_skill("demo")

--- a/Tests/Skills/test_zip_import_bundle.py
+++ b/Tests/Skills/test_zip_import_bundle.py
@@ -34,3 +34,93 @@ async def test_zip_slip_rejected(tmp_path):
     data = _zip([("SKILL.md", b"body", 0), ("../evil.md", b"x", 0)])
     with pytest.raises(ValueError):
         await svc.import_skill_file(data, filename="z.zip", content_type="application/zip")
+
+
+# S_IFLNK (0o120000) | 0o777 -- a symlink member's unix mode in external_attr.
+_SYMLINK_MODE = 0o120777
+
+
+@pytest.mark.asyncio
+async def test_zip_import_skips_symlink_member(tmp_path):
+    """A symlink member is skipped (not materialized, not fatal); real siblings import."""
+    svc = LocalSkillsService(store_dir=tmp_path)
+    data = _zip([
+        ("SKILL.md", b"---\nname: sym\n---\nbody\n", 0),
+        ("evil-link", b"/etc/passwd", _SYMLINK_MODE),
+        ("real.txt", b"hi", 0),
+    ])
+    await svc.import_skill_file(data, filename="sym.zip", content_type="application/zip")
+    d = svc._skill_dir("sym")
+    assert not (d / "evil-link").exists()
+    assert (d / "real.txt").read_bytes() == b"hi"
+
+
+@pytest.mark.asyncio
+async def test_zip_import_rejects_case_fold_collision(tmp_path):
+    """Two members differing only in case would collide on a case-insensitive FS."""
+    svc = LocalSkillsService(store_dir=tmp_path)
+    data = _zip([
+        ("SKILL.md", b"---\nname: casec\n---\nbody\n", 0),
+        ("Notes.md", b"a", 0),
+        ("notes.md", b"b", 0),
+    ])
+    with pytest.raises(ValueError, match="case_collision"):
+        await svc.import_skill_file(data, filename="casec.zip", content_type="application/zip")
+
+
+@pytest.mark.asyncio
+async def test_zip_import_prunes_junk_members(tmp_path):
+    """VCS/build junk (``.git/…``, ``__pycache__/*.pyc``) is pruned; real files land."""
+    svc = LocalSkillsService(store_dir=tmp_path)
+    data = _zip([
+        ("SKILL.md", b"---\nname: junk\n---\nbody\n", 0),
+        (".git/config", b"[core]", 0),
+        ("__pycache__/x.pyc", b"\x00", 0),
+        ("keep.txt", b"keep", 0),
+    ])
+    await svc.import_skill_file(data, filename="junk.zip", content_type="application/zip")
+    d = svc._skill_dir("junk")
+    assert not (d / ".git").exists()
+    assert not (d / "__pycache__").exists()
+    assert (d / "keep.txt").read_bytes() == b"keep"
+
+
+@pytest.mark.asyncio
+async def test_zip_import_rejects_oversized_member_leaving_no_skill_dir(tmp_path):
+    """A member over the 5MB per-file cap is rejected BEFORE any skill dir exists.
+
+    Uses a ~5MB+1 highly-compressible member (single repeated byte) so the zip
+    stays tiny and the test is fast -- it exercises the ``member.file_size``
+    per-file guard, not a decompression-ratio bomb.
+    """
+    svc = LocalSkillsService(store_dir=tmp_path)
+    big = b"x" * (5 * 1024 * 1024 + 1)
+    data = _zip([
+        ("SKILL.md", b"---\nname: big\n---\nbody\n", 0),
+        ("big.bin", big, 0),
+    ])
+    with pytest.raises(ValueError, match="too_large"):
+        await svc.import_skill_file(data, filename="big.zip", content_type="application/zip")
+    assert not svc._skill_dir("big").exists()
+
+
+@pytest.mark.asyncio
+async def test_zip_import_rejects_too_many_members_leaving_no_skill_dir(tmp_path):
+    """Exceeding the 500-file count cap is rejected BEFORE any skill dir exists."""
+    svc = LocalSkillsService(store_dir=tmp_path)
+    members = [("SKILL.md", b"---\nname: many\n---\nbody\n", 0)]
+    for i in range(501):
+        members.append((f"f{i}.txt", b"x", 0))
+    data = _zip(members)
+    with pytest.raises(ValueError, match="too_many_files"):
+        await svc.import_skill_file(data, filename="many.zip", content_type="application/zip")
+    assert not svc._skill_dir("many").exists()
+
+
+@pytest.mark.asyncio
+async def test_zip_import_rejects_non_utf8_body_as_valueerror(tmp_path):
+    """A non-UTF-8 SKILL.md body raises a clear ValueError, not a raw decode error."""
+    svc = LocalSkillsService(store_dir=tmp_path)
+    data = _zip([("SKILL.md", b"\xff\xfe not utf8", 0)])
+    with pytest.raises(ValueError, match="local_skill_invalid_archive"):
+        await svc.import_skill_file(data, filename="bad.zip", content_type="application/zip")

--- a/Tests/Skills/test_zip_import_bundle.py
+++ b/Tests/Skills/test_zip_import_bundle.py
@@ -70,28 +70,42 @@ async def test_zip_import_rejects_case_fold_collision(tmp_path):
 
 @pytest.mark.asyncio
 async def test_zip_import_prunes_junk_members(tmp_path):
-    """VCS/build junk (``.git/…``, ``__pycache__/*.pyc``) is pruned; real files land."""
+    """Junk pruning is ISOLATED from the name-pattern reject.
+
+    Both members here have names the supporting-file NAME PATTERN would
+    otherwise ACCEPT, so their absence proves ``_is_junk`` /
+    ``SUPPORTING_JUNK_DIRS`` specifically (not the path validator):
+      * ``notes.pyc`` -- top-level, pattern-valid, dropped by ``_is_junk``
+        (``.pyc`` suffix).
+      * ``node_modules/lib.js`` -- pattern-valid path, dropped because
+        ``node_modules`` is in ``SUPPORTING_JUNK_DIRS``.
+    """
     svc = LocalSkillsService(store_dir=tmp_path)
     data = _zip([
         ("SKILL.md", b"---\nname: junk\n---\nbody\n", 0),
-        (".git/config", b"[core]", 0),
-        ("__pycache__/x.pyc", b"\x00", 0),
+        ("notes.pyc", b"\x00", 0),
+        ("node_modules/lib.js", b"x=1", 0),
         ("keep.txt", b"keep", 0),
     ])
     await svc.import_skill_file(data, filename="junk.zip", content_type="application/zip")
     d = svc._skill_dir("junk")
-    assert not (d / ".git").exists()
-    assert not (d / "__pycache__").exists()
+    assert not (d / "notes.pyc").exists()
+    assert not (d / "node_modules").exists()
     assert (d / "keep.txt").read_bytes() == b"keep"
 
 
 @pytest.mark.asyncio
-async def test_zip_import_rejects_oversized_member_leaving_no_skill_dir(tmp_path):
-    """A member over the 5MB per-file cap is rejected BEFORE any skill dir exists.
+async def test_zip_import_streams_and_rejects_member_whose_actual_content_exceeds_cap(
+    tmp_path,
+):
+    """A member whose ACTUAL content exceeds the 5MB per-file cap is rejected
+    BEFORE any skill dir exists.
 
     Uses a ~5MB+1 highly-compressible member (single repeated byte) so the zip
-    stays tiny and the test is fast -- it exercises the ``member.file_size``
-    per-file guard, not a decompression-ratio bomb.
+    stays tiny and the test is fast/CI-safe -- honest oversize content, no
+    decompression-ratio bomb. The rejection surfaces as the standard
+    ``ValueError`` contract (the ``file_size`` fast-path or the streaming
+    cumulative abort) and leaves no partial skill on disk.
     """
     svc = LocalSkillsService(store_dir=tmp_path)
     big = b"x" * (5 * 1024 * 1024 + 1)
@@ -99,9 +113,43 @@ async def test_zip_import_rejects_oversized_member_leaving_no_skill_dir(tmp_path
         ("SKILL.md", b"---\nname: big\n---\nbody\n", 0),
         ("big.bin", big, 0),
     ])
-    with pytest.raises(ValueError, match="too_large"):
+    with pytest.raises(ValueError, match="local_skill_file_too_large|corrupt_member"):
         await svc.import_skill_file(data, filename="big.zip", content_type="application/zip")
     assert not svc._skill_dir("big").exists()
+
+
+def _zip_with_understated_file_size(*, declared: int = 5) -> bytes:
+    """Build a zip whose ``big.bin`` central-directory ``file_size`` LIES.
+
+    The member is written with real (larger) content, then its ZipInfo's
+    ``file_size`` is mutated smaller before ``close()`` writes the central
+    directory -- so ``infolist()`` reports the understated size (defeating a
+    naive ``member.file_size`` pre-check) while the actual DEFLATE payload is
+    bigger. Reading such a member trips a CRC mismatch (``BadZipFile``); the
+    service must surface that as a ``ValueError``, never a raw ``BadZipFile``.
+    """
+    buf = io.BytesIO()
+    z = zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED)
+    z.writestr("SKILL.md", b"---\nname: forged\n---\nbody\n")
+    info = zipfile.ZipInfo("big.bin")
+    z.writestr(info, b"y" * 4096)   # local header + data written with real size
+    info.file_size = declared        # mutate BEFORE close -> central dir lies
+    z.close()
+    return buf.getvalue()
+
+
+@pytest.mark.asyncio
+async def test_zip_import_wraps_forged_understated_member_as_valueerror(tmp_path):
+    """A member with a forged/understated ``file_size`` header (a lying zip that
+    a pre-check cannot catch) surfaces as the standard ``ValueError`` contract,
+    not a raw ``zipfile.BadZipFile``, and leaves no skill dir behind."""
+    svc = LocalSkillsService(store_dir=tmp_path)
+    data = _zip_with_understated_file_size()
+    with pytest.raises(ValueError, match="corrupt_member|local_skill_file_too_large"):
+        await svc.import_skill_file(
+            data, filename="forged.zip", content_type="application/zip"
+        )
+    assert not svc._skill_dir("forged").exists()
 
 
 @pytest.mark.asyncio

--- a/Tests/Skills/test_zip_import_bundle.py
+++ b/Tests/Skills/test_zip_import_bundle.py
@@ -29,6 +29,27 @@ async def test_zip_import_nested_binary_exec(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_zip_import_narrows_exec_bit_widening_to_owner_only(tmp_path):
+    """Same owner-exec-only trust contract as the directory-import path: the
+    zip import's exec-bit-preservation chmod must not widen group/other
+    permissions beyond what the freshly written dest file already has (zero
+    exec bits, since Python's default open() mode carries none)."""
+    svc = LocalSkillsService(store_dir=tmp_path)
+    data = _zip([
+        ("SKILL.md", b"---\nname: narrowexec\n---\nbody\n", 0),
+        ("scripts/run.sh", b"#!/bin/sh\n", 0o700),  # owner-only exec in the archive
+    ])
+    await svc.import_skill_file(
+        data, filename="narrowexec.zip", content_type="application/zip"
+    )
+    d = svc._skill_dir("narrowexec")
+    dest_mode = d.joinpath("scripts", "run.sh").stat().st_mode
+    assert dest_mode & stat.S_IXUSR        # owner-exec preserved
+    assert not dest_mode & stat.S_IXGRP    # group-exec NOT widened
+    assert not dest_mode & stat.S_IXOTH    # other-exec NOT widened
+
+
+@pytest.mark.asyncio
 async def test_zip_slip_rejected(tmp_path):
     svc = LocalSkillsService(store_dir=tmp_path)
     data = _zip([("SKILL.md", b"body", 0), ("../evil.md", b"x", 0)])
@@ -163,6 +184,25 @@ async def test_zip_import_rejects_too_many_members_leaving_no_skill_dir(tmp_path
     with pytest.raises(ValueError, match="too_many_files"):
         await svc.import_skill_file(data, filename="many.zip", content_type="application/zip")
     assert not svc._skill_dir("many").exists()
+
+
+@pytest.mark.asyncio
+async def test_zip_import_skips_empty_named_member(tmp_path):
+    """A crafted non-directory member with a zero-length name must not raise a
+    raw IndexError -- it's skipped (junk/invalid), matching the symlink/junk
+    skip-not-fail contract used for other unroutable members. The rest of the
+    archive still imports cleanly."""
+    svc = LocalSkillsService(store_dir=tmp_path)
+    data = _zip([
+        ("SKILL.md", b"---\nname: emptymember\n---\nbody\n", 0),
+        ("", b"mystery", 0),
+        ("real.txt", b"hi", 0),
+    ])
+    await svc.import_skill_file(
+        data, filename="emptymember.zip", content_type="application/zip"
+    )
+    d = svc._skill_dir("emptymember")
+    assert (d / "real.txt").read_bytes() == b"hi"
 
 
 @pytest.mark.asyncio

--- a/Tests/Skills/test_zip_import_bundle.py
+++ b/Tests/Skills/test_zip_import_bundle.py
@@ -1,0 +1,36 @@
+import io, zipfile, stat, pytest
+from tldw_chatbook.Skills_Interop.local_skills_service import LocalSkillsService
+
+
+def _zip(members):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        for name, data, mode in members:
+            info = zipfile.ZipInfo(name)
+            if mode:
+                info.external_attr = mode << 16
+            z.writestr(info, data)
+    return buf.getvalue()
+
+
+@pytest.mark.asyncio
+async def test_zip_import_nested_binary_exec(tmp_path):
+    svc = LocalSkillsService(store_dir=tmp_path)
+    data = _zip([
+        ("SKILL.md", b"---\nname: z\n---\nbody\n", 0),
+        ("scripts/run.sh", b"#!/bin/sh\n", 0o755),
+        ("assets/logo.png", b"\x89PNG\x00bin", 0),
+    ])
+    await svc.import_skill_file(data, filename="z.zip", content_type="application/zip")
+    d = svc._skill_dir("z")
+    assert (d / "scripts" / "run.sh").read_bytes() == b"#!/bin/sh\n"
+    assert d.joinpath("scripts", "run.sh").stat().st_mode & stat.S_IXUSR
+    assert (d / "assets" / "logo.png").read_bytes() == b"\x89PNG\x00bin"
+
+
+@pytest.mark.asyncio
+async def test_zip_slip_rejected(tmp_path):
+    svc = LocalSkillsService(store_dir=tmp_path)
+    data = _zip([("SKILL.md", b"body", 0), ("../evil.md", b"x", 0)])
+    with pytest.raises(ValueError):
+        await svc.import_skill_file(data, filename="z.zip", content_type="application/zip")

--- a/Tests/UI/test_library_skills_canvas.py
+++ b/Tests/UI/test_library_skills_canvas.py
@@ -33,6 +33,7 @@ from tldw_chatbook.Library.library_shell_state import (
 )
 from tldw_chatbook.Library.library_skills_state import (
     SkillEditorState,
+    SkillEditorSupportingFile,
     SkillListRow,
     SkillsListState,
 )
@@ -329,7 +330,9 @@ def _editor_state(
     context: str = "inline",
     model: str | None = None,
     body: str = "Review the diff.",
-    supporting_files: tuple[tuple[str, int], ...] = (("checklist.md", 42),),
+    supporting_files: tuple[SkillEditorSupportingFile, ...] = (
+        SkillEditorSupportingFile(name="checklist.md", size=42),
+    ),
     version: int | None = 3,
     trust_status: str = "trusted",
     trust_blocked: bool = False,

--- a/Tests/tldw_api/test_skills_schemas_bundle.py
+++ b/Tests/tldw_api/test_skills_schemas_bundle.py
@@ -1,0 +1,48 @@
+import pytest
+
+from tldw_chatbook.tldw_api.skills_schemas import (
+    validate_supporting_file_path,
+    BundleFileInfo,
+    MAX_SUPPORTING_FILES_COUNT,
+)
+
+
+@pytest.mark.parametrize("good", [
+    "notes.md",
+    "scripts/build.sh",
+    "references/api/reference.md",
+    "assets/img/logo.png",
+])
+def test_validate_supporting_file_path_accepts_nested(good):
+    assert validate_supporting_file_path(good) == good
+
+
+@pytest.mark.parametrize("bad", [
+    "/abs.md",                # absolute
+    "../escape.md",           # traversal
+    "a/../b.md",              # traversal segment
+    "a/./b.md",               # dot segment
+    "a//b.md",                # empty segment
+    "back\\slash.md",         # backslash
+    "SKILL.md",               # reserved body (root)
+    "refs/SKILL.md",          # nested shadow (any case)
+    "refs/skill.md",          # nested shadow wrong-case
+    "-leading-dash.md",       # segment must start alnum
+    ".dotfile",                # leading dot
+    "a/" * 9 + "deep.md",     # depth > 8
+    "x" * 256,                # length > 255
+])
+def test_validate_supporting_file_path_rejects(bad):
+    with pytest.raises(ValueError):
+        validate_supporting_file_path(bad)
+
+
+def test_bundle_file_info_shape():
+    info = BundleFileInfo(path="assets/logo.png", size=1234, executable=False, is_text=False)
+    assert info.model_dump() == {
+        "path": "assets/logo.png", "size": 1234, "executable": False, "is_text": False,
+    }
+
+
+def test_caps_raised():
+    assert MAX_SUPPORTING_FILES_COUNT == 500

--- a/tldw_chatbook/Library/library_skills_state.py
+++ b/tldw_chatbook/Library/library_skills_state.py
@@ -8,8 +8,8 @@ Consumes record mappings shaped like ``LocalSkillsService.get_context``'s
 ``trust_reason_code``/``trust_changed_files``/... from
 ``LocalSkillsService._trust_fields_for_record``) and detail mappings shaped
 like ``LocalSkillsService.get_skill``'s response (a ``SkillResponse`` dump --
-adds ``content``, ``supporting_files``, ``version`` -- plus the same trust
-fields).
+adds ``content``, ``supporting_files``, ``bundle_files``, ``version`` -- plus
+the same trust fields).
 
 No Textual/DB/IO imports. The only non-stdlib imports are ``yaml`` (frontmatter
 serialization -- matches the service's own use of it), the static
@@ -90,6 +90,25 @@ class SkillsListState:
 
 
 @dataclass(frozen=True)
+class SkillEditorSupportingFile:
+    """One row in the skill editor's read-only supporting-files list.
+
+    Attributes:
+        name: The file's path, relative to the skill's directory. Nested
+            paths (e.g. ``"references/api.md"``) render as-is.
+        size: The file's size in bytes.
+        is_text: Whether the file is text. ``False`` marks a binary file
+            as view-only (it can't be edited as text). Defaults to
+            ``True`` so the ``supporting_files``-only fallback path
+            (which only ever carries decoded text) stays correct.
+    """
+
+    name: str
+    size: int
+    is_text: bool = True
+
+
+@dataclass(frozen=True)
 class SkillEditorState:
     """Display state for the Library Skills canvas's in-canvas editor.
 
@@ -108,7 +127,9 @@ class SkillEditorState:
         body: The skill's prompt body (the text after the frontmatter
             block), verbatim.
         supporting_files: The skill's supporting files as sorted
-            ``(name, byte_length)`` pairs.
+            ``SkillEditorSupportingFile`` rows (built from ``bundle_files``
+            when present -- covering nested paths and binaries -- falling
+            back to ``supporting_files`` (text only) otherwise).
         version: The skill's optimistic-lock version, or ``None`` when
             unknown.
         trust_status: The skill's current trust status.
@@ -126,7 +147,7 @@ class SkillEditorState:
     context: str
     model: str | None
     body: str
-    supporting_files: tuple[tuple[str, int], ...]
+    supporting_files: tuple[SkillEditorSupportingFile, ...]
     version: int | None
     trust_status: str
     trust_blocked: bool
@@ -371,20 +392,46 @@ def build_skill_editor_state(detail: Mapping[str, Any]) -> SkillEditorState:
     Returns:
         Immutable editor state, with ``allowed_tools`` joined into a
         single comma-separated string and ``supporting_files`` reduced to
-        sorted ``(name, byte_length)`` pairs.
+        sorted ``SkillEditorSupportingFile`` rows -- built from
+        ``bundle_files`` (nested paths, binaries included) when present,
+        falling back to ``supporting_files`` (text only, e.g. a
+        remote/server skill that doesn't populate ``bundle_files``)
+        otherwise.
     """
     if not isinstance(detail, Mapping):
         detail = {}
     content = _raw_text(detail.get("content"))
     front_matter, body = LocalSkillsService._parse_front_matter(content)
 
-    supporting_source = detail.get("supporting_files") or {}
-    supporting_files = tuple(
-        sorted(
-            (name, len(str(text).encode("utf-8")))
-            for name, text in supporting_source.items()
+    bundle_source = detail.get("bundle_files")
+    if bundle_source:
+        supporting_files = tuple(
+            sorted(
+                (
+                    SkillEditorSupportingFile(
+                        name=_text(entry.get("path")),
+                        size=_to_int(entry.get("size")) or 0,
+                        is_text=bool(entry.get("is_text", True)),
+                    )
+                    for entry in bundle_source
+                    if isinstance(entry, Mapping)
+                ),
+                key=lambda row: row.name,
+            )
         )
-    )
+    else:
+        supporting_source = detail.get("supporting_files") or {}
+        supporting_files = tuple(
+            sorted(
+                (
+                    SkillEditorSupportingFile(
+                        name=name, size=len(str(text).encode("utf-8"))
+                    )
+                    for name, text in supporting_source.items()
+                ),
+                key=lambda row: row.name,
+            )
+        )
 
     changed_files = detail.get("trust_changed_files") or ()
 

--- a/tldw_chatbook/Skills_Interop/local_skills_service.py
+++ b/tldw_chatbook/Skills_Interop/local_skills_service.py
@@ -1022,7 +1022,9 @@ class LocalSkillsService:
                 dest = skill_dir / PurePosixPath(relative_path)
                 self._write_bytes_atomic(dest, abs_path.read_bytes())
                 if abs_path.stat().st_mode & stat.S_IXUSR:
-                    os.chmod(dest, dest.stat().st_mode | 0o755)
+                    # Trust only the owner-exec fingerprint; adding 0o755 would
+                    # widen a non-world-readable source to world-r/x.
+                    os.chmod(dest, dest.stat().st_mode | 0o100)
             record = self._metadata_from_content(
                 name=skill_name,
                 content=content,
@@ -1086,6 +1088,8 @@ class LocalSkillsService:
                 if _stat.S_ISLNK(mode):
                     continue                       # symlink member: skip-not-fail
                 parts = PurePosixPath(member.filename).parts
+                if not parts:
+                    continue                       # empty/all-slash member name: skip-not-fail
                 if any(p in SUPPORTING_JUNK_DIRS for p in parts) or _is_junk(parts[-1]):
                     continue                       # junk pruned
                 member_name = self._validate_archive_member(member.filename)  # raises on zip-slip
@@ -1137,7 +1141,9 @@ class LocalSkillsService:
             # Every dest was contained-checked during collection; write only now.
             self._write_bytes_atomic(dest, data)
             if executable:
-                _os.chmod(dest, dest.stat().st_mode | 0o755)
+                # Trust only the owner-exec fingerprint; adding 0o755 would
+                # widen a non-world-readable source to world-r/x.
+                _os.chmod(dest, dest.stat().st_mode | 0o100)
         # Re-derive trust state now that the full bundle is on disk.
         self._trust_after_approved_mutation(skill_name, trust_approved=trust_approved)
         return self._response_for_record(self._load_index()[skill_name])

--- a/tldw_chatbook/Skills_Interop/local_skills_service.py
+++ b/tldw_chatbook/Skills_Interop/local_skills_service.py
@@ -1027,9 +1027,16 @@ class LocalSkillsService:
             MAX_SUPPORTING_FILES_TOTAL_BYTES,
         )
         skill_name = self._derive_name_from_filename(filename)
-        members: list[tuple[str, bytes, bool]] = []
+        # Compute the (not-yet-created) destination dir up front so every member
+        # can be fully validated -- caps, zip-slip containment, decodability --
+        # BEFORE import_skill creates SKILL.md + an index entry. A rejection then
+        # leaves no partial trust-pending skill behind (atomicity).
+        skill_dir = self._skill_dir(skill_name)
+        base = skill_dir.resolve()
+        members: list[tuple[Path, bytes, bool]] = []
         skill_content: str | None = None
         total = 0
+        count = 0
         seen_lower: set[str] = set()
         with zipfile.ZipFile(io.BytesIO(file_content), "r") as archive:
             for member in archive.infolist():
@@ -1046,32 +1053,47 @@ class LocalSkillsService:
                 if lower in seen_lower:             # case-fold collision on a case-insensitive FS
                     raise ValueError(f"local_skill_invalid_archive:case_collision:{member_name}")
                 seen_lower.add(lower)
-                data = archive.read(member)
-                if len(data) > MAX_SUPPORTING_FILE_BYTES:
+                # DoS guard: reject by the DECLARED uncompressed size (free from
+                # the zip header) BEFORE inflating. A crafted DEFLATE member can
+                # carry multiple GB from a few-MB upload and OOM the process if we
+                # read first and check after.
+                if member.file_size > MAX_SUPPORTING_FILE_BYTES:
                     raise ValueError(f"local_skill_file_too_large:{member_name}")
-                total += len(data)
+                total += member.file_size
+                if total > MAX_SUPPORTING_FILES_TOTAL_BYTES:     # early exit before more reads
+                    raise ValueError("local_skill_bundle_too_large")
                 if member_name == _SKILL_FILENAME:
-                    skill_content = data.decode("utf-8")
-                else:
-                    members.append((member_name, data, bool(mode & 0o111)))
+                    data = archive.read(member)
+                    if len(data) > MAX_SUPPORTING_FILE_BYTES:    # lying-header guard
+                        raise ValueError(f"local_skill_file_too_large:{member_name}")
+                    try:
+                        skill_content = data.decode("utf-8")
+                    except UnicodeDecodeError as exc:
+                        raise ValueError(
+                            f"local_skill_invalid_archive:non_utf8_body:{member_name}"
+                        ) from exc
+                    continue
+                count += 1
+                if count > MAX_SUPPORTING_FILES_COUNT:           # early exit before more reads
+                    raise ValueError("local_skill_too_many_files")
+                # Zip-slip containment resolved against the computed dest BEFORE
+                # anything is created on disk.
+                dest = skill_dir / PurePosixPath(member_name)
+                if base not in dest.resolve().parents:
+                    raise ValueError(f"local_skill_invalid_archive:{member_name}")
+                data = archive.read(member)
+                if len(data) > MAX_SUPPORTING_FILE_BYTES:        # lying-header guard
+                    raise ValueError(f"local_skill_file_too_large:{member_name}")
+                members.append((dest, data, bool(mode & 0o111)))
         if skill_content is None:
             raise ValueError("local_skill_invalid_archive:missing_skill_md")
-        if len(members) > MAX_SUPPORTING_FILES_COUNT:
-            raise ValueError("local_skill_too_many_files")
-        if total > MAX_SUPPORTING_FILES_TOTAL_BYTES:
-            raise ValueError("local_skill_bundle_too_large")
-        result = await self.import_skill(
+        await self.import_skill(
             name=skill_name, content=skill_content, overwrite=overwrite,
             trust_approved=False,   # re-trusted below only if approved
         )
-        skill_dir = self._skill_dir(skill_name)
-        base = skill_dir.resolve()
         import os as _os
-        from pathlib import PurePosixPath as _PP
-        for member_name, data, executable in members:
-            dest = skill_dir / _PP(member_name)
-            if base not in dest.resolve().parents:
-                raise ValueError(f"local_skill_invalid_archive:{member_name}")
+        for dest, data, executable in members:
+            # Every dest was contained-checked during collection; write only now.
             self._write_bytes_atomic(dest, data)
             if executable:
                 _os.chmod(dest, dest.stat().st_mode | 0o755)

--- a/tldw_chatbook/Skills_Interop/local_skills_service.py
+++ b/tldw_chatbook/Skills_Interop/local_skills_service.py
@@ -941,7 +941,9 @@ class LocalSkillsService:
         skill_name = _normalize_skill_name(name)
         source_dir = Path(source_dir)
         body = source_dir / _SKILL_FILENAME
-        if not body.is_file():
+        # A symlinked SKILL.md would read its (out-of-bundle) target into the
+        # skill body -- reject it as an invalid body, not follow it.
+        if body.is_symlink() or not body.is_file():
             raise ValueError("local_skill_missing_skill_md")
         content = body.read_text(encoding="utf-8", errors="strict")
         # Enforce the same body-length bounds ``import_skill`` gets for free from
@@ -952,7 +954,11 @@ class LocalSkillsService:
         files: list[tuple[str, Path]] = []
         total = 0
         for relative_path, abs_path in self._iter_bundle_files(source_dir):
-            if abs_path.is_symlink():
+            # Skip symlinks and non-regular files (FIFOs/sockets/device nodes):
+            # opening a FIFO with no writer would block read_bytes() forever --
+            # and this runs under self._lock, so it would wedge the whole store.
+            # Mirrors the guard in _read_supporting_files/_read_bundle_manifest.
+            if abs_path.is_symlink() or not abs_path.is_file():
                 continue  # skip-not-fail
             try:
                 validate_supporting_file_path(relative_path)

--- a/tldw_chatbook/Skills_Interop/local_skills_service.py
+++ b/tldw_chatbook/Skills_Interop/local_skills_service.py
@@ -915,6 +915,88 @@ class LocalSkillsService:
             )
             return self._response_for_record(record)
 
+    async def import_skill_directory(
+        self,
+        source_dir: Path,
+        *,
+        name: str,
+        overwrite: bool = False,
+        trust_approved: bool = False,
+    ) -> dict[str, Any]:
+        import os
+        import stat
+        from pathlib import PurePosixPath
+
+        # Deferred import: avoid module-scope tldw_api schema import (task-285 phase 2).
+        from ..tldw_api import SkillImportRequest
+        from ..tldw_api.skills_schemas import (
+            MAX_SUPPORTING_FILE_BYTES,
+            MAX_SUPPORTING_FILES_COUNT,
+            MAX_SUPPORTING_FILES_TOTAL_BYTES,
+            _normalize_skill_name,
+            validate_supporting_file_path,
+        )
+
+        self._enforce("skills.import.launch.local")
+        skill_name = _normalize_skill_name(name)
+        source_dir = Path(source_dir)
+        body = source_dir / _SKILL_FILENAME
+        if not body.is_file():
+            raise ValueError("local_skill_missing_skill_md")
+        content = body.read_text(encoding="utf-8", errors="strict")
+        # Enforce the same body-length bounds ``import_skill`` gets for free from
+        # ``SkillImportRequest`` -- this path builds the record directly rather
+        # than routing content through that model, so the check is explicit here.
+        SkillImportRequest(name=skill_name, content=content)
+        # Collect the faithful file set (junk pruned, symlinks skipped, caps enforced).
+        files: list[tuple[str, Path]] = []
+        total = 0
+        for relative_path, abs_path in self._iter_bundle_files(source_dir):
+            if abs_path.is_symlink():
+                continue  # skip-not-fail
+            try:
+                validate_supporting_file_path(relative_path)
+            except ValueError:
+                continue
+            size = abs_path.stat().st_size
+            if size > MAX_SUPPORTING_FILE_BYTES:
+                raise ValueError(f"local_skill_file_too_large:{relative_path}")
+            total += size
+            files.append((relative_path, abs_path))
+        if len(files) > MAX_SUPPORTING_FILES_COUNT:
+            raise ValueError("local_skill_too_many_files")
+        if total > MAX_SUPPORTING_FILES_TOTAL_BYTES:
+            raise ValueError("local_skill_bundle_too_large")
+        async with self._lock:
+            records = self._load_index()
+            if skill_name in records and not overwrite:
+                raise ValueError(f"local_skill_exists:{skill_name}")
+            skill_dir = self._skill_dir(skill_name)
+            if overwrite and skill_dir.exists():
+                shutil.rmtree(skill_dir)
+            skill_dir.mkdir(parents=True, exist_ok=True)
+            existing = records.get(skill_name) if overwrite else None
+            self._write_text_atomic(skill_dir / _SKILL_FILENAME, content)
+            for relative_path, abs_path in files:
+                dest = skill_dir / PurePosixPath(relative_path)
+                self._write_bytes_atomic(dest, abs_path.read_bytes())
+                if abs_path.stat().st_mode & stat.S_IXUSR:
+                    os.chmod(dest, dest.stat().st_mode | 0o755)
+            record = self._metadata_from_content(
+                name=skill_name,
+                content=content,
+                skill_dir=skill_dir,
+                existing=existing,
+            )
+            if existing is not None:
+                record["version"] = int(existing.get("version", 0)) + 1
+            records[skill_name] = record
+            self._save_index(records)
+            self._trust_after_approved_mutation(
+                skill_name, trust_approved=trust_approved
+            )
+            return self._response_for_record(record)
+
     async def import_skill_file(
         self,
         file_content: bytes,

--- a/tldw_chatbook/Skills_Interop/local_skills_service.py
+++ b/tldw_chatbook/Skills_Interop/local_skills_service.py
@@ -1143,20 +1143,31 @@ class LocalSkillsService:
         return self._response_for_record(self._load_index()[skill_name])
 
     async def export_skill(self, skill_name: str) -> Any:
+        import stat
+
+        from ..tldw_api.skills_schemas import _normalize_skill_name
+
         self._enforce("skills.export.launch.local")
-        skill = await self.get_skill(skill_name)
+        normalized = _normalize_skill_name(skill_name)
+        skill_dir = self._skill_dir(normalized)
         archive_buffer = io.BytesIO()
         with zipfile.ZipFile(
             archive_buffer, "w", compression=zipfile.ZIP_DEFLATED
         ) as archive:
-            archive.writestr(_SKILL_FILENAME, skill["content"])
-            for filename, content in sorted(
-                (skill.get("supporting_files") or {}).items()
+            body = skill_dir / _SKILL_FILENAME
+            archive.writestr(_SKILL_FILENAME, body.read_bytes())
+            for relative_path, path in sorted(
+                self._iter_bundle_files(skill_dir), key=lambda x: x[0]
             ):
-                archive.writestr(filename, content)
+                if path.is_symlink() or not path.is_file():
+                    continue
+                info = zipfile.ZipInfo(relative_path)
+                mode = path.stat().st_mode
+                info.external_attr = (mode & 0xFFFF) << 16
+                archive.writestr(info, path.read_bytes())
         return {
             "content": archive_buffer.getvalue(),
-            "filename": f"{skill['name']}.zip",
+            "filename": f"{normalized}.zip",
             "content_type": "application/zip",
         }
 

--- a/tldw_chatbook/Skills_Interop/local_skills_service.py
+++ b/tldw_chatbook/Skills_Interop/local_skills_service.py
@@ -154,6 +154,14 @@ class LocalSkillsService:
         temp_path.replace(path)
 
     @staticmethod
+    def _write_bytes_atomic(path: Path, data: bytes) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = path.with_name(f"{path.name}.tmp")
+        with temp_path.open("wb") as handle:
+            handle.write(data)
+        temp_path.replace(path)
+
+    @staticmethod
     def _parse_front_matter(content: str) -> tuple[dict[str, Any], str]:
         match = _FRONT_MATTER_PATTERN.match(content)
         if match is None:
@@ -389,20 +397,93 @@ class LocalSkillsService:
         return base
 
     @staticmethod
-    def _read_supporting_files(skill_dir: Path) -> dict[str, str] | None:
+    def _iter_bundle_files(skill_dir: Path):
+        """Yield (relative_posix, abs_path) for every non-junk file, junk dirs pruned.
+
+        Skips the top-level ``SKILL.md`` body by comparing the POSIX relative
+        path to exactly ``"SKILL.md"`` -- not by a fragile ``Path(root) ==
+        skill_dir`` comparison. A nested file literally named ``SKILL.md``
+        (e.g. ``references/SKILL.md``) is therefore NOT skipped here; it is
+        later rejected by ``validate_supporting_file_path``, which is the
+        correct handling for a shadow body file.
+        """
+        from .skill_trust_scanner import SUPPORTING_JUNK_DIRS, _is_junk  # reuse
+        import os
+        from pathlib import PurePosixPath
+
         if not skill_dir.exists():
-            return None
-        supporting_files: dict[str, str] = {}
-        for path in sorted(skill_dir.iterdir(), key=lambda item: item.name):
-            if not path.is_file() or path.name == _SKILL_FILENAME:
-                continue
-            supporting_files[path.name] = (
-                LocalSkillsService._read_text_preserving_newlines(
-                    path,
-                    base_dir=skill_dir,
+            return
+        for root, dirs, files in os.walk(skill_dir, followlinks=False):
+            dirs[:] = [d for d in dirs if d not in SUPPORTING_JUNK_DIRS]
+            for name in files:
+                if _is_junk(name):
+                    continue
+                abs_path = Path(root) / name
+                relative_path = str(
+                    PurePosixPath(abs_path.relative_to(skill_dir).as_posix())
                 )
-            )
+                if relative_path == _SKILL_FILENAME:
+                    continue
+                yield relative_path, abs_path
+
+    @staticmethod
+    def _read_supporting_files(skill_dir: Path) -> dict[str, str] | None:
+        from ..tldw_api.skills_schemas import validate_supporting_file_path
+
+        supporting_files: dict[str, str] = {}
+        for relative_path, path in sorted(
+            LocalSkillsService._iter_bundle_files(skill_dir), key=lambda x: x[0]
+        ):
+            if path.is_symlink():
+                continue
+            try:
+                validate_supporting_file_path(relative_path)
+            except ValueError:
+                continue
+            try:
+                raw = path.read_bytes()
+            except OSError:
+                continue
+            if b"\x00" in raw:
+                continue
+            try:
+                supporting_files[relative_path] = raw.decode("utf-8")
+            except UnicodeDecodeError:
+                continue  # binary — excluded from the text view, never raises
         return supporting_files or None
+
+    @staticmethod
+    def _read_bundle_manifest(skill_dir: Path) -> list[dict[str, Any]] | None:
+        import stat
+
+        from ..tldw_api.skills_schemas import validate_supporting_file_path
+
+        manifest: list[dict[str, Any]] = []
+        for relative_path, path in sorted(
+            LocalSkillsService._iter_bundle_files(skill_dir), key=lambda x: x[0]
+        ):
+            if path.is_symlink() or not path.is_file():
+                continue
+            try:
+                validate_supporting_file_path(relative_path)
+                raw = path.read_bytes()
+            except (ValueError, OSError):
+                continue
+            is_text = b"\x00" not in raw
+            if is_text:
+                try:
+                    raw.decode("utf-8")
+                except UnicodeDecodeError:
+                    is_text = False
+            manifest.append(
+                {
+                    "path": relative_path,
+                    "size": len(raw),
+                    "executable": bool(path.stat().st_mode & stat.S_IXUSR),
+                    "is_text": is_text,
+                }
+            )
+        return manifest or None
 
     @staticmethod
     def _read_text_preserving_newlines(
@@ -432,6 +513,7 @@ class LocalSkillsService:
             **record,
             content=content,
             supporting_files=self._read_supporting_files(skill_dir),
+            bundle_files=self._read_bundle_manifest(skill_dir),
         )
         payload = self._dump(response)
         payload.update(self._trust_fields_for_record(record))
@@ -560,10 +642,16 @@ class LocalSkillsService:
     def _apply_supporting_files(
         skill_dir: Path, supporting_files: dict[str, str | None] | None
     ) -> None:
+        from ..tldw_api.skills_schemas import validate_supporting_file_path
+
         if supporting_files is None:
             return
+        base = skill_dir.resolve()
         for filename, content in supporting_files.items():
+            validate_supporting_file_path(filename)  # raises on traversal/bad name
             path = skill_dir / filename
+            if base not in path.resolve().parents and path.resolve() != base:
+                raise ValueError(f"unsafe supporting file path: {filename}")
             if content is None:
                 if path.exists():
                     path.unlink()

--- a/tldw_chatbook/Skills_Interop/local_skills_service.py
+++ b/tldw_chatbook/Skills_Interop/local_skills_service.py
@@ -685,6 +685,46 @@ class LocalSkillsService:
             return _SKILL_FILENAME
         return validate_supporting_file_path(str(posix))
 
+    @staticmethod
+    def _read_zip_member_bounded(
+        archive: "zipfile.ZipFile",
+        member: "zipfile.ZipInfo",
+        member_name: str,
+        max_bytes: int,
+    ) -> bytes:
+        """Read a zip member with a bounded, streaming decompress.
+
+        Pulls fixed-size chunks via ``archive.open(member)`` so the transient
+        decompressor allocation is capped at ~one chunk regardless of the
+        member's (possibly forged/understated) declared ``file_size`` -- unlike
+        ``archive.read(member)``, which decompresses the whole member into RAM
+        before truncating output, letting a high-ratio DEFLATE bomb spike memory
+        to hundreds of MB from a few-hundred-KB upload. Aborts the moment
+        cumulative bytes exceed ``max_bytes``; a corrupt/forged member (CRC
+        mismatch, bad deflate stream) surfaces as the standard ``ValueError``
+        contract, never a raw ``zipfile.BadZipFile``.
+        """
+        import zlib
+
+        chunk_size = 65536
+        buffer = bytearray()
+        try:
+            with archive.open(member) as handle:
+                while True:
+                    chunk = handle.read(chunk_size)
+                    if not chunk:
+                        break
+                    buffer.extend(chunk)
+                    if len(buffer) > max_bytes:
+                        raise ValueError(
+                            f"local_skill_file_too_large:{member_name}"
+                        )
+        except (zipfile.BadZipFile, zlib.error, OSError) as exc:
+            raise ValueError(
+                f"local_skill_invalid_archive:corrupt_member:{member_name}"
+            ) from exc
+        return bytes(buffer)
+
     async def list_skills(
         self,
         *,
@@ -1053,19 +1093,20 @@ class LocalSkillsService:
                 if lower in seen_lower:             # case-fold collision on a case-insensitive FS
                     raise ValueError(f"local_skill_invalid_archive:case_collision:{member_name}")
                 seen_lower.add(lower)
-                # DoS guard: reject by the DECLARED uncompressed size (free from
-                # the zip header) BEFORE inflating. A crafted DEFLATE member can
-                # carry multiple GB from a few-MB upload and OOM the process if we
-                # read first and check after.
+                # DoS guard, fast path: reject an obviously-oversized DECLARED
+                # size (free from the zip header) without even opening the
+                # member. The real defense is the bounded streaming read below
+                # -- a forged/understated header cannot slip past it because it
+                # aborts on CUMULATIVE bytes actually read, not the declared size.
                 if member.file_size > MAX_SUPPORTING_FILE_BYTES:
                     raise ValueError(f"local_skill_file_too_large:{member_name}")
                 total += member.file_size
                 if total > MAX_SUPPORTING_FILES_TOTAL_BYTES:     # early exit before more reads
                     raise ValueError("local_skill_bundle_too_large")
                 if member_name == _SKILL_FILENAME:
-                    data = archive.read(member)
-                    if len(data) > MAX_SUPPORTING_FILE_BYTES:    # lying-header guard
-                        raise ValueError(f"local_skill_file_too_large:{member_name}")
+                    data = self._read_zip_member_bounded(
+                        archive, member, member_name, MAX_SUPPORTING_FILE_BYTES
+                    )
                     try:
                         skill_content = data.decode("utf-8")
                     except UnicodeDecodeError as exc:
@@ -1081,9 +1122,9 @@ class LocalSkillsService:
                 dest = skill_dir / PurePosixPath(member_name)
                 if base not in dest.resolve().parents:
                     raise ValueError(f"local_skill_invalid_archive:{member_name}")
-                data = archive.read(member)
-                if len(data) > MAX_SUPPORTING_FILE_BYTES:        # lying-header guard
-                    raise ValueError(f"local_skill_file_too_large:{member_name}")
+                data = self._read_zip_member_bounded(
+                    archive, member, member_name, MAX_SUPPORTING_FILE_BYTES
+                )
                 members.append((dest, data, bool(mode & 0o111)))
         if skill_content is None:
             raise ValueError("local_skill_invalid_archive:missing_skill_md")

--- a/tldw_chatbook/Skills_Interop/local_skills_service.py
+++ b/tldw_chatbook/Skills_Interop/local_skills_service.py
@@ -678,17 +678,12 @@ class LocalSkillsService:
 
     @staticmethod
     def _validate_archive_member(name: str) -> str:
-        posix_path = PurePosixPath(name)
-        if (
-            posix_path.is_absolute()
-            or ".." in posix_path.parts
-            or len(posix_path.parts) != 1
-        ):
-            raise ValueError(f"local_skill_invalid_archive:{name}")
-        filename = posix_path.name
-        if not filename:
-            raise ValueError(f"local_skill_invalid_archive:{name}")
-        return filename
+        from ..tldw_api.skills_schemas import validate_supporting_file_path
+
+        posix = PurePosixPath(name)
+        if str(posix) == _SKILL_FILENAME:
+            return _SKILL_FILENAME
+        return validate_supporting_file_path(str(posix))
 
     async def list_skills(
         self,
@@ -1025,27 +1020,64 @@ class LocalSkillsService:
                 trust_approved=trust_approved,
             )
 
-        supporting_files: dict[str, str] = {}
+        import stat as _stat
+        from .skill_trust_scanner import SUPPORTING_JUNK_DIRS, _is_junk
+        from ..tldw_api.skills_schemas import (
+            MAX_SUPPORTING_FILES_COUNT, MAX_SUPPORTING_FILE_BYTES,
+            MAX_SUPPORTING_FILES_TOTAL_BYTES,
+        )
+        skill_name = self._derive_name_from_filename(filename)
+        members: list[tuple[str, bytes, bool]] = []
         skill_content: str | None = None
+        total = 0
+        seen_lower: set[str] = set()
         with zipfile.ZipFile(io.BytesIO(file_content), "r") as archive:
             for member in archive.infolist():
                 if member.is_dir():
                     continue
-                member_name = self._validate_archive_member(member.filename)
-                data = archive.read(member).decode("utf-8")
+                mode = (member.external_attr >> 16) & 0xFFFF
+                if _stat.S_ISLNK(mode):
+                    continue                       # symlink member: skip-not-fail
+                parts = PurePosixPath(member.filename).parts
+                if any(p in SUPPORTING_JUNK_DIRS for p in parts) or _is_junk(parts[-1]):
+                    continue                       # junk pruned
+                member_name = self._validate_archive_member(member.filename)  # raises on zip-slip
+                lower = member_name.lower()
+                if lower in seen_lower:             # case-fold collision on a case-insensitive FS
+                    raise ValueError(f"local_skill_invalid_archive:case_collision:{member_name}")
+                seen_lower.add(lower)
+                data = archive.read(member)
+                if len(data) > MAX_SUPPORTING_FILE_BYTES:
+                    raise ValueError(f"local_skill_file_too_large:{member_name}")
+                total += len(data)
                 if member_name == _SKILL_FILENAME:
-                    skill_content = data
+                    skill_content = data.decode("utf-8")
                 else:
-                    supporting_files[member_name] = data
+                    members.append((member_name, data, bool(mode & 0o111)))
         if skill_content is None:
             raise ValueError("local_skill_invalid_archive:missing_skill_md")
-        return await self.import_skill(
-            name=self._derive_name_from_filename(filename),
-            content=skill_content,
-            supporting_files=supporting_files or None,
-            overwrite=overwrite,
-            trust_approved=trust_approved,
+        if len(members) > MAX_SUPPORTING_FILES_COUNT:
+            raise ValueError("local_skill_too_many_files")
+        if total > MAX_SUPPORTING_FILES_TOTAL_BYTES:
+            raise ValueError("local_skill_bundle_too_large")
+        result = await self.import_skill(
+            name=skill_name, content=skill_content, overwrite=overwrite,
+            trust_approved=False,   # re-trusted below only if approved
         )
+        skill_dir = self._skill_dir(skill_name)
+        base = skill_dir.resolve()
+        import os as _os
+        from pathlib import PurePosixPath as _PP
+        for member_name, data, executable in members:
+            dest = skill_dir / _PP(member_name)
+            if base not in dest.resolve().parents:
+                raise ValueError(f"local_skill_invalid_archive:{member_name}")
+            self._write_bytes_atomic(dest, data)
+            if executable:
+                _os.chmod(dest, dest.stat().st_mode | 0o755)
+        # Re-derive trust state now that the full bundle is on disk.
+        self._trust_after_approved_mutation(skill_name, trust_approved=trust_approved)
+        return self._response_for_record(self._load_index()[skill_name])
 
     async def export_skill(self, skill_name: str) -> Any:
         self._enforce("skills.export.launch.local")

--- a/tldw_chatbook/Skills_Interop/local_skills_service.py
+++ b/tldw_chatbook/Skills_Interop/local_skills_service.py
@@ -1018,8 +1018,17 @@ class LocalSkillsService:
             skill_dir.mkdir(parents=True, exist_ok=True)
             existing = records.get(skill_name) if overwrite else None
             self._write_text_atomic(skill_dir / _SKILL_FILENAME, content)
+            # Belt-and-braces containment, mirroring the zip-import path's own
+            # resolve-and-contain check (~:1127): every relative_path here was
+            # already collected via _iter_bundle_files + validate_supporting_
+            # file_path above, so this should never actually trip -- but a
+            # filesystem write is cheap insurance to assert against, not a
+            # place to trust a single upstream validation layer.
+            base = skill_dir.resolve()
             for relative_path, abs_path in files:
                 dest = skill_dir / PurePosixPath(relative_path)
+                if base not in dest.resolve().parents:
+                    raise ValueError(f"local_skill_invalid_bundle_path:{relative_path}")
                 self._write_bytes_atomic(dest, abs_path.read_bytes())
                 if abs_path.stat().st_mode & stat.S_IXUSR:
                     # Trust only the owner-exec fingerprint; adding 0o755 would
@@ -1161,6 +1170,14 @@ class LocalSkillsService:
             archive_buffer, "w", compression=zipfile.ZIP_DEFLATED
         ) as archive:
             body = skill_dir / _SKILL_FILENAME
+            # Same guard every other body read in this service already has
+            # (e.g. import_skill_directory's own check): a corrupted store
+            # (index entry present, on-disk body missing) must fail with a
+            # domain error, not a raw FileNotFoundError -- and a symlinked
+            # body must be rejected, not followed, to avoid archiving
+            # content from outside the bundle.
+            if body.is_symlink() or not body.is_file():
+                raise ValueError(f"local_skill_missing_skill_md:{normalized}")
             archive.writestr(_SKILL_FILENAME, body.read_bytes())
             for relative_path, path in sorted(
                 self._iter_bundle_files(skill_dir), key=lambda x: x[0]

--- a/tldw_chatbook/Skills_Interop/local_skills_service.py
+++ b/tldw_chatbook/Skills_Interop/local_skills_service.py
@@ -434,7 +434,10 @@ class LocalSkillsService:
         for relative_path, path in sorted(
             LocalSkillsService._iter_bundle_files(skill_dir), key=lambda x: x[0]
         ):
-            if path.is_symlink():
+            # Skip symlinks and non-regular files (FIFOs/sockets/device nodes):
+            # opening a FIFO with no writer would block read_bytes() forever.
+            # Mirrors the guard in _read_bundle_manifest.
+            if path.is_symlink() or not path.is_file():
                 continue
             try:
                 validate_supporting_file_path(relative_path)

--- a/tldw_chatbook/Skills_Interop/skill_trust_models.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_models.py
@@ -37,16 +37,24 @@ class SkillFileFingerprint:
     file_type: str
     byte_length: int
     sha256: str
+    executable: bool = False
 
     def as_manifest_entry(self) -> dict[str, Any]:
-        """Return the JSON-safe manifest representation for this fingerprint."""
+        """Return the JSON-safe manifest representation for this fingerprint.
 
-        return {
+        The ``executable`` key is emitted ONLY when True so that a flat,
+        all-text, non-executable skill serializes byte-identically to the
+        pre-Spec-2 form (preserving existing manifests' HMAC validity).
+        """
+        entry = {
             "relative_path": self.relative_path,
             "file_type": self.file_type,
             "byte_length": self.byte_length,
             "sha256": self.sha256,
         }
+        if self.executable:
+            entry["executable"] = True
+        return entry
 
 
 @dataclass(frozen=True, slots=True)

--- a/tldw_chatbook/Skills_Interop/skill_trust_scanner.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_scanner.py
@@ -61,12 +61,17 @@ def scan_skill_directory(skill_name: str, skill_dir: Path) -> SkillDirectorySnap
         # from ``dirs`` so the walk never descends into them.
         kept_dirs: list[str] = []
         for name in dirs:
-            if name in SUPPORTING_JUNK_DIRS:
-                continue
             dir_abs = Path(root) / name
+            # A symlink is suspicious regardless of its name: check is_symlink()
+            # BEFORE the junk-name filter so a symlink named like a junk dir
+            # (e.g. node_modules, .git) still surfaces in unsupported_paths
+            # instead of being silently pruned. Junk-name pruning applies only
+            # to REAL directories.
             if dir_abs.is_symlink():
                 rel = PurePosixPath(dir_abs.relative_to(skill_dir).as_posix())
                 collected.append((str(rel), dir_abs))
+                continue
+            if name in SUPPORTING_JUNK_DIRS:
                 continue
             kept_dirs.append(name)
         dirs[:] = kept_dirs

--- a/tldw_chatbook/Skills_Interop/skill_trust_scanner.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_scanner.py
@@ -2,52 +2,77 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+import os
+import stat
+from pathlib import Path, PurePosixPath
 
 from .skill_trust_crypto import sha256_hex
 from .skill_trust_models import SkillDirectorySnapshot, SkillFileFingerprint
 
-
 _SKILL_FILENAME = "SKILL.md"
-_TEMP_SUFFIXES = (".tmp", ".swp", ".part")
+SUPPORTING_JUNK_DIRS = frozenset({".git", ".github", ".hg", ".svn", "node_modules", "__pycache__"})
+SUPPORTING_JUNK_FILES = frozenset({".DS_Store", "Thumbs.db"})
+SUPPORTING_JUNK_SUFFIXES = (".pyc", ".pyo", "~", ".bak", ".orig", ".tmp", ".swp", ".part")
 
 
-def _is_supported_filename(filename: str) -> bool:
+def _is_junk(name: str) -> bool:
+    return name in SUPPORTING_JUNK_FILES or name.lower().endswith(SUPPORTING_JUNK_SUFFIXES)
+
+
+def _validate_relative_path(relative_path: str) -> bool:
     # Deferred import: avoid module-scope tldw_api schema import (task-285 phase 2).
-    from ..tldw_api.skills_schemas import SUPPORTING_FILE_NAME_PATTERN
+    from ..tldw_api.skills_schemas import validate_supporting_file_path
 
-    if filename == _SKILL_FILENAME:
+    try:
+        validate_supporting_file_path(relative_path)
         return True
-    normalized_filename = filename.lower()
-    if normalized_filename == _SKILL_FILENAME.lower():
+    except ValueError:
         return False
-    if normalized_filename.endswith(_TEMP_SUFFIXES):
-        return False
-    return bool(SUPPORTING_FILE_NAME_PATTERN.fullmatch(filename))
 
 
 def scan_skill_directory(skill_name: str, skill_dir: Path) -> SkillDirectorySnapshot:
-    """Return a deterministic trust snapshot for immediate files in a skill directory.
+    """Return a deterministic trust snapshot for a skill directory tree.
+
+    Walks ``skill_dir`` recursively (never following symlinks), pruning
+    VCS/OS/build junk, sorting by POSIX relative path. Text files are decoded
+    into ``text_files``; binaries are fingerprinted (``file_type=
+    "supporting_binary"``) but not decoded. Symlinks and files failing path
+    validation are recorded in ``unsupported_paths`` (they are NOT trust
+    material) but never raise here.
 
     Args:
         skill_name: Local skill name represented by the directory.
-        skill_dir: Directory to scan. Only immediate child files are considered.
+        skill_dir: Directory to scan.
 
     Returns:
-        Snapshot containing trusted file fingerprints, decoded text, and unsupported
-        path names that must be excluded from trust material.
+        Snapshot with fingerprints (sorted by relative path), decoded text
+        files, and unsupported path names.
     """
-
     fingerprints: list[SkillFileFingerprint] = []
     text_files: dict[str, str] = {}
     unsupported_paths: list[str] = []
 
-    for path in sorted(skill_dir.iterdir(), key=lambda child: child.name):
-        relative_path = path.name
-        if path.is_symlink() or not _is_supported_filename(relative_path):
+    collected: list[tuple[str, Path]] = []
+    for root, dirs, files in os.walk(skill_dir, followlinks=False):
+        # Prune junk directories in-place so os.walk does not descend them.
+        dirs[:] = sorted(d for d in dirs if d not in SUPPORTING_JUNK_DIRS)
+        for name in files:
+            if _is_junk(name):
+                continue
+            abs_path = Path(root) / name
+            rel = PurePosixPath(abs_path.relative_to(skill_dir).as_posix())
+            collected.append((str(rel), abs_path))
+    collected.sort(key=lambda item: item[0])
+
+    for relative_path, path in collected:
+        is_body = relative_path == _SKILL_FILENAME
+        # The reserved SKILL.md basename check inside validate_supporting_file_path
+        # exists to reject *shadow* SKILL.md files nested under subdirectories; the
+        # real top-level body file must bypass it rather than be misclassified as
+        # unsupported.
+        if path.is_symlink() or (not is_body and not _validate_relative_path(relative_path)):
             unsupported_paths.append(relative_path)
             continue
-
         try:
             if not path.is_file():
                 unsupported_paths.append(relative_path)
@@ -57,27 +82,33 @@ def scan_skill_directory(skill_name: str, skill_dir: Path) -> SkillDirectorySnap
             unsupported_paths.append(relative_path)
             continue
 
-        if b"\x00" in raw:
-            unsupported_paths.append(relative_path)
-            continue
+        is_binary = b"\x00" in raw
+        text: str | None = None
+        if not is_binary:
+            try:
+                text = raw.decode("utf-8")
+            except UnicodeDecodeError:
+                is_binary = True
 
-        try:
-            text = raw.decode("utf-8")
-        except UnicodeDecodeError:
-            unsupported_paths.append(relative_path)
-            continue
+        if is_body:
+            file_type = "skill"
+        elif is_binary:
+            file_type = "supporting_binary"
+        else:
+            file_type = "supporting_text"
 
+        executable = bool(path.stat().st_mode & stat.S_IXUSR)
         fingerprints.append(
             SkillFileFingerprint(
                 relative_path=relative_path,
-                file_type="skill"
-                if relative_path == _SKILL_FILENAME
-                else "supporting_text",
+                file_type=file_type,
                 byte_length=len(raw),
                 sha256=sha256_hex(raw),
+                executable=executable,
             )
         )
-        text_files[relative_path] = text
+        if text is not None:
+            text_files[relative_path] = text
 
     return SkillDirectorySnapshot(
         skill_name=skill_name,

--- a/tldw_chatbook/Skills_Interop/skill_trust_scanner.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_scanner.py
@@ -55,7 +55,21 @@ def scan_skill_directory(skill_name: str, skill_dir: Path) -> SkillDirectorySnap
     collected: list[tuple[str, Path]] = []
     for root, dirs, files in os.walk(skill_dir, followlinks=False):
         # Prune junk directories in-place so os.walk does not descend them.
-        dirs[:] = sorted(d for d in dirs if d not in SUPPORTING_JUNK_DIRS)
+        # Symlinked directories must NOT be followed, but must still surface as
+        # unsupported (never silently vanish): route them through ``collected``
+        # so the shared ``path.is_symlink()`` check records them, and drop them
+        # from ``dirs`` so the walk never descends into them.
+        kept_dirs: list[str] = []
+        for name in dirs:
+            if name in SUPPORTING_JUNK_DIRS:
+                continue
+            dir_abs = Path(root) / name
+            if dir_abs.is_symlink():
+                rel = PurePosixPath(dir_abs.relative_to(skill_dir).as_posix())
+                collected.append((str(rel), dir_abs))
+                continue
+            kept_dirs.append(name)
+        dirs[:] = kept_dirs
         for name in files:
             if _is_junk(name):
                 continue
@@ -78,6 +92,10 @@ def scan_skill_directory(skill_name: str, skill_dir: Path) -> SkillDirectorySnap
                 unsupported_paths.append(relative_path)
                 continue
             raw = path.read_bytes()
+            # Read the exec bit inside the same guarded region so a concurrent
+            # deletion between read_bytes() and stat() routes to unsupported_paths
+            # rather than raising (honors the never-raise contract).
+            executable = bool(path.stat().st_mode & stat.S_IXUSR)
         except OSError:
             unsupported_paths.append(relative_path)
             continue
@@ -97,7 +115,6 @@ def scan_skill_directory(skill_name: str, skill_dir: Path) -> SkillDirectorySnap
         else:
             file_type = "supporting_text"
 
-        executable = bool(path.stat().st_mode & stat.S_IXUSR)
         fingerprints.append(
             SkillFileFingerprint(
                 relative_path=relative_path,

--- a/tldw_chatbook/Skills_Interop/skill_trust_scanner.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_scanner.py
@@ -12,7 +12,7 @@ from .skill_trust_models import SkillDirectorySnapshot, SkillFileFingerprint
 _SKILL_FILENAME = "SKILL.md"
 SUPPORTING_JUNK_DIRS = frozenset({".git", ".github", ".hg", ".svn", "node_modules", "__pycache__"})
 SUPPORTING_JUNK_FILES = frozenset({".DS_Store", "Thumbs.db"})
-SUPPORTING_JUNK_SUFFIXES = (".pyc", ".pyo", "~", ".bak", ".orig", ".tmp", ".swp", ".part")
+SUPPORTING_JUNK_SUFFIXES = (".pyc", ".pyo", "~", ".tmp", ".swp", ".part")
 
 
 def _is_junk(name: str) -> bool:

--- a/tldw_chatbook/Skills_Interop/skill_trust_service.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_service.py
@@ -218,8 +218,6 @@ class SkillTrustService:
 
         for normalized_name, skill_dir in self._iter_skill_dirs():
             snapshot = scan_skill_directory(normalized_name, skill_dir)
-            if snapshot.unsupported_paths:
-                raise ValueError(TRUST_REASON_UNSUPPORTED_PATH)
             snapshot_id = self._snapshot_id(normalized_name, generation)
             self.trust_store.save_snapshot(
                 snapshot_id,
@@ -515,8 +513,6 @@ class SkillTrustService:
         manifest = self._load_valid_manifest()
         generation = int(manifest["generation"]) + 1
         current = snapshot or self._scan_skill(normalized_name)
-        if current.unsupported_paths:
-            raise ValueError(TRUST_REASON_UNSUPPORTED_PATH)
         if not current.fingerprints:
             raise ValueError(TRUST_REASON_SKILL_DELETED)
 

--- a/tldw_chatbook/Skills_Interop/skill_trust_service.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_service.py
@@ -400,11 +400,22 @@ class SkillTrustService:
             skill_content=skill_content,
             supporting_files=supporting_files,
         )
-        missing = set(trusted_files) - set(current_files)
+        # The in-memory reconstruction is text-only and mode-blind. Binary and
+        # executable files cannot be represented here, so scope the in-memory
+        # comparison to reconstructable (text, non-executable) trusted files;
+        # ensure_skill_trusted() above already verified the full on-disk bundle
+        # (binaries + exec bits) against the manifest via a recursive scan.
+        reconstructable = {
+            path
+            for path, entry in trusted_files.items()
+            if entry.get("file_type") != "supporting_binary"
+            and not entry.get("executable")
+        }
+        missing = reconstructable - set(current_files)
         added = set(current_files) - set(trusted_files)
         modified = {
             path
-            for path in trusted_files.keys() & current_files.keys()
+            for path in reconstructable & current_files.keys()
             if trusted_files[path] != current_files[path]
         }
         changed = tuple(sorted(missing | added | modified))

--- a/tldw_chatbook/Skills_Interop/skills_scope_service.py
+++ b/tldw_chatbook/Skills_Interop/skills_scope_service.py
@@ -276,6 +276,21 @@ class SkillsScopeService:
             kwargs=kwargs,
         )
 
+    async def import_skill_directory(
+        self,
+        source_dir: Any,
+        *,
+        mode: SkillsBackend | str | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        return await self._call(
+            mode=mode,
+            action_id="skills.import.launch.server",
+            method_name="import_skill_directory",
+            args=(source_dir,),
+            kwargs=kwargs,
+        )
+
     async def export_skill(
         self, skill_name: str, *, mode: SkillsBackend | str | None = None
     ) -> Any:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -7203,10 +7203,11 @@ class LibraryScreen(BaseAppScreen):
         "Review changes" action -- see ``skill_trust_review_enabled``).
 
         Two path shapes are accepted, both resolving to the SAME skill
-        name (the directory's own name) -- this matters because every
-        real skill package (e.g. the ``superpowers`` skillset) is a
-        directory named after the skill containing a file LITERALLY named
-        ``SKILL.md``, so deriving the name from the file's own basename
+        name (the directory's own name) AND the SAME faithful import --
+        this matters because every real skill package (e.g. the
+        ``superpowers`` skillset) is a directory named after the skill
+        containing a file LITERALLY named ``SKILL.md``, so deriving the
+        name from the file's own basename
         (``local_skills_service._derive_name_from_filename``, which is
         what a plain ``import_skill_file(..., filename="SKILL.md")`` call
         would do) would incorrectly produce ``"skill"`` for every import
@@ -7214,20 +7215,20 @@ class LibraryScreen(BaseAppScreen):
 
         - A file path whose basename is ``SKILL.md`` (case-insensitive):
           treated as that file's PARENT directory's skill (the common
-          case for a real skillset laid out one-directory-per-skill).
-          Calls ``import_skill(name=<directory name>, content=..., ...)``
-          directly (the name is already known, so no filename-derivation
-          guesswork is needed) and threads any FLAT sibling files in
-          that same directory through as ``supporting_files`` (nested
-          subdirectories are NOT recursed into for this shape --
-          ``import_skill``'s own supporting-file model has no
-          nested-path support).
-        - A directory path containing a top-level ``SKILL.md``: calls
-          ``import_skill_directory(source_dir, name=<directory name>,
-          ...)`` instead, which copies the WHOLE tree faithfully --
-          nested subdirectories, binary files, and the executable bit
-          are all preserved (junk pruned, symlinks skipped, size/count
-          caps enforced).
+          case for a real skillset laid out one-directory-per-skill) --
+          the parent directory IS the skill directory.
+        - A directory path containing a top-level ``SKILL.md``: the
+          directory itself is the skill directory.
+
+        Both shapes call ``import_skill_directory(skill_dir,
+        name=<directory name>, ...)``, which copies the WHOLE tree
+        faithfully -- nested subdirectories, binary files, and the
+        executable bit are all preserved (junk pruned, symlinks skipped,
+        size/count caps enforced). A flat, text-only read here would
+        silently drop all of that for the SKILL.md-file shape even though
+        the directory-path shape (pointed at the very same directory)
+        would have preserved it -- the two shapes must behave identically
+        since they resolve to the same skill directory.
 
         Any OTHER file path (e.g. a standalone ``some-skill.md`` not named
         ``SKILL.md``, or a ``.zip`` export) is imported via
@@ -7258,83 +7259,45 @@ class LibraryScreen(BaseAppScreen):
             return
 
         service = getattr(self.app_instance, "skills_scope_service", None)
-        import_skill = getattr(service, "import_skill", None)
         import_skill_file = getattr(service, "import_skill_file", None)
-        if not callable(import_skill) or not callable(import_skill_file):
+        import_skill_directory = getattr(service, "import_skill_directory", None)
+        if not callable(import_skill_directory) or not callable(import_skill_file):
             self._apply_library_skills_import_status("Skill import is unavailable.")
             return
 
         if validated_path.is_dir():
             skill_dir = validated_path
-            if self._find_skill_md_in_dir(skill_dir) is None:
-                self._apply_library_skills_import_status(
-                    "No SKILL.md found in that folder."
-                )
-                return
-            import_skill_directory = getattr(
-                service, "import_skill_directory", None
-            )
-            if not callable(import_skill_directory):
-                self._apply_library_skills_import_status(
-                    "Skill import is unavailable."
-                )
-                return
-            skill_name = skill_dir.name
-            try:
-                await self._run_library_service_call(
-                    import_skill_directory,
-                    skill_dir,
-                    mode="local",
-                    name=skill_name,
-                    trust_approved=False,
-                    isolate_in_worker=True,
-                )
-            except Exception as exc:
-                self._apply_library_skills_import_outcome_from_exception(
-                    skill_name, exc
-                )
-                return
-            self._apply_library_skills_import_success(skill_name)
-            return
         elif validated_path.name.lower() == _SKILL_MD_FILENAME.lower():
+            # The SKILL.md file's PARENT directory IS the skill directory --
+            # same faithful import as the folder-path shape below.
             skill_dir = validated_path.parent
-            skill_md_path = validated_path
         else:
             await self._import_library_skill_from_loose_file(
                 validated_path, import_skill_file
             )
             return
 
-        try:
-            content = await asyncio.to_thread(
-                skill_md_path.read_text, encoding="utf-8", errors="strict"
+        if self._find_skill_md_in_dir(skill_dir) is None:
+            self._apply_library_skills_import_status(
+                "No SKILL.md found in that folder."
             )
-        except Exception:
-            logger.opt(exception=True).warning(
-                f"Could not read Library skill import file '{skill_md_path}'."
-            )
-            self._apply_library_skills_import_status("Could not read that file.")
             return
 
-        supporting_files = self._read_library_skill_import_supporting_files(
-            skill_dir, skill_md_path
-        )
         skill_name = skill_dir.name
-
         try:
             await self._run_library_service_call(
-                import_skill,
+                import_skill_directory,
+                skill_dir,
                 mode="local",
                 name=skill_name,
-                content=content,
-                supporting_files=supporting_files or None,
                 trust_approved=False,
                 isolate_in_worker=True,
             )
         except Exception as exc:
-            self._apply_library_skills_import_outcome_from_exception(skill_name, exc)
+            self._apply_library_skills_import_outcome_from_exception(
+                skill_name, exc
+            )
             return
-
         self._apply_library_skills_import_success(skill_name)
 
     async def _import_library_skill_from_loose_file(
@@ -7475,50 +7438,6 @@ class LibraryScreen(BaseAppScreen):
             if child.is_file() and child.name.lower() == _SKILL_MD_FILENAME.lower():
                 return child
         return None
-
-    @staticmethod
-    def _read_library_skill_import_supporting_files(
-        skill_dir: Path,
-        skill_md_path: Path,
-    ) -> dict[str, str]:
-        """Read the skill directory's FLAT sibling files as supporting files.
-
-        Only immediate-child FILES are read (mirrors
-        ``local_skills_service._read_supporting_files``'s own flat-only
-        model) -- nested subdirectories (e.g. a real skill's own
-        ``references/`` folder) are skipped entirely rather than
-        recursed into or flattened, since the service's supporting-file
-        name pattern has no path-separator support. A sibling that fails
-        to decode as UTF-8 text (e.g. a binary asset) is skipped
-        individually rather than failing the whole import.
-
-        Args:
-            skill_dir: The skill's own directory.
-            skill_md_path: The directory's ``SKILL.md`` file (excluded
-                from the result).
-
-        Returns:
-            A ``{filename: content}`` mapping of every readable flat
-            sibling file, excluding ``SKILL.md`` itself.
-        """
-        supporting_files: dict[str, str] = {}
-        try:
-            children = sorted(skill_dir.iterdir(), key=lambda item: item.name)
-        except Exception:
-            return supporting_files
-        for child in children:
-            if not child.is_file() or child.resolve() == skill_md_path.resolve():
-                continue
-            try:
-                supporting_files[child.name] = child.read_text(
-                    encoding="utf-8", errors="strict"
-                )
-            except Exception:
-                logger.debug(
-                    f"Skipping unreadable Library skill supporting file '{child}'."
-                )
-                continue
-        return supporting_files
 
     @on(Button.Pressed, ".library-skill-row")
     async def handle_library_skill_row(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -7215,19 +7215,19 @@ class LibraryScreen(BaseAppScreen):
         - A file path whose basename is ``SKILL.md`` (case-insensitive):
           treated as that file's PARENT directory's skill (the common
           case for a real skillset laid out one-directory-per-skill).
-        - A directory path containing a top-level ``SKILL.md``: same
-          shape, just already pointing at the directory.
-
-        Both call ``import_skill(name=<directory name>, content=..., ...)``
-        directly (the name is already known, so no filename-derivation
-        guesswork is needed) and thread any FLAT sibling files in that
-        same directory through as ``supporting_files`` (nested
-        subdirectories -- e.g. a ``references/`` folder -- are NOT
-        recursed into: ``local_skills_service``'s own supporting-file
-        model has no nested-path support, so those would either be
-        silently dropped or rejected by the service's own filename
-        pattern; skipping them here keeps this import path's own failure
-        mode explicit rather than surprising).
+          Calls ``import_skill(name=<directory name>, content=..., ...)``
+          directly (the name is already known, so no filename-derivation
+          guesswork is needed) and threads any FLAT sibling files in
+          that same directory through as ``supporting_files`` (nested
+          subdirectories are NOT recursed into for this shape --
+          ``import_skill``'s own supporting-file model has no
+          nested-path support).
+        - A directory path containing a top-level ``SKILL.md``: calls
+          ``import_skill_directory(source_dir, name=<directory name>,
+          ...)`` instead, which copies the WHOLE tree faithfully --
+          nested subdirectories, binary files, and the executable bit
+          are all preserved (junk pruned, symlinks skipped, size/count
+          caps enforced).
 
         Any OTHER file path (e.g. a standalone ``some-skill.md`` not named
         ``SKILL.md``, or a ``.zip`` export) is imported via
@@ -7266,12 +7266,36 @@ class LibraryScreen(BaseAppScreen):
 
         if validated_path.is_dir():
             skill_dir = validated_path
-            skill_md_path = self._find_skill_md_in_dir(skill_dir)
-            if skill_md_path is None:
+            if self._find_skill_md_in_dir(skill_dir) is None:
                 self._apply_library_skills_import_status(
                     "No SKILL.md found in that folder."
                 )
                 return
+            import_skill_directory = getattr(
+                service, "import_skill_directory", None
+            )
+            if not callable(import_skill_directory):
+                self._apply_library_skills_import_status(
+                    "Skill import is unavailable."
+                )
+                return
+            skill_name = skill_dir.name
+            try:
+                await self._run_library_service_call(
+                    import_skill_directory,
+                    skill_dir,
+                    mode="local",
+                    name=skill_name,
+                    trust_approved=False,
+                    isolate_in_worker=True,
+                )
+            except Exception as exc:
+                self._apply_library_skills_import_outcome_from_exception(
+                    skill_name, exc
+                )
+                return
+            self._apply_library_skills_import_success(skill_name)
+            return
         elif validated_path.name.lower() == _SKILL_MD_FILENAME.lower():
             skill_dir = validated_path.parent
             skill_md_path = validated_path

--- a/tldw_chatbook/Widgets/Library/library_skills_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_skills_canvas.py
@@ -254,8 +254,11 @@ def skill_trust_review_preview(active_review: Mapping[str, Any] | None) -> str:
             review is active).
 
     Returns:
-        Labelled per-file content blocks, ``(deleted)`` markers for
-        changed files with no on-disk content, each file capped at
+        Labelled per-file content blocks. A changed file absent from
+        ``current_files`` (text) is disambiguated using
+        ``current_fingerprints``: a present binary renders
+        ``(binary file — N bytes, sha256 ...)`` while a genuinely
+        missing file renders ``(deleted)``. Each text file is capped at
         ``_TRUST_REVIEW_PREVIEW_FILE_CHAR_CAP`` chars; empty string while
         no review is active. Rendering is bounded to
         ``_TRUST_REVIEW_PREVIEW_MAX_FILES`` files and
@@ -270,6 +273,11 @@ def skill_trust_review_preview(active_review: Mapping[str, Any] | None) -> str:
         return ""
     raw_files = active_review.get("current_files")
     current_files = dict(raw_files) if isinstance(raw_files, Mapping) else {}
+    fingerprints = {
+        str(fp.get("relative_path")): fp
+        for fp in (active_review.get("current_fingerprints") or [])
+        if isinstance(fp, Mapping)
+    }
     blocks: list[str] = []
     total_chars = 0
     rendered = 0
@@ -283,7 +291,15 @@ def skill_trust_review_preview(active_review: Mapping[str, Any] | None) -> str:
             break
         content = current_files.get(file_name)
         if content is None:
-            block = f"── {file_name} ──\n(deleted — no longer on disk)"
+            fp = fingerprints.get(file_name)
+            if fp is not None:
+                block = (
+                    f"── {file_name} ──\n"
+                    f"(binary file — {fp.get('byte_length', 0)} bytes, "
+                    f"sha256 {str(fp.get('sha256', ''))[:12]}…)"
+                )
+            else:
+                block = f"── {file_name} ──\n(deleted — no longer on disk)"
         else:
             text = str(content)
             if len(text) > _TRUST_REVIEW_PREVIEW_FILE_CHAR_CAP:

--- a/tldw_chatbook/Widgets/Library/library_skills_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_skills_canvas.py
@@ -37,6 +37,7 @@ from textual.widgets import Button, Input, Static, TextArea
 
 from tldw_chatbook.Library.library_skills_state import (
     SkillEditorState,
+    SkillEditorSupportingFile,
     SkillsListState,
     save_marks_needs_review,
     skill_name_shadows_builtin,
@@ -422,11 +423,25 @@ def next_skill_context(context: str) -> str:
     return "fork" if context == "inline" else "inline"
 
 
-def skill_supporting_files_text(supporting_files: tuple[tuple[str, int], ...]) -> str:
-    """Render the read-only supporting-files list as plain text."""
+def skill_supporting_files_text(
+    supporting_files: tuple[SkillEditorSupportingFile, ...],
+) -> str:
+    """Render the read-only supporting-files list as plain text.
+
+    Nested paths (e.g. ``"references/api.md"``) render as-is. Binary rows
+    (``is_text is False``) get a ``(binary)`` marker -- the list is already
+    read-only, so this is purely informational: binaries were never
+    editable as text in the first place.
+    """
     if not supporting_files:
         return "No supporting files."
-    return "\n".join(f"{name} ({size} bytes)" for name, size in supporting_files)
+    lines = []
+    for file in supporting_files:
+        if file.is_text:
+            lines.append(f"{file.name} ({file.size} bytes)")
+        else:
+            lines.append(f"{file.name} — {file.size} bytes (binary)")
+    return "\n".join(lines)
 
 
 class LibrarySkillsListCanvas(VerticalScroll):

--- a/tldw_chatbook/tldw_api/skills_schemas.py
+++ b/tldw_chatbook/tldw_api/skills_schemas.py
@@ -9,9 +9,47 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 SKILL_NAME_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$")
 SUPPORTING_FILE_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,99}$")
-MAX_SUPPORTING_FILES_COUNT = 20
-MAX_SUPPORTING_FILE_BYTES = 500000
-MAX_SUPPORTING_FILES_TOTAL_BYTES = 5 * 1024 * 1024
+SEGMENT_PATTERN = SUPPORTING_FILE_NAME_PATTERN  # each path segment obeys the same rule
+MAX_SUPPORTING_FILES_COUNT = 500
+MAX_SUPPORTING_FILE_BYTES = 5 * 1024 * 1024
+MAX_SUPPORTING_FILES_TOTAL_BYTES = 25 * 1024 * 1024
+MAX_SUPPORTING_FILE_PATH_DEPTH = 8
+MAX_SUPPORTING_FILE_PATH_LEN = 255
+_RESERVED_BODY_BASENAME = "skill.md"
+
+
+def validate_supporting_file_path(path: str) -> str:
+    """Validate a relative POSIX supporting-file subpath, returning it normalized.
+
+    Args:
+        path: Candidate relative POSIX path (e.g. ``scripts/build.sh``).
+
+    Returns:
+        The same path when valid.
+
+    Raises:
+        ValueError: On absolute paths, ``..``/``.``/empty segments, backslashes,
+            a segment failing ``SEGMENT_PATTERN``, any-case ``skill.md`` basename,
+            depth greater than ``MAX_SUPPORTING_FILE_PATH_DEPTH``, or a total
+            length exceeding ``MAX_SUPPORTING_FILE_PATH_LEN``.
+    """
+    if not path or path != path.strip():
+        raise ValueError(f"Invalid supporting file path: {path!r}")
+    if "\\" in path or path.startswith("/"):
+        raise ValueError(f"Invalid supporting file path: {path!r}")
+    if len(path.encode("utf-8")) > MAX_SUPPORTING_FILE_PATH_LEN:
+        raise ValueError(f"Supporting file path too long: {path!r}")
+    segments = path.split("/")
+    if len(segments) > MAX_SUPPORTING_FILE_PATH_DEPTH:
+        raise ValueError(f"Supporting file path too deep: {path!r}")
+    for segment in segments:
+        if segment in ("", ".", ".."):
+            raise ValueError(f"Invalid path segment in {path!r}")
+        if not SEGMENT_PATTERN.fullmatch(segment):
+            raise ValueError(f"Invalid path segment {segment!r} in {path!r}")
+    if segments[-1].lower() == _RESERVED_BODY_BASENAME:
+        raise ValueError("SKILL.md is the skill body, not a supporting file")
+    return path
 
 
 def _normalize_skill_name(value: str) -> str:
@@ -34,10 +72,7 @@ def _validate_supporting_files(
     non_null_count = 0
     total_bytes = 0
     for filename, content in value.items():
-        if not SUPPORTING_FILE_NAME_PATTERN.match(filename):
-            raise ValueError(f"Invalid supporting file name: {filename}")
-        if filename.lower() == "skill.md":
-            raise ValueError("SKILL.md cannot be a supporting file")
+        validate_supporting_file_path(filename)  # replaces pattern + skill.md checks
         if content is None:
             if allow_deletes:
                 continue
@@ -49,10 +84,10 @@ def _validate_supporting_files(
             )
         file_bytes = len(content.encode("utf-8"))
         if file_bytes > MAX_SUPPORTING_FILE_BYTES:
-            raise ValueError(f"Supporting file {filename} exceeds 500KB limit")
+            raise ValueError(f"Supporting file {filename} exceeds file size limit")
         total_bytes += file_bytes
     if total_bytes > MAX_SUPPORTING_FILES_TOTAL_BYTES:
-        raise ValueError("Total supporting files size exceeds 5MB limit")
+        raise ValueError("Total supporting files size exceeds bundle limit")
     return value
 
 
@@ -103,6 +138,13 @@ class SkillUpdate(BaseModel):
         return _validate_supporting_files(value, allow_deletes=True)
 
 
+class BundleFileInfo(BaseModel):
+    path: str
+    size: int
+    executable: bool = False
+    is_text: bool = True
+
+
 class SkillResponse(SkillBase):
     id: str
     content: str
@@ -111,6 +153,7 @@ class SkillResponse(SkillBase):
     created_at: datetime
     last_modified: datetime
     version: int
+    bundle_files: list[BundleFileInfo] | None = None
 
     model_config = ConfigDict(from_attributes=True, extra="allow")
 


### PR DESCRIPTION
## Summary

**Skills Foundation — Full-Bundle Supporting-File Fidelity (Layer 0, Spec 2).**

The second layer of the "a user asks an agent to install a skill/pack from a GitHub link" program (sibling of the trust-foundation PR #762). Makes tldw's local-skills subsystem faithfully **import, store, trust-verify, and export** a spec-conformant [Agent Skills](https://agentskills.io/specification) bundle — arbitrary **nested directories**, **binary assets**, and **executable scripts** — instead of today's flat, text-only model that silently drops them (UAT finding #3: importing `obra/superpowers` dropped its `scripts/` files).

Design + plan: `Docs/superpowers/specs/2026-07-22-skills-foundation-bundle-fidelity-design.md`, `Docs/superpowers/plans/2026-07-22-skills-foundation-bundle-fidelity-plan.md`.

## What this does

- **Directory-native model.** The skill dir on disk is the source of truth; `supporting_files` stays a nested-path **text** view, and a new metadata-only `bundle_files` list surfaces binaries (`path/size/executable/is_text`) — so **binary bytes never cross the JSON wire**.
- **Recursive, binary/mode-aware trust scanner** with a **load-bearing backward-compat guarantee**: for any skill with no nested paths, no binaries, and no exec bits, the canonical snapshot is **byte-identical** to before (`executable` is emitted only when `True`), so **every currently-trusted skill stays trusted** — no mass re-review.
- **Cryptographic tamper-evidence over every file** (text and binary): each file's SHA-256 lives inside the existing HMAC-authenticated manifest, so a content-or-mode change flips the skill to needs-review.
- **Faithful import (folder + zip) and export**, preserving nesting, raw binary bytes, and the executable bit.
- **Tolerate-and-surface** for unsupported files (symlinks, bad names) — never a hard-raise dead-end, and a skill with one is never reported fully trusted.
- **Editor + trust-review UI** handle nested paths and binaries (binaries are view-only; the review preview shows `binary — N bytes, sha256 …` instead of mislabeling a present binary as "deleted").

## Security hardening (all verified by adversarial review)

- **Zip decompression-bomb DoS** defeated by a bounded streaming reader (64 KB chunks) — a crafted forged-header member that spiked memory ~815 MB via `archive.read()` is bounded to ~20 MB and rejected as a clean `ValueError`.
- **Zip-slip** contained (validator + resolve-and-assert-within-`skill_dir`); **symlink** members/dirs surfaced-not-followed (`os.walk(followlinks=False)`); **case-fold collisions** rejected; **junk** (`.git`/`__pycache__`/`.DS_Store`/…) pruned.
- **FIFO/non-regular-file hang** guarded (`is_file()` before `read_bytes()`) on every walk path — important because import runs under the store lock.
- **Size caps**: 5 MB/file, 25 MB/bundle, 500 files; the legacy 20-file/500 KB/5 MB caps raised to match.

## Verification

- Built subagent-driven: 12 TDD tasks, each spec+quality reviewed; the review gate caught 2 Critical security bugs the plan had missed (symlinked-dir trust-gate bypass; the zip bomb) and a recurring FIFO-hang class — all fixed.
- Final **whole-branch review returned MERGE READY** (no Critical/Important); its follow-up hardening (closed the one `.bak`/`.orig` backward-compat hole; narrowed exec-bit to owner-only; guarded empty zip-member names) is included.
- `Tests/Skills/` + `Tests/Library/` + `Tests/UI/test_library_skills_canvas.py`: **950 passed, 0 failed**.

## Out of scope (later layers)

Storage fidelity is a **prerequisite**, not the whole north star: `execute_skill` still returns only the rendered `SKILL.md` body, so a bundled `scripts/x.py` is stored faithfully but **not yet reachable by the agent at execution** — that's a dedicated later layer. Also deferred: SKILL.md frontmatter conformance (`license`/`compatibility`/`metadata`), a folder/GitHub picker UX, multi-skill packs, and asymmetric publisher signatures.

## Release note

Skills may now contain nested directories, binary assets, and executable scripts, imported/exported faithfully with per-file tamper-evidence. VCS/OS/build junk is ignored on import. Trust rollback restores text files; a tampered binary is flagged for re-review rather than auto-reverted. No trust-data migration — existing trusted skills are undisturbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full-bundle fidelity for skills: nested directories, binaries, and executables are imported, stored, verified, and exported faithfully, fixing the flat text-only model that dropped files. Existing trusted skills remain trusted; per-file hashes add tamper-evidence without sending binary bytes over the wire.

- **New Features**
  - Directory-native model: `supporting_files` stays text (nested keys); new `bundle_files` lists path/size/is_text/executable for non-text files — binary bytes never cross JSON.
  - Path validator accepts nested POSIX paths and rejects traversal/backslash/reserved `SKILL.md`; recursive scanner fingerprints text vs binary, captures exec bit, and preserves byte-identical manifests for flat all-text skills.
  - Faithful import from folder (`import_skill_directory`) and zip, with junk pruning, symlink skip, and owner-exec bit preservation; export walks the tree and preserves modes for a byte-identical round-trip.
  - UI: editor lists nested paths and marks binaries as view-only; trust review preview shows “binary — N bytes, sha256 …” instead of “deleted”.

- **Bug Fixes**
  - Zip-bomb defense via bounded streaming reads; early size/count/total caps; validate-before-write so rejected bundles leave no residue.
  - Zip-slip containment; case-fold collision rejection; FIFO/non-regular-file guards; symlinked dirs are surfaced as unsupported; body classification uses top-level `SKILL.md` only.
  - Limits raised for real bundles: 500 files, 5 MB/file, 25 MB total; VCS/OS/build junk pruned (keeps `.bak`/`.orig` text files for backward-compat).
  - Verification scopes in-memory checks to reconstructable text files; unsupported files are tolerated and flagged for review instead of hard-failing trust.
  - Import hardening: `SKILL.md` file-path imports route through `import_skill_directory`; folder/zip imports add resolve-and-contain checks; `export_skill` guards a missing/symlinked `SKILL.md`; exec-bit handling narrowed to owner-only.

<sup>Written for commit 95defb4498b1bbb4af8351dc4e35bbe2cb36cf77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

