### PR TITLE
fix(console): picker-correctness cluster — attach-cap gate + typed-path file highlight (tasks 377/378)

### DIFF
--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -7227,6 +7227,75 @@ async def test_pending_image_on_vision_model_does_not_block(monkeypatch):
         assert console._console_attachment_blocked_reason() == ""
 
 
+@pytest.mark.asyncio
+async def test_attach_at_cap_blocks_picker_before_selection(monkeypatch):
+    """TASK-377: at the attachment cap, pressing Attach must report the limit
+    immediately rather than opening the picker and rejecting the pick afterwards.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from tldw_chatbook.Chat.console_chat_store import MAX_PENDING_ATTACHMENTS
+
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    host = ConsoleHarness(app)
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        store = console._ensure_console_chat_store()
+        session = store.ensure_session()
+        for _ in range(MAX_PENDING_ATTACHMENTS):
+            assert store.add_pending_attachment(session.id, _staged_image_attachment())
+        assert len(store.pending_attachments(session.id)) == MAX_PENDING_ATTACHMENTS
+
+        pushed: list = []
+        monkeypatch.setattr(
+            console.app,
+            "push_screen",
+            AsyncMock(side_effect=lambda *a, **k: pushed.append(a)),
+        )
+        notes: list = []
+        monkeypatch.setattr(
+            console.app_instance,
+            "notify",
+            MagicMock(side_effect=lambda *a, **k: notes.append(a)),
+        )
+
+        await console._handle_console_attach_context(MagicMock())
+
+        assert not pushed, "picker opened despite being at the attachment cap"
+        assert any("limit reached" in str(a[0]).lower() for a in notes), notes
+
+
+@pytest.mark.asyncio
+async def test_attach_below_cap_still_opens_picker(monkeypatch):
+    """TASK-377 guard: below the cap the Attach button still opens the picker."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from tldw_chatbook.Chat.console_chat_store import MAX_PENDING_ATTACHMENTS
+
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    host = ConsoleHarness(app)
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        store = console._ensure_console_chat_store()
+        session = store.ensure_session()
+        for _ in range(MAX_PENDING_ATTACHMENTS - 1):
+            store.add_pending_attachment(session.id, _staged_image_attachment())
+
+        pushed: list = []
+        monkeypatch.setattr(
+            console.app,
+            "push_screen",
+            AsyncMock(side_effect=lambda *a, **k: pushed.append(a)),
+        )
+        await console._handle_console_attach_context(MagicMock())
+
+        assert pushed, "picker did not open while below the attachment cap"
+
+
 def test_resume_hydrates_image_messages_including_image_only_rows():
     """Verify resuming a saved conversation keeps image-only rows and their bytes."""
     screen = ChatScreen(_build_test_app())

--- a/Tests/UI/test_fspicker_path_highlight.py
+++ b/Tests/UI/test_fspicker_path_highlight.py
@@ -1,0 +1,58 @@
+"""TASK-378: a full file path entered in the picker path bar must land ON the file.
+
+Previously ``DirectoryNavigation`` navigated to the typed file's parent directory
+and left the highlight on ``..`` (index 0), so a keyboard user pasting a known
+path never selected the file. ``show_and_highlight`` now reveals and highlights it.
+"""
+
+import pytest
+from textual.app import App, ComposeResult
+
+from tldw_chatbook.Third_Party.textual_fspicker.parts.directory_navigation import (
+    DirectoryEntry,
+    DirectoryNavigation,
+)
+
+
+async def _highlighted_entry(nav: DirectoryNavigation, pilot, *, want: str):
+    """Pump the event loop until the highlighted option is ``want`` (or give up)."""
+    for _ in range(40):
+        await pilot.pause(0.05)
+        index = nav.highlighted
+        if index is None:
+            continue
+        option = nav.get_option_at_index(index)
+        if isinstance(option, DirectoryEntry) and option.location.name == want:
+            return option
+    return None if nav.highlighted is None else nav.get_option_at_index(nav.highlighted)
+
+
+@pytest.mark.asyncio
+async def test_show_and_highlight_lands_on_the_file_in_another_directory(tmp_path):
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "unrelated.txt").write_text("x")
+    (tmp_path / "aaa.txt").write_text("a")
+    target = tmp_path / "zzz-target.png"
+    target.write_text("z")
+
+    class _App(App):
+        def compose(self) -> ComposeResult:
+            # Start in the subdirectory; the target lives one level up, so a typed
+            # absolute path must reload the parent dir AND highlight the file.
+            yield DirectoryNavigation(str(sub))
+
+    app = _App()
+    async with app.run_test() as pilot:
+        nav = app.query_one(DirectoryNavigation)
+        await pilot.pause()
+        await pilot.pause()
+
+        nav.show_and_highlight(target)
+
+        option = await _highlighted_entry(nav, pilot, want="zzz-target.png")
+        assert option is not None, "nothing highlighted"
+        assert isinstance(option, DirectoryEntry)
+        assert option.location.name == "zzz-target.png"
+        # And the navigation followed the file into its parent directory.
+        assert nav.location == tmp_path

