### PR TITLE
fix(console): task-372 render assistant markdown emphasis in the transcript

### DIFF
--- a/Tests/UI/test_console_transcript_markdown.py
+++ b/Tests/UI/test_console_transcript_markdown.py
@@ -1,0 +1,65 @@
+"""TASK-372: render assistant markdown emphasis in the Console transcript.
+
+Headings / **bold** / `code` were shown with literal marker characters. They now
+render with terminal emphasis, and -- critically -- via literal-text + styled
+spans, so a message can never inject Rich markup (the transcript's safety
+guarantee is preserved).
+"""
+
+from tldw_chatbook.Chat.console_chat_models import ConsoleChatMessage, ConsoleMessageRole
+from tldw_chatbook.Widgets.Console.console_transcript import (
+    _markdown_body_spans,
+    _message_render_text,
+)
+
+
+def test_markdown_spans_render_heading_bold_and_code():
+    assert _markdown_body_spans("### Understanding WAL") == [("Understanding WAL", "bold underline")]
+    assert _markdown_body_spans("use **local RAG** now") == [
+        "use ",
+        ("local RAG", "bold"),
+        " now",
+    ]
+    assert _markdown_body_spans("run `pytest` here") == [
+        "run ",
+        ("pytest", "italic"),
+        " here",
+    ]
+
+
+def test_markdown_spans_leave_unclosed_markers_literal():
+    # A half-streamed bold marker must stay literal until it closes.
+    assert _markdown_body_spans("**bold not closed") == ["**bold not closed"]
+
+
+def test_assistant_render_strips_heading_markers():
+    msg = ConsoleChatMessage(
+        role=ConsoleMessageRole.ASSISTANT,
+        content="#### The Checkpointing Process",
+        status="complete",
+    )
+    plain = _message_render_text(msg, selected=False).plain
+    assert "The Checkpointing Process" in plain
+    assert "####" not in plain
+
+
+def test_assistant_render_does_not_interpret_injected_markup():
+    msg = ConsoleChatMessage(
+        role=ConsoleMessageRole.ASSISTANT,
+        content="danger [bold red]x[/bold red] end",
+        status="complete",
+    )
+    plain = _message_render_text(msg, selected=False).plain
+    # The bracket tokens survive as literal text (not parsed/stripped as markup).
+    assert "[bold red]x[/bold red]" in plain
+
+
+def test_user_message_text_is_left_verbatim():
+    msg = ConsoleChatMessage(
+        role=ConsoleMessageRole.USER,
+        content="literal **stars** and ## hash",
+        status="complete",
+    )
+    plain = _message_render_text(msg, selected=False).plain
+    assert "**stars**" in plain
+    assert "## hash" in plain

