### PR TITLE
ci(css): task-395 guard CSS bundle reproducibility from sources

### DIFF
--- a/.github/workflows/css-bundle-guard.yml
+++ b/.github/workflows/css-bundle-guard.yml
@@ -1,0 +1,33 @@
+name: CSS Bundle Guard
+
+# TASK-395: a source .tcss edited without regenerating the bundle (or the bundle
+# hand-edited directly) silently ships broken styling -- every rebuild, including
+# the app's boot-time rebuild, strips the hand-edit. This guard fails any change
+# under tldw_chatbook/css/** whose committed bundle does not reproduce from its
+# sources. Like backlog-guard, it is a standalone workflow so it runs even while
+# the general CI suite is left in the intentionally-cancelled state.
+
+on:
+  pull_request:
+    paths:
+      - 'tldw_chatbook/css/**'
+  push:
+    branches: [dev, main]
+    paths:
+      - 'tldw_chatbook/css/**'
+
+jobs:
+  css-bundle-reproducible:
+    name: CSS bundle reproduces from its sources
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Bundle must match its source modules
+        run: |
+          # check_bundle_sync rebuilds the bundle into a temp file and diffs it
+          # against the committed one, ignoring only the `Generated:` timestamp;
+          # it names any drifted MODULE block. Stdlib-only, no install needed.
+          python tldw_chatbook/css/check_bundle_sync.py

--- a/Tests/UI/test_css_bundle_sync_guard.py
+++ b/Tests/UI/test_css_bundle_sync_guard.py
@@ -1,0 +1,35 @@
+"""TASK-395: the CSS-bundle reproducibility guard.
+
+`check_bundle_sync` rebuilds the bundle and fails when the committed one does not
+reproduce from its sources (ignoring the `Generated:` timestamp), naming the
+drifted module. Also asserts the repo's own committed bundle is currently in sync.
+"""
+
+from tldw_chatbook.css import check_bundle_sync as guard
+
+
+def _bundle(overrides_body: str, timestamp: str = "2026-01-01 00:00:00") -> str:
+    return (
+        f"/* GENERATED */\n * Generated: {timestamp}\n\n"
+        "/* ===== MODULE: core/_variables.tcss ===== */\n$x: 1;\n"
+        f"/* ===== MODULE: utilities/_overrides.tcss ===== */\n{overrides_body}\n"
+    )
+
+
+def test_drifted_modules_ignores_the_generated_timestamp():
+    """A faithful rebuild differing only in the timestamp reports no drift."""
+    committed = _bundle("Tooltip { border: none; }", timestamp="2026-01-01 00:00:00")
+    rebuilt = _bundle("Tooltip { border: none; }", timestamp="2026-07-24 06:31:20")
+    assert guard.drifted_modules(committed, rebuilt) is None
+
+
+def test_drifted_modules_names_the_changed_module():
+    """A source edited without regenerating names the drifted MODULE block."""
+    committed = _bundle("Tooltip { border: none; }")
+    rebuilt = _bundle("Tooltip { border: round $primary; }")
+    assert guard.drifted_modules(committed, rebuilt) == ["utilities/_overrides.tcss"]
+
+
+def test_committed_bundle_reproduces_from_sources():
+    """The repo's committed bundle is in sync (and the guard passes end-to-end)."""
+    assert guard.main() == 0

--- a/backlog/tasks/task-395 - Guard-CSS-bundle-reproducibility-from-sources-in-CI.md
+++ b/backlog/tasks/task-395 - Guard-CSS-bundle-reproducibility-from-sources-in-CI.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-395
 title: Guard CSS bundle reproducibility from sources in CI
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-20 18:35'
 labels: [css, ci, tech-debt]
 dependencies: []
