### PR TITLE
Console conversation branching — Phase B (Edit & resend user branching)

### DIFF
--- a/Docs/superpowers/plans/2026-07-23-console-branching-phase-b.md
+++ b/Docs/superpowers/plans/2026-07-23-console-branching-phase-b.md
@@ -1,0 +1,172 @@
+# Console Conversation Branching — Phase B Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Let a user edit a past **user** message and re-send it, forking a new branch from that point — the "Edit & resend" half of the branching foundation (Phase A shipped assistant regenerate-branching).
+
+**Architecture:** Reuse Phase A's tree entirely. Editing-and-resending a user message U with new text T calls the existing role-parameterized `store.create_sibling(U.id, role=USER, content=T)` (a sibling of U under U's parent; U's old subtree is preserved off-path), then streams an assistant reply under the new user node via the existing streaming path. The `<`/`>` swipe + `n/m` counter are already role-generic (Phase A Task 7 gates on `sibling_count > 1`), so user-message branches navigate with no new UI. The only genuinely new surface is the edit modal's **"Edit & resend"** affordance and a controller `edit_and_resend_message` method modeled on `regenerate_message`.
+
+**Tech Stack:** Python ≥3.11, Textual, SQLite (ChaChaNotes), pytest.
+
+## Global Constraints
+
+- **Spec:** `Docs/superpowers/specs/2026-07-22-console-conversation-branching-foundation-design.md` (Phase B section + decision **D1**: in-place "Edit" stays; branching is an *explicit* "Edit & resend"). Do not change assistant regenerate (Phase A) or start Phase C (agent markers).
+- **In-place edit must remain unchanged** for the plain "Save" path (`update_message_content`). "Edit & resend" is an additional, explicit choice — never the default.
+- **Reuse, don't reinvent:** `store.create_sibling(anchor_message_id, *, role, content="", persist=False)` already exists and is role-parameterized. `regenerate_message` (assistant) is the structural template. Do NOT add a parallel branching path.
+- **Persist correctly:** pass `persist=self.store.persistence is not None` to `create_sibling` and to any appended assistant node (the Phase A Task-6 lesson — an unpersisted branch vanishes on resume).
+- **Failure semantics** match regenerate: a failed/empty resend leaves a retryable `failed` assistant node on the new branch; the old branch is reachable by swiping back.
+- **Tests:** real in-memory SQLite / real store+controller (existing harnesses), not mocks. Run via `./.venv/bin/python -m pytest`. Baseline: `Tests/Chat/test_anthropic_native_tools.py` and `test_chat_functions.py` carry pre-existing unrelated failures — ignore.
+- **Style/commits:** match surrounding code; commit after each task; end commit messages with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+## File Structure
+
+- **Modify** `tldw_chatbook/Widgets/Console/console_edit_message_modal.py` — widen the dismiss contract; add an "Edit & resend" button shown only for user messages.
+- **Modify** `tldw_chatbook/Chat/console_chat_controller.py` — add `edit_and_resend_message(message_id, new_content)`.
+- **Modify** `tldw_chatbook/UI/Screens/chat_screen.py` — `_open_console_message_edit_modal` passes `can_resend`; `_apply_edit` branches in-place-save vs edit-&-resend (worker, like regenerate).
+- **Add tests** under `Tests/Chat/` and `Tests/integration/`.
+
+Two facts (verified on this base):
+- Edit modal is `ModalScreen[str | None]`; Save dismisses the text, Cancel dismisses `None`; it has a `_EditMessageTextArea` stale-key guard (TASK-360) — preserve it.
+- `_apply_edit` (chat_screen.py ~:12972) currently does `store.update_message_content(message_id, result)` in place. `regenerate_message` (controller ~:1243) does `create_sibling(role=ASSISTANT)` → `_provider_messages_for_session(before_message_id=...)` → `_stream_assistant_response(variant_mode=False)`.
+
+---
+
+### Task 1: Widen the edit modal + add "Edit & resend" (user messages only)
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Console/console_edit_message_modal.py`
+- Test: `Tests/Chat/test_console_edit_message_modal.py`
+
+**Interfaces:**
+- Produces: a result type `ConsoleEditResult` (frozen dataclass: `text: str`, `resend: bool`) and `ConsoleEditMessageModal(ModalScreen[ConsoleEditResult | None])` taking a new kwarg `can_resend: bool = False`. Cancel/Escape → `None`. "Save" → `ConsoleEditResult(text, resend=False)`. "Edit & resend" (only rendered when `can_resend`) → `ConsoleEditResult(text, resend=True)`. Blank text still blocked inline on both actions.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# Tests/Chat/test_console_edit_message_modal.py
+from tldw_chatbook.Widgets.Console.console_edit_message_modal import (
+    ConsoleEditMessageModal, ConsoleEditResult,
+)
+
+def test_edit_result_dataclass_shape():
+    r = ConsoleEditResult(text="hi", resend=True)
+    assert (r.text, r.resend) == ("hi", True)
+
+def test_modal_accepts_can_resend_kwarg():
+    # construction only (no mount) — the resend button is gated on can_resend
+    m = ConsoleEditMessageModal(content="orig", can_resend=True)
+    assert m._can_resend is True
+    m2 = ConsoleEditMessageModal(content="orig")
+    assert m2._can_resend is False
+```
+
+- [ ] **Step 2: Run to verify it fails** — `./.venv/bin/python -m pytest Tests/Chat/test_console_edit_message_modal.py -v` → FAIL (`ConsoleEditResult` undefined / no `can_resend`).
+
+- [ ] **Step 3: Implement.** Add the frozen dataclass; change the generic type to `ConsoleEditResult | None`; add `can_resend` to `__init__` (store `self._can_resend`); in `compose`, when `self._can_resend`, yield a third button `Button("Edit & resend", id="console-edit-message-resend", variant="primary")` (make plain "Save" `variant="default"` when resend is present, per surrounding style); update the context Static copy to mention the resend option only when `can_resend`. Add `@on(Button.Pressed, "#console-edit-message-resend")` mirroring `_save`'s blank-check but dismissing `ConsoleEditResult(text, resend=True)`; change `_save` to dismiss `ConsoleEditResult(text, resend=False)`; `action_dismiss`/`_cancel` dismiss `None`. Keep the `_EditMessageTextArea` stale-key guard untouched, and give the new button width in DEFAULT_CSS.
+
+- [ ] **Step 4: Run to verify it passes** (+ add a mounted `run_test` pilot assertion if the existing modal tests use one — mirror them).
+
+- [ ] **Step 5: Commit** — `feat(console): edit modal gains an "Edit & resend" option`.
+
+---
+
+### Task 2: Controller `edit_and_resend_message`
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py`
+- Test: `Tests/Chat/test_console_edit_resend.py`
+
+**Interfaces:**
+- Consumes: `store.create_sibling`, `_provider_messages_for_session`, `_stream_assistant_response`, the existing skill/dictionary/world-info/prefill transforms used by `regenerate_message`.
+- Produces: `async edit_and_resend_message(message_id: str, new_content: str) -> ConsoleSubmitResult`.
+
+Behavior (mirror `regenerate_message`, but for a USER anchor and creating BOTH a user sibling and its reply):
+1. Active-run rejection gate; resolve session; block if `message_id` is not a USER message ("Only your messages can be edited and re-sent.").
+2. `_validated_draft(new_content)`-style non-blank guard; block on empty.
+3. `_set_run_state(VALIDATING…)`; `resolution = await self.provider_gateway.resolve_for_send(self._provider_selection())`; block if not ready.
+4. `new_user = self.store.create_sibling(message_id, role=ConsoleMessageRole.USER, content=new_content, persist=self.store.persistence is not None)` — new_user becomes the active leaf; U's old subtree is off-path.
+5. `assistant = self.store.append_message(session_id, role=ConsoleMessageRole.ASSISTANT, content="", persist=self.store.persistence is not None)` — parented at new_user (the active leaf), becomes the new active leaf.
+6. `provider_messages = self._provider_messages_for_session(session_id, before_message_id=assistant.id)` — the active path up to but excluding the empty assistant = history + the edited user prompt.
+7. Apply the same `_apply_skill_substitution` / `_apply_chat_dictionaries` / `_apply_world_info` / `_pinned_prefill_for_session` steps `regenerate_message` applies (block on skill refusal).
+8. `return await self._stream_assistant_response(resolution=resolution, provider_messages=provider_messages, assistant_message_id=assistant.id, variant_mode=False, prefill=prefill)`.
+
+> Confirm ordering against `regenerate_message`: create the tree nodes only AFTER the block checks (Phase A Task-6 lesson — a blocked resend must leave no orphan sibling). If a blocked path is reached after `create_sibling`, that is acceptable only if it matches regenerate's own post-fork behavior; prefer gating before the fork.
+
+- [ ] **Step 1: Write the failing test** (controller-level, reuse the fake provider/gateway harness from `Tests/Chat/test_console_regenerate_branching.py` / `test_console_chat_controller.py`):
+
+```
+# contract:
+# after edit_and_resend_message(u1.id, "edited"):
+#   - u1's parent now has TWO user children (u1 and the new sibling)
+#   - the new user sibling's content == "edited", and it is on the active path
+#   - an assistant reply node exists under the new user sibling with the streamed text
+#   - u1 (and any old tail under it) still exist off the active path
+#   - a non-USER message id is rejected (blocked)
+```
+
+- [ ] **Step 2: Run RED.**
+- [ ] **Step 3: Implement** per the behavior above.
+- [ ] **Step 4: Run GREEN** + `./.venv/bin/python -m pytest Tests/Chat/ -k "controller or regenerate or edit_resend or sibling" -q`.
+- [ ] **Step 5: Commit** — `feat(console): edit_and_resend forks a user-message branch`.
+
+---
+
+### Task 3: Screen wiring — branch in-place-save vs edit-&-resend
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` (`_open_console_message_edit_modal` ~:12966, `_apply_edit` ~:12972)
+- Test: extend an existing chat_screen console test or add `Tests/UI/test_console_edit_resend_wiring.py`
+
+**Interfaces:**
+- Consumes: `ConsoleEditResult`, `controller.edit_and_resend_message`, the existing worker pattern used for regenerate (`run_worker(..., exclusive=True, group="console-run")`).
+
+- [ ] **Step 1: Write the failing test** — assert that dismissing the modal with `resend=True` routes to `edit_and_resend_message` (spy/fake controller) and with `resend=False` routes to `store.update_message_content` (existing in-place path), and that the modal is opened with `can_resend=True` only for a USER message.
+
+- [ ] **Step 2: Run RED.**
+
+- [ ] **Step 3: Implement.**
+- `_open_console_message_edit_modal(message_id, content)`: fetch the message; pass `can_resend = (message.role is ConsoleMessageRole.USER)` into `ConsoleEditMessageModal(content=content, can_resend=...)`.
+- `_apply_edit(result: ConsoleEditResult | None)`: `if result is None: return`. `if not result.resend:` → existing `store.update_message_content(message_id, result.text)` path (unchanged, incl. its ValueError/KeyError handling + notify). `else:` gate on `controller.run_state.is_send_allowed` (notify `CONSOLE_RUN_ALREADY_RUNNING_COPY` if not), then `self.run_worker(self._edit_resend_console_message(controller, message_id, result.text), exclusive=True, group="console-run")`. Add a small `_edit_resend_console_message` worker mirroring `_regenerate_console_message` (start the transcript sync timer, `await controller.edit_and_resend_message(...)`, notify on `not accepted`, `await self._sync_native_console_chat_ui()`).
+
+- [ ] **Step 4: Run GREEN** + console UI/chat_screen console suites.
+- [ ] **Step 5: Commit** — `feat(console): wire Edit & resend into the transcript edit flow`.
+
+---
+
+### Task 4: User-message sibling navigation (verify + close any assistant-only gap)
+
+The `<`/`>` + counter already gate on `sibling_count > 1` (Phase A Task 7), so a user message with siblings should show them. This task verifies the user-row path end-to-end and fixes any place that assumed siblings only exist on assistant rows.
+
+**Files:**
+- Test: `Tests/Chat/test_console_user_sibling_nav.py`
+- Modify (only if a gap is found): `tldw_chatbook/Chat/console_message_actions.py` / `tldw_chatbook/Widgets/Console/console_transcript.py` / the screen's `_select_console_message_variant`.
+
+- [ ] **Step 1: Write the test** — build two user siblings via `store.create_sibling(role=USER)`; assert `siblings_at` reports count 2 for the user node; assert `ConsoleMessageActionService.available_actions(user_msg_with_sibling_count_2)` includes `variant-previous`/`variant-next`; assert the counter renders on a user row; assert `_select_console_message_variant` moves the active leaf across the user siblings.
+- [ ] **Step 2: Run.** If it passes with no production change, record that (the role-generic gate already covers it). If it fails, fix the specific assistant-only assumption (Step 3), then re-run.
+- [ ] **Step 3 (conditional): Implement the fix** for whatever assistant-only assumption surfaced.
+- [ ] **Step 4: Commit** — `test(console): user-message sibling navigation` (or `fix(console): …` if a gap was closed).
+
+---
+
+### Task 5: End-to-end + regression
+
+**Files:**
+- Test: `Tests/integration/test_console_edit_resend_e2e.py`
+
+- [ ] **Step 1: Write the E2E** over real DB + store + controller (fake provider): send U1→A1; **edit U1 & resend** with new text → assert two user siblings under U1's parent, the new one active with its own assistant reply, U1's old subtree preserved off-path; swipe the user row `<`→ old branch (U1 + A1), `>` → new branch; persist→drop→resume → the active branch is restored (active-leaf pointer honored); in-place "Save" on a user message still edits in place (no new sibling).
+- [ ] **Step 2: Run + regression sweep** — `./.venv/bin/python -m pytest Tests/Chat/ Tests/UI/test_console_native_transcript.py Tests/integration/ -q`; call out that non-passing tests are the known pre-existing baseline files. Fix any integration bug surfaced (document prominently).
+- [ ] **Step 3: Commit** — `test(console): end-to-end edit-&-resend user branching`.
+
+---
+
+## Self-Review
+
+**Spec coverage (Phase B):** widen edit modal + "Edit & resend" (Task 1); controller resend that forks a user sibling + reply (Task 2); screen routing keeping in-place edit as default (Task 3); user-row swipe/counter (Task 4, mostly pre-existing); e2e incl. resume (Task 5). In-place edit unchanged for plain Save (Tasks 1/3). ✅
+
+**Placeholder scan:** Task 2/3 give the exact method behavior + interfaces + test contracts rather than full pasted bodies, because they are structural mirrors of the quoted `regenerate_message`/`_apply_edit`/`submit_draft` — the tests are the precise contract. Tasks 1/4/5 carry concrete code/contracts. No TBDs.
+
+**Type consistency:** `ConsoleEditResult(text: str, resend: bool)` used across Tasks 1/3; `edit_and_resend_message(message_id, new_content) -> ConsoleSubmitResult` across Tasks 2/3/5; `create_sibling(role=USER, persist=…)` per Global Constraints.
+
+**Known carry-forward (from Phase A, not Phase B's job):** the deferred-marker (task-498) and regenerate-failure-eviction (task-499) items also apply to a failed edit-&-resend (same node model) — no new work here, but Task 2's failure semantics should match regenerate so those follow-ups cover both.

--- a/Tests/Chat/test_console_edit_message_modal.py
+++ b/Tests/Chat/test_console_edit_message_modal.py
@@ -1,0 +1,150 @@
+"""TASK-1 (Console branching Phase B): the edit modal gains an explicit
+"Edit & resend" affordance alongside the existing in-place "Save".
+
+Construction-level tests are the minimum contract (per the task brief); a
+mounted `run_test` pilot assertion is added to mirror the existing modal
+suite's style (Tests/UI/test_console_edit_modal_keystroke_guard.py).
+"""
+
+import pytest
+from textual.app import App
+from textual.widgets import Button, Static, TextArea
+
+from tldw_chatbook.Widgets.Console.console_edit_message_modal import (
+    ConsoleEditMessageModal,
+    ConsoleEditResult,
+)
+
+
+def test_edit_result_dataclass_shape():
+    r = ConsoleEditResult(text="hi", resend=True)
+    assert (r.text, r.resend) == ("hi", True)
+
+
+def test_edit_result_is_frozen():
+    r = ConsoleEditResult(text="hi", resend=True)
+    with pytest.raises(Exception):
+        r.text = "changed"  # type: ignore[misc]
+
+
+def test_modal_accepts_can_resend_kwarg():
+    # construction only (no mount) — the resend button is gated on can_resend
+    m = ConsoleEditMessageModal(content="orig", can_resend=True)
+    assert m._can_resend is True
+    m2 = ConsoleEditMessageModal(content="orig")
+    assert m2._can_resend is False
+
+
+class _ModalHost(App):
+    pass
+
+
+def _static_plain_text(widget: Static) -> str:
+    renderable = widget.renderable
+    return getattr(renderable, "plain", str(renderable))
+
+
+@pytest.mark.asyncio
+async def test_modal_without_resend_has_no_resend_button():
+    app = _ModalHost()
+    async with app.run_test(size=(120, 40)) as pilot:
+        modal = ConsoleEditMessageModal(content="orig")
+        app.push_screen(modal)
+        await pilot.pause()
+
+        assert len(modal.query("#console-edit-message-resend")) == 0
+        save_button = modal.query_one("#console-edit-message-save", Button)
+        assert save_button.variant == "primary"
+
+
+@pytest.mark.asyncio
+async def test_modal_with_resend_shows_resend_button_and_demotes_save():
+    app = _ModalHost()
+    async with app.run_test(size=(120, 40)) as pilot:
+        modal = ConsoleEditMessageModal(content="orig", can_resend=True)
+        app.push_screen(modal)
+        await pilot.pause()
+
+        resend_button = modal.query_one("#console-edit-message-resend", Button)
+        assert resend_button.variant == "primary"
+        save_button = modal.query_one("#console-edit-message-save", Button)
+        assert save_button.variant == "default"
+
+
+@pytest.mark.asyncio
+async def test_save_dismisses_edit_result_with_resend_false():
+    app = _ModalHost()
+    result: list[ConsoleEditResult | None] = []
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        modal = ConsoleEditMessageModal(content="orig")
+        await app.push_screen(modal, callback=result.append)
+        await pilot.pause()
+
+        editor = modal.query_one("#console-edit-message-body", TextArea)
+        editor.text = "edited"
+        await pilot.click("#console-edit-message-save")
+        await pilot.pause()
+
+    assert result == [ConsoleEditResult(text="edited", resend=False)]
+
+
+@pytest.mark.asyncio
+async def test_resend_dismisses_edit_result_with_resend_true():
+    app = _ModalHost()
+    result: list[ConsoleEditResult | None] = []
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        modal = ConsoleEditMessageModal(content="orig", can_resend=True)
+        await app.push_screen(modal, callback=result.append)
+        await pilot.pause()
+
+        editor = modal.query_one("#console-edit-message-body", TextArea)
+        editor.text = "edited"
+        await pilot.click("#console-edit-message-resend")
+        await pilot.pause()
+
+    assert result == [ConsoleEditResult(text="edited", resend=True)]
+
+
+@pytest.mark.asyncio
+async def test_resend_blank_text_blocked_inline():
+    app = _ModalHost()
+    result: list[ConsoleEditResult | None] = []
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        modal = ConsoleEditMessageModal(content="orig", can_resend=True)
+        await app.push_screen(modal, callback=result.append)
+        await pilot.pause()
+
+        editor = modal.query_one("#console-edit-message-body", TextArea)
+        editor.text = "   "
+        await pilot.click("#console-edit-message-resend")
+        await pilot.pause()
+
+        assert result == []
+        error = modal.query_one("#console-edit-message-error", Static)
+        assert "cannot be blank" in _static_plain_text(error).lower()
+
+
+@pytest.mark.asyncio
+async def test_cancel_dismisses_none_even_with_resend_available():
+    app = _ModalHost()
+    result: list[ConsoleEditResult | None] = []
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        modal = ConsoleEditMessageModal(content="orig", can_resend=True)
+        await app.push_screen(modal, callback=result.append)
+        await pilot.pause()
+
+        await pilot.click("#console-edit-message-cancel")
+        await pilot.pause()
+
+    assert result == [None]
+
+
+def test_context_copy_mentions_resend_only_when_can_resend():
+    m_plain = ConsoleEditMessageModal(content="orig")
+    m_resend = ConsoleEditMessageModal(content="orig", can_resend=True)
+    assert m_plain._can_resend is False
+    assert m_resend._can_resend is True

--- a/Tests/Chat/test_console_edit_message_modal.py
+++ b/Tests/Chat/test_console_edit_message_modal.py
@@ -143,8 +143,27 @@ async def test_cancel_dismisses_none_even_with_resend_available():
     assert result == [None]
 
 
-def test_context_copy_mentions_resend_only_when_can_resend():
-    m_plain = ConsoleEditMessageModal(content="orig")
-    m_resend = ConsoleEditMessageModal(content="orig", can_resend=True)
-    assert m_plain._can_resend is False
-    assert m_resend._can_resend is True
+@pytest.mark.asyncio
+async def test_context_copy_mentions_resend_only_when_can_resend():
+    # can_resend=True: the context Static explains the resend fork option.
+    app = _ModalHost()
+    async with app.run_test(size=(120, 40)) as pilot:
+        modal = ConsoleEditMessageModal(content="orig", can_resend=True)
+        app.push_screen(modal)
+        await pilot.pause()
+        context = _static_plain_text(
+            modal.query_one("#console-edit-message-context", Static)
+        )
+        assert "Edit & resend" in context
+
+    # can_resend=False: the context Static uses the plain in-place copy only.
+    app_plain = _ModalHost()
+    async with app_plain.run_test(size=(120, 40)) as pilot:
+        modal_plain = ConsoleEditMessageModal(content="orig")
+        app_plain.push_screen(modal_plain)
+        await pilot.pause()
+        context_plain = _static_plain_text(
+            modal_plain.query_one("#console-edit-message-context", Static)
+        )
+        assert "Edit & resend" not in context_plain
+        assert "will not create a new prompt" in context_plain

--- a/Tests/Chat/test_console_edit_resend.py
+++ b/Tests/Chat/test_console_edit_resend.py
@@ -235,6 +235,47 @@ async def test_edit_and_resend_provider_not_ready_blocks_without_orphan_sibling(
 
 
 @pytest.mark.asyncio
+async def test_edit_and_resend_blocks_off_active_path_anchor():
+    """Qodo PR #811 finding 2: ``_provider_messages_for_session`` scans the
+    ACTIVE-PATH transcript until ``before_message_id`` is seen -- if the
+    anchor is not on the active path, that scan never breaks and the resend
+    payload would be built from the wrong branch. Edit is only exposed on
+    active-path rows today, but the controller must refuse a
+    directly-called off-path anchor rather than silently mis-building the
+    payload."""
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    session = store.ensure_session()
+    u1 = store.append_message(session.id, role=ConsoleMessageRole.USER, content="q1")
+    # Forking a sibling makes IT the new active leaf, leaving u1 off-path.
+    sibling = store.create_sibling(u1.id, role=ConsoleMessageRole.USER, content="q1-b")
+    assert store.active_leaf(session.id) == sibling.id
+    active_path_ids = store.active_path_message_ids(session.id)
+    assert u1.id not in active_path_ids
+    _siblings, _index, count_before = store.siblings_at(u1.id)
+    assert count_before == 2
+
+    result = await controller.edit_and_resend_message(u1.id, "edited")
+
+    assert result.accepted is False
+    assert (
+        "Switch to that branch before editing and re-sending this message."
+        in result.visible_copy
+    )
+    # No third sibling was forked, and no pending assistant node anywhere.
+    _siblings, _index, count_after = store.siblings_at(u1.id)
+    assert count_after == count_before
+    assert all(
+        m.status != "pending" for m in store.messages_for_session(session.id)
+    )
+    # u1 itself is untouched, and neither u1 nor the sibling gained a new
+    # USER/ASSISTANT child -- `_block` only appends a SYSTEM notice under
+    # the (unrelated) active leaf, same as every other block gate.
+    assert store.get_message(u1.id).content == "q1"
+    assert store.get_message(sibling.id).content == "q1-b"
+
+
+@pytest.mark.asyncio
 async def test_edit_and_resend_skill_refusal_leaves_no_pending_node():
     """Critical (Phase B Task 2 review): a skill-substitution refusal
     discovered while resending an edited message must not leave a stray

--- a/Tests/Chat/test_console_edit_resend.py
+++ b/Tests/Chat/test_console_edit_resend.py
@@ -1,0 +1,234 @@
+"""Controller-level tests for edit-and-resend-as-sibling (Phase B, Task 2).
+
+``edit_and_resend_message`` forks a NEW USER sibling branch alongside the
+edited message (``store.create_sibling``, mirroring how
+``regenerate_message`` forks assistant siblings) and appends a fresh empty
+ASSISTANT node under it to stream a reply into. The anchor USER message
+(and any old tail beneath it -- its prior assistant reply, and anything
+after it) is left untouched and simply drops off the active path.
+"""
+
+import pytest
+
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+
+
+class StreamingGateway:
+    async def resolve_for_send(self, selection):
+        return type(
+            "Resolution",
+            (),
+            {
+                "ready": True,
+                "provider": "llama_cpp",
+                "model": "test-model",
+                "base_url": "http://127.0.0.1:9099",
+                "visible_copy": "",
+            },
+        )()
+
+    async def stream_chat(self, resolution, messages):
+        for chunk in ("edi", "ted-reply"):
+            yield chunk
+
+
+class NotReadyGateway:
+    async def resolve_for_send(self, selection):
+        return type(
+            "Resolution",
+            (),
+            {
+                "ready": False,
+                "provider": "llama_cpp",
+                "model": "test-model",
+                "base_url": "http://127.0.0.1:9099",
+                "visible_copy": "WIP: provider offline",
+            },
+        )()
+
+    async def stream_chat(self, resolution, messages):  # pragma: no cover - unreachable
+        yield ""
+
+
+class _EditResendPersistence:
+    """Records create_message calls; hands back predictable ``msg-N`` ids.
+
+    Mirrors ``_RegeneratePersistence`` in
+    ``test_console_regenerate_branching.py``.
+    """
+
+    def __init__(self):
+        self.created_messages = []
+
+    def create_conversation(self, **kwargs):
+        return "conv-1"
+
+    def create_message(
+        self,
+        *,
+        conversation_id,
+        sender,
+        content,
+        image_data,
+        image_mime_type,
+        message_id=None,
+        parent_message_id=None,
+        feedback=None,
+    ):
+        pid = f"msg-{len(self.created_messages) + 1}"
+        self.created_messages.append(
+            {
+                "id": pid,
+                "conversation_id": conversation_id,
+                "sender": sender,
+                "content": content,
+                "parent_message_id": parent_message_id,
+            }
+        )
+        return pid
+
+    def update_message_content(self, **kwargs):
+        return True
+
+
+@pytest.mark.asyncio
+async def test_edit_and_resend_forks_user_sibling_and_streams_reply():
+    """Core contract: two USER children under u1's parent, new sibling active,
+    an assistant reply forked under it, and u1's old tail preserved off-path.
+    """
+    persistence = _EditResendPersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    session = store.create_session(title="t")
+    store.active_session_id = session.id
+    u1 = store.append_message(
+        session.id, role=ConsoleMessageRole.USER, content="original", persist=True
+    )
+    a1 = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content="original-reply", persist=True
+    )
+    persistence.created_messages.clear()
+
+    result = await controller.edit_and_resend_message(u1.id, "edited")
+
+    assert result.accepted is True
+
+    # u1's parent now has TWO user children (u1 and the new sibling).
+    siblings, _index, count = store.siblings_at(u1.id)
+    assert count == 2
+    sibling_ids = {s.id for s in siblings}
+    assert u1.id in sibling_ids
+
+    # The new sibling carries the edited content and is on the active path.
+    new_leaf_ancestor_ids = set(store.active_path_message_ids(session.id))
+    new_user_id = next(iter(sibling_ids - {u1.id}))
+    assert new_user_id in new_leaf_ancestor_ids
+    new_user = store.get_message(new_user_id)
+    assert new_user.content == "edited"
+    assert new_user.role is ConsoleMessageRole.USER
+    assert new_user.persisted_message_id is not None
+
+    # An assistant reply node exists under it with the streamed text, and is
+    # the new active leaf.
+    active_leaf_id = store.active_leaf(session.id)
+    assistant_reply = store.get_message(active_leaf_id)
+    assert assistant_reply.role is ConsoleMessageRole.ASSISTANT
+    assert assistant_reply.content == "edited-reply"
+    assert assistant_reply.status == "complete"
+    assert assistant_reply.persisted_message_id is not None
+
+    # u1 and its old tail (a1) are preserved, untouched, off the active path.
+    assert store.get_message(u1.id).content == "original"
+    assert store.get_message(a1.id).content == "original-reply"
+    active_path_ids = store.active_path_message_ids(session.id)
+    assert u1.id not in active_path_ids
+    assert a1.id not in active_path_ids
+    assert active_path_ids == [new_user_id, active_leaf_id]
+
+    # The old branch is still reachable by swiping back.
+    store.set_active_leaf(session.id, a1.id)
+    assert store.active_path_message_ids(session.id) == [u1.id, a1.id]
+
+
+@pytest.mark.asyncio
+async def test_edit_and_resend_mid_conversation_preserves_rest_of_old_branch():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    session = store.ensure_session()
+    u1 = store.append_message(session.id, role=ConsoleMessageRole.USER, content="q1")
+    a1 = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content="a1-seed"
+    )
+    u2 = store.append_message(session.id, role=ConsoleMessageRole.USER, content="q2")
+    a2 = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content="a2-seed"
+    )
+
+    result = await controller.edit_and_resend_message(u1.id, "edited q1")
+
+    assert result.accepted is True
+    active_path_ids = store.active_path_message_ids(session.id)
+    assert len(active_path_ids) == 2
+    new_user_id, new_assistant_id = active_path_ids
+    assert store.get_message(new_user_id).content == "edited q1"
+    assert store.get_message(new_assistant_id).content == "edited-reply"
+
+    # The entire old branch (a1, u2, a2) is preserved off-path.
+    assert store.get_message(a1.id).content == "a1-seed"
+    assert store.get_message(u2.id).content == "q2"
+    assert store.get_message(a2.id).content == "a2-seed"
+    store.set_active_leaf(session.id, a2.id)
+    assert store.active_path_message_ids(session.id) == [u1.id, a1.id, u2.id, a2.id]
+
+
+@pytest.mark.asyncio
+async def test_edit_and_resend_blocks_non_user_message():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    session = store.ensure_session()
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="Hi")
+    a1 = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content="seed"
+    )
+
+    result = await controller.edit_and_resend_message(a1.id, "edited")
+
+    assert result.accepted is False
+    assert "Only your messages can be edited and re-sent." in result.visible_copy
+    # No sibling was created: a1 still has no siblings at all.
+    siblings, _index, count = store.siblings_at(a1.id)
+    assert count == 1
+    assert store.get_message(a1.id).content == "seed"
+
+
+@pytest.mark.asyncio
+async def test_edit_and_resend_blank_content_blocks_without_mutating_tree():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    session = store.ensure_session()
+    u1 = store.append_message(session.id, role=ConsoleMessageRole.USER, content="Hi")
+
+    result = await controller.edit_and_resend_message(u1.id, "   ")
+
+    assert result.accepted is False
+    siblings, _index, count = store.siblings_at(u1.id)
+    assert count == 1
+    assert store.get_message(u1.id).content == "Hi"
+
+
+@pytest.mark.asyncio
+async def test_edit_and_resend_provider_not_ready_blocks_without_orphan_sibling():
+    """Phase A Task-6 lesson: a blocked resend must leave no orphan sibling."""
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=NotReadyGateway())
+    session = store.ensure_session()
+    u1 = store.append_message(session.id, role=ConsoleMessageRole.USER, content="Hi")
+
+    result = await controller.edit_and_resend_message(u1.id, "edited")
+
+    assert result.accepted is False
+    siblings, _index, count = store.siblings_at(u1.id)
+    assert count == 1
+    assert store.get_message(u1.id).content == "Hi"

--- a/Tests/Chat/test_console_edit_resend.py
+++ b/Tests/Chat/test_console_edit_resend.py
@@ -232,3 +232,46 @@ async def test_edit_and_resend_provider_not_ready_blocks_without_orphan_sibling(
     siblings, _index, count = store.siblings_at(u1.id)
     assert count == 1
     assert store.get_message(u1.id).content == "Hi"
+
+
+@pytest.mark.asyncio
+async def test_edit_and_resend_skill_refusal_leaves_no_pending_node():
+    """Critical (Phase B Task 2 review): a skill-substitution refusal
+    discovered while resending an edited message must not leave a stray
+    ``pending`` ASSISTANT node forked into the tree.
+
+    Before the fix, ``new_user``/``assistant`` were created BEFORE the
+    skill-substitution check ran, so a refusal returned ``_block(...)``
+    while the empty ``assistant`` node was already on the active path --
+    it never streams (so it never becomes ``"failed"``), and
+    ``retry_message`` requires ``"failed"``, so it was permanently stuck
+    tree litter. The fix builds and transforms the provider payload FIRST
+    and only creates ``new_user``/``assistant`` after every transform
+    (including skill substitution) has succeeded, mirroring
+    ``regenerate_message``'s "mutate last" discipline.
+    """
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    session = store.ensure_session()
+    u1 = store.append_message(session.id, role=ConsoleMessageRole.USER, content="original")
+
+    async def _refuse(provider_messages):
+        return provider_messages, "Skill refused for testing.", ()
+
+    controller._apply_skill_substitution = _refuse
+
+    result = await controller.edit_and_resend_message(u1.id, "edited")
+
+    assert result.accepted is False
+    assert result.visible_copy == "Skill refused for testing."
+
+    # No new USER sibling was forked: u1 still has no siblings at all.
+    siblings, _index, count = store.siblings_at(u1.id)
+    assert count == 1
+    assert store.get_message(u1.id).content == "original"
+
+    # No pending assistant node anywhere on the active path (or off it --
+    # nothing was ever created).
+    assert all(
+        m.status != "pending" for m in store.messages_for_session(session.id)
+    )

--- a/Tests/Chat/test_console_user_sibling_nav.py
+++ b/Tests/Chat/test_console_user_sibling_nav.py
@@ -1,0 +1,216 @@
+"""User-message sibling-navigation tests (Console branching Phase B, Task 4).
+
+Phase A's swipe/counter gate is role-generic (``sibling_count > 1``): the
+transcript counter, the `<`/`>` action row, and ``ChatScreen.
+_select_console_message_variant`` were all written against the store's
+persisted-sibling tree, not against a hard-coded "assistant only" rule. The
+sibling-nav tests filed under Task 7 (``Tests/Chat/test_console_sibling_
+nav.py``, ``Tests/UI/test_console_native_transcript.py``) only ever exercise
+ASSISTANT siblings (regenerate's own use case), so this file pins the same
+contracts for USER rows -- e.g. an edited user message that keeps its
+original alongside it as a sibling -- to confirm no assistant-only
+assumption slipped in anywhere along the path.
+
+Built via the same unmounted-``ChatScreen(app)`` pattern as
+``Tests/Chat/test_console_sibling_nav.py``: the store and
+``_select_console_message_variant`` only touch
+``self._ensure_console_chat_store()``, never widget queries, so no Textual
+mount is required.
+"""
+
+from Tests.UI.test_screen_navigation import _build_test_app
+from tldw_chatbook.Chat.console_chat_models import ConsoleChatMessage, ConsoleMessageRole
+from tldw_chatbook.Chat.console_message_actions import ConsoleMessageActionService
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from tldw_chatbook.Widgets.Console.console_transcript import _message_render_text
+
+
+def _build_screen():
+    app = _build_test_app()
+    screen = ChatScreen(app)
+    return app, screen
+
+
+def _build_two_user_siblings():
+    """Build session: user1(u1) -> assistant(a1), then fork u1 into u2.
+
+    Mirrors an edit-and-resend: ``u1`` keeps its own downstream reply ``a1``
+    off to the side, while the new ``u2`` sibling becomes the active leaf --
+    the same "anchor with its own descendants" shape Task 7's assistant
+    tests exercise, just rooted at a USER node instead.
+    """
+    app, screen = _build_screen()
+    store = screen._ensure_console_chat_store()
+    session = store.ensure_session(title="t")
+    u1 = store.append_message(session.id, role=ConsoleMessageRole.USER, content="hi")
+    a1 = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content="reply to hi"
+    )
+    u2 = store.create_sibling(u1.id, role=ConsoleMessageRole.USER, content="edited hi")
+    return app, screen, store, session, u1, a1, u2
+
+
+# --- Assertion 1: store.siblings_at reports two USER children -------------
+
+
+def test_siblings_at_reports_two_user_siblings():
+    _app, _screen, store, _session, u1, _a1, u2 = _build_two_user_siblings()
+
+    siblings, index, count = store.siblings_at(u1.id)
+
+    assert count == 2
+    assert [s.id for s in siblings] == [u1.id, u2.id]
+    assert index == 0
+    assert all(s.role == ConsoleMessageRole.USER for s in siblings)
+
+    # Resolves from the new sibling too (off-anchor lookup, same contract
+    # ``siblings_at``'s docstring promises for off-path nodes).
+    _siblings2, index2, count2 = store.siblings_at(u2.id)
+    assert count2 == 2
+    assert index2 == 1
+
+
+# --- Assertion 2: available_actions offers variant-previous/-next on a ----
+# --- USER message snapshot with sibling_count == 2, not gated on role ----
+
+
+def test_available_actions_offers_variant_nav_for_user_message_with_siblings():
+    _app, _screen, store, session, u1, _a1, u2 = _build_two_user_siblings()
+
+    # u2 is the freshly retargeted active leaf, so its transient
+    # sibling_index/sibling_count were just filled in by the store's single
+    # active-path writer (_recompute_active_path) -- fetch the live snapshot
+    # rather than constructing one by hand.
+    active_user_message = store.get_message(u2.id)
+    assert active_user_message.role == ConsoleMessageRole.USER
+    assert active_user_message.sibling_count == 2
+    assert active_user_message.sibling_index == 1
+
+    service = ConsoleMessageActionService()
+    actions = {
+        action.action_id: action
+        for action in service.available_actions(active_user_message)
+    }
+
+    assert "variant-previous" in actions
+    assert "variant-next" in actions
+    # index 1 of 2: previous is enabled (there is a sibling before it), next
+    # is disabled (it's the last sibling) -- same enablement rule Task 7
+    # pinned for assistant rows, unchanged by role.
+    assert actions["variant-previous"].enabled is True
+    assert actions["variant-next"].enabled is False
+    assert actions["variant-next"].disabled_reason
+
+    # Not gated on assistant-only: contrast with "regenerate", which IS
+    # intentionally assistant-only (nothing to regenerate on a user turn) --
+    # that stays blocked while variant nav stays offered.
+    assert actions["regenerate"].enabled is False
+
+    # session id sanity: both messages belong to the same session.
+    assert store.session_id_for_message(u2.id) == session.id
+
+
+def test_available_actions_also_offers_variant_nav_for_off_path_user_sibling():
+    """The FIRST user sibling (off the active path after the fork) still
+    reports sibling_count == 2 via ``siblings_at`` -- ``available_actions``
+    should offer nav for it too when a snapshot carries that count, since
+    the action row's gate is the message's own field, not "is this the
+    active leaf" or "is this an assistant message"."""
+    _app, _screen, store, _session, u1, _a1, _u2 = _build_two_user_siblings()
+
+    off_path_siblings, off_path_index, off_path_count = store.siblings_at(u1.id)
+    off_path_user_message = off_path_siblings[off_path_index]
+    assert off_path_user_message.id == u1.id
+    assert off_path_count == 2
+
+    # siblings_at() snapshots don't carry the active-path-only sibling_count
+    # field (that's filled by _recompute_active_path for on-path nodes
+    # only) -- build the equivalent snapshot explicitly to isolate the
+    # available_actions() contract from the store's active-path bookkeeping.
+    snapshot_with_count = ConsoleChatMessage(
+        role=off_path_user_message.role,
+        content=off_path_user_message.content,
+        id=off_path_user_message.id,
+        sibling_index=off_path_index,
+        sibling_count=off_path_count,
+    )
+
+    service = ConsoleMessageActionService()
+    action_ids = [
+        action.action_id
+        for action in service.available_actions(snapshot_with_count)
+    ]
+
+    assert "variant-previous" in action_ids
+    assert "variant-next" in action_ids
+
+
+# --- Assertion 3: transcript counter renders (n/m) for a USER row --------
+
+
+def test_transcript_counter_renders_for_user_row_with_siblings():
+    """Mirrors ``test_sibling_counter_rendered_for_message_with_siblings``
+    in ``Tests/UI/test_console_native_transcript.py`` (which pins this for
+    an ASSISTANT row) -- same helper, USER role."""
+    message = ConsoleChatMessage(
+        role=ConsoleMessageRole.USER,
+        content="edited hi",
+        id="u2",
+        sibling_index=1,
+        sibling_count=2,
+    )
+
+    rendered = _message_render_text(message, selected=False)
+
+    assert "(2/2)" in rendered.plain
+
+
+def test_transcript_counter_renders_for_live_user_sibling_snapshot():
+    """Same assertion, but sourced from the real store (not a hand-built
+    snapshot) -- end-to-end from ``create_sibling`` through to the
+    renderer."""
+    _app, _screen, store, _session, _u1, _a1, u2 = _build_two_user_siblings()
+
+    active_user_message = store.get_message(u2.id)
+    rendered = _message_render_text(active_user_message, selected=False)
+
+    assert "(2/2)" in rendered.plain
+
+
+# --- Assertion 4: _select_console_message_variant moves the active leaf --
+# --- across USER siblings -------------------------------------------------
+
+
+def test_select_console_message_variant_moves_active_leaf_between_user_siblings():
+    _app, screen, store, session, u1, _a1, u2 = _build_two_user_siblings()
+    assert store.active_leaf(session.id) == u2.id
+
+    screen._select_console_message_variant(u2.id, direction="variant-previous")
+
+    # u1 has its own downstream reply (a1), so swiping back lands on u1's
+    # most-recent descendant -- the same "resume mid-conversation" contract
+    # Task 7 pins for assistant forks (test_sibling_nav_previous_restores_
+    # deepest_descendant_of_sibling_subtree), now exercised on a user fork.
+    assert store.active_leaf(session.id) == _a1_id(store, u1)
+
+    screen._select_console_message_variant(u1.id, direction="variant-next")
+
+    assert store.active_leaf(session.id) == u2.id
+
+
+def _a1_id(store, u1):
+    """Return the id of u1's own most-recent descendant."""
+    return store._leaf_under(u1.id)
+
+
+def test_select_console_message_variant_noop_at_either_end_for_user_siblings():
+    _app, screen, store, session, u1, _a1, u2 = _build_two_user_siblings()
+
+    # u1 is the FIRST user sibling (index 0) -- pressing "previous" on its
+    # row must not move the active leaf (still u2, off u1's row).
+    screen._select_console_message_variant(u1.id, direction="variant-previous")
+    assert store.active_leaf(session.id) == u2.id
+
+    # u2 is the LAST user sibling -- pressing "next" on it is a no-op too.
+    screen._select_console_message_variant(u2.id, direction="variant-next")
+    assert store.active_leaf(session.id) == u2.id

--- a/Tests/UI/test_chat_screen_worker_groups.py
+++ b/Tests/UI/test_chat_screen_worker_groups.py
@@ -87,6 +87,7 @@ def test_console_run_and_sync_workers_use_disjoint_groups():
         "_retry_console_message",
         "_regenerate_console_message",
         "_continue_console_message",
+        "_edit_resend_console_message",
     }
     SYNC_COROUTINE = "_sync_native_console_chat_ui"
     run_groups: set[str] = set()

--- a/Tests/UI/test_console_edit_resend_wiring.py
+++ b/Tests/UI/test_console_edit_resend_wiring.py
@@ -1,0 +1,200 @@
+"""Screen wiring for Console branching Phase B Task 3.
+
+After Task 1 widened the edit modal to return ``ConsoleEditResult`` instead
+of a bare string, ``_apply_edit`` still called ``store.update_message_content``
+with the whole dataclass -- breaking in-place Save (regression covered by
+``Tests/UI/test_console_native_chat_flow.py::
+test_console_selected_message_edit_action_opens_modal_and_saves_content``).
+This file pins the branch this task adds: ``resend=False`` keeps routing to
+``store.update_message_content`` (restored), ``resend=True`` routes to the
+NEW ``controller.edit_and_resend_message`` path via a ``console-run`` worker,
+gated by the same ``run_state.is_send_allowed`` check as retry/regenerate/
+continue -- and the modal is only offered ``can_resend=True`` for a USER
+message (the only role ``edit_and_resend_message`` accepts).
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from textual.widgets import TextArea
+
+from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+
+from tldw_chatbook.Chat.console_chat_controller import ConsoleSubmitResult
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleMessageRole,
+    ConsoleRunState,
+    ConsoleRunStatus,
+)
+from tldw_chatbook.Widgets.Console import ConsoleTranscript
+
+
+CONSOLE_RUN_ALREADY_RUNNING_COPY = "A Console run is already running."
+
+
+async def _open_edit_modal(console, pilot, message_id: str):
+    """Select ``message_id`` and click its Edit action; return the pushed modal."""
+    transcript = console.query_one("#console-native-transcript", ConsoleTranscript)
+    transcript.select_message(message_id)
+    await console._sync_native_console_chat_ui()
+    await _wait_for_selector(
+        console, pilot, f"#console-message-action-edit-{message_id}"
+    )
+    await pilot.click(f"#console-message-action-edit-{message_id}")
+    host = console.app
+    await _wait_for_selector(
+        host.screen_stack[-1], pilot, "#console-edit-message-modal"
+    )
+    return host.screen_stack[-1]
+
+
+async def _wait_until(predicate, pilot, *, attempts: int = 80) -> None:
+    for _ in range(attempts):
+        if predicate():
+            return
+        await pilot.pause(0.02)
+    raise AssertionError("Condition never became true.")
+
+
+@pytest.mark.asyncio
+async def test_edit_modal_offers_resend_only_for_user_message():
+    """A USER message's edit modal shows the resend button; an ASSISTANT
+    message's does not -- ``edit_and_resend_message`` only accepts USER rows."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        store = console._ensure_console_chat_store()
+        session = store.ensure_session()
+        user_message = store.append_message(
+            session.id, role=ConsoleMessageRole.USER, content="hi"
+        )
+        assistant_message = store.append_message(
+            session.id, role=ConsoleMessageRole.ASSISTANT, content="hello"
+        )
+        await console._sync_native_console_chat_ui()
+
+        user_modal = await _open_edit_modal(console, pilot, user_message.id)
+        assert user_modal.query("#console-edit-message-resend")
+        await pilot.click("#console-edit-message-cancel")
+        await pilot.pause()
+
+        assistant_modal = await _open_edit_modal(console, pilot, assistant_message.id)
+        assert not assistant_modal.query("#console-edit-message-resend")
+        await pilot.click("#console-edit-message-cancel")
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_edit_save_still_routes_to_update_message_content_in_place():
+    """``resend=False`` (Save) must still land through the ORIGINAL in-place
+    path, not the new resend worker -- this is the transitional-break fix."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        store = console._ensure_console_chat_store()
+        session = store.ensure_session()
+        message = store.append_message(
+            session.id, role=ConsoleMessageRole.USER, content="original"
+        )
+        await console._sync_native_console_chat_ui()
+
+        controller = console._ensure_console_chat_controller()
+        spy_resend = AsyncMock()
+        controller.edit_and_resend_message = spy_resend
+
+        edit_modal = await _open_edit_modal(console, pilot, message.id)
+        editor = edit_modal.query_one("#console-edit-message-body", TextArea)
+        editor.text = "edited in place"
+        await pilot.click("#console-edit-message-save")
+        await pilot.pause()
+
+    assert store.get_message(message.id).content == "edited in place"
+    assert console._last_console_action.action_id == "edit"
+    spy_resend.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_edit_and_resend_dispatches_controller_edit_and_resend_message():
+    """``resend=True`` (Edit & resend) routes to
+    ``controller.edit_and_resend_message`` via a ``console-run`` worker,
+    leaving the original message untouched (the controller forks a branch)."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        store = console._ensure_console_chat_store()
+        session = store.ensure_session()
+        message = store.append_message(
+            session.id, role=ConsoleMessageRole.USER, content="original"
+        )
+        await console._sync_native_console_chat_ui()
+
+        controller = console._ensure_console_chat_controller()
+        spy_resend = AsyncMock(
+            return_value=ConsoleSubmitResult(
+                accepted=True, should_clear_draft=True, visible_copy=""
+            )
+        )
+        controller.edit_and_resend_message = spy_resend
+
+        edit_modal = await _open_edit_modal(console, pilot, message.id)
+        editor = edit_modal.query_one("#console-edit-message-body", TextArea)
+        editor.text = "edited and resent"
+        await pilot.click("#console-edit-message-resend")
+        await pilot.pause()
+
+        await _wait_until(lambda: spy_resend.await_count > 0, pilot)
+
+    spy_resend.assert_awaited_once_with(message.id, "edited and resent")
+    # The in-place path must NOT have fired -- the original node is untouched.
+    assert store.get_message(message.id).content == "original"
+
+
+@pytest.mark.asyncio
+async def test_edit_and_resend_blocked_while_a_run_is_already_active():
+    """Mirrors retry/regenerate/continue's mid-run gate (TASK-232): a
+    ``console-run`` worker must never be spawned while one is already
+    streaming -- it would cancel the in-flight run at creation time, before
+    the controller's own rejection can run."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        store = console._ensure_console_chat_store()
+        session = store.ensure_session()
+        message = store.append_message(
+            session.id, role=ConsoleMessageRole.USER, content="original"
+        )
+        await console._sync_native_console_chat_ui()
+
+        controller = console._ensure_console_chat_controller()
+        spy_resend = AsyncMock()
+        controller.edit_and_resend_message = spy_resend
+        controller._set_run_state(
+            ConsoleRunState(ConsoleRunStatus.STREAMING, "Streaming response.")
+        )
+
+        notices: list[str] = []
+        app.notify = lambda message_text, **kwargs: notices.append(str(message_text))
+
+        edit_modal = await _open_edit_modal(console, pilot, message.id)
+        editor = edit_modal.query_one("#console-edit-message-body", TextArea)
+        editor.text = "edited and resent"
+        await pilot.click("#console-edit-message-resend")
+        await pilot.pause()
+
+    spy_resend.assert_not_awaited()
+    assert any(CONSOLE_RUN_ALREADY_RUNNING_COPY in note for note in notices)

--- a/Tests/UI/test_console_edit_resend_wiring.py
+++ b/Tests/UI/test_console_edit_resend_wiring.py
@@ -162,6 +162,48 @@ async def test_edit_and_resend_dispatches_controller_edit_and_resend_message():
 
 
 @pytest.mark.asyncio
+async def test_open_edit_modal_notifies_and_returns_on_stale_message_id():
+    """Qodo PR #811 finding 3: ``_open_console_message_edit_modal`` calls
+    ``store.get_message(message_id)`` (added for ``can_resend``) to decide
+    whether to offer resend. A stale/removed id must not raise -- it should
+    notify with the same copy the in-place-save ``KeyError`` path already
+    uses (below, in this same function) and return without pushing a
+    modal."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        store = console._ensure_console_chat_store()
+        session = store.ensure_session()
+        message = store.append_message(
+            session.id, role=ConsoleMessageRole.USER, content="original"
+        )
+        stale_id = message.id
+        store.delete_message(stale_id)
+
+        notices: list[tuple[str, str]] = []
+        app.notify = lambda message_text, **kwargs: notices.append(
+            (str(message_text), kwargs.get("severity", ""))
+        )
+
+        screens_before = len(host.screen_stack)
+        # Must not raise despite the id no longer existing in the store.
+        await console._open_console_message_edit_modal(
+            message_id=stale_id, content="original"
+        )
+        await pilot.pause()
+
+        assert len(host.screen_stack) == screens_before
+        assert not host.screen_stack[-1].query("#console-edit-message-modal")
+        assert (
+            "Console message action target no longer exists.",
+            "error",
+        ) in notices
+
+
+@pytest.mark.asyncio
 async def test_edit_and_resend_blocked_while_a_run_is_already_active():
     """Mirrors retry/regenerate/continue's mid-run gate (TASK-232): a
     ``console-run`` worker must never be spawned while one is already

--- a/Tests/integration/test_console_edit_resend_e2e.py
+++ b/Tests/integration/test_console_edit_resend_e2e.py
@@ -1,0 +1,222 @@
+"""End-to-end integration test for Console "Edit & resend" branching (Phase B, Task 5).
+
+Exercises the full edit-and-resend lifecycle over the REAL stack -- an
+in-memory ``CharactersRAGDB`` behind the real ``ChatPersistenceService`` /
+``ChatConversationService``, a real ``ConsoleChatStore``, and the real
+``ConsoleChatController`` (with a fake streaming provider gateway, mirroring
+the harness used by ``Tests/Chat/test_console_edit_resend.py``) -- through:
+linear send, edit-and-resend (forking a new USER sibling branch), swipe
+between the old and new USER branches, persist -> drop the store -> resume
+(via the real ``ChatScreen`` flatten + ``restore_persisted_session`` path
+used by ``Tests/integration/test_console_branching_e2e.py``), and a
+plain in-place "Save" edit that must NOT fork a new branch.
+
+No shortcuts: every step drives the same store/controller methods the
+production ``ChatScreen`` drives, and resume is a genuine persist -> drop ->
+reload round-trip against the real database, not a hand-rolled fake.
+"""
+
+import pytest
+
+from tldw_chatbook.Chat.chat_conversation_service import ChatConversationService
+from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+from Tests.UI.test_destination_shells import _build_test_app
+
+
+class _SequencedGateway:
+    """Fake provider gateway: streams one scripted full-text reply per call.
+
+    Mirrors ``_SequencedGateway`` in ``test_console_branching_e2e.py``: each
+    controller call (``submit_draft``/``edit_and_resend_message``) consumes
+    the next scripted reply in order, so the E2E scenario can tell A1 and the
+    edited branch's own reply apart.
+    """
+
+    def __init__(self, replies):
+        self._replies = list(replies)
+        self._calls = 0
+
+    async def resolve_for_send(self, selection):
+        return type(
+            "Resolution",
+            (),
+            {
+                "ready": True,
+                "provider": "llama_cpp",
+                "model": "test-model",
+                "base_url": "http://127.0.0.1:9099",
+                "visible_copy": "",
+            },
+        )()
+
+    async def stream_chat(self, resolution, messages):
+        text = self._replies[self._calls]
+        self._calls += 1
+        yield text
+
+
+def _new_controller(db: CharactersRAGDB, replies):
+    """Real store (real DB-backed persistence) + real controller + fake gateway."""
+    store = ConsoleChatStore(persistence=ChatPersistenceService(db))
+    controller = ConsoleChatController(
+        store=store, provider_gateway=_SequencedGateway(replies)
+    )
+    session = store.create_session(title="Edit-Resend E2E")
+    store.active_session_id = session.id
+    return store, controller, session
+
+
+def _resume_into_fresh_store(db: CharactersRAGDB, conversation_id: str):
+    """Genuine persist -> drop -> resume round-trip via the real resume path.
+
+    Mirrors ``_resume_into_fresh_store`` in ``test_console_branching_e2e.py``:
+    the real ``ChatConversationService.get_conversation_tree`` full-tree read,
+    the real ``ChatScreen._console_messages_from_conversation_tree`` flatten,
+    the real ``db.get_conversation_active_leaf`` pointer read, and a brand
+    new ``ConsoleChatStore`` fed through ``restore_persisted_session`` -- the
+    exact same plumbing ``_resume_console_workspace_conversation`` drives.
+    """
+    service = ChatConversationService(db)
+    tree = service.get_conversation_tree(
+        conversation_id, depth_cap=10_000, root_limit=10_000
+    )
+    screen = ChatScreen(_build_test_app())
+    screen.app_instance.chachanotes_db = db
+    all_nodes = screen._console_messages_from_conversation_tree(tree)
+    active_leaf_id = db.get_conversation_active_leaf(conversation_id)
+    store = ConsoleChatStore(persistence=ChatPersistenceService(db))
+    session = store.restore_persisted_session(
+        title="Edit-Resend E2E",
+        workspace_id=None,
+        persisted_conversation_id=conversation_id,
+        all_nodes=all_nodes,
+        active_leaf_persisted_id=active_leaf_id,
+    )
+    return store, session
+
+
+@pytest.mark.asyncio
+async def test_console_edit_and_resend_full_lifecycle_persist_resume_swipe():
+    db = CharactersRAGDB(":memory:", "test_client")
+    try:
+        store, controller, session = _new_controller(
+            db, replies=["A1", "edited-reply"]
+        )
+
+        # ---- Step 1: send U1 -> A1 (linear) ----
+        result1 = await controller.submit_draft("U1")
+        assert result1.accepted is True
+        transcript = store.messages_for_session(session.id)
+        assert [m.content for m in transcript] == ["U1", "A1"]
+        u1, a1 = transcript
+        _sibs, _idx, count = store.siblings_at(u1.id)
+        assert count == 1  # no siblings yet -- linear
+
+        # ---- Step 2: edit U1 & resend -> forks a NEW user sibling branch ----
+        result2 = await controller.edit_and_resend_message(u1.id, "edited prompt")
+        assert result2.accepted is True
+
+        # u1's parent now has TWO user children.
+        siblings, _index, sib_count = store.siblings_at(u1.id)
+        assert sib_count == 2
+        sibling_ids = {s.id for s in siblings}
+        assert u1.id in sibling_ids
+        new_user_id = next(iter(sibling_ids - {u1.id}))
+
+        # The new sibling carries the edited text and sits on the active path.
+        active_path_ids = store.active_path_message_ids(session.id)
+        assert new_user_id in active_path_ids
+        new_user = store.get_message(new_user_id)
+        assert new_user.content == "edited prompt"
+
+        # It has its own assistant reply, which is the new active leaf.
+        active_leaf_id = store.active_leaf(session.id)
+        new_reply = store.get_message(active_leaf_id)
+        assert new_reply.content == "edited-reply"
+        assert new_reply.status == "complete"
+        assert active_path_ids == [new_user_id, active_leaf_id]
+
+        # U1 (and its old subtree A1) are preserved OFF the active path.
+        assert store.get_message(u1.id).content == "U1"
+        assert store.get_message(a1.id).content == "A1"
+        assert u1.id not in active_path_ids
+        assert a1.id not in active_path_ids
+
+        transcript_after_edit = [
+            m.content for m in store.messages_for_session(session.id)
+        ]
+        assert transcript_after_edit == ["edited prompt", "edited-reply"]
+
+        # ---- Step 3: swipe the USER row: `<` to the old branch, `>` back ----
+        store.set_active_leaf(session.id, store._leaf_under(u1.id))
+        old_branch_view = [
+            m.content for m in store.messages_for_session(session.id)
+        ]
+        assert old_branch_view == ["U1", "A1"]
+
+        store.set_active_leaf(session.id, store._leaf_under(new_user_id))
+        new_branch_view = [
+            m.content for m in store.messages_for_session(session.id)
+        ]
+        assert new_branch_view == ["edited prompt", "edited-reply"]
+
+        conversation_id = session.persisted_conversation_id
+        assert conversation_id is not None  # real persistence engaged throughout
+
+        # ---- Step 4: persist, DROP the store, resume via the real resume path ----
+        resumed_store, resumed_session = _resume_into_fresh_store(db, conversation_id)
+        resumed_transcript = [
+            m.content for m in resumed_store.messages_for_session(resumed_session.id)
+        ]
+        # The active branch (the edited one, left active above) is restored.
+        assert resumed_transcript == ["edited prompt", "edited-reply"]
+        resumed_leaf_id = resumed_store.active_leaf(resumed_session.id)
+        assert resumed_store.get_message(resumed_leaf_id).content == "edited-reply"
+        assert resumed_store.get_message(resumed_leaf_id).persisted_message_id == (
+            new_reply.persisted_message_id
+        )
+
+        # The old branch (U1/A1) is still reachable off-path after resume.
+        resumed_new_user = resumed_store.messages_for_session(resumed_session.id)[0]
+        resumed_sibs, _idx, resumed_count = resumed_store.siblings_at(
+            resumed_new_user.id
+        )
+        assert resumed_count == 2
+        resumed_u1 = next(
+            s for s in resumed_sibs if s.id != resumed_new_user.id
+        )
+        assert resumed_u1.content == "U1"
+        resumed_store.set_active_leaf(
+            resumed_session.id, resumed_store._leaf_under(resumed_u1.id)
+        )
+        assert [
+            m.content
+            for m in resumed_store.messages_for_session(resumed_session.id)
+        ] == ["U1", "A1"]
+        # Swipe back to the edited branch before moving on.
+        resumed_store.set_active_leaf(
+            resumed_session.id, resumed_store._leaf_under(resumed_new_user.id)
+        )
+
+        # ---- Step 5: in-place "Save" (NOT resend) still edits in place ----
+        resumed_edited_user_id = resumed_new_user.id
+        _before_sibs, _idx, before_count = resumed_store.siblings_at(
+            resumed_edited_user_id
+        )
+        resumed_store.update_message_content(resumed_edited_user_id, "typo fix")
+        after_sibs, _idx, after_count = resumed_store.siblings_at(
+            resumed_edited_user_id
+        )
+        assert after_count == before_count  # no new branch created
+        assert resumed_store.get_message(resumed_edited_user_id).content == "typo fix"
+        assert [
+            m.content
+            for m in resumed_store.messages_for_session(resumed_session.id)
+        ] == ["typo fix", "edited-reply"]
+    finally:
+        db.close_connection()

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1341,6 +1341,119 @@ class ConsoleChatController:
             prefill=prefill,
         )
 
+    async def edit_and_resend_message(
+        self, message_id: str, new_content: str
+    ) -> ConsoleSubmitResult:
+        """Edit a USER message and resend it, forking a NEW sibling branch.
+
+        Sibling counterpart to ``regenerate_message``, but the anchor is a
+        USER message rather than an assistant one, and this creates TWO new
+        nodes instead of one: a USER sibling of ``message_id`` (``store.
+        create_sibling``, parented at the anchor's own parent, carrying the
+        edited text) followed by an empty ASSISTANT node appended under it
+        (``store.append_message``, which always parents at the current
+        active leaf -- the freshly created sibling). The anchor
+        (``message_id``) and any old tail beneath it (its prior assistant
+        reply, and anything after it for a mid-conversation edit) are left
+        untouched and simply drop off the active path -- still reachable via
+        ``store.set_active_leaf``, never deleted.
+
+        All validation/blocking checks (active run, message role/session
+        ownership, non-blank content, provider readiness) run BEFORE either
+        new node is created, mirroring ``regenerate_message``'s
+        mutate-only-once-committed discipline: a blocked edit-and-resend
+        must not leave a stray orphan sibling forked into the tree. Building
+        ``provider_messages`` necessarily happens AFTER the fork here
+        (unlike ``regenerate_message``, which can build it from the still-
+        on-path anchor before forking) because the edited text itself must
+        be part of the payload -- it only exists once ``new_user`` has been
+        created. A skill-substitution refusal discovered at that point still
+        aborts the turn via ``_block`` exactly as ``regenerate_message``
+        does; the two new nodes remain forked (the edit itself is not
+        undone), matching ``submit_draft``'s own post-echo block precedent.
+
+        On stream FAILURE, the new assistant node becomes a ``failed`` node
+        on the active path (retryable via ``retry_message``), rather than
+        restoring the anchor's prior reply in place -- this is the intended
+        node-model behavior, not a regression: the anchor is a completely
+        separate node and was never touched.
+        """
+        active_rejection = self._active_run_rejection()
+        if active_rejection is not None:
+            return active_rejection
+
+        session_id = self.store.active_session_id
+        if session_id is None:
+            return ConsoleSubmitResult(False, False, "No active Console session.")
+        message = self.store.get_message(message_id)
+        if message.role is not ConsoleMessageRole.USER:
+            return self._block(
+                session_id, "Only your messages can be edited and re-sent."
+            )
+        if self.store.session_id_for_message(message_id) != session_id:
+            visible_copy = "Open the original session before editing this message."
+            self._set_run_state(ConsoleRunState.blocked(visible_copy))
+            return ConsoleSubmitResult(False, False, visible_copy)
+
+        clean_content, validation_error = self._validated_draft(new_content)
+        if validation_error is not None:
+            return self._block(session_id, validation_error)
+
+        self._set_run_state(
+            ConsoleRunState(ConsoleRunStatus.VALIDATING, "Validating provider.")
+        )
+        resolution = await self.provider_gateway.resolve_for_send(
+            self._provider_selection()
+        )
+        if not getattr(resolution, "ready", False):
+            visible_copy = self._blocked_visible_copy(
+                getattr(resolution, "visible_copy", "")
+            )
+            return self._block(session_id, visible_copy)
+
+        new_user = self.store.create_sibling(
+            message_id,
+            role=ConsoleMessageRole.USER,
+            content=clean_content,
+            persist=self.store.persistence is not None,
+        )
+        assistant = self.store.append_message(
+            session_id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="",
+            persist=self.store.persistence is not None,
+        )
+        provider_messages = self._provider_messages_for_session(
+            session_id,
+            before_message_id=assistant.id,
+        )
+        self._ensure_user_continuation_instruction(provider_messages)
+        provider_messages, refuse, skill_notes = await self._apply_skill_substitution(
+            provider_messages
+        )
+        if refuse is not None:
+            return self._block(session_id, refuse)
+        for note in skill_notes:
+            # An embedded skipped-skill note is never an abort: append the
+            # same system-row copy `_block` would, then let the turn proceed.
+            self.store.append_message(
+                session_id, role=ConsoleMessageRole.SYSTEM, content=note
+            )
+        provider_messages = await self._apply_chat_dictionaries(
+            provider_messages, session_id
+        )
+        provider_messages = await self._apply_world_info(
+            provider_messages, session_id
+        )
+        prefill = self._pinned_prefill_for_session(session_id)
+        return await self._stream_assistant_response(
+            resolution=resolution,
+            provider_messages=provider_messages,
+            assistant_message_id=assistant.id,
+            variant_mode=False,
+            prefill=prefill,
+        )
+
     async def build_context_snapshot(
         self,
         draft: str,

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1359,18 +1359,26 @@ class ConsoleChatController:
         ``store.set_active_leaf``, never deleted.
 
         All validation/blocking checks (active run, message role/session
-        ownership, non-blank content, provider readiness) run BEFORE either
-        new node is created, mirroring ``regenerate_message``'s
-        mutate-only-once-committed discipline: a blocked edit-and-resend
-        must not leave a stray orphan sibling forked into the tree. Building
-        ``provider_messages`` necessarily happens AFTER the fork here
-        (unlike ``regenerate_message``, which can build it from the still-
-        on-path anchor before forking) because the edited text itself must
-        be part of the payload -- it only exists once ``new_user`` has been
-        created. A skill-substitution refusal discovered at that point still
-        aborts the turn via ``_block`` exactly as ``regenerate_message``
-        does; the two new nodes remain forked (the edit itself is not
-        undone), matching ``submit_draft``'s own post-echo block precedent.
+        ownership, non-blank content, provider readiness) AND every payload
+        transform (skill substitution, chat dictionaries, world info) run
+        BEFORE either new node is created, mirroring ``regenerate_message``'s
+        "mutate last" discipline: a blocked or refused edit-and-resend must
+        not leave a stray orphan sibling -- or an un-streamed, un-retryable
+        ``"pending"`` assistant node -- forked into the tree. Unlike
+        ``regenerate_message`` (whose anchor is still on the active path, so
+        its payload can be read straight off the store), the edited text
+        does not exist as a stored node yet, so ``provider_messages`` is
+        built from the anchor's ancestors (``_provider_messages_for_session``
+        with ``before_message_id=message_id``, which excludes the anchor and
+        its subtree) plus a synthesized ``{"role": "user", "content":
+        clean_content}`` dict standing in for the not-yet-created sibling.
+        The transform pipeline operates purely on that ``list[dict]``
+        payload and never needs the real nodes to exist, so a
+        skill-substitution refusal aborts the turn via ``_block`` with
+        nothing to clean up. Only once every transform has succeeded are
+        ``new_user`` (``store.create_sibling``) and the empty ``assistant``
+        node (``store.append_message``) actually created, and the stream is
+        started against them.
 
         On stream FAILURE, the new assistant node becomes a ``failed`` node
         on the active path (retryable via ``retry_message``), rather than
@@ -1411,21 +1419,18 @@ class ConsoleChatController:
             )
             return self._block(session_id, visible_copy)
 
-        new_user = self.store.create_sibling(
-            message_id,
-            role=ConsoleMessageRole.USER,
-            content=clean_content,
-            persist=self.store.persistence is not None,
-        )
-        assistant = self.store.append_message(
-            session_id,
-            role=ConsoleMessageRole.ASSISTANT,
-            content="",
-            persist=self.store.persistence is not None,
-        )
+        # Build + transform the payload BEFORE creating either new node
+        # (task-2 review fix): the edited text is synthesized as a plain
+        # dict standing in for the not-yet-created sibling, so a
+        # skill-substitution refusal (or any other transform failure) has
+        # nothing to clean up -- no orphan sibling, no stuck "pending"
+        # assistant node.
         provider_messages = self._provider_messages_for_session(
             session_id,
-            before_message_id=assistant.id,
+            before_message_id=message_id,
+        )
+        provider_messages.append(
+            {"role": ConsoleMessageRole.USER.value, "content": clean_content}
         )
         self._ensure_user_continuation_instruction(provider_messages)
         provider_messages, refuse, skill_notes = await self._apply_skill_substitution(
@@ -1446,6 +1451,21 @@ class ConsoleChatController:
             provider_messages, session_id
         )
         prefill = self._pinned_prefill_for_session(session_id)
+
+        # Every transform succeeded: now (and only now) fork the edited USER
+        # sibling and append the empty ASSISTANT node to stream into.
+        new_user = self.store.create_sibling(
+            message_id,
+            role=ConsoleMessageRole.USER,
+            content=clean_content,
+            persist=self.store.persistence is not None,
+        )
+        assistant = self.store.append_message(
+            session_id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="",
+            persist=self.store.persistence is not None,
+        )
         return await self._stream_assistant_response(
             resolution=resolution,
             provider_messages=provider_messages,

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1385,6 +1385,25 @@ class ConsoleChatController:
         restoring the anchor's prior reply in place -- this is the intended
         node-model behavior, not a regression: the anchor is a completely
         separate node and was never touched.
+
+        Args:
+            message_id: Native id of the USER message being edited (the
+                anchor whose ancestor chain -- read with
+                ``before_message_id=message_id``, which excludes the anchor
+                and its own subtree -- becomes the base for the new branch).
+            new_content: The edited text to resend as the new sibling USER
+                message.
+
+        Returns:
+            A ``ConsoleSubmitResult``. ``accepted`` is ``True`` once the new
+            USER/ASSISTANT sibling pair has been created and streaming has
+            started (whether the stream itself later completes or fails);
+            ``False`` if any pre-mutation block gate (active run, message
+            role, session ownership, off-active-path anchor, blank content,
+            provider readiness, skill refusal) rejected the resend before
+            either new node was created. ``visible_copy`` carries the
+            block/refusal copy shown to the user when ``accepted`` is
+            ``False`` (and the streamed/failure copy otherwise).
         """
         active_rejection = self._active_run_rejection()
         if active_rejection is not None:
@@ -1402,6 +1421,18 @@ class ConsoleChatController:
             visible_copy = "Open the original session before editing this message."
             self._set_run_state(ConsoleRunState.blocked(visible_copy))
             return ConsoleSubmitResult(False, False, visible_copy)
+        if message_id not in self.store.active_path_message_ids(session_id):
+            # Task 2 review fix (Qodo finding 2): `_provider_messages_for_session`
+            # builds the resend payload by scanning the ACTIVE-PATH transcript
+            # until `message_id` is seen. If the anchor is not on the active
+            # path, that scan never breaks and the payload would be built from
+            # the wrong branch entirely. Edit is only exposed on active-path
+            # rows today, so this is currently unreachable from the UI -- but
+            # guard it here too so the method is safe to call directly.
+            return self._block(
+                session_id,
+                "Switch to that branch before editing and re-sending this message.",
+            )
 
         clean_content, validation_error = self._validated_draft(new_content)
         if validation_error is not None:

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -2021,13 +2021,31 @@ class ConsoleChatStore:
         walks only the LAST root, collapsing the transcript to its final message
         and rendering a phantom ``n/n`` sibling counter on the survivor.
 
-        A GENUINE Console branch is ALWAYS a set of siblings under a shared
-        *non-None* parent (regenerate / create-sibling parent the new node at
-        the anchor's parent), NEVER two separate root threads -- a conversation's
-        real root is its single first message. Therefore more than one
-        root-level thread unambiguously means legacy flat data (fully flat, or a
-        flat prefix followed by post-feature branched messages), and it is
-        always correct to chain the roots into a single linear spine.
+        Historically a GENUINE Console branch was ALWAYS a set of siblings
+        under a shared *non-None* parent (regenerate / create-sibling parent
+        the new node at the anchor's parent), NEVER two separate root
+        threads -- a conversation's real root is its single first message.
+        So more than one root-level thread meant legacy flat data (fully
+        flat, or a flat prefix followed by post-feature branched messages),
+        and it was always correct to chain the roots into a single linear
+        spine.
+
+        Phase B's ``edit_and_resend_message`` broke that invariant on
+        purpose: editing-and-resending the conversation's very FIRST user
+        message forks a NEW root-level USER sibling (``create_sibling``
+        parents the fork at the anchor's own parent, which is ``None`` for a
+        root message) -- a genuine branch that legitimately has more than one
+        root thread. Legacy flat data, by construction, ALWAYS mixes roles at
+        the root (every message, both USER and ASSISTANT, was written with
+        ``parent_message_id=NULL``), whereas a genuine root-level fork's
+        siblings are ALWAYS all USER (an ASSISTANT node's native parent is
+        never ``None`` -- it always replies to a user turn, even the very
+        first one). So role-homogeneity is the distinguishing signal: when
+        every root shares one role, this is a genuine Phase-B branch and must
+        be left alone (chaining it would silently splice the newer branch
+        onto the older one as a fake parent-child link, corrupting the tree
+        so a swipe/resume shows the wrong content); only a role-MIXED root
+        set is unambiguously legacy data.
 
         Roots are chained in their existing insertion order, which is the DB's
         timestamp-ASC order (``get_root_messages_for_conversation`` orders roots
@@ -2050,6 +2068,14 @@ class ConsoleChatStore:
             return
         roots = children.get(None, [])
         if len(roots) <= 1:
+            return
+        nodes = self._nodes_by_session.get(session_id, {})
+        root_roles = {nodes[root_id].role for root_id in roots if root_id in nodes}
+        if len(root_roles) <= 1:
+            # Every root-level node shares one role: a genuine Phase-B
+            # root-level branch (all USER), not legacy flat data (which
+            # always mixes USER and ASSISTANT rows at the root). Leave each
+            # root independently navigable via `siblings_at`/`set_active_leaf`.
             return
         # Keep only the first root under None; chain the rest onto their
         # predecessor, preserving each root's own existing subtree.

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -2035,17 +2035,28 @@ class ConsoleChatStore:
         message forks a NEW root-level USER sibling (``create_sibling``
         parents the fork at the anchor's own parent, which is ``None`` for a
         root message) -- a genuine branch that legitimately has more than one
-        root thread. Legacy flat data, by construction, ALWAYS mixes roles at
-        the root (every message, both USER and ASSISTANT, was written with
-        ``parent_message_id=NULL``), whereas a genuine root-level fork's
-        siblings are ALWAYS all USER (an ASSISTANT node's native parent is
-        never ``None`` -- it always replies to a user turn, even the very
-        first one). So role-homogeneity is the distinguishing signal: when
-        every root shares one role, this is a genuine Phase-B branch and must
-        be left alone (chaining it would silently splice the newer branch
-        onto the older one as a fake parent-child link, corrupting the tree
-        so a swipe/resume shows the wrong content); only a role-MIXED root
-        set is unambiguously legacy data.
+        root thread. A genuine root-level fork's siblings are ALWAYS all USER
+        (an ASSISTANT node's native parent is never ``None`` -- it always
+        replies to a user turn, even the very first one), so a role-MIXED root
+        set (both USER and ASSISTANT at the root) can ONLY be legacy flat data
+        and is chained. Role-homogeneity is thus the distinguishing signal: a
+        single-role (all-USER) root set is treated as a genuine Phase-B branch
+        and left alone (chaining it would silently splice the newer branch onto
+        the older as a fake parent-child link, corrupting the tree so a
+        swipe/resume shows the wrong content).
+
+        KNOWN LIMITATION (not airtight): legacy flat data with at least one
+        assistant reply mixes roles and is chained correctly, but a DEGENERATE
+        legacy conversation whose 2+ user turns each got NO assistant reply
+        loads as all-USER roots and is (wrongly) left un-chained -- it resumes
+        showing only the last user message with a phantom sibling counter. This
+        is a narrow, non-data-loss regression (every message stays navigable via
+        ``siblings_at``/``set_active_leaf``): the all-USER-legacy and all-USER
+        genuine-fork shapes are provably indistinguishable from the persisted
+        tree alone, so no local heuristic can be perfect, and always-chaining
+        (the alternative) corrupts the common first-message-edit feature -- the
+        worse trade. A stronger legacy fingerprint (e.g. "conversation contains
+        a NULL-parent ASSISTANT row") is a filed follow-up.
 
         Roots are chained in their existing insertion order, which is the DB's
         timestamp-ASC order (``get_root_messages_for_conversation`` orders roots

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -258,6 +258,7 @@ from ...Widgets.Console import (
     ConsoleDraftStash,
     ConsoleControlBar,
     ConsoleEditMessageModal,
+    ConsoleEditResult,
     ConsoleRailHandle,
     ConsoleRenameSessionModal,
     ConsoleRetrievalScopeRow,
@@ -12968,37 +12969,57 @@ class ChatScreen(BaseAppScreen):
     ) -> None:
         """Open the dedicated transcript edit modal for one Console message."""
         store = self._ensure_console_chat_store()
+        message = store.get_message(message_id)
+        can_resend = message.role is ConsoleMessageRole.USER
 
-        def _apply_edit(result: str | None) -> None:
+        def _apply_edit(result: ConsoleEditResult | None) -> None:
             if result is None:
                 return
-            try:
-                store.update_message_content(message_id, result)
-            except ValueError as exc:
-                self.app_instance.notify(str(exc), severity="warning")
+            if not result.resend:
+                try:
+                    store.update_message_content(message_id, result.text)
+                except ValueError as exc:
+                    self.app_instance.notify(str(exc), severity="warning")
+                    return
+                except KeyError:
+                    self.app_instance.notify(
+                        "Console message action target no longer exists.",
+                        severity="error",
+                    )
+                    return
+                self._last_console_action = ConsoleActionResult(
+                    action_id="edit",
+                    status="completed",
+                    visible_copy="Edited message.",
+                    target_message_id=message_id,
+                    target_content=result.text,
+                )
+                self.run_worker(
+                    self._sync_native_console_chat_ui(),
+                    exclusive=True,
+                    group="console-sync",
+                )
+                self.app_instance.notify("Edited message.", severity="information")
                 return
-            except KeyError:
+            controller = self._ensure_console_chat_controller()
+            # Gate BEFORE spawning: an exclusive console-run worker cancels the
+            # in-flight run at creation time, before the controller's own
+            # rejection can run -- the screen must refuse, like the submit path.
+            if not controller.run_state.is_send_allowed:
                 self.app_instance.notify(
-                    "Console message action target no longer exists.",
-                    severity="error",
+                    CONSOLE_RUN_ALREADY_RUNNING_COPY, severity="warning"
                 )
                 return
-            self._last_console_action = ConsoleActionResult(
-                action_id="edit",
-                status="completed",
-                visible_copy="Edited message.",
-                target_message_id=message_id,
-                target_content=result,
-            )
             self.run_worker(
-                self._sync_native_console_chat_ui(),
+                self._edit_resend_console_message(
+                    controller, message_id, result.text
+                ),
                 exclusive=True,
-                group="console-sync",
+                group="console-run",
             )
-            self.app_instance.notify("Edited message.", severity="information")
 
         await self.app.push_screen(
-            ConsoleEditMessageModal(content=content),
+            ConsoleEditMessageModal(content=content, can_resend=can_resend),
             callback=_apply_edit,
         )
 
@@ -13061,6 +13082,21 @@ class ChatScreen(BaseAppScreen):
     ) -> None:
         self._start_console_transcript_sync_timer()
         result = await controller.regenerate_message(message_id)
+        if result.visible_copy and not result.accepted:
+            self.app_instance.notify(result.visible_copy, severity="warning")
+        await self._sync_native_console_chat_ui()
+
+    async def _edit_resend_console_message(
+        self,
+        controller: ConsoleChatController,
+        message_id: str,
+        new_content: str,
+    ) -> None:
+        # TASK-343: without the sync timer these awaits run the whole
+        # generation with zero on-screen feedback (the timer self-stops
+        # when the run leaves an active status).
+        self._start_console_transcript_sync_timer()
+        result = await controller.edit_and_resend_message(message_id, new_content)
         if result.visible_copy and not result.accepted:
             self.app_instance.notify(result.visible_copy, severity="warning")
         await self._sync_native_console_chat_ui()

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -12969,7 +12969,14 @@ class ChatScreen(BaseAppScreen):
     ) -> None:
         """Open the dedicated transcript edit modal for one Console message."""
         store = self._ensure_console_chat_store()
-        message = store.get_message(message_id)
+        try:
+            message = store.get_message(message_id)
+        except KeyError:
+            self.app_instance.notify(
+                "Console message action target no longer exists.",
+                severity="error",
+            )
+            return
         can_resend = message.role is ConsoleMessageRole.USER
 
         def _apply_edit(result: ConsoleEditResult | None) -> None:

--- a/tldw_chatbook/Widgets/Console/__init__.py
+++ b/tldw_chatbook/Widgets/Console/__init__.py
@@ -3,7 +3,7 @@
 from .console_control_bar import ConsoleControlBar
 from .console_composer_bar import ConsoleComposerBar, ConsoleDraftStash
 from .console_background_effect import ConsoleBackgroundEffect, ConsoleTranscriptSurface
-from .console_edit_message_modal import ConsoleEditMessageModal
+from .console_edit_message_modal import ConsoleEditMessageModal, ConsoleEditResult
 from .console_rail_handle import ConsoleRailHandle
 from .console_rename_session_modal import ConsoleRenameSessionModal
 from .console_retrieval_scope_row import ConsoleRetrievalScopeRow
@@ -26,6 +26,7 @@ __all__ = [
     "ConsoleBackgroundEffect",
     "ConsoleControlBar",
     "ConsoleEditMessageModal",
+    "ConsoleEditResult",
     "ConsoleRailHandle",
     "ConsoleRenameSessionModal",
     "ConsoleRetrievalScopeRow",

--- a/tldw_chatbook/Widgets/Console/console_edit_message_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_edit_message_modal.py
@@ -2,11 +2,23 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from textual import events, on
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Button, Static, TextArea
+
+
+@dataclass(frozen=True)
+class ConsoleEditResult:
+    """Outcome of the edit modal: the (possibly unchanged) text, and whether
+    the caller asked to fork a new branch (Console branching Phase B) rather
+    than edit the message in place."""
+
+    text: str
+    resend: bool
 
 
 class _EditMessageTextArea(TextArea):
@@ -29,7 +41,7 @@ class _EditMessageTextArea(TextArea):
         await super()._on_key(event)
 
 
-class ConsoleEditMessageModal(ModalScreen[str | None]):
+class ConsoleEditMessageModal(ModalScreen[ConsoleEditResult | None]):
     """Edit an existing Console transcript message without using the composer."""
 
     DEFAULT_CSS = """
@@ -69,25 +81,41 @@ class ConsoleEditMessageModal(ModalScreen[str | None]):
     }
 
     #console-edit-message-cancel,
-    #console-edit-message-save {
+    #console-edit-message-save,
+    #console-edit-message-resend {
         width: 10;
         min-width: 10;
         height: 3;
         min-height: 3;
     }
+
+    #console-edit-message-resend {
+        width: 18;
+        min-width: 18;
+    }
     """
 
     BINDINGS = [("escape", "dismiss", "Cancel")]
 
-    def __init__(self, *, content: str) -> None:
+    def __init__(self, *, content: str, can_resend: bool = False) -> None:
         super().__init__()
         self._content = content
+        self._can_resend = can_resend
 
     def compose(self) -> ComposeResult:
         with Vertical(id="console-edit-message-modal"):
             yield Static("Edit Message", classes="console-modal-header")
+            if self._can_resend:
+                context_copy = (
+                    "Editing existing transcript message. Save keeps the edit in "
+                    "place; Edit & resend forks a new branch and gets a fresh reply."
+                )
+            else:
+                context_copy = (
+                    "Editing existing transcript message. This will not create a new prompt."
+                )
             yield Static(
-                "Editing existing transcript message. This will not create a new prompt.",
+                context_copy,
                 id="console-edit-message-context",
                 markup=False,
             )
@@ -95,7 +123,17 @@ class ConsoleEditMessageModal(ModalScreen[str | None]):
             yield Static("", id="console-edit-message-error", markup=False)
             with Horizontal(id="console-edit-message-actions"):
                 yield Button("Cancel", id="console-edit-message-cancel")
-                yield Button("Save", id="console-edit-message-save", variant="primary")
+                yield Button(
+                    "Save",
+                    id="console-edit-message-save",
+                    variant="default" if self._can_resend else "primary",
+                )
+                if self._can_resend:
+                    yield Button(
+                        "Edit & resend",
+                        id="console-edit-message-resend",
+                        variant="primary",
+                    )
 
     def on_mount(self, event: events.Mount) -> None:
         # Event time shares the clock domain of Key.time — the stale-key
@@ -122,4 +160,15 @@ class ConsoleEditMessageModal(ModalScreen[str | None]):
                 "Message content cannot be blank."
             )
             return
-        self.dismiss(edited_content)
+        self.dismiss(ConsoleEditResult(text=edited_content, resend=False))
+
+    @on(Button.Pressed, "#console-edit-message-resend")
+    def _resend(self, event: Button.Pressed) -> None:
+        event.stop()
+        edited_content = self.query_one("#console-edit-message-body", TextArea).text
+        if not edited_content.strip():
+            self.query_one("#console-edit-message-error", Static).update(
+                "Message content cannot be blank."
+            )
+            return
+        self.dismiss(ConsoleEditResult(text=edited_content, resend=True))


### PR DESCRIPTION
## What & why

Phase B of the **Console `/rewind`** program (Phase A merged as #799). Adds user-message **"Edit & resend" branching**: editing a past *user* message and choosing "Edit & resend" forks a new branch from that point (a user sibling + its own reply), while plain **Save** still edits in place. Together with Phase A's assistant regenerate-branching, this completes the "fork from any node" foundation.

Plan: `Docs/superpowers/plans/2026-07-23-console-branching-phase-b.md`

## What's delivered

- **Edit modal** gains "Edit & resend" (shown only for user messages); in-place Save is byte-for-byte behavior-preserved.
- **`edit_and_resend_message`** forks a user sibling via the existing role-parameterized `store.create_sibling(role=USER)` and streams a reply under it — no parallel branching path.
- **Swipe / `n/m` counter / resume** work on user-message branches with **zero new production code** — Phase A's gates were already role-generic.

## Reuse & correctness

- Every created node gets `persist=self.store.persistence is not None` (Phase A lesson); verified through a real persist→drop→resume round-trip.
- **No orphan on any block path**: the implementation transforms a *synthesized* provider payload (ancestors + the edited-user dict) before creating any node, so a skill refusal / not-ready provider leaves zero litter (this fixed a Critical the review caught — a stuck `pending` assistant node).
- Failure semantics mirror `regenerate_message` (a failed resend = retryable `failed` node; old branch preserved off-path).

## Review caught two real bugs a green suite hid

- **Orphan `pending` node** on skill-refuse → fixed by deferring all node creation past every block check.
- **Root-fork corruption**: editing the conversation's *first* user message forks a **root-level** branch, which Phase A's `_chain_legacy_flat_roots` (">1 root ⟺ legacy flat data") mis-classified and would splice into a linear spine, corrupting the tree on resume. Fixed via a **role-homogeneity** signal (a genuine root fork is all-USER since an assistant node's parent is never None; legacy flat data with any reply mixes roles). Documented known limitation: a *degenerate* all-USER legacy conversation (2+ user turns, no replies) shows a cosmetic phantom counter — non-data-loss, messages stay swipe-navigable; a stronger fingerprint is a filed follow-up.

## Testing

- 28 new Phase B tests + 72 Phase A regression tests green in the worktree; a focused 369-test branching/console sweep passes. Only pre-existing baseline failures remain (`test_anthropic_native_tools`, `test_chat_functions`, and the `continue`/`regenerate` `Text not found: 'hello'` flow tests — fail on `dev` too).

## Deferred follow-ups (not in this PR)

- Stronger legacy-flat fingerprint (the all-USER-legacy phantom-counter edge).
- Attachment carry-over on Edit-&-resend (the edit modal is text-only, so an anchor image is dropped from the resent branch).
- Plus the Phase A carry-forwards (agent-marker drop #498, failed-reply eviction #499) which apply to a failed resend too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds “Edit & resend” branching for past user messages in the Console. Choosing Edit & resend creates a new user-sibling branch and streams a fresh reply; Save still edits in place. Together with Phase A regenerate-branching, this completes fork-from-any-node.

- **New Features**
  - Edit modal adds an “Edit & resend” button for user messages and returns ConsoleEditResult; Save remains in-place; blank text is blocked.
  - Controller edit_and_resend_message builds provider payload first (ancestors + edited user dict), then creates a USER sibling, appends an empty assistant reply, and streams; nodes persist when a DB is present; failed streams leave a retryable failed node.
  - Screen routes resend=True to _edit_resend_console_message (run-state gated) and resend=False to store.update_message_content; swipe/counter/resume work for user branches.

- **Bug Fixes**
  - Prevented orphan pending assistant nodes by deferring all node creation until after provider readiness and transform checks; blocked off‑path/non‑USER targets in edit_and_resend_message; opening the edit modal on a stale message id now notifies “target no longer exists.”
  - Fixed root‑fork corruption when editing the first user message by only chaining mixed‑role root sets in _chain_legacy_flat_roots; genuine all‑USER root forks are preserved. Known edge: degenerate all‑USER legacy threads may show a cosmetic phantom counter.

<sup>Written for commit 90731ca767ef55e21b5c7fa40afa93e31dae838a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

