### PR TITLE
feat(console): Roleplay P3d-1 — reactive character expression avatar

### DIFF
--- a/Docs/superpowers/plans/2026-07-22-roleplay-p3d-console-expression-avatar.md
+++ b/Docs/superpowers/plans/2026-07-22-roleplay-p3d-console-expression-avatar.md
@@ -1,0 +1,856 @@
+# Roleplay P3d-1 — Reactive Console Character Expression Avatar — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Console Character-rail avatar (P3c, #782) swap among idle/thinking/speaking/error images as the character generates and streams a reply, using per-state images stored locally on the character.
+
+**Architecture:** A new `character_expression_images` BLOB table (migration v22→v23) holds non-idle images; idle reuses `character_cards.image`. A pure DB-free function derives the current state from the store's in-memory message statuses. The P3c avatar scope-guard widens from `(character_id,)` to `(character_id, state)`, so the *already-wired* `_sync_native_console_chat_ui` refresh (0.2s poll + transition syncs) drives the swap — no new hook. All P3c render/refresh machinery is reused; a per-state decode cache makes revisiting a state instant. Authoring adds three upload slots to the character editor.
+
+**Tech Stack:** Python ≥3.11, Textual, SQLite (CharactersRAGDB, threading.local connections), PIL/rich_pixels/textual_image, loguru.
+
+## Global Constraints
+
+- **MIGRATION v22→v23**: idempotent (`CREATE TABLE IF NOT EXISTS`); **pre-flight re-verify `_CURRENT_SCHEMA_VERSION` is still 22** at plan+merge time (concurrent sessions may take v23). Only DB change; `character_cards` untouched (idle stays `character_cards.image`). New tables live ONLY in the migration, never the frozen base CREATE.
+- Resolve active character ONLY off the live `ConsoleChatSession`; resolve expression state ONLY off in-memory store status — **NEVER a DB read on the derivation path** (it runs on the 0.2s tick).
+- REUSE the single `self._console_image_cache` + `resolve_default_mode` + `fit_image_cell_size` + the P3c render/refresh methods. Do NOT create a second render cache. Decode stays OFF-THREAD (`asyncio.to_thread`).
+- **NEVER raise** into `_sync_native_console_chat_ui`; preserve EVERY P3c invariant (config-off early-return + `_last_console_avatar_scope=None` reset, post-await re-check — now on `(character_id, state)`, cache-as-SPEC-not-widget, scope-guard = no rebuild/decode except on a real state change).
+- **DO NOT touch** `_active_console_dictionary_scope_ids` (P3c pin — feeds the "what's in play" summaries; not inert).
+- Authoring slots apply the `_character_editor_generation` render-token discipline PER slot; expression saves write straight to the table, **independent of the card's optimistic-lock version**.
+- Config-gated: `[chat.images].show_character_avatar` (section) + `[chat.images].react_character_expressions` (swapping), BOTH default **True**. `react` off ⇒ derivation pins state to `idle` (P3c avatar still renders); `show_character_avatar` off ⇒ section cleared entirely.
+- Characters-only (personas have no image). State-id validation lives in the Python seam, not a DB CHECK (keeps the table state-agnostic for future custom states).
+- **CONCURRENT-SESSION HAZARD**: `chat_screen.py` / `personas_screen.py` / `ChaChaNotes_DB.py` are heavily edited by other sessions — keep P3d localized; expect a rebase before merge.
+- Implementers stage ONLY their task's files (never `git add -A`, never `.superpowers/`). NO background/broad test sweeps; NEVER broad-pkill pytest — scope to the worktree.
+- `Tests/UI/pytest.ini` sets `asyncio_mode=auto`: keep async tests in `Tests/UI/` OR add explicit `@pytest.mark.asyncio`; do NOT mix `Tests/UI` with another dir in one pytest invocation (rootdir shift drops auto-mode).
+- **Test env prefix** (all pytest + import runs): `HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest ... -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread`
+- Worktree: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/personas-redesign`. Subagents PREPEND `cd <worktree> && ` to EVERY Bash call (cwd doesn't persist; main checkout is on another branch).
+- **DB tests use a file-backed `CharactersRAGDB(tmp_path / "...db", "test-client")`, NEVER `:memory:`** — the avatar fetch runs off-thread and `:memory:` is connection-private (a worker thread would see an empty DB).
+
+---
+
+## File Structure
+
+- `tldw_chatbook/DB/ChaChaNotes_DB.py` — **modify**: new `character_expression_images` table via a v22→v23 migration + 4 CRUD methods. (Task 1)
+- `tldw_chatbook/Chat/console_expression_state.py` — **create**: pure `resolve_console_expression_state` + the state constants. (Task 2)
+- `tldw_chatbook/Chat/console_image_view.py` — **modify**: add `resolve_react_character_expressions`. (Task 2)
+- `tldw_chatbook/UI/Screens/chat_screen.py` — **modify**: widen the P3c avatar scope to `(character_id, state)`, add the per-state decode cache + table-fetch-with-fallback. (Task 3)
+- `tldw_chatbook/UI/Screens/personas_screen.py` (+ its CSS) — **modify**: 3 expression upload slots in the character editor. (Task 4)
+- `tldw_chatbook/config.py` — **modify**: document `react_character_expressions` in the `[chat.images]` block. (Task 5)
+
+---
+
+## Task 1: `character_expression_images` table + migration + CRUD seam
+
+**Files:**
+- Modify: `tldw_chatbook/DB/ChaChaNotes_DB.py`
+- Test: `Tests/Character_Chat/test_character_expression_images.py` (create)
+
+**Interfaces:**
+- Produces (methods on `CharactersRAGDB`):
+  - `set_character_expression_image(character_id: int, state_id: str, image: bytes, mime: str | None = None) -> None`
+  - `get_character_expression_image(character_id: int, state_id: str) -> bytes | None`
+  - `list_character_expression_states(character_id: int) -> list[str]`
+  - `delete_character_expression_image(character_id: int, state_id: str) -> None`
+  - Module constant `_EXPRESSION_IMAGE_STATE_IDS = frozenset({"thinking", "speaking", "error"})` (validation set).
+
+- [ ] **Step 1: PRE-FLIGHT — verify the schema version is still 22**
+
+Run:
+```
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/personas-redesign && grep -n "_CURRENT_SCHEMA_VERSION = " tldw_chatbook/DB/ChaChaNotes_DB.py
+```
+Expected: `_CURRENT_SCHEMA_VERSION = 22`. **If it is NOT 22** (another session took v23), STOP and report BLOCKED — the migration target must become v23→v24 and the plan needs re-basing.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `Tests/Character_Chat/test_character_expression_images.py`:
+```python
+import pytest
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    # File-backed (NOT :memory:) — CharactersRAGDB uses threading.local connections
+    # and the production avatar fetch runs off-thread; :memory: is connection-private.
+    return CharactersRAGDB(tmp_path / "expr.db", "test-client")
+
+
+def _make_character(db) -> int:
+    return db.add_character_card({"name": "Ada"})
+
+
+def test_schema_is_v23(db):
+    assert db._get_db_version(db.get_connection()) == 23
+
+
+def test_set_then_get_round_trips(db):
+    cid = _make_character(db)
+    db.set_character_expression_image(cid, "speaking", b"PNGBYTES", "image/png")
+    assert db.get_character_expression_image(cid, "speaking") == b"PNGBYTES"
+
+
+def test_get_missing_returns_none(db):
+    cid = _make_character(db)
+    assert db.get_character_expression_image(cid, "thinking") is None
+
+
+def test_set_is_upsert_on_character_and_state(db):
+    cid = _make_character(db)
+    db.set_character_expression_image(cid, "speaking", b"one")
+    db.set_character_expression_image(cid, "speaking", b"two")
+    assert db.get_character_expression_image(cid, "speaking") == b"two"
+    assert db.list_character_expression_states(cid) == ["speaking"]  # not duplicated
+
+
+def test_list_states_returns_only_active(db):
+    cid = _make_character(db)
+    db.set_character_expression_image(cid, "thinking", b"t")
+    db.set_character_expression_image(cid, "error", b"e")
+    assert sorted(db.list_character_expression_states(cid)) == ["error", "thinking"]
+
+
+def test_delete_is_soft_and_get_returns_none(db):
+    cid = _make_character(db)
+    db.set_character_expression_image(cid, "speaking", b"s")
+    db.delete_character_expression_image(cid, "speaking")
+    assert db.get_character_expression_image(cid, "speaking") is None
+    assert db.list_character_expression_states(cid) == []
+
+
+def test_set_after_delete_reactivates(db):
+    cid = _make_character(db)
+    db.set_character_expression_image(cid, "speaking", b"s1")
+    db.delete_character_expression_image(cid, "speaking")
+    db.set_character_expression_image(cid, "speaking", b"s2")
+    assert db.get_character_expression_image(cid, "speaking") == b"s2"
+
+
+def test_invalid_state_id_rejected(db):
+    cid = _make_character(db)
+    with pytest.raises(ValueError):
+        db.set_character_expression_image(cid, "idle", b"x")   # idle is never stored
+    with pytest.raises(ValueError):
+        db.set_character_expression_image(cid, "bogus", b"x")
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run:
+```
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/personas-redesign && HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Character_Chat/test_character_expression_images.py -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: FAIL — `test_schema_is_v23` fails (version is 22) and `AttributeError: 'CharactersRAGDB' object has no attribute 'set_character_expression_image'`.
+
+- [ ] **Step 4: Add the migration SQL constant**
+
+In `ChaChaNotes_DB.py`, next to the other `_MIGRATE_V*_SQL` constants (e.g. just after `_MIGRATE_V21_TO_V22_SQL`), add:
+```python
+    # Keep this runner SQL aligned with
+    # tldw_chatbook/DB/migrations/chachanotes_v22_to_v23_character_expression_images.sql.
+    _MIGRATE_V22_TO_V23_SQL = """
+CREATE TABLE IF NOT EXISTS character_expression_images(
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  character_id  INTEGER NOT NULL REFERENCES character_cards(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  state_id      TEXT    NOT NULL,
+  image         BLOB    NOT NULL,
+  mime          TEXT,
+  created_at    TEXT    NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','NOW')),
+  updated_at    TEXT    NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','NOW')),
+  deleted       INTEGER NOT NULL DEFAULT 0,
+  UNIQUE(character_id, state_id)
+);
+CREATE INDEX IF NOT EXISTS idx_char_expr_images_char ON character_expression_images(character_id);
+UPDATE db_schema_version
+   SET version = 23
+ WHERE schema_name = 'rag_char_chat_schema'
+   AND version = 22;
+"""
+```
+
+- [ ] **Step 5: Add the migration method**
+
+Add just after `_migrate_from_v21_to_v22` (mirror its shape; no `PRAGMA table_info` column-guard is needed because `CREATE TABLE IF NOT EXISTS` is already idempotent):
+```python
+    def _migrate_from_v22_to_v23(self, conn: sqlite3.Connection):
+        """Migrate schema V22→V23: add the local ``character_expression_images``
+        BLOB table (per-state reaction avatars; idle reuses character_cards.image)."""
+        logger.info(f"Migrating schema from V22 to V23 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}...")
+        try:
+            conn.executescript(self._MIGRATE_V22_TO_V23_SQL)
+            logger.debug(f"[{self._SCHEMA_NAME} V22→V23] Migration script executed.")
+            final_version = self._get_db_version(conn)
+            if final_version != 23:
+                raise SchemaError(
+                    f"[{self._SCHEMA_NAME} V22→V23] Migration version check failed. Expected 23, got: {final_version}"
+                )
+            logger.info(f"[{self._SCHEMA_NAME} V22→V23] Migration completed successfully for DB: {self.db_path_str}.")
+        except sqlite3.Error as e:
+            logger.opt(exception=True).error(f"[{self._SCHEMA_NAME} V22→V23] Migration failed: {e}")
+            raise SchemaError(f"Migration from V22 to V23 failed for '{self._SCHEMA_NAME}': {e}") from e
+        except Exception as e:
+            logger.opt(exception=True).error(f"[{self._SCHEMA_NAME} V22→V23] Unexpected error during migration: {e}")
+            raise SchemaError(f"Unexpected error migrating from V22 to V23 for '{self._SCHEMA_NAME}': {e}") from e
+```
+
+- [ ] **Step 6: Register the step + bump the version**
+
+In the `migration_steps` dict (the ladder), add the new entry after `21: self._migrate_from_v21_to_v22,`:
+```python
+                    22: self._migrate_from_v22_to_v23,
+```
+Change the version constant:
+```python
+    _CURRENT_SCHEMA_VERSION = 23  # Adds character_expression_images (P3d reaction avatars).
+```
+
+- [ ] **Step 7: Add the CRUD seam**
+
+Add near the other character-card methods (e.g. after `get_character_card_by_id`). `_EXPRESSION_IMAGE_STATE_IDS` goes at module scope near the top of the class file:
+```python
+_EXPRESSION_IMAGE_STATE_IDS = frozenset({"thinking", "speaking", "error"})
+```
+```python
+    def set_character_expression_image(
+        self, character_id: int, state_id: str, image: bytes, mime: str | None = None
+    ) -> None:
+        """Upsert a per-state expression image for a character (state-agnostic
+        store; ``idle`` is never stored here -- it reuses character_cards.image)."""
+        if state_id not in _EXPRESSION_IMAGE_STATE_IDS:
+            raise ValueError(f"Unknown expression state_id: {state_id!r}")
+        if not isinstance(image, (bytes, bytearray)) or not image:
+            raise ValueError("Expression image must be non-empty bytes.")
+        query = """
+            INSERT INTO character_expression_images(character_id, state_id, image, mime, deleted, updated_at)
+            VALUES (?, ?, ?, ?, 0, STRFTIME('%Y-%m-%dT%H:%M:%fZ','NOW'))
+            ON CONFLICT(character_id, state_id) DO UPDATE SET
+                image = excluded.image,
+                mime = excluded.mime,
+                deleted = 0,
+                updated_at = STRFTIME('%Y-%m-%dT%H:%M:%fZ','NOW')
+        """
+        with self.transaction() as cur:
+            cur.execute(query, (character_id, state_id, bytes(image), mime))
+
+    def get_character_expression_image(self, character_id: int, state_id: str) -> bytes | None:
+        """Return the active image bytes for (character, state), or None."""
+        cur = self.get_connection().execute(
+            "SELECT image FROM character_expression_images "
+            "WHERE character_id = ? AND state_id = ? AND deleted = 0",
+            (character_id, state_id),
+        )
+        row = cur.fetchone()
+        return bytes(row[0]) if row is not None and row[0] is not None else None
+
+    def list_character_expression_states(self, character_id: int) -> list[str]:
+        """Return the state_ids with an active image for a character."""
+        cur = self.get_connection().execute(
+            "SELECT state_id FROM character_expression_images "
+            "WHERE character_id = ? AND deleted = 0 ORDER BY state_id",
+            (character_id,),
+        )
+        return [row[0] for row in cur.fetchall()]
+
+    def delete_character_expression_image(self, character_id: int, state_id: str) -> None:
+        """Soft-delete the (character, state) expression image."""
+        with self.transaction() as cur:
+            cur.execute(
+                "UPDATE character_expression_images SET deleted = 1, "
+                "updated_at = STRFTIME('%Y-%m-%dT%H:%M:%fZ','NOW') "
+                "WHERE character_id = ? AND state_id = ?",
+                (character_id, state_id),
+            )
+```
+NOTE: match the codebase's actual transaction/cursor idiom — verify whether the class exposes `self.transaction()` (context manager) or a different helper by reading how `add_character_card` / `update_character_card` execute writes, and mirror that exact idiom for the two write methods above. Reads use `self.get_connection().execute(...)` as shown.
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run:
+```
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/personas-redesign && HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Character_Chat/test_character_expression_images.py -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: PASS (8 tests). Also confirm the app imports:
+```
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/personas-redesign && HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -c "import tldw_chatbook.app"
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tldw_chatbook/DB/ChaChaNotes_DB.py Tests/Character_Chat/test_character_expression_images.py
+git commit -m "feat(db): P3d-1 Task 1 — character_expression_images table (v22->v23) + CRUD seam"
+```
+
+---
+
+## Task 2: `resolve_console_expression_state` + `resolve_react_character_expressions`
+
+**Files:**
+- Create: `tldw_chatbook/Chat/console_expression_state.py`
+- Modify: `tldw_chatbook/Chat/console_image_view.py`
+- Test: `Tests/Chat/test_console_expression_state.py` (create)
+
+**Interfaces:**
+- Consumes: the store's `messages_for_session(session_id) -> list[ConsoleChatMessage]` (in-memory) and `ConsoleMessageRole.ASSISTANT` / `ConsoleMessageStatus` from `tldw_chatbook.Chat.console_chat_models`. Status values: `Literal["complete","pending","streaming","stopped","failed"]`.
+- Produces:
+  - `EXPRESSION_STATES: tuple = ("idle", "thinking", "speaking", "error")`
+  - `EXPRESSION_IMAGE_STATES: tuple = ("thinking", "speaking", "error")`
+  - `resolve_console_expression_state(store, active_session_id: str | None, *, react_enabled: bool) -> str`
+  - `resolve_react_character_expressions(app_config: Mapping[str, Any]) -> bool` (in `console_image_view.py`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/Chat/test_console_expression_state.py`:
+```python
+import pytest
+from tldw_chatbook.Chat.console_expression_state import (
+    EXPRESSION_STATES,
+    EXPRESSION_IMAGE_STATES,
+    resolve_console_expression_state,
+)
+from tldw_chatbook.Chat.console_image_view import resolve_react_character_expressions
+
+
+class _Msg:
+    def __init__(self, role, status):
+        self.role = role
+        self.status = status
+
+
+class _FakeRole:
+    ASSISTANT = object()
+    USER = object()
+
+
+class _FakeStore:
+    """Minimal stand-in exposing messages_for_session, matching the real signature."""
+    def __init__(self, messages_by_session):
+        self._m = messages_by_session
+
+    def messages_for_session(self, session_id):
+        if session_id not in self._m:
+            raise KeyError(session_id)
+        return list(self._m[session_id])
+
+
+@pytest.fixture(autouse=True)
+def _patch_role(monkeypatch):
+    # Point the resolver at the fake role sentinel so _Msg.role comparisons match.
+    import tldw_chatbook.Chat.console_expression_state as mod
+    monkeypatch.setattr(mod, "ConsoleMessageRole", _FakeRole)
+
+
+def _state(messages, *, react=True, sid="s1"):
+    store = _FakeStore({sid: messages})
+    return resolve_console_expression_state(store, sid, react_enabled=react)
+
+
+def test_no_session_is_idle():
+    store = _FakeStore({})
+    assert resolve_console_expression_state(store, None, react_enabled=True) == "idle"
+
+
+def test_missing_session_is_idle():
+    store = _FakeStore({})
+    assert resolve_console_expression_state(store, "nope", react_enabled=True) == "idle"
+
+
+def test_no_assistant_message_is_idle():
+    assert _state([_Msg(_FakeRole.USER, "complete")]) == "idle"
+
+
+def test_pending_assistant_is_thinking():
+    assert _state([_Msg(_FakeRole.USER, "complete"), _Msg(_FakeRole.ASSISTANT, "pending")]) == "thinking"
+
+
+def test_streaming_assistant_is_speaking():
+    assert _state([_Msg(_FakeRole.ASSISTANT, "streaming")]) == "speaking"
+
+
+def test_complete_assistant_is_idle():
+    assert _state([_Msg(_FakeRole.ASSISTANT, "complete")]) == "idle"
+
+
+def test_stopped_assistant_is_idle():
+    assert _state([_Msg(_FakeRole.ASSISTANT, "stopped")]) == "idle"
+
+
+def test_failed_assistant_is_error():
+    assert _state([_Msg(_FakeRole.ASSISTANT, "failed")]) == "error"
+
+
+def test_last_assistant_wins():
+    # A completed turn followed by a new pending turn -> thinking.
+    msgs = [_Msg(_FakeRole.ASSISTANT, "complete"), _Msg(_FakeRole.ASSISTANT, "pending")]
+    assert _state(msgs) == "thinking"
+
+
+def test_react_disabled_pins_idle():
+    assert _state([_Msg(_FakeRole.ASSISTANT, "streaming")], react=False) == "idle"
+
+
+def test_constants():
+    assert EXPRESSION_STATES == ("idle", "thinking", "speaking", "error")
+    assert EXPRESSION_IMAGE_STATES == ("thinking", "speaking", "error")
+
+
+def test_react_config_helper_defaults_true():
+    assert resolve_react_character_expressions({}) is True
+    cfg = {"chat": {"images": {"react_character_expressions": False}}}
+    assert resolve_react_character_expressions(cfg) is False
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/personas-redesign && HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Chat/test_console_expression_state.py -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: FAIL — `ModuleNotFoundError: tldw_chatbook.Chat.console_expression_state` / `resolve_react_character_expressions` not found.
+
+- [ ] **Step 3: Create the derivation module**
+
+Create `tldw_chatbook/Chat/console_expression_state.py`:
+```python
+"""Pure, DB-free derivation of the Console 'expression state' for the reactive
+character avatar (P3d). Reads only the store's in-memory message statuses -- safe
+to call on the 0.2s transcript poll tick.
+
+State machine (from the active session's last assistant message status):
+  pending   -> "thinking"   (created, awaiting first token)
+  streaming -> "speaking"   (tokens flowing)
+  complete  -> "idle"
+  stopped   -> "idle"       (user stop is not an error)
+  failed    -> "error"
+  (no assistant message / no session / react disabled) -> "idle"
+"""
+from __future__ import annotations
+
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+
+EXPRESSION_STATES = ("idle", "thinking", "speaking", "error")
+EXPRESSION_IMAGE_STATES = ("thinking", "speaking", "error")
+
+_STATUS_TO_STATE = {
+    "pending": "thinking",
+    "streaming": "speaking",
+    "complete": "idle",
+    "stopped": "idle",
+    "failed": "error",
+}
+
+
+def resolve_console_expression_state(store, active_session_id, *, react_enabled: bool) -> str:
+    """Return the current expression state for the active Console session.
+
+    Args:
+        store: the ConsoleChatStore (exposes ``messages_for_session``).
+        active_session_id: the live session id, or None.
+        react_enabled: whether reactive swapping is enabled; when False, always idle.
+
+    Returns:
+        One of EXPRESSION_STATES. Never raises (any lookup failure -> "idle").
+    """
+    if not react_enabled or active_session_id is None or store is None:
+        return "idle"
+    try:
+        messages = store.messages_for_session(active_session_id)
+    except Exception:
+        return "idle"
+    last_assistant = None
+    for message in messages:  # transcript order; keep the last assistant turn
+        if getattr(message, "role", None) is ConsoleMessageRole.ASSISTANT:
+            last_assistant = message
+    if last_assistant is None:
+        return "idle"
+    return _STATUS_TO_STATE.get(getattr(last_assistant, "status", "complete"), "idle")
+```
+
+- [ ] **Step 4: Add the config helper**
+
+In `tldw_chatbook/Chat/console_image_view.py`, immediately after `resolve_show_character_avatar`, add (mirroring it exactly):
+```python
+def resolve_react_character_expressions(app_config: Mapping[str, Any]) -> bool:
+    """Whether the Console avatar reacts (swaps images) as the character
+    thinks/speaks (default True). Reads ``[chat.images].react_character_expressions``
+    via the same both-shapes accessor as ``resolve_show_character_avatar``.
+
+    Returns:
+        True unless explicitly disabled via ``react_character_expressions = false``.
+    """
+    value = _chat_images_config(app_config).get("react_character_expressions", True)
+    return bool(value)
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run:
+```
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/personas-redesign && HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Chat/test_console_expression_state.py -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: PASS (12 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_expression_state.py tldw_chatbook/Chat/console_image_view.py Tests/Chat/test_console_expression_state.py
+git commit -m "feat(console): P3d-1 Task 2 — expression-state derivation + react config helper"
+```
+
+---
+
+## Task 3: Widen the P3c avatar scope to `(character_id, state)` + per-state cache + table fetch
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` (the P3c avatar refresh; `_refresh_active_character_avatar_if_scope_changed` ~:3935 — READ FRESH, lines drift)
+- Test: `Tests/UI/test_console_character_avatar.py` (extend)
+
+**Interfaces:**
+- Consumes: `resolve_console_expression_state` + `EXPRESSION_IMAGE_STATES` (Task 2); `resolve_react_character_expressions` (Task 2); `db.get_character_expression_image` (Task 1). The P3c methods `_current_console_rail_character_id/_name`, `_active_native_console_session`, `_ensure_console_image_view`, `_fetch_character_card_for_avatar`, `_build_character_avatar_widget`, `_render_character_avatar_into_section`, and the fields `_active_character_avatar`, `_active_character_avatar_name`, `_last_console_avatar_scope`, `self._console_image_cache`, `self._console_image_default_mode`, `CHARACTER_AVATAR_COLS`/`CHARACTER_AVATAR_LINES`.
+- Produces: a `(character_id, state)`-keyed decode cache; the refresh now swaps on state change.
+
+**READ FIRST at plan time:** the current body of `_refresh_active_character_avatar_if_scope_changed`, `_render_character_avatar_into_section`, `_build_character_avatar_widget`, `_fetch_character_card_for_avatar`, and the P3c cache-field inits. The steps below describe the *edits* to make; preserve every existing P3c guard.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `Tests/UI/test_console_character_avatar.py` (reuse the existing `console_screen_with_db` fixture + `_set_active_console_character` helper). This drives the state via a fake store the screen already exposes, OR by setting message statuses on the real controller store. Use the store the screen's controller exposes:
+```python
+@pytest.mark.asyncio
+async def test_avatar_swaps_across_expression_states(console_screen_with_db, monkeypatch):
+    app, screen, db = console_screen_with_db
+    from PIL import Image as PILImage
+    from io import BytesIO
+    def _png(color):
+        buf = BytesIO(); PILImage.new("RGB", (32, 32), color).save(buf, format="PNG"); return buf.getvalue()
+    char_id = db.add_character_card({"name": "Ada", "image": _png((10, 10, 10))})
+    db.set_character_expression_image(char_id, "speaking", _png((0, 200, 0)))
+    _set_active_console_character(screen, char_id, "Ada")
+
+    # Drive the derived state directly (the pure resolver is unit-tested separately);
+    # here we assert the refresh reacts to the state it computes.
+    import tldw_chatbook.UI.Screens.chat_screen as cs
+    state_box = {"v": "idle"}
+    monkeypatch.setattr(cs, "resolve_console_expression_state", lambda *a, **k: state_box["v"])
+
+    state_box["v"] = "idle"
+    await screen._refresh_active_character_avatar_if_scope_changed()
+    assert screen._active_character_avatar is not None
+    assert screen._last_console_avatar_scope == (char_id, "idle")
+
+    state_box["v"] = "speaking"
+    await screen._refresh_active_character_avatar_if_scope_changed()
+    assert screen._last_console_avatar_scope == (char_id, "speaking")
+
+    # Revisiting a state is served from the per-state cache (no re-decode).
+    assert (char_id, "speaking") in screen._console_expression_spec_cache
+
+
+@pytest.mark.asyncio
+async def test_expression_state_falls_back_to_idle_image(console_screen_with_db, monkeypatch):
+    app, screen, db = console_screen_with_db
+    from PIL import Image as PILImage
+    from io import BytesIO
+    buf = BytesIO(); PILImage.new("RGB", (32, 32), (5, 5, 5)).save(buf, format="PNG")
+    char_id = db.add_character_card({"name": "Ada", "image": buf.getvalue()})   # idle image only
+    _set_active_console_character(screen, char_id, "Ada")
+    import tldw_chatbook.UI.Screens.chat_screen as cs
+    monkeypatch.setattr(cs, "resolve_console_expression_state", lambda *a, **k: "thinking")
+
+    await screen._refresh_active_character_avatar_if_scope_changed()   # no thinking image -> idle image
+    assert screen._active_character_avatar is not None   # rendered the idle fallback, did not crash
+    assert screen._last_console_avatar_scope == (char_id, "thinking")
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/personas-redesign && HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_character_avatar.py::test_avatar_swaps_across_expression_states -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: FAIL — scope is `(char_id,)` not `(char_id, "idle")`, and `_console_expression_spec_cache` does not exist.
+
+- [ ] **Step 3: Add the imports + the per-state cache field**
+
+At the top of `chat_screen.py` (with the other P3c imports), add:
+```python
+from tldw_chatbook.Chat.console_expression_state import (
+    resolve_console_expression_state,
+    EXPRESSION_IMAGE_STATES,
+)
+from tldw_chatbook.Chat.console_image_view import resolve_react_character_expressions
+```
+(`resolve_show_character_avatar` / `fit_image_cell_size` are already imported from P3c.) In `__init__`, next to the P3c avatar cache fields, add:
+```python
+        self._console_expression_spec_cache: dict[tuple[int, str], dict] = {}
+```
+
+- [ ] **Step 4: Add a state-aware fetch helper**
+
+Add next to `_fetch_character_card_for_avatar`:
+```python
+    def _fetch_expression_image_bytes(self, character_id: int, state: str) -> bytes | None:
+        """Return the image bytes for (character, state): the expression-table
+        image for a non-idle state, else the character's idle avatar. Runs
+        off-thread (called via asyncio.to_thread). Never raises -> None on any error."""
+        try:
+            db = getattr(self.app_instance, "chachanotes_db", None)
+            if db is None:
+                return None
+            if state in EXPRESSION_IMAGE_STATES:
+                img = db.get_character_expression_image(character_id, state)
+                if img:
+                    return img
+            card = self._fetch_character_card_for_avatar(character_id)  # idle fallback
+            image = (card or {}).get("image")
+            return bytes(image) if isinstance(image, (bytes, bytearray)) and image else None
+        except Exception:
+            logger.opt(exception=True).debug("avatar: expression fetch failed")
+            return None
+```
+
+- [ ] **Step 5: Rewrite the refresh to be state-aware**
+
+Edit `_refresh_active_character_avatar_if_scope_changed` so that (preserving every existing P3c guard):
+1. The `show_character_avatar` config-off branch is unchanged (early-return, clear `_active_character_avatar`/`_name`, reset `_last_console_avatar_scope = None`).
+2. Compute the state and scope:
+```python
+        character_id = self._current_console_rail_character_id()
+        controller = getattr(self, "_console_chat_controller", None)
+        store = getattr(controller, "store", None) if controller is not None else None
+        active_session_id = getattr(store, "active_session_id", None) if store is not None else None
+        react = resolve_react_character_expressions(
+            getattr(getattr(self, "app_instance", None), "app_config", {}) or {}
+        )
+        state = resolve_console_expression_state(store, active_session_id, react_enabled=react)
+        scope = (character_id, state)
+        if scope == self._last_console_avatar_scope:
+            return
+        self._last_console_avatar_scope = scope
+        name = self._current_console_rail_character_name()
+        self._active_character_avatar_name = name
+        if character_id is None:
+            self._active_character_avatar = None
+            await self._render_character_avatar_into_section()
+            return
+```
+3. Serve from the per-state cache when present (no decode):
+```python
+        cached = self._console_expression_spec_cache.get((character_id, state))
+        if cached is not None:
+            self._active_character_avatar = cached
+            await self._render_character_avatar_into_section()
+            return
+```
+4. Otherwise decode off-thread (mirror the P3c fetch/prepare, but via `_fetch_expression_image_bytes` and a state-scoped cache key `f"character:{character_id}:{state}"`), build the spec, then **post-await re-check the full `(character_id, state)` scope** (recompute state) before storing/rendering — drop a stale render if the scope moved:
+```python
+        _, cache = self._ensure_console_image_view()
+        mode = getattr(self, "_console_image_default_mode", "pixels")
+        key = f"character:{character_id}:{state}"
+        spec = {"character_id": character_id, "state": state, "name": name,
+                "mode": mode, "pil": None, "pixels": None}
+        try:
+            image = await asyncio.to_thread(self._fetch_expression_image_bytes, character_id, state)
+            if image:
+                ok = await asyncio.to_thread(cache.prepare, key, image)
+                if ok:
+                    spec["pil"] = cache.get_pil(key)
+                    if mode != "graphics":
+                        spec["pixels"] = cache.get_pixels(key)
+        except Exception:
+            logger.opt(exception=True).debug("avatar: expression decode failed")
+        # Post-await staleness re-check on the FULL (character_id, state) scope:
+        # the state can flip mid-decode while streaming, so recompute it from
+        # the SAME store/session captured above and drop a stale render.
+        current_state = resolve_console_expression_state(store, active_session_id, react_enabled=react)
+        if (self._current_console_rail_character_id(), current_state) != scope or not self.is_mounted:
+            return
+        self._console_expression_spec_cache[(character_id, state)] = spec
+        self._active_character_avatar = spec
+        await self._render_character_avatar_into_section()
+```
+NOTE: keep the exact `cache.prepare`/`get_pil`/`get_pixels`/`_ensure_console_image_view`/`fit_image_cell_size` calls identical to the current P3c body — only the fetch source (`_fetch_expression_image_bytes`), the cache key (state-scoped), the scope tuple, and the per-state spec cache are new. Do NOT change `_build_character_avatar_widget` (it already reads `spec["pil"]`/`spec["pixels"]`/`spec["mode"]`; the extra `"state"` key is ignored) and do NOT change `_render_character_avatar_into_section`.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run:
+```
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/personas-redesign && HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_character_avatar.py -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: PASS (all existing P3c tests + the 2 new ones). The pre-existing P3c tests still assert the old `(char_id,)` scope in some places — UPDATE those assertions to `(char_id, "idle")` where they check `_last_console_avatar_scope` (the generic/idle path now yields `(char_id, "idle")`; a None character yields `(None, "idle")`). Do NOT weaken any never-raise / config-off test.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/chat_screen.py Tests/UI/test_console_character_avatar.py
+git commit -m "feat(console): P3d-1 Task 3 — reactive avatar scope (character_id,state) + per-state cache + table fetch"
+```
+
+---
+
+## Task 4: Expression authoring slots in the character editor
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py` (+ its `.tcss` if the avatar thumb has dedicated CSS — mirror the avatar-thumb rule for the 3 slots)
+- Test: `Tests/UI/test_personas_expression_slots.py` (create)
+
+**Interfaces:**
+- Consumes: `db.set_character_expression_image` / `get_character_expression_image` / `delete_character_expression_image` (Task 1); the existing editor avatar machinery: `_character_editor_generation`, `_avatar_upload_dialog_worker` (~:4156), `_fit_avatar_cell_size` (~:4034), `_build_avatar_pixels` (~:4071), and the ConsoleImageRenderCache + `resolve_default_mode` off-thread pattern.
+- Produces: three per-state upload/preview/clear slots (thinking/speaking/error) that write directly to the expression table, independent of the card's optimistic-lock version.
+
+**READ FIRST at plan time:** the current avatar-slot compose + `_avatar_upload_dialog_worker` + `_render_character_editor_avatar` (the method around :3960-4032 that reads `editor.current_avatar_bytes()`, captures the generation token, decodes off-thread, and re-checks the token) to mirror the shape for each expression slot.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/UI/test_personas_expression_slots.py` — mount the personas screen editor for a saved character, assert the 3 slots exist and that uploading writes a row / clearing soft-deletes it. Mirror the existing personas editor test harness (find it with `grep -rln "personas_screen\|PersonasScreen\|character editor" Tests/UI`). Skeleton:
+```python
+import pytest
+# ... import the personas screen + its harness exactly as the existing editor tests do ...
+
+@pytest.mark.asyncio
+async def test_expression_slots_present_for_saved_character(personas_editor_with_saved_character):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    for state in ("thinking", "speaking", "error"):
+        assert screen.query_one(f"#char-expression-slot-{state}") is not None
+
+
+@pytest.mark.asyncio
+async def test_upload_writes_expression_row(personas_editor_with_saved_character):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    from PIL import Image as PILImage
+    from io import BytesIO
+    buf = BytesIO(); PILImage.new("RGB", (16, 16)).save(buf, format="PNG")
+    await screen._apply_expression_upload(char_id, "speaking", buf.getvalue(), "image/png")
+    assert db.get_character_expression_image(char_id, "speaking") is not None
+
+
+@pytest.mark.asyncio
+async def test_clear_soft_deletes_expression_row(personas_editor_with_saved_character):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    db.set_character_expression_image(char_id, "error", b"x")
+    await screen._clear_expression_slot(char_id, "error")
+    assert db.get_character_expression_image(char_id, "error") is None
+```
+(Adjust method names to the ones you implement in Step 3; the test asserts the write-through behavior, not internal wiring.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/personas-redesign && HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_personas_expression_slots.py -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: FAIL — the slots and the `_apply_expression_upload` / `_clear_expression_slot` methods do not exist.
+
+- [ ] **Step 3: Add the slots + write-through handlers**
+
+In the character editor compose (next to the avatar thumbnail), add an "Expressions" area containing three slots, each `id="char-expression-slot-{state}"` with an upload button, a thumbnail `Static`, and a clear button. Implement:
+- `_apply_expression_upload(character_id: int, state: str, image: bytes, mime: str | None) -> None`: `db.set_character_expression_image(...)`, then bump `self._character_editor_generation` and re-render THAT slot's thumbnail (mirror `_render_character_editor_avatar`'s token-capture + off-thread decode + post-await token re-check, per slot).
+- `_clear_expression_slot(character_id: int, state: str) -> None`: `db.delete_character_expression_image(...)`, bump the generation, clear that slot's thumbnail to the empty hint.
+- An upload worker per slot mirroring `_avatar_upload_dialog_worker` (reuse the same dialog; on accept, call `_apply_expression_upload`).
+- On editor open for a saved character, load each slot's existing image via `db.get_character_expression_image` and render its thumbnail.
+- **Slots are enabled only for a SAVED character (has an id).** For a brand-new unsaved character, show the slots disabled with a hint "Save the character to add expressions." (A new character has no id to attach rows to.)
+- Personas mode shows NO expression slots (characters-only).
+
+Each slot's decode uses the SAME `_character_editor_generation` token discipline as the avatar: capture the token before the off-thread decode, and after it re-check `token == self._character_editor_generation and self.is_mounted` before mounting — a slot replaced/cleared mid-decode must drop its stale render.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+```
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/personas-redesign && HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_personas_expression_slots.py -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: PASS. Also run the existing personas editor test module (find it via grep) to confirm no regression, and `python -c "import tldw_chatbook.app"`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/personas_screen.py Tests/UI/test_personas_expression_slots.py
+# include the .tcss file only if you added an expression-slot CSS rule
+git commit -m "feat(personas): P3d-1 Task 4 — character expression authoring slots (thinking/speaking/error)"
+```
+
+---
+
+## Task 5: Config documentation + end-to-end integration & fail-soft
+
+**Files:**
+- Modify: `tldw_chatbook/config.py` (document `react_character_expressions` in the `[chat.images]` block ~:2740)
+- Test: `Tests/UI/test_console_character_avatar.py` (extend with the full-arc + gate + fail-soft integration tests)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-4.
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Append to `Tests/UI/test_console_character_avatar.py`:
+```python
+@pytest.mark.asyncio
+async def test_react_off_pins_idle_even_when_streaming(console_screen_with_db, monkeypatch):
+    app, screen, db = console_screen_with_db
+    from PIL import Image as PILImage
+    from io import BytesIO
+    def _png(c):
+        b = BytesIO(); PILImage.new("RGB", (16, 16), c).save(b, format="PNG"); return b.getvalue()
+    char_id = db.add_character_card({"name": "Ada", "image": _png((1, 1, 1))})
+    db.set_character_expression_image(char_id, "speaking", _png((0, 255, 0)))
+    _set_active_console_character(screen, char_id, "Ada")
+    app.app_config["chat"] = {"images": {"react_character_expressions": False}}
+    import tldw_chatbook.UI.Screens.chat_screen as cs
+    # Even if the raw status would say "streaming", react-off must pin idle.
+    # (resolve_console_expression_state honors react_enabled=False internally.)
+    await screen._refresh_active_character_avatar_if_scope_changed()
+    assert screen._last_console_avatar_scope == (char_id, "idle")
+
+
+@pytest.mark.asyncio
+async def test_reactive_avatar_never_raises_on_corrupt_expression(console_screen_with_db, monkeypatch):
+    app, screen, db = console_screen_with_db
+    char_id = db.add_character_card({"name": "Bad"})
+    db.set_character_expression_image(char_id, "speaking", b"not-an-image")
+    _set_active_console_character(screen, char_id, "Ada")
+    import tldw_chatbook.UI.Screens.chat_screen as cs
+    monkeypatch.setattr(cs, "resolve_console_expression_state", lambda *a, **k: "speaking")
+    # Must not raise into the sync tick even though the image is corrupt.
+    await screen._refresh_active_character_avatar_if_scope_changed()
+    assert screen._last_console_avatar_scope == (char_id, "speaking")
+```
+
+- [ ] **Step 2: Run to verify it fails (or passes trivially), then implement the doc**
+
+Run the two tests. `test_reactive_avatar_never_raises_on_corrupt_expression` should already pass (never-raise inherited); `test_react_off_pins_idle_even_when_streaming` should pass once Task 3 is in. If both pass, they are regression guards — proceed. Then document the config key.
+
+- [ ] **Step 3: Document `react_character_expressions`**
+
+In `tldw_chatbook/config.py`, in the `[chat.images]` block (near `show_character_avatar` ~:2740), add a documented default line mirroring the existing style, e.g.:
+```python
+# react_character_expressions = true   # Swap the Console character avatar among
+#   idle/thinking/speaking/error as it generates a reply (requires per-state images
+#   on the character; default true). Set false to keep a static avatar.
+```
+(Match the exact comment/entry style used for `show_character_avatar` in that block — read it and mirror.)
+
+- [ ] **Step 4: Run the focused suite + app import**
+
+Run:
+```
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/personas-redesign && HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_character_avatar.py Tests/UI/test_console_persistent_rails.py -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Then Chat + DB suites (separate invocation — different rootdir):
+```
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/personas-redesign && HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Chat/test_console_expression_state.py Tests/Character_Chat/test_character_expression_images.py -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Then `python -c "import tldw_chatbook.app"`. Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/config.py Tests/UI/test_console_character_avatar.py
+git commit -m "feat(console): P3d-1 Task 5 — document react_character_expressions + full-arc & fail-soft tests"
+```
+
+---
+
+## Self-Review (author)
+
+- **Spec coverage:** table+migration+CRUD (Task 1) ✓; `resolve_console_expression_state` DB-free + `resolve_react_character_expressions` + react-off-pins-idle (Task 2) ✓; scope `(character_id,state)` + per-state cache + fallback chain state→idle→text + never-raise + post-await re-check on the full tuple, all P3c machinery reused (Task 3) ✓; authoring slots with render-token discipline + independent-of-card-version save (Task 4) ✓; config doc + gate + fail-soft integration (Task 5) ✓. Out-of-scope items (animation/atlas/import/server-MCP/registry/custom states) are in NO task ✓.
+- **Type consistency:** `resolve_console_expression_state(store, active_session_id, *, react_enabled)` and `EXPRESSION_IMAGE_STATES`/`EXPRESSION_STATES` are defined in Task 2 and consumed with matching signatures in Task 3. `set/get/list/delete_character_expression_image` signatures match between Task 1 (definition) and Tasks 3/4 (consumption). Scope tuple `(character_id, state)` is consistent across Task 3 and the Task 3/5 test assertions. Cache field `_console_expression_spec_cache: dict[tuple[int,str],dict]` and cache key `f"character:{character_id}:{state}"` are consistent.
+- **Placeholder scan:** no TBD/TODO; every code step shows code; the two "READ FIRST at plan time" notes point at named methods to mirror, not vague hand-waving. Task 4's compose is described structurally (slot ids fixed: `char-expression-slot-{state}`) because it mirrors an existing avatar slot the implementer must read — the exact widget tree follows that sibling.
+- **Known drift risk:** all `chat_screen.py` / `personas_screen.py` / `ChaChaNotes_DB.py` line numbers are approximate (concurrent edits) — every task says READ FRESH. The migration ladder + `_MIGRATE_V*_SQL` pattern and the `db_schema_version` bump are verified against `_migrate_from_v21_to_v22` / `_MIGRATE_V18_TO_V19_SQL`.

--- a/Docs/superpowers/specs/2026-07-22-roleplay-p3d-console-expression-avatar-design.md
+++ b/Docs/superpowers/specs/2026-07-22-roleplay-p3d-console-expression-avatar-design.md
@@ -1,0 +1,142 @@
+# Roleplay P3d-1 — Reactive Character Expression Avatar (Console) — Design
+
+**Date:** 2026-07-22
+**Program:** Roleplay (Personas) redesign — character-presence theme, cycle 3 (P3b editor → P3c chat avatar → **P3d reactions**)
+**Status:** design approved (brainstorming); ready for implementation plan.
+
+## Goal
+
+Make the Console Character-rail avatar (shipped in P3c, PR #782) **react as the character thinks and speaks**: swap among a small set of per-state images — *idle / thinking / speaking / error* — driven by the Console's own send/stream lifecycle, using images stored locally on the character. Fully additive: a character with no expression images just shows its normal avatar, exactly as today.
+
+## Context
+
+P3d is the character-presence theme's final, most ambitious cycle. The user's north-star framing was "copying the webui/browser-extension for tldw_server … multiple reaction images / changes in the profile pic as the message renders (like animating a character reacting as they speak)."
+
+That reference is real: **tldw_server2 has a "Persona Visual Packs" / "Persona Buddy" system** — a manifest-backed pack (`states` → animations → ordered `frames`), a fixed core state set (`idle, listening, thinking, speaking, tool_running, approval_needed, error, offline`) plus freeform custom states, portable `.tldw-persona-vpack` archives, a renderer capability registry, and an external MCP pack-provider contract. Crucially, in that system **"reacting as it speaks" is NOT an LLM emotion classifier** — it is a **deterministic client-side state machine** driven by the app's runtime state (voice/tool/session), priority-ordered.
+
+The full system is far too large for one spec (it mirrors ~30 server-side design tasks) and much of it assumes a graphical renderer (smooth sprite animation, atlas cropping, Live2D) that a terminal cannot do. So **P3d decomposes into cycles**, and this spec is the first: the **minimal terminal-portable core** — a local `terminal_static` renderer that frame-swaps one static image per state, driven by the Console lifecycle. Later cycles (out of scope here) add archive import, the server/MCP pack provider, the full capability registry, and custom/mood/tool/voice states.
+
+### Foundation this builds on (P3c, PR #782, merged to dev)
+
+- Config-gated **"Character"** collapsible section in `#console-left-rail` (`[chat.images].show_character_avatar`, default True).
+- Active character resolved **only** off the live `ConsoleChatSession` (`_current_console_rail_character_id()` / `_name()`), never legacy `app.current_chat_*`.
+- Avatar render pipeline: cache-as-**spec** (data dict, not a live widget) + off-thread decode via the single `self._console_image_cache` (`ConsoleImageRenderCache`) + `fit_image_cell_size` + graphics/pixels/text fallback in `_build_character_avatar_widget`, mounted by the async `_render_character_avatar_into_section`.
+- `_refresh_active_character_avatar_if_scope_changed`: scope-guarded on `(character_id,)`, guard set **before** the `await`, off-thread fetch, post-await scope re-check drops a stale render, **never raises** into the sync tick, config-off early-return that also resets the scope guard to `None`.
+- Called from `_sync_native_console_chat_ui`.
+
+## Verified ground truths (from code scout — use verbatim, do not re-derive)
+
+1. **Message status lifecycle** (`Chat/console_chat_store.py`): `_initial_status(role, content)` returns `"pending"` for an empty ASSISTANT message; `append_stream_chunk` sets status `"streaming"`; terminal statuses are `"complete"`, `"stopped"` (user stop), `"failed"` (error). **There is no `"error"` status — the error state maps to `"failed"`.** `stopped` is a user action, not an error → maps to idle.
+2. **The trigger is already wired.** `_sync_native_console_chat_ui` runs every 0.2s via `_poll_transcript` (`chat_screen.py:~10434`, `set_interval(0.2, _poll_transcript)`) during a send, **and once on completion** — `_poll_transcript` calls `await self._sync_native_console_chat_ui()` *before* it checks `run_state.status` and stops the timer. So the avatar refresh already fires on every streaming tick and on the terminal tick. P3d needs **no new hook** — only a wider scope tuple.
+3. **Character image today** is a single BLOB: `character_cards.image` (schema `image BLOB`), read via `get_character_card_by_id(character_id: int)`. `character_id` is INT.
+4. **Character editor** (authoring host) is in `personas_screen.py` (P3b) with an existing avatar upload + thumbnail path (`_fit_avatar_cell_size`, `ConsoleImageRenderCache`, per-generation render token `_character_editor_generation`).
+5. **Schema** is ChaChaNotes v22 (P3a/P3b/P3c added no migration). The next migration is `v22→v23`. `CharactersRAGDB` uses `threading.local()` connections.
+6. **DO NOT touch** `_active_console_dictionary_scope_ids` (P3c pin — it feeds the "what's in play" summaries; not inert).
+
+## Architecture
+
+Five units, each independently testable:
+
+### 1. Data model — `character_expression_images` table (migration v22→v23)
+
+New table storing one raster image per (character, **non-idle** state):
+
+```
+character_expression_images(
+  id            INTEGER PRIMARY KEY,
+  character_id  INTEGER NOT NULL REFERENCES character_cards(id),
+  state_id      TEXT NOT NULL,          -- 'thinking' | 'speaking' | 'error'
+  image         BLOB NOT NULL,
+  mime          TEXT,
+  created_at    TEXT,
+  updated_at    TEXT,
+  deleted       INTEGER NOT NULL DEFAULT 0,   -- soft-delete, mirrors character_cards
+  UNIQUE(character_id, state_id)
+)
+```
+
+- **idle is never stored here** — it reuses `character_cards.image`.
+- Migration is idempotent (PRAGMA/`CREATE TABLE IF NOT EXISTS`-guarded), bumps schema to v23. Pre-flight at plan time: re-verify dev is still v22 (concurrent sessions may have taken v23) and that no other in-flight migration collides.
+- On character hard-delete, expression rows cascade; on soft-delete, they follow the card (excluded from reads).
+- CRUD seam on `CharactersRAGDB`: `set_character_expression_image(character_id, state_id, image, mime)`, `get_character_expression_image(character_id, state_id) -> bytes|None`, `list_character_expression_states(character_id) -> list[str]`, `delete_character_expression_image(character_id, state_id)`. All parameterized; `state_id` validated against the known set.
+- **Independent save:** expression images write straight to this table and do **not** touch the card's optimistic-lock version — authoring an expression never conflicts the card.
+
+### 2. State derivation — `resolve_console_expression_state`
+
+A pure, **DB-free** function (reads only in-memory store state), safe to call on the 0.2s tick:
+
+```
+resolve_console_expression_state(store, session) -> "idle" | "thinking" | "speaking" | "error"
+```
+
+Derived from the active assistant message's status for the session's conversation:
+- an assistant message with status `"pending"` → **thinking**
+- status `"streaming"` → **speaking**
+- no in-flight message, last assistant `"complete"` or `"stopped"` → **idle**
+- last assistant `"failed"` → **error** (persists until the next send resets to thinking/idle)
+
+No emotion classification of reply text. Non-streaming replies may show a brief/absent "speaking" phase — acceptable and documented, not engineered around.
+
+### 3. Trigger — extend the P3c scope
+
+Change the avatar scope-guard from `(character_id,)` to **`(character_id, expression_state)`**. `_refresh_active_character_avatar_if_scope_changed` computes `state = resolve_console_expression_state(...)` (config-gated on the new sub-gate), builds the scope, and returns early when unchanged — so nothing rebuilds except on an actual state transition. The existing `_sync_native_console_chat_ui` calls (0.2s poll + completion + send/stop + session change) drive it. The post-await re-check now compares the full `(character_id, state)` tuple (state can flip mid-decode during fast streaming).
+
+### 4. Rendering — reuse P3c, add a per-state decode cache
+
+- **Keep** P3c's `_active_character_avatar` as "the spec the render currently mounts" (the render path `_render_character_avatar_into_section` reads it unchanged). **Add** a separate `(character_id, state)`-keyed **decode cache** dict → cached spec (`{character_id, state, name, mode, pil, pixels}`). On a state change, the refresh looks up (or decodes-and-stores) the cache entry for `(character_id, state)`, sets `_active_character_avatar` to it, and renders — so re-visiting a state (idle↔speaking↔idle) is instant, no re-decode. idle's entry is the P3c avatar spec (from `character_cards.image`).
+- Fetch for a state: **fallback chain** = expression-table image for `state` → `character_cards.image` (idle) → text placeholder. If the idle image is null but a state image exists, that state renders its image and idle renders text — consistent with "missing → fall back."
+- Everything else is P3c unchanged: off-thread decode via `self._console_image_cache`, `fit_image_cell_size` to `CHARACTER_AVATAR_COLS/LINES`, `_build_character_avatar_widget` (graphics → pixels → text), async `_render_character_avatar_into_section`, never-raise.
+
+### 5. Authoring — expression slots in the character editor
+
+In the P3b character editor (`personas_screen.py`), a small **"Expressions"** area with three upload slots (thinking / speaking / error), reusing the existing avatar upload + thumbnail machinery:
+- Each slot: upload / preview (thumbnail) / clear. Upload writes to `character_expression_images`; clear soft-deletes the row.
+- Each slot's async decode uses the `_character_editor_generation` render-token discipline (P3b lesson: any action invalidating an in-flight decode must bump the token; the swapped/removed slot must drop stale renders).
+- An empty slot ⇒ that state falls back to idle in chat.
+
+## Configuration
+
+- Reuse `[chat.images].show_character_avatar` (default True): off ⇒ no Character section at all, expressions moot.
+- New sub-gate `[chat.images].react_character_expressions` (default **True**): when False, the Character section shows only the static idle avatar (P3c behavior) and never swaps. Pure config helper `resolve_react_character_expressions(app_config) -> bool` in `console_image_view.py`, mirroring `resolve_show_character_avatar`. Documented in `config.py`'s `[chat.images]` block.
+- **UX caveat (documented):** terminals without a graphics protocol render via pixels, which can flicker on rapid swaps; `react_character_expressions=false` is the escape hatch. Not auto-disabled — user-controllable.
+
+## Data flow (one reply)
+
+1. User sends → controller creates an empty assistant message (`pending`) and starts the 0.2s `_poll_transcript`.
+2. Poll tick → `_sync_native_console_chat_ui` → refresh → state `thinking` (scope changed) → swap to the thinking image (or idle fallback).
+3. First token → `append_stream_chunk` flips status to `streaming` → next poll tick → state `speaking` → swap to the speaking image.
+4. Completion → message `complete`; the terminal poll tick calls sync **before** stopping the timer → state `idle` → swap back to the idle avatar. (Failure → `failed` → `error` image, persisting until the next send.)
+
+## Error handling / fail-soft
+
+Inherited from P3c and made total: state-derivation never raises (pure, guarded), the refresh never raises into the sync tick (P3c invariant preserved, now guarding the wider scope), the render degrades state-image → idle-image → text. A missing/corrupt expression image, a decode failure, or a torn table read all degrade to idle-or-text, never crash the 0.2s tick.
+
+## Testing strategy
+
+- **DB seam:** real in-memory-unsafe note — use a file-backed `CharactersRAGDB(tmp_path/...)` (the fetch runs off-thread; `:memory:` is connection-private). Table CRUD, UNIQUE(character_id, state_id) upsert, soft-delete exclusion, migration applies idempotently and reports v23.
+- **State derivation:** a table of constructed store states → expected state (pending→thinking, streaming→speaking, complete/stopped→idle, failed→error, none→idle). Pure, no live LLM.
+- **Trigger + render:** drive status transitions on a real mounted Console screen (P3c harness) and assert the mounted avatar spec changes across idle→thinking→speaking→idle; assert scope-guard prevents rebuild when state is unchanged; assert per-state cache reuse (second visit to a state does not re-decode).
+- **Fallback:** state with no image ⇒ idle image mounted; no idle image either ⇒ text; corrupt image ⇒ never raises (mirrors P3c `test_refresh_never_raises_on_bad_image`).
+- **Authoring:** upload → row present → thumbnail renders; clear → row soft-deleted → chat falls back to idle; save is independent of the card version.
+- **Config:** `react_character_expressions=false` ⇒ static idle only, no swap; `show_character_avatar=false` ⇒ no section (reuse P3c test).
+
+## Global constraints (for the plan)
+
+- **Migration v22→v23**, idempotent, pre-flight re-verify v22 at plan/merge time. Only DB change; character_cards untouched (idle still `character_cards.image`).
+- Resolve active character **only** off the live `ConsoleChatSession`; resolve expression state **only** off in-memory store status — never DB on the derivation path (safe on the 0.2s tick).
+- **Reuse** the single `self._console_image_cache`, `resolve_default_mode`, `fit_image_cell_size`, and the P3c render/refresh methods. Do not create a second render cache. Decode stays off-thread.
+- **Never raise** into `_sync_native_console_chat_ui`; preserve every P3c invariant (config-off early-return + guard reset, post-await re-check — now on `(character_id, state)`, cache-as-spec-not-widget).
+- **Do not touch** `_active_console_dictionary_scope_ids`.
+- Scope-guard means **no rebuild/decode except on a real state change** (honors the perf-audit "no per-tick DB/rebuild" rule).
+- Authoring slots apply the `_character_editor_generation` render-token discipline per slot; expression saves are independent of the card's optimistic-lock version.
+- Config-gated: `show_character_avatar` (section) and `react_character_expressions` (swapping), both default True.
+- Characters-only (personas have no image). CONCURRENT-SESSION HAZARD: `chat_screen.py` / `personas_screen.py` / `ChaChaNotes_DB.py` edited by other sessions — keep P3d localized to the new table + seam + derivation + scope-tuple + authoring slots; expect rebase.
+- Tests: `Tests/UI/pytest.ini` sets `asyncio_mode=auto` — don't mix Tests/UI with another dir in one invocation, or add explicit `@pytest.mark.asyncio`. Never broad-pkill pytest; scope to the worktree.
+
+## Out of scope — later P3d cycles
+
+- Smooth animation / sprite atlas / frame-rate playback / Live2D (browser-only).
+- `.tldw-persona-vpack` archive import; the full manifest V2 contract.
+- Server/MCP pack provider; the renderer capability **registry** (a `terminal_static` capability marker with no consumer is YAGNI now — the essential fail-soft is already inherited).
+- Custom / mood / tool_running / voice (listening) states; approval_needed / offline.
+- Any emotion classification of reply text (state stays runtime-driven, per the server model).

--- a/Docs/superpowers/specs/2026-07-22-roleplay-p3d-console-expression-avatar-design.md
+++ b/Docs/superpowers/specs/2026-07-22-roleplay-p3d-console-expression-avatar-design.md
@@ -69,11 +69,13 @@ A pure, **DB-free** function (reads only in-memory store state), safe to call on
 resolve_console_expression_state(store, session) -> "idle" | "thinking" | "speaking" | "error"
 ```
 
-Derived from the active assistant message's status for the session's conversation:
+Reads the active session's **in-memory** messages via `store.messages_for_session(active_session_id)` (the same in-memory access the controller's `_active_streaming_assistant_message_id` uses — no DB), and maps the active assistant message's status:
 - an assistant message with status `"pending"` → **thinking**
 - status `"streaming"` → **speaking**
 - no in-flight message, last assistant `"complete"` or `"stopped"` → **idle**
 - last assistant `"failed"` → **error** (persists until the next send resets to thinking/idle)
+
+When the `react_character_expressions` sub-gate is off, the function returns **`"idle"`** unconditionally (the P3c avatar still renders; distinct from `show_character_avatar` off, which clears the section entirely).
 
 No emotion classification of reply text. Non-streaming replies may show a brief/absent "speaking" phase — acceptable and documented, not engineered around.
 
@@ -105,7 +107,7 @@ In the P3b character editor (`personas_screen.py`), a small **"Expressions"** ar
 1. User sends → controller creates an empty assistant message (`pending`) and starts the 0.2s `_poll_transcript`.
 2. Poll tick → `_sync_native_console_chat_ui` → refresh → state `thinking` (scope changed) → swap to the thinking image (or idle fallback).
 3. First token → `append_stream_chunk` flips status to `streaming` → next poll tick → state `speaking` → swap to the speaking image.
-4. Completion → message `complete`; the terminal poll tick calls sync **before** stopping the timer → state `idle` → swap back to the idle avatar. (Failure → `failed` → `error` image, persisting until the next send.)
+4. Completion → message `complete`; the idle revert is **race-safe** — state derives from the *message* status (not `run_state`), and multiple `_sync_native_console_chat_ui` calls fire after the message goes terminal (the poll's final tick, which calls sync **before** stopping the timer, plus the explicit send/stop-transition syncs `run_worker(..., group="console-sync")`). The avatar reverts to idle on whichever fires first; it cannot get stuck on "speaking." (Failure → `failed` → `error` image, persisting until the next send.)
 
 ## Error handling / fail-soft
 

--- a/Tests/Character_Chat/test_character_expression_images.py
+++ b/Tests/Character_Chat/test_character_expression_images.py
@@ -1,0 +1,67 @@
+import pytest
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    # File-backed (NOT :memory:) — CharactersRAGDB uses threading.local connections
+    # and the production avatar fetch runs off-thread; :memory: is connection-private.
+    return CharactersRAGDB(tmp_path / "expr.db", "test-client")
+
+
+def _make_character(db) -> int:
+    return db.add_character_card({"name": "Ada"})
+
+
+def test_schema_is_v23(db):
+    assert db._get_db_version(db.get_connection()) == 23
+
+
+def test_set_then_get_round_trips(db):
+    cid = _make_character(db)
+    db.set_character_expression_image(cid, "speaking", b"PNGBYTES", "image/png")
+    assert db.get_character_expression_image(cid, "speaking") == b"PNGBYTES"
+
+
+def test_get_missing_returns_none(db):
+    cid = _make_character(db)
+    assert db.get_character_expression_image(cid, "thinking") is None
+
+
+def test_set_is_upsert_on_character_and_state(db):
+    cid = _make_character(db)
+    db.set_character_expression_image(cid, "speaking", b"one")
+    db.set_character_expression_image(cid, "speaking", b"two")
+    assert db.get_character_expression_image(cid, "speaking") == b"two"
+    assert db.list_character_expression_states(cid) == ["speaking"]  # not duplicated
+
+
+def test_list_states_returns_only_active(db):
+    cid = _make_character(db)
+    db.set_character_expression_image(cid, "thinking", b"t")
+    db.set_character_expression_image(cid, "error", b"e")
+    assert sorted(db.list_character_expression_states(cid)) == ["error", "thinking"]
+
+
+def test_delete_is_soft_and_get_returns_none(db):
+    cid = _make_character(db)
+    db.set_character_expression_image(cid, "speaking", b"s")
+    db.delete_character_expression_image(cid, "speaking")
+    assert db.get_character_expression_image(cid, "speaking") is None
+    assert db.list_character_expression_states(cid) == []
+
+
+def test_set_after_delete_reactivates(db):
+    cid = _make_character(db)
+    db.set_character_expression_image(cid, "speaking", b"s1")
+    db.delete_character_expression_image(cid, "speaking")
+    db.set_character_expression_image(cid, "speaking", b"s2")
+    assert db.get_character_expression_image(cid, "speaking") == b"s2"
+
+
+def test_invalid_state_id_rejected(db):
+    cid = _make_character(db)
+    with pytest.raises(ValueError):
+        db.set_character_expression_image(cid, "idle", b"x")   # idle is never stored
+    with pytest.raises(ValueError):
+        db.set_character_expression_image(cid, "bogus", b"x")

--- a/Tests/Chat/test_console_expression_state.py
+++ b/Tests/Chat/test_console_expression_state.py
@@ -1,0 +1,96 @@
+import pytest
+from tldw_chatbook.Chat.console_expression_state import (
+    EXPRESSION_STATES,
+    EXPRESSION_IMAGE_STATES,
+    resolve_console_expression_state,
+)
+from tldw_chatbook.Chat.console_image_view import resolve_react_character_expressions
+
+
+class _Msg:
+    def __init__(self, role, status):
+        self.role = role
+        self.status = status
+
+
+class _FakeRole:
+    ASSISTANT = object()
+    USER = object()
+
+
+class _FakeStore:
+    """Minimal stand-in exposing messages_for_session, matching the real signature."""
+    def __init__(self, messages_by_session):
+        self._m = messages_by_session
+
+    def messages_for_session(self, session_id):
+        if session_id not in self._m:
+            raise KeyError(session_id)
+        return list(self._m[session_id])
+
+
+@pytest.fixture(autouse=True)
+def _patch_role(monkeypatch):
+    # Point the resolver at the fake role sentinel so _Msg.role comparisons match.
+    import tldw_chatbook.Chat.console_expression_state as mod
+    monkeypatch.setattr(mod, "ConsoleMessageRole", _FakeRole)
+
+
+def _state(messages, *, react=True, sid="s1"):
+    store = _FakeStore({sid: messages})
+    return resolve_console_expression_state(store, sid, react_enabled=react)
+
+
+def test_no_session_is_idle():
+    store = _FakeStore({})
+    assert resolve_console_expression_state(store, None, react_enabled=True) == "idle"
+
+
+def test_missing_session_is_idle():
+    store = _FakeStore({})
+    assert resolve_console_expression_state(store, "nope", react_enabled=True) == "idle"
+
+
+def test_no_assistant_message_is_idle():
+    assert _state([_Msg(_FakeRole.USER, "complete")]) == "idle"
+
+
+def test_pending_assistant_is_thinking():
+    assert _state([_Msg(_FakeRole.USER, "complete"), _Msg(_FakeRole.ASSISTANT, "pending")]) == "thinking"
+
+
+def test_streaming_assistant_is_speaking():
+    assert _state([_Msg(_FakeRole.ASSISTANT, "streaming")]) == "speaking"
+
+
+def test_complete_assistant_is_idle():
+    assert _state([_Msg(_FakeRole.ASSISTANT, "complete")]) == "idle"
+
+
+def test_stopped_assistant_is_idle():
+    assert _state([_Msg(_FakeRole.ASSISTANT, "stopped")]) == "idle"
+
+
+def test_failed_assistant_is_error():
+    assert _state([_Msg(_FakeRole.ASSISTANT, "failed")]) == "error"
+
+
+def test_last_assistant_wins():
+    # A completed turn followed by a new pending turn -> thinking.
+    msgs = [_Msg(_FakeRole.ASSISTANT, "complete"), _Msg(_FakeRole.ASSISTANT, "pending")]
+    assert _state(msgs) == "thinking"
+
+
+def test_react_disabled_pins_idle():
+    assert _state([_Msg(_FakeRole.ASSISTANT, "streaming")], react=False) == "idle"
+
+
+def test_constants():
+    assert EXPRESSION_STATES == ("idle", "thinking", "speaking", "error")
+    assert EXPRESSION_IMAGE_STATES == ("thinking", "speaking", "error")
+
+
+def test_react_config_helper_defaults_true():
+    assert resolve_react_character_expressions({}) is True
+    cfg = {"chat": {"images": {"react_character_expressions": False}}}
+    assert resolve_react_character_expressions(cfg) is False

--- a/Tests/UI/test_console_character_avatar.py
+++ b/Tests/UI/test_console_character_avatar.py
@@ -475,3 +475,43 @@ async def test_expression_state_falls_back_to_idle_image(console_screen_with_db,
     await screen._refresh_active_character_avatar_if_scope_changed()   # no thinking image -> idle image
     assert screen._active_character_avatar is not None   # rendered the idle fallback, did not crash
     assert screen._last_console_avatar_scope == (char_id, "thinking")
+
+
+# --- P3d-1 Task 3 review fixes ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_expression_spec_cache_is_bounded(console_screen_with_db, monkeypatch):
+    """Review FIX 1: ``_console_expression_spec_cache`` is written on every
+    new ``(character_id, state)`` decode and never evicted -- over a long
+    session visiting many characters this retains unbounded ``PILImage.Image``
+    references (the ``_console_image_cache`` render LRU does NOT protect this
+    cache, since the spec dicts hold their own independent PIL references).
+    Visit 6 characters x 3 states each (18 distinct scopes, more than the
+    16-entry cap) and assert the cache never grows past the cap.
+    """
+    app, screen, db = console_screen_with_db
+    from PIL import Image as PILImage
+    from io import BytesIO
+
+    def _png(color):
+        buf = BytesIO()
+        PILImage.new("RGB", (32, 32), color).save(buf, format="PNG")
+        return buf.getvalue()
+
+    char_ids = [
+        db.add_character_card({"name": f"Char{i}", "image": _png((i * 10, 10, 10))})
+        for i in range(6)
+    ]
+
+    import tldw_chatbook.UI.Screens.chat_screen as cs
+    state_box = {"v": "idle"}
+    monkeypatch.setattr(cs, "resolve_console_expression_state", lambda *a, **k: state_box["v"])
+
+    for char_id in char_ids:
+        _set_active_console_character(screen, char_id, f"Char{char_id}")
+        for state in ("idle", "thinking", "speaking"):
+            state_box["v"] = state
+            await screen._refresh_active_character_avatar_if_scope_changed()
+
+    assert len(screen._console_expression_spec_cache) <= 16

--- a/Tests/UI/test_console_character_avatar.py
+++ b/Tests/UI/test_console_character_avatar.py
@@ -515,3 +515,60 @@ async def test_expression_spec_cache_is_bounded(console_screen_with_db, monkeypa
             await screen._refresh_active_character_avatar_if_scope_changed()
 
     assert len(screen._console_expression_spec_cache) <= 16
+
+
+# --- P3d-1 Task 5: end-to-end integration + fail-soft ------------------------
+#
+# Regression guards locking the react-off gate and the corrupt-image
+# fail-soft path all the way through the real refresh entrypoint (not the
+# pure resolver, which is unit-tested separately).
+
+
+@pytest.mark.asyncio
+async def test_react_off_pins_idle_even_when_streaming(console_screen_with_db, monkeypatch):
+    """A genuinely "streaming" session (real assistant message, real
+    ``store``, no ``resolve_console_expression_state`` monkeypatch -- unlike
+    the P3d-1 Task 3 tests above) still resolves to "idle" once
+    ``react_character_expressions`` is off, proving the config gate is wired
+    all the way through the real refresh entrypoint, not just the pure
+    resolver (already locked at the unit level by
+    ``Tests/Chat/test_console_expression_state.py::test_react_disabled_pins_idle``).
+    """
+    app, screen, db = console_screen_with_db
+    from PIL import Image as PILImage
+    from io import BytesIO
+    from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+    def _png(c):
+        b = BytesIO(); PILImage.new("RGB", (16, 16), c).save(b, format="PNG"); return b.getvalue()
+    char_id = db.add_character_card({"name": "Ada", "image": _png((1, 1, 1))})
+    db.set_character_expression_image(char_id, "speaking", _png((0, 255, 0)))
+    _set_active_console_character(screen, char_id, "Ada")
+
+    # Put a genuinely-streaming assistant message on the active session so
+    # the raw status really would say "streaming" (-> "speaking") if react
+    # were on.
+    controller = screen._ensure_console_chat_controller()
+    session = screen._active_native_console_session()
+    message = controller.store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content=""
+    )
+    controller.store.append_stream_chunk(message.id, "partial reply")
+
+    app.app_config["chat"] = {"images": {"react_character_expressions": False}}
+    # Even though the raw status is "streaming", react-off must pin idle.
+    # (resolve_console_expression_state honors react_enabled=False internally.)
+    await screen._refresh_active_character_avatar_if_scope_changed()
+    assert screen._last_console_avatar_scope == (char_id, "idle")
+
+
+@pytest.mark.asyncio
+async def test_reactive_avatar_never_raises_on_corrupt_expression(console_screen_with_db, monkeypatch):
+    app, screen, db = console_screen_with_db
+    char_id = db.add_character_card({"name": "Bad"})
+    db.set_character_expression_image(char_id, "speaking", b"not-an-image")
+    _set_active_console_character(screen, char_id, "Ada")
+    import tldw_chatbook.UI.Screens.chat_screen as cs
+    monkeypatch.setattr(cs, "resolve_console_expression_state", lambda *a, **k: "speaking")
+    # Must not raise into the sync tick even though the image is corrupt.
+    await screen._refresh_active_character_avatar_if_scope_changed()
+    assert screen._last_console_avatar_scope == (char_id, "speaking")

--- a/Tests/UI/test_console_character_avatar.py
+++ b/Tests/UI/test_console_character_avatar.py
@@ -421,3 +421,57 @@ async def test_refresh_repopulates_after_config_toggle_off_then_on(console_scree
     await screen._refresh_active_character_avatar_if_scope_changed()
     assert screen._active_character_avatar is not None
     assert screen._active_character_avatar.get("character_id") == char_id
+
+
+# --- P3d-1 Task 3: reactive avatar scope (character_id, state) --------------
+#
+# Widens the P3c `(character_id,)` scope guard to `(character_id, state)` so
+# the avatar swaps as the character thinks/speaks/errors, and adds a
+# per-state decode cache so revisiting a state already seen this session is
+# served instantly.
+
+
+@pytest.mark.asyncio
+async def test_avatar_swaps_across_expression_states(console_screen_with_db, monkeypatch):
+    app, screen, db = console_screen_with_db
+    from PIL import Image as PILImage
+    from io import BytesIO
+    def _png(color):
+        buf = BytesIO(); PILImage.new("RGB", (32, 32), color).save(buf, format="PNG"); return buf.getvalue()
+    char_id = db.add_character_card({"name": "Ada", "image": _png((10, 10, 10))})
+    db.set_character_expression_image(char_id, "speaking", _png((0, 200, 0)))
+    _set_active_console_character(screen, char_id, "Ada")
+
+    # Drive the derived state directly (the pure resolver is unit-tested separately);
+    # here we assert the refresh reacts to the state it computes.
+    import tldw_chatbook.UI.Screens.chat_screen as cs
+    state_box = {"v": "idle"}
+    monkeypatch.setattr(cs, "resolve_console_expression_state", lambda *a, **k: state_box["v"])
+
+    state_box["v"] = "idle"
+    await screen._refresh_active_character_avatar_if_scope_changed()
+    assert screen._active_character_avatar is not None
+    assert screen._last_console_avatar_scope == (char_id, "idle")
+
+    state_box["v"] = "speaking"
+    await screen._refresh_active_character_avatar_if_scope_changed()
+    assert screen._last_console_avatar_scope == (char_id, "speaking")
+
+    # Revisiting a state is served from the per-state cache (no re-decode).
+    assert (char_id, "speaking") in screen._console_expression_spec_cache
+
+
+@pytest.mark.asyncio
+async def test_expression_state_falls_back_to_idle_image(console_screen_with_db, monkeypatch):
+    app, screen, db = console_screen_with_db
+    from PIL import Image as PILImage
+    from io import BytesIO
+    buf = BytesIO(); PILImage.new("RGB", (32, 32), (5, 5, 5)).save(buf, format="PNG")
+    char_id = db.add_character_card({"name": "Ada", "image": buf.getvalue()})   # idle image only
+    _set_active_console_character(screen, char_id, "Ada")
+    import tldw_chatbook.UI.Screens.chat_screen as cs
+    monkeypatch.setattr(cs, "resolve_console_expression_state", lambda *a, **k: "thinking")
+
+    await screen._refresh_active_character_avatar_if_scope_changed()   # no thinking image -> idle image
+    assert screen._active_character_avatar is not None   # rendered the idle fallback, did not crash
+    assert screen._last_console_avatar_scope == (char_id, "thinking")

--- a/Tests/UI/test_personas_expression_slots.py
+++ b/Tests/UI/test_personas_expression_slots.py
@@ -1,0 +1,111 @@
+"""Roleplay P3d-1 Task 4: character expression authoring slots
+(thinking/speaking/error) in the character editor.
+
+Mirrors ``test_personas_character_editor_avatar.py``'s screen-level harness
+(real ``CharactersRAGDB``, a character seeded via ``add_character_card``, its
+id fed back into the stubbed ``ccp_character_handler`` module functions, then
+driven through the real ``PersonasScreen``) - wrapped in a
+``pytest_asyncio.fixture`` (the ``console_screen_with_db``-style pattern in
+``test_console_character_avatar.py``) so each test starts with the editor
+already open for a saved character, rather than repeating the mount/select/
+open-editor boilerplate per test.
+"""
+
+from io import BytesIO
+
+import pytest
+import pytest_asyncio
+from PIL import Image
+
+import tldw_chatbook.UI.CCP_Modules.ccp_character_handler as character_handler_module
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
+    EditCharacterRequested,
+)
+
+from Tests.UI.test_personas_dictionaries import PersonasTestApp, patch_character_paging
+
+
+@pytest.fixture
+def expr_db(tmp_path):
+    db = CharactersRAGDB(tmp_path / "personas_char_expression.db", "test-client")
+    yield db
+    db.close_connection()
+
+
+async def _select_character(pilot, char_id):
+    await pilot.pause()
+    await pilot.click(f"#personas-library-row-character-{char_id}")
+    await pilot.pause()
+    await pilot.app.workers.wait_for_complete()
+    await pilot.pause()
+    return pilot.app.screen
+
+
+async def _open_editor_for(pilot, screen, char_id):
+    screen.post_message(EditCharacterRequested(str(char_id)))
+    await pilot.pause()
+    await pilot.app.workers.wait_for_complete()
+    await pilot.pause()
+
+
+@pytest_asyncio.fixture
+async def personas_editor_with_saved_character(mock_app_instance, monkeypatch, expr_db):
+    """Mounted ``PersonasScreen`` with the character editor open for a saved
+    character, wired to a real file-backed ``CharactersRAGDB``."""
+    mock_app_instance.chachanotes_db = expr_db
+    mock_app_instance.chat_dictionary_scope_service = None
+    char_id = expr_db.add_character_card({"name": "Expressive"})
+
+    record = {
+        "id": char_id,
+        "name": "Expressive",
+        "description": "",
+        "first_message": "Hi.",
+        "version": 1,
+    }
+    monkeypatch.setattr(
+        character_handler_module, "fetch_all_characters", lambda: [dict(record)]
+    )
+    monkeypatch.setattr(
+        character_handler_module,
+        "fetch_character_by_id",
+        lambda character_id: (
+            dict(record) if str(character_id) == str(char_id) else None
+        ),
+    )
+    patch_character_paging(monkeypatch)
+
+    app = PersonasTestApp(mock_app_instance)
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _select_character(pilot, char_id)
+        await _open_editor_for(pilot, screen, char_id)
+        yield app, screen, expr_db, char_id
+
+
+@pytest.mark.asyncio
+async def test_expression_slots_present_for_saved_character(
+    personas_editor_with_saved_character,
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    for state in ("thinking", "speaking", "error"):
+        assert screen.query_one(f"#char-expression-slot-{state}") is not None
+
+
+@pytest.mark.asyncio
+async def test_upload_writes_expression_row(personas_editor_with_saved_character):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    buf = BytesIO()
+    Image.new("RGB", (16, 16)).save(buf, format="PNG")
+    await screen._apply_expression_upload(
+        char_id, "speaking", buf.getvalue(), "image/png"
+    )
+    assert db.get_character_expression_image(char_id, "speaking") is not None
+
+
+@pytest.mark.asyncio
+async def test_clear_soft_deletes_expression_row(personas_editor_with_saved_character):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    db.set_character_expression_image(char_id, "error", b"x")
+    await screen._clear_expression_slot(char_id, "error")
+    assert db.get_character_expression_image(char_id, "error") is None

--- a/tldw_chatbook/Chat/console_expression_state.py
+++ b/tldw_chatbook/Chat/console_expression_state.py
@@ -43,10 +43,13 @@ def resolve_console_expression_state(store, active_session_id, *, react_enabled:
         messages = store.messages_for_session(active_session_id)
     except Exception:
         return "idle"
-    last_assistant = None
-    for message in messages:  # transcript order; keep the last assistant turn
+    # Scan from the end and stop at the first assistant turn: the active
+    # turn is at/near the tail, so this is O(1) amortized rather than a full
+    # forward walk of the transcript on every 0.2s Console tick. (The
+    # ``messages_for_session`` snapshot above is itself O(n), but that cost is
+    # pre-existing and shared with the controller's own streaming accessor,
+    # and only paid on active-streaming ticks.)
+    for message in reversed(messages):
         if getattr(message, "role", None) is ConsoleMessageRole.ASSISTANT:
-            last_assistant = message
-    if last_assistant is None:
-        return "idle"
-    return _STATUS_TO_STATE.get(getattr(last_assistant, "status", "complete"), "idle")
+            return _STATUS_TO_STATE.get(getattr(message, "status", "complete"), "idle")
+    return "idle"

--- a/tldw_chatbook/Chat/console_expression_state.py
+++ b/tldw_chatbook/Chat/console_expression_state.py
@@ -1,0 +1,52 @@
+"""Pure, DB-free derivation of the Console 'expression state' for the reactive
+character avatar (P3d). Reads only the store's in-memory message statuses -- safe
+to call on the 0.2s transcript poll tick.
+
+State machine (from the active session's last assistant message status):
+  pending   -> "thinking"   (created, awaiting first token)
+  streaming -> "speaking"   (tokens flowing)
+  complete  -> "idle"
+  stopped   -> "idle"       (user stop is not an error)
+  failed    -> "error"
+  (no assistant message / no session / react disabled) -> "idle"
+"""
+from __future__ import annotations
+
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+
+EXPRESSION_STATES = ("idle", "thinking", "speaking", "error")
+EXPRESSION_IMAGE_STATES = ("thinking", "speaking", "error")
+
+_STATUS_TO_STATE = {
+    "pending": "thinking",
+    "streaming": "speaking",
+    "complete": "idle",
+    "stopped": "idle",
+    "failed": "error",
+}
+
+
+def resolve_console_expression_state(store, active_session_id, *, react_enabled: bool) -> str:
+    """Return the current expression state for the active Console session.
+
+    Args:
+        store: the ConsoleChatStore (exposes ``messages_for_session``).
+        active_session_id: the live session id, or None.
+        react_enabled: whether reactive swapping is enabled; when False, always idle.
+
+    Returns:
+        One of EXPRESSION_STATES. Never raises (any lookup failure -> "idle").
+    """
+    if not react_enabled or active_session_id is None or store is None:
+        return "idle"
+    try:
+        messages = store.messages_for_session(active_session_id)
+    except Exception:
+        return "idle"
+    last_assistant = None
+    for message in messages:  # transcript order; keep the last assistant turn
+        if getattr(message, "role", None) is ConsoleMessageRole.ASSISTANT:
+            last_assistant = message
+    if last_assistant is None:
+        return "idle"
+    return _STATUS_TO_STATE.get(getattr(last_assistant, "status", "complete"), "idle")

--- a/tldw_chatbook/Chat/console_image_view.py
+++ b/tldw_chatbook/Chat/console_image_view.py
@@ -124,6 +124,18 @@ def resolve_show_character_avatar(app_config: Mapping[str, Any]) -> bool:
     return bool(value)
 
 
+def resolve_react_character_expressions(app_config: Mapping[str, Any]) -> bool:
+    """Whether the Console avatar reacts (swaps images) as the character
+    thinks/speaks (default True). Reads ``[chat.images].react_character_expressions``
+    via the same both-shapes accessor as ``resolve_show_character_avatar``.
+
+    Returns:
+        True unless explicitly disabled via ``react_character_expressions = false``.
+    """
+    value = _chat_images_config(app_config).get("react_character_expressions", True)
+    return bool(value)
+
+
 def resolve_default_mode(
     app_config: Mapping[str, Any],
 ) -> Literal["pixels", "graphics"]:

--- a/tldw_chatbook/Chat/console_image_view.py
+++ b/tldw_chatbook/Chat/console_image_view.py
@@ -129,6 +129,10 @@ def resolve_react_character_expressions(app_config: Mapping[str, Any]) -> bool:
     thinks/speaks (default True). Reads ``[chat.images].react_character_expressions``
     via the same both-shapes accessor as ``resolve_show_character_avatar``.
 
+    Args:
+        app_config: The application config mapping (the ``[chat.images]``
+            section is read; missing sections are tolerated).
+
     Returns:
         True unless explicitly disabled via ``react_character_expressions = false``.
     """

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -124,6 +124,12 @@ class ConflictError(CharactersRAGDBError):
         return f"{base} ({', '.join(details)})" if details else base
 
 
+# --- Reaction-avatar expression states (P3d) ---
+# ``idle`` is intentionally excluded: it reuses character_cards.image and is
+# never stored in character_expression_images.
+_EXPRESSION_IMAGE_STATE_IDS = frozenset({"thinking", "speaking", "error"})
+
+
 # --- Database Class ---
 class CharactersRAGDB:
     """
@@ -151,7 +157,7 @@ class CharactersRAGDB:
         db_path_str (str): String representation of the database path for SQLite connection.
     """
 
-    _CURRENT_SCHEMA_VERSION = 22  # Adds world_book_entries.regex (P2d-regex).
+    _CURRENT_SCHEMA_VERSION = 23  # Adds character_expression_images (P3d reaction avatars).
     _SCHEMA_NAME = "rag_char_chat_schema"  # Used for the db_schema_version table
     _ALLOWED_CONVERSATION_STATES = ("in-progress", "resolved", "backlog", "non-viable")
     _DEFAULT_CONVERSATION_STATE = "in-progress"
@@ -2455,6 +2461,27 @@ UPDATE db_schema_version
 """
 
     # Keep this runner SQL aligned with
+    # tldw_chatbook/DB/migrations/chachanotes_v22_to_v23_character_expression_images.sql.
+    _MIGRATE_V22_TO_V23_SQL = """
+CREATE TABLE IF NOT EXISTS character_expression_images(
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  character_id  INTEGER NOT NULL REFERENCES character_cards(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  state_id      TEXT    NOT NULL,
+  image         BLOB    NOT NULL,
+  mime          TEXT,
+  created_at    TEXT    NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','NOW')),
+  updated_at    TEXT    NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','NOW')),
+  deleted       INTEGER NOT NULL DEFAULT 0,
+  UNIQUE(character_id, state_id)
+);
+CREATE INDEX IF NOT EXISTS idx_char_expr_images_char ON character_expression_images(character_id);
+UPDATE db_schema_version
+   SET version = 23
+ WHERE schema_name = 'rag_char_chat_schema'
+   AND version = 22;
+"""
+
+    # Keep this runner SQL aligned with
     # tldw_chatbook/DB/migrations/chachanotes_v18_to_v19_message_attachments.sql.
     _MIGRATE_V18_TO_V19_SQL = """
 CREATE TABLE IF NOT EXISTS message_attachments(
@@ -3799,6 +3826,26 @@ UPDATE db_schema_version
             logger.opt(exception=True).error(f"[{self._SCHEMA_NAME} V21→V22] Unexpected error during migration: {e}")
             raise SchemaError(f"Unexpected error migrating from V21 to V22 for '{self._SCHEMA_NAME}': {e}") from e
 
+    def _migrate_from_v22_to_v23(self, conn: sqlite3.Connection):
+        """Migrate schema V22→V23: add the local ``character_expression_images``
+        BLOB table (per-state reaction avatars; idle reuses character_cards.image)."""
+        logger.info(f"Migrating schema from V22 to V23 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}...")
+        try:
+            conn.executescript(self._MIGRATE_V22_TO_V23_SQL)
+            logger.debug(f"[{self._SCHEMA_NAME} V22→V23] Migration script executed.")
+            final_version = self._get_db_version(conn)
+            if final_version != 23:
+                raise SchemaError(
+                    f"[{self._SCHEMA_NAME} V22→V23] Migration version check failed. Expected 23, got: {final_version}"
+                )
+            logger.info(f"[{self._SCHEMA_NAME} V22→V23] Migration completed successfully for DB: {self.db_path_str}.")
+        except sqlite3.Error as e:
+            logger.opt(exception=True).error(f"[{self._SCHEMA_NAME} V22→V23] Migration failed: {e}")
+            raise SchemaError(f"Migration from V22 to V23 failed for '{self._SCHEMA_NAME}': {e}") from e
+        except Exception as e:
+            logger.opt(exception=True).error(f"[{self._SCHEMA_NAME} V22→V23] Unexpected error during migration: {e}")
+            raise SchemaError(f"Unexpected error migrating from V22 to V23 for '{self._SCHEMA_NAME}': {e}") from e
+
     def _migrate_from_v18_to_v19(self, conn: sqlite3.Connection):
         """
         Migrates the database schema from version 18 to version 19.
@@ -3951,6 +3998,7 @@ UPDATE db_schema_version
                     19: self._migrate_from_v19_to_v20,
                     20: self._migrate_from_v20_to_v21,
                     21: self._migrate_from_v21_to_v22,
+                    22: self._migrate_from_v22_to_v23,
                 }
 
                 if current_db_version == 0:
@@ -4399,6 +4447,58 @@ UPDATE db_schema_version
                 f"Database error fetching character card ID {character_id}: {e}"
             )
             raise
+
+    # --- Reaction-avatar expression images (P3d) ---
+
+    def set_character_expression_image(
+        self, character_id: int, state_id: str, image: bytes, mime: str | None = None
+    ) -> None:
+        """Upsert a per-state expression image for a character (state-agnostic
+        store; ``idle`` is never stored here -- it reuses character_cards.image)."""
+        if state_id not in _EXPRESSION_IMAGE_STATE_IDS:
+            raise ValueError(f"Unknown expression state_id: {state_id!r}")
+        if not isinstance(image, (bytes, bytearray)) or not image:
+            raise ValueError("Expression image must be non-empty bytes.")
+        query = """
+            INSERT INTO character_expression_images(character_id, state_id, image, mime, deleted, updated_at)
+            VALUES (?, ?, ?, ?, 0, STRFTIME('%Y-%m-%dT%H:%M:%fZ','NOW'))
+            ON CONFLICT(character_id, state_id) DO UPDATE SET
+                image = excluded.image,
+                mime = excluded.mime,
+                deleted = 0,
+                updated_at = STRFTIME('%Y-%m-%dT%H:%M:%fZ','NOW')
+        """
+        with self.transaction() as conn:
+            conn.execute(query, (character_id, state_id, bytes(image), mime))
+
+    def get_character_expression_image(self, character_id: int, state_id: str) -> bytes | None:
+        """Return the active image bytes for (character, state), or None."""
+        cur = self.get_connection().execute(
+            "SELECT image FROM character_expression_images "
+            "WHERE character_id = ? AND state_id = ? AND deleted = 0",
+            (character_id, state_id),
+        )
+        row = cur.fetchone()
+        return bytes(row[0]) if row is not None and row[0] is not None else None
+
+    def list_character_expression_states(self, character_id: int) -> list[str]:
+        """Return the state_ids with an active image for a character."""
+        cur = self.get_connection().execute(
+            "SELECT state_id FROM character_expression_images "
+            "WHERE character_id = ? AND deleted = 0 ORDER BY state_id",
+            (character_id,),
+        )
+        return [row[0] for row in cur.fetchall()]
+
+    def delete_character_expression_image(self, character_id: int, state_id: str) -> None:
+        """Soft-delete the (character, state) expression image."""
+        with self.transaction() as conn:
+            conn.execute(
+                "UPDATE character_expression_images SET deleted = 1, "
+                "updated_at = STRFTIME('%Y-%m-%dT%H:%M:%fZ','NOW') "
+                "WHERE character_id = ? AND state_id = ?",
+                (character_id, state_id),
+            )
 
     def get_character_card_by_name(self, name: str) -> Optional[Dict[str, Any]]:
         """

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -4453,8 +4453,24 @@ UPDATE db_schema_version
     def set_character_expression_image(
         self, character_id: int, state_id: str, image: bytes, mime: str | None = None
     ) -> None:
-        """Upsert a per-state expression image for a character (state-agnostic
-        store; ``idle`` is never stored here -- it reuses character_cards.image)."""
+        """Upsert a per-state expression image for a character.
+
+        State-agnostic store; ``idle`` is never stored here -- it reuses
+        ``character_cards.image``. Existing rows for the same
+        ``(character_id, state_id)`` are overwritten and re-activated
+        (``deleted`` reset to 0).
+
+        Args:
+            character_id: Integer id of the owning character card.
+            state_id: One of ``_EXPRESSION_IMAGE_STATE_IDS``
+                (``thinking``/``speaking``/``error``).
+            image: Non-empty raw image bytes.
+            mime: Optional MIME type of the image.
+
+        Raises:
+            ValueError: If ``state_id`` is not a known expression state, or
+                ``image`` is not non-empty bytes.
+        """
         if state_id not in _EXPRESSION_IMAGE_STATE_IDS:
             raise ValueError(f"Unknown expression state_id: {state_id!r}")
         if not isinstance(image, (bytes, bytearray)) or not image:
@@ -4472,26 +4488,47 @@ UPDATE db_schema_version
             conn.execute(query, (character_id, state_id, bytes(image), mime))
 
     def get_character_expression_image(self, character_id: int, state_id: str) -> bytes | None:
-        """Return the active image bytes for (character, state), or None."""
-        cur = self.get_connection().execute(
+        """Return the active expression image bytes for a character state.
+
+        Args:
+            character_id: Integer id of the owning character card.
+            state_id: The expression state to look up.
+
+        Returns:
+            The image bytes, or ``None`` if no active (non-deleted) row exists.
+        """
+        cursor = self.execute_query(
             "SELECT image FROM character_expression_images "
             "WHERE character_id = ? AND state_id = ? AND deleted = 0",
             (character_id, state_id),
         )
-        row = cur.fetchone()
+        row = cursor.fetchone()
         return bytes(row[0]) if row is not None and row[0] is not None else None
 
     def list_character_expression_states(self, character_id: int) -> list[str]:
-        """Return the state_ids with an active image for a character."""
-        cur = self.get_connection().execute(
+        """Return the expression states that have an active image for a character.
+
+        Args:
+            character_id: Integer id of the owning character card.
+
+        Returns:
+            The ``state_id`` values with an active (non-deleted) image,
+            ordered alphabetically.
+        """
+        cursor = self.execute_query(
             "SELECT state_id FROM character_expression_images "
             "WHERE character_id = ? AND deleted = 0 ORDER BY state_id",
             (character_id,),
         )
-        return [row[0] for row in cur.fetchall()]
+        return [row[0] for row in cursor.fetchall()]
 
     def delete_character_expression_image(self, character_id: int, state_id: str) -> None:
-        """Soft-delete the (character, state) expression image."""
+        """Soft-delete a character's expression image for one state.
+
+        Args:
+            character_id: Integer id of the owning character card.
+            state_id: The expression state whose image to soft-delete.
+        """
         with self.transaction() as conn:
             conn.execute(
                 "UPDATE character_expression_images SET deleted = 1, "

--- a/tldw_chatbook/DB/migrations/chachanotes_v22_to_v23_character_expression_images.sql
+++ b/tldw_chatbook/DB/migrations/chachanotes_v22_to_v23_character_expression_images.sql
@@ -1,0 +1,21 @@
+-- Migration: ChaChaNotes V22 to V23 character expression images
+-- Adds the character_expression_images table for per-state reaction avatars
+-- (state_id in thinking/speaking/error; idle reuses character_cards.image).
+-- Local-only BLOB storage; no sync triggers (mirrors message_attachments).
+
+CREATE TABLE IF NOT EXISTS character_expression_images(
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  character_id  INTEGER NOT NULL REFERENCES character_cards(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  state_id      TEXT    NOT NULL,
+  image         BLOB    NOT NULL,
+  mime          TEXT,
+  created_at    TEXT    NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','NOW')),
+  updated_at    TEXT    NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','NOW')),
+  deleted       INTEGER NOT NULL DEFAULT 0,
+  UNIQUE(character_id, state_id)
+);
+CREATE INDEX IF NOT EXISTS idx_char_expr_images_char ON character_expression_images(character_id);
+UPDATE db_schema_version
+   SET version = 23
+ WHERE schema_name = 'rag_char_chat_schema'
+   AND version = 22;

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -434,6 +434,12 @@ CONSOLE_PERSISTED_ROWS_CACHE_TTL_SECONDS = 2.0
 # smaller for the rail's narrower column).
 CHARACTER_AVATAR_COLS = 16
 CHARACTER_AVATAR_LINES = 8
+# P3d-1 Task 3 (review fix): bound `_console_expression_spec_cache` so a
+# long session visiting many characters/states doesn't retain unbounded PIL
+# image references (the spec dicts hold their own `PILImage.Image`, so the
+# `_console_image_cache` LRU cap below does not protect this cache). Matches
+# the render cache's bound.
+_EXPRESSION_SPEC_CACHE_MAX = 16
 CONSOLE_FOCUS_REGISTRY = WorkbenchFocusRegistry(
     (
         "console-left-rail",
@@ -4165,12 +4171,19 @@ class ChatScreen(BaseAppScreen):
             logger.opt(exception=True).debug("avatar: expression decode failed")
         # Post-await staleness re-check on the FULL (character_id, state)
         # scope: the state can flip mid-decode while streaming, so recompute
-        # it from the SAME store/session captured above and drop a stale
-        # render rather than mount an image for a scope we've moved past.
-        current_state = resolve_console_expression_state(store, active_session_id, react_enabled=react)
+        # it live -- both the session id and the state -- rather than reusing
+        # the `active_session_id` captured before the await, so two tabs
+        # sharing one character can't paint a stale render.
+        current_session_id = getattr(store, "active_session_id", None) if store is not None else None
+        current_state = resolve_console_expression_state(store, current_session_id, react_enabled=react)
         if (self._current_console_rail_character_id(), current_state) != scope or not self.is_mounted:
             return
         self._console_expression_spec_cache[(character_id, state)] = spec
+        # Bound the cache: evict oldest insertion-ordered entries (dicts
+        # preserve insertion order) so a long session visiting many
+        # characters/states doesn't retain unbounded PIL image references.
+        while len(self._console_expression_spec_cache) > _EXPRESSION_SPEC_CACHE_MAX:
+            del self._console_expression_spec_cache[next(iter(self._console_expression_spec_cache))]
         self._active_character_avatar = spec
         await self._render_character_avatar_into_section()
 

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -181,6 +181,10 @@ from ...Chat.console_live_work import (
     ConsoleLiveWorkStatusCardState,
 )
 from ...Chat.console_glyphs import GLYPH_COLLAPSE_LEFT, GLYPH_COLLAPSE_RIGHT
+from ...Chat.console_expression_state import (
+    EXPRESSION_IMAGE_STATES,
+    resolve_console_expression_state,
+)
 from ...Chat.console_image_view import (
     IMAGE_CACHE_MAX_ENTRIES,
     ConsoleImageRenderCache,
@@ -189,6 +193,7 @@ from ...Chat.console_image_view import (
     fit_image_cell_size,
     next_view_mode,
     resolve_default_mode,
+    resolve_react_character_expressions,
     resolve_show_character_avatar,
 )
 from ...Chat.console_paste_attach import (
@@ -2005,6 +2010,11 @@ class ChatScreen(BaseAppScreen):
         self._active_character_avatar: dict | None = None
         self._active_character_avatar_name: str | None = None
         self._last_console_avatar_scope: Any | None = None
+        # P3d-1: per-(character_id, state) decode cache so revisiting an
+        # expression state already seen this session is served instantly
+        # (no re-fetch/re-decode). Keyed on the full scope tuple, mirroring
+        # `_last_console_avatar_scope`.
+        self._console_expression_spec_cache: dict[tuple[int, str], dict] = {}
         self.ui_state = UIState()
         self._load_sidebar_state()
 
@@ -4069,8 +4079,34 @@ class ChatScreen(BaseAppScreen):
             logger.opt(exception=True).debug("avatar: character fetch failed")
             return None
 
+    def _fetch_expression_image_bytes(self, character_id: int, state: str) -> bytes | None:
+        """Return the image bytes for (character, state): the expression-table
+        image for a non-idle state, else the character's idle avatar. Runs
+        off-thread (called via asyncio.to_thread). Never raises -> None on any error."""
+        try:
+            db = getattr(self.app_instance, "chachanotes_db", None)
+            if db is None:
+                return None
+            if state in EXPRESSION_IMAGE_STATES:
+                img = db.get_character_expression_image(character_id, state)
+                if img:
+                    return img
+            card = self._fetch_character_card_for_avatar(character_id)  # idle fallback
+            image = (card or {}).get("image")
+            return bytes(image) if isinstance(image, (bytes, bytearray)) and image else None
+        except Exception:
+            logger.opt(exception=True).debug("avatar: expression fetch failed")
+            return None
+
     async def _refresh_active_character_avatar_if_scope_changed(self) -> None:
-        """Refresh the cached character avatar only when the active character changed."""
+        """Refresh the cached character avatar only when the active
+        (character, expression state) scope changed.
+
+        P3d-1: widens the P3c `(character_id,)` scope to `(character_id,
+        state)` so the avatar reacts to the character thinking/speaking, via
+        `resolve_console_expression_state` (pure, DB-free, reads only the
+        active native Console session's live message statuses).
+        """
         if not resolve_show_character_avatar(
             getattr(getattr(self, "app_instance", None), "app_config", {}) or {}
         ):
@@ -4087,7 +4123,14 @@ class ChatScreen(BaseAppScreen):
             self._last_console_avatar_scope = None
             return
         character_id = self._current_console_rail_character_id()
-        scope = (character_id,)
+        controller = getattr(self, "_console_chat_controller", None)
+        store = getattr(controller, "store", None) if controller is not None else None
+        active_session_id = getattr(store, "active_session_id", None) if store is not None else None
+        react = resolve_react_character_expressions(
+            getattr(getattr(self, "app_instance", None), "app_config", {}) or {}
+        )
+        state = resolve_console_expression_state(store, active_session_id, react_enabled=react)
+        scope = (character_id, state)
         if scope == self._last_console_avatar_scope:
             return
         self._last_console_avatar_scope = scope
@@ -4097,25 +4140,37 @@ class ChatScreen(BaseAppScreen):
             self._active_character_avatar = None
             await self._render_character_avatar_into_section()
             return
+        # Serve from the per-state cache when this (character, state) scope
+        # was already decoded this session -- no re-fetch/re-decode.
+        cached = self._console_expression_spec_cache.get((character_id, state))
+        if cached is not None:
+            self._active_character_avatar = cached
+            await self._render_character_avatar_into_section()
+            return
         _, cache = self._ensure_console_image_view()
         mode = getattr(self, "_console_image_default_mode", "pixels")
-        key = f"character:{character_id}"
-        spec = {"character_id": character_id, "name": name, "mode": mode, "pil": None, "pixels": None}
+        key = f"character:{character_id}:{state}"
+        spec = {"character_id": character_id, "state": state, "name": name,
+                "mode": mode, "pil": None, "pixels": None}
         try:
-            card = await asyncio.to_thread(self._fetch_character_card_for_avatar, character_id)
-            image = (card or {}).get("image")
-            if isinstance(image, (bytes, bytearray)) and image:
-                ok = await asyncio.to_thread(cache.prepare, key, bytes(image))
+            image = await asyncio.to_thread(self._fetch_expression_image_bytes, character_id, state)
+            if image:
+                ok = await asyncio.to_thread(cache.prepare, key, image)
                 if ok:
                     if mode == "graphics":
                         spec["pil"] = cache.get_pil(key)
                     else:
                         spec["pixels"] = cache.get_pixels(key)
         except Exception:
-            logger.opt(exception=True).debug("avatar: refresh failed")
-        # Drop a stale render if the active character changed during decode.
-        if (self._current_console_rail_character_id(),) != scope or not self.is_mounted:
+            logger.opt(exception=True).debug("avatar: expression decode failed")
+        # Post-await staleness re-check on the FULL (character_id, state)
+        # scope: the state can flip mid-decode while streaming, so recompute
+        # it from the SAME store/session captured above and drop a stale
+        # render rather than mount an image for a scope we've moved past.
+        current_state = resolve_console_expression_state(store, active_session_id, react_enabled=react)
+        if (self._current_console_rail_character_id(), current_state) != scope or not self.is_mounted:
             return
+        self._console_expression_spec_cache[(character_id, state)] = spec
         self._active_character_avatar = spec
         await self._render_character_avatar_into_section()
 

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -30,6 +30,7 @@ from ...Character_Chat.persona_list_paging import page_persona_profiles
 from ...Character_Chat.world_book_import import normalize_world_book_import
 from ...Character_Chat.world_book_manager import CHARACTER_WORLD_BOOKS_KEY
 from ...Chat.chat_handoff_models import ChatHandoffPayload
+from ...Chat.console_expression_state import EXPRESSION_IMAGE_STATES
 from ...DB.ChaChaNotes_DB import ConflictError
 from ...tldw_api import PersonaProfileCreate, PersonaProfileUpdate
 from ...Utils.path_validation import validate_path_simple
@@ -80,6 +81,8 @@ from ...Widgets.Persona_Widgets.personas_messages import (
 from ...Widgets.Persona_Widgets.tag_filter_picker import TagFilterPicker
 from ...Widgets.Persona_Widgets.personas_pane_messages import (
     CharacterEditorCancelled,
+    CharacterExpressionClearRequested,
+    CharacterExpressionUploadRequested,
     CharacterImageRemoveRequested,
     CharacterImageUploadRequested,
     CharacterSaveRequested,
@@ -3494,9 +3497,12 @@ class PersonasScreen(BaseAppScreen):
         # Change-based dirty tracking: the session starts clean; the editor
         # posts EditorContentChanged on the first real modification.
         self.query_one(PersonasCharacterEditorWidget).new_character()
-        # A new character never has an avatar, but a stale thumbnail from
-        # the previous editor session must not linger under the new one.
-        await self._render_character_editor_avatar()
+        # A new character never has an avatar or expression images, but a
+        # stale thumbnail from the previous editor session must not linger
+        # under the new one. A brand-new character has no id yet, so the
+        # expression slots render empty (and stay disabled - see
+        # PersonasCharacterEditorWidget._sync_expression_slots_enabled).
+        await self._render_all_character_editor_thumbnails(None)
         self._show_center("#ccp-character-editor-view")
         inspector = self.query_one(PersonasInspectorPane)
         # Create mode: the previous selection's identity (and conversation
@@ -3798,11 +3804,17 @@ class PersonasScreen(BaseAppScreen):
         self._character_save_inflight = False
         # Change-based dirty tracking: the session starts clean; the editor
         # posts EditorContentChanged on the first real modification.
-        self.query_one(PersonasCharacterEditorWidget).load_character(record)
+        editor = self.query_one(PersonasCharacterEditorWidget)
+        editor.load_character(record)
         # Sync handler: dispatch the (async, off-thread-decoding) thumbnail
-        # render as a worker rather than awaiting it inline.
+        # render as a worker rather than awaiting it inline. This character
+        # is loaded from a saved record, so expression_character_id() is
+        # populated - the render also loads each expression slot's existing
+        # image (Task 4).
         self.run_worker(
-            self._render_character_editor_avatar(),
+            self._render_all_character_editor_thumbnails(
+                editor.expression_character_id()
+            ),
             group="personas-avatar-render",
             exit_on_error=False,
         )
@@ -4097,6 +4109,119 @@ class PersonasScreen(BaseAppScreen):
         thumb.thumbnail((AVATAR_THUMB_COLS, AVATAR_THUMB_LINES * 2))
         return rich_pixels.Pixels.from_image(thumb)
 
+    async def _render_all_character_editor_thumbnails(
+        self, character_id: int | None
+    ) -> None:
+        """Render the avatar thumbnail plus all 3 expression-state thumbnails.
+
+        Called whenever the character editor session's identity changes: a
+        new create/edit session opens, or a save assigns a brand-new
+        character its first id (Roleplay P3d-1 Task 4). ``character_id``
+        gates the expression slots - ``None`` (a still-unsaved character)
+        clears them instead of reading the DB, since there is no row to read.
+
+        Args:
+            character_id: The loaded character's row id, or ``None`` when
+                the editor session has not been saved yet.
+        """
+        await self._render_character_editor_avatar()
+        try:
+            editor = self.query_one(PersonasCharacterEditorWidget)
+        except QueryError:
+            return
+        if character_id is None:
+            for state in EXPRESSION_IMAGE_STATES:
+                editor.set_expression_thumbnail(state, None)
+            return
+        for state in EXPRESSION_IMAGE_STATES:
+            await self._render_character_expression_slot(character_id, state)
+
+    async def _render_character_expression_slot(
+        self, character_id: int, state: str
+    ) -> None:
+        """Decode and mount one expression slot's thumbnail off-thread.
+
+        Mirrors ``_render_character_editor_avatar``'s token-capture /
+        off-thread decode / post-await token re-check, scoped to a single
+        (character, state) pair read from ``character_expression_images``
+        (Task 1's DB seam) rather than the staged avatar bytes on the
+        character record. Reading the DB is itself an extra off-thread await
+        beyond the avatar path, so the token is re-checked after that read
+        too, not just after the image decode.
+
+        Args:
+            character_id: The character's row id.
+            state: One of ``EXPRESSION_IMAGE_STATES``.
+        """
+        try:
+            editor = self.query_one(PersonasCharacterEditorWidget)
+        except QueryError:
+            return
+        db = getattr(self.app_instance, "chachanotes_db", None)
+        if db is None:
+            editor.set_expression_thumbnail(state, None)
+            return
+        token = self._character_editor_generation
+        try:
+            data = await asyncio.to_thread(
+                db.get_character_expression_image, character_id, state
+            )
+        except Exception:
+            logger.opt(exception=True).debug(
+                f"Could not read the {state} expression image for character "
+                f"{character_id}."
+            )
+            data = None
+        if token != self._character_editor_generation or not self.is_mounted:
+            return  # a different editor session started while reading
+        if not data:
+            editor.set_expression_thumbnail(state, None)
+            return
+        from ...Chat.console_image_view import (
+            ConsoleImageRenderCache,
+            resolve_default_mode,
+        )
+
+        if getattr(self, "_avatar_render_cache", None) is None:
+            self._avatar_render_cache = ConsoleImageRenderCache()
+        cache = self._avatar_render_cache
+        app_config = getattr(self.app_instance, "app_config", {}) or {}
+        mode = resolve_default_mode(app_config)
+        # Per-session, per-state cache key: same rationale as the avatar's
+        # own cache_key (avoid one session's decode racing another's, or one
+        # state's racing another's, under the same cache slot).
+        cache_key = f"char-editor-expr-{state}-{token}"
+        try:
+            ok = await asyncio.to_thread(cache.prepare, cache_key, bytes(data))
+        except Exception:
+            logger.opt(exception=True).debug(f"{state} expression image decode failed.")
+            ok = False
+        if token != self._character_editor_generation or not self.is_mounted:
+            return  # a different editor session started while decoding
+        renderable = None
+        if ok:
+            if mode == "graphics":
+                try:
+                    from textual_image.widget import Image as _GraphicsImage
+
+                    pil = cache.get_pil(cache_key)
+                    if pil is not None:
+                        renderable = _GraphicsImage(pil)
+                        # Fixed cell size - same rationale as the avatar's own
+                        # render (see _render_character_editor_avatar): both
+                        # dims must stay explicit ints to avoid a transient
+                        # 0-width/height resize() crash.
+                        w_cells, h_cells = self._fit_avatar_cell_size(
+                            pil.width, pil.height
+                        )
+                        renderable.styles.width = w_cells
+                        renderable.styles.height = h_cells
+                except Exception:
+                    renderable = self._build_avatar_pixels(cache, cache_key)
+            else:
+                renderable = self._build_avatar_pixels(cache, cache_key)
+        editor.set_expression_thumbnail(state, renderable)
+
     @on(CharacterImageRemoveRequested)
     def _handle_character_image_remove(
         self, message: CharacterImageRemoveRequested
@@ -4126,6 +4251,175 @@ class PersonasScreen(BaseAppScreen):
             group="personas-avatar-render",
             exit_on_error=False,
         )
+
+    # ===== Expression authoring slots (Roleplay P3d-1 Task 4) =====
+    #
+    # Independent of the character card's own optimistic-lock version: these
+    # write straight to character_expression_images (Task 1's DB seam), never
+    # to character_cards - no card save, no version bump.
+
+    async def _apply_expression_upload(
+        self, character_id: int, state: str, image: bytes, mime: str | None = None
+    ) -> None:
+        """Write an uploaded expression-state image and re-render its slot."""
+        db = getattr(self.app_instance, "chachanotes_db", None)
+        if db is None:
+            self._notify("Database is not available.", "error")
+            return
+        try:
+            await asyncio.to_thread(
+                db.set_character_expression_image, character_id, state, image, mime
+            )
+        except Exception as exc:
+            logger.opt(exception=True).error(
+                f"Could not save the {state} expression image for character "
+                f"{character_id}: {exc}"
+            )
+            self._notify(f"Expression upload failed: {exc}", "error")
+            return
+        self._character_editor_generation += 1
+        self._notify(f"{state.capitalize()} expression image saved.", "information")
+        await self._render_character_expression_slot(character_id, state)
+
+    async def _clear_expression_slot(self, character_id: int, state: str) -> None:
+        """Soft-delete an expression-state image and clear its slot's thumbnail."""
+        db = getattr(self.app_instance, "chachanotes_db", None)
+        if db is None:
+            self._notify("Database is not available.", "error")
+            return
+        try:
+            await asyncio.to_thread(
+                db.delete_character_expression_image, character_id, state
+            )
+        except Exception as exc:
+            logger.opt(exception=True).error(
+                f"Could not clear the {state} expression image for character "
+                f"{character_id}: {exc}"
+            )
+            self._notify(f"Could not clear the {state} expression image.", "error")
+            return
+        self._character_editor_generation += 1
+        try:
+            editor = self.query_one(PersonasCharacterEditorWidget)
+        except QueryError:
+            return
+        editor.set_expression_thumbnail(state, None)
+
+    @on(CharacterExpressionUploadRequested)
+    def _handle_character_expression_upload_requested(
+        self, message: CharacterExpressionUploadRequested
+    ) -> None:
+        message.stop()
+        if not self._character_editor_is_active():
+            self._notify(
+                "Open a character editor before uploading an expression image.",
+                "warning",
+            )
+            return
+        editor = self.query_one(PersonasCharacterEditorWidget)
+        character_id = editor.expression_character_id()
+        if character_id is None:
+            self._notify("Save the character to add expressions.", "warning")
+            return
+        if self._io_dialog_active:
+            logger.debug(
+                "Import/export dialog already active; ignoring expression "
+                "upload request."
+            )
+            return
+        self._io_dialog_active = True
+        self.run_worker(
+            self._expression_upload_dialog_worker(character_id, message.state),
+            group="personas-io",
+        )
+
+    @on(CharacterExpressionClearRequested)
+    def _handle_character_expression_clear_requested(
+        self, message: CharacterExpressionClearRequested
+    ) -> None:
+        message.stop()
+        if not self._character_editor_is_active():
+            return
+        editor = self.query_one(PersonasCharacterEditorWidget)
+        character_id = editor.expression_character_id()
+        if character_id is None:
+            return
+        self.run_worker(
+            self._clear_expression_slot(character_id, message.state),
+            group="personas-avatar-render",
+            exit_on_error=False,
+        )
+
+    async def _expression_upload_dialog_worker(
+        self, character_id: int, state: str
+    ) -> None:
+        from ...Widgets.enhanced_file_picker import EnhancedFileOpen, Filters
+
+        try:
+            picker = EnhancedFileOpen(
+                title=f"Upload {state.capitalize()} Expression Image",
+                filters=Filters(
+                    (
+                        "Image Files",
+                        lambda p: p.suffix.lower() in PERSONAS_AVATAR_IMAGE_SUFFIXES,
+                    ),
+                    ("PNG Files", lambda p: p.suffix.lower() == ".png"),
+                    ("JPEG Files", lambda p: p.suffix.lower() in (".jpg", ".jpeg")),
+                    ("WEBP Files", lambda p: p.suffix.lower() == ".webp"),
+                    ("GIF Files", lambda p: p.suffix.lower() == ".gif"),
+                ),
+                context="character_expression_upload",
+            )
+            try:
+                file_path = await self.app.push_screen_wait(picker)
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Could not show the expression image upload file dialog."
+                )
+                return
+            if file_path:
+                await self._stage_character_expression_from_path(
+                    character_id, state, str(file_path)
+                )
+        finally:
+            self._io_dialog_active = False
+
+    async def _stage_character_expression_from_path(
+        self, character_id: int, state: str, path: str
+    ) -> None:
+        session_token = self._character_editor_session_token()
+        if session_token is None:
+            self._notify(
+                "Open a character editor before uploading an expression image.",
+                "warning",
+            )
+            return
+        try:
+            # Reuses the avatar's own read (suffix allowlist + size cap +
+            # non-empty check) - the same constraints apply to expression
+            # images.
+            image_data = await asyncio.to_thread(self._read_avatar_image_bytes, path)
+        except ValueError as exc:
+            self._notify(str(exc), "error")
+            return
+        except OSError as exc:
+            logger.opt(exception=True).error(
+                f"Error reading expression image from {path}: {exc}"
+            )
+            self._notify(f"Expression upload failed: {exc}", "error")
+            return
+        if self._character_editor_session_token() != session_token:
+            logger.debug(
+                "Expression upload result ignored because the character "
+                f"editor session changed. path={path!r}, state={state!r}, "
+                f"original_session={session_token!r}, "
+                f"current_session={self._character_editor_session_token()!r}"
+            )
+            return
+        import mimetypes
+
+        mime = mimetypes.guess_type(path)[0]
+        await self._apply_expression_upload(character_id, state, image_data, mime)
 
     # ===== Import / export =====
     #
@@ -5123,8 +5417,13 @@ class PersonasScreen(BaseAppScreen):
             # which invalidates (drops) any render still in flight from
             # before the save - so re-render now with the new token or the
             # thumbnail can be left blank/stale until the next unrelated
-            # avatar action.
-            await self._render_character_editor_avatar()
+            # avatar action. A create-session's first save is also the
+            # moment a brand-new character gains its id, so this is where
+            # its (still-empty) expression slots flip from disabled to
+            # enabled (mark_saved already re-synced that above).
+            await self._render_all_character_editor_thumbnails(
+                editor.expression_character_id()
+            )
         self._character_save_inflight = False
         self._sync_title_and_console_actions()
         self._notify("Character saved.", severity="information")

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
@@ -20,8 +20,11 @@ from textual.timer import Timer
 from textual.widgets import Button, DataTable, Input, Label, Static, TextArea
 
 from ...Character_Chat.world_book_manager import CHARACTER_WORLD_BOOKS_KEY
+from ...Chat.console_expression_state import EXPRESSION_IMAGE_STATES
 from .personas_pane_messages import (
     CharacterEditorCancelled,
+    CharacterExpressionClearRequested,
+    CharacterExpressionUploadRequested,
     CharacterImageRemoveRequested,
     CharacterImageUploadRequested,
     CharacterSaveRequested,
@@ -118,6 +121,50 @@ class PersonasCharacterEditorWidget(Container):
        transcript image box, since this is a single always-visible avatar
        preview rather than a scrolling message history. */
     PersonasCharacterEditorWidget #personas-char-editor-avatar-thumb {
+        height: 10;
+        max-width: 24;
+        max-height: 10;
+        padding: 0 1;
+    }
+
+    /* Expression authoring slots (Roleplay P3d-1 Task 4) - one row per
+       state, structurally mirroring the avatar-row + avatar-thumb pair
+       above (label/hint/buttons on one line, the thumbnail box below). */
+    PersonasCharacterEditorWidget .personas-char-editor-expression-slot {
+        height: auto;
+        min-height: 1;
+    }
+
+    PersonasCharacterEditorWidget .personas-char-editor-expr-row {
+        height: auto;
+        min-height: 1;
+        padding: 0 1;
+    }
+
+    PersonasCharacterEditorWidget .personas-char-editor-expr-label {
+        width: auto;
+        margin-right: 1;
+    }
+
+    PersonasCharacterEditorWidget .personas-char-editor-expr-hint {
+        width: auto;
+        margin-right: 2;
+    }
+
+    PersonasCharacterEditorWidget .personas-char-editor-expr-upload,
+    PersonasCharacterEditorWidget .personas-char-editor-expr-clear {
+        width: auto;
+        min-width: 0;
+        height: 1;
+        min-height: 1;
+        padding: 0 1;
+        border: none;
+    }
+
+    /* Same box as #personas-char-editor-avatar-thumb above - Task 4 reuses
+       PersonasScreen._fit_avatar_cell_size/_build_avatar_pixels unchanged
+       for the expression thumbnails, so the box must match. */
+    PersonasCharacterEditorWidget .personas-char-editor-expr-thumb {
         height: 10;
         max-width: 24;
         max-height: 10;
@@ -288,6 +335,38 @@ class PersonasCharacterEditorWidget(Container):
                     classes="console-action-subdued",
                 )
             yield Container(id="personas-char-editor-avatar-thumb")
+            yield Static("Expressions", classes="destination-section")
+            for state in EXPRESSION_IMAGE_STATES:
+                with Vertical(
+                    id=f"char-expression-slot-{state}",
+                    classes="personas-char-editor-expression-slot",
+                ):
+                    with Horizontal(classes="personas-char-editor-expr-row"):
+                        yield Static(
+                            f"{state.capitalize()}:",
+                            classes="personas-char-editor-expr-label",
+                        )
+                        yield Static(
+                            "Save the character to add expressions.",
+                            id=f"personas-char-editor-expr-{state}-hint",
+                            classes="personas-char-editor-expr-hint",
+                        )
+                        yield Button(
+                            "Upload",
+                            id=f"personas-char-editor-expr-{state}-upload",
+                            classes="console-action-subdued personas-char-editor-expr-upload",
+                            disabled=True,
+                        )
+                        yield Button(
+                            "Clear",
+                            id=f"personas-char-editor-expr-{state}-clear",
+                            classes="console-action-subdued personas-char-editor-expr-clear",
+                            disabled=True,
+                        )
+                    yield Container(
+                        id=f"personas-char-editor-expr-{state}-thumb",
+                        classes="personas-char-editor-expr-thumb",
+                    )
         yield Static("", id="personas-char-editor-validation")
         with Horizontal(classes="ds-toolbar"):
             yield Button(
@@ -350,6 +429,10 @@ class PersonasCharacterEditorWidget(Container):
         self._loaded_snapshot = self._form_snapshot()
         self._dirty_posted = False
         self.query_one("#personas-char-editor-validation", Static).update("")
+        # A create-session's first Save assigns the brand-new character its
+        # id here - the expression slots must flip from disabled to enabled
+        # in that same moment (see _sync_expression_slots_enabled).
+        self._sync_expression_slots_enabled()
 
     def _populate_form(self, data: Dict[str, Any]) -> None:
         self._character_data = dict(data or {})
@@ -382,6 +465,7 @@ class PersonasCharacterEditorWidget(Container):
         self.query_one("#personas-char-editor-greeting-edit", TextArea).text = ""
         self._render_greetings_table()
         self._set_avatar_status_from_record()
+        self._sync_expression_slots_enabled()
         self.query_one("#personas-char-editor-validation", Static).update("")
         # Clear any stale per-field invalid marks left by a prior session: if
         # the reopened record's values are byte-identical to what's already
@@ -440,6 +524,58 @@ class PersonasCharacterEditorWidget(Container):
                 avatar indicator).
         """
         holder = self.query_one("#personas-char-editor-avatar-thumb", Container)
+        holder.remove_children()
+        if renderable is None:
+            return
+        from textual.widget import Widget as _W
+        from textual.widgets import Static as _S
+
+        holder.mount(renderable if isinstance(renderable, _W) else _S(renderable))
+
+    def expression_character_id(self) -> int | None:
+        """Return the loaded record's integer id, or ``None`` when unsaved.
+
+        The expression-state images (``character_expression_images``, Task 1)
+        are keyed on the character's row id, independent of the card's own
+        optimistic-lock ``version`` - a brand-new, not-yet-saved character has
+        no id to attach them to, which is what gates the upload/clear slots.
+        """
+        character_id = self._character_data.get("id")
+        return character_id if isinstance(character_id, int) else None
+
+    def _sync_expression_slots_enabled(self) -> None:
+        """Enable the expression slots only for a saved character (has an id).
+
+        Called from both ``_populate_form`` (a fresh load/new session) and
+        ``mark_saved`` (a create-session's first Save, which is the moment an
+        until-then-unsaved character gains its id).
+        """
+        enabled = self.expression_character_id() is not None
+        hint_text = "" if enabled else "Save the character to add expressions."
+        for state in EXPRESSION_IMAGE_STATES:
+            self.query_one(
+                f"#personas-char-editor-expr-{state}-upload", Button
+            ).disabled = not enabled
+            self.query_one(
+                f"#personas-char-editor-expr-{state}-clear", Button
+            ).disabled = not enabled
+            self.query_one(
+                f"#personas-char-editor-expr-{state}-hint", Static
+            ).update(hint_text)
+
+    def set_expression_thumbnail(self, state: str, renderable: object | None) -> None:
+        """Mount a prepared expression-slot renderable, or clear it.
+
+        Mirrors ``set_avatar_thumbnail`` exactly, scoped to one state's thumb
+        container; the screen owns decoding and passes the finished
+        renderable here.
+
+        Args:
+            state: One of ``EXPRESSION_IMAGE_STATES``.
+            renderable: The prepared renderable to display, or ``None`` to
+                clear the thumbnail.
+        """
+        holder = self.query_one(f"#personas-char-editor-expr-{state}-thumb", Container)
         holder.remove_children()
         if renderable is None:
             return
@@ -877,6 +1013,34 @@ class PersonasCharacterEditorWidget(Container):
     def _remove_avatar_pressed(self, event: Button.Pressed) -> None:
         event.stop()
         self.post_message(CharacterImageRemoveRequested())
+
+    @staticmethod
+    def _expression_state_from_button_id(button_id: str | None, *, suffix: str) -> str | None:
+        """Recover the ``state`` a per-slot upload/clear button id encodes.
+
+        Ids follow ``personas-char-editor-expr-{state}-{suffix}``; used by
+        the two class-selector handlers below instead of six near-duplicate
+        per-state handlers.
+        """
+        prefix = "personas-char-editor-expr-"
+        if not button_id or not button_id.startswith(prefix) or not button_id.endswith(suffix):
+            return None
+        state = button_id[len(prefix) : -len(suffix)]
+        return state if state in EXPRESSION_IMAGE_STATES else None
+
+    @on(Button.Pressed, ".personas-char-editor-expr-upload")
+    def _expression_upload_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        state = self._expression_state_from_button_id(event.button.id, suffix="-upload")
+        if state is not None:
+            self.post_message(CharacterExpressionUploadRequested(state))
+
+    @on(Button.Pressed, ".personas-char-editor-expr-clear")
+    def _expression_clear_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        state = self._expression_state_from_button_id(event.button.id, suffix="-clear")
+        if state is not None:
+            self.post_message(CharacterExpressionClearRequested(state))
 
     @on(Button.Pressed, "#personas-char-editor-save")
     def _save_pressed(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py
@@ -56,6 +56,28 @@ class CharacterImageRemoveRequested(Message):
     """User requested to remove the avatar image from the active character editor."""
 
 
+class CharacterExpressionUploadRequested(Message):
+    """User requested to choose an image for one expression-state slot
+    (thinking/speaking/error) in the active character editor.
+
+    Roleplay P3d-1 Task 4: distinct from ``CharacterImageUploadRequested``
+    (the card's own avatar) - these write straight to the
+    ``character_expression_images`` table, independent of the card's save.
+    """
+
+    def __init__(self, state: str) -> None:
+        self.state = state
+        super().__init__()
+
+
+class CharacterExpressionClearRequested(Message):
+    """User requested to clear one expression-state slot's image."""
+
+    def __init__(self, state: str) -> None:
+        self.state = state
+        super().__init__()
+
+
 class EditPersonaRequested(Message):
     """Edit was requested for the displayed persona profile."""
 

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -2740,6 +2740,7 @@ max_tabs = 10  # Maximum number of chat tabs allowed
 enabled = true
 show_attach_button = true  # Show/hide the attach file button in chat
 # show_character_avatar = true  # show the active character's avatar in the Console left rail
+# react_character_expressions = true  # swap the Console character avatar among idle/thinking/speaking/error as it generates a reply (requires per-state images on the character); set false to keep a static avatar
 default_render_mode = "auto"  # auto, pixels, regular
 max_size_mb = 10.0
 auto_resize = true


### PR DESCRIPTION
## Roleplay P3d-1 — reactive character expression avatar (Console)

Third and final cycle of the character-presence theme (P3b editor #772 → P3c chat avatar #782 → **P3d reactions**). The Console Character-rail avatar now **reacts as the character thinks and speaks** — swapping among *idle / thinking / speaking / error* images as a reply generates and streams.

This is the minimal terminal-portable core of the tldw_server "Persona Visual / Persona Buddy" system: the **named-state abstraction** and its **runtime-state-driven** trigger (not an emotion classifier), rendered as static frame-swaps in the terminal. Later cycles (out of scope) add archive import, the server/MCP pack provider, animation/sprite atlas, and custom states.

### How it works
- **State is derived, not classified.** A pure, DB-free `resolve_console_expression_state` maps the active session's in-memory assistant-message status → state: `pending`→thinking, `streaming`→speaking, `complete`/`stopped`→idle, `failed`→error. Safe to call on the 0.2s Console tick.
- **The trigger was already wired.** The P3c avatar refresh runs on `_sync_native_console_chat_ui` (the 0.2s `_poll_transcript` + transition syncs). P3d only widens the scope-guard `(character_id,)` → `(character_id, state)`, so the existing tick drives the swap — no new hook.
- **Fully additive.** `idle` reuses the character's existing `character_cards.image`; a character with no expression images just shows its normal avatar. Fallback chain: state-image → idle-image → text.
- **Authoring:** three upload/preview/clear slots (thinking/speaking/error) in the character editor, reusing the avatar render-token discipline, writing straight to the new table (independent of the card's version).

### What's in it
1. `character_expression_images` BLOB table via a **v22→v23 migration** + CRUD seam (state validated in Python, soft-delete, FK→character_cards, `ON DELETE CASCADE`).
2. `resolve_console_expression_state` (DB-free) + `resolve_react_character_expressions` config helper.
3. Widened P3c avatar scope + **bounded** per-state decode cache (`_EXPRESSION_SPEC_CACHE_MAX=16`, FIFO) + table-fetch-with-fallback — all P3c render machinery reused.
4. Character-editor expression authoring slots (saved-character-only, characters-only).
5. `react_character_expressions` config (default True) + full-arc/gate/fail-soft tests.

### Constraints honored
- **No schema collision:** `origin/dev` is still v22; this migration is uncontested. New table lives only in the migration, not the frozen base CREATE.
- **Never raises into the 0.2s sync tick** — verified end-to-end (derivation, fetch, decode, render/build all guarded).
- State derivation is **DB-free**; decode is **off-thread**; the single `_console_image_cache` is reused; the per-state cache is bounded.
- `_active_console_dictionary_scope_ids` untouched; characters-only; both gates default True (react-off pins idle, avatar-off clears the section).

### Review
Subagent-driven (5 tasks, each spec+quality reviewed). Whole-branch review (opus): **APPROVE — no changes required**, all global constraints verified, the never-raise invariant confirmed end-to-end, both per-task Minors non-blocking. **44 P3d tests pass** (DB, derivation, reactive render, authoring, integration/fail-soft). Two Task-3 review findings fixed pre-PR (unbounded cache → bounded; post-await re-check now fully live).

### Tests
`Tests/Character_Chat/test_character_expression_images.py`, `Tests/Chat/test_console_expression_state.py`, `Tests/UI/test_console_character_avatar.py`, `Tests/UI/test_personas_expression_slots.py` — all green; `import tldw_chatbook.app` clean.

Follow-ups (deferred): later P3d cycles (archive import, server/MCP pack provider, animation, custom states); the shared editor render-token could be per-slot (cosmetic); migrate the personas editor `_fit_avatar_cell_size` to the shared `fit_image_cell_size`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Console character avatar reactive: it swaps among idle/thinking/speaking/error as replies are generated and streamed. Adds per‑state images and a safe, lightweight runtime to drive the swap.

- **New Features**
  - Console avatar now swaps by state and is keyed by (character_id, state); falls back to the normal avatar or text if images are missing; turning off `react_character_expressions` pins the avatar to idle.
  - Pure in‑memory state resolver maps message status to thinking/speaking/idle/error; reverse‑scans from the tail for O(1) amortized reads; runs on the 0.2s tick with off‑thread decode and a bounded per‑state cache.
  - Character editor adds three slots (thinking, speaking, error) to upload/preview/clear per‑state images for saved characters.

- **Migration**
  - Schema v22→v23 adds `character_expression_images` for per‑state images (idle reuses the existing avatar); rows cascade on character delete; CRUD reads use `execute_query`.
  - No action needed. Characters without expression images behave as before, and reactions can be disabled via `react_character_expressions = false`.

<sup>Written for commit c20cdad0077e10571be7d4c8cddfb05c8612272b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

