### PR TITLE
chore(backlog): resolve duplicate task-487 (SP2b → 502)

### DIFF
--- a/backlog/tasks/task-495 - Merge-legacy-query-time-RAG-keys-into-the-first-run-Imported-settings-profile.md
+++ b/backlog/tasks/task-495 - Merge-legacy-query-time-RAG-keys-into-the-first-run-Imported-settings-profile.md
@@ -11,7 +11,7 @@ labels:
   - profiles
   - followup
 dependencies:
-  - task-487
+  - task-502
 priority: low
 ---
 

--- a/backlog/tasks/task-502 - RAG-settings-profiles-SP2b-config-resolution-unification.md
+++ b/backlog/tasks/task-502 - RAG-settings-profiles-SP2b-config-resolution-unification.md
@@ -1,8 +1,8 @@
 ---
-id: TASK-487
+id: TASK-502
 title: >-
   RAG settings + profiles SP2b: config-resolution unification onto the active profile
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-23 00:00'
 updated_date: '2026-07-23 00:00'


### PR DESCRIPTION
`task-487` landed twice on dev (backlog CLI resolves by id → ambiguous):
- `task-487 - Add collapsible Console composer reading mode` — status **Done** (@codex), renumbered into 487, no dependents.
- `task-487 - RAG SP2b config-resolution unification` — created earlier (00:00), merged as **PR #795**, depended on by **task-495**.

Per the collision rule (the Done task keeps its id; the not-started task moves), this moves the **SP2b** task to **502** (and marks it **Done**, since #795 merged) and repoints `task-495`'s dependency `487 → 502`. The composer task keeps 487. Dup-check: no duplicate ids remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate backlog ID `task-487` by moving the SP2b config-unification task to `task-502` and marking it Done. Keeps the composer task as `task-487` and updates dependent links.

- **Bug Fixes**
  - Renamed SP2b task file to `task-502 - RAG-settings-profiles-SP2b-config-resolution-unification.md`, set `id: TASK-502` and `status: Done` (PR #795 merged).
  - Updated `task-495` dependency from `task-487` to `task-502`.

<sup>Written for commit 3075ef4c4ee7ce9665a8cafed0bb94e3688f41b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

