### PR TITLE
chore(backlog): renumber TTS slice tasks

### DIFF
--- a/Docs/superpowers/plans/2026-07-23-tts-adapter-registry-legacy-bridge.md
+++ b/Docs/superpowers/plans/2026-07-23-tts-adapter-registry-legacy-bridge.md
@@ -11,7 +11,7 @@
 ## Global Constraints
 
 - This plan implements only delivery slice 1 from the approved design: registry authority, legacy containment, compatibility generation, and progress delivery.
-- Do not implement audio.cpp HTTP discovery, synthesis, configuration, process supervision, or STTS catalog-driven controls in TASK-402.
+- Do not implement audio.cpp HTTP discovery, synthesis, configuration, process supervision, or STTS catalog-driven controls in TASK-561.
 - Canonical provider IDs are exactly `openai`, `elevenlabs`, `kokoro`, `chatterbox`, `higgs`, and `alltalk` for this slice; `audio_cpp` is added by the next ordered slice.
 - The initial provider alias map is empty. Display labels never determine provider identity.
 - Runtime provider registration is sealed. The retained class-global wildcard registry is private to the legacy bridge and closed to new providers.
@@ -25,7 +25,7 @@
 - Architecture-boundary tests parse Python syntax rather than matching raw
   source text. The final independent `rg` check remains required.
 - New registry, bridge, and service diagnostics may not log configuration
-  values or synthesis text; TASK-402 also removes the existing OpenAI
+  values or synthesis text; TASK-561 also removes the existing OpenAI
   API-key-fragment disclosure.
 - No new dependency is added.
 - ADR required: yes
@@ -2587,13 +2587,13 @@ git commit -m "docs(tts): publish adapter service boundary"
 
 ---
 
-### Task 8: Verify compatibility and close TASK-402
+### Task 8: Verify compatibility and close TASK-561
 
 **Files:**
-- Modify: `backlog/tasks/task-402 - Establish-TTS-adapter-registry-authority-and-legacy-bridge.md`
+- Modify: `backlog/tasks/task-561 - Establish-TTS-adapter-registry-authority-and-legacy-bridge.md`
 
 **Interfaces:**
-- Consumes: all TASK-402 production and test changes.
+- Consumes: all TASK-561 production and test changes.
 - Produces: verified task notes, checked acceptance criteria, and Done status.
 
 - [x] **Step 0: Close final-review lifecycle and privacy regressions**
@@ -2679,7 +2679,7 @@ Confirm:
 
 ```bash
 rg -n "ADR-023|023-tts-adapter" \
-  "backlog/tasks/task-402 - Establish-TTS-adapter-registry-authority-and-legacy-bridge.md" \
+  "backlog/tasks/task-561 - Establish-TTS-adapter-registry-authority-and-legacy-bridge.md" \
   Docs/Development/TTS/TTS_MODULE_GUIDE.md
 rg -n "audio_cpp|audiocpp|AudioCpp" \
   tldw_chatbook/TTS Tests/TTS
@@ -2694,13 +2694,13 @@ slice.
 Use:
 
 ```bash
-backlog task edit 402 --notes "Implemented the app-owned sealed TTS adapter registry, operation leases and targeted provider retirement, six provider-scoped legacy adapters, enumerated compatibility routing, operation-scoped progress delivery, explicit application binding/shutdown, and the OpenAI key-prefix logging fix. Added focused registry, bridge, lifecycle, concurrency, privacy, and compatibility coverage. ADR-023 remains the governing architecture decision; audio.cpp native transport and supervision remain in later ordered tasks."
+backlog task edit 561 --notes "Implemented the app-owned sealed TTS adapter registry, operation leases and targeted provider retirement, six provider-scoped legacy adapters, enumerated compatibility routing, operation-scoped progress delivery, explicit application binding/shutdown, and the OpenAI key-prefix logging fix. Added focused registry, bridge, lifecycle, concurrency, privacy, and compatibility coverage. ADR-023 remains the governing architecture decision; audio.cpp native transport and supervision remain in later ordered tasks."
 ```
 
 After the verification evidence passes, check all eight criteria and set Done:
 
 ```bash
-backlog task edit 402 \
+backlog task edit 561 \
   --check-ac 1 \
   --check-ac 2 \
   --check-ac 3 \
@@ -2709,22 +2709,22 @@ backlog task edit 402 \
   --check-ac 6 \
   --check-ac 7 \
   --check-ac 8
