### PR TITLE
Token budget for the agent RunBudget (TASK-326)

### DIFF
--- a/Docs/superpowers/plans/2026-07-23-agent-token-budget.md
+++ b/Docs/superpowers/plans/2026-07-23-agent-token-budget.md
@@ -1,0 +1,474 @@
+# Agent RunBudget Token Budget Implementation Plan (TASK-326)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the agent runtime a token-spend ceiling — `RunBudget.max_total_tokens` — that accumulates prompt+completion tokens per run and stops the loop cleanly (like the existing caps) when exceeded, with real provider usage when reported and a token_counter estimate otherwise.
+
+**Architecture:** Three files. `agent_models.py` gains the data fields (`ModelTurn.tokens`, `RunBudget.max_total_tokens`, `RunOutcome.total_tokens`). `agent_service.py` populates `ModelTurn.tokens` from `resp["usage"]` or the task-321 estimator. `agent_runtime.py`'s pure loop accumulates the spend and adds a top-of-loop budget check mirroring the step/model-turn/wall-clock caps, reporting spend via an `_outcome` helper closure.
+
+**Tech Stack:** Python, pytest. The runtime calls providers with `streaming=False`, so usage is on the response dict.
+
+## Global Constraints
+
+- **Worktree:** all work in `/Users/macbook-dev/Documents/GitHub/tldw_chatbook-agent-token-budget` (branch `feat/agent-token-budget`, off `origin/dev @ c10b5eb9e`). Never touch the main checkout `/Users/macbook-dev/Documents/GitHub/tldw_chatbook`.
+- **Test command (venv is in the main checkout):**
+  `cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook-agent-token-budget && /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <path> -v`
+- **Sentinel default `max_total_tokens = 0` = unlimited** — default runs must be byte-identical (the check is guarded `if budget.max_total_tokens and …`).
+- **`max_total_tokens` is cumulative SPEND** (`Σ(prompt_i + completion_i)` across turns, since the growing prompt is re-sent each call), not a context-window size.
+- New fields `ModelTurn.tokens` and `RunOutcome.total_tokens` are **trailing and defaulted (0)** — backward compatible with every existing construction.
+- **Terminal on exhaustion:** `add(STEP_ERROR, summary="token budget exhausted")` then return `RUN_STUCK` — a clear step, not silent truncation. Placed **after** the existing wall-clock check.
+- **Commit only the files each task names**, with explicit `git add <paths>` — never `git add -A`/`-am` (the repo has a tracked `.superpowers/` scratch area and other stray files).
+
+---
+
+## Task 1: Data-model fields (`agent_models.py`)
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/agent_models.py` (`ModelTurn`, `RunBudget`, `RunOutcome`, `clamp_child_budget`)
+- Test: `Tests/Agents/test_agent_models.py`
+
+**Interfaces:**
+- Produces: `ModelTurn(text, tool_calls, assistant_message, tokens: int = 0)`; `RunBudget(..., max_total_tokens: int = 0)`; `RunOutcome(status, steps, final_text="", subagents_spawned=0, total_tokens: int = 0)`; `clamp_child_budget` preserves `max_total_tokens`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/Agents/test_agent_models.py` (import what's missing at the top of the file: `ModelTurn`, `RunBudget`, `RunOutcome`, `clamp_child_budget` from `tldw_chatbook.Agents.agent_models`):
+
+```python
+def test_modelturn_tokens_defaults_zero():
+    from tldw_chatbook.Agents.agent_models import ModelTurn
+    assert ModelTurn(text="hi").tokens == 0
+    assert ModelTurn(text="hi", tokens=42).tokens == 42
+
+
+def test_runbudget_max_total_tokens_defaults_zero():
+    from tldw_chatbook.Agents.agent_models import RunBudget
+    assert RunBudget().max_total_tokens == 0
+    assert RunBudget(max_total_tokens=5000).max_total_tokens == 5000
+
+
+def test_runoutcome_total_tokens_defaults_zero():
+    from tldw_chatbook.Agents.agent_models import RunOutcome, RUN_DONE
+    assert RunOutcome(RUN_DONE, []).total_tokens == 0
+    assert RunOutcome(RUN_DONE, [], total_tokens=123).total_tokens == 123
+
+
+def test_clamp_child_budget_preserves_max_total_tokens():
+    from tldw_chatbook.Agents.agent_models import RunBudget, clamp_child_budget
+    child = RunBudget(max_total_tokens=7000)
+    assert clamp_child_budget(child, 10.0).max_total_tokens == 7000
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `... -m pytest Tests/Agents/test_agent_models.py -v -k "tokens or clamp_child_budget_preserves"`
+Expected: FAIL (`ModelTurn` has no `tokens`; `RunBudget` has no `max_total_tokens`; etc.).
+
+- [ ] **Step 3: Add `ModelTurn.tokens`**
+
+In `agent_models.py`, add a trailing field to the frozen `ModelTurn` dataclass:
+
+```python
+@dataclass(frozen=True)
+class ModelTurn:
+    text: str = ""
+    tool_calls: tuple[ToolCall, ...] = ()
+    assistant_message: dict | None = None
+    tokens: int = 0
+```
+
+- [ ] **Step 4: Add `RunBudget.max_total_tokens`**
+
+Add a trailing field to the frozen `RunBudget` dataclass (after `max_model_turns`):
+
+```python
+    max_model_turns: int = 8
+    # task-326: cumulative prompt+completion token spend ceiling for one run.
+    # 0 = unlimited (default), keeping existing runs byte-identical. This is a
+    # SPEND ceiling (the growing prompt is re-sent each call), not a window size.
+    max_total_tokens: int = 0
+```
+
+- [ ] **Step 5: Add `RunOutcome.total_tokens`**
+
+Add a trailing field to the `RunOutcome` dataclass:
+
+```python
+@dataclass
+class RunOutcome:
+    status: str
+    steps: list[AgentStep]
+    final_text: str = ""
+    subagents_spawned: int = 0
+    total_tokens: int = 0
+```
+
+- [ ] **Step 6: Preserve `max_total_tokens` in `clamp_child_budget`**
+
+In `clamp_child_budget`, add `max_total_tokens=child.max_total_tokens` to the returned `RunBudget(...)` (alongside the other pass-through fields):
+
+```python
+    return RunBudget(
+        max_steps=child.max_steps,
+        max_wall_seconds=min(
+            child.max_wall_seconds, max(parent_remaining_seconds, 1.0)
+        ),
+        max_subagents=0,
+        max_active_tools=child.max_active_tools,
+        max_subagent_result_chars=child.max_subagent_result_chars,
+        max_model_turns=child.max_model_turns,
+        max_total_tokens=child.max_total_tokens,
+    )
+```
+
+- [ ] **Step 7: Run to verify pass**
+
+Run: `... -m pytest Tests/Agents/test_agent_models.py -v`
+Expected: PASS (new tests + all pre-existing model tests).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tldw_chatbook/Agents/agent_models.py Tests/Agents/test_agent_models.py
+git commit -m "feat(agents): RunBudget.max_total_tokens + ModelTurn.tokens + RunOutcome.total_tokens (TASK-326)"
+```
+
+---
+
+## Task 2: Loop accumulation + token-budget stop (`agent_runtime.py`)
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/agent_runtime.py` (`run_agent_loop`)
+- Test: `Tests/Agents/test_agent_runtime.py`
+
+**Interfaces:**
+- Consumes: `ModelTurn.tokens`, `RunBudget.max_total_tokens`, `RunOutcome.total_tokens` (Task 1).
+- Produces: `run_agent_loop` accumulates `total_tokens += turn.tokens`, stops with `RUN_STUCK` + a `"token budget exhausted"` step when `max_total_tokens` is exceeded, and reports `RunOutcome.total_tokens` on every terminal path.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/Agents/test_agent_runtime.py` (the module already imports `RUN_STUCK`, `RUN_DONE`, `AgentConfig`, `ModelTurn`, `RunBudget`, `run_agent_loop`, `SPAWN_TOOL_NAME`, and defines `fence`, `CFG`, `CALC`, `run`, `make_deps`):
+
+```python
+def test_token_budget_trips_to_stuck():
+    # Tool-calling turns that never finish; each carries 100 tokens so the
+    # cumulative spend crosses max_total_tokens before the (raised) step/turn caps.
+    turns = [
+        ModelTurn(text=fence("calculator", {"expression": str(i)}), tokens=100)
+        for i in range(50)
+    ]
+    cfg = AgentConfig(
+        model="m",
+        system_prompt="s",
+        allowed_tools=("calculator", SPAWN_TOOL_NAME),
+        budget=RunBudget(max_steps=99, max_model_turns=99, max_total_tokens=250),
+    )
+    out = run(turns, config=cfg)
+    assert out.status == RUN_STUCK
+    assert out.steps[-1].summary == "token budget exhausted"
+    assert out.total_tokens >= 250
+
+
+def test_token_budget_sentinel_zero_never_trips():
+    # Huge per-turn tokens but max_total_tokens=0 (default) -> completes normally.
+    turns = [
+        ModelTurn(text=fence("calculator", {"expression": "1"}), tokens=10_000_000),
+        ModelTurn(text="all done", tokens=10_000_000),
+    ]
+    out = run(turns)  # default CFG budget has max_total_tokens=0
+    assert out.status == RUN_DONE
+    assert out.final_text == "all done"
+
+
+def test_token_budget_done_on_crossing_turn_completes():
+    # The final-answer turn itself crosses the budget -> still RUN_DONE
+    # (stop-the-loop, not fail-the-answer), and total_tokens is reported.
+    cfg = AgentConfig(model="m", system_prompt="s", budget=RunBudget(max_total_tokens=50))
+    out = run([ModelTurn(text="the answer", tokens=100)], config=cfg)
+    assert out.status == RUN_DONE
+    assert out.final_text == "the answer"
+    assert out.total_tokens == 100
+
+
+def test_run_outcome_reports_total_tokens_accounting():
+    turns = [
+        ModelTurn(text=fence("calculator", {"expression": "1"}), tokens=30),
+        ModelTurn(text="done", tokens=12),
+    ]
+    out = run(turns)
+    assert out.status == RUN_DONE
+    assert out.total_tokens == 42
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `... -m pytest Tests/Agents/test_agent_runtime.py -v -k "token_budget or total_tokens_accounting"`
+Expected: FAIL (no token accumulation/check yet; `out.total_tokens` is always 0, `RUN_STUCK` step summary absent).
+
+- [ ] **Step 3: Add the `total_tokens` accumulator + `_outcome` helper**
+
+In `run_agent_loop`, initialize `total_tokens` beside the other counters. Find:
+
+```python
+    started = deps.clock()
+    spawned = 0
+    model_turns = 0
+```
+
+Change to:
+
+```python
+    started = deps.clock()
+    spawned = 0
+    model_turns = 0
+    total_tokens = 0
+```
+
+Immediately after the existing `add` closure definition (the `def add(kind: str, **kw) -> AgentStep:` block ending in `return step`), add a sibling `_outcome` helper:
+
+```python
+    def _outcome(status: str, **kw) -> RunOutcome:
+        # Reports run spend on every terminal path; reads enclosing steps/
+        # spawned/total_tokens at call time (no nonlocal, like add()).
+        return RunOutcome(
+            status, steps, subagents_spawned=spawned, total_tokens=total_tokens, **kw
+        )
+```
+
+- [ ] **Step 4: Accumulate tokens after each model turn**
+
+Find the model-turn block:
+
+```python
+        turn = deps.call_model(messages, tuple(active))
+        model_turns += 1
+        add(STEP_MODEL, summary=turn.text[:200])
+```
+
+Change to:
+
+```python
+        turn = deps.call_model(messages, tuple(active))
+        model_turns += 1
+        total_tokens += turn.tokens
+        add(STEP_MODEL, summary=turn.text[:200])
+```
+
+- [ ] **Step 5: Add the token-budget check after the wall-clock check**
+
+Find the wall-clock check:
+
+```python
+        if deps.clock() - started > budget.max_wall_seconds:
+            add(STEP_ERROR, summary="wall-clock budget exhausted")
+            return RunOutcome(RUN_STUCK, steps, subagents_spawned=spawned)
+```
+
+Add immediately after it:
+
+```python
+        if budget.max_total_tokens and total_tokens >= budget.max_total_tokens:
+            add(STEP_ERROR, summary="token budget exhausted")
+            return _outcome(RUN_STUCK)
+```
+
+- [ ] **Step 6: Route every terminal return through `_outcome`**
+
+Convert all **8** existing `return RunOutcome(...)` call-sites in `run_agent_loop` to `_outcome(...)` so each reports `total_tokens`:
+- Every `return RunOutcome(<STATUS>, steps, subagents_spawned=spawned)` → `return _outcome(<STATUS>)` (there are six: the `should_cancel`, step-budget, model-turn-budget, wall-clock-budget, the in-tool-loop cancel, and the loop-detection returns).
+- The two with `final_text=turn.text`:
+  `return RunOutcome(RUN_CANCELLED, steps, final_text=turn.text, subagents_spawned=spawned)` → `return _outcome(RUN_CANCELLED, final_text=turn.text)`
+  `return RunOutcome(RUN_DONE, steps, final_text=turn.text, subagents_spawned=spawned)` → `return _outcome(RUN_DONE, final_text=turn.text)`
+
+Then verify no call-site was missed — only the single definition inside `_outcome` may remain:
+
+Run: `grep -c "RunOutcome(" tldw_chatbook/Agents/agent_runtime.py`
+Expected: `1` (the lone `RunOutcome(...)` constructor inside `_outcome`).
+
+- [ ] **Step 7: Run to verify pass**
+
+Run: `... -m pytest Tests/Agents/test_agent_runtime.py -v`
+Expected: PASS — the four new tests plus every pre-existing loop test (the `_outcome` conversion preserves each prior return's status/final_text; `total_tokens` defaults 0 so untouched-behavior tests are unaffected).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tldw_chatbook/Agents/agent_runtime.py Tests/Agents/test_agent_runtime.py
+git commit -m "feat(agents): accumulate token spend and stop the loop on max_total_tokens (TASK-326)"
+```
+
+---
+
+## Task 3: Populate `ModelTurn.tokens` — real usage or estimate (`agent_service.py`)
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/agent_service.py` (add `_usage_total_tokens`, imports, populate `tokens=` in `_make_call_model.call_model`)
+- Test: `Tests/Agents/test_agent_service.py`
+
+**Interfaces:**
+- Consumes: `ModelTurn.tokens` (Task 1); `count_tokens_messages`, `estimate_tokens` from `tldw_chatbook.Utils.token_counter`.
+- Produces: `_usage_total_tokens(resp) -> int | None`; `call_model` returns `ModelTurn` with `tokens=` populated (real usage when present, else estimate).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/Agents/test_agent_service.py` (it already imports `AgentService`, `ToolCatalogRegistry`, `BuiltinToolProvider`, and defines the `db` fixture; add `from tldw_chatbook.Agents.agent_models import AgentConfig` and `from tldw_chatbook.Agents.agent_service import _usage_total_tokens` at the top):
+
+```python
+def test_usage_total_tokens_reads_total():
+    assert _usage_total_tokens({"usage": {"total_tokens": 150}}) == 150
+
+
+def test_usage_total_tokens_sums_prompt_and_completion():
+    assert _usage_total_tokens(
+        {"usage": {"prompt_tokens": 100, "completion_tokens": 50}}
+    ) == 150
+
+
+def test_usage_total_tokens_none_when_absent_or_malformed():
+    assert _usage_total_tokens({"choices": []}) is None
+    assert _usage_total_tokens("a string") is None
+    assert _usage_total_tokens({"usage": "bad"}) is None
+    assert _usage_total_tokens({"usage": {"prompt_tokens": 10}}) is None
+
+
+def _service_with_chat(db, chat_call):
+    registry = ToolCatalogRegistry()
+    registry.register_provider(BuiltinToolProvider())
+    return AgentService(db=db, registry=registry, chat_call=chat_call)
+
+
+def test_call_model_uses_real_provider_usage(db):
+    def chat(**kwargs):
+        return {
+            "choices": [{"message": {"content": "hello there"}}],
+            "usage": {"total_tokens": 150},
+        }
+    service = _service_with_chat(db, chat)
+    cfg = AgentConfig(model="gpt-4o", system_prompt="s", native_tools=False)
+    call_model = service._make_call_model(cfg, "openai", [])
+    turn = call_model([{"role": "user", "content": "hi"}], ())
+    assert turn.tokens == 150
+
+
+def test_call_model_estimates_when_no_usage(db):
+    def chat(**kwargs):
+        return {"choices": [{"message": {"content": "hello there world"}}]}
+    service = _service_with_chat(db, chat)
+    cfg = AgentConfig(model="gpt-4o", system_prompt="s", native_tools=False)
+    call_model = service._make_call_model(cfg, "openai", [])
+    turn = call_model([{"role": "user", "content": "count these tokens"}], ())
+    # No provider usage -> estimate of sent payload + response text, always > 0.
+    assert turn.tokens > 0
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `... -m pytest Tests/Agents/test_agent_service.py -v -k "usage_total_tokens or call_model_uses_real or call_model_estimates"`
+Expected: FAIL (`cannot import name '_usage_total_tokens'`).
+
+- [ ] **Step 3: Add imports**
+
+At the top of `agent_service.py`, add (with the other `tldw_chatbook` imports):
+
+```python
+from tldw_chatbook.Utils.token_counter import count_tokens_messages, estimate_tokens
+```
+
+- [ ] **Step 4: Add the `_usage_total_tokens` helper**
+
+Add near the existing `_response_text`/`_response_message` module functions:
+
+```python
+def _usage_total_tokens(resp) -> int | None:
+    """Prompt+completion tokens from a provider's OpenAI-shaped usage block,
+    or None when the provider didn't report usage.
+
+    Args:
+        resp: The provider response (dict when the provider reports usage).
+
+    Returns:
+        The total tokens for the call, or None to signal "estimate instead".
+    """
+    try:
+        usage = resp["usage"]
+    except (KeyError, TypeError):
+        return None
+    if not isinstance(usage, dict):
+        return None
+    total = usage.get("total_tokens")
+    if isinstance(total, int) and total > 0:
+        return total
+    prompt = usage.get("prompt_tokens")
+    completion = usage.get("completion_tokens")
+    if isinstance(prompt, int) and isinstance(completion, int):
+        return prompt + completion
+    return None
+```
+
+- [ ] **Step 5: Populate `tokens=` on both `ModelTurn` returns**
+
+In `_make_call_model.call_model`, find:
+
+```python
+            text = _response_text(resp)
+            if not native:
+                return ModelTurn(text=text)
+```
+
+Change to (compute tokens once, before both returns):
+
+```python
+            text = _response_text(resp)
+            tokens = _usage_total_tokens(resp)
+            if tokens is None:
+                # Provider reported no usage -> estimate from sent payload +
+                # response text (native tool_calls JSON is not separately
+                # counted here; the prompt term dominates the per-turn total).
+                tokens = count_tokens_messages(payload, config.model) + estimate_tokens(
+                    text, config.model
+                )
+            if not native:
+                return ModelTurn(text=text, tokens=tokens)
+```
+
+And the native return at the end of `call_model`, find:
+
+```python
+            return ModelTurn(
+                text=text, tool_calls=tool_calls, assistant_message=assistant_message
+            )
+```
+
+Change to:
+
+```python
+            return ModelTurn(
+                text=text,
+                tool_calls=tool_calls,
+                assistant_message=assistant_message,
+                tokens=tokens,
+            )
+```
+
+- [ ] **Step 6: Run to verify pass**
+
+Run: `... -m pytest Tests/Agents/test_agent_service.py -v`
+Expected: PASS — the new tests plus every pre-existing service test (adding `tokens=` to the returns doesn't change text/tool_calls behavior).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tldw_chatbook/Agents/agent_service.py Tests/Agents/test_agent_service.py
+git commit -m "feat(agents): populate ModelTurn.tokens from provider usage or estimate (TASK-326)"
+```
+
+---
+
+## Final verification (after all tasks)
+
+- [ ] Run the full agent suite + the token_counter consumers:
+  `... -m pytest Tests/Agents/ Tests/Chat/test_console_agent_bridge.py -q`
+  Expected: all pass (no behavior change at defaults; `max_total_tokens=0` sentinel).
+- [ ] Confirm the loop has exactly one `RunOutcome(` constructor:
+  `grep -c "RunOutcome(" tldw_chatbook/Agents/agent_runtime.py` → `1`.
+- [ ] Update the `task-326` backlog file (check ACs, add Implementation Notes) as the final step before finishing the branch.

--- a/Docs/superpowers/specs/2026-07-23-agent-token-budget-design.md
+++ b/Docs/superpowers/specs/2026-07-23-agent-token-budget-design.md
@@ -31,6 +31,14 @@ runtime's non-streaming calls, so it can be tracked cheaply.
    byte-identical until a consumer opts in (mirroring how `max_model_turns` is
    unreachable at defaults).
 
+**`max_total_tokens` is cumulative *spend*, not a context-window size.** Because
+the growing prompt (system + accumulated history) is re-sent on every provider
+call, the per-run total is `Σ(prompt_i + completion_i)` across turns — the real
+billed token spend. An 8-turn run over a 50k-token history accumulates ~400k+
+tokens. A consumer setting this must size it as a spend ceiling (hundreds of
+thousands), not as a window (`8192` would trip almost immediately). This is the
+same semantics real provider `usage` reports per call.
+
 ## Architecture
 
 The agent loop `run_agent_loop` (`agent_runtime.py`) is a **pure function**
@@ -104,6 +112,17 @@ if tokens is None:
 `count_tokens_messages`'s string-content assumption holds; no multimodal
 flattening is needed here.)
 
