### PR TITLE
Skills: Codex-style $-mention invocation (breaking: /skill-name removed)

### DIFF
--- a/Docs/superpowers/plans/2026-07-23-skills-dollar-mention-invocation-plan.md
+++ b/Docs/superpowers/plans/2026-07-23-skills-dollar-mention-invocation-plan.md
@@ -1,0 +1,527 @@
+# Codex-Style `$`-Mention Skill Invocation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate Console user skill invocation to the Codex convention — `$skill-name` becomes THE invocation (leading form keeps `{{args}}`; embedded mentions splice argless at position), and `/skill-name` invocation is hard-removed.
+
+**Architecture:** A pure mention scanner (code-span-aware, exact case-sensitive matching) lives in `console_skill_resolver`; `_apply_skill_substitution` in the controller gains a leading-`$` branch (today's semantics re-sigiled) plus an embedded splice pass with a new non-aborting notes channel; the composer's `/`-fallback claiming and the `/skills` run form are deleted.
+
+**Tech Stack:** Python 3.11+, pytest. No new dependencies.
+
+**Design doc:** `Docs/superpowers/specs/2026-07-23-skills-dollar-mention-invocation-design.md` (read it if a requirement here seems ambiguous — it governs).
+
+## Global Constraints
+
+- **Sigil rules (verbatim from spec):** leading `$skill-name args…` = arg-bearing whole-message form (args → `{{args}}`, inline-replace / fork-takeover, untrusted → refuse); embedded `$skill-name` anywhere else = **argless** splice at the mention's position preserving ALL surrounding prose; multiple embedded mentions each expand.
+- **Embedded matching is exact + case-SENSITIVE** against canonical (lowercase) skill names: `$PATH`/`$HOME`/`$5` stay literal. Leading form keeps `resolve_skill_command`'s case-insensitive/unique-prefix behavior.
+- **Code spans skipped:** mentions inside ``` fenced blocks or inline `backtick` spans stay literal.
+- **No recursion:** single pass over the user's original text; a `$mention` inside a spliced body is inert.
+- **Fork cannot be embedded:** embedded mention whose `execute_skill` result has `execution_mode != "inline"` stays literal (no note). Embedded untrusted (SkillTrustBlockedError) stays literal + a system note. A leading resolved mention does NOT get its args embedded-scanned.
+- **Hard remove `/skill-name` at BOTH layers:** the composer fallback resolver (chat_screen registration + `make_skill_fallback_resolver` itself) and the controller's leading-`/` branch. `/skills` bare list stays; its `<name> [args]` run form is removed.
+- **Payload ordering preserved:** skills → dictionaries → world-info at all 4 send sites; the deliberate skip-skills site (search "may execute skills with side effects") stays skill-free.
+- **Ephemeral only:** splicing happens on the provider payload; transcripts keep raw text.
+- **Tests:** run via `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <paths> -q`; trust/UI suites need the `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring` prefix. `Tests/Skills/test_skills_library_flow.py::test_skill_editor_canvas_scrolls_trust_panel_into_view` is a known flaky (cross-test pollution) — re-run in isolation, don't chase.
+- **Commit hygiene:** `git add` ONLY the files each task names — NEVER `git add -A` (the tracked scratch file `.superpowers/sdd/progress.md` must not be swept in).
+
+## File Structure
+
+| File | Change |
+|------|--------|
+| `tldw_chatbook/Chat/console_skill_resolver.py` | Add `MENTION_SIGIL`, `SkillMention`, `find_embedded_mentions`, `_code_span_mask`, `SKILL_MENTION_SKIPPED_NOTE`; `format_skills_list` rows `$name`; DELETE `make_skill_fallback_resolver` (Task 4) |
+| `tldw_chatbook/Chat/console_chat_controller.py` | `_apply_skill_substitution` (def at `:1727`): leading branch re-sigiled to `$`, embedded splice pass, return becomes 3-tuple with notes; 4 call sites updated |
+| `tldw_chatbook/UI/Screens/chat_screen.py` | Remove fallback registration (`:1865-1867`) + `make_skill_fallback_resolver` import (`:100`); `/skills` run form → hint; pick-submit composes `$name`; blocked-hint copy → `$name` |
+| `Tests/Chat/test_console_skill_resolver.py`, `Tests/Chat/test_console_skill_substitution.py`, `Tests/UI/test_console_skill_commands.py`, `Tests/Chat/test_console_command_grammar.py` | New scanner tests; flip `/`-pinning tests to `$`; delete fallback-resolver tests |
+
+---
+
+### Task 1: Pure mention scanner + `$name` list rows (resolver)
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_skill_resolver.py` (constants near `:28`; `format_skills_list` near `:155`)
+- Test: `Tests/Chat/test_console_skill_resolver.py` (extend)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `MENTION_SIGIL = "$"`; `SkillMention(start: int, end: int, name: str)` frozen dataclass (`start` = index of the `$`, `end` = one past the last token char); `find_embedded_mentions(text: str, names: frozenset[str]) -> tuple[SkillMention, ...]`; `SKILL_MENTION_SKIPPED_NOTE` (str, `.format(name=...)`). Task 3 consumes all four.
+
+- [ ] **Step 1: Write the failing tests** (append to `Tests/Chat/test_console_skill_resolver.py`)
+
+```python
+from tldw_chatbook.Chat.console_skill_resolver import (
+    SkillMention,
+    find_embedded_mentions,
+)
+
+_NAMES = frozenset({"code-review", "style-guide", "path"})
+
+
+def test_embedded_mention_found_mid_prose():
+    text = "please $style-guide this draft"
+    mentions = find_embedded_mentions(text, _NAMES)
+    assert mentions == (SkillMention(start=7, end=19, name="style-guide"),)
+    assert text[7:19] == "$style-guide"
+
+
+def test_embedded_mention_trailing_punctuation_stays_prose():
+    mentions = find_embedded_mentions("run $style-guide.", _NAMES)
+    assert mentions[0].name == "style-guide"
+    assert mentions[0].end == 16  # the "." is not part of the token
+
+
+def test_case_sensitive_exact_match_only():
+    # $PATH stays literal even though a skill named "path" exists.
+    assert find_embedded_mentions("echo $PATH", _NAMES) == ()
+    assert find_embedded_mentions("echo $path", _NAMES)[0].name == "path"
+    # prefix / unknown / numeric stay literal
+    assert find_embedded_mentions("$style", _NAMES) == ()
+    assert find_embedded_mentions("$5 and $100", _NAMES) == ()
+
+
+def test_multiple_mentions_all_found_in_order():
+    text = "$code-review then $style-guide"
+    names = [m.name for m in find_embedded_mentions(text, _NAMES)]
+    assert names == ["code-review", "style-guide"]
+
+
+def test_code_spans_are_skipped():
+    fenced = "look:\n```sh\necho $path\n```\nand $path here"
+    mentions = find_embedded_mentions(fenced, _NAMES)
+    assert len(mentions) == 1
+    assert fenced[mentions[0].start :].startswith("$path here"[:5])
+    inline = "use `$path` literally but $path expands"
+    inline_mentions = find_embedded_mentions(inline, _NAMES)
+    assert len(inline_mentions) == 1
+    assert inline_mentions[0].start == inline.rindex("$path")
+
+
+def test_skills_list_rows_use_dollar_sigil():
+    from tldw_chatbook.Chat.console_skill_resolver import (
+        SkillCommandCandidate,
+        format_skills_list,
+    )
+    listing = format_skills_list(
+        (SkillCommandCandidate(name="code-review", description="d"),)
+    )
+    assert "$code-review" in listing
+    assert "/code-review" not in listing
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Chat/test_console_skill_resolver.py -q`
+Expected: FAIL — `ImportError: cannot import name 'SkillMention'`.
+
+- [ ] **Step 3: Implement** (in `console_skill_resolver.py`)
+
+Add near the existing constants (`SKILL_ARGS_MAX` is at `:28`):
+
+```python
+MENTION_SIGIL = "$"
+"""Leading character of a Codex-style skill mention (``$skill-name``)."""
+
+_MENTION_TOKEN = re.compile(r"[A-Za-z0-9-]+")
+
+SKILL_MENTION_SKIPPED_NOTE = (
+    'Skipped "${name}" — this skill needs review before it can run. '
+    "Open /skills to review it."
+)
+
+
+@dataclass(frozen=True)
+class SkillMention:
+    """One embedded ``$skill-name`` mention found in a draft.
+
+    Args:
+        start: Index of the ``$`` sigil in the scanned text.
+        end: Index one past the last token character.
+        name: The matched canonical (lowercase) skill name.
+    """
+
+    start: int
+    end: int
+    name: str
+
+
+def _code_span_mask(text: str) -> list[bool]:
+    """Return a per-character mask, True inside markdown code spans.
+
+    Fenced blocks: a line whose stripped form starts with ``````` toggles
+    fence state; fence lines and everything inside are masked. Inline spans:
+    paired backticks within a non-fence line are masked inclusively; an
+    unpaired backtick masks nothing.
+    """
+    mask = [False] * len(text)
+    in_fence = False
+    pos = 0
+    for line in text.splitlines(keepends=True):
+        if line.strip().startswith("```"):
+            in_fence = not in_fence
+            for i in range(pos, pos + len(line)):
+                mask[i] = True
+        elif in_fence:
+            for i in range(pos, pos + len(line)):
+                mask[i] = True
+        else:
+            i = 0
+            while i < len(line):
+                if line[i] == "`":
+                    close = line.find("`", i + 1)
+                    if close == -1:
+                        break
+                    for j in range(i, close + 1):
+                        mask[pos + j] = True
+                    i = close + 1
+                else:
+                    i += 1
+        pos += len(line)
+    return mask
+
+
+def find_embedded_mentions(
+    text: str, names: frozenset[str]
+) -> tuple[SkillMention, ...]:
+    """Find embedded ``$skill-name`` mentions eligible for splicing.
+
+    Exact, case-SENSITIVE matching against ``names`` (canonical lowercase
+    skill names): ``$PATH`` stays literal even when a skill named ``path``
+    exists. Mentions inside markdown code spans are skipped. Single pass —
+    callers must never re-scan spliced output (no recursion).
+
+    Args:
+        text: The draft text to scan (the user's original message).
+        names: Canonical skill names eligible for expansion.
+
+    Returns:
+        Non-overlapping mentions in document order.
+    """
+    mask = _code_span_mask(text)
+    mentions: list[SkillMention] = []
+    index = 0
+    while index < len(text):
+        if text[index] == MENTION_SIGIL and not mask[index]:
+            match = _MENTION_TOKEN.match(text, index + 1)
+            if match is not None and match.group(0) in names:
+                mentions.append(
+                    SkillMention(start=index, end=match.end(), name=match.group(0))
+                )
+                index = match.end()
+                continue
+        index += 1
+    return tuple(mentions)
+```
+
+(`re` and `dataclass` are already imported in this module; add them if not.)
+
+In `format_skills_list` (near `:155`), change both row-building lines from `f"/{candidate.name} — {candidate.description}"` / `f"/{candidate.name}"` to `f"${candidate.name} — {candidate.description}"` / `f"${candidate.name}"`. Update any pre-existing `format_skills_list` test that asserts `/name` rows to `$name` (that is an intended flip — document it in your report).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Chat/test_console_skill_resolver.py -q`
+Expected: PASS (all, including flipped list-row assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_skill_resolver.py Tests/Chat/test_console_skill_resolver.py
+git commit -m "feat(skills): pure \$-mention scanner with code-span masking + \$name list rows"
+```
+
+---
+
+### Task 2: Controller leading-`$` form (re-sigil the command branch)
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py` — `_apply_skill_substitution` (def `:1727`; the leading-`/` check is at `:1780-1786`)
+- Test: `Tests/Chat/test_console_skill_substitution.py` (flip)
+
+**Interfaces:**
+- Consumes: `MENTION_SIGIL` (Task 1).
+- Produces: leading `$skill-name args…` behaves exactly as today's leading `/skill-name args…` (resolve via `resolve_skill_command` — case-insensitive/prefix — args capped via `cap_skill_args` → `{{args}}`; inline replaces final message; fork drops history except a leading system message; `SkillTrustBlockedError` → `(original_messages, SKILL_UNTRUSTED_REFUSE)`). Return signature UNCHANGED in this task (2-tuple; Task 3 widens it).
+
+- [ ] **Step 1: Flip the pinning tests**
+
+`Tests/Chat/test_console_skill_substitution.py` has 11 tests pinning the `/` sigil (messages like `"/code-review look at this"`). Change every invocation string from `/name…` to `$name…` (e.g. `"$code-review look at this"`). Do NOT weaken any assertion — only the sigil in message fixtures changes. Add one new test:
+
+```python
+@pytest.mark.asyncio
+async def test_leading_slash_no_longer_invokes(monkeypatch):
+    # Hard removal: a leading /code-review message passes through untouched.
+    controller, skills = _make_controller()  # use the file's existing helper pattern
+    messages = [{"role": "user", "content": "/code-review look at this"}]
+    out, refuse = await controller._apply_skill_substitution(messages)
+    assert out == messages
+    assert refuse is None
+    assert skills.executions == []
+```
+
+(Adapt the construction line to the file's existing controller-building helper — read the file first; every existing test constructs the controller the same way.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Chat/test_console_skill_substitution.py -q`
+Expected: FAIL — the flipped `$` tests find no substitution (code still checks `COMMAND_PREFIX`), and the new `/`-passthrough test fails (old code still expands `/`).
+
+- [ ] **Step 3: Implement**
+
+In `_apply_skill_substitution`, import `MENTION_SIGIL` from `console_skill_resolver` (extend the existing import at the top of the file) and change the leading check (`:1780-1786`):
+
+```python
+        content = provider_messages[final_index].get("content")
+        if not isinstance(content, str) or not content.startswith(MENTION_SIGIL):
+            return provider_messages, None
+
+        word, rest = _split_skill_command_word(content)
+        name = word[len(MENTION_SIGIL) :]
+        if not name:
+            return provider_messages, None
+```
+
+Everything below (`resolve_skill_command` → `cap_skill_args` → `execute_skill` → inline/fork/refuse) stays byte-identical. Update the docstring's `COMMAND_PREFIX` reference to `MENTION_SIGIL`. If `COMMAND_PREFIX` is now unused in this file, remove its import.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Chat/test_console_skill_substitution.py Tests/Chat/test_console_chat_controller.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_chat_controller.py Tests/Chat/test_console_skill_substitution.py
+git commit -m "feat(skills): leading \$skill-name form replaces /skill-name in payload substitution"
+```
+
+---
+
+### Task 3: Controller embedded splice + non-aborting notes channel
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py` — `_apply_skill_substitution` + its FOUR call sites (grep `_apply_skill_substitution(` — currently `:465`, `:1143`, `:1201`, `:1265` region; re-grep, lines shift)
+- Test: `Tests/Chat/test_console_skill_substitution.py` (extend)
+
+**Interfaces:**
+- Consumes: `find_embedded_mentions`, `SkillMention`, `SKILL_MENTION_SKIPPED_NOTE` (Task 1).
+- Produces: `_apply_skill_substitution` returns `tuple[list[dict[str, Any]], str | None, tuple[str, ...]]` — `(messages, refuse, notes)`. `refuse` aborts the send (unchanged semantics); `notes` never abort — each is appended by the caller as a system row using the same mechanism the caller already uses for `refuse` copy, then the send proceeds.
+
+- [ ] **Step 1: Write the failing tests** (append; adapt construction to the file's helper)
+
+```python
+@pytest.mark.asyncio
+async def test_embedded_mention_splices_preserving_prose():
+    controller, skills = _make_controller()  # existing helper pattern
+    messages = [{"role": "user", "content": "summarize, $code-review it, then list"}]
+    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    assert refuse is None and notes == ()
+    content = out[0]["content"]
+    assert content.startswith("summarize, RENDERED[")
+    assert content.endswith(" it, then list")
+    assert "$code-review" not in content
+    # embedded is ARGLESS
+    assert skills.executions == [("code-review", "")]
+
+
+@pytest.mark.asyncio
+async def test_embedded_fork_mention_left_literal():
+    controller, skills = _make_controller(mode="fork")
+    messages = [{"role": "user", "content": "please $code-review this"}]
+    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    assert out == messages          # untouched
+    assert refuse is None and notes == ()
+
+
+@pytest.mark.asyncio
+async def test_embedded_untrusted_left_literal_with_note():
+    controller, skills = _make_controller(raise_trust=True)
+    messages = [{"role": "user", "content": "please $code-review this"}]
+    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    assert out == messages          # prose never lost
+    assert refuse is None           # embedded never aborts
+    assert len(notes) == 1 and "code-review" in notes[0]
+
+
+@pytest.mark.asyncio
+async def test_leading_resolved_mention_does_not_scan_args():
+    controller, skills = _make_controller()
+    messages = [{"role": "user", "content": "$code-review also $code-review"}]
+    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    # Leading form: ONE execution with the rest as args; no embedded pass.
+    assert skills.executions == [("code-review", "also $code-review")]
+
+
+@pytest.mark.asyncio
+async def test_leading_unresolved_falls_through_to_embedded():
+    controller, skills = _make_controller()
+    messages = [{"role": "user", "content": "$notaskill but $code-review works"}]
+    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    content = out[0]["content"]
+    assert content.startswith("$notaskill but RENDERED[")
+    assert skills.executions == [("code-review", "")]
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Chat/test_console_skill_substitution.py -q`
+Expected: FAIL — `ValueError: not enough values to unpack` (2-tuple return) and no embedded expansion.
+
+- [ ] **Step 3: Implement**
+
+Restructure `_apply_skill_substitution` (keep the guards through `final_index`/`content` as in Task 2), then:
+
+```python
+        candidates_context = await self._skills_service.get_context(mode="local")
+        candidates = self._skill_candidates_from_context(candidates_context)
+
+        # --- Leading form: message starts with a resolvable $skill-name.
+        if content.startswith(MENTION_SIGIL):
+            word, rest = _split_skill_command_word(content)
+            name = word[len(MENTION_SIGIL) :]
+            if name:
+                resolution = resolve_skill_command(name, rest, candidates)
+                if resolution.kind == "resolved":
+                    args = cap_skill_args(rest)
+                    try:
+                        result = await self._skills_service.execute_skill(
+                            resolution.name, mode="local", args=args
+                        )
+                    except SkillTrustBlockedError as exc:
+                        refuse = SKILL_UNTRUSTED_REFUSE.format(
+                            name=resolution.name, reason=exc.reason_code
+                        )
+                        return provider_messages, refuse, ()
+                    # ... existing rendered/fork/inline blocks, each return
+                    # gaining a trailing empty notes tuple: `, ()`.
+
+        # --- Embedded pass: leading absent or unresolved.
+        names = frozenset(candidate.name for candidate in candidates)
+        mentions = find_embedded_mentions(content, names)
+        if not mentions:
+            return provider_messages, None, ()
+
+        rendered_by_name: dict[str, str | None] = {}
+        notes: list[str] = []
+        for mention in mentions:
+            if mention.name in rendered_by_name:
+                continue
+            try:
+                result = await self._skills_service.execute_skill(
+                    mention.name, mode="local", args=""
+                )
+            except SkillTrustBlockedError:
+                rendered_by_name[mention.name] = None
+                notes.append(SKILL_MENTION_SKIPPED_NOTE.format(name=mention.name))
+                continue
+            execution_mode = (
+                result.get("execution_mode") if isinstance(result, Mapping) else None
+            )
+            rendered = (
+                result.get("rendered_prompt", "") if isinstance(result, Mapping) else ""
+            )
+            # Fork (or anything non-inline) cannot splice: leave literal, no note.
+            rendered_by_name[mention.name] = (
+                rendered if execution_mode == "inline" else None
+            )
+
+        new_content = content
+        for mention in reversed(mentions):
+            body = rendered_by_name.get(mention.name)
+            if body is None:
+                continue
+            new_content = (
+                new_content[: mention.start] + body + new_content[mention.end :]
+            )
+        if new_content == content:
+            return provider_messages, None, tuple(notes)
+        new_messages = list(provider_messages)
+        new_messages[final_index] = {
+            "role": ConsoleMessageRole.USER.value,
+            "content": new_content,
+        }
+        return new_messages, None, tuple(notes)
+```
+
+Update the docstring (leading + embedded semantics, 3-tuple contract). Then update **all four call sites** (grep `= await self._apply_skill_substitution(`): the unpack becomes `provider_messages, refuse, skill_notes = ...`; immediately after each site's existing `refuse` handling, append each note in `skill_notes` as a system row using the SAME mechanism that site uses for `refuse` copy — but do NOT abort for notes (the send continues). The skip-skills site (comment "may execute skills with side effects") is untouched. Import `find_embedded_mentions` and `SKILL_MENTION_SKIPPED_NOTE` alongside the existing resolver imports.
+
+- [ ] **Step 4: Run to verify pass + regression**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Chat/ -q`
+Expected: PASS (all Chat suites — the 4 call-site updates must not break run-turn tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_chat_controller.py Tests/Chat/test_console_skill_substitution.py
+git commit -m "feat(skills): embedded \$-mention splicing with non-aborting skipped-skill notes"
+```
+
+---
+
+### Task 4: Hard-remove `/` invocation (composer layer) + `/skills` run form
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` (fallback registration `:1865-1867`, import `:100`, `_console_command_skills` handler + pick-submit path — grep `_submit` near the skills handler; blocked-hint copy); `tldw_chatbook/Chat/console_skill_resolver.py` (DELETE `make_skill_fallback_resolver`)
+- Test: `Tests/UI/test_console_skill_commands.py`, `Tests/Chat/test_console_skill_resolver.py`, `Tests/Chat/test_console_command_grammar.py` (flip/delete)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: no fallback claiming — a `/former-skill` draft parses `KIND_UNKNOWN` (grammar hint → armed second-Enter literal send, existing behavior); `/skills` bare → list (unchanged); `/skills <name>…` → a transcript hint row with EXACTLY this copy: `Run skills by typing $<name> — /skills only lists them.` (substituting the typed name); the skill-picker submit path composes `$name [args]` instead of `/name [args]`.
+
+- [ ] **Step 1: Write/flip the failing tests**
+
+In `Tests/UI/test_console_skill_commands.py`: flip every submit fixture from `/name…` to `$name…` where the test exercises invocation-through-submit; change the `/skills <name>` run-form tests to assert the new hint copy (`"Run skills by typing $"` appears; no skill executed); assert the pick-submit path produces a draft/message starting with `$`. In `Tests/Chat/test_console_skill_resolver.py`: DELETE the `make_skill_fallback_resolver` tests (the factory is being deleted). In `Tests/Chat/test_console_command_grammar.py`: any test registering the skill fallback flips to asserting `/former-skill` → `KIND_UNKNOWN`.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_skill_commands.py Tests/Chat/test_console_skill_resolver.py Tests/Chat/test_console_command_grammar.py -q`
+Expected: FAIL — old `/` behavior still present.
+
+- [ ] **Step 3: Implement**
+
+1. Delete the registration block at `chat_screen.py:1865-1867` (`self._console_command_registry.register_fallback_resolver(make_skill_fallback_resolver(...))`) and the `make_skill_fallback_resolver` import (`:100`). The `_console_skill_candidates` snapshot itself STAYS (the blocked-hint path and `/skills` list still use it).
+2. Delete `make_skill_fallback_resolver` from `console_skill_resolver.py` (the whole factory; `KIND_FALLBACK` import goes with it if now unused there).
+3. In the `/skills` handler (`_console_command_skills`, dispatch map near `:10879`): keep the bare-args list branch; replace the `<name> [args]` run branch with a transcript hint row: `f"Run skills by typing ${name} — /skills only lists them."` (reuse the same transcript-row mechanism the list response uses).
+4. The skill-picker submit path (the method that submits a raw `/name [args]` command as the user turn — grep `"/"` composition near the skills handler): compose `f"${name}"` / `f"${name} {args}"` instead.
+5. Blocked-hint copy (`_console_skill_blocked_match_response` region): if its copy teaches `/skills <name>` as the run form, update to the `$name` convention. The hint itself STAYS (it lives in the `KIND_UNKNOWN` branch, independent of the fallback resolver).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_skill_commands.py Tests/Chat/test_console_skill_resolver.py Tests/Chat/test_console_command_grammar.py Tests/UI/test_console_command_composer.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/chat_screen.py tldw_chatbook/Chat/console_skill_resolver.py Tests/UI/test_console_skill_commands.py Tests/Chat/test_console_skill_resolver.py Tests/Chat/test_console_command_grammar.py
+git commit -m "feat(skills)!: hard-remove /skill-name invocation; /skills runs point to \$name"
+```
+
+---
+
+### Task 5: Copy sweep + full regression
+
+**Files:**
+- Modify: any file the sweep finds still teaching `/skill-name` invocation (user-visible copy/docstrings only — NOT historical spec docs)
+- Test: full affected suites
+
+- [ ] **Step 1: Sweep for stale invocation copy**
+
+Run: `grep -rn '"/skills <name>\|/skill-name\|typed.*"/"\|COMMAND_PREFIX' tldw_chatbook/Chat/ tldw_chatbook/UI/Screens/chat_screen.py | grep -vi "test"` and review each hit: user-visible copy or docstrings that teach the removed `/name` run convention flip to `$name`; grammar/registry internals that legitimately still use `/` for registered commands (`/skills`, `/prompt`, …) stay.
+
+- [ ] **Step 2: Full regression**
+
+Run: `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Chat/ Tests/UI/test_console_skill_commands.py Tests/UI/test_console_command_composer.py Tests/Skills/ -q`
+Expected: 0 failed (modulo the known flaky, re-run in isolation).
+
+- [ ] **Step 3: Commit** (only if the sweep changed files)
+
+```bash
+git add <exact files the sweep changed>
+git commit -m "chore(skills): sweep remaining /skill-name invocation copy to \$name"
+```
+
+---
+
+## Notes for the executor
+
+- The spec governs on any ambiguity; its §2 safety rules (case-sensitive embedded match, code-span skip, no recursion, fork-embedded literal) are load-bearing.
+- Line numbers in this plan were verified on branch `worktree-skills-dollar-mention` at `184d260f3` — re-grep before editing; they shift.
+- `console_agent_bridge` (`_BridgeSkillRunner`) is UNTOUCHED — model-invoked skills are a different mechanism.
+- The stored-transcript invariant: raw user text (including `$mentions`) is persisted; only the ephemeral payload renders.

--- a/Docs/superpowers/specs/2026-07-23-skills-dollar-mention-invocation-design.md
+++ b/Docs/superpowers/specs/2026-07-23-skills-dollar-mention-invocation-design.md
@@ -113,11 +113,12 @@ Accepted consequences (documented, not bugs):
 - **Historical transcript turns** whose raw persisted text is an old
   `/skill-name args` command no longer re-expand on retry/continue/regenerate
   — they are sent as literal text (only `$` forms render-fresh now).
-- The composer-level **pre-send blocked-skill hint** (the `KIND_UNKNOWN`
-  blocked-match response that told a user a typed skill was needs-review
-  before sending) goes away with the fallback resolver; an untrusted leading
-  `$name` is still refused at payload build with `SKILL_UNTRUSTED_REFUSE`
-  (a system row), which remains the authoritative gate.
+- The composer-level **pre-send blocked-skill hint** SURVIVES (corrected on
+  verification: it lives in the `KIND_UNKNOWN` branch, independent of the
+  fallback resolver — a typed `/blocked-name` still gets the needs-review
+  response). Its copy updates to teach the `$name` convention. The
+  authoritative gate remains the payload-build refusal
+  (`SKILL_UNTRUSTED_REFUSE`) for a leading `$name`.
 
 **`/skills` stays** as the registered browse command in its **bare** form
 (list the available skills). Its `/skills <name> [args]` *run* form is removed

--- a/Docs/superpowers/specs/2026-07-23-skills-dollar-mention-invocation-design.md
+++ b/Docs/superpowers/specs/2026-07-23-skills-dollar-mention-invocation-design.md
@@ -55,17 +55,34 @@ Codex's own usage: `$skill-installer linear` (leading, args) vs. "use
 
 - A candidate token is `$` followed by the longest run of `[a-zA-Z0-9-]`.
   Trailing punctuation stays prose (`$style-guide.` → token `style-guide`).
-- A token expands **only** on an **exact, case-insensitive** match to a known,
-  **user-invocable** skill name. No prefix matching for mentions (the leading
-  form may keep the resolver's unique-prefix behavior; embedded never guesses).
+- An **embedded** token expands **only** on an **exact, case-SENSITIVE** match
+  to a known, **user-invocable** skill name. Skill names are guaranteed
+  lowercase (`SKILL_NAME_PATTERN`), so requiring the exact lowercase token
+  keeps the entire shell-variable class (`$PATH`, `$HOME`, `$USER`) literal
+  *even when* a skill shares the name (skill `path` ≠ prose `$PATH`). No
+  prefix matching for mentions. The **leading** form keeps the resolver's
+  forgiving behavior (case-insensitive, unique-prefix) — it is an explicit
+  command position.
 - Everything else stays literal text: `$5`, `$100`, `$PATH`, `$not-a-skill`.
-  (Residual edge, accepted: a skill literally named `5` or `path` would make
-  those tokens expand — the exact-match gate is the protection; an escape
-  syntax for a literal `$known-skill-name` is out of scope.)
+  (Residual edge, accepted: a skill literally named `5` would make `$5`
+  expand — the exact-match gate is the protection; an escape syntax for a
+  literal `$known-skill-name` is out of scope.)
+- **Code spans are skipped.** Mentions inside markdown fenced blocks
+  (``` ``` ```) and inline backtick spans stay literal — users routinely paste
+  shell/code full of `$vars`, and a pasted `$build`/`$test` must never splice
+  a skill body into their code. (Plain-prose pastes containing an exact
+  lowercase skill token can still expand — accepted, made rare by the
+  case-sensitive exact-match gate.)
+- **No recursive expansion.** Splicing is a single pass over the user's
+  original text; a `$mention` inside a spliced skill body is NOT expanded.
 - **Fork skills cannot be embedded.** A fork skill takes over the turn; there
   is nothing to splice into. An embedded mention of a fork skill is left
   **literal** (no expansion, no error). A *leading* `$fork-skill args` runs
-  fork as today.
+  fork as today. **Mode-detection mechanism:** `SkillCommandCandidate`
+  carries only `name`/`description` (no execution mode), so the embedded scan
+  calls `execute_skill` per mention — which it needs anyway for trust
+  re-verification — and leaves the mention literal when the result's
+  `execution_mode != "inline"` (the discarded fork render is side-effect-free).
 - **Trust.** Every expansion re-verifies through `execute_skill` at payload
   build time (today's discipline, per mention). A **leading** mention of an
   untrusted/blocked skill refuses the send with `SKILL_UNTRUSTED_REFUSE`
@@ -75,12 +92,32 @@ Codex's own usage: `$skill-installer linear` (leading, args) vs. "use
 
 ### 3. `/skill-name` invocation: hard remove
 
-The direct `/skill-name` invocation is removed outright. A message leading
-with `/pdf-processing …` is **no longer a skill invocation**: the skill claim
-in the command grammar (`console_skill_resolver`'s `CommandParse` claiming) is
-removed, and such text receives whatever treatment any other unknown
-slash-leading text gets today (it is NOT intercepted, NOT redirected, and NOT
-expanded). No transition shim, no redirect note — a clean break, per decision.
+The direct `/skill-name` invocation is removed outright — at **both** layers
+that claim it today (verified in code):
+
+1. **Composer layer:** the fallback resolver
+   (`console_skill_resolver.make_skill_fallback_resolver`, registered into
+   `console_command_grammar`'s `ConsoleCommandRegistry`) claims `/skill-name`
+   drafts as `KIND_FALLBACK` at parse time. This registration is removed.
+2. **Controller layer:** `_apply_skill_substitution`'s leading-`/` branch
+   (`content.startswith(COMMAND_PREFIX)` → `_split_skill_command_word` →
+   `resolve_skill_command`) is replaced by the `$` parsing of §1/§2.
+
+Post-removal UX (this is the grammar's existing unknown-command behavior, now
+precisely stated): a draft leading with `/former-skill-name` parses as
+`KIND_UNKNOWN` → the composer shows the standard **"Unknown command" hint**,
+and a **second Enter (armed)** sends the draft as literal text. Feedback, not
+silence — but no shim, no redirect note, per decision.
+
+Accepted consequences (documented, not bugs):
+- **Historical transcript turns** whose raw persisted text is an old
+  `/skill-name args` command no longer re-expand on retry/continue/regenerate
+  — they are sent as literal text (only `$` forms render-fresh now).
+- The composer-level **pre-send blocked-skill hint** (the `KIND_UNKNOWN`
+  blocked-match response that told a user a typed skill was needs-review
+  before sending) goes away with the fallback resolver; an untrusted leading
+  `$name` is still refused at payload build with `SKILL_UNTRUSTED_REFUSE`
+  (a system row), which remains the authoritative gate.
 
 **`/skills` stays** as the registered browse command in its **bare** form
 (list the available skills). Its `/skills <name> [args]` *run* form is removed
@@ -108,10 +145,22 @@ completion. `/`-completion continues to offer registered *commands* (including
   note.
 - `tldw_chatbook/UI/Screens/chat_screen.py` — `/skills` command handler:
   bare-list kept, `<name> [args]` run form removed; skill-pick submit path
-  composes `$name`; composer completion moves skill names to the `$` trigger.
+  composes `$name`; composer completion moves skill names to the `$` trigger;
+  the fallback-resolver registration is removed.
+- `console_skill_resolver.format_skills_list` — the `/skills` transcript
+  listing renders `/{name}` rows today; they become `$name` rows (any other
+  user-visible copy that teaches the `/name` form updates likewise).
 - The **model-invokes-skill-as-tool** path (`console_agent_bridge`,
   `_BridgeSkillRunner`) is untouched — that is Codex's *implicit* invocation
   equivalent and already exists.
+
+**Payload-pass ordering (verified, must be preserved):** all four send sites
+run `_apply_skill_substitution` → `_apply_chat_dictionaries` →
+`_apply_world_info`, so a spliced skill body is subject to the downstream
+dictionary/world-info passes exactly like today's replaced message. The one
+site that deliberately skips skill substitution ("may execute skills with
+side effects") continues to skip it — the embedded scan lives inside
+`_apply_skill_substitution`, so that site stays skill-free automatically.
 
 ### 6. Rendering details
 
@@ -130,22 +179,29 @@ completion. `/`-completion continues to offer registered *commands* (including
 ## Testing strategy
 
 - **Resolver/scanner unit:** token extraction (trailing punctuation, hyphens,
-  `$5`/`$PATH`/unknown → literal); exact-match-only for embedded; leading form
-  arg split preserved; case-insensitivity.
+  `$5`/`$100`/unknown → literal); embedded is exact-match **case-sensitive**
+  (`$PATH` stays literal even with a skill named `path`; `$path` expands);
+  leading form keeps case-insensitive/prefix resolution + arg split; code-span
+  skip (mentions inside ``` fences and inline backticks stay literal); no
+  recursion (a `$mention` inside a spliced body does not expand).
 - **Substitution unit:** single embedded mention splices in place preserving
-  surrounding text; multiple mentions all expand; embedded fork → literal;
-  embedded untrusted → literal + system note (prose not lost); leading
-  untrusted → refuse (unchanged); leading `$skill args` → `{{args}}`
-  substitution with inline-replace AND fork-takeover; `{{args}}` empty for
-  embedded.
-- **Removal:** `/skill-name` no longer resolves as a skill (message passes
-  through as ordinary text); `/skills` bare list unchanged; `/skills <name>`
-  run form removed; skill-pick submit composes `$name`.
+  surrounding text; multiple mentions all expand; embedded fork → literal
+  (via `execution_mode` from the per-mention `execute_skill`); embedded
+  untrusted → literal + system note (prose not lost); leading untrusted →
+  refuse (unchanged); leading `$skill args` → `{{args}}` substitution with
+  inline-replace AND fork-takeover; `{{args}}` empty for embedded.
+- **Removal:** the fallback-resolver registration is gone — a `/former-skill`
+  draft parses `KIND_UNKNOWN` (hint, then armed literal send); the
+  controller's leading-`/` branch no longer expands (a historical raw
+  `/name args` turn retried sends literally); `/skills` bare list unchanged;
+  `/skills <name>` run form removed; skill-pick submit composes `$name`;
+  `format_skills_list` rows render `$name`.
 - **Completion:** `$` surfaces skill candidates; `/` no longer offers skill
   names but still offers `/skills`.
 - **Regression:** existing tests that pin `/skill-name` invocation flip to the
-  `$` forms (they encode the removed convention); dictionary/lorebook
-  substitution ordering on the same payload path unaffected.
+  `$` forms (they encode the removed convention); the verified
+  skills → dictionaries → world-info payload-pass ordering is pinned; the
+  skip-skills send site stays skill-free.
 
 ## Out of scope (later specs)
 

--- a/Docs/superpowers/specs/2026-07-23-skills-dollar-mention-invocation-design.md
+++ b/Docs/superpowers/specs/2026-07-23-skills-dollar-mention-invocation-design.md
@@ -1,0 +1,163 @@
+# Skills Runtime — Codex-Style `$`-Mention Invocation
+
+**Status:** Approved design (2026-07-23).
+**Program:** Skills-install program. Follows Spec 1 (trust foundation, PR #762) and
+Spec 2 (full-bundle fidelity, PR #784), both merged. This spec migrates *user*
+skill invocation in Console chat to the Codex convention; the sibling runtime
+concern (fork reference-file reachability) is the next spec.
+
+## Problem
+
+Console skill invocation today is a whole-message slash command:
+
+- The message must **start** with `/skill-name` (`_apply_skill_substitution`,
+  `console_chat_controller.py:1187` checks `content.startswith(COMMAND_PREFIX)`);
+  everything after the first token becomes `{{args}}`.
+- On match, **inline** mode replaces the *entire* message with the rendered body;
+  **fork** mode drops prior context and runs the body as a sub-agent.
+- A skill mentioned mid-prose (`summarize this, then /style-guide it`) is not
+  recognized at all, and there is no way to expand a skill *into* surrounding
+  text — the invocation consumes the whole message.
+
+Meanwhile the ecosystem has converged on a different convention.
+[Codex](https://developers.openai.com/codex/skills) splits invocation into:
+**`/skills`** (a browse/picker command) and **`$skill-name`** (a *mention*,
+usable **anywhere in the prompt** — "Use `$brainstorming` to explore ideas…"),
+plus implicit model-driven activation. The `$` sigil also solves the detection
+problem an embedded `/` cannot: mid-prose `/` is everywhere (paths, dates,
+URLs, `and/or`), while `$word` is rare and unambiguous.
+
+## Decision (user-approved)
+
+Adopt the **full Codex model**: `$skill-name` becomes THE user invocation;
+`/skill-name` invocation is **hard-removed**; `/skills` remains as the browse
+picker. Leading `$skill-name args…` keeps the `{{args}}` capability; embedded
+mentions are argless.
+
+## Design
+
+### 1. Invocation model
+
+**`$skill-name`** is the only user-typed skill invocation, with two
+position-dependent forms:
+
+| Form | Example | Behavior |
+|------|---------|----------|
+| **Leading** — message starts with `$skill-name` | `$pdf-processing extract the tables` | The arg-bearing whole-message form. Trailing text → `{{args}}`. **inline** mode replaces the message with the rendered body; **fork** mode takes over the turn (drops prior context except a leading system message) — exactly today's leading-command semantics, re-sigiled. |
+| **Embedded** — mention anywhere else in the message | `summarize the draft, $style-guide it, then list open questions` | **Argless** expansion (`{{args}}` renders empty). The rendered **inline** body is spliced **at the mention's position**; all surrounding prose (before, after, between mentions) is preserved verbatim. Multiple embedded mentions each expand. |
+
+The **sigil** disambiguates invocation (`$`) from commands (`/`); position on
+`$` disambiguates args-bearing (leading) from argless (embedded). This matches
+Codex's own usage: `$skill-installer linear` (leading, args) vs. "use
+`$brainstorming` to explore" (embedded, argless).
+
+### 2. Mention detection (the safety rules)
+
+- A candidate token is `$` followed by the longest run of `[a-zA-Z0-9-]`.
+  Trailing punctuation stays prose (`$style-guide.` → token `style-guide`).
+- A token expands **only** on an **exact, case-insensitive** match to a known,
+  **user-invocable** skill name. No prefix matching for mentions (the leading
+  form may keep the resolver's unique-prefix behavior; embedded never guesses).
+- Everything else stays literal text: `$5`, `$100`, `$PATH`, `$not-a-skill`.
+  (Residual edge, accepted: a skill literally named `5` or `path` would make
+  those tokens expand — the exact-match gate is the protection; an escape
+  syntax for a literal `$known-skill-name` is out of scope.)
+- **Fork skills cannot be embedded.** A fork skill takes over the turn; there
+  is nothing to splice into. An embedded mention of a fork skill is left
+  **literal** (no expansion, no error). A *leading* `$fork-skill args` runs
+  fork as today.
+- **Trust.** Every expansion re-verifies through `execute_skill` at payload
+  build time (today's discipline, per mention). A **leading** mention of an
+  untrusted/blocked skill refuses the send with `SKILL_UNTRUSTED_REFUSE`
+  (unchanged semantics). An **embedded** untrusted mention is left literal and
+  a system note names the skipped skill(s) — the surrounding prose is real
+  user content and must not be lost to a refusal.
+
+### 3. `/skill-name` invocation: hard remove
+
+The direct `/skill-name` invocation is removed outright. A message leading
+with `/pdf-processing …` is **no longer a skill invocation**: the skill claim
+in the command grammar (`console_skill_resolver`'s `CommandParse` claiming) is
+removed, and such text receives whatever treatment any other unknown
+slash-leading text gets today (it is NOT intercepted, NOT redirected, and NOT
+expanded). No transition shim, no redirect note — a clean break, per decision.
+
+**`/skills` stays** as the registered browse command in its **bare** form
+(list the available skills). Its `/skills <name> [args]` *run* form is removed
+along with `/skill-name` (same hard-remove treatment); running a skill is
+`$name`'s job now. The picker's "submit a skill" affordance (chat_screen's
+skill-pick → submit path) composes a `$name` message instead of `/name`.
+
+### 4. Autocomplete / composer surfaces
+
+Typing **`$`** in the Console composer surfaces skill-name completion
+(candidates = user-invocable skills), replacing the `/`-triggered skill
+completion. `/`-completion continues to offer registered *commands* (including
+`/skills`) but no longer offers skill names.
+
+### 5. Where it lives (touched surfaces)
+
+- `tldw_chatbook/Chat/console_skill_resolver.py` — resolver gains the mention
+  scanner (token extraction + exact-match rule); the `/`-command
+  `CommandParse` skill-claiming is removed.
+- `tldw_chatbook/Chat/console_chat_controller.py` —
+  `_apply_skill_substitution` (the render-fresh choke point on every send
+  path: fresh, retry, continue, regenerate) reworked: parse leading `$` form
+  (args → `{{args}}`, inline-replace / fork-takeover), then scan-and-splice
+  embedded mentions; per-mention trust verification; untrusted-embedded system
+  note.
+- `tldw_chatbook/UI/Screens/chat_screen.py` — `/skills` command handler:
+  bare-list kept, `<name> [args]` run form removed; skill-pick submit path
+  composes `$name`; composer completion moves skill names to the `$` trigger.
+- The **model-invokes-skill-as-tool** path (`console_agent_bridge`,
+  `_BridgeSkillRunner`) is untouched — that is Codex's *implicit* invocation
+  equivalent and already exists.
+
+### 6. Rendering details
+
+- Embedded splice uses the skill's **inline** rendered body (front-matter
+  stripped, `{{args}}` → empty string), inserted in place of the `$token`
+  text. No added markers or fences around the spliced body (the body is
+  prompt-text, as today).
+- Splicing happens on the **ephemeral provider payload** only — the stored
+  transcript keeps the user's raw text with `$mentions`, exactly as the
+  leading command does today (render-fresh at payload build, never persisted
+  expansion).
+- A message that is *only* a mention (`$style-guide`) is the leading form with
+  empty args — inline-replace (equivalent outcome to a splice of the whole
+  message).
+
+## Testing strategy
+
+- **Resolver/scanner unit:** token extraction (trailing punctuation, hyphens,
+  `$5`/`$PATH`/unknown → literal); exact-match-only for embedded; leading form
+  arg split preserved; case-insensitivity.
+- **Substitution unit:** single embedded mention splices in place preserving
+  surrounding text; multiple mentions all expand; embedded fork → literal;
+  embedded untrusted → literal + system note (prose not lost); leading
+  untrusted → refuse (unchanged); leading `$skill args` → `{{args}}`
+  substitution with inline-replace AND fork-takeover; `{{args}}` empty for
+  embedded.
+- **Removal:** `/skill-name` no longer resolves as a skill (message passes
+  through as ordinary text); `/skills` bare list unchanged; `/skills <name>`
+  run form removed; skill-pick submit composes `$name`.
+- **Completion:** `$` surfaces skill candidates; `/` no longer offers skill
+  names but still offers `/skills`.
+- **Regression:** existing tests that pin `/skill-name` invocation flip to the
+  `$` forms (they encode the removed convention); dictionary/lorebook
+  substitution ordering on the same payload path unaffected.
+
+## Out of scope (later specs)
+
+- Embedded args (a delimiter syntax such as `$name{args}`).
+- Fork reference-file reachability (the `skill_file` scoped-read layer — next).
+- Implicit model-driven activation changes (exists via the agent bridge).
+- An escape syntax for a literal `$known-skill-name` in prose.
+- Any change to trust, storage, or import subsystems.
+
+## Migration / compatibility
+
+Breaking by decision: users who typed `/skill-name` must switch to
+`$skill-name` (the `/skills` picker now composes `$name`, aiding discovery).
+No data migration; stored transcripts are untouched (raw text was always
+persisted). Release note calls out the new convention and its Codex parity.

--- a/Docs/superpowers/specs/2026-07-23-skills-dollar-mention-invocation-design.md
+++ b/Docs/superpowers/specs/2026-07-23-skills-dollar-mention-invocation-design.md
@@ -125,12 +125,15 @@ along with `/skill-name` (same hard-remove treatment); running a skill is
 `$name`'s job now. The picker's "submit a skill" affordance (chat_screen's
 skill-pick → submit path) composes a `$name` message instead of `/name`.
 
-### 4. Autocomplete / composer surfaces
+### 4. Discovery surfaces
 
-Typing **`$`** in the Console composer surfaces skill-name completion
-(candidates = user-invocable skills), replacing the `/`-triggered skill
-completion. `/`-completion continues to offer registered *commands* (including
-`/skills`) but no longer offers skill names.
+Verified: there is **no interactive skill-name autocomplete today** — the
+composer's only skill-discovery surfaces are the `/skills` bare list and the
+unknown-command hint. This spec therefore changes copy, not completion
+machinery: the `/skills` transcript listing (`format_skills_list`) renders
+**`$name`** rows, and any copy that teaches the `/name` form updates
+likewise. An interactive `$`-triggered autocomplete popup is an explicit
+**out-of-scope follow-up**, not part of this migration.
 
 ### 5. Where it lives (touched surfaces)
 
@@ -206,6 +209,8 @@ side effects") continues to skip it — the embedded scan lives inside
 ## Out of scope (later specs)
 
 - Embedded args (a delimiter syntax such as `$name{args}`).
+- An interactive `$`-triggered skill-name autocomplete popup (none exists for
+  `/` today either; copy-only discovery in this spec).
 - Fork reference-file reachability (the `skill_file` scoped-read layer — next).
 - Implicit model-driven activation changes (exists via the agent bridge).
 - An escape syntax for a literal `$known-skill-name` in prose.

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -2409,6 +2409,13 @@ async def test_build_context_snapshot_isolates_assembly_errors():
 
 
 def test_annotate_skill_commands_multimodal_text_part():
+    """Fix 4 (Qodo PR #801 fix wave): a multimodal (list-content) draft must
+    NEVER be annotated, even when its text part starts with a `$name`
+    mention. `_apply_skill_substitution` early-returns on non-str content at
+    send time (replacing list content would drop attachments), so
+    annotating a list-content draft here promised a substitution the actual
+    send never performed -- a dishonest preview. List content now passes
+    through unchanged."""
     messages = [
         {
             "role": "user",
@@ -2421,11 +2428,8 @@ def test_annotate_skill_commands_multimodal_text_part():
 
     annotated = ConsoleChatController._annotate_skill_commands(messages)
 
-    text_part = annotated[0]["content"][0]
-    assert text_part["type"] == "text"
-    assert text_part["text"].startswith("$search tools")
-    assert "Skill command not resolved in preview" in text_part["text"]
-    assert annotated[0]["content"][1] == messages[0]["content"][1]
+    assert annotated[0]["content"] == messages[0]["content"]
+    assert "Skill command not resolved in preview" not in str(annotated[0]["content"])
 
 
 def test_annotate_skill_commands_ignores_leading_whitespace():

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -420,7 +420,7 @@ async def test_skill_refuse_after_optimistic_echo_marks_row_blocked():
     controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
 
     async def _refuse(messages):
-        return messages, "Refused: untrusted skill."
+        return messages, "Refused: untrusted skill.", ()
 
     controller._apply_skill_substitution = _refuse
 

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -2085,9 +2085,9 @@ async def test_build_context_snapshot_does_not_execute_skills():
 
     store.append_message(session.id, role=ConsoleMessageRole.USER, content="Hello")
 
-    snapshot = await controller.build_context_snapshot(draft="/search tools")
+    snapshot = await controller.build_context_snapshot(draft="$search tools")
     final_content = snapshot.next_send_payload["messages"][-1]["content"]
-    assert "/search tools" in final_content
+    assert "$search tools" in final_content
     assert "Skill command not resolved in preview" in final_content
 
 
@@ -2413,7 +2413,7 @@ def test_annotate_skill_commands_multimodal_text_part():
         {
             "role": "user",
             "content": [
-                {"type": "text", "text": "/search tools"},
+                {"type": "text", "text": "$search tools"},
                 {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
             ],
         }
@@ -2423,28 +2423,40 @@ def test_annotate_skill_commands_multimodal_text_part():
 
     text_part = annotated[0]["content"][0]
     assert text_part["type"] == "text"
-    assert text_part["text"].startswith("/search tools")
+    assert text_part["text"].startswith("$search tools")
     assert "Skill command not resolved in preview" in text_part["text"]
     assert annotated[0]["content"][1] == messages[0]["content"][1]
 
 
 def test_annotate_skill_commands_ignores_leading_whitespace():
-    messages = [{"role": "user", "content": "  /search tools"}]
+    messages = [{"role": "user", "content": "  $search tools"}]
 
     annotated = ConsoleChatController._annotate_skill_commands(messages)
 
-    assert annotated[0]["content"].startswith("  /search tools")
+    assert annotated[0]["content"].startswith("  $search tools")
     assert "Skill command not resolved in preview" in annotated[0]["content"]
 
 
 def test_annotate_skill_commands_synthetic_turn_added_false_returns_unchanged():
-    messages = [{"role": "user", "content": "/search tools"}]
+    messages = [{"role": "user", "content": "$search tools"}]
 
     annotated = ConsoleChatController._annotate_skill_commands(
         messages, synthetic_turn_added=False
     )
 
     assert annotated == messages
+    assert "Skill command not resolved in preview" not in annotated[0]["content"]
+
+
+def test_annotate_skill_commands_slash_command_is_not_annotated():
+    """A `/`-prefixed draft is a registered slash command post-migration, not a
+    skill invocation (Task 5 of the `$`-mention migration) -- it must not be
+    flagged as an unresolved skill command in the preview."""
+    messages = [{"role": "user", "content": "/skills search"}]
+
+    annotated = ConsoleChatController._annotate_skill_commands(messages)
+
+    assert annotated[0]["content"] == "/skills search"
     assert "Skill command not resolved in preview" not in annotated[0]["content"]
 
 

--- a/Tests/Chat/test_console_skill_resolver.py
+++ b/Tests/Chat/test_console_skill_resolver.py
@@ -1,4 +1,3 @@
-from tldw_chatbook.Chat.console_command_grammar import KIND_FALLBACK
 from tldw_chatbook.Chat.console_skill_resolver import (
     SKILLS_EMPTY_LIST_ROW,
     SkillCommandCandidate,
@@ -6,7 +5,6 @@ from tldw_chatbook.Chat.console_skill_resolver import (
     cap_skill_args,
     find_embedded_mentions,
     format_skills_list,
-    make_skill_fallback_resolver,
     resolve_skill_command,
 )
 
@@ -71,24 +69,6 @@ def test_format_list_empty():
 def test_format_list_lines_include_name_and_desc():
     text = format_skills_list(_cands("summarize"))
     assert "summarize" in text and "summarize desc" in text
-
-
-def test_fallback_claims_matching_word_only():
-    resolver = make_skill_fallback_resolver(lambda: _cands("summarize"))
-    claimed = resolver("summ", "the doc")
-    assert (
-        claimed is not None and claimed.kind == KIND_FALLBACK and claimed.name == "summ"
-    )
-    assert resolver("unknownword", "x") is None
-
-
-def test_fallback_does_not_claim_a_bare_slash_draft():
-    """A `/` or `/ ` draft (console_command_grammar splits it into an
-    empty word) must fall through to the unknown-command hint, never
-    open a picker or silently resolve to whatever skill happens to exist."""
-    resolver = make_skill_fallback_resolver(lambda: _cands("summarize"))
-    assert resolver("", "") is None
-    assert resolver("", " ") is None
 
 
 _NAMES = frozenset({"code-review", "style-guide", "path"})

--- a/Tests/Chat/test_console_skill_resolver.py
+++ b/Tests/Chat/test_console_skill_resolver.py
@@ -2,7 +2,9 @@ from tldw_chatbook.Chat.console_command_grammar import KIND_FALLBACK
 from tldw_chatbook.Chat.console_skill_resolver import (
     SKILLS_EMPTY_LIST_ROW,
     SkillCommandCandidate,
+    SkillMention,
     cap_skill_args,
+    find_embedded_mentions,
     format_skills_list,
     make_skill_fallback_resolver,
     resolve_skill_command,
@@ -89,11 +91,6 @@ def test_fallback_does_not_claim_a_bare_slash_draft():
     assert resolver("", " ") is None
 
 
-from tldw_chatbook.Chat.console_skill_resolver import (
-    SkillMention,
-    find_embedded_mentions,
-)
-
 _NAMES = frozenset({"code-review", "style-guide", "path"})
 
 
@@ -137,12 +134,28 @@ def test_code_spans_are_skipped():
 
 
 def test_skills_list_rows_use_dollar_sigil():
-    from tldw_chatbook.Chat.console_skill_resolver import (
-        SkillCommandCandidate,
-        format_skills_list,
-    )
     listing = format_skills_list(
         (SkillCommandCandidate(name="code-review", description="d"),)
     )
     assert "$code-review" in listing
     assert "/code-review" not in listing
+
+
+def test_odd_backtick_line_masks_entirely():
+    """A line with an ODD backtick count is unparseable inline code — no
+    pairing scheme is reliable (greedy pairing would let a stray tick
+    consume a real opening tick and un-mask a user-guarded span). Fail
+    SAFE: mask the whole line, mirroring the unclosed-fence philosophy."""
+    assert find_embedded_mentions("a ` b then `$path` here", frozenset({"path"})) == ()
+    # Well-formed control on the same skill: prose mentions still expand.
+    found = find_embedded_mentions("plain $path here", frozenset({"path"}))
+    assert [m.name for m in found] == ["path"]
+
+
+def test_unclosed_fence_masks_to_eof():
+    """An opening ``` fence with no closer masks everything after it — a
+    $mention on a later line stays literal (pins existing behavior)."""
+    text = "before $code-review\n```\necho $path on a later line"
+    mentions = find_embedded_mentions(text, _NAMES)
+    assert [m.name for m in mentions] == ["code-review"]
+    assert not any(m.name == "path" for m in mentions)

--- a/Tests/Chat/test_console_skill_resolver.py
+++ b/Tests/Chat/test_console_skill_resolver.py
@@ -139,3 +139,24 @@ def test_unclosed_fence_masks_to_eof():
     mentions = find_embedded_mentions(text, _NAMES)
     assert [m.name for m in mentions] == ["code-review"]
     assert not any(m.name == "path" for m in mentions)
+
+
+def test_multi_backtick_span_masks_correctly():
+    """Qodo fix 3 (PR #801 review, SECURITY): a code span delimited by a
+    multi-backtick run (CommonMark: an opening backtick run pairs with the
+    NEXT run of exactly equal length) must mask its whole span. The old
+    greedy single-tick pairing mispaired the two adjacent backticks of each
+    2-backtick run as its own EMPTY span, leaving the span's contents --
+    including a live $path mention -- unmasked and eligible to expand."""
+    text = "use `` $path `` here"
+    assert find_embedded_mentions(text, frozenset({"path"})) == ()
+
+
+def test_mixed_unmatched_backtick_runs_masks_entire_line():
+    """Backtick runs of unequal length that can never pair up must mask the
+    whole line even when the line's TOTAL backtick count is even (so the
+    old `% 2 == 1` odd-count fail-safe alone would have missed this case).
+    Three runs of length 2, 3, and 1 (six backticks total) share no equal
+    lengths, so every run is unmatched."""
+    text = "before `` x ``` y ` $path after"
+    assert find_embedded_mentions(text, frozenset({"path"})) == ()

--- a/Tests/Chat/test_console_skill_resolver.py
+++ b/Tests/Chat/test_console_skill_resolver.py
@@ -87,3 +87,62 @@ def test_fallback_does_not_claim_a_bare_slash_draft():
     resolver = make_skill_fallback_resolver(lambda: _cands("summarize"))
     assert resolver("", "") is None
     assert resolver("", " ") is None
+
+
+from tldw_chatbook.Chat.console_skill_resolver import (
+    SkillMention,
+    find_embedded_mentions,
+)
+
+_NAMES = frozenset({"code-review", "style-guide", "path"})
+
+
+def test_embedded_mention_found_mid_prose():
+    text = "please $style-guide this draft"
+    mentions = find_embedded_mentions(text, _NAMES)
+    assert mentions == (SkillMention(start=7, end=19, name="style-guide"),)
+    assert text[7:19] == "$style-guide"
+
+
+def test_embedded_mention_trailing_punctuation_stays_prose():
+    mentions = find_embedded_mentions("run $style-guide.", _NAMES)
+    assert mentions[0].name == "style-guide"
+    assert mentions[0].end == 16  # the "." is not part of the token
+
+
+def test_case_sensitive_exact_match_only():
+    # $PATH stays literal even though a skill named "path" exists.
+    assert find_embedded_mentions("echo $PATH", _NAMES) == ()
+    assert find_embedded_mentions("echo $path", _NAMES)[0].name == "path"
+    # prefix / unknown / numeric stay literal
+    assert find_embedded_mentions("$style", _NAMES) == ()
+    assert find_embedded_mentions("$5 and $100", _NAMES) == ()
+
+
+def test_multiple_mentions_all_found_in_order():
+    text = "$code-review then $style-guide"
+    names = [m.name for m in find_embedded_mentions(text, _NAMES)]
+    assert names == ["code-review", "style-guide"]
+
+
+def test_code_spans_are_skipped():
+    fenced = "look:\n```sh\necho $path\n```\nand $path here"
+    mentions = find_embedded_mentions(fenced, _NAMES)
+    assert len(mentions) == 1
+    assert fenced[mentions[0].start :].startswith("$path here"[:5])
+    inline = "use `$path` literally but $path expands"
+    inline_mentions = find_embedded_mentions(inline, _NAMES)
+    assert len(inline_mentions) == 1
+    assert inline_mentions[0].start == inline.rindex("$path")
+
+
+def test_skills_list_rows_use_dollar_sigil():
+    from tldw_chatbook.Chat.console_skill_resolver import (
+        SkillCommandCandidate,
+        format_skills_list,
+    )
+    listing = format_skills_list(
+        (SkillCommandCandidate(name="code-review", description="d"),)
+    )
+    assert "$code-review" in listing
+    assert "/code-review" not in listing

--- a/Tests/Chat/test_console_skill_substitution.py
+++ b/Tests/Chat/test_console_skill_substitution.py
@@ -259,9 +259,8 @@ async def test_submit_refusal_never_invokes_accepted_hook():
     `submit_draft` called `_notify_submission_accepted()` right after the
     USER row was appended -- BEFORE `_apply_skill_substitution` even ran --
     so a refused/untrusted skill still fired the hook. In the real
-    ChatScreen that hook is the sole consume point for a staged
-    "driving this turn" TOOL marker, so a refused submit still appended a
-    marker claiming the skill ran, right before the refuse row."""
+    ChatScreen that hook clears the composer, so firing it on a refusal
+    would eat the refused draft the user needs to correct in place."""
     skills = _Skills(raise_trust=True)
     store = ConsoleChatStore()
     gateway = _RecordingGateway()

--- a/Tests/Chat/test_console_skill_substitution.py
+++ b/Tests/Chat/test_console_skill_substitution.py
@@ -18,12 +18,18 @@ from tldw_chatbook.Skills_Interop.skill_trust_models import SkillTrustBlockedErr
 
 class _Skills:
     def __init__(
-        self, mode="inline", raise_trust=False, raise_trust_for=(), extra_skills=()
+        self,
+        mode="inline",
+        raise_trust=False,
+        raise_trust_for=(),
+        extra_skills=(),
+        blocked_skills=(),
     ):
         self._mode = mode
         self._raise = raise_trust
         self._raise_for = frozenset(raise_trust_for)
         self._extra_skills = tuple(extra_skills)
+        self._blocked_skills = tuple(blocked_skills)
         self.executions = []
         self.get_context_calls = 0
 
@@ -39,7 +45,7 @@ class _Skills:
                 }
                 for name in ("code-review", *self._extra_skills)
             ],
-            "blocked_skills": [],
+            "blocked_skills": [dict(entry) for entry in self._blocked_skills],
         }
 
     async def execute_skill(self, name, *, mode="local", args=None):
