### PR TITLE
feat(nav): one public name for the Roleplay destination — RP&CD (task-435)

### DIFF
--- a/Docs/superpowers/plans/2026-07-23-rpcd-naming.md
+++ b/Docs/superpowers/plans/2026-07-23-rpcd-naming.md
@@ -1,0 +1,137 @@
+# TASK-435 RP&CD naming — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the Roleplay/Personas destination one public name — **"RP&CD"** (rail) / **"Roleplay & Chat Dictionaries"** (full) — reserving **"Personas"** for the in-screen user-identity mode, with all legacy routes still resolving.
+
+**Architecture:** Pure copy/label change across the destination's user-visible name surfaces (shell destination label + full_label, tab display labels, screen header, two tab tooltips) plus one new `"roleplay"` route alias. No internal id/route/class renames.
+
+**Tech Stack:** Python 3.11+, Textual, pytest.
+
+## Global Constraints
+
+- Destination display name: rail `"RP&CD"`, full `"Roleplay & Chat Dictionaries"`. The in-screen **mode** stays `"Personas"` (do NOT change `MODE_LABELS`).
+- Internal `destination_id`/`primary_route`/`TAB_*` id constants and all file/class/module names stay `"personas"`/unchanged.
+- `"personas"` must still resolve as a route and remain palette-searchable (it already does via `primary_route`/`destination_id` — do not add it to `legacy_routes`). Add only `"roleplay"` to `legacy_routes`.
+- `Tests/` and `tests/` are byte-identical dupes — edit whichever the build treats as source and keep both consistent (verify with a diff after).
+
+---
+
+### Task 1: Rename the destination across all name surfaces + add the `roleplay` alias
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Navigation/shell_destinations.py` (the `personas` `ShellDestination`)
+- Modify: `tldw_chatbook/Constants.py` (`TAB_DISPLAY_LABELS[TAB_CCP]`, `[TAB_PERSONAS]`)
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py` (header `title`, ~line 584)
+- Modify: `tldw_chatbook/app.py` (tab tooltips for `TAB_PERSONAS` ~:704 and `TAB_CCP` ~:712)
+- Test: `Tests/UI/test_shell_destinations.py`, `Tests/UI/test_command_palette_shell_routes.py`, `Tests/UI/test_command_palette_providers.py` (update expectations)
+
+**Interfaces:**
+- Produces: `get_shell_destination("personas").label == "RP&CD"`, `.full_label == .accessible_label == "Roleplay & Chat Dictionaries"`, and `resolve_shell_route("roleplay").destination_id == "personas"`.
+
+- [ ] **Step 1: Write/adjust the failing tests**
+
+Update the destination + palette assertions to the new names, and add the `roleplay` alias + `"&"` render assertions. In `Tests/UI/test_shell_destinations.py` (the block asserting the `personas` destination, ~line 14):
+```python
+    dest = get_shell_destination("personas")
+    assert dest.label == "RP&CD"
+    assert dest.full_label == "Roleplay & Chat Dictionaries"
+    assert dest.accessible_label == "Roleplay & Chat Dictionaries"
+    assert "roleplay" in dest.legacy_routes
+    for route in ("personas", "ccp", "conversations_characters_prompts", "characters", "roleplay"):
+        assert resolve_shell_route(route).destination_id == "personas"
+```
+(Adapt to the file's existing style/imports — it already imports these helpers. If the existing assertion literally checks `"Personas"`, replace that literal.)
+
+In `Tests/UI/test_command_palette_shell_routes.py` (~line 95), replace the `"Personas"` label assertion:
+```python
+    assert {"ccp", "conversations_characters_prompts", "characters", "roleplay"} <= alias_terms["personas"]
+    assert "RP&CD" in alias_terms["personas"]
+    assert "Roleplay & Chat Dictionaries" in alias_terms["personas"]
+    assert "personas" in alias_terms["personas"]   # still searchable via id/primary_route
+```
+
+In `Tests/UI/test_command_palette_providers.py` (~line 356), change the expected label literal `"Personas"` → `"RP&CD"` (match whatever that assertion targets — the tab display label / command title).
+
+Add a `TAB_DISPLAY_LABELS` assertion (in `test_shell_destinations.py` or the providers test):
+```python
+    from tldw_chatbook.Constants import get_tab_display_label, TAB_CCP, TAB_PERSONAS
+    assert get_tab_display_label(TAB_CCP) == "RP&CD"
+    assert get_tab_display_label(TAB_PERSONAS) == "RP&CD"
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+Run: `python -m pytest Tests/UI/test_shell_destinations.py Tests/UI/test_command_palette_shell_routes.py Tests/UI/test_command_palette_providers.py -q`
+Expected: FAIL (assertions still see `"Personas"`, no `roleplay` alias).
+
+- [ ] **Step 3: Rename the shell destination** (`shell_destinations.py`)
+
+In the `personas` `ShellDestination`, change `label` `"Personas"` → `"RP&CD"`, add `full_label="Roleplay & Chat Dictionaries"`, and append `"roleplay"` to `legacy_routes`:
+```python
+    ShellDestination(
+        "personas",
+        "RP&CD",
+        "personas",
+        "Characters, personas, dictionaries, and behavior profiles.",
+        "Manage behavior profiles and persona context.",
+        ("ccp", "conversations_characters_prompts", "characters", "roleplay"),
+        full_label="Roleplay & Chat Dictionaries",
+    ),
+```
+
+- [ ] **Step 4: Rename the tab display labels** (`Constants.py`, `TAB_DISPLAY_LABELS`)
+
+`TAB_CCP: "Personas"` → `TAB_CCP: "RP&CD"` and `TAB_PERSONAS: "Personas"` → `TAB_PERSONAS: "RP&CD"`.
+
+- [ ] **Step 5: Rename the screen header** (`personas_screen.py`, ~line 584)
+
+`title="Roleplay"` → `title="Roleplay & Chat Dictionaries"`.
+
+- [ ] **Step 6: Rename the two tab tooltips** (`app.py`, ~:704 and ~:712)
+
+- `TAB_PERSONAS`: `"Open Personas for characters, prompts, dictionaries, and behavior profiles"` → `"Open Roleplay & Chat Dictionaries for characters, personas, dictionaries, and behavior profiles"`.
+- `TAB_CCP`: `"Switch to Personas for characters, personas, prompts, dictionaries, and world books"` → `"Switch to Roleplay & Chat Dictionaries for characters, personas, dictionaries, and world books"`.
+(The retired "prompts" is dropped while editing these strings.)
+
+- [ ] **Step 7: Run the tests to confirm they pass**
+
+Run: `python -m pytest Tests/UI/test_shell_destinations.py Tests/UI/test_command_palette_shell_routes.py Tests/UI/test_command_palette_providers.py -q`
+Expected: PASS.
+
+- [ ] **Step 8: Grep for any remaining user-visible "Personas" destination string + confirm the mode/internal ones are intentionally kept**
+
+Run:
+```bash
+grep -rn '"Personas"' tldw_chatbook/ | grep -vE 'MODE_LABELS|personas_state'
+grep -rn "Switch to Personas\|Open Personas\|to Personas\b" tldw_chatbook/
+```
+Expected: the only remaining `"Personas"` literals are `MODE_LABELS["personas"] = "Personas"` (the mode — intentional) and internal identifiers/docstrings (not user-visible). No stray destination tooltip/label/help string left saying "Personas". If a NEW user-visible destination string surfaces, rename it too and note it.
+
+- [ ] **Step 9: Regression — the mode chip stays "Personas" + broad label/nav suite**
+
+Run:
+```bash
+python -m pytest Tests/UI/test_destination_visual_parity_correction.py Tests/UI/test_shell_destinations.py Tests/UI/test_command_palette_shell_routes.py Tests/UI/test_command_palette_providers.py Tests/UI/test_screen_navigation.py -q
+```
+Expected: PASS. In particular `test_destination_visual_parity_correction.py` must still expect the `"Personas"` **mode** button (it is unchanged) — if that test breaks, you changed the mode label by mistake; revert `MODE_LABELS`.
+
+- [ ] **Step 10: Verify `Tests/` vs `tests/` consistency**
+
+Run: `for f in test_shell_destinations test_command_palette_shell_routes test_command_palette_providers; do diff Tests/UI/$f.py tests/UI/$f.py >/dev/null 2>&1 && echo "$f: in sync" || echo "$f: DIFFERS — sync it"; done`
+If they differ, apply the same edits to the other copy (or confirm only one is collected). Keep them consistent.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add tldw_chatbook/UI/Navigation/shell_destinations.py tldw_chatbook/Constants.py tldw_chatbook/UI/Screens/personas_screen.py tldw_chatbook/app.py Tests/UI/ tests/UI/
+git commit -m "feat(nav): rename destination to RP&CD / Roleplay & Chat Dictionaries (task-435)"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** AC#1 (nav label, header, mode names mutually consistent, one meaning each) → Steps 3/4/5 (rail `RP&CD` + header full name; mode `Personas` untouched). AC#2 (legacy aliases route) → Step 3 keeps `primary_route="personas"` + ccp/…/characters and adds `roleplay`; Step 1 asserts all resolve. Both covered.
+- **Placeholder scan:** the `~line NNN` references are approximate anchors; each edit names the exact literal string to change, so no ambiguity. The only judgement call is matching the existing test assertions' shape — the source files are named.
+- **Type/name consistency:** `"RP&CD"` and `"Roleplay & Chat Dictionaries"` used identically across shell label/full_label, tab labels, header, and tests; `"roleplay"` added once to `legacy_routes`; `MODE_LABELS` and internal ids deliberately unchanged.

--- a/Docs/superpowers/specs/2026-07-23-rpcd-naming-design.md
+++ b/Docs/superpowers/specs/2026-07-23-rpcd-naming-design.md
@@ -1,0 +1,87 @@
+# TASK-435 — Resolve the Personas/Roleplay naming split → "RP&CD"
+
+- **Date:** 2026-07-23
+- **Task:** TASK-435 (RP/character-card UX review). One public name per meaning.
+- **Branch base:** origin/dev (tip `0f5904e6b`).
+
+## Problem
+
+The destination has three overlapping names: the nav label says **"Personas"**, the screen header says **"Roleplay"**, and an in-screen **mode** is also **"Personas"** (user identity). A user hunting "character chat" must guess, and "Personas" means something different at each level.
+
+## Resolution (user-chosen)
+
+The destination's public name is **"RP&CD"** (abbreviation) / **"Roleplay & Chat Dictionaries"** (full). **"Personas"** is reserved for the in-screen user-identity mode.
+
+- Cramped nav rail shows the abbreviation **"RP&CD"** (matching the other one-word tab labels).
+- The full name **"Roleplay & Chat Dictionaries"** appears where there is room: the screen header, the command-palette command, and tooltips.
+- These are the abbreviated and full forms of **one** name, so nav ⇔ header are mutually consistent (AC#1); "Personas" now means only the mode.
+
+## The naming surfaces (all user-visible destination names)
+
+1. `tldw_chatbook/UI/Navigation/shell_destinations.py` — the `personas` `ShellDestination` `label="Personas"` (nav rail via `destination.label`, `main_navigation.py:176`).
+2. `tldw_chatbook/Constants.py` — `TAB_DISPLAY_LABELS[TAB_CCP]` and `[TAB_PERSONAS]` = `"Personas"`.
+3. `tldw_chatbook/UI/Screens/personas_screen.py:584` — `DestinationHeader(title="Roleplay", ...)`.
+4. `tldw_chatbook/app.py` — the tab tooltip map: `TAB_PERSONAS` (`:704`, "Open Personas for …") and `TAB_CCP` (`:712`, "Switch to Personas for …"). **Both** name the destination "Personas".
+5. `tldw_chatbook/Widgets/Persona_Widgets/personas_state.py:25-30` — `MODE_LABELS["personas"] = "Personas"` (the mode — **unchanged**, its reserved meaning).
+
+## Design
+
+### 1. `shell_destinations.py` — the destination
+```python
+ShellDestination(
+    "personas",                       # destination_id — internal, UNCHANGED
+    "RP&CD",                          # label  (was "Personas")  → nav rail
+    "personas",                       # primary_route — internal, UNCHANGED
+    "Characters, personas, dictionaries, and behavior profiles.",   # purpose (unchanged)
+    "Manage behavior profiles and persona context.",                # tooltip (unchanged)
+    ("ccp", "conversations_characters_prompts", "characters", "roleplay"),  # legacy_routes += "roleplay"
+    full_label="Roleplay & Chat Dictionaries",   # NEW → accessible_label / palette / display
+),
+```
+- `accessible_label` (`= full_label or label`, `shell_destinations.py:21`) now returns "Roleplay & Chat Dictionaries" → the palette command reads "Open Roleplay & Chat Dictionaries for …".
+- `legacy_routes` gains **only** `"roleplay"` so the new public name resolves as a route (`resolve_shell_route("roleplay")` → `personas`) and is a palette search term. `get_tab_display_label("roleplay")` safely returns the title-cased fallback `"Roleplay"` (`Constants.py:105-107`, `.get(tab_id, tab_id.replace("_"," ").title())` — no raise for a non-tab route).
+- **"personas" needs no addition:** `_destination_alias_terms` (`app.py:796-808`) already seeds the term set with `destination.destination_id` **and** `destination.primary_route` — both `"personas"` — so `"personas"` remains both routable (primary route) and palette-searchable without touching `legacy_routes`. (This is what previously supplied the capitalized `"Personas"` term — the destination `label`; after the rename the lowercase `"personas"` term persists via id/primary_route while the label term becomes `"RP&CD"`.)
+
+### 2. `Constants.py` — tab display labels
+`TAB_DISPLAY_LABELS[TAB_CCP]` and `[TAB_PERSONAS]`: `"Personas"` → `"RP&CD"`.
+
+### 3. `personas_screen.py:584` — header
+`title="Roleplay"` → `title="Roleplay & Chat Dictionaries"`. (Header title is a single-line `height:1` Static, `_workbench.tcss:28`; a longer title clips gracefully on very narrow terminals — no wrap/layout break.)
+
+### 4. `app.py` — tab tooltips (704, 712)
+Rename the destination in both, and drop the retired "prompts" (Task 7) while editing:
+- `TAB_PERSONAS`: `"Open Personas for characters, prompts, dictionaries, and behavior profiles"` → `"Open Roleplay & Chat Dictionaries for characters, personas, dictionaries, and behavior profiles"`.
+- `TAB_CCP`: `"Switch to Personas for characters, personas, prompts, dictionaries, and world books"` → `"Switch to Roleplay & Chat Dictionaries for characters, personas, dictionaries, and world books"`.
+
+### 5. Mode label — unchanged
+`MODE_LABELS["personas"] = "Personas"` stays. This is now the single meaning of "Personas".
+
+### Not changed (non-goals)
+- `destination_id`/`primary_route` = `"personas"`, and all `TAB_*` id constants — internal ids, not display names.
+- No file/class/module renames (`personas_screen.py`, `PersonasScreen`, `CCP_Modules/*` docstrings, etc.).
+- The mode name and the `purpose`/`tooltip` content strings that legitimately describe contents (they mention lowercase "personas"/"dictionaries" — the modes/content, which is correct).
+
+## Testing
+
+Update the label/tooltip-asserting tests and add discoverability + rendering assertions:
+- `Tests/UI/test_shell_destinations.py` (~:14): the `personas` destination `label` is `"RP&CD"`, `full_label`/`accessible_label` is `"Roleplay & Chat Dictionaries"`; `legacy_routes` includes `roleplay` (and the pre-existing ccp/conversations_characters_prompts/characters). `resolve_shell_route("personas")`, `("ccp")`, `("roleplay")`, `("characters")` all resolve to destination `personas` (AC#2 — `"personas"` still resolves via primary_route).
+- `Tests/UI/test_command_palette_shell_routes.py` (~:95): the existing `assert "Personas" in alias_terms["personas"]` becomes `assert "RP&CD" in alias_terms["personas"]` and `assert "Roleplay & Chat Dictionaries" in alias_terms["personas"]`; keep `{"ccp","conversations_characters_prompts","characters"} <= alias_terms["personas"]` and add `roleplay`; assert `"personas"` itself is still a term (via destination_id/primary_route). Assert the `"&"` survives literally in the `"RP&CD"` term (renders, not mangled).
+- `Tests/UI/test_command_palette_providers.py` (~:356): update the expected label from `"Personas"` to `"RP&CD"` (or the accessible label, whichever the assertion targets).
+- `TAB_DISPLAY_LABELS`: assert `get_tab_display_label(TAB_CCP) == get_tab_display_label(TAB_PERSONAS) == "RP&CD"`.
+- The `test_destination_visual_parity_correction.py:1104` `"Personas"` button is the **mode chip** (Characters/Personas/Dictionaries/Lore) — must stay `"Personas"`; confirm it is untouched.
+- Live/pilot check: the nav rail button renders `"RP&CD"` literally (the `"&"` is not a Rich-markup metacharacter, so no escaping is needed — assert it appears).
+
+`Tests`/`tests` are byte-identical dupes in this repo — edit whichever the build treats as source and keep them consistent (verify).
+
+## Risks / mitigations
+
+- **`"&"` rendering:** Rich markup only treats `[`/`]` specially, so `"&"` renders literally in the nav button, header, and palette; a rendering assertion pins it.
+- **New `"roleplay"` legacy route:** registers `_ROUTE_MAP["roleplay"] → personas`; `get_tab_display_label("roleplay")` returns the safe title-cased fallback `"Roleplay"`. `"personas"` is left out of `legacy_routes` (already routes via primary_route + is already a search term via destination_id) — no redundant/odd registration.
+- **Header clipping on very narrow terminals:** single-line `height:1` clip, no layout break; the abbreviation "RP&CD" already covers the cramped nav rail.
+- **`Tests`/`tests` duplication:** update both / the build source; keep consistent.
+
+## Non-goals
+
+- Renaming the internal `destination_id`, route keys, `TAB_*` constants, files, classes, or the `CCP_Modules` package.
+- Changing the mode name or the modes list.
+- A broader copy pass on the screen (that is TASK-444's remit).

--- a/Tests/UI/test_chat_first_run_orientation.py
+++ b/Tests/UI/test_chat_first_run_orientation.py
@@ -159,6 +159,6 @@ async def test_chat_tab_first_run_exposes_readiness_and_context_sources(
         assert "No messages yet. Send a prompt or attach context." in text
         assert "Provider setup required before sending." in text
         assert (
-            "Context lanes: Library, Search/RAG, Artifacts, Personas, Skills." in text
+            "Context lanes: Library, Search/RAG, Artifacts, RP&CD, Skills." in text
         )
         assert "Chat is the" not in text

--- a/Tests/UI/test_command_palette_providers.py
+++ b/Tests/UI/test_command_palette_providers.py
@@ -353,7 +353,10 @@ class TestTabNavigationProvider:
             "Console",
             "Library",
             "Artifacts",
-            "Personas",
+            # task-435: the personas destination's palette command uses the
+            # full accessible label (destination.full_label), not the short
+            # "RP&CD" rail label -- see the dedicated assertion below.
+            "Roleplay & Chat Dictionaries",
             "Watchlists",
             "Schedules",
             "Workflows",

--- a/Tests/UI/test_command_palette_shell_routes.py
+++ b/Tests/UI/test_command_palette_shell_routes.py
@@ -88,12 +88,15 @@ def test_legacy_routes_are_searchable_alias_terms_on_their_destination():
     } <= alias_terms["library"]
     # Upstream retirements adopted on rebase: prompts and skills fold into Library.
     assert {"prompts", "skills"} <= alias_terms["library"]
-    assert {"ccp", "conversations_characters_prompts", "characters"} <= alias_terms[
-        "personas"
-    ]
-    assert (
-        "Personas" in alias_terms["personas"]
-    )  # TAB_CCP display label, deduped to one command
+    assert {
+        "ccp",
+        "conversations_characters_prompts",
+        "characters",
+        "roleplay",
+    } <= alias_terms["personas"]
+    assert "RP&CD" in alias_terms["personas"]  # TAB_CCP display label, deduped to one command
+    assert "Roleplay & Chat Dictionaries" in alias_terms["personas"]
+    assert "personas" in alias_terms["personas"]  # still searchable via id/primary_route
     assert {"subscriptions", "subscription", "Subscriptions"} <= alias_terms[
         "watchlists_collections"
     ]

--- a/Tests/UI/test_master_shell_navigation.py
+++ b/Tests/UI/test_master_shell_navigation.py
@@ -51,7 +51,7 @@ async def test_master_shell_navigation_order_and_labels():
         ("nav-console", "2 Console"),
         ("nav-library", "3 Library"),
         ("nav-artifacts", "4 Artifacts"),
-        ("nav-personas", "5 Personas"),
+        ("nav-personas", "5 RP&CD"),
         ("nav-watchlists_collections", "6 Watchlists"),
         ("nav-schedules", "7 Schedules"),
         ("nav-workflows", "8 Workflows"),

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -4704,7 +4704,7 @@ class TestDirtyTracking:
             # now that the save cleared it).
             assert str(subtitle.renderable) == "Editing Detective Sam"
             title = screen.query_one("#personas-header #workbench-header-title", Static)
-            assert str(title.renderable) == "Roleplay"
+            assert str(title.renderable) == "Roleplay & Chat Dictionaries"
 
     async def test_active_row_gets_unsaved_badge(
         self, mock_app_instance, stub_characters, stub_conversations, monkeypatch

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -1255,7 +1255,7 @@ async def test_main_navigation_copy_and_order():
         ("nav-console", "2 Console"),
         ("nav-library", "3 Library"),
         ("nav-artifacts", "4 Artifacts"),
-        ("nav-personas", "5 Personas"),
+        ("nav-personas", "5 RP&CD"),
         ("nav-watchlists_collections", "6 Watchlists"),
         ("nav-schedules", "7 Schedules"),
         ("nav-workflows", "8 Workflows"),

--- a/Tests/UI/test_shell_destinations.py
+++ b/Tests/UI/test_shell_destinations.py
@@ -25,9 +25,11 @@ def test_master_shell_destination_order_matches_spec():
 
 
 def test_personas_destination_renamed_to_rpcd_with_roleplay_alias():
-    """task-435: the nav destination is "RP&CD" / "Roleplay & Chat
-    Dictionaries" -- "Personas" is reserved for the in-screen user-identity
-    mode (``MODE_LABELS["personas"]``), which this test does not touch."""
+    """The nav destination is renamed to "RP&CD" / "Roleplay & Chat Dictionaries".
+
+    "Personas" stays reserved for the in-screen user-identity mode
+    (``MODE_LABELS["personas"]``), which this test does not touch (task-435).
+    """
     dest = get_shell_destination("personas")
     assert dest.label == "RP&CD"
     assert dest.full_label == "Roleplay & Chat Dictionaries"
@@ -44,8 +46,10 @@ def test_personas_destination_renamed_to_rpcd_with_roleplay_alias():
 
 
 def test_tab_display_labels_use_rpcd_for_personas_and_ccp_tabs():
-    """task-435: both tab ids that seat the Personas screen show the
-    renamed destination label in the top-level tab chrome."""
+    """Both Personas-seating tab ids show the renamed destination label.
+
+    Covers the top-level tab chrome for the RP&CD rename (task-435).
+    """
     from tldw_chatbook.Constants import TAB_CCP, TAB_PERSONAS, get_tab_display_label
 
     assert get_tab_display_label(TAB_CCP) == "RP&CD"

--- a/Tests/UI/test_shell_destinations.py
+++ b/Tests/UI/test_shell_destinations.py
@@ -1,5 +1,6 @@
 from tldw_chatbook.UI.Navigation.shell_destinations import (
     SHELL_DESTINATION_ORDER,
+    get_shell_destination,
     resolve_shell_route,
 )
 from Tests.UI.test_screen_navigation import _build_test_app
@@ -11,7 +12,7 @@ def test_master_shell_destination_order_matches_spec():
         "Console",
         "Library",
         "Artifacts",
-        "Personas",
+        "RP&CD",
         "Watchlists",
         "Schedules",
         "Workflows",
@@ -21,6 +22,34 @@ def test_master_shell_destination_order_matches_spec():
         "Logs",
         "Settings",
     ]
+
+
+def test_personas_destination_renamed_to_rpcd_with_roleplay_alias():
+    """task-435: the nav destination is "RP&CD" / "Roleplay & Chat
+    Dictionaries" -- "Personas" is reserved for the in-screen user-identity
+    mode (``MODE_LABELS["personas"]``), which this test does not touch."""
+    dest = get_shell_destination("personas")
+    assert dest.label == "RP&CD"
+    assert dest.full_label == "Roleplay & Chat Dictionaries"
+    assert dest.accessible_label == "Roleplay & Chat Dictionaries"
+    assert "roleplay" in dest.legacy_routes
+    for route in (
+        "personas",
+        "ccp",
+        "conversations_characters_prompts",
+        "characters",
+        "roleplay",
+    ):
+        assert resolve_shell_route(route).destination_id == "personas"
+
+
+def test_tab_display_labels_use_rpcd_for_personas_and_ccp_tabs():
+    """task-435: both tab ids that seat the Personas screen show the
+    renamed destination label in the top-level tab chrome."""
+    from tldw_chatbook.Constants import TAB_CCP, TAB_PERSONAS, get_tab_display_label
+
+    assert get_tab_display_label(TAB_CCP) == "RP&CD"
+    assert get_tab_display_label(TAB_PERSONAS) == "RP&CD"
 
 
 def test_legacy_routes_resolve_to_master_destinations():
@@ -40,6 +69,7 @@ def test_legacy_routes_resolve_to_master_destinations():
         "ccp": ("personas", "personas"),
         "conversation": ("library", "conversation"),
         "conversations_characters_prompts": ("personas", "personas"),
+        "roleplay": ("personas", "personas"),
         "subscriptions": ("watchlists_collections", "subscriptions"),
         "tools_settings": ("mcp", "tools_settings"),
         "settings": ("settings", "settings"),
@@ -61,7 +91,7 @@ def test_legacy_routes_resolve_to_master_destinations():
 
 
 def test_ccp_legacy_routes_resolve_to_personas_destination():
-    for legacy in ("ccp", "characters", "conversations_characters_prompts"):
+    for legacy in ("ccp", "characters", "conversations_characters_prompts", "roleplay"):
         resolved = resolve_shell_route(legacy)
         assert resolved.destination_id == "personas"
         assert resolved.canonical_route == "personas"

--- a/Tests/UI/test_unified_shell_phase6_first_time_replay.py
+++ b/Tests/UI/test_unified_shell_phase6_first_time_replay.py
@@ -34,7 +34,7 @@ EXPECTED_NAV = [
     ("nav-console", "2 Console"),
     ("nav-library", "3 Library"),
     ("nav-artifacts", "4 Artifacts"),
-    ("nav-personas", "5 Personas"),
+    ("nav-personas", "5 RP&CD"),
     ("nav-watchlists_collections", "6 Watchlists"),
     ("nav-schedules", "7 Schedules"),
     ("nav-workflows", "8 Workflows"),

--- a/backlog/tasks/task-435 - Resolve-the-Personas-vs-Roleplay-naming-split.md
+++ b/backlog/tasks/task-435 - Resolve-the-Personas-vs-Roleplay-naming-split.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-435
 title: Resolve the Personas vs Roleplay naming split
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-21 09:38'
+updated_date: '2026-07-23 16:36'
 labels:
   - roleplay
   - ux
@@ -20,6 +21,24 @@ Filed from the RP/character-card UX review (Docs/superpowers/qa/rp-ux-review-202
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Nav label, screen header, and in-screen mode names are mutually consistent and each name has exactly one meaning
-- [ ] #2 Legacy aliases still route correctly
+- [x] #1 Nav label, screen header, and in-screen mode names are mutually consistent and each name has exactly one meaning
+- [x] #2 Legacy aliases still route correctly
 <!-- AC:END -->
+
+## Implementation Notes
+
+Gave the Roleplay/Personas nav destination one public name — **"RP&CD"** (compact rail label) / **"Roleplay & Chat Dictionaries"** (full label) — and reserved **"Personas"** exclusively for the in-screen user-identity mode. Pure copy/label change; no internal id/route/class/file renames.
+
+**Surfaces renamed (AC#1):**
+- `UI/Navigation/shell_destinations.py` — the `personas` `ShellDestination`: `label` "Personas"→"RP&CD", new `full_label="Roleplay & Chat Dictionaries"` (so `accessible_label`/palette/header render the full form).
+- `Constants.py` — `TAB_DISPLAY_LABELS[TAB_CCP]` and `[TAB_PERSONAS]` → "RP&CD".
+- `UI/Screens/personas_screen.py` — header title → "Roleplay & Chat Dictionaries" at **both** sites (`compose_content:584` and the live-refresh `_update_title:1702`).
+- `app.py` — both tab tooltips (`TAB_PERSONAS`, `TAB_CCP`) renamed and the retired word "prompts" dropped; plus 4 navigation toast strings ("Opened Personas…" → "Opened Roleplay & Chat Dictionaries…").
+- `Widgets/Chat_Widgets/chat_session.py` — Console first-run "context lanes" hint "Personas"→"RP&CD".
+- `MODE_LABELS["personas"] = "Personas"` deliberately **unchanged** — now the single meaning of "Personas".
+
+**Legacy routing (AC#2):** added only `"roleplay"` to `legacy_routes`; `resolve_shell_route("personas")` and `("roleplay")` both resolve to destination `personas` (verified), and `"personas"` stays palette-searchable via `destination_id`/`primary_route`.
+
+**Testing:** RED→GREEN on the label/palette suite (`test_shell_destinations`, `test_command_palette_shell_routes`, `test_command_palette_providers` — 81 passed); stale nav-label/header assertions updated in `test_screen_navigation`, `test_master_shell_navigation`, `test_unified_shell_phase6_first_time_replay`, `test_personas_workbench`. Task review: spec ✅, quality Approved.
+
+**Deferred:** the Settings domain-ownership audit still names the destination "Personas" in copy that overlaps the Settings-screen category taxonomy → follow-up **TASK-496** (deliberate copy pass rather than a guess).

--- a/backlog/tasks/task-496 - Rename-residual-Personas-as-destination-copy-in-Settings-domain-ownership-audit.md
+++ b/backlog/tasks/task-496 - Rename-residual-Personas-as-destination-copy-in-Settings-domain-ownership-audit.md
@@ -1,0 +1,27 @@
+---
+id: TASK-496
+title: >-
+  Rename residual 'Personas'-as-destination copy in Settings domain-ownership
+  audit
+status: To Do
+assignee: []
+created_date: '2026-07-23 17:21'
+labels:
+  - ux
+  - roleplay
+  - copy
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The TASK-435 RP&CD rename retired 'Personas' as the destination's public name (it now means only the in-screen user-identity mode). Two user-visible strings in the Settings domain-ownership audit still name the destination 'Personas': the SettingsDomainCategoryContract for the PERSONAS category (title, owner_destination, and its prose source-of-truth/rows/follow-up text) and the SettingsCategorySummary entry. These need renaming to the destination's new public name, but the wording is ambiguous with the Settings-screen category taxonomy, so it was deferred from TASK-435 for a deliberate copy pass.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Settings domain-ownership audit no longer names the destination 'Personas' (uses RP&CD / Roleplay & Chat Dictionaries consistently)
+- [ ] #2 Settings category summary for the persona/character domain reflects the destination's new public name
+- [ ] #3 'Personas' remains only where it means the in-screen user-identity mode; no test regressions in test_settings_configuration_hub
+<!-- AC:END -->

--- a/tldw_chatbook/Constants.py
+++ b/tldw_chatbook/Constants.py
@@ -73,7 +73,7 @@ ALL_TABS = [
 
 TAB_DISPLAY_LABELS = {
     TAB_CHAT: "Console",
-    TAB_CCP: "Personas",
+    TAB_CCP: "RP&CD",
     TAB_MEDIA: "Media",
     TAB_SEARCH: "Search",
     TAB_INGEST: "Ingest",
@@ -91,7 +91,7 @@ TAB_DISPLAY_LABELS = {
     TAB_HOME: "Home",
     TAB_LIBRARY: "Library",
     TAB_ARTIFACTS: "Artifacts",
-    TAB_PERSONAS: "Personas",
+    TAB_PERSONAS: "RP&CD",
     TAB_WATCHLISTS_COLLECTIONS: "Watchlists",
     TAB_SCHEDULES: "Schedules",
     TAB_WORKFLOWS: "Workflows",

--- a/tldw_chatbook/UI/Navigation/shell_destinations.py
+++ b/tldw_chatbook/UI/Navigation/shell_destinations.py
@@ -78,11 +78,12 @@ SHELL_DESTINATION_ORDER: tuple[ShellDestination, ...] = (
     ),
     ShellDestination(
         "personas",
-        "Personas",
+        "RP&CD",
         "personas",
         "Characters, personas, dictionaries, and behavior profiles.",
         "Manage behavior profiles and persona context.",
-        ("ccp", "conversations_characters_prompts", "characters"),
+        ("ccp", "conversations_characters_prompts", "characters", "roleplay"),
+        full_label="Roleplay & Chat Dictionaries",
     ),
     ShellDestination(
         "watchlists_collections",

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -582,7 +582,7 @@ class PersonasScreen(BaseAppScreen):
         with Vertical(id="personas-shell"):
             yield DestinationHeader(
                 WorkbenchHeaderState(
-                    title="Roleplay",
+                    title="Roleplay & Chat Dictionaries",
                     subtitle=self._header_subtitle_text(),
                     status="ready",
                 ),
@@ -1700,7 +1700,7 @@ class PersonasScreen(BaseAppScreen):
             return
         header.sync_state(
             WorkbenchHeaderState(
-                title="Roleplay",
+                title="Roleplay & Chat Dictionaries",
                 subtitle=self._header_subtitle_text(),
                 status="ready",
             )

--- a/tldw_chatbook/UI/Workbench/route_inventory.py
+++ b/tldw_chatbook/UI/Workbench/route_inventory.py
@@ -34,6 +34,9 @@ WORKBENCH_ROUTE_OWNERS: dict[str, str] = {
     "ccp": "personas",
     "conversations_characters_prompts": "personas",
     "characters": "personas",
+    # "roleplay" is the RP&CD destination's public-name route alias (task-435);
+    # it resolves to the personas destination, like the other aliases above.
+    "roleplay": "personas",
     # The Personas "prompts" mode chip is retired (Task 7): the legacy
     # "prompts" route re-points to Library, like "notes" below.
     "prompts": "library",

--- a/tldw_chatbook/Widgets/Chat_Widgets/chat_session.py
+++ b/tldw_chatbook/Widgets/Chat_Widgets/chat_session.py
@@ -241,7 +241,7 @@ class ChatSession(Container):
             "No messages yet. Send a prompt or attach context.\n"
             "Event stream ready. Start with a command or attach sources.\n"
             f"{provider_line}\n"
-            "Context lanes: Library, Search/RAG, Artifacts, Personas, Skills."
+            "Context lanes: Library, Search/RAG, Artifacts, RP&CD, Skills."
         )
 
     async def handle_send_stop_button(self, event):

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -701,7 +701,7 @@ class TabNavigationProvider(Provider):
         TAB_CHAT: "Open Console for live agent work, approvals, tools, and RAG",
         TAB_LIBRARY: "Open Library for source material, imports, notes, media, conversations, and Search/RAG",
         TAB_ARTIFACTS: "Open Artifacts for generated outputs, reports, datasets, and Chatbooks",
-        TAB_PERSONAS: "Open Personas for characters, prompts, dictionaries, and behavior profiles",
+        TAB_PERSONAS: "Open Roleplay & Chat Dictionaries for characters, personas, dictionaries, and behavior profiles",
         TAB_WATCHLISTS_COLLECTIONS: "Open Watchlists for monitored sources, runs, alerts, and recovery",
         TAB_SCHEDULES: "Open Schedules for run timing, triggers, pauses, retries, and recovery",
         TAB_WORKFLOWS: "Open Workflows for reusable procedures, dry-runs, and outputs",
@@ -709,7 +709,7 @@ class TabNavigationProvider(Provider):
         TAB_ACP: "Open ACP for agents, sessions, runtimes, diffs, and terminals",
         TAB_SKILLS: "Open Skills for Agent Skills discovery, validation, and attachments",
         TAB_SETTINGS: "Open global preferences, appearance, accounts, storage, and app behavior",
-        TAB_CCP: "Switch to Personas for characters, personas, prompts, dictionaries, and world books",
+        TAB_CCP: "Switch to Roleplay & Chat Dictionaries for characters, personas, dictionaries, and world books",
         TAB_MEDIA: "Switch to media library",
         TAB_SEARCH: "Switch to search and RAG",
         TAB_INGEST: "Switch to content ingestion",
@@ -1054,7 +1054,9 @@ class QuickActionsProvider(Provider):
                 )
             elif action_id == "new_character":
                 _navigate_via_screen(
-                    self.app, TAB_PERSONAS, "Opened Personas for character setup"
+                    self.app,
+                    TAB_PERSONAS,
+                    "Opened Roleplay & Chat Dictionaries for character setup",
                 )
             elif action_id == "new_note":
                 _navigate_via_screen(
@@ -1227,14 +1229,22 @@ class CharacterProvider(Provider):
         """Handle character management actions."""
         try:
             if action_id == "open_character_tab":
-                _navigate_via_screen(self.app, TAB_PERSONAS, "Opened Personas")
+                _navigate_via_screen(
+                    self.app,
+                    TAB_PERSONAS,
+                    "Opened Roleplay & Chat Dictionaries",
+                )
             elif action_id == "new_character":
                 _navigate_via_screen(
-                    self.app, TAB_PERSONAS, "Opened Personas to create a character"
+                    self.app,
+                    TAB_PERSONAS,
+                    "Opened Roleplay & Chat Dictionaries to create a character",
                 )
             elif action_id == "list_characters":
                 _navigate_via_screen(
-                    self.app, TAB_PERSONAS, "Opened Personas to list characters"
+                    self.app,
+                    TAB_PERSONAS,
+                    "Opened Roleplay & Chat Dictionaries to list characters",
                 )
         except Exception as e:
             self.app.notify(


### PR DESCRIPTION
## Summary

Resolves the three-way "Personas / Roleplay / Personas-mode" naming collision (TASK-435, from the RP UX review). The nav **destination** now has one public name — **"RP&CD"** (compact rail label) / **"Roleplay & Chat Dictionaries"** (full label, used in the screen header, command palette, and tooltips). The name **"Personas"** is reserved exclusively for the in-screen user-identity **mode**.

Pure copy/label change — no internal `destination_id`/route/`TAB_*`/class/file renames.

## Changes

**Name surfaces (AC#1):**
- `UI/Navigation/shell_destinations.py` — `personas` destination `label` "Personas"→"RP&CD", new `full_label="Roleplay & Chat Dictionaries"`.
- `Constants.py` — `TAB_DISPLAY_LABELS[TAB_CCP]`/`[TAB_PERSONAS]` → "RP&CD".
- `UI/Screens/personas_screen.py` — header title → "Roleplay & Chat Dictionaries" at both the compose site and the live-refresh `_update_title`.
- `app.py` — both tab tooltips renamed (retired word "prompts" dropped) + 4 navigation toast strings ("Opened Personas…" → "Opened Roleplay & Chat Dictionaries…").
- `Widgets/Chat_Widgets/chat_session.py` — Console first-run "context lanes" hint "Personas"→"RP&CD".
- `MODE_LABELS["personas"] = "Personas"` deliberately **unchanged** — now the single meaning of "Personas".

**Legacy routing (AC#2):** added only `"roleplay"` to `legacy_routes`; `resolve_shell_route("personas")` and `("roleplay")` both resolve to destination `personas`; `"personas"` stays palette-searchable via `destination_id`/`primary_route`.

## Testing

RED→GREEN on the label/palette suite (`test_shell_destinations`, `test_command_palette_shell_routes`, `test_command_palette_providers` — 81 passed); stale nav-label/header assertions updated in `test_screen_navigation`, `test_master_shell_navigation`, `test_unified_shell_phase6_first_time_replay`, `test_personas_workbench`. Subagent-driven task review: spec ✅, code quality Approved.

## Follow-up

- **TASK-496** — the Settings domain-ownership audit still names the destination "Personas" in copy that overlaps the Settings-screen category taxonomy; deferred to a deliberate copy pass rather than guessed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the Roleplay/Personas destination under one public name from TASK-435: RP&CD (rail) and Roleplay & Chat Dictionaries (full). "Personas" now refers only to the in-screen user-identity mode; internal IDs and primary routes remain unchanged.

- **New Features**
  - Renamed the destination across the nav rail, screen header, command palette, and tooltips to "RP&CD" / "Roleplay & Chat Dictionaries".
  - Added a `roleplay` legacy route alias that resolves to the `personas` destination; `personas` remains routable/searchable via its id/primary route.
  - Updated `TAB_DISPLAY_LABELS` for `TAB_PERSONAS` and `TAB_CCP` to "RP&CD".
  - Refreshed quick-action toasts and the console first-run hint to match the new name.

- **Bug Fixes**
  - Mapped the `roleplay` route to `personas` in `tldw_chatbook/UI/Workbench/route_inventory.py` to cover workbench route ownership and resolve the missing-owner check.

- **Migration**
  - No internal ids, primary routes, or class/file names changed.
  - No breaking changes; existing `personas` links still work.

<sup>Written for commit 31ae1702f01ee0f63208c07e5c31351384e21833. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