+**Documented estimate-fallback limitation.** On a *native tool-call* turn from a
+provider that reports *no* usage, `_response_text(resp)` (= `message["content"]`)
+is often empty — the model returns `tool_calls` with null content — so the
+completion estimate is ~0 and the turn's tool-call JSON isn't counted. This is a
+narrow fallback-of-a-fallback (usage-less provider AND native tools); the prompt
+term (the full re-sent history) dominates each turn's total, so the under-count
+is small and errs toward letting the loop run slightly longer, never toward a
+false stop. Providers that do native tool-calling generally report usage (the
+accurate path). Left as a documented limitation rather than serializing
+`tool_calls` into the estimate.
+
 ### Unit C — `RunBudget.max_total_tokens` + accumulation + terminal stop
 
 **`agent_models.py`:**
@@ -119,21 +138,30 @@ flattening is needed here.)
 
 **`agent_runtime.py` `run_agent_loop`:**
 - Initialize `total_tokens = 0` beside `model_turns = 0`.
+- Add a local `_outcome` helper closure next to the existing `add()` closure, so
+  every one of the loop's **8** terminal returns reports the current spend
+  without threading the field into each site by hand (miss-a-site risk):
+  ```python
+  def _outcome(status: str, **kw) -> RunOutcome:
+      return RunOutcome(status, steps, subagents_spawned=spawned,
+                        total_tokens=total_tokens, **kw)
+  ```
+  It only *reads* the enclosing `steps`/`spawned`/`total_tokens` (no `nonlocal`
+  needed, same as `add()`), so each return reflects state at call time. Convert
+  the loop's `return RunOutcome(STATUS, steps, subagents_spawned=spawned, …)`
+  sites to `return _outcome(STATUS, …)` — the `RUN_DONE` site keeps its
+  `final_text=turn.text`.
 - After each model turn (`turn = deps.call_model(...)`; `model_turns += 1`),
   add `total_tokens += turn.tokens`.