@@ -470,3 +476,85 @@ async def test_mixed_spliced_and_blocked_mentions():
     assert content == "run RENDERED[] then $danger-zone please"
     assert len(notes) == 1 and "danger-zone" in notes[0]
     assert skills.executions == [("code-review", ""), ("danger-zone", "")]
+
+
+# ---------------------------------------------------------------------------
+# Qodo fix 1 (PR #801 review): a skill sitting in `blocked_skills` (trust
+# needs-review) must be DETECTED -- leading refuses, embedded degrades to
+# literal + note -- instead of silently staying literal with no signal at
+# all, per spec. Detection is scoped to trusted candidates UNION
+# user-invocable blocked skills; `execute_skill` remains the sole authority
+# on whether a resolved name may actually run.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_leading_blocked_skill_mention_refuses():
+    skills = _Skills(
+        raise_trust_for={"blocked-name"},
+        blocked_skills=({"name": "blocked-name", "user_invocable": True},),
+    )
+    controller, _store = _controller(skills)
+    messages = [{"role": "user", "content": "$blocked-name args here"}]
+    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    assert out == messages
+    assert refuse == (
+        'Skill "blocked-name" isn\'t trusted (skill_modified) — '
+        "review and approve it in Library ▸ Skills before running it."
+    )
+    assert notes == ()
+    assert skills.executions == [("blocked-name", "args here")]
+
+
+@pytest.mark.asyncio
+async def test_embedded_blocked_skill_mention_literal_with_note():
+    skills = _Skills(
+        raise_trust_for={"blocked-name"},
+        blocked_skills=({"name": "blocked-name", "user_invocable": True},),
+    )
+    controller, _store = _controller(skills)
+    messages = [{"role": "user", "content": "please $blocked-name this"}]
+    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    assert out == messages  # literal text untouched
+    assert refuse is None  # embedded never aborts
+    assert len(notes) == 1 and "blocked-name" in notes[0]
+
+
+@pytest.mark.asyncio
+async def test_non_user_invocable_blocked_skill_never_detected():
+    """A `user_invocable: False` blocked skill must never be detected --
+    blocked or not -- mirroring the existing trusted-candidate filter's
+    discipline. It stays literal with no note and the skills service is
+    never even asked to execute it."""
+    skills = _Skills(
+        raise_trust_for={"blocked-name"},
+        blocked_skills=({"name": "blocked-name", "user_invocable": False},),
+    )
+    controller, _store = _controller(skills)
+    messages = [{"role": "user", "content": "please $blocked-name this"}]
+    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    assert out == messages
+    assert refuse is None
+    assert notes == ()
+    assert skills.executions == []
+
+
+# ---------------------------------------------------------------------------
+# Qodo fix 2 (PR #801 review): the leading form must tolerate leading
+# whitespace -- the preview annotator's `_annotate_skill_commands` already
+# `lstrip()`s before checking for the sigil, so an indented draft that
+# demoted to the embedded ARGLESS form here silently contradicted what the
+# preview promised.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_leading_form_tolerates_leading_whitespace():
+    skills = _Skills("inline")
+    controller, _store = _controller(skills)
+    messages = [{"role": "user", "content": "  $code-review fix it"}]
+    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    assert refuse is None
+    # Leading form (args-bearing), not embedded-ARGLESS.
+    assert skills.executions == [("code-review", "fix it")]
+    assert out[-1] == {"role": "user", "content": "RENDERED[fix it]"}

