### PR TITLE
Security hardening: git-clone RCE + tool-sandbox + pickle→json + eval RLIMIT (TASK-330/331/332)

### DIFF
--- a/Docs/superpowers/plans/2026-07-24-security-hardening-cluster.md
+++ b/Docs/superpowers/plans/2026-07-24-security-hardening-cluster.md
@@ -1,0 +1,725 @@
+# Security Hardening Cluster Implementation Plan (TASK-330 + 331#1/#2 + 332)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Four independent defensive-security fixes: git-clone transport/argument-injection hardening, a real file-tool sandbox root, pickle→json (+ a crash) in the tool-result cache, and surfacing the silently-unenforced eval-sandbox memory limit.
+
+**Architecture:** Each fix is confined to one subsystem. New git-URL validators live in `Utils/input_validation.py`; the other fixes are in-place edits to `Media/local_media_reading_service.py`, `Tools/file_operation_tools.py`, `Tools/tool_executor.py`, and `Evals/specialized_runners.py`.
+
+**Tech Stack:** Python 3.11, pytest, unittest.mock. No new dependencies.
+
+**Spec:** `Docs/superpowers/specs/2026-07-24-security-hardening-cluster-design.md` (committed `b0cc04ab3`). TASK-331 **#3** (permission/confirmation gate) is DEFERRED to its own spec — do NOT implement it here.
+
+## Global Constraints
+
+1. **Git URL allowlist:** explicit scheme ∈ `{"https","ssh"}` ONLY. Reject `ext`, `file`, `fd`, `git`, `http`, scp-shorthand (`user@host:path`), absent scheme, whitespace/backslash/control chars, and a leading `-`. Same env on the clone: `GIT_ALLOW_PROTOCOL="https:ssh"`, `GIT_PROTOCOL_FROM_USER="0"`, plus a literal `"--"` argv separator before the URL.
+2. **Sandbox root** default = `get_user_data_dir() / "tool_sandbox"` (the real API; `USER_DATA_DIR` does NOT exist), config-overridable via `[tools] file_sandbox_root`, `mkdir(parents=True, exist_ok=True)`.
+3. **Cache serializer** = `json` (NOT pickle); no migration needed (no legacy pickle files exist — the path crashed before ever writing one). The existing try/except around load/save already degrades gracefully.
+4. **RLIMIT surfacing** is PARENT-side (`platform.system()=="Darwin"` → not enforced); one-time WARNING + `results["sandbox_warnings"]`. Only `RLIMIT_AS` is the gap; do NOT touch `RLIMIT_NPROC`.
+5. **DEFERRED (do not touch):** TASK-331 #3 permission gate; the `file://`-local-read vector (follow-up).
+6. Worktree `/Users/macbook-dev/Documents/GitHub/tldw_chatbook-sec-hardening` (branch `feat/security-hardening-cluster`); tests via `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest` FROM the worktree. Never touch the main checkout. `git add` only each task's listed files, never `-A`.
+7. **Line numbers below are as-of origin/dev `5a402cbb7` — re-verify with `grep -n` before editing; the target text is authoritative.**
+
+**Baseline:** `Tools/` and `Media/` and the git-clone path have essentially no existing tests for the touched code; `Tests/Evals/test_code_execution_security.py` exists. Run `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Evals/test_code_execution_security.py -q` before Task 5 and note any pre-existing failures — report, don't fix.
+
+---
+
+### Task 1: Git URL + ref validators (`Utils/input_validation.py`)
+
+**Files:**
+- Modify: `tldw_chatbook/Utils/input_validation.py` (add two functions near `validate_url`; `ValidationError` already exists at ~L455, `urlparse` imported at L9, `re` at L5)
+- Test: `Tests/Utils/test_git_url_validation.py` (create)
+
+**Interfaces:**
+- Produces: `validate_git_repo_url(url: str) -> None` (raises `ValidationError` on reject) and `validate_git_ref(ref: str) -> None` (raises `ValidationError` on reject). Both no-op-return when valid.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/Utils/test_git_url_validation.py`:
+
+```python
+import pytest
+
+from tldw_chatbook.Utils.input_validation import (
+    ValidationError,
+    validate_git_repo_url,
+    validate_git_ref,
+)
+
+
+@pytest.mark.parametrize("url", [
+    "https://github.com/owner/repo.git",
+    "https://gitlab.example.com/a/b",
+    "ssh://git@github.com/owner/repo.git",
+])
+def test_valid_repo_urls_pass(url):
+    validate_git_repo_url(url)  # no raise
+
+
+@pytest.mark.parametrize("url", [
+    "ext::sh -c 'touch /tmp/pwn'",          # RCE transport
+    "ext::git-upload-pack",
+    "file:///etc/passwd",
+    "file::/etc/passwd",
+    "fd::17",
+    "git://example.com/repo.git",           # unauthenticated transport, not allowlisted
+    "http://example.com/repo.git",          # http not allowlisted (https only)
+    "git@github.com:owner/repo.git",        # scp-shorthand rejected (ambiguous) — use ssh://
+    "-upload-pack=/bin/sh",                 # leading dash (arg injection)
+    "--upload-pack=x",
+    "  https://x/y ",                        # whitespace
+    "https://exa\\mple.com/y",              # backslash
+    "/local/path/repo",                      # no scheme
+    "repo",                                  # no scheme
+    "",                                       # empty
+])
+def test_malicious_or_disallowed_repo_urls_raise(url):
+    with pytest.raises(ValidationError):
+        validate_git_repo_url(url)
+
+
+@pytest.mark.parametrize("ref", ["main", "v1.2.3", "feature/new-thing", "release_1"])
+def test_valid_refs_pass(ref):
+    validate_git_ref(ref)  # no raise
+
+
+@pytest.mark.parametrize("ref", [
+    "--upload-pack=/bin/sh",   # leading dash
+    "-b",
+    "a b",                      # whitespace
+    "a\tb",
+    "..",                       # traversal-ish / invalid ref
+    "a..b",
+    "a\nb",                     # control char
+    "",
+])
+def test_malicious_or_invalid_refs_raise(ref):
+    with pytest.raises(ValidationError):
+        validate_git_ref(ref)
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Utils/test_git_url_validation.py -q`
+Expected: ImportError (`validate_git_repo_url`/`validate_git_ref` don't exist).
+
+- [ ] **Step 3: Implement** — add to `tldw_chatbook/Utils/input_validation.py` (place after `validate_url`, before `ValidationError` is fine — `ValidationError` is referenced at call time, not import time; if the linter prefers, put them after the `ValidationError` class):
+
+```python
+_GIT_ALLOWED_SCHEMES = frozenset({"https", "ssh"})
+_GIT_REF_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
+
+
+def validate_git_repo_url(url: str) -> None:
+    """Validate a git clone repo URL against a strict transport allowlist.
+
+    Only explicit ``https://`` and ``ssh://`` schemes are accepted. scp-style
+    shorthand (``user@host:path``) is rejected because its no-scheme,
+    colon-before-slash shape is ambiguous with git's ``ext::``/``fd::`` custom
+    transports and with leading-dash argument-injection payloads; use
+    ``ssh://git@host/path`` instead. Rejects custom transports (``ext``,
+    ``file``, ``fd``, ``git``, ...), whitespace/backslash/control characters,
+    a leading ``-`` (git-option injection), and anything without a scheme.
+
+    Args:
+        url: The candidate repo URL.
+
+    Raises:
+        ValidationError: If ``url`` is not an allowlisted, well-formed git URL.
+    """
+    if not isinstance(url, str) or not url:
+        raise ValidationError("repo_url must be a non-empty string")
+    if url != url.strip() or any(c.isspace() for c in url):
+        raise ValidationError("repo_url must not contain whitespace")
+    if "\\" in url or any(ord(c) < 0x20 for c in url):
+        raise ValidationError("repo_url must not contain backslashes or control characters")
+    if url.startswith("-"):
+        raise ValidationError("repo_url must not start with '-' (git-option injection)")
+    try:
+        parsed = urlparse(url)
+    except ValueError as exc:
+        raise ValidationError(f"repo_url is not a parseable URL: {exc}")
+    if parsed.scheme.lower() not in _GIT_ALLOWED_SCHEMES:
+        raise ValidationError(
+            f"repo_url scheme {parsed.scheme!r} is not allowed; "
+            "only https:// and ssh:// git URLs are permitted"
+        )
+    if not parsed.hostname:
+        raise ValidationError("repo_url must include a host")
+
+
+def validate_git_ref(ref: str) -> None:
+    """Validate a git branch/ref name for use as a ``--branch`` value.
+
+    Rejects a leading ``-`` (git-option injection), whitespace/control chars,
+    ``..``, and any character outside ``[A-Za-z0-9._/-]``.
+
+    Args:
+        ref: The candidate branch/ref name.
+
+    Raises:
+        ValidationError: If ``ref`` is unsafe or not a well-formed ref name.
+    """
+    if not isinstance(ref, str) or not ref:
+        raise ValidationError("ref must be a non-empty string")
+    if ref.startswith("-"):
+        raise ValidationError("ref must not start with '-' (git-option injection)")
+    if ".." in ref:
+        raise ValidationError("ref must not contain '..'")
+    if not _GIT_REF_RE.match(ref):
+        raise ValidationError(
+            "ref may only contain letters, digits, '.', '_', '/', '-'"
+        )
+```
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Utils/test_git_url_validation.py -q`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Utils/input_validation.py Tests/Utils/test_git_url_validation.py
+git commit -m "feat(security): git repo-url + ref validators (transport allowlist, no arg injection) [TASK-330]"
+```
+
+---
+
+### Task 2: Wire `_clone_git_repository` (`Media/local_media_reading_service.py`)
+
+**Files:**
+- Modify: `tldw_chatbook/Media/local_media_reading_service.py` (`_clone_git_repository`, ~L4246)
+- Test: `Tests/Media/test_git_clone_hardening.py` (create)
+
+**Interfaces:**
+- Consumes: `validate_git_repo_url`, `validate_git_ref`, `ValidationError` from `tldw_chatbook.Utils.input_validation`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/Media/test_git_clone_hardening.py`:
+
+```python
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from tldw_chatbook.Media.local_media_reading_service import LocalMediaReadingService
+from tldw_chatbook.Utils.input_validation import ValidationError
+
+
+def _clone(repo_url, ref=None):
+    return LocalMediaReadingService._clone_git_repository(
+        repo_url, Path("/tmp/checkout_target"), ref=ref
+    )
+
+
+@pytest.mark.parametrize("repo_url", [
+    "ext::sh -c 'touch /tmp/pwn'",
+    "file:///etc/passwd",
+    "-upload-pack=/bin/sh",
+    "git@github.com:owner/repo.git",
+])
+def test_malicious_repo_url_rejected_before_subprocess(repo_url):
+    with patch("subprocess.run") as mock_run:
+        with pytest.raises((ValidationError, ValueError, RuntimeError)):
+            _clone(repo_url)
+        mock_run.assert_not_called()
+
+
+def test_malicious_ref_rejected_before_subprocess():
+    with patch("subprocess.run") as mock_run:
+        with pytest.raises((ValidationError, ValueError, RuntimeError)):
+            _clone("https://github.com/owner/repo.git", ref="--upload-pack=/bin/sh")
+        mock_run.assert_not_called()
+
+
+def test_valid_clone_uses_separator_and_restricted_env():
+    ok = MagicMock(returncode=0, stdout="", stderr="")
+    with patch("subprocess.run", return_value=ok) as mock_run:
+        _clone("https://github.com/owner/repo.git", ref="main")
+    assert mock_run.call_count == 1
+    argv = mock_run.call_args[0][0]
+    # "--" separator immediately precedes the repo URL
+    assert "--" in argv
+    sep = argv.index("--")
+    assert argv[sep + 1] == "https://github.com/owner/repo.git"
+    assert "--branch" in argv and argv[argv.index("--branch") + 1] == "main"
+    env = mock_run.call_args[1]["env"]
+    assert env["GIT_ALLOW_PROTOCOL"] == "https:ssh"
+    assert env["GIT_PROTOCOL_FROM_USER"] == "0"
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Media/test_git_clone_hardening.py -q`
+Expected: FAIL — malicious inputs currently reach `subprocess.run` (no validation), and the valid case has no `--`/env.
+
+- [ ] **Step 3: Implement** — replace the body of `_clone_git_repository` (keep the `@staticmethod`/signature):
+
+```python
+    @staticmethod
+    def _clone_git_repository(
+        repo_url: str, checkout_path: Path, *, ref: Any = None
+    ) -> None:
+        import os
+        import subprocess
+
+        from ..Utils.input_validation import (
+            validate_git_repo_url,
+            validate_git_ref,
+        )
+
+        validate_git_repo_url(repo_url)
+        command = ["git", "clone", "--depth", "1"]
+        if ref:
+            validate_git_ref(str(ref))
+            command.extend(["--branch", str(ref)])
+        # `--` separates options from positionals so a hostile URL/path can
+        # never be parsed as a git option; the env restricts git to https/ssh
+        # transports even across redirects/submodules (blocks ext::/file:: etc.).
+        command.extend(["--", repo_url, str(checkout_path)])
+        clone_env = {
+            **os.environ,
+            "GIT_ALLOW_PROTOCOL": "https:ssh",
+            "GIT_PROTOCOL_FROM_USER": "0",
+        }
+        completed = subprocess.run(
+            command, capture_output=True, text=True, check=False, env=clone_env
+        )
+        if completed.returncode != 0:
+            message = (
+                completed.stderr.strip()
+                or completed.stdout.strip()
+                or "git clone failed"
+            )
+            raise RuntimeError(message)
+```
+
+(`Any` is already imported in this module — it's used in the existing signature.)
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Media/test_git_clone_hardening.py -q`
+Expected: all pass.
+
+- [ ] **Step 5: Regression-check the existing media suite**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Media/test_local_media_reading_service.py -q`
+Expected: still green (the existing git-source test uses a local dir and takes the filesystem-copy branch, never reaching `_clone_git_repository`). If it regresses, your edit broke a contract — fix the edit.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Media/local_media_reading_service.py Tests/Media/test_git_clone_hardening.py
+git commit -m "fix(security): harden git clone against ext:: transport + arg injection [TASK-330]"
+```
+
+---
+
+### Task 3: Real file-tool sandbox root (`Tools/file_operation_tools.py`)
+
+**Files:**
+- Modify: `tldw_chatbook/Tools/file_operation_tools.py` (add helper; fix 3 `validate_path` calls at ~L63, ~L168, ~L334)
+- Test: `Tests/Tools/test_file_tool_sandbox.py` (create; add `Tests/Tools/__init__.py` if the dir isn't a package — check `ls Tests/Tools/`)
+
+**Interfaces:**
+- Consumes: `validate_path` (already imported: `from ..Utils.path_validation import validate_path`); `get_user_data_dir` / `get_cli_setting` from `..config`.
+- Produces: module-level `_tool_sandbox_root() -> Path`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/Tools/test_file_tool_sandbox.py`:
+
+```python
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Tools import file_operation_tools as fot
+
+
+def test_sandbox_root_is_real_dir_not_literal(monkeypatch, tmp_path):
+    monkeypatch.setattr(fot, "_resolve_sandbox_config", lambda: str(tmp_path / "tool_sandbox"))
+    root = fot._tool_sandbox_root()
+    assert root == (tmp_path / "tool_sandbox").resolve()
+    assert root.is_dir()  # created
+    assert root.name != "file" and root.name != "directory"
+
+
+def test_read_file_rejects_traversal_outside_sandbox(monkeypatch, tmp_path):
+    sandbox = tmp_path / "tool_sandbox"
+    monkeypatch.setattr(fot, "_tool_sandbox_root", lambda: sandbox.resolve())
+    sandbox.mkdir(parents=True, exist_ok=True)
+    # write a secret OUTSIDE the sandbox
+    secret = tmp_path / "secret.txt"
+    secret.write_text("top secret")
+    result = asyncio.run(fot.ReadFileTool().execute(file_path="../secret.txt"))
+    assert result.get("success") is False or "error" in result  # rejected, not leaked
+    assert "top secret" not in str(result)
+
+
+def test_read_file_reads_inside_sandbox(monkeypatch, tmp_path):
+    sandbox = tmp_path / "tool_sandbox"
+    monkeypatch.setattr(fot, "_tool_sandbox_root", lambda: sandbox.resolve())
+    sandbox.mkdir(parents=True, exist_ok=True)
+    (sandbox / "hello.txt").write_text("inside content")
+    result = asyncio.run(fot.ReadFileTool().execute(file_path="hello.txt"))
+    assert "inside content" in str(result)
+```
+
+(Verify `ReadFileTool().execute`'s success/error shape by reading the current method; adjust the assertions to its actual return keys — it returns a dict with either content or an `error`/`success` field. The load-bearing assertions are: traversal → not leaked; in-sandbox → content returned.)
+
+- [ ] **Step 2: Run — verify fail**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Tools/test_file_tool_sandbox.py -q`
+Expected: FAIL — `_tool_sandbox_root`/`_resolve_sandbox_config` don't exist; and with the literal `"file"` root the in-sandbox read fails.
+
+- [ ] **Step 3: Implement** — add near the top of `tldw_chatbook/Tools/file_operation_tools.py` (after the imports):
+
+```python
+def _resolve_sandbox_config() -> str:
+    """Return the configured sandbox root string (indirection for tests)."""
+    from ..config import get_cli_setting, get_user_data_dir
+
+    default_root = str(get_user_data_dir() / "tool_sandbox")
+    return get_cli_setting("tools", "file_sandbox_root", default_root) or default_root
+
+
+def _tool_sandbox_root() -> Path:
+    """Resolve + create the file-tool sandbox root.
+
+    The file tools confine all reads/writes/listings under this directory.
+    Defaults to ``<user data dir>/tool_sandbox``; override with
+    ``[tools] file_sandbox_root`` in config.toml.
+    """
+    root = Path(_resolve_sandbox_config()).expanduser().resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+```
+
+Then change the three call sites:
+- `validate_path(file_path, "file")` (ReadFileTool, ~L63) → `validate_path(file_path, _tool_sandbox_root())`
+- `validate_path(directory_path, "directory")` (ListDirectoryTool, ~L168) → `validate_path(directory_path, _tool_sandbox_root())`
+- `validate_path(file_path, "file")` (WriteFileTool, ~L334) → `validate_path(file_path, _tool_sandbox_root())`
+
+(Confirm `get_cli_setting`'s 3-arg form `get_cli_setting("tools", "file_sandbox_root", default)` matches its signature — the codebase uses both a 3-arg `(section, key, default)` and a dotted form; grep an existing 3-arg call to confirm. If only the section-dict form exists, use `get_cli_setting("tools", {}).get("file_sandbox_root", default_root)`.)
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Tools/test_file_tool_sandbox.py -q`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Tools/file_operation_tools.py Tests/Tools/test_file_tool_sandbox.py
+git commit -m "fix(security): file tools use a real configured sandbox root (not literal strings) [TASK-331]"
+```
+
+---
+
+### Task 4: pickle→json + fix the get_tool_executor crash (`Tools/tool_executor.py`)
+
+**Files:**
+- Modify: `tldw_chatbook/Tools/tool_executor.py` (`_load_from_disk` ~L205, `_save_to_disk` ~L227, `get_tool_executor` import ~L633)
+- Test: `Tests/Tools/test_tool_cache_json.py` (create)
+
+**Interfaces:**
+- Consumes: `get_user_data_dir` from `..config`. `json` is already imported at the top of the module (no new import); `pickle` import (~L10) becomes unused — remove it.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/Tools/test_tool_cache_json.py`:
+
+```python
+import asyncio
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Tools.tool_executor import ToolResultCache
+
+
+def test_cache_round_trips_through_json(tmp_path):
+    persist = tmp_path / "tool_results.cache"
+
+    async def run():
+        c1 = ToolResultCache(persist_path=persist)
+        await c1.set("mytool", {"a": 1}, {"result": "ok", "n": 3}, ttl=3600)
+        await c1._save_to_disk()
+        # the on-disk file is valid JSON (not pickle)
+        raw = persist.read_text(encoding="utf-8")
+        json.loads(raw)  # would raise if pickle
+        c2 = ToolResultCache(persist_path=persist)
+        await c2._load_from_disk()
+        got = await c2.get("mytool", {"a": 1})
+        return raw, got
+
+    raw, got = asyncio.run(run())
+    assert got == {"result": "ok", "n": 3}
+    assert "\x80" not in raw  # not a pickle opcode stream
+
+
+def test_corrupt_cache_file_degrades_gracefully(tmp_path):
+    persist = tmp_path / "tool_results.cache"
+    persist.write_text("not valid json {{{", encoding="utf-8")
+
+    async def run():
+        c = ToolResultCache(persist_path=persist)
+        await c._load_from_disk()  # must not raise
+        return await c.get("anything", {})
+
+    assert asyncio.run(run()) is None
+
+
+def test_get_tool_executor_with_cache_enabled_does_not_importerror(monkeypatch):
+    # Previously `from ..config import USER_DATA_DIR` raised ImportError here.
+    from tldw_chatbook.Tools import tool_executor as te
+
+    monkeypatch.setattr(
+        te, "get_tool_executor", te.get_tool_executor
+    )  # ensure symbol import path is exercised
+    import tldw_chatbook.config as cfg
+
+    monkeypatch.setattr(
+        cfg, "get_cli_setting",
+        lambda section, key=None, default=None: (
+            {"cache_enabled": True, "cache_persist": True} if section == "tools" and key is None
+            else default
+        ),
+    )
+    te.reset_tool_executor() if hasattr(te, "reset_tool_executor") else None
+    ex = te.get_tool_executor()  # must not raise ImportError
+    assert ex is not None
+```
+
+(The third test's exact mechanics depend on how `get_tool_executor` reads config and whether a reset helper exists — read the module and adapt: the ONLY load-bearing assertion is "calling `get_tool_executor()` with cache enabled does not raise `ImportError`." If a global singleton makes it hard to force a fresh build, assert instead that `import tldw_chatbook.Tools.tool_executor` + a direct call of the persist-path code path resolves `get_user_data_dir` without `ImportError`.)
+
+- [ ] **Step 2: Run — verify fail**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Tools/test_tool_cache_json.py -q`
+Expected: FAIL — the on-disk file is pickle (json.loads raises), and/or cache-enabled build raises `ImportError`.
+
+- [ ] **Step 3a: Swap pickle→json in the cache.** In `_load_from_disk` change:
+```python
+                with open(self.persist_path, "rb") as f:
+                    loaded_cache = pickle.load(f)
+```
+to:
+```python
+                with open(self.persist_path, "r", encoding="utf-8") as f:
+                    loaded_cache = json.load(f)
+```
+(The subsequent `for key, (result, expiry_time) in loaded_cache.items():` unpacks a 2-element JSON list identically to a tuple — no change needed.)
+
+In `_save_to_disk` change:
+```python
+            with open(self.persist_path, "wb") as f:
+                pickle.dump(cache_copy, f)
+```
+to:
+```python
+            with open(self.persist_path, "w", encoding="utf-8") as f:
+                json.dump(cache_copy, f)
+```
+(The existing `try/except Exception` around `_save_to_disk` already logs+skips if a value is non-JSON-serializable, degrading to in-memory-only — no extra code needed. Tuples serialize as JSON arrays.)
+
+Remove the now-unused `import pickle` (~L10).
+
+- [ ] **Step 3b: Fix the crash in `get_tool_executor`.** Change (~L633):
+```python
+            from ..config import USER_DATA_DIR
+
+            cache_dir = Path(USER_DATA_DIR) / "tool_cache"
+```
+to:
+```python
+            from ..config import get_user_data_dir
+
+            cache_dir = get_user_data_dir() / "tool_cache"
+```
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Tools/test_tool_cache_json.py -q`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Tools/tool_executor.py Tests/Tools/test_tool_cache_json.py
+git commit -m "fix(security): tool-result cache uses json not pickle; fix USER_DATA_DIR ImportError crash [TASK-331]"
+```
+
+---
+
+### Task 5: Surface RLIMIT_AS non-enforcement (`Evals/specialized_runners.py`)
+
+**Files:**
+- Modify: `tldw_chatbook/Evals/specialized_runners.py` (add `import platform` + `_memory_limit_enforced()`; `_execute_code` docstring ~L258-272 + results dict ~L276-282 + a warning emission)
+- Test: `Tests/Evals/test_rlimit_surfacing.py` (create)
+
+**Interfaces:**
+- Produces: module-level `_memory_limit_enforced() -> bool`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/Evals/test_rlimit_surfacing.py`:
+
+```python
+import pytest
+
+from tldw_chatbook.Evals import specialized_runners as sr
+
+
+def test_memory_limit_not_enforced_on_darwin(monkeypatch):
+    monkeypatch.setattr(sr.platform, "system", lambda: "Darwin")
+    assert sr._memory_limit_enforced() is False
+
+
+def test_memory_limit_enforced_on_linux(monkeypatch):
+    monkeypatch.setattr(sr.platform, "system", lambda: "Linux")
+    assert sr._memory_limit_enforced() is True
+
+
+def test_warns_and_records_when_unenforced(monkeypatch):
+    # A helper that builds the results dict + appends the sandbox warning when
+    # memory isn't enforced. On Darwin it must surface a warning entry.
+    monkeypatch.setattr(sr, "_memory_limit_enforced", lambda: False)
+    warnings = sr._sandbox_warnings()
+    assert any("memory" in w.lower() for w in warnings)
+
+
+def test_no_warning_when_enforced(monkeypatch):
+    monkeypatch.setattr(sr, "_memory_limit_enforced", lambda: True)
+    assert sr._sandbox_warnings() == []
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Evals/test_rlimit_surfacing.py -q`
+Expected: FAIL — `_memory_limit_enforced` / `_sandbox_warnings` don't exist (and `platform` not imported).
+
+- [ ] **Step 3a: Add `import platform`** near the other stdlib imports (~L19-26) in `specialized_runners.py`, and add module-level helpers (after imports / near the top-level of the module):
+
+```python
+_MEMORY_LIMIT_WARNED = False
+
+
+def _memory_limit_enforced() -> bool:
+    """Whether the eval sandbox's RLIMIT_AS memory cap is enforced here.
+
+    On macOS/BSD ``setrlimit(RLIMIT_AS, ...)`` raises ``ValueError`` (the
+    address-space limit is aliased to RSS and cannot be lowered), so the
+    256MB memory cap silently does not apply. Time is still bounded by the
+    subprocess wall-clock timeout on every platform; only peak memory is
+    unbounded where this returns False.
+    """
+    return platform.system() != "Darwin"
+
+
+def _sandbox_warnings() -> list:
+    """One-time-logged, per-result warnings about non-enforced sandbox limits."""
+    global _MEMORY_LIMIT_WARNED
+    warnings: list = []
+    if not _memory_limit_enforced():
+        msg = (
+            "eval sandbox: RLIMIT_AS memory limit is NOT enforced on this "
+            "platform (macOS/BSD); model-generated code is bounded by the "
+            "execution timeout but not by peak memory"
+        )
+        warnings.append(msg)
+        if not _MEMORY_LIMIT_WARNED:
+            logger.warning(msg)
+            _MEMORY_LIMIT_WARNED = True
+    return warnings
+```
+
+- [ ] **Step 3b: Wire into `_execute_code`.** In the `results = {...}` init (~L276-282) add the key:
+```python
+            "execution_time": 0.0,
+            "sandbox_warnings": _sandbox_warnings(),
+```
+And fix the docstring (~L258-272) — change the security-measures list so "memory" is qualified:
+```python
+        Security measures implemented:
+        - CPU time + wall-clock timeout (cross-platform)
+        - Memory cap via RLIMIT_AS -- best-effort; NOT enforced on macOS/BSD
+          (setrlimit(RLIMIT_AS) raises ValueError there), surfaced via
+          results["sandbox_warnings"]; see _memory_limit_enforced()
+        - Process/file-descriptor/file-write limits (RLIMIT_NPROC/NOFILE/FSIZE)
+        - Dangerous builtins disabled (eval, exec, compile, etc.)
+        - Restricted environment with minimal PATH
+        - Runs in temporary directory with restricted HOME
+```
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Evals/test_rlimit_surfacing.py Tests/Evals/test_code_execution_security.py -q`
+Expected: the new tests pass; the existing security suite stays green (you didn't change the generated RLIMIT code, only added parent-side surfacing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Evals/specialized_runners.py Tests/Evals/test_rlimit_surfacing.py
+git commit -m "fix(security): surface non-enforced RLIMIT_AS memory limit on macOS; correct sandbox docstring [TASK-332]"
+```
+
+---
+
+### Task 6: Backlog bookkeeping + follow-ups
+
+**Files:**
+- Modify: `backlog/tasks/task-330 - Harden-git-clone-against-transport-and-argument-injection.md`
+- Modify: `backlog/tasks/task-331 - Tool-executor-security-hardening.md`
+- Modify: `backlog/tasks/task-332 - Eval-runner-resource-limits-robust-on-macOS.md`
+- Create: two follow-up task files (IDs via the collision-safe scan)
+
+- [ ] **Step 1: Assign follow-up IDs.** Scan both namespaces against origin/dev + working tree:
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook-sec-hardening && git fetch -q origin
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python - <<'EOF'
+import os, re, subprocess
+ids=set()
+for name in subprocess.run(["git","ls-tree","-r","--name-only","origin/dev","backlog/"],capture_output=True,text=True).stdout.splitlines():
+    m=re.search(r"task-(\d+)",name)
+    if m: ids.add(int(m.group(1)))
+for root in ("backlog/tasks","backlog/drafts"):
+    if os.path.isdir(root):
+        for name in os.listdir(root):
+            m=re.search(r"task-(\d+)",name)
+            if m: ids.add(int(m.group(1)))
+print("next ids:", max(ids)+1, max(ids)+2)
+EOF
+```
+Use the two printed ids for the follow-ups below (call them `<GATE_ID>` and `<FILEURL_ID>`).
+
+- [ ] **Step 2: Close TASK-330** — read it; check all ACs (`- [ ]`→`- [x]`), `status: Done`, add `## Implementation Notes`: validators `validate_git_repo_url`/`validate_git_ref` in `Utils/input_validation.py` (https/ssh explicit-scheme allowlist; reject ext/file/fd/git/scp-shorthand/leading-dash/whitespace); `_clone_git_repository` now validates repo_url+ref, inserts `--`, and runs with `GIT_ALLOW_PROTOCOL=https:ssh` + `GIT_PROTOCOL_FROM_USER=0`; tests cover ext::/file::/leading-dash/malicious-ref rejection before subprocess. Note the follow-up (`file://`-resolves-to-local-dir read vector → task-`<FILEURL_ID>`).
+
+- [ ] **Step 3: Close TASK-332** — check ACs, `status: Done`, `## Implementation Notes`: only `RLIMIT_AS` silently no-ops on macOS (RLIMIT_NPROC works); parent-side `_memory_limit_enforced()` (False on Darwin) → one-time WARNING + `results["sandbox_warnings"]`; docstring corrected; the pre-existing memory-exhaustion test was vacuous (static scan blocks its payload).
+
+- [ ] **Step 4: Partially close TASK-331** — check ACs #1 and #2 (`- [x]`), LEAVE #3 unchecked, `status: Done` with `## Implementation Notes` stating: AC#1 (real sandbox root via `[tools] file_sandbox_root` default `get_user_data_dir()/tool_sandbox`) and AC#2 (pickle→json in ToolResultCache + fixed the `USER_DATA_DIR` ImportError that crashed `get_tool_executor` when caching was enabled) are done; **AC#3 (the confirmation/permission gate) is split to a dedicated follow-up, task-`<GATE_ID>`**, because it is a cross-system + UI integration (two call sites, risk-tagging the `Tool` ABC, reusing `MCPPermissionStore`/`resolve_effective_state` + `ChatApprovalCard`) far larger than this bundle.
+
+- [ ] **Step 5: File the two follow-ups** (copy an existing task file's frontmatter format):
+  - `backlog/tasks/task-<GATE_ID> - Wire-built-in-tool-executor-into-MCP-permission-gate.md` — labels `tools,security`; priority medium; deps `[task-331]`. Description: built-in fs/mutating tools (`write_file`/`create_note`/`update_note`, all default-off) auto-execute on model tool_calls with NO allow/ask/deny gate. Wire `ToolExecutor` (Site A: `Event_Handlers/…execute_tool_calls`, main-loop) and/or the agent-runtime `BuiltinToolProvider` (Site B: worker-thread) into the existing `MCP/permission_store.py` model (`resolve_effective_state`/`EffectiveToolState`, kill switch, `HIGH_RISK_TAGS`), add a risk-tag field to the `Tool` ABC and tag the mutating tools, and reuse `Widgets/Chat_Widgets/chat_approval_card.py` for the "ask" confirmation. AC: a mutating built-in tool requested by the model is gated allow/ask/deny before execution, with a test. NOTE the Task-3 interaction: the sandbox fix made these tools functional-within-a-sandbox, so this gate is the intended protection.
+  - `backlog/tasks/task-<FILEURL_ID> - Restrict-file-scheme-local-read-in-git-ingestion-source.md` — labels `security,media`; priority low; deps `[task-330]`. Description: `_local_git_repository_path`/`_sync_git_repository_source_items` resolve a `file://`/no-scheme `repo_url` pointing at a real local dir and read it directly (skipping the clone) — a secondary local-file-read vector not covered by the clone-time transport allowlist. AC: local-path ingestion sources are restricted/validated (or explicitly opt-in).
+
+- [ ] **Step 6: Commit**
+```bash
+git add "backlog/tasks/task-330 - Harden-git-clone-against-transport-and-argument-injection.md" "backlog/tasks/task-331 - Tool-executor-security-hardening.md" "backlog/tasks/task-332 - Eval-runner-resource-limits-robust-on-macOS.md" backlog/tasks/task-<GATE_ID>*.md backlog/tasks/task-<FILEURL_ID>*.md
+git commit -m "docs(backlog): close TASK-330/332, partial TASK-331 (#1/#2); file gate + file:// follow-ups"
+```
+
+---
+
+## Post-plan notes for the controller (not for task implementers)
+
+- SDD models: Task 1 (isolated validators, complete code) → cheapest tier; Tasks 2-5 (in-place edits on real files) → mid tier; Task 6 (backlog) → cheapest tier. Final whole-branch review → most capable.
+- The three fs tools become functional-within-a-sandbox after Task 3 while the gate is deferred — this is the intended, on-the-record tradeoff (default-off + narrow sandbox); the final review should confirm write_file's blast radius is confined to the sandbox root.
+- Re-verify every `~Lnnn` against the current file before editing (concurrent dev drift).
+

--- a/Docs/superpowers/specs/2026-07-24-security-hardening-cluster-design.md
+++ b/Docs/superpowers/specs/2026-07-24-security-hardening-cluster-design.md
@@ -1,0 +1,71 @@
+# Security hardening cluster (TASK-330 + TASK-331 #1/#2 + TASK-332)
+
+**Date:** 2026-07-24
+**Backlog:** TASK-330 (git-clone transport/arg-injection, MEDIUM) + TASK-331 #1/#2 (tool-executor: sandbox root + pickle→json, LOW) + TASK-332 (eval-runner RLIMIT surfacing, LOW). One PR. The final security cluster of the LLM-harness review 2026-07 (327 agent-runtime durability remains after this).
+**Branch:** `feat/security-hardening-cluster` (worktree off `origin/dev` @ `5a402cbb7`).
+**Explicitly out of scope:** TASK-331 **#3** (the full permission/confirmation gate) — decomposed into its own next spec (a two-call-site, thread-crossing, tag-plumbing, confirmation-UI build ~as large as everything here combined). A follow-up task tracks it.
+
+All findings verified against origin/dev. Confirmed no other branch edits the five target files ahead of dev (clean rebase runway); re-verify line numbers at implementation time regardless — heavy concurrent activity on dev.
+
+## Part A — TASK-330: git-clone RCE hardening
+
+### Vuln (confirmed)
+`_clone_git_repository` (`Media/local_media_reading_service.py`, ~L4245) builds
+`["git","clone","--depth","1", (…"--branch",str(ref)…), repo_url, str(checkout_path)]`
+with `subprocess.run(command)` — argv (not shell), but **no scheme validation, no `--` separator, no env restriction**. `repo_url` and `ref` come from an ingestion-source config dict (`config.get("repo_url")` / `config.get("branch") or config.get("ref")`) that is stored verbatim from user/imported JSON with zero validation. `repo_url = "ext::sh -c '<cmd>'"` → git's `ext::` transport → arbitrary shell RCE; a leading-`-` `repo_url` (positional) → parsed as a git option (argument injection). Zero test coverage of this path today (the one existing git-source test takes the local-filesystem-copy branch and never reaches the clone).
+
+### Fix (all three ACs, defense-in-depth)
+1. **New validators in `Utils/input_validation.py`** (next to `validate_url`; `validate_url`/`egress.evaluate_url_policy` can't be reused — both hard-restrict to http/https, but git needs `ssh://`):
+   - `validate_git_repo_url(url: str) -> None` — parse with `urlparse`; require **an explicit scheme in the allowlist `{"https", "ssh"}`** (deliberately NOT scp-shorthand `user@host:path` — its colon-before-slash / no-`://` shape is ambiguous with `ext::…`/`-flag:x` and a security-sensitive parser to get right; users needing SSH write `ssh://git@host/path`). Reject: any other/absent scheme (`ext`, `file`, `fd`, `git`, `http`, ``), whitespace/backslash/control chars, a leading `-`, and empty. Raise `ValidationError` with a clear message.
+   - `validate_git_ref(ref: str) -> None` — reject a leading `-`, whitespace, control chars, `..`, and shell/ref-dangerous metacharacters; allow normal ref names (alphanumerics, `/`, `-`, `_`, `.`). Raise `ValidationError`.
+2. **`_clone_git_repository`**: call the validators on `repo_url` (always) and `ref` (when truthy) **before** building argv → build `["git","clone","--depth","1", …("--branch", ref)…, "--", repo_url, str(checkout_path)]` (the `--` separator, so even a validator gap can't make a positional parse as an option) → `subprocess.run(command, env={**os.environ, "GIT_ALLOW_PROTOCOL": "https:ssh", "GIT_PROTOCOL_FROM_USER": "0"}, …)` so git itself blocks any non-{https,ssh} transport even in redirects/submodules.
+3. **Tests** (`Tests/Media/`): `ext::` `repo_url`, `file://` `repo_url`, leading-dash `repo_url`, and leading-dash `ref` each raise (validator) **before** any `subprocess.run` (assert the mock was never called); a valid `https://…` builds argv containing `"--"` immediately before the url and runs with the restricted env (subprocess mocked — assert `command` and `env`).
+
+### Noted follow-up (out of scope)
+`_local_git_repository_path` resolves a `file://`/no-scheme `repo_url` that points at a real local dir and reads it directly (skipping the clone) — a secondary local-file-read vector. Out of this task's argv-injection scope; file as a follow-up.
+
+## Part B — TASK-331 #1: real sandbox root
+
+### Vuln (confirmed)
+`ReadFileTool`/`ListDirectoryTool`/`WriteFileTool` (`Tools/file_operation_tools.py`, ~L63/168/334) call `validate_path(path, "file")` / `validate_path(path, "directory")` — the literal strings `"file"`/`"directory"` land in `validate_path`'s **`base_directory`** (sandbox root) parameter, resolving to a bogus, CWD-relative `<cwd>/file`. Fails closed only by accident (the root doesn't exist), so the tools are effectively non-functional; no real configured sandbox root exists.
+
+### Fix
+- Add a `[tools] file_sandbox_root` config key, **defaulting to `get_user_data_dir() / "tool_sandbox"`** (the real data-dir API is `get_user_data_dir()` in `config.py`, NOT the nonexistent `USER_DATA_DIR`). A shared module helper `_tool_sandbox_root() -> Path` reads the config, expands `~`, resolves, and `mkdir(parents=True, exist_ok=True)`.
+- Pass `_tool_sandbox_root()` as `base_directory` at all three call sites instead of the literal strings.
+- **Tests:** a traversal payload (`../../etc/passwd`) is still rejected against the real root; an in-sandbox relative path resolves inside the root; the root directory is created.
+
+### Interaction with the deferred gate (on the record)
+This makes the tools functional-within-a-sandbox, which removes the accidental confinement that today blocks `write_file` entirely — and TASK-331 **#3 (the confirmation gate) is deferred**. Acceptable posture because: the fs tools remain **default-OFF** (a user must explicitly enable `write_file`), and the sandbox defaults to a **narrow, empty** `<user_data>/tool_sandbox` (small blast radius; the user must explicitly widen `file_sandbox_root` to make the tools broadly useful). Stated here and in the #3 follow-up so it's a conscious tradeoff, not a silent regression.
+
+## Part C — TASK-331 #2: pickle→json + fix the crash
+
+### Vulns (confirmed — two bugs)
+1. `ToolResultCache._load_from_disk`/`_save_to_disk` (`Tools/tool_executor.py`, ~L213/241) use `pickle.load`/`pickle.dump` on a local cache file — deserialization anti-pattern (a locally-planted malicious pickle → code execution on next load).
+2. `get_tool_executor()` (~L631) does `from ..config import USER_DATA_DIR` — **a name that doesn't exist in `config.py`** (it has `get_user_data_dir()` / `BASE_DATA_DIR_CLI`), UNGUARDED — so `get_tool_executor()` **raises `ImportError` whenever `[tools] cache_enabled = true`**. (This is why the pickle path is currently unreachable, and why no legacy pickle cache files exist in the wild — clean cutover, no migration.)
+
+### Fix
+- Replace `pickle.load`/`pickle.dump` with `json.load`/`json.dump`. Cache values are `(result_dict, expiry_float)` tuples; JSON stores each as a 2-element list, reconstructed to a tuple on load. All current tool results are JSON-serializable dicts. Make the save **defensive**: on `TypeError` (a future non-serializable result), log + skip persistence (the in-memory cache still works) rather than crashing the save. The existing load try/except already degrades a corrupt/old file to an empty cache.
+- Change `from ..config import USER_DATA_DIR` → `from ..config import get_user_data_dir` and `cache_dir = get_user_data_dir() / "tool_cache"`.
+- **Tests** (`Tests/Tools/`): a cache round-trips through the JSON path (`set` → save → new-instance load → `get` returns the value with correct expiry-tuple shape); a corrupt/non-JSON cache file loads to an empty cache without raising; `get_tool_executor()` with cache enabled no longer raises `ImportError` (the persist path computes).
+
+## Part D — TASK-332: surface RLIMIT_AS non-enforcement + document
+
+### Vuln (confirmed, and the finding refined)
+The eval code-runner (`Evals/specialized_runners.py`, generated child ~L378-401) sets RLIMITs inside the model-code subprocess. `RLIMIT_AS` (256MB memory) is wrapped in `except (ValueError, OSError): pass` — and on macOS/BSD `setrlimit(RLIMIT_AS, …)` raises `ValueError` (address-space limit aliased to RSS, unsettable), so the memory cap **silently no-ops with no warning/fallback**. (Refinement: `RLIMIT_NPROC` — also flagged — actually *works* on macOS; only `RLIMIT_AS` is the silent gap. The wall-clock `subprocess.run(timeout=…)` still bounds *time* cross-platform, so only *peak memory within ~5s* is unbounded on macOS.) The runner docstring overclaims "memory" as an enforced measure. The one existing memory-exhaustion test is vacuous (the static AST scan blocks its literal payload before the subprocess spawns).
+
+### Fix (AC#1 surface non-enforcement, AC#2 document)
+- **Parent-side detection** (robust; the child can't write a report file because `RLIMIT_FSIZE=0`, and grepping child stderr risks colliding with model output): a module-level `_memory_limit_enforced() -> bool` returning `False` on platforms where `RLIMIT_AS` can't apply (`platform.system() == "Darwin"`; extensible). When it returns `False`, the runner logs a **one-time** `WARNING` ("eval sandbox: RLIMIT_AS memory limit not enforced on this platform; model-generated code is bounded by time (timeout) but not peak memory") and records the caveat in each result (`results["sandbox_warnings"]`, a list) so callers/UI see it — no silent gap.
+- **Docstring**: correct `_execute_code`'s security-measures docstring to note that on macOS/BSD the `RLIMIT_AS` memory cap is best-effort / not enforced, and that the primary cross-platform bound is the wall-clock timeout.
+- **Tests** (`Tests/Evals/`): `_memory_limit_enforced()` returns `False` on Darwin / `True` on Linux (monkeypatch `platform.system`); a run on a non-enforcing platform surfaces a `sandbox_warnings` entry; the warning logs at most once. Platform-aware (no false failure on either OS).
+
+## Cross-cutting
+
+- One PR; ~5 commits: (A) git validators + `_clone_git_repository` wiring + tests; (B) sandbox root + tests; (C) pickle→json + import fix + tests; (D) RLIMIT surfacing + docstring + tests; (E) backlog.
+- **Backlog:** TASK-330 → Done; TASK-332 → Done; TASK-331 → check ACs #1/#2, add Implementation Note that **AC #3 (the permission/confirmation gate) is split to a new follow-up task**; file that follow-up task (labels `tools,security`; description = the full-MCP-permission-integration scope from this brainstorm: two call sites A/B, risk-tagging the `Tool` ABC, reusing `MCPPermissionStore`/`resolve_effective_state` + `ChatApprovalCard`). Also file the Part-A `file://` local-read follow-up. IDs via the collision-safe two-namespace scan.
+- Fresh worktree; `git add` only listed files (never `-A`); tests via the main checkout `.venv`.
+
+## Out of scope / residual (explicit)
+- TASK-331 #3 permission/confirmation gate (own spec).
+- The `file://`-resolves-to-local-dir secondary read vector in the git-sync path (follow-up).
+- A psutil RSS memory watchdog for the eval sandbox (the chosen approach surfaces non-enforcement rather than adding an enforcement mechanism; watchdog is a possible future enhancement).
+- Broadening/validating the ingestion-source `config` dict at creation time (Part A validates at clone time, the security boundary; input-time validation is a defense-in-depth nicety, not required).

--- a/Tests/Evals/test_rlimit_surfacing.py
+++ b/Tests/Evals/test_rlimit_surfacing.py
@@ -1,0 +1,26 @@
+import pytest
+
+from tldw_chatbook.Evals import specialized_runners as sr
+
+
+def test_memory_limit_not_enforced_on_darwin(monkeypatch):
+    monkeypatch.setattr(sr.platform, "system", lambda: "Darwin")
+    assert sr._memory_limit_enforced() is False
+
+
+def test_memory_limit_enforced_on_linux(monkeypatch):
+    monkeypatch.setattr(sr.platform, "system", lambda: "Linux")
+    assert sr._memory_limit_enforced() is True
+
+
+def test_warns_and_records_when_unenforced(monkeypatch):
+    # A helper that builds the results dict + appends the sandbox warning when
+    # memory isn't enforced. On Darwin it must surface a warning entry.
+    monkeypatch.setattr(sr, "_memory_limit_enforced", lambda: False)
+    warnings = sr._sandbox_warnings()
+    assert any("memory" in w.lower() for w in warnings)
+
+
+def test_no_warning_when_enforced(monkeypatch):
+    monkeypatch.setattr(sr, "_memory_limit_enforced", lambda: True)
+    assert sr._sandbox_warnings() == []

--- a/Tests/Media/test_git_clone_hardening.py
+++ b/Tests/Media/test_git_clone_hardening.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from tldw_chatbook.Media.local_media_reading_service import LocalMediaReadingService
+from tldw_chatbook.Utils.input_validation import ValidationError
+
+
+def _clone(repo_url, ref=None):
+    return LocalMediaReadingService._clone_git_repository(
+        repo_url, Path("/tmp/checkout_target"), ref=ref
+    )
+
+
+@pytest.mark.parametrize("repo_url", [
+    "ext::sh -c 'touch /tmp/pwn'",
+    "file:///etc/passwd",
+    "-upload-pack=/bin/sh",
+    "git@github.com:owner/repo.git",
+])
+def test_malicious_repo_url_rejected_before_subprocess(repo_url):
+    with patch("subprocess.run") as mock_run:
+        with pytest.raises((ValidationError, ValueError, RuntimeError)):
+            _clone(repo_url)
+        mock_run.assert_not_called()
+
+
+def test_malicious_ref_rejected_before_subprocess():
+    with patch("subprocess.run") as mock_run:
+        with pytest.raises((ValidationError, ValueError, RuntimeError)):
+            _clone("https://github.com/owner/repo.git", ref="--upload-pack=/bin/sh")
+        mock_run.assert_not_called()
+
+
+def test_valid_clone_uses_separator_and_restricted_env():
+    ok = MagicMock(returncode=0, stdout="", stderr="")
+    with patch("subprocess.run", return_value=ok) as mock_run:
+        _clone("https://github.com/owner/repo.git", ref="main")
+    assert mock_run.call_count == 1
+    argv = mock_run.call_args[0][0]
+    # "--" separator immediately precedes the repo URL
+    assert "--" in argv
+    sep = argv.index("--")
+    assert argv[sep + 1] == "https://github.com/owner/repo.git"
+    assert "--branch" in argv and argv[argv.index("--branch") + 1] == "main"
+    env = mock_run.call_args[1]["env"]
+    assert env["GIT_ALLOW_PROTOCOL"] == "https:ssh"
+    assert env["GIT_PROTOCOL_FROM_USER"] == "0"

--- a/Tests/Tools/test_file_tool_sandbox.py
+++ b/Tests/Tools/test_file_tool_sandbox.py
@@ -33,3 +33,36 @@ def test_read_file_reads_inside_sandbox(monkeypatch, tmp_path):
     (sandbox / "hello.txt").write_text("inside content")
     result = asyncio.run(fot.ReadFileTool().execute(file_path="hello.txt"))
     assert "inside content" in str(result)
+
+
+def test_read_write_work_under_dotted_ancestor_root(monkeypatch, tmp_path):
+    """Regression test: the real default sandbox root lives under a dotted
+    ancestor (``get_user_data_dir()/"tool_sandbox"`` resolves to something
+    like ``~/.local/share/tldw_cli/.../tool_sandbox``). validate_path must
+    not reject in-sandbox paths just because the sandbox *root* itself sits
+    under a dotted directory component -- only a dotted component in the
+    user-supplied (relative) portion of the path should be rejected.
+    """
+    # Simulate the real default: sandbox under a `.local`-style dotted ancestor.
+    sandbox = tmp_path / ".local" / "share" / "tldw" / "tool_sandbox"
+    monkeypatch.setattr(fot, "_tool_sandbox_root", lambda: sandbox.resolve())
+    sandbox.mkdir(parents=True, exist_ok=True)
+
+    # A normal in-sandbox write must succeed even though the sandbox root
+    # itself is nested under dotted directories.
+    write_result = asyncio.run(
+        fot.WriteFileTool().execute(file_path="note.txt", content="hi there")
+    )
+    assert "error" not in write_result
+    assert (sandbox / "note.txt").read_text() == "hi there"
+
+    # And the corresponding read must succeed too.
+    read_result = asyncio.run(fot.ReadFileTool().execute(file_path="note.txt"))
+    assert "error" not in read_result
+    assert read_result.get("content") == "hi there"
+
+    # A user-supplied path containing a dotted component is STILL rejected --
+    # the security property is preserved, only the sandbox's own location is
+    # exempted from the hidden-file check.
+    bad_result = asyncio.run(fot.ReadFileTool().execute(file_path=".secret"))
+    assert "error" in bad_result

--- a/Tests/Tools/test_file_tool_sandbox.py
+++ b/Tests/Tools/test_file_tool_sandbox.py
@@ -1,0 +1,35 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Tools import file_operation_tools as fot
+
+
+def test_sandbox_root_is_real_dir_not_literal(monkeypatch, tmp_path):
+    monkeypatch.setattr(fot, "_resolve_sandbox_config", lambda: str(tmp_path / "tool_sandbox"))
+    root = fot._tool_sandbox_root()
+    assert root == (tmp_path / "tool_sandbox").resolve()
+    assert root.is_dir()  # created
+    assert root.name != "file" and root.name != "directory"
+
+
+def test_read_file_rejects_traversal_outside_sandbox(monkeypatch, tmp_path):
+    sandbox = tmp_path / "tool_sandbox"
+    monkeypatch.setattr(fot, "_tool_sandbox_root", lambda: sandbox.resolve())
+    sandbox.mkdir(parents=True, exist_ok=True)
+    # write a secret OUTSIDE the sandbox
+    secret = tmp_path / "secret.txt"
+    secret.write_text("top secret")
+    result = asyncio.run(fot.ReadFileTool().execute(file_path="../secret.txt"))
+    assert result.get("success") is False or "error" in result  # rejected, not leaked
+    assert "top secret" not in str(result)
+
+
+def test_read_file_reads_inside_sandbox(monkeypatch, tmp_path):
+    sandbox = tmp_path / "tool_sandbox"
+    monkeypatch.setattr(fot, "_tool_sandbox_root", lambda: sandbox.resolve())
+    sandbox.mkdir(parents=True, exist_ok=True)
+    (sandbox / "hello.txt").write_text("inside content")
+    result = asyncio.run(fot.ReadFileTool().execute(file_path="hello.txt"))
+    assert "inside content" in str(result)

--- a/Tests/Tools/test_tool_cache_json.py
+++ b/Tests/Tools/test_tool_cache_json.py
@@ -1,0 +1,74 @@
+import asyncio
+import json
+
+import pytest
+
+from tldw_chatbook.Tools.tool_executor import ToolResultCache
+
+
+def test_cache_round_trips_through_json(tmp_path):
+    persist = tmp_path / "tool_results.cache"
+
+    async def run():
+        c1 = ToolResultCache(persist_path=persist)
+        await c1.set("mytool", {"a": 1}, {"result": "ok", "n": 3}, ttl=3600)
+        await c1._save_to_disk()
+        # the on-disk file is valid JSON (not pickle)
+        raw = persist.read_text(encoding="utf-8")
+        json.loads(raw)  # would raise if pickle
+        c2 = ToolResultCache(persist_path=persist)
+        await c2._load_from_disk()
+        got = await c2.get("mytool", {"a": 1})
+        return raw, got
+
+    raw, got = asyncio.run(run())
+    assert got == {"result": "ok", "n": 3}
+    assert "\x80" not in raw  # not a pickle opcode stream
+
+
+def test_corrupt_cache_file_degrades_gracefully(tmp_path):
+    persist = tmp_path / "tool_results.cache"
+    persist.write_text("not valid json {{{", encoding="utf-8")
+
+    async def run():
+        c = ToolResultCache(persist_path=persist)
+        await c._load_from_disk()  # must not raise
+        return await c.get("anything", {})
+
+    assert asyncio.run(run()) is None
+
+
+def test_get_tool_executor_with_cache_enabled_does_not_importerror(monkeypatch, tmp_path):
+    """Regression test: `get_tool_executor()` used to do
+    `from ..config import USER_DATA_DIR`, which doesn't exist and raised an
+    unguarded ImportError whenever tools.cache_enabled + tools.cache_persist
+    resolved true. It must instead resolve the persist directory via
+    `get_user_data_dir()`.
+    """
+    from tldw_chatbook.Tools import tool_executor as te
+    import tldw_chatbook.config as cfg
+
+    def fake_get_cli_setting(section, key=None, default=None):
+        # get_tool_executor calls get_cli_setting("tools", {}); real
+        # get_cli_setting treats a non-string second positional as the
+        # default-value slot, so mirror that contract here.
+        if section == "tools":
+            return {"cache_enabled": True, "cache_persist": True}
+        return default
+
+    monkeypatch.setattr(cfg, "get_cli_setting", fake_get_cli_setting)
+    monkeypatch.setattr(cfg, "get_user_data_dir", lambda: tmp_path)
+    # Force a fresh build regardless of what earlier tests left cached.
+    monkeypatch.setattr(te, "_global_executor", None)
+
+    async def run():
+        return te.reload_tool_executor()  # must not raise ImportError
+
+    ex = asyncio.run(run())
+    try:
+        assert ex is not None
+        assert ex.cache is not None
+        assert ex.cache.persist_path == tmp_path / "tool_cache" / "tool_results.cache"
+    finally:
+        # Don't leak the monkeypatched executor into later tests.
+        monkeypatch.setattr(te, "_global_executor", None)

--- a/Tests/Tools/test_tool_cache_json.py
+++ b/Tests/Tools/test_tool_cache_json.py
@@ -72,3 +72,42 @@ def test_get_tool_executor_with_cache_enabled_does_not_importerror(monkeypatch, 
     finally:
         # Don't leak the monkeypatched executor into later tests.
         monkeypatch.setattr(te, "_global_executor", None)
+
+
+def test_cache_construct_from_sync_context_does_not_raise(tmp_path):
+    """Regression: constructing the cache with a persist_path from a SYNC
+    context (no running event loop) must not raise 'no running event loop' --
+    the disk load is deferred and started lazily on the first async get/set.
+    """
+    persist = tmp_path / "tool_results.cache"
+    # No running loop here (plain sync call) -- previously raised RuntimeError.
+    cache = ToolResultCache(persist_path=persist)
+    assert cache._load_task is None  # deferred, not eagerly created
+
+    async def run():
+        # First async op triggers the lazy load and round-trips a value.
+        await cache.set("t", {"x": 1}, {"ok": True}, ttl=3600)
+        return await cache.get("t", {"x": 1})
+
+    assert asyncio.run(run()) == {"ok": True}
+
+
+def test_cache_lazy_load_reads_prewritten_disk_file(tmp_path):
+    """A cache constructed from a sync context still loads an existing on-disk
+    file lazily on first async get()."""
+    persist = tmp_path / "tool_results.cache"
+
+    async def seed():
+        c1 = ToolResultCache(persist_path=persist)
+        await c1.set("seed", {"k": 1}, {"v": 42}, ttl=3600)
+        await c1._save_to_disk()
+
+    asyncio.run(seed())
+
+    cache = ToolResultCache(persist_path=persist)  # sync construction
+    assert cache._load_task is None
+
+    async def run():
+        return await cache.get("seed", {"k": 1})
+
+    assert asyncio.run(run()) == {"v": 42}

--- a/Tests/Utils/test_git_url_validation.py
+++ b/Tests/Utils/test_git_url_validation.py
@@ -56,3 +56,21 @@ def test_valid_refs_pass(ref):
 def test_malicious_or_invalid_refs_raise(ref):
     with pytest.raises(ValidationError):
         validate_git_ref(ref)
+
+
+@pytest.mark.parametrize("url", [
+    "ssh://-oProxyCommand=touch$IFS/tmp/pwn/repo",
+    "ssh://user@-oProxyCommand=x/repo",
+    "ssh://-flag/repo",
+    "https://x/y​",              # zero-width space (U+200B)
+    "https://x/y‎",              # LTR mark (format char, U+200E)
+])
+def test_ssh_host_dash_and_zerowidth_rejected(url):
+    with pytest.raises(ValidationError):
+        validate_git_repo_url(url)
+
+
+@pytest.mark.parametrize("ref", ["main\n", "feature/x\n", "v1\r"])
+def test_ref_trailing_control_char_rejected(ref):
+    with pytest.raises(ValidationError):
+        validate_git_ref(ref)

--- a/Tests/Utils/test_git_url_validation.py
+++ b/Tests/Utils/test_git_url_validation.py
@@ -1,0 +1,58 @@
+import pytest
+
+from tldw_chatbook.Utils.input_validation import (
+    ValidationError,
+    validate_git_repo_url,
+    validate_git_ref,
+)
+
+
+@pytest.mark.parametrize("url", [
+    "https://github.com/owner/repo.git",
+    "https://gitlab.example.com/a/b",
+    "ssh://git@github.com/owner/repo.git",
+])
+def test_valid_repo_urls_pass(url):
+    validate_git_repo_url(url)  # no raise
+
+
+@pytest.mark.parametrize("url", [
+    "ext::sh -c 'touch /tmp/pwn'",          # RCE transport
+    "ext::git-upload-pack",
+    "file:///etc/passwd",
+    "file::/etc/passwd",
+    "fd::17",
+    "git://example.com/repo.git",           # unauthenticated transport, not allowlisted
+    "http://example.com/repo.git",          # http not allowlisted (https only)
+    "git@github.com:owner/repo.git",        # scp-shorthand rejected (ambiguous) — use ssh://
+    "-upload-pack=/bin/sh",                 # leading dash (arg injection)
+    "--upload-pack=x",
+    "  https://x/y ",                        # whitespace
+    "https://exa\\mple.com/y",              # backslash
+    "/local/path/repo",                      # no scheme
+    "repo",                                  # no scheme
+    "",                                       # empty
+])
+def test_malicious_or_disallowed_repo_urls_raise(url):
+    with pytest.raises(ValidationError):
+        validate_git_repo_url(url)
+
+
+@pytest.mark.parametrize("ref", ["main", "v1.2.3", "feature/new-thing", "release_1"])
+def test_valid_refs_pass(ref):
+    validate_git_ref(ref)  # no raise
+
+
+@pytest.mark.parametrize("ref", [
+    "--upload-pack=/bin/sh",   # leading dash
+    "-b",
+    "a b",                      # whitespace
+    "a\tb",
+    "..",                       # traversal-ish / invalid ref
+    "a..b",
+    "a\nb",                     # control char
+    "",
+])
+def test_malicious_or_invalid_refs_raise(ref):
+    with pytest.raises(ValidationError):
+        validate_git_ref(ref)

--- a/backlog/tasks/task-330 - Harden-git-clone-against-transport-and-argument-injection.md
+++ b/backlog/tasks/task-330 - Harden-git-clone-against-transport-and-argument-injection.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-330
 title: Harden git clone against transport and argument injection
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-20 18:45'
+updated_date: '2026-07-24 12:00'
 labels: [security]
 dependencies: []
 priority: medium
@@ -17,8 +18,14 @@ priority: medium
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `repo_url` scheme is allowlisted (https, optionally ssh/git@); `ext::` and other non-allowlisted transports are rejected
-- [ ] #2 Leading-dash `repo_url`/`ref` values are rejected, and a `--` separator precedes the URL in the argv
-- [ ] #3 The clone runs with `GIT_PROTOCOL_FROM_USER=0` / `GIT_ALLOW_PROTOCOL` restricting protocols
-- [ ] #4 Tests cover an `ext::` payload and a leading-dash payload being rejected
+- [x] #1 `repo_url` scheme is allowlisted (https, optionally ssh/git@); `ext::` and other non-allowlisted transports are rejected
+- [x] #2 Leading-dash `repo_url`/`ref` values are rejected, and a `--` separator precedes the URL in the argv
+- [x] #3 The clone runs with `GIT_PROTOCOL_FROM_USER=0` / `GIT_ALLOW_PROTOCOL` restricting protocols
+- [x] #4 Tests cover an `ext::` payload and a leading-dash payload being rejected
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Validators `validate_git_repo_url`/`validate_git_ref` added to `Utils/input_validation.py` with https/ssh explicit-scheme allowlist; ext, file, fd, git, scp-shorthand, leading-dash, and whitespace are rejected. `_clone_git_repository` now validates repo_url and ref before use, inserts `--` separator before the URL in argv, and runs with `GIT_ALLOW_PROTOCOL=https:ssh` + `GIT_PROTOCOL_FROM_USER=0` environment settings. Tests cover ext:: and file:: payload rejection, leading-dash rejection, and whitespace rejection. Follow-up task-546 addresses a secondary local-file-read vector in `_local_git_repository_path` and `_sync_git_repository_source_items` that resolves file:// or no-scheme URLs pointing at real local directories and reads them directly without clone validation.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-331 - Tool-executor-security-hardening.md
+++ b/backlog/tasks/task-331 - Tool-executor-security-hardening.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-331
 title: Tool-executor security hardening
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-20 18:45'
+updated_date: '2026-07-24 12:00'
 labels: [security, tools]
 dependencies: []
 priority: low
@@ -17,7 +18,13 @@ Low-severity hardening in the shared tool executor and file tools, grouped as on
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `file_operation_tools` passes a real sandbox root to `validate_path` instead of the literal strings `"file"`/`"directory"` (`file_operation_tools.py:65,176,338`); it currently confines ops to `<cwd>/file` — fails closed but is unintended and fragile
-- [ ] #2 The tool-result cache no longer uses `pickle.load` (`tool_executor.py:204`); it is replaced with JSON or another safe serializer
+- [x] #1 `file_operation_tools` passes a real sandbox root to `validate_path` instead of the literal strings `"file"`/`"directory"` (`file_operation_tools.py:65,176,338`); it currently confines ops to `<cwd>/file` — fails closed but is unintended and fragile
+- [x] #2 The tool-result cache no longer uses `pickle.load` (`tool_executor.py:204`); it is replaced with JSON or another safe serializer
 - [ ] #3 fs-mutating built-in tools (`read_file`/`write_file`/`list_directory`) require a confirmation/governance gate before auto-executing on model `tool_calls`, consistent with the MCP Allow/Ask/Off model
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+AC#1 and AC#2 are complete: the sandbox root is now read from `[tools] file_sandbox_root` configuration (defaulting to `get_user_data_dir()/tool_sandbox`) and passed to `validate_path` in `file_operation_tools.py`, confining all file operations to a real, configurable directory; the tool-result cache in `tool_executor.py` was converted from pickle to JSON serialization, fixing an `ImportError` crash when the cache was enabled. AC#3 (confirmation/governance gate for fs-mutating tools) is deferred as a dedicated follow-up task-545 because it requires cross-system integration: wiring `ToolExecutor` (call site: `Event_Handlers`, main-loop) and/or the agent-runtime `BuiltinToolProvider` (call site: worker-thread) into the existing `MCP/permission_store.py` model (`resolve_effective_state`, `EffectiveToolState`), adding a risk-tag field to the `Tool` ABC, tagging mutating tools, and reusing `Widgets/Chat_Widgets/chat_approval_card.py` for ask confirmations — work well beyond the scope of this hardening bundle.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-332 - Eval-runner-resource-limits-robust-on-macOS.md
+++ b/backlog/tasks/task-332 - Eval-runner-resource-limits-robust-on-macOS.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-332
 title: Make eval-runner resource limits robust on platforms lacking RLIMIT
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-20 18:45'
+updated_date: '2026-07-24 12:00'
 labels: [security, evals]
 dependencies: []
 priority: low
@@ -17,6 +18,12 @@ The evals code-runner (`Evals/specialized_runners.py:281`) sandboxes model-gener
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 When `RLIMIT_AS`/`RLIMIT_NPROC` are unavailable, the runner either applies an equivalent bound or surfaces that the limit is not enforced (no silent gap)
-- [ ] #2 The macOS limitation is documented near the runner
+- [x] #1 When `RLIMIT_AS`/`RLIMIT_NPROC` are unavailable, the runner either applies an equivalent bound or surfaces that the limit is not enforced (no silent gap)
+- [x] #2 The macOS limitation is documented near the runner
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+On macOS, `RLIMIT_AS` silently no-ops (the resource is not supported); `RLIMIT_NPROC` works. Parent-side check `_memory_limit_enforced()` returns False on Darwin and logs a one-time WARNING, recording the gap in `results["sandbox_warnings"]`. Docstring updated to clarify that memory limits may not be enforced on all platforms. The pre-existing memory-exhaustion test was vacuous (static AST safety scan blocks its payload) and remains so; deployment users rely on timeout as the primary limit on unsupported platforms.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-545 - Wire-built-in-tool-executor-into-MCP-permission-gate.md
+++ b/backlog/tasks/task-545 - Wire-built-in-tool-executor-into-MCP-permission-gate.md
@@ -1,0 +1,25 @@
+---
+id: TASK-545
+title: Wire built-in tool executor into MCP permission gate
+status: To Do
+assignee: []
+created_date: '2026-07-24 12:00'
+labels: [tools, security]
+dependencies: [TASK-331]
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Built-in fs/mutating tools (`write_file`, `create_note`, `update_note`, all default-off) auto-execute on model tool_calls with no allow/ask/deny gate. Wire `ToolExecutor` (Site A: `Event_Handlers/…execute_tool_calls`, main-loop) and/or the agent-runtime `BuiltinToolProvider` (Site B: worker-thread) into the existing `MCP/permission_store.py` model (`resolve_effective_state`, `EffectiveToolState`, kill switch, `HIGH_RISK_TAGS`). Add a risk-tag field to the `Tool` ABC and tag the mutating tools with it. Reuse `Widgets/Chat_Widgets/chat_approval_card.py` for the "ask" confirmation. TASK-331's sandbox fix made these tools functional-within-a-sandbox, so this gate is the intended protection layer.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] A mutating built-in tool requested by the model is gated allow/ask/deny before execution
+- [ ] Tool ABC has a risk_tags field and mutating tools are tagged with HIGH_RISK or similar
+- [ ] Integration with permission_store.py resolve_effective_state is complete
+- [ ] ask confirmation reuses chat_approval_card.py
+- [ ] Unit test covers tool execution gates (allow, ask, deny scenarios)
+<!-- AC:END -->

--- a/backlog/tasks/task-546 - Restrict-file-scheme-local-read-in-git-ingestion-source.md
+++ b/backlog/tasks/task-546 - Restrict-file-scheme-local-read-in-git-ingestion-source.md
@@ -1,0 +1,24 @@
+---
+id: TASK-546
+title: Restrict file:// scheme local read in git ingestion source
+status: To Do
+assignee: []
+created_date: '2026-07-24 12:00'
+labels: [security, media]
+dependencies: [TASK-330]
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`_local_git_repository_path` and `_sync_git_repository_source_items` resolve a `file://` or no-scheme `repo_url` pointing at a real local directory and read it directly (skipping the clone), using `pathlib.Path(url).glob()` and similar direct filesystem operations. This is a secondary local-file-read vector not covered by the clone-time transport allowlist hardening in TASK-330. An ingestion source with `repo_url = "/etc"` or `repo_url = "file:///etc"` would read system directories without validation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] Local-path ingestion sources (`file://` or no-scheme URLs) are restricted by validating the resolved path against a configurable allowlist or sandbox root
+- [ ] Paths outside the allowlist are rejected at ingestion time (fail-closed)
+- [ ] Or explicit opt-in is required for local-path sources via config flag
+- [ ] Unit test covers rejection of out-of-bounds paths (e.g. /etc, /tmp)
+<!-- AC:END -->

--- a/backlog/tasks/task-547 - Fix-tools-config-unreachable-via-get_cli_setting.md
+++ b/backlog/tasks/task-547 - Fix-tools-config-unreachable-via-get_cli_setting.md
@@ -1,0 +1,24 @@
+---
+id: TASK-547
+title: Fix tools config unreachable via get_cli_setting
+status: To Do
+assignee: []
+created_date: '2026-07-24 12:00'
+labels: [tools, config, bug]
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`get_tool_executor()` reads `tools_config = get_cli_setting("tools", {})` — the `{}` is treated as the DEFAULT-value slot (following get_cli_setting's non-string-2nd-arg convention), so it returns `{}` regardless of the actual `[tools]` TOML section. Net effect: all `[tools]` flags (`read_file_enabled`, `write_file_enabled`, `create_note_enabled`, `update_note_enabled`, `cache_enabled`, etc.) are unreachable and always False in real usage — the entire tools config section is dead and cannot be enabled by users.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] get_cli_setting call is fixed to read the [tools] section correctly (e.g. get_cli_setting("tools") without default, or using the section-dict accessor)
+- [ ] Enabling a [tools] flag in config.toml actually enables that tool in get_tool_executor()
+- [ ] Unit test confirms that setting read_file_enabled = true in [tools] section enables read_file
+- [ ] Review other get_cli_setting calls for similar default-value slot misuse
+<!-- AC:END -->

--- a/tldw_chatbook/Evals/specialized_runners.py
+++ b/tldw_chatbook/Evals/specialized_runners.py
@@ -17,6 +17,7 @@ evaluation logic and metrics.
 """
 
 import ast
+import platform
 import re
 import json
 import subprocess
@@ -30,6 +31,38 @@ from loguru import logger
 from .eval_runner import BaseEvalRunner, EvalSampleResult, EvalSample
 from .task_loader import TaskConfig
 from tldw_chatbook.Metrics.metrics_logger import log_counter, log_histogram
+
+
+_MEMORY_LIMIT_WARNED = False
+
+
+def _memory_limit_enforced() -> bool:
+    """Whether the eval sandbox's RLIMIT_AS memory cap is enforced here.
+
+    On macOS/BSD ``setrlimit(RLIMIT_AS, ...)`` raises ``ValueError`` (the
+    address-space limit is aliased to RSS and cannot be lowered), so the
+    256MB memory cap silently does not apply. Time is still bounded by the
+    subprocess wall-clock timeout on every platform; only peak memory is
+    unbounded where this returns False.
+    """
+    return platform.system() != "Darwin"
+
+
+def _sandbox_warnings() -> list:
+    """One-time-logged, per-result warnings about non-enforced sandbox limits."""
+    global _MEMORY_LIMIT_WARNED
+    warnings: list = []
+    if not _memory_limit_enforced():
+        msg = (
+            "eval sandbox: RLIMIT_AS memory limit is NOT enforced on this "
+            "platform (macOS/BSD); model-generated code is bounded by the "
+            "execution timeout but not by peak memory"
+        )
+        warnings.append(msg)
+        if not _MEMORY_LIMIT_WARNED:
+            logger.warning(msg)
+            _MEMORY_LIMIT_WARNED = True
+    return warnings
 
 
 class CodeExecutionRunner(BaseEvalRunner):
@@ -259,10 +292,13 @@ class CodeExecutionRunner(BaseEvalRunner):
         """Execute code and run test cases.
 
         Security measures implemented:
-        - Resource limits (CPU, memory, processes, file descriptors)
+        - CPU time + wall-clock timeout (cross-platform)
+        - Memory cap via RLIMIT_AS -- best-effort; NOT enforced on macOS/BSD
+          (setrlimit(RLIMIT_AS) raises ValueError there), surfaced via
+          results["sandbox_warnings"]; see _memory_limit_enforced()
+        - Process/file-descriptor/file-write limits (RLIMIT_NPROC/NOFILE/FSIZE)
         - Dangerous builtins disabled (eval, exec, compile, etc.)
         - Restricted environment with minimal PATH
-        - Execution timeout
         - Runs in temporary directory with restricted HOME
 
         Future improvements:
@@ -277,6 +313,7 @@ class CodeExecutionRunner(BaseEvalRunner):
             "test_results": [],
             "error_message": None,
             "execution_time": 0.0,
+            "sandbox_warnings": _sandbox_warnings(),
         }
 
         try:

--- a/tldw_chatbook/Media/local_media_reading_service.py
+++ b/tldw_chatbook/Media/local_media_reading_service.py
@@ -4246,13 +4246,31 @@ class LocalMediaReadingService:
     def _clone_git_repository(
         repo_url: str, checkout_path: Path, *, ref: Any = None
     ) -> None:
+        import os
         import subprocess
 
+        from ..Utils.input_validation import (
+            validate_git_repo_url,
+            validate_git_ref,
+        )
+
+        validate_git_repo_url(repo_url)
         command = ["git", "clone", "--depth", "1"]
         if ref:
+            validate_git_ref(str(ref))
             command.extend(["--branch", str(ref)])
-        command.extend([repo_url, str(checkout_path)])
-        completed = subprocess.run(command, capture_output=True, text=True, check=False)
+        # `--` separates options from positionals so a hostile URL/path can
+        # never be parsed as a git option; the env restricts git to https/ssh
+        # transports even across redirects/submodules (blocks ext::/file:: etc.).
+        command.extend(["--", repo_url, str(checkout_path)])
+        clone_env = {
+            **os.environ,
+            "GIT_ALLOW_PROTOCOL": "https:ssh",
+            "GIT_PROTOCOL_FROM_USER": "0",
+        }
+        completed = subprocess.run(
+            command, capture_output=True, text=True, check=False, env=clone_env
+        )
         if completed.returncode != 0:
             message = (
                 completed.stderr.strip()

--- a/tldw_chatbook/Tools/file_operation_tools.py
+++ b/tldw_chatbook/Tools/file_operation_tools.py
@@ -12,6 +12,26 @@ from . import Tool
 from ..Utils.path_validation import validate_path
 
 
+def _resolve_sandbox_config() -> str:
+    """Return the configured sandbox root string (indirection for tests)."""
+    from ..config import get_cli_setting, get_user_data_dir
+
+    default_root = str(get_user_data_dir() / "tool_sandbox")
+    return get_cli_setting("tools", "file_sandbox_root", default_root) or default_root
+
+
+def _tool_sandbox_root() -> Path:
+    """Resolve + create the file-tool sandbox root.
+
+    The file tools confine all reads/writes/listings under this directory.
+    Defaults to ``<user data dir>/tool_sandbox``; override with
+    ``[tools] file_sandbox_root`` in config.toml.
+    """
+    root = Path(_resolve_sandbox_config()).expanduser().resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
 class ReadFileTool(Tool):
     """Tool for reading file contents."""
 
@@ -60,7 +80,7 @@ class ReadFileTool(Tool):
 
         try:
             # Validate the path
-            validated_path = validate_path(file_path, "file")
+            validated_path = validate_path(file_path, _tool_sandbox_root())
             path = Path(validated_path)
 
             # Check if file exists
@@ -165,7 +185,7 @@ class ListDirectoryTool(Tool):
 
         try:
             # Validate the path
-            validated_path = validate_path(directory_path, "directory")
+            validated_path = validate_path(directory_path, _tool_sandbox_root())
             path = Path(validated_path)
 
             # Check if directory exists
@@ -331,7 +351,7 @@ class WriteFileTool(Tool):
 
         try:
             # Validate the path
-            validated_path = validate_path(file_path, "file")
+            validated_path = validate_path(file_path, _tool_sandbox_root())
             path = Path(validated_path)
 
             # Check if we're overwriting an existing file

--- a/tldw_chatbook/Tools/tool_executor.py
+++ b/tldw_chatbook/Tools/tool_executor.py
@@ -86,10 +86,25 @@ class ToolResultCache:
         self.cache: OrderedDict[str, Tuple[Any, float]] = OrderedDict()
         self._lock = asyncio.Lock()
         self._load_task = None
+        self._load_attempted = False
 
-        # Load cache from disk if persist_path is provided
+        # Load cache from disk if persist_path is provided. Started here when a
+        # running event loop exists; otherwise deferred to the first async
+        # get()/set() so constructing the cache from a sync context (e.g.
+        # get_tool_executor()) never raises "no running event loop".
         if self.persist_path:
+            self._maybe_start_load()
+
+    def _maybe_start_load(self) -> None:
+        """Kick off the disk load once, if a running loop is available."""
+        if self._load_attempted or not self.persist_path:
+            return
+        try:
             self._load_task = asyncio.create_task(self._load_from_disk())
+            self._load_attempted = True
+        except RuntimeError:
+            # No running event loop yet; retry lazily on the next async op.
+            pass
 
     def _generate_cache_key(self, tool_name: str, args: dict) -> str:
         """Generate a unique cache key for tool call."""
@@ -110,6 +125,12 @@ class ToolResultCache:
         Returns:
             Cached result or None
         """
+        # Ensure the deferred disk load has started + completed (a running loop
+        # exists here even if the cache was constructed from a sync context).
+        self._maybe_start_load()
+        if self._load_task and not self._load_task.done():
+            await self._load_task
+
         cache_key = self._generate_cache_key(tool_name, args)
 
         async with self._lock:
@@ -144,7 +165,8 @@ class ToolResultCache:
             result: Execution result
             ttl: Time-to-live in seconds (uses default if None)
         """
-        # Wait for initial load if still in progress
+        # Start the deferred disk load if needed, then wait for it to finish.
+        self._maybe_start_load()
         if self._load_task and not self._load_task.done():
             await self._load_task
 

--- a/tldw_chatbook/Tools/tool_executor.py
+++ b/tldw_chatbook/Tools/tool_executor.py
@@ -7,7 +7,6 @@ import asyncio
 import json
 import hashlib
 import time
-import pickle
 from pathlib import Path
 from abc import ABC, abstractmethod
 from datetime import datetime
@@ -209,8 +208,8 @@ class ToolResultCache:
 
         try:
             async with self._lock:
-                with open(self.persist_path, "rb") as f:
-                    loaded_cache = pickle.load(f)
+                with open(self.persist_path, "r", encoding="utf-8") as f:
+                    loaded_cache = json.load(f)
 
                 # Clear expired entries and validate format
                 current_time = time.time()
@@ -237,8 +236,8 @@ class ToolResultCache:
             cache_copy = dict(self.cache)
 
             # Save to disk
-            with open(self.persist_path, "wb") as f:
-                pickle.dump(cache_copy, f)
+            with open(self.persist_path, "w", encoding="utf-8") as f:
+                json.dump(cache_copy, f)
 
             logger.debug(
                 f"Saved {len(cache_copy)} cache entries to {self.persist_path}"
@@ -630,9 +629,9 @@ def get_tool_executor() -> ToolExecutor:
         # Determine cache persist path if enabled
         cache_persist_path = None
         if enable_cache and tools_config.get("cache_persist", True):
-            from ..config import USER_DATA_DIR
+            from ..config import get_user_data_dir
 
-            cache_dir = Path(USER_DATA_DIR) / "tool_cache"
+            cache_dir = get_user_data_dir() / "tool_cache"
             cache_persist_path = cache_dir / "tool_results.cache"
 
         # Create executor with settings

--- a/tldw_chatbook/Utils/input_validation.py
+++ b/tldw_chatbook/Utils/input_validation.py
@@ -186,6 +186,72 @@ def validate_url(url: str) -> bool:
     return result
 
 
+_GIT_ALLOWED_SCHEMES = frozenset({"https", "ssh"})
+_GIT_REF_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
+
+
+def validate_git_repo_url(url: str) -> None:
+    """Validate a git clone repo URL against a strict transport allowlist.
+
+    Only explicit ``https://`` and ``ssh://`` schemes are accepted. scp-style
+    shorthand (``user@host:path``) is rejected because its no-scheme,
+    colon-before-slash shape is ambiguous with git's ``ext::``/``fd::`` custom
+    transports and with leading-dash argument-injection payloads; use
+    ``ssh://git@host/path`` instead. Rejects custom transports (``ext``,
+    ``file``, ``fd``, ``git``, ...), whitespace/backslash/control characters,
+    a leading ``-`` (git-option injection), and anything without a scheme.
+
+    Args:
+        url: The candidate repo URL.
+
+    Raises:
+        ValidationError: If ``url`` is not an allowlisted, well-formed git URL.
+    """
+    if not isinstance(url, str) or not url:
+        raise ValidationError("repo_url must be a non-empty string")
+    if url != url.strip() or any(c.isspace() for c in url):
+        raise ValidationError("repo_url must not contain whitespace")
+    if "\\" in url or any(ord(c) < 0x20 for c in url):
+        raise ValidationError("repo_url must not contain backslashes or control characters")
+    if url.startswith("-"):
+        raise ValidationError("repo_url must not start with '-' (git-option injection)")
+    try:
+        parsed = urlparse(url)
+    except ValueError as exc:
+        raise ValidationError(f"repo_url is not a parseable URL: {exc}")
+    if parsed.scheme.lower() not in _GIT_ALLOWED_SCHEMES:
+        raise ValidationError(
+            f"repo_url scheme {parsed.scheme!r} is not allowed; "
+            "only https:// and ssh:// git URLs are permitted"
+        )
+    if not parsed.hostname:
+        raise ValidationError("repo_url must include a host")
+
+
+def validate_git_ref(ref: str) -> None:
+    """Validate a git branch/ref name for use as a ``--branch`` value.
+
+    Rejects a leading ``-`` (git-option injection), whitespace/control chars,
+    ``..``, and any character outside ``[A-Za-z0-9._/-]``.
+
+    Args:
+        ref: The candidate branch/ref name.
+
+    Raises:
+        ValidationError: If ``ref`` is unsafe or not a well-formed ref name.
+    """
+    if not isinstance(ref, str) or not ref:
+        raise ValidationError("ref must be a non-empty string")
+    if ref.startswith("-"):
+        raise ValidationError("ref must not start with '-' (git-option injection)")
+    if ".." in ref:
+        raise ValidationError("ref must not contain '..'")
+    if not _GIT_REF_RE.match(ref):
+        raise ValidationError(
+            "ref may only contain letters, digits, '.', '_', '/', '-'"
+        )
+
+
 def validate_filename(filename: str) -> bool:
     """Validate filename to prevent path traversal and dangerous characters."""
     log_counter("input_validation_filename_attempt")

--- a/tldw_chatbook/Utils/input_validation.py
+++ b/tldw_chatbook/Utils/input_validation.py
@@ -187,7 +187,7 @@ def validate_url(url: str) -> bool:
 
 
 _GIT_ALLOWED_SCHEMES = frozenset({"https", "ssh"})
-_GIT_REF_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
+_GIT_REF_RE = re.compile(r"^[A-Za-z0-9._/-]+\Z")
 
 
 def validate_git_repo_url(url: str) -> None:
@@ -213,6 +213,8 @@ def validate_git_repo_url(url: str) -> None:
         raise ValidationError("repo_url must not contain whitespace")
     if "\\" in url or any(ord(c) < 0x20 for c in url):
         raise ValidationError("repo_url must not contain backslashes or control characters")
+    if not url.isprintable():
+        raise ValidationError("repo_url must not contain non-printable/zero-width characters")
     if url.startswith("-"):
         raise ValidationError("repo_url must not start with '-' (git-option injection)")
     try:
@@ -226,6 +228,8 @@ def validate_git_repo_url(url: str) -> None:
         )
     if not parsed.hostname:
         raise ValidationError("repo_url must include a host")
+    if (parsed.hostname or "").startswith("-") or (parsed.username or "").startswith("-"):
+        raise ValidationError("repo_url host/user must not start with '-' (ssh option injection)")
 
 
 def validate_git_ref(ref: str) -> None:

--- a/tldw_chatbook/Utils/path_validation.py
+++ b/tldw_chatbook/Utils/path_validation.py
@@ -56,8 +56,12 @@ def validate_path(
             )
             raise ValueError(f"Path '{user_path}' is outside the allowed directory")
 
-        # Additional checks for safety
-        if any(part.startswith(".") for part in full_path.parts if part != "."):
+        # Additional checks for safety.
+        # Hidden-file check applies only to the user-supplied portion (relative
+        # to base_directory) — a base dir that itself lives under a dotted
+        # ancestor (e.g. ~/.local/share/...) must not falsely trip this.
+        relative_parts = full_path.relative_to(base_directory).parts
+        if any(part.startswith(".") for part in relative_parts if part != "."):
             logger.warning(f"Hidden file/directory access attempt: {full_path}")
             log_counter(
                 "path_validation_security_violation",


### PR DESCRIPTION
## Summary

Four independent defensive-security fixes — the final security cluster of the LLM-harness review 2026-07. Closes **TASK-330**, **TASK-332**, and **TASK-331 #1/#2** (331 #3 deferred to a follow-up).

### TASK-330 — git-clone transport/argument injection (MEDIUM)
`_clone_git_repository` built a `git clone` argv from an ingestion-source `repo_url`/`ref` with no scheme validation, no `--` separator, and no protocol restriction — so `repo_url = "ext::sh -c '<cmd>'"` was arbitrary-shell **RCE**, and a leading-dash `repo_url`/`ref` was git-option injection. Fix:
- New `validate_git_repo_url` / `validate_git_ref` in `Utils/input_validation.py`: allowlist **explicit `https://` and `ssh://` only** (scp-shorthand rejected as ambiguous); reject `ext`/`file`/`fd`/`git`/`http` schemes, leading-dash **and dashed ssh host/user** (CVE-2017-1000117 class), whitespace/backslash/**zero-width unicode**, and ref control chars/`..`.
- `_clone_git_repository` validates both inputs, inserts a literal `--` before the URL, and runs with `env` `GIT_ALLOW_PROTOCOL=https:ssh` + `GIT_PROTOCOL_FROM_USER=0` (git blocks non-{https,ssh} even across redirects/submodules). Defense-in-depth: even a validator gap can't make a positional parse as an option.

### TASK-331 #1 — real file-tool sandbox root
`ReadFileTool`/`ListDirectoryTool`/`WriteFileTool` passed the literal strings `"file"`/`"directory"` as `validate_path`'s sandbox-root argument (confining to a bogus `<cwd>/file`, fails-closed only by accident). Fix: a real `[tools] file_sandbox_root` config (default `get_user_data_dir()/tool_sandbox`) at all three sites — plus a fix to shared `validate_path` so its hidden-file check inspects only the **user-supplied portion relative to the sandbox root** (the default root lives under `~/.local/share`, whose `.local` component was tripping the whole-path check and dead-lettering the tools; this also unbreaks the same latent bug in other `get_user_data_dir()`-based callers). Confinement verified: absolute/traversal/**symlink** escape all rejected; dotted user-path components still rejected.

### TASK-331 #2 — pickle→json + a crash fix
`ToolResultCache` deserialized its on-disk cache with `pickle` (code-execution anti-pattern). Swapped to `json` (all cached values are JSON-serializable; no migration — see below). Also fixed a **second bug**: `get_tool_executor()` did `from ..config import USER_DATA_DIR` — a name that doesn't exist — so it raised `ImportError` whenever caching was enabled (this is why no legacy pickle files exist). Now uses `get_user_data_dir()`.

### TASK-332 — surface non-enforced eval-sandbox memory limit
The eval code-runner set `RLIMIT_AS` (256MB) in `except (ValueError, OSError): pass` — on macOS/BSD that `ValueError` is silently swallowed, so the memory cap doesn't apply (only `RLIMIT_AS`; `RLIMIT_NPROC` works). Fix: parent-side `_memory_limit_enforced()` → a one-time WARNING + `results["sandbox_warnings"]` (no silent gap), and a corrected docstring. Time is still bounded cross-platform by the subprocess timeout.

## Testing

169 tests across the touched areas (git validators incl. adversarial bypass regressions, `path_validation` + all its callers, git-clone hardening, media suite, all `Tools/` tests, eval security + RLIMIT surfacing, file-operations integration).

Built via SDD (fresh implementer + reviewer per task; opus whole-branch review **READY TO MERGE**). Adversarial per-task review caught and fixed **2 Criticals**: the git validator's SSH host-leading-dash option-injection + ref trailing-newline bypasses, and the sandbox being non-functional under the default config.

## Follow-ups filed (TASK-545/546/547)

- **545** — wire the built-in tool executor into the existing MCP Allow/Ask/Deny permission gate (TASK-331 #3, deferred as a cross-system + UI build ~as large as this whole cluster; fs tools remain default-OFF meanwhile).
- **546** — restrict the `file://`/local-path read vector in the git ingestion source (secondary to the clone-time transport allowlist).
- **547** — `get_tool_executor()` reads `get_cli_setting("tools", {})` where `{}` is treated as the default slot, so the entire `[tools]` config (all tool flags + cache) is currently unreachable — a pre-existing bug (which also means the fs tools can't even be enabled today = extra-safe posture).

## Scope note

TASK-331 #3 (the confirmation/permission gate) is **not** in this PR — decomposed into TASK-545. The Task-331#1 sandbox fix makes the fs tools functional-within-a-sandbox while that gate is deferred; the confined, default-off, narrow-empty-sandbox posture is the intended, on-the-record tradeoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened repo ingestion, file tools, and the eval runner to close RCE and sandbox gaps. Blocks `git clone` transport/arg injection, confines file tools to a real sandbox, switches the tool cache to `json` with safer startup, and warns when macOS memory limits aren’t enforced. Addresses TASK-330, TASK-331 (#1/#2), and TASK-332.

- **Bug Fixes**
  - Git clone (TASK-330): Validate repo URL/ref (allow only explicit `https://`/`ssh://`), reject scp shorthand, leading dashes, whitespace/zero‑width/control chars; add `--` separator; run with `GIT_ALLOW_PROTOCOL=https:ssh` and `GIT_PROTOCOL_FROM_USER=0`. Tests ensure malicious inputs fail before spawning `git` (incl. SSH host/user leading‑dash and ref trailing‑newline).
  - File tools sandbox (TASK-331 #1): Use `[tools] file_sandbox_root` (default `<user data dir>/tool_sandbox`). Update `validate_path` so the hidden‑file check inspects only user‑supplied segments; dotted ancestors (e.g. `~/.local/...`) no longer block valid paths. Traversal/symlink escapes still rejected.
  - Tool cache (TASK-331 #2): Replace `pickle` with `json` in `ToolResultCache`; corrupt files degrade gracefully. Fix `get_tool_executor()` to use `get_user_data_dir()` and defer disk‑load when constructed without a running loop (lazy start on first async get/set). Tests cover JSON round‑trip, corrupt files, and no “no running event loop” crash.
  - Eval runner (TASK-332): Add `_memory_limit_enforced()` and `_sandbox_warnings`; surface non‑enforced `RLIMIT_AS` on macOS via one‑time WARNING and per‑result `sandbox_warnings`. Docstring corrected.

- **Migration**
  - No data migration; cache now writes JSON. A sandbox directory is created at `<user data dir>/tool_sandbox`. Tools remain default‑off.
  - Follow‑ups filed: TASK-545 (permission gate), TASK-546 (restrict `file://` local read), TASK-547 (fix tools config reachability).

<sup>Written for commit 476ce0d3c1d4ba9f51e413c272fca0685a369f38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

