### PR TITLE
fix(console): task-485 defer blocked-send echo persistence

### DIFF
--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -371,6 +371,46 @@ async def test_probe_exception_after_optimistic_echo_marks_row_blocked():
 
 
 @pytest.mark.asyncio
+async def test_blocked_send_persists_no_durable_record():
+    """TASK-485: a send blocked before it reaches the provider must leave NO
+    durable record (no conversation, no message), so it cannot re-enter the next
+    send's context after a resume/restart and leaves no orphan row. The in-memory
+    echo is still shown (feedback) and failed (in-session context exclusion)."""
+    from Tests.Chat.test_console_chat_store import FakePersistence
+
+    persistence = FakePersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    controller = ConsoleChatController(store=store, provider_gateway=BlockedGateway())
+
+    result = await controller.submit_draft("hello")
+
+    assert result.accepted is False
+    messages = store.messages_for_session(store.active_session_id)
+    assert messages[0].role.value == "user"
+    assert messages[0].status == "failed"
+    assert persistence.created_conversations == []
+    assert persistence.created_messages == []
+
+
+@pytest.mark.asyncio
+async def test_accepted_send_persists_the_deferred_user_echo():
+    """TASK-485: once a send is accepted the deferred USER echo is flushed to the
+    durable conversation, so a reload shows the user's prompt (not just the
+    assistant reply) — the successful path must not regress to a missing echo."""
+    from Tests.Chat.test_console_chat_store import FakePersistence
+
+    persistence = FakePersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+
+    await controller.submit_draft("hello")
+
+    senders = [m["sender"] for m in persistence.created_messages]
+    assert "user" in senders
+    assert len(persistence.created_conversations) == 1
+
+
+@pytest.mark.asyncio
 async def test_skill_refuse_after_optimistic_echo_marks_row_blocked():
     """TASK-457(a) (code-review finding 1): a skill-substitution refusal after
     the optimistic echo is a block outcome like the not-ready / probe-raise

--- a/Tests/Chat/test_console_chat_store.py
+++ b/Tests/Chat/test_console_chat_store.py
@@ -957,6 +957,31 @@ def test_mark_message_send_blocked_rejects_non_user_rows():
         store.mark_message_send_blocked(system.id)
 
 
+def test_persist_message_if_needed_flushes_a_deferred_message():
+    """TASK-485: a message appended with persist=False stays out of the durable
+    store until persist_message_if_needed flushes it (used on send-accept so a
+    blocked attempt persists nothing); the flush creates the conversation and is
+    idempotent."""
+    persistence = FakePersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.ensure_session(title="Chat 1")
+
+    message = store.append_message(
+        session.id, role=ConsoleMessageRole.USER, content="hello", persist=False
+    )
+    assert persistence.created_messages == []
+    assert persistence.created_conversations == []
+
+    store.persist_message_if_needed(message.id)
+    assert len(persistence.created_conversations) == 1
+    assert len(persistence.created_messages) == 1
+    assert persistence.created_messages[0]["content"] == "hello"
+
+    # Idempotent — a second flush does not double-insert.
+    store.persist_message_if_needed(message.id)
+    assert len(persistence.created_messages) == 1
+
+
 def test_store_persists_chat_when_sync_enqueue_fails():
     persistence = FakePersistence()
     store = ConsoleChatStore(

--- a/backlog/tasks/task-485 - Console-blocked-send-echo-persistence-failed-status-lost-on-reload-and-orphan-block-row.md
+++ b/backlog/tasks/task-485 - Console-blocked-send-echo-persistence-failed-status-lost-on-reload-and-orphan-block-row.md
@@ -3,9 +3,11 @@ id: TASK-485
 title: >-
   Console blocked-send echo persistence: failed status lost on reload +
   orphan block row
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-22 12:19'
+updated_date: '2026-07-22 20:05'
 labels:
   - console
   - ux
@@ -40,10 +42,10 @@ persisted. Two problems follow:
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A send that never reached the provider does not leave a durable record that, on resume, re-enters the next send's provider context (the never-sent row is either not persisted, or its non-sent state round-trips and is still excluded)
-- [ ] #2 Resuming a conversation whose first send was blocked does not show an unexplained lonely user message (no orphan)
-- [ ] #3 A successful first send still persists correctly and appears in the workspace rail with its derived title (no regression to task-457(a))
-- [ ] #4 Regression coverage for the resume/round-trip path of a blocked send
+- [x] #1 A send that never reached the provider does not leave a durable record that, on resume, re-enters the next send's provider context (the never-sent row is either not persisted, or its non-sent state round-trips and is still excluded)
+- [x] #2 Resuming a conversation whose first send was blocked does not show an unexplained lonely user message (no orphan)
+- [x] #3 A successful first send still persists correctly and appears in the workspace rail with its derived title (no regression to task-457(a))
+- [x] #4 Regression coverage for the resume/round-trip path of a blocked send
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -68,3 +70,43 @@ Candidate approaches (pick one, needs a UX/design call):
 The first avoids a schema change and removes both problems at once; prefer it
 unless there's a product reason to keep blocked attempts in durable history.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Took the recommended approach: **defer echo persistence to the accepted path.**
+`submit_draft` now appends the optimistic USER echo with `persist=False` (the
+in-memory echo still gives the immediate cold-send feedback), and flushes it to
+durable storage only once the turn is confirmed to proceed — right after
+`_notify_submission_accepted()` and BEFORE the assistant row, via a new store
+seam `ConsoleChatStore.persist_message_if_needed(id)`. A send blocked/failed
+before it reaches the provider therefore persists NOTHING: no conversation, no
+message. This removes both problems at the root — there is no durable
+send-blocked row to lose its `failed` state on reload (the resume path's
+hardcoded `status="complete"` at `chat_screen.py:3969` is now moot for these
+rows), and no orphan lonely-"hello".
+
+Why it's clean with the existing store: `mark_message_send_blocked` on a
+`persist=False` echo is already a persistence no-op — `_persist_existing_message`
+sees `persisted_message_id is None` and delegates to
+`_persist_pending_message_if_ready`, which returns early because the row isn't in
+`_pending_persistence_message_ids`. `persist_message_if_needed` reuses
+`_persist_new_message_or_defer` (creates the conversation via
+`persist_session_if_needed`, so auto-title — already run before the append in
+457(a) — still lands the derived title), and is idempotent
+(`persisted_message_id is not None` → no-op).
+
+Verified RED→GREEN: `test_persist_message_if_needed_flushes_a_deferred_message`
+(store); `test_blocked_send_persists_no_durable_record` (blocked send → zero
+created_conversations/created_messages, echo still in-memory + failed);
+`test_accepted_send_persists_the_deferred_user_echo` (success → USER echo
+flushed ahead of the assistant, so a reload shows the prompt). AC #3 no-regression
+proven by the native rail-refresh + workspace-switch-persist tests still passing;
+214 controller+store green + full native chat-flow green (only the 2
+pre-existing continue/regenerate baseline failures remain, confirmed on the
+branch base without this change).
+
+Files: `console_chat_store.py` (new `persist_message_if_needed`),
+`console_chat_controller.py` (`submit_draft`: echo `persist=False` +
+`persist_message_if_needed(echoed_user.id)` on accept).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -417,12 +417,19 @@ class ConsoleChatController:
             )
             for index, pending in enumerate(attachment_mode_pendings)
         )
+        # TASK-485: the optimistic echo is appended WITHOUT persistence. A send
+        # that is blocked/fails before it reaches the provider must leave no
+        # durable record — otherwise the resume path (which reconstructs every
+        # row as "complete") would silently drop the row's failed state and let a
+        # never-sent message re-enter the next send's context, and the orphan
+        # would render as a lonely user prompt. The row is flushed to storage
+        # only once the turn is confirmed to proceed (below).
         echoed_user = self.store.append_message(
             session.id,
             role=ConsoleMessageRole.USER,
             content=clean_draft,
             attachments=staged_attachments,
-            persist=self.store.persistence is not None,
+            persist=False,
         )
 
         self._set_run_state(
@@ -493,6 +500,10 @@ class ConsoleChatController:
         # this hook -- this reorder just extends that same rule to cover
         # it too.
         self._notify_submission_accepted()
+        # TASK-485: the turn is confirmed to proceed — flush the deferred USER
+        # echo to durable storage now (creating the conversation), BEFORE the
+        # assistant row, so a reload shows the user's prompt ahead of its reply.
+        self.store.persist_message_if_needed(echoed_user.id)
         assistant = self.store.append_message(
             session.id,
             role=ConsoleMessageRole.ASSISTANT,

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -913,6 +913,31 @@ class ConsoleChatStore:
         self._persist_existing_message(message)
         return self._snapshot(message)
 
+    def persist_message_if_needed(self, message_id: str) -> ConsoleChatMessage:
+        """Flush a message appended with ``persist=False`` to durable storage.
+
+        TASK-485: the cold-send optimistic echo is appended with ``persist=False``
+        so a blocked/failed attempt leaves NO durable record — no orphan row and
+        nothing that could re-enter the next send's provider context after a
+        resume (the resume path reconstructs every row as ``"complete"``, so a
+        persisted send-blocked row would silently lose its failed state). Once the
+        send is confirmed to proceed, the echoed row is flushed here (creating the
+        conversation via ``persist_session_if_needed``). Idempotent: a no-op
+        without a persistence backend or once the row is already persisted.
+
+        Args:
+            message_id: Id of the deferred row to flush.
+
+        Returns:
+            A snapshot of the message.
+        """
+        message = self._message_or_raise(message_id)
+        if self.persistence is None or message.persisted_message_id is not None:
+            return self._snapshot(message)
+        session_id = self._message_session_index[message.id]
+        self._persist_new_message_or_defer(session_id=session_id, message=message)
+        return self._snapshot(message)
+
     def prepare_message_retry(self, message_id: str) -> ConsoleChatMessage:
         """Prepare a failed assistant message to receive replacement stream content."""
         message = self._message_or_raise(message_id)


### PR DESCRIPTION
## What

**task-485** (task-457(a) code-review follow-up, finding 3). The cold-send optimistic echo was appended with `persist=True` *before* the readiness probe, so a **blocked first send created a durable conversation with a `failed` USER row**. Two problems followed:

1. **Status lost on reload (correctness).** The resume path reconstructs every message with a hardcoded `status="complete"` (`chat_screen.py:3969`), so the `failed` state was lost on reload → the never-sent message re-entered the next send's provider context (`skip_failed` no longer excluded it).
2. **Orphan block row (UX).** The `failed` USER row persisted but the SYSTEM block-row did not → a reload showed a lonely unexplained "hello".

## Fix — defer echo persistence to the accepted path

`submit_draft` now appends the optimistic echo with **`persist=False`** (the in-memory echo still gives the immediate cold-send feedback), and flushes it to durable storage only once the turn is confirmed to proceed — right after `_notify_submission_accepted()` and **before** the assistant row — via the new `ConsoleChatStore.persist_message_if_needed(id)`.

A send blocked/failed before it reaches the provider therefore persists **nothing** (no conversation, no message): no durable row to re-leak on resume, no orphan.

**Why it composes cleanly:** `mark_message_send_blocked` on a `persist=False` echo is already a persistence no-op (`_persist_existing_message` → `persisted_message_id is None` → `_persist_pending_message_if_ready` early-returns — the row isn't in `_pending_persistence_message_ids`). `persist_message_if_needed` reuses `_persist_new_message_or_defer` (creates the conversation via `persist_session_if_needed`, so the pre-append auto-title from 457(a) still lands the derived title) and is idempotent.

## Tests (RED→GREEN)

- `test_persist_message_if_needed_flushes_a_deferred_message` (store)
- `test_blocked_send_persists_no_durable_record` — blocked send → zero `created_conversations`/`created_messages`, echo still in-memory + `failed`
- `test_accepted_send_persists_the_deferred_user_echo` — success → USER echo flushed ahead of the assistant

214 controller+store green; native rail-refresh + workspace-switch-persist green (AC #3 no-regression); full native chat-flow green modulo the 2 pre-existing continue/regenerate baseline failures (confirmed on the branch base without this change).

Closes task-485.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes task-485 by deferring persistence of the first optimistic user echo until the send is accepted. Blocked sends no longer create conversations or messages; successful sends flush the echo just before the assistant reply, preventing reload leaks and orphaned rows.

- **Bug Fixes**
  - Controller: append the USER echo with persist=False; on accept, flush it right after `_notify_submission_accepted()` and before the assistant via `ConsoleChatStore.persist_message_if_needed`.
  - Store: add `persist_message_if_needed` (idempotent; creates the conversation via `persist_session_if_needed`).
  - Tests and ACs: added coverage to ensure blocked sends persist nothing, accepted sends persist the user echo, and deferred messages flush correctly; meets task-485 acceptance criteria and keeps auto-title behavior.

<sup>Written for commit c5aceb0c202f3b5dbbb60fd96b43a3d28aa8e863. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

