### PR TITLE
Fix/character card trailing text chunks

### DIFF
--- a/Tests/Character_Chat/test_character_card_lenient_import.py
+++ b/Tests/Character_Chat/test_character_card_lenient_import.py
@@ -50,6 +50,31 @@ def _write_png_with_metadata(path, metadata: dict):
     return path
 
 
+def _write_png_with_trailing_metadata(path, metadata: dict):
+    """Writes a PNG whose text chunks sit AFTER IDAT, like SillyTavern exports."""
+    import struct
+    import zlib
+
+    img = Image.new("RGB", (10, 10), color="green")
+    img.save(path, "PNG")
+    raw = path.read_bytes()
+
+    def make_text_chunk(key: str, value: str) -> bytes:
+        data = key.encode("latin-1") + b"\x00" + value.encode("latin-1")
+        crc = zlib.crc32(b"tEXt" + data) & 0xFFFFFFFF
+        return struct.pack(">I", len(data)) + b"tEXt" + data + struct.pack(">I", crc)
+
+    # Insert the text chunks right before IEND (i.e., after IDAT).
+    iend_start = raw.rfind(b"IEND") - 4  # include IEND's length field
+    assert iend_start > 8
+    out = raw[:iend_start]
+    for key, value in metadata.items():
+        out += make_text_chunk(key, value)
+    out += raw[iend_start:]
+    path.write_bytes(out)
+    return path
+
+
 def _b64_json(payload: dict) -> str:
     return base64.b64encode(json.dumps(payload).encode("utf-8")).decode("utf-8")
 
@@ -384,3 +409,33 @@ def test_unsupported_image_extension_rejected_explicitly(tmp_path):
 def test_traversal_path_rejected():
     assert load_character_card_from_file("../../etc/passwd.json") is None
     assert load_character_card_from_file("..\\..\\Windows\\win.ini") is None
+
+
+# ---------------------------------------------------------------------------
+# Trailing (post-IDAT) PNG metadata - how SillyTavern writes character files
+# ---------------------------------------------------------------------------
+
+
+def test_extract_chara_from_trailing_post_idat_chunk(tmp_path):
+    # SillyTavern writes chara/ccv3 tEXt chunks AFTER the IDAT chunk; Pillow
+    # only surfaces them in .info after a full image decode.
+    png_path = _write_png_with_trailing_metadata(
+        tmp_path / "trailing.png",
+        {"chara": _b64_json(_v2_card()), "ccv3": _b64_json(_v2_card())},
+    )
+
+    extracted = extract_json_from_image_file(str(png_path), str(tmp_path))
+
+    assert extracted is not None
+    assert json.loads(extracted)["data"]["name"] == "Test Char"
+
+
+def test_load_trailing_metadata_png_end_to_end(tmp_path):
+    png_path = _write_png_with_trailing_metadata(
+        tmp_path / "trailing.png", {"chara": _b64_json(_v2_card())}
+    )
+
+    parsed = load_character_card_from_file(png_path)
+
+    assert parsed is not None
+    assert parsed["name"] == "Test Char"

--- a/Tests/Character_Chat/test_character_card_lenient_import.py
+++ b/Tests/Character_Chat/test_character_card_lenient_import.py
@@ -417,8 +417,15 @@ def test_traversal_path_rejected():
 
 
 def test_extract_chara_from_trailing_post_idat_chunk(tmp_path):
