### PR TITLE
chore(backlog): drop mis-specified task-442; mark task-523 Done

### DIFF
--- a/backlog/archive/tasks/task-442 - Active-persona-concept-with-user-name-substitution-in-chats.md
+++ b/backlog/archive/tasks/task-442 - Active-persona-concept-with-user-name-substitution-in-chats.md
@@ -4,6 +4,7 @@ title: Active persona concept with user-name substitution in chats
 status: To Do
 assignee: []
 created_date: '2026-07-21 09:38'
+updated_date: '2026-07-24 14:32'
 labels:
   - roleplay
   - ux
@@ -23,3 +24,9 @@ Filed from the RP/character-card UX review (Docs/superpowers/qa/rp-ux-review-202
 - [ ] #2 Preview and character sends substitute the active persona's name for {{user}} and label the user's messages with it
 - [ ] #3 With no active persona, current behavior is unchanged
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+DROPPED (mis-specified) 2026-07-24. The task inverts this app's macro semantics: {{user}} = the application USER (the human); {{persona}}/{{char}}/{{character}} = the CHARACTER/persona (AI side). AC#2 ('substitute the active persona's name for {{user}}') would write the character-side name INTO the human placeholder, corrupting {{user}}. The whole 'Personas = who you are' premise this task is built on is wrong per the app author. replace_placeholders (Character_Chat_Lib.py:404) already maps {{user}}->user and {{char}}->char correctly (it lacks {{character}}/{{persona}} aliases). If a real gap is pursued later, re-file it correctly (e.g. add {{character}}/{{persona}} aliases; feed the user's real name into {{user}} instead of the literal 'User').
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-523 - Per-intent-Console-gating-in-Roleplay-inspector-Start-Chat-requires-a-ready-provider.md
+++ b/backlog/tasks/task-523 - Per-intent-Console-gating-in-Roleplay-inspector-Start-Chat-requires-a-ready-provider.md
@@ -3,10 +3,10 @@ id: TASK-523
 title: >-
   Per-intent Console gating in Roleplay inspector (Start Chat requires a ready
   provider)
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-24 13:17'
-updated_date: '2026-07-24 13:17'
+updated_date: '2026-07-24 14:32'
 labels:
   - roleplay
   - ux
@@ -28,14 +28,17 @@ Follow-up to TASK-440 (merged with a string-only readiness approach: both Consol
 
 ## Implementation Plan
 
+<!-- SECTION:PLAN:BEGIN -->
 1. Split the inspector's `_apply_action_state` so `provider_block_reason` disables Start Chat only (Attach stays gated on selection alone); readiness copy becomes "Start Chat blocked: ...".
 2. Add a defensive `start_chat` action guard in `_attach_selection_to_console` (re-checks `_provider_send_block_reason()`).
 3. Add the red-cue CSS (`#personas-header.status-blocked .workbench-header-status { color: $error }`) — the header already flips to `status="blocked"` via `_update_title`.
 4. Update the 3 dev tests that asserted the old string-only behavior; add per-intent, action-guard, and header-class tests.
 5. Full workbench + inspector-pane regression; whole-branch review; merge cycle.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 Per-intent Console gating on top of dev's merged TASK-440 (which shipped a string-only "Reply may fail" warning with both buttons enabled).
 
 **Approach:** Reused the merged `_provider_send_block_reason()` / `console_handoff_readiness()` signal — no new provider-resolution logic. The inspector now treats the two Console actions by their send semantics: Attach only stages context (reply deferred), so it stays enabled on a valid selection; Start Chat needs an immediate provider reply, so it is disabled and its readiness reads "Start Chat blocked: <remedy>" when the resolved chat_defaults provider is unready. Precedence is unchanged (Qodo #824-2): the provider axis is only operative once the action gate passes, so a closed gate still shows the single "Console blocked: <reason>" story.
@@ -45,3 +48,4 @@ Per-intent Console gating on top of dev's merged TASK-440 (which shipped a strin
 **Whole-branch review fix (AC #3):** the red-cue rule was first placed in `PersonasScreen.DEFAULT_CSS`, but Textual ranks app-bundle CSS above any widget `DEFAULT_CSS` regardless of selector specificity, so the bundle's `.ds-status-badge { color: $ds-text-primary }` would keep the "Blocked" badge primary-coloured and the cue would never render in the real app. Moved the rule to the app-tier source `css/components/_workbench.tcss` (`#personas-header.status-blocked .workbench-header-status { color: $ds-status-blocked }` — id+class+descendant outranks `.ds-status-badge` at the same tier) and rebuilt the bundle via `build_css.py`. Added a `StyledPersonasTestApp` (real-bundle) regression test asserting the blocked-state badge colour differs from the ready-state colour — which fails if the rule is ever outranked again.
 
 **Modified files:** `Widgets/Persona_Widgets/personas_inspector_pane.py` (per-intent `_apply_action_state`, updated docstring), `UI/Screens/personas_screen.py` (start_chat action guard; red-cue moved out of DEFAULT_CSS with a pointer comment), `css/components/_workbench.tcss` + `css/tldw_cli_modular.tcss` (app-tier red-cue rule + rebuilt bundle), `Tests/UI/test_personas_workbench.py` (3 dev tests updated to per-intent expectations + 4 new tests: action guard, Attach-not-gated, header `status-blocked` class, real-bundle colour differential). 195 workbench + 20 inspector/foundation tests pass.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary

Backlog hygiene, no code changes.

**Drops TASK-442** ("Active persona concept with user-name substitution in chats") by archiving it. The task is mis-specified — it inverts this app's macro semantics:

- `{{user}}` → the **application user** (the human)
- `{{persona}}` / `{{char}}` / `{{character}}` → the **character/persona** (AI side)

Its AC#2 ("substitute the active persona's name for `{{user}}`") would write the *character-side* name into the *human* placeholder, corrupting `{{user}}` — the exact opposite of correct behavior. `replace_placeholders()` (`Character_Chat_Lib.py:404`) already maps `{{user}}`→user and `{{char}}`→char correctly (it merely lacks `{{character}}`/`{{persona}}` aliases). The whole "Personas = who you are" premise the task is built on is wrong per the app author.

Archived (not deleted), with the rationale recorded in-file so it isn't re-filed as-is. Any genuine gap should be re-scoped correctly later.

**Also flips TASK-523** (per-intent Console gating, merged in #837) from `In Progress` → `Done` — the pending status bump.

This removes TASK-442 from the shared To Do pool so a concurrent session doesn't implement the destructive AC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backlog cleanup: archived mis-specified TASK-442 and marked TASK-523 Done. TASK-442 inverted macro semantics (`{{user}}` is the human; `{{char}}`/`{{persona}}`/`{{character}}` is the character), with rationale recorded in the archived note to avoid re-filing the same issue.

<sup>Written for commit 9cc35c7b06a0118b447ab158402703b5336fa152. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

