### PR TITLE
feat(imagegen): multi-provider image-generation foundation (Phase 1)

### DIFF
--- a/Docs/superpowers/plans/2026-07-22-image-generation-multiprovider-foundation.md
+++ b/Docs/superpowers/plans/2026-07-22-image-generation-multiprovider-foundation.md
@@ -624,7 +624,7 @@ Expected: FAIL (`ModuleNotFoundError`).
 """Sync HTTP shim + light egress guard for the ported image adapters.
 
 Provides the exact surface the server's http_client exposed to Image_Generation,
-backed by httpx.Client. Full SSRF hardening is deferred to task-485; this guard
+backed by httpx.Client. Full SSRF hardening is deferred to task-498; this guard
 only rejects non-http(s) schemes and enforces a redirect cap, staying permissive
 for user-configured (incl. local) backend base URLs.
 """
@@ -644,7 +644,7 @@ def _validate_egress_or_raise(url: str) -> None:
     scheme = (urlparse(url).scheme or "").lower()
     if scheme not in ("http", "https"):
         raise ImageGenerationError(f"Refusing non-http(s) URL: {url!r}")
-    # task-485: private/link-local/metadata range blocking for API-returned URLs goes here.
+    # task-498: private/link-local/metadata range blocking for API-returned URLs goes here.
 
 
 def _resolve_redirect_url(base: str, location: str) -> str:
@@ -692,7 +692,7 @@ Expected: PASS (4 passed).
 
 ```bash
 git add tldw_chatbook/Image_Generation/http_client.py Tests/Image_Generation/test_http_client.py
-git commit -m "feat(imagegen): sync http shim + light egress guard (task-485 placeholder)"
+git commit -m "feat(imagegen): sync http shim + light egress guard (task-498 placeholder)"
 ```
 
 ---
@@ -1041,7 +1041,7 @@ def test_novita_submit_then_poll(monkeypatch):
 **Files:** Create `.../modelstudio_image_adapter.py`; Test `test_modelstudio_adapter.py`.
 **Interfaces:** Produces `ModelStudioImageAdapter` (`name="modelstudio"`, sync/async/auto modes).
 
-> **Egress note:** the ported adapter calls `evaluate_url_policy(url)` (no `allowed_hosts`), so under the Phase-1 stub it is permissive — ModelStudio's `aliyuncs` host allowlist is intentionally NOT enforced yet; that enforcement is part of **task-485**. Do not add allowlist logic here.
+> **Egress note:** the ported adapter calls `evaluate_url_policy(url)` (no `allowed_hosts`), so under the Phase-1 stub it is permissive — ModelStudio's `aliyuncs` host allowlist is intentionally NOT enforced yet; that enforcement is part of **task-498**. Do not add allowlist logic here.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -1453,6 +1453,6 @@ Expected: all green.
 - [ ] Run the full package suite once more: `source .venv/bin/activate && pytest Tests/Image_Generation/ -q`.
 - [ ] `grep -rn "tldw_Server_API" tldw_chatbook/Image_Generation/` → must be empty (no server imports leaked).
 - [ ] Confirm the app still boots: `python3 -m tldw_chatbook.app` (splash → app, no import errors).
-- [ ] The design spec's later phases (chat card, `/generate-image`, character canvas, variants/TTS), the `Media_Creation` cleanup, and task-485 (egress hardening) are explicitly out of scope here.
+- [ ] The design spec's later phases (chat card, `/generate-image`, character canvas, variants/TTS), the `Media_Creation` cleanup, and task-498 (egress hardening) are explicitly out of scope here.
 
 **Optional — opt-in live integration tests (spec §8):** the mocked tests above are the automated proof; the *live* proof is Task 17 Step 6 (real backend, real image). If you want an automated live test per backend, add one parametrized test marked `@pytest.mark.optional` that reads creds from env (`OPENROUTER_API_KEY`, a running SwarmUI at `swarmui_base_url`, an `sd` binary path, …) and `pytest.skip(...)` when absent, calls `worker.run_generation(worker.build_request(backend=..., prompt="a red apple on a table"))`, and asserts `res.bytes_len > 0`. Keep these skipped by default so CI stays green without credentials.

