### PR TITLE
Console conversation branching — Phase C (agent-marker anchoring)

### DIFF
--- a/Docs/superpowers/plans/2026-07-24-console-branching-phase-c.md
+++ b/Docs/superpowers/plans/2026-07-24-console-branching-phase-c.md
@@ -122,3 +122,18 @@ Verified facts (research 2026-07-24, worktree base dev 922308e44): `AgentRuns_DB
 **Type consistency:** `create_run(..., assistant_message_id: str|None=None)`, `set_run_assistant_message_id(run_id, assistant_message_id)`, `run_turn(...) -> (run_id, RunOutcome)`, `resume_marker_messages -> list[tuple[str|None, list[ConsoleChatMessage]]]`, `inject_resume_agent_markers(messages, anchored_blocks)` — consistent across Tasks 1–4. The stored/compared id is always the **persisted** id (`ConsoleChatMessage.persisted_message_id`).
 
 **Risk:** Task 2's `run_reply` return-shape change ripples to the `run_reply` fakes in `test_console_agent_swap.py` — update them. The off-path-hide changes the old "orphan → append" semantics for id-set runs (intended); the null-ordinal path preserves it for legacy data.
+
+---
+
+## Addendum (final whole-branch review, 2026-07-24): stopped-via-cancel limitation
+
+The persisted-id write fires on every terminal path **that returns through the finalizer**
+(success, failure, cancelled-outcome, and the post-outcome `stopped_now` race). A user Stop
+delivered via `stop_active_run` → `task.cancel()` is different: the `await asyncio.to_thread(...)`
+raises `CancelledError` before the `(run_id, outcome)` tuple is bound, so the `CancelledError`
+branch returns without ever knowing the run id — that run's `assistant_message_id` stays `NULL`
+and it falls back to the legacy ordinal placement on resume. This is NOT a regression (it is
+exactly the pre-Phase-C behavior for every run) and is benign on a linear resume; it only leaks
+stale markers via leftover-append when a stopped reply later becomes an off-path sibling.
+Follow-up filed: expose the most-recent run id via the bridge so the cancel branch can record it,
+plus a test exercising the real `task.cancel()` path.

--- a/Docs/superpowers/plans/2026-07-24-console-branching-phase-c.md
+++ b/Docs/superpowers/plans/2026-07-24-console-branching-phase-c.md
@@ -1,0 +1,124 @@
+# Console Conversation Branching — Phase C Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** On resume, anchor each agent run's inline TOOL markers to the assistant reply that run actually produced (by durable persisted id), and **hide** markers whose reply is off the active branch — replacing the ordinal Nth-run→Nth-assistant placement that is wrong once conversations branch (Phases A/B).
+
+**Architecture (durable id-anchoring, per design decision 2026-07-24):** The correct anchor is the assistant reply's **persisted** ChaChaNotes id. That id only exists *after* the run completes and the controller marks the reply complete (the empty assistant node persists lazily). So: `AgentRunsDB` gains an `assistant_message_id` column (v1→v2, via a hand-written idempotent `ALTER` — there is no migration framework); `run_reply` returns the run id; the **controller**, after `mark_message_complete`, writes the reply's *persisted* id onto the run (`set_run_assistant_message_id`); and resume placement matches `message.persisted_message_id == run.assistant_message_id`, hiding off-path runs and falling back to the legacy ordinal placement for runs whose id is `NULL` (pre-Phase-C data).
+
+**Tech Stack:** Python ≥3.11, SQLite (AgentRunsDB, no ORM/migration framework), Textual, pytest.
+
+## Global Constraints
+
+- **Design source:** foundation spec `Docs/superpowers/specs/2026-07-22-console-conversation-branching-foundation-design.md` (Phase C) + the 2026-07-24 decision to use **durable id-anchoring via a post-completion persisted-id write** (NOT threading the native id through `create_run`, which stores an id that never matches on resume).
+- **The stored id MUST be the persisted (ChaChaNotes) id**, not the native in-memory session id. Native id at `create_run` time is useless for resume — the load-bearing write is the controller's post-`mark_message_complete` update.
+- **`AgentRunsDB` has NO migration framework** — only `CREATE TABLE IF NOT EXISTS`. A new column requires an explicit **PRAGMA-guarded idempotent `ALTER TABLE agent_runs ADD COLUMN assistant_message_id TEXT`** inside `_initialize_schema`, in addition to adding it to the CREATE TABLE DDL (for fresh DBs). Bump `_CURRENT_SCHEMA_VERSION` to 2 (currently cosmetic).
+- **`assistant_message_id` is optional everywhere** (`create_run`, `run_turn`, `_run_one` default `None`) so every existing call site + test stays green.
+- **Backward-compat:** runs with `assistant_message_id IS NULL` (pre-Phase-C, and sub-agent runs) fall back to the existing ordinal placement; only runs with a set id are id-anchored. Sub-agent runs never carry the id (only the primary run produces a transcript reply).
+- **Off-path = hidden:** a run whose set `assistant_message_id` is not among the resumed active-path messages' `persisted_message_id`s → its block is dropped (not appended). Preserve the content-based idempotency guard.
+- **Tests:** real SQLite / real store+bridge. Run via `./.venv/bin/python -m pytest`. Baseline pre-existing failures (`test_anthropic_native_tools`, `test_chat_functions`, `test_console_native_chat_flow` continue/regenerate "Text not found: 'hello'") — ignore.
+- **No `git stash`** in any subagent (worktrees share a stash stack). Commit after each task; `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+## File Structure
+
+- **Modify** `tldw_chatbook/DB/AgentRuns_DB.py` — v1→v2 column + guarded ALTER + `create_run` param + `set_run_assistant_message_id`.
+- **Modify** `tldw_chatbook/Agents/agent_service.py` — thread `assistant_message_id` through `run_turn`/`_run_one` into `create_run`; sub-agent recursion passes `None`.
+- **Modify** `tldw_chatbook/Chat/console_agent_bridge.py` — `run_reply` passes the id to `run_turn` and **returns the run id**; `resume_marker_messages` returns `(assistant_message_id, block)` pairs; rewrite `inject_resume_agent_markers` (id-anchor + off-path-hide + null-ordinal-fallback + idempotency).
+- **Modify** `tldw_chatbook/Chat/console_chat_controller.py` — after `mark_message_complete`, write the reply's persisted id onto the run.
+- **Modify** `tldw_chatbook/UI/Screens/chat_screen.py` — `_inject_resume_agent_markers` passes the new block shape through (the `apply_resume_marker_overlay` overlay is unchanged; transcript messages already carry `persisted_message_id`).
+
+Verified facts (research 2026-07-24, worktree base dev 922308e44): `AgentRuns_DB._CURRENT_SCHEMA_VERSION=1`, `_initialize_schema` is `CREATE TABLE IF NOT EXISTS` only; `create_run` INSERT at `AgentRuns_DB.py:117-159`; `list_runs`/`get_run` use `SELECT *` + `_row_to_dict` (new column auto-surfaced); `run_turn` `agent_service.py:585`, `_run_one` `:313`, the single `create_run` call `:325`, sub-agent recursion `:484`; `run_reply` `console_agent_bridge.py:832` (already has `assistant_message_id` arg), `service.run_turn(...)` call `:1008` (id NOT passed, `_run_id` discarded); `resume_marker_messages` `:1118`; `inject_resume_agent_markers` ordinal `zip` `:196`; screen seam `chat_screen.py:4440` + overlay call `:4706`; `ConsoleChatMessage.persisted_message_id` `console_chat_models.py:206`.
+
+---
+
+### Task 1: AgentRunsDB v1→v2 — `assistant_message_id` column + guarded ALTER + accessor
+
+**Files:**
+- Modify: `tldw_chatbook/DB/AgentRuns_DB.py`
+- Test: `Tests/DB/test_agent_runs_db.py` (extend)
+
+**Interfaces:**
+- Produces: `assistant_message_id TEXT` on `agent_runs`; `create_run(..., assistant_message_id: str | None = None)`; `set_run_assistant_message_id(run_id: str, assistant_message_id: str | None) -> None`; the id surfaced in `get_run`/`list_runs` dicts (via `SELECT *`).
+
+- [ ] **Step 1: Write failing tests** (real `AgentRunsDB(tmp_path/"agent_runs.db", client_id="test")`):
+  1. `create_run(..., assistant_message_id="m-9")` → `get_run(run_id)["assistant_message_id"] == "m-9"`; and default omitted → `None`.
+  2. `set_run_assistant_message_id(run_id, "p-42")` → `get_run` reflects `"p-42"`; `list_runs` includes it.
+  3. **Migration on an existing v1 DB:** create the db (schema initialized), then simulate a pre-v2 table by dropping the column is hard — instead: open a second `AgentRunsDB` on the SAME file and confirm `create_run(..., assistant_message_id="x")` works (i.e. the guarded ALTER is idempotent across re-open and the column persists). Additionally, construct a raw v1 table (a temp sqlite file with the old 11-column `agent_runs` DDL, no `assistant_message_id`), then open `AgentRunsDB` on it and assert `create_run(..., assistant_message_id="y")` succeeds and round-trips (proving the ALTER ran on legacy data).
+- [ ] **Step 2: Run RED** — `./.venv/bin/python -m pytest Tests/DB/test_agent_runs_db.py -v` (new tests fail: no column / no method).
+- [ ] **Step 3: Implement.** In `_initialize_schema`: add `assistant_message_id TEXT` to the `CREATE TABLE agent_runs` column list; AFTER the executescript, run a guarded ALTER: read `PRAGMA table_info(agent_runs)`; if `"assistant_message_id"` absent, `conn.execute("ALTER TABLE agent_runs ADD COLUMN assistant_message_id TEXT")`. Bump `_CURRENT_SCHEMA_VERSION = 2` and change the seed to keep it consistent (harmless; nothing reads it). Add `assistant_message_id: str | None = None` to `create_run` + its INSERT (column, placeholder, param). Add `set_run_assistant_message_id(run_id, assistant_message_id)` — an `UPDATE agent_runs SET assistant_message_id = ?, updated_at = ? WHERE id = ?` in a transaction.
+- [ ] **Step 4: Run GREEN** + the full `Tests/DB/test_agent_runs_db.py` (all pre-existing create_run calls that omit the kwarg must still pass).
+- [ ] **Step 5: Commit** — `feat(agents): agent_runs.assistant_message_id column (v1->v2) + setter`.
+
+---
+
+### Task 2: Write-path — thread the id + return the run id, then write the PERSISTED id from the controller
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/agent_service.py` (`run_turn` :585, `_run_one` :313 + create_run call :325, sub-agent recursion :484)
+- Modify: `tldw_chatbook/Chat/console_agent_bridge.py` (`run_reply` :832 — pass id to `run_turn` :1008, return the run id)
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py` (the agent path in `_stream_assistant_response`/`_complete_agent_message`, after `mark_message_complete`)
+- Test: `Tests/Agents/test_agent_service.py` / `Tests/Chat/test_console_agent_bridge.py` + a controller test
+
+**Interfaces:**
+- Consumes: Task 1's `create_run(assistant_message_id=…)` + `set_run_assistant_message_id`.
+- Produces: `run_turn(..., assistant_message_id=None) -> (run_id, RunOutcome)`; `_run_one(..., assistant_message_id=None)`; `run_reply(...)` returns the primary run id alongside/within its result (see below); controller writes the persisted id post-completion.
+
+- [ ] **Step 1: Write failing tests.**
+  - Service: `run_turn(..., assistant_message_id="a1")` → the created primary run's `assistant_message_id == "a1"` (via a real `AgentRunsDB`); a spawned sub-agent run has `assistant_message_id is None`.
+  - Bridge/controller: after a full agent reply completes on a persisted store, the primary run's `assistant_message_id` equals the assistant message's **persisted_message_id** (not the native id).
+- [ ] **Step 2: Run RED.**
+- [ ] **Step 3: Implement.**
+  - `agent_service.py`: add `assistant_message_id: str | None = None` to `run_turn` and `_run_one`; pass it into the single `create_run(...)` call; the `spawn` recursion passes `assistant_message_id=None`.
+  - `console_agent_bridge.py`: pass `assistant_message_id=assistant_message_id` in the `service.run_turn(...)` call; capture the returned `run_id`. **Expose the primary run id to `run_reply`'s caller** — the least-invasive way (choose one and note it): (a) store it on a bridge field keyed by session/assistant id that the controller reads, or (b) change `run_reply` to return `(run_id, outcome)` and update its call site(s) + the `run_reply` fakes in `test_console_agent_swap.py`. Prefer (b) if the call sites are few; the id must reach the controller.
+  - `console_chat_controller.py`: in the agent completion path, AFTER `store.mark_message_complete(assistant_message_id)` (which assigns the persisted id), resolve `persisted = store.get_message(assistant_message_id).persisted_message_id` and, if a run id and persisted id exist, call `agent_runs_db.set_run_assistant_message_id(run_id, persisted)`. Guard for the no-persistence / no-run cases (no-op). Note the native `create_run` value gets corrected to the persisted id here — this is the load-bearing write.
+- [ ] **Step 4: Run GREEN** + the agent bridge/service suites + `test_console_agent_swap.py` (fakes still valid).
+- [ ] **Step 5: Commit** — `feat(console): record the produced assistant reply's persisted id on the agent run`.
+
+---
+
+### Task 3: Read-path — id-anchored resume placement (off-path hidden, null → ordinal fallback)
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_agent_bridge.py` (`resume_marker_messages` :1118, `inject_resume_agent_markers` :196)
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` (`_inject_resume_agent_markers` :4440 — pass the new shape through)
+- Test: `Tests/Chat/test_console_agent_bridge.py` (rewrite the placement tests), `Tests/UI/test_console_native_chat_flow.py` (the resume-wiring test)
+
+**Interfaces:**
+- Produces: `resume_marker_messages(conversation_id) -> list[tuple[str | None, list[ConsoleChatMessage]]]` (anchor id per block; `None` for legacy/null runs). `inject_resume_agent_markers(messages, anchored_blocks)` — new second-arg shape.
+
+- [ ] **Step 1: Write failing tests.**
+  - `resume_marker_messages` returns `(assistant_message_id, block)` pairs (the id read from `record["assistant_message_id"]`).
+  - `inject_resume_agent_markers`: (a) a block with an anchor id matching a message's `persisted_message_id` lands **immediately after that message** (even if it's not the last assistant); (b) a block whose anchor id matches NO active-path message is **dropped/hidden** (off-path); (c) a block with `anchor id == None` (legacy) is placed by the **ordinal fallback** (Nth null-block → Nth assistant among the messages not already id-claimed); (d) idempotency (second call adds no dupes) and empty-block skipping preserved.
+  - Update the existing ordinal tests (`test_inject_resume_agent_markers_places_block_after_matching_assistant_message` etc.) to set `persisted_message_id` on the test messages + anchor ids on the blocks; keep the leftover/idempotency/empty tests.
+- [ ] **Step 2: Run RED.**
+- [ ] **Step 3: Implement.**
+  - `resume_marker_messages`: attach `record.get("assistant_message_id")` to each block (return `(anchor_id, block)`).
+  - `inject_resume_agent_markers`: build `by_persisted = {m.persisted_message_id: index for index, m in enumerate(messages) if m.persisted_message_id}`. Partition anchored blocks into id-set and null. For id-set blocks: if `anchor_id in by_persisted` → insert after that index; else → **drop** (off-path/stale). For null blocks: apply the existing ordinal placement against the assistant indexes **not already used by an id match**. Keep the `_already_present` content-idempotency guard on every insert.
+  - `chat_screen.py:_inject_resume_agent_markers`: pass the `(anchor, block)` list straight through (signature of the module fn changed; the call adapts).
+- [ ] **Step 4: Run GREEN** + the full `test_console_agent_bridge.py` and the resume-wiring test.
+- [ ] **Step 5: Commit** — `feat(console): anchor resumed agent markers to the produced reply; hide off-branch`.
+
+---
+
+### Task 4: End-to-end (agent run on a branch) + regression
+
+**Files:**
+- Test: `Tests/integration/test_console_agent_marker_anchoring_e2e.py`
+
+- [ ] **Step 1: Write the E2E** over real DB + store + controller + a fake agent path (reuse the agent-bridge test harness): run an agent reply A1 (produces TOOL steps), regenerate → agent reply A1' (its own steps), so two assistant siblings each with their own run. Persist → drop store → resume on the A1' branch: assert A1's markers are **hidden** and A1''s markers render after A1'; swipe to A1 → its markers now show, A1''s hidden (after a fresh resume/overlay). Include a legacy run (null `assistant_message_id`) asserting the ordinal fallback still places it.
+- [ ] **Step 2: Run + regression sweep** — `./.venv/bin/python -m pytest Tests/Chat/test_console_agent_bridge.py Tests/Agents/ Tests/DB/test_agent_runs_db.py Tests/UI/test_console_native_chat_flow.py Tests/integration/ -q`; name the known pre-existing baseline failures and confirm zero new. Fix any integration bug surfaced (document prominently).
+- [ ] **Step 3: Commit** — `test(console): end-to-end agent-marker anchoring across branches`.
+
+---
+
+## Self-Review
+
+**Spec coverage:** column+migration (Task 1); id threaded + persisted-id written post-completion (Task 2 — resolves the native-vs-persisted timing the design decision called out); resume placement id-anchored with off-path-hide + null-ordinal-fallback + idempotency (Task 3); e2e across branches (Task 4). Backward-compat (null-id → ordinal) and sub-agent-runs-carry-no-id are explicit constraints.
+
+**Placeholder scan:** Task 2 leaves ONE bounded choice (how `run_reply` exposes the run id — return-tuple vs bridge field) to the implementer with a stated preference and the test as contract; everything else is concrete. No TBDs.
+
+**Type consistency:** `create_run(..., assistant_message_id: str|None=None)`, `set_run_assistant_message_id(run_id, assistant_message_id)`, `run_turn(...) -> (run_id, RunOutcome)`, `resume_marker_messages -> list[tuple[str|None, list[ConsoleChatMessage]]]`, `inject_resume_agent_markers(messages, anchored_blocks)` — consistent across Tasks 1–4. The stored/compared id is always the **persisted** id (`ConsoleChatMessage.persisted_message_id`).
+
+**Risk:** Task 2's `run_reply` return-shape change ripples to the `run_reply` fakes in `test_console_agent_swap.py` — update them. The off-path-hide changes the old "orphan → append" semantics for id-set runs (intended); the null-ordinal path preserves it for legacy data.

