### PR TITLE
feat(skills): install skills from GitHub/zip URLs via the Library import row

### DIFF
--- a/Docs/superpowers/plans/2026-07-24-skills-remote-fetch-plan.md
+++ b/Docs/superpowers/plans/2026-07-24-skills-remote-fetch-plan.md
@@ -1,0 +1,924 @@
+# Remote Skill Fetch (install from a GitHub link) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Install a skill from a pasted GitHub or zip URL: classify → SSRF-hardened fetch → bounded re-root → the EXISTING hardened `import_skill_file` → trust-pending.
+
+**Architecture:** One new module `Skills_Interop/skill_remote_fetch.py` owns classification (pure), the hardened fetcher (httpx, manual redirects, resolve-and-reject), the bounded extraction bridge, and the install seam. Token/branches reuse the existing `Utils/github_api_client.GitHubAPIClient`. Policy enforced via a new public `SkillsScopeService.enforce_install_remote()`. The UI is a URL branch at the top of the existing import flow.
+
+**Tech Stack:** Python 3.11+, httpx (existing dep), `ipaddress`/`socket` stdlib, pytest + `httpx.MockTransport`. No new dependencies.
+
+**Design doc:** `Docs/superpowers/specs/2026-07-24-skills-remote-fetch-design.md` (governs on ambiguity).
+
+## Global Constraints
+
+- **Fetch policy (verbatim):** https-only; `validate_url` first; resolve-and-reject EVERY resolved address (A+AAAA; mixed public+private → reject; IP-literal hosts checked directly) — private/loopback/link-local/reserved/multicast/unspecified all rejected; `follow_redirects=False` with a manual ≤3-hop loop re-running ALL checks per hop; auth header (`token <t>`) ONLY while the current hop's host ∈ {`github.com`, `api.github.com`, `codeload.github.com`, `objects.githubusercontent.com`}; streamed download aborting past **30 MB** compressed; timeouts 10 s connect / 60 s total.
+- **GitHub normalization:** `api.github.com/repos/{owner}/{repo}/zipball/{ref}` (`HEAD` default) — never codeload-direct.
+- **Ref-split:** one-segment tail = ref; multi-segment → longest-prefix match against `get_branches` (which gains `per_page=100` — one additive edit); no match OR API failure → first-segment heuristic (never a wrong silent match).
+- **Bridge is bounded:** candidate discovery is central-directory-only (no decompression); re-root synthesis reuses `LocalSkillsService._read_zip_member_bounded(archive, member, member_name, max_bytes)` and enforces `MAX_SUPPORTING_FILE_BYTES` (5 MB)/`MAX_SUPPORTING_FILES_TOTAL_BYTES` (25 MB)/`MAX_SUPPORTING_FILES_COUNT` (500) DURING synthesis; many candidates → error listing ≤20 paths.
+- **Policy:** REQUIRED registry entry `_resource("skills.install_remote", actions=(LAUNCH,))` (engine fails closed); enforced via the NEW public `SkillsScopeService.enforce_install_remote()` BEFORE any network I/O; the import path's own `skills.import.launch.local` gate remains (intentional double-gate).
+- Always trust-pending (`trust_approved=False`). Network stays OUT of `LocalSkillsService`.
+- **Tests:** `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <dirs> -q` (directories only — never a file plus its parent dir); Skills/UI suites need `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring`. Known baselines: `Tests/Chat/test_anthropic_native_tools.py::test_anthropic_shaped_tools_pass_through_untouched`; flaky `Tests/Skills/test_skills_library_flow.py::test_skill_editor_canvas_scrolls_trust_panel_into_view` (isolate, don't chase).
+- **Commit hygiene:** `git add` ONLY named files — NEVER `git add -A`. SUBAGENTS MUST NOT touch/checkout `.superpowers/sdd/progress.md`.
+- Anchors verified at `c8082f9cf` — re-grep before editing.
+
+## File Structure
+
+| File | Change |
+|---|---|
+| `tldw_chatbook/Skills_Interop/skill_remote_fetch.py` | NEW: classifier, ref-split, fetcher, bridge, `install_skill_from_url` |
+| `tldw_chatbook/runtime_policy/registry.py` | `_resource("skills.install_remote", actions=(LAUNCH,))` |
+| `tldw_chatbook/Skills_Interop/skills_scope_service.py` | public `enforce_install_remote()` |
+| `tldw_chatbook/Utils/github_api_client.py` | `get_branches` gains `per_page=100` (one line) |
+| `tldw_chatbook/UI/Screens/library_screen.py` | URL branch at top of `_run_library_skills_import` |
+| Tests | `Tests/Skills/test_skill_remote_fetch.py` (new; classifier/fetcher/bridge/seam), UI test in `Tests/Skills/test_skills_import.py` or the file's existing import-row suite |
+
+---
+
+### Task 1: Policy entry + public enforcement passthrough + branches pagination
+
+**Files:**
+- Modify: `tldw_chatbook/runtime_policy/registry.py` (`server_skills` block, sibling of `skills.read_file`); `tldw_chatbook/Skills_Interop/skills_scope_service.py`; `tldw_chatbook/Utils/github_api_client.py` (`get_branches` ~:200)
+- Test: `Tests/Skills/test_skill_remote_fetch.py` (create)
+
+**Interfaces:**
+- Produces: action id `skills.install_remote.launch.local` registered; `SkillsScopeService.enforce_install_remote() -> None` (public; raises `PolicyDeniedError` on denial, no-op without an enforcer); `get_branches` requests `params={"per_page": 100}`.
+
+- [ ] **Step 1: Failing tests** (create the test file)
+
+```python
+import pytest
+
+
+def test_policy_action_id_registered():
+    # Engine fails CLOSED on unknown ids — pin registration. Mirror the access
+    # idiom Tests/ already uses for skills.read_file.launch.local (grep it).
+    from tldw_chatbook.runtime_policy.registry import CAPABILITY_REGISTRY
+
+    assert "skills.install_remote.launch.local" in CAPABILITY_REGISTRY
+
+
+def test_scope_service_public_enforce_passthrough():
+    from tldw_chatbook.Skills_Interop.skills_scope_service import SkillsScopeService
+
+    calls = []
+
+    class _Enforcer:
+        def require_allowed(self, *, action_id):
+            calls.append(action_id)
+
+    scope = SkillsScopeService(
+        local_service=None, server_service=None, policy_enforcer=_Enforcer()
+    )
+    scope.enforce_install_remote()
+    assert calls == ["skills.install_remote.launch.local"]
+    # No enforcer wired -> no-op, no raise (matches _enforce_policy semantics).
+    SkillsScopeService(local_service=None, server_service=None).enforce_install_remote()
+
+
+@pytest.mark.asyncio
+async def test_get_branches_requests_full_page(monkeypatch):
+    from tldw_chatbook.Utils.github_api_client import GitHubAPIClient
+
+    client = GitHubAPIClient(token="t")
+    captured = {}
+
+    class _Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return [{"name": "main"}]
+
+    class _Client:
+        async def get(self, url, **kwargs):
+            captured["url"] = url
+            captured["params"] = kwargs.get("params")
+            return _Resp()
+
+    monkeypatch.setattr(type(client), "client", property(lambda self: _Client()))
+    branches = await client.get_branches("o", "r")
+    assert branches == ["main"]
+    assert captured["params"] == {"per_page": 100}
+```
+
+(Adapt the registry access and SkillsScopeService construction to the real signatures — READ both files first; the assertions are the contract. If `client` is a plain property returning a cached httpx client, monkeypatch whatever the file's other tests patch — grep `Tests/` for existing `GitHubAPIClient` test idioms and mirror.)
+
+- [ ] **Step 2: RED** — `KeyError`/`AttributeError`/missing params. **Step 3: Implement**: registry line `_resource("skills.install_remote", actions=(LAUNCH,)),` after the `skills.read_file` entry; scope-service method:
+
+```python
+    def enforce_install_remote(self) -> None:
+        """Gate a remote skill install (public seam for skill_remote_fetch).
+
+        Enforces ``skills.install_remote.launch.local`` BEFORE any network
+        I/O happens. Public by design: the fetch module must not reach the
+        private ``_enforce_policy`` across the class boundary.
+
+        Raises:
+            PolicyDeniedError: When a wired policy enforcer denies the action.
+        """
+        self._enforce_policy("skills.install_remote.launch.local")
+```
+
+`get_branches`: change `response = await self.client.get(url)` → `response = await self.client.get(url, params={"per_page": 100})` (cache key unaffected — verify `_get_cache_key(url)` signature; if it accepts params, pass them for key correctness).
+
+- [ ] **Step 4: GREEN** + regression: `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/ Tests/RuntimePolicy/ -q` (RuntimePolicy has 2 known pre-existing failures — watchlists/study drift; stash-prove if unsure). **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/runtime_policy/registry.py tldw_chatbook/Skills_Interop/skills_scope_service.py tldw_chatbook/Utils/github_api_client.py Tests/Skills/test_skill_remote_fetch.py
+git commit -m "feat(skills): install_remote policy entry, public enforce seam, paged branches"
+```
+
+---
+
+### Task 2: Pure URL classifier + ref-split
+
+**Files:**
+- Create: `tldw_chatbook/Skills_Interop/skill_remote_fetch.py`
+- Test: `Tests/Skills/test_skill_remote_fetch.py` (extend)
+
+**Interfaces:**
+- Produces (module-level, all pure):
+
+```python
+@dataclass(frozen=True)
+class GitHubZipSource:
+    owner: str
+    repo: str
+    tree_tail: tuple[str, ...]   # raw /tree/ segments; ref/subdir split later
+    suggested_name: str          # subdir basename or repo name (raw; import normalizes)
+
+@dataclass(frozen=True)
+class DirectZipSource:
+    url: str
+    github_auth: bool            # release-asset URLs on github.com
+    suggested_name: str          # asset/zip basename sans .zip
+
+class RemoteSkillError(ValueError):
+    """User-presentable remote-install failure."""
+
+def classify_skill_source_url(url: str) -> GitHubZipSource | DirectZipSource:
+    ...  # raises RemoteSkillError on anything unsupported
+
+async def resolve_ref_and_subdir(
+    source: GitHubZipSource,
+    list_branches,  # async callable (owner, repo) -> list[str]
+) -> tuple[str, str]:
+    ...  # -> (ref, subdir-posix-or-""), per the spec's §2 rules
+```
+
+- [ ] **Step 1: Failing tests** (append)
+
+```python
+from tldw_chatbook.Skills_Interop.skill_remote_fetch import (
+    DirectZipSource,
+    GitHubZipSource,
+    RemoteSkillError,
+    classify_skill_source_url,
+    resolve_ref_and_subdir,
+)
+
+
+def test_classify_repo_root():
+    src = classify_skill_source_url("https://github.com/obra/superpowers")
+    assert src == GitHubZipSource(
+        owner="obra", repo="superpowers", tree_tail=(), suggested_name="superpowers"
+    )
+
+
+def test_classify_tree_subdir():
+    src = classify_skill_source_url(
+        "https://github.com/obra/superpowers/tree/main/skills/brainstorming"
+    )
+    assert isinstance(src, GitHubZipSource)
+    assert src.tree_tail == ("main", "skills", "brainstorming")
+    assert src.suggested_name == "brainstorming"
+
+
+def test_classify_release_asset_and_direct_zip():
+    rel = classify_skill_source_url(
+        "https://github.com/o/r/releases/download/v1/my-skill.zip"
+    )
+    assert rel == DirectZipSource(
+        url="https://github.com/o/r/releases/download/v1/my-skill.zip",
+        github_auth=True,
+        suggested_name="my-skill",
+    )
+    direct = classify_skill_source_url("https://example.com/pkg/my-skill.zip")
+    assert direct.github_auth is False and direct.suggested_name == "my-skill"
+
+
+@pytest.mark.parametrize("bad", [
+    "http://github.com/o/r",                    # http
+    "https://example.com/not-a-zip",            # non-github non-zip
+    "git@github.com:o/r.git",                   # git protocol
+    "https://github.com/onlyowner",             # no repo
+    "ftp://example.com/x.zip",
+])
+def test_classify_rejects(bad):
+    with pytest.raises(RemoteSkillError):
+        classify_skill_source_url(bad)
+
+
+@pytest.mark.asyncio
+async def test_ref_split_single_segment_is_ref():
+    src = classify_skill_source_url("https://github.com/o/r/tree/v1.2")
+    async def _boom(o, r):  # must NOT be called for single-segment tails
+        raise AssertionError("branch listing not needed")
+    assert await resolve_ref_and_subdir(src, _boom) == ("v1.2", "")
+
+
+@pytest.mark.asyncio
+async def test_ref_split_longest_prefix_branch_wins():
+    src = classify_skill_source_url("https://github.com/o/r/tree/feature/foo/skills/x")
+    async def _branches(o, r):
+        return ["main", "feature/foo", "feature"]
+    ref, subdir = await resolve_ref_and_subdir(src, _branches)
+    assert (ref, subdir) == ("feature/foo", "skills/x")
+
+
+@pytest.mark.asyncio
+async def test_ref_split_no_match_falls_back_to_first_segment():
+    src = classify_skill_source_url("https://github.com/o/r/tree/main/skills/x")
+    async def _branches(o, r):
+        return ["dev"]  # capped/truncated list without the real branch
+    assert await resolve_ref_and_subdir(src, _branches) == ("main", "skills/x")
+
+
+@pytest.mark.asyncio
+async def test_ref_split_api_failure_falls_back():
+    src = classify_skill_source_url("https://github.com/o/r/tree/main/skills/x")
+    async def _branches(o, r):
+        raise RuntimeError("offline")
+    assert await resolve_ref_and_subdir(src, _branches) == ("main", "skills/x")
+```
+
+- [ ] **Step 2: RED** (ImportError). **Step 3: Implement** (new module; complete):
+
+```python
+"""Remote skill fetch: URL classification, hardened download, bounded re-root.
+
+The install path for "paste a GitHub link": classify -> fetch (SSRF-hardened)
+-> re-root the archive to a single-skill zip -> the EXISTING hardened
+``import_skill_file`` seam. This module owns all skill-install network I/O;
+``LocalSkillsService`` stays network-free.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+
+@dataclass(frozen=True)
+class GitHubZipSource:
+    """A GitHub repo/tree URL normalized for zipball download."""
+
+    owner: str
+    repo: str
+    tree_tail: tuple[str, ...]
+    suggested_name: str
+
+
+@dataclass(frozen=True)
+class DirectZipSource:
+    """A direct https zip URL (GitHub release asset or third-party)."""
+
+    url: str
+    github_auth: bool
+    suggested_name: str
+
+
+class RemoteSkillError(ValueError):
+    """User-presentable remote-install failure."""
+
+
+def _zip_basename(path_segment: str) -> str:
+    name = path_segment.rsplit("/", 1)[-1]
+    return name[:-4] if name.lower().endswith(".zip") else name
+
+
+def classify_skill_source_url(url: str) -> GitHubZipSource | DirectZipSource:
+    """Classify a pasted URL into a fetchable skill source.
+
+    Args:
+        url: The pasted URL.
+
+    Returns:
+        A ``GitHubZipSource`` (repo/tree form, zipball-normalized later) or a
+        ``DirectZipSource`` (release asset / any https ``.zip``).
+
+    Raises:
+        RemoteSkillError: Non-https, non-GitHub non-zip, or malformed input.
+    """
+    # Deferred import: input_validation pulls metrics plumbing.
+    from ..Utils.input_validation import validate_url
+
+    if not validate_url(url):
+        raise RemoteSkillError("That doesn't look like a valid URL.")
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        raise RemoteSkillError("Only https:// URLs are supported.")
+    host = (parsed.hostname or "").lower()
+    path = parsed.path.strip("/")
+    segments = tuple(s for s in path.split("/") if s)
+
+    if host == "github.com":
+        if len(segments) >= 4 and segments[2] == "releases" and segments[3] == "download":
+            if not path.lower().endswith(".zip"):
+                raise RemoteSkillError("Only .zip release assets are supported.")
+            return DirectZipSource(
+                url=url, github_auth=True, suggested_name=_zip_basename(path)
+            )
+        if len(segments) == 2:
+            owner, repo = segments
+            return GitHubZipSource(
+                owner=owner, repo=repo, tree_tail=(), suggested_name=repo
+            )
+        if len(segments) >= 4 and segments[2] == "tree":
+            owner, repo = segments[0], segments[1]
+            tail = segments[3:]
+            return GitHubZipSource(
+                owner=owner,
+                repo=repo,
+                tree_tail=tail,
+                suggested_name=tail[-1] if len(tail) > 1 else repo,
+            )
+        raise RemoteSkillError(
+            "Unsupported GitHub URL — use a repo, /tree/<branch>/<subdir>, "
+            "or a .zip release asset."
+        )
+
+    if path.lower().endswith(".zip"):
+        return DirectZipSource(
+            url=url, github_auth=False, suggested_name=_zip_basename(path)
+        )
+    raise RemoteSkillError(
+        "Unsupported URL — paste a GitHub repo/subdirectory URL or a direct .zip link."
+    )
+
+
+async def resolve_ref_and_subdir(
+    source: GitHubZipSource, list_branches
+) -> tuple[str, str]:
+    """Split a ``/tree/`` tail into (ref, subdir) per the spec's §2 rules.
+
+    Single-segment tails are the ref outright. Multi-segment tails try a
+    longest-prefix match against the repo's branch list (possibly capped at
+    100 — a missing match degrades to the first-segment heuristic, never a
+    wrong silent match). Branch-list failures degrade the same way.
+
+    Args:
+        source: The classified GitHub source (``tree_tail`` may be empty).
+        list_branches: Async callable ``(owner, repo) -> list[str]``.
+
+    Returns:
+        ``(ref, subdir)`` — subdir is ``""`` or a POSIX relative path.
+    """
+    tail = source.tree_tail
+    if not tail:
+        return "HEAD", ""
+    if len(tail) == 1:
+        return tail[0], ""
+    try:
+        branches = await list_branches(source.owner, source.repo)
+    except Exception:
+        branches = []
+    joined = "/".join(tail)
+    best = ""
+    for branch in branches:
+        if (joined == branch or joined.startswith(branch + "/")) and len(branch) > len(best):
+            best = branch
+    if best:
+        subdir = joined[len(best):].strip("/")
+        return best, subdir
+    return tail[0], "/".join(tail[1:])
+```
+
+- [ ] **Step 4: GREEN**: `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/ -q`. **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Skills_Interop/skill_remote_fetch.py Tests/Skills/test_skill_remote_fetch.py
+git commit -m "feat(skills): pure remote-source classifier + slash-ref splitting"
+```
+
+---
+
+### Task 3: SSRF-hardened fetcher
+
+**Files:**
+- Modify: `tldw_chatbook/Skills_Interop/skill_remote_fetch.py`
+- Test: `Tests/Skills/test_skill_remote_fetch.py` (extend)
+
+**Interfaces:**
+- Produces:
+
+```python
+REMOTE_FETCH_MAX_BYTES = 30 * 1024 * 1024
+REMOTE_FETCH_MAX_HOPS = 3
+GITHUB_AUTH_HOSTS = frozenset(
+    {"github.com", "api.github.com", "codeload.github.com", "objects.githubusercontent.com"}
+)
+
+async def fetch_zip_bytes(
+    url: str,
+    *,
+    token: str | None = None,
+    transport=None,           # httpx transport injection for tests
+    resolver=None,            # (host: str) -> list[str] of IPs; None = socket.getaddrinfo
+) -> bytes:
+    ...  # raises RemoteSkillError on every rejection class
+```
+
+- [ ] **Step 1: Failing tests** (append; `httpx.MockTransport` + an injected fake resolver — full code)
+
+```python
+import httpx
+
+from tldw_chatbook.Skills_Interop.skill_remote_fetch import (
+    GITHUB_AUTH_HOSTS,
+    REMOTE_FETCH_MAX_BYTES,
+    fetch_zip_bytes,
+)
+
+_PUB = lambda host: ["93.184.216.34"]          # public resolver
+
+
+def _transport(handler):
+    return httpx.MockTransport(handler)
+
+
+@pytest.mark.asyncio
+async def test_fetch_happy_path_streams_bytes():
+    def handler(request):
+        return httpx.Response(200, content=b"PK\x03\x04zipbytes")
+    out = await fetch_zip_bytes(
+        "https://api.github.com/repos/o/r/zipball/HEAD",
+        transport=_transport(handler), resolver=_PUB,
+    )
+    assert out.startswith(b"PK")
+
+
+@pytest.mark.asyncio
+async def test_private_and_mixed_resolution_rejected():
+    with pytest.raises(RemoteSkillError):
+        await fetch_zip_bytes("https://internal.example/x.zip",
+                              transport=_transport(lambda r: httpx.Response(200)),
+                              resolver=lambda h: ["10.0.0.5"])
+    with pytest.raises(RemoteSkillError):  # mixed public+private -> reject
+        await fetch_zip_bytes("https://mixed.example/x.zip",
+                              transport=_transport(lambda r: httpx.Response(200)),
+                              resolver=lambda h: ["93.184.216.34", "fd00::1"])
+    with pytest.raises(RemoteSkillError):  # IP-literal host
+        await fetch_zip_bytes("https://169.254.169.254/x.zip",
+                              transport=_transport(lambda r: httpx.Response(200)),
+                              resolver=_PUB)
+
+
+@pytest.mark.asyncio
+async def test_redirect_hop_revalidated_and_capped():
+    def handler(request):
+        host = request.url.host
+        if host == "a.example":
+            return httpx.Response(302, headers={"location": "https://b.example/x.zip"})
+        if host == "b.example":
+            return httpx.Response(302, headers={"location": "http://c.example/x.zip"})
+        raise AssertionError("unexpected host")
+    with pytest.raises(RemoteSkillError):   # https->http hop rejected
+        await fetch_zip_bytes("https://a.example/x.zip",
+                              transport=_transport(handler), resolver=_PUB)
+
+    def loop_handler(request):
+        return httpx.Response(302, headers={"location": str(request.url)})
+    with pytest.raises(RemoteSkillError):   # >3 hops
+        await fetch_zip_bytes("https://a.example/x.zip",
+                              transport=_transport(loop_handler), resolver=_PUB)
+
+    def private_hop(request):
+        if request.url.host == "a.example":
+            return httpx.Response(302, headers={"location": "https://evil.internal/x.zip"})
+        raise AssertionError
+    with pytest.raises(RemoteSkillError):   # hop host resolves private
+        await fetch_zip_bytes(
+            "https://a.example/x.zip", transport=_transport(private_hop),
+            resolver=lambda h: ["10.1.1.1"] if h == "evil.internal" else ["93.184.216.34"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_auth_scoped_to_github_family():
+    seen = {}
+    def handler(request):
+        seen[request.url.host] = request.headers.get("authorization")
+        if request.url.host == "api.github.com":
+            return httpx.Response(
+                302, headers={"location": "https://codeload.github.com/o/r/zip/HEAD"})
+        if request.url.host == "codeload.github.com":
+            return httpx.Response(
+                302, headers={"location": "https://cdn.example.com/x.zip"})
+        return httpx.Response(200, content=b"PK\x03\x04")
+    await fetch_zip_bytes("https://api.github.com/repos/o/r/zipball/HEAD",
+                          token="SECRET", transport=_transport(handler), resolver=_PUB)
+    assert seen["api.github.com"] == "token SECRET"
+    assert seen["codeload.github.com"] == "token SECRET"
+    assert seen["cdn.example.com"] is None    # STRIPPED off-family
+
+
+@pytest.mark.asyncio
+async def test_stream_cap_aborts():
+    big = b"x" * (REMOTE_FETCH_MAX_BYTES + 1024)
+    def handler(request):
+        return httpx.Response(200, content=big)
+    with pytest.raises(RemoteSkillError, match="too large"):
+        await fetch_zip_bytes("https://example.com/x.zip",
+                              transport=_transport(handler), resolver=_PUB)
+```
+
+- [ ] **Step 2: RED**. **Step 3: Implement** (append to the module):
+
+```python
+import ipaddress
+import socket
+
+import httpx
+
+REMOTE_FETCH_MAX_BYTES = 30 * 1024 * 1024
+REMOTE_FETCH_MAX_HOPS = 3
+_FETCH_CHUNK = 65536
+GITHUB_AUTH_HOSTS = frozenset(
+    {"github.com", "api.github.com", "codeload.github.com",
+     "objects.githubusercontent.com"}
+)
+
+
+def _default_resolver(host: str) -> list[str]:
+    infos = socket.getaddrinfo(host, 443, proto=socket.IPPROTO_TCP)
+    return [info[4][0] for info in infos]
+
+
+def _assert_host_allowed(host: str, resolver) -> None:
+    """Reject unless EVERY resolved address is public (mixed sets reject)."""
+    try:
+        literal = ipaddress.ip_address(host)
+        addresses = [str(literal)]
+    except ValueError:
+        try:
+            addresses = resolver(host)
+        except OSError as exc:
+            raise RemoteSkillError(f"Could not resolve {host}.") from exc
+    if not addresses:
+        raise RemoteSkillError(f"Could not resolve {host}.")
+    for raw in addresses:
+        addr = ipaddress.ip_address(raw.split("%", 1)[0])
+        if (addr.is_private or addr.is_loopback or addr.is_link_local
+                or addr.is_reserved or addr.is_multicast or addr.is_unspecified):
+            raise RemoteSkillError("That host is not reachable from here.")
+
+
+async def fetch_zip_bytes(
+    url: str, *, token: str | None = None, transport=None, resolver=None
+) -> bytes:
+    """Download a zip with SSRF hardening, manual redirects, and a size cap.
+
+    Args:
+        url: The (already classified/normalized) https URL to download.
+        token: Optional GitHub token; attached ONLY on GITHUB_AUTH_HOSTS hops.
+        transport: httpx transport override (tests).
+        resolver: ``(host) -> list[str]`` override (tests); defaults to
+            ``socket.getaddrinfo``.
+
+    Returns:
+        The raw (compressed) zip bytes, at most ``REMOTE_FETCH_MAX_BYTES``.
+
+    Raises:
+        RemoteSkillError: On every rejection class (scheme, host, hops, cap,
+            HTTP status, timeouts).
+    """
+    from ..Utils.input_validation import validate_url
+
+    resolver = resolver or _default_resolver
+    timeout = httpx.Timeout(60.0, connect=10.0)
+    current = url
+    async with httpx.AsyncClient(
+        transport=transport, timeout=timeout, follow_redirects=False
+    ) as client:
+        for _hop in range(REMOTE_FETCH_MAX_HOPS + 1):
+            if not validate_url(current):
+                raise RemoteSkillError("Invalid URL after redirect.")
+            parsed = httpx.URL(current)
+            if parsed.scheme != "https":
+                raise RemoteSkillError("Only https:// is allowed (redirect downgraded).")
+            host = (parsed.host or "").lower()
+            _assert_host_allowed(host, resolver)
+            headers = {}
+            if token and host in GITHUB_AUTH_HOSTS:
+                headers["Authorization"] = f"token {token}"
+            try:
+                async with client.stream("GET", current, headers=headers) as response:
+                    if response.status_code in (301, 302, 303, 307, 308):
+                        location = response.headers.get("location")
+                        if not location:
+                            raise RemoteSkillError("Redirect without a location.")
+                        current = str(parsed.join(location))
+                        continue
+                    if response.status_code != 200:
+                        raise RemoteSkillError(
+                            f"Download failed (HTTP {response.status_code})."
+                        )
+                    chunks: list[bytes] = []
+                    received = 0
+                    async for chunk in response.aiter_bytes(_FETCH_CHUNK):
+                        received += len(chunk)
+                        if received > REMOTE_FETCH_MAX_BYTES:
+                            raise RemoteSkillError(
+                                "Download too large (over 30 MB compressed)."
+                            )
+                        chunks.append(chunk)
+                    return b"".join(chunks)
+            except httpx.TimeoutException as exc:
+                raise RemoteSkillError("Download timed out.") from exc
+            except httpx.HTTPError as exc:
+                raise RemoteSkillError(f"Download failed: {exc}") from exc
+        raise RemoteSkillError("Too many redirects.")
+```
+
+- [ ] **Step 4: GREEN** (same suite command). **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Skills_Interop/skill_remote_fetch.py Tests/Skills/test_skill_remote_fetch.py
+git commit -m "feat(skills): SSRF-hardened streaming zip fetcher with scoped GitHub auth"
+```
+
+---
+
+### Task 4: Bounded extraction bridge
+
+**Files:**
+- Modify: `tldw_chatbook/Skills_Interop/skill_remote_fetch.py`
+- Test: `Tests/Skills/test_skill_remote_fetch.py` (extend)
+
+**Interfaces:**
+- Consumes: `LocalSkillsService._read_zip_member_bounded(archive, member, member_name, max_bytes) -> bytes` (staticmethod, exists — import the CLASS and call the staticmethod); caps from `tldw_api.skills_schemas`.
+- Produces: `re_root_skill_zip(zip_bytes: bytes, *, subdir: str, suggested_name: str) -> tuple[bytes, str]` → (single-skill zip bytes, final name). Raises `RemoteSkillError` for zero candidates, many candidates (message lists ≤20 paths + "paste a subdirectory URL"), corrupt zip, or cap violations during synthesis.
+
+- [ ] **Step 1: Failing tests** (append — build archives with zipfile in-memory)
+
+```python
+import io
+import zipfile
+
+from tldw_chatbook.Skills_Interop.skill_remote_fetch import re_root_skill_zip
+
+
+def _zipball(entries, wrapper="repo-abc123/"):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        for name, data in entries:
+            z.writestr(wrapper + name, data)
+    return buf.getvalue()
+
+
+def test_reroot_subdir_install():
+    data = _zipball([
+        ("skills/brainstorm/SKILL.md", "---\nname: brainstorm\n---\nbody"),
+        ("skills/brainstorm/references/api.md", "# api"),
+        ("skills/other/SKILL.md", "x"),
+        ("README.md", "top"),
+    ])
+    out, name = re_root_skill_zip(data, subdir="skills/brainstorm", suggested_name="brainstorm")
+    with zipfile.ZipFile(io.BytesIO(out)) as z:
+        assert set(z.namelist()) == {"SKILL.md", "references/api.md"}
+    assert name == "brainstorm"
+
+
+def test_reroot_root_is_skill_and_unwrapped_asset():
+    wrapped = _zipball([("SKILL.md", "body"), ("notes.md", "n")])
+    out, _ = re_root_skill_zip(wrapped, subdir="", suggested_name="repo")
+    with zipfile.ZipFile(io.BytesIO(out)) as z:
+        assert "SKILL.md" in z.namelist()
+    unwrapped = _zipball([("SKILL.md", "body")], wrapper="")   # release-asset shape
+    out2, _ = re_root_skill_zip(unwrapped, subdir="", suggested_name="asset")
+    with zipfile.ZipFile(io.BytesIO(out2)) as z:
+        assert "SKILL.md" in z.namelist()
+
+
+def test_reroot_single_candidate_auto_installs():
+    data = _zipball([("skills/only/SKILL.md", "body"), ("README.md", "r")])
+    out, name = re_root_skill_zip(data, subdir="", suggested_name="repo")
+    assert name == "only"
+
+
+def test_reroot_many_candidates_error_lists_paths():
+    entries = [(f"skills/s{i}/SKILL.md", "b") for i in range(25)] 
+    data = _zipball(entries)
+    with pytest.raises(RemoteSkillError) as exc:
+        re_root_skill_zip(data, subdir="", suggested_name="repo")
+    msg = str(exc.value)
+    assert "skills/s0" in msg and "subdirectory URL" in msg
+    assert msg.count("skills/s") <= 20
+
+
+def test_reroot_zero_candidates_and_corrupt():
+    with pytest.raises(RemoteSkillError, match="No SKILL.md"):
+        re_root_skill_zip(_zipball([("README.md", "r")]), subdir="", suggested_name="x")
+    with pytest.raises(RemoteSkillError):
+        re_root_skill_zip(b"not a zip", subdir="", suggested_name="x")
+
+
+def test_reroot_lying_header_bomb_aborts_bounded():
+    # Forge a member whose declared size is tiny but whose stream is huge:
+    # simplest honest proxy — a member whose ACTUAL content exceeds the
+    # per-file cap; the bounded reader must abort during synthesis.
+    from tldw_chatbook.tldw_api.skills_schemas import MAX_SUPPORTING_FILE_BYTES
+    big = "x" * (MAX_SUPPORTING_FILE_BYTES + 100)
+    data = _zipball([("SKILL.md", "body"), ("references/huge.md", big)])
+    with pytest.raises(RemoteSkillError, match="too large"):
+        re_root_skill_zip(data, subdir="", suggested_name="repo")
+```
+
+- [ ] **Step 2: RED**. **Step 3: Implement** (append):
+
+```python
+import zipfile as _zipfile
+from io import BytesIO
+
+_CANDIDATE_SCAN_DEPTH = 3
+_CANDIDATE_LIST_LIMIT = 20
+
+
+def _archive_names(archive: "_zipfile.ZipFile") -> list[str]:
+    return [m.filename for m in archive.infolist() if not m.is_dir()]
+
+
+def _detect_root(names: list[str]) -> str:
+    """Root prefix: '' when SKILL.md sits at top; descend ONE wrapper dir."""
+    if "SKILL.md" in names:
+        return ""
+    tops = {n.split("/", 1)[0] for n in names if "/" in n}
+    loose = [n for n in names if "/" not in n]
+    if len(tops) == 1 and not loose:
+        return next(iter(tops)) + "/"
+    return ""
+
+
+def re_root_skill_zip(
+    zip_bytes: bytes, *, subdir: str, suggested_name: str
+) -> tuple[bytes, str]:
+    """Re-root a fetched archive to a single-skill zip (BOUNDED synthesis).
+
+    Candidate discovery is central-directory-only (no decompression). Member
+    extraction reuses ``LocalSkillsService._read_zip_member_bounded`` and
+    enforces the import caps DURING synthesis, so a lying-header bomb aborts
+    here exactly as it would in the importer.
+
+    Args:
+        zip_bytes: The fetched archive (already download-capped).
+        subdir: POSIX subdir to install from ('' = auto-detect at root).
+        suggested_name: Fallback skill name (subdir basename wins upstream).
+
+    Returns:
+        ``(single_skill_zip_bytes, final_name)``.
+
+    Raises:
+        RemoteSkillError: Corrupt archive, zero/many candidates, cap abort.
+    """
+    from .local_skills_service import LocalSkillsService
+    from ..tldw_api.skills_schemas import (
+        MAX_SUPPORTING_FILE_BYTES,
+        MAX_SUPPORTING_FILES_COUNT,
+        MAX_SUPPORTING_FILES_TOTAL_BYTES,
+    )
+
+    try:
+        archive = _zipfile.ZipFile(BytesIO(zip_bytes))
+    except _zipfile.BadZipFile as exc:
+        raise RemoteSkillError("The download was not a valid zip archive.") from exc
+    with archive:
+        names = _archive_names(archive)
+        root = _detect_root(names)
+        base = root + (subdir.strip("/") + "/" if subdir.strip("/") else "")
+
+        if base and not any(n.startswith(base) for n in names):
+            raise RemoteSkillError(f"No such folder in the archive: {subdir}")
+
+        skill_root = base
+        final_name = suggested_name
+        if (skill_root + "SKILL.md") not in names:
+            # Depth-limited candidate scan under the current base.
+            candidates = sorted(
+                n[len(base):-len("/SKILL.md")]
+                for n in names
+                if n.startswith(base)
+                and n.endswith("/SKILL.md")
+                and n[len(base):].count("/") <= _CANDIDATE_SCAN_DEPTH
+            )
+            if not candidates:
+                raise RemoteSkillError("No SKILL.md found in that archive.")
+            if len(candidates) > 1:
+                shown = ", ".join(candidates[:_CANDIDATE_LIST_LIMIT])
+                more = len(candidates) - min(len(candidates), _CANDIDATE_LIST_LIMIT)
+                suffix = f" (+{more} more)" if more > 0 else ""
+                raise RemoteSkillError(
+                    f"Found {len(candidates)} skills in that repository: "
+                    f"{shown}{suffix}. Paste a subdirectory URL to install one."
+                )
+            skill_root = base + candidates[0] + "/"
+            final_name = candidates[0].rsplit("/", 1)[-1]
+
+        members = [
+            m for m in archive.infolist()
+            if not m.is_dir() and m.filename.startswith(skill_root)
+        ]
+        if len(members) > MAX_SUPPORTING_FILES_COUNT + 1:
+            raise RemoteSkillError("That skill bundle has too many files.")
+        out = BytesIO()
+        total = 0
+        with _zipfile.ZipFile(out, "w", compression=_zipfile.ZIP_DEFLATED) as dest:
+            for member in members:
+                relative = member.filename[len(skill_root):]
+                if not relative:
+                    continue
+                if member.file_size > MAX_SUPPORTING_FILE_BYTES:
+                    raise RemoteSkillError(
+                        f"File too large in bundle: {relative}"
+                    )
+                try:
+                    data = LocalSkillsService._read_zip_member_bounded(
+                        archive, member, relative, MAX_SUPPORTING_FILE_BYTES
+                    )
+                except ValueError as exc:
+                    raise RemoteSkillError(f"File too large in bundle: {relative}") from exc
+                total += len(data)
+                if total > MAX_SUPPORTING_FILES_TOTAL_BYTES:
+                    raise RemoteSkillError("That skill bundle is too large.")
+                info = _zipfile.ZipInfo(relative)
+                info.external_attr = member.external_attr
+                dest.writestr(info, data)
+        return out.getvalue(), final_name
+```
+
+(Check `_read_zip_member_bounded`'s raise type for over-cap — it raises `ValueError("local_skill_file_too_large:…")`; the wrap above maps it to `RemoteSkillError` matching "too large". Adjust the match string if the helper's message differs — READ it first.)
+
+- [ ] **Step 4: GREEN**. **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Skills_Interop/skill_remote_fetch.py Tests/Skills/test_skill_remote_fetch.py
+git commit -m "feat(skills): bounded archive re-rooting bridge with candidate discovery"
+```
+
+---
+
+### Task 5: Install seam + UI URL branch
+
+**Files:**
+- Modify: `tldw_chatbook/Skills_Interop/skill_remote_fetch.py`; `tldw_chatbook/UI/Screens/library_screen.py` (`_run_library_skills_import` head ~:7248; placeholder copy in `Widgets/Library/library_skills_canvas.py` import-row Input ~:766)
+- Test: `Tests/Skills/test_skill_remote_fetch.py` (seam) + the import-row UI suite in `Tests/Skills/test_skills_import.py` (URL routing)
+
+**Interfaces:**
+- Produces: `async install_skill_from_url(url: str, *, scope_service, overwrite: bool = False, transport=None, resolver=None) -> dict` — order: classify (pure, may raise) → `scope_service.enforce_install_remote()` → token via `GitHubAPIClient` → (GitHub source) `resolve_ref_and_subdir(source, api.get_branches)` → normalized `https://api.github.com/repos/{owner}/{repo}/zipball/{ref}` → `fetch_zip_bytes` → `re_root_skill_zip` → `await scope_service.import_skill_file(bytes, mode="local", filename=f"{name}.zip", content_type="application/zip", overwrite=overwrite, trust_approved=False)`; returns the import result dict. The `GitHubAPIClient` instance is closed (`await api.close()`) in a finally.
+- UI: at the TOP of `_run_library_skills_import`, before `validate_path_simple`:
+
+```python
+        if raw_path.startswith(("http://", "https://")):
+            await self._install_library_skill_from_url(raw_path)
+            return
+```
+
+with a new `_install_library_skill_from_url` mirroring `_import_library_skill_from_loose_file` (~:7303): resolve `skills_scope_service`; call `install_skill_from_url`; success → `self._apply_library_skills_import_success(result.get("name", ""))`; `RemoteSkillError` → `self._apply_library_skills_import_status(str(exc))` (user-presentable by construction); other exceptions → `self._apply_library_skills_import_outcome_from_exception(name_guess, exc)`. Placeholder copy: append "or GitHub/zip URL".
+
+- [ ] **Step 1: Failing tests**: seam test with a fake scope service (records `enforce_install_remote` called BEFORE any transport request; import_skill_file receives the re-rooted bytes + `trust_approved=False` + `filename="brainstorm.zip"`), MockTransport serving a zipball for `/repos/o/r/zipball/main`; an http:// URL raises without touching enforce (classify-first is fine — but enforcement MUST precede network: assert transport saw zero requests when enforce raises PolicyDeniedError-like). UI test: a URL draft routes to the fetch path (monkeypatch `install_skill_from_url` in the screen module's namespace) and success primes the Review button — mirror the existing import-row test idioms in `Tests/Skills/test_skills_import.py`.
+- [ ] **Step 2: RED** → **Step 3: implement seam** (compose the Task 2–4 pieces exactly per the Interfaces block; GitHubAPIClient used for `.token` + `get_branches`, closed in finally) **+ UI branch** → **Step 4: GREEN** + `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/ -q`. **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Skills_Interop/skill_remote_fetch.py tldw_chatbook/UI/Screens/library_screen.py tldw_chatbook/Widgets/Library/library_skills_canvas.py Tests/Skills/test_skill_remote_fetch.py Tests/Skills/test_skills_import.py
+git commit -m "feat(skills): install_skill_from_url seam + Library URL import branch"
+```
+
+---
+
+### Task 6: E2E + full regression
+
+**Files:**
+- Test: `Tests/Skills/test_skill_remote_fetch.py` (extend)
+
+- [ ] **Step 1: E2E test** — MockTransport serving: `api.github.com/repos/obra/superpowers/zipball/main` → 302 to `codeload.github.com/...` → 200 with a real zipball-shaped archive (`superpowers-abc/skills/demo/SKILL.md` + `references/api.md`); a REAL `LocalSkillsService(store_dir=tmp_path)` behind a REAL `SkillsScopeService`; `install_skill_from_url("https://github.com/obra/superpowers/tree/main/skills/demo", scope_service=..., transport=..., resolver=fake_public)` → skill "demo" exists on disk with `references/api.md`, trust-pending (not trusted), and the auth-scoping/302 path exercised end to end.
+- [ ] **Step 2: Full gate:**
+
+Run: `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/ Tests/RuntimePolicy/ Tests/UI/test_library_skills_canvas.py -q`
+Expected: 0 failed beyond the known baselines (RuntimePolicy's 2 pre-existing; the flaky canvas test).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Tests/Skills/test_skill_remote_fetch.py
+git commit -m "test(skills): e2e — install a skill from a GitHub tree URL via mocked transports"
+```
+
+---
+
+## Notes for the executor
+
+- The spec governs; its §3 fetch policy and §4 bounded-bridge rules are load-bearing security.
+- `RemoteSkillError` messages are user-presentable BY DESIGN — the UI shows them verbatim; keep them human.
+- The DNS-rebinding residual is documented in the spec — do NOT attempt transport-level IP pinning in this plan.
+- Re-grep every anchor; files shift.

--- a/Docs/superpowers/specs/2026-07-24-skills-remote-fetch-design.md
+++ b/Docs/superpowers/specs/2026-07-24-skills-remote-fetch-design.md
@@ -1,0 +1,176 @@
+# Skills Runtime — Remote Fetch (install a skill from a GitHub link)
+
+**Status:** Approved design (2026-07-24), amended after the pre-spec review round.
+**Program:** Skills-install program, the critical-path layer for the north star
+("a user asks an agent to install a skill/pack from a GitHub link"). Follows
+trust (#762), bundle fidelity (#784), `$`-mention invocation (#801), and
+reference-file reachability (#814) — all merged. The agent-callable install
+tool is the NEXT layer and wraps this one.
+
+## Problem
+
+The import machinery is done and hardened (zip + folder → trust-pending →
+review → `$use`), and installed skills are usable — but nothing can fetch
+bytes from a URL. "Install `github.com/obra/superpowers/tree/main/skills/
+brainstorming`" dead-ends at a copy-paste-clone detour. This layer adds the
+fetch: URL → hardened download → the EXISTING import pipeline. It adds **zero
+new import logic** — every import guarantee (caps, junk pruning, symlink/
+case-fold/zip-slip rejection, bounded decompression, trust-pending landing)
+stays owned by `import_skill_file`.
+
+## Decisions (user-approved)
+
+- **URL surface:** GitHub forms (repo root, `/tree/{ref}[/{subdir}]`, release
+  assets) normalized to the codeload zipball, PLUS any direct `https://…zip`.
+- **Private repos:** the existing `[github]` token attaches when configured —
+  ONLY to GitHub-family hosts, stripped on any cross-host redirect.
+- **Multi-skill repo roots:** error + candidate listing (single-skill install
+  this layer; pack import remains its own planned layer).
+- Caps/policy: **30 MB compressed** download cap (streamed, aborts mid-stream),
+  ≤3 manual redirect hops, connect/total timeouts 10 s/60 s.
+
+## Design
+
+### 1. URL classification (pure) — `classify_skill_source_url(url)`
+
+Recognizes and normalizes, rejecting everything else BEFORE any network I/O:
+
+| Input | Result |
+|---|---|
+| `github.com/{owner}/{repo}` | GitHub ref: codeload zipball `…/zip/HEAD` (no API call needed for the default branch), no subdir |
+| `github.com/{owner}/{repo}/tree/{tail…}` | GitHub ref + subdir (tail split per §2) |
+| `github.com/{owner}/{repo}/releases/download/{tag}/{asset}` | Direct zip with GitHub auth eligibility |
+| any other `https://…zip` | Direct zip, no auth |
+| anything else (http:, non-zip non-GitHub, git@, etc.) | Rejected with a clear message |
+
+Skill-name suggestion: subdir basename → else repo name → else asset/zip
+basename (all through the existing `_derive_name_from_filename`
+normalization).
+
+### 2. Ref-vs-subdir disambiguation (slash-refs are real)
+
+`/tree/{tail}` cannot be split from the URL alone when branch names contain
+slashes (`feature/foo`). Rules:
+- Tail has ONE segment → it is the ref, no subdir.
+- Tail has MULTIPLE segments → list branches via the **existing**
+  `Utils/github_api_client.GitHubAPIClient.get_branches` and take the
+  **longest branch name that prefix-matches** the tail; the remainder is the
+  subdir. API unavailable (offline/rate-limited) → fall back to the
+  first-segment heuristic, and the eventual 404's error copy says a
+  slash-containing branch may need the plain repo URL + subdir-less form.
+
+`GitHubAPIClient` is also the ONLY token source (its param→env→config
+resolution with placeholder guards is reused, never reimplemented). Its API
+calls touch only `api.github.com` (safe surface); it is NOT used for byte
+downloads.
+
+### 3. Hardened fetcher — new `Skills_Interop/skill_remote_fetch.py` (httpx)
+
+Owns ALL byte downloads. Per request:
+1. **https-only**; `input_validation.validate_url` first (parse-level:
+   whitespace/backslash/credential/malformed-host rejection — verified it does
+   NOT do IP-range checks, hence:)
+2. **Resolve-and-reject before connect:** resolve the host (or take the
+   IP-literal directly) and reject private, loopback, link-local, reserved,
+   multicast, and unspecified ranges (covers 169.254.169.254 metadata).
+3. **Manual redirects:** `follow_redirects=False`; loop ≤3 hops; every hop
+   re-runs steps 1–2; scheme must remain https.
+4. **Auth scoping:** the token header attaches only while the CURRENT hop's
+   host ∈ {`github.com`, `api.github.com`, `codeload.github.com`,
+   `objects.githubusercontent.com`} (release assets 302 to the last one);
+   any hop outside the family proceeds WITHOUT the header.
+5. **Streaming cap:** iterate the body in chunks, abort with a clean error
+   the moment cumulative bytes exceed **30 MB** (compressed). Timeouts
+   10 s connect / 60 s total.
+6. Content-type is advisory only (GitHub serves zips as `application/zip`;
+   octet-stream accepted); the zip's own magic/parse failure is the real
+   gate downstream.
+
+**Documented residual:** DNS rebinding between the resolve-check and the
+connect is mitigated, not eliminated (single-resolve pinning via a custom
+transport is the named follow-up if this ever matters; this is a local
+single-user TUI, not a multi-tenant server).
+
+### 4. Extraction bridge — bounded re-rooting (bomb-class guard)
+
+The fetched zip is re-rooted to a single-skill zip and handed to
+`import_skill_file`. **The bridge is itself a decompression surface and MUST
+be bounded** — the 30 MB cap bounds only the compressed download:
+
+- Candidate discovery is **decompression-free** (central-directory namelist
+  only).
+- Root normalization: root `SKILL.md` → the archive IS the skill; else a
+  single top-level wrapper dir (the `{repo}-{sha}/` zipball shape — also
+  covers wrapped release assets; unwrapped assets hit the first rule) →
+  descend once and re-test; else scan (depth-limited) for `*/SKILL.md`.
+- Subdir install: members under `{root}/{subdir}/` only.
+- Exactly ONE candidate → re-root; MANY → clean error listing up to 20
+  discovered skill paths ("paste a subdirectory URL"); ZERO → "no SKILL.md
+  found".
+- **Re-root synthesis reuses `_read_zip_member_bounded`** (the existing
+  bounded streaming member reader) and enforces the import caps (5 MB/file,
+  25 MB total, 500 files) DURING synthesis — a lying-header bomb aborts here
+  exactly as it would in the importer. Junk/symlink members are simply
+  copied through or dropped cheaply; the importer remains the authority on
+  every import rule (no duplicated validation beyond the caps needed to
+  bound the synthesis itself).
+- Output: an in-memory zip named `{suggested-name}.zip` →
+  `import_skill_file(bytes, filename=…)` → trust-pending, existing review
+  flow.
+
+### 5. Seam, policy, UI
+
+- `install_skill_from_url(url, *, overwrite=False)` in
+  `skill_remote_fetch.py` (network stays OUT of `LocalSkillsService`;
+  the function calls INTO the existing import seam via the scope service).
+- **Required registry entry** (fail-closed lesson):
+  `_resource("skills.install_remote", actions=(LAUNCH,))` in the
+  `server_skills` capability block → `skills.install_remote.launch.local`,
+  enforced at the seam before any network I/O.
+- UI: the Library import row's existing path input detects `http(s)://` and
+  routes to a fetch worker; identical success/outcome/Review-button flow;
+  placeholder copy gains "or GitHub/zip URL". No new widgets.
+- Always lands trust-pending. Never `trust_approved`.
+
+## Components & boundaries
+
+| Unit | File | Responsibility |
+|---|---|---|
+| Classifier + ref-split (pure) | `Skills_Interop/skill_remote_fetch.py` | URL → GitHubRef/DirectZip/reject; name suggestion; §2 tail split (branch list injected as a callable) |
+| Hardened fetcher | same module | §3: https-only, resolve-and-reject, manual hops, auth scoping, streamed cap |
+| Extraction bridge | same module | §4: bounded re-rooting → in-memory skill zip |
+| Install seam | same module | policy gate → fetch → bridge → `import_skill_file` |
+| Token/branches reuse | `Utils/github_api_client.py` | token resolution; `get_branches` for slash-ref disambiguation (unchanged file) |
+| Policy entry | `runtime_policy/registry.py` | `skills.install_remote` (REQUIRED — engine fails closed) |
+| UI routing | `UI/Screens/library_screen.py` | URL detection in `_run_library_skills_import`; worker + outcome copy |
+
+## Testing strategy
+
+- **Classifier (pure table tests):** all five URL classes; rejects http:,
+  git@, non-zip; name suggestions; single- vs multi-segment tails (branch
+  list injected as a fake callable — longest-prefix win; fallback heuristic).
+- **Fetcher (httpx.MockTransport):** private/loopback/metadata IP rejection
+  (direct AND on a redirect hop); >3 hops rejected; https→http hop rejected;
+  auth present on codeload + objects.githubusercontent hops, STRIPPED on a
+  cross-host hop; mid-stream cap abort; timeout mapping to a clean error.
+- **Bridge:** zipball-wrapper descent; unwrapped asset; subdir re-root;
+  one/many(≤20 listed)/zero candidates; **lying-header bomb inside the
+  fetched zip aborts during synthesis** (bounded reader reused); caps
+  enforced during synthesis.
+- **Seam/policy:** `skills.install_remote.launch.local` registered (engine
+  fails closed — pinned); install lands trust-pending; disabled policy denies
+  cleanly before network.
+- **UI:** URL routes to the fetch worker; error copy surfaces (multi-skill
+  listing, over-cap, bad URL); success primes the same Review button.
+- **E2E (MockTransport):** a real zipball-shaped archive (wrapper dir +
+  `skills/demo/SKILL.md` + references) installs via a `/tree/…` URL,
+  trust-pending, then approvable.
+
+## Out of scope (deliberate)
+
+Pack/multi-skill install (next layer, unchanged plan); the agent-callable
+install tool (wraps this next); other forges' URL normalization (direct .zip
+covers them); `git` protocol/clone; provenance signatures; auto-update
+subscriptions; DNS-rebinding single-resolve pinning (named follow-up);
+private-repo UI for entering a token (config/env only, as the existing
+`[github]` section documents).

--- a/Docs/superpowers/specs/2026-07-24-skills-remote-fetch-design.md
+++ b/Docs/superpowers/specs/2026-07-24-skills-remote-fetch-design.md
@@ -37,11 +37,19 @@ Recognizes and normalizes, rejecting everything else BEFORE any network I/O:
 
 | Input | Result |
 |---|---|
-| `github.com/{owner}/{repo}` | GitHub ref: codeload zipball `…/zip/HEAD` (no API call needed for the default branch), no subdir |
-| `github.com/{owner}/{repo}/tree/{tail…}` | GitHub ref + subdir (tail split per §2) |
+| `github.com/{owner}/{repo}` | GitHub ref: `https://api.github.com/repos/{owner}/{repo}/zipball/HEAD`, no subdir |
+| `github.com/{owner}/{repo}/tree/{tail…}` | GitHub ref + subdir (tail split per §2) → `…/zipball/{ref}` |
 | `github.com/{owner}/{repo}/releases/download/{tag}/{asset}` | Direct zip with GitHub auth eligibility |
 | any other `https://…zip` | Direct zip, no auth |
 | anything else (http:, non-zip non-GitHub, git@, etc.) | Rejected with a clear message |
+
+**Normalization targets the documented API zipball endpoint**
+(`api.github.com/repos/{o}/{r}/zipball/{ref}`, `HEAD` for the default
+branch), NOT codeload directly: the API endpoint honors the `Authorization`
+header for public AND private repos and 302s to codeload — an in-family hop
+the manual-redirect policy (§3) already handles. One uniform URL shape,
+correct private-repo auth (codeload-direct with a header is a known 403
+trap).
 
 Skill-name suggestion: subdir basename → else repo name → else asset/zip
 basename (all through the existing `_derive_name_from_filename`
@@ -55,9 +63,16 @@ slashes (`feature/foo`). Rules:
 - Tail has MULTIPLE segments → list branches via the **existing**
   `Utils/github_api_client.GitHubAPIClient.get_branches` and take the
   **longest branch name that prefix-matches** the tail; the remainder is the
-  subdir. API unavailable (offline/rate-limited) → fall back to the
-  first-segment heuristic, and the eventual 404's error copy says a
-  slash-containing branch may need the plain repo URL + subdir-less form.
+  subdir. Verified constraint: `get_branches` currently issues ONE unpaged
+  request (GitHub defaults to 30/page — silent truncation) and caches for
+  5 minutes, so this layer makes a **one-line edit** to it: request
+  `per_page=100` (additive, backward-compatible for existing callers).
+  Repos with >100 branches can still truncate: therefore "no branch in the
+  (possibly-capped) list prefix-matches the tail" is treated EXACTLY like
+  "API unavailable" → fall back to the first-segment heuristic, and the
+  eventual 404's error copy says a slash-containing branch may need the
+  plain repo URL + subdir-less form. A truncated list can only cause a
+  clear failure, never a wrong silent match.
 
 `GitHubAPIClient` is also the ONLY token source (its param→env→config
 resolution with placeholder guards is reused, never reimplemented). Its API
@@ -71,8 +86,10 @@ Owns ALL byte downloads. Per request:
    whitespace/backslash/credential/malformed-host rejection — verified it does
    NOT do IP-range checks, hence:)
 2. **Resolve-and-reject before connect:** resolve the host (or take the
-   IP-literal directly) and reject private, loopback, link-local, reserved,
-   multicast, and unspecified ranges (covers 169.254.169.254 metadata).
+   IP-literal directly) and check **EVERY resolved address** (A and AAAA —
+   a malicious resolver can pair a public v4 with a private v6); reject if
+   ANY address is private, loopback, link-local, reserved, multicast, or
+   unspecified (covers 169.254.169.254 metadata).
 3. **Manual redirects:** `follow_redirects=False`; loop ≤3 hops; every hop
    re-runs steps 1–2; scheme must remain https.
 4. **Auth scoping:** the token header attaches only while the CURRENT hop's
@@ -120,16 +137,27 @@ be bounded** — the 30 MB cap bounds only the compressed download:
 
 ### 5. Seam, policy, UI
 
-- `install_skill_from_url(url, *, overwrite=False)` in
-  `skill_remote_fetch.py` (network stays OUT of `LocalSkillsService`;
-  the function calls INTO the existing import seam via the scope service).
+- `install_skill_from_url(url, *, scope_service, overwrite=False)` in
+  `skill_remote_fetch.py` (network stays OUT of `LocalSkillsService`; the
+  function calls INTO the existing import seam via the scope service, which
+  the UI already holds).
 - **Required registry entry** (fail-closed lesson):
   `_resource("skills.install_remote", actions=(LAUNCH,))` in the
   `server_skills` capability block → `skills.install_remote.launch.local`,
-  enforced at the seam before any network I/O.
-- UI: the Library import row's existing path input detects `http(s)://` and
-  routes to a fetch worker; identical success/outcome/Review-button flow;
-  placeholder copy gains "or GitHub/zip URL". No new widgets.
+  enforced BEFORE any network I/O via a **new small PUBLIC passthrough on
+  `SkillsScopeService`** (e.g. `enforce_install_remote()` wrapping its
+  private `_enforce_policy`) — verified: `_enforce_policy` is private and
+  never called across the class boundary; the module must not reach past
+  the underscore. The existing import path's own
+  `skills.import.launch.local` gate still fires inside `import_skill_file`
+  — intentional defense-in-depth (double-gated), not a bug.
+- UI: the URL branch goes at the TOP of `_run_library_skills_import`,
+  BEFORE the `validate_path_simple(..., require_exists=True)` call
+  (verified: a URL otherwise dies there as "Could not find that file or
+  folder"); the three existing outcome helpers
+  (`_apply_library_skills_import_status` / `_success` /
+  `_outcome_from_exception`) are reused unchanged; placeholder copy gains
+  "or GitHub/zip URL". No new widgets.
 - Always lands trust-pending. Never `trust_approved`.
 
 ## Components & boundaries
@@ -140,7 +168,8 @@ be bounded** — the 30 MB cap bounds only the compressed download:
 | Hardened fetcher | same module | §3: https-only, resolve-and-reject, manual hops, auth scoping, streamed cap |
 | Extraction bridge | same module | §4: bounded re-rooting → in-memory skill zip |
 | Install seam | same module | policy gate → fetch → bridge → `import_skill_file` |
-| Token/branches reuse | `Utils/github_api_client.py` | token resolution; `get_branches` for slash-ref disambiguation (unchanged file) |
+| Token/branches reuse | `Utils/github_api_client.py` | token resolution; `get_branches` for slash-ref disambiguation (ONE additive edit: `per_page=100` on the branches request) |
+| Public policy passthrough | `Skills_Interop/skills_scope_service.py` | `enforce_install_remote()` — public wrapper so the module never calls the private `_enforce_policy` |
 | Policy entry | `runtime_policy/registry.py` | `skills.install_remote` (REQUIRED — engine fails closed) |
 | UI routing | `UI/Screens/library_screen.py` | URL detection in `_run_library_skills_import`; worker + outcome copy |
 
@@ -150,9 +179,14 @@ be bounded** — the 30 MB cap bounds only the compressed download:
   git@, non-zip; name suggestions; single- vs multi-segment tails (branch
   list injected as a fake callable — longest-prefix win; fallback heuristic).
 - **Fetcher (httpx.MockTransport):** private/loopback/metadata IP rejection
-  (direct AND on a redirect hop); >3 hops rejected; https→http hop rejected;
-  auth present on codeload + objects.githubusercontent hops, STRIPPED on a
-  cross-host hop; mid-stream cap abort; timeout mapping to a clean error.
+  (direct AND on a redirect hop; a host resolving to a MIXED public+private
+  address set is rejected); >3 hops rejected; https→http hop rejected;
+  auth present on api.github.com/codeload/objects.githubusercontent hops,
+  STRIPPED on a cross-host hop; mid-stream cap abort; timeout mapping to a
+  clean error.
+- **Branches edit:** `get_branches` requests `per_page=100` (pinned); a
+  multi-segment tail with NO prefix match in the returned list falls back
+  to the heuristic (never a wrong silent match).
 - **Bridge:** zipball-wrapper descent; unwrapped asset; subdir re-root;
   one/many(≤20 listed)/zero candidates; **lying-header bomb inside the
   fetched zip aborts during synthesis** (bounded reader reused); caps

--- a/Tests/RuntimePolicy/test_runtime_policy_core.py
+++ b/Tests/RuntimePolicy/test_runtime_policy_core.py
@@ -837,8 +837,12 @@ EXPECTED_ACTION_IDS_BY_CAPABILITY = {
         skills.export.launch.server
         skills.import.launch.local
         skills.import.launch.server
+        skills.install_remote.launch.local
+        skills.install_remote.launch.server
         skills.list.local
         skills.list.server
+        skills.read_file.launch.local
+        skills.read_file.launch.server
         skills.seed.launch.local
         skills.seed.launch.server
         skills.trust.approve.local

--- a/Tests/Skills/test_skill_remote_fetch.py
+++ b/Tests/Skills/test_skill_remote_fetch.py
@@ -6,6 +6,9 @@ public policy-enforcement passthrough on ``SkillsScopeService``, and the
 defaults to 30 results/page -- installers need the full branch list).
 """
 
+import io
+import zipfile
+
 import pytest
 import httpx
 
@@ -75,6 +78,7 @@ from tldw_chatbook.Skills_Interop.skill_remote_fetch import (
     classify_skill_source_url,
     fetch_zip_bytes,
     resolve_ref_and_subdir,
+    re_root_skill_zip,
 )
 
 
@@ -243,3 +247,69 @@ async def test_stream_cap_aborts():
     with pytest.raises(RemoteSkillError, match="too large"):
         await fetch_zip_bytes("https://example.com/x.zip",
                               transport=_transport(handler), resolver=_PUB)
+
+
+def _zipball(entries, wrapper="repo-abc123/"):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        for name, data in entries:
+            z.writestr(wrapper + name, data)
+    return buf.getvalue()
+
+
+def test_reroot_subdir_install():
+    data = _zipball([
+        ("skills/brainstorm/SKILL.md", "---\nname: brainstorm\n---\nbody"),
+        ("skills/brainstorm/references/api.md", "# api"),
+        ("skills/other/SKILL.md", "x"),
+        ("README.md", "top"),
+    ])
+    out, name = re_root_skill_zip(data, subdir="skills/brainstorm", suggested_name="brainstorm")
+    with zipfile.ZipFile(io.BytesIO(out)) as z:
+        assert set(z.namelist()) == {"SKILL.md", "references/api.md"}
+    assert name == "brainstorm"
+
+
+def test_reroot_root_is_skill_and_unwrapped_asset():
+    wrapped = _zipball([("SKILL.md", "body"), ("notes.md", "n")])
+    out, _ = re_root_skill_zip(wrapped, subdir="", suggested_name="repo")
+    with zipfile.ZipFile(io.BytesIO(out)) as z:
+        assert "SKILL.md" in z.namelist()
+    unwrapped = _zipball([("SKILL.md", "body")], wrapper="")   # release-asset shape
+    out2, _ = re_root_skill_zip(unwrapped, subdir="", suggested_name="asset")
+    with zipfile.ZipFile(io.BytesIO(out2)) as z:
+        assert "SKILL.md" in z.namelist()
+
+
+def test_reroot_single_candidate_auto_installs():
+    data = _zipball([("skills/only/SKILL.md", "body"), ("README.md", "r")])
+    out, name = re_root_skill_zip(data, subdir="", suggested_name="repo")
+    assert name == "only"
+
+
+def test_reroot_many_candidates_error_lists_paths():
+    entries = [(f"skills/s{i}/SKILL.md", "b") for i in range(25)]
+    data = _zipball(entries)
+    with pytest.raises(RemoteSkillError) as exc:
+        re_root_skill_zip(data, subdir="", suggested_name="repo")
+    msg = str(exc.value)
+    assert "skills/s0" in msg and "subdirectory URL" in msg
+    assert msg.count("skills/s") <= 20
+
+
+def test_reroot_zero_candidates_and_corrupt():
+    with pytest.raises(RemoteSkillError, match="No SKILL.md"):
+        re_root_skill_zip(_zipball([("README.md", "r")]), subdir="", suggested_name="x")
+    with pytest.raises(RemoteSkillError):
+        re_root_skill_zip(b"not a zip", subdir="", suggested_name="x")
+
+
+def test_reroot_lying_header_bomb_aborts_bounded():
+    # Forge a member whose declared size is tiny but whose stream is huge:
+    # simplest honest proxy — a member whose ACTUAL content exceeds the
+    # per-file cap; the bounded reader must abort during synthesis.
+    from tldw_chatbook.tldw_api.skills_schemas import MAX_SUPPORTING_FILE_BYTES
+    big = "x" * (MAX_SUPPORTING_FILE_BYTES + 100)
+    data = _zipball([("SKILL.md", "body"), ("references/huge.md", big)])
+    with pytest.raises(RemoteSkillError, match="too large"):
+        re_root_skill_zip(data, subdir="", suggested_name="repo")

--- a/Tests/Skills/test_skill_remote_fetch.py
+++ b/Tests/Skills/test_skill_remote_fetch.py
@@ -6,6 +6,7 @@ public policy-enforcement passthrough on ``SkillsScopeService``, and the
 defaults to 30 results/page -- installers need the full branch list).
 """
 
+import asyncio
 import io
 import zipfile
 
@@ -247,6 +248,39 @@ async def test_stream_cap_aborts():
     with pytest.raises(RemoteSkillError, match="too large"):
         await fetch_zip_bytes("https://example.com/x.zip",
                               transport=_transport(handler), resolver=_PUB)
+
+
+@pytest.mark.asyncio
+async def test_fetch_total_deadline_aborts_slow_drip():
+    # A server that never trips the per-hop httpx.Timeout (each individual
+    # read completes well inside it) but keeps the whole exchange alive
+    # longer than the TOTAL budget must still be aborted -- this is the
+    # must-fix: the old code only bounded a single connect/read, not the
+    # whole hop loop.
+    async def handler(request):
+        await asyncio.sleep(0.3)
+        return httpx.Response(200, content=b"PK\x03\x04zipbytes")
+    with pytest.raises(RemoteSkillError, match="timed out"):
+        await fetch_zip_bytes(
+            "https://api.github.com/repos/o/r/zipball/HEAD",
+            transport=_transport(handler), resolver=_PUB,
+            total_deadline=0.05,
+        )
+
+
+@pytest.mark.asyncio
+async def test_fetch_accepts_explicit_total_deadline():
+    # Pins the `total_deadline` keyword's existence/signature independent of
+    # the abort behavior covered above -- a generous explicit deadline must
+    # not change the happy path.
+    def handler(request):
+        return httpx.Response(200, content=b"PK\x03\x04zipbytes")
+    out = await fetch_zip_bytes(
+        "https://api.github.com/repos/o/r/zipball/HEAD",
+        transport=_transport(handler), resolver=_PUB,
+        total_deadline=5.0,
+    )
+    assert out.startswith(b"PK")
 
 
 def _zipball(entries, wrapper="repo-abc123/"):
@@ -545,6 +579,55 @@ async def test_install_seam_overwrite_flag_passed_through():
     assert scope.import_kwargs["overwrite"] is True
 
 
+@pytest.mark.asyncio
+async def test_install_seam_404_slash_branch_gets_hint(monkeypatch):
+    # A /tree/ tail of >1 segment is ambiguous: resolve_ref_and_subdir's
+    # branch split may have guessed wrong when the real branch name itself
+    # contains a slash (see its docstring). A 404 in that shape should carry
+    # the "try the plain repo URL" hint.
+    from tldw_chatbook.Skills_Interop.skill_remote_fetch import install_skill_from_url
+    from tldw_chatbook.Utils.github_api_client import GitHubAPIClient
+
+    async def _fake_get_branches(self, owner, repo):
+        return ["main", "feature/foo"]
+    monkeypatch.setattr(GitHubAPIClient, "get_branches", _fake_get_branches)
+
+    scope = _RecordingScopeService()
+
+    def handler(request):
+        return httpx.Response(404)
+
+    with pytest.raises(RemoteSkillError, match="branch name contains a slash"):
+        await install_skill_from_url(
+            "https://github.com/o/r/tree/feature/foo/skills/x",
+            scope_service=scope,
+            transport=_transport(handler),
+            resolver=_PUB,
+        )
+
+
+@pytest.mark.asyncio
+async def test_install_seam_404_single_segment_ref_no_hint():
+    # A single-segment /tree/<ref> tail has no ref/subdir split to get
+    # wrong -- the ambiguity the hint addresses doesn't apply, so a 404
+    # here must NOT carry it.
+    from tldw_chatbook.Skills_Interop.skill_remote_fetch import install_skill_from_url
+
+    scope = _RecordingScopeService()
+
+    def handler(request):
+        return httpx.Response(404)
+
+    with pytest.raises(RemoteSkillError) as exc_info:
+        await install_skill_from_url(
+            "https://github.com/o/r/tree/v1.2",
+            scope_service=scope,
+            transport=_transport(handler),
+            resolver=_PUB,
+        )
+    assert "branch name contains a slash" not in str(exc_info.value)
+
+
 # ---------------------------------------------------------------------------
 # Task 6: end-to-end -- REAL LocalSkillsService/SkillsScopeService/
 # SkillTrustService behind the public install seam, mocked transport only.
@@ -557,9 +640,12 @@ async def test_e2e_install_skill_from_github_tree_url_real_services(tmp_path, mo
     real 302 hop (api.github.com -> codeload.github.com) -> bounded re-root
     -> the real hardened ``import_skill_file`` seam, against REAL
     ``LocalSkillsService``/``SkillsScopeService``/``SkillTrustService``
-    instances (no fakes for the service layer). Only the two network-facing
+    instances (no fakes for the service layer). Only three network-facing
     seams are mocked: the httpx transport (``fetch_zip_bytes``'s own
-    ``AsyncClient``) and DNS resolution (SSRF host-allow check).
+    ``AsyncClient``), DNS resolution (SSRF host-allow check), and
+    ``GitHubAPIClient.get_branches`` (it owns its own internal
+    ``httpx.AsyncClient``, so it is monkeypatched on the class rather than
+    reachable through the ``transport=`` override -- see below).
 
     ``GitHubAPIClient.get_branches`` is monkeypatched directly on the class
     (it owns its own internal ``httpx.AsyncClient``, not the ``transport=``

--- a/Tests/Skills/test_skill_remote_fetch.py
+++ b/Tests/Skills/test_skill_remote_fetch.py
@@ -313,3 +313,70 @@ def test_reroot_lying_header_bomb_aborts_bounded():
     data = _zipball([("SKILL.md", "body"), ("references/huge.md", big)])
     with pytest.raises(RemoteSkillError, match="too large"):
         re_root_skill_zip(data, subdir="", suggested_name="repo")
+
+
+def test_reroot_rejects_zip_slip_relative_member():
+    # A member name that -- once the skill_root prefix is stripped -- still
+    # carries ".." segments. Raw member selection is a naive
+    # ``startswith(skill_root)`` string match, so this still reaches
+    # synthesis; the per-member path validator must catch it there.
+    data = _zipball([
+        ("SKILL.md", "body"),
+        ("refs/../../evil.md", "evil"),
+    ])
+    # Sanity: writestr does not normalize the traversal out of the name.
+    with zipfile.ZipFile(io.BytesIO(data)) as z:
+        assert any(n.endswith("refs/../../evil.md") for n in z.namelist())
+    with pytest.raises(RemoteSkillError, match="Unsafe file path") as exc_info:
+        re_root_skill_zip(data, subdir="", suggested_name="repo")
+    assert "evil.md" in str(exc_info.value)
+
+
+def test_reroot_prunes_junk_before_count_cap():
+    # Junk-heavy but otherwise-legitimate bundles must not be falsely
+    # rejected by the count cap: the cap applies to the PRUNED member list,
+    # matching LocalSkillsService.import_skill_file's own ordering.
+    from tldw_chatbook.tldw_api.skills_schemas import MAX_SUPPORTING_FILES_COUNT
+
+    entries = [
+        ("SKILL.md", "body"),
+        ("references/a.md", "a"),
+        ("references/b.md", "b"),
+        ("scripts/run.sh", "run"),
+    ]
+    entries += [
+        (f"__pycache__/x{i}.pyc", "junk")
+        for i in range(MAX_SUPPORTING_FILES_COUNT + 5)
+    ]
+    data = _zipball(entries)
+    out, name = re_root_skill_zip(data, subdir="", suggested_name="repo")
+    with zipfile.ZipFile(io.BytesIO(out)) as z:
+        names = z.namelist()
+    assert not any("__pycache__" in n for n in names)
+    assert set(names) == {
+        "SKILL.md", "references/a.md", "references/b.md", "scripts/run.sh",
+    }
+
+
+def _reroot_zip_with_understated_file_size(declared: int = 5) -> bytes:
+    """Bridge-shaped analog of ``test_zip_import_bundle.py``'s
+    ``_zip_with_understated_file_size``: a member whose central-directory
+    ``file_size`` lies smaller than its real (compressed) payload, tripping a
+    CRC mismatch on read -- exercising the "corrupt", not "too large", branch
+    of ``_read_zip_member_bounded``'s ``ValueError`` contract.
+    """
+    buf = io.BytesIO()
+    z = zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED)
+    z.writestr("SKILL.md", b"---\nname: forged\n---\nbody\n")
+    info = zipfile.ZipInfo("big.bin")
+    z.writestr(info, b"y" * 4096)   # local header + data written with real size
+    info.file_size = declared        # mutate BEFORE close -> central dir lies
+    z.close()
+    return buf.getvalue()
+
+
+def test_reroot_labels_corrupt_member_not_too_large():
+    data = _reroot_zip_with_understated_file_size()
+    with pytest.raises(RemoteSkillError, match="Corrupt file in bundle") as exc_info:
+        re_root_skill_zip(data, subdir="", suggested_name="x")
+    assert "too large" not in str(exc_info.value)

--- a/Tests/Skills/test_skill_remote_fetch.py
+++ b/Tests/Skills/test_skill_remote_fetch.py
@@ -543,3 +543,138 @@ async def test_install_seam_overwrite_flag_passed_through():
         resolver=_PUB,
     )
     assert scope.import_kwargs["overwrite"] is True
+
+
+# ---------------------------------------------------------------------------
+# Task 6: end-to-end -- REAL LocalSkillsService/SkillsScopeService/
+# SkillTrustService behind the public install seam, mocked transport only.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_e2e_install_skill_from_github_tree_url_real_services(tmp_path, monkeypatch):
+    """Paste a GitHub ``/tree/`` URL -> classify -> real policy gate ->
+    real 302 hop (api.github.com -> codeload.github.com) -> bounded re-root
+    -> the real hardened ``import_skill_file`` seam, against REAL
+    ``LocalSkillsService``/``SkillsScopeService``/``SkillTrustService``
+    instances (no fakes for the service layer). Only the two network-facing
+    seams are mocked: the httpx transport (``fetch_zip_bytes``'s own
+    ``AsyncClient``) and DNS resolution (SSRF host-allow check).
+
+    ``GitHubAPIClient.get_branches`` (used to resolve the ``/tree/`` ref) is
+    deliberately left unmocked -- it owns its own internal ``httpx.AsyncClient``,
+    not the ``transport=`` override passed to ``install_skill_from_url``, and
+    has a bare-except fallback to ``["main", "master"]`` on ANY failure
+    (network unavailable, or -- as forced here via a deliberately-invalid
+    injected token -- a real 401 from the real GitHub API). Both outcomes
+    converge on branches == ["main", "master"], so the ref/subdir split
+    ("main", "skills/demo") is deterministic regardless of the sandbox's
+    network access, and the test never depends on GitHub's actual branch
+    list for obra/superpowers.
+    """
+    from tldw_chatbook.Skills_Interop.local_skills_service import LocalSkillsService
+    from tldw_chatbook.Skills_Interop.skill_remote_fetch import install_skill_from_url
+    from tldw_chatbook.Skills_Interop.skill_trust_service import SkillTrustService
+    from tldw_chatbook.Skills_Interop.skill_trust_store import (
+        FileSkillTrustGenerationMarkerStore,
+        SkillTrustStore,
+    )
+    from tldw_chatbook.Skills_Interop.skills_scope_service import SkillsScopeService
+
+    # A real, unlocked trust service, bootstrapped against an EMPTY store --
+    # mirrors Tests/Skills/test_skills_library_flow.py's
+    # ``_real_trust_service`` + the bootstrap-before-any-skill-exists idiom
+    # from ``test_library_shell_create_skill_save_arrives_needs_review_with_panel_primed``,
+    # so the skill installed below is unambiguously "added since the
+    # baseline" (quarantined_added / trust-pending) rather than merely
+    # unreviewed due to a missing trust service.
+    trust_service = SkillTrustService(
+        skills_dir=tmp_path / "skills",
+        trust_store=SkillTrustStore(
+            store_dir=tmp_path / "trust",
+            marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json"),
+        ),
+    )
+    trust_service.unlock_with_passphrase("e2e-passphrase", salt=b"7" * 32)
+    trust_service.bootstrap_trust()
+
+    local_service = LocalSkillsService(store_dir=tmp_path, trust_service=trust_service)
+    # No policy_enforcer wired on either service -- _enforce/_enforce_policy
+    # are documented no-ops in that state (see
+    # test_scope_service_public_enforce_passthrough above), so
+    # enforce_install_remote() genuinely PASSES here rather than being
+    # bypassed by a fake.
+    scope_service = SkillsScopeService(local_service=local_service, server_service=None)
+
+    # GitHubAPIClient reads its token from the env var named by
+    # [github].api_token_env_var ("GITHUB_API_TOKEN" by default -- confirmed
+    # against config.py's default template). install_skill_from_url
+    # constructs its own GitHubAPIClient() internally, so the
+    # constructor-injection idiom Tests/Utils/test_github_api_client.py uses
+    # isn't reachable from here; the env var is the clean seam. The value is
+    # deliberately garbage: it still proves auth-header presence on both
+    # GitHub-family hops, and its rejection by the real API is exactly what
+    # keeps the branch-listing hop's outcome deterministic (see docstring).
+    monkeypatch.setenv("GITHUB_API_TOKEN", "e2e-secret-token")
+
+    zip_bytes = _zipball(
+        [
+            ("skills/demo/SKILL.md", "---\nname: demo\n---\nDemo skill body.\n"),
+            ("skills/demo/references/api.md", "# API\n\nReference doc.\n"),
+        ],
+        wrapper="superpowers-abc/",
+    )
+
+    seen_auth: dict[str, str | None] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        host = request.url.host
+        seen_auth[host] = request.headers.get("authorization")
+        if host == "api.github.com":
+            assert request.url.path == "/repos/obra/superpowers/zipball/main"
+            return httpx.Response(
+                302,
+                headers={
+                    "location": "https://codeload.github.com/obra/superpowers/legacy.zip/main"
+                },
+            )
+        if host == "codeload.github.com":
+            return httpx.Response(200, content=zip_bytes)
+        raise AssertionError(f"unexpected host hit: {host}")
+
+    fake_public = lambda host: ["93.184.216.34"]
+
+    result = await install_skill_from_url(
+        "https://github.com/obra/superpowers/tree/main/skills/demo",
+        scope_service=scope_service,
+        transport=_transport(handler),
+        resolver=fake_public,
+    )
+
+    # The auth header was present on BOTH github-family hops -- the redirect
+    # origin AND the codeload landing spot -- proving the 302 re-validates
+    # auth-scoping per hop rather than assuming it carries over (the
+    # off-family-strip half of this is already covered by
+    # test_auth_scoped_to_github_family above; this proves the presence half
+    # end to end through the public install seam).
+    assert seen_auth == {
+        "api.github.com": "token e2e-secret-token",
+        "codeload.github.com": "token e2e-secret-token",
+    }
+
+    assert result["name"] == "demo"
+    assert result["backend"] == "local"
+    assert result["trust_status"] == "quarantined_added"
+    assert result["trust_blocked"] is True
+
+    skill_dir = tmp_path / "skills" / "demo"
+    assert (skill_dir / "SKILL.md").is_file()
+    assert (skill_dir / "references" / "api.md").is_file()
+
+    # Re-confirm not-trusted through the service's own trust-status accessor
+    # -- not by re-deriving it from the install() return value -- so this
+    # proves the persisted index + on-disk bundle actually reflect
+    # trust-pending, not just the one response object.
+    fetched = await scope_service.get_skill("demo", mode="local")
+    assert fetched["trust_status"] == "quarantined_added"
+    assert fetched["trust_blocked"] is True

--- a/Tests/Skills/test_skill_remote_fetch.py
+++ b/Tests/Skills/test_skill_remote_fetch.py
@@ -380,3 +380,166 @@ def test_reroot_labels_corrupt_member_not_too_large():
     with pytest.raises(RemoteSkillError, match="Corrupt file in bundle") as exc_info:
         re_root_skill_zip(data, subdir="", suggested_name="x")
     assert "too large" not in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Task 5: the public install seam (compose classify -> enforce -> fetch ->
+# re-root -> the existing import_skill_file seam).
+# ---------------------------------------------------------------------------
+
+
+class _RecordingScopeService:
+    """Fake ``SkillsScopeService`` recording call order + captured kwargs.
+
+    ``calls`` is shared with the fake transport handler (appended to
+    directly by the test) so a single list proves ordering across BOTH
+    the policy gate and the network hop -- not just the two scope-service
+    methods on their own.
+    """
+
+    def __init__(self, *, enforce_error: Exception | None = None):
+        self.calls: list[str] = []
+        self._enforce_error = enforce_error
+        self.import_content: bytes | None = None
+        self.import_kwargs: dict | None = None
+
+    def enforce_install_remote(self) -> None:
+        self.calls.append("enforce")
+        if self._enforce_error is not None:
+            raise self._enforce_error
+
+    async def import_skill_file(self, content, **kwargs):
+        self.calls.append("import")
+        self.import_content = content
+        self.import_kwargs = kwargs
+        return {"name": kwargs["filename"].removesuffix(".zip"), "backend": "local"}
+
+
+@pytest.mark.asyncio
+async def test_install_seam_classification_precedes_enforce_for_bad_urls():
+    # Classification is pure and may run before enforcement -- an invalid
+    # URL is rejected without ever touching the policy gate.
+    from tldw_chatbook.Skills_Interop.skill_remote_fetch import install_skill_from_url
+
+    scope = _RecordingScopeService()
+    with pytest.raises(RemoteSkillError):
+        await install_skill_from_url("http://github.com/o/r", scope_service=scope)
+    assert scope.calls == []
+
+
+@pytest.mark.asyncio
+async def test_install_seam_enforces_before_any_network():
+    from tldw_chatbook.runtime_policy.types import PolicyDeniedError
+    from tldw_chatbook.Skills_Interop.skill_remote_fetch import install_skill_from_url
+
+    denial = PolicyDeniedError(
+        action_id="skills.install_remote.launch.local",
+        reason_code="policy_denied",
+        user_message="Remote skill installs are disabled.",
+        effective_source="config",
+        authority_owner="local",
+    )
+    scope = _RecordingScopeService(enforce_error=denial)
+    requests_seen: list[httpx.Request] = []
+
+    def handler(request):
+        requests_seen.append(request)
+        return httpx.Response(200, content=b"PK\x03\x04")
+
+    with pytest.raises(PolicyDeniedError):
+        await install_skill_from_url(
+            "https://github.com/o/r/tree/main",
+            scope_service=scope,
+            transport=_transport(handler),
+            resolver=_PUB,
+        )
+    assert scope.calls == ["enforce"]
+    assert requests_seen == []
+
+
+@pytest.mark.asyncio
+async def test_install_seam_github_zip_source_happy_path():
+    from tldw_chatbook.Skills_Interop.skill_remote_fetch import install_skill_from_url
+
+    zip_bytes = _zipball(
+        [("SKILL.md", "---\nname: brainstorm\n---\nbody")],
+        wrapper="o-brainstorm-abc123/",
+    )
+    scope = _RecordingScopeService()
+
+    def handler(request):
+        assert request.url.host == "api.github.com"
+        assert request.url.path == "/repos/o/brainstorm/zipball/main"
+        scope.calls.append("network")
+        return httpx.Response(200, content=zip_bytes)
+
+    result = await install_skill_from_url(
+        "https://github.com/o/brainstorm/tree/main",
+        scope_service=scope,
+        transport=_transport(handler),
+        resolver=_PUB,
+    )
+
+    assert scope.calls == ["enforce", "network", "import"]
+    assert scope.import_kwargs == {
+        "mode": "local",
+        "filename": "brainstorm.zip",
+        "content_type": "application/zip",
+        "overwrite": False,
+        "trust_approved": False,
+    }
+    with zipfile.ZipFile(io.BytesIO(scope.import_content)) as z:
+        assert "SKILL.md" in z.namelist()
+    assert result == {"name": "brainstorm", "backend": "local"}
+
+
+@pytest.mark.asyncio
+async def test_install_seam_direct_zip_source_flow():
+    from tldw_chatbook.Skills_Interop.skill_remote_fetch import install_skill_from_url
+
+    zip_bytes = _zipball(
+        [("SKILL.md", "---\nname: widget\n---\nbody")], wrapper="widget-1.0/"
+    )
+    scope = _RecordingScopeService()
+    seen_auth: list[str | None] = []
+
+    def handler(request):
+        seen_auth.append(request.headers.get("authorization"))
+        scope.calls.append("network")
+        return httpx.Response(200, content=zip_bytes)
+
+    result = await install_skill_from_url(
+        "https://example.com/pkg/widget.zip",
+        scope_service=scope,
+        transport=_transport(handler),
+        resolver=_PUB,
+    )
+
+    assert scope.calls == ["enforce", "network", "import"]
+    assert seen_auth == [None]  # third-party host: never GitHub-token-scoped
+    assert scope.import_kwargs["filename"] == "widget.zip"
+    assert scope.import_kwargs["overwrite"] is False
+    assert scope.import_kwargs["trust_approved"] is False
+    assert result == {"name": "widget", "backend": "local"}
+
+
+@pytest.mark.asyncio
+async def test_install_seam_overwrite_flag_passed_through():
+    from tldw_chatbook.Skills_Interop.skill_remote_fetch import install_skill_from_url
+
+    zip_bytes = _zipball(
+        [("SKILL.md", "---\nname: widget\n---\nbody")], wrapper="widget-1.0/"
+    )
+    scope = _RecordingScopeService()
+
+    def handler(request):
+        return httpx.Response(200, content=zip_bytes)
+
+    await install_skill_from_url(
+        "https://example.com/pkg/widget.zip",
+        scope_service=scope,
+        overwrite=True,
+        transport=_transport(handler),
+        resolver=_PUB,
+    )
+    assert scope.import_kwargs["overwrite"] is True

--- a/Tests/Skills/test_skill_remote_fetch.py
+++ b/Tests/Skills/test_skill_remote_fetch.py
@@ -416,6 +416,49 @@ def test_reroot_labels_corrupt_member_not_too_large():
     assert "too large" not in str(exc_info.value)
 
 
+def _zipball_with_symlink(link_content="target.md", wrapper="repo-1/"):
+    """Like ``_zipball`` but the second member is a symlink (external_attr's
+    upper 16 bits encode ``S_IFLNK`` -- the same shape ``git archive``/GitHub's
+    zipball producer emits for a repo symlink).
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr(wrapper + "SKILL.md", "---\nname: x\n---\nbody")
+        link = zipfile.ZipInfo(wrapper + "link.md")
+        link.external_attr = 0o120777 << 16
+        z.writestr(link, link_content)
+    return buf.getvalue()
+
+
+def test_reroot_skips_symlink_member():
+    # A symlink member must be skipped at the bridge exactly as
+    # LocalSkillsService.import_skill_file's importer skips it (see
+    # local_skills_service.py's own mode/S_ISLNK check) -- it must not be
+    # copied into the synthesized zip.
+    data = _zipball_with_symlink()
+    out, _ = re_root_skill_zip(data, subdir="", suggested_name="repo")
+    with zipfile.ZipFile(io.BytesIO(out)) as z:
+        names = z.namelist()
+    assert "SKILL.md" in names
+    assert "link.md" not in names
+
+
+def test_reroot_symlink_skipped_before_size_cap():
+    # A symlink whose content exceeds the per-file cap must NOT trip the
+    # "too large" abort -- proving the symlink is skipped BEFORE cap
+    # accounting/decompression, not merely excluded from the final zip.
+    # Without the fix, this raises RemoteSkillError("File too large...").
+    from tldw_chatbook.tldw_api.skills_schemas import MAX_SUPPORTING_FILE_BYTES
+
+    big = "x" * (MAX_SUPPORTING_FILE_BYTES + 100)
+    data = _zipball_with_symlink(link_content=big)
+    out, _ = re_root_skill_zip(data, subdir="", suggested_name="repo")
+    with zipfile.ZipFile(io.BytesIO(out)) as z:
+        names = z.namelist()
+    assert "SKILL.md" in names
+    assert "link.md" not in names
+
+
 # ---------------------------------------------------------------------------
 # Task 5: the public install seam (compose classify -> enforce -> fetch ->
 # re-root -> the existing import_skill_file seam).