-backlog task edit 402 \
+backlog task edit 561 \
   --check-dod 1 \
   --check-dod 2 \
   --check-dod 3 \
   --check-dod 4 \
   --check-dod 5
-backlog task edit 402 -s Done
-backlog task 402 --plain
+backlog task edit 561 -s Done
+backlog task 561 --plain
 ```
 
-Expected: TASK-402 shows status `Done`, all acceptance criteria checked, the
+Expected: TASK-561 shows status `Done`, all acceptance criteria checked, the
 implementation plan and notes present, and links to ADR-023 and this plan.
 
 - [ ] **Step 6: Commit task completion metadata**
 
 ```bash
-git add "backlog/tasks/task-402 - Establish-TTS-adapter-registry-authority-and-legacy-bridge.md"
+git add "backlog/tasks/task-561 - Establish-TTS-adapter-registry-authority-and-legacy-bridge.md"
 git commit -m "chore(tts): complete registry bridge task"
 ```

--- a/Docs/superpowers/plans/2026-07-24-audio-cpp-external-adapter.md
+++ b/Docs/superpowers/plans/2026-07-24-audio-cpp-external-adapter.md
@@ -55,7 +55,7 @@
   document the landed external adapter and the explicit provider-neutral lazy
   voice operation.
 - Modify
-  `backlog/tasks/task-551 - Add-external-audio.cpp-native-TTS-adapter.md`: record
+  `backlog/tasks/task-560 - Add-external-audio.cpp-native-TTS-adapter.md`: record
   plan, verification, acceptance completion, and implementation notes.
 
 ### Task 1: Extend the provider-neutral response and voice contracts
@@ -404,7 +404,7 @@ git commit -m "test(tts): harden audio cpp lifecycle and privacy"
 - Modify: `Docs/superpowers/specs/2026-07-23-audio-cpp-tts-adapter-registry-design.md`
 - Modify: `backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md`
 - Modify:
-  `backlog/tasks/task-551 - Add-external-audio.cpp-native-TTS-adapter.md`
+  `backlog/tasks/task-560 - Add-external-audio.cpp-native-TTS-adapter.md`
 
 - [x] **Step 1: Document the landed external adapter**
 
@@ -427,15 +427,15 @@ binary/`server.json` supervision is Slices 4–5.
 - [x] **Step 4: Commit documentation**
 
 ```bash
-git add Docs backlog/decisions backlog/tasks/task-551*
+git add Docs backlog/decisions backlog/tasks/task-560*
 git commit -m "docs(tts): document external audio cpp adapter"
 ```
 
-### Task 8: Run the full verification gate and finish TASK-551
+### Task 8: Run the full verification gate and finish TASK-560
 
 **Files:**
 - Modify:
-  `backlog/tasks/task-551 - Add-external-audio.cpp-native-TTS-adapter.md`
+  `backlog/tasks/task-560 - Add-external-audio.cpp-native-TTS-adapter.md`
 
 - [x] **Step 1: Run focused tests**
 
@@ -495,13 +495,13 @@ diagnostics, no text/value logging, no fallback, and no managed/UI code.
 - [x] **Step 5: Finish Backlog evidence**
 
 Check every acceptance and Definition-of-Done item, add concise implementation
-notes with exact verification counts, and move TASK-551 to Done only after all
+notes with exact verification counts, and move TASK-560 to Done only after all
 evidence is current.
 
 - [x] **Step 6: Final commit**
 
 ```bash
