### PR TITLE
fix(personas): workbench preserves selection + preview across navigation (TASK-434)

### DIFF
--- a/Docs/superpowers/plans/2026-07-23-personas-workbench-selection-persistence.md
+++ b/Docs/superpowers/plans/2026-07-23-personas-workbench-selection-persistence.md
@@ -1,0 +1,380 @@
+# TASK-434 Personas workbench selection+preview persistence — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Returning to the Personas screen within a session restores the previously selected item, mode, and center view (AC#1), and the preview conversation (greeting + turns) survives the round-trip (AC#2).
+
+**Architecture:** The app stores `screen.save_state()` on navigate-away and calls `restore_state()` on a fresh screen when returning. `PersonasScreen` will override both to persist its `PersonasWorkbenchState` dataclass and the preview conversation, and re-apply the selection at the end of `on_mount`.
+
+**Tech Stack:** Python 3.11+, Textual, pytest (+ pytest-asyncio).
+
+## Global Constraints
+
+- The preview is split: `PersonasPreviewController.history` holds only sent turns; the **greeting** is in `PersonasPreviewPane._greeting` (NOT in history). Capture and restore **both**.
+- In `restore_conversation`, set `self.seeded_for` **before the first `await`** — `invalidate()` does NOT cancel the character-load worker, whose `handle_character_loaded` must hit the `:133` guard (`refresh_greeting_seed`, no erase).
+- `restore_state` runs **before** mount; rebuild `PersonasWorkbenchState` filtered to known dataclass fields (version-drift tolerant), and only stash a pending restore when there is a real selection.
+- Non-goals: restoring an unsaved editor, cross-restart persistence, changing the screen-caching model.
+- Files: `tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py`, `tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py`, `tldw_chatbook/UI/Screens/personas_screen.py`, and tests.
+
+---
+
+### Task 1: Preview capture + restore primitives
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py` (add a `greeting_text` property)
+- Modify: `tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py` (add `restore_conversation`)
+- Test: `Tests/UI/test_personas_preview.py` (pane property, via the existing pane harness) + `Tests/UI/test_personas_preview_restore.py` (new — controller `restore_conversation` with a mock screen/pane)
+
+**Interfaces:**
+- Produces: `PersonasPreviewPane.greeting_text -> str` (read-only property returning `self._greeting`).
+- Produces: `PersonasPreviewController.restore_conversation(self, *, greeting: str, history: list[dict], seeded_for) -> None` (async).
+
+- [ ] **Step 1: Write the failing pane-property test**
+
+```python
+# Tests/UI/test_personas_preview.py  (mirror the existing pane-harness tests, e.g. test_seed_append_reset_roundtrip)
+@pytest.mark.asyncio
+async def test_greeting_text_property_returns_seeded_greeting():
+    app = PreviewApp()  # the pane harness this file already defines (composes PersonasPreviewPane)
+    async with app.run_test() as pilot:
+        pane = pilot.app.query_one(PersonasPreviewPane)
+        await pane.seed_greeting("Hello, traveller.")
+        assert pane.greeting_text == "Hello, traveller."
+        pane.refresh_greeting_seed("Updated greeting.")
+        assert pane.greeting_text == "Updated greeting."
+```
+(Use the exact harness/import the other tests in that file use — copy their setup.)
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `python -m pytest Tests/UI/test_personas_preview.py::test_greeting_text_property_returns_seeded_greeting -q`
+Expected: FAIL (`AttributeError: 'PersonasPreviewPane' object has no attribute 'greeting_text'`).
+
+- [ ] **Step 3: Add the `greeting_text` property** (`personas_preview_pane.py`, near the public API, after `refresh_greeting_seed`)
+
+```python
+    @property
+    def greeting_text(self) -> str:
+        """The greeting a Reset restores (transcript line 0), for state capture."""
+        return self._greeting
+```
+
+- [ ] **Step 4: Run it to confirm it passes**
+
+Run: `python -m pytest Tests/UI/test_personas_preview.py::test_greeting_text_property_returns_seeded_greeting -q`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing `restore_conversation` test** (new file, mock screen/pane)
+
+```python
+# Tests/UI/test_personas_preview_restore.py
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from tldw_chatbook.UI.Persona_Modules.personas_preview_controller import (
+    PersonasPreviewController,
+)
+
+
+def _controller_with_mock_pane():
+    ctrl = PersonasPreviewController.__new__(PersonasPreviewController)
+    ctrl.history = [{"role": "assistant", "content": "old"}]
+    ctrl.seeded_for = None
+    ctrl.generation = 0
+    ctrl.gateway = None
+    events = []
+    pane = MagicMock()
+    pane.append_user = lambda t: events.append(("user", t))
+    pane.append_reply = lambda t: events.append(("reply", t))
+
+    async def _seed(text):
+        # Ordering guard: seeded_for MUST already be set when the first await runs.
+        events.append(("seed", text, ctrl.seeded_for))
+    pane.seed_greeting = AsyncMock(side_effect=_seed)
+
+    screen = MagicMock()
+    screen.query_one.return_value = pane
+    screen.workers.cancel_group = MagicMock()
+    ctrl.screen = screen
+    return ctrl, events
+
+
+@pytest.mark.asyncio
+async def test_restore_conversation_seeds_greeting_then_turns_and_sets_seeded_for_first():
+    ctrl, events = _controller_with_mock_pane()
+    history = [
+        {"role": "assistant", "content": "Greetings."},   # note: greeting is NOT in history
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+    await ctrl.restore_conversation(
+        greeting="Greetings.", history=history, seeded_for="7"
+    )
+    # seeded_for was already "7" at the first await (the seed call)
+    seed_events = [e for e in events if e[0] == "seed"]
+    assert seed_events and seed_events[0][2] == "7"
+    # greeting seeded, then each history turn rendered in order
+    assert events[0] == ("seed", "Greetings.", "7")
+    assert ("user", "hi") in events and ("reply", "hello") in events
+    # controller state updated
+    assert ctrl.seeded_for == "7"
+    assert ctrl.history == history
+```
+
+- [ ] **Step 6: Run it to confirm it fails**
+
+Run: `python -m pytest Tests/UI/test_personas_preview_restore.py -q`
+Expected: FAIL (`AttributeError: ... has no attribute 'restore_conversation'`).
+
+- [ ] **Step 7: Add `restore_conversation`** (`personas_preview_controller.py`, after `reset_for_character`)
+
+```python
+    async def restore_conversation(
+        self, *, greeting: str, history: list[dict], seeded_for
+    ) -> None:
+        """Rebuild the preview (greeting + turns) from saved state (task-434).
+
+        Sets ``seeded_for`` before the first ``await``: ``invalidate`` cancels
+        only the preview worker group, so the character-load worker's
+        ``handle_character_loaded`` may still fire -- and must hit the
+        seeded-for guard (``:133``) rather than erase the restored turns.
+        """
+        self.invalidate()
+        self.seeded_for = str(seeded_for) if seeded_for else None
+        try:
+            pane = self.screen.query_one(PersonasPreviewPane)
+        except QueryError:
+            return
+        await pane.seed_greeting(greeting)
+        for message in history:
+            role = message.get("role")
+            content = str(message.get("content") or "")
+            if role == "user":
+                pane.append_user(content)
+            elif role == "assistant":
+                pane.append_reply(content)
+        self.history = [dict(m) for m in history]
+```
+(`PersonasPreviewPane` and `QueryError` are already imported in this module — confirm; if not, add them.)
+
+- [ ] **Step 8: Run it to confirm it passes**
+
+Run: `python -m pytest Tests/UI/test_personas_preview_restore.py Tests/UI/test_personas_preview.py -q`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py Tests/UI/test_personas_preview.py Tests/UI/test_personas_preview_restore.py
+git commit -m "feat(personas): preview greeting_text + restore_conversation primitives (task-434)"
+```
+
+---
+
+### Task 2: PersonasScreen state persistence + deferred re-selection
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py` (add `import dataclasses`; override `save_state`/`restore_state`; add `_apply_pending_restore`; call it at the end of `on_mount`; add `restore_preview` param to `_select_character`)
+- Test: `Tests/UI/test_personas_workbench_state.py` (new — full-screen round-trip; mirror the harness in `Tests/UI/test_personas_dictionaries.py`: a harness `App` that `push_screen(PersonasScreen(self))` + a `_mounted(pilot)` helper)
+
+**Interfaces:**
+- Consumes: `PersonasPreviewController.restore_conversation` + `PersonasPreviewPane.greeting_text` (Task 1); `PersonasWorkbenchState` (dataclass); the existing `_select_character/_select_profile/_select_dictionary/_select_lore_entry`.
+
+- [ ] **Step 1: Write the failing AC#1 round-trip test**
+
+```python
+# Tests/UI/test_personas_workbench_state.py
+# Harness: copy the PersonasScreen-mounting app + _mounted(pilot) from Tests/UI/test_personas_dictionaries.py.
+@pytest.mark.asyncio
+async def test_save_restore_preserves_character_selection_and_center():
+    app = _PersonasHarness()  # push_screen(PersonasScreen(self))
+    async with app.run_test() as pilot:
+        screen = await _mounted(pilot)
+        # select a seeded character (use the same seeding the dictionaries/workbench tests use)
+        await screen._select_character("char-1", "Elara")
+        await pilot.pause()
+        assert screen.state.selected_entity_id == "char-1"
+
+        saved = screen.save_state()
+        assert saved["personas_workbench"]["selected_entity_id"] == "char-1"
+
+    # Fresh screen restores from saved state, then mounts
+    app2 = _PersonasHarness()
+    async with app2.run_test() as pilot2:
+        screen2 = app2.query_one(PersonasScreen)  # or however the harness exposes it
+        screen2.restore_state(saved)
+        await pilot2.pause()
+        # after mount + deferred restore
+        assert screen2.state.selected_entity_id == "char-1"
+        assert screen2.state.selected_entity_kind == "character"
+        # center shows the character card view, not blank
+        assert screen2.query_one("#ccp-character-card-view").display is True
+```
+Adjust the harness/seeding and the "fresh screen" mounting to whatever the dictionaries/workbench harness supports (it may require creating the screen, calling `restore_state`, then pushing it — mirror how the app does it: `restore_state` before `switch_screen`). If the harness can't cleanly re-create a second screen, drive `restore_state` on a freshly constructed `PersonasScreen(app)` and `push_screen` it, then assert after `pilot.pause()`.
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `python -m pytest Tests/UI/test_personas_workbench_state.py::test_save_restore_preserves_character_selection_and_center -q`
+Expected: FAIL — `save_state` returns the base state_data without `personas_workbench`, and the restored screen shows "Selected: none"/blank center.
+
+- [ ] **Step 3: Add `import dataclasses`** at the top of `personas_screen.py` (with the other stdlib imports).
+
+- [ ] **Step 4: Override `save_state` / `restore_state`** (methods on `PersonasScreen`)
+
+```python
+    def save_state(self) -> dict:
+        state = dict(super().save_state() or {})
+        state["personas_workbench"] = dataclasses.asdict(self.state)
+        preview = getattr(self, "preview", None)
+        if preview is not None:
+            greeting = ""
+            try:
+                greeting = self.query_one(PersonasPreviewPane).greeting_text
+            except QueryError:
+                pass
+            state["personas_preview"] = {
+                "greeting": greeting,
+                "history": [dict(m) for m in preview.history],
+                "seeded_for": preview.seeded_for,
+            }
+        return state
+
+    def restore_state(self, state: dict) -> None:
+        super().restore_state(state)
+        if not isinstance(state, dict):
+            self._pending_restore = None
+            return
+        wb = state.get("personas_workbench")
+        if isinstance(wb, dict):
+            names = {f.name for f in dataclasses.fields(PersonasWorkbenchState)}
+            self.state = PersonasWorkbenchState(
+                **{k: v for k, v in wb.items() if k in names}
+            )
+        self._pending_restore = (
+            {
+                "kind": self.state.selected_entity_kind,
+                "id": self.state.selected_entity_id,
+                "name": self.state.selected_entity_name,
+                "preview": state.get("personas_preview"),
+            }
+            if self.state.selected_entity_id
+            else None
+        )
+```
+Initialize `self._pending_restore = None` in `__init__` (next to `self.state = PersonasWorkbenchState()`).
+
+- [ ] **Step 5: Add `_apply_pending_restore` and call it at the end of `on_mount`**
+
+In `on_mount`, after `self._sync_title_and_console_actions()`:
+```python
+        await self._apply_pending_restore()
+```
+New method:
+```python
+    async def _apply_pending_restore(self) -> None:
+        """Re-apply a selection saved before a navigation round-trip (task-434)."""
+        pending = getattr(self, "_pending_restore", None)
+        self._pending_restore = None
+        if not pending or not pending.get("id"):
+            return
+        kind = pending.get("kind")
+        entity_id = str(pending["id"])
+        name = str(pending.get("name") or "")
+        try:
+            if kind == "character":
+                await self._select_character(
+                    entity_id, name, restore_preview=pending.get("preview")
+                )
+            elif kind == "persona_profile":
+                await self._select_profile(entity_id, name)
+            elif kind == "dictionary":
+                await self._select_dictionary(entity_id, name)
+            elif kind == "lore":
+                await self._select_lore_entry(entity_id, name)
+        except Exception:
+            # A stale/deleted entity must degrade to the blank center, not crash.
+            logger.opt(exception=True).warning(
+                "Personas: could not restore selection %s/%s; showing blank center.",
+                kind,
+                entity_id,
+            )
+            self._show_center(None)
+```
+(Use whatever logger the module already binds.)
+
+- [ ] **Step 6: Add the `restore_preview` branch to `_select_character`**
+
+Change the signature to `async def _select_character(self, entity_id, entity_name, *, restore_preview=None)` and replace the `reset_for_character` tail:
+```python
+        if restore_preview is not None:
+            await self.preview.restore_conversation(
+                greeting=str(restore_preview.get("greeting") or ""),
+                history=list(restore_preview.get("history") or []),
+                seeded_for=entity_id,
+            )
+        else:
+            record = self._full_character_record(entity_id)
+            await self.preview.reset_for_character(
+                character_id=entity_id, character_name=entity_name, record=record
+            )
+```
+
+- [ ] **Step 7: Run the AC#1 test to confirm it passes**
+
+Run: `python -m pytest Tests/UI/test_personas_workbench_state.py::test_save_restore_preserves_character_selection_and_center -q`
+Expected: PASS.
+
+- [ ] **Step 8: Write + pass the AC#2 preview-survival test**
+
+```python
+@pytest.mark.asyncio
+async def test_save_restore_preserves_preview_greeting_and_turns():
+    app = _PersonasHarness()
+    async with app.run_test() as pilot:
+        screen = await _mounted(pilot)
+        await screen._select_character("char-1", "Elara")
+        await pilot.pause()
+        # simulate a preview conversation: greeting seeded + a couple of turns
+        pane = screen.query_one(PersonasPreviewPane)
+        await pane.seed_greeting("Greetings, traveller.")
+        pane.append_user("hi"); screen.preview.history.append({"role": "user", "content": "hi"})
+        pane.append_reply("well met"); screen.preview.history.append({"role": "assistant", "content": "well met"})
+        saved = screen.save_state()
+
+    # restore into a fresh screen
+    screen2 = PersonasScreen(app)
+    screen2.restore_state(saved)
+    await app.push_screen(screen2)
+    await pilot.pause()  # (use the harness's pilot; or a fresh run_test as in Step 1)
+    pane2 = screen2.query_one(PersonasPreviewPane)
+    assert pane2.greeting_text == "Greetings, traveller."
+    text = pane2.transcript_text()
+    assert "Greetings, traveller." in text and "hi" in text and "well met" in text
+    assert screen2.preview.history == saved["personas_preview"]["history"]
+```
+Then add a test that drives `handle_character_loaded` after restore and asserts the turns survive (the `:133` guard). Adjust the second-screen mounting mechanics to the harness (mirror Step 1's approach).
+
+Run: `python -m pytest Tests/UI/test_personas_workbench_state.py -q`
+Expected: PASS.
+
+- [ ] **Step 9: Regression + commit**
+
+Run:
+```bash
+python -c "import tldw_chatbook.UI.Screens.personas_screen"
+python -m pytest Tests/UI/test_personas_workbench_state.py Tests/UI/test_personas_preview.py Tests/UI/test_personas_preview_restore.py Tests/UI/test_personas_dictionaries.py Tests/UI/test_personas_workbench.py Tests/UI/test_personas_lore.py -q
+```
+Expected: PASS (existing personas tests unaffected).
+
+```bash
+git add tldw_chatbook/UI/Screens/personas_screen.py Tests/UI/test_personas_workbench_state.py
+git commit -m "feat(personas): persist workbench selection + preview across navigation (task-434)"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** AC#1 → Task 2 (save/restore `PersonasWorkbenchState` + deferred `_select_*` re-selection). AC#2 → Task 1 primitives + Task 2's `restore_preview` branch. Both covered.
+- **Placeholder scan:** the only prose-only bits are "use the harness the existing tests use" (Task 1 pane harness; Task 2 `test_personas_dictionaries.py` harness) and the exact character-seeding id — these are verification-against-real-fixtures, with the source files named. No TBD logic.
+- **Type/name consistency:** `restore_conversation(greeting, history, seeded_for)` and `greeting_text` used identically in Task 1 (definition) and Task 2 (call sites); `_pending_restore` dict shape identical in `restore_state` and `_apply_pending_restore`; `personas_workbench`/`personas_preview` keys identical in `save_state`/`restore_state`.
+- **Ordering:** `seeded_for` set before the first `await` in `restore_conversation` (Global Constraint) — pinned by Task 1 Step 5's test.

--- a/Docs/superpowers/specs/2026-07-23-personas-workbench-selection-persistence-design.md
+++ b/Docs/superpowers/specs/2026-07-23-personas-workbench-selection-persistence-design.md
@@ -1,0 +1,133 @@
+# TASK-434 — Personas workbench preserves selection + preview across navigation
+
+- **Date:** 2026-07-23
+- **Task:** TASK-434 (RP/character-card UX review). Personas ▸ Console ▸ back loses the working context.
+- **Branch base:** origin/dev (tip `f08343b67`).
+- **Scope:** Full — AC#1 (selection/mode/center) **and** AC#2 (preview transcript survives).
+
+## Problem
+
+Navigating Personas → Console → back resets the workbench to "Selected: none", a blank center, "Console blocked: select an item", and a collapsed preview. The design encourages the workbench↔Console loop, but every round-trip drops the working context.
+
+**Root cause:** the app never caches screen instances (`app.py:5550` "Screens must never be cached and re-mounted"). Instead, on navigate-away it stores `screen.save_state()` in `app._screen_states[screen_name]`; on return it builds a *fresh* screen and calls `restore_state()` (`app.py:5647-5703`). `PersonasScreen` overrides neither, so the base no-ops run and the workbench `self.state` (a `PersonasWorkbenchState` dataclass) and the preview are lost. `on_mount` then blanks the center via `_show_center(None)` (`personas_screen.py:714`).
+
+## Key mechanics (verified)
+
+- `restore_state()` runs **before** the new screen mounts (`app.py:5682` precedes `switch_screen` at `:5703`). So it can seed `self.state` (which `on_mount`'s `set_mode(self.state.active_mode)` then honors) and stash a "pending restore" for `on_mount` to finish.
+- `PersonasWorkbenchState` (`personas_state.py:36`) is a flat `@dataclass` of primitives (`active_mode`, `sort_key`, `tag_filter`, `page_offset`, `selected_entity_kind/id/name`, `search_query`, `filter_text`, `has_unsaved_changes`, `status_message`, ...) — cleanly `asdict()`-serializable.
+- The preview conversation lives in `PersonasPreviewController.history` (`list[{"role","content"}]`) with `seeded_for` (the character id the greeting seeded). The pane renders via `append_user`/`append_reply`/`seed_greeting`; `transcript_text()` reads it back.
+- Selecting a character runs `_select_character` → sets state, marks the row, loads the record (thread worker), `_show_center("#ccp-character-card-view")`, updates the inspector + conversations, and `reset_for_character` → `reset` → `invalidate()` which **unconditionally clears** `history`. The async load worker later calls `handle_character_loaded`, which **preserves** an in-progress conversation when `seeded_for == character_id and pane.transcript_text()` (`personas_preview_controller.py:133`). This guard is what a restore leverages.
+
+## Design
+
+### 1. `save_state()` override (`PersonasScreen`)
+```python
+def save_state(self) -> dict:
+    state = dict(super().save_state() or {})
+    state["personas_workbench"] = asdict(self.state)
+    state["personas_preview"] = {
+        "history": [dict(m) for m in self.preview.history],
+        "seeded_for": self.preview.seeded_for,
+    }
+    return state
+```
+Captures the whole workbench dataclass + the preview conversation. (History is character-scoped; for non-character selections it is empty/irrelevant and simply restores as empty.)
+
+### 2. `restore_state()` override (`PersonasScreen`) — runs pre-mount
+```python
+def restore_state(self, state: dict) -> None:
+    super().restore_state(state)
+    wb = state.get("personas_workbench")
+    if isinstance(wb, dict):
+        fields = {f.name for f in dataclasses.fields(PersonasWorkbenchState)}
+        self.state = PersonasWorkbenchState(**{k: v for k, v in wb.items() if k in fields})
+    self._pending_restore = {
+        "kind": self.state.selected_entity_kind,
+        "id": self.state.selected_entity_id,
+        "name": self.state.selected_entity_name,
+        "preview": state.get("personas_preview"),
+    } if self.state.selected_entity_id else None
+```
+Rebuilding the dataclass (filtered to known fields — tolerant of version drift) sets `active_mode` before mount, so `on_mount`'s `set_mode` and list refresh land in the right mode. Only a real selection schedules a pending restore.
+
+### 3. Deferred re-selection at the end of `on_mount`
+After the existing `on_mount` body (`refresh_character_list()` etc.), apply the pending restore instead of leaving the center blank:
+```python
+    ...
+    self._sync_title_and_console_actions()
+    await self._apply_pending_restore()
+
+async def _apply_pending_restore(self) -> None:
+    pending = getattr(self, "_pending_restore", None)
+    self._pending_restore = None
+    if not pending:
+        return
+    kind, entity_id, name = pending["kind"], pending["id"], pending["name"]
+    preview = pending.get("preview")
+    if kind == "character":
+        await self._select_character(entity_id, name, restore_preview=preview)
+    elif kind == "persona_profile":
+        await self._select_profile(entity_id, name)
+    elif kind == "dictionary":
+        await self._select_dictionary(entity_id, name)
+    elif kind == "lore":
+        await self._select_lore_entry(entity_id, name)
+```
+The `_select_*` calls re-establish the selection, center pane, inspector, and conversations — AC#1. (Guard each in try/except-tolerant restore: a stale id whose entity was deleted must degrade to blank center, not crash — reuse the existing `_run_guarded`/selection error handling.)
+
+### 4. Preview restore (AC#2) — new branch on `_select_character`
+Add an optional `restore_preview` parameter so restore does not lose the transcript to `reset_for_character`'s `invalidate()`:
+```python
+async def _select_character(self, entity_id, entity_name, *, restore_preview=None):
+    ...  # state, mark row, load_character (schedules worker), show center, inspector, conversations
+    if restore_preview and restore_preview.get("history"):
+        await self.preview.restore_history(
+            restore_preview["history"], seeded_for=entity_id
+        )
+    else:
+        record = self._full_character_record(entity_id)
+        await self.preview.reset_for_character(
+            character_id=entity_id, character_name=entity_name, record=record
+        )
+```
+New `PersonasPreviewController.restore_history`:
+```python
+async def restore_history(self, history, *, seeded_for) -> None:
+    self.invalidate()                    # cancel workers + clear
+    try:
+        pane = self.screen.query_one(PersonasPreviewPane)
+    except QueryError:
+        return
+    await pane.restore_transcript(history)   # new pane method: reset + re-render each entry
+    self.history = [dict(m) for m in history]
+    self.seeded_for = str(seeded_for)
+```
+New `PersonasPreviewPane.restore_transcript(history)`: `await self.reset()` then render each entry — the first `assistant` entry via `seed_greeting` (preserves greeting styling), the rest via `append_user`/`append_reply`. Setting `seeded_for` + a non-empty transcript means the later `handle_character_loaded` worker hits the `:133` guard (`refresh_greeting_seed`, no erase) — the ordering holds because `_select_character` sets these synchronously within the coroutine before the thread worker's callback can run.
+
+### Non-character selections and empty preview
+Persona/dictionary/lore restore only AC#1 (they have no preview transcript). A character with an empty saved history falls through to the normal `reset_for_character` greeting seed.
+
+## Testing
+
+Mirror `Tests/UI/test_chat_screen_state.py` / `test_chat_screen_suspend.py` (bare-ish screen or pilot harness for `save_state`/`restore_state`), plus the existing Personas pilot harness (`Tests/UI/test_personas_*`):
+- **save→restore round-trip (AC#1):** build a `PersonasScreen`, select a character, `state = screen.save_state()`; a fresh screen `restore_state(state)` then mounts → the restored screen shows the same selected id/kind/name, `active_mode`, and center pane (`#ccp-character-card-view`), not "Selected: none".
+- **preview survives (AC#2):** seed a preview with a multi-message `history`, save, restore → the restored preview's `controller.history` equals the saved list and `pane.transcript_text()` contains the earlier turns (not just the greeting); `seeded_for` restored.
+- **restore skips the greeting-reset:** assert `_select_character(..., restore_preview=...)` does NOT call `reset_for_character` (or that the restored transcript is intact after the character-load worker fires — drive the `handle_character_loaded` guard).
+- **non-character selection restores center only:** a saved persona/dictionary/lore selection restores its center pane; no preview crash.
+- **stale/deleted entity:** a saved selection whose id no longer exists degrades to blank center without raising.
+- **no selection:** empty pending restore leaves today's blank-center behavior unchanged.
+- **Regression:** existing `test_personas_*` and `test_screen_navigation` stay green; `save_state` returning the enriched dict doesn't break the app's `add_runtime_policy_snapshot`/`reconcile_saved_screen_state` round-trip (it wraps a dict — our extra keys are preserved).
+
+## Risks / mitigations
+
+- **Async greeting-seed race (AC#2):** the restore sets `seeded_for` + renders the transcript synchronously within `_select_character` before the thread worker's `handle_character_loaded` callback can run; the `:133` guard then preserves it. Tested by driving the loaded-callback after restore.
+- **Version drift in saved state:** `restore_state` filters to known dataclass fields and guards non-dict payloads, so an old/foreign saved blob can't crash construction.
+- **Stale selection:** deleted-entity restore is guarded to fall back to blank center.
+- **`reconcile_saved_screen_state`:** our keys ride inside the same state dict the app already snapshots/reconciles; no change to that flow.
+
+## Non-goals
+
+- Restoring an **in-progress editor** with unsaved changes (leaving with unsaved edits is already gated by the unsaved-changes dialog; restore targets the view/selection).
+- Persisting the workbench across **app restarts** (`_screen_states` is in-memory session state, matching every other screen).
+- Changing the navigation/screen-caching model.
+- Preserving library scroll position beyond `page_offset` (already in the dataclass).

--- a/Docs/superpowers/specs/2026-07-23-personas-workbench-selection-persistence-design.md
+++ b/Docs/superpowers/specs/2026-07-23-personas-workbench-selection-persistence-design.md
@@ -15,7 +15,7 @@ Navigating Personas → Console → back resets the workbench to "Selected: none
 
 - `restore_state()` runs **before** the new screen mounts (`app.py:5682` precedes `switch_screen` at `:5703`). So it can seed `self.state` (which `on_mount`'s `set_mode(self.state.active_mode)` then honors) and stash a "pending restore" for `on_mount` to finish.
 - `PersonasWorkbenchState` (`personas_state.py:36`) is a flat `@dataclass` of primitives (`active_mode`, `sort_key`, `tag_filter`, `page_offset`, `selected_entity_kind/id/name`, `search_query`, `filter_text`, `has_unsaved_changes`, `status_message`, ...) — cleanly `asdict()`-serializable.
-- The preview conversation lives in `PersonasPreviewController.history` (`list[{"role","content"}]`) with `seeded_for` (the character id the greeting seeded). The pane renders via `append_user`/`append_reply`/`seed_greeting`; `transcript_text()` reads it back.
+- The preview conversation is split across two objects: `PersonasPreviewController.history` (`list[{"role","content"}]`) holds only the **sent turns** (user/assistant), while the **greeting is not in `history`** — it lives in `PersonasPreviewPane._greeting` (a string set by `seed_greeting`, rendered as transcript line 0). `seeded_for` (controller) is the character id the greeting seeded. So a faithful capture needs **both** `pane._greeting` and `controller.history`.
 - Selecting a character runs `_select_character` → sets state, marks the row, loads the record (thread worker), `_show_center("#ccp-character-card-view")`, updates the inspector + conversations, and `reset_for_character` → `reset` → `invalidate()` which **unconditionally clears** `history`. The async load worker later calls `handle_character_loaded`, which **preserves** an in-progress conversation when `seeded_for == character_id and pane.transcript_text()` (`personas_preview_controller.py:133`). This guard is what a restore leverages.
 
 ## Design
@@ -25,13 +25,21 @@ Navigating Personas → Console → back resets the workbench to "Selected: none
 def save_state(self) -> dict:
     state = dict(super().save_state() or {})
     state["personas_workbench"] = asdict(self.state)
-    state["personas_preview"] = {
-        "history": [dict(m) for m in self.preview.history],
-        "seeded_for": self.preview.seeded_for,
-    }
+    preview = getattr(self, "preview", None)
+    if preview is not None:
+        greeting = ""
+        try:
+            greeting = self.query_one(PersonasPreviewPane).greeting_text
+        except QueryError:
+            pass  # pane torn down / not mounted
+        state["personas_preview"] = {
+            "greeting": greeting,
+            "history": [dict(m) for m in preview.history],
+            "seeded_for": preview.seeded_for,
+        }
     return state
 ```
-Captures the whole workbench dataclass + the preview conversation. (History is character-scoped; for non-character selections it is empty/irrelevant and simply restores as empty.)
+Captures the whole workbench dataclass + **both** halves of the preview (greeting **and** turns). Add a small `PersonasPreviewPane.greeting_text` read-only property returning `self._greeting` (avoids reaching into a private attr from the screen). History is character-scoped; non-character selections restore an empty preview.
 
 ### 2. `restore_state()` override (`PersonasScreen`) — runs pre-mount
 ```python
@@ -76,13 +84,15 @@ async def _apply_pending_restore(self) -> None:
 The `_select_*` calls re-establish the selection, center pane, inspector, and conversations — AC#1. (Guard each in try/except-tolerant restore: a stale id whose entity was deleted must degrade to blank center, not crash — reuse the existing `_run_guarded`/selection error handling.)
 
 ### 4. Preview restore (AC#2) — new branch on `_select_character`
-Add an optional `restore_preview` parameter so restore does not lose the transcript to `reset_for_character`'s `invalidate()`:
+Add an optional `restore_preview` parameter so restore rebuilds the transcript itself instead of going through `reset_for_character` (which `invalidate()`s the turns and re-seeds the greeting):
 ```python
 async def _select_character(self, entity_id, entity_name, *, restore_preview=None):
-    ...  # state, mark row, load_character (schedules worker), show center, inspector, conversations
-    if restore_preview and restore_preview.get("history"):
-        await self.preview.restore_history(
-            restore_preview["history"], seeded_for=entity_id
+    ...  # state, mark row, load_character (schedules the char-load worker), show center, inspector, conversations
+    if restore_preview is not None:
+        await self.preview.restore_conversation(
+            greeting=restore_preview.get("greeting", ""),
+            history=restore_preview.get("history", []),
+            seeded_for=entity_id,
         )
     else:
         record = self._full_character_record(entity_id)
@@ -90,19 +100,25 @@ async def _select_character(self, entity_id, entity_name, *, restore_preview=Non
             character_id=entity_id, character_name=entity_name, record=record
         )
 ```
-New `PersonasPreviewController.restore_history`:
+New `PersonasPreviewController.restore_conversation` — rebuilds greeting **and** turns, and sets `seeded_for` **before** any `await` so the still-pending character-load worker's `handle_character_loaded` hits the `:133` guard (`refresh_greeting_seed`, no erase) even if it interleaves:
 ```python
-async def restore_history(self, history, *, seeded_for) -> None:
-    self.invalidate()                    # cancel workers + clear
+async def restore_conversation(self, *, greeting, history, seeded_for) -> None:
+    self.invalidate()                       # clears history, cancels only preview workers
+    self.seeded_for = str(seeded_for)       # set FIRST: invalidate does NOT cancel the char-load worker
     try:
         pane = self.screen.query_one(PersonasPreviewPane)
     except QueryError:
         return
-    await pane.restore_transcript(history)   # new pane method: reset + re-render each entry
+    await pane.seed_greeting(greeting)       # renders + stores pane._greeting (transcript now non-empty)
+    for m in history:
+        role, content = m.get("role"), str(m.get("content") or "")
+        if role == "user":
+            pane.append_user(content)
+        elif role == "assistant":
+            pane.append_reply(content)
     self.history = [dict(m) for m in history]
-    self.seeded_for = str(seeded_for)
 ```
-New `PersonasPreviewPane.restore_transcript(history)`: `await self.reset()` then render each entry — the first `assistant` entry via `seed_greeting` (preserves greeting styling), the rest via `append_user`/`append_reply`. Setting `seeded_for` + a non-empty transcript means the later `handle_character_loaded` worker hits the `:133` guard (`refresh_greeting_seed`, no erase) — the ordering holds because `_select_character` sets these synchronously within the coroutine before the thread worker's callback can run.
+The greeting comes from the saved `personas_preview["greeting"]`, so restore does not depend on the async record load; when the char-load worker later delivers, the `:133` guard (`seeded_for == id and transcript_text()`) just `refresh_greeting_seed`s the stored greeting (typically identical) without erasing the turns.
 
 ### Non-character selections and empty preview
 Persona/dictionary/lore restore only AC#1 (they have no preview transcript). A character with an empty saved history falls through to the normal `reset_for_character` greeting seed.
@@ -111,8 +127,8 @@ Persona/dictionary/lore restore only AC#1 (they have no preview transcript). A c
 
 Mirror `Tests/UI/test_chat_screen_state.py` / `test_chat_screen_suspend.py` (bare-ish screen or pilot harness for `save_state`/`restore_state`), plus the existing Personas pilot harness (`Tests/UI/test_personas_*`):
 - **save→restore round-trip (AC#1):** build a `PersonasScreen`, select a character, `state = screen.save_state()`; a fresh screen `restore_state(state)` then mounts → the restored screen shows the same selected id/kind/name, `active_mode`, and center pane (`#ccp-character-card-view`), not "Selected: none".
-- **preview survives (AC#2):** seed a preview with a multi-message `history`, save, restore → the restored preview's `controller.history` equals the saved list and `pane.transcript_text()` contains the earlier turns (not just the greeting); `seeded_for` restored.
-- **restore skips the greeting-reset:** assert `_select_character(..., restore_preview=...)` does NOT call `reset_for_character` (or that the restored transcript is intact after the character-load worker fires — drive the `handle_character_loaded` guard).
+- **preview survives incl. greeting (AC#2):** seed a preview with a greeting **and** a multi-turn `history`, save, restore → `controller.history` equals the saved turns, `pane.greeting_text` equals the saved greeting, `pane.transcript_text()` contains the greeting **and** the turns, and `seeded_for` is restored.
+- **restore survives the async char-load worker:** after restore, drive `handle_character_loaded(character_id=<id>, card_data=<record>)` and assert the transcript still has the turns (the `:133` guard `refresh_greeting_seed`s, does not `invalidate`) — this pins the "set `seeded_for` first" ordering.
 - **non-character selection restores center only:** a saved persona/dictionary/lore selection restores its center pane; no preview crash.
 - **stale/deleted entity:** a saved selection whose id no longer exists degrades to blank center without raising.
 - **no selection:** empty pending restore leaves today's blank-center behavior unchanged.
@@ -120,7 +136,8 @@ Mirror `Tests/UI/test_chat_screen_state.py` / `test_chat_screen_suspend.py` (bar
 
 ## Risks / mitigations
 
-- **Async greeting-seed race (AC#2):** the restore sets `seeded_for` + renders the transcript synchronously within `_select_character` before the thread worker's `handle_character_loaded` callback can run; the `:133` guard then preserves it. Tested by driving the loaded-callback after restore.
+- **Async char-load worker race (AC#2):** `_select_character` schedules the char-load worker (which `invalidate()` does **not** cancel — that only cancels the `personas-preview` group). `restore_conversation` therefore sets `self.seeded_for` **before its first `await`**, and the greeting render makes the transcript non-empty, so even if `handle_character_loaded` interleaves it hits the `:133` guard and preserves the turns. Directly tested by driving the loaded-callback after restore.
+- **Greeting not in `history`:** the greeting is captured separately (`pane.greeting_text`) and restored via `seed_greeting`, so it is not lost (a plain `history` capture would drop it).
 - **Version drift in saved state:** `restore_state` filters to known dataclass fields and guards non-dict payloads, so an old/foreign saved blob can't crash construction.
 - **Stale selection:** deleted-entity restore is guarded to fall back to blank center.
 - **`reconcile_saved_screen_state`:** our keys ride inside the same state dict the app already snapshots/reconciles; no change to that flow.

--- a/Tests/UI/test_personas_preview.py
+++ b/Tests/UI/test_personas_preview.py
@@ -405,3 +405,13 @@ async def test_status_is_readable():
         status = str(pilot.app.query_one("#personas-preview-status", Static).renderable)
         assert status == "Running"
         assert "Traceback" not in status
+
+
+async def test_greeting_text_property_returns_seeded_greeting():
+    app = PreviewApp()
+    async with app.run_test() as pilot:
+        pane = pilot.app.query_one(PersonasPreviewPane)
+        await pane.seed_greeting("Hello, traveller.")
+        assert pane.greeting_text == "Hello, traveller."
+        pane.refresh_greeting_seed("Updated greeting.")
+        assert pane.greeting_text == "Updated greeting."

--- a/Tests/UI/test_personas_preview_restore.py
+++ b/Tests/UI/test_personas_preview_restore.py
@@ -1,0 +1,53 @@
+"""Tests for PersonasPreviewController.restore_conversation (task-434)."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from tldw_chatbook.UI.Persona_Modules.personas_preview_controller import (
+    PersonasPreviewController,
+)
+
+
+def _controller_with_mock_pane():
+    ctrl = PersonasPreviewController.__new__(PersonasPreviewController)
+    ctrl.history = [{"role": "assistant", "content": "old"}]
+    ctrl.seeded_for = None
+    ctrl.generation = 0
+    ctrl.gateway = None
+    events = []
+    pane = MagicMock()
+    pane.append_user = lambda t: events.append(("user", t))
+    pane.append_reply = lambda t: events.append(("reply", t))
+
+    async def _seed(text):
+        # Ordering guard: seeded_for MUST already be set when the first await runs.
+        events.append(("seed", text, ctrl.seeded_for))
+    pane.seed_greeting = AsyncMock(side_effect=_seed)
+
+    screen = MagicMock()
+    screen.query_one.return_value = pane
+    screen.workers.cancel_group = MagicMock()
+    ctrl.screen = screen
+    return ctrl, events
+
+
+@pytest.mark.asyncio
+async def test_restore_conversation_seeds_greeting_then_turns_and_sets_seeded_for_first():
+    ctrl, events = _controller_with_mock_pane()
+    history = [
+        {"role": "assistant", "content": "Greetings."},   # note: greeting is NOT in history
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+    await ctrl.restore_conversation(
+        greeting="Greetings.", history=history, seeded_for="7"
+    )
+    # seeded_for was already "7" at the first await (the seed call)
+    seed_events = [e for e in events if e[0] == "seed"]
+    assert seed_events and seed_events[0][2] == "7"
+    # greeting seeded, then each history turn rendered in order
+    assert events[0] == ("seed", "Greetings.", "7")
+    assert ("user", "hi") in events and ("reply", "hello") in events
+    # controller state updated
+    assert ctrl.seeded_for == "7"
+    assert ctrl.history == history

--- a/Tests/UI/test_personas_workbench_state.py
+++ b/Tests/UI/test_personas_workbench_state.py
@@ -1,0 +1,295 @@
+"""PersonasScreen state persistence across navigation (task-434, Task 2).
+
+A Personas -> Console -> back round-trip pushes/pops ``PersonasScreen``.
+``BaseAppScreen``'s default ``save_state``/``restore_state`` only round-trips
+``self.state_data`` (unused here), so without an override the workbench
+selection and the ephemeral preview conversation (which lives outside
+``self.state`` entirely - see ``PersonasPreviewController``) were lost on
+every round-trip.
+
+This module covers ``PersonasScreen.save_state``/``restore_state`` and
+``_apply_pending_restore``:
+
+- AC#1: the previously selected item, mode, and center view are restored.
+- AC#2: the preview conversation (greeting + turns) survives the round-trip.
+- The ``:133`` seeded-for guard in
+  ``PersonasPreviewController.handle_character_loaded`` must not erase a
+  preview transcript rebuilt by ``restore_conversation``.
+
+Harness: mirrors ``Tests/UI/test_personas_dictionaries.py``'s
+``PersonasTestApp`` (a delegating ``App`` that ``push_screen(PersonasScreen(
+self))``) and its ``_mounted(pilot)`` helper. The "fresh screen restores"
+half of each test mirrors how ``app.py``'s navigation actually does it
+(``tldw_chatbook/app.py`` around the ``_screen_states``/``switch_screen``
+code): construct a new screen, call ``restore_state`` on it, THEN push it -
+never mount a screen before its saved state has been seeded.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from textual.app import App
+
+import tldw_chatbook.UI.CCP_Modules.ccp_character_handler as character_handler_module
+from tldw_chatbook.UI.Screens.personas_screen import PersonasScreen
+from tldw_chatbook.Widgets.AppFooterStatus import AppFooterStatus
+from tldw_chatbook.Widgets.Persona_Widgets.personas_preview_pane import (
+    PersonasPreviewPane,
+)
+
+from Tests.UI.test_personas_dictionaries import (
+    PersonasTestApp,
+    _mounted,
+    patch_character_paging,
+)
+
+pytestmark = pytest.mark.asyncio
+
+CHARACTERS = [
+    {
+        "id": "char-1",
+        "name": "Elara",
+        "description": "A wandering healer",
+        "first_message": "Greetings, traveller.",
+        "version": 1,
+    },
+]
+
+
+@pytest.fixture
+def stub_characters(monkeypatch):
+    """Stub the character library + loader for a single seeded character.
+
+    ``CCPCharacterHandler.load_character`` is patched to a no-op AsyncMock:
+    this module tests ``PersonasScreen.save_state``/``restore_state`` and the
+    preview-restoration path, not the (separately covered elsewhere)
+    character-load worker pipeline. Leaving the real thread worker running
+    would race its own ``CharacterMessage.Loaded`` -> ``handle_character_loaded``
+    delivery against this module's manual preview-seeding calls, since both
+    touch the same ``seeded_for``/transcript state.
+    """
+    monkeypatch.setattr(
+        character_handler_module,
+        "fetch_all_characters",
+        lambda: [dict(c) for c in CHARACTERS],
+    )
+    monkeypatch.setattr(
+        character_handler_module,
+        "fetch_character_by_id",
+        lambda character_id: next(
+            (dict(c) for c in CHARACTERS if str(c["id"]) == str(character_id)), None
+        ),
+    )
+    patch_character_paging(monkeypatch)
+    monkeypatch.setattr(
+        character_handler_module.CCPCharacterHandler, "load_character", AsyncMock()
+    )
+
+
+class _RestoringPersonasTestApp(App):
+    """Harness that seeds ``restore_state`` before the screen ever mounts.
+
+    Mirrors ``tldw_chatbook/app.py``'s navigation handler, which constructs
+    the destination screen, calls ``new_screen.restore_state(...)``, and only
+    then pushes/switches to it - restore_state must run on a screen that does
+    not exist in the DOM yet.
+
+    Deliberately NOT a ``PersonasTestApp`` subclass: Textual's message
+    dispatch (``MessagePump._get_dispatch_methods``) looks up ``on_mount`` in
+    *every* class's own ``__dict__`` along the MRO and invokes each one it
+    finds - not just the most-derived override. Subclassing ``PersonasTestApp``
+    (which defines its own unconditional, non-restoring ``on_mount``) would
+    therefore mount a SECOND, un-restored ``PersonasScreen`` alongside this
+    one and leave it on top of the screen stack. This class duplicates
+    ``PersonasTestApp``'s tiny delegating ``__getattr__``/``compose`` instead.
+    """
+
+    _NON_DELEGATED_PREFIXES = (
+        "_",
+        "watch_",
+        "compute_",
+        "validate_",
+        "action_",
+        "key_",
+        "on_",
+    )
+
+    def __init__(self, mock_app_instance, saved_state):
+        super().__init__()
+        self._mock = mock_app_instance
+        self.character_persona_scope_service = (
+            mock_app_instance.character_persona_scope_service
+        )
+        self._saved_state = saved_state
+
+    def __getattr__(self, name):
+        if name.startswith(self._NON_DELEGATED_PREFIXES):
+            raise AttributeError(name)
+        return getattr(self.__dict__["_mock"], name)
+
+    def compose(self):
+        yield AppFooterStatus(id="app-footer-status")
+
+    def on_mount(self) -> None:
+        screen = PersonasScreen(self)
+        screen.restore_state(self._saved_state)
+        self.push_screen(screen)
+
+
+def _seed_preview_turns(screen) -> "PersonasPreviewPane":
+    """Manually seed a greeting + one user/assistant turn in the preview."""
+    pane = screen.query_one(PersonasPreviewPane)
+    return pane
+
+
+class TestWorkbenchSelectionRestore:
+    """AC#1: selection, mode, and center view survive the round-trip."""
+
+    async def test_save_restore_preserves_character_selection_and_center(
+        self, mock_app_instance, stub_characters
+    ):
+        mock_app_instance.chat_dictionary_scope_service = None
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            await screen._select_character("char-1", "Elara")
+            await pilot.pause()
+            assert screen.state.selected_entity_id == "char-1"
+
+            saved = screen.save_state()
+            assert saved["personas_workbench"]["selected_entity_id"] == "char-1"
+            assert saved["personas_workbench"]["selected_entity_kind"] == "character"
+
+        app2 = _RestoringPersonasTestApp(mock_app_instance, saved)
+        async with app2.run_test() as pilot2:
+            screen2 = await _mounted(pilot2)
+            assert screen2.state.selected_entity_id == "char-1"
+            assert screen2.state.selected_entity_kind == "character"
+            assert screen2.state.selected_entity_name == "Elara"
+            # center shows the character card view, not blank
+            assert screen2.query_one("#ccp-character-card-view").display is True
+
+    async def test_fresh_screen_without_saved_state_shows_blank_center(
+        self, mock_app_instance, stub_characters
+    ):
+        """No prior selection: on_mount's default (blank) center is untouched."""
+        mock_app_instance.chat_dictionary_scope_service = None
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            assert screen.state.selected_entity_id is None
+            assert screen.query_one("#ccp-character-card-view").display is False
+
+
+class TestPreviewRestore:
+    """AC#2: the preview conversation (greeting + turns) survives the round-trip."""
+
+    async def test_save_restore_preserves_preview_greeting_and_turns(
+        self, mock_app_instance, stub_characters
+    ):
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            await screen._select_character("char-1", "Elara")
+            await pilot.pause()
+            pane = _seed_preview_turns(screen)
+            await pane.seed_greeting("Greetings, traveller.")
+            pane.append_user("hi")
+            screen.preview.history.append({"role": "user", "content": "hi"})
+            pane.append_reply("well met")
+            screen.preview.history.append(
+                {"role": "assistant", "content": "well met"}
+            )
+
+            saved = screen.save_state()
+            assert saved["personas_preview"]["greeting"] == "Greetings, traveller."
+            assert saved["personas_preview"]["history"] == [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "well met"},
+            ]
+
+        app2 = _RestoringPersonasTestApp(mock_app_instance, saved)
+        async with app2.run_test() as pilot2:
+            screen2 = await _mounted(pilot2)
+            pane2 = screen2.query_one(PersonasPreviewPane)
+            assert pane2.greeting_text == "Greetings, traveller."
+            text = pane2.transcript_text()
+            assert "Greetings, traveller." in text
+            assert "hi" in text
+            assert "well met" in text
+            assert screen2.preview.history == saved["personas_preview"]["history"]
+
+    async def test_late_character_loaded_worker_does_not_erase_restored_turns(
+        self, mock_app_instance, stub_characters
+    ):
+        """The seeded-for guard (personas_preview_controller.py ``:159``):
+
+        a character-load worker's ``CharacterMessage.Loaded`` delivered after
+        the screen already restored a preview transcript must refresh the
+        reset-seed greeting only, never invalidate/erase the restored turns.
+        ``load_character`` is mocked to a no-op by ``stub_characters`` (no
+        real background thread races this), so this test drives
+        ``handle_character_loaded`` directly to simulate the late delivery.
+        """
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            await screen._select_character("char-1", "Elara")
+            await pilot.pause()
+            pane = _seed_preview_turns(screen)
+            await pane.seed_greeting("Greetings, traveller.")
+            pane.append_user("hi")
+            screen.preview.history.append({"role": "user", "content": "hi"})
+            pane.append_reply("well met")
+            screen.preview.history.append(
+                {"role": "assistant", "content": "well met"}
+            )
+            saved = screen.save_state()
+
+        app2 = _RestoringPersonasTestApp(mock_app_instance, saved)
+        async with app2.run_test() as pilot2:
+            screen2 = await _mounted(pilot2)
+            pane2 = screen2.query_one(PersonasPreviewPane)
+            assert screen2.preview.seeded_for == "char-1"
+
+            await screen2.preview.handle_character_loaded(
+                character_id="char-1",
+                card_data={"name": "Elara", "first_message": "Greetings, traveller."},
+            )
+
+            text = pane2.transcript_text()
+            assert "Greetings, traveller." in text
+            assert "hi" in text
+            assert "well met" in text
+            assert screen2.preview.history == saved["personas_preview"]["history"]
+
+
+class TestPendingRestoreGuards:
+    """_apply_pending_restore must degrade gracefully, never crash on_mount."""
+
+    async def test_selection_failure_during_restore_degrades_to_blank_center(
+        self, mock_app_instance, stub_characters, monkeypatch
+    ):
+        """A ``_select_*`` raising for a stale/deleted entity must not crash
+        ``on_mount``; the screen falls back to the blank center instead."""
+        mock_app_instance.chat_dictionary_scope_service = None
+        saved = {
+            "personas_workbench": {
+                "active_mode": "characters",
+                "selected_entity_kind": "character",
+                "selected_entity_id": "char-1",
+                "selected_entity_name": "Elara",
+            },
+            "personas_preview": None,
+        }
+
+        def _boom(self, *args, **kwargs):
+            raise RuntimeError("stale entity")
+
+        monkeypatch.setattr(PersonasScreen, "_select_character", _boom)
+
+        app = _RestoringPersonasTestApp(mock_app_instance, saved)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            # Must not have crashed the app; center stays blank.
+            assert screen.query_one("#ccp-character-card-view").display is False

--- a/Tests/UI/test_personas_workbench_state.py
+++ b/Tests/UI/test_personas_workbench_state.py
@@ -271,7 +271,9 @@ class TestPendingRestoreGuards:
         self, mock_app_instance, stub_characters, monkeypatch
     ):
         """A ``_select_*`` raising for a stale/deleted entity must not crash
-        ``on_mount``; the screen falls back to the blank center instead."""
+        ``on_mount``; the screen falls back to a fully cleared selection (not
+        just a blank center) so ``_console_action_allowed()`` cannot still
+        treat the stale entity as attachable."""
         mock_app_instance.chat_dictionary_scope_service = None
         saved = {
             "personas_workbench": {
@@ -293,6 +295,13 @@ class TestPendingRestoreGuards:
             screen = await _mounted(pilot)
             # Must not have crashed the app; center stays blank.
             assert screen.query_one("#ccp-character-card-view").display is False
+            # The workbench selection itself must degrade to NO selection -
+            # a lingering stale selected_entity_id would keep
+            # _console_action_allowed() (attach/Start-Chat) wrongly enabled
+            # and the inspector showing a stale name/kind.
+            assert screen.state.selected_entity_id is None
+            assert screen.state.selected_entity_kind is None
+            assert screen._console_action_allowed() is False
 
 
 class TestNonCharacterModeRestoreGate:

--- a/Tests/UI/test_personas_workbench_state.py
+++ b/Tests/UI/test_personas_workbench_state.py
@@ -293,3 +293,41 @@ class TestPendingRestoreGuards:
             screen = await _mounted(pilot)
             # Must not have crashed the app; center stays blank.
             assert screen.query_one("#ccp-character-card-view").display is False
+
+
+class TestNonCharacterModeRestoreGate:
+    """A saved non-Characters mode must never be restored (task-434 review).
+
+    ``on_mount`` only unconditionally wires the Characters path; every other
+    mode's library rows and mode-specific widgets (Preview pane, Try-It
+    panes) are refreshed/toggled solely by ``_apply_mode``, which a restore
+    never calls. Reconstructing ``self.state`` for a saved non-Characters
+    mode would therefore restore the mode chip while leaving the library
+    empty and the wrong panes visible - a regression, not a restore. The
+    gate keeps that path on the safe, already-correct default view.
+    """
+
+    async def test_saved_dictionaries_mode_falls_back_to_characters_on_restore(
+        self, mock_app_instance, stub_characters
+    ):
+        mock_app_instance.chat_dictionary_scope_service = None
+        saved = {
+            "personas_workbench": {
+                "active_mode": "dictionaries",
+                "selected_entity_kind": "dictionary",
+                "selected_entity_id": "dict-1",
+                "selected_entity_name": "Some Dictionary",
+            },
+            "personas_preview": None,
+        }
+
+        app = _RestoringPersonasTestApp(mock_app_instance, saved)
+        async with app.run_test() as pilot:
+            screen2 = await _mounted(pilot)
+            # Falls back to the fresh default: Characters mode, no selection.
+            assert screen2.state.active_mode == "characters"
+            assert screen2.state.selected_entity_id is None
+            assert screen2.state.selected_entity_kind is None
+            assert screen2._pending_restore is None
+            # Blank center, same as any fresh Characters-mode mount.
+            assert screen2.query_one("#ccp-character-card-view").display is False

--- a/backlog/tasks/task-434 - Roleplay-workbench-preserves-selection-across-navigation.md
+++ b/backlog/tasks/task-434 - Roleplay-workbench-preserves-selection-across-navigation.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-434
 title: Roleplay workbench preserves selection across navigation
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-21 09:38'
+updated_date: '2026-07-23 15:35'
 labels:
   - roleplay
   - ux
@@ -19,6 +20,22 @@ Filed from the RP/character-card UX review (Docs/superpowers/qa/rp-ux-review-202
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Returning to the Personas screen restores the previously selected item, mode, and center view within a session
-- [ ] #2 Preview conversation contents survive the round-trip (until Reset or selection change)
+- [x] #1 Returning to the Personas screen restores the previously selected item, mode, and center view within a session
+- [x] #2 Preview conversation contents survive the round-trip (until Reset or selection change)
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause: the app never caches screens — navigate-away stores screen.save_state() in app._screen_states, return builds a FRESH PersonasScreen and calls restore_state(). PersonasScreen overrode neither, so the workbench self.state (a PersonasWorkbenchState dataclass) + the preview were lost; on_mount blanked the center.
+
+Fix (full scope AC#1+AC#2, characters mode):
+- Task 1 (primitives): PersonasPreviewPane.greeting_text property (the greeting is stored in the pane, NOT in controller.history) + PersonasPreviewController.restore_conversation(greeting, history, seeded_for) which sets seeded_for BEFORE its first await so the still-pending character-load worker's handle_character_loaded guard (:159) preserves rather than erases the restored turns.
+- Task 2 (screen): save_state captures asdict(self.state) + preview {greeting, history, seeded_for}; restore_state (runs pre-mount) rebuilds PersonasWorkbenchState filtered to known dataclass fields; deferred _apply_pending_restore at the end of on_mount re-applies the selection via the existing _select_* flow (guarded so a stale/deleted entity degrades to blank center); _select_character gains a restore_preview branch that calls restore_conversation instead of reset_for_character (mutual exclusion — reset_for_character's invalidate() would wipe the restored turns).
+
+SCOPE (whole-branch review Finding 1): restoration is GATED to active_mode=='characters'. Non-character modes (dictionaries/lore/personas) fall back to today's default characters view, because their row-render + mode-widget-visibility live only in _apply_mode which restore doesn't call — restoring them naively left an empty list + mis-toggled Preview/Try-It widgets. So AC#1 (selection/mode/center) + AC#2 (preview greeting+turns survive) are fully met for CHARACTERS mode — the task's driver and the review scenario. Full non-character-mode restore filed as follow-up TASK-488.
+
+Verification: full SDD (per-task implement + review, whole-branch opus review). seeded_for-first ordering mutation-verified; AC#1/AC#2/stale mutation-verified non-vacuous; async race doubly-safe (seeded_for-first belt + same-Screen-message-pump serialization). 6 state tests + 320 personas regression pass. Minors kept: dead saved seeded_for field (entity_id is authoritative), no corrupt-value validation on restore (same tolerance as pre-existing, in-memory same-session only).
+
+Files: personas_preview_pane.py, personas_preview_controller.py, personas_screen.py, Tests/UI/test_personas_preview.py, test_personas_preview_restore.py, test_personas_workbench_state.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-488 - Restore-non-character-workbench-modes-dictionaries-lore-personas-across-navigation.md
+++ b/backlog/tasks/task-488 - Restore-non-character-workbench-modes-dictionaries-lore-personas-across-navigation.md
@@ -1,0 +1,25 @@
+---
+id: TASK-488
+title: >-
+  Restore non-character workbench modes (dictionaries/lore/personas) across
+  navigation
+status: To Do
+assignee: []
+created_date: '2026-07-23 15:30'
+labels:
+  - roleplay
+  - ux
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up from TASK-434. TASK-434 restores the Personas workbench selection + preview across a navigation round-trip, but only for CHARACTERS mode; restore is gated to characters because the row-render + mode-widget-visibility (PreviewPane.display, Try-It .display, _render_dictionary_rows/_render_lore_rows/_refresh_profile_rows_worker) live only in _apply_mode, which the restore path does not call. Non-character modes therefore fall back to the default characters view on return. Extend restoration so dictionaries/lore/personas modes restore their mode, list, selection, and center too — via a light 'render current mode's list + sync widget visibility' helper that does NOT switch_mode (which would reset sort/tag/page/selection).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Returning to Personas after a dictionaries/lore/personas round-trip restores that mode with a populated list, the prior selection, correct center pane, and correct Preview/Try-It widget visibility
+<!-- AC:END -->

--- a/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
+++ b/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
@@ -97,7 +97,7 @@ class PersonasPreviewController:
         Sets ``seeded_for`` before the first ``await``: ``invalidate`` cancels
         only the preview worker group, so the character-load worker's
         ``handle_character_loaded`` may still fire -- and must hit the
-        seeded-for guard (``:133``) rather than erase the restored turns.
+        seeded-for guard (``:159``) rather than erase the restored turns.
         """
         self.invalidate()
         self.seeded_for = str(seeded_for) if seeded_for else None

--- a/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
+++ b/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
@@ -90,7 +90,7 @@ class PersonasPreviewController:
         await self.reset(greeting, seeded_for=character_id)
 
     async def restore_conversation(
-        self, *, greeting: str, history: list[dict], seeded_for
+        self, *, greeting: str, history: list[dict], seeded_for: str | None
     ) -> None:
         """Rebuild the preview (greeting + turns) from saved state (task-434).
 
@@ -98,6 +98,15 @@ class PersonasPreviewController:
         only the preview worker group, so the character-load worker's
         ``handle_character_loaded`` may still fire -- and must hit the
         seeded-for guard (``:159``) rather than erase the restored turns.
+
+        Args:
+            greeting: Saved greeting text to reseed the preview pane with.
+            history: Saved user/assistant turns to replay into the pane.
+            seeded_for: Entity id the saved preview was seeded for, normalized
+                to ``str(seeded_for)`` (or ``None`` if falsy).
+
+        Returns:
+            None.
         """
         self.invalidate()
         self.seeded_for = str(seeded_for) if seeded_for else None

--- a/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
+++ b/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
@@ -89,6 +89,32 @@ class PersonasPreviewController:
         )
         await self.reset(greeting, seeded_for=character_id)
 
+    async def restore_conversation(
+        self, *, greeting: str, history: list[dict], seeded_for
+    ) -> None:
+        """Rebuild the preview (greeting + turns) from saved state (task-434).
+
+        Sets ``seeded_for`` before the first ``await``: ``invalidate`` cancels
+        only the preview worker group, so the character-load worker's
+        ``handle_character_loaded`` may still fire -- and must hit the
+        seeded-for guard (``:133``) rather than erase the restored turns.
+        """
+        self.invalidate()
+        self.seeded_for = str(seeded_for) if seeded_for else None
+        try:
+            pane = self.screen.query_one(PersonasPreviewPane)
+        except QueryError:
+            return
+        await pane.seed_greeting(greeting)
+        for message in history:
+            role = message.get("role")
+            content = str(message.get("content") or "")
+            if role == "user":
+                pane.append_user(content)
+            elif role == "assistant":
+                pane.append_reply(content)
+        self.history = [dict(m) for m in history]
+
     async def close_gateway(self) -> None:
         """Release the preview gateway's HTTP client if it was created."""
         gateway = self.gateway

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import json
 import re
 from datetime import datetime
@@ -513,6 +514,10 @@ class PersonasScreen(BaseAppScreen):
     def __init__(self, app_instance: Any, **kwargs: Any) -> None:
         super().__init__(app_instance, "personas", **kwargs)
         self.state = PersonasWorkbenchState()
+        # A selection + preview snapshot captured by save_state() before a
+        # navigation round-trip (task-434); consumed once by
+        # _apply_pending_restore() at the end of on_mount.
+        self._pending_restore: dict | None = None
         self._edit_mode: str = "view"
         self._guard_active: bool = False
         # Refuse-reentry flag for the import/export file dialogs. Cancelling
@@ -701,6 +706,89 @@ class PersonasScreen(BaseAppScreen):
                     inspector_handle.display = False
                 yield inspector_handle
 
+    # ===== State persistence (task-434) =====
+    #
+    # A Personas -> Console -> back round-trip pushes/pops this screen, and
+    # ``BaseAppScreen``'s default save_state/restore_state only round-trips
+    # ``self.state_data`` (empty for this screen). Capture the workbench
+    # selection (``PersonasWorkbenchState``) and the ephemeral preview
+    # (greeting + turns, which live outside ``self.state``) so both survive.
+
+    def save_state(self) -> dict:
+        """Snapshot the workbench selection and preview for a later restore."""
+        state = dict(super().save_state() or {})
+        state["personas_workbench"] = dataclasses.asdict(self.state)
+        preview = getattr(self, "preview", None)
+        if preview is not None:
+            greeting = ""
+            try:
+                greeting = self.query_one(PersonasPreviewPane).greeting_text
+            except QueryError:
+                # Tolerate a save requested before/around the pane's lifetime.
+                pass
+            state["personas_preview"] = {
+                "greeting": greeting,
+                "history": [dict(m) for m in preview.history],
+                "seeded_for": preview.seeded_for,
+            }
+        return state
+
+    def restore_state(self, state: dict) -> None:
+        """Seed ``self.state`` and stash the deferred re-selection payload.
+
+        Runs before this (fresh) screen mounts, so it only seeds state here;
+        the actual re-selection is applied by ``_apply_pending_restore`` once
+        the screen (and its widgets) exist.
+        """
+        super().restore_state(state)
+        if not isinstance(state, dict):
+            self._pending_restore = None
+            return
+        wb = state.get("personas_workbench")
+        if isinstance(wb, dict):
+            names = {f.name for f in dataclasses.fields(PersonasWorkbenchState)}
+            self.state = PersonasWorkbenchState(
+                **{k: v for k, v in wb.items() if k in names}
+            )
+        self._pending_restore = (
+            {
+                "kind": self.state.selected_entity_kind,
+                "id": self.state.selected_entity_id,
+                "name": self.state.selected_entity_name,
+                "preview": state.get("personas_preview"),
+            }
+            if self.state.selected_entity_id
+            else None
+        )
+
+    async def _apply_pending_restore(self) -> None:
+        """Re-apply a selection saved before a navigation round-trip (task-434)."""
+        pending = getattr(self, "_pending_restore", None)
+        self._pending_restore = None
+        if not pending or not pending.get("id"):
+            return
+        kind = pending.get("kind")
+        entity_id = str(pending["id"])
+        name = str(pending.get("name") or "")
+        try:
+            if kind == "character":
+                await self._select_character(
+                    entity_id, name, restore_preview=pending.get("preview")
+                )
+            elif kind == "persona_profile":
+                await self._select_profile(entity_id, name)
+            elif kind == "dictionary":
+                await self._select_dictionary(entity_id, name)
+            elif kind == "lore":
+                await self._select_lore_entry(entity_id, name)
+        except Exception:
+            # A stale/deleted entity must degrade to the blank center, not crash.
+            logger.opt(exception=True).warning(
+                f"Could not restore Personas selection {kind}/{entity_id}; "
+                "showing blank center."
+            )
+            self._show_center(None)
+
     async def on_mount(self) -> None:
         super().on_mount()
         loading_manager = getattr(self, "loading_manager", None)
@@ -714,6 +802,7 @@ class PersonasScreen(BaseAppScreen):
         self._show_center(None)
         await self.character_handler.refresh_character_list()
         self._sync_title_and_console_actions()
+        await self._apply_pending_restore()
 
     async def on_unmount(self) -> None:
         super().on_unmount()
@@ -1635,7 +1724,9 @@ class PersonasScreen(BaseAppScreen):
         # Prompts are not wired here: prompt management is retired from
         # Personas and lives entirely inside Library (Task 7).
 
-    async def _select_character(self, entity_id: str, entity_name: str) -> None:
+    async def _select_character(
+        self, entity_id: str, entity_name: str, *, restore_preview: dict | None = None
+    ) -> None:
         self.state.select_entity(
             entity_kind="character",
             entity_id=entity_id,
@@ -1656,18 +1747,28 @@ class PersonasScreen(BaseAppScreen):
         self.conversations.reset()
         await inspector.show_conversations_loading()
         self.conversations.load_conversations(entity_id)
-        # Seed the ephemeral preview with the character's greeting. The list
-        # rows are id/name-only summaries and load_character only SCHEDULES a
-        # thread worker, so the full record (with first_message) is usually
-        # not available yet here. Instant path: when the handler already holds
-        # this character's full card (re-selection), seed now; otherwise clear
-        # the preview and let the CharacterMessage.Loaded handler seed it.
-        record = self._full_character_record(entity_id)
-        await self.preview.reset_for_character(
-            character_id=entity_id,
-            character_name=entity_name,
-            record=record,
-        )
+        if restore_preview is not None:
+            # A navigation round-trip (task-434): rebuild the saved preview
+            # transcript instead of reseeding just the greeting.
+            await self.preview.restore_conversation(
+                greeting=str(restore_preview.get("greeting") or ""),
+                history=list(restore_preview.get("history") or []),
+                seeded_for=entity_id,
+            )
+        else:
+            # Seed the ephemeral preview with the character's greeting. The
+            # list rows are id/name-only summaries and load_character only
+            # SCHEDULES a thread worker, so the full record (with
+            # first_message) is usually not available yet here. Instant
+            # path: when the handler already holds this character's full
+            # card (re-selection), seed now; otherwise clear the preview and
+            # let the CharacterMessage.Loaded handler seed it.
+            record = self._full_character_record(entity_id)
+            await self.preview.reset_for_character(
+                character_id=entity_id,
+                character_name=entity_name,
+                record=record,
+            )
         await self._refresh_character_dictionaries()
         await self._refresh_character_worldbooks()
 

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -796,12 +796,21 @@ class PersonasScreen(BaseAppScreen):
             elif kind == "lore":
                 await self._select_lore_entry(entity_id, name)
         except Exception:
-            # A stale/deleted entity must degrade to the blank center, not crash.
+            # A stale/deleted entity must degrade to a fully cleared selection,
+            # not just a blank center: leaving self.state's selection populated
+            # would let _console_action_allowed() keep attach/Start-Chat wrongly
+            # enabled and the inspector showing a stale selection.
             logger.opt(exception=True).warning(
                 f"Could not restore Personas selection {kind}/{entity_id}; "
-                "showing blank center."
+                "clearing selection."
             )
+            self.state.clear_selection()
+            try:
+                await self.query_one(PersonasInspectorPane).clear_selection()
+            except QueryError:
+                pass
             self._show_center(None)
+            self._sync_title_and_console_actions()
 
     async def on_mount(self) -> None:
         super().on_mount()

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -739,27 +739,41 @@ class PersonasScreen(BaseAppScreen):
         Runs before this (fresh) screen mounts, so it only seeds state here;
         the actual re-selection is applied by ``_apply_pending_restore`` once
         the screen (and its widgets) exist.
+
+        Gated to Characters mode: ``on_mount`` only unconditionally wires the
+        Characters path (character list refresh, center-view routing) -
+        every other mode's library rows and mode-specific widgets (the
+        Preview pane, the Dictionary/Lore Try-It panes) are only refreshed
+        and toggled by ``_apply_mode``, which a restore never calls.
+        Reconstructing ``self.state`` for a saved non-Characters mode here
+        would restore the mode chip while leaving the library empty and the
+        wrong panes visible/hidden - a regression, not a restore. So a
+        non-Characters round-trip is left at the fresh ``__init__`` default
+        (Characters, no selection) instead; restoring the other modes in
+        full is a filed follow-up.
         """
         super().restore_state(state)
         if not isinstance(state, dict):
             self._pending_restore = None
             return
         wb = state.get("personas_workbench")
-        if isinstance(wb, dict):
+        if isinstance(wb, dict) and wb.get("active_mode") == "characters":
             names = {f.name for f in dataclasses.fields(PersonasWorkbenchState)}
             self.state = PersonasWorkbenchState(
                 **{k: v for k, v in wb.items() if k in names}
             )
-        self._pending_restore = (
-            {
-                "kind": self.state.selected_entity_kind,
-                "id": self.state.selected_entity_id,
-                "name": self.state.selected_entity_name,
-                "preview": state.get("personas_preview"),
-            }
-            if self.state.selected_entity_id
-            else None
-        )
+            self._pending_restore = (
+                {
+                    "kind": self.state.selected_entity_kind,
+                    "id": self.state.selected_entity_id,
+                    "name": self.state.selected_entity_name,
+                    "preview": state.get("personas_preview"),
+                }
+                if self.state.selected_entity_id
+                else None
+            )
+        else:
+            self._pending_restore = None
 
     async def _apply_pending_restore(self) -> None:
         """Re-apply a selection saved before a navigation round-trip (task-434)."""

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py
@@ -145,6 +145,11 @@ class PersonasPreviewPane(Vertical):
         """
         self._greeting = str(text or "")
 
+    @property
+    def greeting_text(self) -> str:
+        """The greeting a Reset restores (transcript line 0), for state capture."""
+        return self._greeting
+
     def append_user(self, text: str) -> None:
         """Append a "you: ..." transcript line."""
         self._append_line(f"you: {text}", "personas-preview-line-you")


### PR DESCRIPTION
## Summary

Fixes the RP-review bug where the Personas workbench resets to "Selected: none" (blank center, "Console blocked", collapsed preview) after every Personas → Console → back round-trip — dropping the working context the workbench↔Console loop encourages.

**Root cause:** the app never caches screens; it stores `screen.save_state()` on navigate-away and calls `restore_state()` on a *fresh* `PersonasScreen` on return. `PersonasScreen` overrode neither, so the workbench `self.state` (a `PersonasWorkbenchState` dataclass) and the preview were lost.

## Changes

- **Preview primitives:** `PersonasPreviewPane.greeting_text` (the greeting lives in the pane, **not** in `controller.history`) + `PersonasPreviewController.restore_conversation(greeting, history, seeded_for)`, which sets `seeded_for` **before its first `await`** so the still-pending character-load worker's `handle_character_loaded` guard *preserves* the restored turns instead of erasing them.
- **Screen persistence:** `PersonasScreen.save_state`/`restore_state` capture the workbench dataclass + preview `{greeting, history, seeded_for}`; a deferred `_apply_pending_restore` at the end of `on_mount` re-applies the selection via the existing `_select_*` flow (guarded so a stale/deleted entity degrades to a blank center); `_select_character` gains a `restore_preview` branch (mutually exclusive with `reset_for_character`, whose `invalidate()` would wipe the restored turns).

So a character round-trip restores the selected item, mode, center pane **and** the preview conversation (greeting + turns) — AC#1 + AC#2.

## Scope

Restoration is **gated to `characters` mode** (the task's driver and the review scenario). A whole-branch review found that restoring non-character modes (dictionaries/lore/personas) naively would leave an empty list + mis-toggled Preview/Try-It widgets, because their row-render + widget-visibility live only in `_apply_mode` (which restore doesn't call). Non-character modes therefore fall back to today's clean default view — no regression, no broken view. **Full non-character-mode restore is filed as TASK-488.**

## Testing

- Preview primitives: `greeting_text` + `restore_conversation` (seeded-for-first ordering **mutation-verified**).
- Full-screen round-trip: AC#1 selection/center restore, AC#2 greeting+turns survive, the async-worker guard (drives `handle_character_loaded` directly), stale-entity degrade, and the non-character-mode gate — all RED→GREEN, mutation-verified non-vacuous.
- 320 Personas regression tests pass.

SDD-executed (per-task implement + spec/quality review; whole-branch opus review → one Medium finding fixed + follow-up filed).

Closes TASK-434.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Personas workbench losing its selection and preview when navigating to Console and back by persisting the workbench state and preview transcript. Implements TASK-434 for Characters mode so your context survives within a session.

- **Bug Fixes**
  - `PersonasScreen.save_state`/`restore_state` now snapshot `PersonasWorkbenchState` and preview `{greeting, history, seeded_for}`; the selection is re-applied after mount.
  - Added `PersonasPreviewPane.greeting_text` and `PersonasPreviewController.restore_conversation()` to rebuild greeting + turns; `seeded_for` is set before the first await to prevent late character-load from erasing turns.
  - `_select_character` accepts a `restore_preview` path to rebuild the transcript instead of resetting it.
  - On failed restore (stale/deleted entity), the selection is fully cleared and the center is blanked to avoid stale console actions.
  - Restore is gated to Characters mode; other modes return to the default view (follow-up in TASK-488).
  - Tests cover preview restore, round-trip, late worker race, stale-entity handling, and the non-character-mode gate.

<sup>Written for commit 25355ac18da4648754ede6c297620906776fa4bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

