### PR TITLE
feat(roleplay): alternate greeting selector in the preview (task-438)

### DIFF
--- a/Docs/superpowers/plans/2026-07-23-alternate-greeting-selector.md
+++ b/Docs/superpowers/plans/2026-07-23-alternate-greeting-selector.md
@@ -1,0 +1,300 @@
+# TASK-438 Alternate greeting selector — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a character has alternate greetings, the Roleplay preview shows a dropdown to pick which greeting seeds the conversation, and Reset returns to the chosen greeting (not the primary).
+
+**Architecture:** A `Select` in the preview pane (shown only when alternates exist). The controller owns the placeholder-processed greetings list `[first_message, *alternate_greetings]` and a `_current_greeting_index`; picking an option re-seeds via `pane.seed_greeting(chosen)`, which sets `pane._greeting` so the existing Reset (`_render_seed_lines` from `_greeting`) returns to the chosen greeting with no new Reset logic.
+
+**Tech Stack:** Python 3.11+, Textual, pytest.
+
+## Global Constraints
+
+- The selector lives in the **preview pane** only (not the card view / Console). It is shown **only when `len(greetings) > 1`** (≥1 alternate); a character with no alternates shows no selector (unchanged behavior).
+- `alternate_greetings` is a top-level `list[str]` on the record, available reliably only from the **async `handle_character_loaded`** path (and synchronously on a cached re-selection). Do not attempt to populate synchronously on a cold first selection.
+- Re-seed is guarded by the controller's `_current_greeting_index` (re-selecting the current index is a no-op) — this absorbs the **asynchronous `Select.Changed`** fired by the programmatic `set_options`/`value=0`, so no suppression flag is used.
+- Reset uses the existing `_greeting` re-render — do NOT add greeting logic to the Reset path. Picking a greeting must go through `seed_greeting` (which sets `_greeting`).
+- The selector is cleared (`set_greetings([])` → row hidden) whenever the preview loses its character, i.e. `PersonasPreviewController.reset(...)` is called with `seeded_for is None` (all persona/mode-switch/delete blank paths).
+- Placeholder processing (`replace_placeholders(g, name, "User")`) is applied uniformly to every greeting, matching the existing `first_message` handling.
+
+---
+
+### Task 1: Alternate greeting selector in the preview
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py` (new `PreviewGreetingSelected`)
+- Modify: `tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py` (import `Select` + `PreviewGreetingSelected`; compose row ~:123; `set_greetings`; `_greeting_option_label`; `@on(Select.Changed)`)
+- Modify: `tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py` (`__init__` :41; `reset` :63; `reset_for_character` :94-100; `handle_character_loaded` :244-261; new `_load_greetings` + `handle_greeting_selected`)
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py` (import `PreviewGreetingSelected`; `@on` handler near :3592-3614)
+- Test: `Tests/UI/test_personas_preview.py`, `Tests/UI/test_personas_workbench.py`
+
+**Interfaces:**
+- Produces: `PreviewGreetingSelected(index: int)`; `PersonasPreviewPane.set_greetings(greetings: list[str])`; `PersonasPreviewController.handle_greeting_selected(index: int)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+**Pane tests** (`Tests/UI/test_personas_preview.py`, reuse the `PreviewApp` harness; import `Select` from `textual.widgets` and `PreviewGreetingSelected` from `tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages`):
+```python
+async def test_greeting_selector_hidden_without_alternates():
+    app = PreviewApp()
+    async with app.run_test() as pilot:
+        pane = app.query_one(PersonasPreviewPane)
+        pane.set_greetings(["Only greeting."])
+        await pilot.pause()
+        assert app.query_one("#personas-preview-greeting-row").display is False
+
+
+async def test_greeting_selector_shown_with_alternates():
+    app = PreviewApp()
+    async with app.run_test() as pilot:
+        pane = app.query_one(PersonasPreviewPane)
+        pane.set_greetings(["Primary.", "Alt one.", "Alt two."])
+        await pilot.pause()
+        assert app.query_one("#personas-preview-greeting-row").display is True
+        from textual.widgets import Select
+        select = app.query_one("#personas-preview-greeting-select", Select)
+        assert len(list(select._options)) == 3  # 3 greetings
+
+
+async def test_choosing_greeting_posts_message():
+    from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
+        PreviewGreetingSelected,
+    )
+    posted = []
+    app = PreviewApp()
+    async with app.run_test() as pilot:
+        pane = app.query_one(PersonasPreviewPane)
+
+        def _capture(message):
+            if isinstance(message, PreviewGreetingSelected):
+                posted.append(message.index)
+        # drive the pane handler directly with a Select.Changed for index 1
+        from textual.widgets import Select
+        pane.set_greetings(["Primary.", "Alt one."])
+        await pilot.pause()
+        select = app.query_one("#personas-preview-greeting-select", Select)
+        select.value = 1
+        await pilot.pause()
+        # the pane re-posts PreviewGreetingSelected to its screen; assert via
+        # a spy on post_message OR assert the Changed handler ran (adapt to the
+        # harness — simplest: check the pane's handler posts by monkeypatching
+        # pane.post_message to record PreviewGreetingSelected indices).
+```
+> Implementer note for Step 1: `Select._options` is private; if it is not stable in this Textual version, assert option count another way (e.g. select the value and confirm it takes, or query the rendered options). For `test_choosing_greeting_posts_message`, the robust approach is to monkeypatch `pane.post_message` to capture `PreviewGreetingSelected` instances, then set `select.value = 1` and assert index 1 was posted (the programmatic `value=0` from `set_greetings` may also post index 0 — assert `1 in captured`, not exact equality).
+
+**Integration tests** (`Tests/UI/test_personas_workbench.py`): add an `alternate_greetings` entry to the `CHARACTERS` fixture (`:43-57`) — give character id 1 ("Detective Sam") `"alternate_greetings": ["An alternate opener.", "A third opener."]`. Then:
+```python
+    async def test_alternate_greeting_selector_seeds_and_reset_returns_to_choice(
+        self, mock_app_instance, stub_characters, stub_conversations
+    ):
+        from tldw_chatbook.Widgets.Persona_Widgets.personas_preview_pane import (
+            PersonasPreviewPane,
+        )
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await self._select_first_character(pilot)
+            pane = screen.query_one("#personas-preview-pane", PersonasPreviewPane)
+            assert screen.query_one("#personas-preview-greeting-row").display is True
+            # choose alternate index 1
+            await screen.preview.handle_greeting_selected(1)
+            await pilot.pause()
+            assert "An alternate opener." in pane.transcript_text()
+            # send a turn, then Reset -> returns to the CHOSEN alternate, not primary
+            pane.append_user("hi")
+            pane.append_reply("hello")
+            await pilot.pause()
+            await pane.reset()
+            await pilot.pause()
+            assert "An alternate opener." in pane.transcript_text()
+            assert "hi" not in pane.transcript_text()
+```
+And a no-alternates case (mirror an existing character without `alternate_greetings`) asserting `#personas-preview-greeting-row` `display is False`.
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+Run: `python -m pytest Tests/UI/test_personas_preview.py -k greeting_selector Tests/UI/test_personas_workbench.py -k alternate_greeting -q`
+Expected: FAIL — `#personas-preview-greeting-row`/`set_greetings`/`handle_greeting_selected` do not exist.
+
+- [ ] **Step 3: Add the `PreviewGreetingSelected` message**
+
+In `personas_pane_messages.py`, alongside the other preview messages:
+```python
+class PreviewGreetingSelected(Message):
+    """The user picked a greeting (index into the greetings list) to seed from."""
+
+    def __init__(self, index: int) -> None:
+        super().__init__()
+        self.index = index
+```
+
+- [ ] **Step 4: Pane — Select import, compose row, `set_greetings`, handler**
+
+`personas_preview_pane.py`:
+- Import: `from textual.widgets import Button, Input, Select, Static` (add `Select`); add `PreviewGreetingSelected` to the `.personas_pane_messages` import block.
+- In `compose()`, right after the status Static (`:123`, before the `Input` at `:124`):
+```python
+            yield Static("", id="personas-preview-status")
+            with Horizontal(id="personas-preview-greeting-row", classes="ds-toolbar"):
+                yield Static("Greeting:", classes="personas-preview-greeting-label")
+                yield Select(
+                    [],
+                    id="personas-preview-greeting-select",
+                    classes="form-select",
+                    allow_blank=False,
+                    prompt="Greeting",
+                )
+            yield Input(placeholder="Test message...", id="personas-preview-input")
+```
+- Hide the row initially — in `__init__` after mount is not available, so set it in `on_mount` (the pane already has one; if not, do it at the top of `set_greetings` default). Simplest: in `compose` the row renders; add `self.query_one("#personas-preview-greeting-row").display = False` to the pane's existing `on_mount`, or rely on `set_greetings([])` being called on first clear. To be safe, set `display = False` in the compose by constructing the `Horizontal` and setting `.display` is not possible inline; instead add to `on_mount`:
+```python
+    def on_mount(self) -> None:
+        self.query_one("#personas-preview-greeting-row").display = False
+```
+(If `on_mount` already exists in the pane, add this line to it.)
+- Add the methods (near `set_speakers`/`reset_speakers`):
+```python
+    def set_greetings(self, greetings: list[str]) -> None:
+        """Populate the greeting selector; show it only when alternates exist.
+
+        Args:
+            greetings: Processed greetings, ``greetings[0]`` the primary
+                ``first_message`` and the rest alternates.
+        """
+        row = self.query_one("#personas-preview-greeting-row")
+        if len(greetings) > 1:
+            select = self.query_one("#personas-preview-greeting-select", Select)
+            select.set_options(
+                [(self._greeting_option_label(i, g), i) for i, g in enumerate(greetings)]
+            )
+            select.value = 0
+            row.display = True
+        else:
+            row.display = False
+
+    def _greeting_option_label(self, index: int, text: str) -> str:
+        """Dropdown label: 'Greeting N (default): <~40-char preview>'."""
+        preview = " ".join(str(text).split())
+        if len(preview) > 40:
+            preview = preview[:39] + "…"
+        tag = " (default)" if index == 0 else ""
+        base = f"Greeting {index + 1}{tag}"
+        return f"{base}: {preview}" if preview else base
+
+    @on(Select.Changed, "#personas-preview-greeting-select")
+    def _handle_greeting_selected(self, event: Select.Changed) -> None:
+        if isinstance(event.value, int):
+            self.post_message(PreviewGreetingSelected(event.value))
+```
+
+- [ ] **Step 5: Controller — greetings list, index, re-seed, clear**
+
+`personas_preview_controller.py`:
+- `__init__` (after `self._readout_nav_provider`, `:55`):
+```python
+        self._greetings: list[str] = []
+        self._current_greeting_index: int = 0
+```
+- `reset` (`:63-78`) — clear the selector on the no-character (blank) path. After `self.seeded_for = seeded_for` (`:77`), before `refresh_provider_readout`:
+```python
+        if seeded_for is None:
+            self._greetings = []
+            try:
+                self.screen.query_one(PersonasPreviewPane).set_greetings([])
+            except QueryError:
+                pass
+```
+- New helper (place above `reset_for_character`):
+```python
+    def _load_greetings(self, record: dict[str, Any], name: str) -> str:
+        """Store the processed greeting list, populate the selector, return the primary."""
+        raw = [str(record.get("first_message") or "")]
+        raw += [
+            str(g)
+            for g in (record.get("alternate_greetings") or [])
+            if isinstance(g, str)
+        ]
+        self._greetings = [replace_placeholders(g, name, "User") for g in raw]
+        self._current_greeting_index = 0
+        try:
+            self.screen.query_one(PersonasPreviewPane).set_greetings(self._greetings)
+        except QueryError:
+            pass
+        return self._greetings[0] if self._greetings else ""
+```
+- `reset_for_character` (`:97-100`): replace the inline greeting build with:
+```python
+        greeting = self._load_greetings(record, character_name)
+        await self.reset(greeting, seeded_for=character_id)
+```
+- `handle_character_loaded` (`:246-248`): replace
+```python
+        greeting = replace_placeholders(
+            str(record.get("first_message") or ""), name, "User"
+        )
+```
+  with `greeting = self._load_greetings(record, name)`.
+- New selection handler (place after `handle_reset`):
+```python
+    async def handle_greeting_selected(self, index: int) -> None:
+        """Re-seed the preview from the chosen greeting (AC#1); Reset then returns to it (AC#2)."""
+        if index == self._current_greeting_index or not (
+            0 <= index < len(self._greetings)
+        ):
+            return
+        self._current_greeting_index = index
+        self.invalidate()
+        try:
+            await self.screen.query_one(PersonasPreviewPane).seed_greeting(
+                self._greetings[index]
+            )
+        except QueryError:
+            pass
+```
+
+- [ ] **Step 6: Screen wiring**
+
+`personas_screen.py`:
+- Add `PreviewGreetingSelected` to the import from `personas_pane_messages`.
+- Add the handler alongside the other preview `@on` handlers (`:3592-3614`):
+```python
+    @on(PreviewGreetingSelected)
+    async def _handle_preview_greeting_selected(
+        self, message: PreviewGreetingSelected
+    ) -> None:
+        message.stop()
+        await self.preview.handle_greeting_selected(message.index)
+```
+
+- [ ] **Step 7: Run the tests to confirm they pass**
+
+Run: `python -m pytest Tests/UI/test_personas_preview.py -k greeting Tests/UI/test_personas_workbench.py -k alternate_greeting -q`
+Expected: PASS.
+
+- [ ] **Step 8: Regression**
+
+Run:
+```bash
+python -m pytest Tests/UI/test_personas_preview.py Tests/UI/test_personas_preview_restore.py -q
+python -m pytest Tests/UI/test_personas_workbench.py -q
+```
+Expected: PASS. The added `alternate_greetings` fixture field must not break existing character tests (they ignore it). `test_character_book_errors_render_in_editor_footer` is a known pre-existing test-order isolation flake (passes alone) — ignore it.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py \
+        tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py \
+        tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py \
+        tldw_chatbook/UI/Screens/personas_screen.py \
+        Tests/UI/test_personas_preview.py Tests/UI/test_personas_workbench.py
+git commit -m "feat(roleplay): alternate greeting selector in the preview (task-438)"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** AC#1 (pick which greeting seeds) → Steps 4-6 + `test_greeting_selector_shown_with_alternates`/`test_choosing_greeting_posts_message`/the integration seed assertion. AC#2 (Reset returns to chosen) → `handle_greeting_selected` → `seed_greeting` sets `_greeting` → existing Reset re-render; pinned by `test_alternate_greeting_selector_seeds_and_reset_returns_to_choice`. Both covered.
+- **Placeholder scan:** the only implementer judgement is the Textual/`Select` test-introspection API (`_options`/capturing `post_message`), flagged with a robust fallback; all shipped code is concrete.
+- **Type/name consistency:** `set_greetings`, `_greeting_option_label`, `PreviewGreetingSelected(index)`, `handle_greeting_selected`, `_load_greetings`, `_greetings`, `_current_greeting_index` used identically across pane/controller/screen/tests. `_greeting` (singular, the seeded text for Reset) is unchanged from TASK-437/434.
+- **Idempotence:** the programmatic `set_options`/`value=0` fires `Select.Changed(0)` → pane posts `PreviewGreetingSelected(0)` → `handle_greeting_selected(0)` no-ops because `0 == _current_greeting_index` — no double-seed.

