### PR TITLE
Skills: reference-file reachability — the skill_file runtime tool

### DIFF
--- a/Docs/superpowers/plans/2026-07-23-skills-reference-file-reachability-plan.md
+++ b/Docs/superpowers/plans/2026-07-23-skills-reference-file-reachability-plan.md
@@ -1,0 +1,534 @@
+# Reference-File Reachability (`skill_file` runtime tool) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let agents read a skill's bundled reference files on demand: a `skill_file(skill_name, path)` runtime tool available to model-invoked skill forks and to native-tools Console turns driven by `$skill` invocations.
+
+**Architecture:** One trust-gated, contained read seam in Skills_Interop; `skill_file` becomes the fourth RUNTIME tool (schema pinned via `runtime_schemas`, name-branch dispatch in `run_agent_loop`, authorization via a per-run mutable `SkillFileBindings` seeded from the turn's `$skill` names and extended when `SkillRunner` spawns a skill child). A "Bundled files" block is rendered only where the tool's existence is certain (bridge `run_reply` + `SkillRunner.run`).
+
+**Tech Stack:** Python 3.11+, pytest. No new dependencies.
+
+**Design doc:** `Docs/superpowers/specs/2026-07-23-skills-reference-file-reachability-design.md` (governs on any ambiguity).
+
+## Global Constraints
+
+- **Read seam order (verbatim from spec §1):** `_enforce("skills.read_file.launch.local")` → `_require_trusted_skill(skill_name)` (per-READ trust re-verification; raises `SkillTrustBlockedError`) → `validate_supporting_file_path(relative_path)` → contained read via the `_read_text_preserving_newlines` discipline → binary = clean refusal string, never raises → cap **100,000 chars** with `truncated: True` + trailing marker.
+- **Policy registry entry is REQUIRED** (`_resource("skills.read_file", actions=(LAUNCH,))` in the `server_skills` capability block) — the engine FAILS CLOSED on unknown action ids.
+- **Runtime-tool pattern:** schema pinned into `runtime_schemas` when bindings non-empty (active from step 1, never disclosure-gated); dispatch via a name-branch in `run_agent_loop` BEFORE `deps.invoke_tool`; authorization = membership in `SkillFileBindings.authorized`, NOT `config.allowed_tools`. `agent_runtime.py` must NOT import Skills_Interop.
+- **Bindings:** per-run, mutable; seeded from `turn_skill_bindings` (leading-resolved + embedded-SPLICED names only — never blocked/fork-literal mentions); `_BridgeSkillRunner.run` adds the spawned skill's name BEFORE `spawn`. Own bundle always readable — independent of frontmatter `allowed-tools`.
+- **"Bundled files" block** renders ONLY bridge-side (`run_reply`, trailing user message of its OWN `agent_messages` copy) and in `SkillRunner.run` (spawned body) — never at substitution time, never in the stored transcript, never on plain sends.
+- **Collision:** `SKILL_FILE_TOOL_NAME` joins `RUNTIME_TOOL_NAMES` (agent_models.py:33) — the existing consumers (`_non_colliding_skill_entries`, bridge composition) then exclude a skill literally named `skill_file` automatically.
+- **Sync everywhere:** the agent runtime runs on a worker thread with no event loop; the reader closure wraps the async scope-service call with `asyncio.run(...)` exactly like `BuiltinToolProvider.invoke` / `_BridgeSkillRunner.run` do.
+- **Tests:** `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <paths> -q`; Skills/UI suites need `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring`. Known baselines: `Tests/Chat/test_anthropic_native_tools.py::test_anthropic_shaped_tools_pass_through_untouched` (pre-existing); `Tests/Skills/test_skills_library_flow.py::test_skill_editor_canvas_scrolls_trust_panel_into_view` (flaky — re-run in isolation, don't chase).
+- **Commit hygiene:** `git add` ONLY named files — NEVER `git add -A` (tracked scratch `.superpowers/sdd/progress.md` must stay out; SUBAGENTS MUST NOT `git checkout` it).
+- Line anchors below were verified on this branch at `fbb17d81d` — re-grep before editing; they shift.
+
+## File Structure
+
+| File | Change |
+|------|--------|
+| `tldw_chatbook/runtime_policy/registry.py` (~:1019) | `_resource("skills.read_file", actions=(LAUNCH,))` |
+| `tldw_chatbook/Skills_Interop/local_skills_service.py` | `read_skill_file`; `execute_skill` gains `reference_files` |
+| `tldw_chatbook/Skills_Interop/skills_scope_service.py` | local-only `read_skill_file` passthrough |
+| `tldw_chatbook/tldw_api/skills_schemas.py` | `SkillExecutionResult.reference_files` (additive) |
+| `tldw_chatbook/Agents/agent_models.py` | `SKILL_FILE_TOOL_NAME`, join `RUNTIME_TOOL_NAMES`, `SkillFileBindings` |
+| `tldw_chatbook/Agents/tool_catalog.py` | `SKILL_FILE_TOOL_SCHEMA` |
+| `tldw_chatbook/Agents/agent_service.py` | ctor kwarg, runtime_schemas pin, reader closure into LoopDeps |
+| `tldw_chatbook/Agents/agent_runtime.py` | `LoopDeps.read_skill_file` field + name-branch dispatch |
+| `tldw_chatbook/Chat/console_agent_bridge.py` | bindings per run_reply; SkillRunner grant + block; bridge-side block; `turn_skill_bindings` param |
+| `tldw_chatbook/Chat/console_chat_controller.py` | 4-tuple widening + funnel threading |
+| Tests | `Tests/Skills/test_read_skill_file.py`, `Tests/Agents/test_skill_file_runtime_tool.py`, extensions to `Tests/Chat/test_console_skill_substitution.py` + `Tests/Agents/test_skill_tool_spawn.py` |
+
+---
+
+### Task 1: Policy entry + the read seam
+
+**Files:**
+- Modify: `tldw_chatbook/runtime_policy/registry.py` (the `server_skills` capability block, `_resource("skills.execute", ...)` is at ~:1019); `tldw_chatbook/Skills_Interop/local_skills_service.py`; `tldw_chatbook/Skills_Interop/skills_scope_service.py`
+- Test: `Tests/Skills/test_read_skill_file.py` (create)
+
+**Interfaces:**
+- Produces: `LocalSkillsService.read_skill_file(skill_name: str, relative_path: str) -> dict` returning `{"content": str, "truncated": bool, "size": int}` (sync-callable via `await` — it is `async def` for service-interface symmetry but does no awaiting I/O); `SkillsScopeService.read_skill_file(skill_name, relative_path, *, mode=None)` — local-only, `ValueError("skill_file reads are local-only")` for server mode; constant `SKILL_FILE_READ_CAP_CHARS = 100_000` in `local_skills_service.py`.
+
+- [ ] **Step 1: Write the failing tests** (create `Tests/Skills/test_read_skill_file.py`)
+
+```python
+import pytest
+
+from tldw_chatbook.Skills_Interop.local_skills_service import (
+    SKILL_FILE_READ_CAP_CHARS,
+    LocalSkillsService,
+)
+from tldw_chatbook.Skills_Interop.skill_trust_models import SkillTrustBlockedError
+
+
+def _svc(tmp_path):
+    return LocalSkillsService(store_dir=tmp_path)
+
+
+async def _make_skill(svc, name="demo"):
+    await svc.create_skill(name=name, content=f"---\nname: {name}\n---\nbody\n")
+    d = svc._skill_dir(name)
+    (d / "references").mkdir(parents=True, exist_ok=True)
+    (d / "references" / "api.md").write_text("# api docs\n", encoding="utf-8")
+    (d / "assets").mkdir(exist_ok=True)
+    (d / "assets" / "logo.png").write_bytes(b"\x89PNG\x00bin")
+    return d
+
+
+@pytest.mark.asyncio
+async def test_read_happy_path_nested(tmp_path):
+    svc = _svc(tmp_path)
+    await _make_skill(svc)
+    out = await svc.read_skill_file("demo", "references/api.md")
+    assert out == {"content": "# api docs\n", "truncated": False, "size": len("# api docs\n")}
+
+
+@pytest.mark.asyncio
+async def test_read_traversal_and_bad_paths_rejected(tmp_path):
+    svc = _svc(tmp_path)
+    await _make_skill(svc)
+    for bad in ("../escape.md", "/abs.md", "refs/SKILL.md"):
+        with pytest.raises(ValueError):
+            await svc.read_skill_file("demo", bad)
+
+
+@pytest.mark.asyncio
+async def test_read_binary_returns_refusal_not_bytes(tmp_path):
+    svc = _svc(tmp_path)
+    await _make_skill(svc)
+    out = await svc.read_skill_file("demo", "assets/logo.png")
+    assert out["truncated"] is False
+    assert "binary file" in out["content"]
+    assert "\x89" not in out["content"]
+
+
+@pytest.mark.asyncio
+async def test_read_truncates_over_cap(tmp_path):
+    svc = _svc(tmp_path)
+    d = await _make_skill(svc)
+    (d / "references" / "big.md").write_text("x" * (SKILL_FILE_READ_CAP_CHARS + 500), encoding="utf-8")
+    out = await svc.read_skill_file("demo", "references/big.md")
+    assert out["truncated"] is True
+    assert len(out["content"]) < SKILL_FILE_READ_CAP_CHARS + 200  # cap + marker line
+    assert "truncated" in out["content"].rsplit("\n", 1)[-1]
+
+
+@pytest.mark.asyncio
+async def test_read_untrusted_raises_blocked(tmp_path, monkeypatch):
+    svc = _svc(tmp_path)
+    await _make_skill(svc)
+
+    def _deny(name):
+        raise SkillTrustBlockedError(
+            skill_name=name, reason_code="skill_modified", trust_status="quarantined_modified"
+        )
+
+    monkeypatch.setattr(svc, "_require_trusted_skill", _deny)
+    with pytest.raises(SkillTrustBlockedError):
+        await svc.read_skill_file("demo", "references/api.md")
+
+
+@pytest.mark.asyncio
+async def test_read_missing_file_clean_error(tmp_path):
+    svc = _svc(tmp_path)
+    await _make_skill(svc)
+    with pytest.raises(ValueError, match="local_skill_file_not_found"):
+        await svc.read_skill_file("demo", "references/nope.md")
+
+
+@pytest.mark.asyncio
+async def test_scope_service_server_mode_rejected(tmp_path):
+    from tldw_chatbook.Skills_Interop.skills_scope_service import SkillsScopeService
+
+    scope = SkillsScopeService(local_service=_svc(tmp_path), server_service=None)
+    with pytest.raises(ValueError, match="local-only"):
+        await scope.read_skill_file("demo", "references/api.md", mode="server")
+
+
+def test_policy_action_id_registered():
+    # The engine denies unknown ids (fail-closed) — pin that the new id exists.
+    from tldw_chatbook.runtime_policy.registry import build_default_registry  # adjust to the module's actual builder name after reading it
+
+    registry = build_default_registry()
+    assert "skills.read_file.launch.local" in registry
+```
+
+(For the policy test: READ `runtime_policy/registry.py` first and use its actual public builder/lookup — the assertion contract is "the concrete action id `skills.read_file.launch.local` is registered"; adapt the access idiom to whatever `skills.execute.launch.local` is reachable through, e.g. the same structure existing policy tests in `Tests/` use — grep `skills.execute.launch` in `Tests/` and mirror.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/test_read_skill_file.py -q`
+Expected: FAIL — `ImportError: cannot import name 'SKILL_FILE_READ_CAP_CHARS'`.
+
+- [ ] **Step 3: Implement**
+
+`registry.py` — inside the `server_skills` capability's `resources=(...)` tuple, after the `skills.execute` line:
+
+```python
+            _resource("skills.read_file", actions=(LAUNCH,)),
+```
+
+`local_skills_service.py` — add near the other module constants: `SKILL_FILE_READ_CAP_CHARS = 100_000`, then the method (place near `execute_skill`):
+
+```python
+    async def read_skill_file(
+        self, skill_name: str, relative_path: str
+    ) -> dict[str, Any]:
+        """Read one bundled supporting file of a trusted skill, contained + capped.
+
+        The runtime `skill_file` tool's single backing seam. Order is
+        load-bearing: policy gate, per-READ trust re-verification (a skill
+        revoked mid-run stops being readable immediately), path validation,
+        then the same containment discipline `_read_text_preserving_newlines`
+        already applies to the skill body.
+
+        Args:
+            skill_name: Canonical skill name.
+            relative_path: POSIX relative path within the skill's bundle.
+
+        Returns:
+            ``{"content", "truncated", "size"}``; a binary file yields a
+            clean refusal string as ``content`` (never bytes, never raises).
+
+        Raises:
+            SkillTrustBlockedError: Skill not currently trusted.
+            ValueError: Bad path, unknown skill, or missing file
+                (``local_skill_file_not_found:...``).
+        """
+        # Deferred import: avoid module-scope tldw_api schema import (task-285 phase 2).
+        from ..tldw_api.skills_schemas import validate_supporting_file_path
+
+        self._enforce("skills.read_file.launch.local")
+        self._require_trusted_skill(skill_name)
+        validate_supporting_file_path(relative_path)
+        skill_dir = self._skill_dir(skill_name)
+        if not skill_dir.is_dir():
+            raise ValueError(f"local_skill_not_found:{skill_name}")
+        path = skill_dir / PurePosixPath(relative_path)
+        if path.is_symlink() or not path.is_file():
+            raise ValueError(f"local_skill_file_not_found:{relative_path}")
+        raw_size = path.stat().st_size
+        try:
+            text = self._read_text_preserving_newlines(path, base_dir=skill_dir)
+        except UnicodeDecodeError:
+            return {
+                "content": f"binary file — {raw_size} bytes; not readable as text",
+                "truncated": False,
+                "size": raw_size,
+            }
+        if "\x00" in text:
+            return {
+                "content": f"binary file — {raw_size} bytes; not readable as text",
+                "truncated": False,
+                "size": raw_size,
+            }
+        if len(text) > SKILL_FILE_READ_CAP_CHARS:
+            text = (
+                text[:SKILL_FILE_READ_CAP_CHARS]
+                + f"\n[truncated — file is {raw_size} bytes; showing first {SKILL_FILE_READ_CAP_CHARS} characters]"
+            )
+            return {"content": text, "truncated": True, "size": raw_size}
+        return {"content": text, "truncated": False, "size": raw_size}
+```
+
+(`PurePosixPath` is already imported in this module; verify.) `skills_scope_service.py` — bespoke local-only dispatch mirroring `count_skills` (:174-200):
+
+```python
+    async def read_skill_file(
+        self,
+        skill_name: str,
+        relative_path: str,
+        *,
+        mode: SkillsBackend | str | None = None,
+    ) -> dict[str, Any]:
+        """Read a bundled file of a LOCAL trusted skill (runtime skill_file seam).
+
+        Local-only by design: the server backend has no read_skill_file and
+        every runtime skill path is already hardcoded local. Rejecting server
+        mode here beats surfacing a raw AttributeError from _call.
+        """
+        normalized_mode = self._normalize_mode(mode) if mode is not None else SkillsBackend.LOCAL
+        if normalized_mode is not SkillsBackend.LOCAL:
+            raise ValueError("skill_file reads are local-only")
+        service = self._require_service(SkillsBackend.LOCAL)
+        self._enforce_policy("skills.read_file.launch.local")
+        return await self._maybe_await(service.read_skill_file(skill_name, relative_path))
+```
+
+(Match `_normalize_mode`/`_require_service`/`_enforce_policy`/`_maybe_await` exactly to the file's existing idioms — read `count_skills` first.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/test_read_skill_file.py Tests/Skills/ -q`
+Expected: new file PASS; full Tests/Skills green (modulo known flaky).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/runtime_policy/registry.py tldw_chatbook/Skills_Interop/local_skills_service.py tldw_chatbook/Skills_Interop/skills_scope_service.py Tests/Skills/test_read_skill_file.py
+git commit -m "feat(skills): trust-gated contained read_skill_file seam + policy entry"
+```
+
+---
+
+### Task 2: `reference_files` metadata on execute_skill
+
+**Files:**
+- Modify: `tldw_chatbook/Skills_Interop/local_skills_service.py` (`execute_skill`, ~:1197); `tldw_chatbook/tldw_api/skills_schemas.py` (`SkillExecutionResult`, :137-145)
+- Test: `Tests/Skills/test_read_skill_file.py` (extend)
+
+**Interfaces:**
+- Produces: `execute_skill` result dict gains `reference_files: list[{"path": str, "size": int, "is_text": bool}] | None` (from `_read_bundle_manifest`, dropping the `executable` field — not needed for reads). `SkillExecutionResult` gains the matching optional field.
+
+- [ ] **Step 1: Failing test** (append)
+
+```python
+@pytest.mark.asyncio
+async def test_execute_skill_carries_reference_files(tmp_path):
+    svc = _svc(tmp_path)
+    await _make_skill(svc)
+    svc.allow_untrusted_without_trust_service = True  # match existing execute tests' trust setup; READ the file's existing execute_skill tests and mirror their trust arrangement instead if different
+    result = await svc.execute_skill("demo")
+    refs = {r["path"]: r for r in (result.get("reference_files") or [])}
+    assert refs["references/api.md"]["is_text"] is True
+    assert refs["assets/logo.png"]["is_text"] is False
+```
+
+(READ the existing `execute_skill` tests first — `grep -rn "execute_skill" Tests/Skills/` — and mirror their trust setup exactly; the assertion contract is the field's presence and shape.)
+
+- [ ] **Step 2: RED** — field absent. **Step 3: Implement**: in `execute_skill`, after building the result fields, add `reference_files=` derived from `self._read_bundle_manifest(self._skill_dir(skill["name"]))`, mapping each entry to `{"path", "size", "is_text"}` (or `None` when the manifest is `None`); add `reference_files: list[dict] | None = None` to `SkillExecutionResult` (it has `extra="allow"`, but declare explicitly). **Step 4: GREEN** + `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring .venv-path pytest Tests/Skills/ Tests/Chat/test_console_skill_substitution.py -q` (substitution consumers must be unaffected). **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Skills_Interop/local_skills_service.py tldw_chatbook/tldw_api/skills_schemas.py Tests/Skills/test_read_skill_file.py
+git commit -m "feat(skills): execute_skill carries reference_files bundle metadata"
+```
+
+---
+
+### Task 3: Runtime core — bindings, schema pin, dispatch branch
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/agent_models.py` (:30-33 names block + new dataclass); `tldw_chatbook/Agents/tool_catalog.py` (schemas near :28-58); `tldw_chatbook/Agents/agent_service.py` (ctor :162-175, runtime_schemas :340-344, LoopDeps build :547-561); `tldw_chatbook/Agents/agent_runtime.py` (LoopDeps :199-230, dispatch :416-521)
+- Test: `Tests/Agents/test_skill_file_runtime_tool.py` (create)
+
+**Interfaces:**
+- Consumes: nothing from Skills_Interop directly (layering: the reader is an injected callable).
+- Produces: `SKILL_FILE_TOOL_NAME = "skill_file"` (in `RUNTIME_TOOL_NAMES`); `SkillFileBindings` (mutable dataclass: `authorized: set[str]`, `reader: Callable[[str, str], dict] | None`); `SKILL_FILE_TOOL_SCHEMA` (ToolSchema; params: `skill_name` str required, `path` str required); `AgentService(..., skill_file_bindings: SkillFileBindings | None = None)`; `LoopDeps.read_skill_file: Callable[[str, str], ToolResult] | None = None`; loop branch: when `call.name == SKILL_FILE_TOOL_NAME` and `deps.read_skill_file` is set → dispatch to it (bindings/authorization enforced INSIDE the service-built closure, not the loop).
+
+- [ ] **Step 1: Failing tests** (create; model the harness on `Tests/Agents/test_skill_tool_spawn.py` — READ it first and reuse its fake chat_call/registry scaffolding idioms)
+
+```python
+from tldw_chatbook.Agents.agent_models import (
+    RUNTIME_TOOL_NAMES,
+    SKILL_FILE_TOOL_NAME,
+    SkillFileBindings,
+)
+
+
+def test_skill_file_is_a_runtime_tool_name():
+    assert SKILL_FILE_TOOL_NAME == "skill_file"
+    assert SKILL_FILE_TOOL_NAME in RUNTIME_TOOL_NAMES  # collision exclusion rides existing consumers
+
+
+def test_bindings_object_shape():
+    b = SkillFileBindings(authorized=set(), reader=None)
+    b.authorized.add("demo")
+    assert "demo" in b.authorized
+```
+
+Plus two loop-level tests (using the file's established fake-model scaffolding): (a) with `skill_file_bindings=SkillFileBindings(authorized={"demo"}, reader=<fake returning {"content": "REF", "truncated": False, "size": 3}>)` and a scripted model turn calling `skill_file(skill_name="demo", path="references/api.md")` → the tool result contains `REF`, and the provider call's schema list INCLUDES the `skill_file` schema on the FIRST turn; (b) same but calling `skill_name="other"` (not authorized) → `ToolResult(ok=False)` with a refusal mentioning `other`, and with `skill_file_bindings=None` → the schema is NOT offered and a call to the name falls through to normal unknown-tool handling. Write these concretely against the harness you find; the assertions above are the contract.
+
+- [ ] **Step 2: RED** (ImportError). **Step 3: Implement**:
+
+`agent_models.py` (names block):
+
+```python
+SKILL_FILE_TOOL_NAME = "skill_file"
+RUNTIME_TOOL_NAMES = frozenset({SPAWN_TOOL_NAME, FIND_TOOLS_NAME, LOAD_TOOLS_NAME, SKILL_FILE_TOOL_NAME})
+
+
+@dataclass
+class SkillFileBindings:
+    """Per-run authorization + reader for the skill_file runtime tool.
+
+    Mutable by design: seeded with the turn's $skill names; SkillRunner adds
+    each spawned skill's name before spawn so a skill can always read its own
+    bundle. Authorization lives here, never in config.allowed_tools.
+    """
+
+    authorized: set[str]
+    reader: Callable[[str, str], dict] | None = None
+```
+
+`tool_catalog.py` (beside the other runtime schemas):
+
+```python
+SKILL_FILE_TOOL_SCHEMA = ToolSchema(
+    id="runtime:skill_file",
+    name=SKILL_FILE_TOOL_NAME,
+    description=(
+        "Read a bundled reference file of a skill active in this run. "
+        "Args: skill_name (the skill whose bundle to read), path (relative "
+        "POSIX path, e.g. references/api.md). Text files only."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "skill_name": {"type": "string"},
+            "path": {"type": "string"},
+        },
+        "required": ["skill_name", "path"],
+    },
+)
+```
+
+`agent_service.py`: ctor gains `skill_file_bindings: SkillFileBindings | None = None` stored as `self.skill_file_bindings` (keyword-only, beside `skill_runner`). In `_run_one`'s runtime_schemas block (:340-344):
+
+```python
+        if self.skill_file_bindings is not None and self.skill_file_bindings.authorized:
+            runtime_schemas.append(SKILL_FILE_TOOL_SCHEMA)
+```
+
+Build the reader closure beside `invoke_tool` and thread into LoopDeps:
+
+```python
+        def read_skill_file_tool(skill_name: str, path: str) -> ToolResult:
+            bindings = self.skill_file_bindings
+            if bindings is None or skill_name not in bindings.authorized:
+                return ToolResult(ok=False, error=f"skill_file: '{skill_name}' is not active in this run")
+            if bindings.reader is None:
+                return ToolResult(ok=False, error="skill_file: no reader configured")
+            try:
+                out = bindings.reader(skill_name, path)
+            except Exception as exc:  # SkillTrustBlockedError, ValueError, OSError
+                return ToolResult(ok=False, error=f"skill_file: {exc}")
+            return ToolResult(ok=True, content=str(out.get("content", "")))
+```
+
+`agent_runtime.py`: `LoopDeps` gains `read_skill_file: Callable[..., ToolResult] | None = None`; in the dispatch chain (before the final `else` at ~:519), add:
+
+```python
+                elif call.name == SKILL_FILE_TOOL_NAME and deps.read_skill_file is not None:
+                    add(STEP_TOOL_CALL, tool_name=call.name, args=dict(call.args))
+                    result = deps.read_skill_file(
+                        str(call.args.get("skill_name", "")), str(call.args.get("path", ""))
+                    )
+```
+
+then let it flow into the existing shared tool-result handling exactly as the `deps.invoke_tool` branch does (READ the surrounding code; mirror how `result` is recorded/fed back — do not duplicate logic). Import `SKILL_FILE_TOOL_NAME` from agent_models (agent_runtime already imports from there).
+
+- [ ] **Step 4: GREEN** + regression `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Agents/ -q` (all pass — RUNTIME_TOOL_NAMES growth may affect collision tests; if a pre-existing test enumerates the frozenset's exact members, update it — intended). **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Agents/agent_models.py tldw_chatbook/Agents/tool_catalog.py tldw_chatbook/Agents/agent_service.py tldw_chatbook/Agents/agent_runtime.py Tests/Agents/test_skill_file_runtime_tool.py
+git commit -m "feat(agents): skill_file fourth runtime tool with per-run bindings"
+```
+
+---
+
+### Task 4: Bridge fork side — bindings wiring, own-bundle grant, spawned-body block
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_agent_bridge.py` (run_reply AgentService ctor ~:992-1001; `_BridgeSkillRunner` ~:727-772)
+- Test: `Tests/Agents/test_skill_tool_spawn.py` (extend) or the bridge's existing test file (READ both, put tests where the existing SkillRunner tests live)
+
+**Interfaces:**
+- Consumes: `SkillFileBindings`, `SKILL_FILE_TOOL_NAME` (Task 3); `SkillsScopeService.read_skill_file` (Task 1); `reference_files` on execute result (Task 2).
+- Produces: `run_reply` constructs one `SkillFileBindings` per run — `reader` wraps the scope service (`lambda name, path: asyncio.run(self._skills_service.read_skill_file(name, path, mode="local"))`), `authorized` seeded empty for now (Task 5 seeds turn bindings) — and passes it to BOTH `AgentService(skill_file_bindings=...)` and `_BridgeSkillRunner(..., skill_file_bindings=...)`. `_BridgeSkillRunner.run`: after a successful `execute_skill`, `self._skill_file_bindings.authorized.add(name)` (when bindings present), and append the "Bundled files" block to `rendered` before `spawn` when `reference_files` non-empty:
+
+```python
+        refs = result.get("reference_files") if isinstance(result, Mapping) else None
+        if refs and self._skill_file_bindings is not None:
+            rows = ", ".join(
+                f"{r['path']} ({r['size']} bytes{'' if r.get('is_text', True) else ', binary'})"
+                for r in refs
+            )
+            rendered = f"{rendered}\n\nBundled files (readable via skill_file): {rows}"
+```
+
+- [ ] **Step 1: Failing tests**: (a) SkillRunner.run with a fake skills service whose execute result carries `reference_files` → the spawned task text contains `Bundled files (readable via skill_file): references/api.md` AND the bindings' `authorized` now contains the skill name; (b) with `reference_files=None` → body unchanged, name still authorized; (c) bindings=None (non-bridge construction) → byte-identical legacy behavior (no block, no crash). Model on the file's existing `_BridgeSkillRunner`/spawn tests.
+- [ ] **Step 2: RED** → **Step 3: implement** (ctor param with default `None` for compat; wire in run_reply) → **Step 4: GREEN** + `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring .venv pytest Tests/Agents/ Tests/Chat/ -q` (baseline failures only). **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_agent_bridge.py <the test file(s) you extended>
+git commit -m "feat(skills): fork skill children read their own bundle via skill_file"
+```
+
+---
+
+### Task 5: Turn bindings — controller 4-tuple + bridge seeding + bridge-side block
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py` (`_apply_skill_substitution` ~:1790-2012 — 7 returns; call sites :470/:1150/:1214/:1312; funnel `_stream_assistant_response` ~:2349 / `_run_agent_reply` ~:2550 / run_reply call ~:2634); `tldw_chatbook/Chat/console_agent_bridge.py` (`run_reply` signature ~:832-846 + bindings seeding + block append)
+- Test: `Tests/Chat/test_console_skill_substitution.py` (extend)
+
+**Interfaces:**
+- Consumes: bindings object from Task 4's run_reply wiring; `reference_files` on the execute results the substitution already holds (Task 2).
+- Produces (NORMATIVE): `_apply_skill_substitution` widens to a **5-tuple** `(messages, refuse, notes, skill_bindings, skill_bundle_block)`:
+  - `skill_bindings: tuple[str, ...]` — the leading-RESOLVED name (inline AND fork outcomes; not on refuse) plus embedded names that actually SPLICED (never blocked-literal, never fork-literal).
+  - `skill_bundle_block: str` — the fully-rendered "Bundled files" block for all bound skills with non-empty `reference_files` (Task 4's row format, one combined block headed `Bundled files (readable via skill_file):`), or `""`. Built at substitution as **pure string work from the execute results already in hand** (no re-execution, no extra service calls) but **NEVER inserted into `messages` here** — only `run_reply` appends it, so plain sends drop it unused and the invariant (block only where the tool exists) holds.
+  - All 7 returns updated; all 4 call-site unpacks widened; `_stream_assistant_response` and `_run_agent_reply` gain `skill_bindings: tuple[str, ...] = ()` and `skill_bundle_block: str = ""` kwargs threaded to `run_reply(turn_skill_bindings=..., turn_bundle_block=...)`.
+  - `run_reply`: seeds `bindings.authorized.update(turn_skill_bindings)`; when `turn_bundle_block` is non-empty, appends `\n\n{turn_bundle_block}` to the LAST `role=="user"` entry of its OWN copied `agent_messages` list before `run_turn`.
+
+- [ ] **Step 1: Failing tests** (extend substitution tests; construct as the file does):
+
+```python
+@pytest.mark.asyncio
+async def test_leading_mention_returns_binding_and_block():
+    controller, skills = ...  # file's existing construction; execute result must carry reference_files
+    messages = [{"role": "user", "content": "$code-review look"}]
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(messages)
+    assert bindings == ("code-review",)
+    assert "Bundled files (readable via skill_file):" in block
+    assert all("Bundled files" not in m.get("content", "") for m in out)  # NEVER in messages here
+
+
+@pytest.mark.asyncio
+async def test_embedded_spliced_binds_but_blocked_does_not():
+    ...  # one spliced + one blocked mention -> bindings == (spliced_name,)
+
+
+@pytest.mark.asyncio
+async def test_plain_text_no_bindings():
+    ...  # no $ -> bindings == () and block == ""
+```
+
+(Also update EVERY existing unpack in the file — mechanical 3→5 widening; assertions unchanged. And the `test_console_chat_controller.py` monkeypatch fake that returns the tuple.)
+
+- [ ] **Step 2: RED** → **Step 3: implement** (7 returns; block built from execute results' `reference_files` with the Task 4 row format, one combined block headed `Bundled files (readable via skill_file):`; fork-literal/blocked mentions excluded from bindings AND block) → thread through funnel (2 signatures + 4 call sites + run_reply params; run_reply: `if self._skill_file_bindings...` — seed `bindings.authorized.update(turn_skill_bindings)`; `if turn_bundle_block:` append `\n\n{turn_bundle_block}` to the LAST `role=="user"` entry of its own copied `agent_messages` list before `run_turn`).
+- [ ] **Step 4: GREEN** + full: `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring .venv pytest Tests/Chat/ Tests/Agents/ -q` (baselines only). **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_chat_controller.py tldw_chatbook/Chat/console_agent_bridge.py Tests/Chat/test_console_skill_substitution.py Tests/Chat/test_console_chat_controller.py
+git commit -m "feat(skills): turn \$-bindings authorize skill_file; bridge-side bundled-files block"
+```
+
+---
+
+### Task 6: E2E + full regression
+
+**Files:**
+- Test: `Tests/Agents/test_skill_file_runtime_tool.py` (extend with the e2e), full suites
+
+- [ ] **Step 1: E2E test** — real `LocalSkillsService` (tmp store) with a trusted skill carrying `references/api.md`; a scripted model that (turn 1) calls `skill_file(skill_name=..., path="references/api.md")` and (turn 2) finishes; run through `AgentService` with bindings authorized for that skill and reader = the real scope-service read — assert the tool result fed back contains the file text and the run completes. (Compose from Task 1's service + Task 3's harness; trust via the same arrangement Tests/Skills uses — file-marker keyring fallback.)
+- [ ] **Step 2: Full regression:**
+
+Run: `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/ Tests/Agents/ Tests/Chat/ Tests/UI/test_console_skill_commands.py -q`
+Expected: 0 failed modulo the two known baselines.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Tests/Agents/test_skill_file_runtime_tool.py
+git commit -m "test(skills): e2e — fork skill reads its own reference file on demand"
+```
+
+---
+
+## Notes for the executor
+
+- The spec governs. §2's registry/disclosure rationale is why this is a RUNTIME tool — do not "simplify" to a provider registration.
+- Task 5 contains a normative RESOLUTION paragraph (5-tuple; block rendered at substitution as a STRING, inserted only by run_reply) — it supersedes the spec's looser "metadata fetched at that point" wording; the spec's invariant (block only where the tool exists; never stored transcript; never plain sends) is unchanged.
+- `agent_runtime.py` must not import Skills_Interop; the reader is injected.
+- Re-grep every anchor; files shift.

--- a/Docs/superpowers/specs/2026-07-23-skills-reference-file-reachability-design.md
+++ b/Docs/superpowers/specs/2026-07-23-skills-reference-file-reachability-design.md
@@ -119,14 +119,30 @@ Bindings are **per-turn** (a plain follow-up message gets no tool). The bridge's
 per-conversation snapshot dicts are the named seam if accumulation is ever
 wanted — explicitly out of scope now.
 
-### 4. Discovery metadata travels with capability
+### 4. Discovery metadata travels with capability (rendered where certainty exists)
 
 `execute_skill` gains an additive `reference_files` field (relative path, size,
-`is_text` — from Spec 2's `_read_bundle_manifest`). Only the two tool-injecting
-consumers render it into the prompt — a compact block appended to the rendered
-body: `Bundled files (readable via skill_file): references/api.md (2 KB), …`.
-Plain sends ignore the field (no dangling promise). Binaries are listed with a
-`(binary)` marker (listable, not readable).
+`is_text` — from Spec 2's `_read_bundle_manifest`). **Verified constraint:** the
+controller CANNOT know at substitution time whether the turn will run with
+native tools — `prefill` and `force_plain` are computed after substitution at
+every call site, and `force_plain` derives from a message that does not yet
+exist. Therefore the "Bundled files" block is rendered at the two points where
+the tool's existence is already CERTAIN:
+
+- **Bridge turn path:** `run_reply`, right where it seeds `SkillFileBindings`
+  from `turn_skill_bindings`, appends the block to the trailing user message of
+  its own `agent_messages` copy before `run_turn` — zero-race by construction
+  (run_reply only executes once bridge-vs-plain is decided). The
+  `reference_files` metadata for the bound skills is fetched via the skills
+  service at that point.
+- **Fork path:** `SkillRunner.run` appends the block to the rendered body it
+  passes to `spawn` (it already holds the `execute_skill` result carrying
+  `reference_files`).
+
+Block form: `Bundled files (readable via skill_file): references/api.md (2 KB),
+assets/logo.png (12 KB, binary), …`. Plain sends never see it (substitution
+does not render it). Binaries are listed with a `(binary)` marker (listable,
+not readable).
 
 ### 5. Bounds
 
@@ -140,7 +156,8 @@ into user prose, no recursion concerns.
 |------|------|----------------|
 | Read seam | `Skills_Interop/local_skills_service.py` | `read_skill_file` (policy → trust → validate → contained read → cap); reuses `_read_text_preserving_newlines` + `validate_supporting_file_path` + `_require_trusted_skill` |
 | Scope passthrough | `Skills_Interop/skills_scope_service.py` | local-only bespoke dispatch; clean server-mode rejection |
-| Bindings object + schema | `Agents/agent_models.py` (or sibling) | `SkillFileBindings`; `SKILL_FILE_TOOL_NAME`/schema constant |
+| Bindings object + constants | `Agents/agent_models.py` (NAME + `SkillFileBindings`) / `Agents/tool_catalog.py` (SCHEMA) | follows the existing split convention: `SPAWN_TOOL_NAME` et al. live in agent_models, `SPAWN_TOOL_SCHEMA` et al. in tool_catalog; `SKILL_FILE_TOOL_NAME` joins `RUNTIME_TOOL_NAMES` |
+| **Policy registry entry (REQUIRED)** | `runtime_policy/registry.py` (~:1019, the `server_skills` capability block) | add `_resource("skills.read_file", actions=(LAUNCH,))` — the policy engine FAILS CLOSED on unknown action ids, so without this entry every read is denied wherever an enforcer is wired |
 | Runtime dispatch | `Agents/agent_runtime.py` + `Agents/agent_service.py` | pin schema into `runtime_schemas` when bindings non-empty; `skill_file` name-branch → reader closure; sync |
 | Fork grant | `Chat/console_agent_bridge.py` (`_BridgeSkillRunner.run`) | add spawned skill's name to bindings before `spawn` |
 | Turn bindings | `Chat/console_chat_controller.py` | 4-tuple widening; thread `turn_skill_bindings` through the funnel to `run_reply` |
@@ -163,6 +180,12 @@ into user prose, no recursion concerns.
   (blocked/fork-literal mentions do NOT); plain send → no tool; 4-tuple threaded
   at all 4 call sites (mechanical unpack updates).
 - **Collision:** a skill named `skill_file` is not registered as a skill tool.
+- **Policy:** `skills.read_file.launch.local` evaluates ALLOWED by default with
+  a real enforcer wired (pins the required registry entry — the engine denies
+  unknown ids); a policy-disabled configuration denies the read cleanly.
+- **Bridge-side block:** the "Bundled files" block lands on the trailing user
+  message of `run_reply`'s `agent_messages` (never in the stored transcript,
+  never on plain sends); `SkillRunner.run` appends it to the spawned body.
 - **E2E:** fork skill whose body references `references/api.md` reads it on
   demand; the "Bundled files" block appears exactly where the tool exists.
 

--- a/Docs/superpowers/specs/2026-07-23-skills-reference-file-reachability-design.md
+++ b/Docs/superpowers/specs/2026-07-23-skills-reference-file-reachability-design.md
@@ -132,9 +132,11 @@ the tool's existence is already CERTAIN:
 - **Bridge turn path:** `run_reply`, right where it seeds `SkillFileBindings`
   from `turn_skill_bindings`, appends the block to the trailing user message of
   its own `agent_messages` copy before `run_turn` — zero-race by construction
-  (run_reply only executes once bridge-vs-plain is decided). The
-  `reference_files` metadata for the bound skills is fetched via the skills
-  service at that point.
+  (run_reply only executes once bridge-vs-plain is decided). The block TEXT is
+  pre-rendered at substitution time as pure string work from the execute
+  results already in hand (`reference_files`, no re-execution) and threaded to
+  `run_reply` alongside the binding names; substitution itself never inserts it
+  into messages, so plain sends simply drop it unused.
 - **Fork path:** `SkillRunner.run` appends the block to the rendered body it
   passes to `spawn` (it already holds the `execute_skill` result carrying
   `reference_files`).

--- a/Docs/superpowers/specs/2026-07-23-skills-reference-file-reachability-design.md
+++ b/Docs/superpowers/specs/2026-07-23-skills-reference-file-reachability-design.md
@@ -1,0 +1,175 @@
+# Skills Runtime — Reference-File Reachability (`skill_file` tool)
+
+**Status:** Approved design (2026-07-23), mechanism hardened after two code-verified
+runtime traces.
+**Program:** Skills-install program. Follows Spec 2 (full-bundle fidelity, PR #784)
+and the `$`-mention invocation migration (PR #801), both merged. This spec makes
+the faithfully-stored bundles *usable*: an agent can read a skill's
+`references/*` on demand.
+
+## Problem
+
+Spec 2 stores a skill's nested `references/`, `scripts/`, and `assets/`
+faithfully, but nothing exposes them at runtime. `execute_skill` returns only the
+rendered `SKILL.md` body; the Agents runtime's builtin tools are Calculator and
+DateTime — **there is no file-read capability anywhere in the agent tool
+catalog**. A skill body that says "see `references/api.md`" dead-ends: the
+sub-agent that IS the skill cannot read its own bundle, and the main Console
+agent cannot read the bundles of skills the user just `$`-mentioned. This spec
+adds the first file capability to the agent runtime — which makes tight scoping
+load-bearing, not a nicety.
+
+## Decisions (user-approved)
+
+- **Mechanism B**: a skill-scoped read tool (not path-in-prompt, not eager
+  inlining) — preserves progressive disclosure and containment.
+- **Scope**: model-invoked skill forks AND native-tools user turns whose payload
+  was produced by `$skill` invocations. Plain sends (no tool loop) get nothing —
+  no tool, no dangling "bundled files" promise.
+- **Always granted for a skill's own bundle**: reading your own references is
+  the progressive-disclosure baseline, NOT subject to the skill's frontmatter
+  `allowed-tools` narrowing.
+- **Per-read cap 100 KB** with an explicit truncation marker; text-only.
+
+## Design
+
+### 1. One read seam: `LocalSkillsService.read_skill_file`
+
+`read_skill_file(skill_name: str, relative_path: str) -> dict` with
+`{content: str, truncated: bool, size: int}`. Synchronous (the whole agent
+runtime runs on a worker thread with no event loop). Per call, in order:
+
+1. `_enforce("skills.read_file.launch.local")` (policy gate, mirroring
+   `execute_skill`).
+2. `_require_trusted_skill(skill_name)` — trust re-verified at READ time
+   (sync; raises `SkillTrustBlockedError`). A skill revoked mid-run stops
+   being readable immediately, mirroring the render-fresh discipline.
+3. `validate_supporting_file_path(relative_path)` — traversal/bad-name/depth
+   rejection (Spec 2's validator).
+4. Containment + read via the existing `_read_text_preserving_newlines`
+   discipline (resolve, symlink checks on dir and file,
+   `get_safe_relative_path` containment, UTF-8 decode) — reused, not
+   re-implemented. `SKILL.md` itself is readable (harmless; it is the body).
+5. A binary file (null byte / decode failure) returns a clean refusal string
+   ("binary file — N bytes; not readable as text"), never bytes, never raises.
+6. Output capped at **100,000 characters**; `truncated: True` plus a trailing
+   marker line when cut.
+
+**Scope-service passthrough is LOCAL-ONLY**: `SkillsScopeService.read_skill_file`
+uses the bespoke-dispatch pattern (like `count_skills`/`delete_skill`) and
+rejects `mode="server"` with a clear domain error — never a raw
+`AttributeError` from a missing server method. (All existing runtime skill
+paths are already hardcoded `mode="local"`.)
+
+### 2. `skill_file` is the FOURTH RUNTIME TOOL (verified mechanism)
+
+Two traced facts force this shape: (a) the tool registry is **per-run and
+shared** between the primary agent and its skill-children — a
+provider-registered tool cannot distinguish callers and, on the service-owned
+registry, would leak across runs; (b) provider-registered tools pass through
+disclosure budgets (`initial_disclosure` direct-discloses only when the catalog
+is ≤ 8 entries), which could silently hide a capability the rendered prompt
+advertises. The runtime tools (`spawn_subagent`/`find_tools`/`load_tools`)
+already solve both problems: pinned via `runtime_schemas` (active from step 1,
+never disclosure-gated), dispatched by a name-branch in `run_agent_loop`,
+authorized by their own logic rather than `config.allowed_tools` membership.
+
+`skill_file(skill_name: str, path: str)` joins them:
+
+- **Schema pinning:** `_run_one` appends the `skill_file` schema to its
+  `runtime_schemas` whenever the run's bindings object (below) is non-empty —
+  for the primary run AND for a skill-spawned child.
+- **Dispatch:** a `skill_file` name-branch (runtime-tool pattern) invoking a
+  per-run reader closure; NOT `ToolCatalogRegistry.invoke_by_name`, NOT a
+  provider.
+- **Authorization: the per-run `SkillFileBindings` object.** A small mutable
+  holder created per `run_reply`/agent run: `{authorized: set[str],
+  reader: <scope-service read_skill_file>}`.
+  - Seeded with the TURN's `$skill` binding set (see §3).
+  - `SkillRunner.run` **adds the spawned skill's name** before `spawn(...)`,
+    so the sub-agent that IS the skill can always read its own bundle —
+    independent of its frontmatter `allowed-tools` (which only ever narrows
+    builtins and is untouched).
+  - A `skill_file` call naming a skill outside `authorized` → clean
+    `ToolResult(ok=False, ...)` refusal. Within one run, primary and children
+    share the bindings union — acceptable: every authorized name is a
+    trusted, user- or model-triggered skill in this same conversation, and
+    the real security boundary is per-call trust re-verification +
+    directory containment in §1, not caller identity.
+- **Collision exclusion:** `skill_file` joins the composition-time
+  collision-exclusion set (the `RUNTIME_TOOL_NAMES` mechanism that already
+  keeps skills named `spawn_subagent`/`find_tools`/`load_tools` out of the
+  catalog), so a skill literally named `skill_file` is never registered as a
+  skill tool.
+
+### 3. Turn bindings: recorded at substitution, threaded to the run
+
+`_apply_skill_substitution` already executes every `$skill` that drives a turn.
+It now ALSO returns the set of skill names that actually rendered (leading
+resolved name; embedded successfully-spliced names — NOT blocked/fork-literal
+mentions): the return widens from 3-tuple to 4-tuple
+`(messages, refuse, notes, skill_bindings)` — the same widening idiom the notes
+channel used, applied at the same 4 call sites, threaded through the single
+shared funnel (`_stream_assistant_response` → `_run_agent_reply` →
+`bridge.run_reply(turn_skill_bindings=...)`). `run_reply` seeds the
+`SkillFileBindings` object; empty bindings + no skill spawn ⇒ the schema is
+never pinned and the tool simply doesn't exist for the run.
+
+Bindings are **per-turn** (a plain follow-up message gets no tool). The bridge's
+per-conversation snapshot dicts are the named seam if accumulation is ever
+wanted — explicitly out of scope now.
+
+### 4. Discovery metadata travels with capability
+
+`execute_skill` gains an additive `reference_files` field (relative path, size,
+`is_text` — from Spec 2's `_read_bundle_manifest`). Only the two tool-injecting
+consumers render it into the prompt — a compact block appended to the rendered
+body: `Bundled files (readable via skill_file): references/api.md (2 KB), …`.
+Plain sends ignore the field (no dangling promise). Binaries are listed with a
+`(binary)` marker (listable, not readable).
+
+### 5. Bounds
+
+Per-read 100 KB cap (§1). Tool-call count rides the loop's existing per-run
+budgets (no new budget). Reads return text as tool results only — never spliced
+into user prose, no recursion concerns.
+
+## Components & boundaries
+
+| Unit | File | Responsibility |
+|------|------|----------------|
+| Read seam | `Skills_Interop/local_skills_service.py` | `read_skill_file` (policy → trust → validate → contained read → cap); reuses `_read_text_preserving_newlines` + `validate_supporting_file_path` + `_require_trusted_skill` |
+| Scope passthrough | `Skills_Interop/skills_scope_service.py` | local-only bespoke dispatch; clean server-mode rejection |
+| Bindings object + schema | `Agents/agent_models.py` (or sibling) | `SkillFileBindings`; `SKILL_FILE_TOOL_NAME`/schema constant |
+| Runtime dispatch | `Agents/agent_runtime.py` + `Agents/agent_service.py` | pin schema into `runtime_schemas` when bindings non-empty; `skill_file` name-branch → reader closure; sync |
+| Fork grant | `Chat/console_agent_bridge.py` (`_BridgeSkillRunner.run`) | add spawned skill's name to bindings before `spawn` |
+| Turn bindings | `Chat/console_chat_controller.py` | 4-tuple widening; thread `turn_skill_bindings` through the funnel to `run_reply` |
+| Collision exclusion | `Chat/console_agent_bridge.py` (`_non_colliding_skill_entries`) / `RUNTIME_TOOL_NAMES` | a skill named `skill_file` is never catalog-registered |
+| Prompt metadata | `Skills_Interop/local_skills_service.py` (`execute_skill`) + the two injecting consumers | additive `reference_files`; "Bundled files" block rendered only where the tool exists |
+
+## Testing strategy
+
+- **Seam unit:** trusted read happy path (nested path); trust-revoked →
+  `SkillTrustBlockedError`; traversal (`../`), absolute, bad segment → rejected;
+  symlink → rejected; binary → clean refusal string; >100 KB → truncated flag +
+  marker; unknown skill/file → clean error; scope service `mode="server"` →
+  domain error.
+- **Bindings/authorization unit:** call naming an unauthorized skill → refusal;
+  authorized → content; empty bindings ⇒ schema not pinned (tool absent).
+- **Fork path:** a skill child spawned via `SkillRunner` can read its OWN
+  `references/x.md`; cannot read a non-bound other skill; grant independent of
+  frontmatter `allowed-tools`.
+- **Turn path:** leading `$skill` and embedded splices record bindings
+  (blocked/fork-literal mentions do NOT); plain send → no tool; 4-tuple threaded
+  at all 4 call sites (mechanical unpack updates).
+- **Collision:** a skill named `skill_file` is not registered as a skill tool.
+- **E2E:** fork skill whose body references `references/api.md` reads it on
+  demand; the "Bundled files" block appears exactly where the tool exists.
+
+## Out of scope (deliberate)
+
+- Script **execution** (`scripts/*` running) — the trust-gated follow-on layer.
+- Binary reads / asset serving; per-conversation binding accumulation (seam
+  named: the bridge's per-conversation dicts); plain-send fallback listings;
+  audit-trail entries for reads; remote/server skills; multimodal-turn bindings
+  (multimodal payloads still skip substitution entirely, pre-existing).

--- a/Tests/Agents/test_agent_models.py
+++ b/Tests/Agents/test_agent_models.py
@@ -48,7 +48,12 @@ def test_run_status_values_and_terminal_set():
 
 def test_runtime_tool_names():
     assert SPAWN_TOOL_NAME == "spawn_subagent"
-    assert RUNTIME_TOOL_NAMES == {"spawn_subagent", "find_tools", "load_tools"}
+    assert RUNTIME_TOOL_NAMES == {
+        "spawn_subagent",
+        "find_tools",
+        "load_tools",
+        "skill_file",
+    }
     assert DIRECT_DISCLOSE_THRESHOLD == 8 and LOOP_DETECTION_N == 3
 
 

--- a/Tests/Agents/test_skill_file_runtime_tool.py
+++ b/Tests/Agents/test_skill_file_runtime_tool.py
@@ -202,6 +202,62 @@ def test_skill_file_reader_returning_non_mapping_fails_the_call_not_the_run(
     assert "skill_file" in refusal
 
 
+def test_skill_file_empty_authorized_schema_absent_and_falls_through(tmp_path):
+    # Qodo/PR#814: schema pinning (~agent_service.py:356-360) already
+    # requires bindings.authorized to be non-empty, but the OLD
+    # LoopDeps.read_skill_file wiring only checked bindings is not None --
+    # so bindings with an EMPTY authorized set (no skill forked yet in this
+    # run) still reached the named-refusal dispatch for a hallucinated
+    # call, leaking the tool's existence to an undisclosed name. Wiring
+    # must use the SAME predicate as schema pinning: empty authorized falls
+    # through to the generic "Tool not permitted" path, identical to
+    # bindings=None.
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    reg = _registry_with_builtins()
+
+    def reader(skill_name, path):
+        raise AssertionError("reader must not be called with empty authorized")
+
+    bindings = SkillFileBindings(authorized=set(), reader=reader)
+
+    script = [
+        {
+            "choices": [
+                {
+                    "message": {
+                        "content": _skill_file_fence("demo", "references/api.md")
+                    }
+                }
+            ]
+        },
+        {"choices": [{"message": {"content": "Done."}}]},
+    ]
+    calls = []
+
+    def chat_call(**kwargs):
+        calls.append(kwargs)
+        return script.pop(0)
+
+    service = AgentService(db, reg, chat_call=chat_call, skill_file_bindings=bindings)
+    run_id, outcome = service.run_turn(
+        conversation_id="c1",
+        messages=[{"role": "user", "content": "go"}],
+        config=_base_config(),
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+
+    first_system_content = calls[0]["messages_payload"][0]["content"]
+    assert SKILL_FILE_TOOL_NAME not in first_system_content
+
+    run = db.get_run(run_id)
+    results = [s for s in run["steps"] if s["kind"] == "tool_result"]
+    # Falls through to the SAME permission-gate path any other undisclosed/
+    # disallowed tool name hits -- not the skill_file-specific
+    # "'demo' is not active in this run" refusal.
+    assert "Tool not permitted: skill_file" in results[0]["result"]
+
+
 def test_skill_file_bindings_none_schema_absent_and_falls_through(tmp_path):
     db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
     reg = _registry_with_builtins()

--- a/Tests/Agents/test_skill_file_runtime_tool.py
+++ b/Tests/Agents/test_skill_file_runtime_tool.py
@@ -7,6 +7,7 @@ runtime_schemas (never disclosure-gated) and its authorization lives on the
 per-run SkillFileBindings object, never config.allowed_tools.
 """
 
+import asyncio
 import json
 
 from tldw_chatbook.Agents.agent_models import (
@@ -21,6 +22,7 @@ from tldw_chatbook.Agents.agent_runtime import FENCE_OPEN
 from tldw_chatbook.Agents.agent_service import AgentService
 from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider, ToolCatalogRegistry
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+from tldw_chatbook.Skills_Interop.local_skills_service import LocalSkillsService
 
 
 def _fence(name, args):
@@ -241,3 +243,66 @@ def test_skill_file_bindings_none_schema_absent_and_falls_through(tmp_path):
     # Falls through to the SAME permission-gate path any other undisclosed/
     # disallowed tool name hits -- not a skill_file-specific refusal.
     assert "Tool not permitted: skill_file" in results[0]["result"]
+
+
+# --- Step 1 e2e: real LocalSkillsService, no fake reader --------------------
+
+
+def test_skill_file_e2e_fork_reads_its_own_reference_file(tmp_path):
+    """End-to-end through the REAL read seam: a real `LocalSkillsService`
+    (file-marker trust arrangement mirrored from Tests/Skills/
+    test_read_skill_file.py's `_svc` -- no keyring, no policy_enforcer, so
+    `_enforce` and `_require_trusted_skill` both no-op) backs a skill whose
+    bundle has `references/api.md`. The bindings reader is the real sync
+    adapter (`asyncio.run` over the async service call), not a fake -- this
+    is the seam the bridge itself uses in production. Drives the same
+    scripted-model harness as the unit tests above: turn 1 calls skill_file,
+    turn 2 finishes."""
+    svc = LocalSkillsService(
+        store_dir=tmp_path / "skills_store",
+        allow_untrusted_without_trust_service=True,
+    )
+    asyncio.run(
+        svc.create_skill(name="demo", content="---\nname: demo\n---\nbody\n")
+    )
+    skill_dir = svc._skill_dir("demo")
+    (skill_dir / "references").mkdir(parents=True, exist_ok=True)
+    (skill_dir / "references" / "api.md").write_text(
+        "# api docs\n", encoding="utf-8"
+    )
+
+    def reader(skill_name, path):
+        return asyncio.run(svc.read_skill_file(skill_name, path))
+
+    bindings = SkillFileBindings(authorized={"demo"}, reader=reader)
+
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    reg = _registry_with_builtins()
+
+    script = [
+        {
+            "choices": [
+                {
+                    "message": {
+                        "content": _skill_file_fence("demo", "references/api.md")
+                    }
+                }
+            ]
+        },
+        {"choices": [{"message": {"content": "Done."}}]},
+    ]
+
+    service = AgentService(
+        db, reg, chat_call=lambda **k: script.pop(0), skill_file_bindings=bindings
+    )
+    run_id, outcome = service.run_turn(
+        conversation_id="c1",
+        messages=[{"role": "user", "content": "go"}],
+        config=_base_config(),
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+
+    run = db.get_run(run_id)
+    results = [s for s in run["steps"] if s["kind"] == "tool_result"]
+    assert any("# api docs" in r["result"] for r in results)

--- a/Tests/Agents/test_skill_file_runtime_tool.py
+++ b/Tests/Agents/test_skill_file_runtime_tool.py
@@ -155,6 +155,51 @@ def test_skill_file_unauthorized_name_is_refused(tmp_path):
     assert "other" in refusal
 
 
+def test_skill_file_reader_returning_non_mapping_fails_the_call_not_the_run(
+    tmp_path,
+):
+    """A reader is caller-supplied (the bridge's asyncio.run adapter over
+    SkillsScopeService.read_skill_file); a malformed/misbehaving reader that
+    returns a bare string (not a dict-like result) must fail only THAT tool
+    call -- not crash the whole run via an uncaught AttributeError from
+    `.get` on a non-mapping."""
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    reg = _registry_with_builtins()
+
+    def bad_reader(skill_name, path):
+        return "not a dict"
+
+    bindings = SkillFileBindings(authorized={"demo"}, reader=bad_reader)
+
+    script = [
+        {
+            "choices": [
+                {
+                    "message": {
+                        "content": _skill_file_fence("demo", "references/api.md")
+                    }
+                }
+            ]
+        },
+        {"choices": [{"message": {"content": "Done."}}]},
+    ]
+    service = AgentService(
+        db, reg, chat_call=lambda **k: script.pop(0), skill_file_bindings=bindings
+    )
+    run_id, outcome = service.run_turn(
+        conversation_id="c1",
+        messages=[{"role": "user", "content": "go"}],
+        config=_base_config(),
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    run = db.get_run(run_id)
+    results = [s for s in run["steps"] if s["kind"] == "tool_result"]
+    refusal = results[0]["result"]
+    assert refusal.startswith("ERROR:")
+    assert "skill_file" in refusal
+
+
 def test_skill_file_bindings_none_schema_absent_and_falls_through(tmp_path):
     db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
     reg = _registry_with_builtins()

--- a/Tests/Agents/test_skill_file_runtime_tool.py
+++ b/Tests/Agents/test_skill_file_runtime_tool.py
@@ -1,0 +1,198 @@
+"""skill_file: the fourth runtime tool -- bindings, schema pin, dispatch.
+
+Model: Tests/Agents/test_skill_tool_spawn.py's fake chat_call/registry
+scaffolding (AgentService + AgentRunsDB + a scripted fence-protocol
+provider). skill_file is NOT a ToolProvider -- its schema is pinned into
+runtime_schemas (never disclosure-gated) and its authorization lives on the
+per-run SkillFileBindings object, never config.allowed_tools.
+"""
+
+import json
+
+from tldw_chatbook.Agents.agent_models import (
+    AgentConfig,
+    RUN_DONE,
+    RUNTIME_TOOL_NAMES,
+    RunBudget,
+    SKILL_FILE_TOOL_NAME,
+    SkillFileBindings,
+)
+from tldw_chatbook.Agents.agent_runtime import FENCE_OPEN
+from tldw_chatbook.Agents.agent_service import AgentService
+from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider, ToolCatalogRegistry
+from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+
+def _fence(name, args):
+    return f"{FENCE_OPEN}\n{json.dumps({'name': name, 'arguments': args})}\n```"
+
+
+def _skill_file_fence(skill_name, path):
+    return _fence(SKILL_FILE_TOOL_NAME, {"skill_name": skill_name, "path": path})
+
+
+def _base_config():
+    return AgentConfig(
+        model="m",
+        system_prompt="s",
+        allowed_tools=("calculator",),
+        budget=RunBudget(),
+    )
+
+
+def _registry_with_builtins():
+    reg = ToolCatalogRegistry()
+    reg.register_provider(BuiltinToolProvider())
+    return reg
+
+
+# --- Step 1 unit tests (brief's exact contract) -----------------------------
+
+
+def test_skill_file_is_a_runtime_tool_name():
+    assert SKILL_FILE_TOOL_NAME == "skill_file"
+    # collision exclusion rides existing consumers
+    assert SKILL_FILE_TOOL_NAME in RUNTIME_TOOL_NAMES
+
+
+def test_bindings_object_shape():
+    b = SkillFileBindings(authorized=set(), reader=None)
+    b.authorized.add("demo")
+    assert "demo" in b.authorized
+
+
+# --- Loop-level tests, run through AgentService (only it wires runtime_
+# schemas / the reader closure -- the loop itself just dispatches by name). --
+
+
+def test_skill_file_schema_offered_first_turn_and_authorized_read_succeeds(tmp_path):
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    reg = _registry_with_builtins()
+
+    read_calls = []
+
+    def reader(skill_name, path):
+        read_calls.append((skill_name, path))
+        return {"content": "REF", "truncated": False, "size": 3}
+
+    bindings = SkillFileBindings(authorized={"demo"}, reader=reader)
+
+    script = [
+        {
+            "choices": [
+                {
+                    "message": {
+                        "content": _skill_file_fence("demo", "references/api.md")
+                    }
+                }
+            ]
+        },
+        {"choices": [{"message": {"content": "Done."}}]},
+    ]
+    calls = []
+
+    def chat_call(**kwargs):
+        calls.append(kwargs)
+        return script.pop(0)
+
+    service = AgentService(db, reg, chat_call=chat_call, skill_file_bindings=bindings)
+    run_id, outcome = service.run_turn(
+        conversation_id="c1",
+        messages=[{"role": "user", "content": "go"}],
+        config=_base_config(),
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    assert read_calls == [("demo", "references/api.md")]
+
+    # Active from the FIRST provider call, never disclosure-gated -- unlike
+    # a ToolProvider entry, which would need find_tools/load_tools first.
+    first_system_content = calls[0]["messages_payload"][0]["content"]
+    assert SKILL_FILE_TOOL_NAME in first_system_content
+
+    run = db.get_run(run_id)
+    results = [s for s in run["steps"] if s["kind"] == "tool_result"]
+    assert any("REF" in r["result"] for r in results)
+
+
+def test_skill_file_unauthorized_name_is_refused(tmp_path):
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    reg = _registry_with_builtins()
+
+    def reader(skill_name, path):
+        raise AssertionError("reader must not be called for an unauthorized name")
+
+    # "demo" is active in this run; "other" is not -- the model asks for
+    # "other" anyway (e.g. a stale/hallucinated skill name).
+    bindings = SkillFileBindings(authorized={"demo"}, reader=reader)
+
+    script = [
+        {
+            "choices": [
+                {
+                    "message": {
+                        "content": _skill_file_fence("other", "references/api.md")
+                    }
+                }
+            ]
+        },
+        {"choices": [{"message": {"content": "Done."}}]},
+    ]
+    service = AgentService(
+        db, reg, chat_call=lambda **k: script.pop(0), skill_file_bindings=bindings
+    )
+    run_id, outcome = service.run_turn(
+        conversation_id="c1",
+        messages=[{"role": "user", "content": "go"}],
+        config=_base_config(),
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    run = db.get_run(run_id)
+    results = [s for s in run["steps"] if s["kind"] == "tool_result"]
+    refusal = results[0]["result"]
+    assert refusal.startswith("ERROR:")
+    assert "other" in refusal
+
+
+def test_skill_file_bindings_none_schema_absent_and_falls_through(tmp_path):
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    reg = _registry_with_builtins()
+
+    script = [
+        {
+            "choices": [
+                {
+                    "message": {
+                        "content": _skill_file_fence("demo", "references/api.md")
+                    }
+                }
+            ]
+        },
+        {"choices": [{"message": {"content": "Done."}}]},
+    ]
+    calls = []
+
+    def chat_call(**kwargs):
+        calls.append(kwargs)
+        return script.pop(0)
+
+    # No skill_file_bindings passed at all -- the feature was never
+    # configured for this run.
+    service = AgentService(db, reg, chat_call=chat_call)
+    run_id, outcome = service.run_turn(
+        conversation_id="c1",
+        messages=[{"role": "user", "content": "go"}],
+        config=_base_config(),
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+
+    first_system_content = calls[0]["messages_payload"][0]["content"]
+    assert SKILL_FILE_TOOL_NAME not in first_system_content
+
+    run = db.get_run(run_id)
+    results = [s for s in run["steps"] if s["kind"] == "tool_result"]
+    # Falls through to the SAME permission-gate path any other undisclosed/
+    # disallowed tool name hits -- not a skill_file-specific refusal.
+    assert "Tool not permitted: skill_file" in results[0]["result"]

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -12,6 +12,7 @@ from tldw_chatbook.Chat.console_agent_bridge import (
     compose_agent_system_prompt,
     format_agent_step_marker,
     inject_resume_agent_markers,
+    _BridgeSkillRunner,
     _compose_run_allowed_tools,
     _compose_run_registry_and_allowed,
     _non_colliding_mcp_names,
@@ -33,6 +34,7 @@ from tldw_chatbook.Agents.agent_models import (
     STEP_SPAWN,
     STEP_TOOL_RESULT,
     RunOutcome,
+    SkillFileBindings,
     ToolCatalogEntry,
     ToolResult,
     ToolSchema,
@@ -966,6 +968,152 @@ def test_skill_trust_blocked_refuses_without_spawning(tmp_path):
 
     assert outcome.status == "done"
     assert db.count_subagent_runs("conv-blocked") == 0
+
+
+# -- task-4 (skills-fork-reachability): _BridgeSkillRunner grants its own
+# name skill_file authorization pre-spawn and appends a "Bundled files"
+# pointer block to the rendered task text whenever execute_skill reports
+# reference_files -- unit-level, directly against _BridgeSkillRunner, so
+# these don't need a full run_reply/model round trip. --
+
+
+class _FakeSkillsServiceWithRefs(_FakeSkillsService):
+    """Same fake as above, but execute_skill also reports a bundle manifest."""
+
+    async def execute_skill(self, name, *, mode="local", args=None):
+        self.execute_calls.append(args)
+        return {
+            "skill_name": name,
+            "rendered_prompt": f"Review this: {args}",
+            "allowed_tools": self.allowed_tools,
+            "execution_mode": "inline",
+            "reference_files": [
+                {"path": "references/api.md", "size": 120, "is_text": True},
+                {"path": "assets/logo.png", "size": 2048, "is_text": False},
+            ],
+        }
+
+
+def test_bridge_skill_runner_grants_own_name_and_appends_bundle_block_before_spawn():
+    skills_service = _FakeSkillsServiceWithRefs()
+    bindings = SkillFileBindings(authorized=set())
+    runner = _BridgeSkillRunner(
+        skills_service=skills_service,
+        skill_names=frozenset({"code-review"}),
+        builtin_names=(),
+        skill_file_bindings=bindings,
+    )
+    spawn_calls = []
+
+    def spawn(rendered, *, allowed_tools):
+        # The name must already be authorized by the time spawn actually
+        # runs -- so the spawned child's very first turn can read its own
+        # bundle -- not merely by the time .run() returns.
+        assert "code-review" in bindings.authorized
+        spawn_calls.append(rendered)
+        return ToolResult(ok=True, content="sub-agent result")
+
+    result = runner.run("code-review", "the diff", spawn)
+
+    assert result.ok
+    assert spawn_calls == [
+        "Review this: the diff\n\nBundled files (readable via skill_file): "
+        "references/api.md (120 bytes), assets/logo.png (2048 bytes, binary)"
+    ]
+    assert "code-review" in bindings.authorized
+
+
+def test_bridge_skill_runner_no_reference_files_body_unchanged_still_authorizes():
+    skills_service = _FakeSkillsService()  # no reference_files key at all
+    bindings = SkillFileBindings(authorized=set())
+    runner = _BridgeSkillRunner(
+        skills_service=skills_service,
+        skill_names=frozenset({"code-review"}),
+        builtin_names=(),
+        skill_file_bindings=bindings,
+    )
+    spawn_calls = []
+
+    def spawn(rendered, *, allowed_tools):
+        spawn_calls.append(rendered)
+        return ToolResult(ok=True, content="sub-agent result")
+
+    runner.run("code-review", "the diff", spawn)
+
+    assert spawn_calls == ["Review this: the diff"]
+    assert "code-review" in bindings.authorized
+
+
+def test_bridge_skill_runner_bindings_none_is_byte_identical_legacy_behavior():
+    # reference_files IS present in the execute_skill result, but with no
+    # skill_file_bindings wired at all (legacy/non-bridge construction) the
+    # block must never be appended and nothing must crash.
+    skills_service = _FakeSkillsServiceWithRefs()
+    runner = _BridgeSkillRunner(
+        skills_service=skills_service,
+        skill_names=frozenset({"code-review"}),
+        builtin_names=(),
+    )
+    spawn_calls = []
+
+    def spawn(rendered, *, allowed_tools):
+        spawn_calls.append(rendered)
+        return ToolResult(ok=True, content="sub-agent result")
+
+    runner.run("code-review", "the diff", spawn)
+
+    assert spawn_calls == ["Review this: the diff"]
+
+
+def test_run_reply_wires_one_skill_file_bindings_to_both_service_and_runner(
+    tmp_path,
+):
+    """run_reply must construct exactly ONE SkillFileBindings per run and
+    hand the SAME object to both AgentService and the _BridgeSkillRunner --
+    never two independently-seeded copies (which would let the runner's
+    pre-spawn grant silently fail to reach the loop's authorization check)."""
+    captured = {}
+    real_runner_init = _BridgeSkillRunner.__init__
+    real_service_init = AgentService.__init__
+
+    def spy_runner_init(self, **kwargs):
+        captured["runner_bindings"] = kwargs.get("skill_file_bindings")
+        real_runner_init(self, **kwargs)
+
+    def spy_service_init(self, *args, **kwargs):
+        captured["service_bindings"] = kwargs.get("skill_file_bindings")
+        real_service_init(self, *args, **kwargs)
+
+    scripts = [
+        [_fence("code-review", {"args": "the diff"})],
+        ["Looks fine to me."],
+        ["All done."],
+    ]
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    store = ConsoleChatStore()
+    session = store.ensure_session()
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="hi")
+    assistant = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content=""
+    )
+    skills_service = _FakeSkillsService()
+    bridge = ConsoleAgentBridge(
+        agent_runs_db=db,
+        store=store,
+        provider_gateway=_ChunkGateway(scripts),
+        skills_service=skills_service,
+    )
+
+    with patch.object(_BridgeSkillRunner, "__init__", spy_runner_init), patch.object(
+        AgentService, "__init__", spy_service_init
+    ):
+        outcome = _run(
+            bridge, store, session, assistant.id, conversation_id="conv-bindings"
+        )
+
+    assert outcome.status == "done"
+    assert captured["runner_bindings"] is not None
+    assert captured["runner_bindings"] is captured["service_bindings"]
 
 
 def test_no_skills_service_leaves_shared_registry_path_untouched(tmp_path):

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -1116,6 +1116,137 @@ def test_run_reply_wires_one_skill_file_bindings_to_both_service_and_runner(
     assert captured["runner_bindings"] is captured["service_bindings"]
 
 
+def test_run_reply_seeds_turn_bindings_into_shared_object(tmp_path):
+    """Task 5: the turn's already-resolved `$skill` binding names (splice
+    output the CONTROLLER computed for the triggering turn) must be seeded
+    into THIS run's SkillFileBindings.authorized -- the SAME shared object
+    handed to both AgentService and the _BridgeSkillRunner (Task 4) -- so
+    the primary agent's very first turn can already read that skill's own
+    bundle via skill_file. Reuses the sibling wiring test's spy idiom to
+    prove the seed lands on the one shared object, not a second copy."""
+    captured = {}
+    real_runner_init = _BridgeSkillRunner.__init__
+    real_service_init = AgentService.__init__
+
+    def spy_runner_init(self, **kwargs):
+        captured["runner_bindings"] = kwargs.get("skill_file_bindings")
+        real_runner_init(self, **kwargs)
+
+    def spy_service_init(self, *args, **kwargs):
+        captured["service_bindings"] = kwargs.get("skill_file_bindings")
+        real_service_init(self, *args, **kwargs)
+
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    store = ConsoleChatStore()
+    session = store.ensure_session()
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="hi")
+    assistant = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content=""
+    )
+    skills_service = _FakeSkillsService()
+    bridge = ConsoleAgentBridge(
+        agent_runs_db=db,
+        store=store,
+        provider_gateway=_ChunkGateway([["Tokyo."]]),
+        skills_service=skills_service,
+    )
+
+    with patch.object(_BridgeSkillRunner, "__init__", spy_runner_init), patch.object(
+        AgentService, "__init__", spy_service_init
+    ):
+        outcome = _run(
+            bridge,
+            store,
+            session,
+            assistant.id,
+            conversation_id="conv-turn-bindings",
+            turn_skill_bindings=("code-review",),
+        )
+
+    assert outcome.status == "done"
+    assert captured["runner_bindings"] is not None
+    assert "code-review" in captured["runner_bindings"].authorized
+    # Seeded onto the ONE shared object -- never two independently-seeded
+    # copies (Task 4's invariant, re-verified here under a non-empty seed).
+    assert captured["runner_bindings"] is captured["service_bindings"]
+
+
+def test_run_reply_appends_bundle_block_copy_safely(tmp_path):
+    """Task 5: the turn's pre-rendered "Bundled files" block is appended to
+    a NEW list + NEW dict for the last role=="user" entry -- the caller's
+    own `agent_messages` list and its message dict are never mutated. A
+    future refactor that switches to in-place `message["content"] += ...`
+    must fail assertions (b) below."""
+    real_run_turn = AgentService.run_turn
+
+    def _spy(captured):
+        def spy_run_turn(self, **kwargs):
+            captured["messages"] = kwargs.get("messages")
+            return real_run_turn(self, **kwargs)
+
+        return spy_run_turn
+
+    block = "Bundled files (readable via skill_file): notes.md (1 bytes)"
+
+    # -- (a) + (b): a non-empty block is appended copy-safely -------------
+    bridge, _db, store, session, aid = _bridge(tmp_path, [["Tokyo."]])
+    original_user_message = {"role": "user", "content": "hi"}
+    agent_messages = [original_user_message]
+    captured = {}
+
+    with patch.object(AgentService, "run_turn", _spy(captured)):
+        outcome = _run(
+            bridge,
+            store,
+            session,
+            aid,
+            conversation_id="conv-bundle-block",
+            agent_messages=agent_messages,
+            turn_bundle_block=block,
+        )
+
+    assert outcome.status == "done"
+    run_messages = captured["messages"]
+    assert run_messages is not None
+    # (a) the run actually received the block appended after "\n\n" on the
+    # last user entry.
+    assert run_messages[-1]["content"] == f"hi\n\n{block}"
+    assert run_messages[-1]["role"] == "user"
+    # (b) non-mutation contract: the caller's own list length and the dict
+    # identity at that index are unchanged, and the original dict's content
+    # carries no trace of the block. This is exactly what would break if
+    # the append were switched to in-place `message["content"] += ...`.
+    assert len(agent_messages) == 1
+    assert agent_messages[0] is original_user_message
+    assert original_user_message["content"] == "hi"
+    assert "Bundled files" not in original_user_message["content"]
+    # A new list AND a new dict were built for the run -- not the caller's.
+    assert run_messages is not agent_messages
+    assert run_messages[-1] is not original_user_message
+
+    # -- (c) sibling case: an empty block appends nothing, no-op path -----
+    bridge2, _db2, store2, session2, aid2 = _bridge(tmp_path, [["Tokyo."]])
+    agent_messages2 = [{"role": "user", "content": "hi"}]
+    captured2 = {}
+
+    with patch.object(AgentService, "run_turn", _spy(captured2)):
+        outcome2 = _run(
+            bridge2,
+            store2,
+            session2,
+            aid2,
+            conversation_id="conv-bundle-block-empty",
+            agent_messages=agent_messages2,
+            turn_bundle_block="",
+        )
+
+    assert outcome2.status == "done"
+    assert captured2["messages"][-1]["content"] == "hi"
+    # No block to append: the original list is used unchanged (not merely
+    # equal -- the very same object), matching the documented no-op path.
+    assert captured2["messages"] is agent_messages2
+
+
 def test_no_skills_service_leaves_shared_registry_path_untouched(tmp_path):
     """The no-skills-service path (skills_service=None, the default) must
     stay byte-identical to the pre-Task-12 behavior: no get_context call, no

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -420,7 +420,7 @@ async def test_skill_refuse_after_optimistic_echo_marks_row_blocked():
     controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
 
     async def _refuse(messages):
-        return messages, "Refused: untrusted skill.", ()
+        return messages, "Refused: untrusted skill.", (), (), ""
 
     controller._apply_skill_substitution = _refuse
 

--- a/Tests/Chat/test_console_edit_resend.py
+++ b/Tests/Chat/test_console_edit_resend.py
@@ -297,7 +297,9 @@ async def test_edit_and_resend_skill_refusal_leaves_no_pending_node():
     u1 = store.append_message(session.id, role=ConsoleMessageRole.USER, content="original")
 
     async def _refuse(provider_messages):
-        return provider_messages, "Skill refused for testing.", ()
+        # 5-tuple contract: (messages, refuse, notes, skill_bindings,
+        # skill_bundle_block) — widened by the skill_file reachability work.
+        return provider_messages, "Skill refused for testing.", (), (), ""
 
     controller._apply_skill_substitution = _refuse
 

--- a/Tests/Chat/test_console_skill_substitution.py
+++ b/Tests/Chat/test_console_skill_substitution.py
@@ -24,12 +24,20 @@ class _Skills:
         raise_trust_for=(),
         extra_skills=(),
         blocked_skills=(),
+        reference_files=None,
+        reference_files_for=None,
     ):
         self._mode = mode
         self._raise = raise_trust
         self._raise_for = frozenset(raise_trust_for)
         self._extra_skills = tuple(extra_skills)
         self._blocked_skills = tuple(blocked_skills)
+        # Task 5: `reference_files` is a default applied to every
+        # execute_skill result; `reference_files_for` overrides it per skill
+        # name (both mirror Task 2's contract -- the key is ABSENT from the
+        # result entirely when a skill has no bundle beyond SKILL.md).
+        self._reference_files = reference_files
+        self._reference_files_for = dict(reference_files_for or {})
         self.executions = []
         self.get_context_calls = 0
 
@@ -56,13 +64,17 @@ class _Skills:
                 reason_code="skill_modified",
                 trust_status="quarantined_modified",
             )
-        return {
+        result = {
             "skill_name": name,
             "rendered_prompt": f"RENDERED[{args}]",
             "allowed_tools": None,
             "execution_mode": self._mode,
             "fork_output": None,
         }
+        refs = self._reference_files_for.get(name, self._reference_files)
+        if refs is not None:
+            result["reference_files"] = refs
+        return result
 
 
 class _ReadyResolution:
@@ -109,7 +121,9 @@ async def test_inline_substitutes_final_user_message_only():
         {"role": "assistant", "content": "ok"},
         {"role": "user", "content": "$code-review fix it"},
     ]
-    out, refuse, notes = await controller._apply_skill_substitution(msgs)
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        msgs
+    )
     assert refuse is None
     assert out[-1] == {"role": "user", "content": "RENDERED[fix it]"}
     assert out[1] == {"role": "user", "content": "earlier"}  # history preserved
@@ -123,7 +137,9 @@ async def test_fork_drops_history_keeps_system():
         {"role": "user", "content": "earlier"},
         {"role": "user", "content": "$code-review go"},
     ]
-    out, refuse, notes = await controller._apply_skill_substitution(msgs)
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        msgs
+    )
     assert refuse is None
     assert out == [
         {"role": "system", "content": "sys"},
@@ -135,7 +151,9 @@ async def test_fork_drops_history_keeps_system():
 async def test_non_skill_final_message_unchanged():
     controller, _store = _controller(_Skills("inline"))
     msgs = [{"role": "user", "content": "just a question"}]
-    out, refuse, notes = await controller._apply_skill_substitution(msgs)
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        msgs
+    )
     assert out == msgs and refuse is None
 
 
@@ -143,7 +161,9 @@ async def test_non_skill_final_message_unchanged():
 async def test_edited_skill_refuses_at_build():
     controller, _store = _controller(_Skills(raise_trust=True))
     msgs = [{"role": "user", "content": "$code-review go"}]
-    out, refuse, notes = await controller._apply_skill_substitution(msgs)
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        msgs
+    )
     assert out == msgs
     assert refuse == (
         'Skill "code-review" isn\'t trusted (skill_modified) — '
@@ -158,7 +178,9 @@ async def test_no_skills_service_is_a_noop():
         store=store, provider_gateway=object(), provider="llama_cpp", model="m"
     )
     msgs = [{"role": "user", "content": "$code-review go"}]
-    out, refuse, notes = await controller._apply_skill_substitution(msgs)
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        msgs
+    )
     assert out == msgs and refuse is None
 
 
@@ -357,7 +379,9 @@ async def test_leading_slash_no_longer_invokes():
     skills = _Skills("inline")
     controller, _store = _controller(skills)
     messages = [{"role": "user", "content": "/code-review look at this"}]
-    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        messages
+    )
     assert out == messages
     assert refuse is None
     assert skills.executions == []
@@ -374,7 +398,9 @@ async def test_embedded_mention_splices_preserving_prose():
     skills = _Skills("inline")
     controller, _store = _controller(skills)
     messages = [{"role": "user", "content": "summarize, $code-review it, then list"}]
-    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        messages
+    )
     assert refuse is None and notes == ()
     content = out[0]["content"]
     assert content.startswith("summarize, RENDERED[")
@@ -389,7 +415,9 @@ async def test_embedded_fork_mention_left_literal():
     skills = _Skills("fork")
     controller, _store = _controller(skills)
     messages = [{"role": "user", "content": "please $code-review this"}]
-    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        messages
+    )
     assert out == messages          # untouched
     assert refuse is None and notes == ()
 
@@ -399,7 +427,9 @@ async def test_embedded_untrusted_left_literal_with_note():
     skills = _Skills(raise_trust=True)
     controller, _store = _controller(skills)
     messages = [{"role": "user", "content": "please $code-review this"}]
-    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        messages
+    )
     assert out == messages          # prose never lost
     assert refuse is None           # embedded never aborts
     assert len(notes) == 1 and "code-review" in notes[0]
@@ -410,7 +440,9 @@ async def test_leading_resolved_mention_does_not_scan_args():
     skills = _Skills("inline")
     controller, _store = _controller(skills)
     messages = [{"role": "user", "content": "$code-review also $code-review"}]
-    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        messages
+    )
     # Leading form: ONE execution with the rest as args; no embedded pass.
     assert skills.executions == [("code-review", "also $code-review")]
 
@@ -420,7 +452,9 @@ async def test_leading_unresolved_falls_through_to_embedded():
     skills = _Skills("inline")
     controller, _store = _controller(skills)
     messages = [{"role": "user", "content": "$notaskill but $code-review works"}]
-    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        messages
+    )
     content = out[0]["content"]
     assert content.startswith("$notaskill but RENDERED[")
     assert skills.executions == [("code-review", "")]
@@ -434,7 +468,9 @@ async def test_plain_text_send_never_touches_skills_service():
     skills = _Skills("inline")
     controller, _store = _controller(skills)
     messages = [{"role": "user", "content": "just a plain question, no sigil"}]
-    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        messages
+    )
     assert out == messages
     assert refuse is None
     assert notes == ()
@@ -449,7 +485,9 @@ async def test_same_skill_mentioned_twice_embedded_splices_both():
     messages = [
         {"role": "user", "content": "start $code-review mid $code-review end"}
     ]
-    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        messages
+    )
     assert refuse is None and notes == ()
     content = out[0]["content"]
     # BOTH occurrences spliced, prose preserved.
@@ -470,7 +508,9 @@ async def test_mixed_spliced_and_blocked_mentions():
     messages = [
         {"role": "user", "content": "run $code-review then $danger-zone please"}
     ]
-    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        messages
+    )
     assert refuse is None  # embedded never aborts
     content = out[0]["content"]
     assert content == "run RENDERED[] then $danger-zone please"
@@ -496,7 +536,9 @@ async def test_leading_blocked_skill_mention_refuses():
     )
     controller, _store = _controller(skills)
     messages = [{"role": "user", "content": "$blocked-name args here"}]
-    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        messages
+    )
     assert out == messages
     assert refuse == (
         'Skill "blocked-name" isn\'t trusted (skill_modified) — '
@@ -514,7 +556,9 @@ async def test_embedded_blocked_skill_mention_literal_with_note():
     )
     controller, _store = _controller(skills)
     messages = [{"role": "user", "content": "please $blocked-name this"}]
-    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        messages
+    )
     assert out == messages  # literal text untouched
     assert refuse is None  # embedded never aborts
     assert len(notes) == 1 and "blocked-name" in notes[0]
@@ -532,7 +576,9 @@ async def test_non_user_invocable_blocked_skill_never_detected():
     )
     controller, _store = _controller(skills)
     messages = [{"role": "user", "content": "please $blocked-name this"}]
-    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        messages
+    )
     assert out == messages
     assert refuse is None
     assert notes == ()
@@ -553,8 +599,164 @@ async def test_leading_form_tolerates_leading_whitespace():
     skills = _Skills("inline")
     controller, _store = _controller(skills)
     messages = [{"role": "user", "content": "  $code-review fix it"}]
-    out, refuse, notes = await controller._apply_skill_substitution(messages)
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        messages
+    )
     assert refuse is None
     # Leading form (args-bearing), not embedded-ARGLESS.
     assert skills.executions == [("code-review", "fix it")]
     assert out[-1] == {"role": "user", "content": "RENDERED[fix it]"}
+
+
+# ---------------------------------------------------------------------------
+# Task 5 (skills-fork-reachability): the substitution return widens to a
+# 5-tuple -- `skill_bindings` (names authorized for THIS turn's skill_file
+# reads) and `skill_bundle_block` (the pre-rendered "Bundled files" block,
+# built purely from the execute results already in hand). The block is
+# NEVER inserted into `messages` here -- only `run_reply` appends it
+# (bridge-side), so plain sends and the stored transcript never see it.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_leading_mention_returns_binding_and_block():
+    skills = _Skills(
+        "inline",
+        reference_files=[{"path": "references/api.md", "size": 120, "is_text": True}],
+    )
+    controller, _store = _controller(skills)
+    messages = [{"role": "user", "content": "$code-review look"}]
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        messages
+    )
+    assert refuse is None
+    assert bindings == ("code-review",)
+    assert block == (
+        "Bundled files (readable via skill_file): references/api.md (120 bytes)"
+    )
+    assert "Bundled files (readable via skill_file):" in block
+    # NEVER inserted into messages here -- only run_reply appends it.
+    assert all("Bundled files" not in m.get("content", "") for m in out)
+
+
+@pytest.mark.asyncio
+async def test_leading_fork_mention_also_binds_and_blocks():
+    skills = _Skills(
+        "fork",
+        reference_files=[
+            {"path": "assets/logo.png", "size": 2048, "is_text": False},
+        ],
+    )
+    controller, _store = _controller(skills)
+    messages = [{"role": "user", "content": "$code-review go"}]
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        messages
+    )
+    assert refuse is None
+    assert bindings == ("code-review",)
+    assert block == (
+        "Bundled files (readable via skill_file): "
+        "assets/logo.png (2048 bytes, binary)"
+    )
+    assert all("Bundled files" not in m.get("content", "") for m in out)
+
+
+@pytest.mark.asyncio
+async def test_leading_refuse_has_no_bindings_or_block():
+    skills = _Skills(
+        raise_trust=True,
+        reference_files=[{"path": "notes.md", "size": 1, "is_text": True}],
+    )
+    controller, _store = _controller(skills)
+    messages = [{"role": "user", "content": "$code-review go"}]
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        messages
+    )
+    assert refuse is not None
+    assert bindings == ()
+    assert block == ""
+
+
+@pytest.mark.asyncio
+async def test_embedded_spliced_binds_but_blocked_does_not():
+    skills = _Skills(
+        "inline",
+        raise_trust_for={"danger-zone"},
+        extra_skills=("danger-zone",),
+        reference_files_for={
+            "code-review": [{"path": "notes.md", "size": 42, "is_text": True}],
+        },
+    )
+    controller, _store = _controller(skills)
+    messages = [
+        {"role": "user", "content": "run $code-review then $danger-zone please"}
+    ]
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        messages
+    )
+    assert refuse is None
+    assert bindings == ("code-review",)
+    assert block == "Bundled files (readable via skill_file): notes.md (42 bytes)"
+    assert "danger-zone" not in block
+    assert all("Bundled files" not in m.get("content", "") for m in out)
+
+
+@pytest.mark.asyncio
+async def test_embedded_fork_literal_mention_does_not_bind():
+    """An embedded mention resolving to a `fork` skill stays literal text
+    (no "in place" splice meaning) -- it must never be counted as bound,
+    and its reference_files must never leak into the block."""
+    skills = _Skills(
+        "fork",
+        reference_files=[{"path": "notes.md", "size": 42, "is_text": True}],
+    )
+    controller, _store = _controller(skills)
+    messages = [{"role": "user", "content": "please $code-review this"}]
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        messages
+    )
+    assert refuse is None
+    assert out == messages
+    assert bindings == ()
+    assert block == ""
+
+
+@pytest.mark.asyncio
+async def test_plain_text_no_bindings():
+    skills = _Skills("inline")
+    controller, _store = _controller(skills)
+    messages = [{"role": "user", "content": "just a plain question, no sigil"}]
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        messages
+    )
+    assert bindings == ()
+    assert block == ""
+
+
+@pytest.mark.asyncio
+async def test_no_embedded_mentions_no_bindings():
+    skills = _Skills("inline")
+    controller, _store = _controller(skills)
+    messages = [{"role": "user", "content": "$notaskill has no known mentions"}]
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        messages
+    )
+    assert bindings == ()
+    assert block == ""
+
+
+@pytest.mark.asyncio
+async def test_skill_with_no_reference_files_binds_with_empty_block():
+    """`reference_files` absent from the execute result (the common case --
+    a skill with no bundle beyond SKILL.md) still authorizes the name; the
+    block is simply empty, matching Task 2's "key ABSENT when none"
+    contract."""
+    skills = _Skills("inline")  # no reference_files configured at all
+    controller, _store = _controller(skills)
+    messages = [{"role": "user", "content": "$code-review look"}]
+    out, refuse, notes, bindings, block = await controller._apply_skill_substitution(
+        messages
+    )
+    assert refuse is None
+    assert bindings == ("code-review",)
+    assert block == ""

--- a/Tests/Skills/test_read_skill_file.py
+++ b/Tests/Skills/test_read_skill_file.py
@@ -98,3 +98,22 @@ def test_policy_action_id_registered():
     from tldw_chatbook.runtime_policy.registry import CAPABILITY_REGISTRY
 
     assert "skills.read_file.launch.local" in CAPABILITY_REGISTRY
+
+
+@pytest.mark.asyncio
+async def test_execute_skill_carries_reference_files(tmp_path):
+    svc = _svc(tmp_path)
+    await _make_skill(svc)
+    result = await svc.execute_skill("demo")
+    refs = {r["path"]: r for r in (result.get("reference_files") or [])}
+    assert refs["references/api.md"]["is_text"] is True
+    assert refs["assets/logo.png"]["is_text"] is False
+    assert "executable" not in refs["references/api.md"]
+
+
+@pytest.mark.asyncio
+async def test_execute_skill_reference_files_none_when_no_bundle(tmp_path):
+    svc = _svc(tmp_path)
+    await svc.create_skill(name="bare", content="---\nname: bare\n---\nbody\n")
+    result = await svc.execute_skill("bare")
+    assert result.get("reference_files") is None

--- a/Tests/Skills/test_read_skill_file.py
+++ b/Tests/Skills/test_read_skill_file.py
@@ -41,6 +41,33 @@ async def test_read_traversal_and_bad_paths_rejected(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_intermediate_symlink_dir_yields_not_found_not_unsafe(tmp_path):
+    # Qodo/PR#814 hardening: an intermediate symlinked directory inside the
+    # bundle must never act as an existence/size oracle -- an escape that
+    # resolves to a REAL file outside the bundle must raise the SAME
+    # "local_skill_file_not_found" error as an escape that resolves to
+    # nothing, never the "unsafe local skill path" message a downstream
+    # containment check would otherwise leak only when the target exists.
+    svc = _svc(tmp_path)
+    d = await _make_skill(svc)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.md").write_text("top secret\n", encoding="utf-8")
+    link = d / "link"
+    link.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError) as existing_exc:
+        await svc.read_skill_file("demo", "link/secret.md")
+    with pytest.raises(ValueError) as missing_exc:
+        await svc.read_skill_file("demo", "link/nonexistent.md")
+
+    assert "local_skill_file_not_found" in str(existing_exc.value)
+    assert "local_skill_file_not_found" in str(missing_exc.value)
+    assert "unsafe" not in str(existing_exc.value)
+    assert "unsafe" not in str(missing_exc.value)
+
+
+@pytest.mark.asyncio
 async def test_read_binary_returns_refusal_not_bytes(tmp_path):
     svc = _svc(tmp_path)
     await _make_skill(svc)
@@ -82,6 +109,33 @@ async def test_read_missing_file_clean_error(tmp_path):
     await _make_skill(svc)
     with pytest.raises(ValueError, match="local_skill_file_not_found"):
         await svc.read_skill_file("demo", "references/nope.md")
+
+
+@pytest.mark.asyncio
+async def test_read_skill_md_body_is_readable(tmp_path):
+    # Qodo/PR#814: the spec says the skill body IS readable through this
+    # seam -- validate_supporting_file_path's case-insensitive "skill.md"
+    # rejection must not apply to the exact canonical body path.
+    svc = _svc(tmp_path)
+    await _make_skill(svc)
+    out = await svc.read_skill_file("demo", "SKILL.md")
+    assert out["content"] == "---\nname: demo\n---\nbody\n"
+    assert out["truncated"] is False
+
+
+@pytest.mark.asyncio
+async def test_read_nested_or_wrongcase_skill_md_still_rejected(tmp_path):
+    # Only the EXACT "SKILL.md" top-level path is exempted -- a nested
+    # shadow file and any-case variants still go through the validator and
+    # are rejected exactly as before (the validator's case-insensitive
+    # "skill.md" basename check, not a not-found -- these paths never reach
+    # the filesystem).
+    svc = _svc(tmp_path)
+    await _make_skill(svc)
+    with pytest.raises(ValueError):
+        await svc.read_skill_file("demo", "references/SKILL.md")
+    with pytest.raises(ValueError):
+        await svc.read_skill_file("demo", "skill.md")
 
 
 @pytest.mark.asyncio

--- a/Tests/Skills/test_read_skill_file.py
+++ b/Tests/Skills/test_read_skill_file.py
@@ -1,0 +1,100 @@
+import pytest
+
+from tldw_chatbook.Skills_Interop.local_skills_service import (
+    SKILL_FILE_READ_CAP_CHARS,
+    LocalSkillsService,
+)
+from tldw_chatbook.Skills_Interop.skill_trust_models import SkillTrustBlockedError
+
+
+def _svc(tmp_path):
+    return LocalSkillsService(
+        store_dir=tmp_path, allow_untrusted_without_trust_service=True
+    )
+
+
+async def _make_skill(svc, name="demo"):
+    await svc.create_skill(name=name, content=f"---\nname: {name}\n---\nbody\n")
+    d = svc._skill_dir(name)
+    (d / "references").mkdir(parents=True, exist_ok=True)
+    (d / "references" / "api.md").write_text("# api docs\n", encoding="utf-8")
+    (d / "assets").mkdir(exist_ok=True)
+    (d / "assets" / "logo.png").write_bytes(b"\x89PNG\x00bin")
+    return d
+
+
+@pytest.mark.asyncio
+async def test_read_happy_path_nested(tmp_path):
+    svc = _svc(tmp_path)
+    await _make_skill(svc)
+    out = await svc.read_skill_file("demo", "references/api.md")
+    assert out == {"content": "# api docs\n", "truncated": False, "size": len("# api docs\n")}
+
+
+@pytest.mark.asyncio
+async def test_read_traversal_and_bad_paths_rejected(tmp_path):
+    svc = _svc(tmp_path)
+    await _make_skill(svc)
+    for bad in ("../escape.md", "/abs.md", "refs/SKILL.md"):
+        with pytest.raises(ValueError):
+            await svc.read_skill_file("demo", bad)
+
+
+@pytest.mark.asyncio
+async def test_read_binary_returns_refusal_not_bytes(tmp_path):
+    svc = _svc(tmp_path)
+    await _make_skill(svc)
+    out = await svc.read_skill_file("demo", "assets/logo.png")
+    assert out["truncated"] is False
+    assert "binary file" in out["content"]
+    assert "\x89" not in out["content"]
+
+
+@pytest.mark.asyncio
+async def test_read_truncates_over_cap(tmp_path):
+    svc = _svc(tmp_path)
+    d = await _make_skill(svc)
+    (d / "references" / "big.md").write_text("x" * (SKILL_FILE_READ_CAP_CHARS + 500), encoding="utf-8")
+    out = await svc.read_skill_file("demo", "references/big.md")
+    assert out["truncated"] is True
+    assert len(out["content"]) < SKILL_FILE_READ_CAP_CHARS + 200  # cap + marker line
+    assert "truncated" in out["content"].rsplit("\n", 1)[-1]
+
+
+@pytest.mark.asyncio
+async def test_read_untrusted_raises_blocked(tmp_path, monkeypatch):
+    svc = _svc(tmp_path)
+    await _make_skill(svc)
+
+    def _deny(name):
+        raise SkillTrustBlockedError(
+            skill_name=name, reason_code="skill_modified", trust_status="quarantined_modified"
+        )
+
+    monkeypatch.setattr(svc, "_require_trusted_skill", _deny)
+    with pytest.raises(SkillTrustBlockedError):
+        await svc.read_skill_file("demo", "references/api.md")
+
+
+@pytest.mark.asyncio
+async def test_read_missing_file_clean_error(tmp_path):
+    svc = _svc(tmp_path)
+    await _make_skill(svc)
+    with pytest.raises(ValueError, match="local_skill_file_not_found"):
+        await svc.read_skill_file("demo", "references/nope.md")
+
+
+@pytest.mark.asyncio
+async def test_scope_service_server_mode_rejected(tmp_path):
+    from tldw_chatbook.Skills_Interop.skills_scope_service import SkillsScopeService
+
+    scope = SkillsScopeService(local_service=_svc(tmp_path), server_service=None)
+    with pytest.raises(ValueError, match="local-only"):
+        await scope.read_skill_file("demo", "references/api.md", mode="server")
+
+
+def test_policy_action_id_registered():
+    # The engine denies unknown ids (fail-closed) — pin that the new id exists.
+    from tldw_chatbook.runtime_policy.registry import CAPABILITY_REGISTRY
+
+    assert "skills.read_file.launch.local" in CAPABILITY_REGISTRY

--- a/Tests/Skills/test_read_skill_file.py
+++ b/Tests/Skills/test_read_skill_file.py
@@ -101,14 +101,26 @@ def test_policy_action_id_registered():
 
 
 @pytest.mark.asyncio
-async def test_execute_skill_carries_reference_files(tmp_path):
+async def test_execute_skill_carries_reference_files(tmp_path, monkeypatch):
     svc = _svc(tmp_path)
     await _make_skill(svc)
+
+    real_manifest = svc._read_bundle_manifest
+    walks = []
+
+    def _counting(skill_dir):
+        walks.append(skill_dir)
+        return real_manifest(skill_dir)
+
+    monkeypatch.setattr(svc, "_read_bundle_manifest", _counting)
     result = await svc.execute_skill("demo")
     refs = {r["path"]: r for r in (result.get("reference_files") or [])}
     assert refs["references/api.md"]["is_text"] is True
     assert refs["assets/logo.png"]["is_text"] is False
     assert "executable" not in refs["references/api.md"]
+    # Mechanism: exactly ONE bundle walk per invocation (get_skill's own) —
+    # reference_files must be derived from the in-hand payload, not a re-walk.
+    assert len(walks) == 1
 
 
 @pytest.mark.asyncio

--- a/tldw_chatbook/Agents/agent_models.py
+++ b/tldw_chatbook/Agents/agent_models.py
@@ -7,6 +7,7 @@ No Textual, app, DB, or I/O imports — see the vertical-slice spec
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Callable
 
 RUN_RUNNING = "running"
 RUN_DONE = "done"
@@ -30,10 +31,26 @@ STEP_ERROR = "error"
 SPAWN_TOOL_NAME = "spawn_subagent"
 FIND_TOOLS_NAME = "find_tools"
 LOAD_TOOLS_NAME = "load_tools"
-RUNTIME_TOOL_NAMES = frozenset({SPAWN_TOOL_NAME, FIND_TOOLS_NAME, LOAD_TOOLS_NAME})
+SKILL_FILE_TOOL_NAME = "skill_file"
+RUNTIME_TOOL_NAMES = frozenset(
+    {SPAWN_TOOL_NAME, FIND_TOOLS_NAME, LOAD_TOOLS_NAME, SKILL_FILE_TOOL_NAME}
+)
 
 DIRECT_DISCLOSE_THRESHOLD = 8
 LOOP_DETECTION_N = 3
+
+
+@dataclass
+class SkillFileBindings:
+    """Per-run authorization + reader for the skill_file runtime tool.
+
+    Mutable by design: seeded with the turn's $skill names; SkillRunner adds
+    each spawned skill's name before spawn so a skill can always read its own
+    bundle. Authorization lives here, never in config.allowed_tools.
+    """
+
+    authorized: set[str]
+    reader: Callable[[str, str], dict] | None = None
 
 
 @dataclass(frozen=True)

--- a/tldw_chatbook/Agents/agent_runtime.py
+++ b/tldw_chatbook/Agents/agent_runtime.py
@@ -18,6 +18,7 @@ from .agent_models import (
     RUN_CANCELLED,
     RUN_DONE,
     RUN_STUCK,
+    SKILL_FILE_TOOL_NAME,
     SPAWN_TOOL_NAME,
     STEP_ERROR,
     STEP_MODEL,
@@ -228,6 +229,14 @@ class LoopDeps:
     # closure, not in this generic runtime. ``None`` (the default) is a
     # no-op: every call proceeds, byte-identical to pre-Task-4 behavior.
     review_tool_calls: Callable[[list[ToolCall]], dict[str, str]] | None = None
+    # skill_file: the fourth runtime tool (task-3, skills-foundation). Unlike
+    # a ToolProvider entry, its schema is pinned into runtime_schemas by the
+    # service (never disclosure-gated) and its authorization lives on a
+    # per-run SkillFileBindings object -- never config.allowed_tools. `None`
+    # (the default) means the service never wired this run for skill_file at
+    # all, and a call by that name falls through to the same
+    # deps.invoke_tool path any other unrecognized/undisclosed name hits.
+    read_skill_file: Callable[[str, str], ToolResult] | None = None
 
 
 def _catalog_lines(entries: list) -> str:
@@ -516,6 +525,15 @@ def run_agent_loop(
                                 )
                             else:
                                 result = ToolResult(ok=True, content="no room")
+                elif (
+                    call.name == SKILL_FILE_TOOL_NAME
+                    and deps.read_skill_file is not None
+                ):
+                    add(STEP_TOOL_CALL, tool_name=call.name, args=dict(call.args))
+                    result = deps.read_skill_file(
+                        str(call.args.get("skill_name", "")),
+                        str(call.args.get("path", "")),
+                    )
                 else:
                     add(STEP_TOOL_CALL, tool_name=call.name, args=dict(call.args))
                     result = deps.invoke_tool(call)

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -30,6 +30,7 @@ from .agent_models import (
     AgentStep,
     ModelTurn,
     RunOutcome,
+    SkillFileBindings,
     ToolCall,
     ToolResult,
     clamp_child_budget,
@@ -44,6 +45,7 @@ from .native_tools import (
 from .tool_catalog import (
     FIND_TOOLS_SCHEMA,
     LOAD_TOOLS_SCHEMA,
+    SKILL_FILE_TOOL_SCHEMA,
     SPAWN_TOOL_SCHEMA,
     ToolCatalogRegistry,
     initial_disclosure,
@@ -167,6 +169,7 @@ class AgentService:
         clock: Callable[[], float] = time.monotonic,
         on_step: Callable[[AgentStep, str], None] | None = None,
         skill_runner: SkillRunner | None = None,
+        skill_file_bindings: SkillFileBindings | None = None,
         review_tool_calls: Callable[[list[ToolCall]], dict[str, str]] | None = None,
         review_state_scope: Callable[[], "contextlib.AbstractContextManager"]
         | None = None,
@@ -177,6 +180,13 @@ class AgentService:
         self.clock = clock
         self._on_step = on_step
         self.skill_runner = skill_runner
+        # task-3 (skills-foundation): per-run authorization + reader for the
+        # skill_file runtime tool. `None` (the default, and every caller
+        # before this task) means the run is never wired for skill_file at
+        # all -- its schema is never pinned into runtime_schemas and a call
+        # by that name falls through to normal unknown-tool handling (see
+        # LoopDeps.read_skill_file's own docstring).
+        self.skill_file_bindings = skill_file_bindings
         # P5 Task 4: generic pre-dispatch batch-review hook, threaded
         # straight into every LoopDeps this service builds (mirrors how
         # should_cancel flows through run_turn/_run_one). MCP-specific
@@ -342,6 +352,11 @@ class AgentService:
             runtime_schemas.append(SPAWN_TOOL_SCHEMA)
         if offer_find_load:
             runtime_schemas.extend([FIND_TOOLS_SCHEMA, LOAD_TOOLS_SCHEMA])
+        if (
+            self.skill_file_bindings is not None
+            and self.skill_file_bindings.authorized
+        ):
+            runtime_schemas.append(SKILL_FILE_TOOL_SCHEMA)
 
         def find_tools(query: str):
             # Q7(b): never surface a disallowed tool through find_tools,
@@ -544,6 +559,28 @@ class AgentService:
                 )
             return builtin_invoke_tool(call)
 
+        # task-3 (skills-foundation): reader closure for the skill_file
+        # runtime tool, built beside invoke_tool. Authorization is enforced
+        # HERE (against self.skill_file_bindings.authorized), never in the
+        # loop and never via config.allowed_tools -- see SkillFileBindings'
+        # own docstring. The bindings-None guard below is defensive (the
+        # LoopDeps wiring already gates this closure out entirely when no
+        # bindings were passed to this service at all).
+        def read_skill_file_tool(skill_name: str, path: str) -> ToolResult:
+            bindings = self.skill_file_bindings
+            if bindings is None or skill_name not in bindings.authorized:
+                return ToolResult(
+                    ok=False,
+                    error=f"skill_file: '{skill_name}' is not active in this run",
+                )
+            if bindings.reader is None:
+                return ToolResult(ok=False, error="skill_file: no reader configured")
+            try:
+                out = bindings.reader(skill_name, path)
+            except Exception as exc:  # SkillTrustBlockedError, ValueError, OSError
+                return ToolResult(ok=False, error=f"skill_file: {exc}")
+            return ToolResult(ok=True, content=str(out.get("content", "")))
+
         deps = LoopDeps(
             call_model=self._make_call_model(config, api_endpoint, runtime_schemas),
             invoke_tool=invoke_tool,
@@ -558,6 +595,9 @@ class AgentService:
                 else (lambda s: None)
             ),
             review_tool_calls=self.review_tool_calls,
+            read_skill_file=(
+                read_skill_file_tool if self.skill_file_bindings is not None else None
+            ),
         )
         try:
             outcome = run_agent_loop(config, messages, active, deps)

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import contextlib
 import dataclasses
 import time
+from collections.abc import Mapping
 from datetime import datetime, timezone
 from typing import Callable, Protocol
 
@@ -577,9 +578,21 @@ class AgentService:
                 return ToolResult(ok=False, error="skill_file: no reader configured")
             try:
                 out = bindings.reader(skill_name, path)
+                # task-4 (skills-fork-reachability) hardening: a reader is
+                # caller-supplied (the bridge's asyncio.run adapter over
+                # SkillsScopeService.read_skill_file) -- a misbehaving one
+                # returning a non-mapping must fail only THIS call, not
+                # crash the whole run via an uncaught AttributeError from
+                # `.get` on something that isn't dict-like.
+                if not isinstance(out, Mapping):
+                    return ToolResult(
+                        ok=False,
+                        error="skill_file: reader returned invalid result",
+                    )
+                content = out.get("content", "")
             except Exception as exc:  # SkillTrustBlockedError, ValueError, OSError
                 return ToolResult(ok=False, error=f"skill_file: {exc}")
-            return ToolResult(ok=True, content=str(out.get("content", "")))
+            return ToolResult(ok=True, content=str(content))
 
         deps = LoopDeps(
             call_model=self._make_call_model(config, api_endpoint, runtime_schemas),

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -608,8 +608,17 @@ class AgentService:
                 else (lambda s: None)
             ),
             review_tool_calls=self.review_tool_calls,
+            # Qodo/PR#814: wired under the SAME predicate as the schema pin
+            # above (~:356-360) -- bindings with an EMPTY authorized set
+            # must never reach the named-refusal dispatch either; a
+            # hallucinated call for an unpinned tool falls through to the
+            # generic "Tool not permitted" path like any other undisclosed
+            # tool name.
             read_skill_file=(
-                read_skill_file_tool if self.skill_file_bindings is not None else None
+                read_skill_file_tool
+                if self.skill_file_bindings is not None
+                and self.skill_file_bindings.authorized
+                else None
             ),
         )
         try:

--- a/tldw_chatbook/Agents/tool_catalog.py
+++ b/tldw_chatbook/Agents/tool_catalog.py
@@ -19,6 +19,7 @@ from .agent_models import (
     FIND_TOOLS_NAME,
     LOAD_TOOLS_NAME,
     RunBudget,
+    SKILL_FILE_TOOL_NAME,
     SPAWN_TOOL_NAME,
     ToolCatalogEntry,
     ToolResult,
@@ -63,6 +64,24 @@ LOAD_TOOLS_SCHEMA = ToolSchema(
         "type": "object",
         "properties": {"ids": {"type": "array", "items": {"type": "string"}}},
         "required": ["ids"],
+    },
+)
+
+SKILL_FILE_TOOL_SCHEMA = ToolSchema(
+    id="runtime:skill_file",
+    name=SKILL_FILE_TOOL_NAME,
+    description=(
+        "Read a bundled reference file of a skill active in this run. "
+        "Args: skill_name (the skill whose bundle to read), path (relative "
+        "POSIX path, e.g. references/api.md). Text files only."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "skill_name": {"type": "string"},
+            "path": {"type": "string"},
+        },
+        "required": ["skill_name", "path"],
     },
 )
 

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -863,6 +863,8 @@ class ConsoleAgentBridge:
         supersede_previous: bool = False,
         mcp_provider: Any | None = None,
         review_tool_calls: Callable[[list[ToolCall]], dict[str, str]] | None = None,
+        turn_skill_bindings: tuple[str, ...] = (),
+        turn_bundle_block: str = "",
     ) -> RunOutcome:
         # Per-run tool registry + allow-list (Task 12, extended by P5-T6 for
         # MCP): rebuilt FRESH for this run whenever there is a skills
@@ -918,6 +920,18 @@ class ConsoleAgentBridge:
                     builtin_names=builtin_names,
                     skill_file_bindings=skill_file_bindings,
                 )
+        # task-5 (skills-fork-reachability): seed this run's own bindings
+        # with the names the CONTROLLER already resolved/spliced for the
+        # triggering turn (a leading `$skill` mention, or embedded mentions
+        # that actually spliced) -- so the primary agent's very first turn
+        # can already read that skill's bundle via skill_file, matching
+        # what a spawned skill child gets for its OWN bundle (Task 4).
+        # `skill_file_bindings` is None whenever there is no skills service
+        # for this run, in which case a non-empty `turn_skill_bindings`
+        # (which can only happen when the controller's own skills-service-
+        # gated substitution ran) has nothing to seed.
+        if skill_file_bindings is not None:
+            skill_file_bindings.authorized.update(turn_skill_bindings)
         # [console] native_tool_calls kill-switch (Task 5): a caller-supplied
         # predicate (chat_screen.py's _console_native_tool_calls_enabled)
         # gates whether this run may use native provider tool-calls at all;
@@ -1045,10 +1059,36 @@ class ConsoleAgentBridge:
             if supersede_previous
             else None
         )
+        # task-5 (skills-fork-reachability): append the turn's pre-rendered
+        # "Bundled files" block (built controller-side as pure string work
+        # over `execute_skill` results already in hand -- Task 4's
+        # byte-identical row format) to the LAST role=="user" entry of THIS
+        # run's OWN copy of `agent_messages` -- the caller's list and
+        # message dict are never mutated. This is the only place the block
+        # is ever inserted into a payload: substitution built it but never
+        # wrote it into messages, and plain (non-agent) sends never call
+        # run_reply at all, so they drop it unused. No-op (the original
+        # `agent_messages` list is used unchanged) when there is no block
+        # to append or no user message to append it to.
+        run_messages = agent_messages
+        if turn_bundle_block:
+            for index in range(len(agent_messages) - 1, -1, -1):
+                message = agent_messages[index]
+                content = message.get("content")
+                if (
+                    message.get("role") == ConsoleMessageRole.USER.value
+                    and isinstance(content, str)
+                ):
+                    run_messages = list(agent_messages)
+                    run_messages[index] = {
+                        **message,
+                        "content": f"{content}\n\n{turn_bundle_block}",
+                    }
+                    break
         try:
             _run_id, outcome = service.run_turn(
                 conversation_id=conversation_id,
-                messages=agent_messages,
+                messages=run_messages,
                 config=config,
                 # execution_key-first (Task 5): the service's capability
                 # check keys off api_endpoint, and execution_key is by

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -32,6 +32,7 @@ from tldw_chatbook.Agents.agent_models import (
     AgentConfig,
     AgentStep,
     RunOutcome,
+    SkillFileBindings,
     ToolCall,
     ToolCatalogEntry,
     ToolResult,
@@ -742,10 +743,12 @@ class _BridgeSkillRunner:
         skills_service: Any,
         skill_names: frozenset[str],
         builtin_names: tuple[str, ...],
+        skill_file_bindings: SkillFileBindings | None = None,
     ) -> None:
         self._skills_service = skills_service
         self._skill_names = skill_names
         self._builtin_names = builtin_names
+        self._skill_file_bindings = skill_file_bindings
 
     def is_skill_tool(self, name: str) -> bool:
         return name in self._skill_names
@@ -769,6 +772,23 @@ class _BridgeSkillRunner:
         allowed_tools = intersect_skill_tools(
             declared_allowed_tools, self._builtin_names
         )
+        # task-4 (skills-fork-reachability): grant the spawned skill's own
+        # name skill_file authorization BEFORE spawn -- so the child's very
+        # first turn can already read its own bundled reference files (see
+        # SkillFileBindings' own docstring: authorization lives here, never
+        # in config.allowed_tools) -- then append a "Bundled files" pointer
+        # block to the rendered task text whenever execute_skill reported
+        # any (absent when the skill has no bundle beyond SKILL.md).
+        if self._skill_file_bindings is not None:
+            self._skill_file_bindings.authorized.add(name)
+        refs = result.get("reference_files") if isinstance(result, Mapping) else None
+        if refs and self._skill_file_bindings is not None:
+            rows = ", ".join(
+                f"{r['path']} ({r['size']} bytes"
+                f"{'' if r.get('is_text', True) else ', binary'})"
+                for r in refs
+            )
+            rendered = f"{rendered}\n\nBundled files (readable via skill_file): {rows}"
         return spawn(rendered, allowed_tools=allowed_tools)
 
 
@@ -862,6 +882,16 @@ class ConsoleAgentBridge:
         registry = self._registry
         allowed_tools = self._allowed_tools
         skill_runner = None
+        # task-4 (skills-fork-reachability): one SkillFileBindings per run,
+        # handed to BOTH AgentService (the loop's authorization + reader
+        # closure -- Task 3) and this run's _BridgeSkillRunner (which grants
+        # a spawned skill's own name pre-spawn) -- never two independently-
+        # seeded copies, or the runner's grant would never reach the loop's
+        # check. `authorized` starts empty here (Task 5 seeds the turn's
+        # $skill names); the reader is a SYNC adapter over the async scope-
+        # service read, matching _BridgeSkillRunner.run's own
+        # asyncio.run-in-worker-thread pattern just below.
+        skill_file_bindings = None
         if self._skills_service is not None or mcp_provider is not None:
             context: Mapping[str, Any] = {}
             if self._skills_service is not None:
@@ -874,10 +904,19 @@ class ConsoleAgentBridge:
                     str(item["name"])
                     for item in _non_colliding_skill_entries(context, builtin_names)
                 )
+                skill_file_bindings = SkillFileBindings(
+                    authorized=set(),
+                    reader=lambda skill_name, path: asyncio.run(
+                        self._skills_service.read_skill_file(
+                            skill_name, path, mode="local"
+                        )
+                    ),
+                )
                 skill_runner = _BridgeSkillRunner(
                     skills_service=self._skills_service,
                     skill_names=skill_names,
                     builtin_names=builtin_names,
+                    skill_file_bindings=skill_file_bindings,
                 )
         # [console] native_tool_calls kill-switch (Task 5): a caller-supplied
         # predicate (chat_screen.py's _console_native_tool_calls_enabled)
@@ -996,6 +1035,7 @@ class ConsoleAgentBridge:
             clock=self._clock,
             on_step=on_step,
             skill_runner=skill_runner,
+            skill_file_bindings=skill_file_bindings,
             review_tool_calls=review_tool_calls,
             review_state_scope=review_state_scope,
         )

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -231,6 +231,47 @@ def _split_skill_command_word(text: str) -> tuple[str, str]:
     return text, ""
 
 
+def _render_skill_bundle_block(results: Iterable[Mapping[str, Any]]) -> str:
+    """Render one combined "Bundled files" block for a turn's bound skills.
+
+    Task 5 (skills-fork-reachability): `_apply_skill_substitution` builds
+    this as pure string work from `execute_skill` results it already holds
+    -- no re-execution, no extra service calls -- for every skill actually
+    bound this turn (leading-resolved, or embedded mentions that spliced).
+    `run_reply` (never here) is the only place that ever appends the
+    returned string to a message, so plain sends and the stored transcript
+    never see it.
+
+    Row format matches `_BridgeSkillRunner.run`'s own bundle-pointer block
+    byte-for-byte (Task 4) -- ``{path} ({size} bytes)`` / ``{path} ({size}
+    bytes, binary)``, comma-joined under one combined header -- so a bound
+    skill's `skill_file` reads look identical whether granted turn-side
+    (this function) or fork-side (a spawned skill reading its own bundle).
+
+    Args:
+        results: `execute_skill` result mappings for the bound skills, in
+            any order; a result missing `reference_files` (absent when a
+            skill has no bundle beyond SKILL.md) or with it empty
+            contributes no rows.
+
+    Returns:
+        The combined block, or ``""`` when no result carries any rows.
+    """
+    rows: list[str] = []
+    for result in results:
+        refs = result.get("reference_files") if isinstance(result, Mapping) else None
+        if not refs:
+            continue
+        rows.extend(
+            f"{ref['path']} ({ref['size']} bytes"
+            f"{'' if ref.get('is_text', True) else ', binary'})"
+            for ref in refs
+        )
+    if not rows:
+        return ""
+    return "Bundled files (readable via skill_file): " + ", ".join(rows)
+
+
 class ConsoleProviderGatewayProtocol(Protocol):
     """Provider gateway surface required by the Console controller."""
 
@@ -467,9 +508,13 @@ class ConsoleChatController:
             self.store.clear_pending_attachments(session.id)
         try:
             provider_messages = self._provider_messages_for_session(session.id)
-            provider_messages, refuse, skill_notes = await self._apply_skill_substitution(
-                provider_messages
-            )
+            (
+                provider_messages,
+                refuse,
+                skill_notes,
+                skill_bindings,
+                skill_bundle_block,
+            ) = await self._apply_skill_substitution(provider_messages)
             if refuse is not None:
                 # A substitution refusal is a block outcome like any other
                 # (provider not ready, probe raise): fail the echoed row so the
@@ -523,6 +568,8 @@ class ConsoleChatController:
             assistant_message_id=assistant.id,
             prefill=prefill,
             prefill_from_one_shot=prefill_from_one_shot,
+            skill_bindings=skill_bindings,
+            skill_bundle_block=skill_bundle_block,
         )
 
     def new_session(
@@ -1147,9 +1194,13 @@ class ConsoleChatController:
             before_message_id=message_id,
         )
         self._ensure_user_continuation_instruction(provider_messages)
-        provider_messages, refuse, skill_notes = await self._apply_skill_substitution(
-            provider_messages
-        )
+        (
+            provider_messages,
+            refuse,
+            skill_notes,
+            skill_bindings,
+            skill_bundle_block,
+        ) = await self._apply_skill_substitution(provider_messages)
         if refuse is not None:
             return self._block(session_id, refuse)
         for note in skill_notes:
@@ -1171,6 +1222,8 @@ class ConsoleChatController:
             assistant_message_id=message_id,
             prepare_retry=True,
             prefill=prefill,
+            skill_bindings=skill_bindings,
+            skill_bundle_block=skill_bundle_block,
         )
 
     async def continue_from_message(self, message_id: str) -> ConsoleSubmitResult:
@@ -1211,9 +1264,13 @@ class ConsoleChatController:
                 session_id,
                 "Nothing to continue before the first message.",
             )
-        provider_messages, refuse, skill_notes = await self._apply_skill_substitution(
-            provider_messages
-        )
+        (
+            provider_messages,
+            refuse,
+            skill_notes,
+            skill_bindings,
+            skill_bundle_block,
+        ) = await self._apply_skill_substitution(provider_messages)
         if refuse is not None:
             return self._block(session_id, refuse)
         for note in skill_notes:
@@ -1238,6 +1295,8 @@ class ConsoleChatController:
             resolution=resolution,
             provider_messages=provider_messages,
             assistant_message_id=assistant.id,
+            skill_bindings=skill_bindings,
+            skill_bundle_block=skill_bundle_block,
         )
 
     async def regenerate_message(self, message_id: str) -> ConsoleSubmitResult:
@@ -1309,9 +1368,13 @@ class ConsoleChatController:
                 session_id,
                 "Nothing to regenerate before the first message.",
             )
-        provider_messages, refuse, skill_notes = await self._apply_skill_substitution(
-            provider_messages
-        )
+        (
+            provider_messages,
+            refuse,
+            skill_notes,
+            skill_bindings,
+            skill_bundle_block,
+        ) = await self._apply_skill_substitution(provider_messages)
         if refuse is not None:
             return self._block(session_id, refuse)
         for note in skill_notes:
@@ -1339,6 +1402,8 @@ class ConsoleChatController:
             assistant_message_id=new_message.id,
             variant_mode=False,
             prefill=prefill,
+            skill_bindings=skill_bindings,
+            skill_bundle_block=skill_bundle_block,
         )
 
     async def edit_and_resend_message(
@@ -1953,7 +2018,9 @@ class ConsoleChatController:
 
     async def _apply_skill_substitution(
         self, provider_messages: list[dict[str, Any]]
-    ) -> tuple[list[dict[str, Any]], str | None, tuple[str, ...]]:
+    ) -> tuple[
+        list[dict[str, Any]], str | None, tuple[str, ...], tuple[str, ...], str
+    ]:
         """Render-fresh the triggering turn's skill mention(s) at payload build time.
 
         Spec: "Invocation semantics" §5 (the substitution rule) -- one rule
@@ -2011,28 +2078,46 @@ class ConsoleChatController:
                 message and any synthesized continuation instruction).
 
         Returns:
-            ``(provider_messages, None, ())`` unchanged when there is no
-            skills service configured, substitution is disabled, there is
-            no final user message, that message's content isn't a string,
-            or neither form applies. ``(new_messages, None, notes)`` when
-            the leading form resolves and renders (``notes`` always empty
-            for the leading form) or when the embedded pass splices one or
-            more mentions (``notes`` carries one `SKILL_MENTION_SKIPPED_
-            NOTE` per unique trust-blocked mention name, in document
-            order); ``inline`` replaces just the final message in place
-            (history preserved); leading-form ``fork`` drops every message
-            before it except a leading ``role == "system"`` message (clean
-            context = session system prompt + rendered turn only).
-            ``(provider_messages, refuse_copy, ())`` -- the ORIGINAL,
-            unmodified messages, paired with `SKILL_UNTRUSTED_REFUSE` copy
-            -- when a LEADING resolved skill is no longer trusted
-            (`SkillTrustBlockedError` at execute-time); the caller must
-            append `refuse_copy` as a system row and abort the turn without
-            sending. An embedded mention never refuses/aborts -- it
-            degrades to a literal-plus-note instead, and the send proceeds.
+            A 5-tuple ``(provider_messages, refuse, notes, skill_bindings,
+            skill_bundle_block)`` (Task 5, skills-fork-reachability).
+            ``skill_bindings`` is the leading-RESOLVED skill's name (both
+            ``inline`` and ``fork`` outcomes -- never on refuse) plus every
+            embedded mention name that actually SPLICED (never a
+            trust-blocked-literal or fork-literal mention).
+            ``skill_bundle_block`` is the fully-rendered "Bundled files"
+            block (`_render_skill_bundle_block`) for every bound skill
+            whose `execute_skill` result carried non-empty
+            `reference_files`, built as pure string work from the results
+            already in hand this call (no re-execution, no extra service
+            calls), or ``""`` when nothing bound has any. It is NEVER
+            inserted into ``provider_messages`` here -- only ``run_reply``
+            (bridge-side) ever appends it, so plain sends and the stored
+            transcript never see it.
+
+            ``(provider_messages, None, (), (), "")`` unchanged when there
+            is no skills service configured, substitution is disabled,
+            there is no final user message, that message's content isn't a
+            string, or neither form applies. ``(new_messages, None, notes,
+            skill_bindings, skill_bundle_block)`` when the leading form
+            resolves and renders (``notes`` always empty for the leading
+            form) or when the embedded pass splices one or more mentions
+            (``notes`` carries one `SKILL_MENTION_SKIPPED_NOTE` per unique
+            trust-blocked mention name, in document order); ``inline``
+            replaces just the final message in place (history preserved);
+            leading-form ``fork`` drops every message before it except a
+            leading ``role == "system"`` message (clean context = session
+            system prompt + rendered turn only).
+            ``(provider_messages, refuse_copy, (), (), "")`` -- the
+            ORIGINAL, unmodified messages, paired with
+            `SKILL_UNTRUSTED_REFUSE` copy -- when a LEADING resolved skill
+            is no longer trusted (`SkillTrustBlockedError` at
+            execute-time); the caller must append `refuse_copy` as a
+            system row and abort the turn without sending. An embedded
+            mention never refuses/aborts -- it degrades to a
+            literal-plus-note instead, and the send proceeds.
         """
         if self._skills_service is None or not self._skill_substitution_enabled:
-            return provider_messages, None, ()
+            return provider_messages, None, (), (), ""
 
         final_index: int | None = None
         for index in range(len(provider_messages) - 1, -1, -1):
@@ -2040,15 +2125,15 @@ class ConsoleChatController:
                 final_index = index
                 break
         if final_index is None:
-            return provider_messages, None, ()
+            return provider_messages, None, (), (), ""
 
         content = provider_messages[final_index].get("content")
         if not isinstance(content, str):
-            return provider_messages, None, ()
+            return provider_messages, None, (), (), ""
         if MENTION_SIGIL not in content:
             # Fast path: no sigil anywhere means neither form can possibly
             # apply -- plain-text sends never touch the skills service.
-            return provider_messages, None, ()
+            return provider_messages, None, (), (), ""
 
         context = await self._skills_service.get_context(mode="local")
         candidates = self._skill_candidates_from_context(context)
@@ -2088,7 +2173,7 @@ class ConsoleChatController:
                         refuse = SKILL_UNTRUSTED_REFUSE.format(
                             name=resolution.name, reason=exc.reason_code
                         )
-                        return provider_messages, refuse, ()
+                        return provider_messages, refuse, (), (), ""
 
                     rendered = (
                         result.get("rendered_prompt", "")
@@ -2104,6 +2189,16 @@ class ConsoleChatController:
                         if isinstance(result, Mapping)
                         else None
                     )
+                    # Task 5: a resolved leading mention always binds its
+                    # name (fork AND inline outcomes -- never on refuse,
+                    # which already returned above) and its block is
+                    # rendered from this single execute_skill result.
+                    bindings = (resolution.name,)
+                    block = (
+                        _render_skill_bundle_block([result])
+                        if isinstance(result, Mapping)
+                        else ""
+                    )
                     if execution_mode == "fork":
                         leading = (
                             [provider_messages[0]]
@@ -2112,11 +2207,11 @@ class ConsoleChatController:
                             == ConsoleMessageRole.SYSTEM.value
                             else []
                         )
-                        return leading + [rendered_message], None, ()
+                        return leading + [rendered_message], None, (), bindings, block
 
                     new_messages = list(provider_messages)
                     new_messages[final_index] = rendered_message
-                    return new_messages, None, ()
+                    return new_messages, None, (), bindings, block
 
         # --- Embedded pass: no leading mention, or the leading word didn't
         # resolve to a known skill. Scans the ORIGINAL (unstripped) content
@@ -2128,9 +2223,15 @@ class ConsoleChatController:
         names = frozenset(candidate.name for candidate in detection_candidates)
         mentions = find_embedded_mentions(content, names)
         if not mentions:
-            return provider_messages, None, ()
+            return provider_messages, None, (), (), ""
 
         rendered_by_name: dict[str, str | None] = {}
+        # Task 5: results_by_name only keeps a name's execute_skill result
+        # when that mention actually SPLICED (execution_mode == "inline")
+        # -- a blocked-literal or fork-literal mention's result is
+        # discarded here, so it can never leak into skill_bindings or the
+        # rendered bundle block below.
+        results_by_name: dict[str, Mapping[str, Any]] = {}
         notes: list[str] = []
         for mention in mentions:
             if mention.name in rendered_by_name:
@@ -2156,6 +2257,8 @@ class ConsoleChatController:
             rendered_by_name[mention.name] = (
                 rendered if execution_mode == "inline" else None
             )
+            if execution_mode == "inline" and isinstance(result, Mapping):
+                results_by_name[mention.name] = result
 
         new_content = content
         for mention in reversed(mentions):
@@ -2166,14 +2269,27 @@ class ConsoleChatController:
                 new_content[: mention.start] + body + new_content[mention.end :]
             )
         if new_content == content:
-            return provider_messages, None, tuple(notes)
+            return provider_messages, None, tuple(notes), (), ""
 
+        # Task 5: bound names are every unique mention that actually
+        # spliced, in first-occurrence document order (`dict.fromkeys` on
+        # `mentions` dedups while preserving order) -- never a
+        # blocked-literal or fork-literal mention, which never reached
+        # `results_by_name`.
+        spliced_names = tuple(
+            name
+            for name in dict.fromkeys(mention.name for mention in mentions)
+            if rendered_by_name.get(name) is not None
+        )
+        block = _render_skill_bundle_block(
+            results_by_name[name] for name in spliced_names if name in results_by_name
+        )
         new_messages = list(provider_messages)
         new_messages[final_index] = {
             "role": ConsoleMessageRole.USER.value,
             "content": new_content,
         }
-        return new_messages, None, tuple(notes)
+        return new_messages, None, tuple(notes), spliced_names, block
 
     async def _apply_world_info(
         self, provider_messages: list[dict[str, Any]], session_id: str
@@ -2520,6 +2636,8 @@ class ConsoleChatController:
         variant_mode: bool = False,
         prefill: str | None = None,
         prefill_from_one_shot: bool = False,
+        skill_bindings: tuple[str, ...] = (),
+        skill_bundle_block: str = "",
     ) -> ConsoleSubmitResult:
         try:
             owner_id = self.store.session_id_for_message(assistant_message_id)
@@ -2565,6 +2683,8 @@ class ConsoleChatController:
                 assistant_message_id=assistant_message_id,
                 prepare_retry=prepare_retry,
                 variant_mode=variant_mode,
+                skill_bindings=skill_bindings,
+                skill_bundle_block=skill_bundle_block,
             )
         one_shot_used = prefill if prefill_from_one_shot else None
         if prefill:
@@ -2719,6 +2839,8 @@ class ConsoleChatController:
         assistant_message_id: str,
         prepare_retry: bool,
         variant_mode: bool,
+        skill_bindings: tuple[str, ...] = (),
+        skill_bundle_block: str = "",
     ) -> ConsoleSubmitResult:
         """Run the agent loop as the reply engine, streaming into the target row."""
         logger.info(
@@ -2809,6 +2931,8 @@ class ConsoleChatController:
                 supersede_previous=bool(prepare_retry or variant_mode),
                 mcp_provider=mcp_provider,
                 review_tool_calls=mcp_review_hook,
+                turn_skill_bindings=skill_bindings,
+                turn_bundle_block=skill_bundle_block,
             )
         except asyncio.CancelledError:
             if self._stop_requested:

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1529,9 +1529,13 @@ class ConsoleChatController:
             {"role": ConsoleMessageRole.USER.value, "content": clean_content}
         )
         self._ensure_user_continuation_instruction(provider_messages)
-        provider_messages, refuse, skill_notes = await self._apply_skill_substitution(
-            provider_messages
-        )
+        (
+            provider_messages,
+            refuse,
+            skill_notes,
+            skill_bindings,
+            skill_bundle_block,
+        ) = await self._apply_skill_substitution(provider_messages)
         if refuse is not None:
             return self._block(session_id, refuse)
         for note in skill_notes:
@@ -1568,6 +1572,8 @@ class ConsoleChatController:
             assistant_message_id=assistant.id,
             variant_mode=False,
             prefill=prefill,
+            skill_bindings=skill_bindings,
+            skill_bundle_block=skill_bundle_block,
         )
 
     async def build_context_snapshot(

--- a/tldw_chatbook/Library/library_skills_state.py
+++ b/tldw_chatbook/Library/library_skills_state.py
@@ -48,6 +48,10 @@ _SHADOWED_BUILTIN_NAMES = frozenset(
         "prefill",
         "system",
         "skills",
+        # The skill_file runtime tool (reference-file reachability; the
+        # drift-guard sync test flagged the gap when it joined
+        # RUNTIME_TOOL_NAMES).
+        "skill_file",
     )
 )
 

--- a/tldw_chatbook/Skills_Interop/local_skills_service.py
+++ b/tldw_chatbook/Skills_Interop/local_skills_service.py
@@ -1208,13 +1208,15 @@ class LocalSkillsService:
         self._verify_exact_skill_content(skill)
         _, body = self._parse_front_matter(skill["content"])
         rendered_prompt = body.strip().replace("{{args}}", request.args or "")
-        manifest = self._read_bundle_manifest(self._skill_dir(skill["name"]))
+        # get_skill's payload already carries the bundle manifest — derive from
+        # it rather than re-walking the skill directory a second time.
+        bundle_files = skill.get("bundle_files")
         reference_files = (
             [
                 {"path": entry["path"], "size": entry["size"], "is_text": entry["is_text"]}
-                for entry in manifest
+                for entry in bundle_files
             ]
-            if manifest is not None
+            if bundle_files
             else None
         )
         payload = self._dump(

--- a/tldw_chatbook/Skills_Interop/local_skills_service.py
+++ b/tldw_chatbook/Skills_Interop/local_skills_service.py
@@ -1239,17 +1239,23 @@ class LocalSkillsService:
     async def read_skill_file(
         self, skill_name: str, relative_path: str
     ) -> dict[str, Any]:
-        """Read one bundled supporting file of a trusted skill, contained + capped.
+        """Read one bundled file of a trusted skill, contained + capped.
 
         The runtime `skill_file` tool's single backing seam. Order is
         load-bearing: policy gate, per-READ trust re-verification (a skill
         revoked mid-run stops being readable immediately), path validation,
-        then the same containment discipline `_read_text_preserving_newlines`
-        already applies to the skill body.
+        containment (checked before any filesystem stat, so an escape can
+        never be distinguished from a genuinely missing file), then the same
+        read discipline `_read_text_preserving_newlines` already applies to
+        the skill body. The exact canonical body path (``"SKILL.md"``) is
+        readable through this seam too -- only that literal path skips the
+        supporting-file validator's case-insensitive rejection; any nested
+        or differently-cased variant still goes through it unchanged.
 
         Args:
             skill_name: Canonical skill name.
-            relative_path: POSIX relative path within the skill's bundle.
+            relative_path: POSIX relative path within the skill's bundle
+                (or the literal ``"SKILL.md"`` for the body itself).
 
         Returns:
             ``{"content", "truncated", "size"}``; a binary file yields a
@@ -1265,11 +1271,32 @@ class LocalSkillsService:
 
         self._enforce("skills.read_file.launch.local")
         self._require_trusted_skill(skill_name)
-        validate_supporting_file_path(relative_path)
+        # The canonical body path is exempted from the supporting-file
+        # validator (which otherwise rejects any-case "skill.md" as a
+        # shadow-body attempt) -- the spec says the body IS readable
+        # through this seam. Exact match only: a nested or wrong-case
+        # variant (e.g. "references/SKILL.md", "skill.md") still goes
+        # through the validator and is rejected exactly as before.
+        # Containment is still enforced below via the same contained read.
+        if relative_path != _SKILL_FILENAME:
+            validate_supporting_file_path(relative_path)
         skill_dir = self._skill_dir(skill_name)
         if not skill_dir.is_dir():
             raise ValueError(f"local_skill_not_found:{skill_name}")
         path = skill_dir / PurePosixPath(relative_path)
+        # Containment is checked BEFORE any is_file()/stat() touches the
+        # candidate path (Qodo/PR#814 hardening): an intermediate symlinked
+        # directory planted inside the bundle between the trust re-scan and
+        # this read would otherwise let is_file()/stat() follow it and act
+        # as an existence/size oracle for paths outside the bundle -- an
+        # escape that resolves to a real file would raise a DIFFERENT error
+        # ("unsafe local skill path" from the read below) than a genuinely
+        # missing one. Checking containment first means every path whose
+        # resolution escapes skill_dir short-circuits to the SAME
+        # "local_skill_file_not_found" error as a missing file, before
+        # is_file()/stat() ever run on it.
+        if get_safe_relative_path(path, skill_dir) is None:
+            raise ValueError(f"local_skill_file_not_found:{relative_path}")
         if path.is_symlink() or not path.is_file():
             raise ValueError(f"local_skill_file_not_found:{relative_path}")
         raw_size = path.stat().st_size

--- a/tldw_chatbook/Skills_Interop/local_skills_service.py
+++ b/tldw_chatbook/Skills_Interop/local_skills_service.py
@@ -1208,7 +1208,16 @@ class LocalSkillsService:
         self._verify_exact_skill_content(skill)
         _, body = self._parse_front_matter(skill["content"])
         rendered_prompt = body.strip().replace("{{args}}", request.args or "")
-        return self._dump(
+        manifest = self._read_bundle_manifest(self._skill_dir(skill["name"]))
+        reference_files = (
+            [
+                {"path": entry["path"], "size": entry["size"], "is_text": entry["is_text"]}
+                for entry in manifest
+            ]
+            if manifest is not None
+            else None
+        )
+        payload = self._dump(
             SkillExecutionResult(
                 skill_name=skill["name"],
                 rendered_prompt=rendered_prompt,
@@ -1216,8 +1225,14 @@ class LocalSkillsService:
                 model_override=skill.get("model"),
                 execution_mode=skill.get("context") or "inline",
                 fork_output=None,
+                reference_files=reference_files,
             )
         )
+        if reference_files is None:
+            # Omit (rather than null) when there's no bundle — preserves the
+            # exact-dict-equality contract existing execute_skill callers rely on.
+            payload.pop("reference_files", None)
+        return payload
 
     async def read_skill_file(
         self, skill_name: str, relative_path: str

--- a/tldw_chatbook/Skills_Interop/local_skills_service.py
+++ b/tldw_chatbook/Skills_Interop/local_skills_service.py
@@ -54,6 +54,7 @@ _TEXT_FIELD_LIMITS = {
 }
 _TRUST_STATUS_SERVICE_UNAVAILABLE = "trust_locked"
 _TRUST_REASON_SERVICE_UNAVAILABLE = "trust_service_unavailable"
+SKILL_FILE_READ_CAP_CHARS = 100_000
 
 
 class LocalSkillsService:
@@ -1217,6 +1218,65 @@ class LocalSkillsService:
                 fork_output=None,
             )
         )
+
+    async def read_skill_file(
+        self, skill_name: str, relative_path: str
+    ) -> dict[str, Any]:
+        """Read one bundled supporting file of a trusted skill, contained + capped.
+
+        The runtime `skill_file` tool's single backing seam. Order is
+        load-bearing: policy gate, per-READ trust re-verification (a skill
+        revoked mid-run stops being readable immediately), path validation,
+        then the same containment discipline `_read_text_preserving_newlines`
+        already applies to the skill body.
+
+        Args:
+            skill_name: Canonical skill name.
+            relative_path: POSIX relative path within the skill's bundle.
+
+        Returns:
+            ``{"content", "truncated", "size"}``; a binary file yields a
+            clean refusal string as ``content`` (never bytes, never raises).
+
+        Raises:
+            SkillTrustBlockedError: Skill not currently trusted.
+            ValueError: Bad path, unknown skill, or missing file
+                (``local_skill_file_not_found:...``).
+        """
+        # Deferred import: avoid module-scope tldw_api schema import (task-285 phase 2).
+        from ..tldw_api.skills_schemas import validate_supporting_file_path
+
+        self._enforce("skills.read_file.launch.local")
+        self._require_trusted_skill(skill_name)
+        validate_supporting_file_path(relative_path)
+        skill_dir = self._skill_dir(skill_name)
+        if not skill_dir.is_dir():
+            raise ValueError(f"local_skill_not_found:{skill_name}")
+        path = skill_dir / PurePosixPath(relative_path)
+        if path.is_symlink() or not path.is_file():
+            raise ValueError(f"local_skill_file_not_found:{relative_path}")
+        raw_size = path.stat().st_size
+        try:
+            text = self._read_text_preserving_newlines(path, base_dir=skill_dir)
+        except UnicodeDecodeError:
+            return {
+                "content": f"binary file — {raw_size} bytes; not readable as text",
+                "truncated": False,
+                "size": raw_size,
+            }
+        if "\x00" in text:
+            return {
+                "content": f"binary file — {raw_size} bytes; not readable as text",
+                "truncated": False,
+                "size": raw_size,
+            }
+        if len(text) > SKILL_FILE_READ_CAP_CHARS:
+            text = (
+                text[:SKILL_FILE_READ_CAP_CHARS]
+                + f"\n[truncated — file is {raw_size} bytes; showing first {SKILL_FILE_READ_CAP_CHARS} characters]"
+            )
+            return {"content": text, "truncated": True, "size": raw_size}
+        return {"content": text, "truncated": False, "size": raw_size}
 
     async def seed_builtin_skills(self, *, overwrite: bool = False) -> dict[str, Any]:
         self._enforce("skills.seed.launch.local")

--- a/tldw_chatbook/Skills_Interop/skills_scope_service.py
+++ b/tldw_chatbook/Skills_Interop/skills_scope_service.py
@@ -328,6 +328,25 @@ class SkillsScopeService:
         Local-only by design: the server backend has no read_skill_file and
         every runtime skill path is already hardcoded local. Rejecting server
         mode here beats surfacing a raw AttributeError from _call.
+
+        Args:
+            skill_name: Canonical skill name.
+            relative_path: POSIX relative path within the skill's bundle
+                (or the literal ``"SKILL.md"`` for the body itself).
+            mode: Backend selector; only ``None``/``SkillsBackend.LOCAL`` is
+                accepted (defaults to local, unlike this class's other
+                methods, which default to server).
+
+        Returns:
+            ``{"content", "truncated", "size"}``; a binary file yields a
+            clean refusal string as ``content`` (never bytes, never raises).
+
+        Raises:
+            ValueError: ``mode`` resolves to server (``"skill_file reads
+                are local-only"``), the local backend is unavailable, or
+                the underlying local read rejects the path/skill (bad
+                path, unknown skill, or missing file).
+            SkillTrustBlockedError: Skill not currently trusted.
         """
         normalized_mode = self._normalize_mode(mode) if mode is not None else SkillsBackend.LOCAL
         if normalized_mode is not SkillsBackend.LOCAL:

--- a/tldw_chatbook/Skills_Interop/skills_scope_service.py
+++ b/tldw_chatbook/Skills_Interop/skills_scope_service.py
@@ -316,6 +316,26 @@ class SkillsScopeService:
             kwargs=kwargs,
         )
 
+    async def read_skill_file(
+        self,
+        skill_name: str,
+        relative_path: str,
+        *,
+        mode: SkillsBackend | str | None = None,
+    ) -> dict[str, Any]:
+        """Read a bundled file of a LOCAL trusted skill (runtime skill_file seam).
+
+        Local-only by design: the server backend has no read_skill_file and
+        every runtime skill path is already hardcoded local. Rejecting server
+        mode here beats surfacing a raw AttributeError from _call.
+        """
+        normalized_mode = self._normalize_mode(mode) if mode is not None else SkillsBackend.LOCAL
+        if normalized_mode is not SkillsBackend.LOCAL:
+            raise ValueError("skill_file reads are local-only")
+        service = self._require_service(SkillsBackend.LOCAL)
+        self._enforce_policy("skills.read_file.launch.local")
+        return await self._maybe_await(service.read_skill_file(skill_name, relative_path))
+
     async def seed_builtin_skills(
         self, *, mode: SkillsBackend | str | None = None, **kwargs: Any
     ) -> dict[str, Any]:

--- a/tldw_chatbook/runtime_policy/registry.py
+++ b/tldw_chatbook/runtime_policy/registry.py
@@ -1017,6 +1017,7 @@ AUDITED_CAPABILITY_SEEDS = (
             _resource("skills.import", actions=(LAUNCH,)),
             _resource("skills.export", actions=(LAUNCH,)),
             _resource("skills.execute", actions=(LAUNCH,)),
+            _resource("skills.read_file", actions=(LAUNCH,)),
             _resource("skills.seed", actions=(LAUNCH,)),
             _resource(
                 "skills.trust",

--- a/tldw_chatbook/tldw_api/skills_schemas.py
+++ b/tldw_chatbook/tldw_api/skills_schemas.py
@@ -190,6 +190,7 @@ class SkillExecutionResult(BaseModel):
     model_override: str | None = None
     execution_mode: Literal["inline", "fork"]
     fork_output: str | None = None
+    reference_files: list[dict] | None = None
 
     model_config = ConfigDict(from_attributes=True, extra="allow")
 


### PR DESCRIPTION
## Summary

**Reference-file reachability — the `skill_file` runtime tool.** Makes the skills program's faithfully-stored bundles (PR #784) actually *usable*: agents can now read a skill's bundled `references/*` on demand, with progressive disclosure instead of context-stuffing.

Follows the trust foundation (PR #762), bundle fidelity (PR #784), and `$`-mention invocation (PR #801). Design + plan: `Docs/superpowers/specs/2026-07-23-skills-reference-file-reachability-design.md`, `Docs/superpowers/plans/2026-07-23-skills-reference-file-reachability-plan.md`.

## What this does

- **One trust-gated read seam** — `read_skill_file(skill_name, relative_path)`: policy gate (new `skills.read_file.launch.local` registry entry — the engine fails closed on unknown ids) → **per-read trust re-verification** (a skill revoked mid-run stops being readable immediately) → path validation → contained read (resolve/symlink/containment — an intermediate-symlinked-directory escape was live-probed and blocked in review) → binaries return a clean refusal string → 100 KB cap with truncation marker. Scope-service passthrough is local-only with a clean server-mode rejection.
- **`skill_file` is the fourth runtime tool** (joining `spawn_subagent`/`find_tools`/`load_tools`): schema pinned per run whenever bindings exist — always active from step 1, never hidden behind tool-disclosure budgets — with authorization via a per-run `SkillFileBindings` object, never `allowed_tools` membership. Unauthorized or hallucinated names get a named per-call refusal; a misbehaving reader fails the call, never the run.
- **Who gets it:** model-invoked skill forks always read their *own* bundle (granted before spawn, independent of frontmatter `allowed-tools` — reading your own references is the progressive-disclosure baseline), and native-tools Console turns get the tool for the skills the user's `$mentions` actually rendered that turn (leading + spliced embedded; never blocked/fork-literal mentions). Plain sends get nothing — no tool, no dangling promise.
- **Discovery travels with capability:** a `Bundled files (readable via skill_file): references/api.md (2 KB), …` block is pre-rendered at substitution (pure string work from metadata already in hand) but inserted only where the tool's existence is certain — bridge-side onto the run's own message copy (copy-safe; the non-mutation contract is pinned by a test proven non-vacuous) and into spawned fork bodies. Never the stored transcript.
- `execute_skill` results carry additive `reference_files` metadata (derived from the payload already computed — no extra bundle walk).

## Verification

- Built subagent-driven: 6 TDD tasks, each spec+quality reviewed. Review-gate catches this run: a live symlink-escape probe validating containment; a double unbounded bundle-walk on every skill invocation (fixed, RED-proven); the Library shadow-name drift guard firing exactly as designed when `skill_file` joined the runtime tool names; a run-crash hardening for contract-violating readers; and direct coverage forced for the copy-safe block-append (an in-place-mutation variant fails the test).
- Final **whole-branch review returned MERGE READY** (no Critical/Important): end-to-end security (single gated seam, no scope-service bypass, revocation backstop verified), bindings lifecycle (fresh per run, no cross-run leaks), byte-identical block formats, clean layering (`agent_runtime` has no Skills_Interop import).
- Full gate: `Tests/Skills/` + `Tests/Agents/` + `Tests/Chat/` + skill-command suite → **1807 passed**, only the known pre-existing baseline.
- Rebased onto latest `dev` (+49): the rebase surfaced a **fifth** substitution call site in dev's new edit-and-resend path still unpacking the old 3-tuple (guaranteed runtime `ValueError`) — integrated with the 5-tuple contract and kwargs threaded, mirroring the sibling sites; targeted suites green.

## Out of scope (follow-ups)

Script **execution** (`scripts/*` running — the trust-gated next layer); per-conversation binding accumulation (per-turn by design; seam named); binary reads; multimodal-turn bindings; exact-100 KB-boundary unit pin; per-row skill attribution in multi-skill blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a trust-gated `skill_file` runtime tool so agents can read a skill’s bundled `references/*` on demand, with progressive disclosure. Hardens the read seam based on review (supports exact `SKILL.md`, stronger containment, and an undisclosed‑tool leak fix).

- **New Features**
  - `skill_file(skill_name, path)` runtime tool with per-run `SkillFileBindings`; schema pinned and name-dispatched in the runtime; `skill_file` added to `RUNTIME_TOOL_NAMES`.
  - Availability: skill forks can always read their own bundle; console turns grant reads for skills invoked via `$mentions`; plain sends grant nothing.
  - Secure read seam (local-only): policy `skills.read_file.launch.local`, per-read trust re-check, path containment/symlink escape blocking done before any file ops, text-only with 100 KB cap and truncation marker; exact `SKILL.md` is readable; server mode cleanly rejected.
  - `execute_skill` returns `reference_files`; bridge appends one “Bundled files (readable via `skill_file`)” block to the run’s message copy and spawned fork body only when the tool exists (never stored transcripts).

- **Bug Fixes**
  - Edit-and-resend path updated to the new 5‑tuple `_apply_skill_substitution` contract, avoiding a runtime `ValueError`.
  - Tool call hardening: a bad `skill_file` reader fails only the call, not the run.
  - Avoided redundant bundle walks by deriving `reference_files` from the `get_skill` payload.
  - Review hardening: allow reading exact `SKILL.md`; align runtime dispatch with schema pinning to avoid undisclosed‑tool leakage; check containment before any stat/is_file to block symlink oracles; add a local‑only docstring to `SkillsScopeService.read_skill_file`.

<sup>Written for commit e13ba32953c42bb5401f341efdc2e0a12dde673e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