--- a/Tests/Agents/test_agent_service.py
+++ b/Tests/Agents/test_agent_service.py
@@ -329,6 +329,30 @@ def test_spawn_creates_linked_child_with_clean_context(db):
     assert db.count_subagent_runs("c") == 1
 
 
+def test_run_turn_records_assistant_message_id_on_primary_only(db):
+    """The primary run records the assistant_message_id it is handed; a
+    spawned sub-agent run records None (it produces no transcript reply)."""
+    service, _ = make_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "compute 6*7"}),  # parent turn 1
+            "sub answer: 42",  # CHILD turn 1
+            "The sub-agent says 42.",  # parent turn 2
+        ],
+    )
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "delegate this"}],
+        config=CFG,
+        api_endpoint="llama_cpp",
+        assistant_message_id="a1",
+    )
+    assert outcome.status == RUN_DONE and outcome.subagents_spawned == 1
+    assert db.get_run(run_id)["assistant_message_id"] == "a1"
+    child = next(r for r in db.list_runs("c") if r["agent_kind"] == "subagent")
+    assert child["assistant_message_id"] is None
+
+
 def test_subagent_result_is_capped(db):
     long_answer = "x" * 10000
     service, _ = make_service(

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -1770,9 +1770,14 @@ def test_run_reply_returns_runoutcome_error():
     assert result.status == RUN_ERROR
 
 
-def test_run_reply_returns_run_id_and_threads_assistant_message_id():
-    """run_reply exposes the primary run id to its caller and threads the
-    native assistant_message_id into run_turn (so create_run can record it)."""
+def test_run_reply_returns_run_id_and_does_not_store_native_assistant_id():
+    """run_reply exposes the primary run id to its caller but must NOT forward
+    the native in-memory assistant_message_id into run_turn: create_run would
+    store it, and that native id can never match any persisted_message_id, so an
+    unfinished/crashed run would be left holding a stale non-null id. The run
+    row therefore starts NULL (assistant_message_id omitted / None); the
+    controller writes the durable persisted id onto the run on every terminal
+    path later, via record_run_assistant_message."""
     bridge = _make_bridge()
     outcome = RunOutcome(status=RUN_DONE, steps=[], final_text="done")
 
@@ -1792,7 +1797,9 @@ def test_run_reply_returns_run_id_and_threads_assistant_message_id():
 
     assert run_id == "run-xyz"
     assert result is outcome
-    assert run_turn.call_args.kwargs["assistant_message_id"] == "native-a1"
+    # The native id is NOT forwarded -- the kwarg is omitted (or None), so
+    # create_run leaves the run's assistant_message_id NULL at create time.
+    assert run_turn.call_args.kwargs.get("assistant_message_id") is None
 
 
 def test_native_tool_schemas_returns_builtin_tool_schemas():

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -163,7 +163,9 @@ def _run(bridge, store, session, assistant_id, **over):
         should_cancel=lambda: False,
     )
     kwargs.update(over)
-    return bridge.run_reply(**kwargs)
+    # run_reply returns (run_id, outcome); these tests assert on the outcome.
+    _run_id, outcome = bridge.run_reply(**kwargs)
+    return outcome
 
 
 def test_compose_prepends_session_prompt_then_agent_prompt():
@@ -1732,7 +1734,7 @@ def test_run_reply_returns_runoutcome_done():
     outcome = RunOutcome(status=RUN_DONE, steps=[], final_text="done")
 
     with patch.object(AgentService, "run_turn", return_value=("run-1", outcome)):
-        result = bridge.run_reply(
+        run_id, result = bridge.run_reply(
             conversation_id="c1",
             session_id="s1",
             resolution=None,
@@ -1743,6 +1745,7 @@ def test_run_reply_returns_runoutcome_done():
             should_cancel=lambda: False,
         )
 
+    assert run_id == "run-1"
     assert result.status == RUN_DONE
     assert result.final_text == "done"
 
@@ -1752,7 +1755,7 @@ def test_run_reply_returns_runoutcome_error():
     outcome = RunOutcome(status=RUN_ERROR, steps=[], final_text="")
 
     with patch.object(AgentService, "run_turn", return_value=("run-1", outcome)):
-        result = bridge.run_reply(
+        run_id, result = bridge.run_reply(
             conversation_id="c1",
             session_id="s1",
             resolution=None,
@@ -1763,7 +1766,33 @@ def test_run_reply_returns_runoutcome_error():
             should_cancel=lambda: False,
         )
 
+    assert run_id == "run-1"
     assert result.status == RUN_ERROR
+
+
+def test_run_reply_returns_run_id_and_threads_assistant_message_id():
+    """run_reply exposes the primary run id to its caller and threads the
+    native assistant_message_id into run_turn (so create_run can record it)."""
+    bridge = _make_bridge()
+    outcome = RunOutcome(status=RUN_DONE, steps=[], final_text="done")
+
+    with patch.object(
+        AgentService, "run_turn", return_value=("run-xyz", outcome)
+    ) as run_turn:
+        run_id, result = bridge.run_reply(
+            conversation_id="c1",
+            session_id="s1",
+            resolution=None,
+            assistant_message_id="native-a1",
+            model="gpt-4",
+            session_system_prompt="sys",
+            agent_messages=[{"role": "user", "content": "hi"}],
+            should_cancel=lambda: False,
+        )
+
+    assert run_id == "run-xyz"
+    assert result is outcome
+    assert run_turn.call_args.kwargs["assistant_message_id"] == "native-a1"
 
 
 def test_native_tool_schemas_returns_builtin_tool_schemas():

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -630,8 +630,60 @@ def test_resume_marker_messages_reproduces_live_markers_after_simulated_restart(
         agent_runs_db=db, store=None, provider_gateway=None
     )
     blocks = fresh_bridge.resume_marker_messages("conv-1")
-    resumed_tool_contents = [m.content for block in blocks for m in block]
+    resumed_tool_contents = [m.content for _anchor, block in blocks for m in block]
     assert resumed_tool_contents == live_tool_contents
+
+
+def test_resume_marker_messages_surfaces_assistant_message_id_anchor(tmp_path):
+    """Task 3: each block is paired with the run's ``assistant_message_id``
+    (``None`` for a legacy/pre-Phase-C run that never recorded one) so the
+    placement layer can anchor by id instead of guessing ordinally."""
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    anchored = db.create_run(
+        conversation_id="conv-1",
+        agent_kind="primary",
+        assistant_message_id="asst-anchor",
+    )
+    db.append_steps(
+        anchored,
+        [
+            {
+                "index": 0,
+                "kind": STEP_ERROR,
+                "summary": "boom",
+                "tool_name": "",
+                "result": "",
+                "args": None,
+                "created_at": "",
+            },
+        ],
+    )
+    db.set_status(anchored, "done", result="ok")
+    legacy = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    db.append_steps(
+        legacy,
+        [
+            {
+                "index": 0,
+                "kind": STEP_ERROR,
+                "summary": "legacy",
+                "tool_name": "",
+                "result": "",
+                "args": None,
+                "created_at": "",
+            },
+        ],
+    )
+    db.set_status(legacy, "done", result="ok")
+
+    bridge = ConsoleAgentBridge(agent_runs_db=db, store=None, provider_gateway=None)
+    blocks = bridge.resume_marker_messages("conv-1")
+
+    assert len(blocks) == 2
+    assert blocks[0][0] == "asst-anchor"
+    assert "boom" in blocks[0][1][0].content
+    assert blocks[1][0] is None
+    assert "legacy" in blocks[1][1][0].content
 
 
 def test_resume_marker_messages_orders_blocks_chronologically_oldest_first(tmp_path):
@@ -672,8 +724,8 @@ def test_resume_marker_messages_orders_blocks_chronologically_oldest_first(tmp_p
     bridge = ConsoleAgentBridge(agent_runs_db=db, store=None, provider_gateway=None)
     blocks = bridge.resume_marker_messages("conv-1")
     assert len(blocks) == 2
-    assert "calculator" in blocks[0][0].content
-    assert "timed out" in blocks[1][0].content
+    assert "calculator" in blocks[0][1][0].content
+    assert "timed out" in blocks[1][1][0].content
 
 
 def test_resume_marker_messages_skips_superseded_runs(tmp_path):
@@ -714,7 +766,7 @@ def test_resume_marker_messages_skips_superseded_runs(tmp_path):
     bridge = ConsoleAgentBridge(agent_runs_db=db, store=None, provider_gateway=None)
     blocks = bridge.resume_marker_messages("conv-1")
     assert len(blocks) == 1
-    assert "final attempt" in blocks[0][0].content
+    assert "final attempt" in blocks[0][1][0].content
 
 
 def _tool_marker(text: str) -> ConsoleChatMessage:
@@ -724,17 +776,32 @@ def _tool_marker(text: str) -> ConsoleChatMessage:
 
 
 def test_inject_resume_agent_markers_places_block_after_matching_assistant_message():
+    """Task 3: placement follows the block's anchor id (matched against
+    each message's ``persisted_message_id``), not block order/ordinal
+    position. The blocks below are listed in the OPPOSITE order of their
+    anchors -- the block for the SECOND assistant reply ("asst-2") comes
+    first in the list -- so an ordinal placement would put it after "42."
+    (wrong); id-anchoring must still put it after "ok." (right)."""
     messages = [
         ConsoleChatMessage(role=ConsoleMessageRole.USER, content="hi"),
         ConsoleChatMessage(
-            role=ConsoleMessageRole.ASSISTANT, content="42.", status="complete"
+            role=ConsoleMessageRole.ASSISTANT,
+            content="42.",
+            status="complete",
+            persisted_message_id="asst-1",
         ),
         ConsoleChatMessage(role=ConsoleMessageRole.USER, content="again"),
         ConsoleChatMessage(
-            role=ConsoleMessageRole.ASSISTANT, content="ok.", status="complete"
+            role=ConsoleMessageRole.ASSISTANT,
+            content="ok.",
+            status="complete",
+            persisted_message_id="asst-2",
         ),
     ]
-    blocks = [[_tool_marker("⚙ calculator → 42")], [_tool_marker("⚠ retry")]]
+    blocks = [
+        ("asst-2", [_tool_marker("⚠ retry")]),
+        ("asst-1", [_tool_marker("⚙ calculator → 42")]),
+    ]
 
     result = inject_resume_agent_markers(messages, blocks)
 
@@ -749,14 +816,110 @@ def test_inject_resume_agent_markers_places_block_after_matching_assistant_messa
     ]
 
 
+def test_inject_resume_agent_markers_drops_block_whose_anchor_matches_no_active_path_message():
+    """A block anchored to an assistant_message_id that isn't in the
+    active-path ``messages`` (the run's reply lives on another branch) must
+    be hidden entirely -- never appended anywhere -- rather than leak an
+    off-branch tool trace onto the visible transcript."""
+    messages = [
+        ConsoleChatMessage(role=ConsoleMessageRole.USER, content="hi"),
+        ConsoleChatMessage(
+            role=ConsoleMessageRole.ASSISTANT,
+            content="42.",
+            status="complete",
+            persisted_message_id="asst-1",
+        ),
+    ]
+    blocks = [("asst-OFF-PATH", [_tool_marker("⚙ calculator → 999")])]
+
+    result = inject_resume_agent_markers(messages, blocks)
+
+    assert [m.content for m in result] == ["hi", "42."]
+    assert not any(m.role is ConsoleMessageRole.TOOL for m in result)
+
+
+def test_inject_resume_agent_markers_null_anchor_blocks_place_ordinally_when_no_id_claims():
+    """Legacy (pre-Phase-C) runs never recorded an assistant_message_id --
+    their blocks carry a ``None`` anchor and keep the old ordinal
+    placement: Nth null block <-> Nth assistant reply."""
+    messages = [
+        ConsoleChatMessage(role=ConsoleMessageRole.USER, content="hi"),
+        ConsoleChatMessage(
+            role=ConsoleMessageRole.ASSISTANT, content="42.", status="complete"
+        ),
+        ConsoleChatMessage(role=ConsoleMessageRole.USER, content="again"),
+        ConsoleChatMessage(
+            role=ConsoleMessageRole.ASSISTANT, content="ok.", status="complete"
+        ),
+    ]
+    blocks = [
+        (None, [_tool_marker("⚙ calculator → 42")]),
+        (None, [_tool_marker("⚠ retry")]),
+    ]
+
+    result = inject_resume_agent_markers(messages, blocks)
+
+    roles = [(m.role, m.content) for m in result]
+    assert roles == [
+        (ConsoleMessageRole.USER, "hi"),
+        (ConsoleMessageRole.ASSISTANT, "42."),
+        (ConsoleMessageRole.TOOL, "⚙ calculator → 42"),
+        (ConsoleMessageRole.USER, "again"),
+        (ConsoleMessageRole.ASSISTANT, "ok."),
+        (ConsoleMessageRole.TOOL, "⚠ retry"),
+    ]
+
+
+def test_inject_resume_agent_markers_mixed_id_and_null_anchors_null_skips_claimed_assistant():
+    """Mixed case: one block is id-anchored to the FIRST assistant reply: the
+    remaining null (legacy) block's ordinal fallback must skip that already
+    id-claimed reply and land on the next unclaimed one, not double up on
+    "42."."""
+    messages = [
+        ConsoleChatMessage(role=ConsoleMessageRole.USER, content="hi"),
+        ConsoleChatMessage(
+            role=ConsoleMessageRole.ASSISTANT,
+            content="42.",
+            status="complete",
+            persisted_message_id="asst-1",
+        ),
+        ConsoleChatMessage(role=ConsoleMessageRole.USER, content="again"),
+        ConsoleChatMessage(
+            role=ConsoleMessageRole.ASSISTANT, content="ok.", status="complete"
+        ),
+    ]
+    blocks = [
+        ("asst-1", [_tool_marker("⚙ calculator → 42")]),
+        (None, [_tool_marker("⚠ legacy retry")]),
+    ]
+
+    result = inject_resume_agent_markers(messages, blocks)
+
+    roles = [(m.role, m.content) for m in result]
+    assert roles == [
+        (ConsoleMessageRole.USER, "hi"),
+        (ConsoleMessageRole.ASSISTANT, "42."),
+        (ConsoleMessageRole.TOOL, "⚙ calculator → 42"),
+        (ConsoleMessageRole.USER, "again"),
+        (ConsoleMessageRole.ASSISTANT, "ok."),
+        (ConsoleMessageRole.TOOL, "⚠ legacy retry"),
+    ]
+
+
 def test_inject_resume_agent_markers_appends_leftover_block_when_more_runs_than_replies():
+    """Preserves the old leftover-append behavior, now for NULL-anchored
+    blocks: a legacy run with no corresponding assistant reply left in the
+    active path is appended at the end rather than dropped."""
     messages = [
         ConsoleChatMessage(role=ConsoleMessageRole.USER, content="hi"),
         ConsoleChatMessage(
             role=ConsoleMessageRole.ASSISTANT, content="42.", status="complete"
         ),
     ]
-    blocks = [[_tool_marker("⚙ calculator → 42")], [_tool_marker("⚠ orphan run")]]
+    blocks = [
+        (None, [_tool_marker("⚙ calculator → 42")]),
+        (None, [_tool_marker("⚠ orphan run")]),
+    ]
 
     result = inject_resume_agent_markers(messages, blocks)
 
@@ -774,7 +937,7 @@ def test_inject_resume_agent_markers_skips_empty_blocks():
             role=ConsoleMessageRole.ASSISTANT, content="ok.", status="complete"
         ),
     ]
