### PR TITLE
fix(config): call-time user-data-dir resolution — restores test HOME isolation (task-519)

### DIFF
--- a/Tests/RAG/test_first_run_import.py
+++ b/Tests/RAG/test_first_run_import.py
@@ -162,8 +162,9 @@ def test_get_shared_rag_service_calls_first_run_import_at_most_once(
 
     calls = []
     monkeypatch.setattr(ac, "ensure_imported_profile", lambda: calls.append(1) or None)
-    # Bypass the test-mode safety skip so the wiring path under test actually runs.
-    monkeypatch.setattr(ii, "_running_under_pytest", lambda: False)
+    # No test-mode skip to bypass anymore (task-519 removed the
+    # PYTEST_CURRENT_TEST guard): the _reset_first_run_wiring fixture already
+    # resets _first_run_import_attempted so this exercises the real path.
 
     fake_service = object()
     ii.set_shared_rag_service(fake_service)
@@ -203,7 +204,9 @@ def test_first_run_import_runs_before_shared_service_lock_is_held(
         acquired.append(got)
 
     monkeypatch.setattr(ac, "ensure_imported_profile", _fake_ensure_imported_profile)
-    monkeypatch.setattr(ii, "_running_under_pytest", lambda: False)
+    # No test-mode skip to bypass anymore (task-519 removed the
+    # PYTEST_CURRENT_TEST guard): the _reset_first_run_wiring fixture already
+    # resets _first_run_import_attempted so this exercises the real path.
     # Avoid a real (possibly slow/dependency-gated) RAGService build -- this
     # test is only exercising the lock-acquisition ordering, not construction.
     monkeypatch.setattr(simplified_pkg, "create_rag_service", lambda **kwargs: object())

--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -381,15 +381,21 @@ def isolate_test_environment(monkeypatch, tmp_path):
     # "imported_settings" RAG profile under the (now-isolated, but still
     # real-filesystem) data dir. Tests that specifically want to exercise
     # `_maybe_run_first_run_import` reset this flag themselves (see
-    # `Tests/RAG/test_first_run_import.py`). Imported lazily/defensively so a
-    # test run that never touches the RAG stack doesn't pay for (or fail on)
-    # this import.
-    try:
-        from tldw_chatbook.RAG_Search import ingestion_indexing
-
-        monkeypatch.setattr(ingestion_indexing, "_first_run_import_attempted", True)
-    except ImportError:
-        pass
+    # `Tests/RAG/test_first_run_import.py`).
+    #
+    # This must NOT `import tldw_chatbook.RAG_Search.ingestion_indexing` itself
+    # (review finding on task-519/PR #845): that would drag the RAG stack into
+    # every single test in the suite, autouse, even ones that never touch RAG.
+    # Instead only arm the flag if the module is ALREADY in sys.modules (i.e.
+    # some earlier-collected test already imported it) -- the first-run wiring
+    # lives INSIDE that module, so if it isn't imported it cannot fire. If a
+    # test imports it later in its own body, task-519's call-time HOME
+    # resolution already isolates any first-run write under the HOME/
+    # XDG_DATA_HOME patched above, so this pre-arm is belt-and-braces for
+    # modules that happen to already be loaded, not a correctness requirement.
+    ii = sys.modules.get("tldw_chatbook.RAG_Search.ingestion_indexing")
+    if ii is not None:
+        monkeypatch.setattr(ii, "_first_run_import_attempted", True, raising=False)
 
     yield test_data_dir
 

--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -367,12 +367,27 @@ def isolate_test_environment(monkeypatch, tmp_path):
         str(test_data_dir / "config" / "config.toml"),
     )
 
-    # Patch common data directory paths if they're imported
-    try:
-        from tldw_chatbook import config
+    # NOTE (task-519): this used to also try to
+    # `monkeypatch.setattr(config, "get_data_dir", ...)`, but `config` has no
+    # `get_data_dir` attribute -- that patch was a silent no-op. It's removed
+    # rather than fixed because it's no longer needed: `get_user_data_dir()`'s
+    # default-dir fallback now resolves HOME/XDG_DATA_HOME at CALL time (see
+    # `config._default_base_data_dir`), so the HOME/XDG_DATA_HOME env patches
+    # above are sufficient on their own.
 
-        if hasattr(config, "get_data_dir"):
-            monkeypatch.setattr(config, "get_data_dir", lambda: test_data_dir)
+    # Pre-arm SP2b's first-run-import once-flag so the RAG ingestion module's
+    # real (no-longer-pytest-gated, see task-519) first-run wiring never fires
+    # organically inside an unrelated test and creates a real
+    # "imported_settings" RAG profile under the (now-isolated, but still
+    # real-filesystem) data dir. Tests that specifically want to exercise
+    # `_maybe_run_first_run_import` reset this flag themselves (see
+    # `Tests/RAG/test_first_run_import.py`). Imported lazily/defensively so a
+    # test run that never touches the RAG stack doesn't pay for (or fail on)
+    # this import.
+    try:
+        from tldw_chatbook.RAG_Search import ingestion_indexing
+
+        monkeypatch.setattr(ingestion_indexing, "_first_run_import_attempted", True)
     except ImportError:
         pass
 

--- a/Tests/test_user_data_dir_isolation.py
+++ b/Tests/test_user_data_dir_isolation.py
@@ -1,13 +1,22 @@
 """Regression tests for task-519: get_user_data_dir()'s default-dir fallback
-must resolve HOME/XDG_DATA_HOME at CALL time, not at module-import time.
+must resolve HOME at CALL time, not at module-import time.
 
 Background: `tldw_chatbook.config.BASE_DATA_DIR_CLI` used to be a module-level
 `Path.home()` constant, frozen the first time `config.py` was imported into
-the process (i.e. before any per-test HOME/XDG_DATA_HOME monkeypatch could
-possibly run). Any test that exercised the *default* data-dir fallback (no
-`paths.data_dir` configured) therefore silently read/wrote the real
-developer/CI-runner home directory -- this bit the RAG settings+profiles
-program three separate times. See backlog task-519 for the full history.
+the process (i.e. before any per-test HOME monkeypatch could possibly run).
+Any test that exercised the *default* data-dir fallback (no `paths.data_dir`
+configured) therefore silently read/wrote the real developer/CI-runner home
+directory -- this bit the RAG settings+profiles program three separate
+times. See backlog task-519 for the full history.
+
+Note on XDG_DATA_HOME: an earlier version of this fix also made the default
+fallback honor XDG_DATA_HOME (taking precedence over HOME). That was reverted
+after review: the pre-existing default NEVER consulted XDG_DATA_HOME, so
+honoring it would silently relocate a real XDG-configured user's data dir on
+upgrade -- their entire existing data tree under ~/.local/share/tldw_cli
+would appear to have vanished, with no migration and no warning. The default
+is therefore deliberately HOME-only; the tests below assert XDG_DATA_HOME is
+ignored.
 """
 
 import pytest
@@ -66,17 +75,30 @@ def test_get_user_data_dir_honors_home_set_after_import(monkeypatch, tmp_path):
     )
 
 
