### PR TITLE
Backlog: Console branching//rewind follow-up filing rework (tasks 570-576)

### DIFF
--- a/backlog/tasks/task-442 - Active-persona-concept-with-user-name-substitution-in-chats.md
+++ b/backlog/tasks/task-442 - Active-persona-concept-with-user-name-substitution-in-chats.md
@@ -1,0 +1,25 @@
+---
+id: TASK-442
+title: Active persona concept with user-name substitution in chats
+status: To Do
+assignee: []
+created_date: '2026-07-21 09:38'
+labels:
+  - roleplay
+  - ux
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Filed from the RP/character-card UX review (Docs/superpowers/qa/rp-ux-review-2026-07-21/report.md). Personas (who you are) are currently one-shot staged text for Console; there is no default/active persona, no import, and the preview always renders the user as "you"/"User" (placeholders replace {{user}} with the literal "User"). An RP user expects to pick a persona once and have their name/description flow into greetings, placeholder substitution, and sends.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A persona can be marked active/default and persists across sessions
+- [ ] #2 Preview and character sends substitute the active persona's name for {{user}} and label the user's messages with it
+- [ ] #3 With no active persona, current behavior is unchanged
+<!-- AC:END -->

--- a/backlog/tasks/task-484 - Fix-builtin-profiles-with-invalid-chunking_method-values.md
+++ b/backlog/tasks/task-484 - Fix-builtin-profiles-with-invalid-chunking_method-values.md
@@ -1,0 +1,31 @@
+---
+id: TASK-484
+title: >-
+  Fix builtin RAG profiles with invalid chunking_method values
+status: To Do
+assignee: []
+created_date: '2026-07-22 01:45'
+updated_date: '2026-07-22 01:45'
+labels:
+  - rag
+  - profiles
+  - followup
+dependencies:
+  - task-483
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up from SP2a (task-483) Task 2 review. Three builtin profiles in `tldw_chatbook/RAG_Search/config_profiles.py` set the CORRECT field `chunking_method` but to values that are NOT in the pipeline's valid set (words/sentences/paragraphs/tokens/semantic/json/ebook_chapters/xml/rolling_summarize): `hybrid_full` and `research_papers` use `"hierarchical"`, `technical_docs` uses `"structural"`. These are silently unused today, but if the enhanced-chunking code path (`Chunker.chunk_text`) is ever exercised for a profile with these values it raises `InvalidChunkingMethodError`. This is a different bug class from the SP2a dead-attribute fix (correct field, invalid value), so it was left as a follow-up.
+
+Decide the correct valid `chunking_method` for each (these builtins also set `preserve_structure`; "paragraphs" is the closest structure-respecting valid method) and set it, or remove the line to fall back to the default. Needs a small design decision on intended chunking behavior for each.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] Every builtin profile's `chunking_method` is a value accepted by the runtime chunker (no `InvalidChunkingMethodError` possible from any builtin).
+- [ ] A test asserts all builtins use a valid `chunking_method`.
+<!-- AC:END -->