-    # SillyTavern writes chara/ccv3 tEXt chunks AFTER the IDAT chunk; Pillow
-    # only surfaces them in .info after a full image decode.
+    """Post-IDAT chara/ccv3 chunks are recovered via a forced full decode.
+
+    SillyTavern writes chara/ccv3 tEXt chunks AFTER the IDAT chunk; Pillow
+    only surfaces them in .info after a full image decode, so the extractor
+    must load the image before concluding there is no card metadata.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory for the PNG fixture.
+    """
     png_path = _write_png_with_trailing_metadata(
         tmp_path / "trailing.png",
         {"chara": _b64_json(_v2_card()), "ccv3": _b64_json(_v2_card())},
@@ -431,6 +438,11 @@ def test_extract_chara_from_trailing_post_idat_chunk(tmp_path):
 
 
 def test_load_trailing_metadata_png_end_to_end(tmp_path):
+    """A SillyTavern-layout PNG loads end to end through the card loader.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory for the PNG fixture.
+    """
     png_path = _write_png_with_trailing_metadata(
         tmp_path / "trailing.png", {"chara": _b64_json(_v2_card())}
     )
@@ -439,3 +451,39 @@ def test_load_trailing_metadata_png_end_to_end(tmp_path):
 
     assert parsed is not None
     assert parsed["name"] == "Test Char"
+
+
+def test_oversized_png_skips_trailing_chunk_probe(tmp_path, monkeypatch):
+    """PNGs above the pixel bound are not fully decoded for metadata probing.
+
+    The full decode used to reveal trailing (post-IDAT) chunks is guarded by
+    ``_MAX_CARD_DECODE_PIXELS`` so oversized untrusted images cannot cause
+    CPU/memory spikes; such a card is rejected instead of decoded.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory for the PNG fixture.
+        monkeypatch: Pytest fixture used to shrink the pixel bound so a tiny
+            test image counts as "oversized".
+    """
+    import tldw_chatbook.Character_Chat.Character_Chat_Lib as cc_lib
+
+    monkeypatch.setattr(cc_lib, "_MAX_CARD_DECODE_PIXELS", 50)  # 10x10 = 100 px
+    png_path = _write_png_with_trailing_metadata(
+        tmp_path / "trailing.png", {"chara": _b64_json(_v2_card())}
+    )
+
+    # The project logs via loguru, so capture with a temporary sink rather
+    # than stdlib caplog.
+    warnings = []
+    sink_id = cc_lib.logger.add(
+        lambda msg: warnings.append(str(msg)), level="WARNING"
+    )
+    try:
+        extracted = extract_json_from_image_file(str(png_path), str(tmp_path))
+    finally:
+        cc_lib.logger.remove(sink_id)
+
+    assert extracted is None
+    assert any(
+        "oversized" in message for message in warnings
+    ), "expected a warning that the oversized PNG decode was skipped"

--- a/backlog/tasks/task-109 - Support-PNG-character-cards-with-post-IDAT-text-chunks.md
+++ b/backlog/tasks/task-109 - Support-PNG-character-cards-with-post-IDAT-text-chunks.md
@@ -47,9 +47,11 @@ Modified/added files:
 - `Tests/Character_Chat/test_character_card_lenient_import.py` (PNG chunk-surgery helper + 2 regression tests)
 
 Verification:
-- `pytest Tests/Character_Chat/test_character_card_lenient_import.py` -> 28 passed.
+- `pytest Tests/Character_Chat/test_character_card_lenient_import.py` -> 29 passed.
 - Full import path over reporter's folder -> IMPORTED: 108, FAILED: 0.
 - Full import path over SillyTavern characters folder -> IMPORTED: 95, FAILED: 0 (includes reported `Ann1.png`).
+
+Review hardening (Qodo): the metadata keys are now a shared module constant (`_CARD_IMAGE_METADATA_KEYS`), the forced decode is PNG-only (WebP/JPEG skip straight to EXIF) and bounded by `_MAX_CARD_DECODE_PIXELS` (50 MP, checked pre-decode via `img_obj.size`) to prevent CPU/memory spikes on oversized untrusted images, and PNG decode failures log at warning. A regression test covers the oversized-skip path.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-109 - Support-PNG-character-cards-with-post-IDAT-text-chunks.md
+++ b/backlog/tasks/task-109 - Support-PNG-character-cards-with-post-IDAT-text-chunks.md
@@ -1,0 +1,63 @@
+---
+id: TASK-109
+title: Support PNG character cards with post-IDAT text chunks (SillyTavern)
+status: In Progress
+labels:
+- character-chat
+- import
+- bugfix
+- regression
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+After TASK-100 shipped, the reporter still could not import cards from their SillyTavern characters folder (`Ann1.png` failing with "no character JSON metadata found"). Root cause: SillyTavern (and some other exporters) write the `chara`/`ccv3` tEXt chunks AFTER the IDAT image-data chunk, and Pillow only surfaces trailing chunks in `Image.info` once the image data has been decoded. `extract_json_from_image_file` only inspected `.info` before any decode, so it never saw the metadata and rejected the card. This also explains the single "failure" noted in TASK-100 (`Awkward Questions FM.png`), which likewise carries a trailing `chara` chunk.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PNG cards whose `chara`/`ccv3` tEXt chunks appear after the IDAT chunk are detected and imported.
+- [x] #2 Cards with pre-IDAT metadata, EXIF UserComment cards, and metadata-less plain images keep their existing behavior (no regressions; plain images are still rejected cleanly).
+- [x] #3 All cards in the reporter's collection import end-to-end through the app's full import path (verified: 108/108 in E:\LLM-Models\Charcards).
+- [x] #4 All cards in a real SillyTavern characters folder import (verified: 95/95, including the reported `Ann1.png`).
+- [x] #5 Regression tests build a real PNG with a post-IDAT tEXt chunk and cover both metadata extraction and full card load.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: N/A
+Reason: Bug fix within the existing image-metadata extraction path; no storage/schema, sync policy, provider boundary, or architectural decision changes.
+
+1. Reproduce with the reported `Ann1.png`; inspect PNG chunk layout to confirm post-IDAT placement of the `chara` chunk.
+2. In `extract_json_from_image_file`, force a full decode (`img.load()`) when no metadata key is found in `.info`, then re-check for `chara`/`ccv3` before the EXIF UserComment fallback.
+3. Add regression tests that construct a PNG with a trailing tEXt chunk via chunk surgery (insert before IEND) and assert extraction plus end-to-end card load.
+4. Re-verify the reporter's 108-card folder and a real SillyTavern characters folder through `import_and_save_character_from_file`.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+`extract_json_from_image_file` in `Character_Chat_Lib.py` now, when the initial `.info` scan finds no `chara`/`ccv3` key, calls `img_obj.load()` (exceptions logged at debug and ignored) and re-checks `.info`, logging when metadata is found in a trailing (post-IDAT) chunk. All pre-existing paths (pre-IDAT chunks, EXIF UserComment for WebP/JPEG, clean rejection of plain images) are unchanged. The full decode happens only on the previously-failing path, so there is no performance change for cards that already worked.
+
+Modified/added files:
+- `tldw_chatbook/Character_Chat/Character_Chat_Lib.py` (post-IDAT metadata recovery in `extract_json_from_image_file`)
+- `Tests/Character_Chat/test_character_card_lenient_import.py` (PNG chunk-surgery helper + 2 regression tests)
+
+Verification:
+- `pytest Tests/Character_Chat/test_character_card_lenient_import.py` -> 28 passed.
+- Full import path over reporter's folder -> IMPORTED: 108, FAILED: 0.
+- Full import path over SillyTavern characters folder -> IMPORTED: 95, FAILED: 0 (includes reported `Ann1.png`).
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+PNG character cards written by SillyTavern-style exporters (metadata chunk after IDAT) import correctly; the extractor forces a full image decode before concluding a card has no embedded metadata.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/tldw_chatbook/Character_Chat/Character_Chat_Lib.py
+++ b/tldw_chatbook/Character_Chat/Character_Chat_Lib.py
@@ -1278,6 +1278,27 @@ def extract_json_from_image_file(
                     metadata_key = candidate_key
                     break
 
+        # SillyTavern and other tools write the character text chunks AFTER
+        # the IDAT (image data) chunk. Pillow only surfaces trailing chunks in
+        # .info once the image data has been decoded, so force a full load and
+        # re-check before falling back to EXIF or giving up.
+        if metadata_key is None:
+            try:
+                img_obj.load()
+            except Exception as load_err:
+                logger.debug(
+                    f"Full image decode failed for '{file_name_for_log}': {load_err}"
+                )
+            if hasattr(img_obj, "info") and isinstance(img_obj.info, dict):
+                for candidate_key in ("chara", "ccv3"):
+                    if candidate_key in img_obj.info:
+                        metadata_key = candidate_key
+                        break
+            if metadata_key:
+                logger.debug(
+                    f"Found '{metadata_key}' metadata in a trailing (post-IDAT) chunk of '{file_name_for_log}'."
+                )
+
         # WebP (and JPEG) character cards embed the base64 card JSON in the
         # EXIF UserComment tag (37510) instead of a 'chara' text chunk.
         exif_user_comment: Optional[Any] = None

--- a/tldw_chatbook/Character_Chat/Character_Chat_Lib.py
+++ b/tldw_chatbook/Character_Chat/Character_Chat_Lib.py
@@ -42,6 +42,16 @@ from tldw_chatbook.Utils.path_validation import (  # noqa: E402
 #
 # Constants
 DEFAULT_CHARACTER_ID = 1
+
+# Image metadata keys that carry embedded character-card JSON:
+# 'chara' holds V1/V2 cards, 'ccv3' holds V3 cards (PNG tEXt/zTXt/iTXt chunks).
+_CARD_IMAGE_METADATA_KEYS = ("chara", "ccv3")
+
+# Upper bound on image dimensions for the full decode used to reveal trailing
+# (post-IDAT) PNG metadata chunks. Character card images are typically well
+# under 1 MP; this guards untrusted-import paths against CPU/memory spikes
+# from oversized images.
+_MAX_CARD_DECODE_PIXELS = 50_000_000
 #
 
 # String boolean vocabularies for loosely-typed card/lorebook fields
@@ -1273,7 +1283,7 @@ def extract_json_from_image_file(
         # 'chara' holds V1/V2 cards; 'ccv3' holds V3 cards.
         metadata_key: Optional[str] = None
         if hasattr(img_obj, "info") and isinstance(img_obj.info, dict):
-            for candidate_key in ("chara", "ccv3"):
+            for candidate_key in _CARD_IMAGE_METADATA_KEYS:
                 if candidate_key in img_obj.info:
                     metadata_key = candidate_key
                     break
@@ -1281,23 +1291,35 @@ def extract_json_from_image_file(
         # SillyTavern and other tools write the character text chunks AFTER
         # the IDAT (image data) chunk. Pillow only surfaces trailing chunks in
         # .info once the image data has been decoded, so force a full load and
-        # re-check before falling back to EXIF or giving up.
-        if metadata_key is None:
-            try:
-                img_obj.load()
-            except Exception as load_err:
-                logger.debug(
-                    f"Full image decode failed for '{file_name_for_log}': {load_err}"
+        # re-check before falling back to EXIF or giving up. PNG-only: WebP and
+        # JPEG carry card data in EXIF instead, and the decode is bounded by
+        # _MAX_CARD_DECODE_PIXELS to avoid CPU/memory spikes on huge untrusted
+        # images.
+        if metadata_key is None and img_obj.format == "PNG":
+            width, height = img_obj.size
+            if width * height > _MAX_CARD_DECODE_PIXELS:
+                logger.warning(
+                    f"Skipping full decode of oversized PNG '{file_name_for_log}' "
+                    f"({width}x{height} > {_MAX_CARD_DECODE_PIXELS} pixels); "
+                    "trailing (post-IDAT) card metadata cannot be probed."
                 )
-            if hasattr(img_obj, "info") and isinstance(img_obj.info, dict):
-                for candidate_key in ("chara", "ccv3"):
-                    if candidate_key in img_obj.info:
-                        metadata_key = candidate_key
-                        break
-            if metadata_key:
-                logger.debug(
-                    f"Found '{metadata_key}' metadata in a trailing (post-IDAT) chunk of '{file_name_for_log}'."
-                )
+            else:
+                try:
+                    img_obj.load()
+                except Exception as load_err:
+                    logger.warning(
+                        f"Full image decode failed for PNG '{file_name_for_log}': {load_err}. "
+                        "Trailing (post-IDAT) card metadata cannot be recovered."
+                    )
+                if hasattr(img_obj, "info") and isinstance(img_obj.info, dict):
+                    for candidate_key in _CARD_IMAGE_METADATA_KEYS:
+                        if candidate_key in img_obj.info:
+                            metadata_key = candidate_key
+                            break
+                if metadata_key:
+                    logger.debug(
+                        f"Found '{metadata_key}' metadata in a trailing (post-IDAT) chunk of '{file_name_for_log}'."
+                    )
 
         # WebP (and JPEG) character cards embed the base64 card JSON in the
         # EXIF UserComment tag (37510) instead of a 'chara' text chunk.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix PNG character card imports when `chara`/`ccv3` tEXt chunks are written after `IDAT` (SillyTavern-style). We now do a bounded PNG decode before reading metadata so these cards import correctly. Addresses TASK-109.

- **Bug Fixes**
  - In `tldw_chatbook/Character_Chat/Character_Chat_Lib.py`, `extract_json_from_image_file` does a PNG-only full decode when no metadata is found, guarded by `_MAX_CARD_DECODE_PIXELS`, then re-checks `.info` for `_CARD_IMAGE_METADATA_KEYS`.
  - Added regression tests for trailing tEXt chunks and for skipping the probe on oversized PNGs; improved test docstrings.
  - Verified imports: 108/108 in the reporter’s folder; 95/95 in a SillyTavern characters folder (includes `Ann1.png`). Tests: 29 lenient-import and 36 image/import-related pass.
  - No regressions: pre-IDAT PNG metadata, EXIF `UserComment`, and plain images behave as before.

<sup>Written for commit 8d7e7b5dada553a68266694e18e0ca266a9fba3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