@@ -19,7 +20,24 @@ Raised by review on PR #723 (Qodo suggestion 2).
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A PR that edits a `.tcss` source without regenerating the bundle (or edits the bundle directly) fails the check with a message naming the drifted module
-- [ ] #2 The comparison ignores the `Generated:` timestamp line so a faithful rebuild passes
-- [ ] #3 The check runs on PRs touching `tldw_chatbook/css/**` and post-merge on dev, like backlog-guard
+- [x] #1 A PR that edits a `.tcss` source without regenerating the bundle (or edits the bundle directly) fails the check with a message naming the drifted module
+- [x] #2 The comparison ignores the `Generated:` timestamp line so a faithful rebuild passes
+- [x] #3 The check runs on PRs touching `tldw_chatbook/css/**` and post-merge on dev, like backlog-guard
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+New standalone `.github/workflows/css-bundle-guard.yml` (modeled on backlog-guard,
+so it runs even while general CI is intentionally-cancelled) triggers on PRs
+touching `tldw_chatbook/css/**` and post-merge on dev/main (AC#3). It runs
+`tldw_chatbook/css/check_bundle_sync.py` — a stdlib-only, non-destructive checker
+that rebuilds the bundle into a TEMP file (via `build_css.build_css(css_dir, out)`),
+strips the `Generated:` timestamp line from both (AC#2), and reports drift. On
+drift it names the specific MODULE block(s) via the `/* ===== MODULE: X ===== */`
+markers (AC#1) and exits 1 with `::error::` annotations. build_css/check are
+imported as sibling modules (no package __init__), so no `pip install` is needed.
+Verified: in-sync repo → exit 0; a source edited without rebuilding → exit 1
+naming `utilities/_overrides.tcss`. 3 unit tests (timestamp-ignore, module-naming,
+committed-bundle-in-sync) + existing css_build_integrity green.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/css/check_bundle_sync.py
+++ b/tldw_chatbook/css/check_bundle_sync.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Guard: the generated CSS bundle must reproduce from its source modules.
+
+TASK-395: ``778f75813`` hand-edited the generated ``tldw_cli_modular.tcss``
+instead of a source module; the desync shipped unnoticed for a day because every
+rebuild (including the app's boot-time rebuild) silently stripped the live
+styling. This checker rebuilds the bundle into a temp file (non-destructive) and
+compares it to the committed one, ignoring only the ``Generated:`` timestamp
+line, and names any drifted MODULE block so the fix is obvious.
+
+Run locally or in CI:  ``python tldw_chatbook/css/check_bundle_sync.py``
+Exits 0 when in sync, 1 (with ``::error::`` annotations) when drifted.
+
+Stdlib-only and imported as a sibling module, so it runs without installing the
+app's dependencies (matching the standalone backlog-guard workflow).
+"""
+
+import contextlib
+import io
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+import build_css as _build_css  # noqa: E402  (sibling module, no package import)
+
+_TIMESTAMP_RE = re.compile(r"^ \* Generated:.*$", re.MULTILINE)
+_MODULE_SPLIT_RE = re.compile(r"/\* ===== MODULE: (.+?) ===== \*/")
+
+
+def _strip_timestamp(text: str) -> str:
+    """Blank the non-deterministic ``Generated:`` header line."""
+    return _TIMESTAMP_RE.sub(" * Generated: <timestamp>", text)
+
+
+def _modules(text: str) -> dict[str, str]:
+    """Split a bundle into ``{module_name: block_body}`` by its MODULE markers."""
+    parts = _MODULE_SPLIT_RE.split(text)
+    return {parts[i]: parts[i + 1] for i in range(1, len(parts), 2)}
+
+
+def drifted_modules(committed: str, rebuilt: str) -> list[str] | None:
+    """Return the drifted module names, or None when the bundle is in sync.
+
+    Args:
+        committed: The committed bundle text.
+        rebuilt: The freshly rebuilt bundle text.
+
+    Returns:
+        ``None`` when the two match once the timestamp line is ignored; otherwise
+        the sorted names of MODULE blocks that differ (``["<header>"]`` when only
+        the non-module header region drifted).
+    """
+    committed, rebuilt = _strip_timestamp(committed), _strip_timestamp(rebuilt)
+    if committed == rebuilt:
+        return None
+    committed_modules, rebuilt_modules = _modules(committed), _modules(rebuilt)
+    drifted = sorted(
+        name
+        for name in set(committed_modules) | set(rebuilt_modules)
+        if committed_modules.get(name) != rebuilt_modules.get(name)
+    )
+    return drifted or ["<header / non-module region>"]
+
+
+def main() -> int:
+    """Rebuild the bundle to a temp file and compare it to the committed one."""
+    css_dir = Path(__file__).parent
+    committed = (css_dir / "tldw_cli_modular.tcss").read_text(encoding="utf-8")
+    with tempfile.TemporaryDirectory() as tmp:
+        rebuilt_path = Path(tmp) / "rebuilt.tcss"
+        # build_css narrates each module; silence it so CI logs stay readable.
+        with contextlib.redirect_stdout(io.StringIO()):
+            _build_css.build_css(css_dir, rebuilt_path)
+        rebuilt = rebuilt_path.read_text(encoding="utf-8")
+
+    drifted = drifted_modules(committed, rebuilt)
+    if drifted is None:
+        print("CSS bundle reproduces from its source modules.")
+        return 0
+
+    print(
+        "::error::CSS bundle is out of sync with its source modules. Run "
+        "`python tldw_chatbook/css/build_css.py` and commit the regenerated "
+        "tldw_cli_modular.tcss."
+    )
+    for module in drifted:
+        print(f"::error::drifted module: {module}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tldw_chatbook/css/check_bundle_sync.py
+++ b/tldw_chatbook/css/check_bundle_sync.py
@@ -22,8 +22,14 @@ import sys
 import tempfile
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent))
-import build_css as _build_css  # noqa: E402  (sibling module, no package import)
+try:
+    # Normal package import (tests, `python -m`) -- no global side effects.
+    from . import build_css as _build_css
+except ImportError:  # pragma: no cover - only when run as a bare script
+    # Direct script execution (`python tldw_chatbook/css/build_css.py`'s dir on
+    # sys.path) has no package context; add the sibling dir just for this path.
+    sys.path.insert(0, str(Path(__file__).parent))
+    import build_css as _build_css  # noqa: E402
 
 _TIMESTAMP_RE = re.compile(r"^ \* Generated:.*$", re.MULTILINE)
 _MODULE_SPLIT_RE = re.compile(r"/\* ===== MODULE: (.+?) ===== \*/")
@@ -65,14 +71,30 @@ def drifted_modules(committed: str, rebuilt: str) -> list[str] | None:
 
 
 def main() -> int:
-    """Rebuild the bundle to a temp file and compare it to the committed one."""
+    """Rebuild the bundle to a temp file and compare it to the committed one.
+
+    Returns:
+        ``0`` when the committed bundle reproduces from its sources; ``1`` when it
+        has drifted or cannot be rebuilt (with ``::error::`` annotations naming
+        the drifted modules or the missing source).
+    """
     css_dir = Path(__file__).parent
     committed = (css_dir / "tldw_cli_modular.tcss").read_text(encoding="utf-8")
     with tempfile.TemporaryDirectory() as tmp:
         rebuilt_path = Path(tmp) / "rebuilt.tcss"
-        # build_css narrates each module; silence it so CI logs stay readable.
-        with contextlib.redirect_stdout(io.StringIO()):
-            _build_css.build_css(css_dir, rebuilt_path)
+        try:
+            # build_css narrates each module; silence it so CI logs stay clean.
+            with contextlib.redirect_stdout(io.StringIO()):
+                _build_css.build_css(css_dir, rebuilt_path)
+        except FileNotFoundError as exc:
+            # A declared module was removed without updating the manifest -- a
+            # desync worth failing on, but reported clearly rather than as a
+            # traceback (Qodo #835).
+            print(
+                f"::error::CSS bundle could not be rebuilt: {exc}. Update the "
+                "CSS_MODULES manifest in build_css.py to match the source tree."
+            )
+            return 1
         rebuilt = rebuilt_path.read_text(encoding="utf-8")
 
     drifted = drifted_modules(committed, rebuilt)


### PR DESCRIPTION
## Summary

Console UX review follow-up (Qodo suggestion on #723). A source `.tcss` edited without regenerating the bundle — or the bundle hand-edited directly — silently ships broken styling, because every rebuild (including the app's boot-time rebuild) strips the hand-edit. `778f75813` did exactly this and the desync shipped unnoticed for a day.

## What it does
New **standalone** workflow `css-bundle-guard.yml` (modeled on `backlog-guard`, so it runs even while the general CI suite is left in the intentionally-cancelled state):
- triggers on PRs touching `tldw_chatbook/css/**` and post-merge on `dev`/`main` **(AC#3)**
- runs `tldw_chatbook/css/check_bundle_sync.py` — a stdlib-only, **non-destructive** checker that rebuilds the bundle into a temp file, strips the `Generated:` timestamp line from both **(AC#2)**, and fails when they differ, **naming the drifted MODULE block(s)** **(AC#1)**

`build_css`/`check_bundle_sync` are imported as sibling modules (no package `__init__`), so no `pip install` is needed.

## Verification
- in-sync repo → exit 0 (`CSS bundle reproduces from its source modules.`)
- a source edited without rebuilding → exit 1: `::error::drifted module: utilities/_overrides.tcss`
- 3 unit tests (timestamp-ignore, module-naming, committed-bundle-in-sync) + existing `test_css_build_integrity` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a standalone CI guard to ensure the generated CSS bundle reproduces from its source `.tcss` modules, failing PRs when out of sync and naming the drifted modules. Also handles missing-module build failures cleanly with `::error::` messages.

- **New Features**
  - New workflow `.github/workflows/css-bundle-guard.yml` runs on PRs touching `tldw_chatbook/css/**` and pushes to `dev`/`main` (TASK-395 AC#3). Modeled on the standalone backlog guard.
  - `tldw_chatbook/css/check_bundle_sync.py` (stdlib-only) rebuilds to a temp file, ignores the `Generated:` timestamp, diffs, and reports `::error::drifted module` names (TASK-395 AC#1–#2). Uses package-relative import, and turns rebuild failures (e.g., missing declared module) into clear `::error::` output instead of a traceback. Unit tests cover timestamp ignore, module naming, and current repo sync.

- **Migration**
  - If the check fails, run `python tldw_chatbook/css/build_css.py` and commit the regenerated `tldw_cli_modular.tcss`.

<sup>Written for commit e080657770ad6fc1faf8761c865d09757329728d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