--- a/Tests/Chat/test_console_skill_substitution.py
+++ b/Tests/Chat/test_console_skill_substitution.py
@@ -96,7 +96,7 @@ async def test_inline_substitutes_final_user_message_only():
         {"role": "assistant", "content": "ok"},
         {"role": "user", "content": "$code-review fix it"},
     ]
-    out, refuse = await controller._apply_skill_substitution(msgs)
+    out, refuse, notes = await controller._apply_skill_substitution(msgs)
     assert refuse is None
     assert out[-1] == {"role": "user", "content": "RENDERED[fix it]"}
     assert out[1] == {"role": "user", "content": "earlier"}  # history preserved
@@ -110,7 +110,7 @@ async def test_fork_drops_history_keeps_system():
         {"role": "user", "content": "earlier"},
         {"role": "user", "content": "$code-review go"},
     ]
-    out, refuse = await controller._apply_skill_substitution(msgs)
+    out, refuse, notes = await controller._apply_skill_substitution(msgs)
     assert refuse is None
     assert out == [
         {"role": "system", "content": "sys"},
@@ -122,7 +122,7 @@ async def test_fork_drops_history_keeps_system():
 async def test_non_skill_final_message_unchanged():
     controller, _store = _controller(_Skills("inline"))
     msgs = [{"role": "user", "content": "just a question"}]
-    out, refuse = await controller._apply_skill_substitution(msgs)
+    out, refuse, notes = await controller._apply_skill_substitution(msgs)
     assert out == msgs and refuse is None
 
 
@@ -130,7 +130,7 @@ async def test_non_skill_final_message_unchanged():
 async def test_edited_skill_refuses_at_build():
     controller, _store = _controller(_Skills(raise_trust=True))
     msgs = [{"role": "user", "content": "$code-review go"}]
-    out, refuse = await controller._apply_skill_substitution(msgs)
+    out, refuse, notes = await controller._apply_skill_substitution(msgs)
     assert out == msgs
     assert refuse == (
         'Skill "code-review" isn\'t trusted (skill_modified) — '
@@ -145,7 +145,7 @@ async def test_no_skills_service_is_a_noop():
         store=store, provider_gateway=object(), provider="llama_cpp", model="m"
     )
     msgs = [{"role": "user", "content": "$code-review go"}]
-    out, refuse = await controller._apply_skill_substitution(msgs)
+    out, refuse, notes = await controller._apply_skill_substitution(msgs)
     assert out == msgs and refuse is None
 
 
@@ -345,7 +345,70 @@ async def test_leading_slash_no_longer_invokes():
     skills = _Skills("inline")
     controller, _store = _controller(skills)
     messages = [{"role": "user", "content": "/code-review look at this"}]
-    out, refuse = await controller._apply_skill_substitution(messages)
+    out, refuse, notes = await controller._apply_skill_substitution(messages)
     assert out == messages
     assert refuse is None
     assert skills.executions == []
+
+
+# ---------------------------------------------------------------------------
+# Embedded `$skill-name` mentions (Task 3): argless splice at the mention's
+# position, preserving surrounding prose; non-aborting "skipped skill" notes.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_embedded_mention_splices_preserving_prose():
+    skills = _Skills("inline")
+    controller, _store = _controller(skills)
+    messages = [{"role": "user", "content": "summarize, $code-review it, then list"}]
+    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    assert refuse is None and notes == ()
+    content = out[0]["content"]
+    assert content.startswith("summarize, RENDERED[")
+    assert content.endswith(" it, then list")
+    assert "$code-review" not in content
+    # embedded is ARGLESS
+    assert skills.executions == [("code-review", "")]
+
+
+@pytest.mark.asyncio
+async def test_embedded_fork_mention_left_literal():
+    skills = _Skills("fork")
+    controller, _store = _controller(skills)
+    messages = [{"role": "user", "content": "please $code-review this"}]
+    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    assert out == messages          # untouched
+    assert refuse is None and notes == ()
+
+
+@pytest.mark.asyncio
+async def test_embedded_untrusted_left_literal_with_note():
+    skills = _Skills(raise_trust=True)
+    controller, _store = _controller(skills)
+    messages = [{"role": "user", "content": "please $code-review this"}]
+    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    assert out == messages          # prose never lost
+    assert refuse is None           # embedded never aborts
+    assert len(notes) == 1 and "code-review" in notes[0]
+
+
+@pytest.mark.asyncio
+async def test_leading_resolved_mention_does_not_scan_args():
+    skills = _Skills("inline")
+    controller, _store = _controller(skills)
+    messages = [{"role": "user", "content": "$code-review also $code-review"}]
+    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    # Leading form: ONE execution with the rest as args; no embedded pass.
+    assert skills.executions == [("code-review", "also $code-review")]
+
+
+@pytest.mark.asyncio
+async def test_leading_unresolved_falls_through_to_embedded():
+    skills = _Skills("inline")
+    controller, _store = _controller(skills)
+    messages = [{"role": "user", "content": "$notaskill but $code-review works"}]
+    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    content = out[0]["content"]
+    assert content.startswith("$notaskill but RENDERED[")
+    assert skills.executions == [("code-review", "")]

--- a/Tests/Chat/test_console_skill_substitution.py
+++ b/Tests/Chat/test_console_skill_substitution.py
@@ -17,27 +17,34 @@ from tldw_chatbook.Skills_Interop.skill_trust_models import SkillTrustBlockedErr
 
 
 class _Skills:
-    def __init__(self, mode="inline", raise_trust=False):
+    def __init__(
+        self, mode="inline", raise_trust=False, raise_trust_for=(), extra_skills=()
+    ):
         self._mode = mode
         self._raise = raise_trust
+        self._raise_for = frozenset(raise_trust_for)
+        self._extra_skills = tuple(extra_skills)
         self.executions = []
+        self.get_context_calls = 0
 
     async def get_context(self, *, mode="local"):
+        self.get_context_calls += 1
         return {
             "available_skills": [
                 {
-                    "name": "code-review",
+                    "name": name,
                     "description": "d",
                     "user_invocable": True,
                     "trust_blocked": False,
                 }
+                for name in ("code-review", *self._extra_skills)
             ],
             "blocked_skills": [],
         }
 
     async def execute_skill(self, name, *, mode="local", args=None):
         self.executions.append((name, args))
-        if self._raise:
+        if self._raise or name in self._raise_for:
             raise SkillTrustBlockedError(
                 skill_name=name,
                 reason_code="skill_modified",
@@ -412,3 +419,55 @@ async def test_leading_unresolved_falls_through_to_embedded():
     content = out[0]["content"]
     assert content.startswith("$notaskill but RENDERED[")
     assert skills.executions == [("code-review", "")]
+
+
+@pytest.mark.asyncio
+async def test_plain_text_send_never_touches_skills_service():
+    """Fast path: a final user message with no `$` anywhere must return
+    unchanged WITHOUT consulting the skills service at all (no get_context,
+    no execute_skill) -- plain-text sends pay zero skills overhead."""
+    skills = _Skills("inline")
+    controller, _store = _controller(skills)
+    messages = [{"role": "user", "content": "just a plain question, no sigil"}]
+    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    assert out == messages
+    assert refuse is None
+    assert notes == ()
+    assert skills.executions == []
+    assert skills.get_context_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_same_skill_mentioned_twice_embedded_splices_both():
+    skills = _Skills("inline")
+    controller, _store = _controller(skills)
+    messages = [
+        {"role": "user", "content": "start $code-review mid $code-review end"}
+    ]
+    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    assert refuse is None and notes == ()
+    content = out[0]["content"]
+    # BOTH occurrences spliced, prose preserved.
+    assert content == "start RENDERED[] mid RENDERED[] end"
+    assert "$code-review" not in content
+    # Per-name cache: exactly ONE execution despite two mentions.
+    assert skills.executions == [("code-review", "")]
+
+
+@pytest.mark.asyncio
+async def test_mixed_spliced_and_blocked_mentions():
+    """One mention splices while a trust-blocked one stays literal with a
+    note -- and the blocked mention never aborts the send."""
+    skills = _Skills(
+        "inline", raise_trust_for={"danger-zone"}, extra_skills=("danger-zone",)
+    )
+    controller, _store = _controller(skills)
+    messages = [
+        {"role": "user", "content": "run $code-review then $danger-zone please"}
+    ]
+    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    assert refuse is None  # embedded never aborts
+    content = out[0]["content"]
+    assert content == "run RENDERED[] then $danger-zone please"
+    assert len(notes) == 1 and "danger-zone" in notes[0]
+    assert skills.executions == [("code-review", ""), ("danger-zone", "")]

--- a/Tests/Chat/test_console_skill_substitution.py
+++ b/Tests/Chat/test_console_skill_substitution.py
@@ -94,7 +94,7 @@ async def test_inline_substitutes_final_user_message_only():
         {"role": "system", "content": "sys"},
         {"role": "user", "content": "earlier"},
         {"role": "assistant", "content": "ok"},
-        {"role": "user", "content": "/code-review fix it"},
+        {"role": "user", "content": "$code-review fix it"},
     ]
     out, refuse = await controller._apply_skill_substitution(msgs)
     assert refuse is None
@@ -108,7 +108,7 @@ async def test_fork_drops_history_keeps_system():
     msgs = [
         {"role": "system", "content": "sys"},
         {"role": "user", "content": "earlier"},
-        {"role": "user", "content": "/code-review go"},
+        {"role": "user", "content": "$code-review go"},
     ]
     out, refuse = await controller._apply_skill_substitution(msgs)
     assert refuse is None
@@ -129,7 +129,7 @@ async def test_non_skill_final_message_unchanged():
 @pytest.mark.asyncio
 async def test_edited_skill_refuses_at_build():
     controller, _store = _controller(_Skills(raise_trust=True))
-    msgs = [{"role": "user", "content": "/code-review go"}]
+    msgs = [{"role": "user", "content": "$code-review go"}]
     out, refuse = await controller._apply_skill_substitution(msgs)
     assert out == msgs
     assert refuse == (
@@ -144,7 +144,7 @@ async def test_no_skills_service_is_a_noop():
     controller = ConsoleChatController(
         store=store, provider_gateway=object(), provider="llama_cpp", model="m"
     )
-    msgs = [{"role": "user", "content": "/code-review go"}]
+    msgs = [{"role": "user", "content": "$code-review go"}]
     out, refuse = await controller._apply_skill_substitution(msgs)
     assert out == msgs and refuse is None
 
@@ -167,7 +167,7 @@ async def test_submit_sends_rendered_payload_but_stores_raw_command():
         skills_service=skills,
     )
 
-    result = await controller.submit_draft("/code-review fix it")
+    result = await controller.submit_draft("$code-review fix it")
 
     assert result.accepted is True
     # Provider saw the rendered body as the triggering turn.
@@ -175,7 +175,7 @@ async def test_submit_sends_rendered_payload_but_stores_raw_command():
     # The store (transcript + persistence source) keeps the RAW command.
     messages = store.messages_for_session(store.active_session_id)
     user_rows = [m for m in messages if m.role is ConsoleMessageRole.USER]
-    assert user_rows[-1].content == "/code-review fix it"
+    assert user_rows[-1].content == "$code-review fix it"
 
 
 @pytest.mark.asyncio
@@ -190,7 +190,7 @@ async def test_fork_survives_retry_by_re_rendering_fresh():
         model="m",
         skills_service=skills,
     )