-def test_get_user_data_dir_honors_xdg_data_home_precedence(monkeypatch, tmp_path):
-    """XDG_DATA_HOME, when set, must take precedence over HOME/.local/share."""
-    xdg_dir = tmp_path / "xdg_data"
-    xdg_dir.mkdir(parents=True, exist_ok=True)
-    _isolate(monkeypatch, tmp_path, xdg_data=xdg_dir)
+def test_get_user_data_dir_ignores_xdg_data_home(monkeypatch, tmp_path):
+    """XDG_DATA_HOME must NOT override the default data dir, even when set.
+
+    The pre-task-519 default fallback (BASE_DATA_DIR_CLI) never consulted
+    XDG_DATA_HOME -- it was always ~/.local/share/tldw_cli. A real user who
+    has XDG_DATA_HOME exported (common on Linux desktops) already has their
+    entire tldw_cli data tree under ~/.local/share/tldw_cli from every prior
+    run. If the default fallback started honoring XDG_DATA_HOME, that user's
+    very next launch would silently resolve to a brand-new, empty
+    $XDG_DATA_HOME/tldw_cli directory -- with no migration and no warning,
+    their conversations/notes/media would appear to have vanished. So this
+    default is deliberately HOME-only; see task-519 review notes.
+    """
+    home_dir = _isolate(
+        monkeypatch, tmp_path, xdg_data=tmp_path / "xdg_data_should_be_ignored"
+    )
 
     user_dir = config.get_user_data_dir()
 
