### PR TITLE
fix(console): P3 comprehension cluster — humanize rail Scope, tab labels, footer stats, first-run jargon (tasks 373/375/387/390)

### DIFF
--- a/Tests/UI/test_app_footer_shortcut_context.py
+++ b/Tests/UI/test_app_footer_shortcut_context.py
@@ -75,3 +75,28 @@ async def test_footer_renders_workbench_shortcuts():
 
         assert "F6 next pane" in rendered
         assert "F1 help" in rendered
+
+
+@pytest.mark.asyncio
+async def test_footer_db_size_stats_expose_decode_legend_tooltip():
+    """The cryptic P:/C/N:/M: DB-size stats must be decodable on hover."""
+
+    class TestApp(App):
+        def compose(self):
+            yield AppFooterStatus(id="footer")
+
+    app = TestApp()
+
+    async with app.run_test(size=(100, 12)) as pilot:
+        await pilot.pause(0.1)
+        footer = app.query_one("#footer", AppFooterStatus)
+
+        db_display = footer.query_one("#internal-db-size-indicator", Static)
+        tooltip = str(db_display.tooltip or "")
+
+        # Every abbreviation shown in the footer must be spelled out.
+        assert "Prompts" in tooltip
+        assert "Conversations" in tooltip or "Notes" in tooltip
+        assert "Media" in tooltip
+        # And the legend should say these are database file sizes.
+        assert "size" in tooltip.lower()

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -6587,9 +6587,38 @@ async def test_console_native_tab_title_has_stable_visible_label_region():
             "Active Console tab: Planning session with a long descriptive name. "
             "Click again to rename."
         )
-        assert str(tab.label) == "Planning session..."
+        # TASK-375: middle-truncated with a single-cell ellipsis (visible mark),
+        # preserving the distinguishing words at both ends.
+        assert str(tab.label) == "Planning…tive name"
         assert tab.region.width >= 18
-        assert "Planning session" in _visible_text(console)
+        assert "Planning" in _visible_text(console)
+        assert "…" in _visible_text(console)
+
+
+def test_console_tab_label_middle_truncates_with_visible_ellipsis():
+    """TASK-375: long tab titles middle-truncate with a single-cell ellipsis,
+    always showing the truncation mark and keeping distinguishing words at both
+    ends (so two titles sharing a first word are not the same fragment)."""
+    from tldw_chatbook.Widgets.Console.console_session_surface import (
+        CONSOLE_SESSION_TAB_DISPLAY_CHARS,
+        ConsoleSessionSurface,
+    )
+
+    display = ConsoleSessionSurface._display_title
+
+    short = display("Chat 1")
+    assert short == "Chat 1"  # short titles are untouched
+
+    a = display("Long conversation about embeddings and vector stores in local RAG")
+    b = display("Long conversation about Terraform state migration and remote backends")
+    for label in (a, b):
+        assert "…" in label
+        assert "..." not in label
+        assert len(label) <= CONSOLE_SESSION_TAB_DISPLAY_CHARS
+        assert label.startswith("Long")  # head preserved
+    # The distinguishing END survives, so the two aren't the same fragment.
+    assert a.endswith("RAG")
+    assert a != b
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_settings_provider_test_draft.py
+++ b/Tests/UI/test_settings_provider_test_draft.py
@@ -329,6 +329,42 @@ async def test_model_field_suggester_completes_discovered_ids():
     assert screen._model_field_suggester() is None
 
 
