### PR TITLE
fix(footer): task-451 key hints win over debug memory stats when narrow

### DIFF
--- a/Tests/UI/test_app_footer_shortcut_context.py
+++ b/Tests/UI/test_app_footer_shortcut_context.py
@@ -100,3 +100,42 @@ async def test_footer_db_size_stats_expose_decode_legend_tooltip():
         assert "Media" in tooltip
         # And the legend should say these are database file sizes.
         assert "size" in tooltip.lower()
+
+
+@pytest.mark.asyncio
+async def test_footer_memory_stats_yield_to_key_hints_when_narrow():
+    """TASK-451: on a narrow footer the debug memory stats hide so the key hints
+    (navigation) are preserved, rather than the reverse."""
+
+    class TestApp(App):
+        def compose(self):
+            yield AppFooterStatus(id="footer")
+
+    app = TestApp()
+    async with app.run_test(size=(200, 12)) as pilot:
+        footer = app.query_one("#footer", AppFooterStatus)
+        footer.set_workbench_shortcuts(
+            source="console",
+            shortcuts=(
+                ("F6", "next pane"),
+                ("Shift+F6", "previous pane"),
+                ("F1", "help"),
+                ("Ctrl+K", "switch session"),
+            ),
+        )
+        footer.update_db_sizes_display("P: 144.0 KB | C/N: 904.0 KB | M: 376.0 KB")
+        await pilot.pause()
+        db = app.query_one("#internal-db-size-indicator", Static)
+
+        # Wide: both fit -> memory stats shown (AC#2 no regression at normal width).
+        assert db.display is True
+
+        # Narrow: not enough room for both -> memory stats yield, hints preserved.
+        await pilot.resize_terminal(60, 12)
+        await pilot.pause()
+        assert db.display is False
+
+        # Widen again -> memory stats return.
+        await pilot.resize_terminal(200, 12)
+        await pilot.pause()
+        assert db.display is True

--- a/Tests/UI/test_app_footer_shortcut_context.py
+++ b/Tests/UI/test_app_footer_shortcut_context.py
@@ -104,8 +104,7 @@ async def test_footer_db_size_stats_expose_decode_legend_tooltip():
 
 @pytest.mark.asyncio
 async def test_footer_memory_stats_yield_to_key_hints_when_narrow():
-    """TASK-451: on a narrow footer the debug memory stats hide so the key hints
-    (navigation) are preserved, rather than the reverse."""
+    """A narrow footer hides the debug memory stats to preserve the key hints."""
 
     class TestApp(App):
         def compose(self):
@@ -137,5 +136,32 @@ async def test_footer_memory_stats_yield_to_key_hints_when_narrow():
 
         # Widen again -> memory stats return.
         await pilot.resize_terminal(200, 12)
+        await pilot.pause()
+        assert db.display is True
+
+
+@pytest.mark.asyncio
+async def test_footer_reflows_when_counts_change_without_a_resize():
+    """A word/token count change re-runs the priority reflow (Qodo #834)."""
+
+    class TestApp(App):
+        def compose(self):
+            yield AppFooterStatus(id="footer")
+
+    app = TestApp()
+    async with app.run_test(size=(100, 12)) as pilot:
+        footer = app.query_one("#footer", AppFooterStatus)
+        footer.update_db_sizes_display("P: 144.0 KB | C/N: 904.0 KB | M: 376.0 KB")
+        await pilot.pause()
+        db = app.query_one("#internal-db-size-indicator", Static)
+        assert db.display is True
+
+        # Growing the word count (no resize) can push past the width -> stats yield.
+        footer.update_word_count(999_999_999)
+        await pilot.pause()
+        assert db.display is False
+
+        # Clearing it brings them back.
+        footer.update_word_count(0)
         await pilot.pause()
         assert db.display is True

--- a/backlog/tasks/task-451 - Footer-key-hints-should-win-over-debug-memory-stats-when-truncating.md
+++ b/backlog/tasks/task-451 - Footer-key-hints-should-win-over-debug-memory-stats-when-truncating.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-451
 title: Footer key hints should win over debug memory stats when truncating
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-21 20:00'
 labels: [console, ux, footer]
 dependencies: []
