### PR TITLE
Console branching//rewind follow-ups, batch 1 (tasks 500, 549, 550)

### DIFF
--- a/Tests/Chat/test_console_chat_store_tree.py
+++ b/Tests/Chat/test_console_chat_store_tree.py
@@ -325,3 +325,38 @@ def test_deferred_active_leaf_pointer_written_on_append_after_swipe():
         assert db.get_conversation_active_leaf(conversation_id) == a2_pid
     finally:
         db.close_connection()
+
+
+def test_active_path_message_ids_terminates_on_manufactured_cycle():
+    """A visited-set guard keeps the ancestry walk from hanging on a cycle.
+
+    Real DBs can't produce a cyclic parent chain (unique PKs), so this is
+    defensive-only hardening (mirrors ``_nearest_persisted_ancestor_id``'s
+    guard) against a malformed test double or future in-memory bug -- hand
+    -wire a 2-cycle into ``_native_parent_by_message`` directly since the
+    public API refuses to create one.
+    """
+    store, sid = _store_with_session()
+    u = store.append_message(sid, role=ConsoleMessageRole.USER, content="hi")
+    a = store.append_message(sid, role=ConsoleMessageRole.ASSISTANT, content="yo")
+    # hand-wire a cycle: a -> u -> a (bypassing the normal append plumbing,
+    # which can never produce this)
+    store._native_parent_by_message[u.id] = a.id
+
+    ids = store.active_path_message_ids(sid)
+    assert set(ids) <= {u.id, a.id}
+    assert len(ids) <= 2
+
+
+def test_recompute_active_path_terminates_on_manufactured_cycle():
+    """Same cycle guard for ``_recompute_active_path``'s node-materializing walk."""
+    store, sid = _store_with_session()
+    u = store.append_message(sid, role=ConsoleMessageRole.USER, content="hi")
+    a = store.append_message(sid, role=ConsoleMessageRole.ASSISTANT, content="yo")
+    store._native_parent_by_message[u.id] = a.id
+
+    store._recompute_active_path(sid)
+
+    path = store.messages_for_session(sid)
+    assert len(path) <= 2
+    assert {m.id for m in path} <= {u.id, a.id}

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -112,38 +112,6 @@ def test_console_workspace_status_row_empty_value_uses_unavailable():
     )
 
 