--- a/Tests/Skills/test_skill_remote_fetch.py
+++ b/Tests/Skills/test_skill_remote_fetch.py
@@ -7,6 +7,7 @@ defaults to 30 results/page -- installers need the full branch list).
 """
 
 import pytest
+import httpx
 
 
 def test_policy_action_id_registered():
@@ -66,10 +67,13 @@ async def test_get_branches_requests_full_page():
 
 
 from tldw_chatbook.Skills_Interop.skill_remote_fetch import (
+    GITHUB_AUTH_HOSTS,
+    REMOTE_FETCH_MAX_BYTES,
     DirectZipSource,
     GitHubZipSource,
     RemoteSkillError,
     classify_skill_source_url,
+    fetch_zip_bytes,
     resolve_ref_and_subdir,
 )
 
@@ -146,3 +150,96 @@ async def test_ref_split_api_failure_falls_back():
     async def _branches(o, r):
         raise RuntimeError("offline")
     assert await resolve_ref_and_subdir(src, _branches) == ("main", "skills/x")
+
+
+_PUB = lambda host: ["93.184.216.34"]          # public resolver
+
+
+def _transport(handler):
+    return httpx.MockTransport(handler)
+
+
+@pytest.mark.asyncio
+async def test_fetch_happy_path_streams_bytes():
+    def handler(request):
+        return httpx.Response(200, content=b"PK\x03\x04zipbytes")
+    out = await fetch_zip_bytes(
+        "https://api.github.com/repos/o/r/zipball/HEAD",
+        transport=_transport(handler), resolver=_PUB,
+    )
+    assert out.startswith(b"PK")
+
+
+@pytest.mark.asyncio
+async def test_private_and_mixed_resolution_rejected():
+    with pytest.raises(RemoteSkillError):
+        await fetch_zip_bytes("https://internal.example/x.zip",
+                              transport=_transport(lambda r: httpx.Response(200)),
+                              resolver=lambda h: ["10.0.0.5"])
+    with pytest.raises(RemoteSkillError):  # mixed public+private -> reject
+        await fetch_zip_bytes("https://mixed.example/x.zip",
+                              transport=_transport(lambda r: httpx.Response(200)),
+                              resolver=lambda h: ["93.184.216.34", "fd00::1"])
+    with pytest.raises(RemoteSkillError):  # IP-literal host
+        await fetch_zip_bytes("https://169.254.169.254/x.zip",
+                              transport=_transport(lambda r: httpx.Response(200)),
+                              resolver=_PUB)
+
+
+@pytest.mark.asyncio
+async def test_redirect_hop_revalidated_and_capped():
+    def handler(request):
+        host = request.url.host
+        if host == "a.example":
+            return httpx.Response(302, headers={"location": "https://b.example/x.zip"})
+        if host == "b.example":
+            return httpx.Response(302, headers={"location": "http://c.example/x.zip"})
+        raise AssertionError("unexpected host")
+    with pytest.raises(RemoteSkillError):   # https->http hop rejected
+        await fetch_zip_bytes("https://a.example/x.zip",
+                              transport=_transport(handler), resolver=_PUB)
+
+    def loop_handler(request):
+        return httpx.Response(302, headers={"location": str(request.url)})
+    with pytest.raises(RemoteSkillError):   # >3 hops
+        await fetch_zip_bytes("https://a.example/x.zip",
+                              transport=_transport(loop_handler), resolver=_PUB)
+
+    def private_hop(request):
+        if request.url.host == "a.example":
+            return httpx.Response(302, headers={"location": "https://evil.internal/x.zip"})
+        raise AssertionError
+    with pytest.raises(RemoteSkillError):   # hop host resolves private
+        await fetch_zip_bytes(
+            "https://a.example/x.zip", transport=_transport(private_hop),
+            resolver=lambda h: ["10.1.1.1"] if h == "evil.internal" else ["93.184.216.34"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_auth_scoped_to_github_family():
+    seen = {}
+    def handler(request):
+        seen[request.url.host] = request.headers.get("authorization")
+        if request.url.host == "api.github.com":
+            return httpx.Response(
+                302, headers={"location": "https://codeload.github.com/o/r/zip/HEAD"})
+        if request.url.host == "codeload.github.com":
+            return httpx.Response(
+                302, headers={"location": "https://cdn.example.com/x.zip"})
+        return httpx.Response(200, content=b"PK\x03\x04")
+    await fetch_zip_bytes("https://api.github.com/repos/o/r/zipball/HEAD",
+                          token="SECRET", transport=_transport(handler), resolver=_PUB)
+    assert seen["api.github.com"] == "token SECRET"
+    assert seen["codeload.github.com"] == "token SECRET"
+    assert seen["cdn.example.com"] is None    # STRIPPED off-family
+
+
+@pytest.mark.asyncio
+async def test_stream_cap_aborts():
+    big = b"x" * (REMOTE_FETCH_MAX_BYTES + 1024)
+    def handler(request):
+        return httpx.Response(200, content=big)
+    with pytest.raises(RemoteSkillError, match="too large"):
+        await fetch_zip_bytes("https://example.com/x.zip",
+                              transport=_transport(handler), resolver=_PUB)

--- a/Tests/Skills/test_skill_remote_fetch.py
+++ b/Tests/Skills/test_skill_remote_fetch.py
@@ -561,16 +561,33 @@ async def test_e2e_install_skill_from_github_tree_url_real_services(tmp_path, mo
     seams are mocked: the httpx transport (``fetch_zip_bytes``'s own
     ``AsyncClient``) and DNS resolution (SSRF host-allow check).
 
-    ``GitHubAPIClient.get_branches`` (used to resolve the ``/tree/`` ref) is
-    deliberately left unmocked -- it owns its own internal ``httpx.AsyncClient``,
-    not the ``transport=`` override passed to ``install_skill_from_url``, and
-    has a bare-except fallback to ``["main", "master"]`` on ANY failure
-    (network unavailable, or -- as forced here via a deliberately-invalid
-    injected token -- a real 401 from the real GitHub API). Both outcomes
-    converge on branches == ["main", "master"], so the ref/subdir split
-    ("main", "skills/demo") is deterministic regardless of the sandbox's
-    network access, and the test never depends on GitHub's actual branch
-    list for obra/superpowers.
+    ``GitHubAPIClient.get_branches`` is monkeypatched directly on the class
+    (it owns its own internal ``httpx.AsyncClient``, not the ``transport=``
+    override passed to ``install_skill_from_url``, so the fake transport
+    below cannot reach it) to return ``["main", "master"]`` -- the exact
+    shape ``get_branches``'s real success path returns (a plain
+    ``list[str]`` of branch names; see ``GitHubAPIClient.get_branches`` in
+    ``tldw_chatbook/Utils/github_api_client.py``). This keeps the test fully
+    hermetic -- no live request to ``api.github.com`` for either the branch
+    listing or the zip download -- while still exercising the real
+    ``resolve_ref_and_subdir`` longest-prefix match, which resolves to
+    ``("main", "skills/demo")`` for the pasted ``/tree/main/skills/demo``
+    URL.
+
+    Policy enforcement is REAL, not a no-op: a real ``ServicePolicyEnforcer``
+    bound to the real ``CAPABILITY_REGISTRY``/``PolicyEngine`` is wired onto
+    both ``local_service`` and ``scope_service`` below, mirroring how
+    ``app.py`` (~:4536) wires one ``ServicePolicyEnforcer`` instance into
+    every scope-service layer, and how
+    ``test_skill_editor_opens_under_real_runtime_policy_enforcer`` in
+    ``Tests/Skills/test_skills_library_flow.py`` proves the equivalent gate
+    for the editor seam. This test therefore proves
+    ``skills.install_remote.launch.local`` (and the
+    ``skills.import.launch.local`` hop inside ``import_skill_file``)
+    genuinely resolve ALLOWED under the real engine's default local-source
+    policy -- not merely that ``enforce_install_remote()`` is a harmless
+    no-op when no enforcer is wired (that no-op path is already covered by
+    ``test_scope_service_public_enforce_passthrough`` above).
     """
     from tldw_chatbook.Skills_Interop.local_skills_service import LocalSkillsService
     from tldw_chatbook.Skills_Interop.skill_remote_fetch import install_skill_from_url
