### PR TITLE
chore(backlog): image-gen housekeeping — 522→558 collision fix, 498 rescope, 559 P2b follow-ups

### DIFF
--- a/backlog/tasks/task-498 - Adopt-image-generation-egress-SSRF-policy.md
+++ b/backlog/tasks/task-498 - Adopt-image-generation-egress-SSRF-policy.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-498
 title: >-
-  Port image-generation egress/SSRF protections from tldw_server
+  Adopt image-generation egress/SSRF policy (Utils/egress.py)
 status: To Do
 assignee: []
 created_date: '2026-07-22 11:32'
-updated_date: '2026-07-24 13:30'
+updated_date: '2026-07-24 16:45'
 labels:
   - image-generation
   - security

--- a/backlog/tasks/task-498 - Port-image-generation-egress-SSRF-protections-from-tldw_server.md
+++ b/backlog/tasks/task-498 - Port-image-generation-egress-SSRF-protections-from-tldw_server.md
@@ -5,7 +5,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-07-22 11:32'
-updated_date: '2026-07-22 11:32'
+updated_date: '2026-07-24 13:30'
 labels:
   - image-generation
   - security
@@ -17,20 +17,16 @@ priority: medium
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Follow-up to the image-generation multi-provider foundation (Phase 1 of the in-chat image-gen program; see `docs/superpowers/specs/` image-generation design). The server's `Image_Generation` package we port includes egress/SSRF guards that tldw_chatbook currently lacks app-wide: `_validate_egress_or_raise` / `_resolve_redirect_url` in `http_client`, and `evaluate_url_policy` from `Security/egress`. Phase 1 deliberately ships only a **light** guard (reject non-`http(s)` schemes; keep each adapter's built-in per-backend host checks — SwarmUI same-origin, ModelStudio `aliyuncs` allowlist) and stays permissive for user-configured `base_url`s so local backends (127.0.0.1 SwarmUI, local sd.cpp) keep working.
-
-That light guard does NOT protect against SSRF via **API-returned image URLs** (OpenRouter / Novita / ModelStudio can return arbitrary `http(s)` URLs that the adapters then fetch via `fetch_image_bytes`). Port the server's real egress protections so those fetches are validated (block private/link-local/metadata ranges for URLs the app did not originate, DNS-rebinding-aware where feasible), while still allowing user-configured local backend base URLs. This is the security hardening the light guard is a placeholder for, and it doubles as the first real SSRF protection in the app.
-
-TASK-328 has now shipped a shared egress module at `tldw_chatbook/Utils/egress.py` that can be reused here (see TASK-506 for the adoption follow-up).
+RESCOPED 2026-07-24: dev now ships its own SSRF policy — `Utils/egress.py` (PR #822: per-hop redirect revalidation, private/link-local/metadata blocking, cross-origin cred-strip, byte caps) — so this task is no longer a port from tldw_server. Instead, ADOPT `Utils/egress.py` inside `tldw_chatbook/Image_Generation/http_client.py`, replacing the Phase-1 light guard (`_validate_egress_or_raise` scheme-check placeholder). The original intent stands: image URLs RETURNED by remote backends (OpenRouter/Novita/ModelStudio) must be validated before fetch, while user-configured local backend base_urls (127.0.0.1 SwarmUI, local sd.cpp) keep working. Also wire ModelStudio's dead `allowlist` local (built but only partially enforced) through the adopted policy, and cover `fetch_json`'s manual redirect loop + `image_format_utils.fetch_image_bytes`.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] Image URLs returned by remote backends (OpenRouter/Novita/ModelStudio) are validated before fetch: private, link-local, loopback, and cloud-metadata (169.254.169.254) ranges are blocked for app-non-originated URLs.
-- [ ] User-configured backend `base_url`s (e.g. `http://127.0.0.1:7801` SwarmUI, local paths) continue to work — the guard distinguishes user-configured endpoints from API-returned URLs.
-- [ ] Non-`http(s)` schemes and redirect chains beyond the configured max are rejected.
-- [ ] Guard is unit-tested with SSRF payloads (private IPs, metadata IP, scheme abuse, redirect-to-private) and does not regress local-backend generation.
+- [ ] `Image_Generation/http_client.py`'s egress guard delegates to `Utils/egress.py` policy (no parallel/duplicate SSRF logic): API-returned image URLs are blocked for private/link-local/loopback/metadata ranges; user-configured backend `base_url`s (e.g. `http://127.0.0.1:7801`) continue to work.
+- [ ] Every hop of `fetch_json`'s manual redirect loop and `fetch_image_bytes` re-validates through the adopted policy.
+- [ ] ModelStudio's host allowlist (aliyuncs + base host) is enforced via the adopted policy; the dead `allowlist` local in `modelstudio_image_adapter._is_allowed_remote_image_url` is wired or removed.
+- [ ] Unit tests with SSRF payloads (private IPs, metadata IP, scheme abuse, redirect-to-private) pass and local-backend generation does not regress.
 <!-- AC:END -->
 
 ## Implementation Plan

--- a/backlog/tasks/task-558 - Image-gen-P2a-polish-follow-ups.md
+++ b/backlog/tasks/task-558 - Image-gen-P2a-polish-follow-ups.md
@@ -1,11 +1,11 @@
 ---
-id: TASK-522
+id: TASK-558
 title: >-
   Image-gen P2a polish follow-ups
 status: To Do
 assignee: []
 created_date: '2026-07-24 09:05'
-updated_date: '2026-07-24 09:05'
+updated_date: '2026-07-24 13:30'
 labels:
   - image-generation
   - console
@@ -25,7 +25,7 @@ Non-blocking findings from the whole-branch review of the image-gen Console card
 <!-- AC:BEGIN -->
 - [ ] In-memory screen-state restore path (`ChatScreen.restore_state` → `_restore_console_message`) rehydrates `generation_metadata` the same way it already rehydrates attachments, so a tab-switch-restored generation message keeps its card (today only the DB-resume path hydrates).
 - [ ] Generation records capture the resolved seed/model where the backend reports them (card currently shows the requested seed or "random" and no model; extend `run_generation_batch`/`GenerationVariantMeta` population when `ImageGenResult` grows the fields).
-- [ ] `/generate-image` clamps the initial batch to `max_variants_per_message` (today only regenerate enforces the cap; a misconfigured `default_batch` can exceed it).
+- [x] `/generate-image` clamps the initial batch to `max_variants_per_message` (today only regenerate enforces the cap; a misconfigured `default_batch` can exceed it).
 - [ ] Stale narrative fixed in `test_console_generation_store.py`'s round-trip test (comments claim `restore_persisted_session` doesn't hydrate — false since the resume fix; drop the redundant manual hydrate calls) and `restore_persisted_session`'s docstring documents the hydration it now performs.
 - [ ] Draft is restored to the composer when the generation batch RAISES (today only the zero-success return path restores it).
 - [ ] Test-coverage nits closed: generation-vs-sibling precedence pinned with `sibling_count=3`; exact-limit (80-char) content-marker boundary asserted; empty-negative-prompt card branch covered.