-def test_console_tree_messages_follow_latest_branch_only():
-    """Verify resumed transcripts do not flatten regenerated alternatives."""
-    rows = ChatScreen._iter_console_tree_messages(
-        [
-            {
-                "id": "root",
-                "content": "prompt",
-                "children": [
-                    {
-                        "id": "old-assistant",
-                        "content": "old draft",
-                        "children": [],
-                    },
-                    {
-                        "id": "latest-assistant",
-                        "content": "latest draft",
-                        "children": [
-                            {
-                                "id": "followup",
-                                "content": "followup",
-                                "children": [],
-                            }
-                        ],
-                    },
-                ],
-            }
-        ]
-    )
-
-    assert [row["id"] for row in rows] == ["root", "latest-assistant", "followup"]
-
-
 def test_console_workspace_conversation_search_worker_uses_dedicated_group():
     source = inspect.getsource(
         ChatScreen.on_console_workspace_conversation_search_changed

--- a/Tests/UI/test_console_resume_active_path.py
+++ b/Tests/UI/test_console_resume_active_path.py
@@ -158,6 +158,71 @@ def _persist_mixed_legacy_then_branched_conversation(db: CharactersRAGDB):
     return conversation_id
 
 
+def _persist_genuine_multi_root_conversation(db: CharactersRAGDB):
+    """Persist a genuine root-level fork: two independent USER-rooted threads.
+
+    Mirrors editing-and-resending the conversation's very FIRST user message
+    (Phase B ``edit_and_resend_message``): ``create_sibling`` parents the fork
+    at the anchor's own parent, which is ``None`` for a root message, so the
+    edit becomes a SECOND root-level USER sibling with its own subtree. Both
+    roots are USER (role-homogeneous), the signal
+    ``ConsoleChatStore._chain_legacy_flat_roots`` uses to distinguish a
+    genuine multi-root fork (left un-chained, both roots independently
+    navigable) from legacy flat data (mixed USER/ASSISTANT roots, chained
+    into one spine) -- see that method's docstring.
+    """
+    service = ChatConversationService(db)
+    conversation_id = service.create_conversation(
+        id="multi-root-conv-1",
+        title="Multi-root",
+        scope_type="global",
+        state="in-progress",
+    )
+    u1 = db.add_message(
+        {
+            "id": "m-u1",
+            "conversation_id": conversation_id,
+            "sender": "user",
+            "role": "user",
+            "content": "u1",
+            "timestamp": "2026-01-01T00:00:00.000000+00:00",
+        }
+    )
+    a1 = db.add_message(
+        {
+            "id": "m-a1",
+            "conversation_id": conversation_id,
+            "parent_message_id": u1,
+            "sender": "assistant",
+            "role": "assistant",
+            "content": "a1",
+            "timestamp": "2026-01-01T00:00:01.000000+00:00",
+        }
+    )
+    u1_prime = db.add_message(
+        {
+            "id": "m-u1-prime",
+            "conversation_id": conversation_id,
+            "sender": "user",
+            "role": "user",
+            "content": "u1-prime",
+            "timestamp": "2026-01-01T00:00:02.000000+00:00",
+        }
+    )
+    a1_prime = db.add_message(
+        {
+            "id": "m-a1-prime",
+            "conversation_id": conversation_id,
+            "parent_message_id": u1_prime,
+            "sender": "assistant",
+            "role": "assistant",
+            "content": "a1-prime",
+            "timestamp": "2026-01-01T00:00:03.000000+00:00",
+        }
+    )
+    return conversation_id, u1, a1, u1_prime, a1_prime
+
+
 def _resume_into_store(db: CharactersRAGDB, conversation_id: str):
     """Mirror the production resume plumbing end to end.
 
@@ -336,5 +401,83 @@ def test_resume_falls_back_when_pointer_dangles():
         view = [m.content for m in store.messages_for_session(session.id)]
         assert view == ["u1", "a1-prime"]
         assert db.get_conversation_active_leaf(conversation_id) == a1_prime
+    finally:
+        db.close_connection()
+
+
+def test_resume_second_root_loads_off_path_but_is_not_shown():
+    """Genuine multi-root resume: active leaf under the first root shows only
+    that root's branch; the second root loads too (navigable via
+    ``siblings_at``) but is not part of the visible transcript.
+
+    Unlike the legacy-flat-roots cases above (mixed USER/ASSISTANT roots,
+    chained into one spine), two role-homogeneous all-USER roots are the
+    genuine Phase-B root-level fork shape and are correctly left un-chained.
+    """
+    db = CharactersRAGDB(":memory:", "test_client")
+    try:
+        conversation_id, _u1, a1, _u1_prime, _a1_prime = (
+            _persist_genuine_multi_root_conversation(db)
+        )
+        db.set_conversation_active_leaf(conversation_id, a1)
+
+        store, session = _resume_into_store(db, conversation_id)
+
+        view = [m.content for m in store.messages_for_session(session.id)]
+        assert view == ["u1", "a1"]
+
+        root_message = store.messages_for_session(session.id)[0]
+        assert root_message.persisted_message_id == "m-u1"
+        snapshots, index, count = store.siblings_at(root_message.id)
+        assert count == 2
+        assert index == 0
+        other_root = next(s for s in snapshots if s.id != root_message.id)
+        assert other_root.content == "u1-prime"
+        assert other_root.persisted_message_id == "m-u1-prime"
+    finally:
+        db.close_connection()
+
+
+def test_resume_clears_stale_persisted_summary_with_dangling_boundary():
+    """TASK-550: a persisted `/rewind` summary whose boundary id maps to no
+    message on the just-loaded tree (e.g. the boundary message's branch was
+    hard-deleted, or a foreign client rewrote history) is permanently
+    orphaned. Resume leaves the in-memory summary unset (fail-open, as
+    before Task-550) AND best-effort clears the stale persisted pair so it
+    doesn't linger in the DB row indefinitely.
+    """
+    db = CharactersRAGDB(":memory:", "test_client")
+    try:
+        conversation_id, _u1, _a1, _a1_prime = _persist_branched_conversation(db)
+        db.set_conversation_context_summary(
+            conversation_id, "stale recap", "deleted-boundary-id"
+        )
+
+        store, session = _resume_into_store(db, conversation_id)
+
+        assert store.session_context_summary(session.id) == (None, None)
+        assert db.get_conversation_context_summary(conversation_id) == (None, None)
+    finally:
+        db.close_connection()
+
+
+def test_resume_leaves_valid_persisted_summary_boundary_untouched():
+    """A persisted summary whose boundary DOES resolve on the loaded tree
+    restores unchanged, and the DB row is left exactly as persisted (only
+    the dangling case in the test above clears it)."""
+    db = CharactersRAGDB(":memory:", "test_client")
+    try:
+        conversation_id, u1, _a1, _a1_prime = _persist_branched_conversation(db)
+        db.set_conversation_context_summary(conversation_id, "earlier recap", u1)
+
+        store, session = _resume_into_store(db, conversation_id)
+
+        summary, boundary_native_id = store.session_context_summary(session.id)
+        assert summary == "earlier recap"
+        assert boundary_native_id is not None
+        assert db.get_conversation_context_summary(conversation_id) == (
+            "earlier recap",
+            u1,
+        )
     finally:
         db.close_connection()

--- a/Tests/UI/test_console_rewind_restore.py
+++ b/Tests/UI/test_console_rewind_restore.py
@@ -345,6 +345,95 @@ async def test_restore_to_a_stale_message_id_makes_no_mutation_and_notifies():
 
 
 @pytest.mark.asyncio
+async def test_restore_choice_guards_against_changed_active_session():
+    """TASK-549: if the active session changed while the modal was up (a
+    ``ModalScreen`` blocks this today, but the guard is future-proofing), a
+    restore choice captured for the OLD session must no-op with a notify
+    instead of mutating the now-different active session's tree.
+    """
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        store = console._ensure_console_chat_store()
+        session, ids = await _seed_u1_a1_u2_a2(console)
+        original_path = store.active_path_message_ids(session.id)
+
+        # Simulate the active session changing out from under the modal
+        # between "opened" and "choice applied".
+        other_session = store.create_session(title="other")
+        store.switch_session(other_session.id)
+        other_path = store.active_path_message_ids(other_session.id)
+
+        spy_insert = MagicMock(return_value=True)
+        console._insert_prompt_text_into_composer = spy_insert
+
+        notices: list[tuple[str, str]] = []
+        app.notify = lambda message_text, **kwargs: notices.append(
+            (str(message_text), kwargs.get("severity", ""))
+        )
+
+        await console._apply_console_rewind_choice(
+            session.id,
+            ConsoleRewindChoice(kind="restore", message_id=ids["u2"].id, prompt_text="U2"),
+        )
+        await pilot.pause()
+
+    # No mutation anywhere: neither session's tree nor the composer changed.
+    assert store.active_path_message_ids(session.id) == original_path
+    assert store.active_path_message_ids(other_session.id) == other_path
+    spy_insert.assert_not_called()
+    assert any(
+        "session changed" in text.lower() and severity == "warning"
+        for text, severity in notices
+    )
+
+
+@pytest.mark.asyncio
+async def test_summarize_choice_guards_against_changed_active_session():
+    """Same session-changed guard covers the summarize-up-to branch: no
+    worker is dispatched and nothing is stored."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        store = console._ensure_console_chat_store()
+        session, ids = await _seed_u1_a1_u2_a2(console)
+        original_path = store.active_path_message_ids(session.id)
+
+        other_session = store.create_session(title="other")
+        store.switch_session(other_session.id)
+
+        spy_worker = MagicMock(side_effect=lambda coro, **kwargs: coro.close())
+        console.run_worker = spy_worker
+
+        notices: list[tuple[str, str]] = []
+        app.notify = lambda message_text, **kwargs: notices.append(
+            (str(message_text), kwargs.get("severity", ""))
+        )
+
+        await console._apply_console_rewind_choice(
+            session.id,
+            ConsoleRewindChoice(
+                kind="summarize-up-to", message_id=ids["u2"].id, prompt_text="U2"
+            ),
+        )
+        await pilot.pause()
+
+    assert spy_worker.call_count == 0
+    assert store.active_path_message_ids(session.id) == original_path
+    assert store.session_context_summary(session.id) == (None, None)
+    assert any(
+        "session changed" in text.lower() and severity == "warning"
+        for text, severity in notices
+    )
+
+
+@pytest.mark.asyncio
 async def test_console_command_rewind_pushes_modal_with_newest_first_rows():
     app = _build_test_app()
     host = ConsoleHarness(app)

