### PR TITLE
fix(console): composer attachment-label correctness (tasks 376/380)

### DIFF
--- a/Tests/Chat/test_attachment_core.py
+++ b/Tests/Chat/test_attachment_core.py
@@ -48,6 +48,36 @@ def test_process_attachment_path_inlines_text_files(tmp_path):
     assert attachment.label.startswith("notes.md · ")
 
 
+def test_inline_attachment_label_shows_real_file_size_not_wrapped_size():
+    """TASK-376: an inserted text file's pill shows the file size the user picked,
+    not the larger wrapped-content length ('115 B' for a 60 B file)."""
+    from tldw_chatbook.Chat.attachment_core import PendingAttachment, _format_size
+
+    inline = PendingAttachment(
+        file_path="/x/notes.txt",
+        display_name="notes.txt",
+        file_type="text",
+        insert_mode="inline",
+        text_content="wrapped-and-longer",
+        original_size=60,
+        processed_size=115,
+    )
+    assert _format_size(60) in inline.label
+    assert _format_size(115) not in inline.label
+
+    # Real attachments (images) keep the processed (attached) byte size.
+    attach = PendingAttachment(
+        file_path="/x/photo.png",
+        display_name="photo.png",
+        file_type="image",
+        insert_mode="attachment",
+        data=b"x" * 240,
+        original_size=1000,
+        processed_size=240,
+    )
+    assert _format_size(240) in attach.label
+
+
 def test_process_attachment_path_attaches_images(tmp_path):
     image = tmp_path / "photo.png"
     _write_png(image)

--- a/Tests/Chat/test_attachment_core.py
+++ b/Tests/Chat/test_attachment_core.py
@@ -78,6 +78,24 @@ def test_inline_attachment_label_shows_real_file_size_not_wrapped_size():
     assert _format_size(240) in attach.label
 
 
+def test_inline_attachment_label_reports_zero_for_empty_file():
+    """TASK-376 (Qodo #818): a genuinely empty inline file shows its real 0-byte
+    size, not a fallback to the wrapped-content length."""
+    from tldw_chatbook.Chat.attachment_core import PendingAttachment, _format_size
+
+    empty = PendingAttachment(
+        file_path="/x/empty.txt",
+        display_name="empty.txt",
+        file_type="text",
+        insert_mode="inline",
+        text_content="wrapper-header\n\nwrapper-footer",
+        original_size=0,
+        processed_size=30,
+    )
+    assert empty.label == f"empty.txt · {_format_size(0)}"
+    assert _format_size(30) not in empty.label
+
+
 def test_process_attachment_path_attaches_images(tmp_path):
     image = tmp_path / "photo.png"
     _write_png(image)

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -7134,6 +7134,35 @@ async def test_attachment_indicator_visibility_follows_label():
 
 
 @pytest.mark.asyncio
+async def test_staged_attach_button_keeps_verb_and_count_accurate_tooltips():
+    """TASK-380: staging must not morph Attach into a status glyph -- the button
+    keeps the action verb and the tooltips reflect the real staged count."""
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    host = ConsoleHarness(app)
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        attach_button = console.query_one("#console-attach-context", Button)
+        clear_button = console.query_one("#console-clear-attachment", Button)
+
+        composer.set_pending_attachment_label("2 files", count=2, total=5)
+        await pilot.pause()
+        # Verb kept, not the "attached OK" status glyph.
+        assert "Attach" in str(attach_button.label)
+        assert "✓" not in str(attach_button.label)
+        # Count-accurate tooltips.
+        assert "2 of 5" in str(attach_button.tooltip)
+        assert "2 attachments" in str(clear_button.tooltip)
+
+        composer.set_pending_attachment_label("photo.png · 240 B", count=1, total=5)
+        await pilot.pause()
+        assert "Attach" in str(attach_button.label)
+        assert str(clear_button.tooltip) == "Clear the attachment."
+
+
+@pytest.mark.asyncio
 async def test_console_attachment_worker_stages_image_and_inlines_text(tmp_path):
     from PIL import Image as PILImage
 

--- a/backlog/tasks/task-376 - Distinguish-attach-vs-insert-content-behavior-for-text-files-in-the-composer.md
+++ b/backlog/tasks/task-376 - Distinguish-attach-vs-insert-content-behavior-for-text-files-in-the-composer.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-376
 title: Distinguish attach vs insert-content behavior for text files in the composer
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-20 14:21'
 labels: [console, ux]
 dependencies: []