--- a/backlog/tasks/task-570 - Console-branching-agent-inline-TOOL-markers-vanish-each-turn.md
+++ b/backlog/tasks/task-570 - Console-branching-agent-inline-TOOL-markers-vanish-each-turn.md
@@ -1,0 +1,32 @@
+---
+id: TASK-570
+title: >-
+  Console branching: agent inline TOOL markers vanish each turn on active-path
+  recompute
+status: To Do
+assignee: []
+created_date: '2026-07-25'
+labels:
+  - console
+  - chat
+  - agents
+  - tech-debt
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+(Re-filed from task-498 in the PR #803 rework: that ID was taken over by the image-gen program on dev; re-triaged post-Phase-C.)
+
+Console conversation branching (Phase A, PR #799) made `_messages_by_session` a derived active-path view rebuilt by `_recompute_active_path`. Live agent TOOL markers (the inline `⚙ tool → …` / `⤷ spawned …` scrollback rows) are appended display-only (`append_message(role=TOOL, persist=False)`), so they are correctly kept out of the message tree — but any subsequent recompute (the next send, a swipe, a delete) rebuilds the view from real tree nodes and drops them. Net effect: after an agent turn, the inline TOOL markers disappear from the transcript on the very next turn (the rail's agent summary is unaffected).
+
+Post-Phase-C re-triage (2026-07-25): Phase C (PR #827) landed durable id-anchoring for RESUME marker placement (`agent_runs.assistant_message_id`, id-match → anchor-after, off-path → hidden), but markers remain transient by design — `apply_resume_marker_overlay`'s own docstring states the next `_recompute_active_path` drops them, exactly as live markers are ephemeral. So the drop-each-turn behavior still reproduces on current dev. The remaining fix is retention: re-derive/re-overlay the markers after each recompute (Phase C's id-anchored placement makes this well-defined for the first time), or an equivalent durable display-row mechanism.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Inline agent TOOL markers persist in the Console transcript across subsequent turns/swipes for a conversation that used the agent runtime (or the limitation is documented honestly where users see it)
+- [ ] #2 Marker persistence does not reintroduce TOOL rows into the conversation tree (they must stay display-only, never parents)
+- [ ] #3 Behavior verified in the live TUI with an agent-runtime conversation
+<!-- AC:END -->

--- a/backlog/tasks/task-571 - Console-branching-failed-regenerate-drops-prior-answer-from-context.md
+++ b/backlog/tasks/task-571 - Console-branching-failed-regenerate-drops-prior-answer-from-context.md
@@ -1,0 +1,29 @@
+---
+id: TASK-571
+title: >-
+  Console branching: a failed regenerate drops the prior good answer from
+  provider context until swipe-back
+status: To Do
+assignee: []
+created_date: '2026-07-25'
+labels:
+  - console
+  - chat
+  - ux
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+(Re-filed from task-499 in the PR #803 rework, unchanged in substance.)
+
+With Console branching (Phase A, PR #799), regenerate forks a new empty sibling assistant node and moves the active leaf onto it. If that regenerate stream fails or returns empty, the new sibling ends `failed` (there is no variant base to restore, since `variant_mode=False`), so `_provider_messages_for_session(skip_failed=True)` excludes it — and the original good answer (the anchor) is now off the active path, so it is excluded too. The model therefore loses the previously-good answer from context until the user swipes back to the anchor or retries the failed node. This is a deliberate consequence of the node model and is recoverable/visible (the failed node is shown, and swipe + retry-on-failed-sibling are the recovery paths), but the UX footgun is worth smoothing.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A failed/empty regenerate does not silently strip the anchor's prior good answer from the next send's context without a clear, discoverable recovery affordance
+- [ ] #2 Chosen approach (e.g. auto-restore the anchor as active on failed regenerate, or surface a one-key swipe-back/retry hint on the failed sibling) is documented and unit-covered
+- [ ] #3 Verified in the live TUI: regenerate → force a failure → confirm the good answer is recoverable in one obvious step
+<!-- AC:END -->

--- a/backlog/tasks/task-572 - Console-branching-stronger-legacy-flat-fingerprint-for-root-chaining.md
+++ b/backlog/tasks/task-572 - Console-branching-stronger-legacy-flat-fingerprint-for-root-chaining.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-520
+id: TASK-572
 title: >-
   Console branching: stronger legacy-flat fingerprint for resume root-chaining
   (all-USER-legacy phantom counter)
@@ -16,6 +16,8 @@ dependencies: []
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
+(Renumbered from task-520 in the PR #803 rework: that ID collided with an unrelated Done task on dev, which keeps the ID per the Done-tasks-never-move rule.)
+
 `ConsoleChatStore._chain_legacy_flat_roots` (Phase A, amended in Phase B PR #811) chains multiple root-level threads into a linear spine on resume only when the root set is role-MIXED, because a genuine Phase-B root fork (edit-&-resend of the conversation's first user message) produces an all-USER root set that must NOT be chained. Known non-airtight edge, documented in the method's docstring: a DEGENERATE legacy conversation whose 2+ user turns each got NO assistant reply (reachable in the flat era via repeated failed/blocked sends) loads as all-USER roots and is wrongly left un-chained — it resumes showing only the last user message plus a phantom sibling counter. Non-data-loss (all messages stay reachable via swipe), and the two shapes are provably indistinguishable from the persisted tree alone, but a stronger fingerprint can close most of the gap: gate the legacy-chain decision on "the conversation contains at least one NULL-parent ASSISTANT row" (the true legacy signature — legacy wrote every row parentless, and any conversation with a reply then has a parentless assistant) instead of mere role-mixing. Note the flat-prefix case (legacy prefix + post-feature branched continuation) must keep chaining; see `Tests/UI/test_console_resume_active_path.py` for the covering tests.
 <!-- SECTION:DESCRIPTION:END -->
 

--- a/backlog/tasks/task-573 - Console-branching-carry-attachments-on-Edit-and-resend.md
+++ b/backlog/tasks/task-573 - Console-branching-carry-attachments-on-Edit-and-resend.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-521
+id: TASK-573
 title: 'Console branching: carry attachments across Edit & resend'
 status: To Do
 assignee: []
@@ -14,6 +14,8 @@ dependencies: []
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
+(Renumbered from task-521 in the PR #803 rework: that ID collided with an unrelated Done task on dev, which keeps the ID per the Done-tasks-never-move rule.)
+
 Phase B's "Edit & resend" (PR #811) forks a new user-message branch from an edited user message, but the edit modal is text-only: `edit_and_resend_message` calls `create_sibling(role=USER, content=...)` and synthesizes a text-only provider dict, so if the anchor user message carried attachments (an image), the new branch loses them in BOTH the persisted sibling and the provider payload. The old branch keeps them off-path, so nothing is destroyed — but a user who edits the caption of an image prompt silently re-sends without the image. Fix: copy the anchor's `attachments` tuple onto the resent sibling (and include them in the provider payload the same way `submit_draft` embeds staged attachments), or — at minimum — surface the text-only limitation in the edit modal copy when the anchor has attachments. Respect the vision-capability gate the send path applies (`vision_block_reason`).
 <!-- SECTION:DESCRIPTION:END -->
 

--- a/backlog/tasks/task-574 - Console-rewind-restore-to-before-first-message-not-restart-durable.md
+++ b/backlog/tasks/task-574 - Console-rewind-restore-to-before-first-message-not-restart-durable.md
@@ -1,0 +1,25 @@
+---
+id: TASK-574
+title: 'Console /rewind: restore-to-before-first-message does not survive restart'
+status: To Do
+assignee: []
+created_date: '2026-07-25'
+labels:
+  - console
+  - chat
+  - rewind
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Documented v1 limitation of the `/rewind` menu (SP2, PR #844): restoring to before the FIRST message clears the active leaf via `set_active_leaf(None)`, but the persisted `active_leaf_message_id` column treats NULL as "unset", so resume falls back to the most-recent leaf — the restore silently un-does itself across an app restart. Within the running session the behavior is correct. Closing this needs a way to persist "deliberately before the first message" distinctly from "no pointer stored" (a sentinel value or an additional local-only column; either way the pointer stays local-only and must not sync, matching the Phase A design).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A /rewind restore to before the first message survives an app restart: the conversation resumes showing an empty active path (with all turns recoverable by swipe/rewind), not the most-recent leaf
+- [ ] #2 Conversations with a genuinely-unset pointer (legacy, or never rewound) keep the existing most-recent-leaf resume fallback
+- [ ] #3 The persisted representation stays local-only (no sync_log row, matching active_leaf_message_id's write-through)
+<!-- AC:END -->

--- a/backlog/tasks/task-575 - Console-rewind-add-Summarize-from-here.md
+++ b/backlog/tasks/task-575 - Console-rewind-add-Summarize-from-here.md
@@ -1,0 +1,25 @@
+---
+id: TASK-575
+title: 'Console /rewind: add a Summarize-from-here complement to Summarize-up-to-here'
+status: To Do
+assignee: []
+created_date: '2026-07-25'
+labels:
+  - console
+  - chat
+  - rewind
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Deferred v1 scope cut from the `/rewind` menu (SP2, PR #844, decision D2: v1 = Restore + Summarize-up-to-here only). Up-to-here compresses the OLDEST turns and keeps the recent tail verbatim; the complementary gesture — keep the early framing verbatim and compress a recent tangent — has no affordance. Design decision needed first: exact semantics of "from here" (compress from the selected turn through the current leaf into a summary that sits at the boundary), how it composes with an existing up-to-here boundary (two boundaries vs replace), and whether the existing single `(context_summary, summary_boundary_message_id)` conversation-field pair can represent it or a second pair/shape is required. Reuses the SP2 machinery: session-provider summarization through the gateway, editable Internal_Prompts entry, render-derived banner (never a tree node), and the id-anchored leak rule (compaction only when the boundary row is in the payload).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Semantics for Summarize-from-here (including interaction with an existing up-to-here boundary) are decided and written down before implementation
+- [ ] #2 The /rewind menu offers the new option and the resulting compaction follows the same leak rule as up-to-here (pre-boundary sends never receive a summary of turns they precede)
+- [ ] #3 The summary banner renders derived-only (never a tree node) and survives resume
+<!-- AC:END -->

--- a/backlog/tasks/task-576 - Console-rewind-discoverability-beyond-slash-command.md
+++ b/backlog/tasks/task-576 - Console-rewind-discoverability-beyond-slash-command.md
@@ -1,0 +1,26 @@
+---
+id: TASK-576
+title: 'Console /rewind: discoverability beyond the bare slash command'
+status: To Do
+assignee: []
+created_date: '2026-07-25'
+labels:
+  - console
+  - chat
+  - rewind
+  - ux
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Documented v1 limitation of the `/rewind` menu (SP2, PR #844): the menu opens only by typing `/rewind` in the composer. Nothing in the UI advertises it — no command-palette entry, no transcript-selection action, no help/guide mention — so the feature is invisible to anyone who has not read the docs. Add at least one discoverable surface: a command-palette entry, and/or a message-action affordance on a selected transcript row (which would also pre-seed the restore target), and/or a line in the transcript action guide. Keep the composer command as the primary path; `/rewind` parses BEFORE readiness gating and any new surface must preserve that (the menu opens while sends are blocked).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 /rewind is reachable from at least one discoverable UI surface in addition to typing the command
+- [ ] #2 Any new surface opens the same menu with identical behavior, including while sends are blocked (readiness-gated states)
+- [ ] #3 Discoverability copy (guide/help/palette label) is present and accurate
+<!-- AC:END -->


### PR DESCRIPTION
Reworks the original Phase A follow-up filing (498-501), which went stale under it:

- **Dropped 500/501** — both shipped Done on dev via PRs #852 and #860.
- **498 → 570** — the 498 ID was taken over by the image-gen program on dev. Re-triaged post-Phase-C: PR #827's id-anchoring fixed marker *placement*, but markers remain transient by design (`apply_resume_marker_overlay` drops them on any recompute), so the vanish-each-turn issue is still live; the task now states the remaining fix is retention (re-overlay after recompute), which Phase C's anchoring makes well-defined.
- **499 → 571** — failed regenerate drops the anchor's prior good answer from provider context until swipe-back; unchanged in substance.
- **520 → 572, 521 → 573** — collision cleanup: both IDs had duplicate files on dev (an unrelated Done task each). The Done twins keep their IDs (Done tasks never move); the To-Do branching tasks are renumbered.
- **574–576 (new)** — the three /rewind v1 limitations documented in the SP2 spec are now tracked as tasks: restore-to-before-first not restart-durable, Summarize-from-here, and discoverability beyond the bare slash command.

IDs 570–576 verified free across origin/dev, every remote branch, and every local worktree (Python filename scanner) immediately before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)