### PR TITLE
fix(console): task-381 Ctrl+J newline chord + composer capabilities in F1 help

### DIFF
--- a/Tests/UI/test_console_multiline_composer.py
+++ b/Tests/UI/test_console_multiline_composer.py
@@ -1,0 +1,55 @@
+"""TASK-381: a terminal-portable newline chord + composer capabilities in help.
+
+Shift+Enter inserts a newline but terminals deliver it as a plain CR (send), so
+the composer also needs Ctrl+J, which survives any terminal. The F1 help must
+document the newline chords plus the attach / paste-path / cap capabilities that
+were previously undiscoverable.
+"""
+
+import pytest
+from textual.events import Key
+
+from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+from Tests.UI.test_console_native_chat_flow import (
+    ConsoleHarness,
+    _configure_native_ready_console,
+)
+from tldw_chatbook.UI.Screens.chat_screen import CONSOLE_WORKBENCH_SHORTCUT_GROUPS
+from tldw_chatbook.Widgets.Console.console_composer_bar import ConsoleComposerBar
+
+
+def test_composer_help_documents_newline_attach_and_cap():
+    """AC#2: the Composer help group covers the real composer capabilities."""
+    groups = dict(CONSOLE_WORKBENCH_SHORTCUT_GROUPS)
+    assert "Composer" in groups
+    composer = groups["Composer"]
+    flat = " ".join(f"{key} {label}" for key, label in composer).lower()
+
+    # AC#1: a terminal-safe newline chord is documented.
+    assert any("ctrl+j" in key.lower() for key, _ in composer)
+    assert "newline" in flat
+    # AC#2: attach, paste-path, and the per-message cap are covered.
+    assert "attach" in flat
+    assert "paste" in flat
+    assert "5" in flat
+
+
+@pytest.mark.asyncio
+async def test_ctrl_j_inserts_a_newline_in_the_composer():
+    """AC#1: Ctrl+J inserts a newline (Shift+Enter is swallowed as CR by terminals)."""
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.focus()
+        await pilot.pause()
+        composer.load_draft("line one")
+
+        console.on_key(Key(key="ctrl+j", character="\n"))
+        composer.insert_text("line two")
+
+        assert composer.draft_text() == "line one\nline two"

--- a/Tests/UI/test_console_multiline_composer.py
+++ b/Tests/UI/test_console_multiline_composer.py
@@ -14,6 +14,7 @@ from Tests.UI.test_console_native_chat_flow import (
     ConsoleHarness,
     _configure_native_ready_console,
 )
+from tldw_chatbook.Chat.console_chat_store import MAX_PENDING_ATTACHMENTS
 from tldw_chatbook.UI.Screens.chat_screen import CONSOLE_WORKBENCH_SHORTCUT_GROUPS
 from tldw_chatbook.Widgets.Console.console_composer_bar import ConsoleComposerBar
 
@@ -31,7 +32,7 @@ def test_composer_help_documents_newline_attach_and_cap():
     # AC#2: attach, paste-path, and the per-message cap are covered.
     assert "attach" in flat
     assert "paste" in flat
-    assert "5" in flat
+    assert str(MAX_PENDING_ATTACHMENTS) in flat
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-381 - Provide-a-discoverable-multiline-draft-path-in-the-composer.md
+++ b/backlog/tasks/task-381 - Provide-a-discoverable-multiline-draft-path-in-the-composer.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-381
 title: Provide a discoverable multiline-draft path in the composer
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-20 14:21'
 labels: [console, ux]
 dependencies: []
