### PR TITLE
Backlog: Console branching B/C follow-ups (519-521)

### DIFF
--- a/backlog/tasks/task-519 - Console-branching-record-run-id-on-stopped-via-cancel-agent-runs.md
+++ b/backlog/tasks/task-519 - Console-branching-record-run-id-on-stopped-via-cancel-agent-runs.md
@@ -1,0 +1,29 @@
+---
+id: TASK-519
+title: >-
+  Console branching: record the persisted reply id for stopped-via-cancel agent
+  runs
+status: To Do
+assignee: []
+created_date: '2026-07-24'
+labels:
+  - console
+  - agents
+  - tech-debt
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Phase C (agent-marker anchoring) writes the produced assistant reply's persisted id onto the agent run on every terminal path that returns through the finalizer (success, failure, cancelled-outcome, and the post-outcome `stopped_now` race). The dominant user-Stop path is different: `stop_active_run` calls `task.cancel()`, so the controller's `run_id, outcome = await asyncio.to_thread(...)` raises `CancelledError` before `run_id` is ever bound, and the `except asyncio.CancelledError` branch returns without recording. The run's `assistant_message_id` stays NULL even though the stopped reply WAS persisted, so it falls to the ordinal fallback on resume instead of being id-anchored + off-path-hidden. This is not a regression (it is exactly pre-Phase-C behavior) and is benign on a linear resume; it only leaks stale markers via leftover-append when a stopped reply later becomes an off-path sibling (stop → edit-&-resend the parent turn → resume onto the new branch). Documented in the Phase C plan addendum.
+
+Fix direction (final-review recommendation): expose the most-recent primary run id via the bridge (per conversation/session) so the CancelledError branch can call `_record_run_assistant_message` too, and add a test that exercises the REAL `stop_active_run` → `task.cancel()` path (every current stop/cancel test simulates the stop via a normally-returning `run_reply`, so the gap is invisible to the suite).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A user Stop delivered via task cancellation records the stopped reply's persisted id on the run (id-anchored + off-path-hidden on resume, same as other terminal paths)
+- [ ] #2 A test exercises the real `stop_active_run` → `task.cancel()` path and asserts the run's `assistant_message_id`
+- [ ] #3 A never-persisted stopped reply still leaves the run NULL (ordinal fallback), never a stale id
+<!-- AC:END -->

--- a/backlog/tasks/task-520 - Console-branching-stronger-legacy-flat-fingerprint-for-root-chaining.md
+++ b/backlog/tasks/task-520 - Console-branching-stronger-legacy-flat-fingerprint-for-root-chaining.md
@@ -1,0 +1,27 @@
+---
+id: TASK-520
+title: >-
+  Console branching: stronger legacy-flat fingerprint for resume root-chaining
+  (all-USER-legacy phantom counter)
+status: To Do
+assignee: []
+created_date: '2026-07-24'
+labels:
+  - console
+  - chat
+  - tech-debt
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`ConsoleChatStore._chain_legacy_flat_roots` (Phase A, amended in Phase B PR #811) chains multiple root-level threads into a linear spine on resume only when the root set is role-MIXED, because a genuine Phase-B root fork (edit-&-resend of the conversation's first user message) produces an all-USER root set that must NOT be chained. Known non-airtight edge, documented in the method's docstring: a DEGENERATE legacy conversation whose 2+ user turns each got NO assistant reply (reachable in the flat era via repeated failed/blocked sends) loads as all-USER roots and is wrongly left un-chained — it resumes showing only the last user message plus a phantom sibling counter. Non-data-loss (all messages stay reachable via swipe), and the two shapes are provably indistinguishable from the persisted tree alone, but a stronger fingerprint can close most of the gap: gate the legacy-chain decision on "the conversation contains at least one NULL-parent ASSISTANT row" (the true legacy signature — legacy wrote every row parentless, and any conversation with a reply then has a parentless assistant) instead of mere role-mixing. Note the flat-prefix case (legacy prefix + post-feature branched continuation) must keep chaining; see `Tests/UI/test_console_resume_active_path.py` for the covering tests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A degenerate all-USER legacy conversation (multiple parentless user rows, no replies) resumes showing the full sequence in order with no phantom sibling counter
+- [ ] #2 A genuine first-message edit-&-resend root fork is still left un-chained (both branches navigable)
+- [ ] #3 Existing legacy-flat and flat-prefix chaining tests still pass
+<!-- AC:END -->

--- a/backlog/tasks/task-521 - Console-branching-carry-attachments-on-Edit-and-resend.md
+++ b/backlog/tasks/task-521 - Console-branching-carry-attachments-on-Edit-and-resend.md
@@ -1,0 +1,25 @@
+---
+id: TASK-521
+title: 'Console branching: carry attachments across Edit & resend'
+status: To Do
+assignee: []
+created_date: '2026-07-24'
+labels:
+  - console
+  - chat
+  - ux
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Phase B's "Edit & resend" (PR #811) forks a new user-message branch from an edited user message, but the edit modal is text-only: `edit_and_resend_message` calls `create_sibling(role=USER, content=...)` and synthesizes a text-only provider dict, so if the anchor user message carried attachments (an image), the new branch loses them in BOTH the persisted sibling and the provider payload. The old branch keeps them off-path, so nothing is destroyed — but a user who edits the caption of an image prompt silently re-sends without the image. Fix: copy the anchor's `attachments` tuple onto the resent sibling (and include them in the provider payload the same way `submit_draft` embeds staged attachments), or — at minimum — surface the text-only limitation in the edit modal copy when the anchor has attachments. Respect the vision-capability gate the send path applies (`vision_block_reason`).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Edit & resend on a user message with attachments carries the attachments onto the new sibling (persisted) and into the provider payload, or clearly informs the user they will be dropped
+- [ ] #2 The vision-capability block applies the same way it does on a fresh send
+- [ ] #3 Plain in-place Save continues to leave attachments untouched
+<!-- AC:END -->


### PR DESCRIPTION
Files the deferred follow-ups from the Phase B (#811) and Phase C (#827) final reviews:

- **task-519** — record the persisted reply id for stopped-via-cancel agent runs (the `task.cancel()` path never binds `run_id`; documented in the Phase C plan addendum).
- **task-520** — stronger legacy-flat fingerprint for resume root-chaining (the all-USER-legacy phantom-counter edge; gate on "NULL-parent ASSISTANT row exists").
- **task-521** — carry attachments across Edit & resend (text-only modal silently drops an anchor image from the resent branch).

Docs-only. IDs swept against all remote branches (max was 518; 519–521 free).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three backlog task docs (TASK-519 to TASK-521) capturing Console branching Phase B/C follow-ups.
They cover recording the persisted reply ID on cancel-stopped agent runs, strengthening legacy-flat root-chaining detection on resume, and carrying attachments across Edit & resend with the same vision-capability checks.

<sup>Written for commit 10ac628a3eebc99167f1f9a9359bd718e8ada5d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