--- a/Tests/UI/test_console_transcript_markdown.py
+++ b/Tests/UI/test_console_transcript_markdown.py
@@ -14,6 +14,7 @@ from tldw_chatbook.Widgets.Console.console_transcript import (
 
 
 def test_markdown_spans_render_heading_bold_and_code():
+    """Headings, **bold**, and `code` map to the expected styled segments."""
     assert _markdown_body_spans("### Understanding WAL") == [("Understanding WAL", "bold underline")]
     assert _markdown_body_spans("use **local RAG** now") == [
         "use ",
@@ -28,11 +29,12 @@ def test_markdown_spans_render_heading_bold_and_code():
 
 
 def test_markdown_spans_leave_unclosed_markers_literal():
-    # A half-streamed bold marker must stay literal until it closes.
+    """A half-streamed (unclosed) bold marker stays literal until it closes."""
     assert _markdown_body_spans("**bold not closed") == ["**bold not closed"]
 
 
 def test_assistant_render_strips_heading_markers():
+    """An assistant heading renders without its literal ``#`` markers."""
     msg = ConsoleChatMessage(
         role=ConsoleMessageRole.ASSISTANT,
         content="#### The Checkpointing Process",
@@ -44,6 +46,7 @@ def test_assistant_render_strips_heading_markers():
 
 
 def test_assistant_render_does_not_interpret_injected_markup():
+    """Bracket tokens in an assistant reply render literally, never as markup."""
     msg = ConsoleChatMessage(
         role=ConsoleMessageRole.ASSISTANT,
         content="danger [bold red]x[/bold red] end",
@@ -55,6 +58,7 @@ def test_assistant_render_does_not_interpret_injected_markup():
 
 
 def test_user_message_text_is_left_verbatim():
+    """User input is shown verbatim -- its markdown markers are not restyled."""
     msg = ConsoleChatMessage(
         role=ConsoleMessageRole.USER,
         content="literal **stars** and ## hash",
@@ -63,3 +67,18 @@ def test_user_message_text_is_left_verbatim():
     plain = _message_render_text(msg, selected=False).plain
     assert "**stars**" in plain
     assert "## hash" in plain
+
+
+def test_system_and_tool_messages_are_left_verbatim():
+    """Qodo #823: SYSTEM diagnostics and TOOL output keep their literal markers
+    (their #/**/backtick characters may be meaningful) -- only ASSISTANT renders."""
+    for role in (ConsoleMessageRole.SYSTEM, ConsoleMessageRole.TOOL):
+        msg = ConsoleChatMessage(
+            role=role,
+            content="### not a heading  **not bold**  `not code`",
+            status="complete",
+        )
+        plain = _message_render_text(msg, selected=False).plain
+        assert "### not a heading" in plain
+        assert "**not bold**" in plain
+        assert "`not code`" in plain

--- a/backlog/tasks/task-372 - Render-markdown-emphasis-and-headings-in-the-Console-transcript.md
+++ b/backlog/tasks/task-372 - Render-markdown-emphasis-and-headings-in-the-Console-transcript.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-372
 title: Render markdown emphasis and headings in the Console transcript
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-20 14:21'
 labels: [console, ux]
 dependencies: []
@@ -25,5 +26,24 @@ Also observed independently in J2 returning power user as `j2-markdown-asterisks
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Render headings with terminal-appropriate emphasis (bold/underline/color) or strip the marker characters
+- [x] #1 Render headings with terminal-appropriate emphasis (bold/underline/color) or strip the marker characters
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The transcript rendered assistant markdown with literal markers (### / ** / `)
+because `_message_render_text` used markup-off `Content.assemble` (injection
+safety). A safe subset now renders with terminal emphasis: headings -> bold
+underline (markers stripped), **bold** -> bold, `code` -> italic, via new pure
+`_markdown_body_spans`/`_inline_markdown_spans`. CRITICAL: every segment is
+emitted as literal text with the style applied through a `(text, style)` tuple --
+the message text is NEVER markup-parsed, so a reply containing `[red]` renders
+literally (injection-safety guarantee preserved, covered by test). Applied to
+non-USER, non-placeholder bodies only (user text stays verbatim); unclosed
+markers mid-stream stay literal until they close. This is pure Content-assembly
+logic, so it is unit-test-definitive (5 tests incl. exact spans + injection
+safety) rather than needing served-app repro like the CSS/layout tasks. The 2
+continue/regen native-chat-flow failures are pre-existing baseline (verified
+failing identically on clean origin/dev).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -257,13 +257,15 @@ def _message_render_text(message: ConsoleChatMessage, *, selected: bool) -> Cont
         body = f"{body}\n{chip_lines}" if body else chip_lines
     if _is_generating_placeholder_body(message, body):
         body_segments: list = [(body, "dim")]
-    elif message.role is ConsoleMessageRole.USER:
-        # The user's own text is shown verbatim -- don't restyle their input.
-        body_segments = [body]
-    else:
+    elif message.role is ConsoleMessageRole.ASSISTANT:
         # TASK-372: render assistant markdown (headings/**bold**/`code`) with
-        # terminal emphasis instead of literal marker characters.
+        # terminal emphasis instead of literal marker characters. Only ASSISTANT
+        # replies are markdown -- USER input, SYSTEM diagnostics, and TOOL output
+        # stay verbatim, since their #/**/backtick characters may be literal and
+        # meaningful (Qodo #823).
         body_segments = _markdown_body_spans(body)
+    else:
+        body_segments = [body]
     separator = "  " if not selected and "\n" not in body and len(body) <= 120 else "\n"
     return Content.assemble((role_label, "dim"), separator, *body_segments)
 

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 from dataclasses import dataclass
 from time import monotonic
 
@@ -170,6 +171,66 @@ def _message_attachment_chips(message: ConsoleChatMessage) -> list[str]:
     return chips
 
 
+#: Inline markdown handled in-transcript: **bold** and `code`. Matched as closed
+#: pairs only, so an unclosed marker mid-stream stays literal until it closes.
+_INLINE_MD_RE = re.compile(r"\*\*(.+?)\*\*|`([^`]+)`")
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*\S)\s*$")
+
+
+def _inline_markdown_spans(line: str) -> list:
+    """Split one line into Content segments, styling **bold**/`code` inline.
+
+    Text is always emitted literally (styles are applied via ``(text, style)``
+    tuples, never markup parsing), so message text can never inject Rich markup.
+
+    Args:
+        line: A single raw text line.
+
+    Returns:
+        A list of ``str`` / ``(str, style)`` segments for ``Content.assemble``.
+    """
+    out: list = []
+    pos = 0
+    for match in _INLINE_MD_RE.finditer(line):
+        if match.start() > pos:
+            out.append(line[pos : match.start()])
+        if match.group(1) is not None:
+            out.append((match.group(1), "bold"))
+        else:
+            out.append((match.group(2), "italic"))
+        pos = match.end()
+    if pos < len(line):
+        out.append(line[pos:])
+    return out or [line]
+
+
+def _markdown_body_spans(body: str) -> list:
+    """Render a safe subset of markdown (headings, **bold**, `code`) to segments.
+
+    TASK-372: assistant replies arrive as markdown and were shown raw (literal
+    ``###`` / ``**`` / backticks). Headings render as bold underline with the
+    ``#`` markers stripped; inline bold/code render via
+    ``_inline_markdown_spans``. All styling goes through ``(text, style)`` tuples
+    so nothing in the message is markup-parsed.
+
+    Args:
+        body: The raw message body text.
+
+    Returns:
+        A list of ``str`` / ``(str, style)`` segments for ``Content.assemble``.
+    """
+    segments: list = []
+    for index, line in enumerate(body.split("\n")):
+        if index:
+            segments.append("\n")
+        heading = _HEADING_RE.match(line)
+        if heading:
+            segments.append((heading.group(2), "bold underline"))
+        else:
+            segments.extend(_inline_markdown_spans(line))
+    return segments
+
+
 def _message_render_text(message: ConsoleChatMessage, *, selected: bool) -> Content:
     """Return the compact transcript row renderable for a message.
 
@@ -194,12 +255,17 @@ def _message_render_text(message: ConsoleChatMessage, *, selected: bool) -> Cont
     if chips:
         chip_lines = "\n".join(chips)
         body = f"{body}\n{chip_lines}" if body else chip_lines
-    body_part: tuple[str, str] | str = body
     if _is_generating_placeholder_body(message, body):
-        body_part = (body, "dim")
-    if not selected and "\n" not in body and len(body) <= 120:
-        return Content.assemble((role_label, "dim"), "  ", body_part)
-    return Content.assemble((role_label, "dim"), "\n", body_part)
+        body_segments: list = [(body, "dim")]
+    elif message.role is ConsoleMessageRole.USER:
+        # The user's own text is shown verbatim -- don't restyle their input.
+        body_segments = [body]
+    else:
+        # TASK-372: render assistant markdown (headings/**bold**/`code`) with
+        # terminal emphasis instead of literal marker characters.
+        body_segments = _markdown_body_spans(body)
+    separator = "  " if not selected and "\n" not in body and len(body) <= 120 else "\n"
+    return Content.assemble((role_label, "dim"), separator, *body_segments)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary

P3 from the Console UX review (j4-raw-markdown-headings-in-transcript, j2-markdown-asterisks-raw). Assistant replies arrived as markdown and were shown with **literal marker characters** (`### heading`, `**bold**`, `` `code` ``) because the transcript renders markup-off `Content.assemble` for injection safety.

## Fix
A safe markdown subset now renders with terminal emphasis:
- `# … ###### heading` → **bold underline**, markers stripped
- `**bold**` → bold
- `` `code` `` → italic

Every segment is emitted as **literal text with the style applied via a `(text, style)` tuple** — the message text is *never* markup-parsed, so the transcript's injection-safety guarantee is preserved (a reply containing `[red]` renders literally — covered by a test). Applied to non-user, non-placeholder bodies only (user input stays verbatim); unclosed markers mid-stream stay literal until they close.

## Tests
`Tests/UI/test_console_transcript_markdown.py` (5, RED→GREEN):
- exact spans for heading / bold / code
- unclosed marker stays literal
- assistant heading markers stripped from the render
- **injection safety**: `[bold red]x[/bold red]` survives as literal text
- user message left verbatim

This is pure `Content`-assembly logic, so it's unit-test-definitive (unlike the CSS/layout tasks in #821 whose bugs were pilot-invisible and needed served-app repro). The 2 continue/regen native-chat-flow failures are pre-existing baseline — verified failing identically on clean `origin/dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix assistant replies showing raw markdown in the Console transcript by rendering headings, bold, and code with terminal styles while keeping injection safety. Scoped to ASSISTANT only; USER, SYSTEM, and TOOL messages render verbatim. Addresses TASK-372.

- **Bug Fixes**
  - Headings (#–######) render as bold underline; markers stripped.
  - `**bold**` → bold; `` `code` `` → italic.
  - Uses literal text + style spans only; unclosed markers stay literal; injection-safe.
  - Scope: only ASSISTANT replies are restyled; USER/SYSTEM/TOOL stay verbatim.
  - Tests cover spans, heading stripping, injection safety, and role scoping regression.

<sup>Written for commit 97cc6c18ac3e4efa58b02030c30a2961dc9993c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