--- a/backlog/tasks/task-559 - Image-gen-P2b-follow-ups.md
+++ b/backlog/tasks/task-559 - Image-gen-P2b-follow-ups.md
@@ -1,0 +1,40 @@
+---
+id: TASK-559
+title: >-
+  Image-gen P2b follow-ups
+status: To Do
+assignee: []
+created_date: '2026-07-24 13:30'
+updated_date: '2026-07-24 13:30'
+labels:
+  - image-generation
+  - console
+  - followup
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Deferred/polish items from the image-gen P2b slice (PR #850: speak 🔊, @style presets + picker, generate-from-conversation; spec `Docs/superpowers/specs/2026-07-24-image-gen-p2b-tts-style-context-design.md` §4). Post-merge live smoke 2026-07-24 verified all wiring end-to-end in the real app (style refusals, picker draft composition, draft restore, speak's graceful no-TTS toast, context-path dispatch) — these are enhancements, not defects. Distinct from [[task-497]] (P1 polish), [[task-498]] (egress adoption), and [[task-558]] (P2a polish).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] Richer conversation-context extraction for `/generate-image` with no prompt: the current `extract_context_from_messages` is keyword-shallow (mood via keyword match; `mentioned_characters`/`mentioned_settings` never populated). Design and implement a better context builder (e.g. LLM-composed prompt from the last N turns), keeping the composed-prompt-visible-in-card behavior.
+- [ ] Console TTS playback controls: speak is fire-and-forget today; add stop (and optionally pause/save) for Console-originated speech, reusing the legacy widgets' `TTSPlaybackEvent` actions.
+- [ ] Style picker offers template previews (base-prompt/negative snippet) in the row or a detail pane, not just name — category — id.
+- [ ] Per-style user-defined templates (beyond the 13 built-ins) loadable from config or a templates dir.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
Backlog-only. (1) **task-522 collision**: a concurrent session's DB-paths task-522 merged later but is **Done** (IDs frozen) → the To-Do image-gen P2a-polish task renumbers to **558**; its batch-clamp AC is checked off (shipped in #832's review fixes). (2) **task-498 rescoped**: dev now ships `Utils/egress.py` (#822) — adopt it in `Image_Generation/http_client` instead of porting from tldw_server; covers the ModelStudio dead-allowlist wiring. (3) **task-559 filed**: P2b (#850) deferred items — richer context extractor, Console TTS controls, picker previews, user templates. Post-merge live smoke (2026-07-24) verified all P2b wiring end-to-end in the real app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Housekeeping for the image generation backlog to keep task IDs and scopes accurate and track P2b follow-ups.

Renumbers TASK-522 to TASK-558 (batch clamp AC checked off), rescopes TASK-498 to adopt the app’s `Utils/egress.py` SSRF policy in `Image_Generation/http_client.py` (including ModelStudio allowlist enforcement), and adds TASK-559 for P2b follow-ups: richer context extraction, Console TTS controls, style picker previews, and user templates.

<sup>Written for commit f5e4e49b6da468efa6142d9d14c283b6f03a2e3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