--- a/Docs/superpowers/specs/2026-07-23-alternate-greeting-selector-design.md
+++ b/Docs/superpowers/specs/2026-07-23-alternate-greeting-selector-design.md
@@ -1,0 +1,160 @@
+# TASK-438 — Alternate greeting selector in the Roleplay preview
+
+- **Date:** 2026-07-23
+- **Task:** TASK-438 (RP/character-card UX review). The preview always seeds the primary `first_message`; alternate greetings are unreachable.
+- **Branch base:** origin/dev (tip `c700081db`, includes TASK-437 preview speaker labels).
+
+## Problem
+
+A character card can carry `alternate_greetings` (the card view even shows "Alternate greetings: N"), but the Roleplay preview always seeds the primary `first_message` and there is no way to start from an alternate anywhere in the app.
+
+- **AC#1:** when a character has alternate greetings, the preview offers a way to pick which greeting seeds the conversation.
+- **AC#2:** Reset returns to the chosen greeting, not silently to the primary one.
+
+## Key mechanics (verified)
+
+- **`alternate_greetings` is a top-level `list[str]`** on the app record dict, alongside `first_message` (`Character_Chat_Lib.py:1310/1315`, placeholder-processed at load `:736-745`; DB round-trips it as JSON, `ChaChaNotes_DB.py:205/4217`).
+- **The preview seeds only `first_message`** — `reset_for_character` (`personas_preview_controller.py:97-100`) and `handle_character_loaded` (`:246-261`) both `replace_placeholders(record.get("first_message"), name, "User")` → `pane.seed_greeting(...)`. `alternate_greetings` is read nowhere in the seeding path.
+- **Reset is already a dumb re-render from `pane._greeting`** — `PersonasPreviewPane.reset()` → `_render_seed_lines()` rebuilds from `self._greeting` (`personas_preview_pane.py:334-357`); `seed_greeting`/`refresh_greeting_seed` set `self._greeting` (`:158-175`). **So AC#2 reduces to: write the chosen greeting into `_greeting` via `seed_greeting` — Reset needs no new logic.**
+- **Availability is async.** On first selection the screen's record is `None` (`_full_character_record` returns None unless the handler already cached the full card, `personas_screen.py:4032-4042`); the greeting — and thus `alternate_greetings` — is only reliably present once `handle_character_loaded` runs with `card_data`. So the selector must populate from that async path (and synchronously on cached re-selection).
+- **Toolbar + message pattern.** Preview controls compose in `personas_preview_pane.py:107-147` (`Input`, then a `Horizontal(classes="ds-toolbar")` of buttons). Pane→screen uses `post_message(PreviewXRequested())` → `@on(...)` in `personas_screen.py:3592-3614` → `self.preview.<method>()`. Existing messages in `personas_pane_messages.py:119-136`.
+- **`Select` widget (Textual, verified):** `Select(options=[(label, value)], *, allow_blank, value=, id=, classes=)`; repopulate via `select.set_options([(label, value)])` (mirrors `Widgets/Evals/ab_test_dialog.py:446/458`); emits `Select.Changed(select, value)`; codebase style `classes="form-select"` + `@on(Select.Changed)`. **Setting `select.value`/`set_options` fires `Changed` asynchronously**, so a suppression flag is unreliable — the re-seed is guarded by a `_current_greeting_index` on the controller instead (idempotent).
+
+## Design
+
+### 1. Greeting row + `Select` in the preview pane
+
+In `compose()` (just above the `Input` at `:124`, so it sits between the transcript and the toolbar), add a hidden row:
+```python
+with Horizontal(id="personas-preview-greeting-row", classes="ds-toolbar"):
+    yield Static("Greeting:", classes="personas-preview-greeting-label")
+    yield Select([], id="personas-preview-greeting-select",
+                 classes="form-select", allow_blank=False,
+                 prompt="Greeting")
+# row starts hidden; shown by set_greetings() only when there are alternates
+```
+Set `self.query_one("#personas-preview-greeting-row").display = False` at mount (or via `set_greetings`).
+
+New pane API:
+```python
+def set_greetings(self, greetings: list[str]) -> None:
+    """Populate the greeting selector; show it only when there are alternates.
+
+    greetings[0] is the primary first_message; the rest are alternates.
+    """
+    row = self.query_one("#personas-preview-greeting-row")
+    if len(greetings) > 1:
+        select = self.query_one("#personas-preview-greeting-select", Select)
+        select.set_options(
+            [(self._greeting_option_label(i, g), i) for i, g in enumerate(greetings)]
+        )
+        select.value = 0
+        row.display = True
+    else:
+        row.display = False
+
+def _greeting_option_label(self, index: int, text: str) -> str:
+    """Dropdown label: 'Greeting N (default): <~40-char preview>'."""
+    preview = " ".join(str(text).split())
+    if len(preview) > 40:
+        preview = preview[:39] + "…"
+    tag = " (default)" if index == 0 else ""
+    return f"Greeting {index + 1}{tag}: {preview}" if preview else f"Greeting {index + 1}{tag}"
+```
+
+Handle user selection (mirrors the existing `@on` handlers), posting a new message:
+```python
+@on(Select.Changed, "#personas-preview-greeting-select")
+def _handle_greeting_selected(self, event: Select.Changed) -> None:
+    if isinstance(event.value, int):
+        self.post_message(PreviewGreetingSelected(event.value))
+```
+(The pane posts on **every** `Changed`, including the programmatic one fired by `set_options`/`value=0`; the controller's index guard makes a re-select of the current index a no-op, so no fragile suppression flag is needed.)
+
+### 2. New message
+
+`personas_pane_messages.py` (alongside the other preview messages):
+```python
+class PreviewGreetingSelected(Message):
+    """The user picked a greeting (index into the greetings list) to seed from."""
+    def __init__(self, index: int) -> None:
+        super().__init__()
+        self.index = index
+```
+
+### 3. Controller: own the greetings list + index, re-seed on change
+
+`PersonasPreviewController` gains `self._greetings: list[str] = []` and `self._current_greeting_index: int = 0`.
+
+Add a helper that builds the placeholder-processed list and pushes it to the pane, used at both seed points:
+```python
+def _load_greetings(self, record: dict, name: str) -> str:
+    """Store the processed greeting list, populate the selector, return the primary."""
+    raw = [str(record.get("first_message") or "")]
+    raw += [str(g) for g in (record.get("alternate_greetings") or []) if isinstance(g, str)]
+    self._greetings = [replace_placeholders(g, name, "User") for g in raw]
+    self._current_greeting_index = 0
+    self.screen.query_one(PersonasPreviewPane).set_greetings(self._greetings)
+    return self._greetings[0] if self._greetings else ""
+```
+- `reset_for_character` (`:97-100`): when `record` is present, `greeting = self._load_greetings(record, character_name)`; when `record is None`, clear (`self._greetings = []`; `pane.set_greetings([])`) then `await self.reset("")`.
+- `handle_character_loaded` (`:246`): `greeting = self._load_greetings(record, name)` in place of the inline `replace_placeholders(first_message...)`. The rest (`refresh_greeting_seed` preserve branch / `seed_greeting`) is unchanged and now uses the primary from the list.
+
+Handle the selection (screen forwards it):
+```python
+async def handle_greeting_selected(self, index: int) -> None:
+    """Re-seed the preview from the chosen greeting (AC#1); Reset then returns to it (AC#2)."""
+    if index == self._current_greeting_index or not (0 <= index < len(self._greetings)):
+        return
+    self._current_greeting_index = index
+    self.invalidate()
+    await self.screen.query_one(PersonasPreviewPane).seed_greeting(self._greetings[index])
+```
+`seed_greeting` sets `pane._greeting = chosen`, so **Reset (`_render_seed_lines` from `_greeting`) returns to the chosen greeting — AC#2 with no new Reset logic.** `invalidate()` drops the prior ephemeral turns (the user is choosing a fresh starting greeting).
+
+### 4. Screen wiring
+
+`personas_screen.py`, alongside the other preview `@on` handlers (`:3592-3614`):
+```python
+@on(PreviewGreetingSelected)
+async def _handle_preview_greeting_selected(self, message: PreviewGreetingSelected) -> None:
+    message.stop()
+    await self.preview.handle_greeting_selected(message.index)
+```
+
+### Clearing on non-character context
+
+The selector must hide when the preview loses its character (persona/dictionary/lore selection, mode switch). Those paths all call `self.preview.reset("")` — i.e. `PersonasPreviewController.reset(text, *, seeded_for=None)` with the default `seeded_for=None`, whereas a real character seed passes `seeded_for=<id>` (`reset_for_character:100`). So `reset` clears the selector exactly when `seeded_for is None`:
+```python
+async def reset(self, text="", *, seeded_for=None):
+    ...
+    if seeded_for is None:
+        self._greetings = []
+        try:
+            self.screen.query_one(PersonasPreviewPane).set_greetings([])
+        except QueryError:
+            pass
+    ...
+```
+This mirrors where TASK-437's `reset_speakers()` hangs off the same blank/mode-switch points.
+
+## Testing
+
+- **Pane (`test_personas_preview.py`):** `set_greetings([primary])` hides the row; `set_greetings([primary, alt])` shows it and populates two options; choosing an option posts `PreviewGreetingSelected(index)`.
+- **Controller/integration (`test_personas_workbench.py`):** a new fixture character with `alternate_greetings` (the `CHARACTERS` fixture at `:43-57` needs an entry). After load, the selector is visible with N+1 options; selecting alternate index 1 re-seeds the transcript to that greeting; **pressing Reset returns to the chosen greeting, not the primary** (extends the existing `test_reset_after_character_reload_uses_updated_greeting` pattern at `:2980`); a character with no alternates shows no selector.
+- **Idempotence:** the programmatic `set_options`/`value=0` on load does not re-seed or duplicate the greeting (the `_current_greeting_index` guard) — assert the transcript has exactly one greeting line after load.
+- **Restore (`test_personas_preview_restore.py`):** unaffected — `restore_conversation` still seeds the saved `_greeting`; the chosen greeting survives navigation via TASK-434's `_greeting` capture.
+
+## Risks / mitigations
+
+- **Programmatic `Changed` re-entrancy:** guarded by the controller `_current_greeting_index` (a re-select of the current index is a no-op), robust to however many `Changed` events `set_options`/`value=` fire.
+- **Async availability:** the selector populates from `handle_character_loaded` (and cached re-selection), exactly like the greeting itself — no attempt to populate synchronously on a cold first selection.
+- **Placeholder double-processing:** `replace_placeholders` is idempotent on already-substituted text; applying it uniformly to every greeting matches the existing `first_message` handling.
+- **Speaker labels (437):** `seed_greeting` renders with the current `_character_label`; choosing a greeting re-renders consistently.
+- **Stale selector on non-character context:** cleared via `set_greetings([])` on the blank/mode-switch paths.
+
+## Non-goals
+
+- A greeting picker in the **card view** or in **Console/Start-Chat** (the AC scopes this to the preview; Console handoff seeds from whatever the preview shows).
+- Persisting the *selected index* across navigation as a distinct field (the chosen greeting **text** already survives via `_greeting`; the dropdown re-defaults to index 0 on reload while the transcript shows the chosen text — a cosmetic edge, possible follow-up).
+- Editing/adding alternate greetings (read-only selection only).

--- a/Tests/UI/test_personas_preview.py
+++ b/Tests/UI/test_personas_preview.py
@@ -2,9 +2,10 @@
 
 import pytest
 from textual.app import App
-from textual.widgets import Button, Input, Static
+from textual.widgets import Button, Input, Select, Static
 
 from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
+    PreviewGreetingSelected,
     PreviewOpenInConsoleRequested,
     PreviewReplyRequested,
     PreviewResetRequested,
@@ -510,3 +511,51 @@ async def test_reset_speakers_restores_defaults():
         pane.append_reply("Hello.")
         await pilot.pause()
         assert _line_texts(app) == ["you: Hi", "character: Hello."]
+
+
+# ===== TASK-438: alternate-greeting selector =====
+
+
+async def test_greeting_selector_hidden_without_alternates():
+    app = PreviewApp()
+    async with app.run_test() as pilot:
+        pane = app.query_one(PersonasPreviewPane)
+        pane.set_greetings(["Only greeting."])
+        await pilot.pause()
+        assert app.query_one("#personas-preview-greeting-row").display is False
+
+
+async def test_greeting_selector_shown_with_alternates():
+    app = PreviewApp()
+    async with app.run_test() as pilot:
+        pane = app.query_one(PersonasPreviewPane)
+        pane.set_greetings(["Primary.", "Alt one.", "Alt two."])
+        await pilot.pause()
+        assert app.query_one("#personas-preview-greeting-row").display is True
+        select = app.query_one("#personas-preview-greeting-select", Select)
+        assert len(list(select._options)) == 3  # 3 greetings
+
+
+async def test_choosing_greeting_posts_message():
+    posted: list[int] = []
+    app = PreviewApp()
+    async with app.run_test() as pilot:
+        pane = app.query_one(PersonasPreviewPane)
+
+        original_post_message = pane.post_message
+
+        def _capture(message):
+            if isinstance(message, PreviewGreetingSelected):
+                posted.append(message.index)
+            return original_post_message(message)
+
+        pane.post_message = _capture
+
+        pane.set_greetings(["Primary.", "Alt one."])
+        await pilot.pause()
+        select = app.query_one("#personas-preview-greeting-select", Select)
+        select.value = 1
+        await pilot.pause()
+        # The programmatic set_options/value=0 from set_greetings may also
+        # post index 0 asynchronously - assert membership, not exact equality.
+        assert 1 in posted

--- a/Tests/UI/test_personas_preview.py
+++ b/Tests/UI/test_personas_preview.py
@@ -556,6 +556,7 @@ async def test_choosing_greeting_posts_message():
         select = app.query_one("#personas-preview-greeting-select", Select)
         select.value = 1
         await pilot.pause()
-        # The programmatic set_options/value=0 from set_greetings may also
-        # post index 0 asynchronously - assert membership, not exact equality.
-        assert 1 in posted
+        # set_greetings populates the Select under prevent(Select.Changed), so the
+        # only PreviewGreetingSelected is this genuine user pick (index 1) - no
+        # spurious programmatic index-0 post (task-438 review).
+        assert posted == [1]

--- a/Tests/UI/test_personas_preview_restore.py
+++ b/Tests/UI/test_personas_preview_restore.py
@@ -79,3 +79,39 @@ async def test_handle_character_loaded_does_not_relabel_on_preserve():
     # Reload refreshed the reset seed but did NOT relabel (no mixed prefixes).
     pane.refresh_greeting_seed.assert_called_once()
     pane.set_speakers.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_restore_then_reload_keeps_chosen_greeting():
+    # task-438 review: a navigation restore of a chosen ALTERNATE greeting must
+    # survive the async same-character reload. restore_conversation restores the
+    # chosen index so handle_character_loaded's preserve path keeps it, instead
+    # of reverting the reset seed to the primary (which would break Reset/AC#2).
+    ctrl, _ = _controller_with_mock_pane()
+    pane = ctrl.screen.query_one.return_value
+    pane.transcript_text = MagicMock(return_value="Char: An alternate opener.")
+    pane.refresh_greeting_seed = MagicMock()
+    ctrl.refresh_provider_readout = MagicMock()
+    ctrl.screen.state = MagicMock(
+        active_mode="characters",
+        selected_entity_kind="character",
+        selected_entity_id="1",
+        selected_entity_name="Char",
+    )
+    # Restore a preview that had alternate greeting index 1 chosen.
+    await ctrl.restore_conversation(
+        greeting="An alternate opener.", history=[], seeded_for="1", greeting_index=1
+    )
+    assert ctrl._current_greeting_index == 1
+    # The async character-load worker then fires for the same character (preserve).
+    await ctrl.handle_character_loaded(
+        character_id="1",
+        card_data={
+            "name": "Char",
+            "first_message": "Primary greeting.",
+            "alternate_greetings": ["An alternate opener.", "A third opener."],
+        },
+    )
+    # The chosen index is kept and the reset seed stays the ALTERNATE, not primary.
+    assert ctrl._current_greeting_index == 1
+    pane.refresh_greeting_seed.assert_called_once_with("An alternate opener.")

--- a/Tests/UI/test_personas_preview_restore.py
+++ b/Tests/UI/test_personas_preview_restore.py
@@ -14,6 +14,8 @@ def _controller_with_mock_pane():
     ctrl.seeded_for = None
     ctrl.generation = 0
     ctrl.gateway = None
+    ctrl._greetings = []
+    ctrl._current_greeting_index = 0
     events = []
     pane = MagicMock()
     pane.append_user = lambda t: events.append(("user", t))

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -3052,6 +3052,42 @@ class TestPreviewIntegration:
             assert "An alternate opener." in pane.transcript_text()
             assert "hi" not in pane.transcript_text()
 
+    async def test_reload_preserves_chosen_alternate_greeting(
+        self, mock_app_instance, stub_characters, stub_conversations
+    ):
+        """TASK-438 review: a same-character reload (edit+save) that preserves the
+        in-progress transcript keeps the CHOSEN alternate greeting, so Reset still
+        returns to it rather than silently reverting to the primary."""
+        from tldw_chatbook.Widgets.Persona_Widgets.personas_preview_pane import (
+            PersonasPreviewPane,
+        )
+
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await self._select_first_character(pilot)
+            pane = screen.query_one("#personas-preview-pane", PersonasPreviewPane)
+            await screen.preview.handle_greeting_selected(1)  # choose alternate
+            await pilot.pause()
+            pane.append_user("hi")
+            pane.append_reply("hello")
+            await pilot.pause()
+            # Same-character reload (the task-437 preserve path): CharacterMessage.Loaded
+            await screen.preview.handle_character_loaded(
+                character_id="1",
+                card_data={
+                    "name": "Detective Sam",
+                    "first_message": "The name's {{char}}. Who's asking?",
+                    "alternate_greetings": ["An alternate opener.", "A third opener."],
+                },
+            )
+            await pilot.pause()
+            # the chosen index is preserved (selector + Reset seed), not reset to 0
+            assert screen.preview._current_greeting_index == 1
+            await pane.reset()
+            await pilot.pause()
+            assert "An alternate opener." in pane.transcript_text()
+            assert "Who's asking" not in pane.transcript_text()
+
     async def test_greeting_selector_hidden_without_alternates(
         self, mock_app_instance, stub_characters, stub_conversations
     ):

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -3088,6 +3088,43 @@ class TestPreviewIntegration:
             assert "An alternate opener." in pane.transcript_text()
             assert "Who's asking" not in pane.transcript_text()
 
+    async def test_reload_via_real_select_does_not_wipe_transcript(
+        self, mock_app_instance, stub_characters, stub_conversations
+    ):
+        """TASK-438 review: choosing an alternate through the REAL Select widget
+        then a same-character reload must NOT wipe the in-progress transcript —
+        the programmatic set_options() must not fire a spurious re-seed."""
+        from textual.widgets import Select
+        from tldw_chatbook.Widgets.Persona_Widgets.personas_preview_pane import (
+            PersonasPreviewPane,
+        )
+
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await self._select_first_character(pilot)
+            pane = screen.query_one("#personas-preview-pane", PersonasPreviewPane)
+            # pick alternate index 1 via the real widget (fires Select.Changed)
+            pane.query_one("#personas-preview-greeting-select", Select).value = 1
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            pane.append_user("hi")
+            pane.append_reply("hello")
+            await pilot.pause()
+            # same-character reload (edit+save path)
+            await screen.preview.handle_character_loaded(
+                character_id="1",
+                card_data={
+                    "name": "Detective Sam",
+                    "first_message": "The name's {{char}}. Who's asking?",
+                    "alternate_greetings": ["An alternate opener.", "A third opener."],
+                },
+            )
+            await pilot.pause()
+            text = pane.transcript_text()
+            assert "hi" in text and "hello" in text  # conversation survived
+            assert screen.preview._current_greeting_index == 1
+
     async def test_greeting_selector_hidden_without_alternates(
         self, mock_app_instance, stub_characters, stub_conversations
     ):

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -46,6 +46,7 @@ CHARACTERS = [
         "name": "Detective Sam",
         "description": "Noir detective",
         "first_message": "The name's {{char}}. Who's asking?",
+        "alternate_greetings": ["An alternate opener.", "A third opener."],
         "version": 1,
     },
     {
@@ -3023,6 +3024,52 @@ class TestPreviewIntegration:
             assert pane.transcript_text() == (
                 "Detective Sam: Edited opener from Detective Sam to User."
             )
+
+    async def test_alternate_greeting_selector_seeds_and_reset_returns_to_choice(
+        self, mock_app_instance, stub_characters, stub_conversations
+    ):
+        """TASK-438: picking an alternate greeting re-seeds the preview, and
+        Reset returns to the CHOSEN greeting, not the primary."""
+        from tldw_chatbook.Widgets.Persona_Widgets.personas_preview_pane import (
+            PersonasPreviewPane,
+        )
+
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await self._select_first_character(pilot)
+            pane = screen.query_one("#personas-preview-pane", PersonasPreviewPane)
+            assert screen.query_one("#personas-preview-greeting-row").display is True
+            # choose alternate index 1
+            await screen.preview.handle_greeting_selected(1)
+            await pilot.pause()
+            assert "An alternate opener." in pane.transcript_text()
+            # send a turn, then Reset -> returns to the CHOSEN alternate, not primary
+            pane.append_user("hi")
+            pane.append_reply("hello")
+            await pilot.pause()
+            await pane.reset()
+            await pilot.pause()
+            assert "An alternate opener." in pane.transcript_text()
+            assert "hi" not in pane.transcript_text()
+
+    async def test_greeting_selector_hidden_without_alternates(
+        self, mock_app_instance, stub_characters, stub_conversations
+    ):
+        """A character without ``alternate_greetings`` keeps the row hidden."""
+        from tldw_chatbook.Widgets.Persona_Widgets.personas_preview_pane import (
+            PersonasPreviewPane,
+        )
+
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+            await pilot.pause()
+            await pilot.click("#personas-library-row-character-2")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            screen.query_one("#personas-preview-pane", PersonasPreviewPane)
+            assert screen.query_one("#personas-preview-greeting-row").display is False
 
     async def _readout_text(self, screen):
         from textual.widgets import Static as _Static

--- a/Tests/UI/test_personas_workbench_state.py
+++ b/Tests/UI/test_personas_workbench_state.py
@@ -238,9 +238,12 @@ class TestPreviewRestore:
             screen.preview.history.append(
                 {"role": "assistant", "content": "well met"}
             )
+            # simulate a chosen alternate greeting (task-438)
+            screen.preview._current_greeting_index = 1
 
             saved = screen.save_state()
             assert saved["personas_preview"]["greeting"] == "Greetings, traveller."
+            assert saved["personas_preview"]["greeting_index"] == 1
             assert saved["personas_preview"]["history"] == [
                 {"role": "user", "content": "hi"},
                 {"role": "assistant", "content": "well met"},
@@ -251,6 +254,8 @@ class TestPreviewRestore:
             screen2 = await _mounted(pilot2)
             pane2 = screen2.query_one(PersonasPreviewPane)
             assert pane2.greeting_text == "Greetings, traveller."
+            # the chosen greeting index survives the round-trip (task-438 review)
+            assert screen2.preview._current_greeting_index == 1
             text = pane2.transcript_text()
             assert "Greetings, traveller." in text
             assert "hi" in text

--- a/backlog/tasks/task-438 - Alternate-greeting-selector-in-Roleplay-preview.md
+++ b/backlog/tasks/task-438 - Alternate-greeting-selector-in-Roleplay-preview.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-438
 title: Alternate greeting selector in Roleplay preview
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-21 09:38'
-updated_date: '2026-07-23 22:15'
+updated_date: '2026-07-24 01:41'
 labels:
   - roleplay
   - ux
@@ -20,6 +20,23 @@ Filed from the RP/character-card UX review (Docs/superpowers/qa/rp-ux-review-202
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 When a character has alternate greetings, the preview offers a way to pick which greeting seeds the conversation
-- [ ] #2 Reset returns to the chosen greeting, not silently to the primary one
+- [x] #1 When a character has alternate greetings, the preview offers a way to pick which greeting seeds the conversation
+- [x] #2 Reset returns to the chosen greeting, not silently to the primary one
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The Roleplay preview now offers a dropdown to choose which greeting (primary or an alternate) seeds the conversation, and Reset returns to the chosen greeting.
+
+**AC#1 — selector:** a `Select` (`#personas-preview-greeting-select`) in a `#personas-preview-greeting-row`, shown only when a character has ≥1 alternate greeting. The controller owns the placeholder-processed greetings list `[first_message, *alternate_greetings]` (top-level `list[str]` on the record, available from the async `handle_character_loaded`) and a `_current_greeting_index`. Picking an option → `PreviewGreetingSelected(index)` → `handle_greeting_selected` → `pane.seed_greeting(chosen)`.
+
+**AC#2 — Reset returns to the chosen greeting:** `seed_greeting` sets `pane._greeting`, and Reset already re-renders from `_greeting` — no new Reset logic. Verified end-to-end.
+
+**Notable subtleties resolved during review (the `Select` widget is a footgun):**
+- *AC#2 on same-character reload:* editing+saving the card after picking an alternate re-fires `handle_character_loaded` on the preserve path; the greeting-list rebuild must **keep** the chosen index (`keep_index`/clamp), else Reset silently reverts to the primary.
+- *Critical — transcript wipe:* `Select.set_options()` internally snaps `value→0`, which (when a real alternate was selected) fired a spurious `Select.Changed(0)` that the controller misread as a user reselection and used to `invalidate()` the in-progress transcript. Fixed by wrapping the programmatic population in `with self.prevent(Select.Changed)` (suppresses the event at Textual's `check_message_enabled`). A test that drives the **real Select widget** now guards this (the earlier test called the controller directly and missed it).
+- `EmptySelectError` in this Textual (8.2.7) for `Select([], allow_blank=False)` → constructed with an inert placeholder overwritten before the row is shown.
+
+**Scope:** preview only (not the card view / Console). Files: `personas_pane_messages.py`, `personas_preview_pane.py`, `personas_preview_controller.py`, `personas_screen.py`, `Tests/UI/test_personas_preview.py`, `test_personas_workbench.py`, `test_personas_preview_restore.py`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-438 - Alternate-greeting-selector-in-Roleplay-preview.md
+++ b/backlog/tasks/task-438 - Alternate-greeting-selector-in-Roleplay-preview.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-438
 title: Alternate greeting selector in Roleplay preview
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-21 09:38'
+updated_date: '2026-07-23 22:15'
 labels:
   - roleplay
   - ux

--- a/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
+++ b/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
@@ -87,8 +87,22 @@ class PersonasPreviewController:
                 pass
         self.refresh_provider_readout()
 
-    def _load_greetings(self, record: dict[str, Any], name: str) -> str:
-        """Store the processed greeting list, populate the selector, return the primary."""
+    def _load_greetings(
+        self, record: dict[str, Any], name: str, *, keep_index: bool = False
+    ) -> str:
+        """Store the processed greeting list, populate the selector, return the seed.
+
+        Args:
+            record: Character record carrying ``first_message``/``alternate_greetings``.
+            name: Display name for greeting placeholders.
+            keep_index: On a same-character reload that preserves the transcript,
+                keep the user's chosen greeting (clamped to the new list) instead
+                of resetting to the primary — so Reset/the selector still reflect
+                the choice.
+
+        Returns:
+            The greeting text for the current index (primary when not keeping).
+        """
         raw = [str(record.get("first_message") or "")]
         raw += [
             str(g)
@@ -96,12 +110,21 @@ class PersonasPreviewController:
             if isinstance(g, str)
         ]
         self._greetings = [replace_placeholders(g, name, "User") for g in raw]
-        self._current_greeting_index = 0
+        if keep_index and self._greetings:
+            self._current_greeting_index = min(
+                self._current_greeting_index, len(self._greetings) - 1
+            )
+        else:
+            self._current_greeting_index = 0
         try:
-            self.screen.query_one(PersonasPreviewPane).set_greetings(self._greetings)
+            self.screen.query_one(PersonasPreviewPane).set_greetings(
+                self._greetings, self._current_greeting_index
+            )
         except QueryError:
             pass
-        return self._greetings[0] if self._greetings else ""
+        return (
+            self._greetings[self._current_greeting_index] if self._greetings else ""
+        )
 
     async def reset_for_character(
         self,
@@ -267,15 +290,18 @@ class PersonasPreviewController:
             return
         record = dict(card_data or {})
         name = str(record.get("name") or screen.state.selected_entity_name or "")
-        greeting = self._load_greetings(record, name)
+        # Same-character reloads after an edit should update the reset seed, not
+        # erase an in-progress preview conversation — and must keep the user's
+        # chosen alternate greeting (else Reset/the selector silently revert to
+        # the primary, task-438 review).
+        preserve = self.seeded_for == character_id and bool(pane.transcript_text())
+        greeting = self._load_greetings(record, name, keep_index=preserve)
         # The speaker label is set once at selection (_select_character, from the
         # selection's display name) and must NOT be re-set here: set_speakers only
         # relabels FUTURE lines, so changing it on a same-character reload that
         # preserves the transcript would leave the existing lines under the old
         # prefix (mixed/stale prefixes — task-437 review).
-        # Same-character reloads after an edit should update the reset seed,
-        # not erase an in-progress preview conversation.
-        if self.seeded_for == character_id and pane.transcript_text():
+        if preserve:
             pane.refresh_greeting_seed(greeting)
             self.refresh_provider_readout()
             return

--- a/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
+++ b/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
@@ -53,6 +53,10 @@ class PersonasPreviewController:
         # ready so replies stop falling back - even after a fallback send has
         # repainted the readout text with the provider that actually answered.
         self._readout_nav_provider: str = ""
+        # Processed greetings for the selected character: index 0 is the
+        # primary first_message, the rest are alternate_greetings (task-438).
+        self._greetings: list[str] = []
+        self._current_greeting_index: int = 0
 
     def invalidate(self) -> None:
         """Clear history and cancel in-flight preview workers."""
@@ -75,7 +79,29 @@ class PersonasPreviewController:
             # Tolerate calls that race screen teardown.
             pass
         self.seeded_for = seeded_for
+        if seeded_for is None:
+            self._greetings = []
+            try:
+                self.screen.query_one(PersonasPreviewPane).set_greetings([])
+            except QueryError:
+                pass
         self.refresh_provider_readout()
+
+    def _load_greetings(self, record: dict[str, Any], name: str) -> str:
+        """Store the processed greeting list, populate the selector, return the primary."""
+        raw = [str(record.get("first_message") or "")]
+        raw += [
+            str(g)
+            for g in (record.get("alternate_greetings") or [])
+            if isinstance(g, str)
+        ]
+        self._greetings = [replace_placeholders(g, name, "User") for g in raw]
+        self._current_greeting_index = 0
+        try:
+            self.screen.query_one(PersonasPreviewPane).set_greetings(self._greetings)
+        except QueryError:
+            pass
+        return self._greetings[0] if self._greetings else ""
 
     async def reset_for_character(
         self,
@@ -94,9 +120,7 @@ class PersonasPreviewController:
         if record is None:
             await self.reset("")
             return
-        greeting = replace_placeholders(
-            str(record.get("first_message") or ""), character_name, "User"
-        )
+        greeting = self._load_greetings(record, character_name)
         await self.reset(greeting, seeded_for=character_id)
 
     async def restore_conversation(
@@ -243,9 +267,7 @@ class PersonasPreviewController:
             return
         record = dict(card_data or {})
         name = str(record.get("name") or screen.state.selected_entity_name or "")
-        greeting = replace_placeholders(
-            str(record.get("first_message") or ""), name, "User"
-        )
+        greeting = self._load_greetings(record, name)
         # The speaker label is set once at selection (_select_character, from the
         # selection's display name) and must NOT be re-set here: set_speakers only
         # relabels FUTURE lines, so changing it on a same-character reload that
@@ -335,6 +357,21 @@ class PersonasPreviewController:
     def handle_reset(self) -> None:
         """Clear provider-facing preview state after the pane resets itself."""
         self.invalidate()
+
+    async def handle_greeting_selected(self, index: int) -> None:
+        """Re-seed the preview from the chosen greeting (AC#1); Reset then returns to it (AC#2)."""
+        if index == self._current_greeting_index or not (
+            0 <= index < len(self._greetings)
+        ):
+            return
+        self._current_greeting_index = index
+        self.invalidate()
+        try:
+            await self.screen.query_one(PersonasPreviewPane).seed_greeting(
+                self._greetings[index]
+            )
+        except QueryError:
+            pass
 
     def open_in_console(self) -> None:
         """Stage the current preview transcript as a Console handoff."""

--- a/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
+++ b/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
@@ -147,7 +147,12 @@ class PersonasPreviewController:
         await self.reset(greeting, seeded_for=character_id)
 
     async def restore_conversation(
-        self, *, greeting: str, history: list[dict], seeded_for: str | None
+        self,
+        *,
+        greeting: str,
+        history: list[dict],
+        seeded_for: str | None,
+        greeting_index: int = 0,
     ) -> None:
         """Rebuild the preview (greeting + turns) from saved state (task-434).
 
@@ -161,12 +166,16 @@ class PersonasPreviewController:
             history: Saved user/assistant turns to replay into the pane.
             seeded_for: Entity id the saved preview was seeded for, normalized
                 to ``str(seeded_for)`` (or ``None`` if falsy).
+            greeting_index: The chosen greeting index at save time (task-438), so
+                the async ``handle_character_loaded`` preserve path keeps the
+                restored greeting instead of overwriting it with the primary.
 
         Returns:
             None.
         """
         self.invalidate()
         self.seeded_for = str(seeded_for) if seeded_for else None
+        self._current_greeting_index = greeting_index if greeting_index >= 0 else 0
         try:
             pane = self.screen.query_one(PersonasPreviewPane)
         except QueryError:
@@ -385,7 +394,12 @@ class PersonasPreviewController:
         self.invalidate()
 
     async def handle_greeting_selected(self, index: int) -> None:
-        """Re-seed the preview from the chosen greeting (AC#1); Reset then returns to it (AC#2)."""
+        """Re-seed the preview from the chosen greeting (AC#1); Reset then returns to it (AC#2).
+
+        Args:
+            index: Index into the greetings list to seed from; a no-op when it
+                equals the current index or is out of range.
+        """
         if index == self._current_greeting_index or not (
             0 <= index < len(self._greetings)
         ):

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -96,6 +96,7 @@ from ...Widgets.Persona_Widgets.personas_pane_messages import (
     PersonaProfileEditCancelled,
     PersonaProfileSaveRequested,
     PreviewConfigureProviderRequested,
+    PreviewGreetingSelected,
     PreviewOpenInConsoleRequested,
     PreviewReplyRequested,
     PreviewResetRequested,
@@ -3612,6 +3613,13 @@ class PersonasScreen(BaseAppScreen):
     ) -> None:
         message.stop()
         self.preview.open_provider_settings()
+
+    @on(PreviewGreetingSelected)
+    async def _handle_preview_greeting_selected(
+        self, message: PreviewGreetingSelected
+    ) -> None:
+        message.stop()
+        await self.preview.handle_greeting_selected(message.index)
 
     # ===== Create / edit =====
 

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -760,6 +760,7 @@ class PersonasScreen(BaseAppScreen):
                 "greeting": greeting,
                 "history": [dict(m) for m in preview.history],
                 "seeded_for": preview.seeded_for,
+                "greeting_index": preview._current_greeting_index,
             }
         return state
 
@@ -1812,6 +1813,7 @@ class PersonasScreen(BaseAppScreen):
                 greeting=str(restore_preview.get("greeting") or ""),
                 history=list(restore_preview.get("history") or []),
                 seeded_for=entity_id,
+                greeting_index=int(restore_preview.get("greeting_index") or 0),
             )
         else:
             # Seed the ephemeral preview with the character's greeting. The

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py
@@ -128,6 +128,14 @@ class PreviewResetRequested(Message):
     """The preview-conversation transcript was reset."""
 
 
+class PreviewGreetingSelected(Message):
+    """The user picked a greeting (index into the greetings list) to seed from."""
+
+    def __init__(self, index: int) -> None:
+        super().__init__()
+        self.index = index
+
+
 class PreviewOpenInConsoleRequested(Message):
     """Open the preview-conversation transcript in Console."""
 

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py
@@ -233,10 +233,17 @@ class PersonasPreviewPane(Vertical):
         row = self.query_one("#personas-preview-greeting-row")
         if len(greetings) > 1:
             select = self.query_one("#personas-preview-greeting-select", Select)
-            select.set_options(
-                [(self._greeting_option_label(i, g), i) for i, g in enumerate(greetings)]
-            )
-            select.value = selected_index if 0 <= selected_index < len(greetings) else 0
+            target = selected_index if 0 <= selected_index < len(greetings) else 0
+            # Populate/repoint the Select WITHOUT firing Select.Changed. set_options
+            # snaps value back to 0 and the explicit assignment would each post a
+            # (spurious) Changed that _handle_greeting_selected would misread as a
+            # user pick and re-seed — wiping an in-progress transcript on a
+            # same-character reload (task-438 review). prevent() suppresses both.
+            with self.prevent(Select.Changed):
+                select.set_options(
+                    [(self._greeting_option_label(i, g), i) for i, g in enumerate(greetings)]
+                )
+                select.value = target
             row.display = True
         else:
             row.display = False

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py
@@ -15,11 +15,12 @@ from rich.text import Text
 from textual import on
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
-from textual.widgets import Button, Input, Static
+from textual.widgets import Button, Input, Select, Static
 
 from ...Utils.input_validation import validate_text_input
 from .personas_pane_messages import (
     PreviewConfigureProviderRequested,
+    PreviewGreetingSelected,
     PreviewOpenInConsoleRequested,
     PreviewReplyRequested,
     PreviewResetRequested,
@@ -121,6 +122,19 @@ class PersonasPreviewPane(Vertical):
             # BELOW the transcript so provider/error messages never render
             # above the chronological greeting -> you -> character history.
             yield Static("", id="personas-preview-status")
+            with Horizontal(id="personas-preview-greeting-row", classes="ds-toolbar"):
+                yield Static("Greeting:", classes="personas-preview-greeting-label")
+                yield Select(
+                    # A single placeholder option: this Textual version's
+                    # Select requires allow_blank=False constructions to have
+                    # at least one option. The row stays hidden (on_mount)
+                    # until set_greetings() replaces this with the real list.
+                    [("Greeting", 0)],
+                    id="personas-preview-greeting-select",
+                    classes="form-select",
+                    allow_blank=False,
+                    prompt="Greeting",
+                )
             yield Input(placeholder="Test message...", id="personas-preview-input")
             with Horizontal(classes="ds-toolbar"):
                 yield Button(
@@ -148,6 +162,7 @@ class PersonasPreviewPane(Vertical):
 
     def on_mount(self) -> None:
         self.query_one("#personas-preview-body").display = False
+        self.query_one("#personas-preview-greeting-row").display = False
 
     # ===== Public API =====
 
@@ -207,6 +222,33 @@ class PersonasPreviewPane(Vertical):
         """
         self._character_label = _DEFAULT_CHARACTER_LABEL
         self._user_label = _DEFAULT_USER_LABEL
+
+    def set_greetings(self, greetings: list[str]) -> None:
+        """Populate the greeting selector; show it only when alternates exist.
+
+        Args:
+            greetings: Processed greetings, ``greetings[0]`` the primary
+                ``first_message`` and the rest alternates.
+        """
+        row = self.query_one("#personas-preview-greeting-row")
+        if len(greetings) > 1:
+            select = self.query_one("#personas-preview-greeting-select", Select)
+            select.set_options(
+                [(self._greeting_option_label(i, g), i) for i, g in enumerate(greetings)]
+            )
+            select.value = 0
+            row.display = True
+        else:
+            row.display = False
+
+    def _greeting_option_label(self, index: int, text: str) -> str:
+        """Dropdown label: 'Greeting N (default): <~40-char preview>'."""
+        preview = " ".join(str(text).split())
+        if len(preview) > 40:
+            preview = preview[:39] + "…"
+        tag = " (default)" if index == 0 else ""
+        base = f"Greeting {index + 1}{tag}"
+        return f"{base}: {preview}" if preview else base
 
     def _relabel_character_lines(self, old_label: str, new_label: str) -> None:
         """Rewrite already-rendered character-role lines to a new speaker label.
@@ -427,6 +469,11 @@ class PersonasPreviewPane(Vertical):
     def _handle_configure(self, event: Button.Pressed) -> None:
         event.stop()
         self.post_message(PreviewConfigureProviderRequested())
+
+    @on(Select.Changed, "#personas-preview-greeting-select")
+    def _handle_greeting_selected(self, event: Select.Changed) -> None:
+        if isinstance(event.value, int):
+            self.post_message(PreviewGreetingSelected(event.value))
 
 
 __all__ = ["PersonasPreviewPane"]

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py
@@ -229,6 +229,8 @@ class PersonasPreviewPane(Vertical):
         Args:
             greetings: Processed greetings, ``greetings[0]`` the primary
                 ``first_message`` and the rest alternates.
+            selected_index: Index to point the Select at (bounds-checked); used
+                to keep a chosen alternate on a same-character reload.
         """
         row = self.query_one("#personas-preview-greeting-row")
         if len(greetings) > 1:

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py
@@ -223,7 +223,7 @@ class PersonasPreviewPane(Vertical):
         self._character_label = _DEFAULT_CHARACTER_LABEL
         self._user_label = _DEFAULT_USER_LABEL
 
-    def set_greetings(self, greetings: list[str]) -> None:
+    def set_greetings(self, greetings: list[str], selected_index: int = 0) -> None:
         """Populate the greeting selector; show it only when alternates exist.
 
         Args:
@@ -236,7 +236,7 @@ class PersonasPreviewPane(Vertical):
             select.set_options(
                 [(self._greeting_option_label(i, g), i) for i, g in enumerate(greetings)]
             )
-            select.value = 0
+            select.value = selected_index if 0 <= selected_index < len(greetings) else 0
             row.display = True
         else:
             row.display = False
@@ -472,6 +472,7 @@ class PersonasPreviewPane(Vertical):
 
     @on(Select.Changed, "#personas-preview-greeting-select")
     def _handle_greeting_selected(self, event: Select.Changed) -> None:
+        event.stop()
         if isinstance(event.value, int):
             self.post_message(PreviewGreetingSelected(event.value))
 


### PR DESCRIPTION
## Summary

Lets the Roleplay preview start from an **alternate greeting** (TASK-438, from the RP UX review). Previously the preview always seeded the primary `first_message` and alternate greetings were unreachable anywhere in the app.

## Changes

**AC#1 — greeting selector**
- A `Select` (`#personas-preview-greeting-select`) in a new preview row, shown **only when the character has ≥1 alternate**. The controller owns the placeholder-processed greetings list `[first_message, *alternate_greetings]` + a `_current_greeting_index`; picking → `PreviewGreetingSelected(index)` → `handle_greeting_selected` → `pane.seed_greeting(chosen)`.

**AC#2 — Reset returns to the chosen greeting**
- `seed_greeting` sets `pane._greeting`, and Reset already re-renders from `_greeting` — no new Reset logic.

## Review-driven fixes (the `Select` widget had two subtle traps)
- **Same-character reload** (edit+save the card after picking an alternate) must **keep** the chosen index, else Reset silently reverted to the primary — fixed with `keep_index`/clamp.
- **Critical:** `Select.set_options()` internally snaps `value→0`, firing a spurious `Select.Changed(0)` that was misread as a user reselection and `invalidate()`d the in-progress transcript on reload — fixed by wrapping the programmatic population in `with self.prevent(Select.Changed)`. A test that drives the **real Select widget** guards this (the earlier controller-direct test missed it).

## Testing

Pane tests (selector shown/hidden, picking posts the message); integration tests (pick re-seeds; **Reset returns to the chosen greeting**; same-character reload preserves the choice + the transcript; no-alternates hides the selector). Task review + two adversarial re-reviews (both found real bugs, both fixed + mutation-verified). Suites green.

## Scope

Preview only (not the card view / Console). A `Select.set_options()`-resets-value footgun noted at a couple of other call sites (which already carry hazard-comments) — out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a greeting selector to the Roleplay preview so you can start a conversation from any alternate greeting. Reset returns to the chosen greeting, and the choice now persists across navigation restores. (TASK-438)

- **New Features**
  - Greeting dropdown in the preview, shown only when a character has alternates.
  - Choosing an option re-seeds the preview from that greeting.
  - Selector hides when no alternates or the preview is cleared.
  - All greetings get the same placeholder processing as the primary.

- **Bug Fixes**
  - Keeps the chosen greeting after same-character reloads (edit/save), so Reset still uses it.
  - Prevents a spurious `Select.Changed` from programmatic repopulation that could wipe the transcript.
  - Persists the selected greeting across save/restore navigation, preventing silent reversion to the primary.

<sup>Written for commit 868acf399074cfbbbcbd57587aa065a68048ab69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

