### PR TITLE
chore(backlog): resolve duplicate task-483 (credential-redact → 486)

### DIFF
--- a/backlog/tasks/task-432 - Provider-test-reports-draft-values-and-the-Test-control-is-clickable.md
+++ b/backlog/tasks/task-432 - Provider-test-reports-draft-values-and-the-Test-control-is-clickable.md
@@ -39,7 +39,7 @@ AC#2/AC#3: no production change (already wired). Pilot tests pin the real Button
 
 Tests (Tests/UI/test_settings_provider_test_draft.py): 13 total — 5 pure overlay, 4 bare-instance findings (incl. draft-key-value-never-printed), 4 pilot (AC#2, AC#3-from-focus, AC#3-hotkey-no-op, draft-endpoint wiring). All RED→GREEN; mutation-checked. No-draft path byte-identical (20 existing hub provider tests green).
 
-Follow-up filed TASK-483 (pre-existing: env-var VALUES redacted only by name-pattern; harden to present/missing or positional redaction).
+Follow-up filed TASK-486 (pre-existing: a custom-named credential query param, e.g. ?mycred=SEKRET, in a provider endpoint still prints unredacted in the Test evidence — same name-based-redaction gap class, for query strings).
 
 Files: tldw_chatbook/UI/Screens/settings_screen.py, Tests/UI/test_settings_provider_test_draft.py.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-483 - RAG-settings-profiles-SP2a-profile-storage-foundation.md
+++ b/backlog/tasks/task-483 - RAG-settings-profiles-SP2a-profile-storage-foundation.md
@@ -2,7 +2,7 @@
 id: TASK-483
 title: >-
   RAG settings + profiles SP2a: profile storage foundation
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-22 01:15'
 updated_date: '2026-07-22 01:15'

--- a/backlog/tasks/task-486 - Redact-custom-named-credential-query-params-in-provider-test-endpoint-display.md
+++ b/backlog/tasks/task-486 - Redact-custom-named-credential-query-params-in-provider-test-endpoint-display.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-483
+id: TASK-486
 title: Redact custom-named credential query params in provider-test endpoint display
 status: To Do
 assignee: []


### PR DESCRIPTION
Two different `task-483` files landed on `dev` (the backlog CLI resolves by id, so a duplicate is ambiguous/broken):
- `task-483 - RAG settings + profiles SP2a: profile storage foundation` — filed 2026-07-22 01:15, referenced by PR #780 (merged) and depended on by `task-484`.
- `task-483 - Redact custom-named credential query params…` — filed 19:27, a standalone low-priority follow-up of task-432 with no dependents.

Per the collision rule (the completed/referenced task keeps its id; the standalone not-started task moves), this:
- renames the credential follow-up **task-483 → task-486** (file + frontmatter `id:`),
- updates its inbound reference in **task-432** ("Follow-up filed TASK-483" → TASK-486),
- marks the merged SP2a **task-483 → Done**.

Two-namespace dup-check on the result: no duplicate ids remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolved a duplicate `TASK-483` by keeping the SP2a RAG profiles task as 483 and moving the credential-redaction follow-up to `TASK-486`. Marked SP2a 483 as Done to unblock the backlog CLI and dependent work.

- **Bug Fixes**
  - Renamed credential-redaction task file and `id:` from `TASK-483` to `TASK-486`.
  - Updated task-432 to reference `TASK-486` and clarified the follow-up scope (custom-named credential query params show unredacted in Test evidence).
  - Set `TASK-483` (SP2a profile storage foundation) status to Done.

<sup>Written for commit 71b8406b992a7ec44247c592b7c33ba7a657618f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