--- a/Docs/superpowers/plans/2026-07-22-image-generation-multiprovider-foundation.md
+++ b/Docs/superpowers/plans/2026-07-22-image-generation-multiprovider-foundation.md
@@ -1,0 +1,1458 @@
+# Image Generation — Multi-Provider Foundation (Phase 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port tldw_server's `Image_Generation` core into `tldw_chatbook` as a self-contained, 6-backend image-generation engine, re-homed onto TOML + keyring + httpx, proven by a throwaway command-palette demo panel — with no chat UI and no DB schema change.
+
+**Architecture:** The server package is FastAPI/pydantic-free and its adapters are fully synchronous. We port the pure files verbatim, re-home only the config loader (nested TOML + keyring) and a sync `http_client` shim, and drive the blocking adapters from a Textual thread worker. A temporary demo screen renders one generated image to prove the pipeline end-to-end.
+
+**Tech Stack:** Python ≥3.11, Textual, httpx (sync), Pillow, loguru — all already core deps. No new pip dependencies. `stable_diffusion_cpp` requires a user-supplied local `sd` binary at runtime only.
+
+**Design spec:** `Docs/superpowers/specs/2026-07-22-image-generation-multiprovider-foundation-design.md` (read it before starting).
+
+## Global Constraints
+
+- **Server source root (SRV):** `/Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/app/core/Image_Generation` — the files being ported. Read-only reference; copy from here.
+- **Destination package (DEST):** `tldw_chatbook/Image_Generation/`.
+- **Keep the server's flat field names identical** in `ImageGenerationConfig` (`swarmui_base_url`, `openrouter_image_api_key`, …) so ported adapters/`request_validation`/`listing` need no edits.
+- **`loguru` is this app's logger** — ported files keep `from loguru import logger` unchanged (no logger swap).
+- **No DB schema migration** in this phase. No writes to ChaChaNotes.
+- **Secrets never logged.** The config object holds resolved secrets in memory — never log/serialize it wholesale.
+- **Import-light package:** `tldw_chatbook/Image_Generation/__init__.py` must NOT import adapters or Pillow at import time (adapters lazy-load via the registry; `image_format_utils`/Pillow load only when an adapter runs).
+- **First-run defaults:** `default_backend = "swarmui"`, `enabled_backends = ["swarmui"]`.
+- **Adapters are synchronous & blocking** — never call `.generate()` on the asyncio/UI loop; only from a thread worker.
+- **Tests run in the project venv only:** `source .venv/bin/activate` first. Never broad-`pkill pytest` (multi-session environment) — scope test runs to `Tests/Image_Generation/`.
+- **Standard import-repoint recipe** (used by every "port" task; macOS `sed`):
+
+  ```bash
+  # $F = destination file just copied from SRV
+  sed -i '' \
+    -e 's#tldw_Server_API\.app\.core\.Image_Generation#tldw_chatbook.Image_Generation#g' \
+    -e 's#tldw_Server_API\.app\.core\.http_client#tldw_chatbook.Image_Generation.http_client#g' \
+    -e 's#tldw_Server_API\.app\.core\.Security\.egress#tldw_chatbook.Image_Generation.http_client#g' \
+    "$F"
+  ```
+- **Every task's commit runs in the worktree** `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/image-gen-foundation` on branch `claude/image-gen-multiprovider-foundation`.
+
+## File structure (created in this plan)
+
+```
+tldw_chatbook/Image_Generation/
+  __init__.py                 # import-light public surface
+  exceptions.py               # port verbatim
+  capabilities.py             # port verbatim (defines ResolvedReferenceImage)
+  prompt_refinement.py        # port verbatim
+  config.py                   # RE-HOME: nested TOML + env + keyring -> flat dataclass
+  http_client.py              # NEW: sync fetch_json/create_client + light egress guard
+  request_validation.py       # port verbatim
+  listing.py                  # port verbatim
+  adapter_registry.py         # port; repoint DEFAULT_ADAPTERS strings
+  worker.py                   # NEW: request builder + thread-worker entry
+  adapters/
+    __init__.py
+    base.py                   # port verbatim (ImageGenRequest/ImageGenResult/protocol)
+    image_format_utils.py     # port; re-home fetch_image_bytes onto local http_client
+    stable_diffusion_cpp_adapter.py  # port
+    swarmui_adapter.py               # port
+    openrouter_image_adapter.py      # port
+    novita_image_adapter.py          # port
+    together_image_adapter.py        # port
+    modelstudio_image_adapter.py     # port
+tldw_chatbook/config.py         # MODIFY: add [image_generation] default template block
+tldw_chatbook/UI/Screens/image_gen_demo_screen.py   # NEW: throwaway demo panel
+tldw_chatbook/UI/image_gen_command_provider.py       # NEW: command-palette entry
+tldw_chatbook/app.py            # MODIFY: register the command provider
+Tests/Image_Generation/         # NEW test package
+```
+
+**Not ported (dropped):** `reference_images.py` (media-DB/object-store coupled; only ModelStudio uses it, and it guards on `reference_image is not None`). `config.py`'s server loader body is replaced, not copied.
+
+---
+
+### Task 1: Package skeleton + exceptions
+
+**Files:**
+- Create: `tldw_chatbook/Image_Generation/__init__.py`, `tldw_chatbook/Image_Generation/exceptions.py`, `tldw_chatbook/Image_Generation/adapters/__init__.py`
+- Create: `Tests/Image_Generation/__init__.py`, `Tests/Image_Generation/test_package_skeleton.py`
+
+**Interfaces:**
+- Produces: package `tldw_chatbook.Image_Generation`; `exceptions.ImageGenerationError(RuntimeError)`, `exceptions.ImageBackendUnavailableError(ImageGenerationError)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# Tests/Image_Generation/test_package_skeleton.py
+def test_exceptions_hierarchy():
+    from tldw_chatbook.Image_Generation.exceptions import (
+        ImageGenerationError, ImageBackendUnavailableError,
+    )
+    assert issubclass(ImageGenerationError, RuntimeError)
+    assert issubclass(ImageBackendUnavailableError, ImageGenerationError)
+
+def test_package_imports_clean():
+    import importlib
+    mod = importlib.import_module("tldw_chatbook.Image_Generation")
+    assert mod is not None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest Tests/Image_Generation/test_package_skeleton.py -v`
+Expected: FAIL (`ModuleNotFoundError: tldw_chatbook.Image_Generation`).
+
+- [ ] **Step 3: Copy exceptions.py and create the package files**
+
+```bash
+mkdir -p tldw_chatbook/Image_Generation/adapters Tests/Image_Generation
+cp "$SRV/exceptions.py" tldw_chatbook/Image_Generation/exceptions.py   # $SRV per Global Constraints
+: > tldw_chatbook/Image_Generation/adapters/__init__.py
+: > Tests/Image_Generation/__init__.py
+```
+
+Write `tldw_chatbook/Image_Generation/__init__.py` (import-light — only re-export the cheap symbols; do NOT import adapters/config/http_client here yet):
+
+```python
+"""Multi-provider image generation (ported from tldw_server). Import-light."""
+from tldw_chatbook.Image_Generation.exceptions import (
+    ImageGenerationError,
+    ImageBackendUnavailableError,
+)
+
+__all__ = ["ImageGenerationError", "ImageBackendUnavailableError"]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `source .venv/bin/activate && pytest Tests/Image_Generation/test_package_skeleton.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Image_Generation/ Tests/Image_Generation/
+git commit -m "feat(imagegen): package skeleton + exceptions (ported)"
+```
+
+---
+
+### Task 2: Core contracts (capabilities + adapters/base)
+
+**Files:**
+- Create: `tldw_chatbook/Image_Generation/capabilities.py`, `tldw_chatbook/Image_Generation/adapters/base.py`
+- Test: `Tests/Image_Generation/test_contracts.py`
+
+**Interfaces:**
+- Produces: `capabilities.ResolvedReferenceImage`, `capabilities.ReferenceImageCapability`, `capabilities.resolve_reference_image_capability`, `capabilities.resolve_backend_reference_image_capability`; `adapters.base.ImageGenRequest`, `adapters.base.ImageGenResult`, `adapters.base.ImageGenerationAdapter` (Protocol).
+- `ImageGenRequest(backend, prompt, negative_prompt, width, height, steps, cfg_scale, seed, sampler, model, format, extra_params, request_id=None, reference_image=None)` — frozen.
+- `ImageGenResult(content: bytes, content_type: str, bytes_len: int)` — frozen.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# Tests/Image_Generation/test_contracts.py
+def test_request_and_result_dataclasses():
+    from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest, ImageGenResult
+    req = ImageGenRequest(
+        backend="swarmui", prompt="a red dragon", negative_prompt=None,
+        width=512, height=512, steps=20, cfg_scale=7.0, seed=-1,
+        sampler=None, model=None, format="png", extra_params={},
+    )
+    assert req.backend == "swarmui"
+    assert req.reference_image is None  # default
+    res = ImageGenResult(content=b"\x89PNG", content_type="image/png", bytes_len=4)
+    assert res.bytes_len == 4
+
+def test_resolved_reference_image_defined_locally():
+    # Must be defined in capabilities.py, NOT imported from reference_images (which we dropped)
+    from tldw_chatbook.Image_Generation.capabilities import ResolvedReferenceImage
+    r = ResolvedReferenceImage(
+        file_id=1, filename=None, mime_type="image/png",
+        width=None, height=None, bytes_len=3, content=b"abc", temp_path=None,
+    )
+    assert r.mime_type == "image/png"
+
+def test_adapter_is_structural_protocol():
+    from tldw_chatbook.Image_Generation.adapters.base import ImageGenerationAdapter
+    from typing import runtime_checkable, Protocol
+    # It is a Protocol; a duck-typed object with name/supported_formats/generate satisfies it structurally.
+    assert issubclass(ImageGenerationAdapter, Protocol)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest Tests/Image_Generation/test_contracts.py -v`
+Expected: FAIL (`ModuleNotFoundError` for `capabilities`/`base`).
+
+- [ ] **Step 3: Port the files + repoint imports**
+
+```bash
+cp "$SRV/capabilities.py" tldw_chatbook/Image_Generation/capabilities.py
+cp "$SRV/adapters/base.py" tldw_chatbook/Image_Generation/adapters/base.py
+for F in tldw_chatbook/Image_Generation/capabilities.py tldw_chatbook/Image_Generation/adapters/base.py; do
+  sed -i '' \
+    -e 's#tldw_Server_API\.app\.core\.Image_Generation#tldw_chatbook.Image_Generation#g' \
+    -e 's#tldw_Server_API\.app\.core\.http_client#tldw_chatbook.Image_Generation.http_client#g' \
+    -e 's#tldw_Server_API\.app\.core\.Security\.egress#tldw_chatbook.Image_Generation.http_client#g' \
+    "$F"
+done
+```
+
+Then open both files and confirm no remaining `tldw_Server_API` imports:
+`grep -rn "tldw_Server_API" tldw_chatbook/Image_Generation/capabilities.py tldw_chatbook/Image_Generation/adapters/base.py` → must be empty. (`capabilities.py`'s only cross-module import is a `TYPE_CHECKING`-guarded `config` import, now repointed to `tldw_chatbook.Image_Generation.config` — that module arrives in Task 4; because it's `TYPE_CHECKING`-only, imports work now.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `source .venv/bin/activate && pytest Tests/Image_Generation/test_contracts.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Image_Generation/capabilities.py tldw_chatbook/Image_Generation/adapters/base.py Tests/Image_Generation/test_contracts.py
+git commit -m "feat(imagegen): port core contracts (capabilities + adapters/base)"
+```
+
+---
+
+### Task 3: Prompt refinement
+
+**Files:**
+- Create: `tldw_chatbook/Image_Generation/prompt_refinement.py`
+- Test: `Tests/Image_Generation/test_prompt_refinement.py`
+
+**Interfaces:**
+- Produces: `prompt_refinement.refine_image_prompt(prompt, *, mode="auto", quality_suffix=..., max_length=None) -> str`; `prompt_refinement.normalize_prompt_refinement_mode(value, *, default="auto") -> str`; constant `DEFAULT_QUALITY_SUFFIX`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# Tests/Image_Generation/test_prompt_refinement.py
+import pytest
+
+@pytest.fixture
+def pr():
+    from tldw_chatbook.Image_Generation import prompt_refinement as m
+    return m
+
+def test_off_returns_prompt_unchanged(pr):
+    assert pr.refine_image_prompt("a cat", mode="off") == "a cat"
+
+def test_basic_always_appends_suffix(pr):
+    out = pr.refine_image_prompt("a cat", mode="basic")
+    assert pr.DEFAULT_QUALITY_SUFFIX in out
+
+def test_auto_skips_when_prompt_already_detailed(pr):
+    detailed = "a cat, highly detailed, cinematic lighting, sharp focus, 8k, masterpiece composition"
+    assert pr.refine_image_prompt(detailed, mode="auto") == detailed  # has quality cues -> no append
+
+def test_auto_appends_for_short_sparse_prompt(pr):
+    out = pr.refine_image_prompt("a cat", mode="auto")
+    assert pr.DEFAULT_QUALITY_SUFFIX in out
+
+def test_normalize_mode_aliases(pr):
+    assert pr.normalize_prompt_refinement_mode(True) == "basic"
+    assert pr.normalize_prompt_refinement_mode(False) == "off"
+    assert pr.normalize_prompt_refinement_mode("none") == "off"
+    assert pr.normalize_prompt_refinement_mode("garbage") == "auto"  # default
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest Tests/Image_Generation/test_prompt_refinement.py -v`
+Expected: FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 3: Port the file**
+
+```bash
+cp "$SRV/prompt_refinement.py" tldw_chatbook/Image_Generation/prompt_refinement.py
+# no cross-package imports; repoint is a no-op but run it for consistency:
+sed -i '' -e 's#tldw_Server_API\.app\.core\.Image_Generation#tldw_chatbook.Image_Generation#g' tldw_chatbook/Image_Generation/prompt_refinement.py
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `source .venv/bin/activate && pytest Tests/Image_Generation/test_prompt_refinement.py -v`
+Expected: PASS (5 passed). If `test_auto_skips_when_prompt_already_detailed` fails, read the ported `_needs_quality_guidance`/`_QUALITY_CUES` to align the test's cue words — do not weaken the assertion beyond matching the ported logic.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Image_Generation/prompt_refinement.py Tests/Image_Generation/test_prompt_refinement.py
+git commit -m "feat(imagegen): port prompt refinement"
+```
+
+---
+
+### Task 4: Config re-home (the crux) + config template
+
+**Files:**
+- Create: `tldw_chatbook/Image_Generation/config.py`
+- Modify: `tldw_chatbook/config.py` (add `[image_generation]` default template block)
+- Test: `Tests/Image_Generation/test_config_loader.py`
+
+**Interfaces:**
+- Consumes: `tldw_chatbook.config.get_cli_setting`, `tldw_chatbook.config.load_settings`, `tldw_chatbook.config.get_api_key`; keyring (optional).
+- Produces: `config.ImageGenerationConfig` (frozen dataclass, server field names); `config.get_image_generation_config(reload=False) -> ImageGenerationConfig`; `config.reset_image_generation_config_cache()`; all server `DEFAULT_*` constants; helper `config._load_image_generation_section() -> dict` (flat mapping).
+
+**Approach:** Copy the server `config.py` to preserve its `DEFAULT_*` constants, `_coerce_*`/`_parse_*` helpers, `ImageGenerationConfig` dataclass, and the `get_image_generation_config()` builder **verbatim**. Replace ONLY its data source: swap `get_config_section("Image-Generation")` for a new `_load_image_generation_section()` that assembles the identical flat mapping from nested TOML + env + keyring, and populate secret fields per spec §4.3.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# Tests/Image_Generation/test_config_loader.py
+import pytest
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    from tldw_chatbook.Image_Generation import config as c
+    c.reset_image_generation_config_cache()
+    yield
+    c.reset_image_generation_config_cache()
+
+def test_defaults_when_unconfigured(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as c
+    # No TOML section, no env, no keyring: fall back to documented defaults.
+    monkeypatch.setattr(c, "_read_image_generation_toml", lambda: {}, raising=False)
+    monkeypatch.setattr(c, "_keyring_get", lambda backend: None, raising=False)  # avoid real keyring
+    for var in ("OPENROUTER_API_KEY", "NOVITA_API_KEY", "TOGETHER_API_KEY", "DASHSCOPE_API_KEY", "QWEN_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    cfg = c.get_image_generation_config(reload=True)
+    assert cfg.swarmui_base_url == c.DEFAULT_SWARMUI_BASE_URL
+    assert cfg.max_width == c.DEFAULT_MAX_WIDTH
+    assert cfg.openrouter_image_api_key in (None, "")  # unconfigured
+
+def test_nested_toml_flattens_to_flat_fields(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as c
+    fake = {
+        "default_backend": "swarmui",
+        "enabled_backends": ["swarmui", "openrouter"],
+        "swarmui": {"base_url": "http://example:9999"},
+        "openrouter": {"default_model": "openai/gpt-image-1", "timeout_seconds": 42},
+    }
+    monkeypatch.setattr(c, "_read_image_generation_toml", lambda: fake, raising=False)
+    cfg = c.get_image_generation_config(reload=True)
+    assert cfg.swarmui_base_url == "http://example:9999"
+    assert cfg.openrouter_image_default_model == "openai/gpt-image-1"
+    assert cfg.openrouter_image_timeout_seconds == 42
+    assert cfg.enabled_backends == ["swarmui", "openrouter"]
+
+def test_secret_precedence_env_over_config(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as c
+    fake = {"openrouter": {"api_key": "from-config"}}
+    monkeypatch.setattr(c, "_read_image_generation_toml", lambda: fake, raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "from-env")
+    cfg = c.get_image_generation_config(reload=True)
+    assert cfg.openrouter_image_api_key == "from-env"
+
+def test_secret_from_keyring_populates_field(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as c
+    monkeypatch.setattr(c, "_read_image_generation_toml", lambda: {}, raising=False)
+    monkeypatch.delenv("NOVITA_API_KEY", raising=False)
+    # keyring-only secret must land on the config field so listing.is_configured sees it (spec §4.2 step 5)
+    monkeypatch.setattr(c, "_keyring_get", lambda backend: "kr-secret" if backend == "novita" else None, raising=False)
+    cfg = c.get_image_generation_config(reload=True)
+    assert cfg.novita_image_api_key == "kr-secret"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest Tests/Image_Generation/test_config_loader.py -v`
+Expected: FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 3: Copy server config.py, repoint, and replace the loader source**
+
+```bash
+cp "$SRV/config.py" tldw_chatbook/Image_Generation/config.py
+sed -i '' -e 's#tldw_Server_API\.app\.core\.Image_Generation#tldw_chatbook.Image_Generation#g' tldw_chatbook/Image_Generation/config.py
+```
+
+Now edit `tldw_chatbook/Image_Generation/config.py`:
+
+1. **Remove** the server config import: delete the line `from tldw_Server_API.app.core.config import get_config_section` (and any other `tldw_Server_API` import — verify with `grep tldw_Server_API`).
+2. **Read `get_image_generation_config()`** and note the local name it binds the section mapping to (e.g. `section = get_config_section("Image-Generation", ...)`). Replace that single assignment's RHS with `section = _load_image_generation_section()`. Keep the rest of the builder (all the `_coerce_*` / `section.get(...)` calls and the `ImageGenerationConfig(...)` construction) verbatim — the flat keys already match the dataclass field names.
+3. **Add** these helpers near the top of the module (below the `DEFAULT_*` constants). `_KEYS` maps each nested `[image_generation.<backend>].<toml_key>` to the flat field name the builder reads:
+
+```python
+import os
+import keyring
+from loguru import logger
+from tldw_chatbook.config import get_cli_setting, get_api_key
+
+# Secret fields: backend -> (flat_field_name, [env vars in precedence order], keyring_backend_id)
+_SECRETS = {
+    "swarmui":     ("swarmui_swarm_token",        ["SWARMUI_TOKEN"],                       "swarmui"),
+    "openrouter":  ("openrouter_image_api_key",   ["OPENROUTER_API_KEY"],                  "openrouter"),
+    "novita":      ("novita_image_api_key",       ["NOVITA_API_KEY"],                      "novita"),
+    "together":    ("together_image_api_key",     ["TOGETHER_API_KEY"],                    "together"),
+    "modelstudio": ("modelstudio_image_api_key",  ["DASHSCOPE_API_KEY", "QWEN_API_KEY"],   "modelstudio"),
+}
+# Non-secret nested keys: (backend, toml_key) -> flat_field_name
+_NON_SECRET = {
+    ("stable_diffusion_cpp", "binary_path"):          "sd_cpp_binary_path",
+    ("stable_diffusion_cpp", "diffusion_model_path"): "sd_cpp_diffusion_model_path",
+    ("stable_diffusion_cpp", "model_path"):           "sd_cpp_model_path",
+    ("stable_diffusion_cpp", "vae_path"):             "sd_cpp_vae_path",
+    ("stable_diffusion_cpp", "lora_paths"):           "sd_cpp_lora_paths",
+    ("stable_diffusion_cpp", "device"):               "sd_cpp_device",
+    ("stable_diffusion_cpp", "default_steps"):        "sd_cpp_default_steps",
+    ("stable_diffusion_cpp", "default_cfg_scale"):    "sd_cpp_default_cfg_scale",
+    ("stable_diffusion_cpp", "default_sampler"):      "sd_cpp_default_sampler",
+    ("stable_diffusion_cpp", "timeout_seconds"):      "sd_cpp_timeout_seconds",
+    ("stable_diffusion_cpp", "allowed_extra_params"): "sd_cpp_allowed_extra_params",
+    ("swarmui", "base_url"):              "swarmui_base_url",
+    ("swarmui", "default_model"):         "swarmui_default_model",
+    ("swarmui", "timeout_seconds"):       "swarmui_timeout_seconds",
+    ("swarmui", "allowed_extra_params"):  "swarmui_allowed_extra_params",
+    ("openrouter", "base_url"):              "openrouter_image_base_url",
+    ("openrouter", "default_model"):         "openrouter_image_default_model",
+    ("openrouter", "timeout_seconds"):       "openrouter_image_timeout_seconds",
+    ("openrouter", "allowed_extra_params"):  "openrouter_image_allowed_extra_params",
+    ("novita", "base_url"):              "novita_image_base_url",
+    ("novita", "default_model"):         "novita_image_default_model",
+    ("novita", "timeout_seconds"):       "novita_image_timeout_seconds",
+    ("novita", "poll_interval_seconds"): "novita_image_poll_interval_seconds",
+    ("novita", "allowed_extra_params"):  "novita_image_allowed_extra_params",
+    ("together", "base_url"):              "together_image_base_url",
+    ("together", "default_model"):         "together_image_default_model",
+    ("together", "timeout_seconds"):       "together_image_timeout_seconds",
+    ("together", "allowed_extra_params"):  "together_image_allowed_extra_params",
+    ("modelstudio", "base_url"):              "modelstudio_image_base_url",
+    ("modelstudio", "default_model"):         "modelstudio_image_default_model",
+    ("modelstudio", "region"):                "modelstudio_image_region",
+    ("modelstudio", "mode"):                  "modelstudio_image_mode",
+    ("modelstudio", "poll_interval_seconds"): "modelstudio_image_poll_interval_seconds",
+    ("modelstudio", "timeout_seconds"):       "modelstudio_image_timeout_seconds",
+    ("modelstudio", "allowed_extra_params"):  "modelstudio_image_allowed_extra_params",
+}
+_GLOBAL_KEYS = [
+    "default_backend", "enabled_backends", "max_width", "max_height",
+    "max_pixels", "max_steps", "max_prompt_length", "inline_max_bytes",
+]
+
+def _read_image_generation_toml() -> dict:
+    """Return the raw [image_generation] section dict (nested). Patch point in tests."""
+    from tldw_chatbook.config import load_settings
+    return load_settings().get("image_generation", {}) or {}
+
+def _keyring_get(backend: str):
+    """Namespaced keyring lookup; never raises. Patch point in tests."""
+    try:
+        return keyring.get_password("tldw_chatbook_imagegen", backend)
+    except Exception as e:  # keyring backend may be unavailable
+        logger.debug(f"keyring lookup failed for imagegen/{backend}: {e}")
+        return None
+
+def _resolve_secret(backend: str, sub: dict):
+    field, env_vars, kr_id = _SECRETS[backend]
+    for ev in env_vars:                       # 1. env
+        v = os.getenv(ev)
+        if v:
+            return field, v
+    cfg_val = (sub or {}).get("api_key")       # 2. config
+    if cfg_val and cfg_val != "<API_KEY_HERE>":
+        return field, cfg_val
+    kr = _keyring_get(kr_id)                    # 3. keyring
+    if kr:
+        return field, kr
+    return field, None                         # 4. optional shared handled by adapter/get_api_key opt-in
+
+def _load_image_generation_section() -> dict:
+    """Assemble the FLAT mapping the config builder expects, from nested TOML + env + keyring."""
+    raw = _read_image_generation_toml()
+    flat: dict = {}
+    for k in _GLOBAL_KEYS:
+        if k in raw:
+            flat[k] = raw[k]
+    for (backend, toml_key), field in _NON_SECRET.items():
+        sub = raw.get(backend) or {}
+        if toml_key in sub:
+            flat[field] = sub[toml_key]
+    for backend in _SECRETS:
+        field, value = _resolve_secret(backend, raw.get(backend) or {})
+        if value:
+            flat[field] = value
+    return flat
+```
+
+> Note: `flat` intentionally omits keys that are unset so the builder falls back to its `DEFAULT_*` constants exactly as it did with a sparse INI section. If the builder indexes `section[...]` directly (not `.get`), keep passing through `_coerce_*` as the server does — do not change coercion.
+
+- [ ] **Step 4: Add the `[image_generation]` default block to the app config template**
+
+In `tldw_chatbook/config.py`, find the default config TOML template (search for an existing block like `[chat.images]` or `[embeddings]`). Add the block from spec §4.1 (`[image_generation]` + the 6 `[image_generation.<backend>]` subsections) alongside it, so the section materializes for users. Do NOT put real secrets in the template; leave `api_key = "<API_KEY_HERE>"` where a key would go, matching the `[API]` convention.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `source .venv/bin/activate && pytest Tests/Image_Generation/test_config_loader.py -v`
+Expected: PASS (4 passed). If the builder binds the section under a different local name, wire `_load_image_generation_section()` there; the tests assert behavior, not the internal name.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Image_Generation/config.py tldw_chatbook/config.py Tests/Image_Generation/test_config_loader.py
+git commit -m "feat(imagegen): re-home config loader onto TOML+env+keyring; add config template"
+```
+
+---
+
+### Task 5: Request validation
+
+**Files:**
+- Create: `tldw_chatbook/Image_Generation/request_validation.py`
+- Test: `Tests/Image_Generation/test_request_validation.py`
+
+**Interfaces:**
+- Consumes: `config.get_image_generation_config`, `config.DEFAULT_*`.
+- Produces: `request_validation.validate_image_generation_request(structured: dict, *, config=None) -> list`; `request_validation.effective_inline_max_bytes(config=None) -> int`; `request_validation.allowed_extra_params_for_backend(backend, config) -> set`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# Tests/Image_Generation/test_request_validation.py
+import pytest
+
+@pytest.fixture
+def rv():
+    from tldw_chatbook.Image_Generation import request_validation as m
+    return m
+
+def _codes(issues):
+    return {i.path for i in issues}
+
+def test_valid_request_has_no_issues(rv):
+    ok = {"backend": "swarmui", "prompt": "cat", "width": 512, "height": 512, "steps": 20, "cfg_scale": 7.0, "extra_params": {}}
+    assert rv.validate_image_generation_request(ok) == []
+
+def test_oversize_dimensions_flagged(rv):
+    bad = {"backend": "swarmui", "prompt": "cat", "width": 9000, "height": 9000, "extra_params": {}}
+    issues = rv.validate_image_generation_request(bad)
+    assert any("width" in p for p in _codes(issues))
+
+def test_negative_cfg_scale_flagged(rv):
+    bad = {"backend": "swarmui", "prompt": "cat", "cfg_scale": -1.0, "extra_params": {}}
+    assert any("cfg_scale" in p for p in _codes(rv.validate_image_generation_request(bad)))
+
+def test_extra_params_not_in_allowlist_flagged(rv):
+    bad = {"backend": "swarmui", "prompt": "cat", "extra_params": {"totally_unknown": 1}}
+    issues = rv.validate_image_generation_request(bad)
+    assert any("extra_params" in p for p in _codes(issues))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest Tests/Image_Generation/test_request_validation.py -v`
+Expected: FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 3: Port + repoint**
+
+```bash
+cp "$SRV/request_validation.py" tldw_chatbook/Image_Generation/request_validation.py
+sed -i '' -e 's#tldw_Server_API\.app\.core\.Image_Generation#tldw_chatbook.Image_Generation#g' tldw_chatbook/Image_Generation/request_validation.py
+grep -n "tldw_Server_API" tldw_chatbook/Image_Generation/request_validation.py   # must be empty
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `source .venv/bin/activate && pytest Tests/Image_Generation/test_request_validation.py -v`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Image_Generation/request_validation.py Tests/Image_Generation/test_request_validation.py
+git commit -m "feat(imagegen): port request validation"
+```
+
+---
+
+### Task 6: HTTP shim + light egress guard
+
+**Files:**
+- Create: `tldw_chatbook/Image_Generation/http_client.py`
+- Test: `Tests/Image_Generation/test_http_client.py`
+
+**Interfaces:**
+- Produces: `http_client.fetch_json(method, url, *, headers=None, json=None, params=None, cookies=None, timeout=None)`; `http_client.create_client(timeout=None) -> httpx.Client`; `http_client.DEFAULT_MAX_REDIRECTS: int`; `http_client._resolve_redirect_url(base, location) -> str`; `http_client._validate_egress_or_raise(url) -> None`; `http_client.evaluate_url_policy(url, *, allowed_hosts=None) -> object` (has `.allowed: bool`, `.reason: str|None`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# Tests/Image_Generation/test_http_client.py
+import pytest
+
+@pytest.fixture
+def hc():
+    from tldw_chatbook.Image_Generation import http_client as m
+    return m
+
+def test_rejects_non_http_scheme(hc):
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+    with pytest.raises(ImageGenerationError):
+        hc._validate_egress_or_raise("file:///etc/passwd")
+
+def test_allows_local_backend_url(hc):
+    # user-configured local backends must pass the light guard
+    hc._validate_egress_or_raise("http://127.0.0.1:7801/API/GetNewSession")  # no raise
+
+def test_evaluate_url_policy_allowlist(hc):
+    r = hc.evaluate_url_policy("https://x.aliyuncs.com/i.png", allowed_hosts={"aliyuncs.com"})
+    assert r.allowed is True
+    r2 = hc.evaluate_url_policy("https://evil.example/i.png", allowed_hosts={"aliyuncs.com"})
+    assert r2.allowed is False
+
+def test_fetch_json_parses(monkeypatch, hc):
+    class FakeResp:
+        status_code = 200
+        def json(self): return {"ok": True}
+        def raise_for_status(self): pass
+    class FakeClient:
+        def __init__(self, *a, **k): pass
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def request(self, *a, **k): return FakeResp()
+    monkeypatch.setattr(hc.httpx, "Client", FakeClient)
+    assert hc.fetch_json("POST", "http://127.0.0.1:7801/API/x", json={"a": 1}) == {"ok": True}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest Tests/Image_Generation/test_http_client.py -v`
+Expected: FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 3: Write `http_client.py`**
+
+```python
+"""Sync HTTP shim + light egress guard for the ported image adapters.
+
+Provides the exact surface the server's http_client exposed to Image_Generation,
+backed by httpx.Client. Full SSRF hardening is deferred to task-485; this guard
+only rejects non-http(s) schemes and enforces a redirect cap, staying permissive
+for user-configured (incl. local) backend base URLs.
+"""
+from __future__ import annotations
+import os
+from dataclasses import dataclass
+from urllib.parse import urljoin, urlparse
+import httpx
+from loguru import logger
+from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+DEFAULT_MAX_REDIRECTS = int(os.getenv("HTTP_MAX_REDIRECTS", "5"))
+_DEFAULT_TIMEOUT = 120.0
+
+
+def _validate_egress_or_raise(url: str) -> None:
+    scheme = (urlparse(url).scheme or "").lower()
+    if scheme not in ("http", "https"):
+        raise ImageGenerationError(f"Refusing non-http(s) URL: {url!r}")
+    # task-485: private/link-local/metadata range blocking for API-returned URLs goes here.
+
+
+def _resolve_redirect_url(base: str, location: str) -> str:
+    return urljoin(base, location)
+
+
+@dataclass(frozen=True)
+class URLPolicyResult:
+    allowed: bool
+    reason: str | None = None
+
+
+def evaluate_url_policy(url: str, *, allowed_hosts: set[str] | None = None) -> URLPolicyResult:
+    _validate_egress_or_raise(url)
+    if not allowed_hosts:
+        return URLPolicyResult(True, None)
+    host = (urlparse(url).hostname or "").lower()
+    if any(host == h or host.endswith("." + h) for h in allowed_hosts):
+        return URLPolicyResult(True, None)
+    return URLPolicyResult(False, f"host {host!r} not in allowlist")
+
+
+def create_client(timeout: float | None = None) -> httpx.Client:
+    return httpx.Client(
+        timeout=timeout or _DEFAULT_TIMEOUT,
+        follow_redirects=True,
+        max_redirects=DEFAULT_MAX_REDIRECTS,
+    )
+
+
+def fetch_json(method, url, *, headers=None, json=None, params=None, cookies=None, timeout=None):
+    _validate_egress_or_raise(url)
+    with create_client(timeout=timeout) as client:
+        resp = client.request(method, url, headers=headers, json=json, params=params, cookies=cookies)
+        resp.raise_for_status()
+        return resp.json()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `source .venv/bin/activate && pytest Tests/Image_Generation/test_http_client.py -v`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Image_Generation/http_client.py Tests/Image_Generation/test_http_client.py
+git commit -m "feat(imagegen): sync http shim + light egress guard (task-485 placeholder)"
+```
+
+---
+
+### Task 7: Image format utils (Pillow bytes layer)
+
+**Files:**
+- Create: `tldw_chatbook/Image_Generation/adapters/image_format_utils.py`
+- Test: `Tests/Image_Generation/test_image_format_utils.py`
+
+**Interfaces:**
+- Consumes: `http_client.{create_client, _validate_egress_or_raise, _resolve_redirect_url, DEFAULT_MAX_REDIRECTS}`.
+- Produces: `image_format_utils.{format_from_bytes, content_type_for_format, validate_and_convert_image_output, decode_base64_image, decode_data_url, fetch_image_bytes, reference_image_data_url}`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# Tests/Image_Generation/test_image_format_utils.py
+import io, pytest
+from PIL import Image
+
+def _png_bytes(size=(8, 8)):
+    buf = io.BytesIO(); Image.new("RGB", size, (200, 30, 30)).save(buf, format="PNG"); return buf.getvalue()
+
+@pytest.fixture
+def ifu():
+    from tldw_chatbook.Image_Generation.adapters import image_format_utils as m
+    return m
+
+def test_format_from_bytes_detects_png(ifu):
+    assert ifu.format_from_bytes(_png_bytes()) == "png"
+
+def test_validate_and_convert_output_roundtrip(ifu):
+    data, ctype = ifu.validate_and_convert_image_output(_png_bytes(), requested_format="png", max_bytes=10_000_000)
+    assert ctype == "image/png" and isinstance(data, (bytes, bytearray))
+
+def test_validate_rejects_when_over_max_bytes(ifu):
+    with pytest.raises(Exception):
+        ifu.validate_and_convert_image_output(_png_bytes((256, 256)), requested_format="png", max_bytes=10)
+```
+
+> Read the ported signature of `validate_and_convert_image_output` first and adjust the keyword names in the test to match it exactly (it may take positional `format`/`max_bytes`). Keep the three assertions.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest Tests/Image_Generation/test_image_format_utils.py -v`
+Expected: FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 3: Port + repoint**
+
+```bash
+cp "$SRV/adapters/image_format_utils.py" tldw_chatbook/Image_Generation/adapters/image_format_utils.py
+sed -i '' \
+  -e 's#tldw_Server_API\.app\.core\.Image_Generation#tldw_chatbook.Image_Generation#g' \
+  -e 's#tldw_Server_API\.app\.core\.http_client#tldw_chatbook.Image_Generation.http_client#g' \
+  tldw_chatbook/Image_Generation/adapters/image_format_utils.py
+grep -n "tldw_Server_API" tldw_chatbook/Image_Generation/adapters/image_format_utils.py   # must be empty
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `source .venv/bin/activate && pytest Tests/Image_Generation/test_image_format_utils.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Image_Generation/adapters/image_format_utils.py Tests/Image_Generation/test_image_format_utils.py
+git commit -m "feat(imagegen): port image format utils (re-homed fetch_image_bytes)"
+```
+
+---
+
+### Task 8: Adapter registry
+
+**Files:**
+- Create: `tldw_chatbook/Image_Generation/adapter_registry.py`
+- Test: `Tests/Image_Generation/test_adapter_registry.py`
+
+**Interfaces:**
+- Consumes: `config.get_image_generation_config`.
+- Produces: `adapter_registry.ImageAdapterRegistry`, `adapter_registry.get_registry()`, `adapter_registry.reset_registry()`, and `DEFAULT_ADAPTERS` mapping name→"tldw_chatbook.Image_Generation.adapters.<mod>.<Class>".
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# Tests/Image_Generation/test_adapter_registry.py
+import pytest
+
+@pytest.fixture(autouse=True)
+def _reset():
+    from tldw_chatbook.Image_Generation import adapter_registry as r
+    r.reset_registry()
+    yield
+    r.reset_registry()
+
+def test_resolve_backend_requires_enabled():
+    from tldw_chatbook.Image_Generation.adapter_registry import ImageAdapterRegistry
+    reg = ImageAdapterRegistry(config_override={"enabled_backends": ["swarmui"], "default_backend": "swarmui"})
+    assert reg.resolve_backend("swarmui") == "swarmui"
+    assert reg.resolve_backend("novita") is None      # not enabled
+    assert reg.resolve_backend(None) == "swarmui"     # default
+
+def test_nothing_enabled_by_default():
+    from tldw_chatbook.Image_Generation.adapter_registry import ImageAdapterRegistry
+    reg = ImageAdapterRegistry(config_override={"enabled_backends": [], "default_backend": "swarmui"})
+    assert reg.resolve_backend("swarmui") is None
+
+def test_default_adapters_point_at_local_package():
+    from tldw_chatbook.Image_Generation.adapter_registry import DEFAULT_ADAPTERS
+    assert set(DEFAULT_ADAPTERS) == {
+        "stable_diffusion_cpp", "swarmui", "openrouter", "novita", "together", "modelstudio"
+    }
+    assert all(v.startswith("tldw_chatbook.Image_Generation.adapters.") for v in DEFAULT_ADAPTERS.values())
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest Tests/Image_Generation/test_adapter_registry.py -v`
+Expected: FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 3: Port + repoint the DEFAULT_ADAPTERS strings**
+
+```bash
+cp "$SRV/adapter_registry.py" tldw_chatbook/Image_Generation/adapter_registry.py
+sed -i '' -e 's#tldw_Server_API\.app\.core\.Image_Generation#tldw_chatbook.Image_Generation#g' tldw_chatbook/Image_Generation/adapter_registry.py
+grep -n "tldw_Server_API" tldw_chatbook/Image_Generation/adapter_registry.py   # must be empty
+```
+
+The `sed` also rewrites the fully-qualified `DEFAULT_ADAPTERS` values (they contain `...Image_Generation.adapters...`). Confirm they now read `tldw_chatbook.Image_Generation.adapters.<mod>.<Class>`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `source .venv/bin/activate && pytest Tests/Image_Generation/test_adapter_registry.py -v`
+Expected: PASS (3 passed). (Adapters are lazy-imported only on `get_adapter`, so these tests don't require the adapter modules to exist yet.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Image_Generation/adapter_registry.py Tests/Image_Generation/test_adapter_registry.py
+git commit -m "feat(imagegen): port adapter registry (lazy, local module paths)"
+```
+
+---
+
+### Tasks 9–14: Port the six adapters
+
+Each adapter is the same shape: **copy → repoint → focused mocked test → commit.** Do them one at a time (each is its own reviewable task). For every adapter, after copying run the standard repoint recipe and `grep -n "tldw_Server_API" <file>` (must be empty).
+
+#### Task 9: SwarmUI adapter
+
+**Files:** Create `tldw_chatbook/Image_Generation/adapters/swarmui_adapter.py`; Test `Tests/Image_Generation/test_swarmui_adapter.py`.
+**Interfaces:** Produces `SwarmUIAdapter` (`name="swarmui"`, `supported_formats={"png","jpg"}`, sync `generate(ImageGenRequest)->ImageGenResult`).
+
+- [ ] **Step 1: Failing test**
+
+```python
+# Tests/Image_Generation/test_swarmui_adapter.py
+import io, pytest
+from PIL import Image
+
+def _png_b64():
+    import base64; buf = io.BytesIO(); Image.new("RGB", (8, 8), (10, 10, 200)).save(buf, "PNG")
+    return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
+
+def test_swarmui_generate_happy_path(monkeypatch):
+    from tldw_chatbook.Image_Generation.adapters import swarmui_adapter as m
+    from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest
+    calls = []
+    def fake_fetch_json(method, url, **kw):
+        calls.append(url)
+        if url.endswith("/API/GetNewSession"):
+            return {"session_id": "sess-1"}
+        return {"images": [{"image": _png_b64()}]}
+    monkeypatch.setattr(m, "fetch_json", fake_fetch_json)
+    req = ImageGenRequest(backend="swarmui", prompt="dragon", negative_prompt=None, width=512,
+                          height=512, steps=20, cfg_scale=7.0, seed=-1, sampler=None, model=None,
+                          format="png", extra_params={})
+    res = m.SwarmUIAdapter().generate(req)
+    assert res.content_type.startswith("image/") and res.bytes_len > 0
+    assert any("GetNewSession" in c for c in calls)
+```
+
+> The ported adapter imports `fetch_json` at module level (`from tldw_chatbook.Image_Generation.http_client import fetch_json`), so `monkeypatch.setattr(m, "fetch_json", ...)` intercepts it. If it instead calls `http_client.fetch_json`, patch that attribute path instead.
+
+- [ ] **Step 2: Run → FAIL** (`ModuleNotFoundError`).
+- [ ] **Step 3: Copy + repoint**
+
+```bash
+F=tldw_chatbook/Image_Generation/adapters/swarmui_adapter.py
+cp "$SRV/adapters/swarmui_adapter.py" "$F"
+sed -i '' \
+  -e 's#tldw_Server_API\.app\.core\.Image_Generation#tldw_chatbook.Image_Generation#g' \
+  -e 's#tldw_Server_API\.app\.core\.http_client#tldw_chatbook.Image_Generation.http_client#g' \
+  -e 's#tldw_Server_API\.app\.core\.Security\.egress#tldw_chatbook.Image_Generation.http_client#g' "$F"
+grep -n "tldw_Server_API" "$F"   # empty
+```
+
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** `feat(imagegen): port swarmui adapter`.
+
+#### Task 10: Stable-Diffusion.cpp adapter
+
+**Files:** Create `.../stable_diffusion_cpp_adapter.py`; Test `test_sd_cpp_adapter.py`.
+**Interfaces:** Produces `StableDiffusionCppAdapter` (`name="stable_diffusion_cpp"`, subprocess-driven).
+
+- [ ] **Step 1: Failing test** — mock `subprocess.run` and the config paths.
+
+```python
+# Tests/Image_Generation/test_sd_cpp_adapter.py
+import io, pytest
+from PIL import Image
+
+def test_sd_cpp_missing_binary_raises(monkeypatch, tmp_path):
+    from tldw_chatbook.Image_Generation.adapters import stable_diffusion_cpp_adapter as m
+    from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest
+    from tldw_chatbook.Image_Generation.exceptions import ImageBackendUnavailableError
+    # config with no binary path -> unavailable
+    req = ImageGenRequest(backend="stable_diffusion_cpp", prompt="cat", negative_prompt=None, width=512,
+                          height=512, steps=10, cfg_scale=7.0, seed=-1, sampler=None, model=None,
+                          format="png", extra_params={})
+    with pytest.raises((ImageBackendUnavailableError, Exception)):
+        m.StableDiffusionCppAdapter().generate(req)
+```
+
+> This asserts the graceful-unavailable path (no local binary in CI). A full happy-path test that mocks `subprocess.run` to drop a PNG into the temp dir is a nice-to-have; add it only if you can inject the output path the adapter expects. Read the ported `_build_command`/`generate` first.
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Copy + repoint** (standard recipe, file `stable_diffusion_cpp_adapter.py`).
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** `feat(imagegen): port stable-diffusion.cpp adapter`.
+
+#### Task 11: OpenRouter adapter
+
+**Files:** Create `.../openrouter_image_adapter.py`; Test `test_openrouter_adapter.py`.
+**Interfaces:** Produces `OpenRouterImageAdapter` (`name="openrouter"`, chat-completions shape).
+
+- [ ] **Step 1: Failing test** — mock `fetch_json` to return a chat-completions payload embedding a base64 image; set `OPENROUTER_API_KEY`.
+
+```python
+# Tests/Image_Generation/test_openrouter_adapter.py
+import io, base64, pytest
+from PIL import Image
+
+def _b64():
+    buf = io.BytesIO(); Image.new("RGB", (8, 8), (0, 180, 0)).save(buf, "PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+def test_openrouter_extracts_image(monkeypatch):
+    from tldw_chatbook.Image_Generation.adapters import openrouter_image_adapter as m
+    from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest
+    monkeypatch.setenv("OPENROUTER_API_KEY", "k")
+    monkeypatch.setattr(m, "fetch_json", lambda method, url, **kw: {
+        "choices": [{"message": {"images": [{"image_url": {"url": "data:image/png;base64," + _b64()}}]}}]
+    })
+    req = ImageGenRequest(backend="openrouter", prompt="fox", negative_prompt=None, width=None, height=None,
+                          steps=None, cfg_scale=None, seed=None, sampler=None, model="openai/gpt-image-1",
+                          format="png", extra_params={})
+    res = m.OpenRouterImageAdapter().generate(req)
+    assert res.bytes_len > 0
+```
+
+> The exact JSON path the walker extracts from may differ; read the ported `_extract_from_node`/`_extract_from_link_value` and shape the fake payload to a form it accepts (a `data:` URL anywhere in the tree is the safest).
+
+- [ ] **Step 2: Run → FAIL.** **Step 3: Copy + repoint.** **Step 4: Run → PASS.** **Step 5: Commit** `feat(imagegen): port openrouter adapter`.
+
+#### Task 12: Together adapter
+
+**Files:** Create `.../together_image_adapter.py`; Test `test_together_adapter.py`.
+**Interfaces:** Produces `TogetherImageAdapter` (`name="together"`, `/v1/images/generations`, single call).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# Tests/Image_Generation/test_together_adapter.py
+import io, base64, pytest
+from PIL import Image
+
+def _b64():
+    buf = io.BytesIO(); Image.new("RGB", (8, 8), (180, 120, 0)).save(buf, "PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+def test_together_extracts_image_and_no_v1_doubling(monkeypatch):
+    from tldw_chatbook.Image_Generation.adapters import together_image_adapter as m
+    from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest
+    monkeypatch.setenv("TOGETHER_API_KEY", "k")
+    seen = {}
+    def fake_fetch_json(method, url, **kw):
+        seen["url"] = url
+        return {"data": [{"b64_json": _b64()}]}
+    monkeypatch.setattr(m, "fetch_json", fake_fetch_json)
+    req = ImageGenRequest(backend="together", prompt="owl", negative_prompt=None, width=512, height=512,
+                          steps=None, cfg_scale=None, seed=None, sampler=None,
+                          model="black-forest-labs/FLUX.1-schnell-Free", format="png", extra_params={})
+    res = m.TogetherImageAdapter().generate(req)
+    assert res.bytes_len > 0
+    # default base_url ends in /v1; the adapter must NOT produce /v1/v1/ (spec verification)
+    assert "/v1/v1/" not in seen["url"]
+```
+
+> If the ported extractor wants a `url`/`data:` field instead of `b64_json`, shape the fake payload to what `_extract_from_node` accepts (read it first). Keep both assertions.
+
+- [ ] **Step 2: Run → FAIL.** **Step 3: Copy + repoint** (standard recipe, `together_image_adapter.py`). **Step 4: Run → PASS.** **Step 5: Commit** `feat(imagegen): port together adapter`.
+
+#### Task 13: Novita adapter
+
+**Files:** Create `.../novita_image_adapter.py`; Test `test_novita_adapter.py`.
+**Interfaces:** Produces `NovitaImageAdapter` (`name="novita"`, async submit + poll).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# Tests/Image_Generation/test_novita_adapter.py
+import io, base64, pytest
+from PIL import Image
+
+def _b64():
+    buf = io.BytesIO(); Image.new("RGB", (8, 8), (0, 120, 200)).save(buf, "PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+def test_novita_submit_then_poll(monkeypatch):
+    from tldw_chatbook.Image_Generation.adapters import novita_image_adapter as m
+    from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest
+    monkeypatch.setenv("NOVITA_API_KEY", "k")
+    monkeypatch.setattr(m.time, "sleep", lambda *_: None)  # skip poll delay
+    step = {"n": 0}
+    def fake_fetch_json(method, url, **kw):
+        if "async/txt2img" in url or method.upper() == "POST":
+            return {"task_id": "t1"}
+        step["n"] += 1
+        return {"task": {"status": "TASK_STATUS_SUCCEED"},
+                "images": [{"image_url": "data:image/png;base64," + _b64()}]}
+    monkeypatch.setattr(m, "fetch_json", fake_fetch_json)
+    req = ImageGenRequest(backend="novita", prompt="whale", negative_prompt=None, width=512, height=512,
+                          steps=20, cfg_scale=7.0, seed=-1, sampler=None, model=None, format="png", extra_params={})
+    res = m.NovitaImageAdapter().generate(req)
+    assert res.bytes_len > 0
+```
+
+> Read the ported adapter's exact submit-URL match, success-state strings, and result JSON path; align the fake's branch condition and status value to what the poll loop treats as terminal-success. Keep the final assertion.
+
+- [ ] **Step 2: Run → FAIL.** **Step 3: Copy + repoint** (standard recipe, `novita_image_adapter.py`). **Step 4: Run → PASS.** **Step 5: Commit** `feat(imagegen): port novita adapter`.
+
+#### Task 14: ModelStudio adapter
+
+**Files:** Create `.../modelstudio_image_adapter.py`; Test `test_modelstudio_adapter.py`.
+**Interfaces:** Produces `ModelStudioImageAdapter` (`name="modelstudio"`, sync/async/auto modes).
+
+> **Egress note:** the ported adapter calls `evaluate_url_policy(url)` (no `allowed_hosts`), so under the Phase-1 stub it is permissive — ModelStudio's `aliyuncs` host allowlist is intentionally NOT enforced yet; that enforcement is part of **task-485**. Do not add allowlist logic here.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# Tests/Image_Generation/test_modelstudio_adapter.py
+import io, base64, pytest
+from PIL import Image
+
+def _b64():
+    buf = io.BytesIO(); Image.new("RGB", (8, 8), (120, 0, 160)).save(buf, "PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+def test_modelstudio_sync_no_reference_image(monkeypatch):
+    from tldw_chatbook.Image_Generation.adapters import modelstudio_image_adapter as m
+    from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "k")
+    monkeypatch.setattr(m.time, "sleep", lambda *_: None)
+    # reference_image=None must never call reference_image_data_url
+    monkeypatch.setattr(m, "reference_image_data_url",
+                        lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not be called")))
+    monkeypatch.setattr(m, "fetch_json", lambda method, url, **kw: {
+        "output": {"choices": [{"message": {"content": [{"image": "data:image/png;base64," + _b64()}]}}]}
+    })
+    req = ImageGenRequest(backend="modelstudio", prompt="lotus", negative_prompt=None, width=None, height=None,
+                          steps=None, cfg_scale=None, seed=None, sampler=None, model="qwen-image",
+                          format="png", extra_params={"mode": "sync"}, reference_image=None)
+    res = m.ModelStudioImageAdapter().generate(req)
+    assert res.bytes_len > 0
+```
+
+> Shape the fake `fetch_json` payload to whatever the ported sync-mode extractor reads (read `_build_sync_payload`/response handling first). The key assertions: an image comes back, and `reference_image_data_url` is never invoked when `reference_image is None`.
+
+- [ ] **Step 2: Run → FAIL.** **Step 3: Copy + repoint** (standard recipe, `modelstudio_image_adapter.py`). **Step 4: Run → PASS.** **Step 5: Commit** `feat(imagegen): port modelstudio adapter`.
+
+---
+
+### Task 15: Model listing / is_configured
+
+**Files:**
+- Create: `tldw_chatbook/Image_Generation/listing.py`
+- Test: `Tests/Image_Generation/test_listing.py`
+
+**Interfaces:**
+- Consumes: `adapter_registry`, `config`, `capabilities`.
+- Produces: `listing.list_image_models_for_catalog() -> list[dict]` (each dict has `id`, `name`, `type="image"`, `is_configured: bool`, `capabilities`, `modalities`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# Tests/Image_Generation/test_listing.py
+import pytest
+
+@pytest.fixture(autouse=True)
+def _reset():
+    from tldw_chatbook.Image_Generation import config as c, adapter_registry as r
+    c.reset_image_generation_config_cache(); r.reset_registry()
+    yield
+    c.reset_image_generation_config_cache(); r.reset_registry()
+
+def test_keyring_populated_backend_reports_configured(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as c, listing as L
+    # enable openrouter; provide its key only via keyring (spec §4.2 step 5 -> is_configured must be True)
+    monkeypatch.setattr(c, "_read_image_generation_toml",
+                        lambda: {"enabled_backends": ["openrouter"], "default_backend": "openrouter"}, raising=False)
+    for var in ("OPENROUTER_API_KEY",):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(c, "_keyring_get", lambda b: "kr" if b == "openrouter" else None, raising=False)
+    c.get_image_generation_config(reload=True)
+    entries = {e["name"]: e for e in L.list_image_models_for_catalog()}
+    assert entries["openrouter"]["is_configured"] is True
+
+def test_disabled_backends_excluded(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as c, listing as L
+    monkeypatch.setattr(c, "_read_image_generation_toml",
+                        lambda: {"enabled_backends": ["swarmui"], "default_backend": "swarmui"}, raising=False)
+    c.get_image_generation_config(reload=True)
+    names = {e["name"] for e in L.list_image_models_for_catalog()}
+    assert "novita" not in names and "swarmui" in names
+```
+
+- [ ] **Step 2: Run → FAIL** (`ModuleNotFoundError`).
+- [ ] **Step 3: Port + repoint**
+
+```bash
+cp "$SRV/listing.py" tldw_chatbook/Image_Generation/listing.py
+sed -i '' -e 's#tldw_Server_API\.app\.core\.Image_Generation#tldw_chatbook.Image_Generation#g' tldw_chatbook/Image_Generation/listing.py
+grep -n "tldw_Server_API" tldw_chatbook/Image_Generation/listing.py   # empty
+```
+
+- [ ] **Step 4: Run → PASS** (2 passed).
+- [ ] **Step 5: Commit** `feat(imagegen): port model listing / is_configured`.
+
+---
+
+### Task 16: Generation worker (request builder + thread entry)
+
+**Files:**
+- Create: `tldw_chatbook/Image_Generation/worker.py`
+- Test: `Tests/Image_Generation/test_worker.py`
+
+**Interfaces:**
+- Consumes: `adapter_registry.get_registry`, `adapters.base.ImageGenRequest`, `exceptions`.
+- Produces:
+  - `worker.build_request(*, backend, prompt, negative_prompt=None, width=None, height=None, steps=None, cfg_scale=None, seed=None, sampler=None, model=None, image_format="png", extra_params=None) -> ImageGenRequest`
+  - `worker.run_generation(request: ImageGenRequest) -> ImageGenResult` (resolves backend via registry, calls adapter `.generate`; **blocking — call only from a thread**).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# Tests/Image_Generation/test_worker.py
+import pytest
+
+def test_build_request_defaults_format_png():
+    from tldw_chatbook.Image_Generation.worker import build_request
+    req = build_request(backend="swarmui", prompt="cat")
+    assert req.format == "png"
+    assert req.extra_params == {}          # never None
+    assert req.negative_prompt is None
+
+def test_run_generation_unknown_backend_raises(monkeypatch):
+    from tldw_chatbook.Image_Generation import worker
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+    req = worker.build_request(backend="nope", prompt="cat")
+    with pytest.raises(ImageGenerationError):
+        worker.run_generation(req)   # registry resolve_backend -> None -> error
+
+def test_run_generation_dispatches_to_adapter(monkeypatch):
+    from tldw_chatbook.Image_Generation import worker
+    from tldw_chatbook.Image_Generation.adapters.base import ImageGenResult
+    class FakeAdapter:
+        name = "swarmui"; supported_formats = {"png"}
+        def generate(self, req): return ImageGenResult(content=b"x", content_type="image/png", bytes_len=1)
+    class FakeReg:
+        def resolve_backend(self, name): return "swarmui" if name == "swarmui" else None
+        def get_adapter(self, name): return FakeAdapter()
+    monkeypatch.setattr(worker, "get_registry", lambda: FakeReg())
+    res = worker.run_generation(worker.build_request(backend="swarmui", prompt="cat"))
+    assert res.bytes_len == 1
+```
+
+- [ ] **Step 2: Run → FAIL** (`ModuleNotFoundError`).
+- [ ] **Step 3: Write `worker.py`**
+
+```python
+"""Request builder + blocking generation entry. The Textual demo screen (and, in
+Phase 2, the chat card) call run_generation() from a thread worker — never on the
+UI loop, because the adapters are synchronous and blocking.
+"""
+from __future__ import annotations
+from tldw_chatbook.Image_Generation.adapter_registry import get_registry
+from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest, ImageGenResult
+from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+
+def build_request(*, backend, prompt, negative_prompt=None, width=None, height=None,
+                  steps=None, cfg_scale=None, seed=None, sampler=None, model=None,
+                  image_format="png", extra_params=None) -> ImageGenRequest:
+    return ImageGenRequest(
+        backend=backend, prompt=prompt, negative_prompt=negative_prompt,
+        width=width, height=height, steps=steps, cfg_scale=cfg_scale, seed=seed,
+        sampler=sampler, model=model, format=image_format,
+        extra_params=dict(extra_params or {}),
+    )
+
+
+def run_generation(request: ImageGenRequest) -> ImageGenResult:
+    """Blocking. Resolve the backend and invoke its adapter. Raises ImageGenerationError."""
+    registry = get_registry()
+    resolved = registry.resolve_backend(request.backend)
+    if resolved is None:
+        raise ImageGenerationError(
+            f"Backend {request.backend!r} is not enabled/available. "
+            f"Check [image_generation].enabled_backends."
+        )
+    adapter = registry.get_adapter(resolved)
+    if adapter is None:
+        raise ImageGenerationError(f"Adapter for backend {resolved!r} failed to load.")
+    return adapter.generate(request)
+```
+
+- [ ] **Step 4: Run → PASS** (3 passed).
+- [ ] **Step 5: Commit** `feat(imagegen): generation worker (request builder + blocking entry)`.
+
+---
+
+### Task 17: Throwaway demo panel + command-palette entry
+
+**Files:**
+- Create: `tldw_chatbook/UI/Screens/image_gen_demo_screen.py`
+- Create: `tldw_chatbook/UI/image_gen_command_provider.py`
+- Modify: `tldw_chatbook/app.py` (add the provider to `COMMANDS`)
+- Test: `Tests/Image_Generation/test_demo_screen.py`
+
+**Interfaces:**
+- Consumes: `worker.build_request`, `worker.run_generation`, `listing.list_image_models_for_catalog`, `BaseAppScreen`.
+- Produces: `ImageGenDemoScreen(BaseAppScreen)`; `ImageGenCommandProvider(Provider)` yielding a "Image Gen (dev)" command that `push_screen`s it.
+
+- [ ] **Step 1: Write the failing test** (Textual async harness)
+
+```python
+# Tests/Image_Generation/test_demo_screen.py
+import pytest
+
+@pytest.mark.asyncio
+async def test_demo_screen_lists_backends_and_generates(monkeypatch):
+    from tldw_chatbook.Image_Generation import worker
+    from tldw_chatbook.Image_Generation.adapters.base import ImageGenResult
+    from tldw_chatbook.UI.Screens.image_gen_demo_screen import ImageGenDemoScreen
+    # stub listing + generation so the test needs no backend
+    import tldw_chatbook.UI.Screens.image_gen_demo_screen as scr
+    monkeypatch.setattr(scr, "list_image_models_for_catalog",
+                        lambda: [{"name": "swarmui", "is_configured": True}])
+    monkeypatch.setattr(scr, "run_generation",
+                        lambda req: ImageGenResult(content=b"x", content_type="image/png", bytes_len=1))
+    # A minimal host app that pushes the screen; ImageGenDemoScreen takes the app instance.
+    from textual.app import App
+    class Host(App):
+        def on_mount(self): self.push_screen(ImageGenDemoScreen(self))
+    app = Host()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # backend select is populated
+        assert app.screen.query("#imagegen-backend")
+```
+
+> If `BaseAppScreen` requires the real `TldwCli` app rather than a bare `App`, use the project's standard screen-test harness (see an existing `Tests/.../test_*_screen.py` that drives `app.run_test()`), and keep the two assertions: backend select present, and a generate action calls `run_generation`.
+
+- [ ] **Step 2: Run → FAIL** (`ModuleNotFoundError`).
+- [ ] **Step 3: Write the demo screen**
+
+```python
+# tldw_chatbook/UI/Screens/image_gen_demo_screen.py
+"""THROWAWAY dev panel (Phase 1). Replaced by the real chat card in Phase 2.
+Renders one generated image via the low-level rich-pixels/textual-image primitives
+(NOT the Console transcript path). Persists nothing.
+"""
+from __future__ import annotations
+from textual import work
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Select, TextArea, Input, Button, Static, Label
+from tldw_chatbook.UI.Navigation.base_app_screen import BaseAppScreen
+from tldw_chatbook.Image_Generation.worker import build_request, run_generation
+from tldw_chatbook.Image_Generation.listing import list_image_models_for_catalog
+
+
+class ImageGenDemoScreen(BaseAppScreen):
+    def compose(self) -> ComposeResult:
+        with Vertical(id="imagegen-demo"):
+            yield Label("Image Gen (dev) — throwaway Phase-1 panel")
+            opts = [(f'{e["name"]}{"" if e.get("is_configured") else "  (not configured)"}', e["name"])
+                    for e in list_image_models_for_catalog()]
+            yield Select(opts or [("(no backends enabled)", "")], id="imagegen-backend")
+            yield TextArea(id="imagegen-prompt")
+            yield TextArea(id="imagegen-negative")
+            yield Input(placeholder="seed (blank = -1)", id="imagegen-seed")
+            yield Button("Generate", id="imagegen-generate", variant="primary")
+            yield Static(id="imagegen-status")
+            yield Static(id="imagegen-image")
+            yield Static(id="imagegen-meta")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "imagegen-generate":
+            self._generate()
+
+    @work(thread=True, exclusive=True, group="imagegen-demo")
+    def _generate(self) -> None:
+        backend = self.query_one("#imagegen-backend", Select).value
+        prompt = self.query_one("#imagegen-prompt", TextArea).text
+        negative = self.query_one("#imagegen-negative", TextArea).text or None
+        seed_raw = self.query_one("#imagegen-seed", Input).value.strip()
+        seed = int(seed_raw) if seed_raw.lstrip("-").isdigit() else -1
+        self.app.call_from_thread(self.query_one("#imagegen-status", Static).update, "Generating…")
+        try:
+            req = build_request(backend=backend, prompt=prompt, negative_prompt=negative,
+                                seed=seed, image_format="png")
+            res = run_generation(req)               # blocking; we are in a thread
+        except Exception as e:  # surface the error clearly (incl. inline_max_bytes cap)
+            self.app.call_from_thread(self.query_one("#imagegen-status", Static).update, f"Error: {e}")
+            return
+        self.app.call_from_thread(self._render_result, res, req)
+
+    def _render_result(self, res, req) -> None:
+        # low-level render (rich-pixels), decoupled from the transcript path
+        from rich_pixels import Pixels
+        from PIL import Image as PILImage
+        import io
+        img = PILImage.open(io.BytesIO(res.content))
+        img.thumbnail((80, 40))
+        self.query_one("#imagegen-status", Static).update("Done")
+        self.query_one("#imagegen-image", Static).update(Pixels.from_image(img))
+        self.query_one("#imagegen-meta", Static).update(
+            f"backend={req.backend} format={res.content_type} bytes={res.bytes_len} "
+            f"seed={req.seed} prompt={req.prompt!r}"
+        )
+```
+
+- [ ] **Step 4: Write the command provider + register it**
+
+```python
+# tldw_chatbook/UI/image_gen_command_provider.py
+"""Command-palette entry for the throwaway Image Gen (dev) panel (Phase 1)."""
+from textual.command import Provider, Hit, Hits
+from tldw_chatbook.UI.Screens.image_gen_demo_screen import ImageGenDemoScreen
+
+
+class ImageGenCommandProvider(Provider):
+    async def search(self, query: str) -> Hits:
+        matcher = self.matcher(query)
+        label = "Image Gen (dev)"
+        score = matcher.match(label)
+        if score > 0:
+            yield Hit(score, matcher.highlight(label),
+                      lambda: self.app.push_screen(ImageGenDemoScreen(self.app)),
+                      help="Open the throwaway image-generation demo panel")
+```
+
+In `tldw_chatbook/app.py`, add the provider to the app's `COMMANDS` set (search for the existing `COMMANDS = {...}` or `get_system_commands`; follow the pattern used by `tldw_chatbook/UI/console_command_provider.py`). Example:
+
+```python
+from tldw_chatbook.UI.image_gen_command_provider import ImageGenCommandProvider
+# ... in the TldwCli class body:
+COMMANDS = App.COMMANDS | {ImageGenCommandProvider}
+```
+
+- [ ] **Step 5: Run → PASS** (adjust the harness per the note if `BaseAppScreen` needs the real app).
+- [ ] **Step 6: Manual verification (the real proof surface)**
+
+```bash
+source .venv/bin/activate && python3 -m tldw_chatbook.app
+```
+Open the command palette → "Image Gen (dev)" → pick `swarmui` (with a local SwarmUI running) → type a prompt → Generate → an image renders with metadata below it. (With no backend configured, the status shows a clear error — that's the expected unconfigured path.)
+
+- [ ] **Step 7: Commit** `feat(imagegen): throwaway demo panel + command-palette entry`.
+
+---
+
+### Task 18: Cold-start import guard + public surface finalize
+
+**Files:**
+- Modify: `tldw_chatbook/Image_Generation/__init__.py` (add lazy accessors, keep import-light)
+- Test: `Tests/Image_Generation/test_cold_start.py`
+
+**Interfaces:**
+- Produces: `Image_Generation.get_image_generation_config` and `Image_Generation.get_registry` re-exported *lazily* (via `__getattr__`) so importing the package still pulls no adapters/Pillow.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# Tests/Image_Generation/test_cold_start.py
+import sys, importlib
+
+def test_importing_package_pulls_no_adapters_or_pillow():
+    # drop anything already imported so the assertion is meaningful
+    for name in list(sys.modules):
+        if name.startswith("tldw_chatbook.Image_Generation") or name == "PIL":
+            del sys.modules[name]
+    importlib.import_module("tldw_chatbook.Image_Generation")
+    loaded = set(sys.modules)
+    assert not any(n.startswith("tldw_chatbook.Image_Generation.adapters.") and n.endswith("_adapter")
+                   for n in loaded), "adapters must be lazy"
+    assert "tldw_chatbook.Image_Generation.adapters.image_format_utils" not in loaded
+    assert "PIL" not in loaded, "Pillow must not import at package import time"
+
+def test_lazy_accessors_available():
+    import tldw_chatbook.Image_Generation as ig
+    assert callable(ig.get_image_generation_config)
+    assert callable(ig.get_registry)
+```
+
+- [ ] **Step 2: Run → FAIL** (either Pillow gets imported, or accessors missing).
+- [ ] **Step 3: Make `__init__.py` lazy**
+
+```python
+"""Multi-provider image generation (ported from tldw_server). Import-light."""
+from tldw_chatbook.Image_Generation.exceptions import (
+    ImageGenerationError, ImageBackendUnavailableError,
+)
+
+__all__ = [
+    "ImageGenerationError", "ImageBackendUnavailableError",
+    "get_image_generation_config", "get_registry",
+]
+
+def __getattr__(name):  # PEP 562 lazy re-export; keeps adapters/Pillow out of import time
+    if name == "get_image_generation_config":
+        from tldw_chatbook.Image_Generation.config import get_image_generation_config as f
+        return f
+    if name == "get_registry":
+        from tldw_chatbook.Image_Generation.adapter_registry import get_registry as f
+        return f
+    raise AttributeError(name)
+```
+
+> If Task 4's `config.py` imports anything Pillow-touching at module level, move that import inside the function that needs it — `config` must stay Pillow-free so the guard holds.
+
+- [ ] **Step 4: Run → PASS** (2 passed).
+- [ ] **Step 5: Run the whole suite**
+
+Run: `source .venv/bin/activate && pytest Tests/Image_Generation/ -v`
+Expected: all green.
+
+- [ ] **Step 6: Commit** `feat(imagegen): lazy package surface + cold-start guard`.
+
+---
+
+## Wrap-up (after Task 18)
+
+- [ ] Run the full package suite once more: `source .venv/bin/activate && pytest Tests/Image_Generation/ -q`.
+- [ ] `grep -rn "tldw_Server_API" tldw_chatbook/Image_Generation/` → must be empty (no server imports leaked).
+- [ ] Confirm the app still boots: `python3 -m tldw_chatbook.app` (splash → app, no import errors).
+- [ ] The design spec's later phases (chat card, `/generate-image`, character canvas, variants/TTS), the `Media_Creation` cleanup, and task-485 (egress hardening) are explicitly out of scope here.
+
+**Optional — opt-in live integration tests (spec §8):** the mocked tests above are the automated proof; the *live* proof is Task 17 Step 6 (real backend, real image). If you want an automated live test per backend, add one parametrized test marked `@pytest.mark.optional` that reads creds from env (`OPENROUTER_API_KEY`, a running SwarmUI at `swarmui_base_url`, an `sd` binary path, …) and `pytest.skip(...)` when absent, calls `worker.run_generation(worker.build_request(backend=..., prompt="a red apple on a table"))`, and asserts `res.bytes_len > 0`. Keep these skipped by default so CI stays green without credentials.

--- a/Docs/superpowers/specs/2026-07-22-image-generation-multiprovider-foundation-design.md
+++ b/Docs/superpowers/specs/2026-07-22-image-generation-multiprovider-foundation-design.md
@@ -79,12 +79,12 @@ tldw_chatbook/Image_Generation/
 
 | Server file | Action in port |
 |---|---|
-| `exceptions.py`, `prompt_refinement.py`, `capabilities.py`, `adapters/base.py`, `request_validation.py` | **verbatim** (swap `loguru` → app logger only) |
+| `exceptions.py`, `prompt_refinement.py`, `capabilities.py`, `adapters/base.py`, `request_validation.py` | **verbatim** — `loguru` is already this app's logging library (CLAUDE.md key deps), so **no logger swap is needed** |
 | `image_format_utils.py` | port; re-home only `fetch_image_bytes` onto local `http_client` |
-| `adapter_registry.py`, `listing.py` | port; repoint module paths / logger |
+| `adapter_registry.py`, `listing.py` | port; repoint only the `DEFAULT_ADAPTERS` module strings (loguru kept as-is) |
 | `config.py` | **re-home** (see §4); keep flat field names identical |
 | `adapters/{sd_cpp,swarmui,openrouter,novita,together,modelstudio}.py` | port; only change the `fetch_json`/`create_client` import source |
-| `reference_images.py` | **drop** (media-DB/object-store coupled; only ModelStudio uses it) |
+| `reference_images.py` | **drop** — verified safe: `capabilities.py` defines `ResolvedReferenceImage` itself (no import of `reference_images`), and modelstudio guards every reference path on `request.reference_image is not None`, so `reference_image=None` degrades to a no-op |
 
 ### 3.3 Core contracts (unchanged from server)
 
@@ -164,12 +164,13 @@ allowed_extra_params = []
 ### 4.2 Loader responsibilities
 
 A new loader in `Image_Generation/config.py` that:
-1. Reads the nested `[image_generation.*]` TOML via the app's config system.
+1. Reads each nested subsection via the app's **canonical nested accessor** — `get_cli_setting("image_generation", "<subsection>", {})` returns the subsection dict, or read the raw `load_settings().get("image_generation", {}).get("<subsection>", {})`. (Note: the dotted form `get_cli_setting("image_generation.swarmui", ...)` also works — the earlier "dotted lookup is flat/broken" concern was **stale**; `get_cli_setting` was fixed on 2026-07-16 (`b983f2548`) to walk nested TOML tables. No workaround needed.)
 2. **Flattens** nested keys to the server's flat field names (`[image_generation.swarmui].base_url` → `swarmui_base_url`, `[image_generation.openrouter].default_model` → `openrouter_image_default_model`, etc.) so the ported adapters/`request_validation`/`listing` read unchanged.
 3. Applies the server's `DEFAULT_*` constants as fallbacks (documented defaults above).
 4. Retains the `_coerce_*` / `_parse_list` helpers (TOML is typed, but env-var overrides arrive as strings).
-5. Resolves secret fields via §4.3.
+5. **Resolves each secret via §4.3 and writes the result into the config object's `*_api_key` / token field.** This is load-bearing: `listing.py:51-81`'s `is_configured` reads `getattr(cfg, "<backend>_api_key")` *first* (then env), and the adapters read the same field — so populating it from the full precedence (incl. keyring) makes a keyring-only backend correctly report as configured *and* usable, with no change to `listing.py` or the adapters.
 6. Caches like the server (`get_image_generation_config(reload=False)` + reset hook).
+7. **The `[image_generation]` default block (§4.1) must be added to the app's default config template** (`config.py`) so the section materializes for users to edit — the old `[media_creation]` section never existed, which is why the orphaned SwarmUI stack silently fell back to hard-coded defaults. Don't repeat that.
 
 This loader and its precedence are the highest-value test target.
 
@@ -182,7 +183,7 @@ OpenRouter and Together are **both LLM providers and image backends** in this ap
 3. Keyring (image-backend-scoped account name, distinct from LLM-provider accounts).
 4. *Optional* fallback to the shared provider key via `get_api_key()` — only if explicitly opted in, so it never surprises.
 
-Secrets are **never logged** (matches `[API]` handling per CLAUDE.md security rules).
+Secrets are **never logged** (matches `[API]` handling per CLAUDE.md security rules). Because the loader stores resolved secrets on the in-memory config object (§4.2 step 5), that object must never be logged/serialized wholesale — dump non-secret fields only if debugging.
 
 ---
 
@@ -204,6 +205,8 @@ Each adapter's own per-backend URL checks are preserved (SwarmUI same-origin res
 The ported adapters are **fully synchronous and blocking** (sync httpx; `subprocess.run` for sd.cpp; `time.sleep` polling for Novita/ModelStudio). The app therefore **never calls `generate()` on the asyncio/UI loop**. A thin wrapper runs generation on a Textual **thread worker** (`@work(thread=True)` / `run_worker(..., thread=True)`), consistent with the app's known "sync-under-async blocks the UI loop" rule. The demo panel (and later the chat card) both go through this wrapper.
 
 **Cancellation caveat (finding B6):** a blocking `subprocess.run` / `time.sleep` will not cancel promptly, so in-flight generation cannot be cleanly aborted in Phase 1. Mitigations: sane default `timeout_seconds` per backend (as configured), and a clear "generating…" state. A proper cancel/timeout story is deferred to the chat-card phase.
+
+**Request construction:** `ImageGenRequest.format` is a *required* field (no dataclass default). The wrapper that builds the request supplies a default output `format` of `"png"` (overridable). Note `inline_max_bytes` (default 4 MB) caps `validate_and_convert_image_output`; a large PNG can exceed it, so the wrapper surfaces that error clearly and `webp`/`jpg` remain available as smaller-output formats.
 
 ---
 
@@ -228,7 +231,7 @@ The demo panel is the manual proof surface; it does not persist anything.
 - **`request_validation` bounds suite**: prompt length, width/height/pixels, steps, cfg_scale positivity/finiteness, extra_params allowlist (incl. ModelStudio `mode` exemption and `cli_args` list rule).
 - **Registry tests**: `resolve_backend` enabled/disabled/default logic, lazy import, singleton caching, unknown backend.
 - **`prompt_refinement` table tests**: off/basic/auto modes, no-double-append, max-length guard.
-- **Config-loader tests (priority)**: nested TOML → flat field mapping, `DEFAULT_*` fallbacks, `_coerce_*` on string env overrides, and the §4.3 key precedence (env > config > keyring > optional shared).
+- **Config-loader tests (priority)**: nested TOML → flat field mapping, `DEFAULT_*` fallbacks, `_coerce_*` on string env overrides, the §4.3 key precedence (env > config > keyring > optional shared), and that a **keyring-only** secret populated by the loader makes `listing.is_configured` report that backend configured (§4.2 step 5).
 - **Opt-in live integration tests**: one per backend, skipped unless creds/servers/binary are present.
 - Cold-start guard: assert importing `tldw_chatbook.Image_Generation` does not import adapters or Pillow (finding B8).
 

--- a/Docs/superpowers/specs/2026-07-22-image-generation-multiprovider-foundation-design.md
+++ b/Docs/superpowers/specs/2026-07-22-image-generation-multiprovider-foundation-design.md
@@ -1,0 +1,251 @@
+# Image Generation — Multi-Provider Foundation (Phase 1)
+
+**Status:** Design approved, ready for implementation planning
+**Date:** 2026-07-22
+**Program:** In-chat image generation (Console conversations + character canvas), mirroring tldw_server's webui
+**This spec covers:** Phase 1 of the program — the backend layer only. No chat card yet.
+
+---
+
+## 1. Background & motivation
+
+We want image generation available inside chat/conversations and the character/roleplay surface, the way tldw_server's webui does it: a user triggers generation and the result appears as a rich "Image Generation" card (prompt, negative, seed, backend, style, prev/next variants, regenerate, TTS) — as in the reference mockup.
+
+This is a multi-layer feature. Rather than spec it all at once, it is decomposed into phases (§9). **This spec is Phase 1: the multi-provider backend foundation.** It builds and proves the image-generation engine with no chat UI. The visible chat card, slash command, character integration, variants, and TTS are later phases.
+
+### What already exists in tldw_chatbook (and how we treat it)
+
+- A **complete but orphaned SwarmUI stack** lives under `tldw_chatbook/Media_Creation/` (`swarmui_client.py`, `image_generation_service.py`, `generation_templates.py`) plus a `SwarmUIWidget` and an event layer with a DB-save TODO stub pointing at a `media_generations` table that was never built. It is mounted only in a *legacy* settings sidebar the active Console chat does not use, and `[media_creation]` config never existed, so it is wired to nothing.
+- **We do not touch or delete this code in Phase 1** (finding A1). Deleting `swarmui_client.py` / `image_generation_service.py` would break live imports in `swarmui_widget.py`, `swarmui_events.py`, and `settings_sidebar.py`. Instead we build the new package cleanly alongside it. Two pieces are explicitly **kept for reuse in later phases**: `generation_templates.py` (14 "Style" presets → the reference card's "Style: Anime Base") and `ImageGenerationService.extract_context_from_messages` (chat-context → prompt). A separate follow-up task will remove the dead SwarmUI chain once the new package supersedes it.
+
+### The source we port from
+
+tldw_server's `tldw_Server_API/app/core/Image_Generation/` (~3,207 lines) is a clean, self-contained Python package: **zero FastAPI/starlette/pydantic imports**, plain frozen dataclasses, and **fully synchronous adapters** (`def generate(self, request) -> ImageGenResult`) using a sync `httpx.Client`, `subprocess` for the local backend, and `time.sleep` polling for async-job backends. Its only cross-package couplings are a config loader, a sync HTTP helper, egress guards, and a media-DB-backed reference-image resolver. This makes it portable almost verbatim.
+
+---
+
+## 2. Goals & non-goals
+
+### Phase 1 goals
+- A self-contained `tldw_chatbook/Image_Generation/` package supporting **6 backends**: `stable_diffusion_cpp` (local subprocess), `swarmui` (fronts ComfyUI), `openrouter` (gpt-image-1), `novita`, `together`, `modelstudio`.
+- Backend selection via a registry with lazy adapter imports.
+- Request validation, prompt refinement, and model listing (`is_configured` per backend).
+- A `[image_generation]` TOML config surface re-homed onto this app's conventions (TOML + env + keyring), with **identical flat field names** to the server dataclass so adapters need no edits.
+- A thin sync `fetch_json` / `create_client` HTTP shim on `httpx.Client`, plus a **light egress guard** (real SSRF hardening deferred to task-485).
+- A **throwaway in-app demo panel** (command-palette screen) to generate one image end-to-end and eyeball the result + raw metadata.
+- Tests: mocked per-adapter, request-validation bounds, registry logic, prompt-refinement table, config-loader round-trip + key precedence, opt-in live integration.
+
+### Phase 1 non-goals (deferred)
+- The Console chat "Image Generation" card and the `/generate-image` slash command (Phase 2).
+- **Any DB schema change** (finding A3) — no persistence of generation metadata; the demo panel renders in memory / to a temp file only. This deliberately avoids colliding with the concurrent Console-branching program's `v22→v23` migration slot.
+- Character-canvas generation, per-mood reaction images, persona visual packs.
+- Variant navigation (prev/next), regenerate, TTS.
+- Reference-image resolution (`reference_images.py` is dropped; ModelStudio's `reference_image` degrades to `None`).
+- Full SSRF/egress protection (tracked in **task-485**).
+- Deleting the orphaned `Media_Creation` SwarmUI code (separate cleanup task).
+
+---
+
+## 3. Architecture
+
+### 3.1 Package layout
+
+New package `tldw_chatbook/Image_Generation/` (dir name matches the `Media_Creation` / `RAG_Search` / `LLM_Calls` codebase convention; the config section is lowercase `[image_generation]` matching `[chat.images]` / `[embeddings]`):
+
+```
+tldw_chatbook/Image_Generation/
+  __init__.py              # import-light; NO eager adapter/Pillow imports (finding B8)
+  exceptions.py            # port verbatim
+  prompt_refinement.py     # port verbatim
+  capabilities.py          # port verbatim (ResolvedReferenceImage, capability checks)
+  request_validation.py    # port verbatim
+  listing.py               # port; is_configured per backend
+  adapter_registry.py      # port; repoint DEFAULT_ADAPTERS module strings
+  config.py                # RE-HOME: nested TOML + env + keyring -> flat dataclass
+  http_client.py           # NEW: sync fetch_json/create_client on httpx.Client + light egress guard
+  image_format_utils.py    # port; re-home only fetch_image_bytes onto local http_client
+  adapters/
+    __init__.py
+    base.py                # port verbatim (ImageGenRequest/ImageGenResult/protocol)
+    stable_diffusion_cpp_adapter.py
+    swarmui_adapter.py
+    openrouter_image_adapter.py
+    novita_image_adapter.py
+    together_image_adapter.py
+    modelstudio_image_adapter.py
+```
+
+### 3.2 Port map
+
+| Server file | Action in port |
+|---|---|
+| `exceptions.py`, `prompt_refinement.py`, `capabilities.py`, `adapters/base.py`, `request_validation.py` | **verbatim** (swap `loguru` → app logger only) |
+| `image_format_utils.py` | port; re-home only `fetch_image_bytes` onto local `http_client` |
+| `adapter_registry.py`, `listing.py` | port; repoint module paths / logger |
+| `config.py` | **re-home** (see §4); keep flat field names identical |
+| `adapters/{sd_cpp,swarmui,openrouter,novita,together,modelstudio}.py` | port; only change the `fetch_json`/`create_client` import source |
+| `reference_images.py` | **drop** (media-DB/object-store coupled; only ModelStudio uses it) |
+
+### 3.3 Core contracts (unchanged from server)
+
+- `ImageGenRequest` (frozen): `backend, prompt, negative_prompt, width, height, steps, cfg_scale, seed, sampler, model, format, extra_params, request_id=None, reference_image=None`.
+- `ImageGenResult` (frozen): `content: bytes, content_type: str, bytes_len: int`.
+- `ImageGenerationAdapter` — a structural `typing.Protocol` with `name`, `supported_formats`, and **synchronous** `generate(request) -> ImageGenResult`.
+- Registry: lazy `DEFAULT_ADAPTERS` name→"module.Class" strings; `resolve_backend()`; `enabled_backends` gates availability (empty list ⇒ nothing enabled); no-arg adapter constructors that each read config themselves; cached singletons.
+
+---
+
+## 4. Config re-home (the main port work — finding B4)
+
+The server's `ImageGenerationConfig` is a **single flat frozen dataclass** (~50 prefixed fields, e.g. `swarmui_base_url`, `openrouter_image_api_key`) loaded from INI strings via `configparser`. We keep the **exact flat field names** so no adapter changes, but expose a **nested** TOML surface and re-home the loader.
+
+### 4.1 TOML surface
+
+```toml
+[image_generation]
+default_backend = "swarmui"          # finding B7 (server default was sd_cpp)
+enabled_backends = ["swarmui"]        # finding B7 (server default was [] = nothing)
+max_width = 1024
+max_height = 1024
+max_pixels = 1048576
+max_steps = 50
+max_prompt_length = 1000
+inline_max_bytes = 4000000
+
+[image_generation.stable_diffusion_cpp]
+binary_path = ""                      # local `sd` CLI; empty = backend unusable
+diffusion_model_path = ""             # OR model_path
+model_path = ""
+vae_path = ""
+lora_paths = []
+device = "auto"
+default_steps = 25
+default_cfg_scale = 7.5
+default_sampler = "euler_a"
+timeout_seconds = 120
+allowed_extra_params = []
+
+[image_generation.swarmui]
+base_url = "http://127.0.0.1:7801"
+default_model = ""
+timeout_seconds = 120
+allowed_extra_params = []
+# swarm_token: secret, resolved via key precedence (§4.3), not stored plaintext here
+
+[image_generation.openrouter]
+base_url = "https://openrouter.ai/api/v1"
+default_model = "openai/gpt-image-1"
+timeout_seconds = 120
+allowed_extra_params = []
+
+[image_generation.novita]
+base_url = "https://api.novita.ai"
+default_model = "sd_xl_base_1.0.safetensors"
+timeout_seconds = 180
+poll_interval_seconds = 2
+allowed_extra_params = []
+
+[image_generation.together]
+base_url = "https://api.together.xyz/v1"
+default_model = "black-forest-labs/FLUX.1-schnell-Free"
+timeout_seconds = 120
+allowed_extra_params = []
+
+[image_generation.modelstudio]
+base_url = ""                         # region-derived if empty
+default_model = "qwen-image"
+region = "sg"                         # sg|cn|us
+mode = "auto"                         # sync|async|auto
+poll_interval_seconds = 2
+timeout_seconds = 180
+allowed_extra_params = []
+```
+
+### 4.2 Loader responsibilities
+
+A new loader in `Image_Generation/config.py` that:
+1. Reads the nested `[image_generation.*]` TOML via the app's config system.
+2. **Flattens** nested keys to the server's flat field names (`[image_generation.swarmui].base_url` → `swarmui_base_url`, `[image_generation.openrouter].default_model` → `openrouter_image_default_model`, etc.) so the ported adapters/`request_validation`/`listing` read unchanged.
+3. Applies the server's `DEFAULT_*` constants as fallbacks (documented defaults above).
+4. Retains the `_coerce_*` / `_parse_list` helpers (TOML is typed, but env-var overrides arrive as strings).
+5. Resolves secret fields via §4.3.
+6. Caches like the server (`get_image_generation_config(reload=False)` + reset hook).
+
+This loader and its precedence are the highest-value test target.
+
+### 4.3 Secret handling & the OpenRouter/Together collision (finding A2)
+
+OpenRouter and Together are **both LLM providers and image backends** in this app. Reusing `get_api_key("openrouter")` would silently share the LLM key. Image-backend secrets therefore resolve on an **image-specific precedence**, independent by default but reuse-capable:
+
+1. Backend env var — `OPENROUTER_API_KEY`, `NOVITA_API_KEY`, `TOGETHER_API_KEY`, `DASHSCOPE_API_KEY`/`QWEN_API_KEY`; SwarmUI token env if present.
+2. `[image_generation.<backend>].api_key` (config, honoring config-encryption).
+3. Keyring (image-backend-scoped account name, distinct from LLM-provider accounts).
+4. *Optional* fallback to the shared provider key via `get_api_key()` — only if explicitly opted in, so it never surprises.
+
+Secrets are **never logged** (matches `[API]` handling per CLAUDE.md security rules).
+
+---
+
+## 5. HTTP shim & egress (findings §5 + task-485)
+
+New `Image_Generation/http_client.py` provides the sync surface the ported adapters expect:
+- `fetch_json(method, url, *, headers=None, json=None, params=None, cookies=None, timeout=None)` → parsed JSON, on `httpx.Client`.
+- `create_client(timeout=None)` → configured `httpx.Client` (used by `fetch_image_bytes`).
+- Redirect helpers: `DEFAULT_MAX_REDIRECTS`, `_resolve_redirect_url` (urljoin).
+- **Light egress guard** `_validate_egress_or_raise(url)`: reject non-`http(s)` schemes; enforce max redirects. It stays **permissive for user-configured `base_url`s** so local backends (127.0.0.1 SwarmUI, local sd.cpp) keep working. It does **not** block private/metadata ranges for API-returned URLs — that is the deferred hardening.
+- `evaluate_url_policy(url)` stub for ModelStudio → simple host allowlist (`aliyuncs.com` / base host), preserving the adapter's built-in check.
+
+Each adapter's own per-backend URL checks are preserved (SwarmUI same-origin resolution; ModelStudio host allowlist). **Full SSRF protection for API-returned image URLs is task-485**, and this light guard is its explicit placeholder.
+
+---
+
+## 6. Concurrency model (finding §4)
+
+The ported adapters are **fully synchronous and blocking** (sync httpx; `subprocess.run` for sd.cpp; `time.sleep` polling for Novita/ModelStudio). The app therefore **never calls `generate()` on the asyncio/UI loop**. A thin wrapper runs generation on a Textual **thread worker** (`@work(thread=True)` / `run_worker(..., thread=True)`), consistent with the app's known "sync-under-async blocks the UI loop" rule. The demo panel (and later the chat card) both go through this wrapper.
+
+**Cancellation caveat (finding B6):** a blocking `subprocess.run` / `time.sleep` will not cancel promptly, so in-flight generation cannot be cleanly aborted in Phase 1. Mitigations: sane default `timeout_seconds` per backend (as configured), and a clear "generating…" state. A proper cancel/timeout story is deferred to the chat-card phase.
+
+---
+
+## 7. Throwaway demo panel (finding B5)
+
+An `ImageGenDemoScreen` reached via a **command-palette action** ("Image Gen (dev)") — least invasive in a tab-based app, trivial to delete in Phase 2. It is explicitly labeled temporary.
+
+Contents:
+- Backend `Select` populated from `listing.list_image_models_for_catalog()`, showing which backends are `is_configured`; a clear inline message when the chosen backend is enabled-but-not-configured, pointing at config.
+- Prompt + negative-prompt text areas; a few param inputs (size, steps, seed).
+- Generate button → the §6 thread worker → on completion, render the result.
+- **Rendering uses the low-level `textual-image` / `rich-pixels` primitives directly**, NOT the Console transcript render path (which is coupled to message IDs / view-state). This keeps the throwaway decoupled.
+- Raw `ImageGenResult` + request metadata dumped below the image for verification.
+
+The demo panel is the manual proof surface; it does not persist anything.
+
+---
+
+## 8. Testing
+
+- **Per-adapter unit tests** with mocked `fetch_json` (and mocked `subprocess.run` for sd.cpp): request payload shape, response extraction (b64 / data URL / http URL paths), error handling, session refresh (SwarmUI), poll loop terminal states (Novita/ModelStudio).
+- **`request_validation` bounds suite**: prompt length, width/height/pixels, steps, cfg_scale positivity/finiteness, extra_params allowlist (incl. ModelStudio `mode` exemption and `cli_args` list rule).
+- **Registry tests**: `resolve_backend` enabled/disabled/default logic, lazy import, singleton caching, unknown backend.
+- **`prompt_refinement` table tests**: off/basic/auto modes, no-double-append, max-length guard.
+- **Config-loader tests (priority)**: nested TOML → flat field mapping, `DEFAULT_*` fallbacks, `_coerce_*` on string env overrides, and the §4.3 key precedence (env > config > keyring > optional shared).
+- **Opt-in live integration tests**: one per backend, skipped unless creds/servers/binary are present.
+- Cold-start guard: assert importing `tldw_chatbook.Image_Generation` does not import adapters or Pillow (finding B8).
+
+---
+
+## 9. Phase roadmap (context, not in scope here)
+
+- **Phase 1 (this spec):** multi-provider backend foundation + demo panel.
+- **Phase 2:** the Console chat "Image Generation" card (matching the reference), the `/generate-image [:backend] <prompt>` trigger, DB storage of generation metadata + variants (introduces the schema migration deferred here), variant prev/next, regenerate, TTS, and the "Style" field wired to `generation_templates.py`.
+- **Phase 3:** character-canvas generation — auto-prompt from character appearance, per-mood reaction images.
+- **Cleanup task (parallel):** remove the orphaned `Media_Creation` SwarmUI chain once superseded.
+- **task-485 (parallel):** port the real egress/SSRF protections.
+
+---
+
+## 10. Locked decisions & remaining detail
+
+**Locked** (from brainstorming): package `Image_Generation/` with `[image_generation]` config; 6 backends; port the server core; command-palette demo screen; light egress guard now with real SSRF port tracked in task-485; `default_backend = "swarmui"` / `enabled_backends = ["swarmui"]` first-run default; no schema migration in Phase 1; orphaned `Media_Creation` SwarmUI code left in place (separate cleanup task).
+
+**Remaining implementation detail** (settle during planning, not a blocker): the exact keyring account-naming scheme for image-backend secrets — it must be namespaced so it cannot collide with LLM-provider keyring accounts (e.g. an `imagegen:` prefix), per §4.3.

--- a/Docs/superpowers/specs/2026-07-22-image-generation-multiprovider-foundation-design.md
+++ b/Docs/superpowers/specs/2026-07-22-image-generation-multiprovider-foundation-design.md
@@ -31,7 +31,7 @@ tldw_server's `tldw_Server_API/app/core/Image_Generation/` (~3,207 lines) is a c
 - Backend selection via a registry with lazy adapter imports.
 - Request validation, prompt refinement, and model listing (`is_configured` per backend).
 - A `[image_generation]` TOML config surface re-homed onto this app's conventions (TOML + env + keyring), with **identical flat field names** to the server dataclass so adapters need no edits.
-- A thin sync `fetch_json` / `create_client` HTTP shim on `httpx.Client`, plus a **light egress guard** (real SSRF hardening deferred to task-485).
+- A thin sync `fetch_json` / `create_client` HTTP shim on `httpx.Client`, plus a **light egress guard** (real SSRF hardening deferred to task-498).
 - A **throwaway in-app demo panel** (command-palette screen) to generate one image end-to-end and eyeball the result + raw metadata.
 - Tests: mocked per-adapter, request-validation bounds, registry logic, prompt-refinement table, config-loader round-trip + key precedence, opt-in live integration.
 
@@ -41,7 +41,7 @@ tldw_server's `tldw_Server_API/app/core/Image_Generation/` (~3,207 lines) is a c
 - Character-canvas generation, per-mood reaction images, persona visual packs.
 - Variant navigation (prev/next), regenerate, TTS.
 - Reference-image resolution (`reference_images.py` is dropped; ModelStudio's `reference_image` degrades to `None`).
-- Full SSRF/egress protection (tracked in **task-485**).
+- Full SSRF/egress protection (tracked in **task-498**).
 - Deleting the orphaned `Media_Creation` SwarmUI code (separate cleanup task).
 
 ---
@@ -187,7 +187,7 @@ Secrets are **never logged** (matches `[API]` handling per CLAUDE.md security ru
 
 ---
 
-## 5. HTTP shim & egress (findings §5 + task-485)
+## 5. HTTP shim & egress (findings §5 + task-498)
 
 New `Image_Generation/http_client.py` provides the sync surface the ported adapters expect:
 - `fetch_json(method, url, *, headers=None, json=None, params=None, cookies=None, timeout=None)` → parsed JSON, on `httpx.Client`.
@@ -196,7 +196,7 @@ New `Image_Generation/http_client.py` provides the sync surface the ported adapt
 - **Light egress guard** `_validate_egress_or_raise(url)`: reject non-`http(s)` schemes; enforce max redirects. It stays **permissive for user-configured `base_url`s** so local backends (127.0.0.1 SwarmUI, local sd.cpp) keep working. It does **not** block private/metadata ranges for API-returned URLs — that is the deferred hardening.
 - `evaluate_url_policy(url)` stub for ModelStudio → simple host allowlist (`aliyuncs.com` / base host), preserving the adapter's built-in check.
 
-Each adapter's own per-backend URL checks are preserved (SwarmUI same-origin resolution; ModelStudio host allowlist). **Full SSRF protection for API-returned image URLs is task-485**, and this light guard is its explicit placeholder.
+Each adapter's own per-backend URL checks are preserved (SwarmUI same-origin resolution; ModelStudio host allowlist). **Full SSRF protection for API-returned image URLs is task-498**, and this light guard is its explicit placeholder.
 
 ---
 
@@ -243,12 +243,12 @@ The demo panel is the manual proof surface; it does not persist anything.
 - **Phase 2:** the Console chat "Image Generation" card (matching the reference), the `/generate-image [:backend] <prompt>` trigger, DB storage of generation metadata + variants (introduces the schema migration deferred here), variant prev/next, regenerate, TTS, and the "Style" field wired to `generation_templates.py`.
 - **Phase 3:** character-canvas generation — auto-prompt from character appearance, per-mood reaction images.
 - **Cleanup task (parallel):** remove the orphaned `Media_Creation` SwarmUI chain once superseded.
-- **task-485 (parallel):** port the real egress/SSRF protections.
+- **task-498 (parallel):** port the real egress/SSRF protections.
 
 ---
 
 ## 10. Locked decisions & remaining detail
 
-**Locked** (from brainstorming): package `Image_Generation/` with `[image_generation]` config; 6 backends; port the server core; command-palette demo screen; light egress guard now with real SSRF port tracked in task-485; `default_backend = "swarmui"` / `enabled_backends = ["swarmui"]` first-run default; no schema migration in Phase 1; orphaned `Media_Creation` SwarmUI code left in place (separate cleanup task).
+**Locked** (from brainstorming): package `Image_Generation/` with `[image_generation]` config; 6 backends; port the server core; command-palette demo screen; light egress guard now with real SSRF port tracked in task-498; `default_backend = "swarmui"` / `enabled_backends = ["swarmui"]` first-run default; no schema migration in Phase 1; orphaned `Media_Creation` SwarmUI code left in place (separate cleanup task).
 
 **Remaining implementation detail** (settle during planning, not a blocker): the exact keyring account-naming scheme for image-backend secrets — it must be namespaced so it cannot collide with LLM-provider keyring accounts (e.g. an `imagegen:` prefix), per §4.3.

--- a/Tests/Image_Generation/test_adapter_registry.py
+++ b/Tests/Image_Generation/test_adapter_registry.py
@@ -1,0 +1,31 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    from tldw_chatbook.Image_Generation import adapter_registry as r
+    r.reset_registry()
+    yield
+    r.reset_registry()
+
+
+def test_resolve_backend_requires_enabled():
+    from tldw_chatbook.Image_Generation.adapter_registry import ImageAdapterRegistry
+    reg = ImageAdapterRegistry(config_override={"enabled_backends": ["swarmui"], "default_backend": "swarmui"})
+    assert reg.resolve_backend("swarmui") == "swarmui"
+    assert reg.resolve_backend("novita") is None      # not enabled
+    assert reg.resolve_backend(None) == "swarmui"     # default
+
+
+def test_nothing_enabled_by_default():
+    from tldw_chatbook.Image_Generation.adapter_registry import ImageAdapterRegistry
+    reg = ImageAdapterRegistry(config_override={"enabled_backends": [], "default_backend": "swarmui"})
+    assert reg.resolve_backend("swarmui") is None
+
+
+def test_default_adapters_point_at_local_package():
+    from tldw_chatbook.Image_Generation.adapter_registry import DEFAULT_ADAPTERS
+    assert set(DEFAULT_ADAPTERS) == {
+        "stable_diffusion_cpp", "swarmui", "openrouter", "novita", "together", "modelstudio"
+    }
+    assert all(v.startswith("tldw_chatbook.Image_Generation.adapters.") for v in DEFAULT_ADAPTERS.values())

--- a/Tests/Image_Generation/test_cold_start.py
+++ b/Tests/Image_Generation/test_cold_start.py
@@ -1,0 +1,27 @@
+import sys
+import importlib
+
+
+def test_importing_package_pulls_no_adapters_or_pillow():
+    """Verify that importing Image_Generation package doesn't pull adapters or Pillow."""
+    # drop anything already imported so the assertion is meaningful
+    for name in list(sys.modules):
+        if name.startswith("tldw_chatbook.Image_Generation") or name == "PIL":
+            del sys.modules[name]
+    importlib.import_module("tldw_chatbook.Image_Generation")
+    loaded = set(sys.modules)
+    assert not any(
+        n.startswith("tldw_chatbook.Image_Generation.adapters.")
+        and n.endswith("_adapter")
+        for n in loaded
+    ), "adapters must be lazy"
+    assert "tldw_chatbook.Image_Generation.adapters.image_format_utils" not in loaded
+    assert "PIL" not in loaded, "Pillow must not import at package import time"
+
+
+def test_lazy_accessors_available():
+    """Verify that lazy accessors are available after import."""
+    import tldw_chatbook.Image_Generation as ig
+
+    assert callable(ig.get_image_generation_config)
+    assert callable(ig.get_registry)

--- a/Tests/Image_Generation/test_config_loader.py
+++ b/Tests/Image_Generation/test_config_loader.py
@@ -50,3 +50,11 @@ def test_secret_from_keyring_populates_field(monkeypatch):
     monkeypatch.setattr(c, "_keyring_get", lambda backend: "kr-secret" if backend == "novita" else None, raising=False)
     cfg = c.get_image_generation_config(reload=True)
     assert cfg.novita_image_api_key == "kr-secret"
+
+def test_sd_cpp_llm_path_flattens(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as c
+    fake = {"stable_diffusion_cpp": {"llm_path": "/models/qwen.gguf"}}
+    monkeypatch.setattr(c, "_read_image_generation_toml", lambda: fake, raising=False)
+    monkeypatch.setattr(c, "_keyring_get", lambda backend: None, raising=False)
+    cfg = c.get_image_generation_config(reload=True)
+    assert cfg.sd_cpp_llm_path == "/models/qwen.gguf"

--- a/Tests/Image_Generation/test_config_loader.py
+++ b/Tests/Image_Generation/test_config_loader.py
@@ -1,0 +1,52 @@
+import pytest
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    from tldw_chatbook.Image_Generation import config as c
+    c.reset_image_generation_config_cache()
+    yield
+    c.reset_image_generation_config_cache()
+
+def test_defaults_when_unconfigured(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as c
+    # No TOML section, no env, no keyring: fall back to documented defaults.
+    monkeypatch.setattr(c, "_read_image_generation_toml", lambda: {}, raising=False)
+    monkeypatch.setattr(c, "_keyring_get", lambda backend: None, raising=False)  # avoid real keyring
+    for var in ("OPENROUTER_API_KEY", "NOVITA_API_KEY", "TOGETHER_API_KEY", "DASHSCOPE_API_KEY", "QWEN_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    cfg = c.get_image_generation_config(reload=True)
+    assert cfg.swarmui_base_url == c.DEFAULT_SWARMUI_BASE_URL
+    assert cfg.max_width == c.DEFAULT_MAX_WIDTH
+    assert cfg.openrouter_image_api_key in (None, "")  # unconfigured
+
+def test_nested_toml_flattens_to_flat_fields(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as c
+    fake = {
+        "default_backend": "swarmui",
+        "enabled_backends": ["swarmui", "openrouter"],
+        "swarmui": {"base_url": "http://example:9999"},
+        "openrouter": {"default_model": "openai/gpt-image-1", "timeout_seconds": 42},
+    }
+    monkeypatch.setattr(c, "_read_image_generation_toml", lambda: fake, raising=False)
+    cfg = c.get_image_generation_config(reload=True)
+    assert cfg.swarmui_base_url == "http://example:9999"
+    assert cfg.openrouter_image_default_model == "openai/gpt-image-1"
+    assert cfg.openrouter_image_timeout_seconds == 42
+    assert cfg.enabled_backends == ["swarmui", "openrouter"]
+
+def test_secret_precedence_env_over_config(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as c
+    fake = {"openrouter": {"api_key": "from-config"}}
+    monkeypatch.setattr(c, "_read_image_generation_toml", lambda: fake, raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "from-env")
+    cfg = c.get_image_generation_config(reload=True)
+    assert cfg.openrouter_image_api_key == "from-env"
+
+def test_secret_from_keyring_populates_field(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as c
+    monkeypatch.setattr(c, "_read_image_generation_toml", lambda: {}, raising=False)
+    monkeypatch.delenv("NOVITA_API_KEY", raising=False)
+    # keyring-only secret must land on the config field so listing.is_configured sees it (spec §4.2 step 5)
+    monkeypatch.setattr(c, "_keyring_get", lambda backend: "kr-secret" if backend == "novita" else None, raising=False)
+    cfg = c.get_image_generation_config(reload=True)
+    assert cfg.novita_image_api_key == "kr-secret"

--- a/Tests/Image_Generation/test_contracts.py
+++ b/Tests/Image_Generation/test_contracts.py
@@ -21,6 +21,6 @@ def test_resolved_reference_image_defined_locally():
 
 def test_adapter_is_structural_protocol():
     from tldw_chatbook.Image_Generation.adapters.base import ImageGenerationAdapter
-    from typing import runtime_checkable, Protocol
+    from typing import Protocol
     # It is a Protocol; a duck-typed object with name/supported_formats/generate satisfies it structurally.
     assert issubclass(ImageGenerationAdapter, Protocol)

--- a/Tests/Image_Generation/test_contracts.py
+++ b/Tests/Image_Generation/test_contracts.py
@@ -1,0 +1,26 @@
+def test_request_and_result_dataclasses():
+    from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest, ImageGenResult
+    req = ImageGenRequest(
+        backend="swarmui", prompt="a red dragon", negative_prompt=None,
+        width=512, height=512, steps=20, cfg_scale=7.0, seed=-1,
+        sampler=None, model=None, format="png", extra_params={},
+    )
+    assert req.backend == "swarmui"
+    assert req.reference_image is None  # default
+    res = ImageGenResult(content=b"\x89PNG", content_type="image/png", bytes_len=4)
+    assert res.bytes_len == 4
+
+def test_resolved_reference_image_defined_locally():
+    # Must be defined in capabilities.py, NOT imported from reference_images (which we dropped)
+    from tldw_chatbook.Image_Generation.capabilities import ResolvedReferenceImage
+    r = ResolvedReferenceImage(
+        file_id=1, filename=None, mime_type="image/png",
+        width=None, height=None, bytes_len=3, content=b"abc", temp_path=None,
+    )
+    assert r.mime_type == "image/png"
+
+def test_adapter_is_structural_protocol():
+    from tldw_chatbook.Image_Generation.adapters.base import ImageGenerationAdapter
+    from typing import runtime_checkable, Protocol
+    # It is a Protocol; a duck-typed object with name/supported_formats/generate satisfies it structurally.
+    assert issubclass(ImageGenerationAdapter, Protocol)

--- a/Tests/Image_Generation/test_demo_screen.py
+++ b/Tests/Image_Generation/test_demo_screen.py
@@ -1,0 +1,92 @@
+"""Tests for the THROWAWAY Image Gen (dev) demo screen (Phase 1 proof surface).
+
+The screen's real production dependencies are `BaseAppScreen` (which needs a
+back-reference to the running app + a screen_name) and Textual's live app
+loop for `self.app.call_from_thread`. Mounting the full `TldwCli` app for a
+unit test is expensive (it pulls in DB/service wiring across the whole app);
+instead we mount the screen under a minimal bare `App` host, which is enough
+for `BaseAppScreen.compose()` (nav bar + footer) and this screen's own
+widgets to build and query successfully. The worker-thread generate path is
+exercised directly (off the Textual event loop, like the real `@work(thread=True)`
+callable is) with `run_generation` monkeypatched, so no backend is required.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def _tiny_png_bytes() -> bytes:
+    """A real (not merely well-formed-looking) 1x1 PNG.
+
+    The demo screen's render path decodes the result with PIL/rich_pixels
+    (see `_render_result`), so the fake `run_generation` must return actual
+    image bytes -- an arbitrary placeholder like `b"x"` would make PIL raise
+    `UnidentifiedImageError` once the worker thread reaches the render step.
+    """
+    import io
+    from PIL import Image as PILImage
+
+    buf = io.BytesIO()
+    PILImage.new("RGB", (1, 1), color=(255, 0, 0)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+@pytest.mark.asyncio
+async def test_demo_screen_lists_backends_and_generates(monkeypatch):
+    from tldw_chatbook.Image_Generation.adapters.base import ImageGenResult
+    import tldw_chatbook.UI.Screens.image_gen_demo_screen as scr
+    from tldw_chatbook.UI.Screens.image_gen_demo_screen import ImageGenDemoScreen
+
+    # Stub listing + generation so the test needs no real backend.
+    monkeypatch.setattr(
+        scr,
+        "list_image_models_for_catalog",
+        lambda: [{"name": "swarmui", "is_configured": True}],
+    )
+    captured_requests = []
+    png_bytes = _tiny_png_bytes()
+
+    def fake_run_generation(req):
+        captured_requests.append(req)
+        return ImageGenResult(
+            content=png_bytes, content_type="image/png", bytes_len=len(png_bytes)
+        )
+
+    monkeypatch.setattr(scr, "run_generation", fake_run_generation)
+
+    from textual.app import App
+    from textual.widgets import Select, Static, TextArea, Input
+
+    class Host(App):
+        def on_mount(self) -> None:
+            self.push_screen(ImageGenDemoScreen(self))
+
+    app = Host()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        # Backend select is present and populated from the (stubbed) catalog.
+        select = app.screen.query_one("#imagegen-backend", Select)
+        assert select.value == "swarmui"
+
+        # Drive a generate: fill the prompt, press Generate, wait for the
+        # worker thread (@work(thread=True)) to finish (status flips to
+        # "Done" once `_render_result` has decoded the image and updated the
+        # status/image/meta widgets via call_from_thread) and call the
+        # stubbed run_generation with a request built from the form fields.
+        app.screen.query_one("#imagegen-prompt", TextArea).text = "a cat"
+        app.screen.query_one("#imagegen-seed", Input).value = "42"
+        await pilot.click("#imagegen-generate")
+
+        status = app.screen.query_one("#imagegen-status", Static)
+        for _ in range(50):
+            await pilot.pause(0.05)
+            if str(status.renderable) == "Done":
+                break
+
+    assert str(status.renderable) == "Done"
+    assert len(captured_requests) == 1
+    req = captured_requests[0]
+    assert req.backend == "swarmui"
+    assert req.prompt == "a cat"
+    assert req.seed == 42

--- a/Tests/Image_Generation/test_http_client.py
+++ b/Tests/Image_Generation/test_http_client.py
@@ -1,0 +1,34 @@
+import pytest
+
+@pytest.fixture
+def hc():
+    from tldw_chatbook.Image_Generation import http_client as m
+    return m
+
+def test_rejects_non_http_scheme(hc):
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+    with pytest.raises(ImageGenerationError):
+        hc._validate_egress_or_raise("file:///etc/passwd")
+
+def test_allows_local_backend_url(hc):
+    # user-configured local backends must pass the light guard
+    hc._validate_egress_or_raise("http://127.0.0.1:7801/API/GetNewSession")  # no raise
+
+def test_evaluate_url_policy_allowlist(hc):
+    r = hc.evaluate_url_policy("https://x.aliyuncs.com/i.png", allowed_hosts={"aliyuncs.com"})
+    assert r.allowed is True
+    r2 = hc.evaluate_url_policy("https://evil.example/i.png", allowed_hosts={"aliyuncs.com"})
+    assert r2.allowed is False
+
+def test_fetch_json_parses(monkeypatch, hc):
+    class FakeResp:
+        status_code = 200
+        def json(self): return {"ok": True}
+        def raise_for_status(self): pass
+    class FakeClient:
+        def __init__(self, *a, **k): pass
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def request(self, *a, **k): return FakeResp()
+    monkeypatch.setattr(hc.httpx, "Client", FakeClient)
+    assert hc.fetch_json("POST", "http://127.0.0.1:7801/API/x", json={"a": 1}) == {"ok": True}

--- a/Tests/Image_Generation/test_http_client.py
+++ b/Tests/Image_Generation/test_http_client.py
@@ -23,6 +23,7 @@ def test_evaluate_url_policy_allowlist(hc):
 def test_fetch_json_parses(monkeypatch, hc):
     class FakeResp:
         status_code = 200
+        is_redirect = False
         def json(self): return {"ok": True}
         def raise_for_status(self): pass
     class FakeClient:
@@ -32,3 +33,34 @@ def test_fetch_json_parses(monkeypatch, hc):
         def request(self, *a, **k): return FakeResp()
     monkeypatch.setattr(hc.httpx, "Client", FakeClient)
     assert hc.fetch_json("POST", "http://127.0.0.1:7801/API/x", json={"a": 1}) == {"ok": True}
+
+
+def test_fetch_json_revalidates_redirect_hop(monkeypatch, hc):
+    # A redirect to a disallowed scheme must be re-validated and rejected,
+    # not blindly followed (egress guard must run on every hop).
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+    class RedirResp:
+        is_redirect = True
+        headers = {"location": "file:///etc/passwd"}
+        url = "http://127.0.0.1:7801/x"
+        def raise_for_status(self): pass
+        def json(self): return {}
+    class FakeClient:
+        def __init__(self, *a, **k): pass
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def request(self, *a, **k): return RedirResp()
+    monkeypatch.setattr(hc.httpx, "Client", FakeClient)
+    with pytest.raises(ImageGenerationError):
+        hc.fetch_json("GET", "http://127.0.0.1:7801/x")
+
+
+def test_fetch_json_defaults_no_autofollow(hc):
+    # create_client must not auto-follow redirects by default (the manual
+    # validated loop in fetch_json handles them instead).
+    client = hc.create_client()
+    try:
+        assert client.follow_redirects is False
+    finally:
+        client.close()

--- a/Tests/Image_Generation/test_image_format_utils.py
+++ b/Tests/Image_Generation/test_image_format_utils.py
@@ -1,0 +1,29 @@
+import io
+import pytest
+from PIL import Image
+
+
+def _png_bytes(size=(8, 8)):
+    buf = io.BytesIO()
+    Image.new("RGB", size, (200, 30, 30)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+@pytest.fixture
+def ifu():
+    from tldw_chatbook.Image_Generation.adapters import image_format_utils as m
+    return m
+
+
+def test_format_from_bytes_detects_png(ifu):
+    assert ifu.format_from_bytes(_png_bytes()) == "png"
+
+
+def test_validate_and_convert_output_roundtrip(ifu):
+    data, ctype = ifu.validate_and_convert_image_output(_png_bytes(), "image/png", "png", max_bytes=10_000_000)
+    assert ctype == "image/png" and isinstance(data, (bytes, bytearray))
+
+
+def test_validate_rejects_when_over_max_bytes(ifu):
+    with pytest.raises(Exception):
+        ifu.validate_and_convert_image_output(_png_bytes((256, 256)), "image/png", "png", max_bytes=10)

--- a/Tests/Image_Generation/test_listing.py
+++ b/Tests/Image_Generation/test_listing.py
@@ -1,0 +1,33 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    from tldw_chatbook.Image_Generation import config as c, adapter_registry as r
+    c.reset_image_generation_config_cache()
+    r.reset_registry()
+    yield
+    c.reset_image_generation_config_cache()
+    r.reset_registry()
+
+
+def test_keyring_populated_backend_reports_configured(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as c, listing as L
+    # enable openrouter; provide its key only via keyring (spec §4.2 step 5 -> is_configured must be True)
+    monkeypatch.setattr(c, "_read_image_generation_toml",
+                        lambda: {"enabled_backends": ["openrouter"], "default_backend": "openrouter"}, raising=False)
+    for var in ("OPENROUTER_API_KEY",):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(c, "_keyring_get", lambda b: "kr" if b == "openrouter" else None, raising=False)
+    c.get_image_generation_config(reload=True)
+    entries = {e["name"]: e for e in L.list_image_models_for_catalog()}
+    assert entries["openrouter"]["is_configured"] is True
+
+
+def test_disabled_backends_excluded(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as c, listing as L
+    monkeypatch.setattr(c, "_read_image_generation_toml",
+                        lambda: {"enabled_backends": ["swarmui"], "default_backend": "swarmui"}, raising=False)
+    c.get_image_generation_config(reload=True)
+    names = {e["name"] for e in L.list_image_models_for_catalog()}
+    assert "novita" not in names and "swarmui" in names

--- a/Tests/Image_Generation/test_modelstudio_adapter.py
+++ b/Tests/Image_Generation/test_modelstudio_adapter.py
@@ -1,0 +1,70 @@
+"""Test ModelStudio image adapter."""
+
+import base64
+import io
+
+from PIL import Image
+
+from tldw_chatbook.Image_Generation import config as _c
+from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest
+
+
+def _b64():
+    """Generate a test 8x8 PNG in base64."""
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8), (120, 0, 160)).save(buf, "PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+def test_modelstudio_sync_no_reference_image(monkeypatch):
+    """Test ModelStudio sync mode with no reference image.
+
+    Verifies:
+    - Image content is extracted from sync response
+    - reference_image_data_url is never called when reference_image=None
+    """
+    from tldw_chatbook.Image_Generation.adapters import modelstudio_image_adapter as m
+
+    _c.reset_image_generation_config_cache()
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "k")
+    monkeypatch.setattr(m.time, "sleep", lambda *_: None)
+    # reference_image=None must never call reference_image_data_url
+    monkeypatch.setattr(
+        m,
+        "reference_image_data_url",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("reference_image_data_url must not be called")
+        ),
+    )
+    monkeypatch.setattr(
+        m,
+        "fetch_json",
+        lambda method, url, **kw: {
+            "output": {
+                "choices": [
+                    {
+                        "message": {
+                            "content": [{"image": "data:image/png;base64," + _b64()}]
+                        }
+                    }
+                ]
+            }
+        },
+    )
+    req = ImageGenRequest(
+        backend="modelstudio",
+        prompt="lotus",
+        negative_prompt=None,
+        width=None,
+        height=None,
+        steps=None,
+        cfg_scale=None,
+        seed=None,
+        sampler=None,
+        model="qwen-image",
+        format="png",
+        extra_params={"mode": "sync"},
+        reference_image=None,
+    )
+    res = m.ModelStudioImageAdapter().generate(req)
+    assert res.bytes_len > 0

--- a/Tests/Image_Generation/test_novita_adapter.py
+++ b/Tests/Image_Generation/test_novita_adapter.py
@@ -1,0 +1,39 @@
+import io
+import base64
+from PIL import Image
+
+
+def _b64():
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8), (0, 120, 200)).save(buf, "PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+def test_novita_submit_then_poll(monkeypatch):
+    from tldw_chatbook.Image_Generation.adapters import novita_image_adapter as m
+    from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest
+    from tldw_chatbook.Image_Generation import config as _c
+
+    # Reset config cache to ensure fresh state
+    _c.reset_image_generation_config_cache()
+
+    monkeypatch.setenv("NOVITA_API_KEY", "k")
+    monkeypatch.setattr(m.time, "sleep", lambda *_: None)  # skip poll delay
+
+    step = {"n": 0}
+
+    def fake_fetch_json(method, url, **kw):
+        # Submit phase: POST to async/txt2img returns task_id
+        if "async/txt2img" in url or method.upper() == "POST":
+            return {"task_id": "t1"}
+        # Poll phase: GET task-result returns status and image
+        step["n"] += 1
+        return {"status": "succeeded",
+                "images": [{"image_url": "data:image/png;base64," + _b64()}]}
+
+    monkeypatch.setattr(m, "fetch_json", fake_fetch_json)
+
+    req = ImageGenRequest(backend="novita", prompt="whale", negative_prompt=None, width=512, height=512,
+                          steps=20, cfg_scale=7.0, seed=-1, sampler=None, model=None, format="png", extra_params={})
+    res = m.NovitaImageAdapter().generate(req)
+    assert res.bytes_len > 0

--- a/Tests/Image_Generation/test_openrouter_adapter.py
+++ b/Tests/Image_Generation/test_openrouter_adapter.py
@@ -1,0 +1,26 @@
+import io
+import base64
+from PIL import Image
+
+
+def _b64():
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8), (0, 180, 0)).save(buf, "PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+def test_openrouter_extracts_image(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as _c
+    _c.reset_image_generation_config_cache()
+
+    from tldw_chatbook.Image_Generation.adapters import openrouter_image_adapter as m
+    from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest
+    monkeypatch.setenv("OPENROUTER_API_KEY", "k")
+    monkeypatch.setattr(m, "fetch_json", lambda method, url, **kw: {
+        "choices": [{"message": {"images": [{"image_url": {"url": "data:image/png;base64," + _b64()}}]}}]
+    })
+    req = ImageGenRequest(backend="openrouter", prompt="fox", negative_prompt=None, width=None, height=None,
+                          steps=None, cfg_scale=None, seed=None, sampler=None, model="openai/gpt-image-1",
+                          format="png", extra_params={})
+    res = m.OpenRouterImageAdapter().generate(req)
+    assert res.bytes_len > 0

--- a/Tests/Image_Generation/test_package_skeleton.py
+++ b/Tests/Image_Generation/test_package_skeleton.py
@@ -1,0 +1,11 @@
+def test_exceptions_hierarchy():
+    from tldw_chatbook.Image_Generation.exceptions import (
+        ImageGenerationError, ImageBackendUnavailableError,
+    )
+    assert issubclass(ImageGenerationError, RuntimeError)
+    assert issubclass(ImageBackendUnavailableError, ImageGenerationError)
+
+def test_package_imports_clean():
+    import importlib
+    mod = importlib.import_module("tldw_chatbook.Image_Generation")
+    assert mod is not None

--- a/Tests/Image_Generation/test_prompt_refinement.py
+++ b/Tests/Image_Generation/test_prompt_refinement.py
@@ -1,0 +1,33 @@
+import pytest
+
+
+@pytest.fixture
+def pr():
+    from tldw_chatbook.Image_Generation import prompt_refinement as m
+    return m
+
+
+def test_off_returns_prompt_unchanged(pr):
+    assert pr.refine_image_prompt("a cat", mode="off") == "a cat"
+
+
+def test_basic_always_appends_suffix(pr):
+    out = pr.refine_image_prompt("a cat", mode="basic")
+    assert pr.DEFAULT_QUALITY_SUFFIX in out
+
+
+def test_auto_skips_when_prompt_already_detailed(pr):
+    detailed = "a cat, highly detailed, cinematic lighting, sharp focus, 8k, masterpiece composition"
+    assert pr.refine_image_prompt(detailed, mode="auto") == detailed  # has quality cues -> no append
+
+
+def test_auto_appends_for_short_sparse_prompt(pr):
+    out = pr.refine_image_prompt("a cat", mode="auto")
+    assert pr.DEFAULT_QUALITY_SUFFIX in out
+
+
+def test_normalize_mode_aliases(pr):
+    assert pr.normalize_prompt_refinement_mode(True) == "basic"
+    assert pr.normalize_prompt_refinement_mode(False) == "off"
+    assert pr.normalize_prompt_refinement_mode("none") == "off"
+    assert pr.normalize_prompt_refinement_mode("garbage") == "auto"  # default

--- a/Tests/Image_Generation/test_request_validation.py
+++ b/Tests/Image_Generation/test_request_validation.py
@@ -1,0 +1,27 @@
+import pytest
+
+@pytest.fixture
+def rv():
+    from tldw_chatbook.Image_Generation import request_validation as m
+    return m
+
+def _codes(issues):
+    return {i.path for i in issues}
+
+def test_valid_request_has_no_issues(rv):
+    ok = {"backend": "swarmui", "prompt": "cat", "width": 512, "height": 512, "steps": 20, "cfg_scale": 7.0, "extra_params": {}}
+    assert rv.validate_image_generation_request(ok) == []
+
+def test_oversize_dimensions_flagged(rv):
+    bad = {"backend": "swarmui", "prompt": "cat", "width": 9000, "height": 9000, "extra_params": {}}
+    issues = rv.validate_image_generation_request(bad)
+    assert any("width" in p for p in _codes(issues))
+
+def test_negative_cfg_scale_flagged(rv):
+    bad = {"backend": "swarmui", "prompt": "cat", "cfg_scale": -1.0, "extra_params": {}}
+    assert any("cfg_scale" in p for p in _codes(rv.validate_image_generation_request(bad)))
+
+def test_extra_params_not_in_allowlist_flagged(rv):
+    bad = {"backend": "swarmui", "prompt": "cat", "extra_params": {"totally_unknown": 1}}
+    issues = rv.validate_image_generation_request(bad)
+    assert any("extra_params" in p for p in _codes(issues))

--- a/Tests/Image_Generation/test_sd_cpp_adapter.py
+++ b/Tests/Image_Generation/test_sd_cpp_adapter.py
@@ -1,27 +1,23 @@
-import io
 import pytest
-from PIL import Image
 
 
-def test_sd_cpp_missing_binary_raises(monkeypatch, tmp_path):
+def test_sd_cpp_missing_binary_raises(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as c
     from tldw_chatbook.Image_Generation.adapters import stable_diffusion_cpp_adapter as m
     from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest
     from tldw_chatbook.Image_Generation.exceptions import ImageBackendUnavailableError
 
-    # config with no binary path -> unavailable
+    # Deterministic: no backend config at all -> no sd binary path -> must raise.
+    monkeypatch.setattr(c, "_read_image_generation_toml", lambda: {}, raising=False)
+    monkeypatch.setattr(c, "_keyring_get", lambda backend: None, raising=False)
+    c.reset_image_generation_config_cache()
+
     req = ImageGenRequest(
-        backend="stable_diffusion_cpp",
-        prompt="cat",
-        negative_prompt=None,
-        width=512,
-        height=512,
-        steps=10,
-        cfg_scale=7.0,
-        seed=-1,
-        sampler=None,
-        model=None,
-        format="png",
-        extra_params={},
+        backend="stable_diffusion_cpp", prompt="cat", negative_prompt=None,
+        width=512, height=512, steps=10, cfg_scale=7.0, seed=-1,
+        sampler=None, model=None, format="png", extra_params={},
     )
-    with pytest.raises((ImageBackendUnavailableError, Exception)):
+    with pytest.raises(ImageBackendUnavailableError):
         m.StableDiffusionCppAdapter().generate(req)
+
+    c.reset_image_generation_config_cache()

--- a/Tests/Image_Generation/test_sd_cpp_adapter.py
+++ b/Tests/Image_Generation/test_sd_cpp_adapter.py
@@ -1,0 +1,27 @@
+import io
+import pytest
+from PIL import Image
+
+
+def test_sd_cpp_missing_binary_raises(monkeypatch, tmp_path):
+    from tldw_chatbook.Image_Generation.adapters import stable_diffusion_cpp_adapter as m
+    from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest
+    from tldw_chatbook.Image_Generation.exceptions import ImageBackendUnavailableError
+
+    # config with no binary path -> unavailable
+    req = ImageGenRequest(
+        backend="stable_diffusion_cpp",
+        prompt="cat",
+        negative_prompt=None,
+        width=512,
+        height=512,
+        steps=10,
+        cfg_scale=7.0,
+        seed=-1,
+        sampler=None,
+        model=None,
+        format="png",
+        extra_params={},
+    )
+    with pytest.raises((ImageBackendUnavailableError, Exception)):
+        m.StableDiffusionCppAdapter().generate(req)

--- a/Tests/Image_Generation/test_swarmui_adapter.py
+++ b/Tests/Image_Generation/test_swarmui_adapter.py
@@ -1,8 +1,10 @@
-import io, pytest
+import io
 from PIL import Image
 
 def _png_b64():
-    import base64; buf = io.BytesIO(); Image.new("RGB", (8, 8), (10, 10, 200)).save(buf, "PNG")
+    import base64
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8), (10, 10, 200)).save(buf, "PNG")
     return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
 
 def test_swarmui_generate_happy_path(monkeypatch):

--- a/Tests/Image_Generation/test_swarmui_adapter.py
+++ b/Tests/Image_Generation/test_swarmui_adapter.py
@@ -1,0 +1,23 @@
+import io, pytest
+from PIL import Image
+
+def _png_b64():
+    import base64; buf = io.BytesIO(); Image.new("RGB", (8, 8), (10, 10, 200)).save(buf, "PNG")
+    return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
+
+def test_swarmui_generate_happy_path(monkeypatch):
+    from tldw_chatbook.Image_Generation.adapters import swarmui_adapter as m
+    from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest
+    calls = []
+    def fake_fetch_json(method, url, **kw):
+        calls.append(url)
+        if url.endswith("/API/GetNewSession"):
+            return {"session_id": "sess-1"}
+        return {"images": [{"image": _png_b64()}]}
+    monkeypatch.setattr(m, "fetch_json", fake_fetch_json)
+    req = ImageGenRequest(backend="swarmui", prompt="dragon", negative_prompt=None, width=512,
+                          height=512, steps=20, cfg_scale=7.0, seed=-1, sampler=None, model=None,
+                          format="png", extra_params={})
+    res = m.SwarmUIAdapter().generate(req)
+    assert res.content_type.startswith("image/") and res.bytes_len > 0
+    assert any("GetNewSession" in c for c in calls)

--- a/Tests/Image_Generation/test_together_adapter.py
+++ b/Tests/Image_Generation/test_together_adapter.py
@@ -1,0 +1,30 @@
+import base64
+import io
+
+from PIL import Image
+
+
+def _b64():
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8), (180, 120, 0)).save(buf, "PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+def test_together_extracts_image_and_no_v1_doubling(monkeypatch):
+    from tldw_chatbook.Image_Generation.adapters import together_image_adapter as m
+    from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest
+    from tldw_chatbook.Image_Generation import config as _c
+    _c.reset_image_generation_config_cache()
+    monkeypatch.setenv("TOGETHER_API_KEY", "k")
+    seen = {}
+    def fake_fetch_json(method, url, **kw):
+        seen["url"] = url
+        return {"data": [{"b64_json": _b64()}]}
+    monkeypatch.setattr(m, "fetch_json", fake_fetch_json)
+    req = ImageGenRequest(backend="together", prompt="owl", negative_prompt=None, width=512, height=512,
+                          steps=None, cfg_scale=None, seed=None, sampler=None,
+                          model="black-forest-labs/FLUX.1-schnell-Free", format="png", extra_params={})
+    res = m.TogetherImageAdapter().generate(req)
+    assert res.bytes_len > 0
+    # default base_url ends in /v1; the adapter must NOT produce /v1/v1/ (spec verification)
+    assert "/v1/v1/" not in seen["url"]

--- a/Tests/Image_Generation/test_worker.py
+++ b/Tests/Image_Generation/test_worker.py
@@ -1,0 +1,35 @@
+import pytest
+
+
+def test_build_request_defaults_format_png():
+    from tldw_chatbook.Image_Generation.worker import build_request
+    req = build_request(backend="swarmui", prompt="cat")
+    assert req.format == "png"
+    assert req.extra_params == {}          # never None
+    assert req.negative_prompt is None
+
+
+def test_run_generation_unknown_backend_raises(monkeypatch):
+    from tldw_chatbook.Image_Generation import worker
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+    req = worker.build_request(backend="nope", prompt="cat")
+    with pytest.raises(ImageGenerationError):
+        worker.run_generation(req)   # registry resolve_backend -> None -> error
+
+
+def test_run_generation_dispatches_to_adapter(monkeypatch):
+    from tldw_chatbook.Image_Generation import worker
+    from tldw_chatbook.Image_Generation.adapters.base import ImageGenResult
+    class FakeAdapter:
+        name = "swarmui"
+        supported_formats = {"png"}
+        def generate(self, req):
+            return ImageGenResult(content=b"x", content_type="image/png", bytes_len=1)
+    class FakeReg:
+        def resolve_backend(self, name):
+            return "swarmui" if name == "swarmui" else None
+        def get_adapter(self, name):
+            return FakeAdapter()
+    monkeypatch.setattr(worker, "get_registry", lambda: FakeReg())
+    res = worker.run_generation(worker.build_request(backend="swarmui", prompt="cat"))
+    assert res.bytes_len == 1

--- a/backlog/tasks/task-485 - Port-image-generation-egress-SSRF-protections-from-tldw_server.md
+++ b/backlog/tasks/task-485 - Port-image-generation-egress-SSRF-protections-from-tldw_server.md
@@ -1,0 +1,42 @@
+---
+id: TASK-485
+title: >-
+  Port image-generation egress/SSRF protections from tldw_server
+status: To Do
+assignee: []
+created_date: '2026-07-22 11:32'
+updated_date: '2026-07-22 11:32'
+labels:
+  - image-generation
+  - security
+  - followup
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up to the image-generation multi-provider foundation (Phase 1 of the in-chat image-gen program; see `docs/superpowers/specs/` image-generation design). The server's `Image_Generation` package we port includes egress/SSRF guards that tldw_chatbook currently lacks app-wide: `_validate_egress_or_raise` / `_resolve_redirect_url` in `http_client`, and `evaluate_url_policy` from `Security/egress`. Phase 1 deliberately ships only a **light** guard (reject non-`http(s)` schemes; keep each adapter's built-in per-backend host checks — SwarmUI same-origin, ModelStudio `aliyuncs` allowlist) and stays permissive for user-configured `base_url`s so local backends (127.0.0.1 SwarmUI, local sd.cpp) keep working.
+
+That light guard does NOT protect against SSRF via **API-returned image URLs** (OpenRouter / Novita / ModelStudio can return arbitrary `http(s)` URLs that the adapters then fetch via `fetch_image_bytes`). Port the server's real egress protections so those fetches are validated (block private/link-local/metadata ranges for URLs the app did not originate, DNS-rebinding-aware where feasible), while still allowing user-configured local backend base URLs. This is the security hardening the light guard is a placeholder for, and it doubles as the first real SSRF protection in the app.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] Image URLs returned by remote backends (OpenRouter/Novita/ModelStudio) are validated before fetch: private, link-local, loopback, and cloud-metadata (169.254.169.254) ranges are blocked for app-non-originated URLs.
+- [ ] User-configured backend `base_url`s (e.g. `http://127.0.0.1:7801` SwarmUI, local paths) continue to work — the guard distinguishes user-configured endpoints from API-returned URLs.
+- [ ] Non-`http(s)` schemes and redirect chains beyond the configured max are rejected.
+- [ ] Guard is unit-tested with SSRF payloads (private IPs, metadata IP, scheme abuse, redirect-to-private) and does not regress local-backend generation.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-497 - Image-generation-Phase-1-polish-follow-ups.md
+++ b/backlog/tasks/task-497 - Image-generation-Phase-1-polish-follow-ups.md
@@ -1,0 +1,42 @@
+---
+id: TASK-497
+title: >-
+  Image-generation Phase-1 polish follow-ups
+status: To Do
+assignee: []
+created_date: '2026-07-23 12:59'
+updated_date: '2026-07-23 12:59'
+labels:
+  - image-generation
+  - followup
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Non-blocking polish items surfaced by the whole-branch review of the image-generation multi-provider foundation (Phase 1, PR #800). None block that PR; group them into one cleanup pass. Separate from [[task-485]] (real egress/SSRF hardening) and the deferred Phase-2/3 feature work. See the Phase-1 design spec `Docs/superpowers/specs/2026-07-22-image-generation-multiprovider-foundation-design.md`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] Demo panel: the `_generate` error branch no longer calls `query_one(...)` on the worker thread — resolve the status widget on the UI thread (or pass it in) so a mid-generation screen pop can't raise uncaught under `@work(exit_on_error=True)`.
+- [ ] `http_client.py`: add Google-style docstrings to the public functions; `create_client` treats an explicit `timeout=0` correctly instead of falling back to the default; `DEFAULT_MAX_REDIRECTS` tolerates a malformed `HTTP_MAX_REDIRECTS` env value without raising at import.
+- [ ] `worker.py`: add a test covering the adapter-load-failure raise branch (`get_adapter` returns None); `test_worker.py` resets the `get_registry` singleton (autouse fixture) to match the sibling test convention.
+- [ ] `Image_Generation/__init__.py`: `__getattr__` raises a descriptive `AttributeError` (module + attribute name) per the PEP 562 idiom.
+- [ ] `test_cold_start.py`: restore `sys.modules` after the purge (try/finally or `monkeypatch`) so it doesn't permanently mutate the process-wide module cache for later tests.
+- [ ] Demo panel: add the size and steps inputs and the distinct "enabled-but-not-configured" inline message described in design spec §7 (or explicitly record them as intentionally omitted for the throwaway panel).
+- [ ] Add opt-in live integration tests (spec §8): one per backend, `@pytest.mark.optional`, skipped unless creds/servers/binary are present.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-497 - Image-generation-Phase-1-polish-follow-ups.md
+++ b/backlog/tasks/task-497 - Image-generation-Phase-1-polish-follow-ups.md
@@ -16,7 +16,7 @@ priority: low
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Non-blocking polish items surfaced by the whole-branch review of the image-generation multi-provider foundation (Phase 1, PR #800). None block that PR; group them into one cleanup pass. Separate from [[task-485]] (real egress/SSRF hardening) and the deferred Phase-2/3 feature work. See the Phase-1 design spec `Docs/superpowers/specs/2026-07-22-image-generation-multiprovider-foundation-design.md`.
+Non-blocking polish items surfaced by the whole-branch review of the image-generation multi-provider foundation (Phase 1, PR #800). None block that PR; group them into one cleanup pass. Separate from [[task-498]] (real egress/SSRF hardening) and the deferred Phase-2/3 feature work. See the Phase-1 design spec `Docs/superpowers/specs/2026-07-22-image-generation-multiprovider-foundation-design.md`.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria

--- a/backlog/tasks/task-498 - Port-image-generation-egress-SSRF-protections-from-tldw_server.md
+++ b/backlog/tasks/task-498 - Port-image-generation-egress-SSRF-protections-from-tldw_server.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-485
+id: TASK-498
 title: >-
   Port image-generation egress/SSRF protections from tldw_server
 status: To Do

--- a/tldw_chatbook/Image_Generation/__init__.py
+++ b/tldw_chatbook/Image_Generation/__init__.py
@@ -1,0 +1,7 @@
+"""Multi-provider image generation (ported from tldw_server). Import-light."""
+from tldw_chatbook.Image_Generation.exceptions import (
+    ImageGenerationError,
+    ImageBackendUnavailableError,
+)
+
+__all__ = ["ImageGenerationError", "ImageBackendUnavailableError"]

--- a/tldw_chatbook/Image_Generation/__init__.py
+++ b/tldw_chatbook/Image_Generation/__init__.py
@@ -4,4 +4,23 @@ from tldw_chatbook.Image_Generation.exceptions import (
     ImageBackendUnavailableError,
 )
 
-__all__ = ["ImageGenerationError", "ImageBackendUnavailableError"]
+__all__ = [
+    "ImageGenerationError",
+    "ImageBackendUnavailableError",
+    "get_image_generation_config",
+    "get_registry",
+]
+
+
+def __getattr__(name):  # PEP 562 lazy re-export; keeps adapters/Pillow out of import time
+    if name == "get_image_generation_config":
+        from tldw_chatbook.Image_Generation.config import (
+            get_image_generation_config as f,
+        )
+
+        return f
+    if name == "get_registry":
+        from tldw_chatbook.Image_Generation.adapter_registry import get_registry as f
+
+        return f
+    raise AttributeError(name)

--- a/tldw_chatbook/Image_Generation/adapter_registry.py
+++ b/tldw_chatbook/Image_Generation/adapter_registry.py
@@ -1,0 +1,143 @@
+"""Registry for image generation backends."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from typing import Any
+
+from loguru import logger
+
+from tldw_chatbook.Image_Generation.adapters.base import ImageGenerationAdapter
+from tldw_chatbook.Image_Generation.config import get_image_generation_config
+
+
+class ImageAdapterRegistry:
+    """Registry for image generation adapters."""
+
+    DEFAULT_ADAPTERS: dict[str, str] = {
+        "stable_diffusion_cpp": "tldw_chatbook.Image_Generation.adapters.stable_diffusion_cpp_adapter.StableDiffusionCppAdapter",
+        "swarmui": "tldw_chatbook.Image_Generation.adapters.swarmui_adapter.SwarmUIAdapter",
+        "openrouter": "tldw_chatbook.Image_Generation.adapters.openrouter_image_adapter.OpenRouterImageAdapter",
+        "novita": "tldw_chatbook.Image_Generation.adapters.novita_image_adapter.NovitaImageAdapter",
+        "together": "tldw_chatbook.Image_Generation.adapters.together_image_adapter.TogetherImageAdapter",
+        "modelstudio": "tldw_chatbook.Image_Generation.adapters.modelstudio_image_adapter.ModelStudioImageAdapter",
+    }
+
+    def __init__(self, config_override: dict[str, Any] | None = None) -> None:
+        config = get_image_generation_config()
+        default_backend = config.default_backend
+        enabled_backends = list(config.enabled_backends)
+        if config_override:
+            if "default_backend" in config_override:
+                default_backend = str(config_override.get("default_backend") or "").strip() or None
+            if "enabled_backends" in config_override:
+                enabled_backends = self._parse_list(config_override.get("enabled_backends"))
+        self._default_backend = default_backend
+        self._enabled_backends = enabled_backends
+        self._adapters: dict[str, ImageGenerationAdapter] = {}
+        self._adapter_specs: dict[str, Any] = self.DEFAULT_ADAPTERS.copy()
+
+    def register_adapter(self, name: str, adapter: Any) -> None:
+        self._adapter_specs[name] = adapter
+        try:
+            adapter_name = adapter.__name__  # type: ignore[attr-defined]
+        except Exception:
+            adapter_name = str(adapter)
+        logger.info("Registered image adapter {} for backend '{}'", adapter_name, name)
+
+    def list_backend_names(self, *, include_disabled: bool = False) -> list[str]:
+        names = list(self._adapter_specs.keys())
+        if include_disabled:
+            return names
+        if not self._enabled_backends:
+            return []
+        return [name for name in names if name in self._enabled_backends]
+
+    def _resolve_adapter_class(self, spec: Any) -> type[ImageGenerationAdapter]:
+        if isinstance(spec, str):
+            module_path, _, class_name = spec.rpartition(".")
+            if not module_path:
+                raise ImportError(f"Invalid adapter spec '{spec}'")
+            module = importlib.import_module(module_path)
+            return getattr(module, class_name)
+        return spec
+
+    def _is_enabled(self, name: str) -> bool:
+        if not self._enabled_backends:
+            return False
+        return name in self._enabled_backends
+
+    def resolve_backend(self, requested: str | None) -> str | None:
+        name = (requested or self._default_backend or "").strip()
+        if not name:
+            return None
+        if not self._is_enabled(name):
+            return None
+        if name not in self._adapter_specs:
+            return None
+        return name
+
+    def get_adapter(self, name: str) -> ImageGenerationAdapter | None:
+        if name in self._adapters:
+            return self._adapters[name]
+
+        spec = self._adapter_specs.get(name)
+        if not spec:
+            logger.debug("No image adapter spec registered for backend '{}'", name)
+            return None
+
+        try:
+            adapter_cls = self._resolve_adapter_class(spec)
+            adapter = adapter_cls()  # type: ignore[call-arg]
+            self._adapters[name] = adapter
+            return adapter
+        except Exception as exc:
+            logger.error("Failed to initialize image adapter for '{}': {}", name, exc)
+            return None
+
+    def get_adapter_class(self, name: str) -> type[ImageGenerationAdapter] | None:
+        spec = self._adapter_specs.get(name)
+        if not spec:
+            logger.debug("No image adapter spec registered for backend '{}'", name)
+            return None
+        try:
+            return self._resolve_adapter_class(spec)
+        except Exception as exc:
+            logger.error("Failed to resolve image adapter class for '{}': {}", name, exc)
+            return None
+
+    @staticmethod
+    def _parse_list(value: Any) -> list[str]:
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return [str(item).strip() for item in value if str(item).strip()]
+        raw = str(value).strip()
+        if not raw:
+            return []
+        try:
+            parsed = json.loads(raw)
+        except Exception:
+            parsed = None
+        if isinstance(parsed, list):
+            return [str(item).strip() for item in parsed if str(item).strip()]
+        return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+# Export DEFAULT_ADAPTERS at module level for testing and introspection
+DEFAULT_ADAPTERS = ImageAdapterRegistry.DEFAULT_ADAPTERS
+
+_registry: ImageAdapterRegistry | None = None
+
+
+def get_registry() -> ImageAdapterRegistry:
+    global _registry
+    if _registry is None:
+        _registry = ImageAdapterRegistry()
+    return _registry
+
+
+def reset_registry() -> None:
+    global _registry
+    _registry = None

--- a/tldw_chatbook/Image_Generation/adapters/base.py
+++ b/tldw_chatbook/Image_Generation/adapters/base.py
@@ -1,0 +1,44 @@
+"""Base contracts for image generation adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from tldw_chatbook.Image_Generation.capabilities import ResolvedReferenceImage
+
+
+@dataclass(frozen=True)
+class ImageGenRequest:
+    backend: str
+    prompt: str
+    negative_prompt: str | None
+    width: int | None
+    height: int | None
+    steps: int | None
+    cfg_scale: float | None
+    seed: int | None
+    sampler: str | None
+    model: str | None
+    format: str
+    extra_params: dict[str, Any]
+    request_id: str | None = None
+    reference_image: ResolvedReferenceImage | None = None
+
+
+@dataclass(frozen=True)
+class ImageGenResult:
+    content: bytes
+    content_type: str
+    bytes_len: int
+
+
+class ImageGenerationAdapter(Protocol):
+    """Protocol for image generation backends."""
+
+    name: str
+    supported_formats: set[str]
+
+    def generate(self, request: ImageGenRequest) -> ImageGenResult:
+        """Generate an image from the given request."""
+        ...

--- a/tldw_chatbook/Image_Generation/adapters/image_format_utils.py
+++ b/tldw_chatbook/Image_Generation/adapters/image_format_utils.py
@@ -1,0 +1,300 @@
+"""Shared image parsing/format conversion helpers for image-generation adapters."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import io
+from pathlib import Path
+from typing import Any
+
+from tldw_chatbook.Image_Generation.http_client import (
+    DEFAULT_MAX_REDIRECTS,
+    _resolve_redirect_url,
+    _validate_egress_or_raise,
+    create_client,
+)
+from tldw_chatbook.Image_Generation.capabilities import ResolvedReferenceImage
+from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+try:
+    from PIL import Image
+except Exception:  # pragma: no cover - optional dependency guard
+    Image = None  # type: ignore
+
+
+def decode_data_url(data_url: str, *, max_bytes: int | None = None) -> tuple[bytes, str]:
+    header, _, encoded = data_url.partition(",")
+    if not header.startswith("data:"):
+        raise ImageGenerationError("invalid data URL")
+    meta = header[5:]
+    content_type = "application/octet-stream"
+    content_type = meta.split(";", 1)[0] or content_type if ";" in meta else meta or content_type
+    if ";base64" not in header:
+        raise ImageGenerationError("unsupported data URL encoding")
+    encoded_clean = "".join(encoded.split())
+    _enforce_base64_encoded_limit(encoded_clean, max_bytes)
+    try:
+        content = base64.b64decode(encoded_clean, validate=True)
+    except (binascii.Error, TypeError, ValueError) as exc:
+        raise ImageGenerationError("invalid base64 data") from exc
+    _enforce_max_bytes(content, max_bytes)
+    return content, content_type
+
+
+def decode_base64_image(encoded: str, *, max_bytes: int | None = None) -> bytes:
+    _enforce_base64_encoded_limit(encoded, max_bytes)
+    try:
+        content = base64.b64decode(encoded, validate=True)
+    except (binascii.Error, TypeError, ValueError) as exc:
+        raise ImageGenerationError("invalid base64 image data") from exc
+    _enforce_max_bytes(content, max_bytes)
+    return content
+
+
+def maybe_decode_base64_image(encoded: str | None, *, max_bytes: int | None = None) -> bytes | None:
+    if not isinstance(encoded, str):
+        return None
+    raw = encoded.strip()
+    if not raw:
+        return None
+    if raw.startswith("data:"):
+        try:
+            content, _content_type = decode_data_url(raw, max_bytes=max_bytes)
+            return content
+        except ImageGenerationError as exc:
+            if "too large" in str(exc):
+                raise
+            return None
+    if any(ch.isspace() for ch in raw):
+        return None
+    _enforce_base64_encoded_limit(raw, max_bytes)
+    try:
+        content = base64.b64decode(raw, validate=True)
+    except (binascii.Error, TypeError, ValueError):
+        return None
+    _enforce_max_bytes(content, max_bytes)
+    return content
+
+
+def reference_image_data_url(reference_image: ResolvedReferenceImage) -> str:
+    """Encode a normalized reference image into a Model Studio-compatible data URL."""
+
+    content = reference_image.content
+    if content is None:
+        if not reference_image.temp_path:
+            raise ImageGenerationError("invalid reference image data")
+        try:
+            content = Path(reference_image.temp_path).read_bytes()
+        except Exception as exc:
+            raise ImageGenerationError("invalid reference image data") from exc
+    if not content:
+        raise ImageGenerationError("invalid reference image data")
+
+    mime_type = (reference_image.mime_type or "application/octet-stream").split(";", 1)[0].strip().lower()
+    if not mime_type:
+        mime_type = "application/octet-stream"
+    encoded = base64.b64encode(content).decode("ascii")
+    return f"data:{mime_type};base64,{encoded}"
+
+
+def format_from_content_type(content_type: str) -> str | None:
+    if not content_type:
+        return None
+    ctype = content_type.split(";", 1)[0].strip().lower()
+    if ctype == "image/png":
+        return "png"
+    if ctype == "image/jpeg":
+        return "jpg"
+    if ctype == "image/webp":
+        return "webp"
+    return None
+
+
+def format_from_bytes(content: bytes) -> str | None:
+    if not content:
+        return None
+    if content.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "png"
+    if content.startswith(b"\xff\xd8\xff"):
+        return "jpg"
+    if content.startswith(b"RIFF") and content[8:12] == b"WEBP":
+        return "webp"
+    return None
+
+
+def content_type_for_format(fmt: str) -> str:
+    if fmt == "png":
+        return "image/png"
+    if fmt == "jpg":
+        return "image/jpeg"
+    if fmt == "webp":
+        return "image/webp"
+    return "application/octet-stream"
+
+
+def maybe_convert_format(
+    content: bytes,
+    content_type: str,
+    actual_format: str | None,
+    requested_format: str,
+) -> tuple[bytes, str]:
+    if requested_format == actual_format:
+        return content, content_type or content_type_for_format(requested_format)
+    if requested_format not in {"png", "jpg", "webp"}:
+        raise ImageGenerationError(f"unsupported output format: {requested_format}")
+    if actual_format is None:
+        raise ImageGenerationError("invalid image content")
+    if Image is None:
+        raise ImageGenerationError("Pillow is required for image format conversion")
+    try:
+        with Image.open(io.BytesIO(content)) as img:
+            if requested_format == "jpg" and img.mode not in {"RGB"}:
+                img = img.convert("RGB")
+            if requested_format == "png" and img.mode in {"P"}:
+                img = img.convert("RGBA")
+            buf = io.BytesIO()
+            save_format = {
+                "jpg": "JPEG",
+                "png": "PNG",
+                "webp": "WEBP",
+            }[requested_format]
+            img.save(buf, format=save_format)
+            converted = buf.getvalue()
+    except Exception as exc:
+        raise ImageGenerationError(f"failed to convert image: {exc}") from exc
+    return converted, content_type_for_format(requested_format)
+
+
+def validate_and_convert_image_output(
+    content: bytes,
+    content_type: str,
+    requested_format: str,
+    *,
+    max_bytes: int | None = None,
+) -> tuple[bytes, str]:
+    """Validate actual image bytes, enforce size caps, and convert when requested."""
+
+    _enforce_max_bytes(content, max_bytes)
+    output_format = "jpg" if requested_format == "jpeg" else requested_format
+    actual_format = format_from_bytes(content)
+    if actual_format is None:
+        raise ImageGenerationError("invalid image content")
+    actual_content_type = content_type_for_format(actual_format)
+    converted, converted_content_type = maybe_convert_format(
+        content,
+        actual_content_type,
+        actual_format,
+        output_format,
+    )
+    _enforce_max_bytes(converted, max_bytes)
+    return converted, converted_content_type
+
+
+def fetch_image_bytes(
+    url: str,
+    *,
+    timeout: int | float,
+    headers: dict[str, Any] | None = None,
+    cookies: dict[str, Any] | None = None,
+    max_bytes: int | None = None,
+) -> tuple[bytes, str]:
+    current_url = url
+    try:
+        with create_client(timeout=timeout) as client:
+            for _redirect_count in range(DEFAULT_MAX_REDIRECTS + 1):
+                _validate_egress_or_raise(current_url)
+                with client.stream(
+                    "GET",
+                    current_url,
+                    headers=headers,
+                    cookies=cookies,
+                    timeout=timeout,
+                    follow_redirects=False,
+                ) as response:
+                    status = int(getattr(response, "status_code", 0) or 0)
+                    if status in {301, 302, 303, 307, 308}:
+                        location = response.headers.get("location") or response.headers.get("Location")
+                        if not location:
+                            raise ImageGenerationError("image fetch failed: redirect without location")
+                        next_url = _resolve_redirect_url(str(getattr(response, "url", current_url)), str(location))
+                        if not next_url:
+                            raise ImageGenerationError("image fetch failed: invalid redirect")
+                        current_url = next_url
+                        continue
+                    if status >= 400:
+                        raise ImageGenerationError(f"image fetch failed with status {status}")
+
+                    headers_obj = getattr(response, "headers", {}) or {}
+                    _reject_declared_oversize(headers_obj, max_bytes)
+                    content = _read_stream_with_limit(response.iter_bytes(), max_bytes)
+                    content_type = (
+                        headers_obj.get("content-type")
+                        or headers_obj.get("Content-Type")
+                        or "application/octet-stream"
+                    )
+                    return content, content_type.split(";", 1)[0].strip().lower()
+            raise ImageGenerationError("image fetch failed: too many redirects")
+    except ImageGenerationError:
+        raise
+    except Exception as exc:
+        raise ImageGenerationError(f"image fetch failed: {exc}") from exc
+
+
+def _enforce_base64_encoded_limit(encoded: str, max_bytes: int | None) -> None:
+    if max_bytes is None:
+        return
+    try:
+        limit = int(max_bytes)
+    except (TypeError, ValueError):
+        return
+    if limit <= 0:
+        return
+    max_encoded_chars = ((limit + 2) // 3) * 4
+    if len(encoded.strip()) > max_encoded_chars:
+        raise ImageGenerationError("image content too large")
+
+
+def _reject_declared_oversize(headers: Any, max_bytes: int | None) -> None:
+    limit = _positive_byte_limit(max_bytes)
+    if limit is None:
+        return
+    content_length = headers.get("content-length") or headers.get("Content-Length")
+    if content_length is None:
+        return
+    try:
+        declared_size = int(str(content_length).strip())
+    except ValueError:
+        return
+    if declared_size > limit:
+        raise ImageGenerationError("image content too large")
+
+
+def _read_stream_with_limit(chunks: Any, max_bytes: int | None) -> bytes:
+    limit = _positive_byte_limit(max_bytes)
+    total = 0
+    parts: list[bytes] = []
+    for chunk in chunks:
+        if not chunk:
+            continue
+        total += len(chunk)
+        if limit is not None and total > limit:
+            raise ImageGenerationError("image content too large")
+        parts.append(chunk)
+    return b"".join(parts)
+
+
+def _enforce_max_bytes(content: bytes, max_bytes: int | None) -> None:
+    limit = _positive_byte_limit(max_bytes)
+    if limit is not None and len(content) > limit:
+        raise ImageGenerationError("image content too large")
+
+
+def _positive_byte_limit(max_bytes: int | None) -> int | None:
+    if max_bytes is None:
+        return None
+    try:
+        limit = int(max_bytes)
+    except (TypeError, ValueError):
+        return None
+    return limit if limit > 0 else None

--- a/tldw_chatbook/Image_Generation/adapters/modelstudio_image_adapter.py
+++ b/tldw_chatbook/Image_Generation/adapters/modelstudio_image_adapter.py
@@ -393,7 +393,9 @@ class ModelStudioImageAdapter:
         allowlist = list(self._ALLOWED_IMAGE_HOST_ALLOWLIST)
         if base_host:
             allowlist.append(base_host)
-        policy_result = evaluate_url_policy(raw_url)
+        policy_result = evaluate_url_policy(
+            raw_url, allowed_hosts={host.lower() for host in allowlist}
+        )
         if policy_result.allowed:
             return True
         logger.warning(

--- a/tldw_chatbook/Image_Generation/adapters/modelstudio_image_adapter.py
+++ b/tldw_chatbook/Image_Generation/adapters/modelstudio_image_adapter.py
@@ -1,0 +1,443 @@
+"""Alibaba Model Studio image-generation backend adapter."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+from urllib.parse import urlparse
+
+from loguru import logger
+
+from tldw_chatbook.Image_Generation import http_client
+from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest, ImageGenResult
+from tldw_chatbook.Image_Generation.adapters.image_format_utils import (
+    decode_base64_image,
+    decode_data_url,
+    fetch_image_bytes,
+    maybe_decode_base64_image,
+    reference_image_data_url,
+    validate_and_convert_image_output,
+)
+from tldw_chatbook.Image_Generation.capabilities import resolve_reference_image_capability
+from tldw_chatbook.Image_Generation.config import (
+    DEFAULT_MODELSTUDIO_IMAGE_BASE_URL,
+    DEFAULT_MODELSTUDIO_IMAGE_MODEL,
+    DEFAULT_MODELSTUDIO_IMAGE_TIMEOUT_SECONDS,
+    get_image_generation_config,
+)
+from tldw_chatbook.Image_Generation.exceptions import ImageBackendUnavailableError, ImageGenerationError
+from tldw_chatbook.Image_Generation.request_validation import effective_inline_max_bytes
+
+# Import the fetch_json and evaluate_url_policy from http_client
+fetch_json = http_client.fetch_json
+evaluate_url_policy = http_client.evaluate_url_policy
+
+
+class ModelStudioImageAdapter:
+    name = "modelstudio"
+    supported_formats = {"png", "jpg", "webp"}
+    _DONE_STATES = {"success", "succeeded", "done", "finished", "completed"}
+    _FAILED_STATES = {"failed", "error", "cancelled", "canceled"}
+    _REGION_BASE_URLS = {
+        "sg": "https://dashscope-intl.aliyuncs.com/api/v1",
+        "us": "https://dashscope-us.aliyuncs.com/api/v1",
+        "cn": "https://dashscope.aliyuncs.com/api/v1",
+    }
+    _ALLOWED_IMAGE_HOST_ALLOWLIST = ("aliyuncs.com",)
+
+    def __init__(self) -> None:
+        self._config = get_image_generation_config()
+
+    def generate(self, request: ImageGenRequest) -> ImageGenResult:
+        output_format = request.format.lower()
+        if output_format not in self.supported_formats:
+            raise ImageGenerationError(f"unsupported output format: {output_format}")
+
+        has_reference_image = request.reference_image is not None
+        mode = self._resolve_mode(request)
+        if mode == "sync" or has_reference_image:
+            content, content_type = self._generate_sync(request)
+            return self._finalize_result(content, content_type, output_format)
+        if mode == "async":
+            content, content_type = self._generate_async(request)
+            return self._finalize_result(content, content_type, output_format)
+
+        try:
+            content, content_type = self._generate_sync(request)
+        except ImageGenerationError as sync_exc:
+            logger.info("Model Studio auto mode sync path failed; falling back to async")
+            try:
+                content, content_type = self._generate_async(request)
+            except ImageGenerationError as async_exc:
+                logger.warning(
+                    "Model Studio auto mode failed on both paths: sync_error={} async_error={}",
+                    sync_exc,
+                    async_exc,
+                )
+                raise ImageGenerationError("Model Studio generation failed in auto mode") from async_exc
+        return self._finalize_result(content, content_type, output_format)
+
+    def _finalize_result(self, content: bytes, content_type: str, output_format: str) -> ImageGenResult:
+        content, content_type = validate_and_convert_image_output(
+            content,
+            content_type,
+            output_format,
+            max_bytes=self._max_output_bytes(),
+        )
+        return ImageGenResult(content=content, content_type=content_type, bytes_len=len(content))
+
+    def _max_output_bytes(self) -> int:
+        return effective_inline_max_bytes(self._config)
+
+    def _generate_sync(self, request: ImageGenRequest) -> tuple[bytes, str]:
+        api_key = self._resolve_api_key()
+        base_url = self._resolve_base_url()
+        url = self._sync_generation_url(base_url)
+        payload = self._build_sync_payload(request)
+
+        try:
+            data = fetch_json(
+                method="POST",
+                url=url,
+                headers=self._headers(api_key),
+                json=payload,
+                timeout=self._config.modelstudio_image_timeout_seconds or DEFAULT_MODELSTUDIO_IMAGE_TIMEOUT_SECONDS,
+            )
+        except Exception as exc:
+            logger.warning("Model Studio sync request failed: {}", exc)
+            raise ImageGenerationError("Model Studio sync request failed") from exc
+        return self._extract_image_content(data)
+
+    def _generate_async(self, request: ImageGenRequest) -> tuple[bytes, str]:
+        api_key = self._resolve_api_key()
+        base_url = self._resolve_base_url()
+        submit_url = self._async_submit_url(base_url)
+        payload = self._build_async_payload(request)
+
+        try:
+            submit_data = fetch_json(
+                method="POST",
+                url=submit_url,
+                headers=self._headers(api_key),
+                json=payload,
+                timeout=self._config.modelstudio_image_timeout_seconds or DEFAULT_MODELSTUDIO_IMAGE_TIMEOUT_SECONDS,
+            )
+        except Exception as exc:
+            logger.warning("Model Studio async submit failed: {}", exc)
+            raise ImageGenerationError("Model Studio async submit failed") from exc
+
+        task_id = self._extract_task_id(submit_data)
+        if not task_id:
+            raise ImageGenerationError("Model Studio submit response did not include task id")
+
+        timeout_seconds = float(
+            self._config.modelstudio_image_timeout_seconds or DEFAULT_MODELSTUDIO_IMAGE_TIMEOUT_SECONDS
+        )
+        poll_interval = max(0.1, float(self._config.modelstudio_image_poll_interval_seconds or 2))
+        deadline = time.monotonic() + timeout_seconds
+        poll_url = self._task_status_url(base_url, task_id)
+        last_payload: dict[str, Any] = {}
+
+        while time.monotonic() < deadline:
+            try:
+                poll_data = fetch_json(
+                    method="GET",
+                    url=poll_url,
+                    headers=self._headers(api_key),
+                    timeout=self._config.modelstudio_image_timeout_seconds or DEFAULT_MODELSTUDIO_IMAGE_TIMEOUT_SECONDS,
+                )
+            except Exception as exc:
+                logger.warning("Model Studio async polling failed: {}", exc)
+                raise ImageGenerationError("Model Studio async polling failed") from exc
+
+            if isinstance(poll_data, dict):
+                last_payload = poll_data
+            state = self._extract_task_status(poll_data)
+            if state in self._DONE_STATES:
+                return self._extract_image_content(poll_data)
+            if state in self._FAILED_STATES:
+                detail = self._extract_error_message(poll_data) or state
+                raise ImageGenerationError(f"Model Studio task failed: {detail}")
+            time.sleep(poll_interval)
+
+        detail = self._extract_error_message(last_payload) or "timed out waiting for Model Studio image task result"
+        raise ImageGenerationError(detail)
+
+    def _resolve_mode(self, request: ImageGenRequest) -> str:
+        extra_mode = (request.extra_params or {}).get("mode") if isinstance(request.extra_params, dict) else None
+        raw = str(extra_mode or self._config.modelstudio_image_mode or "auto").strip().lower()
+        if raw not in {"sync", "async", "auto"}:
+            return "auto"
+        return raw
+
+    def _resolve_api_key(self) -> str:
+        api_key = (self._config.modelstudio_image_api_key or "").strip()
+        if not api_key:
+            api_key = (os.getenv("DASHSCOPE_API_KEY") or "").strip()
+        if not api_key:
+            api_key = (os.getenv("QWEN_API_KEY") or "").strip()
+        if not api_key:
+            raise ImageBackendUnavailableError("modelstudio image api key is not configured")
+        return api_key
+
+    def _resolve_region(self) -> str:
+        env_region = (os.getenv("MODELSTUDIO_IMAGE_REGION") or "").strip().lower()
+        if env_region in self._REGION_BASE_URLS:
+            return env_region
+        cfg_region = (self._config.modelstudio_image_region or "").strip().lower()
+        if cfg_region in self._REGION_BASE_URLS:
+            return cfg_region
+        return "sg"
+
+    def _resolve_base_url(self) -> str:
+        raw = os.getenv("MODELSTUDIO_IMAGE_BASE_URL") or os.getenv("DASHSCOPE_BASE_URL")
+        if not raw:
+            raw = self._config.modelstudio_image_base_url
+        if not raw:
+            raw = self._REGION_BASE_URLS.get(self._resolve_region(), DEFAULT_MODELSTUDIO_IMAGE_BASE_URL)
+        cleaned = str(raw).strip()
+        if not cleaned:
+            raise ImageBackendUnavailableError("modelstudio image base URL is not configured")
+        if not cleaned.startswith("http://") and not cleaned.startswith("https://"):
+            cleaned = f"https://{cleaned}"
+        return cleaned.rstrip("/")
+
+    @staticmethod
+    def _headers(api_key: str) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    @staticmethod
+    def _sync_generation_url(base_url: str) -> str:
+        suffix = "/services/aigc/multimodal-generation/generation"
+        if base_url.endswith(suffix):
+            return base_url
+        return f"{base_url}{suffix}"
+
+    @staticmethod
+    def _async_submit_url(base_url: str) -> str:
+        suffix = "/services/aigc/text2image/image-synthesis"
+        if base_url.endswith(suffix):
+            return base_url
+        return f"{base_url}{suffix}"
+
+    @staticmethod
+    def _task_status_url(base_url: str, task_id: str) -> str:
+        base = base_url.rstrip("/")
+        return f"{base}/tasks/{task_id}"
+
+    def _resolve_model(self, request: ImageGenRequest) -> str:
+        return (
+            request.model
+            or os.getenv("MODELSTUDIO_IMAGE_MODEL")
+            or self._config.modelstudio_image_default_model
+            or DEFAULT_MODELSTUDIO_IMAGE_MODEL
+        )
+
+    @staticmethod
+    def _apply_extra_payload_fields(payload: dict[str, Any], extra_params: Any) -> None:
+        if not isinstance(extra_params, dict):
+            return
+        for key, value in extra_params.items():
+            if key in {"prompt", "negative_prompt", "mode"}:
+                continue
+            payload[key] = value
+
+    def _build_sync_payload(self, request: ImageGenRequest) -> dict[str, Any]:
+        prompt = request.prompt.strip()
+        if request.negative_prompt:
+            prompt = f"{prompt}\n\nNegative prompt: {request.negative_prompt.strip()}"
+
+        model = self._resolve_model(request)
+        if request.reference_image is not None:
+            capability = resolve_reference_image_capability("modelstudio", model, config=self._config)
+            if not capability.supported:
+                raise ImageGenerationError(f"Model Studio reference images have unsupported model: {model}")
+
+        content: list[dict[str, Any]] = []
+        if request.reference_image is not None:
+            content.append({"image": reference_image_data_url(request.reference_image)})
+        content.append({"text": prompt})
+
+        payload: dict[str, Any] = {
+            "model": model,
+            "input": {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": content,
+                    }
+                ]
+            },
+        }
+        parameters: dict[str, Any] = {}
+        if request.width and request.height:
+            parameters["size"] = f"{request.width}*{request.height}"
+        if request.seed is not None:
+            parameters["seed"] = request.seed
+        if request.steps is not None:
+            parameters["steps"] = request.steps
+        if request.cfg_scale is not None:
+            parameters["guidance_scale"] = request.cfg_scale
+        if request.sampler:
+            parameters["sampler"] = request.sampler
+        if parameters:
+            payload["parameters"] = parameters
+
+        self._apply_extra_payload_fields(payload, request.extra_params or {})
+        return payload
+
+    def _build_async_payload(self, request: ImageGenRequest) -> dict[str, Any]:
+        if request.reference_image is not None:
+            raise ImageGenerationError("Model Studio reference images are only supported in sync mode")
+
+        prompt = request.prompt.strip()
+        if request.negative_prompt:
+            prompt = f"{prompt}\n\nNegative prompt: {request.negative_prompt.strip()}"
+
+        payload: dict[str, Any] = {
+            "model": self._resolve_model(request),
+            "input": {"prompt": prompt},
+        }
+
+        parameters: dict[str, Any] = {}
+        if request.width is not None:
+            parameters["width"] = request.width
+        if request.height is not None:
+            parameters["height"] = request.height
+        if request.seed is not None:
+            parameters["seed"] = request.seed
+        if request.steps is not None:
+            parameters["steps"] = request.steps
+        if request.cfg_scale is not None:
+            parameters["guidance_scale"] = request.cfg_scale
+        if request.sampler:
+            parameters["sampler"] = request.sampler
+        if parameters:
+            payload["parameters"] = parameters
+
+        self._apply_extra_payload_fields(payload, request.extra_params or {})
+        return payload
+
+    def _extract_image_content(self, data: Any) -> tuple[bytes, str]:
+        candidate = self._extract_from_node(data)
+        if candidate:
+            return candidate
+        raise ImageGenerationError("Model Studio did not return image content")
+
+    def _extract_from_node(self, node: Any) -> tuple[bytes, str] | None:
+        if isinstance(node, dict):
+            for key in ("b64_json", "image_base64", "base64", "image_b64"):
+                value = node.get(key)
+                if isinstance(value, str) and value.strip():
+                    return decode_base64_image(value.strip(), max_bytes=self._max_output_bytes()), "image/png"
+
+            for key in ("image_url", "url", "image"):
+                if key in node:
+                    extracted = self._extract_from_link_value(node.get(key))
+                    if extracted:
+                        return extracted
+
+            for key in ("images", "data", "choices", "message", "content", "output", "result", "results"):
+                if key not in node:
+                    continue
+                extracted = self._extract_from_node(node.get(key))
+                if extracted:
+                    return extracted
+            return None
+
+        if isinstance(node, list):
+            for item in node:
+                extracted = self._extract_from_node(item)
+                if extracted:
+                    return extracted
+            return None
+
+        return self._extract_from_link_value(node)
+
+    def _extract_from_link_value(self, value: Any) -> tuple[bytes, str] | None:
+        if isinstance(value, dict):
+            for key in ("url", "image_url", "b64_json", "base64", "image"):
+                if key in value:
+                    extracted = self._extract_from_link_value(value.get(key))
+                    if extracted:
+                        return extracted
+            return None
+
+        if not isinstance(value, str):
+            return None
+        raw = value.strip()
+        if not raw:
+            return None
+        if raw.startswith("data:"):
+            return decode_data_url(raw, max_bytes=self._max_output_bytes())
+        if raw.startswith("http://") or raw.startswith("https://"):
+            if not self._is_allowed_remote_image_url(raw):
+                raise ImageGenerationError("Model Studio returned unsupported image URL host")
+            return fetch_image_bytes(
+                raw,
+                timeout=self._config.modelstudio_image_timeout_seconds or DEFAULT_MODELSTUDIO_IMAGE_TIMEOUT_SECONDS,
+                max_bytes=self._max_output_bytes(),
+            )
+        decoded = maybe_decode_base64_image(raw, max_bytes=self._max_output_bytes())
+        if decoded is not None:
+            return decoded, "image/png"
+        return None
+
+    def _is_allowed_remote_image_url(self, raw_url: str) -> bool:
+        base_host = (urlparse(self._resolve_base_url()).hostname or "").strip().lower()
+        allowlist = list(self._ALLOWED_IMAGE_HOST_ALLOWLIST)
+        if base_host:
+            allowlist.append(base_host)
+        policy_result = evaluate_url_policy(raw_url)
+        if policy_result.allowed:
+            return True
+        logger.warning(
+            "Model Studio blocked remote image URL fetch url={} reason={}",
+            raw_url,
+            policy_result.reason or "policy_denied",
+        )
+        return False
+
+    def _extract_task_id(self, data: Any) -> str | None:
+        if isinstance(data, dict):
+            for key in ("task_id", "taskId", "id"):
+                value = data.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+            for key in ("output", "data", "result"):
+                nested = data.get(key)
+                task_id = self._extract_task_id(nested)
+                if task_id:
+                    return task_id
+        return None
+
+    def _extract_task_status(self, data: Any) -> str:
+        if isinstance(data, dict):
+            for key in ("task_status", "status", "state", "task_state"):
+                value = data.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip().lower()
+            for key in ("output", "data", "result"):
+                nested = data.get(key)
+                nested_state = self._extract_task_status(nested)
+                if nested_state:
+                    return nested_state
+        return ""
+
+    def _extract_error_message(self, data: Any) -> str | None:
+        if isinstance(data, dict):
+            for key in ("message", "error", "error_message", "detail"):
+                value = data.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+            for key in ("output", "data", "result"):
+                nested = data.get(key)
+                nested_message = self._extract_error_message(nested)
+                if nested_message:
+                    return nested_message
+        return None

--- a/tldw_chatbook/Image_Generation/adapters/novita_image_adapter.py
+++ b/tldw_chatbook/Image_Generation/adapters/novita_image_adapter.py
@@ -1,0 +1,273 @@
+"""Novita image-generation backend adapter."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+from tldw_chatbook.Image_Generation.http_client import fetch_json
+from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest, ImageGenResult
+from tldw_chatbook.Image_Generation.adapters.image_format_utils import (
+    decode_base64_image,
+    decode_data_url,
+    fetch_image_bytes,
+    maybe_decode_base64_image,
+    validate_and_convert_image_output,
+)
+from tldw_chatbook.Image_Generation.config import (
+    DEFAULT_NOVITA_IMAGE_BASE_URL,
+    DEFAULT_NOVITA_IMAGE_MODEL,
+    DEFAULT_NOVITA_IMAGE_TIMEOUT_SECONDS,
+    get_image_generation_config,
+)
+from tldw_chatbook.Image_Generation.exceptions import ImageBackendUnavailableError, ImageGenerationError
+from tldw_chatbook.Image_Generation.request_validation import effective_inline_max_bytes
+
+
+class NovitaImageAdapter:
+    name = "novita"
+    supported_formats = {"png", "jpg", "webp"}
+    _DONE_STATES = {"success", "succeeded", "done", "finished", "completed"}
+    _FAILED_STATES = {"failed", "error", "cancelled", "canceled"}
+    _PENDING_STATES = {"pending", "queued", "running", "processing", "in_progress"}
+
+    def __init__(self) -> None:
+        self._config = get_image_generation_config()
+
+    def generate(self, request: ImageGenRequest) -> ImageGenResult:
+        output_format = request.format.lower()
+        if output_format not in self.supported_formats:
+            raise ImageGenerationError(f"unsupported output format: {output_format}")
+
+        api_key = self._resolve_api_key()
+        base_url = self._resolve_base_url()
+
+        submit_url = f"{base_url}/v3/async/txt2img"
+        task_id = self._submit_task(submit_url, api_key, request)
+        result_payload = self._poll_task_result(base_url, api_key, task_id)
+
+        content, content_type = self._extract_image_content(result_payload)
+        content, content_type = validate_and_convert_image_output(
+            content,
+            content_type,
+            output_format,
+            max_bytes=self._max_output_bytes(),
+        )
+        return ImageGenResult(content=content, content_type=content_type, bytes_len=len(content))
+
+    def _max_output_bytes(self) -> int:
+        return effective_inline_max_bytes(self._config)
+
+    def _resolve_api_key(self) -> str:
+        api_key = (self._config.novita_image_api_key or "").strip()
+        if not api_key:
+            api_key = (os.getenv("NOVITA_API_KEY") or "").strip()
+        if not api_key:
+            raise ImageBackendUnavailableError("novita image api key is not configured")
+        return api_key
+
+    def _resolve_base_url(self) -> str:
+        raw = (
+            os.getenv("NOVITA_IMAGE_BASE_URL")
+            or self._config.novita_image_base_url
+            or DEFAULT_NOVITA_IMAGE_BASE_URL
+        )
+        cleaned = str(raw).strip()
+        if not cleaned:
+            raise ImageBackendUnavailableError("novita image base URL is not configured")
+        if not cleaned.startswith("http://") and not cleaned.startswith("https://"):
+            cleaned = f"https://{cleaned}"
+        return cleaned.rstrip("/")
+
+    @staticmethod
+    def _headers(api_key: str) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _submit_task(self, submit_url: str, api_key: str, request: ImageGenRequest) -> str:
+        payload = self._build_submit_payload(request)
+        try:
+            data = fetch_json(
+                method="POST",
+                url=submit_url,
+                headers=self._headers(api_key),
+                json=payload,
+                timeout=self._config.novita_image_timeout_seconds or DEFAULT_NOVITA_IMAGE_TIMEOUT_SECONDS,
+            )
+        except Exception as exc:
+            raise ImageGenerationError(f"Novita submit request failed: {exc}") from exc
+
+        task_id = self._extract_task_id(data)
+        if not task_id:
+            raise ImageGenerationError("Novita submit response did not include task id")
+        return task_id
+
+    def _poll_task_result(self, base_url: str, api_key: str, task_id: str) -> dict[str, Any]:
+        timeout_seconds = float(
+            self._config.novita_image_timeout_seconds or DEFAULT_NOVITA_IMAGE_TIMEOUT_SECONDS
+        )
+        poll_interval = max(1.0, float(self._config.novita_image_poll_interval_seconds or 2))
+        deadline = time.monotonic() + timeout_seconds
+        poll_url = f"{base_url}/v3/async/task-result"
+
+        last_payload: dict[str, Any] = {}
+        while time.monotonic() < deadline:
+            try:
+                data = fetch_json(
+                    method="GET",
+                    url=poll_url,
+                    headers=self._headers(api_key),
+                    params={"task_id": task_id},
+                    timeout=self._config.novita_image_timeout_seconds or DEFAULT_NOVITA_IMAGE_TIMEOUT_SECONDS,
+                )
+            except Exception as exc:
+                raise ImageGenerationError(f"Novita task polling failed: {exc}") from exc
+
+            if isinstance(data, dict):
+                last_payload = data
+            state = self._extract_state(data)
+            if state in self._DONE_STATES:
+                if not isinstance(data, dict):
+                    raise ImageGenerationError("Novita task-result response was not JSON")
+                return data
+            if state in self._FAILED_STATES:
+                detail = self._extract_error_message(data) or state
+                raise ImageGenerationError(f"Novita task failed: {detail}")
+            time.sleep(poll_interval)
+
+        detail = self._extract_error_message(last_payload) or "timed out waiting for Novita image task result"
+        raise ImageGenerationError(detail)
+
+    def _build_submit_payload(self, request: ImageGenRequest) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "model_name": (
+                request.model
+                or os.getenv("NOVITA_IMAGE_MODEL")
+                or self._config.novita_image_default_model
+                or DEFAULT_NOVITA_IMAGE_MODEL
+            ),
+            "prompt": request.prompt,
+        }
+        if request.negative_prompt:
+            payload["negative_prompt"] = request.negative_prompt
+        if request.width is not None:
+            payload["width"] = request.width
+        if request.height is not None:
+            payload["height"] = request.height
+        if request.steps is not None:
+            payload["steps"] = request.steps
+        if request.cfg_scale is not None:
+            payload["guidance_scale"] = request.cfg_scale
+        if request.seed is not None:
+            payload["seed"] = request.seed
+        if request.sampler:
+            payload["sampler_name"] = request.sampler
+
+        extra_params = request.extra_params or {}
+        if isinstance(extra_params, dict):
+            for key, value in extra_params.items():
+                if key in {"prompt", "negative_prompt"}:
+                    continue
+                payload[key] = value
+        return payload
+
+    def _extract_task_id(self, data: Any) -> str | None:
+        if isinstance(data, dict):
+            for key in ("task_id", "taskId", "id"):
+                value = data.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+            for key in ("data", "result", "output"):
+                nested = data.get(key)
+                task_id = self._extract_task_id(nested)
+                if task_id:
+                    return task_id
+        return None
+
+    def _extract_state(self, data: Any) -> str:
+        if isinstance(data, dict):
+            for key in ("status", "task_status", "state", "task_state"):
+                value = data.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip().lower()
+            for key in ("data", "result", "output"):
+                nested = data.get(key)
+                nested_state = self._extract_state(nested)
+                if nested_state:
+                    return nested_state
+        return ""
+
+    def _extract_error_message(self, data: Any) -> str | None:
+        if isinstance(data, dict):
+            for key in ("message", "error", "error_message", "detail"):
+                value = data.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+            for key in ("data", "result", "output"):
+                nested = data.get(key)
+                nested_msg = self._extract_error_message(nested)
+                if nested_msg:
+                    return nested_msg
+        return None
+
+    def _extract_image_content(self, data: Any) -> tuple[bytes, str]:
+        candidate = self._extract_from_node(data)
+        if candidate:
+            return candidate
+        raise ImageGenerationError("Novita did not return image content")
+
+    def _extract_from_node(self, node: Any) -> tuple[bytes, str] | None:
+        if isinstance(node, dict):
+            for key in ("b64_json", "image_base64", "base64", "image_b64"):
+                value = node.get(key)
+                if isinstance(value, str) and value.strip():
+                    return decode_base64_image(value.strip(), max_bytes=self._max_output_bytes()), "image/png"
+            for key in ("image_url", "url", "image"):
+                if key in node:
+                    extracted = self._extract_from_link_value(node.get(key))
+                    if extracted:
+                        return extracted
+            for key in ("images", "data", "output", "result"):
+                if key not in node:
+                    continue
+                extracted = self._extract_from_node(node.get(key))
+                if extracted:
+                    return extracted
+            return None
+        if isinstance(node, list):
+            for item in node:
+                extracted = self._extract_from_node(item)
+                if extracted:
+                    return extracted
+            return None
+        return self._extract_from_link_value(node)
+
+    def _extract_from_link_value(self, value: Any) -> tuple[bytes, str] | None:
+        if isinstance(value, dict):
+            for key in ("url", "image_url", "b64_json", "base64", "image"):
+                if key in value:
+                    extracted = self._extract_from_link_value(value.get(key))
+                    if extracted:
+                        return extracted
+            return None
+
+        if not isinstance(value, str):
+            return None
+        raw = value.strip()
+        if not raw:
+            return None
+        if raw.startswith("data:"):
+            return decode_data_url(raw, max_bytes=self._max_output_bytes())
+        if raw.startswith("http://") or raw.startswith("https://"):
+            return fetch_image_bytes(
+                raw,
+                timeout=self._config.novita_image_timeout_seconds or DEFAULT_NOVITA_IMAGE_TIMEOUT_SECONDS,
+                max_bytes=self._max_output_bytes(),
+            )
+        decoded = maybe_decode_base64_image(raw, max_bytes=self._max_output_bytes())
+        if decoded is not None:
+            return decoded, "image/png"
+        return None

--- a/tldw_chatbook/Image_Generation/adapters/openrouter_image_adapter.py
+++ b/tldw_chatbook/Image_Generation/adapters/openrouter_image_adapter.py
@@ -1,0 +1,204 @@
+"""OpenRouter image-generation backend adapter."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from tldw_chatbook.Image_Generation.http_client import fetch_json
+from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest, ImageGenResult
+from tldw_chatbook.Image_Generation.adapters.image_format_utils import (
+    content_type_for_format,
+    decode_base64_image,
+    decode_data_url,
+    fetch_image_bytes,
+    maybe_decode_base64_image,
+    validate_and_convert_image_output,
+)
+from tldw_chatbook.Image_Generation.config import (
+    DEFAULT_OPENROUTER_IMAGE_BASE_URL,
+    DEFAULT_OPENROUTER_IMAGE_MODEL,
+    DEFAULT_OPENROUTER_IMAGE_TIMEOUT_SECONDS,
+    get_image_generation_config,
+)
+from tldw_chatbook.Image_Generation.exceptions import ImageBackendUnavailableError, ImageGenerationError
+from tldw_chatbook.Image_Generation.request_validation import effective_inline_max_bytes
+
+
+class OpenRouterImageAdapter:
+    name = "openrouter"
+    supported_formats = {"png", "jpg", "webp"}
+
+    def __init__(self) -> None:
+        self._config = get_image_generation_config()
+
+    def generate(self, request: ImageGenRequest) -> ImageGenResult:
+        output_format = request.format.lower()
+        if output_format not in self.supported_formats:
+            raise ImageGenerationError(f"unsupported output format: {output_format}")
+
+        api_key = self._resolve_api_key()
+        base_url = self._resolve_base_url()
+        url = self._chat_completions_url(base_url)
+        payload = self._build_payload(request, output_format)
+
+        try:
+            data = fetch_json(
+                method="POST",
+                url=url,
+                headers=self._headers(api_key),
+                json=payload,
+                timeout=self._config.openrouter_image_timeout_seconds or DEFAULT_OPENROUTER_IMAGE_TIMEOUT_SECONDS,
+            )
+        except Exception as exc:
+            raise ImageGenerationError(f"OpenRouter request failed: {exc}") from exc
+
+        content, content_type = self._extract_image_content(data)
+        content, content_type = validate_and_convert_image_output(
+            content,
+            content_type,
+            output_format,
+            max_bytes=self._max_output_bytes(),
+        )
+        return ImageGenResult(content=content, content_type=content_type, bytes_len=len(content))
+
+    def _max_output_bytes(self) -> int:
+        return effective_inline_max_bytes(self._config)
+
+    def _resolve_api_key(self) -> str:
+        api_key = (self._config.openrouter_image_api_key or "").strip()
+        if not api_key:
+            api_key = (os.getenv("OPENROUTER_API_KEY") or "").strip()
+        if not api_key:
+            raise ImageBackendUnavailableError("openrouter image api key is not configured")
+        return api_key
+
+    def _resolve_base_url(self) -> str:
+        raw = (
+            os.getenv("OPENROUTER_BASE_URL")
+            or self._config.openrouter_image_base_url
+            or DEFAULT_OPENROUTER_IMAGE_BASE_URL
+        )
+        cleaned = str(raw).strip()
+        if not cleaned:
+            raise ImageBackendUnavailableError("openrouter image base URL is not configured")
+        if not cleaned.startswith("http://") and not cleaned.startswith("https://"):
+            cleaned = f"https://{cleaned}"
+        return cleaned.rstrip("/")
+
+    @staticmethod
+    def _chat_completions_url(base_url: str) -> str:
+        lower = base_url.lower()
+        if lower.endswith("/v1"):
+            return f"{base_url}/chat/completions"
+        if lower.endswith("/chat/completions"):
+            return base_url
+        return f"{base_url}/v1/chat/completions"
+
+    def _headers(self, api_key: str) -> dict[str, str]:
+        site_url = os.getenv("OPENROUTER_SITE_URL") or "https://openrouter.ai"
+        site_name = os.getenv("OPENROUTER_SITE_NAME") or "TLDW-API"
+        return {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": site_url,
+            "X-Title": site_name,
+        }
+
+    def _build_payload(self, request: ImageGenRequest, output_format: str) -> dict[str, Any]:
+        prompt = request.prompt.strip()
+        if request.negative_prompt:
+            prompt = f"{prompt}\n\nNegative prompt: {request.negative_prompt.strip()}"
+        payload: dict[str, Any] = {
+            "model": (
+                request.model
+                or os.getenv("OPENROUTER_IMAGE_MODEL")
+                or self._config.openrouter_image_default_model
+                or DEFAULT_OPENROUTER_IMAGE_MODEL
+            ),
+            "messages": [{"role": "user", "content": prompt}],
+            "modalities": ["image", "text"],
+            "stream": False,
+            "image_format": {"type": content_type_for_format(output_format)},
+        }
+        if request.width and request.height:
+            payload["size"] = f"{request.width}x{request.height}"
+        if request.seed is not None:
+            payload["seed"] = request.seed
+        if request.steps is not None:
+            payload["steps"] = request.steps
+        if request.cfg_scale is not None:
+            payload["guidance_scale"] = request.cfg_scale
+        if request.sampler:
+            payload["sampler"] = request.sampler
+
+        extra_params = request.extra_params or {}
+        if isinstance(extra_params, dict):
+            for key, value in extra_params.items():
+                if key in {"messages", "prompt", "negative_prompt"}:
+                    continue
+                payload[key] = value
+        return payload
+
+    def _extract_image_content(self, data: Any) -> tuple[bytes, str]:
+        candidate = self._extract_from_node(data)
+        if candidate:
+            return candidate
+        raise ImageGenerationError("OpenRouter did not return image content")
+
+    def _extract_from_node(self, node: Any) -> tuple[bytes, str] | None:
+        if isinstance(node, dict):
+            for key in ("b64_json", "image_base64", "base64", "image_b64"):
+                value = node.get(key)
+                if isinstance(value, str) and value.strip():
+                    return decode_base64_image(value.strip(), max_bytes=self._max_output_bytes()), "image/png"
+
+            for key in ("image_url", "url", "image"):
+                if key in node:
+                    extracted = self._extract_from_link_value(node.get(key))
+                    if extracted:
+                        return extracted
+
+            for key in ("images", "data", "choices", "message", "content", "output", "result"):
+                if key not in node:
+                    continue
+                extracted = self._extract_from_node(node.get(key))
+                if extracted:
+                    return extracted
+            return None
+
+        if isinstance(node, list):
+            for item in node:
+                extracted = self._extract_from_node(item)
+                if extracted:
+                    return extracted
+            return None
+
+        return self._extract_from_link_value(node)
+
+    def _extract_from_link_value(self, value: Any) -> tuple[bytes, str] | None:
+        if isinstance(value, dict):
+            for key in ("url", "image_url", "b64_json", "base64", "image"):
+                if key in value:
+                    extracted = self._extract_from_link_value(value.get(key))
+                    if extracted:
+                        return extracted
+            return None
+
+        if not isinstance(value, str):
+            return None
+        raw = value.strip()
+        if not raw:
+            return None
+        if raw.startswith("data:"):
+            return decode_data_url(raw, max_bytes=self._max_output_bytes())
+        if raw.startswith("http://") or raw.startswith("https://"):
+            return fetch_image_bytes(
+                raw,
+                timeout=self._config.openrouter_image_timeout_seconds or DEFAULT_OPENROUTER_IMAGE_TIMEOUT_SECONDS,
+                max_bytes=self._max_output_bytes(),
+            )
+        decoded = maybe_decode_base64_image(raw, max_bytes=self._max_output_bytes())
+        if decoded is not None:
+            return decoded, "image/png"
+        return None

--- a/tldw_chatbook/Image_Generation/adapters/stable_diffusion_cpp_adapter.py
+++ b/tldw_chatbook/Image_Generation/adapters/stable_diffusion_cpp_adapter.py
@@ -1,0 +1,217 @@
+"""stable-diffusion.cpp backend adapter."""
+
+from __future__ import annotations
+
+import subprocess  # nosec B404 # Required for configured local stable-diffusion.cpp binary invocation.
+import tempfile
+from pathlib import Path
+
+from loguru import logger
+
+from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest, ImageGenResult
+from tldw_chatbook.Image_Generation.adapters.image_format_utils import validate_and_convert_image_output
+from tldw_chatbook.Image_Generation.config import (
+    DEFAULT_SD_CPP_CFG_SCALE,
+    DEFAULT_SD_CPP_SAMPLER,
+    DEFAULT_SD_CPP_STEPS,
+    get_image_generation_config,
+)
+from tldw_chatbook.Image_Generation.exceptions import ImageBackendUnavailableError, ImageGenerationError
+from tldw_chatbook.Image_Generation.request_validation import effective_inline_max_bytes
+
+
+class StableDiffusionCppAdapter:
+    name = "stable_diffusion_cpp"
+    supported_formats = {"png", "jpg", "webp"}
+
+    def __init__(self) -> None:
+        self._config = get_image_generation_config()
+
+    def generate(self, request: ImageGenRequest) -> ImageGenResult:
+        binary_path = self._resolve_path(self._config.sd_cpp_binary_path, "sd_cpp_binary_path")
+        if self._config.sd_cpp_diffusion_model_path:
+            diffusion_model_path = request.model or self._config.sd_cpp_diffusion_model_path
+            resolved_model_path = self._resolve_path(diffusion_model_path, "sd_cpp_diffusion_model_path")
+            model_flag = "--diffusion-model"
+        else:
+            model_path = request.model or self._config.sd_cpp_model_path
+            resolved_model_path = self._resolve_path(model_path, "sd_cpp_model_path")
+            model_flag = "--model"
+        vae_path = self._resolve_optional_path(self._config.sd_cpp_vae_path)
+        lora_paths = [
+            Path(path).expanduser()
+            for path in self._config.sd_cpp_lora_paths
+            if str(path).strip()
+        ]
+        output_format = request.format.lower()
+        if output_format not in self.supported_formats:
+            raise ImageGenerationError(f"unsupported output format: {output_format}")
+
+        width = request.width if request.width is not None else 512
+        height = request.height if request.height is not None else 512
+        steps = request.steps if request.steps is not None else (self._config.sd_cpp_default_steps or DEFAULT_SD_CPP_STEPS)
+        cfg_scale = request.cfg_scale if request.cfg_scale is not None else (
+            self._config.sd_cpp_default_cfg_scale or DEFAULT_SD_CPP_CFG_SCALE
+        )
+        sampler = request.sampler or self._config.sd_cpp_default_sampler or DEFAULT_SD_CPP_SAMPLER
+        extra_params = dict(request.extra_params or {})
+        if "llm" not in extra_params and self._config.sd_cpp_llm_path:
+            llm_path = self._resolve_path(self._config.sd_cpp_llm_path, "sd_cpp_llm_path")
+            extra_params["llm"] = str(llm_path)
+
+        with tempfile.TemporaryDirectory(prefix="sd_cpp_") as tmp_dir:
+            output_path = Path(tmp_dir) / f"image.{output_format}"
+            cmd = self._build_command(
+                binary_path=binary_path,
+                model_flag=model_flag,
+                model_path=resolved_model_path,
+                output_path=output_path,
+                prompt=request.prompt,
+                negative_prompt=request.negative_prompt,
+                width=width,
+                height=height,
+                steps=steps,
+                cfg_scale=cfg_scale,
+                seed=request.seed,
+                sampler=sampler,
+                vae_path=vae_path,
+                lora_paths=lora_paths,
+                extra_params=extra_params,
+                device=self._config.sd_cpp_device,
+            )
+            logger.info(
+                "stable-diffusion.cpp: running backend binary={} model_flag={} width={} height={} steps={} format={} extra_keys={}",
+                binary_path.name,
+                model_flag,
+                width,
+                height,
+                steps,
+                output_format,
+                sorted(str(key) for key in extra_params),
+            )
+            try:
+                result = subprocess.run(  # nosec B603 # cmd is an argv list for a configured local binary; shell=False.
+                    cmd,
+                    cwd=str(binary_path.parent),
+                    capture_output=True,
+                    text=True,
+                    timeout=self._config.sd_cpp_timeout_seconds,
+                )
+            except subprocess.TimeoutExpired as exc:
+                raise ImageGenerationError("stable-diffusion.cpp timed out") from exc
+
+            if result.returncode != 0:
+                logger.warning(
+                    "stable-diffusion.cpp failed exit_code={} stderr_lines={}",
+                    result.returncode,
+                    len((result.stderr or "").splitlines()),
+                )
+                raise ImageGenerationError("stable-diffusion.cpp failed")
+
+            if not output_path.exists():
+                raise ImageGenerationError("stable-diffusion.cpp did not produce output")
+
+            content = output_path.read_bytes()
+
+        content_type = _content_type_for_format(output_format)
+        content, content_type = validate_and_convert_image_output(
+            content,
+            content_type,
+            output_format,
+            max_bytes=effective_inline_max_bytes(self._config),
+        )
+        return ImageGenResult(content=content, content_type=content_type, bytes_len=len(content))
+
+    @staticmethod
+    def _resolve_path(raw_path: str | None, label: str) -> Path:
+        if not raw_path:
+            raise ImageBackendUnavailableError(f"{label} is not configured")
+        path = Path(raw_path).expanduser()
+        if not path.exists():
+            raise ImageBackendUnavailableError(f"{label} does not exist: {path}")
+        return path
+
+    @staticmethod
+    def _resolve_optional_path(raw_path: str | None) -> Path | None:
+        if not raw_path:
+            return None
+        path = Path(raw_path).expanduser()
+        return path if path.exists() else None
+
+    @staticmethod
+    def _build_command(
+        *,
+        binary_path: Path,
+        model_flag: str,
+        model_path: Path,
+        output_path: Path,
+        prompt: str,
+        negative_prompt: str | None,
+        width: int,
+        height: int,
+        steps: int,
+        cfg_scale: float,
+        seed: int | None,
+        sampler: str,
+        vae_path: Path | None,
+        lora_paths: list[Path],
+        extra_params: dict,
+        device: str | None,
+    ) -> list[str]:
+        cmd = [str(binary_path), model_flag, str(model_path), "-o", str(output_path), "-p", prompt]
+        if negative_prompt:
+            cmd += ["-n", negative_prompt]
+        cmd += ["-W", str(width), "-H", str(height)]
+        cmd += ["--steps", str(steps)]
+        cmd += ["--cfg-scale", str(cfg_scale)]
+        if seed is not None:
+            cmd += ["--seed", str(seed)]
+        if sampler:
+            cmd += ["--sampling-method", sampler]
+        if vae_path:
+            cmd += ["--vae", str(vae_path)]
+        for lora in lora_paths:
+            cmd += ["--lora-model-dir", str(lora)]
+        if device:
+            cmd += ["--device", device]
+
+        if isinstance(extra_params, dict):
+            reserved = {
+                "prompt",
+                "negative_prompt",
+                "width",
+                "height",
+                "steps",
+                "cfg_scale",
+                "seed",
+                "sampler",
+                "model",
+                "format",
+            }
+            for key, value in extra_params.items():
+                if key in reserved:
+                    continue
+                if key == "cli_args" and isinstance(value, list):
+                    cmd.extend([str(v) for v in value])
+                    continue
+                flag = f"--{str(key).replace('_', '-')}"
+                if isinstance(value, bool):
+                    if value:
+                        cmd.append(flag)
+                    continue
+                if isinstance(value, (list, tuple)):
+                    for item in value:
+                        cmd.extend([flag, str(item)])
+                    continue
+                cmd.extend([flag, str(value)])
+        return cmd
+
+
+def _content_type_for_format(fmt: str) -> str:
+    if fmt == "png":
+        return "image/png"
+    if fmt == "jpg":
+        return "image/jpeg"
+    if fmt == "webp":
+        return "image/webp"
+    return "application/octet-stream"

--- a/tldw_chatbook/Image_Generation/adapters/swarmui_adapter.py
+++ b/tldw_chatbook/Image_Generation/adapters/swarmui_adapter.py
@@ -1,0 +1,227 @@
+"""SwarmUI backend adapter."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import quote, urlparse
+
+from loguru import logger
+
+from tldw_chatbook.Image_Generation.http_client import fetch_json
+from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest, ImageGenResult
+from tldw_chatbook.Image_Generation.adapters.image_format_utils import (
+    decode_data_url as decode_shared_data_url,
+    fetch_image_bytes as fetch_shared_image_bytes,
+    validate_and_convert_image_output,
+)
+from tldw_chatbook.Image_Generation.config import (
+    DEFAULT_SWARMUI_BASE_URL,
+    DEFAULT_SWARMUI_TIMEOUT_SECONDS,
+    get_image_generation_config,
+)
+from tldw_chatbook.Image_Generation.exceptions import ImageBackendUnavailableError, ImageGenerationError
+from tldw_chatbook.Image_Generation.request_validation import effective_inline_max_bytes
+
+
+class SwarmUIAdapter:
+    name = "swarmui"
+    supported_formats = {"png", "jpg"}
+
+    def __init__(self) -> None:
+        self._config = get_image_generation_config()
+        self._session_id: str | None = None
+
+    def generate(self, request: ImageGenRequest) -> ImageGenResult:
+        output_format = request.format.lower()
+        if output_format not in self.supported_formats:
+            raise ImageGenerationError(f"unsupported output format: {output_format}")
+
+        base_url = self._resolve_base_url()
+        session_id = self._ensure_session(base_url)
+
+        payload = self._build_payload(request, session_id)
+        generate_url = f"{base_url}/API/GenerateText2Image"
+        data = self._post_generate(generate_url, payload)
+
+        image_ref = self._extract_first_image_ref(data)
+        if not image_ref:
+            raise ImageGenerationError("SwarmUI did not return any images")
+
+        if image_ref.startswith("data:"):
+            content, content_type = decode_shared_data_url(image_ref, max_bytes=self._max_output_bytes())
+            content, content_type = validate_and_convert_image_output(
+                content,
+                content_type,
+                output_format,
+                max_bytes=self._max_output_bytes(),
+            )
+            return ImageGenResult(content=content, content_type=content_type, bytes_len=len(content))
+
+        image_url = self._resolve_image_url(base_url, image_ref)
+        content, content_type = self._fetch_image_bytes(image_url)
+        content, content_type = validate_and_convert_image_output(
+            content,
+            content_type,
+            output_format,
+            max_bytes=self._max_output_bytes(),
+        )
+        return ImageGenResult(content=content, content_type=content_type, bytes_len=len(content))
+
+    def _resolve_base_url(self) -> str:
+        raw = (self._config.swarmui_base_url or DEFAULT_SWARMUI_BASE_URL or "").strip()
+        if not raw:
+            raise ImageBackendUnavailableError("swarmui_base_url is not configured")
+        if not raw.startswith("http://") and not raw.startswith("https://"):
+            raw = f"http://{raw}"
+        return raw.rstrip("/")
+
+    def _cookies(self) -> dict[str, str] | None:
+        token = (self._config.swarmui_swarm_token or "").strip()
+        if not token:
+            return None
+        return {"swarm_token": token}
+
+    def _max_output_bytes(self) -> int:
+        return effective_inline_max_bytes(self._config)
+
+    def _ensure_session(self, base_url: str) -> str:
+        if self._session_id:
+            return self._session_id
+        self._session_id = self._request_session_id(base_url)
+        return self._session_id
+
+    def _request_session_id(self, base_url: str) -> str:
+        url = f"{base_url}/API/GetNewSession"
+        data = self._post_json(url, {})
+        session_id = None
+        if isinstance(data, dict):
+            session_id = data.get("session_id")
+        if not session_id:
+            raise ImageGenerationError("SwarmUI did not return a session_id")
+        return str(session_id)
+
+    def _build_payload(self, request: ImageGenRequest, session_id: str) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "session_id": session_id,
+            "images": 1,
+            "prompt": request.prompt,
+        }
+        if request.negative_prompt:
+            payload["negativeprompt"] = request.negative_prompt
+        if request.width is not None:
+            payload["width"] = request.width
+        if request.height is not None:
+            payload["height"] = request.height
+        if request.steps is not None:
+            payload["steps"] = request.steps
+        if request.cfg_scale is not None:
+            payload["cfgscale"] = request.cfg_scale
+        if request.seed is not None:
+            payload["seed"] = request.seed
+        if request.sampler:
+            payload["sampler"] = request.sampler
+
+        model = request.model or (self._config.swarmui_default_model or None)
+        if model:
+            payload["model"] = model
+
+        extra_params = request.extra_params or {}
+        if isinstance(extra_params, dict):
+            for key, value in extra_params.items():
+                if key in {"session_id", "images"}:
+                    continue
+                payload[key] = value
+        return payload
+
+    def _post_generate(self, url: str, payload: dict[str, Any]) -> dict[str, Any]:
+        data = self._post_json(url, payload)
+        error_id = data.get("error_id") if isinstance(data, dict) else None
+        if error_id == "invalid_session_id":
+            logger.info("SwarmUI session invalid; refreshing session_id")
+            self._session_id = self._request_session_id(self._resolve_base_url())
+            retry_payload = dict(payload)
+            retry_payload["session_id"] = self._session_id
+            data = self._post_json(url, retry_payload)
+            error_id = data.get("error_id") if isinstance(data, dict) else None
+
+        if isinstance(data, dict):
+            if error_id:
+                raise ImageGenerationError(f"SwarmUI error_id: {error_id}")
+            if data.get("error"):
+                raise ImageGenerationError(str(data.get("error")))
+        return data if isinstance(data, dict) else {}
+
+    def _post_json(self, url: str, payload: dict[str, Any]) -> dict[str, Any]:
+        try:
+            data = fetch_json(
+                method="POST",
+                url=url,
+                json=payload,
+                cookies=self._cookies(),
+                timeout=self._config.swarmui_timeout_seconds or DEFAULT_SWARMUI_TIMEOUT_SECONDS,
+            )
+        except Exception as exc:
+            raise ImageGenerationError(f"SwarmUI request failed: {exc}") from exc
+        if not isinstance(data, dict):
+            raise ImageGenerationError("SwarmUI response was not JSON")
+        return data
+
+    @staticmethod
+    def _extract_first_image_ref(data: dict[str, Any]) -> str | None:
+        if not isinstance(data, dict):
+            return None
+        images = data.get("images")
+        if isinstance(images, list) and images:
+            first = images[0]
+            if isinstance(first, dict):
+                image_ref = first.get("image")
+                return str(image_ref) if image_ref else None
+            if isinstance(first, str):
+                return first
+        return None
+
+    @staticmethod
+    def _resolve_image_url(base_url: str, image_ref: str) -> str:
+        if image_ref.startswith("http://") or image_ref.startswith("https://"):
+            if not SwarmUIAdapter._same_origin(base_url, image_ref):
+                raise ImageGenerationError("SwarmUI returned off-origin image URL")
+            return image_ref
+        parsed = urlparse(image_ref)
+        if parsed.scheme in {"http", "https"}:
+            if not SwarmUIAdapter._same_origin(base_url, image_ref):
+                raise ImageGenerationError("SwarmUI returned off-origin image URL")
+            return image_ref
+        path = image_ref.lstrip("/")
+        encoded_path = "/".join(quote(part) for part in path.split("/"))
+        return f"{base_url.rstrip('/')}/{encoded_path}"
+
+    @staticmethod
+    def _same_origin(base_url: str, target_url: str) -> bool:
+        base = urlparse(base_url)
+        target = urlparse(target_url)
+        return (
+            base.scheme.lower() == target.scheme.lower()
+            and (base.hostname or "").lower() == (target.hostname or "").lower()
+            and SwarmUIAdapter._origin_port(base) == SwarmUIAdapter._origin_port(target)
+        )
+
+    @staticmethod
+    def _origin_port(parsed) -> int | None:
+        if parsed.port is not None:
+            return int(parsed.port)
+        if parsed.scheme.lower() == "https":
+            return 443
+        if parsed.scheme.lower() == "http":
+            return 80
+        return None
+
+    def _fetch_image_bytes(self, url: str) -> tuple[bytes, str]:
+        try:
+            return fetch_shared_image_bytes(
+                url,
+                cookies=self._cookies(),
+                timeout=self._config.swarmui_timeout_seconds or DEFAULT_SWARMUI_TIMEOUT_SECONDS,
+                max_bytes=self._max_output_bytes(),
+            )
+        except Exception as exc:
+            raise ImageGenerationError(f"SwarmUI image fetch failed: {exc}") from exc

--- a/tldw_chatbook/Image_Generation/adapters/together_image_adapter.py
+++ b/tldw_chatbook/Image_Generation/adapters/together_image_adapter.py
@@ -1,0 +1,193 @@
+"""Together image-generation backend adapter."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from tldw_chatbook.Image_Generation.http_client import fetch_json
+from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest, ImageGenResult
+from tldw_chatbook.Image_Generation.adapters.image_format_utils import (
+    decode_base64_image,
+    decode_data_url,
+    fetch_image_bytes,
+    maybe_decode_base64_image,
+    validate_and_convert_image_output,
+)
+from tldw_chatbook.Image_Generation.config import (
+    DEFAULT_TOGETHER_IMAGE_BASE_URL,
+    DEFAULT_TOGETHER_IMAGE_MODEL,
+    DEFAULT_TOGETHER_IMAGE_TIMEOUT_SECONDS,
+    get_image_generation_config,
+)
+from tldw_chatbook.Image_Generation.exceptions import ImageBackendUnavailableError, ImageGenerationError
+from tldw_chatbook.Image_Generation.request_validation import effective_inline_max_bytes
+
+
+class TogetherImageAdapter:
+    name = "together"
+    supported_formats = {"png", "jpg", "webp"}
+
+    def __init__(self) -> None:
+        self._config = get_image_generation_config()
+
+    def generate(self, request: ImageGenRequest) -> ImageGenResult:
+        output_format = request.format.lower()
+        if output_format not in self.supported_formats:
+            raise ImageGenerationError(f"unsupported output format: {output_format}")
+
+        api_key = self._resolve_api_key()
+        base_url = self._resolve_base_url()
+        url = self._image_generation_url(base_url)
+        payload = self._build_payload(request)
+
+        try:
+            data = fetch_json(
+                method="POST",
+                url=url,
+                headers=self._headers(api_key),
+                json=payload,
+                timeout=self._config.together_image_timeout_seconds or DEFAULT_TOGETHER_IMAGE_TIMEOUT_SECONDS,
+            )
+        except Exception as exc:
+            raise ImageGenerationError(f"Together image request failed: {exc}") from exc
+
+        content, content_type = self._extract_image_content(data)
+        content, content_type = validate_and_convert_image_output(
+            content,
+            content_type,
+            output_format,
+            max_bytes=self._max_output_bytes(),
+        )
+        return ImageGenResult(content=content, content_type=content_type, bytes_len=len(content))
+
+    def _max_output_bytes(self) -> int:
+        return effective_inline_max_bytes(self._config)
+
+    def _resolve_api_key(self) -> str:
+        api_key = (self._config.together_image_api_key or "").strip()
+        if not api_key:
+            api_key = (os.getenv("TOGETHER_API_KEY") or "").strip()
+        if not api_key:
+            raise ImageBackendUnavailableError("together image api key is not configured")
+        return api_key
+
+    def _resolve_base_url(self) -> str:
+        raw = (
+            os.getenv("TOGETHER_BASE_URL")
+            or self._config.together_image_base_url
+            or DEFAULT_TOGETHER_IMAGE_BASE_URL
+        )
+        cleaned = str(raw).strip()
+        if not cleaned:
+            raise ImageBackendUnavailableError("together image base URL is not configured")
+        if not cleaned.startswith("http://") and not cleaned.startswith("https://"):
+            cleaned = f"https://{cleaned}"
+        return cleaned.rstrip("/")
+
+    @staticmethod
+    def _image_generation_url(base_url: str) -> str:
+        lower = base_url.lower()
+        if lower.endswith("/v1"):
+            return f"{base_url}/images/generations"
+        if lower.endswith("/images/generations"):
+            return base_url
+        return f"{base_url}/v1/images/generations"
+
+    @staticmethod
+    def _headers(api_key: str) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _build_payload(self, request: ImageGenRequest) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "model": (
+                request.model
+                or os.getenv("TOGETHER_IMAGE_MODEL")
+                or self._config.together_image_default_model
+                or DEFAULT_TOGETHER_IMAGE_MODEL
+            ),
+            "prompt": request.prompt,
+            "response_format": "b64_json",
+        }
+        if request.negative_prompt:
+            payload["negative_prompt"] = request.negative_prompt
+        if request.width and request.height:
+            payload["size"] = f"{request.width}x{request.height}"
+            payload["width"] = request.width
+            payload["height"] = request.height
+        if request.steps is not None:
+            payload["steps"] = request.steps
+        if request.cfg_scale is not None:
+            payload["guidance_scale"] = request.cfg_scale
+        if request.seed is not None:
+            payload["seed"] = request.seed
+
+        extra_params = request.extra_params or {}
+        if isinstance(extra_params, dict):
+            for key, value in extra_params.items():
+                if key in {"prompt", "negative_prompt"}:
+                    continue
+                payload[key] = value
+        return payload
+
+    def _extract_image_content(self, data: Any) -> tuple[bytes, str]:
+        candidate = self._extract_from_node(data)
+        if candidate:
+            return candidate
+        raise ImageGenerationError("Together did not return image content")
+
+    def _extract_from_node(self, node: Any) -> tuple[bytes, str] | None:
+        if isinstance(node, dict):
+            for key in ("b64_json", "image_base64", "base64", "image_b64"):
+                value = node.get(key)
+                if isinstance(value, str) and value.strip():
+                    return decode_base64_image(value.strip(), max_bytes=self._max_output_bytes()), "image/png"
+            for key in ("url", "image_url", "image"):
+                if key in node:
+                    extracted = self._extract_from_link_value(node.get(key))
+                    if extracted:
+                        return extracted
+            for key in ("data", "images", "output", "result"):
+                if key not in node:
+                    continue
+                extracted = self._extract_from_node(node.get(key))
+                if extracted:
+                    return extracted
+            return None
+        if isinstance(node, list):
+            for item in node:
+                extracted = self._extract_from_node(item)
+                if extracted:
+                    return extracted
+            return None
+        return self._extract_from_link_value(node)
+
+    def _extract_from_link_value(self, value: Any) -> tuple[bytes, str] | None:
+        if isinstance(value, dict):
+            for key in ("url", "image_url", "b64_json", "base64", "image"):
+                if key in value:
+                    extracted = self._extract_from_link_value(value.get(key))
+                    if extracted:
+                        return extracted
+            return None
+
+        if not isinstance(value, str):
+            return None
+        raw = value.strip()
+        if not raw:
+            return None
+        if raw.startswith("data:"):
+            return decode_data_url(raw, max_bytes=self._max_output_bytes())
+        if raw.startswith("http://") or raw.startswith("https://"):
+            return fetch_image_bytes(
+                raw,
+                timeout=self._config.together_image_timeout_seconds or DEFAULT_TOGETHER_IMAGE_TIMEOUT_SECONDS,
+                max_bytes=self._max_output_bytes(),
+            )
+        decoded = maybe_decode_base64_image(raw, max_bytes=self._max_output_bytes())
+        if decoded is not None:
+            return decoded, "image/png"
+        return None

--- a/tldw_chatbook/Image_Generation/capabilities.py
+++ b/tldw_chatbook/Image_Generation/capabilities.py
@@ -1,0 +1,133 @@
+"""Shared capability resolution for image generation backends."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tldw_chatbook.Image_Generation.config import ImageGenerationConfig
+
+_DEFAULT_REFERENCE_IMAGE_SUPPORT: dict[str, set[str]] = {
+    "modelstudio": {"qwen-image-2.0", "qwen-image-edit"},
+}
+
+
+@dataclass(frozen=True)
+class ResolvedReferenceImage:
+    """Normalized reference image payload used by image generation requests."""
+
+    file_id: int | str
+    filename: str | None
+    mime_type: str
+    width: int | None
+    height: int | None
+    bytes_len: int
+    content: bytes | None
+    temp_path: str | None
+
+    def __post_init__(self) -> None:
+        has_content = self.content is not None
+        has_temp_path = self.temp_path is not None
+        if has_content == has_temp_path:
+            raise ValueError("ResolvedReferenceImage requires exactly one of content or temp_path")
+
+
+@dataclass(frozen=True)
+class ReferenceImageCapability:
+    """Resolved image reference support for a backend/model pair."""
+
+    supported: bool
+    reason: str | None = None
+
+
+def _normalize_key(value: str | None) -> str:
+    return str(value or "").strip().lower()
+
+
+def _normalize_model_family(value: str | None) -> str:
+    return _normalize_key(value).rstrip("*")
+
+
+def _matches_model_family(family_root: str, model: str) -> bool:
+    if not family_root or not model:
+        return False
+    if model == family_root:
+        return True
+    for separator in ("-", ".", "_", "/"):
+        if model.startswith(f"{family_root}{separator}"):
+            return True
+    return False
+
+
+def _normalize_model_map(value: dict[str, list[str]] | None) -> dict[str, set[str]]:
+    if not value:
+        return {}
+    normalized: dict[str, set[str]] = {}
+    for backend, models in value.items():
+        backend_key = _normalize_key(backend)
+        if not backend_key:
+            continue
+        normalized[backend_key] = {_normalize_model_family(model) for model in models if _normalize_model_family(model)}
+    return normalized
+
+
+def _resolve_supported_models(
+    backend_key: str,
+    *,
+    config: ImageGenerationConfig | None = None,
+) -> set[str]:
+    builtin_support = _DEFAULT_REFERENCE_IMAGE_SUPPORT.get(backend_key, set())
+    if not builtin_support:
+        return set()
+
+    configured_support = _normalize_model_map(
+        getattr(config, "reference_image_supported_models", None) if config is not None else None
+    )
+    configured_models = configured_support.get(backend_key)
+    if configured_models is None:
+        return set(builtin_support)
+    return {
+        model
+        for model in configured_models
+        if any(_matches_model_family(builtin_model, model) for builtin_model in builtin_support)
+    }
+
+
+def resolve_backend_reference_image_capability(
+    backend: str | None,
+    *,
+    config: ImageGenerationConfig | None = None,
+) -> ReferenceImageCapability:
+    """Resolve whether a backend exposes any reference-image support."""
+
+    backend_key = _normalize_key(backend)
+    if not backend_key:
+        return ReferenceImageCapability(supported=False, reason="unsupported_model")
+    supported_models = _resolve_supported_models(backend_key, config=config)
+    return ReferenceImageCapability(
+        supported=bool(supported_models),
+        reason=None if supported_models else "unsupported_model",
+    )
+
+
+def resolve_reference_image_capability(
+    backend: str | None,
+    model: str | None,
+    *,
+    config: ImageGenerationConfig | None = None,
+) -> ReferenceImageCapability:
+    """Resolve whether a backend/model pair supports reference-image input."""
+
+    backend_key = _normalize_key(backend)
+    model_key = _normalize_key(model)
+    if not backend_key or not model_key:
+        return ReferenceImageCapability(supported=False, reason="unsupported_model")
+
+    supported_models = _resolve_supported_models(backend_key, config=config)
+    if not supported_models:
+        return ReferenceImageCapability(supported=False, reason="unsupported_model")
+
+    if any(_matches_model_family(supported_model, model_key) for supported_model in supported_models):
+        return ReferenceImageCapability(supported=True)
+    return ReferenceImageCapability(supported=False, reason="unsupported_model")

--- a/tldw_chatbook/Image_Generation/config.py
+++ b/tldw_chatbook/Image_Generation/config.py
@@ -1,0 +1,413 @@
+"""Configuration helpers for image generation backends."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+import keyring
+from loguru import logger
+
+from tldw_chatbook.config import get_cli_setting, get_api_key
+
+DEFAULT_BACKEND = "stable_diffusion_cpp"
+DEFAULT_MAX_WIDTH = 1024
+DEFAULT_MAX_HEIGHT = 1024
+DEFAULT_MAX_PIXELS = 1024 * 1024
+DEFAULT_MAX_STEPS = 50
+DEFAULT_MAX_PROMPT_LENGTH = 1000
+DEFAULT_INLINE_MAX_BYTES = 4_000_000
+
+DEFAULT_SD_CPP_STEPS = 25
+DEFAULT_SD_CPP_CFG_SCALE = 7.5
+DEFAULT_SD_CPP_SAMPLER = "euler_a"
+DEFAULT_SD_CPP_DEVICE = "auto"
+DEFAULT_SD_CPP_TIMEOUT_SECONDS = 120
+DEFAULT_SWARMUI_BASE_URL = "http://127.0.0.1:7801"
+DEFAULT_SWARMUI_TIMEOUT_SECONDS = 120
+DEFAULT_OPENROUTER_IMAGE_BASE_URL = "https://openrouter.ai/api/v1"
+DEFAULT_OPENROUTER_IMAGE_MODEL = "openai/gpt-image-1"
+DEFAULT_OPENROUTER_IMAGE_TIMEOUT_SECONDS = 120
+DEFAULT_NOVITA_IMAGE_BASE_URL = "https://api.novita.ai"
+DEFAULT_NOVITA_IMAGE_MODEL = "sd_xl_base_1.0.safetensors"
+DEFAULT_NOVITA_IMAGE_TIMEOUT_SECONDS = 180
+DEFAULT_NOVITA_IMAGE_POLL_INTERVAL_SECONDS = 2
+DEFAULT_TOGETHER_IMAGE_BASE_URL = "https://api.together.xyz/v1"
+DEFAULT_TOGETHER_IMAGE_MODEL = "black-forest-labs/FLUX.1-schnell-Free"
+DEFAULT_TOGETHER_IMAGE_TIMEOUT_SECONDS = 120
+DEFAULT_MODELSTUDIO_IMAGE_BASE_URL = "https://dashscope-intl.aliyuncs.com/api/v1"
+DEFAULT_MODELSTUDIO_IMAGE_MODEL = "qwen-image"
+DEFAULT_MODELSTUDIO_IMAGE_REGION = "sg"
+DEFAULT_MODELSTUDIO_IMAGE_MODE = "auto"
+DEFAULT_MODELSTUDIO_IMAGE_POLL_INTERVAL_SECONDS = 2
+DEFAULT_MODELSTUDIO_IMAGE_TIMEOUT_SECONDS = 180
+
+# Secret fields: backend -> (flat_field_name, [env vars in precedence order], keyring_backend_id)
+_SECRETS = {
+    "swarmui":     ("swarmui_swarm_token",        ["SWARMUI_TOKEN"],                       "swarmui"),
+    "openrouter":  ("openrouter_image_api_key",   ["OPENROUTER_API_KEY"],                  "openrouter"),
+    "novita":      ("novita_image_api_key",       ["NOVITA_API_KEY"],                      "novita"),
+    "together":    ("together_image_api_key",     ["TOGETHER_API_KEY"],                    "together"),
+    "modelstudio": ("modelstudio_image_api_key",  ["DASHSCOPE_API_KEY", "QWEN_API_KEY"],   "modelstudio"),
+}
+# Non-secret nested keys: (backend, toml_key) -> flat_field_name
+_NON_SECRET = {
+    ("stable_diffusion_cpp", "binary_path"):          "sd_cpp_binary_path",
+    ("stable_diffusion_cpp", "diffusion_model_path"): "sd_cpp_diffusion_model_path",
+    ("stable_diffusion_cpp", "model_path"):           "sd_cpp_model_path",
+    ("stable_diffusion_cpp", "vae_path"):             "sd_cpp_vae_path",
+    ("stable_diffusion_cpp", "lora_paths"):           "sd_cpp_lora_paths",
+    ("stable_diffusion_cpp", "device"):               "sd_cpp_device",
+    ("stable_diffusion_cpp", "default_steps"):        "sd_cpp_default_steps",
+    ("stable_diffusion_cpp", "default_cfg_scale"):    "sd_cpp_default_cfg_scale",
+    ("stable_diffusion_cpp", "default_sampler"):      "sd_cpp_default_sampler",
+    ("stable_diffusion_cpp", "timeout_seconds"):      "sd_cpp_timeout_seconds",
+    ("stable_diffusion_cpp", "allowed_extra_params"): "sd_cpp_allowed_extra_params",
+    ("swarmui", "base_url"):              "swarmui_base_url",
+    ("swarmui", "default_model"):         "swarmui_default_model",
+    ("swarmui", "timeout_seconds"):       "swarmui_timeout_seconds",
+    ("swarmui", "allowed_extra_params"):  "swarmui_allowed_extra_params",
+    ("openrouter", "base_url"):              "openrouter_image_base_url",
+    ("openrouter", "default_model"):         "openrouter_image_default_model",
+    ("openrouter", "timeout_seconds"):       "openrouter_image_timeout_seconds",
+    ("openrouter", "allowed_extra_params"):  "openrouter_image_allowed_extra_params",
+    ("novita", "base_url"):              "novita_image_base_url",
+    ("novita", "default_model"):         "novita_image_default_model",
+    ("novita", "timeout_seconds"):       "novita_image_timeout_seconds",
+    ("novita", "poll_interval_seconds"): "novita_image_poll_interval_seconds",
+    ("novita", "allowed_extra_params"):  "novita_image_allowed_extra_params",
+    ("together", "base_url"):              "together_image_base_url",
+    ("together", "default_model"):         "together_image_default_model",
+    ("together", "timeout_seconds"):       "together_image_timeout_seconds",
+    ("together", "allowed_extra_params"):  "together_image_allowed_extra_params",
+    ("modelstudio", "base_url"):              "modelstudio_image_base_url",
+    ("modelstudio", "default_model"):         "modelstudio_image_default_model",
+    ("modelstudio", "region"):                "modelstudio_image_region",
+    ("modelstudio", "mode"):                  "modelstudio_image_mode",
+    ("modelstudio", "poll_interval_seconds"): "modelstudio_image_poll_interval_seconds",
+    ("modelstudio", "timeout_seconds"):       "modelstudio_image_timeout_seconds",
+    ("modelstudio", "allowed_extra_params"):  "modelstudio_image_allowed_extra_params",
+}
+_GLOBAL_KEYS = [
+    "default_backend", "enabled_backends", "max_width", "max_height",
+    "max_pixels", "max_steps", "max_prompt_length", "inline_max_bytes",
+]
+
+
+def _read_image_generation_toml() -> dict:
+    """Return the raw [image_generation] section dict (nested). Patch point in tests."""
+    from tldw_chatbook.config import load_settings
+    return load_settings().get("image_generation", {}) or {}
+
+
+def _keyring_get(backend: str):
+    """Namespaced keyring lookup; never raises. Patch point in tests."""
+    try:
+        return keyring.get_password("tldw_chatbook_imagegen", backend)
+    except Exception as e:  # keyring backend may be unavailable
+        logger.debug(f"keyring lookup failed for imagegen/{backend}: {e}")
+        return None
+
+
+def _resolve_secret(backend: str, sub: dict):
+    field, env_vars, kr_id = _SECRETS[backend]
+    for ev in env_vars:                       # 1. env
+        v = os.getenv(ev)
+        if v:
+            return field, v
+    cfg_val = (sub or {}).get("api_key")       # 2. config
+    if cfg_val and cfg_val != "<API_KEY_HERE>":
+        return field, cfg_val
+    kr = _keyring_get(kr_id)                    # 3. keyring
+    if kr:
+        return field, kr
+    return field, None                         # 4. optional shared handled by adapter/get_api_key opt-in
+
+
+def _load_image_generation_section() -> dict:
+    """Assemble the FLAT mapping the config builder expects, from nested TOML + env + keyring."""
+    raw = _read_image_generation_toml()
+    flat: dict = {}
+    for k in _GLOBAL_KEYS:
+        if k in raw:
+            flat[k] = raw[k]
+    for (backend, toml_key), field in _NON_SECRET.items():
+        sub = raw.get(backend) or {}
+        if toml_key in sub:
+            flat[field] = sub[toml_key]
+    for backend in _SECRETS:
+        field, value = _resolve_secret(backend, raw.get(backend) or {})
+        if value:
+            flat[field] = value
+    return flat
+
+
+@dataclass(frozen=True)
+class ImageGenerationConfig:
+    default_backend: str | None
+    enabled_backends: list[str]
+    max_width: int
+    max_height: int
+    max_pixels: int
+    max_steps: int
+    max_prompt_length: int
+    inline_max_bytes: int | None
+    sd_cpp_diffusion_model_path: str | None
+    sd_cpp_llm_path: str | None
+    sd_cpp_binary_path: str | None
+    sd_cpp_model_path: str | None
+    sd_cpp_vae_path: str | None
+    sd_cpp_lora_paths: list[str]
+    sd_cpp_allowed_extra_params: list[str]
+    sd_cpp_default_steps: int
+    sd_cpp_default_cfg_scale: float
+    sd_cpp_default_sampler: str
+    sd_cpp_device: str
+    sd_cpp_timeout_seconds: int
+    swarmui_base_url: str | None
+    swarmui_default_model: str | None
+    swarmui_swarm_token: str | None
+    swarmui_allowed_extra_params: list[str]
+    swarmui_timeout_seconds: int
+    openrouter_image_base_url: str | None
+    openrouter_image_api_key: str | None
+    openrouter_image_default_model: str | None
+    openrouter_image_allowed_extra_params: list[str]
+    openrouter_image_timeout_seconds: int
+    novita_image_base_url: str | None
+    novita_image_api_key: str | None
+    novita_image_default_model: str | None
+    novita_image_allowed_extra_params: list[str]
+    novita_image_timeout_seconds: int
+    novita_image_poll_interval_seconds: int
+    together_image_base_url: str | None
+    together_image_api_key: str | None
+    together_image_default_model: str | None
+    together_image_allowed_extra_params: list[str]
+    together_image_timeout_seconds: int
+    modelstudio_image_base_url: str | None
+    modelstudio_image_api_key: str | None
+    modelstudio_image_default_model: str | None
+    modelstudio_image_region: str
+    modelstudio_image_mode: str
+    modelstudio_image_poll_interval_seconds: int
+    modelstudio_image_timeout_seconds: int
+    modelstudio_image_allowed_extra_params: list[str]
+    reference_image_supported_models: dict[str, list[str]] = field(default_factory=dict)
+
+
+_config_cache: ImageGenerationConfig | None = None
+
+
+def _coerce_int(value: Any, default: int) -> int:
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_float(value: Any, default: float) -> float:
+    try:
+        return float(str(value).strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_choice(
+    value: Any,
+    *,
+    default: str,
+    allowed: set[str],
+) -> str:
+    """Normalize a string choice to lowercase and return `default` when invalid."""
+    raw = str(value or "").strip().lower()
+    if raw in allowed:
+        return raw
+    return default
+
+
+def _parse_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    raw = str(value).strip()
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except Exception:
+        parsed = None
+    if isinstance(parsed, list):
+        return [str(item).strip() for item in parsed if str(item).strip()]
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def _parse_mapping_of_lists(value: Any) -> dict[str, list[str]]:
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        parsed = value
+    else:
+        raw = str(value).strip()
+        if not raw:
+            return {}
+        try:
+            parsed = json.loads(raw)
+        except Exception:
+            return {}
+        if not isinstance(parsed, dict):
+            return {}
+
+    result: dict[str, list[str]] = {}
+    for raw_key, raw_values in parsed.items():
+        key = str(raw_key).strip().lower()
+        if not key:
+            continue
+        if isinstance(raw_values, list):
+            items = [str(item).strip() for item in raw_values if str(item).strip()]
+        elif raw_values is None:
+            items = []
+        else:
+            raw = str(raw_values).strip()
+            if not raw:
+                items = []
+            else:
+                try:
+                    candidate = json.loads(raw)
+                except Exception:
+                    candidate = None
+                if isinstance(candidate, list):
+                    items = [str(item).strip() for item in candidate if str(item).strip()]
+                else:
+                    items = [item.strip() for item in raw.split(",") if item.strip()]
+        result[key] = items
+    return result
+
+
+def _get_config_value(section: dict[str, str], key: str) -> str | None:
+    raw = section.get(key)
+    if raw is None:
+        return None
+    value = str(raw).strip()
+    return value or None
+
+
+def get_image_generation_config(*, reload: bool = False) -> ImageGenerationConfig:
+    global _config_cache
+    if _config_cache is not None and not reload:
+        return _config_cache
+
+    section = _load_image_generation_section()
+
+    default_backend = _get_config_value(section, "default_backend") or DEFAULT_BACKEND
+    enabled_backends = _parse_list(section.get("enabled_backends"))
+    if not enabled_backends:
+        enabled_backends = []
+
+    inline_max_bytes_raw = _get_config_value(section, "inline_max_bytes")
+    inline_max_bytes = DEFAULT_INLINE_MAX_BYTES
+    if inline_max_bytes_raw is not None:
+        inline_max_bytes = max(1, _coerce_int(inline_max_bytes_raw, DEFAULT_INLINE_MAX_BYTES))
+
+    config = ImageGenerationConfig(
+        default_backend=default_backend,
+        enabled_backends=enabled_backends,
+        max_width=_coerce_int(section.get("max_width"), DEFAULT_MAX_WIDTH),
+        max_height=_coerce_int(section.get("max_height"), DEFAULT_MAX_HEIGHT),
+        max_pixels=_coerce_int(section.get("max_pixels"), DEFAULT_MAX_PIXELS),
+        max_steps=_coerce_int(section.get("max_steps"), DEFAULT_MAX_STEPS),
+        max_prompt_length=_coerce_int(section.get("max_prompt_length"), DEFAULT_MAX_PROMPT_LENGTH),
+        inline_max_bytes=inline_max_bytes,
+        sd_cpp_diffusion_model_path=_get_config_value(section, "sd_cpp_diffusion_model_path"),
+        sd_cpp_llm_path=_get_config_value(section, "sd_cpp_llm_path"),
+        sd_cpp_binary_path=_get_config_value(section, "sd_cpp_binary_path"),
+        sd_cpp_model_path=_get_config_value(section, "sd_cpp_model_path"),
+        sd_cpp_vae_path=_get_config_value(section, "sd_cpp_vae_path"),
+        sd_cpp_lora_paths=_parse_list(section.get("sd_cpp_lora_paths")),
+        sd_cpp_allowed_extra_params=_parse_list(section.get("sd_cpp_allowed_extra_params")),
+        sd_cpp_default_steps=_coerce_int(section.get("sd_cpp_default_steps"), DEFAULT_SD_CPP_STEPS),
+        sd_cpp_default_cfg_scale=_coerce_float(section.get("sd_cpp_default_cfg_scale"), DEFAULT_SD_CPP_CFG_SCALE),
+        sd_cpp_default_sampler=_get_config_value(section, "sd_cpp_default_sampler") or DEFAULT_SD_CPP_SAMPLER,
+        sd_cpp_device=_get_config_value(section, "sd_cpp_device") or DEFAULT_SD_CPP_DEVICE,
+        sd_cpp_timeout_seconds=_coerce_int(section.get("sd_cpp_timeout_seconds"), DEFAULT_SD_CPP_TIMEOUT_SECONDS),
+        swarmui_base_url=_get_config_value(section, "swarmui_base_url") or DEFAULT_SWARMUI_BASE_URL,
+        swarmui_default_model=_get_config_value(section, "swarmui_default_model"),
+        swarmui_swarm_token=_get_config_value(section, "swarmui_swarm_token"),
+        swarmui_allowed_extra_params=_parse_list(section.get("swarmui_allowed_extra_params")),
+        swarmui_timeout_seconds=_coerce_int(section.get("swarmui_timeout_seconds"), DEFAULT_SWARMUI_TIMEOUT_SECONDS),
+        openrouter_image_base_url=_get_config_value(section, "openrouter_image_base_url")
+        or DEFAULT_OPENROUTER_IMAGE_BASE_URL,
+        openrouter_image_api_key=_get_config_value(section, "openrouter_image_api_key"),
+        openrouter_image_default_model=_get_config_value(section, "openrouter_image_default_model")
+        or DEFAULT_OPENROUTER_IMAGE_MODEL,
+        openrouter_image_allowed_extra_params=_parse_list(section.get("openrouter_image_allowed_extra_params")),
+        openrouter_image_timeout_seconds=_coerce_int(
+            section.get("openrouter_image_timeout_seconds"),
+            DEFAULT_OPENROUTER_IMAGE_TIMEOUT_SECONDS,
+        ),
+        novita_image_base_url=_get_config_value(section, "novita_image_base_url")
+        or DEFAULT_NOVITA_IMAGE_BASE_URL,
+        novita_image_api_key=_get_config_value(section, "novita_image_api_key"),
+        novita_image_default_model=_get_config_value(section, "novita_image_default_model")
+        or DEFAULT_NOVITA_IMAGE_MODEL,
+        novita_image_allowed_extra_params=_parse_list(section.get("novita_image_allowed_extra_params")),
+        novita_image_timeout_seconds=_coerce_int(
+            section.get("novita_image_timeout_seconds"),
+            DEFAULT_NOVITA_IMAGE_TIMEOUT_SECONDS,
+        ),
+        novita_image_poll_interval_seconds=max(
+            1,
+            _coerce_int(
+                section.get("novita_image_poll_interval_seconds"),
+                DEFAULT_NOVITA_IMAGE_POLL_INTERVAL_SECONDS,
+            ),
+        ),
+        together_image_base_url=_get_config_value(section, "together_image_base_url")
+        or DEFAULT_TOGETHER_IMAGE_BASE_URL,
+        together_image_api_key=_get_config_value(section, "together_image_api_key"),
+        together_image_default_model=_get_config_value(section, "together_image_default_model")
+        or DEFAULT_TOGETHER_IMAGE_MODEL,
+        together_image_allowed_extra_params=_parse_list(section.get("together_image_allowed_extra_params")),
+        together_image_timeout_seconds=_coerce_int(
+            section.get("together_image_timeout_seconds"),
+            DEFAULT_TOGETHER_IMAGE_TIMEOUT_SECONDS,
+        ),
+        modelstudio_image_base_url=_get_config_value(section, "modelstudio_image_base_url"),
+        modelstudio_image_api_key=_get_config_value(section, "modelstudio_image_api_key"),
+        modelstudio_image_default_model=_get_config_value(section, "modelstudio_image_default_model")
+        or DEFAULT_MODELSTUDIO_IMAGE_MODEL,
+        modelstudio_image_region=_coerce_choice(
+            _get_config_value(section, "modelstudio_image_region"),
+            default=DEFAULT_MODELSTUDIO_IMAGE_REGION,
+            allowed={"sg", "cn", "us"},
+        ),
+        modelstudio_image_mode=_coerce_choice(
+            _get_config_value(section, "modelstudio_image_mode"),
+            default=DEFAULT_MODELSTUDIO_IMAGE_MODE,
+            allowed={"sync", "async", "auto"},
+        ),
+        modelstudio_image_poll_interval_seconds=max(
+            1,
+            _coerce_int(
+                section.get("modelstudio_image_poll_interval_seconds"),
+                DEFAULT_MODELSTUDIO_IMAGE_POLL_INTERVAL_SECONDS,
+            ),
+        ),
+        modelstudio_image_timeout_seconds=_coerce_int(
+            section.get("modelstudio_image_timeout_seconds"),
+            DEFAULT_MODELSTUDIO_IMAGE_TIMEOUT_SECONDS,
+        ),
+        modelstudio_image_allowed_extra_params=_parse_list(section.get("modelstudio_image_allowed_extra_params")),
+        reference_image_supported_models=_parse_mapping_of_lists(section.get("reference_image_supported_models")),
+    )
+
+    _config_cache = config
+    return config
+
+
+def reset_image_generation_config_cache() -> None:
+    global _config_cache
+    _config_cache = None

--- a/tldw_chatbook/Image_Generation/config.py
+++ b/tldw_chatbook/Image_Generation/config.py
@@ -136,10 +136,10 @@ def _load_image_generation_section() -> dict:
     for k in _GLOBAL_KEYS:
         if k in raw:
             flat[k] = raw[k]
-    for (backend, toml_key), field in _NON_SECRET.items():
+    for (backend, toml_key), flat_field in _NON_SECRET.items():
         sub = raw.get(backend) or {}
         if toml_key in sub:
-            flat[field] = sub[toml_key]
+            flat[flat_field] = sub[toml_key]
     for backend in _SECRETS:
         field, value = _resolve_secret(backend, raw.get(backend) or {})
         if value:

--- a/tldw_chatbook/Image_Generation/config.py
+++ b/tldw_chatbook/Image_Generation/config.py
@@ -10,7 +10,6 @@ from typing import Any
 import keyring
 from loguru import logger
 
-from tldw_chatbook.config import get_cli_setting, get_api_key
 
 DEFAULT_BACKEND = "stable_diffusion_cpp"
 DEFAULT_MAX_WIDTH = 1024
@@ -53,10 +52,14 @@ _SECRETS = {
     "modelstudio": ("modelstudio_image_api_key",  ["DASHSCOPE_API_KEY", "QWEN_API_KEY"],   "modelstudio"),
 }
 # Non-secret nested keys: (backend, toml_key) -> flat_field_name
+# NOTE: `reference_image_supported_models` is intentionally NOT mapped here —
+# reference-image support is deferred (reference_images.py was dropped in Phase 1),
+# so the dataclass field correctly defaults to {} until a later phase wires it.
 _NON_SECRET = {
     ("stable_diffusion_cpp", "binary_path"):          "sd_cpp_binary_path",
     ("stable_diffusion_cpp", "diffusion_model_path"): "sd_cpp_diffusion_model_path",
     ("stable_diffusion_cpp", "model_path"):           "sd_cpp_model_path",
+    ("stable_diffusion_cpp", "llm_path"):             "sd_cpp_llm_path",
     ("stable_diffusion_cpp", "vae_path"):             "sd_cpp_vae_path",
     ("stable_diffusion_cpp", "lora_paths"):           "sd_cpp_lora_paths",
     ("stable_diffusion_cpp", "device"):               "sd_cpp_device",

--- a/tldw_chatbook/Image_Generation/exceptions.py
+++ b/tldw_chatbook/Image_Generation/exceptions.py
@@ -1,0 +1,14 @@
+"""Exceptions for image generation adapters."""
+
+class ImageGenerationError(RuntimeError):
+    """Raised when image generation fails."""
+
+    def __init__(self, message: str = "image generation failed") -> None:
+        super().__init__(message)
+
+
+class ImageBackendUnavailableError(ImageGenerationError):
+    """Raised when an image backend is not configured or available."""
+
+    def __init__(self, message: str = "image backend unavailable") -> None:
+        super().__init__(message)

--- a/tldw_chatbook/Image_Generation/http_client.py
+++ b/tldw_chatbook/Image_Generation/http_client.py
@@ -10,7 +10,6 @@ import os
 from dataclasses import dataclass
 from urllib.parse import urljoin, urlparse
 import httpx
-from loguru import logger
 from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
 
 DEFAULT_MAX_REDIRECTS = int(os.getenv("HTTP_MAX_REDIRECTS", "5"))

--- a/tldw_chatbook/Image_Generation/http_client.py
+++ b/tldw_chatbook/Image_Generation/http_client.py
@@ -1,0 +1,60 @@
+"""Sync HTTP shim + light egress guard for the ported image adapters.
+
+Provides the exact surface the server's http_client exposed to Image_Generation,
+backed by httpx.Client. Full SSRF hardening is deferred to task-485; this guard
+only rejects non-http(s) schemes and enforces a redirect cap, staying permissive
+for user-configured (incl. local) backend base URLs.
+"""
+from __future__ import annotations
+import os
+from dataclasses import dataclass
+from urllib.parse import urljoin, urlparse
+import httpx
+from loguru import logger
+from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+DEFAULT_MAX_REDIRECTS = int(os.getenv("HTTP_MAX_REDIRECTS", "5"))
+_DEFAULT_TIMEOUT = 120.0
+
+
+def _validate_egress_or_raise(url: str) -> None:
+    scheme = (urlparse(url).scheme or "").lower()
+    if scheme not in ("http", "https"):
+        raise ImageGenerationError(f"Refusing non-http(s) URL: {url!r}")
+    # task-485: private/link-local/metadata range blocking for API-returned URLs goes here.
+
+
+def _resolve_redirect_url(base: str, location: str) -> str:
+    return urljoin(base, location)
+
+
+@dataclass(frozen=True)
+class URLPolicyResult:
+    allowed: bool
+    reason: str | None = None
+
+
+def evaluate_url_policy(url: str, *, allowed_hosts: set[str] | None = None) -> URLPolicyResult:
+    _validate_egress_or_raise(url)
+    if not allowed_hosts:
+        return URLPolicyResult(True, None)
+    host = (urlparse(url).hostname or "").lower()
+    if any(host == h or host.endswith("." + h) for h in allowed_hosts):
+        return URLPolicyResult(True, None)
+    return URLPolicyResult(False, f"host {host!r} not in allowlist")
+
+
+def create_client(timeout: float | None = None) -> httpx.Client:
+    return httpx.Client(
+        timeout=timeout or _DEFAULT_TIMEOUT,
+        follow_redirects=True,
+        max_redirects=DEFAULT_MAX_REDIRECTS,
+    )
+
+
+def fetch_json(method, url, *, headers=None, json=None, params=None, cookies=None, timeout=None):
+    _validate_egress_or_raise(url)
+    with create_client(timeout=timeout) as client:
+        resp = client.request(method, url, headers=headers, json=json, params=params, cookies=cookies)
+        resp.raise_for_status()
+        return resp.json()

--- a/tldw_chatbook/Image_Generation/http_client.py
+++ b/tldw_chatbook/Image_Generation/http_client.py
@@ -2,21 +2,48 @@
 
 Provides the exact surface the server's http_client exposed to Image_Generation,
 backed by httpx.Client. Full SSRF hardening is deferred to task-485; this guard
-only rejects non-http(s) schemes and enforces a redirect cap, staying permissive
-for user-configured (incl. local) backend base URLs.
+rejects non-http(s) schemes, enforces a redirect cap, and re-validates every
+redirect hop, while staying permissive for user-configured (incl. local) backend
+base URLs.
 """
 from __future__ import annotations
 import os
 from dataclasses import dataclass
+from typing import Any
 from urllib.parse import urljoin, urlparse
 import httpx
 from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
 
-DEFAULT_MAX_REDIRECTS = int(os.getenv("HTTP_MAX_REDIRECTS", "5"))
+
+def _int_env(name: str, default: int) -> int:
+    """Parse an int environment variable, falling back to ``default``.
+
+    Args:
+        name: Environment variable name.
+        default: Value to use when the variable is unset or not an int.
+
+    Returns:
+        The parsed int, or ``default`` on a missing/invalid value (never raises).
+    """
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+DEFAULT_MAX_REDIRECTS = _int_env("HTTP_MAX_REDIRECTS", 5)
 _DEFAULT_TIMEOUT = 120.0
 
 
 def _validate_egress_or_raise(url: str) -> None:
+    """Reject a URL the adapters must not fetch (light Phase-1 guard).
+
+    Args:
+        url: The absolute URL about to be requested.
+
+    Raises:
+        ImageGenerationError: If the scheme is not http/https.
+    """
     scheme = (urlparse(url).scheme or "").lower()
     if scheme not in ("http", "https"):
         raise ImageGenerationError(f"Refusing non-http(s) URL: {url!r}")
@@ -24,6 +51,7 @@ def _validate_egress_or_raise(url: str) -> None:
 
 
 def _resolve_redirect_url(base: str, location: str) -> str:
+    """Resolve a redirect ``Location`` against the request URL."""
     return urljoin(base, location)
 
 
@@ -34,6 +62,19 @@ class URLPolicyResult:
 
 
 def evaluate_url_policy(url: str, *, allowed_hosts: set[str] | None = None) -> URLPolicyResult:
+    """Decide whether ``url`` may be fetched, optionally against a host allowlist.
+
+    Args:
+        url: The absolute URL to evaluate (scheme is always validated).
+        allowed_hosts: If given, ``url``'s host must equal or be a subdomain of
+            one of these; if empty/None, any http(s) host is allowed.
+
+    Returns:
+        A ``URLPolicyResult`` with ``allowed`` and an optional ``reason``.
+
+    Raises:
+        ImageGenerationError: If the scheme is not http/https.
+    """
     _validate_egress_or_raise(url)
     if not allowed_hosts:
         return URLPolicyResult(True, None)
@@ -43,17 +84,72 @@ def evaluate_url_policy(url: str, *, allowed_hosts: set[str] | None = None) -> U
     return URLPolicyResult(False, f"host {host!r} not in allowlist")
 
 
-def create_client(timeout: float | None = None) -> httpx.Client:
+def create_client(timeout: float | None = None, *, follow_redirects: bool = False) -> httpx.Client:
+    """Build an ``httpx.Client`` for the image adapters.
+
+    Redirects are NOT auto-followed by default: ``fetch_json`` and
+    ``fetch_image_bytes`` run their own per-hop-validated redirect loops, because
+    blindly following a redirect would bypass the egress guard.
+
+    Args:
+        timeout: Per-request timeout in seconds (defaults to 120s).
+        follow_redirects: Whether httpx auto-follows redirects. Default False.
+
+    Returns:
+        A configured ``httpx.Client``.
+    """
     return httpx.Client(
         timeout=timeout or _DEFAULT_TIMEOUT,
-        follow_redirects=True,
+        follow_redirects=follow_redirects,
         max_redirects=DEFAULT_MAX_REDIRECTS,
     )
 
 
-def fetch_json(method, url, *, headers=None, json=None, params=None, cookies=None, timeout=None):
-    _validate_egress_or_raise(url)
+def fetch_json(
+    method: str,
+    url: str,
+    *,
+    headers: dict | None = None,
+    json: Any = None,
+    params: dict | None = None,
+    cookies: dict | None = None,
+    timeout: float | None = None,
+) -> Any:
+    """Issue a JSON HTTP request, validating the egress URL on every hop.
+
+    Redirects are followed manually so ``_validate_egress_or_raise`` re-runs on
+    each ``Location`` — a blindly-followed redirect could reach a disallowed
+    host/scheme and defeat the egress guard.
+
+    Args:
+        method: HTTP method.
+        url: Absolute request URL (validated before each hop).
+        headers: Optional request headers.
+        json: Optional JSON body.
+        params: Optional query params.
+        cookies: Optional cookies.
+        timeout: Per-request timeout in seconds.
+
+    Returns:
+        The parsed JSON response body.
+
+    Raises:
+        ImageGenerationError: On a non-http(s) URL, a redirect without a
+            ``Location``, or exceeding the redirect cap.
+    """
+    current = url
     with create_client(timeout=timeout) as client:
-        resp = client.request(method, url, headers=headers, json=json, params=params, cookies=cookies)
-        resp.raise_for_status()
-        return resp.json()
+        for _ in range(DEFAULT_MAX_REDIRECTS + 1):
+            _validate_egress_or_raise(current)
+            resp = client.request(
+                method, current, headers=headers, json=json, params=params, cookies=cookies
+            )
+            if resp.is_redirect:
+                location = resp.headers.get("location") or resp.headers.get("Location")
+                if not location:
+                    raise ImageGenerationError("request failed: redirect without location")
+                current = _resolve_redirect_url(str(resp.url), str(location))
+                continue
+            resp.raise_for_status()
+            return resp.json()
+    raise ImageGenerationError("request failed: too many redirects")

--- a/tldw_chatbook/Image_Generation/http_client.py
+++ b/tldw_chatbook/Image_Generation/http_client.py
@@ -1,7 +1,7 @@
 """Sync HTTP shim + light egress guard for the ported image adapters.
 
 Provides the exact surface the server's http_client exposed to Image_Generation,
-backed by httpx.Client. Full SSRF hardening is deferred to task-485; this guard
+backed by httpx.Client. Full SSRF hardening is deferred to task-498; this guard
 rejects non-http(s) schemes, enforces a redirect cap, and re-validates every
 redirect hop, while staying permissive for user-configured (incl. local) backend
 base URLs.
@@ -47,7 +47,7 @@ def _validate_egress_or_raise(url: str) -> None:
     scheme = (urlparse(url).scheme or "").lower()
     if scheme not in ("http", "https"):
         raise ImageGenerationError(f"Refusing non-http(s) URL: {url!r}")
-    # task-485: private/link-local/metadata range blocking for API-returned URLs goes here.
+    # task-498: private/link-local/metadata range blocking for API-returned URLs goes here.
 
 
 def _resolve_redirect_url(base: str, location: str) -> str:

--- a/tldw_chatbook/Image_Generation/listing.py
+++ b/tldw_chatbook/Image_Generation/listing.py
@@ -1,0 +1,169 @@
+"""Helpers for exposing image generation backends in model catalogs."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from tldw_chatbook.Image_Generation.capabilities import (
+    resolve_backend_reference_image_capability,
+)
+from tldw_chatbook.Image_Generation.adapter_registry import get_registry
+from tldw_chatbook.Image_Generation.config import get_image_generation_config
+
+_IMAGE_LISTING_NONCRITICAL_EXCEPTIONS = (
+    AttributeError,
+    KeyError,
+    LookupError,
+    OSError,
+    RuntimeError,
+    TypeError,
+    ValueError,
+)
+
+
+def _path_exists(raw: str | None) -> bool:
+    if not raw:
+        return False
+    try:
+        return Path(str(raw)).expanduser().exists()
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return False
+
+
+def _is_sd_cpp_configured(cfg, enabled: bool) -> bool:
+    if not enabled:
+        return False
+    if not _path_exists(cfg.sd_cpp_binary_path):
+        return False
+    return bool(_path_exists(cfg.sd_cpp_diffusion_model_path) or _path_exists(cfg.sd_cpp_model_path))
+
+
+def _is_swarmui_configured(cfg, enabled: bool) -> bool:
+    if not enabled:
+        return False
+    return bool(getattr(cfg, "swarmui_base_url", None))
+
+
+def _is_openrouter_configured(cfg, enabled: bool) -> bool:
+    if not enabled:
+        return False
+    api_key = (getattr(cfg, "openrouter_image_api_key", None) or os.getenv("OPENROUTER_API_KEY") or "").strip()
+    return bool(api_key)
+
+
+def _is_novita_configured(cfg, enabled: bool) -> bool:
+    if not enabled:
+        return False
+    api_key = (getattr(cfg, "novita_image_api_key", None) or os.getenv("NOVITA_API_KEY") or "").strip()
+    return bool(api_key)
+
+
+def _is_together_configured(cfg, enabled: bool) -> bool:
+    if not enabled:
+        return False
+    api_key = (getattr(cfg, "together_image_api_key", None) or os.getenv("TOGETHER_API_KEY") or "").strip()
+    return bool(api_key)
+
+
+def _is_modelstudio_configured(cfg, enabled: bool) -> bool:
+    if not enabled:
+        return False
+    api_key = (
+        getattr(cfg, "modelstudio_image_api_key", None)
+        or os.getenv("DASHSCOPE_API_KEY")
+        or os.getenv("QWEN_API_KEY")
+        or ""
+    ).strip()
+    return bool(api_key)
+
+
+def _resolve_supported_formats(name: str) -> list[str] | None:
+    registry = get_registry()
+    try:
+        adapter_cls = registry.get_adapter_class(name)
+    except _IMAGE_LISTING_NONCRITICAL_EXCEPTIONS:
+        adapter_cls = None
+    if adapter_cls is None:
+        return None
+    try:
+        formats = getattr(adapter_cls, "supported_formats", None)
+    except _IMAGE_LISTING_NONCRITICAL_EXCEPTIONS:
+        formats = None
+    if not isinstance(formats, (list, set, tuple)):
+        return None
+    cleaned = {str(v).strip() for v in formats if v and str(v).strip()}
+    return sorted(cleaned) if cleaned else None
+
+def list_image_models_for_catalog() -> list[dict[str, Any]]:
+    cfg = get_image_generation_config()
+    registry = get_registry()
+    enabled_backends = set(cfg.enabled_backends or [])
+    names = registry.list_backend_names(include_disabled=False)
+    if not names:
+        return []
+
+    entries: list[dict[str, Any]] = []
+    for name in names:
+        enabled = name in enabled_backends
+        is_configured = enabled
+        if name == "stable_diffusion_cpp":
+            try:
+                is_configured = _is_sd_cpp_configured(cfg, enabled)
+            except _IMAGE_LISTING_NONCRITICAL_EXCEPTIONS as exc:
+                logger.debug("Image backend config check failed for {}: {}", name, exc)
+                is_configured = False
+        if name == "swarmui":
+            try:
+                is_configured = _is_swarmui_configured(cfg, enabled)
+            except _IMAGE_LISTING_NONCRITICAL_EXCEPTIONS as exc:
+                logger.debug("Image backend config check failed for {}: {}", name, exc)
+                is_configured = False
+        if name == "openrouter":
+            try:
+                is_configured = _is_openrouter_configured(cfg, enabled)
+            except _IMAGE_LISTING_NONCRITICAL_EXCEPTIONS as exc:
+                logger.debug("Image backend config check failed for {}: {}", name, exc)
+                is_configured = False
+        if name == "novita":
+            try:
+                is_configured = _is_novita_configured(cfg, enabled)
+            except _IMAGE_LISTING_NONCRITICAL_EXCEPTIONS as exc:
+                logger.debug("Image backend config check failed for {}: {}", name, exc)
+                is_configured = False
+        if name == "together":
+            try:
+                is_configured = _is_together_configured(cfg, enabled)
+            except _IMAGE_LISTING_NONCRITICAL_EXCEPTIONS as exc:
+                logger.debug("Image backend config check failed for {}: {}", name, exc)
+                is_configured = False
+        if name == "modelstudio":
+            try:
+                is_configured = _is_modelstudio_configured(cfg, enabled)
+            except _IMAGE_LISTING_NONCRITICAL_EXCEPTIONS as exc:
+                logger.debug("Image backend config check failed for {}: {}", name, exc)
+                is_configured = False
+
+        entry: dict[str, Any] = {
+            "provider": "image",
+            "id": f"image/{name}",
+            "name": name,
+            "type": "image",
+            "capabilities": {
+                "image_generation": True,
+                "image_reference_input": resolve_backend_reference_image_capability(name, config=cfg).supported,
+            },
+            "modalities": {"input": ["text"], "output": ["image"]},
+            "is_configured": bool(is_configured),
+        }
+
+        supported_formats = _resolve_supported_formats(name)
+        if supported_formats:
+            entry["supported_formats"] = supported_formats
+
+        entries.append(entry)
+
+    return entries

--- a/tldw_chatbook/Image_Generation/prompt_refinement.py
+++ b/tldw_chatbook/Image_Generation/prompt_refinement.py
@@ -1,0 +1,92 @@
+"""Deterministic prompt refinement helpers for image generation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+DEFAULT_PROMPT_REFINEMENT_MODE = "auto"
+DEFAULT_QUALITY_SUFFIX = "high detail, coherent composition, natural lighting, sharp focus"
+
+_KNOWN_MODES = {"off", "auto", "basic"}
+_QUALITY_CUES = (
+    "high detail",
+    "highly detailed",
+    "high quality",
+    "ultra detailed",
+    "photorealistic",
+    "cinematic",
+    "composition",
+    "lighting",
+    "sharp focus",
+    "8k",
+)
+
+
+def normalize_prompt_refinement_mode(value: Any, *, default: str = DEFAULT_PROMPT_REFINEMENT_MODE) -> str:
+    """Normalize prompt refinement mode from bool/string input."""
+    normalized_default = str(default or DEFAULT_PROMPT_REFINEMENT_MODE).strip().lower()
+    if normalized_default not in _KNOWN_MODES:
+        normalized_default = DEFAULT_PROMPT_REFINEMENT_MODE
+
+    if isinstance(value, bool):
+        return "basic" if value else "off"
+    if value is None:
+        return normalized_default
+
+    raw = str(value).strip().lower()
+    if not raw:
+        return normalized_default
+    if raw in {"off", "none", "false", "0", "no"}:
+        return "off"
+    if raw in {"on", "true", "1", "yes", "basic"}:
+        return "basic"
+    if raw in {"auto"}:
+        return "auto"
+    return normalized_default
+
+
+def refine_image_prompt(
+    prompt: str,
+    *,
+    mode: Any = DEFAULT_PROMPT_REFINEMENT_MODE,
+    quality_suffix: str = DEFAULT_QUALITY_SUFFIX,
+    max_length: int | None = None,
+) -> str:
+    """Apply deterministic quality refinement to sparse prompts."""
+    normalized_prompt = _normalize_spaces(prompt)
+    if not normalized_prompt:
+        return ""
+
+    mode_name = normalize_prompt_refinement_mode(mode)
+    if mode_name == "off":
+        return normalized_prompt
+
+    should_enrich = mode_name == "basic" or _needs_quality_guidance(normalized_prompt)
+    if not should_enrich:
+        return normalized_prompt
+
+    suffix = _normalize_spaces(quality_suffix)
+    if not suffix:
+        return normalized_prompt
+    if suffix.lower() in normalized_prompt.lower():
+        return normalized_prompt
+
+    candidate = f"{normalized_prompt}, {suffix}"
+    if isinstance(max_length, int) and max_length > 0 and len(candidate) > max_length:
+        return normalized_prompt
+    return candidate
+
+
+def _needs_quality_guidance(prompt: str) -> bool:
+    lowered = prompt.lower()
+    if any(cue in lowered for cue in _QUALITY_CUES):
+        return False
+    word_count = len(prompt.split())
+    if word_count >= 14:
+        return False
+    return True
+
+
+def _normalize_spaces(value: Any) -> str:
+    return " ".join(str(value or "").split()).strip()
+

--- a/tldw_chatbook/Image_Generation/request_validation.py
+++ b/tldw_chatbook/Image_Generation/request_validation.py
@@ -1,0 +1,178 @@
+"""Shared request validation helpers for image-generation entry points."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+from tldw_chatbook.Image_Generation.config import (
+    DEFAULT_INLINE_MAX_BYTES,
+    DEFAULT_MAX_HEIGHT,
+    DEFAULT_MAX_PIXELS,
+    DEFAULT_MAX_PROMPT_LENGTH,
+    DEFAULT_MAX_STEPS,
+    DEFAULT_MAX_WIDTH,
+    get_image_generation_config,
+)
+
+
+@dataclass(frozen=True)
+class ImageGenerationValidationIssue:
+    code: str
+    message: str
+    path: str
+
+
+def effective_inline_max_bytes(config: Any | None = None) -> int:
+    """Return a positive byte cap for inline/remote image payloads."""
+
+    if config is None:
+        config = get_image_generation_config()
+    raw = getattr(config, "inline_max_bytes", None)
+    if raw is None:
+        return DEFAULT_INLINE_MAX_BYTES
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_INLINE_MAX_BYTES
+    return value if value > 0 else DEFAULT_INLINE_MAX_BYTES
+
+
+def allowed_extra_params_for_backend(backend: str, config: Any) -> set[str]:
+    """Return configured passthrough allowlist keys for an image backend."""
+
+    backend_name = str(backend or "").strip().lower()
+    attr_by_backend = {
+        "stable_diffusion_cpp": "sd_cpp_allowed_extra_params",
+        "swarmui": "swarmui_allowed_extra_params",
+        "openrouter": "openrouter_image_allowed_extra_params",
+        "novita": "novita_image_allowed_extra_params",
+        "together": "together_image_allowed_extra_params",
+        "modelstudio": "modelstudio_image_allowed_extra_params",
+    }
+    attr = attr_by_backend.get(backend_name)
+    if not attr:
+        return set()
+    return {str(item).strip() for item in getattr(config, attr, []) or [] if str(item).strip()}
+
+
+def validate_image_generation_request(
+    structured: dict[str, Any],
+    *,
+    config: Any | None = None,
+) -> list[ImageGenerationValidationIssue]:
+    """Validate shared image-generation bounds and backend passthrough controls."""
+
+    if config is None:
+        config = get_image_generation_config()
+
+    issues: list[ImageGenerationValidationIssue] = []
+    prompt = structured.get("prompt")
+    max_prompt_length = _positive_int_attr(config, "max_prompt_length", DEFAULT_MAX_PROMPT_LENGTH)
+    if isinstance(prompt, str) and len(prompt) > max_prompt_length:
+        issues.append(_issue("prompt exceeds max length", "prompt"))
+
+    width = structured.get("width")
+    height = structured.get("height")
+    max_width = _positive_int_attr(config, "max_width", DEFAULT_MAX_WIDTH)
+    max_height = _positive_int_attr(config, "max_height", DEFAULT_MAX_HEIGHT)
+    max_pixels = _positive_int_attr(config, "max_pixels", DEFAULT_MAX_PIXELS)
+
+    width_ok = _validate_int_bound(issues, width, path="width", max_value=max_width)
+    height_ok = _validate_int_bound(issues, height, path="height", max_value=max_height)
+    if width_ok and height_ok and isinstance(width, int) and isinstance(height, int) and width * height > max_pixels:
+        issues.append(_issue("image dimensions exceed max pixels", "width,height"))
+
+    steps = structured.get("steps")
+    max_steps = _positive_int_attr(config, "max_steps", DEFAULT_MAX_STEPS)
+    _validate_int_bound(issues, steps, path="steps", max_value=max_steps)
+
+    _validate_positive_finite_float(issues, structured.get("cfg_scale"), path="cfg_scale")
+    _validate_extra_params(structured, config, issues)
+    return issues
+
+
+def _issue(message: str, path: str) -> ImageGenerationValidationIssue:
+    return ImageGenerationValidationIssue(
+        code="image_params_invalid",
+        message=message,
+        path=path,
+    )
+
+
+def _positive_int_attr(config: Any, attr: str, default: int) -> int:
+    try:
+        value = int(getattr(config, attr, default))
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+def _validate_int_bound(
+    issues: list[ImageGenerationValidationIssue],
+    value: Any,
+    *,
+    path: str,
+    max_value: int,
+) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, bool) or not isinstance(value, int):
+        issues.append(_issue(f"{path} must be an integer", path))
+        return False
+    if value <= 0 or value > max_value:
+        issues.append(_issue(f"{path} out of range", path))
+        return False
+    return True
+
+
+def _validate_positive_finite_float(
+    issues: list[ImageGenerationValidationIssue],
+    value: Any,
+    *,
+    path: str,
+) -> None:
+    if value is None:
+        return
+    if isinstance(value, bool):
+        issues.append(_issue(f"{path} must be a finite positive number", path))
+        return
+    try:
+        candidate = float(value)
+    except (TypeError, ValueError):
+        issues.append(_issue(f"{path} must be a finite positive number", path))
+        return
+    if not math.isfinite(candidate) or candidate <= 0:
+        issues.append(_issue(f"{path} must be a finite positive number", path))
+
+
+def _validate_extra_params(
+    structured: dict[str, Any],
+    config: Any,
+    issues: list[ImageGenerationValidationIssue],
+) -> None:
+    extra_params = structured.get("extra_params") or {}
+    if not extra_params:
+        return
+    if not isinstance(extra_params, dict):
+        issues.append(_issue("extra_params must be an object", "extra_params"))
+        return
+
+    backend = str(structured.get("backend") or "").strip().lower()
+    allowlist = allowed_extra_params_for_backend(backend, config)
+    exempt_control_keys: set[str] = set()
+    if backend == "modelstudio":
+        exempt_control_keys.add("mode")
+
+    keys_to_validate = [key for key in extra_params if key not in exempt_control_keys]
+    if not keys_to_validate:
+        return
+    for key in keys_to_validate:
+        if key not in allowlist:
+            issues.append(_issue("extra_params key not allowlisted", f"extra_params.{key}"))
+
+    if "cli_args" in extra_params and "cli_args" in allowlist:
+        cli_args = extra_params.get("cli_args")
+        if not isinstance(cli_args, (list, tuple)):
+            issues.append(_issue("cli_args must be a list", "extra_params.cli_args"))

--- a/tldw_chatbook/Image_Generation/worker.py
+++ b/tldw_chatbook/Image_Generation/worker.py
@@ -3,14 +3,47 @@ Phase 2, the chat card) call run_generation() from a thread worker — never on 
 UI loop, because the adapters are synchronous and blocking.
 """
 from __future__ import annotations
+from typing import Any
 from tldw_chatbook.Image_Generation.adapter_registry import get_registry
 from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest, ImageGenResult
 from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+from tldw_chatbook.Image_Generation.request_validation import validate_image_generation_request
 
 
-def build_request(*, backend, prompt, negative_prompt=None, width=None, height=None,
-                  steps=None, cfg_scale=None, seed=None, sampler=None, model=None,
-                  image_format="png", extra_params=None) -> ImageGenRequest:
+def build_request(
+    *,
+    backend: str,
+    prompt: str,
+    negative_prompt: str | None = None,
+    width: int | None = None,
+    height: int | None = None,
+    steps: int | None = None,
+    cfg_scale: float | None = None,
+    seed: int | None = None,
+    sampler: str | None = None,
+    model: str | None = None,
+    image_format: str = "png",
+    extra_params: dict[str, Any] | None = None,
+) -> ImageGenRequest:
+    """Build an :class:`ImageGenRequest` from caller/UI inputs.
+
+    Args:
+        backend: Backend name (must be enabled in config).
+        prompt: Positive prompt text.
+        negative_prompt: Optional negative prompt.
+        width: Optional image width in pixels.
+        height: Optional image height in pixels.
+        steps: Optional sampling steps.
+        cfg_scale: Optional classifier-free-guidance scale.
+        seed: Optional seed (``-1`` for random).
+        sampler: Optional sampler name.
+        model: Optional model override.
+        image_format: Output format (defaults to ``"png"``).
+        extra_params: Backend-specific passthrough params (coerced to ``{}`` if None).
+
+    Returns:
+        A frozen :class:`ImageGenRequest`.
+    """
     return ImageGenRequest(
         backend=backend, prompt=prompt, negative_prompt=negative_prompt,
         width=width, height=height, steps=steps, cfg_scale=cfg_scale, seed=seed,
@@ -20,7 +53,25 @@ def build_request(*, backend, prompt, negative_prompt=None, width=None, height=N
 
 
 def run_generation(request: ImageGenRequest) -> ImageGenResult:
-    """Blocking. Resolve the backend and invoke its adapter. Raises ImageGenerationError."""
+    """Validate, resolve the backend, and invoke its adapter. Blocking.
+
+    Enforces the request-validation layer (bounds + per-backend ``extra_params``
+    allowlist) at this single entry point *before* dispatch, so a caller that
+    constructs an :class:`ImageGenRequest` directly cannot bypass it (e.g. the
+    stable-diffusion.cpp ``cli_args`` passthrough).
+
+    Must run on a thread — the adapters are synchronous and blocking.
+
+    Args:
+        request: The image generation request.
+
+    Returns:
+        The generated :class:`ImageGenResult`.
+
+    Raises:
+        ImageGenerationError: If the backend is not enabled/available, the
+            request fails validation, or the adapter fails to load.
+    """
     registry = get_registry()
     resolved = registry.resolve_backend(request.backend)
     if resolved is None:
@@ -28,6 +79,20 @@ def run_generation(request: ImageGenRequest) -> ImageGenResult:
             f"Backend {request.backend!r} is not enabled/available. "
             f"Check [image_generation].enabled_backends."
         )
+    issues = validate_image_generation_request(
+        {
+            "backend": resolved,
+            "prompt": request.prompt,
+            "width": request.width,
+            "height": request.height,
+            "steps": request.steps,
+            "cfg_scale": request.cfg_scale,
+            "extra_params": request.extra_params,
+        }
+    )
+    if issues:
+        detail = "; ".join(f"{issue.path}: {issue.message}" for issue in issues)
+        raise ImageGenerationError(f"Invalid image generation request: {detail}")
     adapter = registry.get_adapter(resolved)
     if adapter is None:
         raise ImageGenerationError(f"Adapter for backend {resolved!r} failed to load.")

--- a/tldw_chatbook/Image_Generation/worker.py
+++ b/tldw_chatbook/Image_Generation/worker.py
@@ -1,0 +1,34 @@
+"""Request builder + blocking generation entry. The Textual demo screen (and, in
+Phase 2, the chat card) call run_generation() from a thread worker — never on the
+UI loop, because the adapters are synchronous and blocking.
+"""
+from __future__ import annotations
+from tldw_chatbook.Image_Generation.adapter_registry import get_registry
+from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest, ImageGenResult
+from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+
+def build_request(*, backend, prompt, negative_prompt=None, width=None, height=None,
+                  steps=None, cfg_scale=None, seed=None, sampler=None, model=None,
+                  image_format="png", extra_params=None) -> ImageGenRequest:
+    return ImageGenRequest(
+        backend=backend, prompt=prompt, negative_prompt=negative_prompt,
+        width=width, height=height, steps=steps, cfg_scale=cfg_scale, seed=seed,
+        sampler=sampler, model=model, format=image_format,
+        extra_params=dict(extra_params or {}),
+    )
+
+
+def run_generation(request: ImageGenRequest) -> ImageGenResult:
+    """Blocking. Resolve the backend and invoke its adapter. Raises ImageGenerationError."""
+    registry = get_registry()
+    resolved = registry.resolve_backend(request.backend)
+    if resolved is None:
+        raise ImageGenerationError(
+            f"Backend {request.backend!r} is not enabled/available. "
+            f"Check [image_generation].enabled_backends."
+        )
+    adapter = registry.get_adapter(resolved)
+    if adapter is None:
+        raise ImageGenerationError(f"Adapter for backend {resolved!r} failed to load.")
+    return adapter.generate(request)

--- a/tldw_chatbook/UI/Screens/image_gen_demo_screen.py
+++ b/tldw_chatbook/UI/Screens/image_gen_demo_screen.py
@@ -43,16 +43,27 @@ class ImageGenDemoScreen(BaseAppScreen):
                 )
                 for entry in list_image_models_for_catalog()
             ]
-            select_options = opts or [("(no backends enabled)", "")]
-            # Pre-select the first entry so the panel is generate-ready
-            # without an extra manual pick -- this is a one-backend-at-a-time
-            # proof surface, not a form the user is expected to leave blank.
-            yield Select(
-                select_options,
-                id="imagegen-backend",
-                value=select_options[0][1],
-                allow_blank=False,
-            )
+            if opts:
+                # Pre-select the first entry so the panel is generate-ready
+                # without an extra manual pick -- a one-backend-at-a-time proof
+                # surface, not a form the user is expected to leave blank.
+                yield Select(
+                    opts,
+                    id="imagegen-backend",
+                    value=opts[0][1],
+                    allow_blank=False,
+                )
+            else:
+                # No enabled backends: a placeholder with a sentinel value.
+                # Generate no-ops with a clear message (see on_button_pressed),
+                # rather than the old contradictory blank-value/allow_blank=False
+                # state that guaranteed a failed generation.
+                yield Select(
+                    [("(no backends enabled)", "none")],
+                    id="imagegen-backend",
+                    value="none",
+                    allow_blank=False,
+                )
             yield TextArea(id="imagegen-prompt")
             yield TextArea(id="imagegen-negative")
             yield Input(placeholder="seed (blank = -1)", id="imagegen-seed")
@@ -67,6 +78,11 @@ class ImageGenDemoScreen(BaseAppScreen):
         # Read all inputs on the main (UI) thread, then hand them to the
         # worker -- query_one() is not thread-safe against the DOM.
         backend = self.query_one("#imagegen-backend", Select).value
+        if not backend or backend == "none":
+            self._set_status(
+                "No backend enabled — set [image_generation].enabled_backends in config."
+            )
+            return
         prompt = self.query_one("#imagegen-prompt", TextArea).text
         negative = self.query_one("#imagegen-negative", TextArea).text or None
         seed_raw = self.query_one("#imagegen-seed", Input).value.strip()
@@ -74,8 +90,13 @@ class ImageGenDemoScreen(BaseAppScreen):
             seed = int(seed_raw)
         except ValueError:
             seed = -1
-        self.query_one("#imagegen-status", Static).update("Generating…")
+        self._set_status("Generating…")
         self._generate(backend, prompt, negative, seed)
+
+    def _set_status(self, message: str) -> None:
+        """Update the status line. UI-thread only (call via ``call_from_thread``
+        from a worker)."""
+        self.query_one("#imagegen-status", Static).update(message)
 
     @work(thread=True, exclusive=True, group="imagegen-demo")
     def _generate(self, backend, prompt, negative, seed) -> None:
@@ -95,9 +116,9 @@ class ImageGenDemoScreen(BaseAppScreen):
             self.app.call_from_thread(self._render_result, res, req)
         except Exception as exc:  # surface any failure (incl. render/decode) as status
             logger.warning("Image Gen (dev) generation failed: {}", exc)
-            self.app.call_from_thread(
-                self.query_one("#imagegen-status", Static).update, f"Error: {exc}"
-            )
+            # Marshal the DOM write onto the UI thread -- query_one() must not
+            # run on the worker thread.
+            self.app.call_from_thread(self._set_status, f"Error: {exc}")
 
     def _render_result(self, res, req) -> None:
         # Low-level render (rich-pixels), decoupled from the Console

--- a/tldw_chatbook/UI/Screens/image_gen_demo_screen.py
+++ b/tldw_chatbook/UI/Screens/image_gen_demo_screen.py
@@ -1,0 +1,109 @@
+"""THROWAWAY dev panel (Phase 1) for the image-generation feature.
+
+Proves the backend engine (`Image_Generation.worker` + `.listing`) end to end
+from inside the Textual app: pick a configured backend, type a prompt, hit
+Generate, see the image. Replaced by the real chat card in Phase 2 -- this
+screen persists nothing and is reachable only via the command palette.
+
+Renders the generated image with the low-level `rich_pixels`/PIL primitives
+directly (NOT the Console transcript/attachment rendering path), since this
+panel has no message list to attach an image to.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from loguru import logger
+from textual import work
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Button, Input, Label, Select, Static, TextArea
+
+from ..Navigation.base_app_screen import BaseAppScreen
+from ...Image_Generation.worker import build_request, run_generation
+from ...Image_Generation.listing import list_image_models_for_catalog
+
+if TYPE_CHECKING:
+    from tldw_chatbook.app import TldwCli
+
+
+class ImageGenDemoScreen(BaseAppScreen):
+    """Throwaway proof-of-life panel for the image-generation backends."""
+
+    def __init__(self, app_instance: "TldwCli", **kwargs):
+        super().__init__(app_instance, "imagegen_demo", **kwargs)
+
+    def compose_content(self) -> ComposeResult:
+        with Vertical(id="imagegen-demo"):
+            yield Label("Image Gen (dev) — throwaway Phase-1 panel")
+            opts = [
+                (
+                    f'{entry["name"]}{"" if entry.get("is_configured") else "  (not configured)"}',
+                    entry["name"],
+                )
+                for entry in list_image_models_for_catalog()
+            ]
+            select_options = opts or [("(no backends enabled)", "")]
+            # Pre-select the first entry so the panel is generate-ready
+            # without an extra manual pick -- this is a one-backend-at-a-time
+            # proof surface, not a form the user is expected to leave blank.
+            yield Select(
+                select_options,
+                id="imagegen-backend",
+                value=select_options[0][1],
+                allow_blank=False,
+            )
+            yield TextArea(id="imagegen-prompt")
+            yield TextArea(id="imagegen-negative")
+            yield Input(placeholder="seed (blank = -1)", id="imagegen-seed")
+            yield Button("Generate", id="imagegen-generate", variant="primary")
+            yield Static(id="imagegen-status")
+            yield Static(id="imagegen-image")
+            yield Static(id="imagegen-meta")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "imagegen-generate":
+            self._generate()
+
+    @work(thread=True, exclusive=True, group="imagegen-demo")
+    def _generate(self) -> None:
+        backend = self.query_one("#imagegen-backend", Select).value
+        prompt = self.query_one("#imagegen-prompt", TextArea).text
+        negative = self.query_one("#imagegen-negative", TextArea).text or None
+        seed_raw = self.query_one("#imagegen-seed", Input).value.strip()
+        seed = int(seed_raw) if seed_raw.lstrip("-").isdigit() else -1
+        self.app.call_from_thread(
+            self.query_one("#imagegen-status", Static).update, "Generating…"
+        )
+        try:
+            req = build_request(
+                backend=backend,
+                prompt=prompt,
+                negative_prompt=negative,
+                seed=seed,
+                image_format="png",
+            )
+            res = run_generation(req)  # blocking; we are in a worker thread
+        except Exception as exc:  # surface the error clearly (incl. inline_max_bytes cap)
+            logger.warning("Image Gen (dev) generation failed: {}", exc)
+            self.app.call_from_thread(
+                self.query_one("#imagegen-status", Static).update, f"Error: {exc}"
+            )
+            return
+        self.app.call_from_thread(self._render_result, res, req)
+
+    def _render_result(self, res, req) -> None:
+        # Low-level render (rich-pixels), decoupled from the Console
+        # transcript/attachment path -- this panel has no message list.
+        from rich_pixels import Pixels
+        from PIL import Image as PILImage
+        import io
+
+        img = PILImage.open(io.BytesIO(res.content))
+        img.thumbnail((80, 40))
+        self.query_one("#imagegen-status", Static).update("Done")
+        self.query_one("#imagegen-image", Static).update(Pixels.from_image(img))
+        self.query_one("#imagegen-meta", Static).update(
+            f"backend={req.backend} format={res.content_type} bytes={res.bytes_len} "
+            f"seed={req.seed} prompt={req.prompt!r}"
+        )

--- a/tldw_chatbook/UI/Screens/image_gen_demo_screen.py
+++ b/tldw_chatbook/UI/Screens/image_gen_demo_screen.py
@@ -62,19 +62,27 @@ class ImageGenDemoScreen(BaseAppScreen):
             yield Static(id="imagegen-meta")
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        if event.button.id == "imagegen-generate":
-            self._generate()
-
-    @work(thread=True, exclusive=True, group="imagegen-demo")
-    def _generate(self) -> None:
+        if event.button.id != "imagegen-generate":
+            return
+        # Read all inputs on the main (UI) thread, then hand them to the
+        # worker -- query_one() is not thread-safe against the DOM.
         backend = self.query_one("#imagegen-backend", Select).value
         prompt = self.query_one("#imagegen-prompt", TextArea).text
         negative = self.query_one("#imagegen-negative", TextArea).text or None
         seed_raw = self.query_one("#imagegen-seed", Input).value.strip()
-        seed = int(seed_raw) if seed_raw.lstrip("-").isdigit() else -1
-        self.app.call_from_thread(
-            self.query_one("#imagegen-status", Static).update, "Generating…"
-        )
+        try:
+            seed = int(seed_raw)
+        except ValueError:
+            seed = -1
+        self.query_one("#imagegen-status", Static).update("Generating…")
+        self._generate(backend, prompt, negative, seed)
+
+    @work(thread=True, exclusive=True, group="imagegen-demo")
+    def _generate(self, backend, prompt, negative, seed) -> None:
+        # Blocking generation on a worker thread; all DOM writes go through
+        # call_from_thread(). Everything (incl. the render/decode step) stays
+        # inside this try/except so no failure mode can crash the app --
+        # @work defaults to exit_on_error=True.
         try:
             req = build_request(
                 backend=backend,
@@ -84,13 +92,12 @@ class ImageGenDemoScreen(BaseAppScreen):
                 image_format="png",
             )
             res = run_generation(req)  # blocking; we are in a worker thread
-        except Exception as exc:  # surface the error clearly (incl. inline_max_bytes cap)
+            self.app.call_from_thread(self._render_result, res, req)
+        except Exception as exc:  # surface any failure (incl. render/decode) as status
             logger.warning("Image Gen (dev) generation failed: {}", exc)
             self.app.call_from_thread(
                 self.query_one("#imagegen-status", Static).update, f"Error: {exc}"
             )
-            return
-        self.app.call_from_thread(self._render_result, res, req)
 
     def _render_result(self, res, req) -> None:
         # Low-level render (rich-pixels), decoupled from the Console

--- a/tldw_chatbook/UI/image_gen_command_provider.py
+++ b/tldw_chatbook/UI/image_gen_command_provider.py
@@ -1,0 +1,22 @@
+"""Command-palette entry for the throwaway Image Gen (dev) panel (Phase 1)."""
+from __future__ import annotations
+
+from textual.command import Hit, Hits, Provider
+
+from .Screens.image_gen_demo_screen import ImageGenDemoScreen
+
+
+class ImageGenCommandProvider(Provider):
+    """Yield a single "Image Gen (dev)" command that opens the demo panel."""
+
+    async def search(self, query: str) -> Hits:
+        matcher = self.matcher(query)
+        label = "Image Gen (dev)"
+        score = matcher.match(label)
+        if score > 0:
+            yield Hit(
+                score,
+                matcher.highlight(label),
+                lambda: self.app.push_screen(ImageGenDemoScreen(self.app)),
+                help="Open the throwaway image-generation demo panel",
+            )

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -343,6 +343,7 @@ INGEST_NAV_BUTTON_IDS: list[str] = []
 INGEST_VIEW_IDS: list[str] = []
 from .UI.Tools_Settings_Window import ToolsSettingsWindow  # noqa: E402
 from .UI.console_command_provider import ConsoleCommandProvider  # noqa: E402
+from .UI.image_gen_command_provider import ImageGenCommandProvider  # noqa: E402
 from tldw_chatbook.Chat_Grammars_Interop import (  # noqa: E402
     ChatGrammarsScopeService,
     LocalChatGrammarsService,
@@ -2747,6 +2748,7 @@ class TldwCli(
         LibraryIngestProvider,
         DeveloperProvider,
         ConsoleCommandProvider,
+        ImageGenCommandProvider,
     }
 
     ALL_INGEST_VIEW_IDS = INGEST_VIEW_IDS

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -766,6 +766,7 @@ def load_settings(force_reload: bool = False) -> Dict:
     final_chat_defaults_cli = get_toml_section("chat_defaults")
     final_character_defaults_cli = get_toml_section("character_defaults")
     final_notes_settings_cli = get_toml_section("notes")
+    final_image_generation_settings_cli = get_toml_section("image_generation")
     final_console_settings_cli = copy.deepcopy(get_toml_section("console"))
     if not isinstance(final_console_settings_cli, dict):
         final_console_settings_cli = {}
@@ -900,6 +901,7 @@ def load_settings(force_reload: bool = False) -> Dict:
         "character_defaults": final_character_defaults_cli,
         "notes": final_notes_settings_cli,  # For notes auto-save settings
         "console": final_console_settings_cli,  # For Console behavior settings
+        "image_generation": final_image_generation_settings_cli,  # For Image_Generation/config.py loader
         # Single User
         "SINGLE_USER_FIXED_ID": single_user_fixed_id,
         # Auth
@@ -2753,6 +2755,68 @@ kitty = "regular"
 wezterm = "regular"
 iterm2 = "regular"
 default = "pixels"
+
+[image_generation]
+default_backend = "swarmui"          # local SwarmUI instance is the friendliest zero-key default
+enabled_backends = ["swarmui"]
+max_width = 1024
+max_height = 1024
+max_pixels = 1048576
+max_steps = 50
+max_prompt_length = 1000
+inline_max_bytes = 4000000
+
+[image_generation.stable_diffusion_cpp]
+binary_path = ""                      # local `sd` CLI; empty = backend unusable
+diffusion_model_path = ""             # OR model_path
+model_path = ""
+vae_path = ""
+lora_paths = []
+device = "auto"
+default_steps = 25
+default_cfg_scale = 7.5
+default_sampler = "euler_a"
+timeout_seconds = 120
+allowed_extra_params = []
+
+[image_generation.swarmui]
+base_url = "http://127.0.0.1:7801"
+default_model = ""
+timeout_seconds = 120
+allowed_extra_params = []
+# swarm_token: secret, resolved via env/keyring precedence, not stored plaintext here
+
+[image_generation.openrouter]
+base_url = "https://openrouter.ai/api/v1"
+default_model = "openai/gpt-image-1"
+timeout_seconds = 120
+allowed_extra_params = []
+api_key = "<API_KEY_HERE>"
+
+[image_generation.novita]
+base_url = "https://api.novita.ai"
+default_model = "sd_xl_base_1.0.safetensors"
+timeout_seconds = 180
+poll_interval_seconds = 2
+allowed_extra_params = []
+api_key = "<API_KEY_HERE>"
+
+[image_generation.together]
+base_url = "https://api.together.xyz/v1"
+default_model = "black-forest-labs/FLUX.1-schnell-Free"
+timeout_seconds = 120
+allowed_extra_params = []
+api_key = "<API_KEY_HERE>"
+
+[image_generation.modelstudio]
+base_url = ""                         # region-derived if empty
+default_model = "qwen-image"
+region = "sg"                         # sg|cn|us
+mode = "auto"                         # sync|async|auto
+poll_interval_seconds = 2
+timeout_seconds = 180
+allowed_extra_params = []
+api_key = "<API_KEY_HERE>"
 
 [character_defaults]
 # Default settings specifically for the 'Character' tab

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -2770,6 +2770,7 @@ inline_max_bytes = 4000000
 binary_path = ""                      # local `sd` CLI; empty = backend unusable
 diffusion_model_path = ""             # OR model_path
 model_path = ""
+llm_path = ""
 vae_path = ""
 lora_paths = []
 device = "auto"


### PR DESCRIPTION
## Image Generation — Multi-Provider Foundation (Phase 1)

Phase 1 of the in-chat image-generation program (Console conversations + character canvas, mirroring tldw_server's webui, styled like the reference render-details card). This PR is **foundation-only**: it ports tldw_server's `Image_Generation` engine into `tldw_chatbook` as a self-contained, 6-backend backend layer, re-homed onto this app's TOML + keyring + `httpx`, and proves it end-to-end with a **throwaway command-palette demo panel**.

**No chat UI and no DB schema change in this phase** (both deliberately deferred — see Scope).

### What's included
- New `tldw_chatbook/Image_Generation/` package — ported mostly verbatim from tldw_server (only import paths repointed), FastAPI/pydantic-free:
  - **6 backends**: `stable_diffusion_cpp` (local subprocess), `swarmui` (fronts ComfyUI), `openrouter` (gpt-image-1), `novita`, `together`, `modelstudio` — behind a lazy adapter registry.
  - Request validation, prompt refinement, model listing / `is_configured`.
  - Re-homed `config.py`: nested `[image_generation]` TOML → the server's flat dataclass field names; secret precedence **env → config → keyring → optional shared**, with resolved secrets written into the config `*_api_key` fields so `is_configured` and the adapters agree (incl. keyring-only backends). Adds the `[image_generation]` default block to the app config template + surfaces the section in `load_settings()`.
  - New sync `http_client.py` shim (`fetch_json`/`create_client`) + a **light egress guard** (rejects non-`http(s)`, permissive for local/user-configured URLs; real SSRF hardening is task-485).
  - `worker.py` — request builder (defaults `format="png"`) + blocking generation entry (called from a Textual thread worker; adapters are synchronous by design).
  - Import-light package (`__getattr__` lazy accessors) so importing it pulls in no adapters/Pillow — guarded by a cold-start test.
- Throwaway `ImageGenDemoScreen` + command-palette entry ("Image Gen (dev)") as the Phase-1 proof surface (renders via `rich-pixels`/PIL, persists nothing, crash-safe on the worker thread).
- 43 tests across `Tests/Image_Generation/` (per-adapter mocked, config-loader precedence incl. keyring-only, request-validation bounds, registry, prompt-refinement, cold-start guard, demo-screen mount).

### Scope (deferred to later phases)
- Phase 2: the Console "Image Generation" chat card + `/generate-image [:backend]` trigger + DB storage of generation metadata/variants (introduces the schema migration) + variants/regenerate/TTS + the "Style" field.
- Phase 3: character-canvas generation (auto-prompt from appearance, per-mood reaction images).
- Reference-image support dropped in Phase 1 (`reference_images.py` not ported; `reference_image=None` no-ops).
- Real egress/SSRF protections: **task-485** (this PR ships a light placeholder guard).
- The orphaned `Media_Creation` SwarmUI stack is left untouched (separate cleanup task).

### Testing / DoD
- `ruff check tldw_chatbook/Image_Generation Tests/Image_Generation` → **All checks passed!**
- `pytest Tests/Image_Generation/` → **43 passed**
- `import tldw_chatbook.app` → clean
- (CI on this repo is intentionally cancelled by another build — verified locally.)

### Review process
Executed via subagent-driven development: each of 18 tasks got a fresh implementer + a task-scoped spec/quality review (three tasks took a review-driven fix), followed by a whole-branch merge-readiness review (verdict: fix-then-merge → lint cleared).

### Non-blocking follow-ups (from the final review)
Demo-panel error-branch `query_one` on the worker thread; `http_client` polish (docstrings, `timeout=0`, env-parse-at-import); `worker.py` untested adapter-load branch + `test_worker` registry reset; `__init__` `AttributeError` message; `test_cold_start` `sys.modules` restore; demo panel's missing size/steps inputs (spec §7); opt-in live integration tests (spec §8); task-485 (egress + ModelStudio dead allowlist local).

⚠️ **Please do not merge without an explicit maintainer gate** (per repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Foundation for multi-provider image generation (Phase 1): adds a new `tldw_chatbook/Image_Generation` engine with 6 backends, a lazy registry, and a command‑palette demo screen. Adds stricter request validation and safer HTTP redirect handling; no chat UI or DB changes.

- New Features
  - New `Image_Generation` package with 6 backends: stable‑diffusion.cpp (local), SwarmUI, OpenRouter, Novita, Together, and Alibaba ModelStudio; lazy registry and sync adapters.
  - Config via `[image_generation]` TOML + env + keyring (env > config > keyring); resolved secrets are written into `*_api_key` and exposed via `load_settings()`.
  - Sync `http_client.py` using `httpx` with a light egress guard (http/https only) and a redirect cap; manual redirect follow with per‑hop revalidation.
  - Shared helpers: request validation, prompt refinement, model listing/`is_configured`, and image format utilities.
  - Worker entry (`build_request` defaults `format="png"`, `run_generation` enforces validation) and a throwaway “Image Gen (dev)” screen from the command palette; renders images inline, persists nothing.
  - Tests cover adapters, registry, config precedence, validation, and the demo panel.

- Bug Fixes
  - Hardened HTTP: `fetch_json` now validates every redirect; client no longer auto‑follows redirects; robust env parsing for `DEFAULT_MAX_REDIRECTS`.
  - ModelStudio enforces an allowlisted host when fetching images.
  - Demo panel updates status on the UI thread and handles “no backends” state.
  - Follow‑ups: task‑498 (egress/SSRF hardening) and task‑497 (Phase‑1 polish).

<sup>Written for commit 27185bc6f45b6c7d756fd88d4d05120289a5d579. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