-- Add a top-of-loop check alongside the step/model-turn/wall-clock checks:
+- Add a top-of-loop check immediately after the existing wall-clock check:
   ```python
   if budget.max_total_tokens and total_tokens >= budget.max_total_tokens:
       add(STEP_ERROR, summary="token budget exhausted")
-      return RunOutcome(RUN_STUCK, steps, subagents_spawned=spawned,
-                        total_tokens=total_tokens)
+      return _outcome(RUN_STUCK)
   ```
   The `budget.max_total_tokens and …` guard makes `0` a true "unlimited"
-  sentinel that never trips.
-- **Thread `total_tokens=total_tokens` into every `RunOutcome(...)` return** in
-  the loop (done, stuck, cancelled, other caps, loop-detection), so the spend
-  is always reported. Checking at the *top* (before the next call) means a run
-  that produces its final answer on the turn it crosses the budget still
+  sentinel that never trips. Checking at the *top* (before the next call) means
+  a run that produces its final answer on the turn it crosses the budget still
   returns `RUN_DONE` — the budget stops the loop from making *more* calls, it
   does not retroactively fail a completed answer (AC#2/#3).
 

--- a/Docs/superpowers/specs/2026-07-23-agent-token-budget-design.md
+++ b/Docs/superpowers/specs/2026-07-23-agent-token-budget-design.md
@@ -1,0 +1,168 @@
+# Token budget for the agent RunBudget (TASK-326)
+
+**Date**: 2026-07-23
+**Status**: Approved design, pending implementation plan
+**Base**: origin/dev @ `c10b5eb9e` (contains 322 + 320/321/325)
+**Backlog**: TASK-326 (harness-review stream; no listed deps)
+
+## Why
+
+The agent runtime bounds steps, model-turns, wall-clock, and sub-agent count
+(`agent_models.py` `RunBudget`) but has **no token budget** — a grep for
+`token_budget`/`cost_budget`/`max_tokens` in `Agents/` returns nothing. A run on
+a large-context model with big, growing tool-loop transcripts can burn
+substantial tokens within the model-turn cap with no spend ceiling and no
+accounting to stop on. This is the documented complement to task-322: **322
+bounds the conversation history *into* the loop at initial dispatch; 326 bounds
+the loop *itself*** — the tool-call/tool-result messages that accumulate across
+iterations within a single turn. Providers already return usage on the
+runtime's non-streaming calls, so it can be tracked cheaply.
+
+## Decisions (user-approved)
+
+1. **Hybrid token source.** Use the real `resp["usage"]` (prompt+completion)
+   when the provider reports it; fall back to the task-321 `token_counter`
+   estimate when it doesn't (some local providers). Accurate where possible,
+   and always counts *something* so the budget can't be silently defeated.
+2. **Tokens only** (`max_total_tokens`). AC#1 says "max_total_tokens (and/or
+   cost)"; a dollar-cost budget needs a per-model price table that doesn't
+   exist yet (`model_capabilities` has no pricing) — a clean follow-up.
+3. **Sentinel default `max_total_tokens = 0` = unlimited**, so default runs are
+   byte-identical until a consumer opts in (mirroring how `max_model_turns` is
+   unreachable at defaults).
+
+## Architecture
+
+The agent loop `run_agent_loop` (`agent_runtime.py`) is a **pure function**
+driven by `deps.call_model(messages, active) -> ModelTurn`; the existing caps
+are checked at the top of each iteration, each producing `add(STEP_ERROR,
+summary="… budget exhausted")` + `return RunOutcome(RUN_STUCK, …)`. The token
+budget mirrors this exactly, so AC#3 (clear terminal status/step, not silent
+truncation) falls out of the existing pattern. Three small units:
+
+### Unit A — `ModelTurn` carries its token cost (`agent_models.py`)
+
+Add one field to the frozen `ModelTurn` dataclass:
+
+```python
+@dataclass(frozen=True)
+class ModelTurn:
+    text: str = ""
+    tool_calls: tuple[ToolCall, ...] = ()
+    assistant_message: dict | None = None
+    tokens: int = 0   # prompt+completion tokens for THIS provider call (0 = unknown)
+```
+
+`tokens` is the total (prompt + completion) tokens attributable to that single
+provider call. Default `0` keeps fence-protocol/test turns and any construction
+site that doesn't set it valid and non-contributing. This is the seam that lets
+the pure loop accumulate spend without knowing the source.
+
+### Unit B — `_make_call_model` populates `ModelTurn.tokens` (`agent_service.py`)
+
+`_make_call_model.call_model` already does `resp = self.chat_call(..., streaming=
+False, model=config.model, ...)` and extracts `text`/message. After that, derive
+the turn's tokens with a hybrid source and set `tokens=` on **both** return
+paths (non-native `ModelTurn(text=text, tokens=…)` and the native
+`ModelTurn(text=…, tool_calls=…, assistant_message=…, tokens=…)`):
+
+```python
+def _usage_total_tokens(resp) -> int | None:
+    """Prompt+completion tokens from a provider's OpenAI-shaped usage block,
+    or None when the provider didn't report usage."""
+    try:
+        usage = resp["usage"]
+    except (KeyError, TypeError):
+        return None
+    if not isinstance(usage, dict):
+        return None
+    total = usage.get("total_tokens")
+    if isinstance(total, int) and total > 0:
+        return total
+    prompt = usage.get("prompt_tokens")
+    completion = usage.get("completion_tokens")
+    if isinstance(prompt, int) and isinstance(completion, int):
+        return prompt + completion
+    return None
+```
+
+In `call_model`, after building `payload` and getting `resp`/`text`:
+
+```python
+tokens = _usage_total_tokens(resp)
+if tokens is None:
+    # Provider reported no usage — estimate from what we sent + received.
+    tokens = count_tokens_messages(payload, config.model) + estimate_tokens(
+        text, config.model
+    )
+```
+
+`payload` is the full sent message list (system + accumulated history), so
+`count_tokens_messages(payload, model)` estimates the prompt and
+`estimate_tokens(text, model)` the completion — summing to this call's spend.
+(Agent payloads are text-only — tool calls/results are JSON/text strings — so
+`count_tokens_messages`'s string-content assumption holds; no multimodal
+flattening is needed here.)
+
+### Unit C — `RunBudget.max_total_tokens` + accumulation + terminal stop
+
+**`agent_models.py`:**
+- Add `max_total_tokens: int = 0` to `RunBudget` (0 = unlimited).
+- `clamp_child_budget` passes it through unchanged (`max_total_tokens=
+  child.max_total_tokens`) — each run, parent or sub-agent, carries its own
+  token budget, exactly as `max_steps` is per-run. (Sub-agent spend counts
+  against the *sub-agent's* budget, not the parent's; cross-run token
+  accounting is out of scope.)
+- Add `total_tokens: int = 0` to `RunOutcome` for observability (the run's
+  measured spend), answering the description's "no accounting" gap. The cap is
+  the AC; this is the cheap accounting complement.
+
+**`agent_runtime.py` `run_agent_loop`:**
+- Initialize `total_tokens = 0` beside `model_turns = 0`.
+- After each model turn (`turn = deps.call_model(...)`; `model_turns += 1`),
+  add `total_tokens += turn.tokens`.
+- Add a top-of-loop check alongside the step/model-turn/wall-clock checks:
+  ```python
+  if budget.max_total_tokens and total_tokens >= budget.max_total_tokens:
+      add(STEP_ERROR, summary="token budget exhausted")
+      return RunOutcome(RUN_STUCK, steps, subagents_spawned=spawned,
+                        total_tokens=total_tokens)
+  ```
+  The `budget.max_total_tokens and …` guard makes `0` a true "unlimited"
+  sentinel that never trips.
+- **Thread `total_tokens=total_tokens` into every `RunOutcome(...)` return** in
+  the loop (done, stuck, cancelled, other caps, loop-detection), so the spend
+  is always reported. Checking at the *top* (before the next call) means a run
+  that produces its final answer on the turn it crosses the budget still
+  returns `RUN_DONE` — the budget stops the loop from making *more* calls, it
+  does not retroactively fail a completed answer (AC#2/#3).
+
+## Testing (AC#4)
+
+- **Loop budget exhaustion (pure, `test_agent_runtime.py` style):** inject a
+  fake `call_model` returning tool-calling `ModelTurn(text=…, tokens=N)` turns;
+  `RunBudget(max_total_tokens=small)`; assert the run returns `RUN_STUCK` with a
+  final `STEP_ERROR` summary `"token budget exhausted"`, and the reported
+  `RunOutcome.total_tokens` reflects the accumulation.
+- **Sentinel:** `max_total_tokens=0` never trips — a run whose turns carry large
+  `tokens` still completes normally (`RUN_DONE`).
+- **Boundary:** a run that crosses the budget on the SAME turn that yields the
+  final answer completes `RUN_DONE` (stop-the-loop, not fail-the-answer).
+- **Accounting:** `RunOutcome.total_tokens` equals the sum of the turns' tokens
+  on a normal `RUN_DONE` run.
+- **Hybrid source (`_usage_total_tokens` + call_model, `test_agent_service.py`
+  style):** a `resp` with `usage.total_tokens` uses it; a `resp` with only
+  `prompt_tokens`+`completion_tokens` sums them; a `resp` with no/`malformed`
+  usage returns `None` and the call_model estimate fallback yields `tokens > 0`.
+- **Child budget:** `clamp_child_budget` preserves `max_total_tokens`.
+
+## Out of scope
+
+- Dollar-cost budgets and per-model price tables (follow-up; AC#1 "and/or").
+- Cross-run/parent-inclusive token accounting for sub-agents (each run has its
+  own budget).
+- Streaming-usage capture — the agent runtime calls providers with
+  `streaming=False`, so usage is already on the response.
+- Surfacing/enforcing the budget in any specific consumer UI; `CONSOLE_RUN_
+  BUDGET` may set a real `max_total_tokens` later, but this task ships the
+  mechanism with the safe unlimited default.

--- a/Tests/Agents/test_agent_models.py
+++ b/Tests/Agents/test_agent_models.py
@@ -118,6 +118,30 @@ def test_models_construct_and_are_frozen_where_stated():
         assert frozen.__dataclass_params__.frozen is True
 
 
+def test_modelturn_tokens_defaults_zero():
+    from tldw_chatbook.Agents.agent_models import ModelTurn
+    assert ModelTurn(text="hi").tokens == 0
+    assert ModelTurn(text="hi", tokens=42).tokens == 42
+
+
+def test_runbudget_max_total_tokens_defaults_zero():
+    from tldw_chatbook.Agents.agent_models import RunBudget
+    assert RunBudget().max_total_tokens == 0
+    assert RunBudget(max_total_tokens=5000).max_total_tokens == 5000
+
+
+def test_runoutcome_total_tokens_defaults_zero():
+    from tldw_chatbook.Agents.agent_models import RunOutcome, RUN_DONE
+    assert RunOutcome(RUN_DONE, []).total_tokens == 0
+    assert RunOutcome(RUN_DONE, [], total_tokens=123).total_tokens == 123
+
+
+def test_clamp_child_budget_preserves_max_total_tokens():
+    from tldw_chatbook.Agents.agent_models import RunBudget, clamp_child_budget
+    child = RunBudget(max_total_tokens=7000)
+    assert clamp_child_budget(child, 10.0).max_total_tokens == 7000
+
+
 def test_pure_module_has_no_forbidden_imports():
     import tldw_chatbook.Agents.agent_models as mod
 

--- a/Tests/Agents/test_agent_runtime.py
+++ b/Tests/Agents/test_agent_runtime.py
@@ -549,6 +549,56 @@ def test_fence_history_convention_unchanged():
     assert history[2]["content"].startswith("Tool result for")
 
 
+def test_token_budget_trips_to_stuck():
+    # Tool-calling turns that never finish; each carries 100 tokens so the
+    # cumulative spend crosses max_total_tokens before the (raised) step/turn caps.
+    turns = [
+        ModelTurn(text=fence("calculator", {"expression": str(i)}), tokens=100)
+        for i in range(50)
+    ]
+    cfg = AgentConfig(
+        model="m",
+        system_prompt="s",
+        allowed_tools=("calculator", SPAWN_TOOL_NAME),
+        budget=RunBudget(max_steps=99, max_model_turns=99, max_total_tokens=250),
+    )
+    out = run(turns, config=cfg)
+    assert out.status == RUN_STUCK
+    assert out.steps[-1].summary == "token budget exhausted"
+    assert out.total_tokens >= 250
+
+
+def test_token_budget_sentinel_zero_never_trips():
+    # Huge per-turn tokens but max_total_tokens=0 (default) -> completes normally.
+    turns = [
+        ModelTurn(text=fence("calculator", {"expression": "1"}), tokens=10_000_000),
+        ModelTurn(text="all done", tokens=10_000_000),
+    ]
+    out = run(turns)  # default CFG budget has max_total_tokens=0
+    assert out.status == RUN_DONE
+    assert out.final_text == "all done"
+
+
+def test_token_budget_done_on_crossing_turn_completes():
+    # The final-answer turn itself crosses the budget -> still RUN_DONE
+    # (stop-the-loop, not fail-the-answer), and total_tokens is reported.
+    cfg = AgentConfig(model="m", system_prompt="s", budget=RunBudget(max_total_tokens=50))
+    out = run([ModelTurn(text="the answer", tokens=100)], config=cfg)
+    assert out.status == RUN_DONE
+    assert out.final_text == "the answer"
+    assert out.total_tokens == 100
+
+
+def test_run_outcome_reports_total_tokens_accounting():
+    turns = [
+        ModelTurn(text=fence("calculator", {"expression": "1"}), tokens=30),
+        ModelTurn(text="done", tokens=12),
+    ]
+    out = run(turns)
+    assert out.status == RUN_DONE
+    assert out.total_tokens == 42
+
+
 def test_load_tools_same_batch_duplicate_names_admit_one_into_active():
     """PR #655 review: the loop's own last line of defense must also dedupe
     by name WITHIN one load batch (a caller can hand the same schema back

--- a/Tests/Agents/test_agent_service.py
+++ b/Tests/Agents/test_agent_service.py
@@ -1025,6 +1025,23 @@ def test_usage_total_tokens_none_when_absent_or_malformed():
     assert _usage_total_tokens("a string") is None
     assert _usage_total_tokens({"usage": "bad"}) is None
     assert _usage_total_tokens({"usage": {"prompt_tokens": 10}}) is None
+    # Malformed values must not corrupt spend accounting (Qodo review):
+    assert _usage_total_tokens({"usage": {"total_tokens": True}}) is None  # bool
+    assert _usage_total_tokens({"usage": {"total_tokens": 0}}) is None
+    assert _usage_total_tokens({"usage": {"total_tokens": -7}}) is None
+    assert _usage_total_tokens(
+        {"usage": {"prompt_tokens": -5, "completion_tokens": 10}}
+    ) is None
+    assert _usage_total_tokens(
+        {"usage": {"prompt_tokens": False, "completion_tokens": 5}}
+    ) is None
+    assert _usage_total_tokens(
+        {"usage": {"prompt_tokens": 0, "completion_tokens": 0}}
+    ) is None
+    # Valid non-negative sum still works.
+    assert _usage_total_tokens(
+        {"usage": {"prompt_tokens": 0, "completion_tokens": 5}}
+    ) == 5
 
 
 def _service_with_chat(db, chat_call):

--- a/Tests/Agents/test_agent_service.py
+++ b/Tests/Agents/test_agent_service.py
@@ -22,6 +22,7 @@ from tldw_chatbook.Agents.agent_models import (
 from tldw_chatbook.Agents.agent_service import (
     SUBAGENT_SYSTEM_PROMPT,
     AgentService,
+    _usage_total_tokens,
 )
 from tldw_chatbook.Agents.tool_catalog import (
     BuiltinToolProvider,
@@ -1007,3 +1008,50 @@ def test_native_endpoint_with_no_schemas_omits_tools_kwarg(db):
     )
     assert outcome.status == RUN_DONE
     assert "tools" not in chat.calls[0]
+
+
+def test_usage_total_tokens_reads_total():
+    assert _usage_total_tokens({"usage": {"total_tokens": 150}}) == 150
+
+
+def test_usage_total_tokens_sums_prompt_and_completion():
+    assert _usage_total_tokens(
+        {"usage": {"prompt_tokens": 100, "completion_tokens": 50}}
+    ) == 150
+
+
+def test_usage_total_tokens_none_when_absent_or_malformed():
+    assert _usage_total_tokens({"choices": []}) is None
+    assert _usage_total_tokens("a string") is None
+    assert _usage_total_tokens({"usage": "bad"}) is None
+    assert _usage_total_tokens({"usage": {"prompt_tokens": 10}}) is None
+
+
+def _service_with_chat(db, chat_call):
+    registry = ToolCatalogRegistry()
+    registry.register_provider(BuiltinToolProvider())
+    return AgentService(db=db, registry=registry, chat_call=chat_call)
+
+
+def test_call_model_uses_real_provider_usage(db):
+    def chat(**kwargs):
+        return {
+            "choices": [{"message": {"content": "hello there"}}],
+            "usage": {"total_tokens": 150},
+        }
+    service = _service_with_chat(db, chat)
+    cfg = AgentConfig(model="gpt-4o", system_prompt="s", native_tools=False)
+    call_model = service._make_call_model(cfg, "openai", [])
+    turn = call_model([{"role": "user", "content": "hi"}], ())
+    assert turn.tokens == 150
+
+
+def test_call_model_estimates_when_no_usage(db):
+    def chat(**kwargs):
+        return {"choices": [{"message": {"content": "hello there world"}}]}
+    service = _service_with_chat(db, chat)
+    cfg = AgentConfig(model="gpt-4o", system_prompt="s", native_tools=False)
+    call_model = service._make_call_model(cfg, "openai", [])
+    turn = call_model([{"role": "user", "content": "count these tokens"}], ())
+    # No provider usage -> estimate of sent payload + response text, always > 0.
+    assert turn.tokens > 0

--- a/Tests/Agents/test_agent_service.py
+++ b/Tests/Agents/test_agent_service.py
@@ -1057,6 +1057,26 @@ def test_call_model_estimates_when_no_usage(db):
     assert turn.tokens > 0
 
 
+def test_call_model_estimate_strips_provider_prefix(db):
+    # A provider-qualified id (openai/gpt-4o-mini) must be normalized for token
+    # counting so the GPT framing overhead applies -> same estimate as the bare
+    # model. (Qodo review: prefixed models otherwise undercount.)
+    def chat(**kwargs):
+        return {"choices": [{"message": {"content": "hello there world"}}]}
+    service = _service_with_chat(db, chat)
+    msgs = [{"role": "user", "content": "count these tokens please"}]
+    prefixed = service._make_call_model(
+        AgentConfig(model="openai/gpt-4o-mini", system_prompt="s", native_tools=False),
+        "openai", [],
+    )(msgs, ())
+    bare = service._make_call_model(
+        AgentConfig(model="gpt-4o-mini", system_prompt="s", native_tools=False),
+        "openai", [],
+    )(msgs, ())
+    assert prefixed.tokens == bare.tokens
+    assert prefixed.tokens > 0
+
+
 def test_call_model_native_path_reports_provider_tokens(db):
     """Native tool-call return path (turn.tool_calls set) must also report
     real provider usage on .tokens -- the non-native tests above only cover

--- a/Tests/Agents/test_agent_service.py
+++ b/Tests/Agents/test_agent_service.py
@@ -1055,3 +1055,29 @@ def test_call_model_estimates_when_no_usage(db):
     turn = call_model([{"role": "user", "content": "count these tokens"}], ())
     # No provider usage -> estimate of sent payload + response text, always > 0.
     assert turn.tokens > 0
+
+
+def test_call_model_native_path_reports_provider_tokens(db):
+    """Native tool-call return path (turn.tool_calls set) must also report
+    real provider usage on .tokens -- the non-native tests above only cover
+    the early ``if not native: return ModelTurn(...)`` branch."""
+
+    def chat(**kwargs):
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": None,
+                        "tool_calls": [native_call("calculator", {"expression": "2+2"})],
+                    }
+                }
+            ],
+            "usage": {"total_tokens": 77},
+        }
+
+    service = _service_with_chat(db, chat)
+    cfg = AgentConfig(model="gpt-4o", system_prompt="s", native_tools=True)
+    call_model = service._make_call_model(cfg, "openai", [])
+    turn = call_model([{"role": "user", "content": "2+2?"}], ())
+    assert turn.tokens == 77
+    assert turn.tool_calls