@@ -30,6 +31,24 @@ half shipped as task-346).
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 When the footer is too narrow to show both, the key hints are preserved and the debug memory stats yield (shrink or hide) rather than the reverse
-- [ ] #2 No regression to the footer at normal widths on any screen
+- [x] #1 When the footer is too narrow to show both, the key hints are preserved and the debug memory stats yield (shrink or hide) rather than the reverse
+- [x] #2 No regression to the footer at normal widths on any screen
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause: the memory stats (`#internal-db-size-indicator`) are `dock: right`,
+so on a narrow footer they RESERVE their width from the right and squeeze the
+`dock: left` key hints (the inversion the review flagged). Fix: `AppFooterStatus`
+now runs a priority reflow on resize (and when the shortcut context / DB stats
+change) that hides the memory stats when there isn't room for the hints AND every
+right-side item (`width < hints + word + token + stats + headroom`) -- freeing the
+docked-right space for the hints. Recomputed from raw renderables so the decision
+is visibility-independent (no flicker). AC#2: at normal widths everything shows
+(unchanged). App-wide widget shared by every screen. Served-app-VERIFIED: at
+1400px the stats show; at 560px they're gone and the hints extend into the freed
+space. Deterministic resize test (wide→shown, narrow→hidden, wide→shown). The one
+pre-existing `test_library_registration...` footer failure is baseline (fails
+identically on clean origin/dev).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Widgets/AppFooterStatus.py
+++ b/tldw_chatbook/Widgets/AppFooterStatus.py
@@ -110,7 +110,12 @@ class AppFooterStatus(Widget):
         yield self._db_status_display  # This is the existing DB size display
 
     def on_resize(self, event: Resize) -> None:
-        """TASK-451: reprioritise the footer when its width changes."""
+        """Reprioritise the footer when its width changes (TASK-451).
+
+        Args:
+            event: The resize event; its ``size.width`` becomes the width the
+                priority reflow measures against.
+        """
         self._last_footer_width = event.size.width
         self._reflow_footer_priority()
 
@@ -195,6 +200,9 @@ class AppFooterStatus(Widget):
                 self._word_count_display.update(f"Words: {word_count} | ")
             else:
                 self._word_count_display.update("")
+            # The count's width feeds the priority threshold, so re-run the
+            # reflow when it changes without a resize (Qodo #834).
+            self._reflow_footer_priority()
         except Exception as e:
             print(f"Error updating word count display: {e}")
 
@@ -205,6 +213,7 @@ class AppFooterStatus(Widget):
                 self._token_count_display.update(f"{display_text} | ")
             else:
                 self._token_count_display.update("")
+            self._reflow_footer_priority()
         except Exception as e:
             print(f"Error updating token count display: {e}")
 

--- a/tldw_chatbook/Widgets/AppFooterStatus.py
+++ b/tldw_chatbook/Widgets/AppFooterStatus.py
@@ -3,7 +3,9 @@
 # Imports
 #
 # 3rd-party Libraries
+from rich.cells import cell_len
 from textual.app import ComposeResult
+from textual.events import Resize
 from textual.widget import Widget
 from textual.widgets import Static
 
@@ -14,6 +16,11 @@ from ..UI.Navigation.shortcut_context import ShortcutAction, ShortcutContext
 ########################################################################################################################
 #
 # AppFooterStatus
+
+#: TASK-451: cells reserved for the footer's padding/margins plus a gap so the
+#: key hints don't sit flush against the debug memory stats at the boundary.
+#: Below `hints + word + token + stats + this`, the memory stats hide.
+_FOOTER_STATS_HEADROOM = 10
 
 
 class AppFooterStatus(Widget):
@@ -91,6 +98,9 @@ class AppFooterStatus(Widget):
             "Local database file sizes\n"
             "P: Prompts   C/N: Conversations & Notes   M: Media"
         )
+        #: TASK-451: last known footer width, so a content change (new shortcut
+        #: context / DB stats) can re-run the priority reflow without a resize.
+        self._last_footer_width = 0
 
     def compose(self) -> ComposeResult:
         yield self._shortcut_display
@@ -99,6 +109,33 @@ class AppFooterStatus(Widget):
         yield self._token_count_display  # Token count display
         yield self._db_status_display  # This is the existing DB size display
 