+def test_discovery_row_labels_use_user_vocabulary_not_internal_jargon():
+    """TASK-387: the model-discovery selection rows must read in plain language,
+    not the internal ``runtime_discovered`` / ``capability=unknown`` enum dump."""
+    screen = _bare_settings_screen({})
+    screen._model_discovery_selected_model_ids = set()
+    screen._model_discovery_models = (
+        SimpleNamespace(
+            model_id="gemma-4.gguf",
+            source="runtime_discovered",
+            capability_status="unknown",
+            persisted=False,
+        ),
+        SimpleNamespace(
+            model_id="mistral-7b.gguf",
+            source="persisted_discovered",
+            capability_status="known",
+            persisted=True,
+        ),
+    )
+
+    labels = [label for label, _id, _sel in screen._model_discovery_selection_options()]
+    joined = " ".join(labels)
+
+    # Model ids are still shown for recognition.
+    assert "gemma-4.gguf" in joined
+    assert "mistral-7b.gguf" in joined
+    # Internal enum jargon is gone.
+    assert "runtime_discovered" not in joined
+    assert "persisted_discovered" not in joined
+    assert "capability=" not in joined
+    # Replaced by user-facing vocabulary.
+    assert "discovered" in labels[0]
+    assert "capabilities unknown" in labels[0]
+    assert "capabilities known" in labels[1]
+
+
 # --- Pilot tests: the clickable Test button path (AC#2/AC#3) + widget wiring ---
 #
 # These drive the real SettingsScreen through the harness

--- a/Tests/Workspaces/test_workspace_display_state.py
+++ b/Tests/Workspaces/test_workspace_display_state.py
@@ -46,6 +46,30 @@ def test_console_workspace_state_explains_missing_service() -> None:
     assert "service not ready" in state.recovery_copy.lower()
 
 
+def test_console_scope_shows_readable_label_not_raw_uuid(tmp_path: Path) -> None:
+    """TASK-373/387: the rail Scope shows a human-readable label with the raw
+    conversation id kept as a hover detail, not the raw UUID in the primary row."""
+    service = _registry(tmp_path)
+    service.ensure_default_workspace()
+    conversation_id = "d1ebe478-c825-46b6-83b3-d5901d7bb3a1"
+
+    state = build_console_workspace_state(
+        registry_service=service,
+        current_conversation=conversation_id,
+    )
+
+    assert state.scope_label == "This conversation"
+    assert conversation_id not in state.scope_label
+    assert state.scope_detail == conversation_id
+
+    empty = build_console_workspace_state(
+        registry_service=service,
+        current_conversation=None,
+    )
+    assert empty.scope_label == ""
+    assert empty.scope_detail == ""
+
+
 def test_console_workspace_state_explains_no_active_workspace(tmp_path: Path) -> None:
     service = _registry(tmp_path)
     service.ensure_default_workspace()

--- a/backlog/tasks/task-373 - Stop-exposing-the-raw-conversation-UUID-as-the-rail-Scope-value.md
+++ b/backlog/tasks/task-373 - Stop-exposing-the-raw-conversation-UUID-as-the-rail-Scope-value.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-373
 title: Stop exposing the raw conversation UUID as the rail Scope value
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-20 14:21'
 labels: [console, ux]
 dependencies: []