-git add "backlog/tasks/task-551 - Add-external-audio.cpp-native-TTS-adapter.md"
+git add "backlog/tasks/task-560 - Add-external-audio.cpp-native-TTS-adapter.md"
 git commit -m "chore(tts): close external audio cpp adapter task"
 ```
 

--- a/Docs/superpowers/specs/2026-07-23-audio-cpp-tts-adapter-registry-design.md
+++ b/Docs/superpowers/specs/2026-07-23-audio-cpp-tts-adapter-registry-design.md
@@ -2,7 +2,7 @@
 
 **Status:** approved by the user on 2026-07-23; review amendments approved on 2026-07-23
 **Date:** 2026-07-23
-**Related tasks:** [TASK-402](<../../../backlog/tasks/task-402 - Establish-TTS-adapter-registry-authority-and-legacy-bridge.md>) and [TASK-551](<../../../backlog/tasks/task-551 - Add-external-audio.cpp-native-TTS-adapter.md>)
+**Related tasks:** [TASK-561](<../../../backlog/tasks/task-561 - Establish-TTS-adapter-registry-authority-and-legacy-bridge.md>) and [TASK-560](<../../../backlog/tasks/task-560 - Add-external-audio.cpp-native-TTS-adapter.md>)
 **Canonical ADR:** [ADR-023](../../../backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md)
 **Upstream contract reviewed:** `0xShug0/audio.cpp` commit `d3d748179e5ace353386fbf17bcaedfacf482d75`
 
@@ -23,7 +23,7 @@ save it.
 
 - Slice 1 established the authoritative registry and placed the six existing
   providers behind the temporary legacy bridge.
-- Slice 2, tracked by TASK-551, implements the external-only `audio_cpp` native
+- Slice 2, tracked by TASK-560, implements the external-only `audio_cpp` native
   adapter, bounded discovery, lazy voices, and complete-WAV synthesis. Its
   exact, alias-free, lazy, exclusive provider spec is registered before the six
   unchanged legacy entries.

--- a/backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md
+++ b/backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md
@@ -2,7 +2,7 @@
 
 Status: Accepted
 Date: 2026-07-23
-Related Tasks: TASK-402, TASK-551
+Related Tasks: TASK-561, TASK-560
 Supersedes: N/A
 
 ## Decision
@@ -54,7 +54,7 @@ Slices 1 and 2 are implemented. The sealed registry registers the exact native
 provider `audio_cpp` first, with no provider alias and exclusive lazy
 reconfiguration, followed by the six unchanged legacy bridge entries.
 
-TASK-551 implements external connection mode only. It reads
+TASK-560 implements external connection mode only. It reads
 `[app_tts.audio_cpp]` with `mode = "external"`, a canonical HTTP(S) origin,
 five-second connect and 600-second overall synthesis timeouts, and positive
 bounds for input characters, response bytes, metadata bytes, catalog models,
@@ -78,7 +78,7 @@ They require `GET /health`, `GET /v1/models`, and complete-WAV
 
 Slice 3 remains the catalog-driven external STTS Playground vertical. Slices
 4–5 remain user-provided prebuilt binary plus user-provided `server.json`
-launch/supervision and managed UI. No process or UI work is part of TASK-551.
+launch/supervision and managed UI. No process or UI work is part of TASK-560.
 
 ## Context
 
@@ -239,7 +239,7 @@ policy, and a cross-module interface.
 ## Links
 
 - [Design spec](../../Docs/superpowers/specs/2026-07-23-audio-cpp-tts-adapter-registry-design.md)
-- [TASK-551](<../tasks/task-551 - Add-external-audio.cpp-native-TTS-adapter.md>)
+- [TASK-560](<../tasks/task-560 - Add-external-audio.cpp-native-TTS-adapter.md>)
 - [Pinned audio.cpp server guide](https://github.com/0xShug0/audio.cpp/blob/d3d748179e5ace353386fbf17bcaedfacf482d75/app/server/README.md)
 - [Pinned audio.cpp server runtime](https://github.com/0xShug0/audio.cpp/blob/d3d748179e5ace353386fbf17bcaedfacf482d75/app/server/runtime.cpp)
 - [Pinned audio.cpp busy guard](https://github.com/0xShug0/audio.cpp/blob/d3d748179e5ace353386fbf17bcaedfacf482d75/app/server/busy_guard.h)

--- a/backlog/tasks/task-560 - Add-external-audio.cpp-native-TTS-adapter.md
+++ b/backlog/tasks/task-560 - Add-external-audio.cpp-native-TTS-adapter.md
@@ -1,17 +1,17 @@
 ---
-id: TASK-551
+id: TASK-560
 title: Add external audio.cpp native TTS adapter
 status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-24 19:45'
-updated_date: '2026-07-25 01:15'
+updated_date: '2026-07-25 01:27'
 labels:
   - tts
   - audio-cpp
   - backend
 dependencies:
-  - TASK-402
+  - TASK-561
 references:
   - backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md
 documentation:
@@ -79,6 +79,11 @@ under [ADR-023](../decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boun
 final verification and acceptance closure were completed in Task 8.
 
 Post-rebase verification against origin/dev 238ac3041b626b7b34fd9bd40649443e26b7abac: 596 focused tests passed; the broader TTS, STTS capability/settings, audio-service, and media regression set passed 813 tests with 14 skips. Ruff checked and formatted 19 changed Python files, compileall passed, scoped mypy passed across 7 source files, the managed-process boundary search returned no production matches, and git diff --check passed. Final whole-branch review found no actionable issue and mapped AC #1-#10 plus DoD #1-#4 to passing evidence; ADR-023 remains sufficient. Pytest exited zero; existing dependency/deprecation warnings and the known interpreter-shutdown temp-file cleanup diagnostic remain outside this slice.
+
+After merge, this task was renumbered from TASK-551 to TASK-560 because the
+latest `dev` already contained an unrelated TASK-551. The filename,
+frontmatter, ADR, design, and implementation-plan references were updated
+without changing the shipped implementation.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-561 - Establish-TTS-adapter-registry-authority-and-legacy-bridge.md
+++ b/backlog/tasks/task-561 - Establish-TTS-adapter-registry-authority-and-legacy-bridge.md
@@ -1,11 +1,11 @@
 ---
-id: TASK-402
+id: TASK-561
 title: Establish TTS adapter registry authority and legacy bridge
 status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-24 00:42'
-updated_date: '2026-07-24 19:40'
+updated_date: '2026-07-25 01:27'
 labels:
   - tts
   - architecture
@@ -63,6 +63,11 @@ Reason: ADR-023 governs the service lifecycle, provider-scoped reconfiguration, 
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented the app-owned sealed TTSAdapterRegistry and application-bound TTSService with exact provider IDs, cancellation-safe leases, targeted reconfiguration, and a single shutdown deadline. Preserved all six existing providers behind isolated legacy adapters with enumerated routing, per-backend locking, bounded cleanup, and value-free diagnostics. Reconciled the rebased PR review fixes by restoring canonical Textual Select values, complete settings-key persistence for OpenAI, Chatterbox, Higgs, and AllTalk, explicit OpenAI endpoint reset and organization clearing, validated endpoint/header configuration, serialized concurrent saves, and service retrieval without ignored compatibility configuration. Kept playground generation in its already-retained same-loop event task and documented why a nested worker would break ownership. Fresh post-format verification: 301 passed and 14 optional skips across TTS, STTS UI, audio-service, and media-reading regressions; Ruff check/format, compileall, scoped mypy, boundary isolation, ADR/scope audit, and git diff hygiene passed. ADR-023 remains governing. Native audio.cpp transport and process supervision remain intentionally deferred to later slices.
+
+After merge, this task was renumbered from TASK-402 to TASK-561 because the
+latest `dev` already contained an unrelated TASK-402. The filename,
+frontmatter, ADR, design, Slice 1 plan, and Slice 2 dependency were updated
+without changing the shipped implementation.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary

- renumber the Slice 2 audio.cpp task from TASK-551 to TASK-560
- renumber the Slice 1 adapter-registry task from TASK-402 to TASK-561
- update ADR-023, the approved design, both implementation plans, and the Slice 2 dependency

The merged `dev` branch already contained unrelated TASK-402 and TASK-551 records. Open PRs had reserved TASK-558 and TASK-559, so TASK-560 and TASK-561 are the first conflict-free IDs. No product code changes.

## Verification

- TASK-402, TASK-551, TASK-560, and TASK-561 each have exactly one filename and one frontmatter ID
- relative to `origin/dev`, the duplicate sets lose only TASK-402 and TASK-551 and gain no IDs
- no stale TTS TASK-402/TASK-551 references remain
- `backlog task 560 --plain` and `backlog task 561 --plain` resolve the completed tasks
- `git diff --check` passes

The unrelated pre-existing TASK-505–TASK-532 duplicate batch remains outside this correction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renumbered TTS slice backlog tasks to avoid ID collisions on dev: TASK-551 → TASK-560 and TASK-402 → TASK-561. No product code changes.

- **Refactors**
  - Updated task filenames and frontmatter IDs; fixed references in ADR-023, design spec, and Slice 1/2 plans.
  - Switched Slice 2 dependency to `TASK-561`; design/specs now link to `TASK-560` and `TASK-561`.
  - Removed stale `TASK-402`/`TASK-551` mentions; each task now has a single filename and ID.

<sup>Written for commit 90b097673e3656f1c112b239686f86f40733d89b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

