### PR TITLE
feat(roleplay): Characters mode empty-state guidance (task-436)

### DIFF
--- a/Docs/superpowers/plans/2026-07-23-characters-empty-state.md
+++ b/Docs/superpowers/plans/2026-07-23-characters-empty-state.md
@@ -1,0 +1,217 @@
+# TASK-436 Characters empty-state guidance — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When the Roleplay/Personas workbench is in Characters mode with no character selected, the center pane shows onboarding guidance naming the three next actions (select a row, New, Import) instead of a blank pane; the guidance disappears the moment a selection exists.
+
+**Architecture:** Add one dedicated `Static` (`#personas-characters-empty`) to the center detail stack and register it in `_CENTER_VIEW_IDS`. Resolve the empty state once, at the top of `_show_center`: when `visible_id is None` and Characters mode has no selection, show the guidance widget instead of blanking. Every no-selection path (mode-enter, first mount, delete, cancel-New, restore-failure) already funnels through `_show_center(None)`, so this single choke point covers them all; explicit-id calls (card/editor) hide the guidance automatically (AC#2).
+
+**Tech Stack:** Python 3.11+, Textual, pytest.
+
+## Global Constraints
+
+- Guidance is **Characters-mode only** — `active_mode == "characters"` and `state.selected_entity_id` empty. Personas/Dictionaries/Lore `_show_center(None)` calls must still blank the center.
+- **Do NOT touch `#personas-mode-placeholder`** or `_mode_placeholder_text`/`_MODE_PLACEHOLDER_BODY` — that widget is the retired-"prompts" mode fallback, pinned by `test_personas_workbench.py:434` and `:828`. The new guidance is a separate widget.
+- Guidance copy is a **single, non-adaptive** module constant (it renders at `on_mount:829` before `_character_total` is loaded, so a count-adaptive copy would be wrong on first mount). It must name all three actions: select a row, **New**, **Import**.
+- CSS goes in the screen's inline `DEFAULT_CSS` (`personas_screen.py:349`), **not** the generated `tldw_cli_modular.tcss` bundle.
+- Guidance body is static app copy only (`markup=True` emphasises literal action words; no user/entity interpolation).
+- AC#2 needs **no** extra wiring — it relies on the exclusive `_show_center` (selecting → `#ccp-character-card-view`, New/Import → `#ccp-character-editor-view`).
+
+---
+
+### Task 1: Characters-mode empty-state guidance
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py` (constant near `:191`; `_CENTER_VIEW_IDS` `:258-267`; `compose_content` Static after `:683`; two helper methods near `_show_center`; the `_show_center` branch `:5756`; `DEFAULT_CSS` after the `#personas-detail-stack` rule `:441`)
+- Test: `Tests/UI/test_personas_workbench.py` (new test class/methods mirroring the existing `PersonasTestApp`/`_mounted`/`_select_first_character` harness)
+
+**Interfaces:**
+- Produces: a `#personas-characters-empty` `Static` that is `display=True` exactly when `active_mode == "characters"` and no selection, else `display=False`. New methods `_should_show_characters_empty_guidance() -> bool` and `_characters_empty_guidance_text() -> str`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/UI/test_personas_workbench.py`. Mirror the file's harness: `PersonasTestApp(mock_app_instance)`, `async with app.run_test(size=(160, 50)) as pilot`, the module-level `_mounted(pilot)` helper, the `stub_characters` fixture, and the existing `_select_first_character(pilot)` selection helper (used by `TestCharacterSelectionAndEdit`; call it the same way those tests do, or inline a `PersonaEntitySelected`/row click as the neighbouring tests do). `Static` is already imported.
+
+```python
+class TestCharactersEmptyStateGuidance:
+    """task-436: Characters mode shows onboarding guidance when nothing is selected."""
+
+    async def test_guidance_shown_when_no_selection(
+        self, mock_app_instance, stub_characters
+    ):
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+            assert screen.state.active_mode == "characters"
+            assert not screen.state.selected_entity_id
+            guidance = screen.query_one("#personas-characters-empty", Static)
+            assert guidance.display is True
+            body = str(guidance.renderable)
+            assert "New" in body and "Import" in body
+            assert screen.query_one("#ccp-character-card-view").display is False
+
+    async def test_guidance_hidden_after_selection(
+        self, mock_app_instance, stub_characters
+    ):
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await self_select_first_character(pilot)  # see note below
+            assert screen.state.selected_entity_id
+            assert screen.query_one("#personas-characters-empty", Static).display is False
+            assert screen.query_one("#ccp-character-card-view").display is True
+
+    async def test_guidance_hidden_in_other_modes(
+        self, mock_app_instance, stub_characters
+    ):
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+            await screen._apply_mode("lore")
+            await pilot.pause()
+            assert screen.query_one("#personas-characters-empty", Static).display is False
+            await screen._apply_mode("characters")
+            await pilot.pause()
+            assert screen.query_one("#personas-characters-empty", Static).display is True
+
+    async def test_guidance_returns_after_delete(
+        self, mock_app_instance, stub_characters
+    ):
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await self_select_first_character(pilot)
+            await screen._delete_entity()  # match the real delete entry point (see note)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            assert not screen.state.selected_entity_id
+            assert screen.query_one("#personas-characters-empty", Static).display is True
+```
+
+> **Implementer notes for Step 1 (resolve before writing):**
+> - Replace `self_select_first_character(pilot)` with however this file selects the first character — the `TestCharacterSelectionAndEdit` class has a `_select_first_character` helper; either subclass/reuse it, make these methods part of that class, or copy its selection idiom (it posts the library row's `PersonaEntitySelected` / clicks the first `.personas-library-row`). Use the exact working idiom already in the file.
+> - For the delete test, drive deletion the same way an existing delete test does (find it via `grep -n "delete" Tests/UI/test_personas_workbench.py`) rather than guessing `_delete_entity`'s signature — the point is: after a real delete of the selected character, guidance returns.
+> - Add a `test_guidance_returns_after_cancel_new` only if the file already has a New-then-cancel idiom to copy; otherwise omit it (the mode-switch + delete tests already exercise the re-show paths).
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+Run: `python -m pytest Tests/UI/test_personas_workbench.py -k CharactersEmptyState -q`
+Expected: FAIL — `#personas-characters-empty` does not exist yet (`NoMatches`/`QueryError`).
+
+- [ ] **Step 3: Add the guidance constant + widget + `_CENTER_VIEW_IDS` entry**
+
+In `personas_screen.py`, after `_PLACEHOLDER_FALLBACK = "This mode is coming soon."` (`:191`):
+```python
+#: Onboarding guidance shown in the Characters center pane when nothing is
+#: selected (task-436). Non-adaptive: rendered at on_mount before the character
+#: count loads, so it must read correctly whether or not characters exist.
+_CHARACTERS_EMPTY_GUIDANCE = (
+    "No character selected. Pick one from the list on the left, or use "
+    "[b]New[/b] or [b]Import[/b] to add a character."
+)
+```
+
+Add to `_CENTER_VIEW_IDS` (`:258-267`), after `"#personas-mode-placeholder",`:
+```python
+    "#personas-mode-placeholder",
+    "#personas-characters-empty",
+)
+```
+
+In `compose_content`, immediately after the `#personas-mode-placeholder` Static (`:681-683`), still inside the `#personas-detail-stack` container:
+```python
+                        yield Static(
+                            self._mode_placeholder_text("prompts"),
+                            id="personas-mode-placeholder",
+                        )
+                        yield Static(
+                            _CHARACTERS_EMPTY_GUIDANCE,
+                            id="personas-characters-empty",
+                            markup=True,
+                        )
+```
+
+- [ ] **Step 4: Add the two helper methods**
+
+Near `_show_center` (e.g. just above it, around `:5755`), add:
+```python
+    def _should_show_characters_empty_guidance(self) -> bool:
+        """True when the Characters center should show onboarding guidance.
+
+        Returns:
+            True in Characters mode with no selection (empty center), else False.
+        """
+        return (
+            self.state.active_mode == "characters"
+            and not self.state.selected_entity_id
+        )
+
+    def _characters_empty_guidance_text(self) -> str:
+        """Return the onboarding guidance for the empty Characters center pane.
+
+        Returns:
+            Static guidance copy naming the three next actions.
+        """
+        return _CHARACTERS_EMPTY_GUIDANCE
+```
+
+- [ ] **Step 5: Resolve the guidance inside `_show_center`**
+
+At the very top of `_show_center` (`:5756`), before the loop over `_CENTER_VIEW_IDS`:
+```python
+    def _show_center(self, visible_id: str | None) -> None:
+        # Characters mode with nothing selected shows onboarding guidance, not a
+        # blank pane (task-436). Every no-selection path funnels through here, so
+        # resolving it once keeps mode-enter, first mount, delete, cancel-New and
+        # restore-failure consistent; non-character modes and explicit-id calls
+        # (card / editor) are unaffected, which makes AC#2 automatic.
+        if visible_id is None and self._should_show_characters_empty_guidance():
+            try:
+                self.query_one("#personas-characters-empty", Static).update(
+                    self._characters_empty_guidance_text()
+                )
+            except QueryError:
+                pass
+            else:
+                visible_id = "#personas-characters-empty"
+        # ... existing body unchanged ...
+```
+(The `try/except QueryError` mirrors `_show_center`'s existing tolerance for widgets not yet mounted; only set `visible_id` if the update succeeded. `QueryError` is already imported in this module.)
+
+- [ ] **Step 6: Add the CSS rule to `DEFAULT_CSS`**
+
+In `DEFAULT_CSS`, right after the `#personas-detail-stack { ... }` rule (`:437-441`):
+```css
+    #personas-characters-empty {
+        width: 1fr;
+        height: 1fr;
+        content-align: center middle;
+        text-align: center;
+        padding: 2 4;
+        color: $text-muted;
+    }
+```
+
+- [ ] **Step 7: Run the tests to confirm they pass**
+
+Run: `python -m pytest Tests/UI/test_personas_workbench.py -k CharactersEmptyState -q`
+Expected: PASS.
+
+- [ ] **Step 8: Regression — personas suite + any blank-center assumption**
+
+Run: `python -m pytest Tests/UI/test_personas_workbench.py Tests/UI/test_personas_workbench_state.py Tests/UI/test_personas_dictionaries.py Tests/UI/test_personas_lore.py -q`
+Expected: PASS. If any pre-existing test assumed the Characters center is fully blank with no selection (e.g. asserting some detail widget hidden as a proxy for "empty"), update it to reflect that `#personas-characters-empty` is now the visible empty state — do NOT weaken the new-guidance assertions. The retired-"prompts" placeholder tests (`:434`,`:828`) and existing `#ccp-character-card-view` display assertions must still pass unchanged (verify).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/personas_screen.py Tests/UI/test_personas_workbench.py
+git commit -m "feat(roleplay): Characters center empty-state guidance (task-436)"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** AC#1 (guidance names select/New/Import when no selection) → Steps 3-6 + tests `test_guidance_shown_when_no_selection`, `test_guidance_hidden_in_other_modes` (switch-back). AC#2 (guidance disappears once a selection exists) → the exclusive `_show_center` + `test_guidance_hidden_after_selection`; re-show after deselect → `test_guidance_returns_after_delete`. Both covered.
+- **Placeholder scan:** the only judgement calls are the test-harness selection/delete idioms, explicitly delegated to the implementer with a concrete way to resolve each (reuse the file's existing helpers) — no `TODO`/`TBD` in the shipped code.
+- **Consistency:** `#personas-characters-empty`, `_should_show_characters_empty_guidance`, `_characters_empty_guidance_text`, `_CHARACTERS_EMPTY_GUIDANCE` used identically across compose, `_CENTER_VIEW_IDS`, helpers, `_show_center`, CSS, and tests. `#personas-mode-placeholder` is left untouched.

--- a/Docs/superpowers/specs/2026-07-23-characters-empty-state-design.md
+++ b/Docs/superpowers/specs/2026-07-23-characters-empty-state-design.md
@@ -1,0 +1,131 @@
+# TASK-436 — Characters mode center-pane empty-state guidance
+
+- **Date:** 2026-07-23
+- **Task:** TASK-436 (RP/character-card UX review). The Characters center pane is blank with no selection → reads as broken.
+- **Branch base:** origin/dev (tip `4d6bb49f3`).
+
+## Problem
+
+On first visit to the Roleplay/Personas workbench (Characters mode is the default), the center pane is a large blank area with no copy until a character is selected. Combined with the inspector's "Console blocked: select an item", the first impression reads as **broken** rather than "select or create a character".
+
+**Root cause:** the Characters branch of `_apply_mode` (`personas_screen.py:1644-1646`), plus `on_mount` (`:829`) and every deselect path, call `self._show_center(None)`. `_show_center(None)` matches none of the exclusive `_CENTER_VIEW_IDS` (`:257-267`), so it sets `display=False` on **every** center view → `#personas-detail-stack` renders nothing (`_show_center`, `:5756-5811`).
+
+The existing library-rail empty row ("No characters yet – use New or Import", `personas_library_pane.py:265-276`) only fires when the **library itself is empty**. In the observed scenario the seeded Default Assistant character exists, so the rail shows rows while the center stays blank — exactly the gap this task closes.
+
+## Key mechanics (verified)
+
+- **The center is a single swappable stack.** `_show_center(visible_id)` iterates `_CENTER_VIEW_IDS` and sets each widget's `display = (selector == visible_id)`; `None` hides all. It also gates `#personas-character-attachments` / the dict panel to only the two character view ids (`#ccp-character-card-view`, `#ccp-character-editor-view`) — so a non-character `visible_id` (including a new guidance id) hides the attachment widgets automatically.
+- **`#personas-mode-placeholder` is NOT reusable.** It is the fallback for retired/un-built modes only — the `else` branch of `_apply_mode` (`:1658-1665`) shows it via `_mode_placeholder_text(mode)` → `_MODE_PLACEHOLDER_BODY`/`_PLACEHOLDER_FALLBACK` (`:188-192`). Its "prompts" behavior ("moving to the Library") is pinned by `test_personas_workbench.py:434` and `:828`. Overloading it for "characters, no selection" would be semantically wrong and break those tests. → use a **dedicated widget**.
+- **All no-selection paths funnel through `_show_center(None)`:** mode-enter (`:1646`), first mount (`:829`), restore-failure (`:816`, task-434), delete (`_delete_entity` `:5292`/`:5333`), and cancel-New (`_finish_cancel_edit` `:5726`). `_finish_cancel_edit` sets `_edit_mode="view"` **before** its `_show_center(None)` (`:5716`,`:5726`), so cancelling New with no prior selection lands on the empty state, not a stale editor.
+- **Selection signal.** `state.selected_entity_id` (`personas_state.py:49-51`) is empty when nothing is selected. Task-434's `restore_state` populates it **pre-mount** from the saved dataclass, so it is reliable at `on_mount:829`. Selecting a character runs `_show_center("#ccp-character-card-view")` (`_select_character`); New/Import open the editor via `_show_center("#ccp-character-editor-view")` — both explicit ids, so they hide any guidance automatically.
+- **Copy idiom.** Empty-state / descriptor copy on this screen lives in module constants (`_MODE_DESCRIPTORS:174`, `_MODE_PLACEHOLDER_BODY:188`, `_PLACEHOLDER_FALLBACK:191`) surfaced by small `_..._text(mode)` helpers. The library-rail empty row adapts on `_import_visible` (populated vs empty).
+
+## Design
+
+### 1. A dedicated guidance widget in the center stack
+
+Add a `Static` to `#personas-detail-stack` (in `compose_content`, alongside the other detail views) and register it in `_CENTER_VIEW_IDS`:
+
+```python
+yield Static("", id="personas-characters-empty", markup=True)
+```
+```python
+_CENTER_VIEW_IDS = ( ... existing ..., "#personas-characters-empty", )
+```
+
+`markup=True` so the three action words can be emphasised; the body is **static app copy only** (no user/entity interpolation), so there is no markup-injection surface.
+
+### 2. Resolve the empty state once, inside `_show_center`
+
+Rather than editing every `_show_center(None)` call site (mode-enter, mount, delete, cancel-New, restore-failure — and any future path), resolve the guidance at the single choke point. At the top of `_show_center`:
+
+```python
+def _show_center(self, visible_id: str | None) -> None:
+    # Characters mode with nothing selected shows onboarding guidance, not a
+    # blank pane (task-436). Every no-selection path funnels through here, so
+    # resolving it once keeps mode-enter, first mount, delete, cancel-New and
+    # restore-failure consistent; non-character modes and explicit-id calls
+    # (card / editor) are unaffected, which makes AC#2 automatic.
+    if visible_id is None and self._should_show_characters_empty_guidance():
+        self.query_one("#personas-characters-empty", Static).update(
+            self._characters_empty_guidance_text()
+        )
+        visible_id = "#personas-characters-empty"
+    # ... existing loop over _CENTER_VIEW_IDS + attachment/dict-panel gates ...
+```
+
+with:
+
+```python
+def _should_show_characters_empty_guidance(self) -> bool:
+    """True when the Characters center should show onboarding guidance."""
+    return (
+        self.state.active_mode == "characters"
+        and not self.state.selected_entity_id
+    )
+```
+
+Because `_should_show_characters_empty_guidance()` gates on `active_mode == "characters"`, the personas/dictionaries/lore `_show_center(None)` calls still blank the center (guidance is Characters-only per AC). Explicit-id calls never enter the branch, so a selected character card, the editor, and the unbuilt-mode placeholder are all unchanged.
+
+### 3. Guidance copy (AC#1 — names the three next actions)
+
+A single module constant + helper mirroring `_mode_placeholder_text`. **Non-adaptive on purpose:** `on_mount` shows the center (`:829`) *before* `refresh_character_list()` (`:830`) populates `self._character_total`, and nothing re-renders the center after the load — so a count-adaptive copy would render its "empty library" variant on first mount even when characters exist. One copy that reads correctly whether or not characters exist avoids that timing trap and still satisfies AC#1 in both states:
+
+```python
+_CHARACTERS_EMPTY_GUIDANCE = (
+    "No character selected. Pick one from the list on the left, or use "
+    "[b]New[/b] or [b]Import[/b] to add a character."
+)
+```
+```python
+def _characters_empty_guidance_text(self) -> str:
+    """Onboarding guidance for the empty Characters center pane."""
+    return _CHARACTERS_EMPTY_GUIDANCE
+```
+
+The copy names all three next actions — select a row, **New**, **Import**. When the library is empty ("Pick one from the list" is momentarily moot), the rail's own empty row ("No characters yet – use New or Import") supplies the same New/Import cue, so the two never conflict. A helper (rather than an inline literal) keeps the copy in one place and leaves room to make it count-adaptive later behind a proper post-load refresh, without changing `_show_center`'s call shape.
+
+### 4. CSS — read as intentional guidance
+
+Add a rule (in the screen's tcss / the same file that styles `#personas-detail-stack`) so the guidance is centered, muted, and padded rather than a stray top-left line:
+
+```css
+#personas-characters-empty {
+    width: 1fr;
+    height: 1fr;
+    content-align: center middle;
+    text-align: center;
+    padding: 2 4;
+    color: $text-muted;
+}
+```
+
+### AC#2 — guidance disappears once a selection exists
+
+No extra wiring: `_select_character` → `_show_center("#ccp-character-card-view")` and New/Import → `_show_center("#ccp-character-editor-view")` are explicit ids, so `_show_center` sets `#personas-characters-empty` `display=False`. Deleting the selected character (`_delete_entity`) clears the selection and calls `_show_center(None)` → guidance re-appears (still Characters mode, now no selection).
+
+## Testing
+
+Mirror the existing personas pilot harness (`Tests/UI/test_personas_workbench.py` / `_workbench_state.py`):
+
+- **AC#1 populated:** mount in Characters mode with ≥1 character, no selection → `#personas-characters-empty` `display is True` and its renderable names "New" and "Import" (and references selecting from the list).
+- **AC#1 empty library:** no characters → the same guidance still shows and names New/Import (no stale-variant / crash).
+- **first-mount timing:** the guidance rendered at `on_mount` (before `refresh_character_list`) names New/Import correctly even though `_character_total` is not yet loaded (pins the reason the copy is non-adaptive).
+- **AC#2 select hides:** select a character → `#personas-characters-empty` `display is False` and `#ccp-character-card-view` `display is True`.
+- **mode isolation:** switch to Lore/Personas (no selection) → `#personas-characters-empty` `display is False` (guidance is Characters-only); switch back to Characters → it shows again.
+- **delete re-shows:** with a selected character, delete it → guidance re-appears.
+- **cancel-New re-shows:** open New (no prior selection), cancel the editor → guidance shows (not blank), `#ccp-character-editor-view` hidden.
+- **regression:** the retired-"prompts" placeholder tests (`test_personas_workbench.py:434/828`) still pass (that widget is untouched); existing `#ccp-character-card-view` display assertions still hold. Run the personas suite and update any test that assumed a fully-blank Characters-empty center.
+
+## Risks / mitigations
+
+- **Overloading `_show_center` with state:** it already reads state to gate attachments; the added branch is guarded to `visible_id is None` and Characters-mode-no-selection only, and explicit-id calls (the common case) are untouched. A single choke point is safer than editing ~6 call sites and missing a future one.
+- **First-mount count timing:** guidance renders at `on_mount:829` before the character list loads (`:830`); the copy is deliberately non-adaptive so it is correct regardless of the not-yet-known count (see §3).
+- **task-434 restore:** the no-selection restore path (`:816`) already calls `_show_center(None)`; it now yields guidance in Characters mode — the intended behavior. Restore **with** a selection uses `_select_character` (explicit id) → unaffected.
+- **markup:** body is static app copy; `markup=True` only emphasises literal action words, no injection.
+
+## Non-goals
+
+- Guidance for Personas/Dictionaries/Lore empty centers (Dictionaries/Lore already have try-it guidance; extending center guidance to all modes is a separate follow-up if wanted).
+- Changing the inspector "Console blocked: select an item" copy (TASK-443's remit).
+- Any change to selection, mode-switch, or restore semantics.

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -4307,7 +4307,19 @@ class TestCharactersEmptyStateGuidance:
     ):
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test(size=(160, 50)) as pilot:
-            screen = await self._select_first_character(pilot)
+            screen = await _mounted(pilot)
+            await pilot.pause()
+            # Guidance is visible before any selection (pins the transition so
+            # the "hidden after" assertion below is non-vacuous).
+            assert (
+                screen.query_one("#personas-characters-empty", Static).display
+                is True
+            )
+            # ... and disappears the moment a character is selected (AC#2).
+            await pilot.click("#personas-library-row-character-1")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
             assert screen.state.selected_entity_id
             assert (
                 screen.query_one("#personas-characters-empty", Static).display

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -4252,6 +4252,115 @@ class TestDelete:
             )
 
 
+class TestCharactersEmptyStateGuidance:
+    """task-436: Characters mode shows onboarding guidance when nothing is
+    selected, instead of a blank center pane that reads as broken."""
+
+    @pytest.fixture
+    def stub_conversations(self, monkeypatch):
+        """Mirrors TestDelete.stub_conversations: stub the DB resolver and
+        conversation listing so a real character selection/delete round-trip
+        doesn't hit an unstubbed DB."""
+        monkeypatch.setattr(
+            character_handler_module, "_default_character_db", lambda: object()
+        )
+        monkeypatch.setattr(
+            conversations_controller_module,
+            "list_character_conversations",
+            lambda db, character_id, limit=50, offset=0: [
+                {"id": "conv-1", "title": "First case"}
+            ],
+        )
+
+    @staticmethod
+    def _bypass_confirm(screen, result: bool) -> None:
+        async def _confirm(name: str) -> bool:
+            return result
+
+        screen._confirm_delete = _confirm
+
+    async def _select_first_character(self, pilot):
+        screen = await _mounted(pilot)
+        await pilot.pause()
+        await pilot.click("#personas-library-row-character-1")
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        return screen
+
+    async def test_guidance_shown_when_no_selection(
+        self, mock_app_instance, stub_characters
+    ):
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+            assert screen.state.active_mode == "characters"
+            assert not screen.state.selected_entity_id
+            guidance = screen.query_one("#personas-characters-empty", Static)
+            assert guidance.display is True
+            body = str(guidance.renderable)
+            assert "New" in body and "Import" in body
+            assert screen.query_one("#ccp-character-card-view").display is False
+
+    async def test_guidance_hidden_after_selection(
+        self, mock_app_instance, stub_characters
+    ):
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await self._select_first_character(pilot)
+            assert screen.state.selected_entity_id
+            assert (
+                screen.query_one("#personas-characters-empty", Static).display
+                is False
+            )
+            assert screen.query_one("#ccp-character-card-view").display is True
+
+    async def test_guidance_hidden_in_other_modes(
+        self, mock_app_instance, stub_characters
+    ):
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+            await screen._apply_mode("lore")
+            await pilot.pause()
+            assert (
+                screen.query_one("#personas-characters-empty", Static).display
+                is False
+            )
+            await screen._apply_mode("characters")
+            await pilot.pause()
+            assert (
+                screen.query_one("#personas-characters-empty", Static).display
+                is True
+            )
+
+    async def test_guidance_returns_after_delete(
+        self, mock_app_instance, stub_characters, stub_conversations, monkeypatch
+    ):
+        monkeypatch.setattr(
+            character_handler_module,
+            "delete_character",
+            lambda character_id, expected_version: True,
+        )
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await self._select_first_character(pilot)
+            assert (
+                screen.query_one("#personas-characters-empty", Static).display
+                is False
+            )
+            self._bypass_confirm(screen, True)
+            screen.query_one("#personas-delete", Button).press()
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            assert not screen.state.selected_entity_id
+            assert (
+                screen.query_one("#personas-characters-empty", Static).display
+                is True
+            )
+
+
 class TestKeyboardInteraction:
     """UX-E2: context-sensitive Escape, real Ctrl+S, mode keys, managed focus."""
 

--- a/backlog/tasks/task-436 - Characters-mode-center-pane-empty-state-guidance.md
+++ b/backlog/tasks/task-436 - Characters-mode-center-pane-empty-state-guidance.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-436
 title: Characters mode center pane empty-state guidance
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-21 09:38'
+updated_date: '2026-07-23 20:00'
 labels:
   - roleplay
   - ux

--- a/backlog/tasks/task-436 - Characters-mode-center-pane-empty-state-guidance.md
+++ b/backlog/tasks/task-436 - Characters-mode-center-pane-empty-state-guidance.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-436
 title: Characters mode center pane empty-state guidance
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-21 09:38'
-updated_date: '2026-07-23 20:00'
+updated_date: '2026-07-23 20:27'
 labels:
   - roleplay
   - ux
@@ -20,6 +20,22 @@ Filed from the RP/character-card UX review (Docs/superpowers/qa/rp-ux-review-202
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 With no selection, the Characters center pane shows guidance for the three next actions (select, New, Import)
-- [ ] #2 Guidance disappears once a selection exists
+- [x] #1 With no selection, the Characters center pane shows guidance for the three next actions (select, New, Import)
+- [x] #2 Guidance disappears once a selection exists
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Characters mode now shows onboarding guidance in the center pane when no character is selected, instead of a blank area that read as broken.
+
+**Approach:** a dedicated `Static` `#personas-characters-empty` in `#personas-detail-stack` (registered in `_CENTER_VIEW_IDS`), resolved once at the top of `_show_center`: when `visible_id is None` and `active_mode == "characters"` and `state.selected_entity_id` is empty, it shows the guidance widget instead of blanking. Because every no-selection path (mode-enter, first mount, delete, cancel-New, restore-failure) funnels through `_show_center(None)`, this single choke point covers them all, and explicit-id calls (character card / editor) hide the guidance automatically — so **AC#2 needs no extra wiring**.
+
+**Copy (AC#1):** a single non-adaptive constant `_CHARACTERS_EMPTY_GUIDANCE` naming all three next actions (pick from the list / **New** / **Import**). Deliberately not count-adaptive: `on_mount` renders the center before `_character_total` loads, so an adaptive copy would be wrong on first mount.
+
+**Not reused:** `#personas-mode-placeholder` (the retired-"prompts" fallback, pinned by tests) is left untouched — the guidance is a separate widget. CSS lives in the screen's inline `DEFAULT_CSS` (not the generated bundle).
+
+**Testing:** 4 pilot tests (guidance shown when no selection naming New/Import; visible-before → hidden-after selection pinning the AC#2 transition; hidden in other modes + returns on switch-back; returns after deleting the selected character). Full personas regression (310) green; live tmux-verified render + swap-to-card. Task review: spec ✅, code quality Approved.
+
+**Scope:** Characters mode only; the inspector "Console blocked" copy is TASK-443's remit; extending center guidance to other empty modes is a possible follow-up. Files: `personas_screen.py`, `Tests/UI/test_personas_workbench.py`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -191,6 +191,14 @@ _MODE_PLACEHOLDER_BODY: dict[str, str] = {
     "prompts": "Prompts are moving to the Library — you'll manage them there.",
 }
 _PLACEHOLDER_FALLBACK = "This mode is coming soon."
+
+#: Onboarding guidance shown in the Characters center pane when nothing is
+#: selected (task-436). Non-adaptive: rendered at on_mount before the character
+#: count loads, so it must read correctly whether or not characters exist.
+_CHARACTERS_EMPTY_GUIDANCE = (
+    "No character selected. Pick one from the list on the left, or use "
+    "[b]New[/b] or [b]Import[/b] to add a character."
+)
 PERSONAS_SEARCH_DEBOUNCE_SECONDS = 0.2
 #: Rows per library page. ``page_offset`` is always kept a multiple of this so
 #: the pane's "start-end of N" label math stays exact.
@@ -266,6 +274,7 @@ _CENTER_VIEW_IDS: tuple[str, ...] = (
     "#ccp-persona-editor-view",
     _CONVERSATION_VIEW_ID,
     "#personas-mode-placeholder",
+    "#personas-characters-empty",
 )
 
 
@@ -440,6 +449,15 @@ class PersonasScreen(BaseAppScreen):
         width: 100%;
         height: 1fr;
         min-height: 0;
+    }
+
+    #personas-characters-empty {
+        width: 1fr;
+        height: 1fr;
+        content-align: center middle;
+        text-align: center;
+        padding: 2 4;
+        color: $text-muted;
     }
 
     #personas-library-rows {
@@ -681,6 +699,11 @@ class PersonasScreen(BaseAppScreen):
                         yield Static(
                             self._mode_placeholder_text("prompts"),
                             id="personas-mode-placeholder",
+                        )
+                        yield Static(
+                            _CHARACTERS_EMPTY_GUIDANCE,
+                            id="personas-characters-empty",
+                            markup=True,
                         )
                     yield PersonasPreviewPane(id="personas-preview-pane")
                     tryit = PersonasDictionaryTryItWidget(id="personas-dict-tryit")
@@ -5984,8 +6007,41 @@ class PersonasScreen(BaseAppScreen):
 
     # ===== Helpers =====
 
+    def _should_show_characters_empty_guidance(self) -> bool:
+        """True when the Characters center should show onboarding guidance.
+
+        Returns:
+            True in Characters mode with no selection (empty center), else False.
+        """
+        return (
+            self.state.active_mode == "characters"
+            and not self.state.selected_entity_id
+        )
+
+    def _characters_empty_guidance_text(self) -> str:
+        """Return the onboarding guidance for the empty Characters center pane.
+
+        Returns:
+            Static guidance copy naming the three next actions.
+        """
+        return _CHARACTERS_EMPTY_GUIDANCE
+
     def _show_center(self, visible_id: str | None) -> None:
         """Show one center-area view (or none); tolerate missing nodes."""
+        # Characters mode with nothing selected shows onboarding guidance, not a
+        # blank pane (task-436). Every no-selection path funnels through here, so
+        # resolving it once keeps mode-enter, first mount, delete, cancel-New and
+        # restore-failure consistent; non-character modes and explicit-id calls
+        # (card / editor) are unaffected, which makes AC#2 automatic.
+        if visible_id is None and self._should_show_characters_empty_guidance():
+            try:
+                self.query_one("#personas-characters-empty", Static).update(
+                    self._characters_empty_guidance_text()
+                )
+            except QueryError:
+                pass
+            else:
+                visible_id = "#personas-characters-empty"
         for selector in _CENTER_VIEW_IDS:
             try:
                 widget = self.query_one(selector)


### PR DESCRIPTION
## Summary

Fixes the Roleplay/Personas workbench first-impression bug (TASK-436, from the RP UX review): in **Characters mode with no character selected**, the center pane was a large blank area, which — with the inspector's "Console blocked: select an item" — read as broken. It now shows onboarding guidance.

## Changes (all in `personas_screen.py`)

- New dedicated `Static` `#personas-characters-empty` in `#personas-detail-stack` (+ `_CENTER_VIEW_IDS`).
- Guidance is resolved **once** at the top of `_show_center`: when `visible_id is None` **and** `active_mode == "characters"` **and** no `selected_entity_id`, it shows the guidance widget instead of blanking. Every no-selection path (mode-enter, first mount, delete, cancel-New, restore-failure) funnels through `_show_center(None)`, so this single choke point covers them all; explicit-id calls (character card / editor) hide it automatically — **AC#2 needs no extra wiring**.
- Single non-adaptive copy `_CHARACTERS_EMPTY_GUIDANCE` naming the three next actions (pick from the list / **New** / **Import**). Non-adaptive on purpose: `on_mount` renders the center before the character count loads.
- `DEFAULT_CSS` rule (centered, muted) so it reads as intentional guidance.

`#personas-mode-placeholder` (the retired-"prompts" fallback) is left untouched; CSS is in the inline `DEFAULT_CSS`, not the generated bundle.

## Testing

4 new pilot tests: guidance shown when no selection (names New/Import); **visible-before → hidden-after** selection (pins the AC#2 transition, non-vacuous per a mutation check); hidden in other modes + returns on switch-back; returns after deleting the selected character. Full personas regression (310) green; live tmux-verified. Task review: spec ✅, code quality Approved.

## Scope

Characters mode only. The inspector "Console blocked" copy is TASK-443's remit; extending center guidance to other empty modes is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an empty-state guidance panel to Characters mode so the center pane shows clear next steps when no character is selected, instead of a blank space. Satisfies TASK-436 by guiding users to select a row or use New/Import, and auto-hiding once a selection exists.

- **New Features**
  - Added `#personas-characters-empty` to the center stack and registered it in `_CENTER_VIEW_IDS`, with centered muted styling in `DEFAULT_CSS`.
  - Resolved once in `_show_center`: when `visible_id is None`, mode is `characters`, and no `selected_entity_id`, show guidance; selecting or opening the editor hides it automatically. Characters-only.
  - Tests verify show-on-mount, hide-after-selection (AC#2), mode isolation, and re-show after delete.

<sup>Written for commit e735a397b1ece252edf1997329b8b30a87fbdd1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