@@ -598,13 +615,32 @@ async def test_e2e_install_skill_from_github_tree_url_real_services(tmp_path, mo
     trust_service.unlock_with_passphrase("e2e-passphrase", salt=b"7" * 32)
     trust_service.bootstrap_trust()
 
-    local_service = LocalSkillsService(store_dir=tmp_path, trust_service=trust_service)
-    # No policy_enforcer wired on either service -- _enforce/_enforce_policy
-    # are documented no-ops in that state (see
-    # test_scope_service_public_enforce_passthrough above), so
-    # enforce_install_remote() genuinely PASSES here rather than being
-    # bypassed by a fake.
-    scope_service = SkillsScopeService(local_service=local_service, server_service=None)
+    from tldw_chatbook.runtime_policy.enforcement import ServicePolicyEnforcer
+    from tldw_chatbook.runtime_policy.types import RuntimeSourceState
+
+    # A REAL policy_enforcer, bound to the real CAPABILITY_REGISTRY/
+    # PolicyEngine (not left unset) -- wired onto BOTH local_service and
+    # scope_service, mirroring app.py's production wiring (~:4536) of one
+    # ServicePolicyEnforcer instance into every scope-service layer. Leaving
+    # this unset would make enforce_install_remote() trivially no-op (see
+    # test_scope_service_public_enforce_passthrough above) without ever
+    # reaching PolicyEngine.evaluate() -- exactly the gate-defect class
+    # test_skill_editor_opens_under_real_runtime_policy_enforcer (in
+    # Tests/Skills/test_skills_library_flow.py) guards against for the
+    # editor seam.
+    policy_enforcer = ServicePolicyEnforcer(
+        state_provider=lambda: RuntimeSourceState(active_source="local"),
+    )
+    local_service = LocalSkillsService(
+        store_dir=tmp_path,
+        trust_service=trust_service,
+        policy_enforcer=policy_enforcer,
+    )
+    scope_service = SkillsScopeService(
+        local_service=local_service,
+        server_service=None,
+        policy_enforcer=policy_enforcer,
+    )
 
     # GitHubAPIClient reads its token from the env var named by
     # [github].api_token_env_var ("GITHUB_API_TOKEN" by default -- confirmed
@@ -612,10 +648,37 @@ async def test_e2e_install_skill_from_github_tree_url_real_services(tmp_path, mo
     # constructs its own GitHubAPIClient() internally, so the
     # constructor-injection idiom Tests/Utils/test_github_api_client.py uses
     # isn't reachable from here; the env var is the clean seam. The value is
-    # deliberately garbage: it still proves auth-header presence on both
-    # GitHub-family hops, and its rejection by the real API is exactly what
-    # keeps the branch-listing hop's outcome deterministic (see docstring).
+    # deliberately non-real -- it is never sent to the real GitHub API (the
+    # branch listing below is monkeypatched, and the zip-fetch hops go
+    # through the fake ``transport=`` handler further down), but it still
+    # proves auth-header presence on both GitHub-family hops.
     monkeypatch.setenv("GITHUB_API_TOKEN", "e2e-secret-token")
+
+    # Mock GitHubAPIClient.get_branches directly on the class -- it owns its
+    # own internal httpx.AsyncClient, not the transport= override passed to
+    # install_skill_from_url below, so leaving it unmocked would send a real
+    # request (carrying the garbage token above) to
+    # api.github.com/repos/obra/superpowers/branches. Patching the method on
+    # the class works even though install_skill_from_url does a local
+    # `from ..Utils.github_api_client import GitHubAPIClient` and constructs
+    # its own instance internally: that import resolves to this same class
+    # object, so the patched method is picked up regardless of where/when it
+    # is imported. The fake return value matches get_branches's real
+    # success-path shape exactly -- a plain list[str] of branch names (see
+    # GitHubAPIClient.get_branches in tldw_chatbook/Utils/github_api_client.py,
+    # success branch: `[branch["name"] for branch in branches]`). "main" must
+    # be present so resolve_ref_and_subdir's longest-prefix match still
+    # yields ("main", "skills/demo") for the pasted /tree/main/skills/demo
+    # URL.
+    from tldw_chatbook.Utils.github_api_client import GitHubAPIClient
+
+    branch_calls: list[tuple[str, str]] = []
+
+    async def _fake_get_branches(self, owner: str, repo: str) -> list[str]:
+        branch_calls.append((owner, repo))
+        return ["main", "master"]
+
+    monkeypatch.setattr(GitHubAPIClient, "get_branches", _fake_get_branches)
 
     zip_bytes = _zipball(
         [
@@ -661,6 +724,12 @@ async def test_e2e_install_skill_from_github_tree_url_real_services(tmp_path, mo
         "api.github.com": "token e2e-secret-token",
         "codeload.github.com": "token e2e-secret-token",
     }
+
+    # The mocked branch listing was actually reached (not skipped) and asked
+    # for the right repo -- proves the ref/subdir split above is exercising
+    # resolve_ref_and_subdir's real longest-prefix logic against the fake
+    # data, not merely trusting an unreached mock.
+    assert branch_calls == [("obra", "superpowers")]
 
     assert result["name"] == "demo"
     assert result["backend"] == "local"

--- a/Tests/Skills/test_skill_remote_fetch.py
+++ b/Tests/Skills/test_skill_remote_fetch.py
@@ -1,0 +1,65 @@
+"""Foundation tests for URL-based skill install (task 1 of the SDD plan).
+
+Covers: the fail-closed policy registry entry for remote skill installs, the
+public policy-enforcement passthrough on ``SkillsScopeService``, and the
+``GitHubAPIClient.get_branches`` pagination fix (GitHub's branches endpoint
+defaults to 30 results/page -- installers need the full branch list).
+"""
+
+import pytest
+
+
+def test_policy_action_id_registered():
+    # The engine denies unknown ids (fail-closed) -- pin that the new id
+    # exists. Mirrors Tests/Skills/test_read_skill_file.py's
+    # test_policy_action_id_registered idiom for skills.read_file.
+    from tldw_chatbook.runtime_policy.registry import CAPABILITY_REGISTRY
+
+    assert "skills.install_remote.launch.local" in CAPABILITY_REGISTRY
+
+
+def test_scope_service_public_enforce_passthrough():
+    from tldw_chatbook.Skills_Interop.skills_scope_service import SkillsScopeService
+
+    calls = []
+
+    class _Enforcer:
+        def require_allowed(self, *, action_id):
+            calls.append(action_id)
+
+    scope = SkillsScopeService(
+        local_service=None, server_service=None, policy_enforcer=_Enforcer()
+    )
+    scope.enforce_install_remote()
+    assert calls == ["skills.install_remote.launch.local"]
+    # No enforcer wired -> no-op, no raise (matches _enforce_policy semantics).
+    SkillsScopeService(local_service=None, server_service=None).enforce_install_remote()
+
+
+@pytest.mark.asyncio
+async def test_get_branches_requests_full_page():
+    from tldw_chatbook.Utils.github_api_client import GitHubAPIClient
+
+    client = GitHubAPIClient(token="t")
+    captured = {}
+
+    class _Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return [{"name": "main"}]
+
+    class _MockHttpClient:
+        async def get(self, url, **kwargs):
+            captured["url"] = url
+            captured["params"] = kwargs.get("params")
+            return _Resp()
+
+    # Mirror Tests/Utils/test_github_api_client.py's idiom: set the private
+    # cached-client attribute directly rather than patching the `client`
+    # property.
+    client._client = _MockHttpClient()
+    branches = await client.get_branches("o", "r")
+    assert branches == ["main"]
+    assert captured["params"] == {"per_page": 100}

--- a/Tests/Skills/test_skill_remote_fetch.py
+++ b/Tests/Skills/test_skill_remote_fetch.py
@@ -63,3 +63,86 @@ async def test_get_branches_requests_full_page():
     branches = await client.get_branches("o", "r")
     assert branches == ["main"]
     assert captured["params"] == {"per_page": 100}
+
+
+from tldw_chatbook.Skills_Interop.skill_remote_fetch import (
+    DirectZipSource,
+    GitHubZipSource,
+    RemoteSkillError,
+    classify_skill_source_url,
+    resolve_ref_and_subdir,
+)
+
+
+def test_classify_repo_root():
+    src = classify_skill_source_url("https://github.com/obra/superpowers")
+    assert src == GitHubZipSource(
+        owner="obra", repo="superpowers", tree_tail=(), suggested_name="superpowers"
+    )
+
+
+def test_classify_tree_subdir():
+    src = classify_skill_source_url(
+        "https://github.com/obra/superpowers/tree/main/skills/brainstorming"
+    )
+    assert isinstance(src, GitHubZipSource)
+    assert src.tree_tail == ("main", "skills", "brainstorming")
+    assert src.suggested_name == "brainstorming"
+
+
+def test_classify_release_asset_and_direct_zip():
+    rel = classify_skill_source_url(
+        "https://github.com/o/r/releases/download/v1/my-skill.zip"
+    )
+    assert rel == DirectZipSource(
+        url="https://github.com/o/r/releases/download/v1/my-skill.zip",
+        github_auth=True,
+        suggested_name="my-skill",
+    )
+    direct = classify_skill_source_url("https://example.com/pkg/my-skill.zip")
+    assert direct.github_auth is False and direct.suggested_name == "my-skill"
+
+
+@pytest.mark.parametrize("bad", [
+    "http://github.com/o/r",                    # http
+    "https://example.com/not-a-zip",            # non-github non-zip
+    "git@github.com:o/r.git",                   # git protocol
+    "https://github.com/onlyowner",             # no repo
+    "ftp://example.com/x.zip",
+])
+def test_classify_rejects(bad):
+    with pytest.raises(RemoteSkillError):
+        classify_skill_source_url(bad)
+
+
+@pytest.mark.asyncio
+async def test_ref_split_single_segment_is_ref():
+    src = classify_skill_source_url("https://github.com/o/r/tree/v1.2")
+    async def _boom(o, r):  # must NOT be called for single-segment tails
+        raise AssertionError("branch listing not needed")
+    assert await resolve_ref_and_subdir(src, _boom) == ("v1.2", "")
+
+
+@pytest.mark.asyncio
+async def test_ref_split_longest_prefix_branch_wins():
+    src = classify_skill_source_url("https://github.com/o/r/tree/feature/foo/skills/x")
+    async def _branches(o, r):
+        return ["main", "feature/foo", "feature"]
+    ref, subdir = await resolve_ref_and_subdir(src, _branches)
+    assert (ref, subdir) == ("feature/foo", "skills/x")
+
+
+@pytest.mark.asyncio
+async def test_ref_split_no_match_falls_back_to_first_segment():
+    src = classify_skill_source_url("https://github.com/o/r/tree/main/skills/x")
+    async def _branches(o, r):
+        return ["dev"]  # capped/truncated list without the real branch
+    assert await resolve_ref_and_subdir(src, _branches) == ("main", "skills/x")
+
+
+@pytest.mark.asyncio
+async def test_ref_split_api_failure_falls_back():
+    src = classify_skill_source_url("https://github.com/o/r/tree/main/skills/x")
+    async def _branches(o, r):
+        raise RuntimeError("offline")
+    assert await resolve_ref_and_subdir(src, _branches) == ("main", "skills/x")

--- a/Tests/Skills/test_skills_import.py
+++ b/Tests/Skills/test_skills_import.py
@@ -565,3 +565,140 @@ async def test_import_row_imports_nested_reference_subfolder(
     supporting_files = record.get("supporting_files") or {}
     assert "references/note.md" in supporting_files
     assert supporting_files["references/note.md"] == "A nested reference file."
+
+
+# ---------------------------------------------------------------------------
+# Task 5: the Import row's URL branch. ``install_skill_from_url`` (the
+# network-touching seam) is monkeypatched IN THE SCREEN MODULE'S OWN
+# NAMESPACE -- it is imported there directly (``from
+# ...Skills_Interop.skill_remote_fetch import install_skill_from_url``),
+# not looked up dynamically off a service object -- so these tests prove
+# routing/outcome-translation only, never real network I/O. The seam's own
+# network/classification/re-root behavior is covered by
+# ``Tests/Skills/test_skill_remote_fetch.py``.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_import_row_url_routes_to_remote_install_and_primes_review(
+    tmp_path, monkeypatch
+):
+    """A pasted ``http(s)://`` URL in the Import row's path field routes to
+    ``install_skill_from_url`` instead of the local file/folder path, and a
+    successful install reports the SAME outcome shape as every other
+    import path: the outcome line names the service-reported skill, and
+    the Review button is primed with it (mirrors
+    ``test_skills_import_success_offers_review_button`` in
+    ``Tests/UI/test_library_skills_canvas.py``).
+    """
+    from tldw_chatbook.UI.Screens import library_screen
+
+    _local_service, service = _real_skills_scope_service_with_trust(tmp_path)
+    app = _build_test_app()
+    _wire_empty_non_skill_services(app)
+    app.skills_scope_service = service
+    host = LibraryHarness(app)
+
+    captured: dict = {}
+
+    async def _fake_install_skill_from_url(url, *, scope_service, **kwargs):
+        captured["url"] = url
+        captured["scope_service"] = scope_service
+        captured["kwargs"] = kwargs
+        return {"name": "remote-skill"}
+
+    monkeypatch.setattr(
+        library_screen, "install_skill_from_url", _fake_install_skill_from_url
+    )
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_skills_import_row(screen, pilot)
+
+        status = await _run_skills_import_via_ui(
+            screen, pilot, "https://github.com/o/remote-skill"
+        )
+        assert status == 'Imported "remote-skill" · re-review it in the trust panel'
+        review = screen.query_one("#library-skills-import-review", Button)
+        assert "remote-skill" in str(review.label)
+
+    assert captured["url"] == "https://github.com/o/remote-skill"
+    assert captured["scope_service"] is service
+
+
+@pytest.mark.asyncio
+async def test_import_row_url_remote_skill_error_becomes_status_line(
+    tmp_path, monkeypatch
+):
+    """``RemoteSkillError`` messages are user-presentable by construction --
+    the Import row must surface the message verbatim, not a generic
+    failure line."""
+    from tldw_chatbook.Skills_Interop.skill_remote_fetch import RemoteSkillError
+    from tldw_chatbook.UI.Screens import library_screen
+
+    _local_service, service = _real_skills_scope_service_with_trust(tmp_path)
+    app = _build_test_app()
+    _wire_empty_non_skill_services(app)
+    app.skills_scope_service = service
+    host = LibraryHarness(app)
+
+    async def _fake_install_skill_from_url(url, *, scope_service, **kwargs):
+        raise RemoteSkillError("Only .zip release assets are supported.")
+
+    monkeypatch.setattr(
+        library_screen, "install_skill_from_url", _fake_install_skill_from_url
+    )
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_skills_import_row(screen, pilot)
+
+        status = await _run_skills_import_via_ui(
+            screen, pilot, "https://github.com/o/r/releases/download/v1/pkg"
+        )
+        assert status == "Only .zip release assets are supported."
+
+    context = await service.get_context(mode="local")
+    assert context["available_skills"] == []
+    assert context["blocked_skills"] == []
+
+
+@pytest.mark.asyncio
+async def test_import_row_url_generic_failure_uses_classified_name_guess(
+    tmp_path, monkeypatch
+):
+    """A non-``RemoteSkillError`` failure (e.g. the underlying
+    ``import_skill_file`` call rejecting a duplicate name) routes through
+    the SAME exception translator every other import path uses
+    (``_apply_library_skills_import_outcome_from_exception``), with a name
+    guess derived from classifying the URL -- the same "derive a plausible
+    skill name from what the user typed" convention the loose-file branch
+    uses (``file_path.stem``), here via the seam's own classification so
+    the guess matches what the seam would actually have named the skill.
+    """
+    from tldw_chatbook.UI.Screens import library_screen
+
+    _local_service, service = _real_skills_scope_service_with_trust(tmp_path)
+    app = _build_test_app()
+    _wire_empty_non_skill_services(app)
+    app.skills_scope_service = service
+    host = LibraryHarness(app)
+
+    async def _fake_install_skill_from_url(url, *, scope_service, **kwargs):
+        raise ValueError("local_skill_exists: brainstorm")
+
+    monkeypatch.setattr(
+        library_screen, "install_skill_from_url", _fake_install_skill_from_url
+    )
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_skills_import_row(screen, pilot)
+
+        status = await _run_skills_import_via_ui(
+            screen, pilot, "https://github.com/o/brainstorm/tree/main"
+        )
+        assert status == 'Skipped — a skill named "brainstorm" already exists.'

--- a/Tests/Utils/test_github_api_client.py
+++ b/Tests/Utils/test_github_api_client.py
@@ -191,10 +191,12 @@ class TestGitHubAPIClient:
         # Get branches
         branches = await api_client.get_branches("owner", "repo")
 
-        # Verify
+        # Verify (per_page=100: remote-skill-fetch slash-ref disambiguation
+        # needs the full first page — GitHub defaults to 30/page).
         assert branches == ["main", "develop", "feature/test"]
         mock_http_client.get.assert_called_once_with(
-            "https://api.github.com/repos/owner/repo/branches"
+            "https://api.github.com/repos/owner/repo/branches",
+            params={"per_page": 100},
         )
 
     @pytest.mark.asyncio

--- a/tldw_chatbook/Skills_Interop/skill_remote_fetch.py
+++ b/tldw_chatbook/Skills_Interop/skill_remote_fetch.py
@@ -1,0 +1,137 @@
+"""Remote skill fetch: URL classification, hardened download, bounded re-root.
+
+The install path for "paste a GitHub link": classify -> fetch (SSRF-hardened)
+-> re-root the archive to a single-skill zip -> the EXISTING hardened
+``import_skill_file`` seam. This module owns all skill-install network I/O;
+``LocalSkillsService`` stays network-free.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+
+@dataclass(frozen=True)
+class GitHubZipSource:
+    """A GitHub repo/tree URL normalized for zipball download."""
+
+    owner: str
+    repo: str
+    tree_tail: tuple[str, ...]
+    suggested_name: str
+
+
+@dataclass(frozen=True)
+class DirectZipSource:
+    """A direct https zip URL (GitHub release asset or third-party)."""
+
+    url: str
+    github_auth: bool
+    suggested_name: str
+
+
+class RemoteSkillError(ValueError):
+    """User-presentable remote-install failure."""
+
+
+def _zip_basename(path_segment: str) -> str:
+    name = path_segment.rsplit("/", 1)[-1]
+    return name[:-4] if name.lower().endswith(".zip") else name
+
+
+def classify_skill_source_url(url: str) -> GitHubZipSource | DirectZipSource:
+    """Classify a pasted URL into a fetchable skill source.
+
+    Args:
+        url: The pasted URL.
+
+    Returns:
+        A ``GitHubZipSource`` (repo/tree form, zipball-normalized later) or a
+        ``DirectZipSource`` (release asset / any https ``.zip``).
+
+    Raises:
+        RemoteSkillError: Non-https, non-GitHub non-zip, or malformed input.
+    """
+    # Deferred import: input_validation pulls metrics plumbing.
+    from ..Utils.input_validation import validate_url
+
+    if not validate_url(url):
+        raise RemoteSkillError("That doesn't look like a valid URL.")
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        raise RemoteSkillError("Only https:// URLs are supported.")
+    host = (parsed.hostname or "").lower()
+    path = parsed.path.strip("/")
+    segments = tuple(s for s in path.split("/") if s)
+
+    if host == "github.com":
+        if len(segments) >= 4 and segments[2] == "releases" and segments[3] == "download":
+            if not path.lower().endswith(".zip"):
+                raise RemoteSkillError("Only .zip release assets are supported.")
+            return DirectZipSource(
+                url=url, github_auth=True, suggested_name=_zip_basename(path)
+            )
+        if len(segments) == 2:
+            owner, repo = segments
+            return GitHubZipSource(
+                owner=owner, repo=repo, tree_tail=(), suggested_name=repo
+            )
+        if len(segments) >= 4 and segments[2] == "tree":
+            owner, repo = segments[0], segments[1]
+            tail = segments[3:]
+            return GitHubZipSource(
+                owner=owner,
+                repo=repo,
+                tree_tail=tail,
+                suggested_name=tail[-1] if len(tail) > 1 else repo,
+            )
+        raise RemoteSkillError(
+            "Unsupported GitHub URL — use a repo, /tree/<branch>/<subdir>, "
+            "or a .zip release asset."
+        )
+
+    if path.lower().endswith(".zip"):
+        return DirectZipSource(
+            url=url, github_auth=False, suggested_name=_zip_basename(path)
+        )
+    raise RemoteSkillError(
+        "Unsupported URL — paste a GitHub repo/subdirectory URL or a direct .zip link."
+    )
+
+
+async def resolve_ref_and_subdir(
+    source: GitHubZipSource, list_branches
+) -> tuple[str, str]:
+    """Split a ``/tree/`` tail into (ref, subdir) per the spec's §2 rules.
+
+    Single-segment tails are the ref outright. Multi-segment tails try a
+    longest-prefix match against the repo's branch list (possibly capped at
+    100 — a missing match degrades to the first-segment heuristic, never a
+    wrong silent match). Branch-list failures degrade the same way.
+
+    Args:
+        source: The classified GitHub source (``tree_tail`` may be empty).
+        list_branches: Async callable ``(owner, repo) -> list[str]``.
+
+    Returns:
+        ``(ref, subdir)`` — subdir is ``""`` or a POSIX relative path.
+    """
+    tail = source.tree_tail
+    if not tail:
+        return "HEAD", ""
+    if len(tail) == 1:
+        return tail[0], ""
+    try:
+        branches = await list_branches(source.owner, source.repo)
+    except Exception:
+        branches = []
+    joined = "/".join(tail)
+    best = ""
+    for branch in branches:
+        if (joined == branch or joined.startswith(branch + "/")) and len(branch) > len(best):
+            best = branch
+    if best:
+        subdir = joined[len(best):].strip("/")
+        return best, subdir
+    return tail[0], "/".join(tail[1:])

--- a/tldw_chatbook/Skills_Interop/skill_remote_fetch.py
+++ b/tldw_chatbook/Skills_Interop/skill_remote_fetch.py
@@ -8,6 +8,7 @@ The install path for "paste a GitHub link": classify -> fetch (SSRF-hardened)
 
 from __future__ import annotations
 
+import asyncio
 import ipaddress
 import socket
 import zipfile as _zipfile
@@ -114,8 +115,13 @@ async def resolve_ref_and_subdir(
 
     Single-segment tails are the ref outright. Multi-segment tails try a
     longest-prefix match against the repo's branch list (possibly capped at
-    100 — a missing match degrades to the first-segment heuristic, never a
-    wrong silent match). Branch-list failures degrade the same way.
+    100 — a missing match degrades to the first-segment heuristic). Branch-list
+    failures degrade the same way. This is not airtight: a truncated branch
+    list combined with a branch-name collision at a ``/`` boundary (e.g.
+    branches ``docs`` and ``docs/skill``, with the list capped before
+    ``docs/skill`` appears) can still yield a plausible-but-wrong split — the
+    caller surfaces that downstream as a 404 at fetch time rather than a
+    silently-wrong install.
 
     Args:
         source: The classified GitHub source (``tree_tail`` may be empty).
@@ -146,6 +152,7 @@ async def resolve_ref_and_subdir(
 
 REMOTE_FETCH_MAX_BYTES = 30 * 1024 * 1024
 REMOTE_FETCH_MAX_HOPS = 3
+REMOTE_FETCH_TOTAL_DEADLINE_SECONDS = 60.0
 _FETCH_CHUNK = 65536
 GITHUB_AUTH_HOSTS = frozenset(
     {"github.com", "api.github.com", "codeload.github.com",
@@ -178,7 +185,12 @@ def _assert_host_allowed(host: str, resolver) -> None:
 
 
 async def fetch_zip_bytes(
-    url: str, *, token: str | None = None, transport=None, resolver=None
+    url: str,
+    *,
+    token: str | None = None,
+    transport=None,
+    resolver=None,
+    total_deadline: float = REMOTE_FETCH_TOTAL_DEADLINE_SECONDS,
 ) -> bytes:
     """Download a zip with SSRF hardening, manual redirects, and a size cap.
 
@@ -188,60 +200,81 @@ async def fetch_zip_bytes(
         transport: httpx transport override (tests).
         resolver: ``(host) -> list[str]`` override (tests); defaults to
             ``socket.getaddrinfo``.
+        total_deadline: Wall-clock ceiling (seconds) for the ENTIRE download —
+            every redirect hop plus the streamed read of the final response.
+            The per-hop ``httpx.Timeout`` below only bounds a single connect
+            or a single socket read/write, so a server that keeps the
+            connection alive by dripping a chunk just under that per-read
+            window (e.g. one chunk every 50s) would otherwise stall forever;
+            this deadline is the backstop that still aborts it.
 
     Returns:
         The raw (compressed) zip bytes, at most ``REMOTE_FETCH_MAX_BYTES``.
 
     Raises:
         RemoteSkillError: On every rejection class (scheme, host, hops, cap,
-            HTTP status, timeouts).
+            HTTP status, per-hop timeouts, and the overall ``total_deadline``
+            being exceeded across all hops).
     """
     from ..Utils.input_validation import validate_url
 
     resolver = resolver or _default_resolver
     timeout = httpx.Timeout(60.0, connect=10.0)
     current = url
-    async with httpx.AsyncClient(
-        transport=transport, timeout=timeout, follow_redirects=False
-    ) as client:
-        for _hop in range(REMOTE_FETCH_MAX_HOPS + 1):
-            if not validate_url(current):
-                raise RemoteSkillError("Invalid URL after redirect.")
-            parsed = httpx.URL(current)
-            if parsed.scheme != "https":
-                raise RemoteSkillError("Only https:// is allowed (redirect downgraded).")
-            host = (parsed.host or "").lower()
-            _assert_host_allowed(host, resolver)
-            headers = {}
-            if token and host in GITHUB_AUTH_HOSTS:
-                headers["Authorization"] = f"token {token}"
-            try:
-                async with client.stream("GET", current, headers=headers) as response:
-                    if response.status_code in (301, 302, 303, 307, 308):
-                        location = response.headers.get("location")
-                        if not location:
-                            raise RemoteSkillError("Redirect without a location.")
-                        current = str(parsed.join(location))
-                        continue
-                    if response.status_code != 200:
+    try:
+        async with asyncio.timeout(total_deadline):
+            async with httpx.AsyncClient(
+                transport=transport, timeout=timeout, follow_redirects=False
+            ) as client:
+                for _hop in range(REMOTE_FETCH_MAX_HOPS + 1):
+                    if not validate_url(current):
+                        raise RemoteSkillError("Invalid URL after redirect.")
+                    parsed = httpx.URL(current)
+                    if parsed.scheme != "https":
                         raise RemoteSkillError(
-                            f"Download failed (HTTP {response.status_code})."
+                            "Only https:// is allowed (redirect downgraded)."
                         )
-                    chunks: list[bytes] = []
-                    received = 0
-                    async for chunk in response.aiter_bytes(_FETCH_CHUNK):
-                        received += len(chunk)
-                        if received > REMOTE_FETCH_MAX_BYTES:
-                            raise RemoteSkillError(
-                                "Download too large (over 30 MB compressed)."
-                            )
-                        chunks.append(chunk)
-                    return b"".join(chunks)
-            except httpx.TimeoutException as exc:
-                raise RemoteSkillError("Download timed out.") from exc
-            except httpx.HTTPError as exc:
-                raise RemoteSkillError(f"Download failed: {exc}") from exc
-        raise RemoteSkillError("Too many redirects.")
+                    host = (parsed.host or "").lower()
+                    _assert_host_allowed(host, resolver)
+                    headers = {}
+                    if token and host in GITHUB_AUTH_HOSTS:
+                        headers["Authorization"] = f"token {token}"
+                    try:
+                        async with client.stream(
+                            "GET", current, headers=headers
+                        ) as response:
+                            if response.status_code in (301, 302, 303, 307, 308):
+                                location = response.headers.get("location")
+                                if not location:
+                                    raise RemoteSkillError(
+                                        "Redirect without a location."
+                                    )
+                                current = str(parsed.join(location))
+                                continue
+                            if response.status_code != 200:
+                                raise RemoteSkillError(
+                                    f"Download failed (HTTP {response.status_code})."
+                                )
+                            chunks: list[bytes] = []
+                            received = 0
+                            async for chunk in response.aiter_bytes(_FETCH_CHUNK):
+                                received += len(chunk)
+                                if received > REMOTE_FETCH_MAX_BYTES:
+                                    raise RemoteSkillError(
+                                        "Download too large (over 30 MB compressed)."
+                                    )
+                                chunks.append(chunk)
+                            return b"".join(chunks)
+                    except httpx.TimeoutException as exc:
+                        raise RemoteSkillError("Download timed out.") from exc
+                    except httpx.HTTPError as exc:
+                        raise RemoteSkillError(f"Download failed: {exc}") from exc
+                raise RemoteSkillError("Too many redirects.")
+    except TimeoutError as exc:
+        # Builtin TimeoutError (raised by asyncio.timeout on expiry) is NOT
+        # an httpx.TimeoutException, so it needs its own clause here — the
+        # inner except above only catches per-hop httpx timeouts.
+        raise RemoteSkillError("Download timed out.") from exc
 
 
 _CANDIDATE_SCAN_DEPTH = 3
@@ -443,9 +476,23 @@ async def install_skill_from_url(
                 f"https://api.github.com/repos/{source.owner}/{source.repo}"
                 f"/zipball/{ref}"
             )
-            zip_bytes = await fetch_zip_bytes(
-                zip_url, token=api.token, transport=transport, resolver=resolver
-            )
+            try:
+                zip_bytes = await fetch_zip_bytes(
+                    zip_url, token=api.token, transport=transport, resolver=resolver
+                )
+            except RemoteSkillError as exc:
+                # A 404 on a multi-segment /tree/ tail is ambiguous: it may be
+                # a genuinely missing ref, OR resolve_ref_and_subdir's branch
+                # split guessed wrong (see its docstring) because the branch
+                # name itself contains a slash. Only hint in that ambiguous
+                # case -- single-segment tails have no split to get wrong.
+                if "HTTP 404" in str(exc) and len(source.tree_tail) > 1:
+                    raise RemoteSkillError(
+                        f"{exc} If the branch name contains a slash, GitHub "
+                        "URLs are ambiguous — try installing from the plain "
+                        "repository URL instead (without the /tree/ path)."
+                    ) from exc
+                raise
         else:
             subdir = ""
             token = api.token if source.github_auth else None

--- a/tldw_chatbook/Skills_Interop/skill_remote_fetch.py
+++ b/tldw_chatbook/Skills_Interop/skill_remote_fetch.py
@@ -8,8 +8,12 @@ The install path for "paste a GitHub link": classify -> fetch (SSRF-hardened)
 
 from __future__ import annotations
 
+import ipaddress
+import socket
 from dataclasses import dataclass
 from urllib.parse import urlparse
+
+import httpx
 
 
 @dataclass(frozen=True)
@@ -135,3 +139,103 @@ async def resolve_ref_and_subdir(
         subdir = joined[len(best):].strip("/")
         return best, subdir
     return tail[0], "/".join(tail[1:])
+
+
+REMOTE_FETCH_MAX_BYTES = 30 * 1024 * 1024
+REMOTE_FETCH_MAX_HOPS = 3
+_FETCH_CHUNK = 65536
+GITHUB_AUTH_HOSTS = frozenset(
+    {"github.com", "api.github.com", "codeload.github.com",
+     "objects.githubusercontent.com"}
+)
+
+
+def _default_resolver(host: str) -> list[str]:
+    infos = socket.getaddrinfo(host, 443, proto=socket.IPPROTO_TCP)
+    return [info[4][0] for info in infos]
+
+
+def _assert_host_allowed(host: str, resolver) -> None:
+    """Reject unless EVERY resolved address is public (mixed sets reject)."""
+    try:
+        literal = ipaddress.ip_address(host)
+        addresses = [str(literal)]
+    except ValueError:
+        try:
+            addresses = resolver(host)
+        except OSError as exc:
+            raise RemoteSkillError(f"Could not resolve {host}.") from exc
+    if not addresses:
+        raise RemoteSkillError(f"Could not resolve {host}.")
+    for raw in addresses:
+        addr = ipaddress.ip_address(raw.split("%", 1)[0])
+        if (addr.is_private or addr.is_loopback or addr.is_link_local
+                or addr.is_reserved or addr.is_multicast or addr.is_unspecified):
+            raise RemoteSkillError("That host is not reachable from here.")
+
+
+async def fetch_zip_bytes(
+    url: str, *, token: str | None = None, transport=None, resolver=None
+) -> bytes:
+    """Download a zip with SSRF hardening, manual redirects, and a size cap.
+
+    Args:
+        url: The (already classified/normalized) https URL to download.
+        token: Optional GitHub token; attached ONLY on GITHUB_AUTH_HOSTS hops.
+        transport: httpx transport override (tests).
+        resolver: ``(host) -> list[str]`` override (tests); defaults to
+            ``socket.getaddrinfo``.
+
+    Returns:
+        The raw (compressed) zip bytes, at most ``REMOTE_FETCH_MAX_BYTES``.
+
+    Raises:
+        RemoteSkillError: On every rejection class (scheme, host, hops, cap,
+            HTTP status, timeouts).
+    """
+    from ..Utils.input_validation import validate_url
+
+    resolver = resolver or _default_resolver
+    timeout = httpx.Timeout(60.0, connect=10.0)
+    current = url
+    async with httpx.AsyncClient(
+        transport=transport, timeout=timeout, follow_redirects=False
+    ) as client:
+        for _hop in range(REMOTE_FETCH_MAX_HOPS + 1):
+            if not validate_url(current):
+                raise RemoteSkillError("Invalid URL after redirect.")
+            parsed = httpx.URL(current)
+            if parsed.scheme != "https":
+                raise RemoteSkillError("Only https:// is allowed (redirect downgraded).")
+            host = (parsed.host or "").lower()
+            _assert_host_allowed(host, resolver)
+            headers = {}
+            if token and host in GITHUB_AUTH_HOSTS:
+                headers["Authorization"] = f"token {token}"
+            try:
+                async with client.stream("GET", current, headers=headers) as response:
+                    if response.status_code in (301, 302, 303, 307, 308):
+                        location = response.headers.get("location")
+                        if not location:
+                            raise RemoteSkillError("Redirect without a location.")
+                        current = str(parsed.join(location))
+                        continue
+                    if response.status_code != 200:
+                        raise RemoteSkillError(
+                            f"Download failed (HTTP {response.status_code})."
+                        )
+                    chunks: list[bytes] = []
+                    received = 0
+                    async for chunk in response.aiter_bytes(_FETCH_CHUNK):
+                        received += len(chunk)
+                        if received > REMOTE_FETCH_MAX_BYTES:
+                            raise RemoteSkillError(
+                                "Download too large (over 30 MB compressed)."
+                            )
+                        chunks.append(chunk)
+                    return b"".join(chunks)
+            except httpx.TimeoutException as exc:
+                raise RemoteSkillError("Download timed out.") from exc
+            except httpx.HTTPError as exc:
+                raise RemoteSkillError(f"Download failed: {exc}") from exc
+        raise RemoteSkillError("Too many redirects.")

--- a/tldw_chatbook/Skills_Interop/skill_remote_fetch.py
+++ b/tldw_chatbook/Skills_Interop/skill_remote_fetch.py
@@ -11,13 +11,18 @@ from __future__ import annotations
 import asyncio
 import ipaddress
 import socket
+import stat
 import zipfile as _zipfile
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from io import BytesIO
-from typing import Any
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import httpx
+
+if TYPE_CHECKING:
+    from .skills_scope_service import SkillsScopeService
 
 
 @dataclass(frozen=True)
@@ -109,7 +114,8 @@ def classify_skill_source_url(url: str) -> GitHubZipSource | DirectZipSource:
 
 
 async def resolve_ref_and_subdir(
-    source: GitHubZipSource, list_branches
+    source: GitHubZipSource,
+    list_branches: Callable[[str, str], Awaitable[list[str]]],
 ) -> tuple[str, str]:
     """Split a ``/tree/`` tail into (ref, subdir) per the spec's §2 rules.
 
@@ -188,8 +194,8 @@ async def fetch_zip_bytes(
     url: str,
     *,
     token: str | None = None,
-    transport=None,
-    resolver=None,
+    transport: httpx.AsyncBaseTransport | None = None,
+    resolver: Callable[[str], list[str]] | None = None,
     total_deadline: float = REMOTE_FETCH_TOTAL_DEADLINE_SECONDS,
 ) -> bytes:
     """Download a zip with SSRF hardening, manual redirects, and a size cap.
@@ -380,6 +386,9 @@ def re_root_skill_zip(
         # ``<skill_root>refs/../../evil.md`` still passes).
         pruned: list[tuple["_zipfile.ZipInfo", str]] = []
         for member in raw_members:
+            mode = (member.external_attr >> 16) & 0xFFFF
+            if stat.S_ISLNK(mode):
+                continue                       # symlink member: skip-not-fail, matches the importer
             relative = member.filename[len(skill_root):]
             if not relative:
                 continue
@@ -430,10 +439,10 @@ def re_root_skill_zip(
 async def install_skill_from_url(
     url: str,
     *,
-    scope_service: Any,
+    scope_service: "SkillsScopeService",
     overwrite: bool = False,
-    transport: Any = None,
-    resolver: Any = None,
+    transport: httpx.AsyncBaseTransport | None = None,
+    resolver: Callable[[str], list[str]] | None = None,
 ) -> dict:
     """Install a skill pasted as a GitHub/zip URL (the public install seam).
 

--- a/tldw_chatbook/Skills_Interop/skill_remote_fetch.py
+++ b/tldw_chatbook/Skills_Interop/skill_remote_fetch.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 import ipaddress
 import socket
+import zipfile as _zipfile
 from dataclasses import dataclass
+from io import BytesIO
 from urllib.parse import urlparse
 
 import httpx
@@ -239,3 +241,118 @@ async def fetch_zip_bytes(
             except httpx.HTTPError as exc:
                 raise RemoteSkillError(f"Download failed: {exc}") from exc
         raise RemoteSkillError("Too many redirects.")
+
+
+_CANDIDATE_SCAN_DEPTH = 3
+_CANDIDATE_LIST_LIMIT = 20
+
+
+def _archive_names(archive: "_zipfile.ZipFile") -> list[str]:
+    return [m.filename for m in archive.infolist() if not m.is_dir()]
+
+
+def _detect_root(names: list[str]) -> str:
+    """Root prefix: '' when SKILL.md sits at top; descend ONE wrapper dir."""
+    if "SKILL.md" in names:
+        return ""
+    tops = {n.split("/", 1)[0] for n in names if "/" in n}
+    loose = [n for n in names if "/" not in n]
+    if len(tops) == 1 and not loose:
+        return next(iter(tops)) + "/"
+    return ""
+
+
+def re_root_skill_zip(
+    zip_bytes: bytes, *, subdir: str, suggested_name: str
+) -> tuple[bytes, str]:
+    """Re-root a fetched archive to a single-skill zip (BOUNDED synthesis).
+
+    Candidate discovery is central-directory-only (no decompression). Member
+    extraction reuses ``LocalSkillsService._read_zip_member_bounded`` and
+    enforces the import caps DURING synthesis, so a lying-header bomb aborts
+    here exactly as it would in the importer.
+
+    Args:
+        zip_bytes: The fetched archive (already download-capped).
+        subdir: POSIX subdir to install from ('' = auto-detect at root).
+        suggested_name: Fallback skill name (subdir basename wins upstream).
+
+    Returns:
+        ``(single_skill_zip_bytes, final_name)``.
+
+    Raises:
+        RemoteSkillError: Corrupt archive, zero/many candidates, cap abort.
+    """
+    from .local_skills_service import LocalSkillsService
+    from ..tldw_api.skills_schemas import (
+        MAX_SUPPORTING_FILE_BYTES,
+        MAX_SUPPORTING_FILES_COUNT,
+        MAX_SUPPORTING_FILES_TOTAL_BYTES,
+    )
+
+    try:
+        archive = _zipfile.ZipFile(BytesIO(zip_bytes))
+    except _zipfile.BadZipFile as exc:
+        raise RemoteSkillError("The download was not a valid zip archive.") from exc
+    with archive:
+        names = _archive_names(archive)
+        root = _detect_root(names)
+        base = root + (subdir.strip("/") + "/" if subdir.strip("/") else "")
+
+        if base and not any(n.startswith(base) for n in names):
+            raise RemoteSkillError(f"No such folder in the archive: {subdir}")
+
+        skill_root = base
+        final_name = suggested_name
+        if (skill_root + "SKILL.md") not in names:
+            # Depth-limited candidate scan under the current base.
+            candidates = sorted(
+                n[len(base):-len("/SKILL.md")]
+                for n in names
+                if n.startswith(base)
+                and n.endswith("/SKILL.md")
+                and n[len(base):].count("/") <= _CANDIDATE_SCAN_DEPTH
+            )
+            if not candidates:
+                raise RemoteSkillError("No SKILL.md found in that archive.")
+            if len(candidates) > 1:
+                shown = ", ".join(candidates[:_CANDIDATE_LIST_LIMIT])
+                more = len(candidates) - min(len(candidates), _CANDIDATE_LIST_LIMIT)
+                suffix = f" (+{more} more)" if more > 0 else ""
+                raise RemoteSkillError(
+                    f"Found {len(candidates)} skills in that repository: "
+                    f"{shown}{suffix}. Paste a subdirectory URL to install one."
+                )
+            skill_root = base + candidates[0] + "/"
+            final_name = candidates[0].rsplit("/", 1)[-1]
+
+        members = [
+            m for m in archive.infolist()
+            if not m.is_dir() and m.filename.startswith(skill_root)
+        ]
+        if len(members) > MAX_SUPPORTING_FILES_COUNT + 1:
+            raise RemoteSkillError("That skill bundle has too many files.")
+        out = BytesIO()
+        total = 0
+        with _zipfile.ZipFile(out, "w", compression=_zipfile.ZIP_DEFLATED) as dest:
+            for member in members:
+                relative = member.filename[len(skill_root):]
+                if not relative:
+                    continue
+                if member.file_size > MAX_SUPPORTING_FILE_BYTES:
+                    raise RemoteSkillError(
+                        f"File too large in bundle: {relative}"
+                    )
+                try:
+                    data = LocalSkillsService._read_zip_member_bounded(
+                        archive, member, relative, MAX_SUPPORTING_FILE_BYTES
+                    )
+                except ValueError as exc:
+                    raise RemoteSkillError(f"File too large in bundle: {relative}") from exc
+                total += len(data)
+                if total > MAX_SUPPORTING_FILES_TOTAL_BYTES:
+                    raise RemoteSkillError("That skill bundle is too large.")
+                info = _zipfile.ZipInfo(relative)
+                info.external_attr = member.external_attr
+                dest.writestr(info, data)
+        return out.getvalue(), final_name

--- a/tldw_chatbook/Skills_Interop/skill_remote_fetch.py
+++ b/tldw_chatbook/Skills_Interop/skill_remote_fetch.py
@@ -326,19 +326,47 @@ def re_root_skill_zip(
             skill_root = base + candidates[0] + "/"
             final_name = candidates[0].rsplit("/", 1)[-1]
 
-        members = [
+        from .skill_trust_scanner import SUPPORTING_JUNK_DIRS, _is_junk
+
+        raw_members = [
             m for m in archive.infolist()
             if not m.is_dir() and m.filename.startswith(skill_root)
         ]
-        if len(members) > MAX_SUPPORTING_FILES_COUNT + 1:
+
+        # Prune + path-validate BEFORE the count cap and BEFORE any
+        # decompression -- mirrors LocalSkillsService.import_skill_file's own
+        # ordering (junk pruned first, so junk-heavy-but-legitimate bundles
+        # aren't falsely rejected by the count cap) and its own per-member
+        # zip-slip validator (``_validate_archive_member``, which special-cases
+        # the literal top-level ``SKILL.md`` name and otherwise delegates to
+        # ``validate_supporting_file_path`` -- rejecting ``..``/absolute
+        # segments so nothing outside ``skill_root`` can leak into the
+        # synthesized zip, even though raw member selection above is a naive
+        # ``startswith(skill_root)`` string match that a crafted name like
+        # ``<skill_root>refs/../../evil.md`` still passes).
+        pruned: list[tuple["_zipfile.ZipInfo", str]] = []
+        for member in raw_members:
+            relative = member.filename[len(skill_root):]
+            if not relative:
+                continue
+            parts = relative.split("/")
+            if any(p in SUPPORTING_JUNK_DIRS for p in parts) or _is_junk(parts[-1]):
+                continue                       # junk pruned, matches the importer
+            try:
+                LocalSkillsService._validate_archive_member(relative)
+            except ValueError as exc:
+                raise RemoteSkillError(
+                    f"Unsafe file path in archive: {relative}"
+                ) from exc
+            pruned.append((member, relative))
+
+        if len(pruned) > MAX_SUPPORTING_FILES_COUNT + 1:
             raise RemoteSkillError("That skill bundle has too many files.")
+
         out = BytesIO()
         total = 0
         with _zipfile.ZipFile(out, "w", compression=_zipfile.ZIP_DEFLATED) as dest:
-            for member in members:
-                relative = member.filename[len(skill_root):]
-                if not relative:
-                    continue
+            for member, relative in pruned:
                 if member.file_size > MAX_SUPPORTING_FILE_BYTES:
                     raise RemoteSkillError(
                         f"File too large in bundle: {relative}"
@@ -348,7 +376,14 @@ def re_root_skill_zip(
                         archive, member, relative, MAX_SUPPORTING_FILE_BYTES
                     )
                 except ValueError as exc:
-                    raise RemoteSkillError(f"File too large in bundle: {relative}") from exc
+                    message = str(exc)
+                    if message.startswith("local_skill_file_too_large"):
+                        raise RemoteSkillError(
+                            f"File too large in bundle: {relative}"
+                        ) from exc
+                    raise RemoteSkillError(
+                        f"Corrupt file in bundle: {relative}"
+                    ) from exc
                 total += len(data)
                 if total > MAX_SUPPORTING_FILES_TOTAL_BYTES:
                     raise RemoteSkillError("That skill bundle is too large.")

--- a/tldw_chatbook/Skills_Interop/skill_remote_fetch.py
+++ b/tldw_chatbook/Skills_Interop/skill_remote_fetch.py
@@ -13,6 +13,7 @@ import socket
 import zipfile as _zipfile
 from dataclasses import dataclass
 from io import BytesIO
+from typing import Any
 from urllib.parse import urlparse
 
 import httpx
@@ -391,3 +392,77 @@ def re_root_skill_zip(
                 info.external_attr = member.external_attr
                 dest.writestr(info, data)
         return out.getvalue(), final_name
+
+
+async def install_skill_from_url(
+    url: str,
+    *,
+    scope_service: Any,
+    overwrite: bool = False,
+    transport: Any = None,
+    resolver: Any = None,
+) -> dict:
+    """Install a skill pasted as a GitHub/zip URL (the public install seam).
+
+    Composes every piece this module owns -- classification, the
+    ``SkillsScopeService`` policy gate, GitHub token/branch lookups, the
+    SSRF-hardened fetch, and the bounded re-root -- then hands the final
+    single-skill zip to the EXISTING hardened ``import_skill_file`` seam.
+    Network I/O never runs before ``scope_service.enforce_install_remote()``
+    -- classification is pure (URL parsing only) and may run first.
+
+    Args:
+        url: The pasted URL (GitHub repo/tree, GitHub release asset, or
+            any direct https ``.zip`` link).
+        scope_service: A ``SkillsScopeService``-shaped object exposing
+            ``enforce_install_remote()`` and ``import_skill_file(...)``.
+        overwrite: Forwarded to ``import_skill_file`` (re-import over an
+            existing skill of the same name).
+        transport: httpx transport override (tests).
+        resolver: ``(host) -> list[str]`` resolver override (tests).
+
+    Returns:
+        The ``import_skill_file`` result dict, unchanged.
+
+    Raises:
+        RemoteSkillError: Every user-presentable failure (bad URL, SSRF
+            rejection, download failure, corrupt/ambiguous archive).
+        PolicyDeniedError: When the wired policy enforcer denies the
+            install (via ``scope_service.enforce_install_remote()``).
+    """
+    source = classify_skill_source_url(url)
+    scope_service.enforce_install_remote()
+
+    from ..Utils.github_api_client import GitHubAPIClient
+
+    api = GitHubAPIClient()
+    try:
+        if isinstance(source, GitHubZipSource):
+            ref, subdir = await resolve_ref_and_subdir(source, api.get_branches)
+            zip_url = (
+                f"https://api.github.com/repos/{source.owner}/{source.repo}"
+                f"/zipball/{ref}"
+            )
+            zip_bytes = await fetch_zip_bytes(
+                zip_url, token=api.token, transport=transport, resolver=resolver
+            )
+        else:
+            subdir = ""
+            token = api.token if source.github_auth else None
+            zip_bytes = await fetch_zip_bytes(
+                source.url, token=token, transport=transport, resolver=resolver
+            )
+    finally:
+        await api.close()
+
+    final_bytes, final_name = re_root_skill_zip(
+        zip_bytes, subdir=subdir, suggested_name=source.suggested_name
+    )
+    return await scope_service.import_skill_file(
+        final_bytes,
+        mode="local",
+        filename=f"{final_name}.zip",
+        content_type="application/zip",
+        overwrite=overwrite,
+        trust_approved=False,
+    )

--- a/tldw_chatbook/Skills_Interop/skills_scope_service.py
+++ b/tldw_chatbook/Skills_Interop/skills_scope_service.py
@@ -355,6 +355,18 @@ class SkillsScopeService:
         self._enforce_policy("skills.read_file.launch.local")
         return await self._maybe_await(service.read_skill_file(skill_name, relative_path))
 
+    def enforce_install_remote(self) -> None:
+        """Gate a remote skill install (public seam for skill_remote_fetch).
+
+        Enforces ``skills.install_remote.launch.local`` BEFORE any network
+        I/O happens. Public by design: the fetch module must not reach the
+        private ``_enforce_policy`` across the class boundary.
+
+        Raises:
+            PolicyDeniedError: When a wired policy enforcer denies the action.
+        """
+        self._enforce_policy("skills.install_remote.launch.local")
+
     async def seed_builtin_skills(
         self, *, mode: SkillsBackend | str | None = None, **kwargs: Any
     ) -> dict[str, Any]:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -165,6 +165,11 @@ from ...Library.library_shell_state import (
 from ...Library.row_selection import RowSelection
 from ...runtime_policy.server_event_scope import event_principal_id_from_active_context
 from ...runtime_policy.types import PolicyDeniedError, RuntimeSourceState
+from ...Skills_Interop.skill_remote_fetch import (
+    RemoteSkillError,
+    classify_skill_source_url,
+    install_skill_from_url,
+)
 from ...Sync_Interop.sync_promotion_state import build_sync_promotion_state
 from ...Sync_Interop.sync_readiness import (
     DEFAULT_SYNC_ELIGIBILITY_REGISTRY,
@@ -7243,8 +7248,14 @@ class LibraryScreen(BaseAppScreen):
         Args:
             raw_path: The Import row's typed path (SKILL.md file, skill
                 directory, standalone ``.md`` file, or ``.zip`` export),
-                already known non-blank by the caller.
+                already known non-blank by the caller. A pasted
+                ``http(s)://`` URL routes to
+                ``_install_library_skill_from_url`` instead -- see that
+                method's docstring for the remote-install flow.
         """
+        if raw_path.startswith(("http://", "https://")):
+            await self._install_library_skill_from_url(raw_path)
+            return
         try:
             validated_path = validate_path_simple(
                 Path(raw_path).expanduser(), require_exists=True
@@ -7374,6 +7385,65 @@ class LibraryScreen(BaseAppScreen):
             if stored_name
             else self._safe_text(file_path.stem, max_length=64)
         )
+
+    async def _install_library_skill_from_url(self, url: str) -> None:
+        """Install a skill fetched from a pasted GitHub repo/tree or zip URL.
+
+        Mirrors ``_import_library_skill_from_loose_file``'s worker/
+        threading pattern and outcome routing: the "file" here is a
+        remote download instead of local bytes, but
+        ``install_skill_from_url`` (``Skills_Interop.skill_remote_fetch``)
+        owns classification, policy enforcement, the SSRF-hardened fetch,
+        and re-rooting before handing the resulting bytes to the SAME
+        ``import_skill_file`` seam every other import path uses -- so the
+        imported skill lands TRUST-PENDING exactly like a local import.
+
+        Three outcome routes, same shape as every other import path:
+        - Success: primes the Review button with the service-reported name.
+        - ``RemoteSkillError``: its message IS the outcome line -- these
+          are user-presentable by construction (bad URL, SSRF rejection,
+          download failure, corrupt/ambiguous archive).
+        - Any other exception (a policy denial, or a plain
+          ``import_skill_file`` failure such as a duplicate name): routed
+          through the shared exception-to-outcome translator, using a
+          name guess derived from the URL -- the same "derive a plausible
+          skill name from what the user typed" convention the loose-file
+          branch uses (``file_path.stem``), here via the same
+          classification the seam itself uses (``suggested_name``, e.g.
+          the repo or release-asset basename) so the guess matches what
+          the seam would actually have named the skill.
+
+        Args:
+            url: The Import row's typed ``http(s)://`` URL, already known
+                non-blank by the caller.
+        """
+        service = getattr(self.app_instance, "skills_scope_service", None)
+        if service is None:
+            self._apply_library_skills_import_status("Skill import is unavailable.")
+            return
+
+        try:
+            name_guess = self._safe_text(
+                classify_skill_source_url(url).suggested_name, max_length=64
+            )
+        except RemoteSkillError:
+            name_guess = self._safe_text(
+                url.rstrip("/").rsplit("/", 1)[-1], max_length=64
+            )
+        try:
+            result = await self._run_library_service_call(
+                install_skill_from_url,
+                url,
+                scope_service=service,
+                isolate_in_worker=True,
+            )
+        except RemoteSkillError as exc:
+            self._apply_library_skills_import_status(str(exc))
+            return
+        except Exception as exc:
+            self._apply_library_skills_import_outcome_from_exception(name_guess, exc)
+            return
+        self._apply_library_skills_import_success(result.get("name", ""))
 
     def _apply_library_skills_import_success(self, skill_name: str) -> None:
         """Report a successful single-skill import and refresh the rail/list.

--- a/tldw_chatbook/Utils/github_api_client.py
+++ b/tldw_chatbook/Utils/github_api_client.py
@@ -198,20 +198,21 @@ class GitHubAPIClient:
             List of branch names
         """
         url = f"{self.base_url}/repos/{owner}/{repo}/branches"
+        params = {"per_page": 100}
 
         # Check cache first
-        cached_data = self._get_from_cache(url)
+        cached_data = self._get_from_cache(url, params)
         if cached_data is not None:
             return cached_data
 
         try:
-            response = await self.client.get(url)
+            response = await self.client.get(url, params=params)
             response.raise_for_status()
             branches = response.json()
             branch_names = [branch["name"] for branch in branches]
 
             # Cache the response
-            self._save_to_cache(url, branch_names)
+            self._save_to_cache(url, branch_names, params)
             return branch_names
         except Exception as e:
             logger.error(f"Failed to fetch branches: {e}")

--- a/tldw_chatbook/Widgets/Library/library_skills_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_skills_canvas.py
@@ -764,7 +764,7 @@ class LibrarySkillsListCanvas(VerticalScroll):
         ``_run_library_skills_import``).
         """
         yield Input(
-            placeholder="SKILL.md file or skill folder path…",
+            placeholder="SKILL.md file or skill folder path… or GitHub/zip URL",
             id="library-skills-import-path",
             value=self.import_path,
         )

--- a/tldw_chatbook/runtime_policy/registry.py
+++ b/tldw_chatbook/runtime_policy/registry.py
@@ -1018,6 +1018,7 @@ AUDITED_CAPABILITY_SEEDS = (
             _resource("skills.export", actions=(LAUNCH,)),
             _resource("skills.execute", actions=(LAUNCH,)),
             _resource("skills.read_file", actions=(LAUNCH,)),
+            _resource("skills.install_remote", actions=(LAUNCH,)),
             _resource("skills.seed", actions=(LAUNCH,)),
             _resource(
                 "skills.trust",


### PR DESCRIPTION
## Summary

Adds URL-based skill install to the Library Skills import row: paste a GitHub repo/tree/release-asset URL or any https .zip, and the app classifies it (pure classifier, five URL classes incl. slash-branch disambiguation via a now-paginated `get_branches`), downloads it through an SSRF-hardened fetcher (https-only, resolve-and-reject on every hop incl. mixed A/AAAA sets, ≤3 manual redirects re-validated per hop, GitHub token scoped strictly to GitHub-family hosts, 30 MB streamed cap, and a 60 s wall-clock deadline across all hops as a slow-drip backstop), and re-roots the archive through a bounded decompression bridge (central-directory discovery, junk pruning, zip-slip validation, import caps enforced during synthesis, multi-skill repos error with a ≤20-candidate listing) before handing the resulting single-skill zip to the existing hardened `import_skill_file` seam — landing trust-pending behind a new fail-closed `skills.install_remote.launch.local` policy gate enforced before any network I/O, with the existing import gate as intentional defense-in-depth. Ambiguous slash-branch 404s carry a "try the plain repository URL" hint.

Spec: `Docs/superpowers/specs/2026-07-24-skills-remote-fetch-design.md` · Plan: `Docs/superpowers/plans/2026-07-24-skills-remote-fetch-plan.md`

## Security notes

- Enforcement precedes network I/O (test-proven: zero transport requests on policy denial).
- Token never leaves the GitHub family ({github.com, api.github.com, codeload.github.com, objects.githubusercontent.com}); stripped on any off-family redirect hop; never logged or surfaced in errors.
- SSRF checks reject private/loopback/link-local/reserved/multicast/unspecified for EVERY resolved address per hop, incl. IP literals, IPv4-mapped IPv6, NAT64, zone-ids, octal/decimal IP tricks (adversarially verified at review).
- The re-rooting bridge is a second decompression surface and enforces the import caps DURING synthesis (streaming bounded reads defeat forged-header zip bombs); zip-slip names are rejected at the bridge itself, with the importer as defense-in-depth.
- Documented accepted residual: no transport-level IP pinning this layer (DNS-rebinding TOCTOU), per spec.

## Tests

- 39 unit/adversarial tests in `Tests/Skills/test_skill_remote_fetch.py` + 3 UI routing tests.
- Real-services e2e: real policy enforcer on both services (non-vacuity mutation-proven — deleting the registry row fails the test), real trust store, mocked transports only (hermeticity verified under a socket-connect block).
- Full gate at tip: Tests/Skills 244 passed; Tests/Skills+RuntimePolicy+library canvas = 588 passed, 2 failures = pre-existing documented RuntimePolicy baselines.

Reviewed task-by-task (subagent-driven) with three fix waves: bridge path-validation/junk-pruning/error labeling; e2e real-enforcer + hermeticity; final-review 60 s total-download deadline + slash-branch 404 hint. Deferred follow-up hardening (post-merge backlog): not-`is_global` CGNAT host check, mapped-IPv6 regression pin, auth-scope test breadth, in-flight-import cancel race (pre-existing pattern), policy-denial copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install skills from GitHub or https .zip URLs directly from the Library import row. Adds an SSRF-hardened downloader and safe re-rooting that feed the existing import flow.

- New Features
  - Accepts GitHub repo/tree-subfolder/release-asset URLs and direct https .zip; GitHub fetches normalize to `https://api.github.com/repos/{owner}/{repo}/zipball/{ref}` and the classifier resolves slash-branch refs using the full branch list.
  - Hardened fetch: https-only, per-hop DNS/IP validation across all A/AAAA (rejects mixed public/private), up to 3 revalidated redirects, GitHub token scoped to GitHub-family hosts, 30 MB streamed cap, and a 60 s total deadline.
  - Safe re-rooting: central-dir discovery, junk pruning, zip-slip checks, symlinks skipped; multi-skill roots error with up to 20 candidates; installs are trust‑pending.
  - Library Import row accepts URLs and routes to `install_skill_from_url` (URL branch runs before path checks), with a hint on ambiguous `/tree/` 404s.

- Migration
  - Grant `skills.install_remote.launch.local` (and/or `.server`) in the runtime policy to enable this; enforcement via `SkillsScopeService.enforce_install_remote()` runs before any network I/O.

<sup>Written for commit a3a6578e46a88bf2ba2610127fe98502136674fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

