### PR TITLE
chore(backlog): resolve duplicate task-503/519 (+file 544 for the 505-512 pileup)

### DIFF
--- a/backlog/tasks/task-542 - Fix-MCP-navigation-crash-by-requiring-Textual-8.md
+++ b/backlog/tasks/task-542 - Fix-MCP-navigation-crash-by-requiring-Textual-8.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-503
+id: TASK-542
 title: Fix MCP navigation crash by requiring Textual 8
 status: Done
 assignee: []
@@ -50,7 +50,7 @@ Implemented the dependency-boundary repair without changing MCP runtime code. Th
 
 Verification: observed the dependency tests RED first (3 expected failures against the old declarations); after rebasing onto the latest `dev`, the normal-runtime suite passed 214 tests with 9 pre-existing MCPWorkbench._clear_tool_view coroutine warnings and the exact Textual 8.0.0 replay passed 209 tests with the same 9 warnings; workflow YAML parsed and all workflow contract tests passed; wheel build succeeded with Requires-Dist: textual<9,>=8.0.0; compileall and git diff --check passed. Independent code review found no Critical issues and no production-code defects; its documentation and test-hardening findings were applied.
 
-PR rebase note: renumbered from TASK-400 to TASK-503 after rebasing onto `dev`, where TASK-400 already identifies the Console staged-sources relocation.
+PR rebase note: renumbered from TASK-400 to TASK-503 after rebasing onto `dev`, then to TASK-542 (503 collided with the RAG SP3 task, which was created earlier and has a dependent).
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-543 - Console-branching-record-run-id-on-stopped-via-cancel-agent-runs.md
+++ b/backlog/tasks/task-543 - Console-branching-record-run-id-on-stopped-via-cancel-agent-runs.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-519
+id: TASK-543
 title: >-
   Console branching: record the persisted reply id for stopped-via-cancel agent
   runs

--- a/backlog/tasks/task-544 - Resolve-duplicate-task-ids-505-512-between-two-open-batches.md
+++ b/backlog/tasks/task-544 - Resolve-duplicate-task-ids-505-512-between-two-open-batches.md
@@ -1,0 +1,29 @@
+---
+id: TASK-544
+title: >-
+  Resolve duplicate task ids 505-512 between two open batches
+status: To Do
+assignee: []
+created_date: '2026-07-24 07:15'
+updated_date: '2026-07-24 07:15'
+labels:
+  - backlog-hygiene
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Every id 505-512 exists TWICE on dev (the backlog CLI resolves by id → all eight are ambiguous). Two batches collided: (a) a web-scraping/egress batch created '2026-07-23 12:00' (Confluence sync, scrape_from_sitemap, recursive_scrape, guarded_fetch, Subscriptions validator, redirect credentials — all To Do), and (b) a model-artifact/STT batch created '2026-07-24 01:01-01:03' (artifact leases/descriptors/downloads/browser, GGUF/ONNX import, STT contracts — task-505 of this batch is **In Progress**).
+
+NOT resolved unilaterally because batch (b) appears to belong to a live session (In Progress task); renumbering under an active branch would just re-introduce dupes on its next merge, and per the standing rule the mover should be the not-started side with its owner aware. Whichever session finishes (or a coordinated cleanup) should renumber ONE side (rule: In Progress/older keeps; per-pair — batch (a) is older for all pairs but batch (b) has the In Progress 505) to the next free ids, updating frontmatter `id:` + any cross-references, then re-run the two-namespace dup-check (python os.listdir scanner, not git-ls-tree|uniq).
+
+Note: this session already resolved its own pairs (503 RAG-SP3 kept / MCP-nav → 542; 519 get_user_data_dir kept / console-branching → 543) in the same PR that files this task.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] Each id 505-512 identifies exactly one task on dev (filename prefix AND frontmatter id namespaces).
+- [ ] All cross-references (dependencies, prose) updated to the surviving/renumbered ids.
+<!-- AC:END -->


### PR DESCRIPTION
Post-merge dup-check after PR #829 found 10 duplicated ids. This PR resolves the two involving that merge and files coordination for the rest:

- **task-503**: RAG SP3 (created 21:00, **Done**, depended on by task-541) keeps the id; `Fix MCP navigation crash` (created 22:51, itself already a 400→503 renumber) → **task-542** (renumber note updated in-file).
- **task-519**: `get_user_data_dir import-time home freeze` (created 23:30, referenced by PR #829) keeps; `Console branching record-run-id` → **task-543**.
- **tasks 505-512** are ALL duplicated between two other batches (web-scraping/egress '23-12:00 vs model-artifact/STT '24-01:0x — the latter has an **In Progress** task, i.e. a live session). Deliberately NOT renumbered here (would re-collide on that session's next merge); filed as **task-544** for coordinated cleanup.

Neither renumbered task has external dependents (verified by grep of dependencies + prose). Dup-check after this PR: 503/519/542/543 each unique; only the documented 505-512 pairs remain (tracked by 544).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolved duplicate task IDs by renumbering the collisions and documenting the remaining batch. This clears backlog CLI ambiguity for 503 and 519; only 505–512 remain for coordinated cleanup.

- **Bug Fixes**
  - Renumbered: MCP navigation crash fix → TASK-542 (from 503), Console branching record-run-id → TASK-543 (from 519); updated frontmatter and notes; no external dependents.
  - Added TASK-544 to track coordinated cleanup for duplicated TASK-505–TASK-512 across two batches (one has an In Progress task).

<sup>Written for commit 3f80d2f3d18712951e999f40830d7fa1bb7dfd6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