@@ -23,6 +24,21 @@ Shift+Enter sent the draft ('line one' became a sent message - expected, since t
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Provide and document a newline chord that survives terminals (e.g. Ctrl+J) and mention paste behavior
-- [ ] #2 Help should cover the composer's real capabilities (attach, paste-path, cap)
+- [x] #1 Provide and document a newline chord that survives terminals (e.g. Ctrl+J) and mention paste behavior
+- [x] #2 Help should cover the composer's real capabilities (attach, paste-path, cap)
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+AC#1: Shift+Enter already inserts a newline but terminals deliver it as a plain
+CR (send), so `on_key` now also accepts `ctrl+j` (a control code that survives
+every terminal) as a portable newline chord -- same `composer.insert_text("\n")`
+path. AC#2: the F1 help Composer group (CONSOLE_WORKBENCH_SHORTCUT_GROUPS) now
+documents both newline chords plus the previously-undiscoverable capabilities --
+Alt+V paste-image, Attach (up to 5 per message = the cap), and paste/drop a file
+path to attach it. The compact footer set (flat CONSOLE_WORKBENCH_SHORTCUTS) is
+unchanged. RED->GREEN: on_key ctrl+j newline test + a pure help-group coverage
+test. Baseline: test_console_rag_action_without_service_stages_recoverable_blocker
+is a load-contention flake (passes solo), unrelated to this change.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -501,7 +501,10 @@ CONSOLE_WORKBENCH_SHORTCUT_GROUPS = (
             ("Ctrl+J", "insert a newline (works in any terminal)"),
             ("Shift+Enter", "insert a newline (where the terminal delivers it)"),
             ("Alt+V", "paste an image from the clipboard"),
-            ("Attach", "attach files — up to 5 per message"),
+            (
+                "Attach",
+                f"attach files — up to {MAX_PENDING_ATTACHMENTS} per message",
+            ),
             ("Paste / drop path", "paste or drop a file path to attach it"),
             ("Ctrl+K", "switch session"),
             ("Ctrl+T", "new tab"),

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -498,7 +498,11 @@ CONSOLE_WORKBENCH_SHORTCUT_GROUPS = (
         "Composer",
         (
             ("Enter", "send"),
-            ("Shift+Enter", "insert a newline"),
+            ("Ctrl+J", "insert a newline (works in any terminal)"),
+            ("Shift+Enter", "insert a newline (where the terminal delivers it)"),
+            ("Alt+V", "paste an image from the clipboard"),
+            ("Attach", "attach files — up to 5 per message"),
+            ("Paste / drop path", "paste or drop a file path to attach it"),
             ("Ctrl+K", "switch session"),
             ("Ctrl+T", "new tab"),
         ),
@@ -13597,7 +13601,10 @@ class ChatScreen(BaseAppScreen):
             event.stop()
             event.prevent_default()
             return
-        if event.key == "shift+enter":
+        # TASK-381: Shift+Enter is the natural newline chord, but terminals
+        # deliver it as a plain CR (which sends), so also accept Ctrl+J -- a
+        # control code that survives every terminal -- as a portable newline.
+        if event.key in ("shift+enter", "ctrl+j"):
             composer.insert_text("\n")
             self._sync_console_workbench_actions_from_draft()
             self._dismiss_console_guidance()


### PR DESCRIPTION
## Summary

P3 from the Console UX expert review 2026-07-20 (finding j3-no-multiline-composer-path). Two clean, harness-testable gaps.

**AC#1 — a terminal-portable newline chord.** Shift+Enter already inserts a newline, but terminals deliver Shift+Enter as a plain CR (which sends), and Ctrl+J fell through unhandled. `on_key` now accepts **Ctrl+J** — a control code that survives every terminal — as a portable newline (same `composer.insert_text("\n")` path).

**AC#2 — help covers the composer's real capabilities.** The F1 help Composer group (`CONSOLE_WORKBENCH_SHORTCUT_GROUPS`) previously listed only Enter/Shift+Enter/Ctrl+K/Ctrl+T. It now documents:
- `Ctrl+J` — insert a newline (works in any terminal)
- `Shift+Enter` — insert a newline (where the terminal delivers it)
- `Alt+V` — paste an image from the clipboard
- `Attach` — attach files, up to 5 per message (the cap)
- `Paste / drop path` — paste or drop a file path to attach it

The compact footer set (flat `CONSOLE_WORKBENCH_SHORTCUTS`) is unchanged.

## Tests (TDD RED→GREEN)
- `test_ctrl_j_inserts_a_newline_in_the_composer` (AC#1 — `on_key(Key("ctrl+j"))`, verified RED: `line oneline two` without the newline)
- `test_composer_help_documents_newline_attach_and_cap` (AC#2 — pure group coverage)

Help suite + broader keyboard/composer suites green (164 passed; the one `test_console_rag_action_without_service_stages_recoverable_blocker` failure is a pre-existing load-contention flake — passes solo — unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a terminal-safe `Ctrl+J` newline chord in the composer and updates F1 help to show all composer actions. Meets TASK-381 and makes multiline drafts reliable across terminals; help now derives the attachment cap from `MAX_PENDING_ATTACHMENTS`.

- **New Features**
  - `Ctrl+J` inserts a newline in the composer and works in any terminal.
  - F1 help now lists: `Ctrl+J`, `Shift+Enter`, `Alt+V` paste image, Attach files (up to the enforced cap), and paste/drop a file path to attach.

<sup>Written for commit e8411603530142113824a0d6daaace070b7f8d72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