--- a/Tests/UI/test_fspicker_path_highlight.py
+++ b/Tests/UI/test_fspicker_path_highlight.py
@@ -29,6 +29,7 @@ async def _highlighted_entry(nav: DirectoryNavigation, pilot, *, want: str):
 
 @pytest.mark.asyncio
 async def test_show_and_highlight_lands_on_the_file_in_another_directory(tmp_path):
+    """A file path in a different directory reloads that dir and highlights it."""
     sub = tmp_path / "sub"
     sub.mkdir()
     (sub / "unrelated.txt").write_text("x")
@@ -56,3 +57,43 @@ async def test_show_and_highlight_lands_on_the_file_in_another_directory(tmp_pat
         assert option.location.name == "zzz-target.png"
         # And the navigation followed the file into its parent directory.
         assert nav.location == tmp_path
+
+
+@pytest.mark.asyncio
+async def test_show_and_highlight_survives_an_in_flight_load(tmp_path):
+    """A highlight requested while the directory is still loading is not dropped.
+
+    Qodo #816: the same-directory fast path can run before the async load
+    populates the list, so a miss must KEEP the pending target for the post-load
+    repopulate rather than clearing it. Reproduced deterministically by emptying
+    the option list (the in-flight state) before the same-directory request.
+    """
+    (tmp_path / "aaa.txt").write_text("a")
+    target = tmp_path / "zzz-target.png"
+    target.write_text("z")
+
+    class _App(App):
+        def compose(self) -> ComposeResult:
+            yield DirectoryNavigation(str(tmp_path))
+
+    app = _App()
+    async with app.run_test() as pilot:
+        nav = app.query_one(DirectoryNavigation)
+        await pilot.pause()
+        await pilot.pause()
+
+        # Simulate the list being empty mid-load, then request the highlight for
+        # a file in the (already-current) directory -> hits the same-dir fast path
+        # with no options to match yet.
+        nav.clear_options()
+        nav.show_and_highlight(target)
+
+        # The request must survive the empty-list miss (the bug dropped it here).
+        assert nav._pending_highlight is not None
+
+        # When the load completes and the list repopulates, the file is revealed.
+        nav._repopulate_display()
+        assert nav.highlighted is not None
+        option = nav.get_option_at_index(nav.highlighted)
+        assert isinstance(option, DirectoryEntry)
+        assert option.location.name == "zzz-target.png"

--- a/backlog/tasks/task-377 - Prevent-picking-a-sixth-attachment-at-the-cap-instead-of-rejecting-it-afterwards.md
+++ b/backlog/tasks/task-377 - Prevent-picking-a-sixth-attachment-at-the-cap-instead-of-rejecting-it-afterwards.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-377
 title: Prevent picking a sixth attachment at the cap instead of rejecting it afterwards
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-20 14:21'
 labels: [console, ux]
 dependencies: []
@@ -23,5 +24,18 @@ With 5 images staged, the attach button still opened the full file picker; I nav
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Disable or annotate the attach affordance at the cap ('5/5'), or block inside the picker before file selection, so the user never does dead work
+- [x] #1 Disable or annotate the attach affordance at the cap ('5/5'), or block inside the picker before file selection, so the user never does dead work
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Pre-picker cap gate: `_handle_console_attach_context` now checks the active
+session's pending count against `MAX_PENDING_ATTACHMENTS` BEFORE opening the file
+picker. At the cap it notifies "Attachment limit reached (5 per message). Remove
+one to attach another." and returns, so the user never navigates + selects a sixth
+file only to have it rejected by a toast after a full picker round-trip. Uses the
+None-safe `store.active_session_id` so clicking Attach with no session yet still
+opens the picker (count 0). Two harness tests bracket the boundary: at-cap blocks
+(picker not pushed, cap notified) and below-cap still opens.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-378 - Fix-the-picker-path-bar-discarding-the-filename-segment-of-a-typed-path.md
+++ b/backlog/tasks/task-378 - Fix-the-picker-path-bar-discarding-the-filename-segment-of-a-typed-path.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-378
 title: Fix the picker path bar discarding the filename segment of a typed path
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-20 14:21'
 labels: [console, ux]
 dependencies: []
@@ -23,5 +24,20 @@ Ctrl+L opens a path input (good), but entering an absolute FILE path and pressin
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A full file path entered in the path bar should select/attach that file (standard file-dialog behavior), or at minimum highlight it in the list and explain
+- [x] #1 A full file path entered in the path bar should select/attach that file (standard file-dialog behavior), or at minimum highlight it in the list and explain
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+`DirectoryNavigation` gained `show_and_highlight(target)`: it navigates to the
+file's parent directory and, once the async directory load repopulates the list,
+highlights the file instead of leaving the cursor on `..`. Implemented via a
+`_pending_highlight` target honored in `_repopulate_display` (before the default
+top-of-list settle), with an immediate path when the directory is already shown.
+`base_dialog.py`'s Ctrl+L path-bar handler now calls it for file paths, resolving
+the long-standing `# TODO: Ideally, we would also select the file in the list`.
+A keyboard user pasting a full path now lands on the file. RED->GREEN test
+(verified: neutering the highlight leaves the cursor on `..`); 29 existing picker
+tests green.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Third_Party/textual_fspicker/base_dialog.py
+++ b/tldw_chatbook/Third_Party/textual_fspicker/base_dialog.py
@@ -527,9 +527,10 @@ class FileSystemPickerScreen(ModalScreen[Union[Path, None]]):
             if path.is_dir():
                 dir_nav.location = path
             else:
-                # If it's a file, navigate to its parent directory
-                dir_nav.location = path.parent
-                # TODO: Ideally, we would also select the file in the list
+                # If it's a file, navigate to its parent directory AND highlight
+                # the file in the list, so a keyboard user who typed a full path
+                # lands on the file instead of on '..' (TASK-378).
+                dir_nav.show_and_highlight(path)
 
             # Hide the path input
             path_container = self.query_one("#path-input-container")

--- a/tldw_chatbook/Third_Party/textual_fspicker/parts/directory_navigation.py
+++ b/tldw_chatbook/Third_Party/textual_fspicker/parts/directory_navigation.py
@@ -340,24 +340,45 @@ class DirectoryNavigation(OptionList):
             # applied when `_repopulate_display` runs on completion.
             self.location = parent
 
-    def _apply_pending_highlight(self) -> bool:
+    def _apply_pending_highlight(self, *, final: bool = False) -> bool:
         """Highlight the pending target if it is present in the current listing.
+
+        The pending request is cleared only once it is resolved -- either the
+        entry was found and highlighted, the load has finished with the entry
+        absent (``final``), or the user navigated to a different directory. A
+        not-yet-found target during an in-flight load is KEPT so the post-load
+        ``_repopulate_display`` can still apply it (the immediate same-directory
+        call may run before the options are populated).
+
+        Args:
+            final: ``True`` when called after a completed directory load, so a
+                target still absent is genuinely gone and the request is dropped;
+                ``False`` for the speculative same-directory fast path, which
+                leaves an unmatched target pending for the post-load pass.
 
         Returns:
             ``True`` when a matching entry was found and highlighted.
         """
         target = self._pending_highlight
-        if target is None or target.parent != self._location:
+        if target is None:
             return False
-        self._pending_highlight = None
+        if target.parent != self._location:
+            # Navigated elsewhere before the target loaded; abandon it.
+            self._pending_highlight = None
+            return False
         for index in range(self.option_count):
             option = self.get_option_at_index(index)
             if (
                 isinstance(option, DirectoryEntry)
                 and option.location.name == target.name
             ):
+                self._pending_highlight = None
                 self.highlighted = index
                 return True
+        if final:
+            # The directory has finished loading and the target is not present;
+            # stop retrying so a stale request cannot linger.
+            self._pending_highlight = None
         return False
 
     @property
@@ -435,8 +456,9 @@ class DirectoryNavigation(OptionList):
                 )
             )
         # Honor a pending "reveal this file" request from the path bar before