-    await controller.submit_draft("/code-review go")
+    await controller.submit_draft("$code-review go")
     messages = store.messages_for_session(store.active_session_id)
     failed = next(
         m
@@ -223,14 +223,14 @@ async def test_submit_refusal_appends_system_row_and_aborts_without_provider_cal
         skills_service=skills,
     )
 
-    result = await controller.submit_draft("/code-review go")
+    result = await controller.submit_draft("$code-review go")
 
     assert result.accepted is False
     assert gateway.payloads == []  # the run never reached the provider
     messages = store.messages_for_session(store.active_session_id)
     # Raw command persists (honest record), followed by the refuse system row.
     assert messages[-2].role is ConsoleMessageRole.USER
-    assert messages[-2].content == "/code-review go"
+    assert messages[-2].content == "$code-review go"
     assert messages[-1].role is ConsoleMessageRole.SYSTEM
     assert messages[-1].content == (
         'Skill "code-review" isn\'t trusted (skill_modified) — '
@@ -268,7 +268,7 @@ async def test_submit_refusal_never_invokes_accepted_hook():
     accepted_calls = []
     controller.on_submission_accepted = lambda: accepted_calls.append(True)
 
-    result = await controller.submit_draft("/code-review go")
+    result = await controller.submit_draft("$code-review go")
 
     assert result.accepted is False
     assert accepted_calls == []
@@ -301,7 +301,7 @@ async def test_submit_success_still_invokes_accepted_hook_before_assistant_row()
 
     controller.on_submission_accepted = _on_accepted
 
-    result = await controller.submit_draft("/code-review go")
+    result = await controller.submit_draft("$code-review go")
 
     assert result.accepted is True
     assert assistant_rows_seen_at_hook_time == [[]]
@@ -319,7 +319,7 @@ async def test_regenerate_refusal_after_skill_edit_keeps_prior_answer():
         model="m",
         skills_service=skills,
     )
-    await controller.submit_draft("/code-review go")
+    await controller.submit_draft("$code-review go")
     messages = store.messages_for_session(store.active_session_id)
     assistant = next(
         m for m in reversed(messages) if m.role is ConsoleMessageRole.ASSISTANT
@@ -336,3 +336,16 @@ async def test_regenerate_refusal_after_skill_edit_keeps_prior_answer():
     # The good prior answer is untouched by the refused regenerate.
     assert store.get_message(assistant.id).content == "reply"
     assert store.get_message(assistant.id).status == "complete"
+
+
+@pytest.mark.asyncio
+async def test_leading_slash_no_longer_invokes():
+    """Hard removal: a leading /code-review message passes through
+    untouched -- `$` is the only recognized skill-command sigil now."""
+    skills = _Skills("inline")
+    controller, _store = _controller(skills)
+    messages = [{"role": "user", "content": "/code-review look at this"}]
+    out, refuse = await controller._apply_skill_substitution(messages)
+    assert out == messages
+    assert refuse is None
+    assert skills.executions == []

--- a/Tests/UI/test_console_skill_commands.py
+++ b/Tests/UI/test_console_skill_commands.py
@@ -1,5 +1,8 @@
-"""Task 9: `/skills` registered command + bare `/skill-name` fallback dispatch
-(list / run / refuse) on the native Console composer.
+"""`/skills` registered command (list / static `$name` run-form hint) on
+the native Console composer (Task 4: the OLD bare `/skill-name` fallback
+dispatch this file used to also cover was hard-removed -- invocation is now
+exclusively the controller-side `$name` mention, tested in
+``Tests/Chat/test_console_skill_substitution.py``).
 
 Mirrors ``Tests/UI/test_console_command_composer.py``'s harness style (real
 ``TldwCli`` app via ``_build_test_app``, real ``ChatScreen`` via
@@ -10,7 +13,6 @@ store.
 
 from __future__ import annotations
 
-from types import SimpleNamespace
 from typing import Any, Mapping
 from unittest.mock import AsyncMock
 
@@ -28,15 +30,10 @@ from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
     ConsoleHarness,
 )
 from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
-from tldw_chatbook.Chat.console_skill_resolver import (
-    SKILL_UNTRUSTED_REFUSE,
-    SKILLS_EMPTY_LIST_ROW,
-)
-from tldw_chatbook.Skills_Interop.skill_trust_models import SkillTrustBlockedError
+from tldw_chatbook.Chat.console_skill_resolver import SKILLS_EMPTY_LIST_ROW
 from tldw_chatbook.UI.Screens.chat_screen import (
     CONSOLE_SKILL_NEEDS_REVIEW_HINT_TEMPLATE,
     CONSOLE_SKILL_RUN_MARKER_TEMPLATE,
-    CONSOLE_SKILL_RUN_REFUSE_REASON_ABSENT,
 )
 from tldw_chatbook.Widgets.Console import ConsoleComposerBar
 
