### PR TITLE
feat(personas): Roleplay P3d-2 — bulk import + export of a character's expression set

### DIFF
--- a/Docs/superpowers/plans/2026-07-23-roleplay-p3d2-expression-set-io.md
+++ b/Docs/superpowers/plans/2026-07-23-roleplay-p3d2-expression-set-io.md
@@ -1,0 +1,779 @@
+# Roleplay P3d-2 — Bulk Import + Export of a Character's Expression Set — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user import a whole character expression set (idle+thinking+speaking+error) from one `.zip`, and export a character's set to a `.zip`, instead of P3d-1's three one-at-a-time upload slots.
+
+**Architecture:** A new pure module `Character_Chat/expression_set_io.py` (zipfile + PIL only) resolves a `.zip`/dir/file list into a validated `{state: bytes}` set, builds an export zip, and applies the non-idle states to a DB. A screen-level `_apply_expression_set` orchestrator stages idle in the editor (persists on card save) + writes the three via the pure DB helper, bumping the render token once. Two editor buttons drive import (single-`.zip` picker) and export (write to the exports dir).
+
+**Tech Stack:** Python ≥3.11, `zipfile`, PIL, Textual, CharactersRAGDB, loguru.
+
+## Global Constraints
+
+- **NO migration** — `character_expression_images` (P3d-1) + `character_cards.image` already exist (schema v23). **Pre-flight re-verify `_CURRENT_SCHEMA_VERSION == 23`** at plan+merge time.
+- **idle is STAGED** via `editor.set_avatar_image(bytes)` (persists on card save, a version-bumping `update_character_card`); the **three reactive states write IMMEDIATELY** via `db.set_character_expression_image` (card-version-independent — P3d-1 invariant). Export reads idle from `editor.current_avatar_bytes()`.
+- **Export PIL-detects the format from the bytes** (`Image.open(BytesIO(b)).format`) — `get_character_expression_image` returns bytes only; the stored mime is unreadable.
+- **Import UI = a single `.zip`** (`EnhancedFileOpen` returns one file). The resolver stays general (`.zip` / dir / image list) for tests + future.
+- **Untrusted-zip security:** read members **into memory** via `zipfile` (never extract attacker paths to disk); enforce `MAX_ZIP_MEMBERS=64`, `MAX_MEMBER_BYTES=16MiB`, `MAX_TOTAL_BYTES=64MiB` against `ZipInfo.file_size` **before** reading each member; PIL-validate every image; skip a bad member (best-effort); a broken/encrypted zip fails cleanly (notification), **never raises into the worker**.
+- **Best-effort partial:** each state applies independently; one bad state never fails the whole op; the summary reports skips.
+- **Reuse P3d-1**: bump `_character_editor_generation` **ONCE** per import then re-render affected slots + avatar (never per-state — that races); mirror `_expression_upload_dialog_worker` (dialog worker) + `_stage_character_expression_from_path` (dialog-free path method) + `_dictionary_export_worker` (exports-dir + atomic temp-replace) + the `_io_dialog_active` guard + `group="personas-io"`.
+- **Saved-character-only** (`editor.expression_character_id() is not None`) + **characters-only** (`_character_editor_is_active()`).
+- **`expression_set_io.py` imports NO Textual and NO DB module** (it may take a `db` object as a parameter and call methods on it; it may import the pure state constants from `Chat/console_expression_state.py`).
+- Never let an exception escape into an `exit_on_error=True` worker (mirror the P3d-1 IO workers' `try/finally` + inner `try/except`).
+- DB tests use a file-backed `CharactersRAGDB(tmp_path / "...db", "test-client")`, **never `:memory:`**.
+- `Tests/UI/pytest.ini` sets `asyncio_mode=auto`: keep async tests in `Tests/UI/` OR add `@pytest.mark.asyncio`; don't mix `Tests/UI` with another dir in one pytest invocation.
+- **Test env prefix:** `HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest ... -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread`
+- Worktree `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/personas-redesign`; subagents PREPEND `cd <worktree> && ` to EVERY Bash call. CONCURRENT-SESSION HAZARD: `personas_screen.py` / `personas_character_editor_widget.py` heavily edited elsewhere — localize; expect a rebase. Stage ONLY task files (never `git add -A`, never `.superpowers/`). NO background/broad sweeps; NEVER pkill.
+
+---
+
+## File Structure
+
+- `tldw_chatbook/Character_Chat/expression_set_io.py` — **create**: pure logic. `resolve_local_expression_set` (Task 1), `build_expression_set_zip` (Task 2), `apply_expression_images_to_db` + the dataclasses + constants (Tasks 1-3).
+- `tldw_chatbook/UI/Screens/personas_screen.py` — **modify**: `_apply_expression_set` orchestrator + the import/export path methods + dialog/export workers + message handlers (Tasks 3-4).
+- `tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py` — **modify**: two buttons + their `post_message` (Task 4).
+- `tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py` — **modify**: two new message classes (Task 4).
+
+---
+
+## Task 1: `resolve_local_expression_set` + security (pure)
+
+**Files:**
+- Create: `tldw_chatbook/Character_Chat/expression_set_io.py`
+- Test: `Tests/Character_Chat/test_expression_set_io.py` (create)
+
+**Interfaces:**
+- Produces:
+  - `EXPRESSION_STATES` / `EXPRESSION_IMAGE_STATES` (imported from `tldw_chatbook.Chat.console_expression_state`).
+  - `@dataclass(frozen=True) class ExpressionSetResolution: images: dict[str, bytes]; skipped: list[tuple[str, str]]; notes: list[str]`
+  - `resolve_local_expression_set(paths: list[Path]) -> ExpressionSetResolution`
+  - Caps: `MAX_ZIP_MEMBERS = 64`, `MAX_MEMBER_BYTES = 16 * 1024 * 1024`, `MAX_TOTAL_BYTES = 64 * 1024 * 1024`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/Character_Chat/test_expression_set_io.py`:
+```python
+import io
+import zipfile
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from tldw_chatbook.Character_Chat.expression_set_io import (
+    resolve_local_expression_set,
+    MAX_ZIP_MEMBERS,
+    MAX_TOTAL_BYTES,
+)
+
+
+def _png(color=(10, 20, 30)) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8), color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _jpg() -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8), (200, 10, 10)).save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def _zip(members: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, data in members.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+def test_zip_maps_by_filename_stem(tmp_path):
+    z = tmp_path / "set.zip"
+    z.write_bytes(_zip({"idle.png": _png(), "speaking.jpg": _jpg()}))
+    res = resolve_local_expression_set([z])
+    assert set(res.images) == {"idle", "speaking"}
+    assert res.images["idle"] == _png()  # bytes preserved verbatim
+
+
+def test_case_insensitive_stem(tmp_path):
+    z = tmp_path / "set.zip"
+    z.write_bytes(_zip({"IDLE.PNG": _png(), "Thinking.png": _png()}))
+    res = resolve_local_expression_set([z])
+    assert set(res.images) == {"idle", "thinking"}
+
+
+def test_non_matching_and_non_image_skipped(tmp_path):
+    z = tmp_path / "set.zip"
+    z.write_bytes(_zip({"speaking.png": _png(), "notes.txt": b"hello", "random.png": _png()}))
+    res = resolve_local_expression_set([z])
+    assert set(res.images) == {"speaking"}
+    assert any(name == "notes.txt" for name, _ in res.skipped)  # not an image / no state
+
+
+def test_bad_image_bytes_skipped_with_reason(tmp_path):
+    z = tmp_path / "set.zip"
+    z.write_bytes(_zip({"error.png": b"not-an-image"}))
+    res = resolve_local_expression_set([z])
+    assert "error" not in res.images
+    assert any(name == "error.png" for name, _ in res.skipped)
+
+
+def test_two_files_one_state_prefers_png(tmp_path):
+    z = tmp_path / "set.zip"
+    z.write_bytes(_zip({"speaking.jpg": _jpg(), "speaking.png": _png()}))
+    res = resolve_local_expression_set([z])
+    assert res.images["speaking"] == _png()  # .png wins
+    assert res.notes  # tie recorded
+
+
+def test_directory_of_images(tmp_path):
+    d = tmp_path / "imgs"
+    d.mkdir()
+    (d / "idle.png").write_bytes(_png())
+    (d / "error.png").write_bytes(_png())
+    res = resolve_local_expression_set([d])
+    assert set(res.images) == {"idle", "error"}
+
+
+def test_list_of_image_files(tmp_path):
+    a = tmp_path / "thinking.png"; a.write_bytes(_png())
+    b = tmp_path / "speaking.png"; b.write_bytes(_png())
+    res = resolve_local_expression_set([a, b])
+    assert set(res.images) == {"thinking", "speaking"}
+
+
+def test_member_count_cap(tmp_path):
+    z = tmp_path / "big.zip"
+    z.write_bytes(_zip({f"file{i}.png": _png() for i in range(MAX_ZIP_MEMBERS + 5)}))
+    res = resolve_local_expression_set([z])
+    # capped: does not read all members; the 4 states may still resolve, but the
+    # resolution notes/skips the cap. At minimum it must not raise and must be bounded.
+    assert isinstance(res.images, dict)
+    assert res.notes  # cap recorded
+
+
+def test_total_size_cap_rejects(tmp_path, monkeypatch):
+    # One member whose declared uncompressed size exceeds the total cap is skipped.
+    import tldw_chatbook.Character_Chat.expression_set_io as mod
+    monkeypatch.setattr(mod, "MAX_TOTAL_BYTES", 100)
+    z = tmp_path / "bomb.zip"
+    z.write_bytes(_zip({"idle.png": _png() * 50}))  # > 100 bytes uncompressed
+    res = resolve_local_expression_set([z])
+    assert "idle" not in res.images
+    assert res.notes or res.skipped
+
+
+def test_not_a_zip_fails_cleanly(tmp_path):
+    bad = tmp_path / "broken.zip"
+    bad.write_bytes(b"this is not a zip")
+    res = resolve_local_expression_set([bad])  # must not raise
+    assert res.images == {}
+    assert res.skipped or res.notes
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/personas-redesign && HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Character_Chat/test_expression_set_io.py -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: FAIL — `ModuleNotFoundError: tldw_chatbook.Character_Chat.expression_set_io`.
+
+- [ ] **Step 3: Create the module + resolver**
+
+Create `tldw_chatbook/Character_Chat/expression_set_io.py`:
+```python
+"""Pure import/export logic for a character's expression image SET
+(idle/thinking/speaking/error). No Textual and no DB-module imports -- takes a
+db object as a parameter where needed. Reused by P3d-3's .vpack extractor.
+"""
+from __future__ import annotations
+
+import io
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from PIL import Image
+
+from tldw_chatbook.Chat.console_expression_state import (
+    EXPRESSION_STATES,       # ("idle","thinking","speaking","error")
+    EXPRESSION_IMAGE_STATES, # ("thinking","speaking","error")
+)
+
+MAX_ZIP_MEMBERS = 64
+MAX_MEMBER_BYTES = 16 * 1024 * 1024
+MAX_TOTAL_BYTES = 64 * 1024 * 1024
+
+_STATE_SET = {s.lower() for s in EXPRESSION_STATES}
+
+
+@dataclass(frozen=True)
+class ExpressionSetResolution:
+    images: dict[str, bytes] = field(default_factory=dict)
+    skipped: list[tuple[str, str]] = field(default_factory=list)   # (name, reason)
+    notes: list[str] = field(default_factory=list)
+
+
+def _valid_image(data: bytes) -> bool:
+    try:
+        with Image.open(io.BytesIO(data)) as im:
+            im.verify()
+        return True
+    except Exception:
+        return False
+
+
+def _prefer(existing_name: str, new_name: str) -> bool:
+    """Return True if new_name should replace existing for the same state."""
+    ext_e, ext_n = Path(existing_name).suffix.lower(), Path(new_name).suffix.lower()
+    if ext_n == ".png" and ext_e != ".png":
+        return True
+    if ext_e == ".png" and ext_n != ".png":
+        return False
+    return new_name.lower() < existing_name.lower()  # first alphabetically
+
+
+def _candidate_pairs(paths: list[Path]) -> tuple[list[tuple[str, bytes]], list[tuple[str, str]], list[str]]:
+    """Yield (base_name, bytes) for every candidate file across the inputs.
+    Handles a .zip (in-memory, security-capped), a directory, or image files.
+    """
+    pairs: list[tuple[str, bytes]] = []
+    skipped: list[tuple[str, str]] = []
+    notes: list[str] = []
+    for path in paths:
+        try:
+            if path.is_dir():
+                for child in sorted(path.iterdir()):
+                    if child.is_file():
+                        pairs.append((child.name, child.read_bytes()))
+            elif zipfile.is_zipfile(path):
+                with zipfile.ZipFile(path) as zf:
+                    infos = [i for i in zf.infolist() if not i.is_dir()]
+                    if len(infos) > MAX_ZIP_MEMBERS:
+                        notes.append(f"Archive has {len(infos)} members; only the first {MAX_ZIP_MEMBERS} were read.")
+                        infos = infos[:MAX_ZIP_MEMBERS]
+                    total = 0
+                    for info in infos:
+                        if info.file_size > MAX_MEMBER_BYTES:
+                            skipped.append((info.filename, "file too large"))
+                            continue
+                        if total + info.file_size > MAX_TOTAL_BYTES:
+                            notes.append("Archive exceeds the total size cap; remaining members skipped.")
+                            break
+                        total += info.file_size
+                        pairs.append((Path(info.filename).name, zf.read(info)))
+            elif path.is_file():
+                pairs.append((path.name, path.read_bytes()))
+            else:
+                skipped.append((str(path), "not found"))
+        except Exception as exc:   # broken/encrypted zip, unreadable dir, etc.
+            skipped.append((str(path), f"could not read: {exc}"))
+    return pairs, skipped, notes
+
+
+def resolve_local_expression_set(paths: list[Path]) -> ExpressionSetResolution:
+    """Resolve selected inputs into a validated {state: bytes} set. Never raises."""
+    pairs, skipped, notes = _candidate_pairs(paths)
+    chosen: dict[str, tuple[str, bytes]] = {}   # state -> (name, bytes)
+    for name, data in pairs:
+        state = Path(name).stem.lower()
+        if state not in _STATE_SET:
+            skipped.append((name, "filename is not a known state"))
+            continue
+        if not _valid_image(data):
+            skipped.append((name, "not a valid image"))
+            continue
+        if state in chosen:
+            keep = chosen[state][0]
+            if _prefer(keep, name):
+                notes.append(f"Multiple files for {state}; used {name}.")
+                chosen[state] = (name, data)
+            else:
+                notes.append(f"Multiple files for {state}; used {keep}.")
+            continue
+        chosen[state] = (name, data)
+    return ExpressionSetResolution(
+        images={state: data for state, (_, data) in chosen.items()},
+        skipped=skipped,
+        notes=notes,
+    )
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run the same command as Step 2. Expected: PASS (11 tests). Also `python -c "import tldw_chatbook.app"` (env prefix) exits 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Character_Chat/expression_set_io.py Tests/Character_Chat/test_expression_set_io.py
+git commit -m "feat(personas): P3d-2 Task 1 — resolve_local_expression_set (zip/dir/files, security-capped)"
+```
+
+---
+
+## Task 2: `build_expression_set_zip` + round-trip (pure)
+
+**Files:**
+- Modify: `tldw_chatbook/Character_Chat/expression_set_io.py`
+- Test: `Tests/Character_Chat/test_expression_set_io.py` (extend)
+
+**Interfaces:**
+- Consumes: `resolve_local_expression_set` (Task 1).
+- Produces: `build_expression_set_zip(character_name: str, images: dict[str, bytes]) -> bytes`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `Tests/Character_Chat/test_expression_set_io.py`:
+```python
+def test_build_zip_round_trips_through_resolver(tmp_path):
+    from tldw_chatbook.Character_Chat.expression_set_io import build_expression_set_zip
+    images = {"idle": _png(), "speaking": _jpg()}
+    blob = build_expression_set_zip("Ada Lovelace", images)
+    out = tmp_path / "ada.zip"
+    out.write_bytes(blob)
+    res = resolve_local_expression_set([out])
+    assert set(res.images) == {"idle", "speaking"}
+
+
+def test_build_zip_uses_detected_extension(tmp_path):
+    from tldw_chatbook.Character_Chat.expression_set_io import build_expression_set_zip
+    blob = build_expression_set_zip("Ada", {"speaking": _jpg()})
+    names = zipfile.ZipFile(io.BytesIO(blob)).namelist()
+    assert "speaking.jpg" in names          # JPEG bytes -> .jpg, not .png
+    assert "expression_set.json" in names    # provenance marker present
+
+
+def test_build_zip_empty_set_is_valid_zip():
+    from tldw_chatbook.Character_Chat.expression_set_io import build_expression_set_zip
+    blob = build_expression_set_zip("Ada", {})
+    zf = zipfile.ZipFile(io.BytesIO(blob))
+    assert zf.namelist() == ["expression_set.json"]
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run the file (Step-2 command from Task 1). Expected: FAIL — `build_expression_set_zip` not defined.
+
+- [ ] **Step 3: Implement the exporter**
+
+Add to `expression_set_io.py`:
+```python
+import json
+
+_FORMAT_TO_EXT = {"PNG": "png", "JPEG": "jpg", "WEBP": "webp", "GIF": "gif"}
+
+
+def _detect_ext(data: bytes) -> str:
+    try:
+        with Image.open(io.BytesIO(data)) as im:
+            return _FORMAT_TO_EXT.get((im.format or "").upper(), "png")
+    except Exception:
+        return "png"
+
+
+def build_expression_set_zip(character_name: str, images: dict[str, bytes]) -> bytes:
+    """Build a .zip (bytes) of a character's expression set.
+
+    Args:
+        character_name: The character's display name (for the provenance marker).
+        images: {state: bytes} for any subset of EXPRESSION_STATES.
+
+    Returns:
+        The zip archive bytes: one ``{state}.{ext}`` per present state (ext
+        PIL-detected from the bytes) plus an ``expression_set.json`` provenance
+        marker. Always a valid zip, even for an empty set.
+    """
+    present = [s for s in EXPRESSION_STATES if s in images and images[s]]
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for state in present:
+            zf.writestr(f"{state}.{_detect_ext(images[state])}", images[state])
+        manifest = {
+            "format": "tldw-expression-set/1",
+            "character": character_name,
+            "states": present,
+        }
+        zf.writestr("expression_set.json", json.dumps(manifest, indent=2))
+    return buf.getvalue()
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run the file. Expected: PASS (14 tests total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Character_Chat/expression_set_io.py Tests/Character_Chat/test_expression_set_io.py
+git commit -m "feat(personas): P3d-2 Task 2 — build_expression_set_zip (format-detected, round-trips)"
+```
+
+---
+
+## Task 3: `apply_expression_images_to_db` helper + `_apply_expression_set` orchestrator
+
+**Files:**
+- Modify: `tldw_chatbook/Character_Chat/expression_set_io.py` (the DB helper)
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py` (the orchestrator — READ FRESH; `_apply_expression_upload` ~:4393, `_render_character_expression_slot` ~:4271, `_character_editor_generation`, `_render_character_editor_avatar`/avatar-thumb render)
+- Test: `Tests/Character_Chat/test_expression_set_io.py` (helper) + `Tests/UI/test_personas_expression_slots.py` (orchestrator)
+
+**Interfaces:**
+- Consumes: `db.set_character_expression_image(character_id, state, bytes, mime)` (P3d-1); `EXPRESSION_IMAGE_STATES`; `editor.set_avatar_image(bytes)`.
+- Produces:
+  - `apply_expression_images_to_db(db, character_id: int, images: dict[str, bytes]) -> tuple[list[str], list[tuple[str, str]]]` (applied, skipped) — writes only `EXPRESSION_IMAGE_STATES` (ignores idle).
+  - `@dataclass(frozen=True) class ExpressionSetApplyResult: applied: list[str]; skipped: list[tuple[str, str]]`
+  - `_apply_expression_set(self, character_id: int, images: dict[str, bytes]) -> ExpressionSetApplyResult` (screen method).
+
+- [ ] **Step 1: Write the failing test (DB helper)**
+
+Append to `Tests/Character_Chat/test_expression_set_io.py`:
+```python
+@pytest.fixture
+def db(tmp_path):
+    from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+    return CharactersRAGDB(tmp_path / "expr.db", "test-client")   # file-backed, not :memory:
+
+
+def test_apply_images_to_db_writes_only_non_idle(db):
+    from tldw_chatbook.Character_Chat.expression_set_io import apply_expression_images_to_db
+    cid = db.add_character_card({"name": "Ada"})
+    applied, skipped = apply_expression_images_to_db(
+        db, cid, {"idle": _png(), "speaking": _png(), "thinking": _png()}
+    )
+    assert set(applied) == {"speaking", "thinking"}     # idle NOT written to the table
+    assert db.get_character_expression_image(cid, "speaking") is not None
+    assert db.get_character_expression_image(cid, "idle") is None
+
+
+def test_apply_images_to_db_best_effort(db, monkeypatch):
+    from tldw_chatbook.Character_Chat.expression_set_io import apply_expression_images_to_db
+    cid = db.add_character_card({"name": "Ada"})
+    orig = db.set_character_expression_image
+    def boom(c, s, i, m=None):
+        if s == "error":
+            raise RuntimeError("disk full")
+        return orig(c, s, i, m)
+    monkeypatch.setattr(db, "set_character_expression_image", boom)
+    applied, skipped = apply_expression_images_to_db(db, cid, {"speaking": _png(), "error": _png()})
+    assert applied == ["speaking"]
+    assert any(s == "error" for s, _ in skipped)
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run the file (Task 1 Step-2 command). Expected: FAIL — `apply_expression_images_to_db` not defined.
+
+- [ ] **Step 3: Implement the DB helper**
+
+Add to `expression_set_io.py`:
+```python
+def apply_expression_images_to_db(db, character_id: int, images: dict[str, bytes]):
+    """Write the non-idle states to the expression table, best-effort.
+
+    Args:
+        db: a CharactersRAGDB-like object exposing ``set_character_expression_image``.
+        character_id: the owning character id.
+        images: {state: bytes}; only EXPRESSION_IMAGE_STATES are written (idle skipped).
+
+    Returns:
+        (applied_states, skipped[(state, reason)]).
+    """
+    applied: list[str] = []
+    skipped: list[tuple[str, str]] = []
+    for state in EXPRESSION_IMAGE_STATES:
+        data = images.get(state)
+        if not data:
+            continue
+        try:
+            db.set_character_expression_image(character_id, state, data, None)
+            applied.append(state)
+        except Exception as exc:
+            skipped.append((state, f"write failed: {exc}"))
+    return applied, skipped
+```
+
+- [ ] **Step 4: Write the failing test (orchestrator)**
+
+Append to `Tests/UI/test_personas_expression_slots.py` (reuse its existing editor harness — grep the file for how it mounts the editor for a saved character; mirror that). Adjust fixture/helper names to the file's:
+```python
+@pytest.mark.asyncio
+async def test_apply_expression_set_stages_idle_and_writes_three(personas_editor_with_saved_character):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    import io as _io
+    from PIL import Image as _Img
+    def _png(c=(1, 2, 3)):
+        b = _io.BytesIO(); _Img.new("RGB", (8, 8), c).save(b, format="PNG"); return b.getvalue()
+
+    result = await screen._apply_expression_set(
+        char_id, {"idle": _png((9, 9, 9)), "speaking": _png(), "thinking": _png()}
+    )
+    # idle STAGED in the editor (not the table); three -> table
+    from tldw_chatbook.Widgets.Persona_Widgets.personas_character_editor_widget import PersonasCharacterEditorWidget
+    editor = screen.query_one(PersonasCharacterEditorWidget)
+    assert editor.current_avatar_bytes() == _png((9, 9, 9))      # idle staged
+    assert db.get_character_expression_image(char_id, "speaking") is not None
+    assert db.get_character_expression_image(char_id, "idle") is None
+    assert set(result.applied) >= {"idle", "speaking", "thinking"}
+```
+
+- [ ] **Step 5: Run to verify it fails**
+
+Run:
+```
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/personas-redesign && HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_personas_expression_slots.py::test_apply_expression_set_stages_idle_and_writes_three -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: FAIL — `_apply_expression_set` not defined.
+
+- [ ] **Step 6: Implement the orchestrator**
+
+In `personas_screen.py`, add `_apply_expression_set` (place it near `_apply_expression_upload`). It bumps `_character_editor_generation` **once** (NOT per state — per-state bumps race the re-renders) and re-renders the affected slots + the avatar:
+```python
+    async def _apply_expression_set(self, character_id: int, images: dict):
+        """Apply a resolved expression set: idle staged in the editor (persists on
+        card save), the three reactive states written immediately. Bumps the render
+        token ONCE, then re-renders the affected slots + the avatar thumbnail."""
+        from ...Character_Chat.expression_set_io import (
+            apply_expression_images_to_db,
+            ExpressionSetApplyResult,
+        )
+        applied: list[str] = []
+        skipped: list = []
+        db = getattr(self.app_instance, "chachanotes_db", None)
+        # idle -> stage in the editor (like a manual avatar upload)
+        idle = images.get("idle")
+        editor = None
+        try:
+            editor = self.query_one(PersonasCharacterEditorWidget)
+        except QueryError:
+            editor = None
+        if idle and editor is not None:
+            editor.set_avatar_image(idle)
+            applied.append("idle")
+        # three -> DB (immediate), off-thread
+        if db is not None:
+            db_applied, db_skipped = await asyncio.to_thread(
+                apply_expression_images_to_db, db, character_id, images
+            )
+            applied.extend(db_applied)
+            skipped.extend(db_skipped)
+        # single generation bump, then ONE re-render of the avatar + all 3 slots
+        self._character_editor_generation += 1
+        await self._render_all_character_editor_thumbnails(character_id)
+        return ExpressionSetApplyResult(applied=applied, skipped=skipped)
+```
+NOTE: `_render_all_character_editor_thumbnails(self, character_id: int | None)` (personas_screen ~:4244) re-renders the avatar thumbnail + all three expression-slot thumbnails, and does NOT bump the token itself — so bump ONCE above, then call it once; all re-renders share the fresh token. Do NOT call `_apply_expression_upload` per state (it bumps the token each time → drops the prior slot's in-flight render — the P3d-1 render-race). READ FRESH to confirm the method name/signature hasn't drifted.
+
+- [ ] **Step 7: Run both test files to verify pass**
+
+Run the DB-helper file and the UI file (separate invocations — different rootdirs):
+```
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/personas-redesign && HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Character_Chat/test_expression_set_io.py -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/personas-redesign && HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_personas_expression_slots.py -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: PASS both. Then `python -c "import tldw_chatbook.app"`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tldw_chatbook/Character_Chat/expression_set_io.py tldw_chatbook/UI/Screens/personas_screen.py Tests/Character_Chat/test_expression_set_io.py Tests/UI/test_personas_expression_slots.py
+git commit -m "feat(personas): P3d-2 Task 3 — apply_expression_images_to_db + _apply_expression_set orchestrator"
+```
+
+---
+
+## Task 4: Import / Export buttons + workers
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py` (2 messages)
+- Modify: `tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py` (2 buttons + post_message; READ the expression-slot compose + the `Button.Pressed`/action that posts `CharacterExpressionUploadRequested` ~:1036 to mirror)
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py` (handlers + import worker + import path method + export worker; READ `_expression_upload_dialog_worker` ~:4485, `_import_dialog_worker` ~:4622, `_dictionary_export_worker`, `_io_dialog_active`, `_character_editor_is_active`, `_notify`)
+- Test: `Tests/UI/test_personas_expression_slots.py` (extend)
+
+**Interfaces:**
+- Consumes: `_apply_expression_set` (Task 3); `resolve_local_expression_set` / `build_expression_set_zip` (Tasks 1-2); `editor.expression_character_id()`, `editor.current_avatar_bytes()`, `db.get_character_expression_image`.
+- Produces: `CharacterExpressionSetImportRequested`, `CharacterExpressionSetExportRequested` messages; `_import_expression_set_from_path(character_id, path)` (dialog-free, testable) + `_export_expression_set(character_id, name)` (dialog-free) + their workers/handlers.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `Tests/UI/test_personas_expression_slots.py` (mirror the file's editor harness). Test the **dialog-free** path methods directly (the P3d-1 pattern):
+```python
+@pytest.mark.asyncio
+async def test_import_expression_set_from_zip_path(personas_editor_with_saved_character, tmp_path):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    from tldw_chatbook.Character_Chat.expression_set_io import build_expression_set_zip
+    import io as _io
+    from PIL import Image as _Img
+    def _png(): b=_io.BytesIO(); _Img.new("RGB",(8,8)).save(b,format="PNG"); return b.getvalue()
+    z = tmp_path / "set.zip"
+    z.write_bytes(build_expression_set_zip("Ada", {"idle": _png(), "speaking": _png()}))
+
+    await screen._import_expression_set_from_path(char_id, str(z))
+
+    assert db.get_character_expression_image(char_id, "speaking") is not None
+    from tldw_chatbook.Widgets.Persona_Widgets.personas_character_editor_widget import PersonasCharacterEditorWidget
+    assert screen.query_one(PersonasCharacterEditorWidget).current_avatar_bytes() is not None  # idle staged
+
+
+@pytest.mark.asyncio
+async def test_export_expression_set_writes_a_zip(personas_editor_with_saved_character):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    import io as _io
+    from PIL import Image as _Img
+    def _png(): b=_io.BytesIO(); _Img.new("RGB",(8,8)).save(b,format="PNG"); return b.getvalue()
+    db.set_character_expression_image(char_id, "speaking", _png())
+    target = await screen._export_expression_set(char_id, "Ada")
+    assert target is not None
+    from pathlib import Path
+    import zipfile
+    assert zipfile.is_zipfile(Path(target))
+    assert "speaking.png" in zipfile.ZipFile(target).namelist()
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run the UI file (Task 3 Step-7 UI command). Expected: FAIL — the path methods don't exist.
+
+- [ ] **Step 3: Add the two messages**
+
+In `personas_pane_messages.py`, mirror `CharacterExpressionUploadRequested` (no payload needed):
+```python
+class CharacterExpressionSetImportRequested(Message):
+    """Roleplay P3d-2: import a whole expression set from a .zip."""
+
+
+class CharacterExpressionSetExportRequested(Message):
+    """Roleplay P3d-2: export the character's expression set to a .zip."""
+```
+
+- [ ] **Step 4: Add the two buttons**
+
+In `personas_character_editor_widget.py`, next to the expression slots, add an "Import set…" and "Export set…" button; on press, `self.post_message(CharacterExpressionSetImportRequested())` / `...ExportRequested()` (mirror the `CharacterExpressionUploadRequested(state)` post at ~:1036). Import the two message classes at the top (~:27).
+
+- [ ] **Step 5: Add the handlers + path methods + workers**
+
+In `personas_screen.py`:
+```python
+    @on(CharacterExpressionSetImportRequested)
+    def _handle_expression_set_import_requested(self, message) -> None:
+        message.stop()
+        if not self._character_editor_is_active():
+            self._notify("Open a character editor before importing an expression set.", "warning")
+            return
+        editor = self.query_one(PersonasCharacterEditorWidget)
+        character_id = editor.expression_character_id()
+        if character_id is None:
+            self._notify("Save the character to import an expression set.", "warning")
+            return
+        if self._io_dialog_active:
+            return
+        self._io_dialog_active = True
+        self.run_worker(self._expression_set_import_dialog_worker(character_id), group="personas-io")
+
+    async def _expression_set_import_dialog_worker(self, character_id: int) -> None:
+        from ...Widgets.enhanced_file_picker import EnhancedFileOpen, Filters
+        try:
+            picker = EnhancedFileOpen(
+                title="Import Expression Set (.zip)",
+                filters=Filters(("Zip Archives", lambda p: p.suffix.lower() == ".zip")),
+                context="character_expression_set_import",
+            )
+            try:
+                file_path = await self.app.push_screen_wait(picker)
+            except Exception:
+                logger.opt(exception=True).warning("Could not show the expression-set import dialog.")
+                return
+            if file_path:
+                await self._import_expression_set_from_path(character_id, str(file_path))
+        finally:
+            self._io_dialog_active = False
+
+    async def _import_expression_set_from_path(self, character_id: int, path: str) -> None:
+        from ...Character_Chat.expression_set_io import resolve_local_expression_set
+        from pathlib import Path
+        res = await asyncio.to_thread(resolve_local_expression_set, [Path(path)])
+        if not res.images:
+            reason = "; ".join(n for n, _ in res.skipped[:2]) or "; ".join(res.notes[:1]) or "no matching images"
+            self._notify(f"Nothing imported ({reason}).", "warning")
+            return
+        result = await self._apply_expression_set(character_id, res.images)
+        applied = ", ".join(result.applied) or "nothing"
+        note = " — save the character to keep idle" if "idle" in result.applied else ""
+        self._notify(f"Imported: {applied}.{note}", "information")
+
+    @on(CharacterExpressionSetExportRequested)
+    def _handle_expression_set_export_requested(self, message) -> None:
+        message.stop()
+        if not self._character_editor_is_active():
+            return
+        editor = self.query_one(PersonasCharacterEditorWidget)
+        character_id = editor.expression_character_id()
+        if character_id is None:
+            self._notify("Save the character before exporting its expression set.", "warning")
+            return
+        name = str(self.state.selected_entity_name or "character")   # screen state (mirrors _dictionary_export_worker); the editor has NO name accessor
+        self.run_worker(self._export_expression_set_worker(character_id, name), group="personas-io", exit_on_error=False)
+
+    async def _export_expression_set_worker(self, character_id: int, name: str) -> None:
+        try:
+            target = await self._export_expression_set(character_id, name)
+            if target:
+                self._notify(f"Expression set exported to {target}.", "information")
+        except Exception as exc:
+            logger.opt(exception=True).error(f"Expression-set export failed: {exc}")
+            self._notify(f"Export failed: {exc}", "error")
+
+    async def _export_expression_set(self, character_id: int, name: str) -> str | None:
+        """Build the export zip and write it to the exports dir (atomic). Returns the path."""
+        from ...Character_Chat.expression_set_io import build_expression_set_zip
+        images: dict[str, bytes] = {}
+        try:
+            editor = self.query_one(PersonasCharacterEditorWidget)
+            idle = editor.current_avatar_bytes()
+            if idle:
+                images["idle"] = idle
+        except QueryError:
+            pass
+        db = getattr(self.app_instance, "chachanotes_db", None)
+        if db is not None:
+            for state in ("thinking", "speaking", "error"):
+                data = await asyncio.to_thread(db.get_character_expression_image, character_id, state)
+                if data:
+                    images[state] = data
+        if not images:
+            self._notify("This character has no expression images to export.", "warning")
+            return None
+        blob = await asyncio.to_thread(build_expression_set_zip, name, images)
+        # Mirror _dictionary_export_worker: exports dir + atomic temp-replace.
+        slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-") or "character"
+        stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        exports_dir = get_user_data_dir() / "exports"
+        exports_dir.mkdir(parents=True, exist_ok=True)
+        target = exports_dir / f"{slug}-expressions-{stamp}.zip"
+        temp = exports_dir / f".{slug}-expressions-{stamp}.zip.tmp"
+        temp.write_bytes(blob)
+        temp.replace(target)
+        return str(target)
+```
+NOTE: verify the exact names `_character_editor_is_active`, `_notify`, `get_user_data_dir`, `PersonasCharacterEditorWidget`, `QueryError`, `re`, `datetime` imports already exist in `personas_screen.py` (they do — `_dictionary_export_worker` uses them). The character NAME comes from `self.state.selected_entity_name` (the screen state `_dictionary_export_worker` uses) — the editor widget has NO name accessor.
+
+- [ ] **Step 6: Run to verify pass**
+
+Run the UI file. Expected: PASS. Then run the DB module file + `python -c "import tldw_chatbook.app"`. Also re-run `Tests/UI/test_personas_character_editor_avatar.py` for no regression.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py tldw_chatbook/UI/Screens/personas_screen.py Tests/UI/test_personas_expression_slots.py
+git commit -m "feat(personas): P3d-2 Task 4 — Import/Export expression set buttons + workers"
+```
+
+---
+
+## Self-Review (author)
+
+- **Spec coverage:** resolver + security (Task 1) ✓; exporter + round-trip + format-detection (Task 2) ✓; DB helper + orchestrator with idle-staged/3-immediate + single-generation-bump (Task 3) ✓; UI buttons + single-.zip import + exports-dir export + saved-char/characters-only gate + best-effort summary (Task 4) ✓. `.vpack` extractor explicitly deferred to P3d-3 (no task). No migration (no task) ✓.
+- **Type consistency:** `resolve_local_expression_set(list[Path]) -> ExpressionSetResolution{images,skipped,notes}` (T1) consumed in T4; `build_expression_set_zip(str, dict) -> bytes` (T2) consumed in T4; `apply_expression_images_to_db(db, int, dict) -> (applied, skipped)` (T3) consumed by `_apply_expression_set` (T3) consumed in T4; `ExpressionSetApplyResult{applied, skipped}` consistent T3→T4. `EXPRESSION_STATES`/`EXPRESSION_IMAGE_STATES` imported from `console_expression_state` throughout.
+- **Placeholder scan:** every code step shows code; the "READ FRESH / confirm the exact name" notes point at specific named methods (avatar-thumb render method, editor name accessor) the implementer must bind — flagged because `personas_screen.py` drifts under concurrent edits, not vague hand-waving.
+- **Known drift:** all `personas_screen.py` / `personas_character_editor_widget.py` line numbers are approximate (concurrent edits) — every task says READ FRESH. The P3d-1 patterns (`_expression_upload_dialog_worker`, `_stage_character_expression_from_path`, `_dictionary_export_worker`, `_render_character_expression_slot`, `_character_editor_generation`, `editor.set_avatar_image/current_avatar_bytes/expression_character_id`) are verified against the current file.

--- a/Docs/superpowers/specs/2026-07-23-roleplay-p3d2-expression-set-io-design.md
+++ b/Docs/superpowers/specs/2026-07-23-roleplay-p3d2-expression-set-io-design.md
@@ -1,0 +1,123 @@
+# Roleplay P3d-2 — Bulk Import + Export of a Character's Expression Set — Design
+
+**Date:** 2026-07-23
+**Program:** Roleplay (Personas) redesign — character-presence theme, P3d cycle 2 (after P3d-1 reactive expression avatar, PR #792).
+**Status:** design approved (brainstorming); ready for implementation plan.
+
+## Goal
+
+Make getting a character's expression images **in and out** fast and shareable: assign the whole set (idle + thinking + speaking + error) at once from a folder / multi-selected files / a `.zip`, and export a character's set as a `.zip` for backup or sharing — instead of P3d-1's three one-at-a-time file-dialog slots.
+
+## Context
+
+P3d-1 shipped a reactive Console avatar that swaps among **idle / thinking / speaking / error** as a reply generates. Storage: the three reactive states are BLOBs in `character_expression_images` (`set/get/list/delete_character_expression_image`, state-validated in Python to `{thinking, speaking, error}`); **idle reuses `character_cards.image`** (the main avatar). Authoring today = three upload/preview/clear slots in the character editor (`personas_screen.py` / `personas_character_editor_widget.py`), reusing the `_character_editor_generation` render-token discipline.
+
+P3d-2 adds **bulk local import** and **export** on top of that, with **no schema change** (the table and the avatar column already exist). The heavier `.tldw-persona-vpack` server-archive extractor is **deferred to P3d-3**, which will plug into the same `apply_expression_set` orchestrator this spec defines.
+
+## Verified ground truths (from code scout — use verbatim)
+
+1. **idle is staged, the three are immediate.** The main avatar is staged in the editor via `editor.set_avatar_image(bytes)` (`personas_screen.py:~3949`) and read back via `editor.current_avatar_bytes()` (`:~3979`); it persists only on **card save** (a version-bumping `update_character_card`). The three reactive states write immediately to the table via `db.set_character_expression_image(...)` (P3d-1, card-version-independent). So a bulk import must handle idle differently from the three.
+2. **File picker** (`Widgets/enhanced_file_picker.py`) supports **multi-select** (per-entry selection markers) and has an `EnhancedFileSave` save dialog (used elsewhere in `personas_screen.py`).
+3. **P3d-1 authoring surface** (to reuse): `_apply_expression_upload(character_id, state, image, mime)`, `_clear_expression_slot(...)`, the `char-expression-slot-{state}` slots, `_character_editor_generation` render token, the off-thread thumbnail render, `_avatar_upload_dialog_worker` (the file-dialog pattern), and `EXPRESSION_IMAGE_STATES = ("thinking","speaking","error")` from `Chat/console_expression_state.py`.
+4. **No migration** — `character_expression_images` and `character_cards.image` already exist (schema v23).
+
+## Architecture — one orchestrator, two flows (import, export)
+
+### Unit 1 — `apply_expression_set` orchestrator (screen-level)
+
+A screen method that applies a resolved set to the currently-edited, **saved** character:
+
+```
+_apply_expression_set(character_id: int, images: dict[str, bytes]) -> ExpressionSetApplyResult
+```
+
+- `images` maps a state name (`idle`/`thinking`/`speaking`/`error`) → raw bytes; any subset may be present.
+- **idle** → `editor.set_avatar_image(bytes)` — **staged** in the editor exactly like a manual avatar upload (persists on card save).
+- **thinking/speaking/error** → `db.set_character_expression_image(character_id, state, bytes, mime)` — immediate (off-thread, as P3d-1 does).
+- Each image is **PIL-validated** before applying; an invalid image for one state is skipped, not fatal (best-effort partial).
+- After applying, bump `_character_editor_generation` once and re-render the affected slot thumbnails + the avatar thumbnail (P3d-1 render-token discipline).
+- Returns `ExpressionSetApplyResult{applied: list[str], skipped: list[(state, reason)]}` so the caller can show a summary.
+- This orchestrator is the single sink; P3d-3's `.vpack` extractor will feed it the same `images` dict.
+
+A pure helper does the DB-only part so it is unit-testable without the editor:
+`apply_expression_images_to_db(db, character_id, images_without_idle) -> (applied, skipped)`.
+
+### Unit 2 — Local importer (folder / multi-select / `.zip` → `dict[state, bytes]`)
+
+A pure function that resolves selected inputs to a validated set:
+
+```
+resolve_local_expression_set(paths: list[Path]) -> ExpressionSetResolution
+```
+
+- Input: a list of selected file paths (multi-selected images), a single directory path (folder), or a single `.zip` path.
+- If a path is a `.zip`: read its members **into memory** (never extract attacker paths to disk); enforce the security caps (Unit 5); treat each member as a candidate file by its base name.
+- If a path is a directory: enumerate its image files (non-recursive).
+- **Filename → state:** the file's stem, **case-insensitive**, matched exactly against `{idle, thinking, speaking, error}`. Non-matching or non-image files are skipped. If two files match one state, prefer `.png`, else the first alphabetically (and record the tie in the resolution's notes).
+- Every candidate is **PIL-validated**; invalid → skipped with a reason.
+- Returns `ExpressionSetResolution{images: dict[str, bytes], skipped: list[(name, reason)], notes: list[str]}`.
+
+### Unit 3 — Exporter (character's set → `.zip`)
+
+```
+build_expression_set_zip(character_name: str, images: dict[str, bytes]) -> bytes
+```
+
+- Input: the character's current set — idle from `editor.current_avatar_bytes()` (the live on-screen avatar), the three from `db.get_character_expression_image(...)`.
+- Output: a `.zip` (bytes) containing one file per present state named `{state}.{ext}`, where `ext` is derived from the stored image format (PIL-detected, or the stored `mime`; default `png`) — so a JPEG-stored state exports as `speaking.jpg`, not a mislabeled `.png`. Plus a minimal self-describing `expression_set.json` (`{"format": "tldw-expression-set/1", "character": <name>, "states": [...]}`).
+- **Symmetric with Unit 2:** an exported zip re-imports directly — the importer maps by filename **stem** (extension-agnostic), so `{state}.{ext}` still resolves to `state`; `expression_set.json` is ignored on import (provenance only).
+- The screen writes these bytes to the path chosen via `EnhancedFileSave`.
+
+### Unit 4 — UI (character editor)
+
+- An **"Import set…"** and **"Export set…"** button pair next to the P3d-1 expression slots. **Saved-character-only** (the three table writes need a `character_id`) and **characters-only** (personas have no images) — same gate as the P3d-1 slots.
+- **Import** opens the file picker (multi-select images, or a single `.zip`; a folder if the picker exposes directory selection cheaply), resolves via Unit 2, applies via Unit 1, and shows a **summary** notification: `Applied: idle (staged), speaking. Skipped: thinking, error (not found).` idle always reads as "staged — save the character to keep it."
+- **Export** reads the current set, builds the zip (Unit 3), and saves via `EnhancedFileSave` (default filename `<character-name>-expressions.zip`).
+- Both run in the editor's IO worker group with the same guard pattern as `_avatar_upload_dialog_worker` (never let an exception escape into an `exit_on_error=True` worker).
+
+### Unit 5 — Security (untrusted `.zip`)
+
+Both the import `.zip` and (in P3d-3) the `.vpack` are untrusted archives. On read:
+- **Read entries into memory** via `zipfile`; never write attacker-controlled paths to disk.
+- Cap **member count** (e.g. ≤ 64), **per-file uncompressed bytes** (e.g. ≤ 16 MB), and **total uncompressed bytes** (zip-bomb guard, e.g. ≤ 64 MB) — checked against `ZipInfo.file_size` *before* reading each member.
+- **PIL-validate** every image member; reject non-images.
+- On any single bad/oversize member: skip that member (best-effort), do not abort the whole import. On a structurally broken zip (not a zip, encrypted): fail the import cleanly with a notification, never raise into the worker.
+
+## Data flow
+
+**Import:** pick files/zip → `resolve_local_expression_set(paths)` (in-memory, validated, security-capped) → `_apply_expression_set(character_id, images)` (idle staged in editor, 3 immediate to DB) → bump generation, re-render thumbnails → summary notification.
+
+**Export:** read idle (`current_avatar_bytes()`) + 3 (`get_character_expression_image`) → `build_expression_set_zip(name, images)` → `EnhancedFileSave` → write bytes.
+
+## Error handling / fail-soft
+
+- Import/export are best-effort and never crash the editor: the resolver and orchestrator return structured skip reasons; the workers wrap everything and degrade to a notification. A missing image, a non-image file, an oversize member, a broken zip, or a DB write failure for one state all produce a summary line, not an exception.
+- idle staging never touches the card version until the user saves; the three writes are independent of the card version (P3d-1 invariant preserved).
+
+## Testing
+
+- **`resolve_local_expression_set`** (pure): multi-select images → correct state map; `.zip` → same; directory → same; case-insensitive stems; non-matching/non-image skipped; two-files-one-state tie resolution; corrupt image skipped with reason; **security** — member-count / per-file / total-size caps reject (real crafted zips), not-a-zip fails cleanly.
+- **`build_expression_set_zip`** + round-trip: export then `resolve_local_expression_set` yields the same states; `expression_set.json` present and ignored on import.
+- **`apply_expression_images_to_db`** (pure DB, file-backed `CharactersRAGDB(tmp_path/...)` — NOT `:memory:`, per the P3d-1 off-thread/threading.local rule): writes the three states, skips idle, best-effort partial.
+- **`_apply_expression_set`** (mounted editor): idle staged (`current_avatar_bytes()` reflects it, card unsaved), three in the table, thumbnails refresh, result summary correct.
+- **UI**: buttons present saved-character-only / characters-only; import summary; export save flow; never raises.
+
+## Global constraints (for the plan)
+
+- **NO migration** (schema stays v23; reuses `character_expression_images` + `character_cards.image`).
+- **idle is staged via `editor.set_avatar_image()`** (persists on card save); the three reactive states write immediately via `db.set_character_expression_image` (card-version-independent — P3d-1 invariant). Export reads idle from `editor.current_avatar_bytes()`.
+- Reuse the P3d-1 authoring surface (`_character_editor_generation` render token — bump once per import + re-render affected slots; the `_avatar_upload_dialog_worker` file-dialog + IO-worker-guard pattern; `EXPRESSION_IMAGE_STATES`).
+- **Saved-character-only** (needs `character_id`) and **characters-only** (personas mode shows no import/export).
+- **Untrusted-zip handling** (Unit 5): in-memory reads, member/per-file/total-size caps, PIL-validate, best-effort skip, never raise into the worker.
+- **Best-effort partial**: every state applies independently; one bad state never fails the whole operation; the summary reports skips.
+- File-backed `CharactersRAGDB(tmp_path/...)` for DB tests (never `:memory:`). Tests/UI `asyncio_mode=auto` — don't mix dirs OR add explicit `@pytest.mark.asyncio`.
+- CONCURRENT-SESSION HAZARD: `personas_screen.py` / `personas_character_editor_widget.py` are heavily edited by other sessions — keep P3d-2 localized to the new orchestrator + importer/exporter + the two buttons; expect a rebase.
+- Implementers stage ONLY their task's files (never `git add -A`, never `.superpowers/`). NO background/broad test sweeps; NEVER broad-pkill pytest — scope to the worktree.
+
+## Out of scope — later cycles
+
+- **`.tldw-persona-vpack` extraction → P3d-3** (its own spec→plan→PR), built on this cycle's `_apply_expression_set` orchestrator: parse `manifest.json`, resolve each of our four states → `frames[0]` → asset → crop region → static image → feed the orchestrator; ignore non-matching server states and animation.
+- Server/MCP pack **fetch** (this cycle imports a local `.zip`, not a server-pulled pack).
+- Animation / sprite playback (terminals do static frame-swap only).
+- Checksum *verification* as a hard gate (lenient extract).
+- Custom / mood / tool / voice states.

--- a/Docs/superpowers/specs/2026-07-23-roleplay-p3d2-expression-set-io-design.md
+++ b/Docs/superpowers/specs/2026-07-23-roleplay-p3d2-expression-set-io-design.md
@@ -6,7 +6,7 @@
 
 ## Goal
 
-Make getting a character's expression images **in and out** fast and shareable: assign the whole set (idle + thinking + speaking + error) at once from a folder / multi-selected files / a `.zip`, and export a character's set as a `.zip` for backup or sharing — instead of P3d-1's three one-at-a-time file-dialog slots.
+Make getting a character's expression images **in and out** fast and shareable: assign the whole set (idle + thinking + speaking + error) at once by importing a `.zip`, and export a character's set as a `.zip` for backup or sharing — instead of P3d-1's three one-at-a-time file-dialog slots. (The `.zip` is the portable, shareable unit and is symmetric: an exported set re-imports directly. The importer's core is written to also accept a folder / multiple files, so a future picker upgrade can add loose-file import with no core change.)
 
 ## Context
 
@@ -17,7 +17,7 @@ P3d-2 adds **bulk local import** and **export** on top of that, with **no schema
 ## Verified ground truths (from code scout — use verbatim)
 
 1. **idle is staged, the three are immediate.** The main avatar is staged in the editor via `editor.set_avatar_image(bytes)` (`personas_screen.py:~3949`) and read back via `editor.current_avatar_bytes()` (`:~3979`); it persists only on **card save** (a version-bumping `update_character_card`). The three reactive states write immediately to the table via `db.set_character_expression_image(...)` (P3d-1, card-version-independent). So a bulk import must handle idle differently from the three.
-2. **File picker** (`Widgets/enhanced_file_picker.py`) supports **multi-select** (per-entry selection markers) and has an `EnhancedFileSave` save dialog (used elsewhere in `personas_screen.py`).
+2. **File picker** (`Widgets/enhanced_file_picker.py`): `EnhancedFileOpen` returns a **single file** — every real usage (`ccp_character_handler`, `chat_attachment_handler`, `ccp_dictionary_handler`, …) gets one `Path` from `push_screen_wait`; `_should_return(candidate: Path)` gates one file. There is **no reliable multi-file return** and no confirmed directory-select. `EnhancedFileSave` is the save dialog. So the import UI selects a **single `.zip`**; multi-select/folder are not available through the standard picker.
 3. **P3d-1 authoring surface** (to reuse): `_apply_expression_upload(character_id, state, image, mime)`, `_clear_expression_slot(...)`, the `char-expression-slot-{state}` slots, `_character_editor_generation` render token, the off-thread thumbnail render, `_avatar_upload_dialog_worker` (the file-dialog pattern), and `EXPRESSION_IMAGE_STATES = ("thinking","speaking","error")` from `Chat/console_expression_state.py`.
 4. **No migration** — `character_expression_images` and `character_cards.image` already exist (schema v23).
 
@@ -42,7 +42,7 @@ _apply_expression_set(character_id: int, images: dict[str, bytes]) -> Expression
 A pure helper does the DB-only part so it is unit-testable without the editor:
 `apply_expression_images_to_db(db, character_id, images_without_idle) -> (applied, skipped)`.
 
-### Unit 2 — Local importer (folder / multi-select / `.zip` → `dict[state, bytes]`)
+### Unit 2 — Local importer (`.zip` → `dict[state, bytes]`; resolver stays general)
 
 A pure function that resolves selected inputs to a validated set:
 
@@ -50,9 +50,9 @@ A pure function that resolves selected inputs to a validated set:
 resolve_local_expression_set(paths: list[Path]) -> ExpressionSetResolution
 ```
 
-- Input: a list of selected file paths (multi-selected images), a single directory path (folder), or a single `.zip` path.
+- **UI input is a single `.zip`** (ground truth #2 — the standard picker returns one file). The resolver is nonetheless written to accept a general `list[Path]` — a single `.zip`, a directory, or multiple image paths — so it is unit-testable without a zip and ready for a future folder/multi-select picker or P3d-3's needs. The UI passes `[selected_zip_path]`.
 - If a path is a `.zip`: read its members **into memory** (never extract attacker paths to disk); enforce the security caps (Unit 5); treat each member as a candidate file by its base name.
-- If a path is a directory: enumerate its image files (non-recursive).
+- If a path is a directory: enumerate its image files (non-recursive). If a path is an image file: use it directly.
 - **Filename → state:** the file's stem, **case-insensitive**, matched exactly against `{idle, thinking, speaking, error}`. Non-matching or non-image files are skipped. If two files match one state, prefer `.png`, else the first alphabetically (and record the tie in the resolution's notes).
 - Every candidate is **PIL-validated**; invalid → skipped with a reason.
 - Returns `ExpressionSetResolution{images: dict[str, bytes], skipped: list[(name, reason)], notes: list[str]}`.
@@ -64,14 +64,14 @@ build_expression_set_zip(character_name: str, images: dict[str, bytes]) -> bytes
 ```
 
 - Input: the character's current set — idle from `editor.current_avatar_bytes()` (the live on-screen avatar), the three from `db.get_character_expression_image(...)`.
-- Output: a `.zip` (bytes) containing one file per present state named `{state}.{ext}`, where `ext` is derived from the stored image format (PIL-detected, or the stored `mime`; default `png`) — so a JPEG-stored state exports as `speaking.jpg`, not a mislabeled `.png`. Plus a minimal self-describing `expression_set.json` (`{"format": "tldw-expression-set/1", "character": <name>, "states": [...]}`).
+- Output: a `.zip` (bytes) containing one file per present state named `{state}.{ext}`, where `ext` is derived by **PIL-detecting the format from the bytes** (`Image.open(BytesIO(b)).format` → `png`/`jpg`/`webp`; default `png`) — the stored `mime` is NOT readable (`get_character_expression_image` returns bytes only), so detection is from the bytes, not the column. So a JPEG-stored state exports as `speaking.jpg`, not a mislabeled `.png`. Plus a minimal self-describing `expression_set.json` (`{"format": "tldw-expression-set/1", "character": <name>, "states": [...]}`).
 - **Symmetric with Unit 2:** an exported zip re-imports directly — the importer maps by filename **stem** (extension-agnostic), so `{state}.{ext}` still resolves to `state`; `expression_set.json` is ignored on import (provenance only).
 - The screen writes these bytes to the path chosen via `EnhancedFileSave`.
 
 ### Unit 4 — UI (character editor)
 
 - An **"Import set…"** and **"Export set…"** button pair next to the P3d-1 expression slots. **Saved-character-only** (the three table writes need a `character_id`) and **characters-only** (personas have no images) — same gate as the P3d-1 slots.
-- **Import** opens the file picker (multi-select images, or a single `.zip`; a folder if the picker exposes directory selection cheaply), resolves via Unit 2, applies via Unit 1, and shows a **summary** notification: `Applied: idle (staged), speaking. Skipped: thinking, error (not found).` idle always reads as "staged — save the character to keep it."
+- **Import** opens `EnhancedFileOpen` filtered to `.zip`, gets one path, resolves via Unit 2 (`[zip_path]`), applies via Unit 1, and shows a **summary** notification: `Applied: idle (staged), speaking. Skipped: thinking, error (not found).` idle always reads as "staged — save the character to keep it." (A `.zip` is the bulk unit and is symmetric with Export; loose-folder / multi-select import is a future enhancement gated on picker capability, not this cycle.)
 - **Export** reads the current set, builds the zip (Unit 3), and saves via `EnhancedFileSave` (default filename `<character-name>-expressions.zip`).
 - Both run in the editor's IO worker group with the same guard pattern as `_avatar_upload_dialog_worker` (never let an exception escape into an `exit_on_error=True` worker).
 
@@ -85,9 +85,9 @@ Both the import `.zip` and (in P3d-3) the `.vpack` are untrusted archives. On re
 
 ## Data flow
 
-**Import:** pick files/zip → `resolve_local_expression_set(paths)` (in-memory, validated, security-capped) → `_apply_expression_set(character_id, images)` (idle staged in editor, 3 immediate to DB) → bump generation, re-render thumbnails → summary notification.
+**Import:** pick one `.zip` (`EnhancedFileOpen`, `.zip` filter) → `resolve_local_expression_set([zip_path])` (in-memory, validated, security-capped) → `_apply_expression_set(character_id, images)` (idle staged in editor, 3 immediate to DB) → bump generation, re-render thumbnails → summary notification.
 
-**Export:** read idle (`current_avatar_bytes()`) + 3 (`get_character_expression_image`) → `build_expression_set_zip(name, images)` → `EnhancedFileSave` → write bytes.
+**Export:** read idle (`current_avatar_bytes()`) + 3 (`get_character_expression_image`) → `build_expression_set_zip(name, images)` (extensions PIL-detected from bytes) → `EnhancedFileSave` → write bytes.
 
 ## Error handling / fail-soft
 

--- a/Tests/Character_Chat/test_expression_set_io.py
+++ b/Tests/Character_Chat/test_expression_set_io.py
@@ -114,3 +114,28 @@ def test_not_a_zip_fails_cleanly(tmp_path):
     res = resolve_local_expression_set([bad])  # must not raise
     assert res.images == {}
     assert res.skipped or res.notes
+
+
+def test_build_zip_round_trips_through_resolver(tmp_path):
+    from tldw_chatbook.Character_Chat.expression_set_io import build_expression_set_zip
+    images = {"idle": _png(), "speaking": _jpg()}
+    blob = build_expression_set_zip("Ada Lovelace", images)
+    out = tmp_path / "ada.zip"
+    out.write_bytes(blob)
+    res = resolve_local_expression_set([out])
+    assert set(res.images) == {"idle", "speaking"}
+
+
+def test_build_zip_uses_detected_extension(tmp_path):
+    from tldw_chatbook.Character_Chat.expression_set_io import build_expression_set_zip
+    blob = build_expression_set_zip("Ada", {"speaking": _jpg()})
+    names = zipfile.ZipFile(io.BytesIO(blob)).namelist()
+    assert "speaking.jpg" in names          # JPEG bytes -> .jpg, not .png
+    assert "expression_set.json" in names    # provenance marker present
+
+
+def test_build_zip_empty_set_is_valid_zip():
+    from tldw_chatbook.Character_Chat.expression_set_io import build_expression_set_zip
+    blob = build_expression_set_zip("Ada", {})
+    zf = zipfile.ZipFile(io.BytesIO(blob))
+    assert zf.namelist() == ["expression_set.json"]

--- a/Tests/Character_Chat/test_expression_set_io.py
+++ b/Tests/Character_Chat/test_expression_set_io.py
@@ -1,6 +1,5 @@
 import io
 import zipfile
-from pathlib import Path
 
 import pytest
 from PIL import Image
@@ -8,7 +7,6 @@ from PIL import Image
 from tldw_chatbook.Character_Chat.expression_set_io import (
     resolve_local_expression_set,
     MAX_ZIP_MEMBERS,
-    MAX_TOTAL_BYTES,
 )
 
 

--- a/Tests/Character_Chat/test_expression_set_io.py
+++ b/Tests/Character_Chat/test_expression_set_io.py
@@ -139,3 +139,34 @@ def test_build_zip_empty_set_is_valid_zip():
     blob = build_expression_set_zip("Ada", {})
     zf = zipfile.ZipFile(io.BytesIO(blob))
     assert zf.namelist() == ["expression_set.json"]
+
+
+@pytest.fixture
+def db(tmp_path):
+    from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+    return CharactersRAGDB(tmp_path / "expr.db", "test-client")   # file-backed, not :memory:
+
+
+def test_apply_images_to_db_writes_only_non_idle(db):
+    from tldw_chatbook.Character_Chat.expression_set_io import apply_expression_images_to_db
+    cid = db.add_character_card({"name": "Ada"})
+    applied, skipped = apply_expression_images_to_db(
+        db, cid, {"idle": _png(), "speaking": _png(), "thinking": _png()}
+    )
+    assert set(applied) == {"speaking", "thinking"}     # idle NOT written to the table
+    assert db.get_character_expression_image(cid, "speaking") is not None
+    assert db.get_character_expression_image(cid, "idle") is None
+
+
+def test_apply_images_to_db_best_effort(db, monkeypatch):
+    from tldw_chatbook.Character_Chat.expression_set_io import apply_expression_images_to_db
+    cid = db.add_character_card({"name": "Ada"})
+    orig = db.set_character_expression_image
+    def boom(c, s, i, m=None):
+        if s == "error":
+            raise RuntimeError("disk full")
+        return orig(c, s, i, m)
+    monkeypatch.setattr(db, "set_character_expression_image", boom)
+    applied, skipped = apply_expression_images_to_db(db, cid, {"speaking": _png(), "error": _png()})
+    assert applied == ["speaking"]
+    assert any(s == "error" for s, _ in skipped)

--- a/Tests/Character_Chat/test_expression_set_io.py
+++ b/Tests/Character_Chat/test_expression_set_io.py
@@ -106,6 +106,42 @@ def test_total_size_cap_rejects(tmp_path, monkeypatch):
     assert res.notes or res.skipped
 
 
+def test_directory_oversize_file_skipped_by_size_cap(tmp_path, monkeypatch):
+    # Qodo fix 5: the directory branch must cap per-file size BEFORE
+    # read_bytes(), same as the .zip branch already did.
+    import tldw_chatbook.Character_Chat.expression_set_io as mod
+    monkeypatch.setattr(mod, "MAX_MEMBER_BYTES", 1000)
+    d = tmp_path / "imgs"
+    d.mkdir()
+    (d / "idle.png").write_bytes(_png())          # small, valid -> resolves
+    (d / "speaking.png").write_bytes(b"X" * 5000)  # over the (patched) cap
+    res = resolve_local_expression_set([d])
+    assert "idle" in res.images
+    assert "speaking" not in res.images
+    assert ("speaking.png", "file too large") in res.skipped
+
+
+def test_standalone_file_oversize_skipped_by_size_cap(tmp_path, monkeypatch):
+    # Same cap, exercised via the standalone-file branch of _candidate_pairs.
+    import tldw_chatbook.Character_Chat.expression_set_io as mod
+    monkeypatch.setattr(mod, "MAX_MEMBER_BYTES", 1000)
+    big = tmp_path / "error.png"
+    big.write_bytes(b"X" * 5000)
+    res = resolve_local_expression_set([big])
+    assert "error" not in res.images
+    assert ("error.png", "file too large") in res.skipped
+
+
+def test_zip_member_backslash_path_normalized_to_basename(tmp_path):
+    # Qodo fix 6: a zip member written with Windows separators
+    # ("dir\\idle.png") must still map to the "idle" state.
+    z = tmp_path / "set.zip"
+    z.write_bytes(_zip({"dir\\idle.png": _png()}))
+    res = resolve_local_expression_set([z])
+    assert "idle" in res.images
+    assert res.images["idle"] == _png()
+
+
 def test_not_a_zip_fails_cleanly(tmp_path):
     bad = tmp_path / "broken.zip"
     bad.write_bytes(b"this is not a zip")

--- a/Tests/Character_Chat/test_expression_set_io.py
+++ b/Tests/Character_Chat/test_expression_set_io.py
@@ -1,0 +1,116 @@
+import io
+import zipfile
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from tldw_chatbook.Character_Chat.expression_set_io import (
+    resolve_local_expression_set,
+    MAX_ZIP_MEMBERS,
+    MAX_TOTAL_BYTES,
+)
+
+
+def _png(color=(10, 20, 30)) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8), color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _jpg() -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8), (200, 10, 10)).save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def _zip(members: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, data in members.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+def test_zip_maps_by_filename_stem(tmp_path):
+    z = tmp_path / "set.zip"
+    z.write_bytes(_zip({"idle.png": _png(), "speaking.jpg": _jpg()}))
+    res = resolve_local_expression_set([z])
+    assert set(res.images) == {"idle", "speaking"}
+    assert res.images["idle"] == _png()  # bytes preserved verbatim
+
+
+def test_case_insensitive_stem(tmp_path):
+    z = tmp_path / "set.zip"
+    z.write_bytes(_zip({"IDLE.PNG": _png(), "Thinking.png": _png()}))
+    res = resolve_local_expression_set([z])
+    assert set(res.images) == {"idle", "thinking"}
+
+
+def test_non_matching_and_non_image_skipped(tmp_path):
+    z = tmp_path / "set.zip"
+    z.write_bytes(_zip({"speaking.png": _png(), "notes.txt": b"hello", "random.png": _png()}))
+    res = resolve_local_expression_set([z])
+    assert set(res.images) == {"speaking"}
+    assert any(name == "notes.txt" for name, _ in res.skipped)  # not an image / no state
+
+
+def test_bad_image_bytes_skipped_with_reason(tmp_path):
+    z = tmp_path / "set.zip"
+    z.write_bytes(_zip({"error.png": b"not-an-image"}))
+    res = resolve_local_expression_set([z])
+    assert "error" not in res.images
+    assert any(name == "error.png" for name, _ in res.skipped)
+
+
+def test_two_files_one_state_prefers_png(tmp_path):
+    z = tmp_path / "set.zip"
+    z.write_bytes(_zip({"speaking.jpg": _jpg(), "speaking.png": _png()}))
+    res = resolve_local_expression_set([z])
+    assert res.images["speaking"] == _png()  # .png wins
+    assert res.notes  # tie recorded
+
+
+def test_directory_of_images(tmp_path):
+    d = tmp_path / "imgs"
+    d.mkdir()
+    (d / "idle.png").write_bytes(_png())
+    (d / "error.png").write_bytes(_png())
+    res = resolve_local_expression_set([d])
+    assert set(res.images) == {"idle", "error"}
+
+
+def test_list_of_image_files(tmp_path):
+    a = tmp_path / "thinking.png"; a.write_bytes(_png())
+    b = tmp_path / "speaking.png"; b.write_bytes(_png())
+    res = resolve_local_expression_set([a, b])
+    assert set(res.images) == {"thinking", "speaking"}
+
+
+def test_member_count_cap(tmp_path):
+    z = tmp_path / "big.zip"
+    z.write_bytes(_zip({f"file{i}.png": _png() for i in range(MAX_ZIP_MEMBERS + 5)}))
+    res = resolve_local_expression_set([z])
+    # capped: does not read all members; the 4 states may still resolve, but the
+    # resolution notes/skips the cap. At minimum it must not raise and must be bounded.
+    assert isinstance(res.images, dict)
+    assert res.notes  # cap recorded
+
+
+def test_total_size_cap_rejects(tmp_path, monkeypatch):
+    # One member whose declared uncompressed size exceeds the total cap is skipped.
+    import tldw_chatbook.Character_Chat.expression_set_io as mod
+    monkeypatch.setattr(mod, "MAX_TOTAL_BYTES", 100)
+    z = tmp_path / "bomb.zip"
+    z.write_bytes(_zip({"idle.png": _png() * 50}))  # > 100 bytes uncompressed
+    res = resolve_local_expression_set([z])
+    assert "idle" not in res.images
+    assert res.notes or res.skipped
+
+
+def test_not_a_zip_fails_cleanly(tmp_path):
+    bad = tmp_path / "broken.zip"
+    bad.write_bytes(b"this is not a zip")
+    res = resolve_local_expression_set([bad])  # must not raise
+    assert res.images == {}
+    assert res.skipped or res.notes

--- a/Tests/UI/test_personas_expression_slots.py
+++ b/Tests/UI/test_personas_expression_slots.py
@@ -129,3 +129,47 @@ async def test_apply_expression_set_stages_idle_and_writes_three(personas_editor
     assert db.get_character_expression_image(char_id, "speaking") is not None
     assert db.get_character_expression_image(char_id, "idle") is None
     assert set(result.applied) >= {"idle", "speaking", "thinking"}
+
+
+# ===== Roleplay P3d-2 Task 4: import/export expression-set buttons + workers =====
+
+
+@pytest.mark.asyncio
+async def test_import_expression_set_from_zip_path(personas_editor_with_saved_character, tmp_path):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    from tldw_chatbook.Character_Chat.expression_set_io import build_expression_set_zip
+    import io as _io
+    from PIL import Image as _Img
+    def _png(): b=_io.BytesIO(); _Img.new("RGB",(8,8)).save(b,format="PNG"); return b.getvalue()
+    z = tmp_path / "set.zip"
+    z.write_bytes(build_expression_set_zip("Ada", {"idle": _png(), "speaking": _png()}))
+
+    await screen._import_expression_set_from_path(char_id, str(z))
+
+    assert db.get_character_expression_image(char_id, "speaking") is not None
+    from tldw_chatbook.Widgets.Persona_Widgets.personas_character_editor_widget import PersonasCharacterEditorWidget
+    assert screen.query_one(PersonasCharacterEditorWidget).current_avatar_bytes() is not None  # idle staged
+
+
+@pytest.mark.asyncio
+async def test_export_expression_set_writes_a_zip(personas_editor_with_saved_character):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    import io as _io
+    from PIL import Image as _Img
+    def _png(): b=_io.BytesIO(); _Img.new("RGB",(8,8)).save(b,format="PNG"); return b.getvalue()
+    db.set_character_expression_image(char_id, "speaking", _png())
+    target = await screen._export_expression_set(char_id, "Ada")
+    assert target is not None
+    from pathlib import Path
+    import zipfile
+    assert zipfile.is_zipfile(Path(target))
+    assert "speaking.png" in zipfile.ZipFile(target).namelist()
+
+
+@pytest.mark.asyncio
+async def test_import_export_buttons_present_for_saved_character(
+    personas_editor_with_saved_character,
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    assert screen.query_one("#personas-char-editor-expr-import") is not None
+    assert screen.query_one("#personas-char-editor-expr-export") is not None

--- a/Tests/UI/test_personas_expression_slots.py
+++ b/Tests/UI/test_personas_expression_slots.py
@@ -109,3 +109,23 @@ async def test_clear_soft_deletes_expression_row(personas_editor_with_saved_char
     db.set_character_expression_image(char_id, "error", b"x")
     await screen._clear_expression_slot(char_id, "error")
     assert db.get_character_expression_image(char_id, "error") is None
+
+
+@pytest.mark.asyncio
+async def test_apply_expression_set_stages_idle_and_writes_three(personas_editor_with_saved_character):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    import io as _io
+    from PIL import Image as _Img
+    def _png(c=(1, 2, 3)):
+        b = _io.BytesIO(); _Img.new("RGB", (8, 8), c).save(b, format="PNG"); return b.getvalue()
+
+    result = await screen._apply_expression_set(
+        char_id, {"idle": _png((9, 9, 9)), "speaking": _png(), "thinking": _png()}
+    )
+    # idle STAGED in the editor (not the table); three -> table
+    from tldw_chatbook.Widgets.Persona_Widgets.personas_character_editor_widget import PersonasCharacterEditorWidget
+    editor = screen.query_one(PersonasCharacterEditorWidget)
+    assert editor.current_avatar_bytes() == _png((9, 9, 9))      # idle staged
+    assert db.get_character_expression_image(char_id, "speaking") is not None
+    assert db.get_character_expression_image(char_id, "idle") is None
+    assert set(result.applied) >= {"idle", "speaking", "thinking"}

--- a/Tests/UI/test_personas_expression_slots.py
+++ b/Tests/UI/test_personas_expression_slots.py
@@ -242,6 +242,85 @@ async def test_import_export_buttons_disabled_for_unsaved_character():
         assert ed.query_one("#personas-char-editor-expr-export", Button).disabled is True
 
 
+# ===== Qodo review fix 1: _import_expression_set_from_path validates the
+# picked path at the screen boundary (mirrors _read_avatar_image_bytes'
+# use of validate_path_simple), instead of handing an unvalidated path
+# straight to the pure resolver. =====
+
+
+@pytest.mark.asyncio
+async def test_import_expression_set_nonexistent_path_notifies_and_does_not_crash(
+    personas_editor_with_saved_character,
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    # Shadow the delegating test App's notify (like TestDictionaryImport's
+    # _capture_notifications) rather than mock_app_instance.notify --
+    # screen.app_instance is the PersonasTestApp, and its real (Textual App)
+    # notify() shadows the mock's via normal attribute lookup.
+    captured: list[tuple[str, str]] = []
+    app.notify = lambda message, severity="information", **kwargs: captured.append(
+        (str(message), severity)
+    )
+
+    # Must not raise -- the invalid path is rejected before it ever reaches
+    # resolve_local_expression_set.
+    await screen._import_expression_set_from_path(char_id, "/no/such/path/set.zip")
+
+    assert captured, "expected a notification for a rejected path"
+    assert captured[-1][1] == "error"
+
+
+# ===== Qodo review fix 7: the export handler must honor the same
+# _io_dialog_active gate as the import handler and _dictionary_export_worker,
+# so a queued export cannot race a second worker onto the same filename. =====
+
+
+@pytest.mark.asyncio
+async def test_export_handler_blocked_while_io_dialog_active(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
+        CharacterExpressionSetExportRequested,
+    )
+
+    calls: list[int] = []
+    monkeypatch.setattr(screen, "run_worker", lambda *a, **k: calls.append(1))
+    screen._io_dialog_active = True
+
+    screen._handle_expression_set_export_requested(
+        CharacterExpressionSetExportRequested()
+    )
+
+    assert calls == []  # gate blocked a second worker from starting
+
+
+@pytest.mark.asyncio
+async def test_export_handler_starts_worker_and_sets_gate_when_clear(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
+        CharacterExpressionSetExportRequested,
+    )
+
+    calls: list[int] = []
+
+    def _fake_run_worker(coro, *a, **k):
+        calls.append(1)
+        coro.close()  # avoid a "coroutine was never awaited" warning
+
+    monkeypatch.setattr(screen, "run_worker", _fake_run_worker)
+    screen._io_dialog_active = False
+
+    screen._handle_expression_set_export_requested(
+        CharacterExpressionSetExportRequested()
+    )
+
+    assert calls == [1]
+    assert screen._io_dialog_active is True  # gate set before the worker starts
+
+
 @pytest.mark.asyncio
 async def test_import_export_buttons_enabled_for_saved_character(
     personas_editor_with_saved_character,

--- a/Tests/UI/test_personas_expression_slots.py
+++ b/Tests/UI/test_personas_expression_slots.py
@@ -12,13 +12,20 @@ open-editor boilerplate per test.
 """
 
 from io import BytesIO
+from pathlib import Path
 
 import pytest
 import pytest_asyncio
 from PIL import Image
+from textual.app import App, ComposeResult
+from textual.widgets import Button
 
 import tldw_chatbook.UI.CCP_Modules.ccp_character_handler as character_handler_module
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.Utils.paths import get_user_data_dir
+from tldw_chatbook.Widgets.Persona_Widgets.personas_character_editor_widget import (
+    PersonasCharacterEditorWidget,
+)
 from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
     EditCharacterRequested,
 )
@@ -173,3 +180,76 @@ async def test_import_export_buttons_present_for_saved_character(
     app, screen, db, char_id = personas_editor_with_saved_character
     assert screen.query_one("#personas-char-editor-expr-import") is not None
     assert screen.query_one("#personas-char-editor-expr-export") is not None
+
+
+# ===== Review fix 1: _export_expression_set cleans up its temp file on
+# failure (mirrors _dictionary_export_worker's try/except OSError +
+# temp.unlink(missing_ok=True) idiom, which the initial implementation
+# omitted). =====
+
+
+@pytest.mark.asyncio
+async def test_export_expression_set_cleans_up_temp_on_replace_failure(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+
+    def _png():
+        buf = BytesIO()
+        Image.new("RGB", (8, 8)).save(buf, format="PNG")
+        return buf.getvalue()
+
+    db.set_character_expression_image(char_id, "speaking", _png())
+
+    def _boom(self, target):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(Path, "replace", _boom)
+
+    # Diff before/after rather than asserting the dir is empty: it's the
+    # shared test-home exports dir, which other test runs may have already
+    # left debris in.
+    exports_dir = get_user_data_dir() / "exports"
+    exports_dir.mkdir(parents=True, exist_ok=True)
+    before = set(exports_dir.glob("*.tmp"))
+
+    with pytest.raises(OSError):
+        await screen._export_expression_set(char_id, "Ada")
+
+    after = set(exports_dir.glob("*.tmp"))
+    assert after - before == set()
+
+
+# ===== Review fix 2: the Import set…/Export set… buttons must be disabled
+# for an unsaved character, same as the per-slot Upload/Clear buttons
+# (_sync_expression_slots_enabled). =====
+
+
+class _UnsavedEditorHost(App):
+    def compose(self) -> ComposeResult:
+        yield PersonasCharacterEditorWidget()
+
+
+@pytest.mark.asyncio
+async def test_import_export_buttons_disabled_for_unsaved_character():
+    app = _UnsavedEditorHost()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        ed.load_character({"name": "A"})  # no "id" key -> unsaved
+        await pilot.pause()
+        assert ed.expression_character_id() is None
+        assert ed.query_one("#personas-char-editor-expr-import", Button).disabled is True
+        assert ed.query_one("#personas-char-editor-expr-export", Button).disabled is True
+
+
+@pytest.mark.asyncio
+async def test_import_export_buttons_enabled_for_saved_character(
+    personas_editor_with_saved_character,
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    assert (
+        screen.query_one("#personas-char-editor-expr-import", Button).disabled is False
+    )
+    assert (
+        screen.query_one("#personas-char-editor-expr-export", Button).disabled is False
+    )

--- a/tldw_chatbook/Character_Chat/expression_set_io.py
+++ b/tldw_chatbook/Character_Chat/expression_set_io.py
@@ -8,7 +8,8 @@ import io
 import json
 import zipfile
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
+from typing import Protocol
 
 from PIL import Image
 
@@ -26,6 +27,21 @@ _STATE_SET = {s.lower() for s in EXPRESSION_STATES}
 
 @dataclass(frozen=True)
 class ExpressionSetResolution:
+    """Outcome of resolving a set of import candidates into character
+    expression-state images.
+
+    Attributes:
+        images: {state: bytes} for each candidate that resolved to a known
+            expression state (a subset of ``EXPRESSION_STATES``) with valid,
+            PIL-decodable image bytes.
+        skipped: (name, reason) pairs for candidates that were rejected --
+            e.g. an unrecognized filename, invalid image bytes, or a
+            size-cap violation.
+        notes: Informational messages about the resolution, e.g. size/count
+            caps that were applied or which file won a same-state naming
+            conflict.
+    """
+
     images: dict[str, bytes] = field(default_factory=dict)
     skipped: list[tuple[str, str]] = field(default_factory=list)   # (name, reason)
     notes: list[str] = field(default_factory=list)
@@ -52,35 +68,62 @@ def _prefer(existing_name: str, new_name: str) -> bool:
 
 def _candidate_pairs(paths: list[Path]) -> tuple[list[tuple[str, bytes]], list[tuple[str, str]], list[str]]:
     """Yield (base_name, bytes) for every candidate file across the inputs.
-    Handles a .zip (in-memory, security-capped), a directory, or image files.
+
+    Handles a .zip (in-memory, security-capped), a directory, or standalone
+    image files. ``MAX_MEMBER_BYTES``/``MAX_TOTAL_BYTES`` are enforced up
+    front -- against each entry's on-disk/declared size, before any bytes
+    are read -- using a single running total shared across every input in
+    ``paths`` (a zip, a directory, and standalone files all draw from the
+    same total-size budget).
     """
     pairs: list[tuple[str, bytes]] = []
     skipped: list[tuple[str, str]] = []
     notes: list[str] = []
+    total = 0
     for path in paths:
         try:
             if path.is_dir():
                 for child in sorted(path.iterdir()):
-                    if child.is_file():
-                        pairs.append((child.name, child.read_bytes()))
+                    if not child.is_file():
+                        continue
+                    size = child.stat().st_size
+                    if size > MAX_MEMBER_BYTES:
+                        skipped.append((child.name, "file too large"))
+                        continue
+                    if total + size > MAX_TOTAL_BYTES:
+                        notes.append("Total size cap exceeded; remaining files were skipped.")
+                        break
+                    total += size
+                    pairs.append((child.name, child.read_bytes()))
             elif zipfile.is_zipfile(path):
                 with zipfile.ZipFile(path) as zf:
                     infos = [i for i in zf.infolist() if not i.is_dir()]
                     if len(infos) > MAX_ZIP_MEMBERS:
                         notes.append(f"Archive has {len(infos)} members; only the first {MAX_ZIP_MEMBERS} were read.")
                         infos = infos[:MAX_ZIP_MEMBERS]
-                    total = 0
                     for info in infos:
+                        # Normalize Windows-style separators: a member written
+                        # on Windows as "dir\\idle.png" has no POSIX path
+                        # separator, so a plain Path(...).name would keep the
+                        # whole "dir\\idle.png" string as the basename.
+                        member = PurePosixPath(info.filename.replace("\\", "/")).name
                         if info.file_size > MAX_MEMBER_BYTES:
-                            skipped.append((info.filename, "file too large"))
+                            skipped.append((member, "file too large"))
                             continue
                         if total + info.file_size > MAX_TOTAL_BYTES:
                             notes.append("Archive exceeds the total size cap; remaining members skipped.")
                             break
                         total += info.file_size
-                        pairs.append((Path(info.filename).name, zf.read(info)))
+                        pairs.append((member, zf.read(info)))
             elif path.is_file():
-                pairs.append((path.name, path.read_bytes()))
+                size = path.stat().st_size
+                if size > MAX_MEMBER_BYTES:
+                    skipped.append((path.name, "file too large"))
+                elif total + size > MAX_TOTAL_BYTES:
+                    notes.append("Total size cap exceeded; remaining files were skipped.")
+                else:
+                    total += size
+                    pairs.append((path.name, path.read_bytes()))
             else:
                 skipped.append((str(path), "not found"))
         except Exception as exc:   # broken/encrypted zip, unreadable dir, etc.
@@ -89,7 +132,19 @@ def _candidate_pairs(paths: list[Path]) -> tuple[list[tuple[str, bytes]], list[t
 
 
 def resolve_local_expression_set(paths: list[Path]) -> ExpressionSetResolution:
-    """Resolve selected inputs into a validated {state: bytes} set. Never raises."""
+    """Resolve selected inputs into a validated {state: bytes} set.
+
+    Args:
+        paths: Filesystem paths to resolve -- any mix of a single ``.zip``
+            archive, a directory of image files, or standalone image files.
+            Callers are responsible for any path validation (this module is
+            pure and never validates against the filesystem policy layer).
+
+    Returns:
+        An ``ExpressionSetResolution`` holding the resolved {state: bytes}
+        images, plus the candidates that were skipped and any informational
+        notes. Never raises.
+    """
     pairs, skipped, notes = _candidate_pairs(paths)
     chosen: dict[str, tuple[str, bytes]] = {}   # state -> (name, bytes)
     for name, data in pairs:
@@ -153,7 +208,19 @@ def build_expression_set_zip(character_name: str, images: dict[str, bytes]) -> b
     return buf.getvalue()
 
 
-def apply_expression_images_to_db(db, character_id: int, images: dict[str, bytes]):
+class _ExpressionImageDB(Protocol):
+    """Minimal shape this pure module needs from a characters DB. Defined
+    here (instead of importing the real DB class) to keep this module free
+    of DB-layer imports."""
+
+    def set_character_expression_image(
+        self, character_id: int, state_id: str, image: bytes, mime: object = None
+    ) -> None: ...
+
+
+def apply_expression_images_to_db(
+    db: _ExpressionImageDB, character_id: int, images: dict[str, bytes]
+) -> tuple[list[str], list[tuple[str, str]]]:
     """Write the non-idle states to the expression table, best-effort.
 
     Args:

--- a/tldw_chatbook/Character_Chat/expression_set_io.py
+++ b/tldw_chatbook/Character_Chat/expression_set_io.py
@@ -151,3 +151,36 @@ def build_expression_set_zip(character_name: str, images: dict[str, bytes]) -> b
         }
         zf.writestr("expression_set.json", json.dumps(manifest, indent=2))
     return buf.getvalue()
+
+
+def apply_expression_images_to_db(db, character_id: int, images: dict[str, bytes]):
+    """Write the non-idle states to the expression table, best-effort.
+
+    Args:
+        db: a CharactersRAGDB-like object exposing ``set_character_expression_image``.
+        character_id: the owning character id.
+        images: {state: bytes}; only EXPRESSION_IMAGE_STATES are written (idle skipped).
+
+    Returns:
+        (applied_states, skipped[(state, reason)]).
+    """
+    applied: list[str] = []
+    skipped: list[tuple[str, str]] = []
+    for state in EXPRESSION_IMAGE_STATES:
+        data = images.get(state)
+        if not data:
+            continue
+        try:
+            db.set_character_expression_image(character_id, state, data, None)
+            applied.append(state)
+        except Exception as exc:
+            skipped.append((state, f"write failed: {exc}"))
+    return applied, skipped
+
+
+@dataclass(frozen=True)
+class ExpressionSetApplyResult:
+    """Outcome of applying a resolved expression set to a character:
+    idle staged in the editor, the reactive states written to the DB."""
+    applied: list[str] = field(default_factory=list)
+    skipped: list[tuple[str, str]] = field(default_factory=list)   # (state, reason)

--- a/tldw_chatbook/Character_Chat/expression_set_io.py
+++ b/tldw_chatbook/Character_Chat/expression_set_io.py
@@ -1,0 +1,115 @@
+"""Pure import/export logic for a character's expression image SET
+(idle/thinking/speaking/error). No Textual and no DB-module imports -- takes a
+db object as a parameter where needed. Reused by P3d-3's .vpack extractor.
+"""
+from __future__ import annotations
+
+import io
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from PIL import Image
+
+from tldw_chatbook.Chat.console_expression_state import (
+    EXPRESSION_STATES,       # ("idle","thinking","speaking","error")
+    EXPRESSION_IMAGE_STATES, # ("thinking","speaking","error")
+)
+
+MAX_ZIP_MEMBERS = 64
+MAX_MEMBER_BYTES = 16 * 1024 * 1024
+MAX_TOTAL_BYTES = 64 * 1024 * 1024
+
+_STATE_SET = {s.lower() for s in EXPRESSION_STATES}
+
+
+@dataclass(frozen=True)
+class ExpressionSetResolution:
+    images: dict[str, bytes] = field(default_factory=dict)
+    skipped: list[tuple[str, str]] = field(default_factory=list)   # (name, reason)
+    notes: list[str] = field(default_factory=list)
+
+
+def _valid_image(data: bytes) -> bool:
+    try:
+        with Image.open(io.BytesIO(data)) as im:
+            im.verify()
+        return True
+    except Exception:
+        return False
+
+
+def _prefer(existing_name: str, new_name: str) -> bool:
+    """Return True if new_name should replace existing for the same state."""
+    ext_e, ext_n = Path(existing_name).suffix.lower(), Path(new_name).suffix.lower()
+    if ext_n == ".png" and ext_e != ".png":
+        return True
+    if ext_e == ".png" and ext_n != ".png":
+        return False
+    return new_name.lower() < existing_name.lower()  # first alphabetically
+
+
+def _candidate_pairs(paths: list[Path]) -> tuple[list[tuple[str, bytes]], list[tuple[str, str]], list[str]]:
+    """Yield (base_name, bytes) for every candidate file across the inputs.
+    Handles a .zip (in-memory, security-capped), a directory, or image files.
+    """
+    pairs: list[tuple[str, bytes]] = []
+    skipped: list[tuple[str, str]] = []
+    notes: list[str] = []
+    for path in paths:
+        try:
+            if path.is_dir():
+                for child in sorted(path.iterdir()):
+                    if child.is_file():
+                        pairs.append((child.name, child.read_bytes()))
+            elif zipfile.is_zipfile(path):
+                with zipfile.ZipFile(path) as zf:
+                    infos = [i for i in zf.infolist() if not i.is_dir()]
+                    if len(infos) > MAX_ZIP_MEMBERS:
+                        notes.append(f"Archive has {len(infos)} members; only the first {MAX_ZIP_MEMBERS} were read.")
+                        infos = infos[:MAX_ZIP_MEMBERS]
+                    total = 0
+                    for info in infos:
+                        if info.file_size > MAX_MEMBER_BYTES:
+                            skipped.append((info.filename, "file too large"))
+                            continue
+                        if total + info.file_size > MAX_TOTAL_BYTES:
+                            notes.append("Archive exceeds the total size cap; remaining members skipped.")
+                            break
+                        total += info.file_size
+                        pairs.append((Path(info.filename).name, zf.read(info)))
+            elif path.is_file():
+                pairs.append((path.name, path.read_bytes()))
+            else:
+                skipped.append((str(path), "not found"))
+        except Exception as exc:   # broken/encrypted zip, unreadable dir, etc.
+            skipped.append((str(path), f"could not read: {exc}"))
+    return pairs, skipped, notes
+
+
+def resolve_local_expression_set(paths: list[Path]) -> ExpressionSetResolution:
+    """Resolve selected inputs into a validated {state: bytes} set. Never raises."""
+    pairs, skipped, notes = _candidate_pairs(paths)
+    chosen: dict[str, tuple[str, bytes]] = {}   # state -> (name, bytes)
+    for name, data in pairs:
+        state = Path(name).stem.lower()
+        if state not in _STATE_SET:
+            skipped.append((name, "filename is not a known state"))
+            continue
+        if not _valid_image(data):
+            skipped.append((name, "not a valid image"))
+            continue
+        if state in chosen:
+            keep = chosen[state][0]
+            if _prefer(keep, name):
+                notes.append(f"Multiple files for {state}; used {name}.")
+                chosen[state] = (name, data)
+            else:
+                notes.append(f"Multiple files for {state}; used {keep}.")
+            continue
+        chosen[state] = (name, data)
+    return ExpressionSetResolution(
+        images={state: data for state, (_, data) in chosen.items()},
+        skipped=skipped,
+        notes=notes,
+    )

--- a/tldw_chatbook/Character_Chat/expression_set_io.py
+++ b/tldw_chatbook/Character_Chat/expression_set_io.py
@@ -5,6 +5,7 @@ db object as a parameter where needed. Reused by P3d-3's .vpack extractor.
 from __future__ import annotations
 
 import io
+import json
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -113,3 +114,40 @@ def resolve_local_expression_set(paths: list[Path]) -> ExpressionSetResolution:
         skipped=skipped,
         notes=notes,
     )
+
+
+_FORMAT_TO_EXT = {"PNG": "png", "JPEG": "jpg", "WEBP": "webp", "GIF": "gif"}
+
+
+def _detect_ext(data: bytes) -> str:
+    try:
+        with Image.open(io.BytesIO(data)) as im:
+            return _FORMAT_TO_EXT.get((im.format or "").upper(), "png")
+    except Exception:
+        return "png"
+
+
+def build_expression_set_zip(character_name: str, images: dict[str, bytes]) -> bytes:
+    """Build a .zip (bytes) of a character's expression set.
+
+    Args:
+        character_name: The character's display name (for the provenance marker).
+        images: {state: bytes} for any subset of EXPRESSION_STATES.
+
+    Returns:
+        The zip archive bytes: one ``{state}.{ext}`` per present state (ext
+        PIL-detected from the bytes) plus an ``expression_set.json`` provenance
+        marker. Always a valid zip, even for an empty set.
+    """
+    present = [s for s in EXPRESSION_STATES if s in images and images[s]]
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for state in present:
+            zf.writestr(f"{state}.{_detect_ext(images[state])}", images[state])
+        manifest = {
+            "format": "tldw-expression-set/1",
+            "character": character_name,
+            "states": present,
+        }
+        zf.writestr("expression_set.json", json.dumps(manifest, indent=2))
+    return buf.getvalue()

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -4749,8 +4749,12 @@ class PersonasScreen(BaseAppScreen):
         exports_dir.mkdir(parents=True, exist_ok=True)
         target = exports_dir / f"{slug}-expressions-{stamp}.zip"
         temp = exports_dir / f".{slug}-expressions-{stamp}.zip.tmp"
-        temp.write_bytes(blob)
-        temp.replace(target)
+        try:
+            temp.write_bytes(blob)
+            temp.replace(target)
+        except OSError:
+            temp.unlink(missing_ok=True)
+            raise
         return str(target)
 
     # ===== Import / export =====

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -83,6 +83,8 @@ from ...Widgets.Persona_Widgets.tag_filter_picker import TagFilterPicker
 from ...Widgets.Persona_Widgets.personas_pane_messages import (
     CharacterEditorCancelled,
     CharacterExpressionClearRequested,
+    CharacterExpressionSetExportRequested,
+    CharacterExpressionSetImportRequested,
     CharacterExpressionUploadRequested,
     CharacterImageRemoveRequested,
     CharacterImageUploadRequested,
@@ -4592,6 +4594,164 @@ class PersonasScreen(BaseAppScreen):
 
         mime = mimetypes.guess_type(path)[0]
         await self._apply_expression_upload(character_id, state, image_data, mime)
+
+    # ===== Expression SET import/export (Roleplay P3d-2 Task 4) =====
+    #
+    # Distinct from the per-slot upload/clear above: these move the whole
+    # idle/thinking/speaking/error set at once, as a .zip built by
+    # expression_set_io (Tasks 1-2) and applied via _apply_expression_set
+    # (Task 3). Same dialog-worker / dialog-free-path-method split as the
+    # rest of the screen's import/export flows.
+
+    @on(CharacterExpressionSetImportRequested)
+    def _handle_expression_set_import_requested(self, message) -> None:
+        message.stop()
+        if not self._character_editor_is_active():
+            self._notify(
+                "Open a character editor before importing an expression set.",
+                "warning",
+            )
+            return
+        editor = self.query_one(PersonasCharacterEditorWidget)
+        character_id = editor.expression_character_id()
+        if character_id is None:
+            self._notify("Save the character to import an expression set.", "warning")
+            return
+        if self._io_dialog_active:
+            logger.debug(
+                "Import/export dialog already active; ignoring expression "
+                "set import request."
+            )
+            return
+        self._io_dialog_active = True
+        self.run_worker(
+            self._expression_set_import_dialog_worker(character_id),
+            group="personas-io",
+        )
+
+    async def _expression_set_import_dialog_worker(self, character_id: int) -> None:
+        from ...Widgets.enhanced_file_picker import EnhancedFileOpen, Filters
+
+        try:
+            picker = EnhancedFileOpen(
+                title="Import Expression Set (.zip)",
+                filters=Filters(("Zip Archives", lambda p: p.suffix.lower() == ".zip")),
+                context="character_expression_set_import",
+            )
+            try:
+                file_path = await self.app.push_screen_wait(picker)
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Could not show the expression-set import dialog."
+                )
+                return
+            if file_path:
+                await self._import_expression_set_from_path(character_id, str(file_path))
+        finally:
+            self._io_dialog_active = False
+
+    async def _import_expression_set_from_path(
+        self, character_id: int, path: str
+    ) -> None:
+        """Resolve a .zip at ``path`` into an expression set and apply it.
+
+        Dialog-free (directly testable): resolution happens off-thread via
+        ``asyncio.to_thread`` since it decodes/validates images, then
+        delegates to ``_apply_expression_set`` (Task 3) for the actual
+        idle-staged/three-immediate application.
+        """
+        from ...Character_Chat.expression_set_io import resolve_local_expression_set
+
+        res = await asyncio.to_thread(resolve_local_expression_set, [Path(path)])
+        if not res.images:
+            reason = (
+                "; ".join(n for n, _ in res.skipped[:2])
+                or "; ".join(res.notes[:1])
+                or "no matching images"
+            )
+            self._notify(f"Nothing imported ({reason}).", "warning")
+            return
+        result = await self._apply_expression_set(character_id, res.images)
+        applied = ", ".join(result.applied) or "nothing"
+        note = " — save the character to keep idle" if "idle" in result.applied else ""
+        self._notify(f"Imported: {applied}.{note}", "information")
+
+    @on(CharacterExpressionSetExportRequested)
+    def _handle_expression_set_export_requested(self, message) -> None:
+        message.stop()
+        if not self._character_editor_is_active():
+            return
+        editor = self.query_one(PersonasCharacterEditorWidget)
+        character_id = editor.expression_character_id()
+        if character_id is None:
+            self._notify(
+                "Save the character before exporting its expression set.", "warning"
+            )
+            return
+        # Screen state, not the editor: the editor widget has no name
+        # accessor (mirrors _dictionary_export_worker's own name source).
+        name = str(self.state.selected_entity_name or "character")
+        self.run_worker(
+            self._export_expression_set_worker(character_id, name),
+            group="personas-io",
+            exit_on_error=False,
+        )
+
+    async def _export_expression_set_worker(self, character_id: int, name: str) -> None:
+        try:
+            target = await self._export_expression_set(character_id, name)
+            if target:
+                self._notify(f"Expression set exported to {target}.", "information")
+        except Exception as exc:
+            logger.opt(exception=True).error(f"Expression-set export failed: {exc}")
+            self._notify(f"Export failed: {exc}", "error")
+
+    async def _export_expression_set(
+        self, character_id: int, name: str
+    ) -> str | None:
+        """Build the export .zip and write it to the exports dir (atomic).
+
+        Dialog-free (directly testable). Collects the idle image from the
+        editor's staged/loaded avatar bytes plus the three reactive states
+        from the DB, then mirrors ``_dictionary_export_worker``'s exports-dir
+        + atomic temp-replace pattern (bytes here, not text, since this is a
+        zip archive).
+
+        Returns:
+            The written file's path, or ``None`` when there is nothing to
+            export (already surfaced via ``_notify``).
+        """
+        from ...Character_Chat.expression_set_io import build_expression_set_zip
+
+        images: dict[str, bytes] = {}
+        try:
+            editor = self.query_one(PersonasCharacterEditorWidget)
+            idle = editor.current_avatar_bytes()
+            if idle:
+                images["idle"] = idle
+        except QueryError:
+            pass
+        db = getattr(self.app_instance, "chachanotes_db", None)
+        if db is not None:
+            for state in EXPRESSION_IMAGE_STATES:
+                data = await asyncio.to_thread(
+                    db.get_character_expression_image, character_id, state
+                )
+                if data:
+                    images[state] = data
+        if not images:
+            self._notify("This character has no expression images to export.", "warning")
+            return None
+        blob = await asyncio.to_thread(build_expression_set_zip, name, images)
+        slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-") or "character"
+        stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        exports_dir = get_user_data_dir() / "exports"
+        exports_dir.mkdir(parents=True, exist_ok=True)
+        target = exports_dir / f"{slug}-expressions-{stamp}.zip"
+        temp = exports_dir / f".{slug}-expressions-{stamp}.zip.tmp"
+        temp.write_bytes(blob)
+        temp.replace(target)
+        return str(target)
 
     # ===== Import / export =====
     #

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -4418,8 +4418,15 @@ class PersonasScreen(BaseAppScreen):
         except QueryError:
             editor = None
         if idle and editor is not None:
-            editor.set_avatar_image(idle)
-            applied.append("idle")
+            # Guard the stage so the orchestrator NEVER raises into its caller
+            # (the import worker runs with exit_on_error=True, and P3d-3's .vpack
+            # extractor will reuse this too). Callers are expected to pass
+            # PIL-validated bytes; a bad idle degrades to a skip, not a crash.
+            try:
+                editor.set_avatar_image(idle)
+                applied.append("idle")
+            except Exception as exc:
+                skipped.append(("idle", f"could not stage avatar: {exc}"))
         # three -> DB (immediate), off-thread
         if db is not None:
             db_applied, db_skipped = await asyncio.to_thread(

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -4662,14 +4662,22 @@ class PersonasScreen(BaseAppScreen):
     ) -> None:
         """Resolve a .zip at ``path`` into an expression set and apply it.
 
-        Dialog-free (directly testable): resolution happens off-thread via
+        Dialog-free (directly testable): the path is validated at this
+        screen boundary (the pure ``expression_set_io`` module never imports
+        ``path_validation``), then resolution happens off-thread via
         ``asyncio.to_thread`` since it decodes/validates images, then
         delegates to ``_apply_expression_set`` (Task 3) for the actual
         idle-staged/three-immediate application.
         """
         from ...Character_Chat.expression_set_io import resolve_local_expression_set
 
-        res = await asyncio.to_thread(resolve_local_expression_set, [Path(path)])
+        try:
+            candidate = validate_path_simple(path, require_exists=True)
+        except (ValueError, OSError) as exc:
+            self._notify(f"Import failed: {exc}", "error")
+            return
+
+        res = await asyncio.to_thread(resolve_local_expression_set, [candidate])
         if not res.images:
             reason = (
                 "; ".join(n for n, _ in res.skipped[:2])
@@ -4695,6 +4703,13 @@ class PersonasScreen(BaseAppScreen):
                 "Save the character before exporting its expression set.", "warning"
             )
             return
+        if self._io_dialog_active:
+            logger.debug(
+                "Import/export dialog already active; ignoring expression "
+                "set export request."
+            )
+            return
+        self._io_dialog_active = True
         # Screen state, not the editor: the editor widget has no name
         # accessor (mirrors _dictionary_export_worker's own name source).
         name = str(self.state.selected_entity_name or "character")
@@ -4712,6 +4727,8 @@ class PersonasScreen(BaseAppScreen):
         except Exception as exc:
             logger.opt(exception=True).error(f"Expression-set export failed: {exc}")
             self._notify(f"Export failed: {exc}", "error")
+        finally:
+            self._io_dialog_active = False
 
     async def _export_expression_set(
         self, character_id: int, name: str
@@ -4751,7 +4768,10 @@ class PersonasScreen(BaseAppScreen):
             return None
         blob = await asyncio.to_thread(build_expression_set_zip, name, images)
         slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-") or "character"
-        stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        # Microsecond precision (not _dictionary_export_worker's second
+        # precision): concurrent exports of the same character within one
+        # second would otherwise collide on the target/temp filenames.
+        stamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
         exports_dir = get_user_data_dir() / "exports"
         exports_dir.mkdir(parents=True, exist_ok=True)
         target = exports_dir / f"{slug}-expressions-{stamp}.zip"

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -4390,6 +4390,46 @@ class PersonasScreen(BaseAppScreen):
     # write straight to character_expression_images (Task 1's DB seam), never
     # to character_cards - no card save, no version bump.
 
+    async def _apply_expression_set(
+        self, character_id: int, images: dict
+    ) -> "ExpressionSetApplyResult":
+        """Apply a resolved expression set: idle staged in the editor (persists on
+        card save), the three reactive states written immediately. Bumps the render
+        token ONCE, then re-renders the affected slots + the avatar thumbnail.
+
+        Does NOT call ``_apply_expression_upload`` per state - that bumps the
+        generation token each time and would drop the prior slot's in-flight
+        render (the P3d-1 render-race). Every write here shares a single fresh
+        token before the (single) re-render pass.
+        """
+        from ...Character_Chat.expression_set_io import (
+            apply_expression_images_to_db,
+            ExpressionSetApplyResult,
+        )
+        applied: list[str] = []
+        skipped: list = []
+        db = getattr(self.app_instance, "chachanotes_db", None)
+        # idle -> stage in the editor (like a manual avatar upload)
+        idle = images.get("idle")
+        try:
+            editor = self.query_one(PersonasCharacterEditorWidget)
+        except QueryError:
+            editor = None
+        if idle and editor is not None:
+            editor.set_avatar_image(idle)
+            applied.append("idle")
+        # three -> DB (immediate), off-thread
+        if db is not None:
+            db_applied, db_skipped = await asyncio.to_thread(
+                apply_expression_images_to_db, db, character_id, images
+            )
+            applied.extend(db_applied)
+            skipped.extend(db_skipped)
+        # single generation bump, then ONE re-render of the avatar + all 3 slots
+        self._character_editor_generation += 1
+        await self._render_all_character_editor_thumbnails(character_id)
+        return ExpressionSetApplyResult(applied=applied, skipped=skipped)
+
     async def _apply_expression_upload(
         self, character_id: int, state: str, image: bytes, mime: str | None = None
     ) -> None:

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
@@ -583,6 +583,8 @@ class PersonasCharacterEditorWidget(Container):
         """
         enabled = self.expression_character_id() is not None
         hint_text = "" if enabled else "Save the character to add expressions."
+        self.query_one("#personas-char-editor-expr-import", Button).disabled = not enabled
+        self.query_one("#personas-char-editor-expr-export", Button).disabled = not enabled
         for state in EXPRESSION_IMAGE_STATES:
             self.query_one(
                 f"#personas-char-editor-expr-{state}-upload", Button

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
@@ -24,6 +24,8 @@ from ...Chat.console_expression_state import EXPRESSION_IMAGE_STATES
 from .personas_pane_messages import (
     CharacterEditorCancelled,
     CharacterExpressionClearRequested,
+    CharacterExpressionSetExportRequested,
+    CharacterExpressionSetImportRequested,
     CharacterExpressionUploadRequested,
     CharacterImageRemoveRequested,
     CharacterImageUploadRequested,
@@ -125,6 +127,24 @@ class PersonasCharacterEditorWidget(Container):
         max-width: 24;
         max-height: 10;
         padding: 0 1;
+    }
+
+    /* Import/export set buttons (Roleplay P3d-2 Task 4) - the "Expressions"
+       section header plus its two whole-set actions on one line. */
+    PersonasCharacterEditorWidget .personas-char-editor-expr-set-row {
+        height: auto;
+        min-height: 1;
+    }
+
+    PersonasCharacterEditorWidget #personas-char-editor-expr-import,
+    PersonasCharacterEditorWidget #personas-char-editor-expr-export {
+        width: auto;
+        min-width: 0;
+        height: 1;
+        min-height: 1;
+        padding: 0 1;
+        margin-left: 1;
+        border: none;
     }
 
     /* Expression authoring slots (Roleplay P3d-1 Task 4) - one row per
@@ -335,7 +355,18 @@ class PersonasCharacterEditorWidget(Container):
                     classes="console-action-subdued",
                 )
             yield Container(id="personas-char-editor-avatar-thumb")
-            yield Static("Expressions", classes="destination-section")
+            with Horizontal(classes="personas-char-editor-expr-set-row"):
+                yield Static("Expressions", classes="destination-section")
+                yield Button(
+                    "Import set…",
+                    id="personas-char-editor-expr-import",
+                    classes="console-action-subdued",
+                )
+                yield Button(
+                    "Export set…",
+                    id="personas-char-editor-expr-export",
+                    classes="console-action-subdued",
+                )
             for state in EXPRESSION_IMAGE_STATES:
                 with Vertical(
                     id=f"char-expression-slot-{state}",
@@ -1041,6 +1072,16 @@ class PersonasCharacterEditorWidget(Container):
         state = self._expression_state_from_button_id(event.button.id, suffix="-clear")
         if state is not None:
             self.post_message(CharacterExpressionClearRequested(state))
+
+    @on(Button.Pressed, "#personas-char-editor-expr-import")
+    def _expression_set_import_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(CharacterExpressionSetImportRequested())
+
+    @on(Button.Pressed, "#personas-char-editor-expr-export")
+    def _expression_set_export_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(CharacterExpressionSetExportRequested())
 
     @on(Button.Pressed, "#personas-char-editor-save")
     def _save_pressed(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py
@@ -78,6 +78,14 @@ class CharacterExpressionClearRequested(Message):
         super().__init__()
 
 
+class CharacterExpressionSetImportRequested(Message):
+    """Roleplay P3d-2: import a whole expression set from a .zip."""
+
+
+class CharacterExpressionSetExportRequested(Message):
+    """Roleplay P3d-2: export the character's expression set to a .zip."""
+
+
 class EditPersonaRequested(Message):
     """Edit was requested for the displayed persona profile."""
 


### PR DESCRIPTION
## Roleplay P3d-2 — bulk import + export of a character's expression set

Second cycle of P3d (after P3d-1 reactive expression avatar, #792). Adds **bulk import + export** of a character's whole expression set (idle + thinking + speaking + error) so you're no longer assigning images one slot at a time.

### What it does
- **Import** a single `.zip` in the character editor → each file is mapped by its **filename stem** (`idle`/`thinking`/`speaking`/`error`, case-insensitive) and applied at once. Best-effort: non-matching / non-image / bad members are skipped and reported in a summary; a broken zip fails cleanly.
- **Export** a character's set → a `.zip` (in the exports dir) with `{state}.{ext}` per state (extension **PIL-detected** from the bytes) + an `expression_set.json` marker. **Symmetric** — an exported zip re-imports directly.

### How it's built
- New **pure** module `Character_Chat/expression_set_io.py` (zipfile + PIL only, no Textual/DB imports): `resolve_local_expression_set` (zip/dir/files → validated `{state: bytes}`, security-capped) + `build_expression_set_zip` + `apply_expression_images_to_db`. Reused by P3d-3's future `.vpack` extractor.
- A screen-level `_apply_expression_set` orchestrator: **idle staged** via `editor.set_avatar_image` (persists on card save), the three **immediate** to the table (card-version-independent), with a **single** `_character_editor_generation` bump then one `_render_all_character_editor_thumbnails` (avoids the P3d-1 render-race).

### Constraints honored
- **No migration** (schema stays v23 — reuses `character_expression_images` + `character_cards.image`).
- **Untrusted-zip security:** members read in-memory (no disk extraction); member/per-file/total-size caps checked against `ZipInfo.file_size` **before** reading; PIL-validate; never raises.
- **Never raises into an `exit_on_error=True` worker** (import: `_io_dialog_active` try/finally + guarded `push_screen_wait`; export: try/except → notify; orchestrator's idle-stage guarded at the source).
- **Atomic export** (temp write + `replace`, `unlink` on failure — no orphaned `.tmp`).
- Saved-character-only + characters-only (buttons disabled for an unsaved character).

### Review
Subagent-driven (4 tasks, each spec+quality reviewed). Whole-branch review (opus): **APPROVE-WITH-NITS**, 0 Critical/Important, all global constraints verified, **25 tests pass**. Two Task-4 findings fixed pre-PR (orphaned-`.tmp` cleanup on export failure; disable set buttons for unsaved character), plus two whole-branch nits (guard idle-staging at the source so the orchestrator never raises for any caller; drop unused test imports).

### Tests
`Tests/Character_Chat/test_expression_set_io.py` (resolver security + round-trip + DB helper), `Tests/UI/test_personas_expression_slots.py` (orchestrator + buttons + import/export path methods) — all green; `import tldw_chatbook.app` clean.

Follow-ups (deferred): **P3d-3** `.tldw-persona-vpack` extraction (built on the same `_apply_expression_set` orchestrator); snapshot idle in the export handler if the rapid-character-switch cosmetic race matters; size-cap the resolver's dir/loose-file branch if a folder/multi-select picker lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bulk import and export of a character’s full expression set via a single .zip to speed authoring and sharing. Import maps files by stem (idle/thinking/speaking/error) and applies in one step; export builds a symmetric zip that re-imports directly.

- New Features
  - Pure module `tldw_chatbook/Character_Chat/expression_set_io.py`: `resolve_local_expression_set`, `build_expression_set_zip`, `apply_expression_images_to_db`.
  - `_apply_expression_set` orchestrator: stages `idle` in the editor and writes `thinking/speaking/error` to the DB with one render bump.
  - Editor UI: “Import set…” and “Export set…” buttons; saved-character-only and characters-only.

- Bug Fixes
  - Safer IO: import path validated; IO gate blocks concurrent dialogs; export filenames microsecond-stamped and written atomically with temp cleanup on failure.
  - Hardened parsing: size caps now applied to `.zip`, directories, and loose files; Windows `\` paths normalized; PIL validation with best-effort skips.
  - Idle staging is guarded to never raise; set buttons are disabled for unsaved characters.

<sup>Written for commit de490d67acfc63690c446a7b83fb095a475d1f46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