-        # falling back to the default top-of-list highlight (TASK-378).
-        if not self._apply_pending_highlight():
+        # falling back to the default top-of-list highlight (TASK-378). This runs
+        # after a completed load, so an absent target is resolved (final=True).
+        if not self._apply_pending_highlight(final=True):
             self._settle_highlight()
 
     @work(exclusive=True, thread=True)

--- a/tldw_chatbook/Third_Party/textual_fspicker/parts/directory_navigation.py
+++ b/tldw_chatbook/Third_Party/textual_fspicker/parts/directory_navigation.py
@@ -290,6 +290,10 @@ class DirectoryNavigation(OptionList):
         self._mounted = False
         self.location = MakePath.of(location).expanduser().absolute()
         self._entries: list[DirectoryEntry] = []
+        #: A file to highlight in the list once the next directory load lands.
+        #: Lets a full path typed in the path bar land ON the file instead of
+        #: on ``..`` after navigating to its parent (TASK-378).
+        self._pending_highlight: Path | None = None
 
     @property
     def location(self) -> Path:
@@ -313,6 +317,48 @@ class DirectoryNavigation(OptionList):
         """Settle the highlight somewhere useful if it's not anywhere."""
         if self.highlighted is None:
             self.highlighted = 0
+
+    def show_and_highlight(self, target: Path) -> None:
+        """Navigate to ``target``'s directory and highlight ``target`` in the list.
+
+        The directory load runs in a worker, so the highlight is applied when the
+        display next repopulates (or immediately when the directory is already
+        shown). Lets a full file path typed into the path bar land on the file
+        rather than on ``..`` (TASK-378).
+
+        Args:
+            target: The file to reveal and highlight.
+        """
+        target = MakePath.of(target).expanduser().absolute()
+        parent = target.parent
+        self._pending_highlight = target
+        if self._mounted and parent == self._location:
+            # Already showing the right directory; highlight now.
+            self._apply_pending_highlight()
+        else:
+            # Changing the location triggers the async reload; the highlight is
+            # applied when `_repopulate_display` runs on completion.
+            self.location = parent
+
+    def _apply_pending_highlight(self) -> bool:
+        """Highlight the pending target if it is present in the current listing.
+
+        Returns:
+            ``True`` when a matching entry was found and highlighted.
+        """
+        target = self._pending_highlight
+        if target is None or target.parent != self._location:
+            return False
+        self._pending_highlight = None
+        for index in range(self.option_count):
+            option = self.get_option_at_index(index)
+            if (
+                isinstance(option, DirectoryEntry)
+                and option.location.name == target.name
+            ):
+                self.highlighted = index
+                return True
+        return False
 
     @property
     def is_root(self) -> bool:
@@ -388,7 +434,10 @@ class DirectoryNavigation(OptionList):
                     entry for entry in self._entries if not self.hide(entry.location)
                 )
             )
-        self._settle_highlight()
+        # Honor a pending "reveal this file" request from the path bar before
+        # falling back to the default top-of-list highlight (TASK-378).
+        if not self._apply_pending_highlight():
+            self._settle_highlight()
 
     @work(exclusive=True, thread=True)
     def _load(self) -> None:

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -12045,6 +12045,21 @@ class ChatScreen(BaseAppScreen):
     async def _handle_console_attach_context(self, event: Button.Pressed) -> None:
         """Open the native Console file picker and stage the selected attachment."""
         event.stop()
+        # TASK-377: block at the cap BEFORE opening the picker. Otherwise the user
+        # navigates the picker and selects a sixth file only to have it silently
+        # rejected by a transient toast after a full picker round-trip (dead work).
+        store = self._ensure_console_chat_store()
+        session_id = store.active_session_id
+        if (
+            session_id is not None
+            and len(store.pending_attachments(session_id)) >= MAX_PENDING_ATTACHMENTS
+        ):
+            self.app_instance.notify(
+                f"Attachment limit reached ({MAX_PENDING_ATTACHMENTS} per message). "
+                "Remove one to attach another.",
+                severity="warning",
+            )
+            return
         from fnmatch import fnmatch
 
         from tldw_chatbook.Chat.attachment_core import attachment_filter_specs