-    assert str(user_dir).startswith(str(xdg_dir)), (
-        f"get_user_data_dir() returned {user_dir!r}, expected a path under "
-        f"XDG_DATA_HOME {xdg_dir!r}."
+    assert str(user_dir).startswith(str(home_dir)), (
+        f"get_user_data_dir() returned {user_dir!r}, expected it to stay "
+        f"under HOME {home_dir!r} -- XDG_DATA_HOME must be ignored by the "
+        f"default fallback to avoid orphaning an existing XDG user's data "
+        f"on upgrade (task-519 review)."
     )
     assert "tldw_cli" in user_dir.parts
 
@@ -92,7 +114,10 @@ def test_default_base_data_dir_helper_uses_home_when_no_xdg(monkeypatch, tmp_pat
     assert resolved == home_dir / ".local" / "share" / "tldw_cli"
 
 
-def test_default_base_data_dir_helper_prefers_xdg(monkeypatch, tmp_path):
+def test_default_base_data_dir_helper_ignores_xdg(monkeypatch, tmp_path):
+    """XDG_DATA_HOME must be ignored even when it points somewhere real and
+    HOME is also set -- honoring it here would silently relocate an existing
+    XDG user's data dir on upgrade with no migration (task-519 review)."""
     home_dir = tmp_path / "plain_home"
     home_dir.mkdir(parents=True, exist_ok=True)
     xdg_dir = tmp_path / "xdg_data"
@@ -102,4 +127,4 @@ def test_default_base_data_dir_helper_prefers_xdg(monkeypatch, tmp_path):
 
     resolved = config._default_base_data_dir()
 
-    assert resolved == xdg_dir / "tldw_cli"
+    assert resolved == home_dir / ".local" / "share" / "tldw_cli"

--- a/Tests/test_user_data_dir_isolation.py
+++ b/Tests/test_user_data_dir_isolation.py
@@ -1,0 +1,105 @@
+"""Regression tests for task-519: get_user_data_dir()'s default-dir fallback
+must resolve HOME/XDG_DATA_HOME at CALL time, not at module-import time.
+
+Background: `tldw_chatbook.config.BASE_DATA_DIR_CLI` used to be a module-level
+`Path.home()` constant, frozen the first time `config.py` was imported into
+the process (i.e. before any per-test HOME/XDG_DATA_HOME monkeypatch could
+possibly run). Any test that exercised the *default* data-dir fallback (no
+`paths.data_dir` configured) therefore silently read/wrote the real
+developer/CI-runner home directory -- this bit the RAG settings+profiles
+program three separate times. See backlog task-519 for the full history.
+"""
+
+import pytest
+
+from tldw_chatbook import config
+
+
+@pytest.fixture(autouse=True)
+def _clear_settings_cache():
+    """Ensure load_settings()/get_cli_setting() re-read from the (monkeypatched)
+    active config path in every test in this module, instead of serving a
+    stale cross-test cache."""
+    config._SETTINGS_CACHE = None
+    config._SETTINGS_CACHE_SOURCE = None
+    config._CONFIG_CACHE = None
+    config._CONFIG_CACHE_SOURCE = None
+    yield
+    config._SETTINGS_CACHE = None
+    config._SETTINGS_CACHE_SOURCE = None
+    config._CONFIG_CACHE = None
+    config._CONFIG_CACHE_SOURCE = None
+
+
+def _isolate(monkeypatch, tmp_path, *, home_name="scratch_home", xdg_data=None):
+    """Point HOME (and optionally XDG_DATA_HOME) at a scratch dir, and give
+    this test its own, guaranteed-empty CLI config file (so `paths.data_dir`
+    is never configured and the default fallback is actually exercised)."""
+    home_dir = tmp_path / home_name
+    home_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HOME", str(home_dir))
+    if xdg_data is not None:
+        monkeypatch.setenv("XDG_DATA_HOME", str(xdg_data))
+    else:
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    # Give this test a private, empty config file so get_cli_setting("paths",
+    # "data_dir", None) genuinely falls through to the default-dir branch,
+    # instead of picking up a data_dir configured by an earlier test/session.
+    scratch_config = tmp_path / "config" / "config.toml"
+    scratch_config.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(scratch_config))
+    return home_dir
+
+
+def test_get_user_data_dir_honors_home_set_after_import(monkeypatch, tmp_path):
+    """The default data dir must live under the CURRENT (test-scoped) HOME,
+    not whatever HOME happened to be true the first time config.py was
+    imported into this process."""
+    home_dir = _isolate(monkeypatch, tmp_path)
+
+    user_dir = config.get_user_data_dir()
+
+    assert str(user_dir).startswith(str(home_dir)), (
+        f"get_user_data_dir() returned {user_dir!r}, which is not under the "
+        f"test-scoped HOME {home_dir!r} -- the default data dir fallback is "
+        f"still resolving against a stale, import-time-frozen home."
+    )
+
+
+def test_get_user_data_dir_honors_xdg_data_home_precedence(monkeypatch, tmp_path):
+    """XDG_DATA_HOME, when set, must take precedence over HOME/.local/share."""
+    xdg_dir = tmp_path / "xdg_data"
+    xdg_dir.mkdir(parents=True, exist_ok=True)
+    _isolate(monkeypatch, tmp_path, xdg_data=xdg_dir)
+
+    user_dir = config.get_user_data_dir()
+
+    assert str(user_dir).startswith(str(xdg_dir)), (
+        f"get_user_data_dir() returned {user_dir!r}, expected a path under "
+        f"XDG_DATA_HOME {xdg_dir!r}."
+    )
+    assert "tldw_cli" in user_dir.parts
+
+
+def test_default_base_data_dir_helper_uses_home_when_no_xdg(monkeypatch, tmp_path):
+    home_dir = tmp_path / "plain_home"
+    home_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+
+    resolved = config._default_base_data_dir()
+
+    assert resolved == home_dir / ".local" / "share" / "tldw_cli"
+
+
+def test_default_base_data_dir_helper_prefers_xdg(monkeypatch, tmp_path):
+    home_dir = tmp_path / "plain_home"
+    home_dir.mkdir(parents=True, exist_ok=True)
+    xdg_dir = tmp_path / "xdg_data"
+    xdg_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setenv("XDG_DATA_HOME", str(xdg_dir))
+
+    resolved = config._default_base_data_dir()
+
+    assert resolved == xdg_dir / "tldw_cli"

--- a/backlog/tasks/task-519 - Fix-get_user_data_dir-import-time-home-freeze-breaking-test-HOME-isolation.md
+++ b/backlog/tasks/task-519 - Fix-get_user_data_dir-import-time-home-freeze-breaking-test-HOME-isolation.md
@@ -4,7 +4,7 @@ title: Fix get_user_data_dir import-time home freeze breaking test HOME isolatio
 status: Done
 assignee: []
 created_date: '2026-07-23 23:30'
-updated_date: '2026-07-24 15:35'
+updated_date: '2026-07-24 15:56'
 labels:
   - testing
   - config
@@ -56,4 +56,14 @@ Scratch-HOME spot-proof: ran the previously-leaking consumers (test_settings_lib
 Regression: Tests/RAG/ 536 passed/8 skipped/0 failed. Tests/UI/ -k settings: 648 passed/7 failed (baseline -- unrelated nav-overlap + API-key-field prefill failures in test_tools_settings_window.py / test_destination_visual_parity_correction.py, confirmed pre-existing per the task dispatch's own documented baseline). Tests/test_config_delete_settings.py + Tests/UI/test_settings_configuration_hub.py: 255 passed/1 failed (test_theme_category_opens_without_crashing) -- reran in isolation and it passed, confirmed flaky under this machine's heavy concurrent multi-session pytest load, not a regression from this change.
 
 Files: tldw_chatbook/config.py, tldw_chatbook/RAG_Search/ingestion_indexing.py, Tests/conftest.py, Tests/RAG/test_first_run_import.py, Tests/test_user_data_dir_isolation.py (new).
+
+--- Review fix-up (2026-07-24) ---
+Two Important findings from merge-gate review, both fixed:
+
+(1) XDG_DATA_HOME precedence reverted -- `_default_base_data_dir()` is now HOME-only, matching the original pre-task-519 BASE_DATA_DIR_CLI semantics exactly (just resolved at call time instead of import time). Rationale: the original default NEVER consulted XDG_DATA_HOME. A real user with XDG_DATA_HOME exported (common on Linux desktops) already has their entire existing tldw_cli data tree under ~/.local/share/tldw_cli from every prior run before this task-519 branch existed. Had the default started honoring XDG_DATA_HOME, that user's very next launch would silently resolve to a brand-new, empty $XDG_DATA_HOME/tldw_cli directory with no migration and no warning -- their conversations/notes/media would appear to have vanished. Test-isolation only ever needed HOME (conftest's isolate_test_environment patches HOME, not XDG_DATA_HOME), so dropping XDG support costs nothing functionally while closing the migration hazard. Confirmed Path.home() itself already honors a live-monkeypatched HOME on this platform/Python (POSIX expanduser reads $HOME on every call, not cached at import), so _default_base_data_dir() uses os.environ.get("HOME") with a Path.home() fallback for extra robustness/documentation clarity, not because Path.home() was found to cache.
+    Tests/test_user_data_dir_isolation.py: replaced both XDG-precedence tests with their inverse (test_get_user_data_dir_ignores_xdg_data_home, test_default_base_data_dir_helper_ignores_xdg), asserting XDG_DATA_HOME set alongside a scratch HOME is ignored and resolution stays under HOME. RED-proof performed: temporarily restored the XDG-honoring implementation, both new tests failed as expected (asserted HOME path, got XDG path); reverted, tests pass.
+
+(2) Settings display consistency -- UI/Screens/settings_screen.py `_configured_user_data_dir_path()` (the "Storage paths" panel's default-branch resolution) was still importing and reading the frozen-at-import `BASE_DATA_DIR_CLI` constant, so in any context where HOME differs from process-start HOME (test harnesses today; any future divergence) the displayed path could disagree with what get_user_data_dir() actually resolves and uses. Switched it to call `_default_base_data_dir()` (the exact same call-time HOME-only helper the real getter's fallback uses) instead of the constant; removed the now-unused `BASE_DATA_DIR_CLI` import. Stays read-only/cheap (no mkdir, matching the existing method's contract). No existing test asserted on BASE_DATA_DIR_CLI or this method's default-branch value directly, so no test needed updating for this half.
+
+Verification: Tests/test_user_data_dir_isolation.py + Tests/RAG/test_first_run_import.py -- 12 passed. Tests/UI/ -k settings -- 648 passed, 7 failed (same documented pre-existing baseline: nav-overlap + API-key-field prefill tests, unrelated to this change). Tests/RAG/ -- 536 passed, 8 skipped, 0 failed (unchanged from documented baseline).
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-519 - Fix-get_user_data_dir-import-time-home-freeze-breaking-test-HOME-isolation.md
+++ b/backlog/tasks/task-519 - Fix-get_user_data_dir-import-time-home-freeze-breaking-test-HOME-isolation.md
@@ -1,11 +1,10 @@
 ---
 id: TASK-519
-title: >-
-  Fix get_user_data_dir import-time home freeze breaking test HOME isolation
-status: In Progress
+title: Fix get_user_data_dir import-time home freeze breaking test HOME isolation
+status: Done
 assignee: []
 created_date: '2026-07-23 23:30'
-updated_date: '2026-07-23 23:30'
+updated_date: '2026-07-24 15:35'
 labels:
   - testing
   - config
@@ -23,9 +22,38 @@ Fix at the root: make `get_user_data_dir()` resolve the home/XDG env at CALL tim
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
-- [ ] `get_user_data_dir()` (and any sibling data-dir accessor) honors `HOME`/`XDG_DATA_HOME` changes made after module import (call-time resolution), or the conftest isolation fixture patches a real seam that achieves the same.
-- [ ] Running the full test suite with `HOME` pointed at a scratch dir creates NO files under the real user data dir (spot-proof with the rag_profiles consumers that leaked before).
-- [ ] The `PYTEST_CURRENT_TEST` guard in `_maybe_run_first_run_import` is replaced by (or demoted behind) a conftest-level fixture, so the production wiring is exercised by the organic suite.
+- [x] #1 `get_user_data_dir()` (and any sibling data-dir accessor) honors `HOME`/`XDG_DATA_HOME` changes made after module import (call-time resolution), or the conftest isolation fixture patches a real seam that achieves the same.
+- [x] #2 Running the full test suite with `HOME` pointed at a scratch dir creates NO files under the real user data dir (spot-proof with the rag_profiles consumers that leaked before).
+- [x] #3 The `PYTEST_CURRENT_TEST` guard in `_maybe_run_first_run_import` is replaced by (or demoted behind) a conftest-level fixture, so the production wiring is exercised by the organic suite.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add _default_base_data_dir() call-time helper in config.py (honors XDG_DATA_HOME/HOME at call time); switch get_user_data_dir()'s fallback to it, keep BASE_DATA_DIR_CLI constant for compat.
+2. Write RED test proving the frozen-constant bug, confirm GREEN after the fix (Tests/test_user_data_dir_isolation.py).
+3. Blast-radius grep for other BASE_DATA_DIR_CLI/Path.home() consumers; leave out-of-scope ones (settings_screen.py display-only path, Helper_Scripts CLI script, DEFAULT_CONFIG_PATH/USER_DB_DIR) documented, not changed.
+4. Retire the PYTEST_CURRENT_TEST guard in ingestion_indexing._maybe_run_first_run_import; conftest.py's autouse isolate_test_environment pre-arms _first_run_import_attempted = True instead (lazy import, try/except ImportError). Remove the dead config.get_data_dir patch.
+5. Update the two test_first_run_import.py tests that bypassed the old guard to drop the now-nonexistent _running_under_pytest monkeypatch (the _reset_first_run_wiring fixture already resets the flag).
+6. Scratch-HOME spot-proof: run the previously-leaking consumers with HOME/XDG_DATA_HOME pointed at a scratch dir, verify writes land under scratch and the real ~/.local/share/tldw_cli gets no new files.
+7. Regression: Tests/RAG/, Tests/UI/ -k settings, config-path consumers.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause confirmed: config.py's BASE_DATA_DIR_CLI = Path.home()/".local"/"share"/"tldw_cli" froze at module-import time, so get_user_data_dir()'s fallback ignored per-test HOME/XDG_DATA_HOME monkeypatches applied afterward. Fixed by resolving the default at CALL time.
+
+Part 1 - config.py: added `_default_base_data_dir()` (reads XDG_DATA_HOME, else HOME/.local/share, at call time) and switched get_user_data_dir()'s `else BASE_DATA_DIR_CLI` fallback to it. BASE_DATA_DIR_CLI itself is kept (compat: Helper_Scripts/Prompts/Prompts_Dump.py and settings_screen.py still read it directly). RED/GREEN proven: new Tests/test_user_data_dir_isolation.py failed against the pre-fix code with get_user_data_dir() resolving to the real dev home (`/Users/.../​.local/share/tldw_cli`) even with HOME monkeypatched post-import; passes after the fix, plus an XDG_DATA_HOME-precedence case.
+
+Blast radius (git grep BASE_DATA_DIR_CLI / module-level Path.home() constants): left unfixed, by design -- (1) UI/Screens/settings_screen.py:3882 `_configured_user_data_dir_path` is a read-only "storage paths" display (no mkdir/write), untested, low risk; (2) Helper_Scripts/Prompts/Prompts_Dump.py is a standalone one-shot CLI script, HOME doesn't change mid-run; (3) config.py:45 DEFAULT_CONFIG_PATH and Utils/Utils.py:77 USER_DB_DIR are separate module-level Path.home() constants for a different subsystem (main config file / legacy unused user-db path) -- not part of the three documented bites, and DEFAULT_CONFIG_PATH already has a call-time-safe override path (_get_effective_config_path() honors TLDW_CONFIG_PATH) used everywhere except 3 untested encryption functions (enable/disable/change_encryption_password), noted as a separate latent issue, no test depends on it. USER_DB_DIR/get_user_database_path is dead code (no callers outside Utils/paths.py).
+
+Part 2 - guard retirement: removed the PYTEST_CURRENT_TEST guard (and now-unused `_running_under_pytest()` helper + `import os`) from ingestion_indexing._maybe_run_first_run_import. Tests/conftest.py's autouse isolate_test_environment now pre-arms `ingestion_indexing._first_run_import_attempted = True` (lazy import, try/except ImportError) so the once-per-process first-run-import path never fires organically inside an unrelated test. Also deleted the dead `config.get_data_dir` hasattr-patch (no such attribute ever existed; silent no-op) since the HOME/XDG_DATA_HOME env patches are now sufficient on their own. Updated the two Tests/RAG/test_first_run_import.py tests that used to bypass the guard via `monkeypatch.setattr(ii, "_running_under_pytest", lambda: False)` -- removed that line; their existing `_reset_first_run_wiring` fixture already resets `_first_run_import_attempted` around each test, so the real (no-longer-gated) wiring path is what the organic suite now exercises. All 8 tests in that file still pass.
+
+Scratch-HOME spot-proof: ran the previously-leaking consumers (test_settings_library_rag_defaults.py, test_settings_rag_profile_adapter.py, test_first_run_import.py) with HOME/XDG_DATA_HOME exported to a scratch dir before pytest started -- 77 passed; writes landed under the scratch XDG_DATA_HOME (tldw_cli/default_user/chat_dicts created there); a `find -newer` diff against a marker file in the real ~/.local/share/tldw_cli showed no new regular files (only unrelated directory-mtime noise from concurrent, independent activity on the shared dev machine -- no file content changed). The known residual leak (RAGConfig.from_settings() -> active_config._manager() -> real ConfigProfileManager(), unpatched by that file's own fixture) is closed automatically by the part-1 fix, since get_profile_manager()'s default profiles_dir now resolves through the fixed get_user_data_dir().
+
+Regression: Tests/RAG/ 536 passed/8 skipped/0 failed. Tests/UI/ -k settings: 648 passed/7 failed (baseline -- unrelated nav-overlap + API-key-field prefill failures in test_tools_settings_window.py / test_destination_visual_parity_correction.py, confirmed pre-existing per the task dispatch's own documented baseline). Tests/test_config_delete_settings.py + Tests/UI/test_settings_configuration_hub.py: 255 passed/1 failed (test_theme_category_opens_without_crashing) -- reran in isolation and it passed, confirmed flaky under this machine's heavy concurrent multi-session pytest load, not a regression from this change.
+
+Files: tldw_chatbook/config.py, tldw_chatbook/RAG_Search/ingestion_indexing.py, Tests/conftest.py, Tests/RAG/test_first_run_import.py, Tests/test_user_data_dir_isolation.py (new).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-519 - Fix-get_user_data_dir-import-time-home-freeze-breaking-test-HOME-isolation.md
+++ b/backlog/tasks/task-519 - Fix-get_user_data_dir-import-time-home-freeze-breaking-test-HOME-isolation.md
@@ -2,7 +2,7 @@
 id: TASK-519
 title: >-
   Fix get_user_data_dir import-time home freeze breaking test HOME isolation
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-23 23:30'
 updated_date: '2026-07-23 23:30'

--- a/backlog/tasks/task-519 - Fix-get_user_data_dir-import-time-home-freeze-breaking-test-HOME-isolation.md
+++ b/backlog/tasks/task-519 - Fix-get_user_data_dir-import-time-home-freeze-breaking-test-HOME-isolation.md
@@ -23,7 +23,7 @@ Fix at the root: make `get_user_data_dir()` resolve the home/XDG env at CALL tim
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [x] #1 `get_user_data_dir()` (and any sibling data-dir accessor) honors `HOME`/`XDG_DATA_HOME` changes made after module import (call-time resolution), or the conftest isolation fixture patches a real seam that achieves the same.
+- [x] #1 `get_user_data_dir()` honors `HOME` changes made after module import (call-time resolution; `XDG_DATA_HOME` deliberately NOT honored — the pre-existing default never consulted it, and adding it would silently relocate an XDG user's data dir on upgrade with no migration; see Notes), and the conftest isolation fixture patches real seams.
 - [x] #2 Running the full test suite with `HOME` pointed at a scratch dir creates NO files under the real user data dir (spot-proof with the rag_profiles consumers that leaked before).
 - [x] #3 The `PYTEST_CURRENT_TEST` guard in `_maybe_run_first_run_import` is replaced by (or demoted behind) a conftest-level fixture, so the production wiring is exercised by the organic suite.
 <!-- AC:END -->

--- a/tldw_chatbook/RAG_Search/ingestion_indexing.py
+++ b/tldw_chatbook/RAG_Search/ingestion_indexing.py
@@ -38,7 +38,6 @@ Design notes:
 from __future__ import annotations
 
 import asyncio
-import os
 import queue
 import threading
 import time
@@ -132,11 +131,6 @@ _first_run_import_attempted = False
 _first_run_lock = threading.Lock()
 
 
-def _running_under_pytest() -> bool:
-    """True when executing inside a pytest run (monkeypatchable test seam)."""
-    return "PYTEST_CURRENT_TEST" in os.environ
-
-
 def _maybe_run_first_run_import() -> None:
     """Best-effort first-run "Imported settings" capture.
 
@@ -156,26 +150,23 @@ def _maybe_run_first_run_import() -> None:
     but flipping the flag must be atomic so only one thread ever proceeds
     past the check.
 
-    Skipped under pytest (``PYTEST_CURRENT_TEST``, the codebase-standard test
-    marker also used by ``Metrics/metrics_logger.py`` and
-    ``Utils/optional_deps.py``): ``ConfigProfileManager``'s default
-    ``profiles_dir`` comes from ``get_user_data_dir()``, whose
-    ``BASE_DATA_DIR_CLI`` fallback is a module-level ``Path.home()`` constant
-    baked in at import time — it predates, and is therefore NOT covered by,
-    the per-test ``HOME``/``XDG_*`` monkeypatches in ``Tests/conftest.py``.
-    Without this guard, the first unmocked ``get_shared_rag_service()`` call
-    anywhere in a pytest session would create a real
-    ``imported_settings`` profile under the developer's actual
-    ``~/.local/share/tldw_cli/.../rag_profiles/``. Tests that want to exercise
-    the real function call it directly (see ``Tests/RAG/test_first_run_import.py``).
+    No longer skipped under pytest (see task-519): the previous
+    ``PYTEST_CURRENT_TEST`` guard existed only because ``get_user_data_dir()``'s
+    default-dir fallback used to be a module-level ``Path.home()`` constant
+    baked in at import time, predating (and therefore ignoring) any per-test
+    ``HOME``/``XDG_*`` monkeypatch. Now that the fallback resolves at CALL
+    time, ``Tests/conftest.py``'s autouse ``isolate_test_environment`` fixture
+    pre-arms ``_first_run_import_attempted = True`` before each test instead,
+    so this function's once-per-process import path is exercised organically
+    by the real test suite (rather than skipped) while still never touching
+    the real user data dir. Tests that want to exercise the guarded call
+    itself reset the flag directly (see ``Tests/RAG/test_first_run_import.py``).
     """
     global _first_run_import_attempted
     with _first_run_lock:
         if _first_run_import_attempted:
             return
         _first_run_import_attempted = True
-    if _running_under_pytest():
-        return
     try:
         from .simplified.active_config import ensure_imported_profile
 

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -66,12 +66,12 @@ from ...Chat.provider_catalog import (
     PROVIDER_GROUP_ORDER,
 )
 from ...config import (
-    BASE_DATA_DIR_CLI,
     DEFAULT_CONFIG_FROM_TOML,
     DEFAULT_CONFIG_PATH,
     DEFAULT_CONSOLE_PASTE_COLLAPSE_THRESHOLD,
     MAX_CONSOLE_PASTE_COLLAPSE_THRESHOLD,
     MIN_CONSOLE_PASTE_COLLAPSE_THRESHOLD,
+    _default_base_data_dir,
     coerce_bool_setting,
     coerce_int_setting,
     load_settings,
@@ -3869,6 +3869,13 @@ class SettingsScreen(BaseAppScreen):
         return safe_user_name if safe_user_name else "default_user"
 
     def _configured_user_data_dir_path(self) -> Path:
+        """Read-only mirror of get_user_data_dir()'s resolution logic (minus
+        the mkdir side effect), so the Settings display never diverges from
+        the path the app actually uses. Uses _default_base_data_dir() (the
+        same call-time HOME resolution as get_user_data_dir()'s fallback)
+        rather than the import-time-frozen BASE_DATA_DIR_CLI constant --
+        those two can disagree, e.g. under test-isolated HOME (task-519
+        review)."""
         configured_data_dir = self._read_cli_config_value_without_writes(
             "paths", "data_dir", None
         )
@@ -3879,7 +3886,7 @@ class SettingsScreen(BaseAppScreen):
         base_data_dir = (
             Path(str(configured_data_dir)).expanduser()
             if configured_data_dir
-            else BASE_DATA_DIR_CLI
+            else _default_base_data_dir()
         )
         return validate_path_simple(
             base_data_dir / self._configured_user_folder_name(),

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -4360,15 +4360,24 @@ BASE_DATA_DIR_CLI = Path.home() / ".local" / "share" / "tldw_cli"  # Renamed for
 # (kept for backward compatibility -- some callers reference it directly).
 # get_user_data_dir()'s fallback below does NOT use it; it resolves the
 # default at CALL time via _default_base_data_dir() instead, so per-test
-# HOME/XDG_DATA_HOME monkeypatches (applied well after this module is first
-# imported) are actually honored. See task-519.
+# HOME monkeypatches (applied well after this module is first imported) are
+# actually honored. See task-519. (XDG_DATA_HOME is deliberately NOT
+# consulted -- see _default_base_data_dir()'s docstring.)
 
 
 def _default_base_data_dir() -> Path:
-    """Resolve the default data dir at CALL time (honors post-import HOME/XDG_DATA_HOME — required for test isolation; see task-519)."""
-    xdg = os.environ.get("XDG_DATA_HOME")
-    base = Path(xdg).expanduser() if xdg else Path.home() / ".local" / "share"
-    return base / "tldw_cli"
+    """Default data dir resolved at CALL time (honors post-import HOME changes
+    for test isolation; task-519). Deliberately does NOT honor XDG_DATA_HOME:
+    the pre-existing default never did, and adding it would silently relocate
+    an XDG user's data dir on upgrade with no migration (task-519 review).
+
+    Uses os.environ["HOME"] explicitly (falling back to Path.home()) because
+    Path.home() is not guaranteed to re-read a post-import HOME monkeypatch
+    on every platform/Python version, whereas os.environ is always read live.
+    """
+    home = os.environ.get("HOME")
+    base = Path(home).expanduser() if home else Path.home()
+    return base / ".local" / "share" / "tldw_cli"
 
 
 def get_api_key(api_name: str) -> Optional[str]:

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -4356,6 +4356,19 @@ def change_encryption_password(old_password: str, new_password: str) -> bool:
 
 # --- CLI Database and Log File Path Getters ---
 BASE_DATA_DIR_CLI = Path.home() / ".local" / "share" / "tldw_cli"  # Renamed for clarity
+# NOTE: BASE_DATA_DIR_CLI is a module-level constant frozen at IMPORT time
+# (kept for backward compatibility -- some callers reference it directly).
+# get_user_data_dir()'s fallback below does NOT use it; it resolves the
+# default at CALL time via _default_base_data_dir() instead, so per-test
+# HOME/XDG_DATA_HOME monkeypatches (applied well after this module is first
+# imported) are actually honored. See task-519.
+
+
+def _default_base_data_dir() -> Path:
+    """Resolve the default data dir at CALL time (honors post-import HOME/XDG_DATA_HOME — required for test isolation; see task-519)."""
+    xdg = os.environ.get("XDG_DATA_HOME")
+    base = Path(xdg).expanduser() if xdg else Path.home() / ".local" / "share"
+    return base / "tldw_cli"
 
 
 def get_api_key(api_name: str) -> Optional[str]:
@@ -4440,7 +4453,7 @@ def get_user_data_dir() -> Path:
     base_data_dir = (
         Path(configured_data_dir).expanduser()
         if configured_data_dir
-        else BASE_DATA_DIR_CLI
+        else _default_base_data_dir()
     )
     user_dir = base_data_dir / user_folder
     # Create directory if it doesn't exist


### PR DESCRIPTION
Root-cause fix for a test-isolation hazard that bit **three** programs (SP2b twice, SP3 once): `get_user_data_dir()`'s fallback was the module constant `BASE_DATA_DIR_CLI = Path.home()/...`, frozen at import — before any test fixture patches `HOME` — so unmocked default-dir consumers (profile manager, first-run import, validators) silently read/wrote the developer's real `~/.local/share/tldw_cli`.

**Fix:**
- `_default_base_data_dir()` resolves `HOME` at **call time** — semantics otherwise identical to before for every real user. (`XDG_DATA_HOME` is **deliberately not honored**: the pre-existing default never consulted it, and adding it would silently relocate an XDG user's entire data dir on upgrade with no migration — caught in review, locked by inverse-XDG tests.)
- `Tests/conftest.py`: removed the dead `get_data_dir` hasattr-patch (that function never existed — the fixture's data-dir patch had been silently no-opping) and the autouse isolation now pre-arms SP2b's first-run once-flag.
- **Retired the `PYTEST_CURRENT_TEST` production guard** in `_maybe_run_first_run_import` — the organic suite now exercises the real first-run wiring; the two wiring tests re-arm the flag directly.
- Settings' "User data directory" display now uses the same call-time resolution (it renders this path in production; the frozen constant could diverge).

**Proof:** RED/GREEN on the frozen-home behavior; scratch-HOME run of the previously-leaking suites → writes landed under scratch, and `find -newer <marker>` on the real data dir showed no new files. `Tests/RAG/` 536 passed; settings suite at its 7-failure pre-existing baseline. Backlog `task-519` → Done. Reviewed (one Important round: the XDG migration hazard, fixed + RED-proven).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves the user data directory at call time to restore test HOME isolation and prevent writes to the real `~/.local/share/tldw_cli`. Settings now use the same path logic. Addresses task-519.

- **Bug Fixes**
  - `get_user_data_dir()` now falls back to `_default_base_data_dir()` which resolves `HOME` at call time; deliberately ignores `XDG_DATA_HOME`.
  - Removed the `PYTEST_CURRENT_TEST` guard in `RAG_Search/ingestion_indexing._maybe_run_first_run_import`; `Tests/conftest.py` pre-arms `_first_run_import_attempted = True` only if the module is already loaded (no implicit import).
  - Settings screen uses `_default_base_data_dir()` for its read-only path display to match runtime resolution.
  - Added regression tests for call-time `HOME` resolution and XDG ignore; updated RAG tests to drop the old guard bypass and removed the dead `config.get_data_dir` patch.

<sup>Written for commit bfe7236285b6b14870bd319af90abb09a395dde2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