--- a/backlog/tasks/task-326 - Add-token-cost-budget-to-agent-RunBudget.md
+++ b/backlog/tasks/task-326 - Add-token-cost-budget-to-agent-RunBudget.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-326
 title: Add a token/cost budget to the agent RunBudget
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-20 18:45'
 labels: [agents, cost]
@@ -17,8 +17,27 @@ The agent runtime bounds steps, model-turns, wall-clock, and sub-agent count (`a
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `RunBudget` gains a `max_total_tokens` (and/or cost) budget
-- [ ] #2 The loop accumulates prompt+completion tokens per run and stops cleanly (like the existing caps) when the budget is exceeded
-- [ ] #3 Reaching the budget produces a clear terminal status/step, not a silent truncation
-- [ ] #4 Tests cover budget exhaustion
+- [x] #1 `RunBudget` gains a `max_total_tokens` (and/or cost) budget
+- [x] #2 The loop accumulates prompt+completion tokens per run and stops cleanly (like the existing caps) when the budget is exceeded
+- [x] #3 Reaching the budget produces a clear terminal status/step, not a silent truncation
+- [x] #4 Tests cover budget exhaustion
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added a **token-spend ceiling** to the agent RunBudget — the documented complement to task-322 (322 bounds conversation history INTO the agent loop at dispatch; 326 bounds the loop ITSELF, the tool-call/result messages accumulating across iterations). Decision (user-approved): tokens-only (`max_total_tokens`); a dollar-cost budget is deferred (needs a per-model price table that doesn't exist yet).
+
+Approach (3 units, all mirroring the existing step/model-turn/wall-clock cap machinery so behavior is byte-identical until a consumer opts in):
+- **`agent_models.py`**: `RunBudget.max_total_tokens: int = 0` (**0 = unlimited sentinel**); `ModelTurn.tokens` (prompt+completion for one provider call); `RunOutcome.total_tokens` (measured run spend, for the "accounting" the description asked for); `clamp_child_budget` passes the field through (each run, parent or sub-agent, has its own budget).
+- **`agent_runtime.py` `run_agent_loop`**: accumulate `total_tokens += turn.tokens` per model turn; a top-of-loop check (after wall-clock) `if budget.max_total_tokens and total_tokens >= budget.max_total_tokens:` → `add(STEP_ERROR, "token budget exhausted")` + `RUN_STUCK` (AC#3, a clear terminal step, not silent truncation). An `_outcome()` helper closure routes all 8 terminal returns so spend is always reported. Checking at the TOP means a run that produces its final answer on the crossing turn still completes `RUN_DONE` (stop-the-loop, not fail-the-answer). The `and` guard is deliberately fail-closed: a negative (invalid) budget trips immediately rather than reading as "unlimited".
+- **`agent_service.py` `_make_call_model`**: **hybrid** token source — real `resp["usage"]` (via `_usage_total_tokens`) when the provider reports it, else the task-321 estimate `count_tokens_messages(payload) + estimate_tokens(text)`. Populated on both `ModelTurn` return paths (native + non-native).
+
+`max_total_tokens` is cumulative SPEND (Σ prompt+completion across turns, since the growing prompt is re-sent each call), NOT a context-window size — a consumer must size it as a spend ceiling (hundreds of thousands).
+
+Testing: full agent suite 275 passed. Loop tests (exhaustion→STUCK, 0-sentinel never trips, DONE-on-crossing-turn boundary, total_tokens accounting); `_usage_total_tokens` (total / prompt+completion / None-on-malformed, never crashes); call_model hybrid on both native and non-native paths. Executed via SDD (implementer+reviewer per task, opus whole-branch review Ready-to-merge, 0 Crit/0 Imp).
+
+Deferred follow-up minors (non-blocking, from reviews): `_usage_total_tokens` doesn't reject `bool`/negative token counts (no real provider emits them); error-path `RunOutcome` (`RUN_ERROR`) reports `total_tokens=0` (partial pre-crash spend lost); `total_tokens` is return-only, not persisted to AgentRuns_DB (surfacing in a consumer UI/DB was out of scope).
+
+Files: `tldw_chatbook/Agents/agent_models.py`, `tldw_chatbook/Agents/agent_runtime.py`, `tldw_chatbook/Agents/agent_service.py`, `Tests/Agents/test_agent_models.py`, `Tests/Agents/test_agent_runtime.py`, `Tests/Agents/test_agent_service.py`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Agents/agent_models.py
+++ b/tldw_chatbook/Agents/agent_models.py
@@ -84,6 +84,7 @@ class ModelTurn:
     text: str = ""
     tool_calls: tuple[ToolCall, ...] = ()
     assistant_message: dict | None = None
+    tokens: int = 0
 
 
 @dataclass(frozen=True)
@@ -110,6 +111,10 @@ class RunBudget:
     # (every model turn appends >=1 step, so the step check fires first) —
     # engine-default behavior is byte-identical to the pre-task-244 loop.
     max_model_turns: int = 8
+    # task-326: cumulative prompt+completion token spend ceiling for one run.
+    # 0 = unlimited (default), keeping existing runs byte-identical. This is a
+    # SPEND ceiling (the growing prompt is re-sent each call), not a window size.
+    max_total_tokens: int = 0
 
 
 @dataclass
@@ -138,6 +143,7 @@ class RunOutcome:
     steps: list[AgentStep]
     final_text: str = ""
     subagents_spawned: int = 0
+    total_tokens: int = 0
 
 
 def clamp_child_budget(child: RunBudget, parent_remaining_seconds: float) -> RunBudget:
@@ -156,4 +162,5 @@ def clamp_child_budget(child: RunBudget, parent_remaining_seconds: float) -> Run
         max_active_tools=child.max_active_tools,
         max_subagent_result_chars=child.max_subagent_result_chars,
         max_model_turns=child.max_model_turns,
+        max_total_tokens=child.max_total_tokens,
     )

--- a/tldw_chatbook/Agents/agent_runtime.py
+++ b/tldw_chatbook/Agents/agent_runtime.py
@@ -276,7 +276,9 @@ def run_agent_loop(
     Args:
         config: The agent's model, system prompt, allow-list, and budget
             (step count, wall-clock seconds, and — task-244 —
-            provider-call/model-turn count all independently cap the run).
+            provider-call/model-turn count all independently cap the run;
+            task-326 adds ``max_total_tokens``, a cumulative prompt+
+            completion token spend ceiling — 0 means unlimited).
         initial_messages: The starting conversation history (role/content
             dicts); not mutated in place — the loop works on a copy.
         active_schemas: Tool schemas already disclosed to the model at the
@@ -289,7 +291,9 @@ def run_agent_loop(
     Returns:
         A ``RunOutcome`` capturing the terminal status
         (``done``/``stuck``/``cancelled``), the full step log, the final
-        answer text (when done), and how many sub-agents were spawned.
+        answer text (when done), how many sub-agents were spawned, and
+        (task-326) ``total_tokens`` — the measured cumulative prompt+
+        completion token spend checked against ``max_total_tokens``.
     """
     budget = config.budget
     steps: list[AgentStep] = []

--- a/tldw_chatbook/Agents/agent_runtime.py
+++ b/tldw_chatbook/Agents/agent_runtime.py
@@ -298,6 +298,7 @@ def run_agent_loop(
     started = deps.clock()
     spawned = 0
     model_turns = 0
+    total_tokens = 0
     last_key: tuple | None = None
     repeat_count = 0
 
@@ -313,21 +314,32 @@ def run_agent_loop(
             pass
         return step
 
+    def _outcome(status: str, **kw) -> RunOutcome:
+        # Reports run spend on every terminal path; reads enclosing steps/
+        # spawned/total_tokens at call time (no nonlocal, like add()).
+        return RunOutcome(
+            status, steps, subagents_spawned=spawned, total_tokens=total_tokens, **kw
+        )
+
     while True:
         if deps.should_cancel():
-            return RunOutcome(RUN_CANCELLED, steps, subagents_spawned=spawned)
+            return _outcome(RUN_CANCELLED)
         if len(steps) >= budget.max_steps:
             add(STEP_ERROR, summary="step budget exhausted")
-            return RunOutcome(RUN_STUCK, steps, subagents_spawned=spawned)
+            return _outcome(RUN_STUCK)
         if model_turns >= budget.max_model_turns:
             add(STEP_ERROR, summary="model-turn budget exhausted")
-            return RunOutcome(RUN_STUCK, steps, subagents_spawned=spawned)
+            return _outcome(RUN_STUCK)
         if deps.clock() - started > budget.max_wall_seconds:
             add(STEP_ERROR, summary="wall-clock budget exhausted")
-            return RunOutcome(RUN_STUCK, steps, subagents_spawned=spawned)
+            return _outcome(RUN_STUCK)
+        if budget.max_total_tokens and total_tokens >= budget.max_total_tokens:
+            add(STEP_ERROR, summary="token budget exhausted")
+            return _outcome(RUN_STUCK)
 
         turn = deps.call_model(messages, tuple(active))
         model_turns += 1
+        total_tokens += turn.tokens
         add(STEP_MODEL, summary=turn.text[:200])
 
         calls = list(turn.tool_calls)
@@ -341,15 +353,8 @@ def run_agent_loop(
                 # this, a cancellation that lands mid-final-answer would be
                 # silently downgraded to a normal completed run.
                 if deps.should_cancel():
-                    return RunOutcome(
-                        RUN_CANCELLED,
-                        steps,
-                        final_text=turn.text,
-                        subagents_spawned=spawned,
-                    )
-                return RunOutcome(
-                    RUN_DONE, steps, final_text=turn.text, subagents_spawned=spawned
-                )
+                    return _outcome(RUN_CANCELLED, final_text=turn.text)
+                return _outcome(RUN_DONE, final_text=turn.text)
             calls = [fenced]
         messages.append(
             turn.assistant_message or {"role": "assistant", "content": turn.text}
@@ -380,7 +385,7 @@ def run_agent_loop(
 
         for call in calls:
             if deps.should_cancel():
-                return RunOutcome(RUN_CANCELLED, steps, subagents_spawned=spawned)
+                return _outcome(RUN_CANCELLED)
             key = (call.name, json.dumps(call.args, sort_keys=True))
             repeat_count = repeat_count + 1 if key == last_key else 1
             last_key = key
@@ -390,7 +395,7 @@ def run_agent_loop(
                     summary=f"loop detected: {call.name} repeated "
                     f"{repeat_count}x with identical args",
                 )
-                return RunOutcome(RUN_STUCK, steps, subagents_spawned=spawned)
+                return _outcome(RUN_STUCK)
 
             # P5 Task 4: a non-"proceed" verdict (an absent name defaults to
             # "proceed" — the hook only reports what it wants to stop)

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -242,9 +242,17 @@ class AgentService:
                 # Provider reported no usage -> estimate from sent payload +
                 # response text (native tool_calls JSON is not separately
                 # counted here; the prompt term dominates the per-turn total).
-                tokens = count_tokens_messages(payload, config.model) + estimate_tokens(
-                    text, config.model
+                # Strip a provider prefix ("openai/gpt-4o-mini" -> "gpt-4o-mini")
+                # so the tokenizer's model-family framing detection matches, and
+                # pass the endpoint as the provider hint for the chars ratio.
+                est_model = (
+                    config.model.split("/", 1)[-1]
+                    if "/" in config.model
+                    else config.model
                 )
+                tokens = count_tokens_messages(
+                    payload, est_model, provider=api_endpoint
+                ) + estimate_tokens(text, est_model, provider=api_endpoint)
             if not native:
                 return ModelTurn(text=text, tokens=tokens)
             message = _response_message(resp)

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -137,12 +137,21 @@ def _usage_total_tokens(resp) -> int | None:
         return None
     if not isinstance(usage, dict):
         return None
+    # `type(x) is int` (not isinstance) rejects bool, which subclasses int;
+    # require positive/non-negative real ints so a malformed usage block can't
+    # corrupt or shrink the accumulated spend the runtime enforces on.
     total = usage.get("total_tokens")
-    if isinstance(total, int) and total > 0:
+    if type(total) is int and total > 0:
         return total
     prompt = usage.get("prompt_tokens")
     completion = usage.get("completion_tokens")
-    if isinstance(prompt, int) and isinstance(completion, int):
+    if (
+        type(prompt) is int
+        and type(completion) is int
+        and prompt >= 0
+        and completion >= 0
+        and prompt + completion > 0
+    ):
         return prompt + completion
     return None
 

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -17,6 +17,7 @@ from typing import Callable, Protocol
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 from tldw_chatbook.Internal_Prompts import get_internal_prompt
 from tldw_chatbook.Internal_Prompts.catalog import CATALOG
+from tldw_chatbook.Utils.token_counter import count_tokens_messages, estimate_tokens
 
 from .agent_models import (
     AGENT_KIND_PRIMARY,
@@ -120,6 +121,32 @@ def _response_message(resp) -> dict:
     return message if isinstance(message, dict) else {}
 
 
+def _usage_total_tokens(resp) -> int | None:
+    """Prompt+completion tokens from a provider's OpenAI-shaped usage block,
+    or None when the provider didn't report usage.
+
+    Args:
+        resp: The provider response (dict when the provider reports usage).
+
+    Returns:
+        The total tokens for the call, or None to signal "estimate instead".
+    """
+    try:
+        usage = resp["usage"]
+    except (KeyError, TypeError):
+        return None
+    if not isinstance(usage, dict):
+        return None
+    total = usage.get("total_tokens")
+    if isinstance(total, int) and total > 0:
+        return total
+    prompt = usage.get("prompt_tokens")
+    completion = usage.get("completion_tokens")
+    if isinstance(prompt, int) and isinstance(completion, int):
+        return prompt + completion
+    return None
+
+
 class AgentService:
     """Run one agent turn (primary + any sub-agents) and persist it."""
 
@@ -210,8 +237,16 @@ class AgentService:
                 **call_kwargs,
             )
             text = _response_text(resp)
+            tokens = _usage_total_tokens(resp)
+            if tokens is None:
+                # Provider reported no usage -> estimate from sent payload +
+                # response text (native tool_calls JSON is not separately
+                # counted here; the prompt term dominates the per-turn total).
+                tokens = count_tokens_messages(payload, config.model) + estimate_tokens(
+                    text, config.model
+                )
             if not native:
-                return ModelTurn(text=text)
+                return ModelTurn(text=text, tokens=tokens)
             message = _response_message(resp)
             # Id-less entries get synthesized ids BEFORE parsing, and the
             # SAME normalized list feeds the assistant echo — the echo and
@@ -229,7 +264,10 @@ class AgentService:
                     "tool_calls": raw_calls,
                 }
             return ModelTurn(
-                text=text, tool_calls=tool_calls, assistant_message=assistant_message
+                text=text,
+                tool_calls=tool_calls,
+                assistant_message=assistant_message,
+                tokens=tokens,
             )
 
         return call_model


### PR DESCRIPTION
Adds a **token-spend ceiling** to the agent RunBudget (**TASK-326**) — the documented complement to task-322. **322 bounds conversation history *into* the agent loop at dispatch; 326 bounds the loop *itself*** — the tool-call/result messages that accumulate across iterations within a single turn, which previously had no spend ceiling.

## What changed (3 units, mirroring the existing step/model-turn/wall-clock caps)

- **`agent_models.py`** — `RunBudget.max_total_tokens: int = 0` (**0 = unlimited sentinel** → default runs byte-identical); `ModelTurn.tokens` (prompt+completion for one provider call); `RunOutcome.total_tokens` (measured run spend, for accounting); `clamp_child_budget` passes the field through (each run has its own budget).
- **`agent_runtime.py` `run_agent_loop`** — accumulates `total_tokens += turn.tokens` per model turn and adds a top-of-loop check (after wall-clock) → `add(STEP_ERROR, "token budget exhausted")` + `RUN_STUCK` (a clear terminal step, not silent truncation). An `_outcome()` helper closure routes all 8 terminal returns so spend is always reported. Because the check is at the *top*, a run that produces its final answer on the crossing turn still completes `RUN_DONE` (stop-the-loop, not fail-the-answer). The `and` guard is deliberately fail-closed.
- **`agent_service.py` `_make_call_model`** — **hybrid** token source: real `resp["usage"]` (via `_usage_total_tokens`, crash-proof on malformed input) when the provider reports it, else the task-321 estimate (`count_tokens_messages(payload) + estimate_tokens(text)`). Set on both `ModelTurn` return paths.

**Semantics:** `max_total_tokens` is cumulative *spend* (Σ prompt+completion across turns, since the growing prompt is re-sent each call), not a context-window size.

## Testing
Full agent suite **275 passed**. Loop tests (exhaustion→STUCK, 0-sentinel never trips, DONE-on-crossing-turn boundary, `total_tokens` accounting); `_usage_total_tokens` (total / prompt+completion / None-on-malformed, never crashes); call_model hybrid on **both** native and non-native return paths. Executed via subagent-driven development (implementer + reviewer per task, whole-branch opus review **Ready-to-merge**, 0 Critical/Important).

## Deferred follow-ups (non-blocking, from reviews)
- `_usage_total_tokens` doesn't reject `bool`/negative token counts (no real provider emits them).
- Error-path `RunOutcome` (`RUN_ERROR`) reports `total_tokens=0` (partial pre-crash spend lost).
- `total_tokens` is return-only, not persisted to AgentRuns_DB (surfacing in a consumer UI/DB was out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a token-spend ceiling to the agent loop via `RunBudget.max_total_tokens`, accumulating per-turn tokens and stopping cleanly when the budget is exceeded. Defaults to unlimited (`0`), so behavior is unchanged unless configured; aligns with TASK-326 and complements task-322.

- **New Features**
  - Data model: `RunBudget.max_total_tokens` (0 = unlimited), `ModelTurn.tokens`, `RunOutcome.total_tokens`; `clamp_child_budget` preserves the cap.
  - Runtime: accumulates `total_tokens` and, after the wall-clock check, stops with `RUN_STUCK` + "token budget exhausted" when over budget; a final answer on the crossing turn still returns `RUN_DONE`.
  - Service: `_usage_total_tokens` reads provider `resp["usage"]`; else falls back to `count_tokens_messages(payload)` + `estimate_tokens(text)`; `tokens` set on both native and non-native `ModelTurn` paths.

- **Bug Fixes**
  - When provider usage is absent, normalize model ids by stripping provider prefixes (e.g., `openai/gpt-4o-mini` → `gpt-4o-mini`) and pass the provider to the token counter to avoid undercount.
  - `_usage_total_tokens` now rejects bool/negative/zero totals and invalid prompt/completion values, falling back to the estimator to keep spend accounting correct.

<sup>Written for commit 0e20dbf6a6bc515ed07f640d2411a5eba23715cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