-    result = inject_resume_agent_markers(messages, [[], []])
+    result = inject_resume_agent_markers(messages, [(None, []), ("some-id", [])])
     assert [m.content for m in result] == ["ok."]
 
 
@@ -782,10 +945,13 @@ def test_inject_resume_agent_markers_is_idempotent_no_duplicates_on_second_call(
     messages = [
         ConsoleChatMessage(role=ConsoleMessageRole.USER, content="hi"),
         ConsoleChatMessage(
-            role=ConsoleMessageRole.ASSISTANT, content="42.", status="complete"
+            role=ConsoleMessageRole.ASSISTANT,
+            content="42.",
+            status="complete",
+            persisted_message_id="asst-1",
         ),
     ]
-    blocks = [[_tool_marker("⚙ calculator → 42")]]
+    blocks = [("asst-1", [_tool_marker("⚙ calculator → 42")])]
 
     once = inject_resume_agent_markers(messages, blocks)
     twice = inject_resume_agent_markers(once, blocks)
@@ -802,11 +968,14 @@ def test_inject_resume_agent_markers_leaves_live_session_with_markers_untouched(
     messages = [
         ConsoleChatMessage(role=ConsoleMessageRole.USER, content="hi"),
         ConsoleChatMessage(
-            role=ConsoleMessageRole.ASSISTANT, content="42.", status="complete"
+            role=ConsoleMessageRole.ASSISTANT,
+            content="42.",
+            status="complete",
+            persisted_message_id="asst-1",
         ),
         _tool_marker("⚙ calculator → 42"),
     ]
-    blocks = [[_tool_marker("⚙ calculator → 42")]]
+    blocks = [("asst-1", [_tool_marker("⚙ calculator → 42")])]
 
     result = inject_resume_agent_markers(messages, blocks)
 

--- a/Tests/Chat/test_console_agent_swap.py
+++ b/Tests/Chat/test_console_agent_swap.py
@@ -90,6 +90,50 @@ async def test_agent_send_no_tools_streams_like_today(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_agent_run_records_persisted_assistant_message_id(tmp_path):
+    """The load-bearing write: after a full agent reply completes on a
+    persisted store, the primary run's ``assistant_message_id`` is the
+    reply's PERSISTED id (durable ChaChaNotes id), NOT the native in-memory
+    id -- so a later resume can anchor markers by ``persisted_message_id``.
+    The native id create_run recorded is corrected to the persisted id here.
+    """
+    from Tests.Chat.test_console_chat_store import FakePersistence
+
+    persistence = FakePersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    gateway = _Gateway([["Tok", "yo."]])
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    bridge = ConsoleAgentBridge(
+        agent_runs_db=db, store=store, provider_gateway=gateway
+    )
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        provider="llama_cpp",
+        model="test-model",
+        agent_bridge=bridge,
+        agent_runtime_enabled=True,
+    )
+
+    result = await controller.submit_draft("capital of Japan?")
+    assert result.accepted is True
+
+    session_id = store.active_session_id
+    assistant = next(
+        m
+        for m in store.messages_for_session(session_id)
+        if m.role is ConsoleMessageRole.ASSISTANT
+    )
+    assert assistant.status == "complete"
+    assert assistant.persisted_message_id is not None
+
+    primary = next(r for r in _all_runs(db) if r["agent_kind"] == "primary")
+    assert primary["assistant_message_id"] == assistant.persisted_message_id
+    # The native id create_run stored was corrected to the persisted id.
+    assert primary["assistant_message_id"] != assistant.id
+
+
+@pytest.mark.asyncio
 async def test_agent_tool_turn_renders_marker_not_prose(tmp_path):
     controller, store, _db = _controller(
         tmp_path, [[_fence("calculator", {"expression": "6*7"})], ["It is ", "42."]]
@@ -250,7 +294,9 @@ async def test_finalize_after_already_stopped_is_a_benign_noop(tmp_path):
         # bridge "returns" RUN_DONE, a concurrent Stop has already
         # finalized the message to "stopped".
         store.mark_message_stopped(assistant_message_id)
-        return RunOutcome(status=RUN_DONE, steps=[], final_text="late done text")
+        return "run-test", RunOutcome(
+            status=RUN_DONE, steps=[], final_text="late done text"
+        )
 
     controller._agent_bridge.run_reply = parked_run_reply
     result = await controller.submit_draft("hi")
@@ -308,7 +354,9 @@ async def test_finalize_after_already_stopped_regenerate_no_phantom_variant(tmp_
         # _finalize_agent_reply runs.
         controller._active_cancel_event.set()
         store.mark_message_stopped(assistant_message_id)
-        return RunOutcome(status=RUN_DONE, steps=[], final_text="late regenerate text")
+        return "run-test", RunOutcome(
+            status=RUN_DONE, steps=[], final_text="late regenerate text"
+        )
 
     controller._agent_bridge.run_reply = parked_regenerate_reply
     regen = await controller.regenerate_message(assistant.id)
@@ -352,7 +400,7 @@ async def test_finalize_after_already_stopped_regenerate_error_no_wedge(tmp_path
     def parked_regenerate_error_reply(*, assistant_message_id, **_kwargs):
         controller._active_cancel_event.set()
         store.mark_message_stopped(assistant_message_id)
-        return RunOutcome(
+        return "run-test", RunOutcome(
             status=RUN_ERROR,
             steps=[
                 AgentStep(index=0, kind=STEP_ERROR, summary="late regenerate error")
@@ -371,7 +419,9 @@ async def test_finalize_after_already_stopped_regenerate_error_no_wedge(tmp_path
     # The run must not be wedged: a fresh send is accepted immediately.
     def next_send_reply(*, assistant_message_id, **_kwargs):
         store.append_stream_chunk(assistant_message_id, "next turn works.")
-        return RunOutcome(status=RUN_DONE, steps=[], final_text="next turn works.")
+        return "run-test", RunOutcome(
+            status=RUN_DONE, steps=[], final_text="next turn works."
+        )
 
     controller._agent_bridge.run_reply = next_send_reply
     second = await controller.submit_draft("still there?")
@@ -502,7 +552,7 @@ async def test_run_error_via_submit_is_failed_retryable_and_excluded_from_contex
         store.append_stream_chunk(
             assistant_message_id, "partial answer before erroring"
         )
-        return RunOutcome(
+        return "run-test", RunOutcome(
             status=RUN_ERROR,
             steps=[AgentStep(index=0, kind=STEP_ERROR, summary="tool exploded")],
         )
@@ -529,7 +579,7 @@ async def test_run_error_via_submit_is_failed_retryable_and_excluded_from_contex
     # Retryable: status "failed" is exactly what retry_message() requires.
     def fixed_run_reply(*, assistant_message_id, **_kwargs):
         store.append_stream_chunk(assistant_message_id, "fixed.")
-        return RunOutcome(status=RUN_DONE, steps=[], final_text="fixed.")
+        return "run-test", RunOutcome(status=RUN_DONE, steps=[], final_text="fixed.")
 
     controller._agent_bridge.run_reply = fixed_run_reply
     retry_result = await controller.retry_message(assistant.id)
@@ -545,7 +595,7 @@ async def test_run_stuck_outcome_is_visibly_failed_not_silent_complete(tmp_path)
 
     def stuck_run_reply(*, assistant_message_id, **_kwargs):
         store.append_stream_chunk(assistant_message_id, "still thinking about it")
-        return RunOutcome(
+        return "run-test", RunOutcome(
             status=RUN_STUCK,
             steps=[
                 AgentStep(index=0, kind=STEP_ERROR, summary="step budget exhausted")
@@ -574,7 +624,9 @@ async def test_run_error_via_regenerate_preserves_original_answer_and_status(tmp
 
     def good_run_reply(*, assistant_message_id, **_kwargs):
         store.append_stream_chunk(assistant_message_id, "good original answer.")
-        return RunOutcome(status=RUN_DONE, steps=[], final_text="good original answer.")
+        return "run-test", RunOutcome(
+            status=RUN_DONE, steps=[], final_text="good original answer."
+        )
 
     controller._agent_bridge.run_reply = good_run_reply
     first = await controller.submit_draft("hi")
@@ -590,7 +642,7 @@ async def test_run_error_via_regenerate_preserves_original_answer_and_status(tmp
 
     def erroring_run_reply(*, assistant_message_id, **_kwargs):
         store.append_stream_chunk(assistant_message_id, "a bad partial regenerate")
-        return RunOutcome(
+        return "run-test", RunOutcome(
             status=RUN_ERROR,
             steps=[AgentStep(index=0, kind=STEP_ERROR, summary="regenerate exploded")],
         )
@@ -764,7 +816,9 @@ async def test_agent_runtime_gate_refreshes_without_screen_teardown():
 
         def run_reply(self, **_kwargs):
             self.calls += 1
-            return RunOutcome(status=RUN_DONE, steps=[], final_text="agent answer.")
+            return "run-test", RunOutcome(
+                status=RUN_DONE, steps=[], final_text="agent answer."
+            )
 
     fake_bridge = _FakeBridge()
     screen = ChatScreen(app)
@@ -809,7 +863,9 @@ def _fake_app(service=None):
 def _capturing_run_reply(captured, *, final_text="ok."):
     def run_reply(**kwargs):
         captured.append(kwargs)
-        return RunOutcome(status=RUN_DONE, steps=[], final_text=final_text)
+        return "run-test", RunOutcome(
+            status=RUN_DONE, steps=[], final_text=final_text
+        )
 
     return run_reply
 

--- a/Tests/Chat/test_console_agent_swap.py
+++ b/Tests/Chat/test_console_agent_swap.py
@@ -134,6 +134,155 @@ async def test_agent_run_records_persisted_assistant_message_id(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_stopped_run_records_persisted_id_not_stale_native(tmp_path):
+    """Critical regression (Phase C Task 2 review): a run STOPPED mid-flight
+    must end with the run's ``assistant_message_id`` == the stopped message's
+    PERSISTED id -- never the stale native create-time id (which can never
+    match any ``persisted_message_id`` on resume, so Task 3 would drop its
+    markers as off-path).
+
+    Reproduces the reviewer's scenario on a persistence-backed store + real
+    ``AgentRunsDB``: a real run is created (``create_run`` -- native id was
+    stored PRE-fix, NULL post-Half-1), then a Stop lands in the window after
+    the bridge returns but before ``_finalize_agent_reply``, leaving the
+    message ``stopped`` and persisted. Finalize's ``stopped_now`` branch must
+    then record the persisted id onto the run.
+
+    RED on HEAD 85e2f3d9: the run keeps the stale native id (stopped path
+    never recorded anything). GREEN with both halves: NULL at create, persisted
+    id recorded on the stopped path.
+    """
+    from Tests.Chat.test_console_chat_store import FakePersistence
+
+    persistence = FakePersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    gateway = _Gateway([["Tok", "yo."]])
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    bridge = ConsoleAgentBridge(agent_runs_db=db, store=store, provider_gateway=gateway)
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        provider="llama_cpp",
+        model="test-model",
+        agent_bridge=bridge,
+        agent_runtime_enabled=True,
+    )
+
+    original = controller._agent_bridge.run_reply
+
+    def stop_after_real_run(**kwargs):
+        # Run the REAL bridge (creates the run row via create_run, streams the
+        # reply into the placeholder), then simulate a Stop landing in the
+        # post-outcome / pre-finalize window: mark the message stopped (which
+        # persists it) exactly as stop_active_run would.
+        run_id, outcome = original(**kwargs)
+        store.mark_message_stopped(kwargs["assistant_message_id"])
+        return run_id, outcome
+
+    controller._agent_bridge.run_reply = stop_after_real_run
+    result = await controller.submit_draft("capital of Japan?")
+    assert result.accepted is True
+
+    session_id = store.active_session_id
+    assistant = next(
+        m
+        for m in store.messages_for_session(session_id)
+        if m.role is ConsoleMessageRole.ASSISTANT
+    )
+    assert assistant.status == "stopped"
+    assert assistant.persisted_message_id is not None
+
+    primary = next(r for r in _all_runs(db) if r["agent_kind"] == "primary")
+    assert primary["assistant_message_id"] == assistant.persisted_message_id
+    assert primary["assistant_message_id"] != assistant.id
+
+
+@pytest.mark.asyncio
+async def test_failed_run_records_persisted_id_on_run(tmp_path):
+    """A run that finalizes via the FAILURE path (RUN_ERROR) must record the
+    failed reply's PERSISTED id onto the run -- same shape as the stopped-run
+    regression, exercising ``_finalize_agent_failure`` instead of the
+    ``stopped_now`` branch. RED on HEAD (only the success path recorded).
+    """
+    from Tests.Chat.test_console_chat_store import FakePersistence
+
+    persistence = FakePersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    gateway = _Gateway([["Tok", "yo."]])
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    bridge = ConsoleAgentBridge(agent_runs_db=db, store=store, provider_gateway=gateway)
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        provider="llama_cpp",
+        model="test-model",
+        agent_bridge=bridge,
+        agent_runtime_enabled=True,
+    )
+
+    original = controller._agent_bridge.run_reply
+
+    def error_after_real_run(**kwargs):
+        # Real run (create_run + stream), but report a non-done outcome so
+        # finalize routes through _finalize_agent_failure.
+        run_id, _outcome = original(**kwargs)
+        return run_id, RunOutcome(
+            status=RUN_ERROR,
+            steps=[AgentStep(index=0, kind=STEP_ERROR, summary="boom")],
+        )
+
+    controller._agent_bridge.run_reply = error_after_real_run
+    result = await controller.submit_draft("capital of Japan?")
+    assert result.accepted is True
+
+    session_id = store.active_session_id
+    assistant = next(
+        m
+        for m in store.messages_for_session(session_id)
+        if m.role is ConsoleMessageRole.ASSISTANT
+    )
+    assert assistant.status == "failed"
+    assert assistant.persisted_message_id is not None
+
+    primary = next(r for r in _all_runs(db) if r["agent_kind"] == "primary")
+    assert primary["assistant_message_id"] == assistant.persisted_message_id
+
+
+@pytest.mark.asyncio
+async def test_stopped_run_without_persistence_stays_null_not_stale(tmp_path):
+    """With NO persistence backend, a stopped run's message never gets a
+    persisted id -- so the run's ``assistant_message_id`` must stay NULL (the
+    helper no-ops), NOT hold the stale native id. This validates Half 1 (never
+    store the native id at create): the row is NULL both at create and after
+    the null-persisted-id stop.
+    """
+    controller, store, db = _controller(tmp_path, [["Tok", "yo."]])
+
+    original = controller._agent_bridge.run_reply
+
+    def stop_after_real_run(**kwargs):
+        run_id, outcome = original(**kwargs)
+        store.mark_message_stopped(kwargs["assistant_message_id"])
+        return run_id, outcome
+
+    controller._agent_bridge.run_reply = stop_after_real_run
+    result = await controller.submit_draft("capital of Japan?")
+    assert result.accepted is True
+
+    session_id = store.active_session_id
+    assistant = next(
+        m
+        for m in store.messages_for_session(session_id)
+        if m.role is ConsoleMessageRole.ASSISTANT
+    )
+    assert assistant.status == "stopped"
+    assert assistant.persisted_message_id is None
+
+    primary = next(r for r in _all_runs(db) if r["agent_kind"] == "primary")
+    assert primary["assistant_message_id"] is None
+
+
+@pytest.mark.asyncio
 async def test_agent_tool_turn_renders_marker_not_prose(tmp_path):
     controller, store, _db = _controller(
         tmp_path, [[_fence("calculator", {"expression": "6*7"})], ["It is ", "42."]]

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -2810,7 +2810,9 @@ async def test_prefilled_send_bypasses_agent_loop():
 
     def run_reply(**kwargs):
         bridge_calls.append(kwargs)
-        return RunOutcome(status=RUN_DONE, steps=[], final_text="agent says")
+        return "run-test", RunOutcome(
+            status=RUN_DONE, steps=[], final_text="agent says"
+        )
 
     controller._agent_bridge = SimpleNamespace(run_reply=run_reply)
     session = _arm_session(store)
@@ -2874,7 +2876,9 @@ async def test_normal_session_still_uses_agent_when_enabled():
 
     def run_reply(**kwargs):
         bridge_calls.append(kwargs)
-        return RunOutcome(status=RUN_DONE, steps=[], final_text="agent says")
+        return "run-test", RunOutcome(
+            status=RUN_DONE, steps=[], final_text="agent says"
+        )
 
     controller._agent_bridge = SimpleNamespace(run_reply=run_reply)
     session = _arm_session(store)

--- a/Tests/DB/test_agent_runs_db.py
+++ b/Tests/DB/test_agent_runs_db.py
@@ -1,5 +1,7 @@
 """AgentRunsDB against a real on-disk SQLite file."""
 
+import sqlite3
+
 import pytest
 
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
@@ -189,3 +191,112 @@ def test_list_runs_default_limit_preserves_behavior(db):
         db.create_run(conversation_id="c", agent_kind="primary")
     assert len(db.list_runs("c")) == 3
     assert len(db.list_runs("c", limit=None)) == 3
+
+
+# --- Phase C Task 1: assistant_message_id column (v1->v2) + setter, so a
+# run can record the persisted id of the assistant reply it produced. ---
+
+
+def test_create_run_with_assistant_message_id_round_trips(db):
+    run_id = db.create_run(
+        conversation_id="c", agent_kind="primary", assistant_message_id="m-9"
+    )
+    assert db.get_run(run_id)["assistant_message_id"] == "m-9"
+
+
+def test_create_run_without_assistant_message_id_defaults_to_none(db):
+    run_id = db.create_run(conversation_id="c", agent_kind="primary")
+    assert db.get_run(run_id)["assistant_message_id"] is None
+
+
+def test_set_run_assistant_message_id_updates_get_and_list(db):
+    run_id = db.create_run(conversation_id="c", agent_kind="primary")
+    db.set_run_assistant_message_id(run_id, "p-42")
+    assert db.get_run(run_id)["assistant_message_id"] == "p-42"
+    listed = db.list_runs("c")
+    assert listed[0]["assistant_message_id"] == "p-42"
+
+
+def test_set_run_assistant_message_id_can_clear_with_none(db):
+    run_id = db.create_run(
+        conversation_id="c", agent_kind="primary", assistant_message_id="m-1"
+    )
+    db.set_run_assistant_message_id(run_id, None)
+    assert db.get_run(run_id)["assistant_message_id"] is None
+
+
+# There's no migration framework here -- _initialize_schema only runs
+# CREATE TABLE IF NOT EXISTS, so a DB file created before this column
+# existed keeps its old 11-column table until a guarded ALTER TABLE runs.
+# These tests replicate that pre-v2 shape by hand and prove the guarded
+# ALTER migrates it (and is idempotent across re-open).
+
+_LEGACY_V1_AGENT_RUNS_DDL = """
+    PRAGMA foreign_keys = ON;
+
+    CREATE TABLE IF NOT EXISTS schema_version (
+        version INTEGER PRIMARY KEY NOT NULL
+    );
+    INSERT OR IGNORE INTO schema_version (version) VALUES (1);
+
+    CREATE TABLE IF NOT EXISTS agent_runs (
+        id TEXT PRIMARY KEY,
+        conversation_id TEXT NOT NULL,
+        parent_run_id TEXT,
+        agent_kind TEXT NOT NULL,
+        task TEXT,
+        status TEXT NOT NULL,
+        steps TEXT NOT NULL DEFAULT '[]',
+        result TEXT,
+        budget TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_agent_runs_conversation
+        ON agent_runs(conversation_id);
+    CREATE INDEX IF NOT EXISTS idx_agent_runs_parent
+        ON agent_runs(parent_run_id);
+"""
+
+
+def test_opening_legacy_v1_db_migrates_column_and_create_run_works(tmp_path):
+    legacy_path = tmp_path / "legacy_agent_runs.db"
+    conn = sqlite3.connect(str(legacy_path))
+    try:
+        conn.executescript(_LEGACY_V1_AGENT_RUNS_DDL)
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Sanity: the raw file really is the old 11-column shape before it's
+    # opened through AgentRunsDB.
+    raw = sqlite3.connect(str(legacy_path))
+    try:
+        cols = {row[1] for row in raw.execute("PRAGMA table_info(agent_runs)")}
+    finally:
+        raw.close()
+    assert "assistant_message_id" not in cols
+
+    migrated = AgentRunsDB(legacy_path, client_id="test")
+    run_id = migrated.create_run(
+        conversation_id="c", agent_kind="primary", assistant_message_id="y"
+    )
+    assert migrated.get_run(run_id)["assistant_message_id"] == "y"
+
+
+def test_reopening_same_file_twice_is_idempotent(tmp_path):
+    path = tmp_path / "agent_runs.db"
+    first = AgentRunsDB(path, client_id="test")
+    first.create_run(
+        conversation_id="c", agent_kind="primary", assistant_message_id="a"
+    )
+
+    # Re-opening must not raise (guarded ALTER is a no-op once the column
+    # already exists) and the second instance must still work correctly.
+    second = AgentRunsDB(path, client_id="test")
+    run_id = second.create_run(
+        conversation_id="c", agent_kind="primary", assistant_message_id="b"
+    )
+    assert second.get_run(run_id)["assistant_message_id"] == "b"
+    assert len(second.list_runs("c")) == 2

--- a/Tests/UI/test_console_dictionary_send_integration.py
+++ b/Tests/UI/test_console_dictionary_send_integration.py
@@ -165,7 +165,7 @@ async def test_native_send_applies_conversation_dictionary_agent_branch(dictiona
 
             store = screen._ensure_console_chat_store()
             store.append_stream_chunk(assistant_message_id, "ok")
-            return RunOutcome(status=RUN_DONE, steps=[])
+            return "run-test", RunOutcome(status=RUN_DONE, steps=[])
 
         class _Bridge:
             run_reply = staticmethod(_fake_run_reply)

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -7363,7 +7363,13 @@ def test_resume_wiring_injects_agent_markers_from_agent_runs_db(tmp_path):
     (`_inject_resume_agent_markers`) must re-derive TOOL markers from the
     real sibling `AgentRunsDB` the same way `_ensure_console_agent_bridge`
     locates it (keyed off `chachanotes_db.db_path`), not just the pure
-    helper functions in isolation."""
+    helper functions in isolation.
+
+    Task 3: the run carries an `assistant_message_id` matching the
+    assistant message's `persisted_message_id`, so this exercises the real
+    id-anchored placement path -- not the ordinal fallback that would
+    coincidentally land the block in the same place for a single-run,
+    single-reply conversation."""
     from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 
     screen = ChatScreen(_build_test_app())
@@ -7371,7 +7377,11 @@ def test_resume_wiring_injects_agent_markers_from_agent_runs_db(tmp_path):
         db_path=str(tmp_path / "chacha.db")
     )
     runs_db = AgentRunsDB(tmp_path / "agent_runs.db", client_id="t")
-    primary_id = runs_db.create_run(conversation_id="conv-x", agent_kind="primary")
+    primary_id = runs_db.create_run(
+        conversation_id="conv-x",
+        agent_kind="primary",
+        assistant_message_id="asst-42",
+    )
     runs_db.append_steps(
         primary_id,
         [
@@ -7391,7 +7401,10 @@ def test_resume_wiring_injects_agent_markers_from_agent_runs_db(tmp_path):
     messages = [
         ConsoleChatMessage(role=ConsoleMessageRole.USER, content="what is 6*7"),
         ConsoleChatMessage(
-            role=ConsoleMessageRole.ASSISTANT, content="It is 42.", status="complete"
+            role=ConsoleMessageRole.ASSISTANT,
+            content="It is 42.",
+            status="complete",
+            persisted_message_id="asst-42",
         ),
     ]
 

--- a/Tests/integration/test_console_agent_marker_anchoring_e2e.py
+++ b/Tests/integration/test_console_agent_marker_anchoring_e2e.py
@@ -1,0 +1,416 @@
+"""End-to-end: agent TOOL markers anchor to the reply that produced them,
+across branches and a real persist -> drop -> resume round trip (Console
+branching Phase C, Task 4).
+
+Exercises the REAL stack throughout: an in-memory ``CharactersRAGDB`` behind
+the real ``ChatPersistenceService``/``ChatConversationService``, a real
+``AgentRunsDB`` file, a real ``ConsoleChatStore`` + ``ConsoleAgentBridge`` +
+``ConsoleChatController`` (fake provider gateway only), and the real
+``ChatScreen`` resume plumbing (``_console_messages_from_conversation_tree``
++ ``restore_persisted_session`` + ``_inject_resume_agent_markers`` +
+``store.apply_resume_marker_overlay`` -- the exact two-step wiring
+``_resume_console_workspace_conversation`` drives). No hand-rolled fakes for
+any of the pieces under test; only the streaming provider is scripted.
+
+Construction note (see the module docstring on
+``test_retry_supersedes_prior_run_dropping_its_resume_markers`` below for the
+full investigation): the task brief speculated that ``regenerate_message``
+sets ``supersede_previous=True`` and that the two-sibling-branch scenario
+would therefore need edit-and-resend instead. Reading
+``console_chat_controller.py`` end to end shows the opposite: post-Task-6,
+``regenerate_message`` forks a sibling and streams into it with
+``variant_mode=False`` and no ``prepare_retry``, so
+``_run_agent_reply``'s ``supersede_previous=bool(prepare_retry or
+variant_mode)`` is always ``False`` there -- ``variant_mode=True`` is never
+passed anywhere in the file any more (it is pre-Task-6, dead-in-practice
+plumbing only referenced in a docstring). The ONLY caller that ever sets
+``supersede_previous=True`` is ``retry_message`` (``prepare_retry=True``).
+Regenerate therefore genuinely produces two independently-anchored, live
+(non-superseded) primary runs -- exactly the brief's original Step 1 shape
+-- so the main scenario below uses ``regenerate_message`` directly, and the
+brief's speculation is corrected (with a dedicated pinning test) rather than
+routed around.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.Agents.agent_models import (
+    RUN_ERROR,
+    STEP_ERROR,
+    STEP_TOOL_RESULT,
+    AgentStep,
+    RunOutcome,
+)
+from tldw_chatbook.Agents.agent_runtime import FENCE_OPEN
+from tldw_chatbook.Chat.chat_conversation_service import ChatConversationService
+from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
+from tldw_chatbook.Chat.console_agent_bridge import ConsoleAgentBridge
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+from Tests.UI.test_destination_shells import _build_test_app
+
+
+def _fence(name, args):
+    return f"{FENCE_OPEN}\n{json.dumps({'name': name, 'arguments': args})}\n```"
+
+
+class _Gateway:
+    """Scripted streaming gateway: each ``stream_chat`` call consumes the
+    next script entry in order (mirrors ``_Gateway`` in
+    ``Tests/Chat/test_console_agent_swap.py``)."""
+
+    def __init__(self, scripts):
+        self._scripts = list(scripts)
+        self.calls = 0
+
+    async def resolve_for_send(self, _selection):
+        return SimpleNamespace(ready=True, provider="llama_cpp", visible_copy="")
+
+    async def stream_chat(self, _resolution, _messages):
+        chunks = self._scripts[self.calls]
+        self.calls += 1
+        for chunk in chunks:
+            yield chunk
+
+
+def _all_runs(agent_db: AgentRunsDB) -> list[dict]:
+    """Read every persisted run record directly (steps stays a JSON string)."""
+    with agent_db.connection() as conn:
+        return [dict(r) for r in conn.execute("SELECT * FROM agent_runs").fetchall()]
+
+
+def _user_and_assistant(messages):
+    """Return ``(user_message, assistant_message)``, ignoring any live TOOL
+    marker rows interleaved by the agent bridge (``_append_marker`` appends
+    those straight into the live view; they are not tree nodes and are not
+    part of the simple two-message shape a fresh turn's transcript has)."""
+    user = next(m for m in messages if m.role is ConsoleMessageRole.USER)
+    assistant = next(m for m in messages if m.role is ConsoleMessageRole.ASSISTANT)
+    return user, assistant
+
+
+def _new_agent_controller(db: CharactersRAGDB, agent_db: AgentRunsDB, scripts):
+    """Real persisted store + real controller + real agent bridge (TOOL steps)."""
+    store = ConsoleChatStore(persistence=ChatPersistenceService(db))
+    gateway = _Gateway(scripts)
+    bridge = ConsoleAgentBridge(
+        agent_runs_db=agent_db, store=store, provider_gateway=gateway
+    )
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        provider="llama_cpp",
+        model="test-model",
+        agent_bridge=bridge,
+        agent_runtime_enabled=True,
+    )
+    session = store.create_session(title="Marker Anchoring E2E")
+    store.active_session_id = session.id
+    return store, controller, session
+
+
+def _resume_with_markers(
+    db: CharactersRAGDB,
+    agent_db: AgentRunsDB,
+    conversation_id: str,
+    *,
+    active_leaf_persisted_id: str | None,
+):
+    """Genuine persist -> drop -> resume round trip, WITH the TOOL-marker overlay.
+
+    Mirrors ``_resume_console_workspace_conversation``'s two-step wiring:
+    ``_console_messages_from_conversation_tree`` + ``restore_persisted_session``
+    reconstruct the active-path view for ``active_leaf_persisted_id``, then
+    ``_inject_resume_agent_markers`` (driven directly on a bare ``ChatScreen``,
+    per the task brief) + ``store.apply_resume_marker_overlay`` re-derive and
+    interleave that branch's agent TOOL markers.
+
+    A FRESH ``ConsoleAgentBridge`` is built for the marker re-derivation
+    (``provider_gateway=None`` -- ``resume_marker_messages`` never touches
+    it), simulating an app restart exactly as
+    ``test_resume_marker_messages_reproduces_live_markers_after_simulated_restart``
+    does at the bridge level, and is installed on the screen's private
+    ``_console_agent_bridge`` slot so ``_ensure_console_agent_bridge``'s own
+    ``:memory:``-DB short-circuit (irrelevant here -- this harness never
+    routes through it) never comes into play.
+    """
+    db.set_conversation_active_leaf(conversation_id, active_leaf_persisted_id)
+    service = ChatConversationService(db)
+    tree = service.get_conversation_tree(
+        conversation_id, depth_cap=10_000, root_limit=10_000
+    )
+    screen = ChatScreen(_build_test_app())
+    screen.app_instance.chachanotes_db = db
+    all_nodes = screen._console_messages_from_conversation_tree(tree)
+    resumed_store = ConsoleChatStore(persistence=ChatPersistenceService(db))
+    resumed_session = resumed_store.restore_persisted_session(
+        title="Marker Anchoring E2E",
+        workspace_id=None,
+        persisted_conversation_id=conversation_id,
+        all_nodes=all_nodes,
+        active_leaf_persisted_id=active_leaf_persisted_id,
+    )
+    fresh_bridge = ConsoleAgentBridge(
+        agent_runs_db=agent_db, store=resumed_store, provider_gateway=None
+    )
+    screen._console_agent_bridge = fresh_bridge
+    markers = screen._inject_resume_agent_markers(
+        resumed_store.messages_for_session(resumed_session.id), conversation_id
+    )
+    resumed_store.apply_resume_marker_overlay(resumed_session.id, markers)
+    return resumed_store, resumed_session
+
+
+@pytest.mark.asyncio
+async def test_agent_marker_anchoring_across_two_sibling_branches_on_resume(tmp_path):
+    """Two sibling agent replies to the SAME user turn, each its own real
+    agent run with its own TOOL step: regenerate forks A1' as a sibling of
+    A1 under the same parent U1 (see the module docstring for why regenerate
+    -- not edit-and-resend -- is the right construction). Persisting, then
+    resuming onto EACH branch in turn, must show only that branch's own
+    run's marker, placed immediately after its own reply -- never the
+    sibling's.
+    """
+    db = CharactersRAGDB(":memory:", "test_client")
+    agent_db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    try:
+        scripts = [
+            [_fence("calculator", {"expression": "6*7"})],  # R1 turn 1: tool fence
+            ["42."],  # R1 turn 2: final answer
+            [_fence("calculator", {"expression": "7*8"})],  # R2 turn 1: tool fence
+            ["56."],  # R2 turn 2: final answer
+        ]
+        store, controller, session = _new_agent_controller(db, agent_db, scripts)
+
+        # ---- A1: U1 -> A1, agent run R1 with its own TOOL step ----
+        result1 = await controller.submit_draft("what is 6*7?")
+        assert result1.accepted is True
+        u1, a1 = _user_and_assistant(store.messages_for_session(session.id))
+        assert a1.content == "42."
+        assert a1.status == "complete"
+        assert a1.persisted_message_id is not None
+
+        # ---- A1': regenerate forks a SIBLING under the SAME parent (u1) ----
+        result2 = await controller.regenerate_message(a1.id)
+        assert result2.accepted is True
+        a1_prime_id = store.active_leaf(session.id)
+        assert a1_prime_id != a1.id
+        a1_prime = store.get_message(a1_prime_id)
+        assert a1_prime.content == "56."
+        assert a1_prime.persisted_message_id is not None
+        siblings, _index, sibling_count = store.siblings_at(a1.id)
+        assert sibling_count == 2
+        assert {s.id for s in siblings} == {a1.id, a1_prime_id}
+        # a1 is untouched, just off the active path (never deleted).
+        assert store.get_message(a1.id).content == "42."
+
+        conversation_id = session.persisted_conversation_id
+        assert conversation_id is not None
+
+        # ---- Both runs are real, distinct, NON-superseded, correctly anchored ----
+        primary_runs = [
+            r for r in _all_runs(agent_db) if r["agent_kind"] == "primary"
+        ]
+        assert len(primary_runs) == 2
+        assert all(r["status"] != "superseded" for r in primary_runs)
+        by_anchor = {r["assistant_message_id"]: r for r in primary_runs}
+        assert set(by_anchor) == {a1.persisted_message_id, a1_prime.persisted_message_id}
+        r1_steps = json.loads(by_anchor[a1.persisted_message_id]["steps"])
+        r2_steps = json.loads(by_anchor[a1_prime.persisted_message_id]["steps"])
+        assert any(s["tool_name"] == "calculator" for s in r1_steps)
+        assert any(s["tool_name"] == "calculator" for s in r2_steps)
+
+        # ---- Resume ON BRANCH A1: R1's marker shows, R2's is entirely absent ----
+        resumed_a_store, resumed_a_session = _resume_with_markers(
+            db,
+            agent_db,
+            conversation_id,
+            active_leaf_persisted_id=a1.persisted_message_id,
+        )
+        view_a = resumed_a_store.messages_for_session(resumed_a_session.id)
+        assert [m.content for m in view_a[:2]] == ["what is 6*7?", "42."]
+        assert len(view_a) == 3  # U1, A1, exactly one TOOL marker
+        assert view_a[2].role is ConsoleMessageRole.TOOL
+        assert "calculator" in view_a[2].content
+        assert "6*7" in view_a[2].content
+        # Branch A1''s run is off-path -- absent, not just its own marker
+        # (checked on the TOOL row only: U1's own question text legitimately
+        # contains "6*7" regardless of which branch is active).
+        tool_rows_a = [m for m in view_a if m.role is ConsoleMessageRole.TOOL]
+        assert len(tool_rows_a) == 1
+        assert "7*8" not in tool_rows_a[0].content
+
+        # ---- Fresh resume ON BRANCH A1': the reverse ----
+        resumed_b_store, resumed_b_session = _resume_with_markers(
+            db,
+            agent_db,
+            conversation_id,
+            active_leaf_persisted_id=a1_prime.persisted_message_id,
+        )
+        view_b = resumed_b_store.messages_for_session(resumed_b_session.id)
+        assert [m.content for m in view_b[:2]] == ["what is 6*7?", "56."]
+        assert len(view_b) == 3
+        assert view_b[2].role is ConsoleMessageRole.TOOL
+        assert "calculator" in view_b[2].content
+        assert "7*8" in view_b[2].content
+        tool_rows_b = [m for m in view_b if m.role is ConsoleMessageRole.TOOL]
+        assert len(tool_rows_b) == 1
+        assert "6*7" not in tool_rows_b[0].content
+    finally:
+        db.close_connection()
+
+
+@pytest.mark.asyncio
+async def test_legacy_null_anchor_run_places_via_ordinal_fallback_on_resume(tmp_path):
+    """A run recorded before Phase C (or one whose terminal write never
+    landed a persisted id) has ``assistant_message_id`` NULL forever --
+    ``set_run_assistant_message_id`` is never retroactively called for it.
+    Task 3's fallback must still place it: the single null-anchored block
+    matched ordinally against the single unclaimed ASSISTANT message, rather
+    than silently dropped.
+
+    Built directly against ``AgentRunsDB`` (bypassing the live bridge, which
+    -- since Task 2 -- always records SOME id, NULL or persisted, on every
+    terminal path) to simulate genuinely pre-Phase-C data: a plain
+    (non-agent) turn with no bridge wired at all, then one run hand-inserted
+    after the fact.
+    """
+    db = CharactersRAGDB(":memory:", "test_client")
+    agent_db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    try:
+        store = ConsoleChatStore(persistence=ChatPersistenceService(db))
+        gateway = _Gateway([["a plain answer."]])
+        controller = ConsoleChatController(store=store, provider_gateway=gateway)
+        session = store.create_session(title="Legacy Fallback")
+        store.active_session_id = session.id
+
+        result = await controller.submit_draft("hello")
+        assert result.accepted is True
+        u1, a1 = _user_and_assistant(store.messages_for_session(session.id))
+        assert a1.content == "a plain answer."
+        assert a1.persisted_message_id is not None
+        conversation_id = session.persisted_conversation_id
+        assert conversation_id is not None
+        # The legacy/no-bridge path never touches AgentRunsDB at all.
+        assert _all_runs(agent_db) == []
+
+        legacy_run_id = agent_db.create_run(
+            conversation_id=conversation_id, agent_kind="primary"
+        )
+        agent_db.append_steps(
+            legacy_run_id,
+            [
+                {
+                    "index": 0,
+                    "kind": STEP_TOOL_RESULT,
+                    "tool_name": "calculator",
+                    "result": "9*9=81",
+                    "summary": "",
+                    "args": None,
+                    "created_at": "",
+                },
+            ],
+        )
+        agent_db.set_status(legacy_run_id, "done", result="a plain answer.")
+        legacy_record = agent_db.get_run(legacy_run_id)
+        assert legacy_record["assistant_message_id"] is None  # the fallback's trigger
+
+        resumed_store, resumed_session = _resume_with_markers(
+            db,
+            agent_db,
+            conversation_id,
+            active_leaf_persisted_id=a1.persisted_message_id,
+        )
+        view = resumed_store.messages_for_session(resumed_session.id)
+        assert [m.content for m in view[:2]] == ["hello", "a plain answer."]
+        assert len(view) == 3
+        assert view[2].role is ConsoleMessageRole.TOOL
+        assert view[2].content == "⚙ calculator → 9*9=81"
+    finally:
+        db.close_connection()
+
+
+@pytest.mark.asyncio
+async def test_retry_supersedes_prior_run_dropping_its_resume_markers(tmp_path):
+    """The investigated finding, pinned directly: ``retry_message`` (NOT
+    ``regenerate_message`` -- see the module docstring) is the only caller
+    that sets ``supersede_previous=True``. It reruns the SAME assistant
+    message id in place, so without superseding, a retried run's stale TOOL
+    marker would reappear ALONGSIDE the fresh one on resume (same anchor id,
+    both blocks would match the same message index) -- ``supersede_run_tree``
+    prevents that duplication by excluding the superseded run from
+    ``resume_marker_messages`` entirely.
+    """
+    db = CharactersRAGDB(":memory:", "test_client")
+    agent_db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    try:
+        scripts = [
+            [_fence("calculator", {"expression": "1*1"})],  # R1 turn 1: tool fence
+            ["1."],  # R1 turn 2: real completion (outcome discarded below)
+            [_fence("calculator", {"expression": "9*9"})],  # R2 turn 1: tool fence
+            ["81."],  # R2 turn 2: final answer
+        ]
+        store, controller, session = _new_agent_controller(db, agent_db, scripts)
+        real_run_reply = controller._agent_bridge.run_reply
+
+        def fail_after_real_run(**kwargs):
+            # Execute the REAL turn (a genuine TOOL step lands on R1 in
+            # AgentRunsDB), but report failure so the assistant message ends
+            # up "failed" -> retryable (mirrors test_console_agent_swap.py's
+            # error_after_real_run pattern).
+            run_id, _outcome = real_run_reply(**kwargs)
+            return run_id, RunOutcome(
+                status=RUN_ERROR,
+                steps=[AgentStep(index=0, kind=STEP_ERROR, summary="boom")],
+            )
+
+        controller._agent_bridge.run_reply = fail_after_real_run
+        result1 = await controller.submit_draft("what is 1*1?")
+        assert result1.accepted is True
+        controller._agent_bridge.run_reply = real_run_reply
+
+        _u1, a1 = _user_and_assistant(store.messages_for_session(session.id))
+        assert a1.status == "failed"
+        conversation_id = session.persisted_conversation_id
+        assert conversation_id is not None
+
+        result2 = await controller.retry_message(a1.id)
+        assert result2.accepted is True
+        retried = store.get_message(a1.id)
+        assert retried.status == "complete"
+        assert retried.content == "81."
+
+        primary_runs = [
+            r for r in _all_runs(agent_db) if r["agent_kind"] == "primary"
+        ]
+        assert len(primary_runs) == 2
+        statuses = sorted(r["status"] for r in primary_runs)
+        assert "superseded" in statuses
+        # Retry reruns IN PLACE -- both runs anchor to the SAME message id.
+        assert {r["assistant_message_id"] for r in primary_runs} == {
+            retried.persisted_message_id
+        }
+
+        resumed_store, resumed_session = _resume_with_markers(
+            db,
+            agent_db,
+            conversation_id,
+            active_leaf_persisted_id=retried.persisted_message_id,
+        )
+        view = resumed_store.messages_for_session(resumed_session.id)
+        tool_rows = [m for m in view if m.role is ConsoleMessageRole.TOOL]
+        # Exactly ONE marker -- the fresh run's (9*9), never a stale
+        # duplicate from the superseded one (1*1).
+        assert len(tool_rows) == 1
+        assert "9*9" in tool_rows[0].content
+        assert "1*1" not in tool_rows[0].content
+    finally:
+        db.close_connection()

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -332,6 +332,7 @@ class AgentService:
         agent_kind: str,
         task: str | None,
         parent_run_id: str | None,
+        assistant_message_id: str | None = None,
     ) -> tuple[str, RunOutcome]:
         run_id = self.db.create_run(
             conversation_id=conversation_id,
@@ -339,6 +340,7 @@ class AgentService:
             task=task,
             parent_run_id=parent_run_id,
             budget=dataclasses.asdict(config.budget),
+            assistant_message_id=assistant_message_id,
         )
         started = self.clock()
 
@@ -653,6 +655,7 @@ class AgentService:
         api_endpoint: str,
         should_cancel: Callable[[], bool] = lambda: False,
         supersede_run_id: str | None = None,
+        assistant_message_id: str | None = None,
     ) -> tuple[str, RunOutcome]:
         """Run one primary-agent turn (and any sub-agents it spawns).
 
@@ -676,6 +679,14 @@ class AgentService:
             supersede_run_id: When set, marks that prior run (and its
                 sub-agent tree) ``superseded`` before starting this run —
                 used by retry/regenerate/continue.
+            assistant_message_id: Recorded on the primary run at creation
+                time (only the primary run — never a spawned sub-agent,
+                which produces no transcript reply). At create time this is
+                the reply's NATIVE in-memory id; the assistant node is not
+                persisted yet, so the caller overwrites it with the durable
+                persisted id via ``AgentRunsDB.set_run_assistant_message_id``
+                once the reply completes (that later write is what resume's
+                marker anchoring reads).
 
         Returns:
             A ``(run_id, outcome)`` tuple: the new primary run's id and its
@@ -700,4 +711,5 @@ class AgentService:
             agent_kind=AGENT_KIND_PRIMARY,
             task=None,
             parent_run_id=None,
+            assistant_message_id=assistant_message_id,
         )

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -865,7 +865,15 @@ class ConsoleAgentBridge:
         review_tool_calls: Callable[[list[ToolCall]], dict[str, str]] | None = None,
         turn_skill_bindings: tuple[str, ...] = (),
         turn_bundle_block: str = "",
-    ) -> RunOutcome:
+    ) -> tuple[str, RunOutcome]:
+        """Run the agent loop as the Console reply engine.
+
+        Returns:
+            A ``(run_id, outcome)`` tuple: the primary run's id (so the
+            caller can record the produced reply's persisted id onto the run
+            via ``record_run_assistant_message`` after the reply is
+            persisted) and its terminal ``RunOutcome``.
+        """
         # Per-run tool registry + allow-list (Task 12, extended by P5-T6 for
         # MCP): rebuilt FRESH for this run whenever there is a skills
         # service OR an already-composed MCP provider for this run (never
@@ -1086,10 +1094,15 @@ class ConsoleAgentBridge:
                     }
                     break
         try:
-            _run_id, outcome = service.run_turn(
+            run_id, outcome = service.run_turn(
                 conversation_id=conversation_id,
                 messages=run_messages,
                 config=config,
+                # The reply's NATIVE in-memory id at create_run time (the
+                # assistant node isn't persisted yet); the controller
+                # overwrites it with the durable persisted id once the reply
+                # completes -- that later write is what resume anchoring reads.
+                assistant_message_id=assistant_message_id,
                 # execution_key-first (Task 5): the service's capability
                 # check keys off api_endpoint, and execution_key is by
                 # definition "Provider key passed to chat_api_call" — the
@@ -1136,7 +1149,7 @@ class ConsoleAgentBridge:
         # rather than reading this run's now-superseded snapshot (belt and
         # braces on top of the pop at run start above).
         self._historical_cache.pop(conversation_id, None)
-        return outcome
+        return run_id, outcome
 
     # -- rail reads -----------------------------------------------------
 
@@ -1183,6 +1196,18 @@ class ConsoleAgentBridge:
 
     def subagent_run(self, run_id: str) -> dict | None:
         return self._db.get_run(run_id)
+
+    def record_run_assistant_message(
+        self, run_id: str, persisted_message_id: str
+    ) -> None:
+        """Record the persisted id of the assistant reply ``run_id`` produced.
+
+        Delegates to ``AgentRunsDB.set_run_assistant_message_id``. Called by
+        the controller AFTER the reply is persisted (its native create-time
+        id is thereby corrected to the durable persisted id), so a later
+        resume can anchor markers by ``persisted_message_id``.
+        """
+        self._db.set_run_assistant_message_id(run_id, persisted_message_id)
 
     def subagent_count(self, conversation_id: str) -> int:
         return self._db.count_subagent_runs(conversation_id)

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -196,22 +196,34 @@ def format_agent_step_marker(
 
 def inject_resume_agent_markers(
     messages: list[ConsoleChatMessage],
-    marker_blocks: list[list[ConsoleChatMessage]],
+    anchored_blocks: list[tuple[str | None, list[ConsoleChatMessage]]],
 ) -> list[ConsoleChatMessage]:
     """Interleave AgentRunsDB-derived TOOL marker blocks into a resumed transcript.
 
-    Placement (Plan-B final-review Medium-1): each run's marker block is
-    matched ordinally to the Nth ASSISTANT message in ``messages`` --
-    oldest run <-> oldest assistant reply -- so in the common case (every
-    assistant reply in the conversation came from the agent path) each
-    run's markers land directly after the answer they belong to, exactly
-    mirroring where they rendered live. This is the "simplest correct"
-    placement given persisted messages carry no per-step timestamp to
-    interleave by more precisely. A run left over with no corresponding
-    assistant message -- only possible when ``agent_runtime`` was toggled
-    off mid-conversation after some replies already used the agent path --
-    has its block appended at the end of the transcript instead of being
-    silently dropped.
+    Task 3 placement, anchored by the run's ``assistant_message_id`` (the
+    persisted id of the reply it produced -- see
+    ``ConsoleAgentBridge.record_run_assistant_message``, written on every
+    terminal path since Task 2):
+
+    - **Anchor id set and it matches** a message's ``persisted_message_id``
+      in ``messages`` -- the block is inserted immediately after that
+      message, wherever it sits (this is exact, not ordinal: a resumed
+      transcript may have been edited/branched since the run happened, so
+      the Nth run no longer need be the Nth reply).
+    - **Anchor id set but it matches no message in ``messages``** -- the
+      reply that run produced lives on a different branch than the one
+      currently active (an edit/regenerate moved the active path off of
+      it). The block is **dropped**: showing that run's tool trace next to
+      a DIFFERENT reply would misattribute it, so hiding it is correct.
+    - **Anchor id is ``None``** -- a legacy (pre-Phase-C) run, a sub-agent
+      run, or one whose terminal path never got to record the id (crash /
+      never-persisted reply). Falls back to the prior ordinal placement:
+      the Nth null-anchored block is matched to the Nth ASSISTANT message
+      in ``messages`` that isn't already claimed by an id-anchored block,
+      oldest first. A null block left over with no unclaimed assistant
+      message to pair with is appended at the end of the transcript
+      instead of being silently dropped, preserving the pre-Task-3
+      leftover behavior for this fallback path.
 
     Idempotent: a block whose marker texts are already present as TOOL
     messages anywhere in ``messages`` is skipped, so calling this twice (or
@@ -222,15 +234,16 @@ def inject_resume_agent_markers(
         messages: The rebuilt transcript (ChaChaNotes-derived; never
             contains TOOL rows on its own, since markers are appended
             live with ``persist=False``).
-        marker_blocks: Per-run marker-message blocks, oldest run first
-            (see ``ConsoleAgentBridge.resume_marker_messages``).
+        anchored_blocks: Per-run ``(assistant_message_id, marker_block)``
+            pairs, oldest run first (see
+            ``ConsoleAgentBridge.resume_marker_messages``).
 
     Returns:
         A new list with marker blocks interleaved; ``messages`` itself is
         not mutated.
     """
-    non_empty_blocks = [block for block in marker_blocks if block]
-    if not non_empty_blocks:
+    non_empty = [(anchor, block) for anchor, block in anchored_blocks if block]
+    if not non_empty:
         return list(messages)
 
     existing_tool_contents = {
@@ -238,23 +251,44 @@ def inject_resume_agent_markers(
         for message in messages
         if message.role is ConsoleMessageRole.TOOL
     }
-    assistant_indexes = [
-        index
-        for index, message in enumerate(messages)
-        if message.role is ConsoleMessageRole.ASSISTANT
-    ]
-    matched = dict(zip(assistant_indexes, non_empty_blocks))
-    leftover_blocks = non_empty_blocks[len(assistant_indexes) :]
 
     def _already_present(block: list[ConsoleChatMessage]) -> bool:
         return all(marker.content in existing_tool_contents for marker in block)
 
+    by_persisted = {
+        message.persisted_message_id: index
+        for index, message in enumerate(messages)
+        if message.persisted_message_id
+    }
+
+    matched: dict[int, list[list[ConsoleChatMessage]]] = {}
+    null_blocks: list[list[ConsoleChatMessage]] = []
+    used_indexes: set[int] = set()
+    for anchor_id, block in non_empty:
+        if anchor_id is None:
+            null_blocks.append(block)
+            continue
+        index = by_persisted.get(anchor_id)
+        if index is None:
+            continue  # off-path: this run's reply lives on another branch
+        matched.setdefault(index, []).append(block)
+        used_indexes.add(index)
+
+    unclaimed_assistant_indexes = [
+        index
+        for index, message in enumerate(messages)
+        if message.role is ConsoleMessageRole.ASSISTANT and index not in used_indexes
+    ]
+    for index, block in zip(unclaimed_assistant_indexes, null_blocks):
+        matched.setdefault(index, []).append(block)
+    leftover_blocks = null_blocks[len(unclaimed_assistant_indexes) :]
+
     result: list[ConsoleChatMessage] = []
     for index, message in enumerate(messages):
         result.append(message)
-        block = matched.get(index)
-        if block is not None and not _already_present(block):
-            result.extend(block)
+        for block in matched.get(index, ()):
+            if not _already_present(block):
+                result.extend(block)
     for block in leftover_blocks:
         if not _already_present(block):
             result.extend(block)
@@ -1238,7 +1272,7 @@ class ConsoleAgentBridge:
 
     def resume_marker_messages(
         self, conversation_id: str
-    ) -> list[list[ConsoleChatMessage]]:
+    ) -> list[tuple[str | None, list[ConsoleChatMessage]]]:
         """Re-derive transcript TOOL marker messages from ``AgentRunsDB`` for resume.
 
         Plan-B final-review Medium-1: the rail (``historical_snapshot``) and
@@ -1248,16 +1282,24 @@ class ConsoleAgentBridge:
         ``persist=False``, so a session rebuilt fresh from ChaChaNotes never
         sees them.
 
-        Returns one marker-message block per non-superseded PRIMARY run for
-        the conversation, oldest run first (``list_runs`` itself returns
-        newest-first, so the order is reversed here). Each block holds that
-        run's own TOOL marker messages, in the run's recorded step order,
-        built with ``format_agent_step_marker`` -- the same formatter the
-        live bridge uses -- so a resumed transcript's markers are
-        byte-identical to what the live run produced. A run with no
-        marker-worthy steps (e.g. a plain answer, no tool/spawn/error step)
-        yields an empty block; callers should skip those rather than inject
-        nothing.
+        Returns one ``(assistant_message_id, marker_block)`` pair per
+        non-superseded PRIMARY run for the conversation, oldest run first
+        (``list_runs`` itself returns newest-first, so the order is
+        reversed here). ``assistant_message_id`` is the run's own
+        ``record["assistant_message_id"]`` -- the persisted id of the
+        reply it produced (set on every terminal path since Task 2), or
+        ``None`` for a legacy/pre-Phase-C run, a sub-agent run, or one
+        whose reply was never persisted -- Task 3's
+        ``inject_resume_agent_markers`` is what turns this id into an
+        anchored (or ordinal-fallback, or dropped) placement.
+
+        Each block holds that run's own TOOL marker messages, in the run's
+        recorded step order, built with ``format_agent_step_marker`` -- the
+        same formatter the live bridge uses -- so a resumed transcript's
+        markers are byte-identical to what the live run produced. A run
+        with no marker-worthy steps (e.g. a plain answer, no
+        tool/spawn/error step) yields an empty block; callers should skip
+        those rather than inject nothing.
 
         Placement of the returned blocks into a transcript is the caller's
         job -- see ``inject_resume_agent_markers``.
@@ -1268,7 +1310,7 @@ class ConsoleAgentBridge:
             if record["agent_kind"] == AGENT_KIND_PRIMARY
         ]
         records.reverse()  # list_runs is newest-first; markers must read chronologically
-        blocks: list[list[ConsoleChatMessage]] = []
+        blocks: list[tuple[str | None, list[ConsoleChatMessage]]] = []
         for record in records:
             block: list[ConsoleChatMessage] = []
             for step in record.get("steps") or []:
@@ -1286,7 +1328,7 @@ class ConsoleAgentBridge:
                             status="complete",
                         )
                     )
-            blocks.append(block)
+            blocks.append((record.get("assistant_message_id"), block))
         return blocks
 
     # -- internals ------------------------------------------------------

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -868,6 +868,15 @@ class ConsoleAgentBridge:
     ) -> tuple[str, RunOutcome]:
         """Run the agent loop as the Console reply engine.
 
+        The primary run row is created with a NULL ``assistant_message_id``
+        (the native ``assistant_message_id`` argument is used only for
+        streaming into the placeholder, never forwarded to ``run_turn`` --
+        see the ``run_turn`` call below for why a native id must never be
+        stored on the run). The caller records the reply's durable persisted
+        id onto the run on every terminal path via
+        ``record_run_assistant_message`` once the reply is persisted; an
+        unfinished/crashed run stays NULL for resume's null->ordinal fallback.
+
         Returns:
             A ``(run_id, outcome)`` tuple: the primary run's id (so the
             caller can record the produced reply's persisted id onto the run
@@ -1098,11 +1107,18 @@ class ConsoleAgentBridge:
                 conversation_id=conversation_id,
                 messages=run_messages,
                 config=config,
-                # The reply's NATIVE in-memory id at create_run time (the
-                # assistant node isn't persisted yet); the controller
-                # overwrites it with the durable persisted id once the reply
-                # completes -- that later write is what resume anchoring reads.
-                assistant_message_id=assistant_message_id,
+                # Intentionally NOT forwarding the native in-memory id here.
+                # create_run would store it, but the native id can never match
+                # any persisted_message_id -- so a run left unfinished (stopped
+                # mid-run, cancelled, failed, or crashed) would hold a stale,
+                # non-null id that resume anchoring can never match (and Task 3
+                # would drop as "off-path", silently hiding its markers). By
+                # omitting it the run row starts NULL; the controller writes the
+                # durable PERSISTED id onto the run on EVERY terminal path once
+                # the reply is persisted (see record_run_assistant_message), and
+                # any still-unfinished run stays NULL for resume's null->ordinal
+                # fallback. run_turn's assistant_message_id threading stays a
+                # generic service capability (its own tests call it directly).
                 # execution_key-first (Task 5): the service's capability
                 # check keys off api_endpoint, and execution_key is by
                 # definition "Provider key passed to chat_api_call" — the

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -2924,7 +2924,10 @@ class ConsoleChatController:
         # control returns to a checkpoint the loop actually polls -- it is
         # not a hard timeout on an in-flight, zero-chunk provider call.
         try:
-            outcome = await asyncio.to_thread(
+            # run_reply returns (run_id, outcome): run_id lets us write the
+            # produced reply's PERSISTED id back onto the run after
+            # completion (the load-bearing write for resume marker anchoring).
+            run_id, outcome = await asyncio.to_thread(
                 self._agent_bridge.run_reply,
                 conversation_id=conversation_id,
                 session_id=session_id,
@@ -3008,6 +3011,7 @@ class ConsoleChatController:
             outcome,
             variant_mode=variant_mode,
             cancel_event=cancel_event,
+            run_id=run_id,
         )
 
     def _agent_conversation_id(self, session_id: str) -> str:
@@ -3025,6 +3029,7 @@ class ConsoleChatController:
         *,
         variant_mode: bool,
         cancel_event: threading.Event | None = None,
+        run_id: str | None = None,
     ) -> ConsoleSubmitResult:
         from tldw_chatbook.Agents.agent_models import RUN_CANCELLED, RUN_DONE
 
@@ -3070,7 +3075,8 @@ class ConsoleChatController:
                 assistant_message_id, session_id, outcome, variant_mode=variant_mode)
 
         return self._finalize_agent_success(
-            assistant_message_id, session_id, outcome, variant_mode=variant_mode)
+            assistant_message_id, session_id, outcome,
+            variant_mode=variant_mode, run_id=run_id)
 
     def _ensure_assistant_placeholder(
         self, assistant_message_id: str, session_id: str,
@@ -3166,7 +3172,7 @@ class ConsoleChatController:
 
     def _finalize_agent_success(
         self, assistant_message_id: str, session_id: str, outcome: Any,
-        *, variant_mode: bool,
+        *, variant_mode: bool, run_id: str | None = None,
     ) -> ConsoleSubmitResult:
         """Handle ``RUN_DONE``: complete the placeholder (or a runtime-written one).
 
@@ -3174,24 +3180,57 @@ class ConsoleChatController:
         response was generated.``. If the placeholder is missing, the runtime
         may have streamed content into an assistant row already; complete it
         when possible, otherwise append a new assistant message.
+
+        Once the reply is completed (and its durable ``persisted_message_id``
+        assigned), that persisted id is written back onto the agent run via
+        ``_record_run_assistant_message`` -- the load-bearing correction of
+        the native id ``create_run`` recorded, which resume anchors markers by.
         """
         placeholder = self._ensure_assistant_placeholder(assistant_message_id, session_id)
         if placeholder is not None:
             completed = self._complete_agent_message(assistant_message_id, variant_mode, outcome)
+            self._record_run_assistant_message(run_id, completed)
             self._set_run_state(ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete."))
             return ConsoleSubmitResult(True, True, completed.content)
 
         runtime_written = self._find_runtime_written_assistant(session_id)
         if runtime_written is not None and runtime_written.status in {"pending", "streaming"}:
             completed = self._complete_agent_message(runtime_written.id, variant_mode=False, outcome=outcome)
+            self._record_run_assistant_message(run_id, completed)
             self._set_run_state(ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete."))
             return ConsoleSubmitResult(True, True, completed.content)
 
         final_text = getattr(outcome, "final_text", "") or "No response was generated."
         completed = self.store.append_message(
             session_id, role=ConsoleMessageRole.ASSISTANT, content=final_text)
+        self._record_run_assistant_message(run_id, completed)
         self._set_run_state(ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete."))
         return ConsoleSubmitResult(True, True, completed.content)
+
+    def _record_run_assistant_message(
+        self, run_id: str | None, completed: ConsoleChatMessage,
+    ) -> None:
+        """Write the completed reply's PERSISTED id onto the agent run.
+
+        On resume, markers anchor by matching a transcript message's durable
+        ``persisted_message_id``; the id recorded at ``create_run`` time is
+        the native in-memory id (the reply was not persisted yet), so it must
+        be corrected here, once the reply has its persisted id. A no-op when
+        there is no run id, no bridge, or no persistence (the native id would
+        be useless to resume). Never fails the turn -- a marker-anchoring
+        bookkeeping write, wrapped defensively like the file's other seams.
+        """
+        persisted = getattr(completed, "persisted_message_id", None)
+        if not run_id or persisted is None or self._agent_bridge is None:
+            return
+        try:
+            self._agent_bridge.record_run_assistant_message(run_id, persisted)
+        except Exception:  # noqa: BLE001 -- bookkeeping must never fail the turn
+            logger.opt(exception=True).warning(
+                "failed to record persisted assistant id on agent run",
+                run_id=run_id,
+                persisted_message_id=persisted,
+            )
 
     def _append_failed_assistant(
         self, session_id: str, visible_copy: str,

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -3061,6 +3061,15 @@ class ConsoleChatController:
             or (cancel_event is not None and cancel_event.is_set())
         )
         if stopped_now:
+            # The stopped message was already persisted by
+            # `mark_message_stopped` (`_persist_existing_message`), so its
+            # durable persisted id is available NOW -- record it onto the run
+            # so resume can anchor markers by it. Without this the run keeps
+            # whatever `create_run` stored (a stale native id pre-fix, NULL
+            # post-fix); a never-persisted stop leaves `current` without a
+            # persisted id and the helper no-ops (row stays NULL -> ordinal
+            # fallback -- correct).
+            self._record_run_assistant_message(run_id, current)
             self._set_run_state(
                 ConsoleRunState(ConsoleRunStatus.STOPPED, "Response stopped.")
             )
@@ -3068,11 +3077,13 @@ class ConsoleChatController:
 
         if outcome.status == RUN_CANCELLED:
             return self._finalize_agent_cancelled(
-                assistant_message_id, session_id, variant_mode=variant_mode)
+                assistant_message_id, session_id, variant_mode=variant_mode,
+                run_id=run_id)
 
         if outcome.status != RUN_DONE:
             return self._finalize_agent_failure(
-                assistant_message_id, session_id, outcome, variant_mode=variant_mode)
+                assistant_message_id, session_id, outcome, variant_mode=variant_mode,
+                run_id=run_id)
 
         return self._finalize_agent_success(
             assistant_message_id, session_id, outcome,
@@ -3121,12 +3132,17 @@ class ConsoleChatController:
 
     def _finalize_agent_cancelled(
         self, assistant_message_id: str, session_id: str, *, variant_mode: bool,
+        run_id: str | None = None,
     ) -> ConsoleSubmitResult:
         """Handle a ``RUN_CANCELLED`` outcome: the placeholder becomes ``failed``.
 
         Per the agent turn-control spec, a runtime-reported cancellation is a
         terminal failure, not a user-initiated stop. If the placeholder has
         vanished, append a failed assistant message carrying the visible copy.
+        The terminal message (``mark_message_failed``/``_append_failed_assistant``,
+        both persisted) has its durable id recorded onto the run so resume can
+        anchor markers by it; a never-persisted reply no-ops (row stays NULL ->
+        ordinal fallback -- see ``_record_run_assistant_message``).
         """
         visible_copy = "Response stopped/cancelled."
         placeholder = self._ensure_assistant_placeholder(assistant_message_id, session_id)
@@ -3134,12 +3150,13 @@ class ConsoleChatController:
             failed = self.store.mark_message_failed(assistant_message_id)
         else:
             failed = self._append_failed_assistant(session_id, visible_copy)
+        self._record_run_assistant_message(run_id, failed)
         self._set_run_state(ConsoleRunState(ConsoleRunStatus.FAILED, visible_copy))
         return ConsoleSubmitResult(True, True, failed.content)
 
     def _finalize_agent_failure(
         self, assistant_message_id: str, session_id: str, outcome: Any,
-        *, variant_mode: bool,
+        *, variant_mode: bool, run_id: str | None = None,
     ) -> ConsoleSubmitResult:
         """Handle ``RUN_ERROR``, ``RUN_STUCK``, or any unknown non-done outcome.
 
@@ -3148,6 +3165,12 @@ class ConsoleChatController:
         is missing, the runtime may have already written an assistant message
         (e.g. streamed partial content before the error); use it when
         possible, otherwise append a new failed assistant message.
+
+        Whichever terminal message resolves (all persisted via
+        ``mark_message_failed``/``_append_failed_assistant``) has its durable id
+        recorded onto the run so resume can anchor markers by it; a
+        never-persisted reply no-ops (row stays NULL -> ordinal fallback -- see
+        ``_record_run_assistant_message``).
         """
         visible_copy = self._agent_failure_visible_copy(outcome)
         if "provider returned HTTP" in visible_copy and (
@@ -3157,6 +3180,7 @@ class ConsoleChatController:
         placeholder = self._ensure_assistant_placeholder(assistant_message_id, session_id)
         if placeholder is not None:
             failed = self.store.mark_message_failed(assistant_message_id)
+            self._record_run_assistant_message(run_id, failed)
             self._append_failure_system_row(session_id, visible_copy)
             self._set_run_state(ConsoleRunState(ConsoleRunStatus.FAILED, visible_copy))
             return ConsoleSubmitResult(True, True, failed.content)
@@ -3167,6 +3191,7 @@ class ConsoleChatController:
             failed = self.store.mark_message_failed(runtime_written.id)
         else:
             failed = self._append_failed_assistant(session_id, visible_copy)
+        self._record_run_assistant_message(run_id, failed)
         self._set_run_state(ConsoleRunState(ConsoleRunStatus.FAILED, visible_copy))
         return ConsoleSubmitResult(True, True, failed.content)
 

--- a/tldw_chatbook/DB/AgentRuns_DB.py
+++ b/tldw_chatbook/DB/AgentRuns_DB.py
@@ -24,7 +24,7 @@ def _now_iso() -> str:
 class AgentRunsDB(BaseDB):
     """Run records for the agent runtime (vertical-slice spec data model)."""
 
-    _CURRENT_SCHEMA_VERSION = 1
+    _CURRENT_SCHEMA_VERSION = 2
 
     def __init__(self, db_path: Union[str, Path], client_id: str = "default") -> None:
         super().__init__(db_path, client_id)
@@ -84,7 +84,7 @@ class AgentRunsDB(BaseDB):
                 CREATE TABLE IF NOT EXISTS schema_version (
                     version INTEGER PRIMARY KEY NOT NULL
                 );
-                INSERT OR IGNORE INTO schema_version (version) VALUES (1);
+                INSERT OR IGNORE INTO schema_version (version) VALUES (2);
 
                 CREATE TABLE IF NOT EXISTS agent_runs (
                     id TEXT PRIMARY KEY,
@@ -97,7 +97,8 @@ class AgentRunsDB(BaseDB):
                     result TEXT,
                     budget TEXT,
                     created_at TEXT NOT NULL,
-                    updated_at TEXT NOT NULL
+                    updated_at TEXT NOT NULL,
+                    assistant_message_id TEXT
                 );
 
                 CREATE INDEX IF NOT EXISTS idx_agent_runs_conversation
@@ -106,6 +107,19 @@ class AgentRunsDB(BaseDB):
                     ON agent_runs(parent_run_id);
                 """
             )
+            # v1->v2: this DB has no migration framework -- _initialize_schema
+            # only runs CREATE TABLE IF NOT EXISTS, so a file created before
+            # assistant_message_id existed keeps its old 11-column table and
+            # never picks up the new one from the DDL above. Guard against
+            # that with an idempotent ALTER TABLE, run on every open.
+            existing_columns = {
+                row[1]
+                for row in conn.execute("PRAGMA table_info(agent_runs)").fetchall()
+            }
+            if "assistant_message_id" not in existing_columns:
+                conn.execute(
+                    "ALTER TABLE agent_runs ADD COLUMN assistant_message_id TEXT"
+                )
 
     @staticmethod
     def _row_to_dict(row: sqlite3.Row) -> dict:
@@ -122,6 +136,7 @@ class AgentRunsDB(BaseDB):
         task: str | None = None,
         parent_run_id: str | None = None,
         budget: dict | None = None,
+        assistant_message_id: str | None = None,
     ) -> str:
         """Create a new run record in ``running`` status.
 
@@ -133,6 +148,11 @@ class AgentRunsDB(BaseDB):
                 for a primary run.
             budget: The run's ``RunBudget`` serialized to a dict, stored
                 as JSON for later inspection; ``None`` if not recorded.
+            assistant_message_id: The persisted id of the assistant reply
+                this run produced, if already known at creation time;
+                ``None`` (the common case) when it will be recorded later
+                via ``set_run_assistant_message_id`` once the reply is
+                persisted.
 
         Returns:
             The newly created run's id (a hex UUID4).
@@ -143,8 +163,9 @@ class AgentRunsDB(BaseDB):
             conn.execute(
                 """INSERT INTO agent_runs
                    (id, conversation_id, parent_run_id, agent_kind, task,
-                    status, steps, result, budget, created_at, updated_at)
-                   VALUES (?, ?, ?, ?, ?, 'running', '[]', NULL, ?, ?, ?)""",
+                    status, steps, result, budget, created_at, updated_at,
+                    assistant_message_id)
+                   VALUES (?, ?, ?, ?, ?, 'running', '[]', NULL, ?, ?, ?, ?)""",
                 (
                     run_id,
                     conversation_id,
@@ -154,6 +175,7 @@ class AgentRunsDB(BaseDB):
                     json.dumps(budget) if budget is not None else None,
                     now,
                     now,
+                    assistant_message_id,
                 ),
             )
         return run_id
@@ -199,6 +221,24 @@ class AgentRunsDB(BaseDB):
                 "UPDATE agent_runs SET status = ?, "
                 "result = COALESCE(?, result), updated_at = ? WHERE id = ?",
                 (status, result, _now_iso(), run_id),
+            )
+
+    def set_run_assistant_message_id(
+        self, run_id: str, assistant_message_id: str | None
+    ) -> None:
+        """Record the persisted id of the assistant reply a run produced.
+
+        Args:
+            run_id: The run to update.
+            assistant_message_id: The persisted message id of the
+                assistant reply this run produced; ``None`` clears a
+                previously recorded id.
+        """
+        with self.transaction() as conn:
+            conn.execute(
+                "UPDATE agent_runs SET assistant_message_id = ?, "
+                "updated_at = ? WHERE id = ?",
+                (assistant_message_id, _now_iso(), run_id),
             )
 
     def get_run(self, run_id: str) -> dict | None:

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -4459,9 +4459,22 @@ class ChatScreen(BaseAppScreen):
         persisted ChaChaNotes rows, where markers never land
         (``ConsoleAgentBridge._append_marker`` uses ``persist=False`` so
         agent activity survives a restart without being written into the
-        conversation itself). See ``inject_resume_agent_markers`` for the
-        placement/idempotency contract, and ``resume_marker_messages`` for
-        how each run's marker block is derived.
+        conversation itself).
+
+        Task 3: ``resume_marker_messages`` now pairs each run's block with
+        the ``assistant_message_id`` of the reply it produced, and
+        ``inject_resume_agent_markers`` anchors placement to that id
+        against ``messages``'s own ``persisted_message_id``s -- a run
+        whose reply isn't on the active path (edited/regenerated onto
+        another branch) has its block hidden rather than misattributed to
+        a different reply; a legacy/null-id run keeps the prior ordinal
+        placement. ``messages`` is the caller's already-active-path
+        transcript (``_console_messages_from_conversation_tree`` walks the
+        active thread only), so this composes correctly with branching
+        without any extra filtering here. See ``inject_resume_agent_
+        markers`` for the full placement/idempotency contract, and
+        ``resume_marker_messages`` for how each run's marker block and
+        anchor id are derived.
 
         Returns ``messages`` unchanged when there is no durable agent
         bridge available (e.g. an in-memory test harness, matching
@@ -4472,6 +4485,9 @@ class ChatScreen(BaseAppScreen):
             return messages
         from tldw_chatbook.Chat.console_agent_bridge import inject_resume_agent_markers
 
+        # bridge.resume_marker_messages returns the (anchor_id, block) pairs
+        # inject_resume_agent_markers now expects directly -- no reshaping
+        # needed here, just passed straight through.
         return inject_resume_agent_markers(
             messages, bridge.resume_marker_messages(conversation_id)
         )


### PR DESCRIPTION
## What & why

Phase C of the **Console `/rewind`** program (Phase A #799, Phase B #811 merged). Makes resumed agent TOOL markers **branch-aware**: each run's inline `⚙`/`⤷` markers anchor to the assistant reply that run actually produced, and markers belonging to another branch are **hidden** — replacing the ordinal Nth-run→Nth-assistant placement that breaks once conversations branch. This completes the SP1 branching foundation.

Plan: `Docs/superpowers/plans/2026-07-24-console-branching-phase-c.md`

## What's delivered

- **`agent_runs.assistant_message_id`** (v1→v2). AgentRunsDB has no migration framework, so the column is added to the CREATE TABLE **and** via a PRAGMA-guarded idempotent `ALTER` on open — proven against a hand-built legacy v1 file.
- **Durable id write:** runs start **NULL** (the native in-memory id is deliberately never stored — wrong id space, would go stale); the controller writes the reply's **persisted** ChaChaNotes id on the finalizer terminal paths (success / stopped / cancelled / failure — all persist partial content). `run_reply` now returns `(run_id, outcome)`.
- **Placement rewrite:** id match → insert after that exact reply; id set but absent from the active path → **dropped (off-branch, hidden)**; NULL → legacy ordinal fallback over unclaimed assistants (pre-Phase-C data, sub-agent runs). Content-idempotency preserved.

## Review-caught bugs fixed before this PR

- **Critical:** stopped/cancelled/failed runs originally kept a **stale native id** (only the success path overwrote it) — under the new drop-non-matching semantics their markers would have been permanently hidden. Fixed: never store the native id; record the persisted id on every finalizer path (stopped-run RED→GREEN regression tests included).
- The e2e **corrected the plan's own assumption**: `regenerate_message` does not supersede the prior run (only `retry_message` does) — pinned with a dedicated test.

## Known limitation (documented in the plan addendum; no regression)

A user Stop delivered via `task.cancel()` raises `CancelledError` before `run_id` is bound, so stopped-via-cancel runs stay NULL → ordinal fallback — exactly the pre-Phase-C behavior for every run. Follow-up task to be filed (bridge-exposed run id + a real cancel-path test).

## Testing

Real-stack tests throughout (real AgentRunsDB + CharactersRAGDB + store/bridge/controller + the real resume path): 20 DB tests incl. legacy-file migration; stopped/failed/no-persistence terminal-path tests; placement tests where the old ordinal algorithm provably fails; 3-test cross-branch e2e (resume on each sibling shows only that branch's markers; NULL-legacy ordinal fallback; retry-supersede dedupe). 160 green at tip; sweeps show zero new failures (baselines: `test_anthropic_native_tools`, `test_chat_functions`, 2 order-dependent `test_console_native_chat_flow` flakes — all pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Anchors resumed agent TOOL markers to the exact assistant reply that produced them using the persisted message id, and hides markers from other branches. Adds `assistant_message_id` to agent runs and rewrites placement to be branch-aware.

- **New Features**
  - Schema v2: added `assistant_message_id` to `agent_runs` with an idempotent on-open migration; no action needed.
  - `run_reply` now returns `(run_id, outcome)`; the controller writes the reply’s persisted id to that run on all terminal paths.
  - Primary runs record the persisted id; sub-agent runs keep `NULL`.
  - Placement is id-anchored: id match → insert after that reply; id set with no match → drop as off-branch; `NULL` → ordinal fallback.
  - `resume_marker_messages` returns `(assistant_message_id, block)` pairs; idempotent insertion preserved.
  - Added a setter to update a run’s `assistant_message_id` post-completion; exposed via the bridge.

- **Bug Fixes**
  - Never store native in-memory ids; always persist the final reply id for success/stopped/cancelled/failed paths.
  - Tests confirm `regenerate_message` does not supersede prior runs (only `retry_message` does).

<sup>Written for commit c841778e53a39e4dea3bfc5f2b5c769e7ec95779. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