@@ -63,13 +60,13 @@ def _blocked_skill(name: str, *, reason: str = "skill_modified") -> dict[str, An
 class FakeSkillsScopeService:
     """Minimal stand-in for ``SkillsScopeService.get_context``/``execute_skill``.
 
-    ``execute_skill`` exists because Task 10's provider-payload substitution
-    rule renders the triggering `/skill-name` turn at build time through
-    the controller's injected skills service (the same object staged on
+    ``execute_skill`` exists because the provider-payload substitution rule
+    renders the triggering `$skill-name` turn at build time through the
+    controller's injected skills service (the same object staged on
     ``app.skills_scope_service`` here) -- a raw-command submit in these
-    tests therefore reaches ``execute_skill`` even though the assertions
-    below are about dispatch (raw command stored + marker order), not the
-    rendered payload.
+    tests therefore reaches ``execute_skill`` even though some assertions
+    below are about dispatch (raw command stored, no skill run) rather than
+    the rendered payload.
     """
 
     def __init__(
@@ -134,8 +131,8 @@ async def test_bare_skills_command_lists_trusted_skills():
 
         system_rows = _console_message_contents(console, ConsoleMessageRole.SYSTEM)
         assert any(
-            "/code-review — Reviews a diff." in row
-            and "/release-notes — Drafts release notes." in row
+            "$code-review — Reviews a diff." in row
+            and "$release-notes — Drafts release notes." in row
             for row in system_rows
         )
 
@@ -162,7 +159,10 @@ async def test_bare_skills_command_with_no_skills_shows_empty_row():
 
 
 @pytest.mark.asyncio
-async def test_skills_command_unknown_name_shows_absent_refuse_row():
+async def test_skills_command_named_run_form_shows_dollar_hint_for_unknown_name():
+    """Hard removal (Task 4): `/skills <name>` never resolves or runs a
+    skill anymore -- it always shows the same "run it with $name" hint,
+    regardless of whether the typed name matches anything at all."""
     app = _build_test_app()
     _configure_native_ready_console(app)
     app.skills_scope_service = FakeSkillsScopeService(
@@ -181,17 +181,18 @@ async def test_skills_command_unknown_name_shows_absent_refuse_row():
         console.query_one("#console-send-message", Button).press()
         await pilot.pause(0.2)
 
-        expected = SKILL_UNTRUSTED_REFUSE.format(
-            name="unknownskill", reason=CONSOLE_SKILL_RUN_REFUSE_REASON_ABSENT
-        )
+        expected = "Run skills by typing $unknownskill — /skills only lists them."
         assert expected in _console_message_contents(console, ConsoleMessageRole.SYSTEM)
         submit_spy.assert_not_called()
-        # The draft is preserved -- a refusal never clears the composer.
+        # The draft is preserved -- the hint never clears the composer.
         assert composer.draft_text() == "/skills unknownskill"
 
 
 @pytest.mark.asyncio
-async def test_skills_command_named_blocked_skill_shows_untrusted_refuse_row():
+async def test_skills_command_named_run_form_shows_dollar_hint_for_blocked_name():
+    """Same hint even when the typed name matches a trust-blocked skill --
+    `/skills <name>` no longer distinguishes blocked/absent/ambiguous, it
+    never resolves anything at all."""
     app = _build_test_app()
     _configure_native_ready_console(app)
     app.skills_scope_service = FakeSkillsScopeService(
@@ -211,20 +212,28 @@ async def test_skills_command_named_blocked_skill_shows_untrusted_refuse_row():
         console.query_one("#console-send-message", Button).press()
         await pilot.pause(0.2)
 
-        expected = SKILL_UNTRUSTED_REFUSE.format(
-            name="sketchy-skill", reason="skill_modified"
-        )
+        expected = "Run skills by typing $sketchy-skill — /skills only lists them."
         assert expected in _console_message_contents(console, ConsoleMessageRole.SYSTEM)
         submit_spy.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_bare_fallback_trusted_skill_submits_raw_command_and_appends_marker():
+async def test_leading_dollar_skill_mention_executes_through_normal_send():
+    """Hard removal (Task 4): typing `$code-review fix it` directly is no
+    longer intercepted by any composer-level command dispatch -- it is a
+    plain user send. The skill still actually runs because the CONTROLLER
+    (Tasks 2/3) resolves and splices the leading `$name` mention at
+    provider-payload build time; the stored transcript keeps the raw
+    `$`-prefixed text untouched (ephemeral substitution only). There is no
+    composer-staged TOOL "driving this turn" marker for this path anymore
+    -- that mechanism only ever fired for the now-removed bare `/name`
+    dispatch-time resolution."""
     app = _build_test_app()
     _configure_native_ready_console(app)
-    app.skills_scope_service = FakeSkillsScopeService(
+    skills = FakeSkillsScopeService(
         available_skills=[_skill("code-review", "Reviews a diff.")]
     )
+    app.skills_scope_service = skills
     gateway = CapturingGateway(chunks=("accepted",))
     app.console_provider_gateway_factory = lambda: gateway
     host = ConsoleHarness(app)
@@ -232,235 +241,110 @@ async def test_bare_fallback_trusted_skill_submits_raw_command_and_appends_marke
     async with host.run_test(size=(160, 48)) as pilot:
         console = host.screen_stack[-1]
         await _wait_for_selector(console, pilot, "#console-native-composer")
-        # Let the mount-time cache refresh populate the fallback resolver's
-        # candidate snapshot before typing a bare `/code-review` draft.
-        for _ in range(40):
-            if console._console_skill_candidates:
-                break
-            await pilot.pause(0.05)
-        assert console._console_skill_candidates, "candidate snapshot never populated"
 
         composer = console.query_one("#console-native-composer", ConsoleComposerBar)
-        composer.load_draft("/code-review fix it")
-        # `wraps=` keeps the real submit path running (needed for the
-        # accepted-hook that now appends the marker -- see below) while
-        # still letting us assert what was actually submitted.
+        composer.load_draft("$code-review fix it")
         submit_spy = await _spy_submit_draft(console)
 
         console.query_one("#console-send-message", Button).press()
         await _wait_for_text(console, pilot, "accepted")
 
-        submit_spy.assert_called_once_with("/code-review fix it")
-        marker_expected = CONSOLE_SKILL_RUN_MARKER_TEMPLATE.format(name="code-review")
-        assert marker_expected in _console_message_contents(
+        # The raw `$`-prefixed draft is submitted verbatim -- no composer
+        # command dispatch ever intercepts it.
+        submit_spy.assert_called_once_with("$code-review fix it")
+        # The skill actually ran (controller-side substitution).
+        assert skills.executions == [("code-review", "fix it")]
+        # The stored transcript keeps the raw mention -- only the ephemeral
+        # provider payload is rendered.
+        user_rows = [
+            message.content
+            for message in console._ensure_console_chat_store().messages_for_session(
+                console._ensure_console_chat_store().active_session_id
+            )
+            if message.role is ConsoleMessageRole.USER
+        ]
+        assert "$code-review fix it" in user_rows
+        # No TOOL "driving this turn" marker -- that composer-staged
+        # mechanism no longer fires for a directly-typed `$name` send.
+        marker_text = CONSOLE_SKILL_RUN_MARKER_TEMPLATE.format(name="code-review")
+        assert marker_text not in _console_message_contents(
             console, ConsoleMessageRole.TOOL
         )
 
 
 @pytest.mark.asyncio
-async def test_bare_fallback_skill_marker_lands_after_user_message_not_before():
-    """Reviewer repro (Task 9 fix-wave): appending the TOOL "driving this
-    turn" marker right after `_dispatch_console_draft_send` merely
-    *schedules* the real submit via `run_worker` -- not after it actually
-    runs -- so the marker could land BEFORE the user turn it is meant to
-    follow. Store order must always be [USER, TOOL, ASSISTANT]."""
+async def test_bare_slash_skill_name_no_longer_auto_runs_shows_unknown_command_hint():
+    """Hard removal (Task 4): a bare `/code-review fix it` draft -- the OLD
+    invocation form -- is no longer claimed by any fallback resolver, even
+    though "code-review" is a real, trusted skill. It parses exactly like
+    any other unrecognized word: the generic "Unknown command" hint, armed
+    for a literal send on a second Enter. The skill never runs."""
     app = _build_test_app()
     _configure_native_ready_console(app)
-    app.skills_scope_service = FakeSkillsScopeService(
+    skills = FakeSkillsScopeService(
         available_skills=[_skill("code-review", "Reviews a diff.")]
     )
-    gateway = CapturingGateway(chunks=("accepted",))
-    app.console_provider_gateway_factory = lambda: gateway
+    app.skills_scope_service = skills
     host = ConsoleHarness(app)
 
     async with host.run_test(size=(160, 48)) as pilot:
         console = host.screen_stack[-1]
         await _wait_for_selector(console, pilot, "#console-native-composer")
-        for _ in range(40):
-            if console._console_skill_candidates:
-                break
-            await pilot.pause(0.05)
-        assert console._console_skill_candidates, "candidate snapshot never populated"
-
         composer = console.query_one("#console-native-composer", ConsoleComposerBar)
         composer.load_draft("/code-review fix it")
+        submit_spy = AsyncMock()
+        console._submit_console_native_draft = submit_spy
 
-        console.query_one("#console-send-message", Button).press()
-        await _wait_for_text(console, pilot, "accepted")
-
-        store = console._ensure_console_chat_store()
-        session_id = store.active_session_id
-        assert session_id is not None
-        messages = store.messages_for_session(session_id)
-
-        marker_expected = CONSOLE_SKILL_RUN_MARKER_TEMPLATE.format(name="code-review")
-        assert [message.role for message in messages] == [
-            ConsoleMessageRole.USER,
-            ConsoleMessageRole.TOOL,
-            ConsoleMessageRole.ASSISTANT,
-        ]
-        assert messages[0].content == "/code-review fix it"
-        assert messages[1].content == marker_expected
-
-
-class _RaceConditionSkillsScopeService(FakeSkillsScopeService):
-    """Reports a skill as trusted at candidate-listing time, but refuses it
-    (``SkillTrustBlockedError``) at actual execute-time -- simulating trust
-    being revoked in the window between the composer's dispatch-time
-    resolution (``_console_command_run_skill``, which staged the "driving
-    this turn" marker) and the controller's own build-time re-verification
-    (``ConsoleChatController._apply_skill_substitution``)."""
-
-    async def execute_skill(self, name, *, mode=None, args=None):
-        self.executions.append((name, args))
-        raise SkillTrustBlockedError(
-            skill_name=name,
-            reason_code="skill_modified",
-            trust_status="quarantined_modified",
-        )
-
-
-@pytest.mark.asyncio
-async def test_skill_trust_revoked_between_resolve_and_submit_refuses_without_marker():
-    """Qodo finding 3 (PR #636 bot review) repro: a skill resolved (and
-    staged for the "driving this turn" marker) at dispatch time can still
-    be refused by the controller's own build-time trust re-check. The
-    refusal must produce NO TOOL marker (the skill never actually ran) and
-    must not leak the staged marker name onto the next, unrelated send."""
-    app = _build_test_app()
-    _configure_native_ready_console(app)
-    app.skills_scope_service = _RaceConditionSkillsScopeService(
-        available_skills=[_skill("code-review", "Reviews a diff.")]
-    )
-    gateway = CapturingGateway(chunks=("accepted",))
-    app.console_provider_gateway_factory = lambda: gateway
-    host = ConsoleHarness(app)
-
-    async with host.run_test(size=(160, 48)) as pilot:
-        console = host.screen_stack[-1]
-        await _wait_for_selector(console, pilot, "#console-native-composer")
-        for _ in range(40):
-            if console._console_skill_candidates:
-                break
-            await pilot.pause(0.05)
-        assert console._console_skill_candidates, "candidate snapshot never populated"
-
-        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
-        composer.load_draft("/code-review fix it")
-        console.query_one("#console-send-message", Button).press()
-        await _wait_for_text(console, pilot, "isn't trusted (skill_modified)")
-
-        store = console._ensure_console_chat_store()
-        session_id = store.active_session_id
-        assert session_id is not None
-        messages = store.messages_for_session(session_id)
-
-        # The raw command still persists (honest record), followed by the
-        # refuse row -- but NO TOOL marker: the skill never actually ran.
-        assert not [m for m in messages if m.role is ConsoleMessageRole.TOOL]
-        expected = SKILL_UNTRUSTED_REFUSE.format(
-            name="code-review", reason="skill_modified"
-        )
-        assert expected in _console_message_contents(console, ConsoleMessageRole.SYSTEM)
-        assert console._console_pending_skill_marker_name is None
-
-        # The staged marker must not leak onto the NEXT, unrelated send.
-        composer.load_draft("just a normal message")
-        console.query_one("#console-send-message", Button).press()
-        await _wait_for_text(console, pilot, "accepted")
-        assert not [
-            message
-            for message in store.messages_for_session(session_id)
-            if message.role is ConsoleMessageRole.TOOL
-        ]
-
-
-class _ToggleReadinessGateway:
-    """First ``resolve_for_send`` call is blocked; every later call is ready.
-
-    Lets a single test drive "the skill run's submit is refused inside
-    `submit_draft`" followed immediately by a normal successful send,
-    without needing to tear down/rebuild the Console controller (whose
-    ``provider_gateway`` is cached at construction) mid test.
-    """
-
-    def __init__(self) -> None:
-        self._calls = 0
-
-    async def resolve_for_send(self, selection):
-        self._calls += 1
-        ready = self._calls > 1
-        return SimpleNamespace(
-            provider=selection.provider,
-            base_url=selection.base_url or "",
-            model=selection.explicit_model
-            or selection.configured_model
-            or "test-model",
-            ready=ready,
-            visible_copy="" if ready else "Provider blocked: test setup incomplete.",
-        )
-
-    async def stream_chat(self, resolution, messages):
-        yield "accepted"
-
-
-@pytest.mark.asyncio
-async def test_blocked_skill_run_does_not_leak_marker_into_next_send():
-    """Leak test: a refused/blocked submit must never leave its staged skill
-    marker name to attach itself to the NEXT, unrelated accepted send."""
-    app = _build_test_app()
-    _configure_native_ready_console(app)
-    app.skills_scope_service = FakeSkillsScopeService(
-        available_skills=[_skill("code-review", "Reviews a diff.")]
-    )
-    gateway = _ToggleReadinessGateway()
-    app.console_provider_gateway_factory = lambda: gateway
-    host = ConsoleHarness(app)
-
-    async with host.run_test(size=(160, 48)) as pilot:
-        console = host.screen_stack[-1]
-        await _wait_for_selector(console, pilot, "#console-native-composer")
-        for _ in range(40):
-            if console._console_skill_candidates:
-                break
-            await pilot.pause(0.05)
-        assert console._console_skill_candidates, "candidate snapshot never populated"
-
-        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
-        composer.load_draft("/code-review fix it")
         console.query_one("#console-send-message", Button).press()
         await pilot.pause(0.2)
 
-        # The blocked first attempt must have cleared the staged marker name
-        # rather than leaving it consumed by whatever sends next.
-        assert console._console_pending_skill_marker_name is None
-
-        store = console._ensure_console_chat_store()
-        session_id = store.active_session_id
-        assert session_id is not None
-        assert not [
-            message
-            for message in store.messages_for_session(session_id)
-            if message.role is ConsoleMessageRole.TOOL
-        ]
-
-        composer.load_draft("just a normal message")
-        console.query_one("#console-send-message", Button).press()
-        await _wait_for_text(console, pilot, "accepted")
-
-        tool_rows = [
-            message.content
-            for message in store.messages_for_session(session_id)
-            if message.role is ConsoleMessageRole.TOOL
-        ]
-        assert tool_rows == []
+        expected = (
+            "Unknown command /code-review — available: "
+            "/prompt, /system, /skills, /prefill. Press Enter again to send as text."
+        )
+        assert expected in _console_message_contents(console, ConsoleMessageRole.SYSTEM)
+        submit_spy.assert_not_called()
+        assert skills.executions == []
+        assert composer.draft_text() == "/code-review fix it"
+        assert console._console_unknown_send_armed == "/code-review fix it"
 
 
 @pytest.mark.asyncio
-async def test_run_skill_prefix_matching_only_blocked_skills_shows_needs_review_hint():
-    """Review-mandated addition: a typed prefix that matches ONLY needs-review
-    skills must not silently open an (always-empty) picker or otherwise read
-    like the generic empty state -- it gets a distinguishing count hint."""
+async def test_run_resolved_console_skill_composes_dollar_command():
+    """The skill-picker submit path (`_run_resolved_console_skill`, the sole
+    remaining consumer of a resolved skill name) composes a `$name [args]`
+    draft, not `/name [args]` -- verified directly since the picker is no
+    longer reachable through any live `/skills` or bare-word composer
+    input (both were hard-removed above)."""
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.skills_scope_service = FakeSkillsScopeService(
+        available_skills=[_skill("code-review", "Reviews a diff.")]
+    )
+    gateway = CapturingGateway(chunks=("accepted",))
+    app.console_provider_gateway_factory = lambda: gateway
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        submit_spy = await _spy_submit_draft(console)
+
+        await console._run_resolved_console_skill("code-review", "fix it")
+        await _wait_for_text(console, pilot, "accepted")
+        submit_spy.assert_called_once_with("$code-review fix it")
+
+        submit_spy.reset_mock()
+        await console._run_resolved_console_skill("code-review", "")
+        await pilot.pause(0.2)
+        submit_spy.assert_called_once_with("$code-review")
+
+
+@pytest.mark.asyncio
+async def test_skills_command_named_run_form_shows_dollar_hint_for_blocked_prefix():
+    """Same static hint even when the typed name is a prefix matching only
+    needs-review skills -- `/skills <name>` no longer distinguishes any
+    resolution outcome, and never opens the (now-unreachable) picker."""
     app = _build_test_app()
     _configure_native_ready_console(app)
     app.skills_scope_service = FakeSkillsScopeService(
@@ -479,17 +363,17 @@ async def test_run_skill_prefix_matching_only_blocked_skills_shows_needs_review_
         console.query_one("#console-send-message", Button).press()
         await pilot.pause(0.2)
 
-        expected = CONSOLE_SKILL_NEEDS_REVIEW_HINT_TEMPLATE.format(count=2)
+        expected = "Run skills by typing $review — /skills only lists them."
         assert expected in _console_message_contents(console, ConsoleMessageRole.SYSTEM)
         assert len(host.screen_stack) == baseline_depth, "no picker should have opened"
 
 
 @pytest.mark.asyncio
-async def test_bare_fallback_prefix_matching_only_blocked_skills_shows_needs_review_hint():
-    """Fold-in (Task 9 fix-wave review): a bare `/name` draft that the
-    fallback resolver leaves as KIND_UNKNOWN (its cached candidate snapshot
-    is trusted-only, so a needs-review-only match never gets claimed) must
-    surface the same distinguishing hint `/skills <name>` shows, not the
+async def test_bare_unknown_word_needs_review_prefix_shows_hint_not_unknown_command():
+    """The blocked-hint path itself STAYS (Task 4 brief): a bare `/name`
+    draft that matches no registered command reaches KIND_UNKNOWN directly
+    (there is no fallback resolver at all anymore), and a needs-review-only
+    match there still surfaces the distinguishing count hint instead of the
     generic "Unknown command" hint."""
     app = _build_test_app()
     _configure_native_ready_console(app)
@@ -516,7 +400,10 @@ async def test_bare_fallback_prefix_matching_only_blocked_skills_shows_needs_rev
 
 
 @pytest.mark.asyncio
-async def test_skills_command_ambiguous_prefix_opens_picker_prefilled():
+async def test_skills_command_named_run_form_shows_dollar_hint_for_ambiguous_prefix():
+    """Same static hint even when the typed name is an ambiguous prefix
+    (multiple trusted matches) -- `/skills <name>` never opens the picker
+    anymore, for any resolution outcome."""
     app = _build_test_app()
     _configure_native_ready_console(app)
     app.skills_scope_service = FakeSkillsScopeService(
@@ -537,17 +424,8 @@ async def test_skills_command_ambiguous_prefix_opens_picker_prefilled():
         console.query_one("#console-send-message", Button).press()
         await pilot.pause(0.2)
 
-        assert len(host.screen_stack) == baseline_depth + 1, (
-            "the picker must have opened"
-        )
-
-        from tldw_chatbook.Widgets.Console.console_skill_picker_modal import (
-            FILTER_INPUT_ID,
-        )
-        from textual.widgets import Input
-
-        picker = host.screen_stack[-1]
-        filter_input = picker.query_one(f"#{FILTER_INPUT_ID}", Input)
-        assert filter_input.value == "code"
-        # The draft is left exactly as typed -- the picker is a detour.
+        expected = "Run skills by typing $code — /skills only lists them."
+        assert expected in _console_message_contents(console, ConsoleMessageRole.SYSTEM)
+        assert len(host.screen_stack) == baseline_depth, "no picker should have opened"
+        # The draft is left exactly as typed.
         assert composer.draft_text() == "/skills code"

--- a/Tests/UI/test_console_skill_commands.py
+++ b/Tests/UI/test_console_skill_commands.py
@@ -33,7 +33,6 @@ from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
 from tldw_chatbook.Chat.console_skill_resolver import SKILLS_EMPTY_LIST_ROW
 from tldw_chatbook.UI.Screens.chat_screen import (
     CONSOLE_SKILL_NEEDS_REVIEW_HINT_TEMPLATE,
-    CONSOLE_SKILL_RUN_MARKER_TEMPLATE,
 )
 from tldw_chatbook.Widgets.Console import ConsoleComposerBar
 
@@ -218,16 +217,49 @@ async def test_skills_command_named_run_form_shows_dollar_hint_for_blocked_name(
 
 
 @pytest.mark.asyncio
+async def test_skills_command_exact_trusted_name_shows_hint_and_never_runs():
+    """The highest-value hard-removal regression: `/skills code-review`
+    where "code-review" EXACTLY matches a real, trusted skill -- the
+    previously-working run form. It must show the same static `$name` hint,
+    execute nothing, and submit nothing."""
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    skills = FakeSkillsScopeService(
+        available_skills=[_skill("code-review", "Reviews a diff.")]
+    )
+    app.skills_scope_service = skills
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("/skills code-review fix it")
+        submit_spy = AsyncMock()
+        console._submit_console_native_draft = submit_spy
+
+        console.query_one("#console-send-message", Button).press()
+        await pilot.pause(0.2)
+
+        expected = "Run skills by typing $code-review — /skills only lists them."
+        assert expected in _console_message_contents(console, ConsoleMessageRole.SYSTEM)
+        submit_spy.assert_not_called()
+        assert skills.executions == []
+        # The draft is preserved for correction into the `$` form.
+        assert composer.draft_text() == "/skills code-review fix it"
+
+
+@pytest.mark.asyncio
 async def test_leading_dollar_skill_mention_executes_through_normal_send():
     """Hard removal (Task 4): typing `$code-review fix it` directly is no
     longer intercepted by any composer-level command dispatch -- it is a
     plain user send. The skill still actually runs because the CONTROLLER
     (Tasks 2/3) resolves and splices the leading `$name` mention at
     provider-payload build time; the stored transcript keeps the raw
-    `$`-prefixed text untouched (ephemeral substitution only). There is no
-    composer-staged TOOL "driving this turn" marker for this path anymore
-    -- that mechanism only ever fired for the now-removed bare `/name`
-    dispatch-time resolution."""
+    `$`-prefixed text untouched (ephemeral substitution only). The
+    composer-staged TOOL "driving this turn" marker machinery was deleted
+    with the bare `/name` dispatch it served (fix-wave branch (a)), so no
+    TOOL row of any kind appears for a `$name` send."""
     app = _build_test_app()
     _configure_native_ready_console(app)
     skills = FakeSkillsScopeService(
@@ -264,12 +296,10 @@ async def test_leading_dollar_skill_mention_executes_through_normal_send():
             if message.role is ConsoleMessageRole.USER
         ]
         assert "$code-review fix it" in user_rows
-        # No TOOL "driving this turn" marker -- that composer-staged
-        # mechanism no longer fires for a directly-typed `$name` send.
-        marker_text = CONSOLE_SKILL_RUN_MARKER_TEMPLATE.format(name="code-review")
-        assert marker_text not in _console_message_contents(
-            console, ConsoleMessageRole.TOOL
-        )
+        # No TOOL rows at all -- the composer-staged "driving this turn"
+        # marker machinery is deleted (the visible `$name` user row already
+        # documents which skill drove the turn).
+        assert _console_message_contents(console, ConsoleMessageRole.TOOL) == []
 
 
 @pytest.mark.asyncio

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -487,7 +487,7 @@ def _eligible_skill_entries(context: Mapping[str, Any]) -> list[Mapping[str, Any
 
     Mirrors ``ChatScreen._console_skill_trusted_candidates_from_context``'s
     defensive filter shape, but scoped to model-invocation eligibility
-    rather than user (``/skill-name``) invocation: a skill is eligible here
+    rather than user (``$skill-name``) invocation: a skill is eligible here
     when it is not ``trust_blocked`` (the local-skill-trust-integrity gate)
     and does not opt out of model calls via ``disable_model_invocation``
     (the skill author's own front-matter flag). Both fields default to
@@ -733,7 +733,7 @@ class _BridgeSkillRunner:
     a cached snapshot -- so a skill approved when the catalog was built but
     revoked before the model actually calls it still refuses (mirrors
     ``ConsoleChatController._apply_skill_substitution``'s own re-verification
-    discipline for the ``/skill-name`` user-invocation path).
+    discipline for the ``$skill-name`` user-invocation path).
     """
 
     def __init__(

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -213,7 +213,7 @@ def build_mcp_review_hook(
 
 
 def _split_skill_command_word(text: str) -> tuple[str, str]:
-    """Split a ``/word rest`` string into its leading token and the remainder.
+    """Split a ``$word rest`` string into its leading token and the remainder.
 
     Mirrors ``console_command_grammar._split_leading_token``'s single-
     whitespace-character split rule. That helper is module-private (by
@@ -221,7 +221,9 @@ def _split_skill_command_word(text: str) -> tuple[str, str]:
     so this is a deliberate small duplicate rather than an import, the same
     precedent ``chat_screen.ChatScreen._split_console_skill_name_args``
     already follows. ``text`` is assumed to already start with
-    `COMMAND_PREFIX`.
+    `MENTION_SIGIL` (the `$`-mention leading form, not `COMMAND_PREFIX`'s
+    `/` -- its sole caller is `_apply_skill_substitution`'s leading-form
+    branch).
     """
     for index, character in enumerate(text):
         if character.isspace():
@@ -1512,6 +1514,19 @@ class ConsoleChatController:
         *,
         synthetic_turn_added: bool = True,
     ) -> list[dict[str, Any]]:
+        """Flag a draft that LOOKS like an unresolved leading `$name` skill mention.
+
+        Cheap textual heuristic only (a leading `MENTION_SIGIL`) -- this
+        preview path deliberately never calls `_apply_skill_substitution`
+        (see the caller's comment), so it has no candidate snapshot to
+        actually resolve the word against. Re-sigiled for the `$`-mention
+        migration (Task 5): a leading ``/`` is now a registered slash
+        command (``/skills``, ``/prompt``, ...), not a skill invocation, so
+        it must NOT be annotated here. Embedded ``$name`` mentions
+        elsewhere in the draft are intentionally not flagged -- this only
+        covers the leading form, mirroring `_apply_skill_substitution`'s
+        own "leading form tried first" precedence.
+        """
         result = copy.deepcopy(messages)
         if not synthetic_turn_added or not result or result[-1].get("role") != "user":
             return result
@@ -1522,7 +1537,7 @@ class ConsoleChatController:
             "actual substitution happens at send time.]"
         )
 
-        if isinstance(content, str) and content.lstrip().startswith("/"):
+        if isinstance(content, str) and content.lstrip().startswith(MENTION_SIGIL):
             result[-1]["content"] = f"{content}\n\n{annotation}"
             return result
 
@@ -1536,7 +1551,7 @@ class ConsoleChatController:
                     and isinstance(part, dict)
                     and part.get("type") == "text"
                     and isinstance(text, str)
-                    and text.lstrip().startswith("/")
+                    and text.lstrip().startswith(MENTION_SIGIL)
                 ):
                     new_parts.append({**part, "text": f"{text}\n\n{annotation}"})
                     annotated = True

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -497,17 +497,13 @@ class ConsoleChatController:
         # The accepted-hook fires only once the turn is confirmed to
         # actually proceed (Qodo finding 3, PR #636 bot review): it used to
         # fire right after the USER row was appended, BEFORE this skill
-        # substitution/trust check ran. In the real ChatScreen, this hook
-        # is the sole consume point for a staged resolved-skill "driving
-        # this turn" TOOL marker (see `_on_console_submission_accepted`'s
-        # own docstring) -- firing it before a substitution refusal meant
-        # a refused/untrusted skill submit still consumed and appended
-        # that marker, claiming the skill drove the turn right before the
-        # refuse row that says it never ran. A substitution refusal is a
-        # `_block()` outcome exactly like any other (provider not ready,
-        # policy block, validation failure) and those already never reach
-        # this hook -- this reorder just extends that same rule to cover
-        # it too.
+        # substitution/trust check ran. In the real ChatScreen this hook
+        # clears the composer, so firing it before a substitution refusal
+        # ate the refused draft the user needs to correct. A substitution
+        # refusal is a `_block()` outcome exactly like any other (provider
+        # not ready, policy block, validation failure) and those already
+        # never reach this hook -- this ordering just extends that same
+        # rule to cover it too.
         self._notify_submission_accepted()
         # TASK-485: the turn is confirmed to proceed — flush the deferred USER
         # echo to durable storage now (creating the conversation), BEFORE the

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1526,6 +1526,16 @@ class ConsoleChatController:
         elsewhere in the draft are intentionally not flagged -- this only
         covers the leading form, mirroring `_apply_skill_substitution`'s
         own "leading form tried first" precedence.
+
+        Only STRING content is ever annotated. A multimodal (list-content)
+        draft -- e.g. a text part plus an image attachment -- is left
+        completely unchanged, even when its text part starts with a
+        `$name` mention: `_apply_skill_substitution` early-returns on
+        non-str content at send time (replacing list content outright would
+        drop the attachments), so this preview never actually substitutes a
+        multimodal draft's skill mention. Annotating it here would promise
+        a substitution the send never performs -- a dishonest preview
+        (Qodo fix 4, PR #801 review).
         """
         result = copy.deepcopy(messages)
         if not synthetic_turn_added or not result or result[-1].get("role") != "user":
@@ -1539,26 +1549,7 @@ class ConsoleChatController:
 
         if isinstance(content, str) and content.lstrip().startswith(MENTION_SIGIL):
             result[-1]["content"] = f"{content}\n\n{annotation}"
-            return result
 
-        if isinstance(content, list):
-            new_parts: list[Any] = []
-            annotated = False
-            for part in content:
-                text = part.get("text") if isinstance(part, dict) else None
-                if (
-                    not annotated
-                    and isinstance(part, dict)
-                    and part.get("type") == "text"
-                    and isinstance(text, str)
-                    and text.lstrip().startswith(MENTION_SIGIL)
-                ):
-                    new_parts.append({**part, "text": f"{text}\n\n{annotation}"})
-                    annotated = True
-                else:
-                    new_parts.append(part)
-            if annotated:
-                result[-1]["content"] = new_parts
         return result
 
     def _build_tools_info_for_snapshot(self) -> dict[str, Any]:
@@ -1781,28 +1772,40 @@ class ConsoleChatController:
         edited (now untrusted) refuses/skips instead of silently re-running
         a stale render.
 
+        Both forms are DETECTED against trusted candidates UNION
+        user-invocable blocked (needs-review) skills -- a blocked skill must
+        still be found (leading refuses, embedded degrades to literal +
+        note) rather than silently staying plain, sigil-prefixed text with
+        no signal at all. `execute_skill` remains the sole trust authority;
+        detection here never grants execution.
+
         Two independent forms, tried in order:
 
-        Leading form -- the message starts with `MENTION_SIGIL` and the
-        leading word resolves to a known skill: the REST of the message is
-        passed as that skill's args (`cap_skill_args`). A resolved leading
-        mention is never also scanned for embedded mentions -- its args are
-        opaque payload, not further mentions to expand.
+        Leading form -- the message, with leading whitespace stripped
+        (mirroring `_annotate_skill_commands`'s own preview `lstrip()`
+        assumption -- a resolved leading mention replaces the whole message
+        either way, so the leading whitespace simply disappears), starts
+        with `MENTION_SIGIL` and the leading word resolves to a known
+        skill: the REST of the (stripped) message is passed as that skill's
+        args (`cap_skill_args`). A resolved leading mention is never also
+        scanned for embedded mentions -- its args are opaque payload, not
+        further mentions to expand.
 
         Embedded form -- tried whenever the leading form doesn't apply (no
-        leading `MENTION_SIGIL`, or the leading word doesn't resolve): every
-        `$skill-name` mention anywhere in the message (case-sensitive,
-        code-span-masked, document order -- `find_embedded_mentions`) is
-        looked up ARGLESS (`execute_skill(name, mode="local", args="")`,
-        once per unique name, right-to-left splice so earlier spans stay
-        valid) and spliced in place at the mention's exact span, preserving
-        all surrounding prose. Only an ``execution_mode == "inline"`` result
-        splices; anything else (e.g. ``fork``, which has no "in place"
-        meaning for an embedded mention) silently leaves that mention's
-        literal `$name` text untouched. A trust-blocked mention
-        (`SkillTrustBlockedError`) also leaves the literal text untouched
-        but records a `SKILL_MENTION_SKIPPED_NOTE` for the caller to surface
-        as a non-aborting system row.
+        leading `MENTION_SIGIL`, or the leading word doesn't resolve):
+        scans the ORIGINAL (unstripped) message. Every `$skill-name`
+        mention anywhere in the message (case-sensitive, code-span-masked,
+        document order -- `find_embedded_mentions`) is looked up ARGLESS
+        (`execute_skill(name, mode="local", args="")`, once per unique
+        name, right-to-left splice so earlier spans stay valid) and spliced
+        in place at the mention's exact span, preserving all surrounding
+        prose. Only an ``execution_mode == "inline"`` result splices;
+        anything else (e.g. ``fork``, which has no "in place" meaning for
+        an embedded mention) silently leaves that mention's literal `$name`
+        text untouched. A trust-blocked mention (`SkillTrustBlockedError`)
+        also leaves the literal text untouched but records a
+        `SKILL_MENTION_SKIPPED_NOTE` for the caller to surface as a
+        non-aborting system row.
 
         Args:
             provider_messages: The fully-built payload about to be sent to
@@ -1851,13 +1854,32 @@ class ConsoleChatController:
 
         context = await self._skills_service.get_context(mode="local")
         candidates = self._skill_candidates_from_context(context)
+        # DETECTION population = trusted candidates UNION user-invocable
+        # blocked (needs-review) skills. A blocked skill must still be
+        # DETECTED -- leading refuses, embedded degrades to literal + note
+        # -- rather than silently staying plain, sigil-prefixed text with no
+        # signal at all. `execute_skill` (not this resolution step) remains
+        # the sole authority on whether a resolved name may actually run:
+        # a name that resolves here to a blocked skill hits
+        # `SkillTrustBlockedError` at the `execute_skill` call below/in the
+        # embedded loop, which already drives the refuse/skip-with-note
+        # paths.
+        detection_candidates = candidates + self._skill_blocked_candidates_from_context(
+            context
+        )
 
         # --- Leading form: message starts with a resolvable $skill-name.
-        if content.startswith(MENTION_SIGIL):
-            word, rest = _split_skill_command_word(content)
+        # Leading whitespace is tolerated (stripped before the sigil check
+        # and the word/rest split) to match `_annotate_skill_commands`'s own
+        # `lstrip()` assumption in the preview -- a resolved leading mention
+        # replaces the ENTIRE message on both the inline-replace and fork
+        # paths, so the leading whitespace simply disappears either way.
+        stripped_content = content.lstrip()
+        if stripped_content.startswith(MENTION_SIGIL):
+            word, rest = _split_skill_command_word(stripped_content)
             name = word[len(MENTION_SIGIL) :]
             if name:
-                resolution = resolve_skill_command(name, rest, candidates)
+                resolution = resolve_skill_command(name, rest, detection_candidates)
                 if resolution.kind == "resolved":
                     args = cap_skill_args(rest)
                     try:
@@ -1899,8 +1921,13 @@ class ConsoleChatController:
                     return new_messages, None, ()
 
         # --- Embedded pass: no leading mention, or the leading word didn't
-        # resolve to a known skill.
-        names = frozenset(candidate.name for candidate in candidates)
+        # resolve to a known skill. Scans the ORIGINAL (unstripped) content
+        # -- the leading-whitespace tolerance above only applies to the
+        # leading form. `names` is the same detection population (trusted
+        # UNION user-invocable blocked) so a blocked mention is found and
+        # routed through the trust-blocked-note path below instead of
+        # staying invisible.
+        names = frozenset(candidate.name for candidate in detection_candidates)
         mentions = find_embedded_mentions(content, names)
         if not mentions:
             return provider_messages, None, ()
@@ -2145,6 +2172,37 @@ class ConsoleChatController:
             and item.get("name")
             and item.get("user_invocable", True)
             and not item.get("trust_blocked", False)
+        )
+
+    @staticmethod
+    def _skill_blocked_candidates_from_context(
+        context: Any,
+    ) -> tuple[SkillCommandCandidate, ...]:
+        """Build the user-invocable, trust-BLOCKED (needs-review) skill
+        candidate population.
+
+        Companion to `_skill_candidates_from_context`: unioned with it in
+        `_apply_skill_substitution` to widen the DETECTION population (never
+        the executable one) so a `$blocked-name` mention resolves a name
+        instead of silently staying literal, sigil-prefixed text with no
+        refusal or note at all. `execute_skill` remains the sole authority
+        on whether a resolved name may actually run -- candidates built here
+        are never executed directly by this method's caller. A blocked
+        skill flagged ``user_invocable: False`` is excluded, mirroring
+        `_skill_candidates_from_context`'s own filter discipline.
+        """
+        blocked = (
+            context.get("blocked_skills") if isinstance(context, Mapping) else None
+        )
+        return tuple(
+            SkillCommandCandidate(
+                name=str(item.get("name")),
+                description=str(item.get("description") or ""),
+            )
+            for item in (blocked or [])
+            if isinstance(item, Mapping)
+            and item.get("name")
+            and item.get("user_invocable", True)
         )
 
     @staticmethod

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -36,6 +36,7 @@ from tldw_chatbook.Chat.console_history_budget import (
 )
 from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
 from tldw_chatbook.Chat.console_skill_resolver import (
+    MENTION_SIGIL,
     SKILL_UNTRUSTED_REFUSE,
     SkillCommandCandidate,
     cap_skill_args,
@@ -1753,7 +1754,7 @@ class ConsoleChatController:
             service configured, substitution is disabled, there is no final
             user message, or that message's content does not resolve to a
             known skill command (not a string, doesn't start with
-            `COMMAND_PREFIX`, or `resolve_skill_command` doesn't return
+            `MENTION_SIGIL`, or `resolve_skill_command` doesn't return
             ``"resolved"``). ``(new_messages, None)`` when a skill resolves
             and renders: ``inline`` replaces just the final message in
             place (history preserved); ``fork`` drops every message before
@@ -1777,11 +1778,11 @@ class ConsoleChatController:
             return provider_messages, None
 
         content = provider_messages[final_index].get("content")
-        if not isinstance(content, str) or not content.startswith(COMMAND_PREFIX):
+        if not isinstance(content, str) or not content.startswith(MENTION_SIGIL):
             return provider_messages, None
 
         word, rest = _split_skill_command_word(content)
-        name = word[len(COMMAND_PREFIX) :]
+        name = word[len(MENTION_SIGIL) :]
         if not name:
             return provider_messages, None
 

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1833,6 +1833,10 @@ class ConsoleChatController:
         content = provider_messages[final_index].get("content")
         if not isinstance(content, str):
             return provider_messages, None, ()
+        if MENTION_SIGIL not in content:
+            # Fast path: no sigil anywhere means neither form can possibly
+            # apply -- plain-text sends never touch the skills service.
+            return provider_messages, None, ()
 
         context = await self._skills_service.get_context(mode="local")
         candidates = self._skill_candidates_from_context(context)

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -37,9 +37,11 @@ from tldw_chatbook.Chat.console_history_budget import (
 from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
 from tldw_chatbook.Chat.console_skill_resolver import (
     MENTION_SIGIL,
+    SKILL_MENTION_SKIPPED_NOTE,
     SKILL_UNTRUSTED_REFUSE,
     SkillCommandCandidate,
     cap_skill_args,
+    find_embedded_mentions,
     resolve_skill_command,
 )
 from loguru import logger
@@ -463,7 +465,7 @@ class ConsoleChatController:
             self.store.clear_pending_attachments(session.id)
         try:
             provider_messages = self._provider_messages_for_session(session.id)
-            provider_messages, refuse = await self._apply_skill_substitution(
+            provider_messages, refuse, skill_notes = await self._apply_skill_substitution(
                 provider_messages
             )
             if refuse is not None:
@@ -472,6 +474,12 @@ class ConsoleChatController:
                 # refused command never enters the next send's provider context.
                 self.store.mark_message_send_blocked(echoed_user.id)
                 return self._block(session.id, refuse)
+            for note in skill_notes:
+                # An embedded skipped-skill note is never an abort: append the
+                # same system-row copy `_block` would, then let the turn proceed.
+                self.store.append_message(
+                    session.id, role=ConsoleMessageRole.SYSTEM, content=note
+                )
             provider_messages = await self._apply_chat_dictionaries(
                 provider_messages, session.id
             )
@@ -1141,11 +1149,17 @@ class ConsoleChatController:
             before_message_id=message_id,
         )
         self._ensure_user_continuation_instruction(provider_messages)
-        provider_messages, refuse = await self._apply_skill_substitution(
+        provider_messages, refuse, skill_notes = await self._apply_skill_substitution(
             provider_messages
         )
         if refuse is not None:
             return self._block(session_id, refuse)
+        for note in skill_notes:
+            # An embedded skipped-skill note is never an abort: append the
+            # same system-row copy `_block` would, then let the turn proceed.
+            self.store.append_message(
+                session_id, role=ConsoleMessageRole.SYSTEM, content=note
+            )
         provider_messages = await self._apply_chat_dictionaries(
             provider_messages, session_id
         )
@@ -1199,11 +1213,17 @@ class ConsoleChatController:
                 session_id,
                 "Nothing to continue before the first message.",
             )
-        provider_messages, refuse = await self._apply_skill_substitution(
+        provider_messages, refuse, skill_notes = await self._apply_skill_substitution(
             provider_messages
         )
         if refuse is not None:
             return self._block(session_id, refuse)
+        for note in skill_notes:
+            # An embedded skipped-skill note is never an abort: append the
+            # same system-row copy `_block` would, then let the turn proceed.
+            self.store.append_message(
+                session_id, role=ConsoleMessageRole.SYSTEM, content=note
+            )
         provider_messages = await self._apply_chat_dictionaries(
             provider_messages, session_id
         )
@@ -1263,11 +1283,17 @@ class ConsoleChatController:
                 session_id,
                 "Nothing to regenerate before the first message.",
             )
-        provider_messages, refuse = await self._apply_skill_substitution(
+        provider_messages, refuse, skill_notes = await self._apply_skill_substitution(
             provider_messages
         )
         if refuse is not None:
             return self._block(session_id, refuse)
+        for note in skill_notes:
+            # An embedded skipped-skill note is never an abort: append the
+            # same system-row copy `_block` would, then let the turn proceed.
+            self.store.append_message(
+                session_id, role=ConsoleMessageRole.SYSTEM, content=note
+            )
         provider_messages = await self._apply_chat_dictionaries(
             provider_messages, session_id
         )
@@ -1727,22 +1753,45 @@ class ConsoleChatController:
 
     async def _apply_skill_substitution(
         self, provider_messages: list[dict[str, Any]]
-    ) -> tuple[list[dict[str, Any]], str | None]:
-        """Render-fresh the triggering turn's skill command at payload build time.
+    ) -> tuple[list[dict[str, Any]], str | None, tuple[str, ...]]:
+        """Render-fresh the triggering turn's skill mention(s) at payload build time.
 
         Spec: "Invocation semantics" §5 (the substitution rule) -- one rule
         for fresh sends AND retry/regenerate/continue. Only the FINAL
         ``role == "user"`` message in ``provider_messages`` (the turn
         actually driving this send) is ever a substitution candidate; every
-        earlier message -- including an earlier raw skill command sitting
+        earlier message -- including an earlier raw skill mention sitting
         in history -- is left untouched, so the persisted transcript always
-        keeps the literal text the user typed (the raw command is what gets
+        keeps the literal text the user typed (the raw mention is what gets
         submitted and stored; only the ephemeral provider payload for this
         turn is ever rendered). Re-resolves against a FRESH candidate
         snapshot and re-verifies trust through ``execute_skill`` on every
         call (never a cached snapshot), so a retry issued after a skill was
-        edited (now untrusted) refuses instead of silently re-running a
-        stale render.
+        edited (now untrusted) refuses/skips instead of silently re-running
+        a stale render.
+
+        Two independent forms, tried in order:
+
+        Leading form -- the message starts with `MENTION_SIGIL` and the
+        leading word resolves to a known skill: the REST of the message is
+        passed as that skill's args (`cap_skill_args`). A resolved leading
+        mention is never also scanned for embedded mentions -- its args are
+        opaque payload, not further mentions to expand.
+
+        Embedded form -- tried whenever the leading form doesn't apply (no
+        leading `MENTION_SIGIL`, or the leading word doesn't resolve): every
+        `$skill-name` mention anywhere in the message (case-sensitive,
+        code-span-masked, document order -- `find_embedded_mentions`) is
+        looked up ARGLESS (`execute_skill(name, mode="local", args="")`,
+        once per unique name, right-to-left splice so earlier spans stay
+        valid) and spliced in place at the mention's exact span, preserving
+        all surrounding prose. Only an ``execution_mode == "inline"`` result
+        splices; anything else (e.g. ``fork``, which has no "in place"
+        meaning for an embedded mention) silently leaves that mention's
+        literal `$name` text untouched. A trust-blocked mention
+        (`SkillTrustBlockedError`) also leaves the literal text untouched
+        but records a `SKILL_MENTION_SKIPPED_NOTE` for the caller to surface
+        as a non-aborting system row.
 
         Args:
             provider_messages: The fully-built payload about to be sent to
@@ -1750,24 +1799,28 @@ class ConsoleChatController:
                 message and any synthesized continuation instruction).
 
         Returns:
-            ``(provider_messages, None)`` unchanged when there is no skills
-            service configured, substitution is disabled, there is no final
-            user message, or that message's content does not resolve to a
-            known skill command (not a string, doesn't start with
-            `MENTION_SIGIL`, or `resolve_skill_command` doesn't return
-            ``"resolved"``). ``(new_messages, None)`` when a skill resolves
-            and renders: ``inline`` replaces just the final message in
-            place (history preserved); ``fork`` drops every message before
-            it except a leading ``role == "system"`` message (clean context
-            = session system prompt + rendered turn only). ``(provider_
-            messages, refuse_copy)`` -- the ORIGINAL, unmodified messages,
-            paired with `SKILL_UNTRUSTED_REFUSE` copy -- when the resolved
-            skill is no longer trusted (`SkillTrustBlockedError` at
-            execute-time); the caller must append `refuse_copy` as a system
-            row and abort the turn without sending.
+            ``(provider_messages, None, ())`` unchanged when there is no
+            skills service configured, substitution is disabled, there is
+            no final user message, that message's content isn't a string,
+            or neither form applies. ``(new_messages, None, notes)`` when
+            the leading form resolves and renders (``notes`` always empty
+            for the leading form) or when the embedded pass splices one or
+            more mentions (``notes`` carries one `SKILL_MENTION_SKIPPED_
+            NOTE` per unique trust-blocked mention name, in document
+            order); ``inline`` replaces just the final message in place
+            (history preserved); leading-form ``fork`` drops every message
+            before it except a leading ``role == "system"`` message (clean
+            context = session system prompt + rendered turn only).
+            ``(provider_messages, refuse_copy, ())`` -- the ORIGINAL,
+            unmodified messages, paired with `SKILL_UNTRUSTED_REFUSE` copy
+            -- when a LEADING resolved skill is no longer trusted
+            (`SkillTrustBlockedError` at execute-time); the caller must
+            append `refuse_copy` as a system row and abort the turn without
+            sending. An embedded mention never refuses/aborts -- it
+            degrades to a literal-plus-note instead, and the send proceeds.
         """
         if self._skills_service is None or not self._skill_substitution_enabled:
-            return provider_messages, None
+            return provider_messages, None, ()
 
         final_index: int | None = None
         for index in range(len(provider_messages) - 1, -1, -1):
@@ -1775,53 +1828,112 @@ class ConsoleChatController:
                 final_index = index
                 break
         if final_index is None:
-            return provider_messages, None
+            return provider_messages, None, ()
 
         content = provider_messages[final_index].get("content")
-        if not isinstance(content, str) or not content.startswith(MENTION_SIGIL):
-            return provider_messages, None
-
-        word, rest = _split_skill_command_word(content)
-        name = word[len(MENTION_SIGIL) :]
-        if not name:
-            return provider_messages, None
+        if not isinstance(content, str):
+            return provider_messages, None, ()
 
         context = await self._skills_service.get_context(mode="local")
         candidates = self._skill_candidates_from_context(context)
-        resolution = resolve_skill_command(name, rest, candidates)
-        if resolution.kind != "resolved":
-            return provider_messages, None
 
-        args = cap_skill_args(rest)
-        try:
-            result = await self._skills_service.execute_skill(
-                resolution.name, mode="local", args=args
-            )
-        except SkillTrustBlockedError as exc:
-            refuse = SKILL_UNTRUSTED_REFUSE.format(
-                name=resolution.name, reason=exc.reason_code
-            )
-            return provider_messages, refuse
+        # --- Leading form: message starts with a resolvable $skill-name.
+        if content.startswith(MENTION_SIGIL):
+            word, rest = _split_skill_command_word(content)
+            name = word[len(MENTION_SIGIL) :]
+            if name:
+                resolution = resolve_skill_command(name, rest, candidates)
+                if resolution.kind == "resolved":
+                    args = cap_skill_args(rest)
+                    try:
+                        result = await self._skills_service.execute_skill(
+                            resolution.name, mode="local", args=args
+                        )
+                    except SkillTrustBlockedError as exc:
+                        refuse = SKILL_UNTRUSTED_REFUSE.format(
+                            name=resolution.name, reason=exc.reason_code
+                        )
+                        return provider_messages, refuse, ()
 
-        rendered = (
-            result.get("rendered_prompt", "") if isinstance(result, Mapping) else ""
-        )
-        rendered_message = {"role": ConsoleMessageRole.USER.value, "content": rendered}
-        execution_mode = (
-            result.get("execution_mode") if isinstance(result, Mapping) else None
-        )
-        if execution_mode == "fork":
-            leading = (
-                [provider_messages[0]]
-                if provider_messages
-                and provider_messages[0].get("role") == ConsoleMessageRole.SYSTEM.value
-                else []
+                    rendered = (
+                        result.get("rendered_prompt", "")
+                        if isinstance(result, Mapping)
+                        else ""
+                    )
+                    rendered_message = {
+                        "role": ConsoleMessageRole.USER.value,
+                        "content": rendered,
+                    }
+                    execution_mode = (
+                        result.get("execution_mode")
+                        if isinstance(result, Mapping)
+                        else None
+                    )
+                    if execution_mode == "fork":
+                        leading = (
+                            [provider_messages[0]]
+                            if provider_messages
+                            and provider_messages[0].get("role")
+                            == ConsoleMessageRole.SYSTEM.value
+                            else []
+                        )
+                        return leading + [rendered_message], None, ()
+
+                    new_messages = list(provider_messages)
+                    new_messages[final_index] = rendered_message
+                    return new_messages, None, ()
+
+        # --- Embedded pass: no leading mention, or the leading word didn't
+        # resolve to a known skill.
+        names = frozenset(candidate.name for candidate in candidates)
+        mentions = find_embedded_mentions(content, names)
+        if not mentions:
+            return provider_messages, None, ()
+
+        rendered_by_name: dict[str, str | None] = {}
+        notes: list[str] = []
+        for mention in mentions:
+            if mention.name in rendered_by_name:
+                continue
+            try:
+                result = await self._skills_service.execute_skill(
+                    mention.name, mode="local", args=""
+                )
+            except SkillTrustBlockedError:
+                rendered_by_name[mention.name] = None
+                notes.append(SKILL_MENTION_SKIPPED_NOTE.format(name=mention.name))
+                continue
+            execution_mode = (
+                result.get("execution_mode") if isinstance(result, Mapping) else None
             )
-            return leading + [rendered_message], None
+            rendered = (
+                result.get("rendered_prompt", "")
+                if isinstance(result, Mapping)
+                else ""
+            )
+            # Fork (or anything non-inline) cannot splice in place: leave
+            # the mention literal, no note (this is not a trust failure).
+            rendered_by_name[mention.name] = (
+                rendered if execution_mode == "inline" else None
+            )
+
+        new_content = content
+        for mention in reversed(mentions):
+            body = rendered_by_name.get(mention.name)
+            if body is None:
+                continue
+            new_content = (
+                new_content[: mention.start] + body + new_content[mention.end :]
+            )
+        if new_content == content:
+            return provider_messages, None, tuple(notes)
 
         new_messages = list(provider_messages)
-        new_messages[final_index] = rendered_message
-        return new_messages, None
+        new_messages[final_index] = {
+            "role": ConsoleMessageRole.USER.value,
+            "content": new_content,
+        }
+        return new_messages, None, tuple(notes)
 
     async def _apply_world_info(
         self, provider_messages: list[dict[str, Any]], session_id: str

--- a/tldw_chatbook/Chat/console_skill_resolver.py
+++ b/tldw_chatbook/Chat/console_skill_resolver.py
@@ -90,8 +90,12 @@ def _code_span_mask(text: str) -> list[bool]:
 
     Fenced blocks: a line whose stripped form starts with ``````` toggles
     fence state; fence lines and everything inside are masked. Inline spans:
-    paired backticks within a non-fence line are masked inclusively; an
-    unpaired backtick masks nothing.
+    on a non-fence line with an EVEN backtick count, paired backticks are
+    masked inclusively (greedy left-to-right pairing — correct for well-
+    formed lines). A line with an ODD backtick count is unparseable inline
+    code: no pairing scheme is reliable (a stray tick shifts the pairing
+    and would un-mask a genuinely guarded span), so the ENTIRE line is
+    masked — failing safe, like an unclosed fence masking to end-of-text.
     """
     mask = [False] * len(text)
     in_fence = False
@@ -104,12 +108,21 @@ def _code_span_mask(text: str) -> list[bool]:
         elif in_fence:
             for i in range(pos, pos + len(line)):
                 mask[i] = True
+        elif line.count("`") % 2 == 1:
+            # Odd backtick count: pairing is ambiguous — fail safe by
+            # masking the whole line (over-mask, never under-mask).
+            for i in range(pos, pos + len(line)):
+                mask[i] = True
         else:
             i = 0
             while i < len(line):
                 if line[i] == "`":
                     close = line.find("`", i + 1)
                     if close == -1:
+                        # Unreachable on even-count lines (every opening
+                        # tick has a closer); kept as a guard because a
+                        # -1 falling through would set ``i = 0`` and loop
+                        # forever if the invariant ever broke.
                         break
                     for j in range(i, close + 1):
                         mask[pos + j] = True

--- a/tldw_chatbook/Chat/console_skill_resolver.py
+++ b/tldw_chatbook/Chat/console_skill_resolver.py
@@ -37,6 +37,7 @@ MENTION_SIGIL = "$"
 """Leading character of a Codex-style skill mention (``$skill-name``)."""
 
 _MENTION_TOKEN = re.compile(r"[A-Za-z0-9-]+")
+_BACKTICK_RUN = re.compile(r"`+")
 
 SKILL_MENTION_SKIPPED_NOTE = (
     'Skipped "${name}" — this skill needs review before it can run. '
@@ -97,13 +98,19 @@ def _code_span_mask(text: str) -> list[bool]:
     """Return a per-character mask, True inside markdown code spans.
 
     Fenced blocks: a line whose stripped form starts with ``````` toggles
-    fence state; fence lines and everything inside are masked. Inline spans:
-    on a non-fence line with an EVEN backtick count, paired backticks are
-    masked inclusively (greedy left-to-right pairing — correct for well-
-    formed lines). A line with an ODD backtick count is unparseable inline
-    code: no pairing scheme is reliable (a stray tick shifts the pairing
-    and would un-mask a genuinely guarded span), so the ENTIRE line is
-    masked — failing safe, like an unclosed fence masking to end-of-text.
+    fence state; fence lines and everything inside are masked.
+
+    Inline spans: each non-fence line is tokenized into RUNS of consecutive
+    backticks. An opening run pairs with the NEXT run of exactly equal
+    length (the CommonMark inline-code rule — a run of *unequal* length
+    encountered along the way is swallowed as the span's own content, never
+    treated as a delimiter itself); the whole span, both runs inclusive, is
+    masked, and scanning resumes right after the closing run. If ANY run on
+    the line ends up without a same-length partner, pairing is ambiguous —
+    fail SAFE by masking the ENTIRE line (over-mask, never under-mask; this
+    generalizes the old odd-backtick-count rule, since an odd total is only
+    one way to produce an unmatched run — an *even* total can too, e.g. one
+    2-backtick run plus one 4-backtick run never pair, six ticks total).
     """
     mask = [False] * len(text)
     in_fence = False
@@ -116,27 +123,34 @@ def _code_span_mask(text: str) -> list[bool]:
         elif in_fence:
             for i in range(pos, pos + len(line)):
                 mask[i] = True
-        elif line.count("`") % 2 == 1:
-            # Odd backtick count: pairing is ambiguous — fail safe by
-            # masking the whole line (over-mask, never under-mask).
-            for i in range(pos, pos + len(line)):
-                mask[i] = True
         else:
+            runs = list(_BACKTICK_RUN.finditer(line))
+            if not runs:
+                pos += len(line)
+                continue
+            spans: list[tuple[int, int]] = []
+            unmatched = False
             i = 0
-            while i < len(line):
-                if line[i] == "`":
-                    close = line.find("`", i + 1)
-                    if close == -1:
-                        # Unreachable on even-count lines (every opening
-                        # tick has a closer); kept as a guard because a
-                        # -1 falling through would set ``i = 0`` and loop
-                        # forever if the invariant ever broke.
+            run_count = len(runs)
+            while i < run_count:
+                opening = runs[i]
+                closer_index = None
+                for j in range(i + 1, run_count):
+                    if len(runs[j].group(0)) == len(opening.group(0)):
+                        closer_index = j
                         break
-                    for j in range(i, close + 1):
+                if closer_index is None:
+                    unmatched = True
+                    break
+                spans.append((opening.start(), runs[closer_index].end()))
+                i = closer_index + 1
+            if unmatched:
+                for i in range(pos, pos + len(line)):
+                    mask[i] = True
+            else:
+                for start, end in spans:
+                    for j in range(start, end):
                         mask[pos + j] = True
-                    i = close + 1
-                else:
-                    i += 1
         pos += len(line)
     return mask
 

--- a/tldw_chatbook/Chat/console_skill_resolver.py
+++ b/tldw_chatbook/Chat/console_skill_resolver.py
@@ -58,7 +58,14 @@ SKILLS_EMPTY_LIST_ROW = "No skills yet — create them in Library ▸ Skills."
 
 @dataclass(frozen=True)
 class SkillCommandCandidate:
-    """One skill eligible for bare ``/skill-name`` resolution.
+    """One skill eligible for bare-word resolution via `resolve_skill_command`.
+
+    ``resolve_skill_command`` is sigil-agnostic -- its live caller is
+    `ConsoleChatController._apply_skill_substitution`'s leading `$skill-
+    name` mention form; `ChatScreen._console_command_run_skill` (formerly
+    reached via a bare ``/skill-name`` composer fallback, hard-removed in
+    Task 4 of the `$`-mention migration) still calls it too but has no live
+    caller of its own -- see that method's docstring.
 
     Args:
         name: Canonical skill name (already scoped to whatever population
@@ -187,10 +194,18 @@ class SkillResolution:
 def resolve_skill_command(
     word: str, args: str, candidates: tuple[SkillCommandCandidate, ...]
 ) -> SkillResolution:
-    """Resolve a bare ``/word`` Console token against a skill candidate snapshot.
+    """Resolve a bare skill-name word against a skill candidate snapshot.
+
+    Sigil-agnostic: the live caller (`ConsoleChatController.
+    _apply_skill_substitution`'s leading `$skill-name` mention form)
+    strips a `$`; the dead-but-retained `ChatScreen._console_command_
+    run_skill` (formerly reached via a bare ``/skill-name`` composer
+    fallback) strips a `/`. Either way ``word`` arrives with its leading
+    sigil already gone.
 
     Args:
-        word: The command word typed after the leading ``/`` (no slash).
+        word: The command word, with its leading sigil already stripped
+            by the caller.
         args: The remaining draft text after ``word``. Unused by the
             resolution rules themselves (callers pre-cap it via
             `cap_skill_args` before it reaches a dispatch layer) but kept in
@@ -200,9 +215,10 @@ def resolve_skill_command(
 
     Returns:
         `SkillResolution` with ``kind`` set as follows: an empty or
-        whitespace-only ``word`` (e.g. a bare ``/`` or ``/ `` draft, which
-        `console_command_grammar` splits into an empty command word) never
-        matches anything and is always `"none"` -- without this guard every
+        whitespace-only ``word`` (e.g. a bare ``$``/``$ `` mention, or a
+        bare ``/``/``/ `` draft which `console_command_grammar` splits into
+        an empty command word) never matches anything and is always
+        `"none"` -- without this guard every
         candidate name trivially ``.startswith("")``, so an empty word
         would otherwise "match" every candidate (resolving to a lone
         candidate, or reporting `"ambiguous"` for two or more) even though

--- a/tldw_chatbook/Chat/console_skill_resolver.py
+++ b/tldw_chatbook/Chat/console_skill_resolver.py
@@ -20,6 +20,7 @@ resolved name is not currently trusted.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Callable
 
@@ -30,6 +31,16 @@ SKILL_ARGS_MAX = 4000
 
 SKILLS_LIST_COMMAND_NAME = "skills"
 """Canonical registered-command name for listing available skills."""
+
+MENTION_SIGIL = "$"
+"""Leading character of a Codex-style skill mention (``$skill-name``)."""
+
+_MENTION_TOKEN = re.compile(r"[A-Za-z0-9-]+")
+
+SKILL_MENTION_SKIPPED_NOTE = (
+    'Skipped "${name}" — this skill needs review before it can run. '
+    "Open /skills to review it."
+)
 
 SKILL_UNTRUSTED_REFUSE = (
     'Skill "{name}" isn\'t trusted ({reason}) — review and approve it in '
@@ -57,6 +68,89 @@ class SkillCommandCandidate:
 
     name: str
     description: str = ""
+
+
+@dataclass(frozen=True)
+class SkillMention:
+    """One embedded ``$skill-name`` mention found in a draft.
+
+    Args:
+        start: Index of the ``$`` sigil in the scanned text.
+        end: Index one past the last token character.
+        name: The matched canonical (lowercase) skill name.
+    """
+
+    start: int
+    end: int
+    name: str
+
+
+def _code_span_mask(text: str) -> list[bool]:
+    """Return a per-character mask, True inside markdown code spans.
+
+    Fenced blocks: a line whose stripped form starts with ``````` toggles
+    fence state; fence lines and everything inside are masked. Inline spans:
+    paired backticks within a non-fence line are masked inclusively; an
+    unpaired backtick masks nothing.
+    """
+    mask = [False] * len(text)
+    in_fence = False
+    pos = 0
+    for line in text.splitlines(keepends=True):
+        if line.strip().startswith("```"):
+            in_fence = not in_fence
+            for i in range(pos, pos + len(line)):
+                mask[i] = True
+        elif in_fence:
+            for i in range(pos, pos + len(line)):
+                mask[i] = True
+        else:
+            i = 0
+            while i < len(line):
+                if line[i] == "`":
+                    close = line.find("`", i + 1)
+                    if close == -1:
+                        break
+                    for j in range(i, close + 1):
+                        mask[pos + j] = True
+                    i = close + 1
+                else:
+                    i += 1
+        pos += len(line)
+    return mask
+
+
+def find_embedded_mentions(
+    text: str, names: frozenset[str]
+) -> tuple[SkillMention, ...]:
+    """Find embedded ``$skill-name`` mentions eligible for splicing.
+
+    Exact, case-SENSITIVE matching against ``names`` (canonical lowercase
+    skill names): ``$PATH`` stays literal even when a skill named ``path``
+    exists. Mentions inside markdown code spans are skipped. Single pass —
+    callers must never re-scan spliced output (no recursion).
+
+    Args:
+        text: The draft text to scan (the user's original message).
+        names: Canonical skill names eligible for expansion.
+
+    Returns:
+        Non-overlapping mentions in document order.
+    """
+    mask = _code_span_mask(text)
+    mentions: list[SkillMention] = []
+    index = 0
+    while index < len(text):
+        if text[index] == MENTION_SIGIL and not mask[index]:
+            match = _MENTION_TOKEN.match(text, index + 1)
+            if match is not None and match.group(0) in names:
+                mentions.append(
+                    SkillMention(start=index, end=match.end(), name=match.group(0))
+                )
+                index = match.end()
+                continue
+        index += 1
+    return tuple(mentions)
 
 
 @dataclass(frozen=True)
@@ -148,7 +242,7 @@ def format_skills_list(candidates: tuple[SkillCommandCandidate, ...]) -> str:
 
     Returns:
         `SKILLS_EMPTY_LIST_ROW` when ``candidates`` is empty; otherwise one
-        ``/name — description`` line per candidate (just ``/name`` when its
+        ``$name — description`` line per candidate (just ``$name`` when its
         description is empty), joined with newlines.
     """
     if not candidates:
@@ -157,9 +251,9 @@ def format_skills_list(candidates: tuple[SkillCommandCandidate, ...]) -> str:
     lines = []
     for candidate in candidates:
         if candidate.description:
-            lines.append(f"/{candidate.name} — {candidate.description}")
+            lines.append(f"${candidate.name} — {candidate.description}")
         else:
-            lines.append(f"/{candidate.name}")
+            lines.append(f"${candidate.name}")
     return "\n".join(lines)
 
 

--- a/tldw_chatbook/Chat/console_skill_resolver.py
+++ b/tldw_chatbook/Chat/console_skill_resolver.py
@@ -1,30 +1,31 @@
-"""Pure skills-command resolver for the native Console composer.
+"""Pure skills-command resolver for the native Console.
 
 This module has no dependency on Textual, the running app, or any I/O — it
 mirrors :mod:`console_command_grammar`'s purity discipline. It resolves a
-bare ``/skill-name [args]`` Console draft against a caller-supplied snapshot
-of skill candidates (exact case-insensitive name, then unique case-
-insensitive name-prefix), and builds the
-:meth:`console_command_grammar.ConsoleCommandRegistry.register_fallback_resolver`
-callable a caller wires up to claim those drafts.
+leading ``$skill-name [args]`` mention (or a `/skills <name>` registered-
+command word) against a caller-supplied snapshot of skill candidates (exact
+case-insensitive name, then unique case-insensitive name-prefix), and finds
+embedded ``$skill-name`` mentions anywhere else in a draft
+(:func:`find_embedded_mentions`).
 
 Callers own everything this module cannot: fetching the actual candidate
 snapshot (scoped to USER-INVOCABLE + TRUSTED skills only — this module never
 filters by trust or invocability itself, it only matches names), re-
-resolving authoritatively at dispatch time (the fallback resolver here only
-decides whether to *claim* a word so unknown words still fall through to the
-existing unknown-command hint), and formatting/emitting the untrusted-skill
-refusal text (:data:`SKILL_UNTRUSTED_REFUSE`) once a caller has determined a
-resolved name is not currently trusted.
+resolving authoritatively at execute time, and formatting/emitting the
+untrusted-skill refusal text (:data:`SKILL_UNTRUSTED_REFUSE`) once a caller
+has determined a resolved name is not currently trusted.
+
+Hard removal (Task 4 of the `$`-mention migration): this module used to also
+build a `console_command_grammar.ConsoleCommandRegistry.register_fallback_resolver`
+callable claiming a bare ``/skill-name`` composer draft
+(``make_skill_fallback_resolver``) — that factory has been deleted. Skill
+invocation is now exclusively the `$name` mention form.
 """
 
 from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Callable
-
-from .console_command_grammar import KIND_FALLBACK, CommandParse
 
 SKILL_ARGS_MAX = 4000
 """Maximum character length of skill invocation args after capping."""
@@ -268,39 +269,3 @@ def format_skills_list(candidates: tuple[SkillCommandCandidate, ...]) -> str:
         else:
             lines.append(f"${candidate.name}")
     return "\n".join(lines)
-
-
-def make_skill_fallback_resolver(
-    candidates_getter: Callable[[], tuple[SkillCommandCandidate, ...]],
-) -> Callable[[str, str], "CommandParse | None"]:
-    """Build a `console_command_grammar` fallback-resolver callable.
-
-    Args:
-        candidates_getter: Zero-argument callable a caller wires to fetch a
-            fresh candidate snapshot at parse time (kept as an injected
-            callable rather than a plain value so this module never imports
-            the real skills service — that wiring belongs to dispatch).
-
-    Returns:
-        A resolver suitable for
-        `console_command_grammar.ConsoleCommandRegistry.register_fallback_resolver`.
-        It claims (returns a `CommandParse`) only when `resolve_skill_command`
-        finds the word plausibly matches a cached skill (`"resolved"` or
-        `"ambiguous"`) — the returned `CommandParse.name` is the *typed*
-        word, not the resolved candidate name, so an unmodified round-trip
-        through the grammar always carries what the user actually typed;
-        re-resolving authoritatively (and refusing untrusted matches) is
-        dispatch's job. Any other word (no match) returns ``None`` so it
-        still falls through to the existing unknown-command hint.
-    """
-
-    def resolver(word: str, rest: str) -> CommandParse | None:
-        candidates = candidates_getter()
-        resolution = resolve_skill_command(word, rest, candidates)
-        if resolution.kind in ("resolved", "ambiguous"):
-            return CommandParse(
-                kind=KIND_FALLBACK, name=word, args=cap_skill_args(rest)
-            )
-        return None
-
-    return resolver

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -380,15 +380,6 @@ CONSOLE_SYSTEM_PROMPT_SAVE_STATUS_COPY = {
     "error": "Couldn't save this prompt. Try again.",
 }
 CONSOLE_SYSTEM_PROMPT_NO_SYSTEM_PART_TEMPLATE = 'Prompt "{name}" has no system part.'
-# Task 9 (Skills Console dispatch): a resolved-single skill run's raw command
-# is submitted as the actual user turn (Task 10 renders the substitution at
-# payload build); this TOOL-role marker is appended once that submit is
-# ACCEPTED (the USER message has actually landed in the store -- see
-# `_on_console_submission_accepted`, never right after `run_worker` merely
-# *schedules* the submit, which raced the scheduled coroutine and could
-# append this marker before the user turn it is meant to follow) so the
-# transcript records which skill is "driving" the turn.
-CONSOLE_SKILL_RUN_MARKER_TEMPLATE = "skill {name} → driving this turn"
 # "Absent" bucket of the untrusted-refuse copy (Task 7's SKILL_UNTRUSTED_REFUSE):
 # a typed skill name that matches nothing at all -- not a trusted candidate,
 # not even a needs-review one.
@@ -1926,24 +1917,7 @@ class ChatScreen(BaseAppScreen):
         self._console_command_registry: ConsoleCommandRegistry = (
             default_console_registry()
         )
-        # Task 9: cached trusted-skill candidate snapshot (refreshed on
-        # mount/resume by `_refresh_console_skill_candidates`). Hard removal
-        # (Task 4 of the `$`-mention migration): no bare `/skill-name`
-        # fallback resolver is registered here anymore -- skill invocation
-        # is exclusively the controller-side `$name` mention now. Any
-        # dispatch-time re-resolution against this snapshot's population
-        # always re-fetches a FRESH `get_context` for the authoritative
-        # trust decision, since this snapshot may be stale.
-        self._console_skill_candidates: tuple[SkillCommandCandidate, ...] = ()
         self._console_unknown_send_armed: str | None = None
-        # Task 9 fix-wave (reviewer repro): the skill name to append as a
-        # TOOL "driving this turn" marker once the submit it was staged for
-        # is actually ACCEPTED (consumed by `_on_console_submission_accepted`,
-        # fired synchronously right after the USER message lands and before
-        # the ASSISTANT placeholder -- see `_run_resolved_console_skill`).
-        # Cleared on consume and on any dispatch failure so a refused/
-        # blocked run never leaks its marker onto a later, unrelated send.
-        self._console_pending_skill_marker_name: str | None = None
         self._console_image_view_state: ConsoleImageViewState | None = None
         self._console_image_cache: ConsoleImageRenderCache | None = None
         self._console_image_default_mode: Literal["pixels", "graphics"] | None = None
@@ -9346,7 +9320,6 @@ class ChatScreen(BaseAppScreen):
         self.call_after_refresh(self._sync_native_console_chat_ui)
         self.call_after_refresh(self._restore_console_workbench_focus)
         self.set_timer(0.2, self._restore_console_workbench_focus)
-        self.run_worker(self._refresh_console_skill_candidates(), exclusive=False)
 
     async def on_unmount(self) -> None:
         """Release Console-native resources owned by this screen."""
@@ -10736,19 +10709,6 @@ class ChatScreen(BaseAppScreen):
         # conversation (title, updated_at) -- invalidate so the browser
         # reflects it on the very next sync instead of the TTL window.
         self._invalidate_console_persisted_rows_cache()
-        if not result.accepted:
-            # A resolved skill run (`_run_resolved_console_skill`) stages its
-            # TOOL marker name BEFORE this worker even runs. `submit_draft`
-            # can still refuse/block the submit for reasons only known once
-            # it actually executes (provider not ready, policy block, an
-            # active-run race) -- entirely separate from the composer-level
-            # gate `_dispatch_console_draft_send` already passed to get here.
-            # None of those paths ever reach the accepted-hook
-            # (`_on_console_submission_accepted`) that would otherwise
-            # consume and clear the staged name, so it must be cleared here
-            # too -- otherwise it would silently leak onto whatever the
-            # NEXT, unrelated accepted send turns out to be.
-            self._console_pending_skill_marker_name = None
         try:
             composer = self.query_one("#console-native-composer", ConsoleComposerBar)
         except QueryError:
@@ -10786,26 +10746,11 @@ class ChatScreen(BaseAppScreen):
         Keeping the sent text in the composer for the whole run reads as
         "not sent" during long local-model generations; blocked submits never
         reach this hook, so their draft is preserved for correction.
-
-        Also the sole consume point for a staged resolved-skill "driving this
-        turn" TOOL marker (Task 9 fix-wave): ``ConsoleChatController.
-        submit_draft`` invokes this hook synchronously after the USER
-        message is appended and after its own skill-substitution/trust
-        re-check settles, but before the ASSISTANT placeholder, so
-        appending the marker here -- rather than back at the dispatch call
-        site -- guarantees store order ``[USER, TOOL, ASSISTANT]`` instead of
-        racing the ``run_worker``-scheduled submit.
-
-        Qodo finding 3 (PR #636 bot review): this hook must NEVER fire for a
-        submit that ``submit_draft`` ultimately blocks -- including a skill
-        substitution refusal (an edited/untrusted skill re-checked at
-        build time). ``submit_draft`` used to call this hook right after the
-        USER append, before that trust re-check ran, so a refused skill
-        submit still consumed the staged marker and appended it right before
-        the refuse row -- a marker claiming the skill drove the turn even
-        though it never ran. The controller now only calls this hook once
-        the substitution check has confirmed the turn actually proceeds, so
-        a refusal (like any other blocked submit) never reaches it.
+        ``ConsoleChatController.submit_draft`` invokes this hook only once
+        its own skill-substitution/trust re-check has confirmed the turn
+        actually proceeds (Qodo finding 3, PR #636 bot review) -- a
+        substitution refusal, like any other blocked submit, never reaches
+        it, so a refused draft stays in the composer too.
         """
         try:
             composer = self.query_one("#console-native-composer", ConsoleComposerBar)
@@ -10818,10 +10763,6 @@ class ChatScreen(BaseAppScreen):
             self._console_inflight_send_stash = None
         elif composer is not None:
             composer.clear_draft()
-        pending_skill_name = self._console_pending_skill_marker_name
-        if pending_skill_name is not None:
-            self._console_pending_skill_marker_name = None
-            self._append_console_skill_run_marker(pending_skill_name)
         # task-351(a): echo the just-appended USER message immediately rather
         # than waiting up to a full 0.2s transcript-poll cycle (and a heavy
         # first poll after it). The composer clears here at acceptance, so
@@ -10995,8 +10936,8 @@ class ChatScreen(BaseAppScreen):
         self, draft: str, stash: "ConsoleDraftStash | None" = None
     ) -> bool:
         """Run the send-blocked/readiness gate, then queue ``draft`` as the
-        user turn (the normal-text-send tail, shared with Task 9's resolved
-        `/skill-name` run path so both go through the exact same gating).
+        user turn (the normal-text-send tail, shared with the skill-picker
+        `$name` submit path so both go through the exact same gating).
 
         ``stash`` is the keypress-captured draft of a keyboard send
         (TASK-340): restored on every blocked path here, handed to the
@@ -11005,10 +10946,9 @@ class ChatScreen(BaseAppScreen):
         Returns:
             ``True`` once the submit has actually been queued via
             ``run_worker`` (a caller-visible "this is really going out"
-            signal -- Task 9's skill-run path only appends its "driving this
-            turn" marker when this is ``True``); ``False`` when blocked or
-            when a run is already in progress, in which case nothing is
-            queued and an explanatory row/toast was already shown.
+            signal); ``False`` when blocked or when a run is already in
+            progress, in which case nothing is queued and an explanatory
+            row/toast was already shown.
         """
         if blocked_reason := self._console_send_blocked_reason():
             self._restore_console_send_stash(stash)
@@ -11635,8 +11575,10 @@ class ChatScreen(BaseAppScreen):
         )
 
     # ------------------------------------------------------------------
-    # Task 9 (Skills spec, Phase 2): `/skills` registered command + bare
-    # `/skill-name` fallback dispatch (list / run / refuse).
+    # Task 9 (Skills spec, Phase 2), reshaped by the `$`-mention migration
+    # (Task 4 hard removal): `/skills` registered command (bare list /
+    # `$name` run-form hint) + the KIND_UNKNOWN needs-review hint.
+    # Invocation itself is the controller-side `$name` mention.
     # ------------------------------------------------------------------
 
     # Bounded skill-search page size for the picker's `skill_search`
@@ -11646,9 +11588,8 @@ class ChatScreen(BaseAppScreen):
     async def _fetch_console_skill_context(self) -> Mapping[str, Any]:
         """Fetch a FRESH ``skills_scope_service.get_context`` payload.
 
-        Used by every run/list/search path that needs an authoritative (not
-        cached) view -- the cached ``_console_skill_candidates`` snapshot is
-        reserved for the fallback resolver's word-claiming decision alone.
+        Used by every list/search/hint path -- always an authoritative
+        fetch, never a cached snapshot.
         Returns ``{}`` (never raises) when the service is unavailable or the
         call fails, so callers can treat "no skills" and "service down" the
         same way: an empty candidate/blocked population.
@@ -11706,18 +11647,6 @@ class ChatScreen(BaseAppScreen):
             item
             for item in (blocked or [])
             if isinstance(item, Mapping) and item.get("name")
-        )
-
-    async def _refresh_console_skill_candidates(self) -> None:
-        """Refresh the cached trusted-candidate snapshot for the fallback resolver.
-
-        Called on Console mount/resume; the fallback resolver itself always
-        reads through ``self._console_skill_candidates`` via a closure, so
-        updating this attribute is all a refresh needs to do.
-        """
-        context = await self._fetch_console_skill_context()
-        self._console_skill_candidates = (
-            self._console_skill_trusted_candidates_from_context(context)
         )
 
     async def _console_skill_search(self, query: str) -> list[Mapping[str, object]]:
@@ -11881,54 +11810,17 @@ class ChatScreen(BaseAppScreen):
         """Submit a resolved skill's raw `$name [args]` command as the user turn.
 
         Hard removal (Task 4 of the `$`-mention migration): this composes
-        the `$`-sigil invocation form now, not `/name [args]`.
-
-        Task 10 (the substitution rule) renders this at payload build time --
-        this method only sends the literal, unmodified command text through
-        the exact same send-blocked/readiness gate a normal Enter-to-send
-        goes through.
-
-        Fix-wave note (reviewer repro): the "driving this turn" TOOL marker
-        is NOT appended here anymore. ``_dispatch_console_draft_send``
-        returning ``True`` only means ``run_worker`` *scheduled* the actual
-        submit -- the USER message it appends has not necessarily landed yet
-        by the time this coroutine resumes, so appending the marker
-        immediately after could (and, per the repro, reliably did) land it
-        BEFORE the user turn it is meant to follow. Instead, ``name`` is
-        staged here and consumed by ``_on_console_submission_accepted``,
-        which fires synchronously from inside the real submit -- right after
-        the USER message is appended and before the ASSISTANT placeholder --
-        guaranteeing store order ``[USER, TOOL, ASSISTANT]``. A dispatch that
-        never even gets queued (blocked send, run already in progress) must
-        not leave a stale marker staged for some later, unrelated send.
+        the `$`-sigil invocation form now, not `/name [args]`. The
+        substitution rule renders it at payload build time -- this method
+        only sends the literal, unmodified command text through the exact
+        same send-blocked/readiness gate a normal Enter-to-send goes
+        through. The old composer-staged TOOL "driving this turn" marker
+        was deleted along with the bare `/name` dispatch it annotated (Task
+        4 fix wave): the visible `$name` USER row is itself the transcript
+        record of which skill drove the turn.
         """
         raw_command = f"${name} {args}" if args else f"${name}"
-        self._console_pending_skill_marker_name = name
-        queued = await self._dispatch_console_draft_send(raw_command)
-        if not queued:
-            self._console_pending_skill_marker_name = None
-
-    def _append_console_skill_run_marker(self, name: str) -> None:
-        """Append the TOOL-role "driving this turn" marker for a resolved skill run.
-
-        Mirrors ``ConsoleAgentBridge._append_marker``: a raw (unescaped)
-        content string, appended without persisting -- both transcript
-        renderers (``console_transcript.py`` and the legacy fallback) render
-        TOOL rows with markup off, so escaping here would just leave stray
-        backslashes in what the user sees.
-        """
-        store = self._ensure_console_chat_store()
-        session_id = store.active_session_id
-        if session_id is None:
-            return
-        try:
-            store.append_message(
-                session_id,
-                role=ConsoleMessageRole.TOOL,
-                content=CONSOLE_SKILL_RUN_MARKER_TEMPLATE.format(name=name),
-            )
-        except KeyError:
-            pass  # session vanished mid-dispatch; nothing left to annotate
+        await self._dispatch_console_draft_send(raw_command)
 
     async def _append_skill_refuse_row(self, name: str, reason: str) -> None:
         """Append the `SKILL_UNTRUSTED_REFUSE` transcript row for a run attempt.
@@ -14651,7 +14543,6 @@ class ChatScreen(BaseAppScreen):
         # regardless of which lifecycle hook scheduled it.
         self.set_timer(0.15, self._consume_pending_console_prompt_insert)
         self.call_after_refresh(self._restore_console_workbench_focus)
-        self.run_worker(self._refresh_console_skill_candidates(), exclusive=False)
         # Note: BaseAppScreen doesn't have on_screen_resume, so no super() call
 
     def set_task_resume_state(self, task_state: TaskResumeState) -> None:

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -97,7 +97,6 @@ from ...Chat.console_skill_resolver import (
     SkillCommandCandidate,
     cap_skill_args,
     format_skills_list,
-    make_skill_fallback_resolver,
     resolve_skill_command,
 )
 from ...Chat.console_chat_models import (
@@ -1927,15 +1926,15 @@ class ChatScreen(BaseAppScreen):
         self._console_command_registry: ConsoleCommandRegistry = (
             default_console_registry()
         )
-        # Task 9: cached snapshot the bare `/skill-name` fallback resolver
-        # closes over (refreshed on mount/resume by
-        # `_refresh_console_skill_candidates`); dispatch itself always
-        # re-resolves against a FRESH `get_context` for the authoritative
+        # Task 9: cached trusted-skill candidate snapshot (refreshed on
+        # mount/resume by `_refresh_console_skill_candidates`). Hard removal
+        # (Task 4 of the `$`-mention migration): no bare `/skill-name`
+        # fallback resolver is registered here anymore -- skill invocation
+        # is exclusively the controller-side `$name` mention now. Any
+        # dispatch-time re-resolution against this snapshot's population
+        # always re-fetches a FRESH `get_context` for the authoritative
         # trust decision, since this snapshot may be stale.
         self._console_skill_candidates: tuple[SkillCommandCandidate, ...] = ()
-        self._console_command_registry.register_fallback_resolver(
-            make_skill_fallback_resolver(lambda: self._console_skill_candidates)
-        )
         self._console_unknown_send_armed: str | None = None
         # Task 9 fix-wave (reviewer repro): the skill name to append as a
         # TOOL "driving this turn" marker once the submit it was staged for
@@ -10957,20 +10956,18 @@ class ChatScreen(BaseAppScreen):
             return
 
         if parse.kind == KIND_UNKNOWN:
-            # Fold-in (Task 9 fix-wave review): the fallback resolver only
-            # ever claims a word against the trusted-only cached
-            # `_console_skill_candidates` snapshot -- a typed `/name` that
-            # matches ONLY needs-review (trust-blocked) skills therefore
-            # always reaches here as KIND_UNKNOWN, previously falling
-            # through to the generic "Unknown command" hint just like any
-            # other unrecognized word. Re-checking against a FRESH context
-            # (never that cached snapshot) surfaces the same
-            # `/skills <name>` needs-review response instead, before the
-            # unknown-command arm/hint logic ever runs. This never arms the
-            # unknown-command escape: a blocked match is a known-but-blocked
-            # command, not an unrecognized one, so a repeated Enter shows
-            # the same response again rather than silently falling through
-            # to a literal send.
+            # Fold-in (Task 9 fix-wave review; hard removal Task 4 -- there
+            # is no fallback resolver at all anymore, so EVERY unmatched
+            # `/word` reaches here as KIND_UNKNOWN): a typed `/name` that
+            # matches ONLY needs-review (trust-blocked) skills would
+            # otherwise fall through to the generic "Unknown command" hint
+            # just like any other unrecognized word. Checking against a
+            # FRESH context surfaces the same needs-review response instead,
+            # before the unknown-command arm/hint logic ever runs. This
+            # never arms the unknown-command escape: a blocked match is a
+            # known-but-blocked command, not an unrecognized one, so a
+            # repeated Enter shows the same response again rather than
+            # silently falling through to a literal send.
             context = await self._fetch_console_skill_context()
             blocked_summaries = self._console_skill_blocked_summaries(context)
             if await self._console_skill_blocked_match_response(
@@ -11092,10 +11089,13 @@ class ChatScreen(BaseAppScreen):
 
         A ``handler_id`` that resolves to nothing (an unrecognized command
         name) is consumed silently: nothing is sent and the draft is left
-        untouched. ``KIND_FALLBACK`` (Task 9's bare `/skill-name` Console
-        surface) always routes to the skill-run handler regardless of any
-        handler-id lookup, since fallback-resolved parses never carry a
-        registered command name.
+        untouched. The ``KIND_FALLBACK`` branch below is dead code as of
+        the hard removal (Task 4 of the `$`-mention migration): no caller
+        registers a fallback resolver anymore, so
+        ``self._console_command_registry.parse`` never produces that kind.
+        Kept only because the grammar's generic
+        ``register_fallback_resolver`` extension point itself is not being
+        removed -- a future caller could still register one.
         """
         if parse.kind == KIND_FALLBACK:
             await self._console_command_run_skill(parse.name, parse.args)
@@ -11751,7 +11751,13 @@ class ChatScreen(BaseAppScreen):
         return text, ""
 
     async def _console_command_skills(self, parse: CommandParse) -> None:
-        """Handle the registered `/skills` command: bare list, or `<name> [args]` run."""
+        """Handle the registered `/skills` command: bare list, or `<name> [args]` hint.
+
+        Hard removal (Task 4 of the `$`-mention migration): `/skills` only
+        ever lists now -- a typed `<name> [args]` never resolves or runs
+        anything, it just points the user at the `$name` invocation form
+        via a transcript hint row (the same mechanism the list uses).
+        """
         args = parse.args.strip()
         if not args:
             context = await self._fetch_console_skill_context()
@@ -11760,16 +11766,23 @@ class ChatScreen(BaseAppScreen):
                 format_skills_list(candidates)
             )
             return
-        name, rest = self._split_console_skill_name_args(args)
-        await self._console_command_run_skill(name, rest)
+        name, _rest = self._split_console_skill_name_args(args)
+        await self._append_native_console_system_message(
+            f"Run skills by typing ${name} — /skills only lists them."
+        )
 
     async def _console_command_run_skill(self, name: str, args: str) -> None:
         """Resolve and run a skill by name (spec Slash surface run semantics).
 
-        Shared by the `/skills <name> [args]` registered command and the
-        bare `/skill-name [args]` fallback -- both converge here. Always
-        re-resolves against a FRESH ``get_context`` (never the cached
-        fallback-resolver snapshot) for the authoritative trust decision.
+        Hard removal (Task 4 of the `$`-mention migration): neither of this
+        method's original two callers reach it anymore -- `/skills <name>`
+        now always shows a static `$name` hint instead
+        (`_console_command_skills`), and the bare `/skill-name` fallback
+        dispatch (`KIND_FALLBACK`) that used to route here has no resolver
+        registered to ever produce that parse kind. Left in place (with the
+        picker chain it opens) since nothing currently calls it; if that
+        changes, it still re-resolves against a FRESH ``get_context`` (never
+        a cached snapshot) for the authoritative trust decision.
         """
         args = cap_skill_args(args)
         context = await self._fetch_console_skill_context()
@@ -11790,9 +11803,8 @@ class ChatScreen(BaseAppScreen):
         # "exists but needs review" before falling back to the picker --
         # review-mandated addition (Task 8 review): a typed name/prefix that
         # matches ONLY needs-review skills must not read like the generic
-        # empty state. Shared with the bare `/skill-name` KIND_UNKNOWN
-        # fallback dispatch site (fix-wave fold-in below) via
-        # `_console_skill_blocked_match_response`.
+        # empty state. Shares `_console_skill_blocked_match_response` with
+        # the composer's KIND_UNKNOWN dispatch site.
         if await self._console_skill_blocked_match_response(name, blocked_summaries):
             return
         if args:
@@ -11807,20 +11819,20 @@ class ChatScreen(BaseAppScreen):
     ) -> bool:
         """Surface the needs-review response for ``name`` against blocked skill summaries.
 
-        Shared by `/skills <name>`'s "none" branch above and the bare
-        `/skill-name` `KIND_UNKNOWN` fallback dispatch site
-        (``_send_console_message_from_visible_action``) -- fold-in from the
-        Task 9 fix-wave review -- so a typed name/prefix that matches ONLY
-        needs-review (trust-blocked) skills reads the same way from either
-        surface, instead of the generic "genuinely absent"/unknown-command
-        copy the fallback resolver's own trusted-only cached snapshot would
-        otherwise fall through to.
+        Called from the composer's `KIND_UNKNOWN` dispatch site (a bare
+        draft that matched no registered command -- there is no fallback
+        resolver to claim it anymore, hard removal Task 4) so a typed
+        name/prefix that matches ONLY needs-review (trust-blocked) skills
+        reads as a distinguishing hint instead of the generic
+        "Unknown command" copy. `_console_command_run_skill`'s "none" branch
+        also calls this (fold-in from the Task 9 fix-wave review), though
+        that method currently has no live caller of its own -- see its
+        docstring.
 
         Args:
             name: The typed command word (no leading slash).
             blocked_summaries: Fresh ``get_context``-derived blocked-skill
-                summaries (never the fallback resolver's cached trusted-only
-                snapshot).
+                summaries (never a cached snapshot).
 
         Returns:
             ``True`` when a blocked match was found and a response was
@@ -11829,8 +11841,8 @@ class ChatScreen(BaseAppScreen):
             ``CONSOLE_SKILL_NEEDS_REVIEW_HINT_TEMPLATE`` hint) -- the caller
             should stop further handling. ``False`` when ``name`` matches no
             blocked skill at all, so the caller falls through to its own
-            default (the skill picker for `/skills <name>`, the generic
-            unknown-command hint for bare fallback).
+            default (the generic "Unknown command" hint for the composer's
+            `KIND_UNKNOWN` site).
         """
         name_lower = name.lower()
         exact_blocked = next(
@@ -11866,7 +11878,10 @@ class ChatScreen(BaseAppScreen):
         return False
 
     async def _run_resolved_console_skill(self, name: str, args: str) -> None:
-        """Submit a resolved skill's raw `/name [args]` command as the user turn.
+        """Submit a resolved skill's raw `$name [args]` command as the user turn.
+
+        Hard removal (Task 4 of the `$`-mention migration): this composes
+        the `$`-sigil invocation form now, not `/name [args]`.
 
         Task 10 (the substitution rule) renders this at payload build time --
         this method only sends the literal, unmodified command text through
@@ -11887,7 +11902,7 @@ class ChatScreen(BaseAppScreen):
         never even gets queued (blocked send, run already in progress) must
         not leave a stale marker staged for some later, unrelated send.
         """
-        raw_command = f"/{name} {args}" if args else f"/{name}"
+        raw_command = f"${name} {args}" if args else f"${name}"
         self._console_pending_skill_marker_name = name
         queued = await self._dispatch_console_draft_send(raw_command)
         if not queued:

--- a/tldw_chatbook/Widgets/Console/console_skill_picker_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_skill_picker_modal.py
@@ -1,8 +1,14 @@
 """Console skill picker modal.
 
-Lets the user search trusted, user-invocable skills and pick one to run via
-the Console `/skill-name` surface (ambiguous-prefix and zero-match-with-args
-cases in Task 9's dispatch open this picker prefilled with the typed word).
+Lets the user search trusted, user-invocable skills and pick one to run.
+Historically reached via the Console `/skill-name` surface (ambiguous-prefix
+and zero-match-with-args cases in Task 9's dispatch, ``ChatScreen.
+_console_command_run_skill``, opened this picker prefilled with the typed
+word). That dispatch has had no live caller since skill invocation moved to
+the `$name` mention form (hard removal, Task 4 of the `$`-mention
+migration) but is intentionally kept in place, so this widget currently has
+no live caller either -- see `_console_command_run_skill`'s own docstring
+for the rationale.
 The caller (Task 9) supplies an already-adapted ``skill_search`` closure over
 the scope service's ``get_context`` seam -- ``get_context`` has no
 server-side filter, so Task 9's closure is expected to filter the returned
@@ -99,9 +105,10 @@ class ConsoleSkillPickerModal(ModalScreen[Optional[Mapping[str, object]]]):
 
         Args:
             initial_query: Prefilled filter text (e.g. the ambiguous or
-                unmatched ``/skill-name`` word Task 9's dispatch opened this
-                picker with), searched immediately on mount without waiting
-                for the debounce.
+                unmatched skill-name word Task 9's now-dead-caller dispatch
+                would open this picker with -- see this module's docstring),
+                searched immediately on mount without waiting for the
+                debounce.
             skill_search: Async callable bound to the scope-service seam
                 (Task 9) by the caller; receives the settled filter text and
                 returns a bounded (<=25) list of trusted, user-invocable


### PR DESCRIPTION
## Summary

**Codex-style `$`-mention skill invocation** — migrates Console user skill invocation to the ecosystem convention ([Codex](https://developers.openai.com/codex/skills): `/skills` browses, `$skill-name` invokes — anywhere in the prompt).

Breaking by design (user-approved full-Codex model): `/skill-name` invocation is **hard-removed**.

Design + plan: `Docs/superpowers/specs/2026-07-23-skills-dollar-mention-invocation-design.md`, `Docs/superpowers/plans/2026-07-23-skills-dollar-mention-invocation-plan.md`.

## What this does

- **`$skill-name` is THE invocation**, in two position-dependent forms:
  - **Leading** (`$pdf-processing extract the tables`): the arg-bearing whole-message form — trailing text → `{{args}}`, inline replaces the message, fork takes over the turn, untrusted refuses. Today's semantics, re-sigiled.
  - **Embedded** (`summarize the draft, $style-guide it, then list questions`): **argless** expansion — the rendered inline body is spliced at the mention's position, all surrounding prose preserved. Multiple mentions each expand (one `execute_skill` per unique name).
- **Safety rails on embedded mentions:** exact case-**sensitive** match against canonical lowercase skill names (`$PATH`/`$HOME`/`$5` stay literal, even if a same-named skill exists); markdown code spans skipped (fences + inline backticks; an odd backtick count fail-safes by masking the whole line); no recursion; fork skills can't be embedded (left literal); an untrusted embedded mention stays literal with a non-aborting system note (your prose is never lost to a refusal).
- **Fast path:** a message without `$` never touches the skills service.
- **Hard removal of `/skill-name`** at both layers (composer fallback resolver deleted; controller branch re-sigiled). A `/former-skill` draft gets the standard unknown-command hint, then an armed second Enter sends it literally. `/skills` stays as the browse list (rows teach `$name`); its run form now responds `Run skills by typing $<name> — /skills only lists them.`; the picker submits `$name`.
- **Dead code swept with the migration:** the orphaned skill-run marker machinery and a write-only candidates snapshot (plus its two mount/resume refresh workers) are deleted; the draft preview annotator flags leading `$` (and no longer mislabels `/` drafts).
- Ephemeral-only: transcripts keep your raw text; the skills → dictionaries → world-info payload ordering is unchanged; model-invoked skills (`console_agent_bridge`) are untouched.

## Verification

- Built subagent-driven: 5 TDD tasks, each spec+quality reviewed. The review gate caught real bugs the plan had missed: a code-span masking hole (a stray backtick could un-mask a guarded `` `$name` `` and splice into it — now fail-safe), an unconditional skills-service fetch on every plain-text send (now short-circuited), and a coverage-vs-dead-code inconsistency (resolved by deleting the genuinely orphaned machinery, premise verified against git history).
- Final **whole-branch review returned MERGE READY** (no Critical/Important). Bounded-execution verified: 1000 repeated `$name` mentions → 1 `execute_skill` call.
- Full gate: `Tests/Chat/` + skill-command + composer + `Tests/Skills/` suites → **1520 passed**; only pre-existing baselines (`test_anthropic_native_tools`, one known flaky) remain.
- Rebased onto latest `dev` (+69 commits; `chat_screen.py` overlap verified free of semantic collisions with the deletions).

## Breaking change / release note

Skills are now invoked with **`$skill-name`** (leading for args, embedded anywhere for argless expansion) — matching Codex, opencode, and the emerging Agent Skills ecosystem convention. `/skill-name` no longer invokes; `/skills` still lists (and now teaches the `$` form). Stored transcripts are unaffected; historical raw `/name` turns retried send as literal text.

## Out of scope (follow-ups)

Interactive `$`-autocomplete popup (none existed for `/` either); embedded args (`$name{...}`); fork reference-file reachability (next layer of the skills program); retained-dead `_console_command_run_skill`/picker-modal cleanup; the indented-leading-mention edge (an indented `$name args` is treated as embedded/argless — pre-existing whitespace-sensitivity, faithfully re-sigiled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Console skill invocation to Codex-style $-mentions with embedded expansion. Removes /skill-name; hardens parsing (CommonMark backticks, indented leading “$”, blocked-skill notes) and keeps a fast path when “$” is absent.

- **New Features**
  - $skill-name is the only invocation:
    - Leading: “$name args” runs the skill with args (inline or fork), unchanged semantics.
    - Embedded: “... $name ...” splices the argless rendered body in place; multiple mentions splice; one execute per unique skill.
  - Safety: exact case-sensitive matching (lowercase names); code spans are skipped with CommonMark-style backtick pairing (odd or unclosed spans mask safely); leading whitespace before “$name args” is tolerated as leading form; no recursion; fork skills cannot be embedded; blocked or untrusted mentions are detected and left literal with a non-blocking system note (leading untrusted still refuses).
  - Performance: messages without “$” bypass the skills service.

- **Migration**
  - /skill-name invocation removed. /skills still lists skills and now tells users to run them by typing $name; the picker submits “$name [args]”.
  - Deleted dead code: skill-run marker machinery and a write-only candidates snapshot. Preview annotator now flags leading $ only and skips multimodal drafts.
  - Transcripts keep raw text; payload ordering unchanged; model-invoked skills paths unaffected.

<sup>Written for commit 96149fd381b030c16320ac59edc4216c9043775b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