+    def on_resize(self, event: Resize) -> None:
+        """TASK-451: reprioritise the footer when its width changes."""
+        self._last_footer_width = event.size.width
+        self._reflow_footer_priority()
+
+    def _reflow_footer_priority(self) -> None:
+        """Preserve the left key hints; the right debug memory stats yield.
+
+        On a narrow footer the right-docked memory stats (``P:/C/N:/M:`` file
+        sizes -- debug telemetry) would otherwise keep full width and squeeze
+        the left-docked key hints (navigation the user needs). When there is not
+        room for the hints AND every right-side item, the memory stats hide
+        (TASK-451). Recomputed from the raw renderables, so the decision is
+        stable regardless of the stats' current visibility (no flicker).
+        """
+        width = self._last_footer_width or self.size.width
+        if width <= 0:
+            return
+        needed = (
+            cell_len(self._shortcut_text)
+            + cell_len(str(self._word_count_display.renderable))
+            + cell_len(str(self._token_count_display.renderable))
+            + cell_len(str(self._db_status_display.renderable))
+            + _FOOTER_STATS_HEADROOM
+        )
+        self._db_status_display.display = width >= needed
+
     @property
     def shortcut_text(self) -> str:
         return self._shortcut_text
@@ -106,6 +143,9 @@ class AppFooterStatus(Widget):
     def _set_shortcut_text(self, text: str) -> None:
         self._shortcut_text = text
         self._shortcut_display.update(text)
+        # A new shortcut context changes how much room the hints need, so the
+        # memory-stats visibility can flip (TASK-451).
+        self._reflow_footer_priority()
 
     def set_shortcut_context(self, context: ShortcutContext) -> None:
         text = context.render() or self.DEFAULT_SHORTCUT_TEXT
@@ -142,6 +182,7 @@ class AppFooterStatus(Widget):
     def update_db_sizes_display(self, status_string: str) -> None:
         try:
             self._db_status_display.update(status_string)
+            self._reflow_footer_priority()
         except Exception as e:
             # If the app is shutting down, the widget might be gone
             # In a real scenario, you'd use self.log from the widget


### PR DESCRIPTION
## Summary

Console UX review follow-up (split from task-346). On narrow terminals the app footer truncated the **left key hints** (`Ctrl+K switch se…`) while the **right debug memory stats** (`P:/C/N:/M:` file sizes) kept full width — the priority is inverted: navigation the user needs vs debug telemetry.

## Root cause + fix
The memory stats (`#internal-db-size-indicator`) are `dock: right`, so they *reserve* their width from the right and squeeze the `dock: left` hints. `AppFooterStatus` now runs a priority reflow on resize (and when the shortcut context / DB stats change) that **hides the memory stats** when there isn't room for the hints AND every right-side item (`width < hints + word + token + stats + headroom`) — freeing the docked-right space for the hints. Computed from the raw renderables, so the decision is visibility-independent (no flicker). At normal widths everything shows (AC#2, no regression).

App-wide widget shared by every screen.

## Verification
- **Served-app**: at 1400px the stats show; at 560px they're gone and the hints extend into the freed space.
- **Test**: `test_footer_memory_stats_yield_to_key_hints_when_narrow` — deterministic resize (wide→shown, narrow→hidden, wide→shown).

The one pre-existing `test_library_registration_updates_the_screens_own_footer` failure is **baseline** (fails identically on clean `origin/dev`, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes console footer layout so key hints take priority over debug memory stats on narrow terminals. Fulfills TASK-451 by keeping navigation visible and hiding stats only when space is insufficient, with no regressions at normal widths.

- **Bug Fixes**
  - Added priority reflow in `AppFooterStatus` that measures content and hides `#internal-db-size-indicator` when width can’t fit hints + word + token + stats + headroom (flicker-free).
  - Reflow runs on resize and on content changes: shortcuts, DB size, and word/token counts; uses `rich.cells.cell_len` and `_FOOTER_STATS_HEADROOM = 10`.
  - Added UI tests: wide → stats shown, narrow → stats hidden, wide again → stats return; count change (no resize) hides/shows stats as needed.

<sup>Written for commit a677df471fc68e97a3f0ef6dc13d9ad105d3a563. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