--- a/backlog/tasks/task-500 - Console-branching-Phase-A-cleanups.md
+++ b/backlog/tasks/task-500 - Console-branching-Phase-A-cleanups.md
@@ -1,0 +1,34 @@
+---
+id: TASK-500
+title: >-
+  Console branching Phase A cleanups: dead resolver, ancestry cycle guards,
+  multi-root resume test
+status: Done
+assignee: []
+created_date: '2026-07-23'
+labels:
+  - console
+  - tech-debt
+  - test
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Minor follow-ups surfaced by the Console branching Phase A final review (PR #799), none blocking merge:
+- `_iter_console_tree_messages` (chat_screen.py) is now dead in production (only a unit test calls it) and its docstring is misleading ("most-recent-branch leaf resolver"); the real fallback resolver is the store's `_most_recent_leaf_native`/`_leaf_under`. Delete it (and its test) or correct the docstring.
+- The ancestry walks in `ConsoleChatStore._recompute_active_path` and `active_path_message_ids` have no cycle guard (unlike `_nearest_persisted_ancestor_id`). Unreachable via real DB (unique PKs), so defensive-only — add a `seen` set for consistency/hardening against malformed test doubles.
+- Multiple-root resume handling is correct-by-construction but untested; add a real-DB test with two root threads where the active leaf is under the first root, asserting the second root loads off-path but is not shown.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Dead `_iter_console_tree_messages` is removed (with its test) or its docstring corrected to reflect its actual role
+- [x] #2 `_recompute_active_path` and `active_path_message_ids` carry a visited-set cycle guard
+- [x] #3 A real-DB multiple-root resume test exists and passes
+<!-- AC:END -->
+
+## Implementation Notes
+
+(a) Deleted the production-dead `_iter_console_tree_messages` helper from chat_screen.py and its orphaned unit test (resume has loaded the full tree since Phase A Task 8; the real fallback resolver is the store's `_most_recent_leaf_native`/`_leaf_under`). (b) Added visited-set cycle guards to `active_path_message_ids` and `_recompute_active_path` (defensive-only; mirrors `_nearest_persisted_ancestor_id`), with manufactured-2-cycle termination tests. (c) Added a real-DB multi-root resume test (genuine all-USER root fork via first-message edit-&-resend): second root loads off-path, is not shown, and stays swipe-reachable.

--- a/backlog/tasks/task-549 - Console-rewind-modal-session-capture-guard.md
+++ b/backlog/tasks/task-549 - Console-rewind-modal-session-capture-guard.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-549
 title: 'Console /rewind: guard the modal callback against a changed active session'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-24'
 labels:
@@ -18,6 +18,10 @@ dependencies: []
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The rewind choice callback no-ops with a notify when the active session differs from the one the modal was opened for
-- [ ] #2 Covered by a unit test (fake a session switch between open and dismiss)
+- [x] #1 The rewind choice callback no-ops with a notify when the active session differs from the one the modal was opened for
+- [x] #2 Covered by a unit test (fake a session switch between open and dismiss)
 <!-- AC:END -->
+
+## Implementation Notes
+
+Added an active-session guard at the top of `_apply_console_rewind_choice`: on a mismatch between the store's active session and the session captured at modal-open, the callback notifies ('Console session changed — rewind cancelled.') and returns with zero mutation — covering restore, summarize, and None branches. Unit tests fake a session switch between open and dismiss for both actions.

--- a/backlog/tasks/task-550 - Console-rewind-clear-stale-summary-row-on-permanent-boundary-loss.md
+++ b/backlog/tasks/task-550 - Console-rewind-clear-stale-summary-row-on-permanent-boundary-loss.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-550
 title: 'Console /rewind: clear the stale persisted summary when its boundary is permanently gone'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-24'
 labels:
@@ -18,7 +18,11 @@ dependencies: []
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Resuming a conversation whose persisted summary boundary maps to no loaded message clears the persisted summary pair (best-effort, non-fatal)
-- [ ] #2 A valid boundary continues to restore the in-memory state unchanged
-- [ ] #3 Covered by a real-DB resume test
+- [x] #1 Resuming a conversation whose persisted summary boundary maps to no loaded message clears the persisted summary pair (best-effort, non-fatal)
+- [x] #2 A valid boundary continues to restore the in-memory state unchanged
+- [x] #3 Covered by a real-DB resume test
 <!-- AC:END -->
+
+## Implementation Notes
+
+On resume, `_resolve_context_summary_on_resume` now best-effort clears the persisted summary pair (`set_conversation_context_summary(conv_id, None, None)`) when the stored boundary maps to no loaded node (dangling), guarded + exception-swallowed like the other write-throughs; a valid boundary restores unchanged. Real-DB tests cover both paths.

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -1342,6 +1342,16 @@ class ConsoleChatStore:
         A visited-set guards against a malformed cyclic parent chain (real
         DBs can't produce one -- unique PKs -- so this is defensive-only,
         mirroring ``_nearest_persisted_ancestor_id``).
+
+        Args:
+            session_id: Native Console session ID.
+
+        Returns:
+            Native message ids on the active path, ordered root first and
+            active leaf last; empty when the session has no active leaf.
+
+        Raises:
+            KeyError: If the session is unknown.
         """
         self._session_or_raise(session_id)
         ids: list[str] = []

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -1337,11 +1337,18 @@ class ConsoleChatStore:
         self._persist_context_summary(session_id, summary, boundary_native_id)
 
     def active_path_message_ids(self, session_id: str) -> list[str]:
-        """Return native ids along the active path, root -> active leaf."""
+        """Return native ids along the active path, root -> active leaf.
+
+        A visited-set guards against a malformed cyclic parent chain (real
+        DBs can't produce one -- unique PKs -- so this is defensive-only,
+        mirroring ``_nearest_persisted_ancestor_id``).
+        """
         self._session_or_raise(session_id)
         ids: list[str] = []
+        visited: set[str] = set()
         current = self._active_leaf_by_session.get(session_id)
-        while current is not None:
+        while current is not None and current not in visited:
+            visited.add(current)
             ids.append(current)
             current = self._native_parent_by_message.get(current)
         ids.reverse()
@@ -2538,12 +2545,18 @@ class ConsoleChatStore:
         transient ``sibling_index``/``sibling_count`` is filled from its native
         parent's ordered child list so the renderer can show ``<``/``>`` + an
         ``n/m`` counter without reaching into store internals.
+
+        A visited-set guards against a malformed cyclic parent chain (real
+        DBs can't produce one -- unique PKs -- so this is defensive-only,
+        mirroring ``_nearest_persisted_ancestor_id``).
         """
         nodes = self._nodes_by_session.get(session_id, {})
         children = self._children_by_parent.get(session_id, {})
         path_ids: list[str] = []
+        visited: set[str] = set()
         current = self._active_leaf_by_session.get(session_id)
-        while current is not None:
+        while current is not None and current not in visited:
+            visited.add(current)
             path_ids.append(current)
             current = self._native_parent_by_message.get(current)
         path_ids.reverse()
@@ -2683,7 +2696,15 @@ class ConsoleChatStore:
         in-memory summary state is set. Absent, unreadable, or dangling (no
         stored summary, or a boundary id not present on the loaded tree)
         leaves the in-memory state unset -- fail-open, matching the design's
-        rule that an inert/dangling boundary falls back to full history.
+        rule that an inert/dangling boundary falls back to full history. A
+        DANGLING boundary additionally best-effort clears the stale
+        persisted pair (``set_conversation_context_summary(conversation_id,
+        None, None)``, guarded + exception-swallowed like the write-through
+        above) so a permanently-orphaned boundary (e.g. its branch was
+        hard-deleted, or a foreign client rewrote history) doesn't linger in
+        the DB row indefinitely -- benign either way (this path already
+        fails open, and the next summarize overwrites it), just misleading
+        to anything that reads the column directly.
         """
         session = self._sessions.get(session_id)
         conversation_id = (
@@ -2710,7 +2731,23 @@ class ConsoleChatStore:
             return
         boundary_native_id = persisted_to_native.get(boundary_persisted_id)
         if boundary_native_id is None:
-            # Dangling: the persisted boundary message isn't on the loaded tree.
+            # Dangling: the persisted boundary message isn't on the loaded
+            # tree. Leave the in-memory state unset (fail-open) AND
+            # best-effort clear the now-permanently-orphaned persisted pair
+            # so it doesn't linger indefinitely -- non-fatal, mirrors
+            # ``_persist_context_summary``'s write-through guard.
+            try:
+                persistence_db.set_conversation_context_summary(
+                    conversation_id, None, None
+                )
+            except Exception:
+                logger.bind(
+                    session_id=session_id,
+                    conversation_id=conversation_id,
+                ).exception(
+                    "Failed to clear stale Console context-summary with a "
+                    "dangling boundary; the persisted pair may linger."
+                )
             return
         self._context_summary_by_session[session_id] = (summary, boundary_native_id)
 

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -4473,29 +4473,6 @@ class ChatScreen(BaseAppScreen):
         return None
 
     @staticmethod
-    def _iter_console_tree_messages(nodes: Any) -> list[dict[str, Any]]:
-        """Return the ``children[-1]`` (latest-branch) path through the tree.
-
-        No longer the resume path (Task 8 loads the full tree; see
-        ``_console_messages_from_conversation_tree``); retained as the
-        most-recent-branch leaf resolver and still directly unit-tested.
-        """
-        ordered: list[dict[str, Any]] = []
-
-        def _visit(node: Any) -> None:
-            if not isinstance(node, dict):
-                return
-            ordered.append(node)
-            children = node.get("children")
-            if isinstance(children, list) and children:
-                _visit(children[-1])
-
-        if isinstance(nodes, list):
-            for root in nodes:
-                _visit(root)
-        return ordered
-
-    @staticmethod
     def _console_message_role_from_persisted(
         message: dict[str, Any],
     ) -> ConsoleMessageRole:
@@ -12127,10 +12104,25 @@ class ChatScreen(BaseAppScreen):
         exclusive `console-run` worker, gated on `is_send_allowed` the same way
         restore is (never mutates while a run is streaming).
 
+        A `ModalScreen` blocks session switching while the rewind modal is up,
+        so today this is theoretical -- but the callback still re-checks the
+        store's active session against the one captured when the modal opened
+        (`session_id`) before doing anything, and no-ops with a notify on a
+        mismatch. This keeps the flow robust against future modal/timing
+        changes (e.g. a background auto-switch or a non-modal rewind surface)
+        that could let the active session change out from under a pending
+        choice.
+
         Args:
             session_id: Native Console session id the modal was opened for.
             choice: The modal's result, or `None`.
         """
+        store = self._ensure_console_chat_store()
+        if store.active_session_id != session_id:
+            self.app_instance.notify(
+                "Console session changed — rewind cancelled.", severity="warning"
+            )
+            return
         if choice is None:
             self._focus_console_composer_if_needed(force=True)
             return
@@ -12152,7 +12144,6 @@ class ChatScreen(BaseAppScreen):
             return
         if choice.kind != "restore":
             return
-        store = self._ensure_console_chat_store()
         controller = self._ensure_console_chat_controller()
         if not controller.run_state.is_send_allowed:
             self.app_instance.notify(


### PR DESCRIPTION
## What

First batch of the Console branching//rewind follow-up backlog — the small hardening trio, each marked Done with Implementation Notes in its backlog file:

- **task-500 — Phase A cleanups**: deleted the production-dead `_iter_console_tree_messages` helper + its orphaned unit test (resume loads the full tree since Phase A Task 8); added visited-set cycle guards to both active-path ancestry walks (defensive-only, mirrors `_nearest_persisted_ancestor_id`) with manufactured-cycle termination tests; added a real-DB multi-root resume test (genuine all-USER root fork via first-message edit-&-resend: the second root loads off-path, isn't shown, stays swipe-reachable).
- **task-549 — rewind session guard**: `_apply_console_rewind_choice` no-ops with a notify if the active session changed since the modal opened (covers restore/summarize/None; theoretical under today's modal, robust for future surfaces), with session-switch tests for both actions.
- **task-550 — stale summary clear**: resume now best-effort clears the persisted `context_summary`/`summary_boundary_message_id` pair when the boundary is dangling (guarded + non-fatal, same pattern as the write-throughs); valid boundaries restore unchanged; real-DB tests for both paths.

## Testing

151 tests green across the covering suites (store/tree/summary/rewind-restore/resume + both e2es); `Tests/UI/test_console_native_chat_flow.py` fully green post-deletion (exit 0).

## Note for the maintainer

**PR #803 (tasks 498–501) is still open** — it files task-500 as To-Do. This PR lands task-500 as Done, so #803 should drop its `task-500` copy on its next rebase (or I can rework #803 to only carry 498/499/501 — say the word).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Console branching and rewind flows by adding ancestry cycle guards, guarding rewind against session switches, and clearing stale persisted summaries on resume. Removes a dead tree-walk helper and adds targeted real-DB tests, including multi-root resume and stale-summary handling.

- **Bug Fixes**
  - Add visited-set guards to `active_path_message_ids` and `_recompute_active_path` to prevent hangs on malformed cycles (Task-500).
  - Rewind: `_apply_console_rewind_choice` no-ops with a warning if the active session changed while the modal was open; covers restore/summarize/None (Task-549).
  - Resume: clear persisted `context_summary` when its boundary message is missing; keep valid boundaries unchanged (Task-550).
  - Remove dead `ChatScreen._iter_console_tree_messages` and its orphaned test; add tests for multi-root resume, cycle termination, session-switch guard (restore/summarize), and summary boundary clear/restore.

<sup>Written for commit 8425716cc051a557398cff21a98b5aac0190a766. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