@@ -25,6 +26,18 @@ Also observed independently in J6 keyboard-only/small-terminal as `j6-scope-raw-
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Human-readable scope ('This conversation') or omit
-- [ ] #2 Keep identifiers in a debug/details view
+- [x] #1 Human-readable scope ('This conversation') or omit
+- [x] #2 Keep identifiers in a debug/details view
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+`build_console_workspace_state` set `scope_label = str(current_conversation or "")`
+— the raw conversation UUID, wrapped mid-token across two rail lines. Now the
+label is "This conversation" (or "" when none), and the raw id is carried in a
+new `scope_detail` field surfaced only as the Scope row's hover tooltip
+("Conversation id: <uuid>") — human-readable primary row, identifier in a details
+view. RED->GREEN `test_console_scope_shows_readable_label_not_raw_uuid`; 63 tests
+green. (Also resolves the Scope-UUID part of task-387.)
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-375 - Improve-tab-label-truncation-add-ellipsis-and-avoid-cryptic-fragments.md
+++ b/backlog/tasks/task-375 - Improve-tab-label-truncation-add-ellipsis-and-avoid-cryptic-fragments.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-375
 title: Improve tab-label truncation - add ellipsis and avoid cryptic fragments
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-20 14:21'
 labels: [console, ux]
 dependencies: []
@@ -23,6 +24,21 @@ Resumed conversations open tabs labelled with ~9-14 characters of the title and 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Truncated tab labels always show a visible truncation mark ('…') so a fragment is never mistaken for the full title
-- [ ] #2 Labels are wide enough (or middle-truncated) to preserve distinguishing words between similarly-named conversations
+- [x] #1 Truncated tab labels always show a visible truncation mark ('…') so a fragment is never mistaken for the full title
+- [x] #2 Labels are wide enough (or middle-truncated) to preserve distinguishing words between similarly-named conversations
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The end-truncation ('...') was defeated by the tab Button's word-wrap (height-1
+showed only the first word, never the mark). Fix: `_display_title` now
+MIDDLE-truncates with a single-cell ellipsis ('Long conv…local RAG'), so the mark
+sits early in the label (well inside the 21-cell button) and the distinguishing
+words at BOTH ends survive — two titles sharing a first word are no longer the
+same fragment. `ConsoleSessionTabButton` gains `text-wrap: nowrap` so the label
+renders on one line instead of wrapping the ellipsis off-screen. Verified via a
+themed SVG screenshot (all tabs render one line with a visible …). RED->GREEN
+pure test + updated the mounted label-region test; the full title stays in the
+tab tooltip. 2 tests green.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-387 - Remove-internal-jargon-from-first-run-surfaces.md
+++ b/backlog/tasks/task-387 - Remove-internal-jargon-from-first-run-surfaces.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-387
 title: Remove internal jargon from first-run surfaces
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-20 14:21'
 labels: [console, ux]
 dependencies: []
@@ -23,6 +24,32 @@ User-facing copy includes 'api_settings.llama_cpp.api_url=http://...', 'LLAMA_CP
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 First-run copy in user vocabulary ('Endpoint', 'API key: not needed', 'Test failed: connection refused')
-- [ ] #2 Internal decision-record IDs and UUIDs kept out of primary UI or behind a details view
+- [x] #1 First-run copy in user vocabulary ('Endpoint', 'API key: not needed', 'Test failed: connection refused')
+- [x] #2 Internal decision-record IDs and UUIDs kept out of primary UI or behind a details view
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Targeted the first-run jargon the verifier flagged, staying inside the caveat
+("target the toast/detail/row copy and the Scope UUID, not config-path language
+wholesale").
+
+AC#1 (user vocabulary): the model-discovery selection rows read
+'gemma-4.gguf · session · discovered · capabilities unknown' instead of the
+enum dump 'gemma-4.gguf | runtime | runtime_discovered | capability=unknown'
+(source enum -> discovered/discovered (cached)/saved; persisted 'runtime' ->
+'session'; 'capability=X' -> 'capabilities X'). The provider-Test *detail* line's
+'status=ready/blocked' + config-path tokens were deliberately left: they are a
+tested TASK-366 diagnostic contract (asserted in 5 places), and the user-facing
+TOAST ('Provider test failed: <message>') plus the app's existing
+'API key: not required for this provider' copy already read in plain language.
+
+AC#2 (no internal ids/UUIDs in primary UI): the raw conversation-UUID Scope
+label was already humanized to 'This conversation' (id on hover) by task-373;
+here the 'Automatic refresh (ADR-020)' Settings heading drops the decision-record
+id to plain 'Automatic refresh' (the id survives in the code comment).
+
+RED->GREEN unit test on the discovery-row label vocabulary. settings_screen.py
+only.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-390 - Explain-or-hide-the-footer-memory-stat-abbreviations.md
+++ b/backlog/tasks/task-390 - Explain-or-hide-the-footer-memory-stat-abbreviations.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-390
 title: Explain or hide the footer memory-stat abbreviations
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-20 14:21'
 labels: [console, ux]
 dependencies: []
@@ -23,5 +24,17 @@ The status bar of the very first screen shows single-letter memory/storage stats
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Spell out or tooltip the abbreviations, or hide diagnostics behind a debug toggle on first-run
+- [x] #1 Spell out or tooltip the abbreviations, or hide diagnostics behind a debug toggle on first-run
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Kept the compact footer stats (they compete with key hints, so widening them is
+the wrong trade) and made them decodable on hover: the DB-size Static now carries
+a static legend tooltip -- 'Local database file sizes / P: Prompts   C/N:
+Conversations & Notes   M: Media'. The abbreviations were never wrong, only
+undocumented; a hover legend spells every letter out without stealing footer
+width. RED->GREEN test asserts the tooltip contains the spelled-out terms and the
+word 'size'. AppFooterStatus.py only.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -5322,10 +5322,20 @@ class SettingsScreen(BaseAppScreen):
                 continue
             source = str(getattr(model, "source", "runtime_discovered"))
             capability = str(getattr(model, "capability_status", "unknown"))
-            persisted = (
-                "saved" if bool(getattr(model, "persisted", False)) else "runtime"
+            # TASK-387: humanize the row so a first-run user can read it instead
+            # of decoding internal enum names (runtime_discovered / capability=…).
+            saved_label = (
+                "saved" if bool(getattr(model, "persisted", False)) else "session"
             )
-            label = f"{model_id} | {persisted} | {source} | capability={capability}"
+            source_label = {
+                "runtime_discovered": "discovered",
+                "persisted_discovered": "discovered (cached)",
+                "saved": "saved",
+            }.get(source, source.replace("_", " "))
+            capability_label = f"capabilities {capability}"
+            label = (
+                f"{model_id} · {saved_label} · {source_label} · {capability_label}"
+            )
             options.append(
                 (
                     label,
@@ -6743,7 +6753,9 @@ class SettingsScreen(BaseAppScreen):
             # inline from the saved config (the Connect block pattern) and
             # persist immediately on change via the handlers below.
             model_catalog_settings = load_model_catalog_settings(load_settings())
-            yield Static("Automatic refresh (ADR-020)", classes="destination-section")
+            # TASK-387: keep the internal decision-record id (ADR-020) out of the
+            # user-facing heading; it survives in the code comment above.
+            yield Static("Automatic refresh", classes="destination-section")
             yield Checkbox(
                 "Auto-refresh model lists on startup",
                 value=model_catalog_settings.auto_refresh_enabled,

--- a/tldw_chatbook/Widgets/AppFooterStatus.py
+++ b/tldw_chatbook/Widgets/AppFooterStatus.py
@@ -85,6 +85,12 @@ class AppFooterStatus(Widget):
             "Tokens: -- | ", id="footer-token-count"
         )
         self._db_status_display: Static = Static("", id="internal-db-size-indicator")
+        # The stats read as cryptic single letters (P: / C/N: / M:); a hover
+        # legend spells them out so a first-run user can decode them.
+        self._db_status_display.tooltip = (
+            "Local database file sizes\n"
+            "P: Prompts   C/N: Conversations & Notes   M: Media"
+        )
 
     def compose(self) -> ComposeResult:
         yield self._shortcut_display

--- a/tldw_chatbook/Widgets/Console/console_session_surface.py
+++ b/tldw_chatbook/Widgets/Console/console_session_surface.py
@@ -56,6 +56,15 @@ class ConsoleSessionTabButton(Button):
     button and stops the event, so the middle-click path must live here.
     """
 
+    # TASK-375: keep the (middle-truncated) label on one line so its ellipsis
+    # renders instead of being word-wrapped onto a hidden second row.
+    DEFAULT_CSS = """
+    ConsoleSessionTabButton {
+        text-wrap: nowrap;
+        text-overflow: clip;
+    }
+    """
+
     def __init__(self, *args: Any, session_id: str, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._session_id = session_id
@@ -136,12 +145,25 @@ class ConsoleSessionSurface(Vertical):
 
     @classmethod
     def _display_title(cls, title: str) -> str:
-        """Return a tab label that preserves space for close/rename controls."""
+        """Return a tab label that preserves space for close/rename controls.
+
+        TASK-375: middle-truncate with a single-cell ellipsis rather than an
+        end "...". The old end-truncation was defeated by the tab button's
+        word-wrap (height-1 showed only the first word, never the mark); a
+        middle ellipsis sits early in the label (well inside the button width),
+        so with the button's nowrap it is always visible, and it preserves the
+        distinguishing words at BOTH ends so two conversations sharing a first
+        word are not reduced to the same fragment.
+        """
         normalized_title = title.strip() or "Untitled"
         if len(normalized_title) <= CONSOLE_SESSION_TAB_DISPLAY_CHARS:
             return normalized_title
-        visible_chars = CONSOLE_SESSION_TAB_DISPLAY_CHARS - 3
-        return f"{normalized_title[:visible_chars].rstrip()}..."
+        keep = CONSOLE_SESSION_TAB_DISPLAY_CHARS - 1  # room for the ellipsis cell
+        head = (keep + 1) // 2
+        tail = keep - head
+        head_text = normalized_title[:head].rstrip()
+        tail_text = normalized_title[len(normalized_title) - tail:].lstrip()
+        return f"{head_text}…{tail_text}"
 
     def _build_session_tab_button(
         self,

--- a/tldw_chatbook/Widgets/Console/console_workspace_context.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_context.py
@@ -776,13 +776,18 @@ class ConsoleWorkspaceContextTray(Vertical):
             )
 
         scope_value = self.state.scope_label or ""
-        yield ConsoleWorkspaceStatusPair(
+        scope_pair = ConsoleWorkspaceStatusPair(
             "Scope",
             scope_value,
             label_id="console-active-scope-label",
             value_id="console-active-scope-value",
             id="console-active-scope",
         )
+        # TASK-373 AC#2: keep the raw conversation identifier available on hover
+        # rather than in the primary row.
+        if self.state.scope_detail:
+            scope_pair.tooltip = f"Conversation id: {self.state.scope_detail}"
+        yield scope_pair
 
         if self.state.recovery_copy:
             yield self._static(

--- a/tldw_chatbook/Workspaces/display_state.py
+++ b/tldw_chatbook/Workspaces/display_state.py
@@ -213,6 +213,9 @@ class ConsoleWorkspaceContextState:
     recovery_copy: str
     workspace_name: str = ""
     scope_label: str = ""
+    #: TASK-373: raw conversation identifier kept out of the primary Scope row,
+    #: surfaced only as a hover detail.
+    scope_detail: str = ""
     new_workspace_enabled: bool = False
     #: Whether the workspace-level RAG retrieval-scope affordance (task-13)
     #: should be enabled. ``True`` only when the active workspace is a real
@@ -293,7 +296,11 @@ def build_console_workspace_state(
         Renderable Console workspace context state.
     """
 
-    scope_label = str(current_conversation or "")
+    # TASK-373/387: the rail Scope row showed the raw conversation UUID (no user
+    # meaning, wrapped mid-token across two lines). Show a human-readable label
+    # and keep the identifier as a hover detail (below), not in the primary row.
+    scope_label = "This conversation" if current_conversation else ""
+    scope_detail = str(current_conversation or "")
     if registry_service is None:
         acp_state = _acp_handoff_state(acp_handoff_state)
         return ConsoleWorkspaceContextState(
@@ -301,6 +308,7 @@ def build_console_workspace_state(
             workspace_label="No workspace selected",
             workspace_name="",
             scope_label=scope_label,
+            scope_detail=scope_detail,
             new_workspace_enabled=False,
             authority_label="Authority: unavailable",
             sync_label="Sync: unavailable",
@@ -336,6 +344,7 @@ def build_console_workspace_state(
             workspace_label="No workspace selected",
             workspace_name="",
             scope_label=scope_label,
+            scope_detail=scope_detail,
             new_workspace_enabled=False,
             authority_label="Authority: unavailable",
             sync_label="Sync: unavailable",
@@ -368,6 +377,7 @@ def build_console_workspace_state(
             workspace_label="Workspace: Local Default",
             workspace_name="Local Default",
             scope_label=scope_label,
+            scope_detail=scope_detail,
             new_workspace_enabled=True,
             authority_label="Authority: local registry ready",
             sync_label="Sync: not configured",
@@ -413,6 +423,7 @@ def build_console_workspace_state(
         workspace_label=f"Workspace: {active_workspace.name}",
         workspace_name=active_workspace.name,
         scope_label=scope_label,
+            scope_detail=scope_detail,
         new_workspace_enabled=True,
         rag_scope_enabled=True,
         authority_label=f"Authority: {active_workspace.authority.value}",


### PR DESCRIPTION
## Summary

First P3 (comprehension/trust polish) cluster from the Console UX expert review 2026-07-20. Four self-contained copy/decodability fixes on new-user-visible surfaces — no behavior changes, no schema/CSS-bundle touch.

| Task | Fix |
|------|-----|
| **373** | Rail **Scope** row now reads `This conversation` (raw conversation UUID moved to the hover tooltip) instead of `Scope b7c3bdfb-99c9-…`. |
| **375** | Session **tab labels** middle-truncate with a visible single-cell ellipsis (`Long conv…local RAG`) — the old end-`...` was word-wrapped off the height-1 button, so long titles showed only their first word with no truncation mark. Adds `text-wrap: nowrap`. Full title stays in the tab tooltip. |
| **387** | Model-discovery selection rows read `gemma-4.gguf · session · discovered · capabilities unknown` instead of the enum dump `… | runtime | runtime_discovered | capability=unknown`; Settings heading `Automatic refresh (ADR-020)` → `Automatic refresh` (decision-record id kept in a code comment). |
| **390** | Footer `P: … | C/N: … | M: …` DB-size stats gain a decode-legend **tooltip** (`Local database file sizes / P: Prompts   C/N: Conversations & Notes   M: Media`) rather than being widened — they already compete with the key hints for footer width. |

## Scope notes (verifier caveats honored)
- **387** deliberately leaves the provider-**Test** detail line's `status=ready/blocked` + config-path tokens: they're a **tested TASK-366 diagnostic contract** (asserted in 5 places) and the user-facing **toast** (`Provider test failed: <message>`) + the app's existing `API key: not required for this provider` copy already read in plain language. The review's "not config-path language wholesale" caveat is respected.
- **373 + 387-AC#2** together close the Scope-UUID finding (373 humanizes it; 387 removes the ADR-020 id).

## Tests
TDD RED→GREEN per task:
- `test_console_scope_shows_readable_label_not_raw_uuid` (373)
- `test_console_tab_label_middle_truncates_with_visible_ellipsis` + updated mounted label-region test (375)
- `test_discovery_row_labels_use_user_vocabulary_not_internal_jargon` (387)
- `test_footer_db_size_stats_expose_decode_legend_tooltip` (390)

All affected suites green (`test_settings_provider_test_draft.py` 24 passed incl. the untouched TASK-366 `status=` contract; footer suite 4 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished first‑run Console copy and labels for better readability, with no behavior changes. Humanizes the rail Scope, fixes tab truncation, clarifies discovery rows, and adds a footer legend.

- **Bug Fixes**
  - Rail Scope now shows "This conversation"; raw UUID moved to a hover tooltip. (Tasks 373, 387)
  - Session tab labels middle‑truncate with a single‑cell ellipsis and `nowrap`; full title stays in the tooltip. (Task 375)
  - Model discovery rows use plain language: "session", "discovered", "capabilities unknown"; Settings heading drops the ADR id. (Task 387)
  - Footer DB‑size stats add a tooltip explaining P/C/N/M abbreviations. (Task 390)

<sup>Written for commit dbc38d295b7cff3e3370d58727a70c5682cda136. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