@@ -23,5 +24,17 @@ Picking test-image.png staged a right-side chip ('test-image.png - 341 B', butto
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 One affordance, one mental model: either stage text files as attachments too, or label the action distinctly at selection time ('Insert as text') and show the real file size
+- [x] #1 One affordance, one mental model: either stage text files as attachments too, or label the action distinctly at selection time ('Insert as text') and show the real file size
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Kept the shipped dual-routing architecture (phase-1 #621) and fixed the confirmed
+mislabels. The `PendingAttachment.label` property now shows the real FILE size
+(`original_size`) for inserted text (`insert_mode == "inline"`) instead of the
+wrapped-content length -- so a 60-byte file no longer reads "115 B". Real
+attachments still show their processed (attached) byte size. The insert toast is
+now distinct at selection time: "<name> inserted as text (not attached)" so the
+user isn't misled into thinking they attached a file. RED->GREEN pure label test.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-380 - Keep-the-Attach-affordance-labeled-after-staging-instead-of-morphing-to-unlabeled-icons.md
+++ b/backlog/tasks/task-380 - Keep-the-Attach-affordance-labeled-after-staging-instead-of-morphing-to-unlabeled-icons.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-380
 title: Keep the Attach affordance labeled after staging instead of morphing to unlabeled icons
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-20 14:21'
 labels: [console, ux]
 dependencies: []
@@ -23,5 +24,18 @@ Idle composer shows 'Send  Attach  Save'. Once anything is staged the middle but
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Keep the verb label ('Attach' or 'Attach more (1/5)') and give the clear control an explicit label or count-accurate tooltip
+- [x] #1 Keep the verb label ('Attach' or 'Attach more (1/5)') and give the clear control an explicit label or count-accurate tooltip
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Staging no longer morphs the Attach button into the status glyph "📎✓" (which read
+as "attached OK", not a control). It keeps the action verb ("Attach +") and the
+tooltips are now count-accurate now that staging appends up to 5 (task-217):
+attach tooltip "Attach another file (N of 5 staged)." and the clear (✕) control
+"Clear all N attachments." / "Clear the attachment." `set_pending_attachment_label`
+gained `count`/`total` params (default 0 = generic copy, backward compatible),
+supplied by `_sync_console_composer_action_state` from `len(pendings)` +
+MAX_PENDING_ATTACHMENTS. Harness test asserts the verb survives + count tooltips.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/attachment_core.py
+++ b/tldw_chatbook/Chat/attachment_core.py
@@ -214,8 +214,17 @@ class PendingAttachment:
 
     @property
     def label(self) -> str:
-        """Return the user-facing chip/indicator label."""
-        size = self.processed_size or self.original_size
+        """Return the user-facing chip/indicator label.
+
+        TASK-376: an inserted text file (``insert_mode == "inline"``) shows the
+        real FILE size the user picked, not the wrapped-content length -- the
+        latter is larger and misleading (e.g. ``115 B`` for a 60-byte file). Real
+        attachments keep their processed (attached) byte size.
+        """
+        if self.insert_mode == "inline":
+            size = self.original_size or self.processed_size
+        else:
+            size = self.processed_size or self.original_size
         return f"{self.display_name} · {_format_size(size)}"
 
 

--- a/tldw_chatbook/Chat/attachment_core.py
+++ b/tldw_chatbook/Chat/attachment_core.py
@@ -220,9 +220,16 @@ class PendingAttachment:
         real FILE size the user picked, not the wrapped-content length -- the
         latter is larger and misleading (e.g. ``115 B`` for a 60-byte file). Real
         attachments keep their processed (attached) byte size.
+
+        Returns:
+            ``"<display_name> · <size>"``. For an inline insert the size is the
+            real file size (``original_size``, used directly so a genuine 0-byte
+            file is not mistaken for "missing" and does not fall back to the
+            wrapped-content length); for an attachment it is the processed byte
+            size, falling back to the original when the processed size is unset.
         """
         if self.insert_mode == "inline":
-            size = self.original_size or self.processed_size
+            size = self.original_size
         else:
             size = self.processed_size or self.original_size
         return f"{self.display_name} · {_format_size(size)}"

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -12213,8 +12213,12 @@ class ChatScreen(BaseAppScreen):
             composer.insert_file_segment(
                 attachment.text_content, f"📄 {attachment.label}"
             )
+            # TASK-376: name the action distinctly -- a text file is inserted as
+            # draft text, not attached like an image, so the user isn't misled
+            # into thinking they attached a file.
             self.app_instance.notify(
-                f"{escape_markup(attachment.display_name)} content inserted"
+                f"{escape_markup(attachment.display_name)} inserted as text "
+                "(not attached)"
             )
         else:
             store = self._ensure_console_chat_store()
@@ -13387,7 +13391,11 @@ class ChatScreen(BaseAppScreen):
             attachment_label = pendings[0].label
         else:
             attachment_label = f"{len(pendings)} files"
-        composer.set_pending_attachment_label(attachment_label)
+        composer.set_pending_attachment_label(
+            attachment_label,
+            count=len(pendings),
+            total=MAX_PENDING_ATTACHMENTS,
+        )
 
     def _hide_console_legacy_chat_inputs(self) -> None:
         """Keep Console on a single native composer surface."""

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -1871,13 +1871,23 @@ class ConsoleComposerBar(Horizontal):
         except NoMatches:
             return
 
-    def set_pending_attachment_label(self, label: str | None) -> None:
+    def set_pending_attachment_label(
+        self,
+        label: str | None,
+        *,
+        count: int = 0,
+        total: int = 0,
+    ) -> None:
         """Show or clear the composer's pending-attachment indicator.
 
         Args:
             label: User-facing attachment label (e.g. ``"photo.png · 184 B"``)
                 to display next to the actions, or None to hide the indicator,
                 the clear button, and restore the Attach button label.
+            count: Number of files currently staged; drives the count-accurate
+                Attach/Clear tooltips (TASK-380). ``0`` falls back to generic copy.
+            total: The per-message attachment cap, for the ``count of total``
+                tooltip; ``0`` omits the cap.
         """
         normalized = label.strip() if label else None
         self._pending_attachment_label = normalized
@@ -1898,8 +1908,20 @@ class ConsoleComposerBar(Horizontal):
             actions.styles.width = 42
             actions.styles.min_width = 42
             actions.styles.max_width = 42
-            attach_button.label = "📎✓"
-            attach_button.tooltip = f"Attached: {escape(normalized)}. Press to replace."
+            # TASK-380: keep the action verb (the old "📎✓" read as a status,
+            # "attached OK", not a control), and make the tooltips count-accurate
+            # now that staging appends up to `total` files (task-217).
+            attach_button.label = "Attach +"
+            if count and total:
+                attach_button.tooltip = (
+                    f"Attach another file ({count} of {total} staged)."
+                )
+            else:
+                attach_button.tooltip = "Attach another file."
+            if count > 1:
+                clear_button.tooltip = f"Clear all {count} attachments."
+            else:
+                clear_button.tooltip = "Clear the attachment."
         else:
             indicator.update("")
             indicator.styles.display = "none"


### PR DESCRIPTION
## Summary

Two harness-testable P3 label-correctness fixes in the composer attachment flow (J3 attachments journey). No architecture change — the shipped dual-routing (attach images / insert text, phase-1 #621) is preserved.

| Task | Fix |
|------|-----|
| **376** | An inserted text file's pill showed the **wrapped-content length** (`processed_size`), so a 60-byte file read `115 B`. `PendingAttachment.label` now shows the real **file size** (`original_size`) for inline inserts (attachments keep their processed byte size). The insert toast is distinct at selection time — `<name> inserted as text (not attached)` — so the user isn't misled into thinking they attached a file. |
| **380** | Staging morphed the Attach button into `📎✓`, which reads as a status ("attached OK") not a control, and the ✕/tooltips were stale single-attachment copy. The button now keeps the verb (`Attach +`) and the tooltips are count-accurate: `Attach another file (N of 5 staged).` and `Clear all N attachments.` / `Clear the attachment.` |

## Implementation
- **380**: `set_pending_attachment_label` gains `count`/`total` params (default `0` = generic copy, backward-compatible), supplied by `_sync_console_composer_action_state` from `len(pendings)` + `MAX_PENDING_ATTACHMENTS`.

## Tests (TDD RED→GREEN)
- `test_inline_attachment_label_shows_real_file_size_not_wrapped_size` (376, pure — verified RED: `'60 B' in 'notes.txt · 115 B'`)
- `test_staged_attach_button_keeps_verb_and_count_accurate_tooltips` (380, harness)

Legacy chat-image path (distinct button + `📄 … content inserted` toast) is a different code path and unaffected — 18 of its tests green; attachment suites (46) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes composer attachment labels: inline text chips now show the real picked file size (including 0‑byte), and the Attach button keeps its verb with count‑accurate tooltips. Addresses TASK-376 and TASK-380.

- **Bug Fixes**
  - TASK-376: Inline text chips use `original_size` directly; 0‑byte files show “0 B” and never fall back to wrapped length. Insert toast reads “inserted as text (not attached)”. Image/file attachments still show processed size.
  - TASK-380: Attach button stays “Attach +”; tooltips reflect counts (“Attach another file (N of 5 staged).”, “Clear all N attachments.” / “Clear the attachment.”). `set_pending_attachment_label(label, *, count, total)` now supports counts, supplied by the composer state.

<sup>Written for commit d0cc0139ae2f1ced20587daa5044514d6fa36a28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