### PR DESCRIPTION
## Summary

Two harness-testable P3 attachment/picker fixes from the Console UX expert review 2026-07-20 (J3 attachments journey).

| Task | Fix |
|------|-----|
| **377** | At the 5-image cap, the paperclip still opened the full picker and only rejected the sixth file with a transient toast *after* selection — a dead round-trip. `_handle_console_attach_context` now checks the active session's pending count against `MAX_PENDING_ATTACHMENTS` **before** opening the picker and reports the limit immediately. Below the cap it still opens. |
| **378** | Entering a full **file** path in the Ctrl+L path bar navigated to the file's parent directory but left the highlight on `..` (a literal `# TODO` in the vendored picker), so a keyboard user pasting a known path never landed on the file. `DirectoryNavigation.show_and_highlight(target)` now highlights the file once the async directory load repopulates the list. |

## Implementation notes
- **377** uses the None-safe `store.active_session_id`, so clicking Attach before any session exists still opens the picker (count 0).
- **378** honors a `_pending_highlight` target in `_repopulate_display` (before the default top-of-list settle), because `location` changes load the directory in a worker thread — the highlight can't be applied synchronously. `base_dialog.py`'s path handler calls the new method for file paths.

## Tests (TDD RED→GREEN)
- `test_attach_at_cap_blocks_picker_before_selection` + `test_attach_below_cap_still_opens_picker` (377 — bracket the boundary)
- `test_show_and_highlight_lands_on_the_file_in_another_directory` (378 — verified RED: neutering the highlight leaves the cursor on `..`)

29 existing file-picker tests green; no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks opening the picker at the 5-attachment cap and makes typed file paths land on—and stay on—the file, including during in-flight loads. Addresses Linear TASK-377 and TASK-378.

- Bug Fixes
  - Attach cap (TASK-377): `_handle_console_attach_context` checks `MAX_PENDING_ATTACHMENTS` before opening; at the cap it warns and returns, below the cap it still opens. Tests cover at-cap blocks and below-cap opens.
  - Path bar (TASK-378): Added `DirectoryNavigation.show_and_highlight(target)` with a durable `_pending_highlight` applied via `_apply_pending_highlight` in `_repopulate_display`, so a typed file path highlights the file and survives in-flight loads; `base_dialog` now uses it for file paths. Tests cover landing on the file and mid-load resilience.

<sup>Written for commit 5377b9a8c4a1ae325fdf089fa5b89ec8f8756131. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

