### PR TITLE
docs(backlog): close task-439 (preview already streams — verified)

### DIFF
--- a/backlog/tasks/task-439 - Stream-replies-in-the-Roleplay-preview-conversation.md
+++ b/backlog/tasks/task-439 - Stream-replies-in-the-Roleplay-preview-conversation.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-439
 title: Stream replies in the Roleplay preview conversation
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-21 09:38'
+updated_date: '2026-07-24 02:29'
 labels:
   - roleplay
   - ux
@@ -19,6 +20,26 @@ Filed from the RP/character-card UX review (Docs/superpowers/qa/rp-ux-review-202
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Preview replies render incrementally for providers that support streaming
-- [ ] #2 Non-streaming providers keep a working status indicator
+- [x] #1 Preview replies render incrementally for providers that support streaming
+- [x] #2 Non-streaming providers keep a working status indicator
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Investigation-first outcome: already satisfied — no code change needed.**
+
+The preview reply worker (`PersonasPreviewController._run_reply`) already streams: it iterates `gateway.stream_chat(...)` (an async generator) and renders each chunk via `pane.begin_reply()` / `append_reply_chunk()` / `finalize_reply()`, with a streaming→non-streaming retry, mid-stream cancellation (`_stale()` + `discard_partial_reply`), and the status line ("Running"/"Ready"/…) intact for the non-streaming path. This was true **at the RP-review baseline `dc196563f`** (the streaming was added by the pre-review "Extract Personas preview controller" commit) — it is not a missing feature.
+
+The gateway genuinely yields incrementally: `stream_llamacpp_chat` does `async for line in response.aiter_lines(): yield chunk` (SSE), and `_stream_generic_chat` yields per item.
+
+**Why the review saw non-streaming ("~20s of static 'Running' then the full reply at once"):** the preview's provider *resolution* at review time — the P0-1 `[character_defaults]` bug (ships `anthropic`/`claude-3-haiku`, normally unconfigured), so the preview resolved an unready provider and errored/fell back instead of streaming. **TASK-425 (fallback to `chat_defaults`) and TASK-426 (provider readout), both merged earlier this campaign, fixed exactly that.** With the current code the preview reaches a ready streaming provider and streams.
+
+**AC#1 — verified:**
+- Existing integration test `test_reply_streams_progressively_into_one_line` asserts the transcript shows the first chunk *while the stream is held open* (real pane).
+- **Live-verified end-to-end** against a real SSE server through the production path (real `ConsoleProviderGateway` → real network SSE at `/v1/chat/completions` → real `PersonasPreviewPane`), the transcript grew token-by-token over ~6.5s: `"character: Greetings"` (t=0.06s) → … → `"character: Greetings, detective. The fog rolls thick over Baker Street tonight."` (t=6.56s).
+
+**AC#2 — verified:** the status line updates independently of streaming (`personas_preview_pane.set_status`); non-streaming providers keep it working — covered by `test_unready_character_provider_falls_back_to_chat_defaults`, `test_fallback_provider_survives_non_streaming_retry`, `test_blocked_provider_shows_readable_status`.
+
+No production files changed. The RP review's streaming symptom was a downstream effect of the provider-resolution defect already fixed by TASK-425/426.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary

Investigation-first close of TASK-439 (stream replies in the Roleplay preview) — **the preview already streams; no production code changed.**

`PersonasPreviewController._run_reply` already iterates `gateway.stream_chat(...)` and renders each chunk via `pane.begin_reply()`/`append_reply_chunk()`/`finalize_reply()`, with a streaming→non-streaming retry and the status line intact — present since **before** the RP-review baseline. The review's non-streaming symptom ("~20s static 'Running' then the full reply") was the `character_defaults` provider-resolution bug, **already fixed by TASK-425/426** this campaign.

## Verification
- **AC#1 (incremental streaming):** existing `test_reply_streams_progressively_into_one_line` + **live-verified end-to-end** through the real production path (real `ConsoleProviderGateway` → real network SSE → real `PersonasPreviewPane`) — the transcript grew token-by-token over ~6.5s.
- **AC#2 (non-streaming keeps status):** `test_unready_character_provider_falls_back_to_chat_defaults`, `test_fallback_provider_survives_non_streaming_retry`, `test_blocked_provider_shows_readable_status`.

Docs-only (backlog task marked Done with the full investigation write-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marked TASK-439 as Done by verifying the Roleplay preview already streams replies; updated the backlog doc with verification notes and acceptance criteria. Linked the prior provider-resolution fixes (TASK-425/426); no production code changes.

<sup>Written for commit d812553c2ce9685deb74fae12964100cd67ed6d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

