### PR TITLE
feat(personas): generate character avatar + expression images (image-gen P3)

### DIFF
--- a/Docs/superpowers/plans/2026-07-24-image-gen-p3-expression-generation.md
+++ b/Docs/superpowers/plans/2026-07-24-image-gen-p3-expression-generation.md
@@ -1,0 +1,188 @@
+# Image Gen P3 — Generate Avatar & Expression Images: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** ✨ Generate buttons on the character editor's avatar row + three expression slots (and a Generate-all), auto-prompting from live form fields (+optional style preset), generating via the existing engine, and persisting through each slot's existing seam.
+
+**Architecture:** Pure prompt composition in a new `Character_Chat/expression_generation.py`; new sibling messages + editor buttons mirroring the upload flow; screen workers following the personas screen's own conventions (`run_worker(..., group="personas-io", exit_on_error=False)`, `asyncio.to_thread`, session-token stale guard) landing on `_apply_expression_upload` (expressions, immediate) / `set_avatar_image` (avatar, staged + explicit 5 MB pre-check). **No schema/config changes.**
+
+**Tech Stack:** Existing `Image_Generation` engine (`worker.build_request`/`run_generation` — blocking, thread-only), `ConsoleStylePickerModal` (verified screen-agnostic), Textual.
+
+**Design spec (read first):** `Docs/superpowers/specs/2026-07-24-image-gen-p3-expression-generation-design.md`
+
+## Global Constraints
+
+- **Worktree:** ALL work in `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/image-gen-p3`, branch `claude/image-gen-p3-expressions`. Subagents start in the MAIN checkout — `cd` in first; never touch the main checkout's `tldw_chatbook/`.
+- **Test command** (worktree has NO `.venv`; MAIN venv + cwd=worktree): `source /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/activate && cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/image-gen-p3 && python -m pytest <paths> -q`
+- **NO BACKGROUND PROCESSES in subagent verification** — the harness kills them; run sweeps foreground, chunked if long.
+- **Git hygiene:** repo tracks a stale `.superpowers/sdd/progress.md` — stage ONLY your own files by explicit path; never `git add -A`.
+- **Worker safety (repo-documented app-panic trap):** every new worker = `run_worker(<async coroutine>, group="personas-io" or "personas-avatar-render", exit_on_error=False)` AND full-body try/except; blocking `run_generation` only ever inside `await asyncio.to_thread(...)`.
+- **Stale-write guard:** capture `self._character_editor_session_token()` before any await; re-check after EVERY await before touching the editor/DB (the screen's established idiom, `personas_screen.py:~4789`).
+- **Live-form reads:** prompts read `editor._area("description").text` / `_input("name").value` / `_area("personality").text` — NEVER `_character_data` (stale copy).
+- **Persistence seams (verbatim reuse):** expressions → `await self._apply_expression_upload(character_id, state, content, content_type)` (`personas_screen.py:~4663`); avatar → `len(content) > PERSONAS_AVATAR_MAX_BYTES` check (`:~221`, 5 MB) then `editor.set_avatar_image(content)` + `self.run_worker(self._render_character_editor_avatar(), group="personas-avatar-render", exit_on_error=False)`.
+- Expression states = `EXPRESSION_IMAGE_STATES` (thinking/speaking/error) from `Chat/console_expression_state.py`. Avatar = the fourth "slot" (state key `"avatar"` in OUR in-flight/message layer only — never passed to the DB API).
+- `ruff check` changed files clean per commit; type hints + Google docstrings; loguru.
+- Baseline discipline: attribute any unexpected failing test by running it at the branch base (`git stash` / base worktree) before treating it as yours.
+- Anchors below are from the verification recon at `origin/dev@238ac3041` — they may drift a few lines; search by name.
+
+## File structure
+
+```
+tldw_chatbook/Character_Chat/expression_generation.py    # NEW: pure composition
+tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py  # MODIFY: 3 new messages
+tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py  # MODIFY: buttons + gating + handlers
+tldw_chatbook/UI/Screens/personas_screen.py              # MODIFY: handlers + workers + style state
+Tests/Character_Chat/test_expression_generation.py       # NEW
+Tests/UI/test_personas_expression_generate.py            # NEW (screen+editor level)
+```
+
+---
+
+### Task 1: Pure composition — `expression_generation.py`
+
+**Files:**
+- Create: `tldw_chatbook/Character_Chat/expression_generation.py`
+- Test: `Tests/Character_Chat/test_expression_generation.py` (check `Tests/Character_Chat/__init__.py` exists; create if missing, mirroring siblings)
+
+**Interfaces:**
+- `EXPRESSION_PROMPT_STATES: tuple[str, ...] = ("avatar", "thinking", "speaking", "error")`.
+- `STATE_MODIFIERS: dict[str, str]` — avatar: `"neutral friendly expression, head and shoulders portrait, looking at viewer"`; thinking: `"pensive thoughtful expression, hand near chin, looking away"`; speaking: `"mid-speech, animated engaged expression, mouth open"`; error: `"confused sheepish expression, embarrassed, sweatdrop"`.
+- `compose_expression_prompt(*, name: str, description: str, personality: str = "", state: str, style_template=None) -> tuple[str, str, dict]` — returns `(prompt, negative_prompt, params)`. Raises `ValueError` on unknown `state` or empty/whitespace `description` (defensive; the screen refuses first). Base text = `f"{name}, {description}"` (name omitted when blank) + `", {personality}"` when non-empty + `", {STATE_MODIFIERS[state]}"`. With `style_template`, wrap via `Chat.console_generate_image.compose_styled_request(base_text_with_modifier, template)` (import inside the function to keep module import-light); without, return `(base, "", {})`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# Tests/Character_Chat/test_expression_generation.py
+import pytest
+
+from tldw_chatbook.Character_Chat.expression_generation import (
+    EXPRESSION_PROMPT_STATES,
+    STATE_MODIFIERS,
+    compose_expression_prompt,
+)
+
+
+@pytest.mark.parametrize("state", EXPRESSION_PROMPT_STATES)
+def test_each_state_modifier_lands_in_prompt(state):
+    prompt, negative, params = compose_expression_prompt(
+        name="Sayori", description="short coral pink hair, red bow", state=state,
+    )
+    assert STATE_MODIFIERS[state] in prompt
+    assert "Sayori" in prompt and "coral pink hair" in prompt
+    assert negative == "" and params == {}
+
+
+def test_personality_included_only_when_nonempty():
+    with_p, _, _ = compose_expression_prompt(
+        name="A", description="desc", personality="cheerful", state="avatar",
+    )
+    without_p, _, _ = compose_expression_prompt(
+        name="A", description="desc", personality="   ", state="avatar",
+    )
+    assert "cheerful" in with_p and "cheerful" not in without_p
+
+
+def test_blank_name_omitted():
+    prompt, _, _ = compose_expression_prompt(name="  ", description="desc", state="avatar")
+    assert not prompt.startswith(",") and "desc" in prompt
+
+
+def test_empty_description_raises():
+    with pytest.raises(ValueError):
+        compose_expression_prompt(name="A", description="   ", state="avatar")
+
+
+def test_unknown_state_raises():
+    with pytest.raises(ValueError):
+        compose_expression_prompt(name="A", description="desc", state="angry")
+
+
+def test_style_template_composes_and_keeps_user_text():
+    from tldw_chatbook.Media_Creation.generation_templates import get_template
+
+    template = get_template("style_anime")
+    prompt, negative, params = compose_expression_prompt(
+        name="Sayori", description="coral pink hair", state="thinking",
+        style_template=template,
+    )
+    assert "coral pink hair" in prompt                     # user text survives (P2b invariant)
+    assert STATE_MODIFIERS["thinking"] in prompt
+    assert negative == template.negative_prompt
+    assert params == template.default_params
+```
+
+- [ ] **Step 2: Run → FAIL** (`ModuleNotFoundError`). `python -m pytest Tests/Character_Chat/test_expression_generation.py -q`
+- [ ] **Step 3: Implement** per Interfaces (read `Chat/console_generate_image.py`'s `compose_styled_request` first — reuse it, don't reimplement the invariant).
+- [ ] **Step 4: Run → PASS** (7 passed). `ruff check` both files.
+- [ ] **Step 5: Commit** `feat(character): expression-generation prompt composition` (stage the 2-3 files by path).
+
+---
+
+### Task 2: Messages + editor buttons + gating
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py` (sibling of `CharacterExpressionUploadRequested`, `:59`)
+- Modify: `tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py` (avatar row `:~101-130`; expression slots `:~372-391`; `_sync_expression_slots_enabled` `:~577`; upload-press handlers `:~1041-1069`)
+- Test: `Tests/UI/test_personas_expression_generate.py` (NEW — find the existing editor/personas test files first: `grep -rl "personas_character_editor\|PersonasCharacterEditorWidget" Tests/ | head`; mirror their harness style)
+
+**Interfaces:**
+- New messages (each a dataclass-style Textual `Message` mirroring `CharacterExpressionUploadRequested`): `CharacterAvatarGenerateRequested()` (no fields), `CharacterExpressionGenerateRequested(state: str)`, `CharacterExpressionGenerateAllRequested()` (no fields).
+- Editor buttons: `#personas-char-editor-avatar-generate` ("✨ Generate") in the avatar row beside Upload; `#personas-char-editor-expr-{state}-generate` (class `personas-char-editor-expr-generate`) in each expression slot beside Upload; `#personas-char-editor-expr-generate-all` ("✨ Generate all") in the expression section header area.
+- Gating: the three per-state generate buttons + generate-all JOIN `_sync_expression_slots_enabled`'s enable/disable loop (disabled until the character is saved, same as upload); the avatar-generate button is always enabled while the editor is active (staged path).
+- Press handlers mirror `_expression_upload_pressed` (`:1064`): `event.stop()` + post the matching message (state recovered via `_expression_state_from_button_id(..., suffix="-generate")`).
+
+- [ ] **Step 1: Write the failing tests** — in the existing harness style; MANDATORY assertions: (a) pressing each generate button posts the right message type (+state); (b) per-state generate + generate-all buttons are disabled before the character is saved and enabled after (drive `_sync_expression_slots_enabled` the way existing slot tests do); (c) avatar-generate stays enabled pre-save. Write real arrange/act/assert after reading the sibling tests — the assertions as named are required.
+- [ ] **Step 2: RED.** **Step 3: Implement.** **Step 4: GREEN** + existing editor suites stay green (`python -m pytest Tests/ -q -k "personas_character_editor or personas_expression"` — attribute any pre-existing failures at base). `ruff check`.
+- [ ] **Step 5: Commit** `feat(personas): generate buttons + messages on avatar and expression slots`.
+
+---
+
+### Task 3: Screen — expression generate handler + worker (the core)
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py` (handler cluster near `_handle_character_expression_upload_requested` `:~4710`; worker near `_expression_upload_dialog_worker` `:~4755`)
+- Test: `Tests/UI/test_personas_expression_generate.py` (extend)
+
+**Interfaces:**
+- `@on(CharacterExpressionGenerateRequested)` handler: `message.stop()`; `_character_editor_is_active()` gate; `editor.expression_character_id()` None → notify "Save the character to add expressions." (same copy as upload); empty/whitespace live description → notify "Add a description first." severity warning, return; in-flight `(character_id, state)` in `self._expression_generate_inflight: set` → notify "already generating", return; else add to set + `run_worker(self._generate_expression_image_worker(character_id, state), group="personas-io", exit_on_error=False)`.
+- `async def _generate_expression_image_worker(self, character_id: int, state: str) -> None`: whole body try/except/finally (finally discards the in-flight key). Read live fields from the editor (name/description/personality) + `self._expression_generate_style` (Task 4; `getattr(self, ..., None)` until then); `compose_expression_prompt(...)`; `build_request(backend=cfg.default_backend, prompt=..., negative_prompt=... or None, seed=-1, image_format="png", width/height/steps/cfg from params when present)`; token = `self._character_editor_session_token()`; `result = await asyncio.to_thread(run_generation, request)`; **re-check token** (changed → log + return, NO write); `await self._apply_expression_upload(character_id, state, result.content, result.content_type)`. Failures → `self._notify(f"Expression generation failed: {exc}", "error")`.
+- Backend refusal: before dispatch, resolve config (`get_image_generation_config()`) — if `default_backend` unresolvable/not enabled per `listing.list_image_models_for_catalog()`, notify the Console's copy (`Image backend ... is not enabled/configured. Check [image_generation] settings.`), return (no worker).
+
+- [ ] **Step 1: Write the failing tests** — screen-level in the existing personas-screen harness style (find how sibling tests drive handlers/workers; the upload flow's tests are the template). MANDATORY: (a) happy path — mocked `run_generation` returns a fake PNG result; assert `_apply_expression_upload` was awaited with (cid, state, content, content_type) [patch it and record]; (b) stale-token pin — token changes between dispatch and completion (mutate `self._character_editor_generation` inside the mocked `run_generation`) → NO `_apply_expression_upload` call + no crash; (c) empty-description refusal → notify called, no worker; (d) in-flight second click → refusal notify, single generation; (e) failure path → error notify, no write, in-flight cleared; (f) unsaved character → save-first notify.
+- [ ] **Step 2: RED.** **Step 3: Implement.** **Step 4: GREEN** + `python -c "import tldw_chatbook.app"` clean + `ruff check`.
+- [ ] **Step 5: Commit** `feat(personas): generate expression images via the image-gen engine`.
+
+---
+
+### Task 4: Screen — avatar generate, generate-all, style picker
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py`
+- Modify: `tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py` (ONLY if a style-readout label is added to the expression section — a small Static `#personas-char-editor-style-readout` "Style: Custom" + a `#personas-char-editor-style-pick` button posting a new `CharacterExpressionStylePickRequested()` message; add the message in `personas_pane_messages.py`)
+- Test: `Tests/UI/test_personas_expression_generate.py` (extend)
+
+**Interfaces:**
+- `@on(CharacterAvatarGenerateRequested)`: gates = editor active + non-empty live description + backend configured + in-flight `(character_id_or_None, "avatar")`; worker mirrors Task 3 but: state `"avatar"` composition; token re-check; then `if len(result.content) > PERSONAS_AVATAR_MAX_BYTES: notify error, return`; else (still on the worker/UI seam — `set_avatar_image` touches widgets, so marshal like the upload flow does; READ how `_stage_character_avatar_from_path`/equivalent calls it and mirror) `editor.set_avatar_image(result.content)` + `self.run_worker(self._render_character_editor_avatar(), group="personas-avatar-render", exit_on_error=False)` + notify "Avatar image generated — Save to keep it."
+- `@on(CharacterExpressionGenerateAllRequested)`: gates once (saved character required — avatar included in the sweep only when the description gate passes; same single in-flight key `(character_id, "all")` PLUS per-slot keys), one worker iterating `("avatar", "thinking", "speaking", "error")` sequentially, reusing the SAME per-slot logic (factor the per-slot body into a helper both workers call: `async def _generate_one_slot(self, character_id, state, style_template) -> bool`), notify a summary "k/4 generated" at the end.
+- Style picker: `@on(CharacterExpressionStylePickRequested)` → worker (io-dialog convention: `_io_dialog_active` flag like `_expression_upload_dialog_worker` `:~4755`) → `await self.app.push_screen_wait(ConsoleStylePickerModal())` → store `self._expression_generate_style: GenerationTemplate | None` (resolve via `get_template(choice["id"])`), update the readout Static ("Style: {name}" / "Style: Custom"), restore focus to the editor (the modal's documented caller responsibility — mirror how the upload dialog restores).
+
+- [ ] **Step 1: Write the failing tests** — MANDATORY: (a) avatar happy path stages via `set_avatar_image` (patched/recorded) + render worker kicked + NOT `_apply_expression_upload`; (b) oversized fake result (> `PERSONAS_AVATAR_MAX_BYTES`) → error notify + no staging; (c) generate-all with one failing state → 3 writes + "3/4" summary; (d) style pick stores the template and subsequent generation's request carries its params (record `build_request` kwargs via the mocked path); (e) style readout text updates.
+- [ ] **Step 2: RED.** **Step 3: Implement** (factor `_generate_one_slot` FIRST, refactor Task 3's worker onto it — a pure refactor with Task 3's tests staying green is the proof). **Step 4: GREEN** + app import + ruff.
+- [ ] **Step 5: Commit** `feat(personas): avatar generate, generate-all, expression style picker`.
+
+---
+
+### Task 5: Sweep + live smoke
+
+- [ ] **Step 1: Full sweeps (foreground, chunked):** `python -m pytest Tests/Character_Chat/ Tests/UI/test_personas_expression_generate.py -q`; then the personas/editor suites (`python -m pytest Tests/ -q -k "personas"`); then `python -m pytest Tests/Chat/ -q` and `python -m pytest Tests/Image_Generation/ -q`. Baseline attribution for anything unexpected (run at branch base).
+- [ ] **Step 2:** `git diff --name-only <plan-commit>..HEAD -- '*.py' | xargs ruff check` clean; `python -c "import tldw_chatbook.app"` clean; `python -m tldw_chatbook.css.check_bundle_sync` (only relevant if CSS changed — buttons may need slot CSS; if any `.tcss` source changed, regenerate the bundle via `./build_css.sh`, NEVER hand-edit).
+- [ ] **Step 3: Live tmux smoke** (per `.claude/skills/verify` + the P2b lesson: pre-seed the scratch config with `[chat_defaults] provider="llama_cpp"` + `[api_settings.llama_cpp] api_url="http://127.0.0.1:9099"` to clear the first-run gate): RP&CD tab → open/create a character with a description → expression slots show ✨ Generate; click one → without a backend server: "Expression generation failed: ... Connection refused" notify, no crash; avatar ✨ pre-save works and stages. Report honestly what was covered.
+- [ ] **Step 4: Commit** any fixes + final ledger note.
+
+---
+
+## Self-review notes (already applied)
+
+- Spec §1 behaviors → T2 (buttons/gating), T3 (expression path + refusals), T4 (avatar/all/style); §2 seams pinned in Global Constraints; §3 tests distributed with the stale-token and oversized-avatar pins mandatory.
+- Type consistency: `compose_expression_prompt` (T1) is the single composition entry used by T3/T4's workers; `_generate_one_slot` introduced in T4 refactors T3's body (T3 tests must stay green — the refactor's gate).
+- Out of scope guarded: no galleries/review queues/new states/persisted style/schema changes.

--- a/Docs/superpowers/specs/2026-07-24-image-gen-p3-expression-generation-design.md
+++ b/Docs/superpowers/specs/2026-07-24-image-gen-p3-expression-generation-design.md
@@ -1,0 +1,39 @@
+# Image Generation P3 — Generate Character Avatar & Expression Images
+
+**Status:** Design approved (user: "lets target the existing expression system"), verified against `origin/dev@238ac3041`
+**Date:** 2026-07-24
+**Program:** In-chat image generation (P1 #800 engine, P2a #832 card+variants, P2b #850 speak/styles/context — all merged). P3 fills the **existing** character expression system with generated images; it invents no new canvas, gallery, or mood states.
+
+## 1. User-visible behavior
+
+- In the character editor (Personas/Roleplay screen), each image slot gains a **✨ Generate** button beside its existing Upload: the **avatar row** and the three **expression slots** (thinking / speaking / error — `EXPRESSION_IMAGE_STATES`). Plus one **Generate all** button (avatar + 3 states, sequential).
+- The prompt is auto-composed from the editor's **live** form text: name + description (+ personality when non-empty), plus a per-state modifier fragment (avatar/idle → neutral portrait framing; thinking → pensive/looking-away; speaking → mid-speech/animated; error → confused/sheepish). Style presets compose on top exactly like P2b (`compose_styled_request`; user-text-always-included invariant).
+- **Style**: an optional style readout + "Pick style…" control in the expression section opens the existing `ConsoleStylePickerModal` (verified screen-agnostic); the chosen style applies to subsequent generations this editor session (not persisted). Unset = no template ("Custom").
+- **Persistence matches each slot's existing rule** (verified):
+  - Generated **avatar** → staged via `set_avatar_image` (dirty-mark; persists on Save; Save-blocking validation unchanged). Works for unsaved characters too.
+  - Generated **expression images** → immediate write via the existing `_apply_expression_upload` seam (DB upsert + editor-generation bump + notify + slot thumbnail re-render, all reused). Requires a saved character — same gating as Upload (`_sync_expression_slots_enabled` extended to the new buttons).
+- **Refusals** (status/notify, no generation): empty description ("Add a description first"); backend not configured/enabled (same copy as Console); a generation already running for that (character, slot).
+- Generation runs off the UI loop; the slot shows a "Generating…" hint; failures surface via the screen's `_notify(..., "error")`; **regenerate = click again** (immediate-overwrite for expressions, restage for avatar — cheap redo replaces any review-queue UI).
+- Switching characters/screens mid-generation never writes into the wrong character (session-token guard, §2).
+
+## 2. Implementation seams (all verified on dev — reuse, don't rebuild)
+
+- **Buttons/messages:** mirror the upload flow exactly. New `CharacterExpressionGenerateRequested(state)` + `CharacterAvatarGenerateRequested()` + `CharacterExpressionGenerateAllRequested()` messages in `Widgets/Persona_Widgets/personas_pane_messages.py` (sibling of `CharacterExpressionUploadRequested`, `:59`). Editor buttons `personas-char-editor-expr-{state}-generate` (+ avatar/all) posted from handlers mirroring `_expression_upload_pressed` (`personas_character_editor_widget.py:1064`); the new buttons JOIN `_sync_expression_slots_enabled`'s loop (`:577` — else they never enable). Avatar-generate is enabled whenever the editor is active (staged path needs no saved id).
+- **Screen handlers** (`UI/Screens/personas_screen.py`): mirror the 5-seam upload chain — `message.stop()`, `_character_editor_is_active()`, saved-id gate (expressions only), then `run_worker(self._generate_expression_worker(...), group="personas-io", exit_on_error=False)` (the 5-of-20 explicit-`False` convention; the repo's documented `exit_on_error=True` app-panic trap) with the whole body in try/except and the in-flight guard cleared in `finally`.
+- **Worker body:** capture `_character_editor_session_token()` BEFORE the await; `await asyncio.to_thread(run_generation, request)` (blocking engine contract); **re-check the token after** (the screen's established stale-guard idiom, `personas_screen.py:4789+`); then:
+  - expressions → `await self._apply_expression_upload(character_id, state, result.content, result.content_type)` (the single call that does write+bump+notify+re-render, `:4663`);
+  - avatar → explicit `len(result.content) > PERSONAS_AVATAR_MAX_BYTES` pre-check (the 5 MB rule; the path-based validator is unreachable for in-memory bytes — verified) → `editor.set_avatar_image(result.content)` + avatar thumb refresh (`_render_character_editor_avatar` worker).
+- **Prompt composition:** new pure module `tldw_chatbook/Character_Chat/expression_generation.py`: per-state modifier constants (NOT in `BUILTIN_TEMPLATES` — internal fragments, not user styles) + `compose_expression_prompt(name, description, personality, state, style_template) -> (prompt, negative, params)` reusing P2b's `compose_styled_request` semantics (user text always included). Reads: `editor._area("description").text` etc. — the LIVE form values, never `_character_data` (verified stale).
+- **Engine:** `Image_Generation.worker.build_request`/`run_generation` unchanged; backend = `cfg.default_backend`; seed −1; one image per slot. Engine output stored **as-is** (768×1024-ish per template params; every existing write path stores raw bytes verbatim; both display surfaces thumbnail render-copies; engine caps — `max_pixels` 1 Mpx, `inline_max_bytes` 4 MB — already sit under the avatar's 5 MB validator).
+- **In-flight guard:** screen-level `set[(int|None, str)]` keyed (character_id-or-None-for-unsaved-avatar, slot); "Generate all" iterates the four slots through the same guard sequentially in one worker.
+- **Style picker:** `push_screen_wait(ConsoleStylePickerModal())` from the worker (the screen's dialog convention) or `push_screen(callback=...)` from sync context; restore focus to the editor after dismiss (the modal's documented caller responsibility).
+- **No DB/schema/config changes.** The v23 table + CRUD is the storage; `[image_generation]` config is reused as-is.
+
+## 3. Testing
+- Pure: `compose_expression_prompt` table (each state's modifier present; name+description included; personality only when non-empty; style template composes; **empty/whitespace description → the SCREEN refuses before composing (the user-facing path), and `compose_expression_prompt` additionally raises `ValueError` as a defensive guard — both pinned**).
+- Screen-level (personas harness style): generate-expression handler writes via `_apply_expression_upload` with generated bytes (mocked `run_generation`); saved-id gate refuses; session-token change between dispatch and completion → NO write (stale-guard pin); avatar path stages via `set_avatar_image` + oversized-bytes refusal (fake >5 MB result); in-flight guard blocks a second click; generate-all runs 4 sequential requests with per-state prompts; failure → `_notify` error + no write; `exit_on_error=False` on the new workers (grep-pin like sibling tests if precedent exists).
+- Editor-level: new buttons enable/disable with `_sync_expression_slots_enabled`; button→message posting.
+- Regression: personas screen suites green vs baseline; live smoke at the end (editor → Generate → SwarmUI conn-refused surfaces as notify, no crash; with a backend, a real image lands in the slot).
+
+## 4. Out of scope
+tldw_server-style visual packs / candidate galleries / review queues; new mood states beyond the 4-state machine; changing Console avatar display; persisting a per-character default style; batch-count >1 per slot; editing generated images. Follow-ups continue in tasks 497/498/558/559.

--- a/Tests/Character_Chat/test_expression_generation.py
+++ b/Tests/Character_Chat/test_expression_generation.py
@@ -1,0 +1,70 @@
+"""Tests for expression generation prompt composition."""
+
+import pytest
+
+from tldw_chatbook.Character_Chat.expression_generation import (
+    EXPRESSION_PROMPT_STATES,
+    STATE_MODIFIERS,
+    compose_expression_prompt,
+)
+
+
+@pytest.mark.parametrize("state", EXPRESSION_PROMPT_STATES)
+def test_each_state_modifier_lands_in_prompt(state):
+    prompt, negative, params = compose_expression_prompt(
+        name="Sayori",
+        description="short coral pink hair, red bow",
+        state=state,
+    )
+    assert STATE_MODIFIERS[state] in prompt
+    assert "Sayori" in prompt and "coral pink hair" in prompt
+    assert negative == "" and params == {}
+
+
+def test_personality_included_only_when_nonempty():
+    with_p, _, _ = compose_expression_prompt(
+        name="A",
+        description="desc",
+        personality="cheerful",
+        state="avatar",
+    )
+    without_p, _, _ = compose_expression_prompt(
+        name="A",
+        description="desc",
+        personality="   ",
+        state="avatar",
+    )
+    assert "cheerful" in with_p and "cheerful" not in without_p
+
+
+def test_blank_name_omitted():
+    prompt, _, _ = compose_expression_prompt(
+        name="  ", description="desc", state="avatar"
+    )
+    assert not prompt.startswith(",") and "desc" in prompt
+
+
+def test_empty_description_raises():
+    with pytest.raises(ValueError):
+        compose_expression_prompt(name="A", description="   ", state="avatar")
+
+
+def test_unknown_state_raises():
+    with pytest.raises(ValueError):
+        compose_expression_prompt(name="A", description="desc", state="angry")
+
+
+def test_style_template_composes_and_keeps_user_text():
+    from tldw_chatbook.Media_Creation.generation_templates import get_template
+
+    template = get_template("style_anime")
+    prompt, negative, params = compose_expression_prompt(
+        name="Sayori",
+        description="coral pink hair",
+        state="thinking",
+        style_template=template,
+    )
+    assert "coral pink hair" in prompt  # user text survives (P2b invariant)
+    assert STATE_MODIFIERS["thinking"] in prompt
+    assert negative == template.negative_prompt
+    assert params == template.default_params

--- a/Tests/UI/test_personas_expression_generate.py
+++ b/Tests/UI/test_personas_expression_generate.py
@@ -1,0 +1,190 @@
+"""Image-gen P3 Task 2: generate buttons + messages on the avatar row and
+per-state expression slots in the character editor.
+
+Widget-level coverage only, mirroring ``test_personas_character_editor_avatar.py``'s
+bare-``PersonasCharacterEditorWidget`` host harness (a small ``App`` subclass
+with ``on_<message>`` handlers that record posted messages) and
+``test_personas_expression_slots.py``'s ``_UnsavedEditorHost``/
+``test_import_export_buttons_disabled_for_unsaved_character`` gating pattern.
+No DB/screen wiring is needed: these buttons only post messages and
+participate in ``_sync_expression_slots_enabled``, both of which are
+observable straight off the bare widget.
+"""
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button
+
+from tldw_chatbook.Widgets.Persona_Widgets.personas_character_editor_widget import (
+    PersonasCharacterEditorWidget,
+)
+from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
+    CharacterAvatarGenerateRequested,
+    CharacterExpressionGenerateAllRequested,
+    CharacterExpressionGenerateRequested,
+)
+
+pytestmark = pytest.mark.asyncio
+
+EXPRESSION_STATES = ("thinking", "speaking", "error")
+
+
+class _CaptureApp(App):
+    """Bare editor host that records the three new generate messages."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.avatar_generate: list[CharacterAvatarGenerateRequested] = []
+        self.expr_generate: list[CharacterExpressionGenerateRequested] = []
+        self.expr_generate_all: list[CharacterExpressionGenerateAllRequested] = []
+
+    def compose(self) -> ComposeResult:
+        yield PersonasCharacterEditorWidget()
+
+    def on_character_avatar_generate_requested(
+        self, message: CharacterAvatarGenerateRequested
+    ) -> None:
+        self.avatar_generate.append(message)
+
+    def on_character_expression_generate_requested(
+        self, message: CharacterExpressionGenerateRequested
+    ) -> None:
+        self.expr_generate.append(message)
+
+    def on_character_expression_generate_all_requested(
+        self, message: CharacterExpressionGenerateAllRequested
+    ) -> None:
+        self.expr_generate_all.append(message)
+
+
+# ===== Buttons exist =====
+
+
+async def test_generate_buttons_present_in_compose():
+    app = _CaptureApp()
+    async with app.run_test():
+        editor = app.query_one(PersonasCharacterEditorWidget)
+        assert editor.query_one("#personas-char-editor-avatar-generate", Button) is not None
+        assert (
+            editor.query_one("#personas-char-editor-expr-generate-all", Button) is not None
+        )
+        for state in EXPRESSION_STATES:
+            assert (
+                editor.query_one(f"#personas-char-editor-expr-{state}-generate", Button)
+                is not None
+            )
+
+
+# ===== Mandatory assertion (a): pressing each generate button posts the
+# right message type (+ state for the per-state one). =====
+
+
+async def test_avatar_generate_button_posts_avatar_generate_requested():
+    app = _CaptureApp()
+    async with app.run_test() as pilot:
+        app.query_one("#personas-char-editor-avatar-generate", Button).press()
+        await pilot.pause()
+        assert len(app.avatar_generate) == 1
+        assert isinstance(app.avatar_generate[0], CharacterAvatarGenerateRequested)
+
+
+async def test_expression_generate_button_posts_message_with_correct_state():
+    app = _CaptureApp()
+    async with app.run_test() as pilot:
+        editor = app.query_one(PersonasCharacterEditorWidget)
+        # A saved character (has "id") is required for the per-state slot
+        # buttons to be enabled/pressable - see the gating tests below.
+        editor.load_character({"id": 1, "name": "A"})
+        await pilot.pause()
+        for state in EXPRESSION_STATES:
+            app.expr_generate.clear()
+            app.query_one(f"#personas-char-editor-expr-{state}-generate", Button).press()
+            await pilot.pause()
+            assert len(app.expr_generate) == 1
+            assert app.expr_generate[0].state == state
+
+
+async def test_generate_all_button_posts_generate_all_requested():
+    app = _CaptureApp()
+    async with app.run_test() as pilot:
+        editor = app.query_one(PersonasCharacterEditorWidget)
+        editor.load_character({"id": 1, "name": "A"})
+        await pilot.pause()
+        app.query_one("#personas-char-editor-expr-generate-all", Button).press()
+        await pilot.pause()
+        assert len(app.expr_generate_all) == 1
+        assert isinstance(app.expr_generate_all[0], CharacterExpressionGenerateAllRequested)
+
+
+# ===== Mandatory assertion (b): per-state generate + generate-all are
+# disabled before the character is saved, enabled after - driving
+# _sync_expression_slots_enabled the same way test_personas_expression_slots.py's
+# import/export gating tests do. =====
+
+
+async def test_expression_generate_buttons_disabled_for_unsaved_character():
+    app = _CaptureApp()
+    async with app.run_test() as pilot:
+        editor = app.query_one(PersonasCharacterEditorWidget)
+        editor.load_character({"name": "A"})  # no "id" key -> unsaved
+        await pilot.pause()
+        assert editor.expression_character_id() is None
+        for state in EXPRESSION_STATES:
+            assert (
+                editor.query_one(
+                    f"#personas-char-editor-expr-{state}-generate", Button
+                ).disabled
+                is True
+            )
+        assert (
+            editor.query_one(
+                "#personas-char-editor-expr-generate-all", Button
+            ).disabled
+            is True
+        )
+
+
+async def test_expression_generate_buttons_enabled_after_save():
+    app = _CaptureApp()
+    async with app.run_test() as pilot:
+        editor = app.query_one(PersonasCharacterEditorWidget)
+        editor.load_character({"name": "A"})
+        await pilot.pause()
+        # mark_saved is the save-in-place path (see its docstring): it
+        # re-baselines the record with a freshly-assigned id and re-runs
+        # _sync_expression_slots_enabled, the exact moment the slots flip
+        # from disabled to enabled for a create session's first Save.
+        editor.mark_saved({"id": 42, "name": "A", "version": 2})
+        await pilot.pause()
+        assert editor.expression_character_id() == 42
+        for state in EXPRESSION_STATES:
+            assert (
+                editor.query_one(
+                    f"#personas-char-editor-expr-{state}-generate", Button
+                ).disabled
+                is False
+            )
+        assert (
+            editor.query_one(
+                "#personas-char-editor-expr-generate-all", Button
+            ).disabled
+            is False
+        )
+
+
+# ===== Mandatory assertion (c): avatar-generate stays enabled pre-save
+# (staged path - same as avatar Upload/Remove, which never gate on
+# expression_character_id()). =====
+
+
+async def test_avatar_generate_button_enabled_for_unsaved_character():
+    app = _CaptureApp()
+    async with app.run_test() as pilot:
+        editor = app.query_one(PersonasCharacterEditorWidget)
+        editor.load_character({"name": "A"})  # no "id" key -> unsaved
+        await pilot.pause()
+        assert editor.expression_character_id() is None
+        assert (
+            editor.query_one("#personas-char-editor-avatar-generate", Button).disabled
+            is False
+        )

--- a/Tests/UI/test_personas_expression_generate.py
+++ b/Tests/UI/test_personas_expression_generate.py
@@ -119,9 +119,15 @@ async def test_expressions_header_does_not_push_siblings_off_row():
     all, and Import/Export set controls - would otherwise claim the entire
     row and render every sibling past the row's right edge. The row is a
     plain ``Horizontal`` (no wrap, no horizontal scrollbar), so those five
-    controls would be permanently unreachable by mouse click. Live tmux
-    verification caught this; this pins the fix (an explicit ``width: auto``
-    on the header) at the compose level."""
+    controls would be unreachable by mouse click. Live tmux verification
+    caught this; this pins the fix (an explicit ``width: auto`` on the
+    header) at the compose level.
+
+    Scope: this only proves the fix at the 200-column viewport tested here -
+    the 1fr-header defect is fixed and the five controls are reachable at
+    that width. It does NOT prove reachability at narrower terminal widths;
+    full narrow-terminal reachability of this row is a separate, already-
+    known issue, independent of the 1fr-header defect fixed here."""
     app = _CaptureApp()
     async with app.run_test(size=(200, 50)):
         editor = app.query_one(PersonasCharacterEditorWidget)
@@ -347,6 +353,46 @@ async def test_generate_worker_stale_token_skips_write(
     await screen._generate_expression_image_worker(char_id, "speaking")
 
     apply_mock.assert_not_awaited()
+
+
+async def test_generate_worker_no_open_editor_session_skips_write(
+    personas_editor_with_saved_character, monkeypatch
+):
+    """Final review F2 (confirmed): the editor is cancelled after the
+    handler dispatched this worker but before the worker's own session
+    token is captured (the token is read fresh inside ``_generate_one_
+    slot``, not passed in by the caller) - e.g. the user hits Cancel in the
+    moment between a generate-button click and the worker actually
+    starting. Without the fix, the freshly-captured token is ``None``
+    (no editor open) and the post-generation re-check compares
+    ``None != None``, which is ``False`` - so the stale-write guard
+    silently passes and the result gets written with no editor open at
+    all. The fix refuses outright when the freshly-captured token is
+    ``None``."""
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    _set_description(screen, "A cheerful adventurer.")
+
+    monkeypatch.setattr(
+        personas_screen_module,
+        "run_generation",
+        lambda request: SimpleNamespace(
+            content=b"png-bytes", content_type="image/png"
+        ),
+    )
+    apply_mock = AsyncMock()
+    monkeypatch.setattr(screen, "_apply_expression_upload", apply_mock)
+
+    # The user cancels the editor after the handler dispatched the worker
+    # but before the worker itself captures a session token.
+    screen._finish_cancel_edit()
+    assert screen._character_editor_session_token() is None
+
+    screen._expression_generate_inflight.add((char_id, "thinking"))
+    await screen._generate_expression_image_worker(char_id, "thinking")
+
+    apply_mock.assert_not_awaited()
+    assert (char_id, "thinking") not in screen._expression_generate_inflight
 
 
 async def test_generate_worker_failure_notifies_and_clears_inflight(
@@ -728,6 +774,76 @@ async def test_generate_all_worker_skips_a_slot_already_in_flight(
     applied_states = {call.args[1] for call in apply_mock.await_args_list}
     assert applied_states == {"speaking", "error"}  # thinking was skipped
     assert notifications[-1] == ("3/4 generated.", "information")
+
+
+async def test_generate_all_worker_stops_sweep_when_character_switches_mid_generation(
+    personas_editor_with_saved_character, monkeypatch
+):
+    """Final review F1 (confirmed, High): the user cancels the editor mid-
+    sweep and opens a DIFFERENT character (B) in the same editor widget
+    while slot 1 (avatar) is still generating. Slot 1 itself is caught by
+    its own pre-existing per-call stale-token guard in ``_generate_one_
+    slot`` (the switch happens mid-call, before ``run_generation``
+    returns). But WITHOUT this fix, slots 2-4 each capture a brand-new
+    session token at the START of their own ``_generate_one_slot`` call -
+    by then already matching character B's now-current session, since no
+    further switch happens during THEIR calls - so they'd sail past their
+    own stale-write guard and write real bytes into character A's DB rows,
+    composed from B's live (unsaved) text. The fix re-verifies session
+    identity against the character id THIS sweep was launched for at the
+    top of every loop iteration and stops the sweep the moment they
+    diverge, so the sweep must not even attempt slots 2-4."""
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    editor = _set_description(screen, "CHARACTER A: a cheerful adventurer.")
+    other_id = db.add_character_card({"name": "Grim"})
+
+    prompts = []
+
+    def _run_generation(request):
+        prompts.append(request.prompt)
+        if len(prompts) == 1:
+            # The user cancels the editor after slot 1 (avatar) dispatched
+            # its generation call, but before that call returns, then
+            # opens a DIFFERENT character (B) in the same editor widget -
+            # mirroring what _handle_edit_requested does for a fresh
+            # EditCharacterRequested.
+            screen._finish_cancel_edit()
+            screen._character_editor_generation += 1
+            screen._edit_mode = "edit"
+            screen.state.select_entity(
+                entity_kind="character",
+                entity_id=str(other_id),
+                entity_name="Grim",
+            )
+            screen._show_center("#ccp-character-editor-view")
+            editor.load_character(
+                {
+                    "id": other_id,
+                    "name": "Grim",
+                    "description": "CHARACTER B: a grim necromancer.",
+                    "version": 1,
+                }
+            )
+        return SimpleNamespace(content=b"png-bytes", content_type="image/png")
+
+    monkeypatch.setattr(personas_screen_module, "run_generation", _run_generation)
+    apply_mock = AsyncMock()
+    monkeypatch.setattr(screen, "_apply_expression_upload", apply_mock)
+    _capture_avatar_render_worker(screen)
+    notifications = _capture_notifications(app)
+    screen._expression_generate_inflight.add((char_id, "all"))
+
+    await screen._generate_all_expression_images_worker(char_id)
+
+    apply_mock.assert_not_awaited()  # zero writes, into A or B, after the switch
+    assert len(prompts) == 1  # only the avatar attempt; nothing dispatched after
+    assert (char_id, "all") not in screen._expression_generate_inflight
+    for state in ("avatar", "thinking", "speaking", "error"):
+        assert (char_id, state) not in screen._expression_generate_inflight
+    # The summary reflects only genuinely-completed slots (zero here - the
+    # switch lands before slot 1 even finishes).
+    assert notifications[-1] == ("0/4 generated.", "information")
 
 
 # ----- Handler: Generate-all gates (saved character required) --------------

--- a/Tests/UI/test_personas_expression_generate.py
+++ b/Tests/UI/test_personas_expression_generate.py
@@ -1,8 +1,9 @@
 # ruff: noqa: F811
-"""Image-gen P3 Tasks 2-3: generate buttons + messages on the avatar row and
-per-state expression slots in the character editor (Task 2), plus the
+"""Image-gen P3 Tasks 2-4: generate buttons + messages on the avatar row and
+per-state expression slots in the character editor (Task 2), the
 screen-level generate handler + worker that turns those messages into an
-actual image-gen call (Task 3).
+actual image-gen call (Task 3), and avatar generation / Generate-all /
+the style picker (Task 4).
 
 Widget-level coverage (Task 2) mirrors ``test_personas_character_editor_avatar.py``'s
 bare-``PersonasCharacterEditorWidget`` host harness (a small ``App`` subclass
@@ -13,12 +14,20 @@ No DB/screen wiring is needed there: those buttons only post messages and
 participate in ``_sync_expression_slots_enabled``, both of which are
 observable straight off the bare widget.
 
-Screen-level coverage (Task 3) reuses ``test_personas_expression_slots.py``'s
+Screen-level coverage (Tasks 3-4) reuses ``test_personas_expression_slots.py``'s
 ``personas_editor_with_saved_character`` fixture (imported directly rather
 than duplicated - the ``# ruff: noqa: F811`` above is the repo's established
 idiom for this, e.g. ``Tests/Character_Chat/test_character_persona_scope_
 service.py``, since pyflakes otherwise flags every test that takes the
 imported fixture name as a parameter as "redefining" the import).
+
+Task 4's worker-level tests exercise ``_generate_expression_image_worker``
+(single-slot, including the avatar) and ``_generate_all_expression_images_
+worker`` directly - the same "call the async method, don't round-trip
+through run_worker" pattern Task 3's own tests use - to prove the Task 4
+refactor (``_generate_one_slot`` factored out of the original Task 3 worker
+body) is behavior-preserving: this file's own 14 Task 3 tests are left
+completely unchanged and must stay green.
 """
 
 from types import SimpleNamespace
@@ -26,8 +35,9 @@ from unittest.mock import AsyncMock
 
 import pytest
 from textual.app import App, ComposeResult
-from textual.widgets import Button
+from textual.widgets import Button, Static
 
+from tldw_chatbook.Media_Creation.generation_templates import get_template
 from tldw_chatbook.UI.Screens import personas_screen as personas_screen_module
 from tldw_chatbook.Widgets.Persona_Widgets.personas_character_editor_widget import (
     PersonasCharacterEditorWidget,
@@ -36,6 +46,7 @@ from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
     CharacterAvatarGenerateRequested,
     CharacterExpressionGenerateAllRequested,
     CharacterExpressionGenerateRequested,
+    CharacterExpressionStylePickRequested,
 )
 
 from Tests.UI.test_personas_expression_slots import (
@@ -49,13 +60,15 @@ EXPRESSION_STATES = ("thinking", "speaking", "error")
 
 
 class _CaptureApp(App):
-    """Bare editor host that records the three new generate messages."""
+    """Bare editor host that records the three new generate messages, plus
+    (Task 4) the style-pick message."""
 
     def __init__(self) -> None:
         super().__init__()
         self.avatar_generate: list[CharacterAvatarGenerateRequested] = []
         self.expr_generate: list[CharacterExpressionGenerateRequested] = []
         self.expr_generate_all: list[CharacterExpressionGenerateAllRequested] = []
+        self.style_pick: list[CharacterExpressionStylePickRequested] = []
 
     def compose(self) -> ComposeResult:
         yield PersonasCharacterEditorWidget()
@@ -74,6 +87,11 @@ class _CaptureApp(App):
         self, message: CharacterExpressionGenerateAllRequested
     ) -> None:
         self.expr_generate_all.append(message)
+
+    def on_character_expression_style_pick_requested(
+        self, message: CharacterExpressionStylePickRequested
+    ) -> None:
+        self.style_pick.append(message)
 
 
 # ===== Buttons exist =====
@@ -437,3 +455,457 @@ async def test_generate_requested_backend_not_configured_notifies(
         == "Image backend 'stable_diffusion_cpp' is not enabled/configured. "
         "Check [image_generation] settings."
     )
+
+
+# ===== Image-gen P3 Task 4: avatar generate, Generate-all, style picker =====
+#
+# The refactor's own proof is above: this file's 14 original Task 3 tests
+# (unchanged) stay green against ``_generate_one_slot`` factored out of the
+# original ``_generate_expression_image_worker`` body. Everything below is
+# new Task 4 coverage.
+
+
+def _capture_avatar_render_worker(screen) -> list:
+    """Patch ``screen.run_worker`` to record + swallow the avatar-render-kick
+    coroutine ``_generate_one_slot``'s avatar branch dispatches, mirroring
+    this file's existing ``coro.close()`` idiom for an un-awaited worker
+    coroutine in a monkeypatched ``run_worker``."""
+    calls: list = []
+
+    def _fake_run_worker(coro, *args, **kwargs):
+        calls.append(kwargs.get("group"))
+        coro.close()
+
+    screen.run_worker = _fake_run_worker
+    return calls
+
+
+# ----- Mandatory (a): avatar happy path stages via set_avatar_image --------
+
+
+async def test_avatar_generate_worker_happy_path_stages_via_set_avatar_image(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    editor = _set_description(screen, "A cheerful adventurer.")
+
+    fake_result = SimpleNamespace(content=b"avatar-bytes", content_type="image/png")
+    monkeypatch.setattr(
+        personas_screen_module, "run_generation", lambda request: fake_result
+    )
+    apply_mock = AsyncMock()
+    monkeypatch.setattr(screen, "_apply_expression_upload", apply_mock)
+    render_calls = _capture_avatar_render_worker(screen)
+    notifications = _capture_notifications(app)
+    screen._expression_generate_inflight.add((char_id, "avatar"))
+
+    await screen._generate_expression_image_worker(char_id, "avatar")
+
+    assert editor.current_avatar_bytes() == b"avatar-bytes"
+    apply_mock.assert_not_awaited()  # NOT the expression-slot DB seam
+    assert render_calls == ["personas-avatar-render"]
+    assert (char_id, "avatar") not in screen._expression_generate_inflight
+    assert notifications
+    assert notifications[-1] == (
+        "Avatar image generated — Save to keep it.",
+        "information",
+    )
+
+
+async def test_avatar_generate_worker_stages_for_unsaved_character(
+    personas_editor_with_saved_character, monkeypatch
+):
+    """Avatar generation is allowed pre-save - the in-flight key's
+    character_id may be ``None`` (Task 4's gate widening)."""
+    app, screen, db, char_id = personas_editor_with_saved_character
+    editor = screen.query_one(PersonasCharacterEditorWidget)
+    editor.new_character()  # clears to an unsaved (id-less) session
+    _configure_backend(monkeypatch)
+    editor._area("description").text = "A cheerful adventurer."
+
+    fake_result = SimpleNamespace(content=b"avatar-bytes", content_type="image/png")
+    monkeypatch.setattr(
+        personas_screen_module, "run_generation", lambda request: fake_result
+    )
+    _capture_avatar_render_worker(screen)
+    screen._expression_generate_inflight.add((None, "avatar"))
+
+    await screen._generate_expression_image_worker(None, "avatar")
+
+    assert editor.current_avatar_bytes() == b"avatar-bytes"
+    assert (None, "avatar") not in screen._expression_generate_inflight
+
+
+# ----- Mandatory (b): oversized avatar result -------------------------------
+
+
+async def test_avatar_generate_worker_oversized_result_notifies_no_staging(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    editor = _set_description(screen, "A cheerful adventurer.")
+
+    oversized = b"x" * (personas_screen_module.PERSONAS_AVATAR_MAX_BYTES + 1)
+    fake_result = SimpleNamespace(content=oversized, content_type="image/png")
+    monkeypatch.setattr(
+        personas_screen_module, "run_generation", lambda request: fake_result
+    )
+    render_calls = _capture_avatar_render_worker(screen)
+    notifications = _capture_notifications(app)
+    screen._expression_generate_inflight.add((char_id, "avatar"))
+
+    await screen._generate_expression_image_worker(char_id, "avatar")
+
+    assert editor.current_avatar_bytes() is None  # not staged
+    assert render_calls == []  # no render kick for a rejected result
+    assert (char_id, "avatar") not in screen._expression_generate_inflight
+    assert notifications
+    assert notifications[-1][1] == "error"
+    assert "5 MB" in notifications[-1][0]
+
+
+# ----- Handler: avatar generate gates (no saved-character gate) ------------
+
+
+async def test_avatar_generate_requested_unsaved_character_dispatches_worker(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    editor = screen.query_one(PersonasCharacterEditorWidget)
+    editor.new_character()
+    editor._area("description").text = "A cheerful adventurer."
+    _configure_backend(monkeypatch)
+
+    calls: list = []
+
+    def _fake_run_worker(coro, *a, **k):
+        calls.append(1)
+        coro.close()
+
+    monkeypatch.setattr(screen, "run_worker", _fake_run_worker)
+    notifications = _capture_notifications(app)
+
+    screen._handle_character_avatar_generate_requested(CharacterAvatarGenerateRequested())
+
+    # No "save the character first" refusal - unlike the per-state handler.
+    assert calls == [1]
+    assert (None, "avatar") in screen._expression_generate_inflight
+    assert not notifications
+
+
+async def test_avatar_generate_requested_empty_description_notifies_no_worker(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _set_description(screen, "   ")
+
+    calls: list = []
+    monkeypatch.setattr(screen, "run_worker", lambda *a, **k: calls.append(1))
+    notifications = _capture_notifications(app)
+
+    screen._handle_character_avatar_generate_requested(CharacterAvatarGenerateRequested())
+
+    assert calls == []
+    assert notifications
+    assert notifications[-1] == ("Add a description first.", "warning")
+
+
+async def test_avatar_generate_requested_inflight_second_click_single_generation(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    _set_description(screen, "A cheerful adventurer.")
+
+    calls: list = []
+
+    def _fake_run_worker(coro, *a, **k):
+        calls.append(1)
+        coro.close()
+
+    monkeypatch.setattr(screen, "run_worker", _fake_run_worker)
+    notifications = _capture_notifications(app)
+
+    screen._handle_character_avatar_generate_requested(CharacterAvatarGenerateRequested())
+    screen._handle_character_avatar_generate_requested(CharacterAvatarGenerateRequested())
+
+    assert calls == [1]
+    assert (char_id, "avatar") in screen._expression_generate_inflight
+    assert notifications
+    assert notifications[-1][1] == "warning"
+    assert "already generating" in notifications[-1][0].lower()
+
+
+# ----- Mandatory (c): Generate-all, one failing state -----------------------
+
+
+async def test_generate_all_worker_one_failing_state_reports_partial_summary(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    editor = _set_description(screen, "A cheerful adventurer.")
+
+    def _run_generation(request):
+        if "mid-speech" in request.prompt:  # the "speaking" state modifier
+            raise RuntimeError("backend exploded")
+        return SimpleNamespace(content=b"png-bytes", content_type="image/png")
+
+    monkeypatch.setattr(personas_screen_module, "run_generation", _run_generation)
+    apply_mock = AsyncMock()
+    monkeypatch.setattr(screen, "_apply_expression_upload", apply_mock)
+    _capture_avatar_render_worker(screen)
+    notifications = _capture_notifications(app)
+    screen._expression_generate_inflight.add((char_id, "all"))
+
+    await screen._generate_all_expression_images_worker(char_id)
+
+    # avatar + thinking + error succeed (3 writes); speaking fails.
+    assert editor.current_avatar_bytes() == b"png-bytes"
+    assert apply_mock.await_count == 2
+    applied_states = {call.args[1] for call in apply_mock.await_args_list}
+    assert applied_states == {"thinking", "error"}
+    assert (char_id, "all") not in screen._expression_generate_inflight
+    for state in ("avatar", "thinking", "speaking", "error"):
+        assert (char_id, state) not in screen._expression_generate_inflight
+    assert notifications
+    assert notifications[-1] == ("3/4 generated.", "information")
+
+
+async def test_generate_all_worker_skips_a_slot_already_in_flight(
+    personas_editor_with_saved_character, monkeypatch
+):
+    """A slot claimed by an independent single-slot generate click (started
+    just before Generate-all) is skipped, not raced."""
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    _set_description(screen, "A cheerful adventurer.")
+
+    fake_result = SimpleNamespace(content=b"png-bytes", content_type="image/png")
+    monkeypatch.setattr(
+        personas_screen_module, "run_generation", lambda request: fake_result
+    )
+    apply_mock = AsyncMock()
+    monkeypatch.setattr(screen, "_apply_expression_upload", apply_mock)
+    _capture_avatar_render_worker(screen)
+    notifications = _capture_notifications(app)
+    screen._expression_generate_inflight.add((char_id, "thinking"))  # already busy
+
+    await screen._generate_all_expression_images_worker(char_id)
+
+    applied_states = {call.args[1] for call in apply_mock.await_args_list}
+    assert applied_states == {"speaking", "error"}  # thinking was skipped
+    assert notifications[-1] == ("3/4 generated.", "information")
+
+
+# ----- Handler: Generate-all gates (saved character required) --------------
+
+
+async def test_generate_all_requested_unsaved_character_notifies_save_first(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    editor = screen.query_one(PersonasCharacterEditorWidget)
+    editor.new_character()
+
+    calls: list = []
+    monkeypatch.setattr(screen, "run_worker", lambda *a, **k: calls.append(1))
+    notifications = _capture_notifications(app)
+
+    screen._handle_character_expression_generate_all_requested(
+        CharacterExpressionGenerateAllRequested()
+    )
+
+    assert calls == []
+    assert notifications
+    assert notifications[-1] == ("Save the character to add expressions.", "warning")
+
+
+async def test_generate_all_requested_saved_character_dispatches_worker(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    _set_description(screen, "A cheerful adventurer.")
+
+    calls: list = []
+
+    def _fake_run_worker(coro, *a, **k):
+        calls.append(1)
+        coro.close()
+
+    monkeypatch.setattr(screen, "run_worker", _fake_run_worker)
+
+    screen._handle_character_expression_generate_all_requested(
+        CharacterExpressionGenerateAllRequested()
+    )
+
+    assert calls == [1]
+    assert (char_id, "all") in screen._expression_generate_inflight
+
+
+async def test_generate_all_requested_inflight_second_click_blocked(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    _set_description(screen, "A cheerful adventurer.")
+
+    calls: list = []
+
+    def _fake_run_worker(coro, *a, **k):
+        calls.append(1)
+        coro.close()
+
+    monkeypatch.setattr(screen, "run_worker", _fake_run_worker)
+    notifications = _capture_notifications(app)
+
+    screen._handle_character_expression_generate_all_requested(
+        CharacterExpressionGenerateAllRequested()
+    )
+    screen._handle_character_expression_generate_all_requested(
+        CharacterExpressionGenerateAllRequested()
+    )
+
+    assert calls == [1]
+    assert notifications
+    assert notifications[-1][1] == "warning"
+    assert "already generating" in notifications[-1][0].lower()
+
+
+# ----- Mandatory (d) + (e): style picker ------------------------------------
+
+
+async def test_style_pick_worker_stores_template_and_updates_readout(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    editor = screen.query_one(PersonasCharacterEditorWidget)
+
+    async def _fake_push_screen_wait(modal):
+        return {"id": "portrait_realistic", "name": "Realistic Portrait"}
+
+    monkeypatch.setattr(app, "push_screen_wait", _fake_push_screen_wait)
+
+    await screen._expression_style_pick_dialog_worker()
+
+    assert screen._expression_generate_style is not None
+    assert screen._expression_generate_style.id == "portrait_realistic"
+    readout = editor.query_one("#personas-char-editor-style-readout", Static)
+    assert str(readout.renderable) == "Style: Realistic Portrait"
+    assert screen._io_dialog_active is False
+
+
+async def test_style_pick_worker_cancel_keeps_previous_style_and_readout(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    editor = screen.query_one(PersonasCharacterEditorWidget)
+    previous = get_template("portrait_realistic")
+    screen._expression_generate_style = previous
+    screen._update_expression_style_readout()
+
+    async def _fake_push_screen_wait(modal):
+        return None  # Escape/Cancel
+
+    monkeypatch.setattr(app, "push_screen_wait", _fake_push_screen_wait)
+
+    await screen._expression_style_pick_dialog_worker()
+
+    assert screen._expression_generate_style is previous  # unchanged
+    readout = editor.query_one("#personas-char-editor-style-readout", Static)
+    assert str(readout.renderable) == "Style: Realistic Portrait"
+
+
+async def test_style_pick_requested_dispatches_dialog_worker(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    calls: list = []
+
+    def _fake_run_worker(coro, *a, **k):
+        calls.append(1)
+        coro.close()
+
+    monkeypatch.setattr(screen, "run_worker", _fake_run_worker)
+    assert screen._io_dialog_active is False
+
+    screen._handle_expression_style_pick_requested(
+        CharacterExpressionStylePickRequested()
+    )
+
+    assert calls == [1]
+    assert screen._io_dialog_active is True
+
+
+async def test_style_pick_requested_blocked_while_io_dialog_active(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    calls: list = []
+    monkeypatch.setattr(screen, "run_worker", lambda *a, **k: calls.append(1))
+    screen._io_dialog_active = True
+
+    screen._handle_expression_style_pick_requested(
+        CharacterExpressionStylePickRequested()
+    )
+
+    assert calls == []
+
+
+async def test_style_pick_affects_subsequent_generation_build_request_kwargs(
+    personas_editor_with_saved_character, monkeypatch
+):
+    """Mandatory (d): the picked style's params flow into the next
+    generation's ``build_request`` call."""
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    _set_description(screen, "A cheerful adventurer.")
+    template = get_template("portrait_realistic")
+    screen._expression_generate_style = template
+
+    captured_kwargs: dict = {}
+
+    def _fake_build_request(**kwargs):
+        captured_kwargs.update(kwargs)
+        return SimpleNamespace(backend=kwargs.get("backend"))
+
+    monkeypatch.setattr(personas_screen_module, "build_request", _fake_build_request)
+    fake_result = SimpleNamespace(content=b"png-bytes", content_type="image/png")
+    monkeypatch.setattr(
+        personas_screen_module, "run_generation", lambda request: fake_result
+    )
+    apply_mock = AsyncMock()
+    monkeypatch.setattr(screen, "_apply_expression_upload", apply_mock)
+    screen._expression_generate_inflight.add((char_id, "thinking"))
+
+    await screen._generate_expression_image_worker(char_id, "thinking")
+
+    assert captured_kwargs["width"] == template.default_params.get("width")
+    assert captured_kwargs["height"] == template.default_params.get("height")
+    assert captured_kwargs["steps"] == template.default_params.get("steps")
+    assert captured_kwargs["cfg_scale"] == template.default_params.get("cfg_scale")
+    apply_mock.assert_awaited_once_with(char_id, "thinking", b"png-bytes", "image/png")
+
+
+# ----- Widget: style-pick button + readout present --------------------------
+
+
+async def test_style_pick_button_and_readout_present_in_compose():
+    app = _CaptureApp()
+    async with app.run_test():
+        editor = app.query_one(PersonasCharacterEditorWidget)
+        assert editor.query_one("#personas-char-editor-style-pick", Button) is not None
+        readout = editor.query_one("#personas-char-editor-style-readout", Static)
+        assert str(readout.renderable) == "Style: Custom"
+
+
+async def test_style_pick_button_posts_style_pick_requested():
+    app = _CaptureApp()
+    async with app.run_test() as pilot:
+        app.query_one("#personas-char-editor-style-pick", Button).press()
+        await pilot.pause()
+        assert len(app.style_pick) == 1
+        assert isinstance(app.style_pick[0], CharacterExpressionStylePickRequested)

--- a/Tests/UI/test_personas_expression_generate.py
+++ b/Tests/UI/test_personas_expression_generate.py
@@ -112,6 +112,36 @@ async def test_generate_buttons_present_in_compose():
             )
 
 
+async def test_expressions_header_does_not_push_siblings_off_row():
+    """Regression (P3 verification sweep): a bare ``Static`` defaults to
+    Textual's ``1fr`` width when nothing constrains it, so the "Expressions"
+    section header - sharing its row with the Style readout/pick, Generate
+    all, and Import/Export set controls - would otherwise claim the entire
+    row and render every sibling past the row's right edge. The row is a
+    plain ``Horizontal`` (no wrap, no horizontal scrollbar), so those five
+    controls would be permanently unreachable by mouse click. Live tmux
+    verification caught this; this pins the fix (an explicit ``width: auto``
+    on the header) at the compose level."""
+    app = _CaptureApp()
+    async with app.run_test(size=(200, 50)):
+        editor = app.query_one(PersonasCharacterEditorWidget)
+        row = editor.query_one(".personas-char-editor-expr-set-row")
+        row_right_edge = row.region.x + row.region.width
+        for widget_id in (
+            "personas-char-editor-style-readout",
+            "personas-char-editor-style-pick",
+            "personas-char-editor-expr-generate-all",
+            "personas-char-editor-expr-import",
+            "personas-char-editor-expr-export",
+        ):
+            node = editor.query_one(f"#{widget_id}")
+            assert node.region.x < row_right_edge, (
+                f"{widget_id} rendered at x={node.region.x}, at/past the "
+                f"row's right edge ({row_right_edge}) - unreachable by mouse "
+                "click."
+            )
+
+
 # ===== Mandatory assertion (a): pressing each generate button posts the
 # right message type (+ state for the per-state one). =====
 

--- a/Tests/UI/test_personas_expression_generate.py
+++ b/Tests/UI/test_personas_expression_generate.py
@@ -1,20 +1,34 @@
-"""Image-gen P3 Task 2: generate buttons + messages on the avatar row and
-per-state expression slots in the character editor.
+# ruff: noqa: F811
+"""Image-gen P3 Tasks 2-3: generate buttons + messages on the avatar row and
+per-state expression slots in the character editor (Task 2), plus the
+screen-level generate handler + worker that turns those messages into an
+actual image-gen call (Task 3).
 
-Widget-level coverage only, mirroring ``test_personas_character_editor_avatar.py``'s
+Widget-level coverage (Task 2) mirrors ``test_personas_character_editor_avatar.py``'s
 bare-``PersonasCharacterEditorWidget`` host harness (a small ``App`` subclass
 with ``on_<message>`` handlers that record posted messages) and
 ``test_personas_expression_slots.py``'s ``_UnsavedEditorHost``/
 ``test_import_export_buttons_disabled_for_unsaved_character`` gating pattern.
-No DB/screen wiring is needed: these buttons only post messages and
+No DB/screen wiring is needed there: those buttons only post messages and
 participate in ``_sync_expression_slots_enabled``, both of which are
 observable straight off the bare widget.
+
+Screen-level coverage (Task 3) reuses ``test_personas_expression_slots.py``'s
+``personas_editor_with_saved_character`` fixture (imported directly rather
+than duplicated - the ``# ruff: noqa: F811`` above is the repo's established
+idiom for this, e.g. ``Tests/Character_Chat/test_character_persona_scope_
+service.py``, since pyflakes otherwise flags every test that takes the
+imported fixture name as a parameter as "redefining" the import).
 """
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from textual.app import App, ComposeResult
 from textual.widgets import Button
 
+from tldw_chatbook.UI.Screens import personas_screen as personas_screen_module
 from tldw_chatbook.Widgets.Persona_Widgets.personas_character_editor_widget import (
     PersonasCharacterEditorWidget,
 )
@@ -22,6 +36,11 @@ from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
     CharacterAvatarGenerateRequested,
     CharacterExpressionGenerateAllRequested,
     CharacterExpressionGenerateRequested,
+)
+
+from Tests.UI.test_personas_expression_slots import (
+    expr_db,  # noqa: F401 -- fixture dependency, not referenced by name
+    personas_editor_with_saved_character,  # noqa: F401 -- used as a fixture
 )
 
 pytestmark = pytest.mark.asyncio
@@ -188,3 +207,233 @@ async def test_avatar_generate_button_enabled_for_unsaved_character():
             editor.query_one("#personas-char-editor-avatar-generate", Button).disabled
             is False
         )
+
+
+# ===== Image-gen P3 Task 3: screen-level handler + worker =====
+#
+# Screen-level coverage, reusing test_personas_expression_slots.py's
+# ``personas_editor_with_saved_character`` fixture (real ``CharactersRAGDB``,
+# a saved character, the editor open on a real ``PersonasScreen``) - the
+# same fixture that flow's upload tests use. The worker is exercised
+# directly (mirrors Tests/Chat/test_console_generation_actions.py's
+# ``_regenerate_console_generation_variant`` pattern: call the async method,
+# don't round-trip through run_worker/wait_for_complete); the handler's
+# gating is exercised by monkeypatching ``screen.run_worker`` to record
+# whether a worker was dispatched (mirrors this same file's
+# ``test_export_handler_blocked_while_io_dialog_active`` pattern).
+
+
+def _configure_backend(monkeypatch, name: str = "test_backend") -> None:
+    """Patch the screen module's image-gen config/listing to a configured backend."""
+    monkeypatch.setattr(
+        personas_screen_module,
+        "get_image_generation_config",
+        lambda: SimpleNamespace(default_backend=name),
+    )
+    monkeypatch.setattr(
+        personas_screen_module,
+        "list_image_models_for_catalog",
+        lambda: [{"name": name, "is_configured": True}],
+    )
+
+
+def _set_description(screen, text: str) -> PersonasCharacterEditorWidget:
+    editor = screen.query_one(PersonasCharacterEditorWidget)
+    editor._area("description").text = text
+    return editor
+
+
+def _capture_notifications(app) -> list:
+    notifications: list = []
+    app.notify = lambda message, severity="information", **kwargs: notifications.append(
+        (str(message), severity)
+    )
+    return notifications
+
+
+# ----- Worker: mandatory assertions (a), (b), (e) -----------------------
+
+
+async def test_generate_worker_happy_path_applies_result(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    _set_description(screen, "A cheerful adventurer.")
+
+    fake_result = SimpleNamespace(content=b"png-bytes", content_type="image/png")
+    monkeypatch.setattr(
+        personas_screen_module, "run_generation", lambda request: fake_result
+    )
+    apply_mock = AsyncMock()
+    monkeypatch.setattr(screen, "_apply_expression_upload", apply_mock)
+    screen._expression_generate_inflight.add((char_id, "thinking"))
+
+    await screen._generate_expression_image_worker(char_id, "thinking")
+
+    apply_mock.assert_awaited_once_with(
+        char_id, "thinking", b"png-bytes", "image/png"
+    )
+    assert (char_id, "thinking") not in screen._expression_generate_inflight
+
+
+async def test_generate_worker_stale_token_skips_write(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    _set_description(screen, "A cheerful adventurer.")
+
+    def _mutating_run_generation(request):
+        # Simulate the character editor session changing (e.g. Cancel, a
+        # new create/edit, a save-in-place) while generation was in flight.
+        screen._character_editor_generation += 1
+        return SimpleNamespace(content=b"png-bytes", content_type="image/png")
+
+    monkeypatch.setattr(
+        personas_screen_module, "run_generation", _mutating_run_generation
+    )
+    apply_mock = AsyncMock()
+    monkeypatch.setattr(screen, "_apply_expression_upload", apply_mock)
+
+    await screen._generate_expression_image_worker(char_id, "speaking")
+
+    apply_mock.assert_not_awaited()
+
+
+async def test_generate_worker_failure_notifies_and_clears_inflight(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    _set_description(screen, "A cheerful adventurer.")
+
+    def _boom(request):
+        raise RuntimeError("backend exploded")
+
+    monkeypatch.setattr(personas_screen_module, "run_generation", _boom)
+    apply_mock = AsyncMock()
+    monkeypatch.setattr(screen, "_apply_expression_upload", apply_mock)
+    notifications = _capture_notifications(app)
+    screen._expression_generate_inflight.add((char_id, "error"))
+
+    await screen._generate_expression_image_worker(char_id, "error")
+
+    apply_mock.assert_not_awaited()
+    assert (char_id, "error") not in screen._expression_generate_inflight
+    assert notifications
+    assert notifications[-1][1] == "error"
+    assert "backend exploded" in notifications[-1][0]
+
+
+# ----- Handler: mandatory assertions (c), (d), (f) -----------------------
+
+
+async def test_generate_requested_empty_description_notifies_no_worker(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    # Deliberately NOT configuring a backend here: the empty-description
+    # gate must fire before the backend-resolution gate, so this notify
+    # text (not the backend-refusal text) proves the ordering.
+    _set_description(screen, "   ")
+
+    calls: list = []
+    monkeypatch.setattr(screen, "run_worker", lambda *a, **k: calls.append(1))
+    notifications = _capture_notifications(app)
+
+    screen._handle_character_expression_generate_requested(
+        CharacterExpressionGenerateRequested("thinking")
+    )
+
+    assert calls == []
+    assert notifications
+    assert notifications[-1] == ("Add a description first.", "warning")
+
+
+async def test_generate_requested_inflight_second_click_single_generation(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    _set_description(screen, "A cheerful adventurer.")
+
+    calls: list = []
+
+    def _fake_run_worker(coro, *a, **k):
+        calls.append(1)
+        coro.close()  # avoid a "coroutine was never awaited" warning
+
+    monkeypatch.setattr(screen, "run_worker", _fake_run_worker)
+    notifications = _capture_notifications(app)
+
+    screen._handle_character_expression_generate_requested(
+        CharacterExpressionGenerateRequested("thinking")
+    )
+    screen._handle_character_expression_generate_requested(
+        CharacterExpressionGenerateRequested("thinking")
+    )
+
+    assert calls == [1]  # only the first click dispatched a worker
+    assert (char_id, "thinking") in screen._expression_generate_inflight
+    assert notifications
+    assert notifications[-1][1] == "warning"
+    assert "already generating" in notifications[-1][0].lower()
+
+
+async def test_generate_requested_unsaved_character_notifies_save_first(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    editor = screen.query_one(PersonasCharacterEditorWidget)
+    editor.new_character()  # clears to an unsaved (id-less) session
+
+    calls: list = []
+    monkeypatch.setattr(screen, "run_worker", lambda *a, **k: calls.append(1))
+    notifications = _capture_notifications(app)
+
+    screen._handle_character_expression_generate_requested(
+        CharacterExpressionGenerateRequested("thinking")
+    )
+
+    assert calls == []
+    assert notifications
+    # Same copy as the upload flow's save-first refusal.
+    assert notifications[-1] == ("Save the character to add expressions.", "warning")
+
+
+# ----- Handler: backend refusal (Console's exact copy) -------------------
+
+
+async def test_generate_requested_backend_not_configured_notifies(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    monkeypatch.setattr(
+        personas_screen_module,
+        "get_image_generation_config",
+        lambda: SimpleNamespace(default_backend="stable_diffusion_cpp"),
+    )
+    monkeypatch.setattr(
+        personas_screen_module,
+        "list_image_models_for_catalog",
+        lambda: [{"name": "stable_diffusion_cpp", "is_configured": False}],
+    )
+    _set_description(screen, "A cheerful adventurer.")
+
+    calls: list = []
+    monkeypatch.setattr(screen, "run_worker", lambda *a, **k: calls.append(1))
+    notifications = _capture_notifications(app)
+
+    screen._handle_character_expression_generate_requested(
+        CharacterExpressionGenerateRequested("thinking")
+    )
+
+    assert calls == []
+    assert notifications
+    assert notifications[-1][1] == "warning"
+    assert (
+        notifications[-1][0]
+        == "Image backend 'stable_diffusion_cpp' is not enabled/configured. "
+        "Check [image_generation] settings."
+    )

--- a/Tests/UI/test_personas_expression_generate.py
+++ b/Tests/UI/test_personas_expression_generate.py
@@ -909,3 +909,108 @@ async def test_style_pick_button_posts_style_pick_requested():
         await pilot.pause()
         assert len(app.style_pick) == 1
         assert isinstance(app.style_pick[0], CharacterExpressionStylePickRequested)
+
+
+# ===== Fix round 1: the picked style must not bleed across editor sessions =
+#
+# Verified finding: _expression_generate_style was set once (style pick) and
+# never reset, so it lived for the whole PersonasScreen instance's lifetime
+# rather than "this editor session" (the spec's own words). Opening a
+# different character (or starting a new create session, or cancelling)
+# after picking a style on character A would silently carry that style over
+# to character B. The fix resets it (+ the readout) at the same 3 sites
+# where ``_character_editor_generation`` bumps to mark a genuinely NEW/ended
+# session - NOT the other bump sites in this file (avatar Remove, expression
+# -set apply, expression upload/clear, save-in-place), which bump the same
+# counter merely to invalidate a stale in-flight render within the SAME
+# session and must leave a picked style untouched.
+
+
+async def test_style_pick_reset_on_new_create_session(
+    personas_editor_with_saved_character, monkeypatch
+):
+    """Mandatory fix-round-1 pin: pick a style, cross a real session
+    boundary (_begin_create_character - the cheapest boundary to drive
+    directly in this harness), then assert the style is cleared, the
+    readout reverts, and the NEXT generation's build_request carries no
+    template params."""
+    app, screen, db, char_id = personas_editor_with_saved_character
+    template = get_template("portrait_realistic")
+    screen._expression_generate_style = template
+    screen._update_expression_style_readout()
+    editor = screen.query_one(PersonasCharacterEditorWidget)
+    readout = editor.query_one("#personas-char-editor-style-readout", Static)
+    assert str(readout.renderable) == "Style: Realistic Portrait"  # sanity
+
+    await screen._begin_create_character()
+
+    assert screen._expression_generate_style is None
+    assert str(readout.renderable) == "Style: Custom"
+
+    # The next generation (now an unsaved/id-less avatar, post-create) must
+    # carry no template params - proves the reset actually affects
+    # composition, not just the bookkeeping fields.
+    _configure_backend(monkeypatch)
+    editor._area("description").text = "A cheerful adventurer."
+    captured_kwargs: dict = {}
+
+    def _fake_build_request(**kwargs):
+        captured_kwargs.update(kwargs)
+        return SimpleNamespace(backend=kwargs.get("backend"))
+
+    monkeypatch.setattr(personas_screen_module, "build_request", _fake_build_request)
+    fake_result = SimpleNamespace(content=b"avatar-bytes", content_type="image/png")
+    monkeypatch.setattr(
+        personas_screen_module, "run_generation", lambda request: fake_result
+    )
+    _capture_avatar_render_worker(screen)
+    screen._expression_generate_inflight.add((None, "avatar"))
+
+    await screen._generate_expression_image_worker(None, "avatar")
+
+    assert captured_kwargs["negative_prompt"] is None
+    assert captured_kwargs["width"] is None
+    assert captured_kwargs["height"] is None
+    assert captured_kwargs["steps"] is None
+    assert captured_kwargs["cfg_scale"] is None
+
+
+async def test_style_pick_reset_on_edit_requested_reopen(
+    personas_editor_with_saved_character
+):
+    """Opening a character for edit (EditCharacterRequested - the
+    "open-different-character" boundary the review flagged by name) also
+    clears a previously-picked style."""
+    from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
+        EditCharacterRequested,
+    )
+
+    app, screen, db, char_id = personas_editor_with_saved_character
+    template = get_template("portrait_realistic")
+    screen._expression_generate_style = template
+    screen._update_expression_style_readout()
+
+    screen._handle_edit_requested(EditCharacterRequested(str(char_id)))
+
+    assert screen._expression_generate_style is None
+    editor = screen.query_one(PersonasCharacterEditorWidget)
+    readout = editor.query_one("#personas-char-editor-style-readout", Static)
+    assert str(readout.renderable) == "Style: Custom"
+
+
+async def test_style_pick_reset_on_cancel_edit(
+    personas_editor_with_saved_character
+):
+    """Cancelling the editor (_finish_cancel_edit) also clears a
+    previously-picked style - the session it belonged to just ended."""
+    app, screen, db, char_id = personas_editor_with_saved_character
+    template = get_template("portrait_realistic")
+    screen._expression_generate_style = template
+    screen._update_expression_style_readout()
+
+    screen._finish_cancel_edit()
+
+    assert screen._expression_generate_style is None
+    editor = screen.query_one(PersonasCharacterEditorWidget)
+    readout = editor.query_one("#personas-char-editor-style-readout", Static)
+    assert str(readout.renderable) == "Style: Custom"

--- a/tldw_chatbook/Character_Chat/expression_generation.py
+++ b/tldw_chatbook/Character_Chat/expression_generation.py
@@ -1,0 +1,75 @@
+"""Pure prompt composition for character expression generation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+EXPRESSION_PROMPT_STATES: tuple[str, ...] = (
+    "avatar",
+    "thinking",
+    "speaking",
+    "error",
+)
+"""Available expression states for character portraits."""
+
+STATE_MODIFIERS: dict[str, str] = {
+    "avatar": "neutral friendly expression, head and shoulders portrait, looking at viewer",
+    "thinking": "pensive thoughtful expression, hand near chin, looking away",
+    "speaking": "mid-speech, animated engaged expression, mouth open",
+    "error": "confused sheepish expression, embarrassed, sweatdrop",
+}
+"""Expression modifiers keyed by state."""
+
+
+def compose_expression_prompt(
+    *,
+    name: str,
+    description: str,
+    personality: str = "",
+    state: str,
+    style_template: Any = None,
+) -> tuple[str, str, dict[str, Any]]:
+    """Compose a character expression generation prompt.
+
+    Builds a prompt from name, description, personality, and state modifier.
+    If a style template is provided, wraps the result via the template engine
+    (ensuring user text survives the composition).
+
+    Args:
+        name: Character name (omitted from prompt if blank/whitespace).
+        description: Character description (required; raises ValueError if empty).
+        personality: Character personality trait (included only if non-empty).
+        state: Expression state (must be in EXPRESSION_PROMPT_STATES).
+        style_template: Optional GenerationTemplate for styling (default None).
+
+    Returns:
+        A (prompt, negative_prompt, params) tuple. When style_template is None,
+        negative_prompt and params are empty string and empty dict.
+
+    Raises:
+        ValueError: If description is empty/whitespace or state is unknown.
+    """
+    if not description.strip():
+        raise ValueError("description must be non-empty")
+
+    if state not in EXPRESSION_PROMPT_STATES:
+        raise ValueError(f"unknown state: {state}")
+
+    # Build base text: name (if non-blank) + description + personality + state modifier
+    parts = []
+    if name.strip():
+        parts.append(name.strip())
+    parts.append(description.strip())
+    if personality.strip():
+        parts.append(personality.strip())
+    parts.append(STATE_MODIFIERS[state])
+
+    base_text = ", ".join(parts)
+
+    # Apply style template if provided
+    if style_template is not None:
+        from tldw_chatbook.Chat.console_generate_image import compose_styled_request
+
+        return compose_styled_request(base_text, style_template)
+
+    return base_text, "", {}

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -42,10 +42,12 @@ from ...DB.ChaChaNotes_DB import ConflictError
 from ...Image_Generation.config import get_image_generation_config
 from ...Image_Generation.listing import list_image_models_for_catalog
 from ...Image_Generation.worker import build_request, run_generation
+from ...Media_Creation.generation_templates import GenerationTemplate, get_template
 from ...tldw_api import UserProfileCreate, UserProfileUpdate
 from ...Utils.path_validation import validate_path_simple
 from ...Utils.paths import get_user_data_dir
 from ...Widgets.Console.console_rail_handle import ConsoleRailHandle
+from ...Widgets.Console.console_style_picker_modal import ConsoleStylePickerModal
 from ...Widgets.confirmation_dialog import ConfirmationDialog, UnsavedChangesDialog
 from ...Widgets.destination_workbench import DestinationModeStrip
 from ...Widgets.Persona_Widgets.persona_profile_card_widget import (
@@ -90,11 +92,14 @@ from ...Widgets.Persona_Widgets.personas_messages import (
 )
 from ...Widgets.Persona_Widgets.tag_filter_picker import TagFilterPicker
 from ...Widgets.Persona_Widgets.personas_pane_messages import (
+    CharacterAvatarGenerateRequested,
     CharacterEditorCancelled,
     CharacterExpressionClearRequested,
+    CharacterExpressionGenerateAllRequested,
     CharacterExpressionGenerateRequested,
     CharacterExpressionSetExportRequested,
     CharacterExpressionSetImportRequested,
+    CharacterExpressionStylePickRequested,
     CharacterExpressionUploadRequested,
     CharacterImageRemoveRequested,
     CharacterImageUploadRequested,
@@ -573,7 +578,15 @@ class PersonasScreen(BaseAppScreen):
         # Image-gen P3 Task 3: (character_id, state) pairs with an expression
         # generation worker currently in flight - refuses a re-entrant
         # generate click for the same slot rather than racing two writes.
-        self._expression_generate_inflight: set[tuple[int, str]] = set()
+        # Task 4 widens the key: the avatar state's character_id may be
+        # ``None`` (an unsaved character - avatar generation is allowed
+        # pre-save), and a Generate-all sweep additionally claims the
+        # ``"all"`` pseudo-state for its own single-flight guard.
+        self._expression_generate_inflight: set[tuple[int | None, str]] = set()
+        # Image-gen P3 Task 4: the style template picked via the "Style…"
+        # button, applied to every subsequent avatar/expression generation
+        # until changed. ``None`` means no style (plain prompt composition).
+        self._expression_generate_style: GenerationTemplate | None = None
         self._profile_save_inflight: bool = False
         # Mirrors _profile_save_inflight for the character editor: guards
         # against a re-entrant Save (double-click/Ctrl+S) while an earlier
@@ -4744,6 +4757,31 @@ class PersonasScreen(BaseAppScreen):
             group="personas-io",
         )
 
+    def _image_generation_backend_warning(self) -> str | None:
+        """Return a warning string if no usable image-gen backend is
+        configured, else ``None``.
+
+        Image-gen P3 Task 4: factored out of the single-slot generate
+        handler so the avatar and Generate-all handlers share the exact
+        same check + copy (matches the Console's own ``/generate-image``
+        refusal text) instead of three near-duplicate blocks.
+        """
+        cfg = get_image_generation_config()
+        backend = cfg.default_backend
+        if not backend:
+            return (
+                "No image generation backend configured. Set "
+                "[image_generation].default_backend."
+            )
+        catalog = list_image_models_for_catalog()
+        entry = next((item for item in catalog if item.get("name") == backend), None)
+        if entry is None or not entry.get("is_configured"):
+            return (
+                f"Image backend '{backend}' is not enabled/configured. "
+                "Check [image_generation] settings."
+            )
+        return None
+
     @on(CharacterExpressionGenerateRequested)
     def _handle_character_expression_generate_requested(
         self, message: CharacterExpressionGenerateRequested
@@ -4772,23 +4810,9 @@ class PersonasScreen(BaseAppScreen):
         if not editor._area("description").text.strip():
             self._notify("Add a description first.", "warning")
             return
-        cfg = get_image_generation_config()
-        backend = cfg.default_backend
-        if not backend:
-            self._notify(
-                "No image generation backend configured. Set "
-                "[image_generation].default_backend.",
-                "warning",
-            )
-            return
-        catalog = list_image_models_for_catalog()
-        entry = next((item for item in catalog if item.get("name") == backend), None)
-        if entry is None or not entry.get("is_configured"):
-            self._notify(
-                f"Image backend '{backend}' is not enabled/configured. "
-                "Check [image_generation] settings.",
-                "warning",
-            )
+        backend_warning = self._image_generation_backend_warning()
+        if backend_warning:
+            self._notify(backend_warning, "warning")
             return
         key = (character_id, message.state)
         if key in self._expression_generate_inflight:
@@ -4802,6 +4826,121 @@ class PersonasScreen(BaseAppScreen):
             self._generate_expression_image_worker(character_id, message.state),
             group="personas-io",
             exit_on_error=False,
+        )
+
+    @on(CharacterAvatarGenerateRequested)
+    def _handle_character_avatar_generate_requested(
+        self, message: CharacterAvatarGenerateRequested
+    ) -> None:
+        """Dispatch an AI-generation worker for the avatar image.
+
+        Image-gen P3 Task 4: mirrors ``_handle_character_expression_generate_
+        requested``'s gate sequence, but WITHOUT the saved-character gate -
+        a generated avatar stages into the editor exactly like a manually
+        uploaded one (``PersonasCharacterEditorWidget.set_avatar_image``),
+        persisting only once the character is Saved, so an unsaved
+        (id-less) session is allowed to generate one. The in-flight key
+        therefore carries ``character_id`` (``None`` when unsaved) rather
+        than requiring it non-``None``.
+        """
+        message.stop()
+        if not self._character_editor_is_active():
+            self._notify(
+                "Open a character editor before generating an avatar image.",
+                "warning",
+            )
+            return
+        editor = self.query_one(PersonasCharacterEditorWidget)
+        if not editor._area("description").text.strip():
+            self._notify("Add a description first.", "warning")
+            return
+        backend_warning = self._image_generation_backend_warning()
+        if backend_warning:
+            self._notify(backend_warning, "warning")
+            return
+        character_id = editor.expression_character_id()
+        key = (character_id, "avatar")
+        if key in self._expression_generate_inflight:
+            self._notify("Already generating the avatar image.", "warning")
+            return
+        self._expression_generate_inflight.add(key)
+        self.run_worker(
+            self._generate_expression_image_worker(character_id, "avatar"),
+            group="personas-io",
+            exit_on_error=False,
+        )
+
+    @on(CharacterExpressionGenerateAllRequested)
+    def _handle_character_expression_generate_all_requested(
+        self, message: CharacterExpressionGenerateAllRequested
+    ) -> None:
+        """Dispatch a single worker that generates avatar + all 3 expression
+        states sequentially.
+
+        Image-gen P3 Task 4: gates once, up front, exactly like the
+        single-slot handler (a saved character IS required here - unlike
+        the avatar-only handler, the sweep also covers the three DB-backed
+        expression states, which always require an id). The ``"all"``
+        pseudo-state claims its own in-flight key so a second Generate-all
+        click is refused independent of any individual slot's own key.
+        """
+        message.stop()
+        if not self._character_editor_is_active():
+            self._notify(
+                "Open a character editor before generating expression images.",
+                "warning",
+            )
+            return
+        editor = self.query_one(PersonasCharacterEditorWidget)
+        character_id = editor.expression_character_id()
+        if character_id is None:
+            self._notify("Save the character to add expressions.", "warning")
+            return
+        if not editor._area("description").text.strip():
+            self._notify("Add a description first.", "warning")
+            return
+        backend_warning = self._image_generation_backend_warning()
+        if backend_warning:
+            self._notify(backend_warning, "warning")
+            return
+        all_key = (character_id, "all")
+        if all_key in self._expression_generate_inflight:
+            self._notify("Already generating all expression images.", "warning")
+            return
+        self._expression_generate_inflight.add(all_key)
+        self.run_worker(
+            self._generate_all_expression_images_worker(character_id),
+            group="personas-io",
+            exit_on_error=False,
+        )
+
+    @on(CharacterExpressionStylePickRequested)
+    def _handle_expression_style_pick_requested(
+        self, message: CharacterExpressionStylePickRequested
+    ) -> None:
+        """Open the style picker to set the AI-generation style template.
+
+        Image-gen P3 Task 4: same io-dialog convention as
+        ``_handle_character_expression_upload_requested``
+        (``_io_dialog_active`` refuse-reentry, since this too pushes a
+        modal via ``push_screen_wait``), but distinct from the whole
+        upload/generate/import/export family - it never touches the DB or
+        an in-flight generation key, only the picked-style state consulted
+        by the next generation.
+        """
+        message.stop()
+        if not self._character_editor_is_active():
+            return
+        if self._io_dialog_active:
+            logger.debug(
+                "Import/export dialog already active; ignoring style pick "
+                "request."
+            )
+            return
+        self._io_dialog_active = True
+        self.run_worker(
+            self._expression_style_pick_dialog_worker(),
+            group="personas-io",
         )
 
     @on(CharacterExpressionClearRequested)
@@ -4892,25 +5031,54 @@ class PersonasScreen(BaseAppScreen):
         mime = mimetypes.guess_type(path)[0]
         await self._apply_expression_upload(character_id, state, image_data, mime)
 
-    async def _generate_expression_image_worker(
-        self, character_id: int, state: str
-    ) -> None:
-        """Generate one expression-state image and write it through the
-        upload seam.
+    async def _generate_one_slot(
+        self,
+        character_id: int | None,
+        state: str,
+        style_template: GenerationTemplate | None,
+    ) -> bool:
+        """Generate one avatar/expression-state image and stage/write it.
 
-        Image-gen P3 Task 3: reads live (unsaved) form values straight from
-        the editor's widgets - never ``_character_data`` - since the user
-        may be generating from text they haven't saved yet. The blocking
-        adapter call runs off-thread via ``asyncio.to_thread``; the session
-        token is captured immediately before that await and re-checked
+        Image-gen P3 Task 4: the shared core both
+        ``_generate_expression_image_worker`` (single-slot, including the
+        avatar) and ``_generate_all_expression_images_worker`` (the
+        sequential Generate-all sweep) call per state - the original Task 3
+        worker's body, factored out so both share one implementation.
+
+        Reads live (unsaved) form values straight from the editor's
+        widgets - never ``_character_data`` - since the user may be
+        generating from text they haven't saved yet. The blocking adapter
+        call runs off-thread via ``asyncio.to_thread``; the session token
+        is captured immediately before that await and re-checked
         immediately after, mirroring ``_stage_character_expression_from_
         path``'s stale-write guard so a Cancel/new-session/save-in-place
         that happens mid-generation drops the result instead of writing it
-        into the wrong (or no-longer-open) character. The whole body is
-        wrapped so a failure at any step (prompt composition, request
-        validation, adapter call, DB write) reports a single error notify
-        instead of propagating into the worker's default panic-on-
-        exception behavior.
+        into the wrong (or no-longer-open) character.
+
+        The ``"avatar"`` state stages the result into the editor (persists
+        on the next Save) exactly like a manual avatar upload - rejecting
+        an oversized result the same way ``_read_avatar_image_bytes``
+        rejects an oversized upload - then kicks the same off-thread
+        thumbnail render an upload does. The three DB-backed expression
+        states write straight through ``_apply_expression_upload`` (the
+        same seam a manual upload uses).
+
+        Never raises: every failure path (prompt composition, request
+        validation, adapter call, oversized avatar, DB write) notifies once
+        and returns ``False`` instead of propagating into the worker's
+        default panic-on-exception behavior - so a Generate-all sweep can
+        keep going through the remaining slots after one fails.
+
+        Args:
+            character_id: The character's row id, or ``None`` for the
+                avatar state on an unsaved (id-less) session.
+            state: ``"avatar"`` or one of ``EXPRESSION_IMAGE_STATES``.
+            style_template: The style template to compose the prompt with,
+                or ``None`` for a plain (unstyled) composition.
+
+        Returns:
+            ``True`` if the image was generated and applied/staged,
+            ``False`` on any failure.
         """
         key = (character_id, state)
         try:
@@ -4923,7 +5091,7 @@ class PersonasScreen(BaseAppScreen):
                 description=description,
                 personality=personality,
                 state=state,
-                style_template=getattr(self, "_expression_generate_style", None),
+                style_template=style_template,
             )
             cfg = get_image_generation_config()
             request = build_request(
@@ -4941,24 +5109,128 @@ class PersonasScreen(BaseAppScreen):
             result = await asyncio.to_thread(run_generation, request)
             if self._character_editor_session_token() != session_token:
                 logger.debug(
-                    "Expression generation result ignored because the "
-                    f"character editor session changed. character_id="
-                    f"{character_id!r}, state={state!r}, "
-                    f"original_session={session_token!r}, "
+                    "Image generation result ignored because the character "
+                    f"editor session changed. character_id={character_id!r}, "
+                    f"state={state!r}, original_session={session_token!r}, "
                     f"current_session={self._character_editor_session_token()!r}"
                 )
-                return
+                return False
+            if state == "avatar":
+                if len(result.content) > PERSONAS_AVATAR_MAX_BYTES:
+                    self._notify(
+                        "Generated avatar image must be "
+                        f"{PERSONAS_AVATAR_MAX_SIZE_COPY} or smaller.",
+                        "error",
+                    )
+                    return False
+                editor.set_avatar_image(result.content)
+                self.run_worker(
+                    self._render_character_editor_avatar(),
+                    group="personas-avatar-render",
+                    exit_on_error=False,
+                )
+                self._notify(
+                    "Avatar image generated — Save to keep it.", "information"
+                )
+                return True
             await self._apply_expression_upload(
                 character_id, state, result.content, result.content_type
             )
+            return True
         except Exception as exc:
             logger.opt(exception=True).error(
-                f"Expression image generation failed for character "
-                f"{character_id} state={state!r}: {exc}"
+                f"Image generation failed for character {character_id!r} "
+                f"state={state!r}: {exc}"
             )
-            self._notify(f"Expression generation failed: {exc}", "error")
+            self._notify(f"Image generation failed: {exc}", "error")
+            return False
         finally:
             self._expression_generate_inflight.discard(key)
+
+    async def _generate_expression_image_worker(
+        self, character_id: int | None, state: str
+    ) -> None:
+        """Single-slot generate worker: a thin wrapper over
+        ``_generate_one_slot`` using the currently-picked style template
+        (Image-gen P3 Task 4's refactor of the original Task 3 worker
+        body - this method's behavior is unchanged, only its
+        implementation moved).
+        """
+        await self._generate_one_slot(
+            character_id, state, getattr(self, "_expression_generate_style", None)
+        )
+
+    async def _generate_all_expression_images_worker(
+        self, character_id: int
+    ) -> None:
+        """Generate avatar + all 3 expression-state images sequentially.
+
+        Image-gen P3 Task 4: reuses ``_generate_one_slot`` per state, so
+        each slot gets the exact same per-slot in-flight guard,
+        session-token guard, and error isolation as a single-slot
+        generate - one state's failure does not abort the sweep. A slot
+        already claimed by an independent single-slot generate click
+        (started just before this sweep) is skipped rather than raced.
+        Reports a single "k/4 generated" summary at the end.
+        """
+        style_template = getattr(self, "_expression_generate_style", None)
+        succeeded = 0
+        try:
+            for state in ("avatar", "thinking", "speaking", "error"):
+                slot_key = (character_id, state)
+                if slot_key in self._expression_generate_inflight:
+                    continue
+                self._expression_generate_inflight.add(slot_key)
+                if await self._generate_one_slot(character_id, state, style_template):
+                    succeeded += 1
+        finally:
+            self._expression_generate_inflight.discard((character_id, "all"))
+        self._notify(f"{succeeded}/4 generated.", "information")
+
+    async def _expression_style_pick_dialog_worker(self) -> None:
+        """Show the style picker; store the choice and refresh the readout.
+
+        Image-gen P3 Task 4: ``None`` (Escape/Cancel) keeps whatever style
+        was previously picked - matches ``ConsoleStylePickerModal``'s own
+        ``dismiss(None)`` convention. The modal's docstring documents that
+        its CALLER is responsible for restoring focus once it dismisses
+        (it only dismisses itself); this refocuses the button that opened
+        it, mirroring how the Console's own style-insert flow refocuses
+        its composer after the same modal closes. Mirrors
+        ``_expression_upload_dialog_worker``'s own nested try/except around
+        ``push_screen_wait``: this worker's ``run_worker`` call does not set
+        ``exit_on_error=False``, so an uncaught exception here would crash
+        the app rather than just this dialog.
+        """
+        try:
+            try:
+                choice = await self.app.push_screen_wait(ConsoleStylePickerModal())
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Could not show the image-generation style picker."
+                )
+                return
+            if choice is not None:
+                style_id = str(choice.get("id") or "")
+                self._expression_generate_style = get_template(style_id)
+                self._update_expression_style_readout()
+        finally:
+            self._io_dialog_active = False
+            try:
+                self.query_one("#personas-char-editor-style-pick", Button).focus()
+            except QueryError:
+                pass
+
+    def _update_expression_style_readout(self) -> None:
+        """Sync the editor's "Style: {name}" / "Style: Custom" readout to
+        ``self._expression_generate_style``."""
+        try:
+            editor = self.query_one(PersonasCharacterEditorWidget)
+        except QueryError:
+            return
+        template = self._expression_generate_style
+        text = f"Style: {template.name}" if template is not None else "Style: Custom"
+        editor.set_style_readout(text)
 
     # ===== Expression SET import/export (Roleplay P3d-2 Task 4) =====
     #

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -32,7 +32,10 @@ from ...Character_Chat.Character_Chat_Lib import (
     list_character_tags,
     validate_character_book,
 )
-from ...Character_Chat.expression_generation import compose_expression_prompt
+from ...Character_Chat.expression_generation import (
+    EXPRESSION_PROMPT_STATES,
+    compose_expression_prompt,
+)
 from ...Character_Chat.persona_list_paging import page_user_profiles
 from ...Character_Chat.world_book_import import normalize_world_book_import
 from ...Character_Chat.world_book_manager import CHARACTER_WORLD_BOOKS_KEY
@@ -5157,7 +5160,7 @@ class PersonasScreen(BaseAppScreen):
                 f"Image generation failed for character {character_id!r} "
                 f"state={state!r}: {exc}"
             )
-            self._notify(f"Image generation failed: {exc}", "error")
+            self._notify(f"Image generation failed for {state}: {exc}", "error")
             return False
         finally:
             self._expression_generate_inflight.discard(key)
@@ -5186,7 +5189,8 @@ class PersonasScreen(BaseAppScreen):
         generate - one state's failure does not abort the sweep. A slot
         already claimed by an independent single-slot generate click
         (started just before this sweep) is skipped rather than raced.
-        Reports a single "k/4 generated" summary at the end - counting only
+        Reports a single "k/N generated" summary at the end (N =
+        len(EXPRESSION_PROMPT_STATES)) - counting only
         the slots that actually completed before any session-identity
         mismatch stopped the sweep (see below).
 
@@ -5207,7 +5211,7 @@ class PersonasScreen(BaseAppScreen):
         style_template = getattr(self, "_expression_generate_style", None)
         succeeded = 0
         try:
-            for state in ("avatar", "thinking", "speaking", "error"):
+            for state in EXPRESSION_PROMPT_STATES:
                 if not self._character_editor_is_active():
                     break
                 try:
@@ -5224,7 +5228,9 @@ class PersonasScreen(BaseAppScreen):
                     succeeded += 1
         finally:
             self._expression_generate_inflight.discard((character_id, "all"))
-        self._notify(f"{succeeded}/4 generated.", "information")
+        self._notify(
+            f"{succeeded}/{len(EXPRESSION_PROMPT_STATES)} generated.", "information"
+        )
 
     async def _expression_style_pick_dialog_worker(self) -> None:
         """Show the style picker; store the choice and refresh the readout.

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -4948,6 +4948,7 @@ class PersonasScreen(BaseAppScreen):
         self.run_worker(
             self._expression_style_pick_dialog_worker(),
             group="personas-io",
+            exit_on_error=False,
         )
 
     @on(CharacterExpressionClearRequested)
@@ -5113,6 +5114,13 @@ class PersonasScreen(BaseAppScreen):
                 cfg_scale=params.get("cfg_scale"),
             )
             session_token = self._character_editor_session_token()
+            if session_token is None:
+                logger.debug(
+                    "Image generation skipped because no character editor "
+                    f"session is open. character_id={character_id!r}, "
+                    f"state={state!r}"
+                )
+                return False
             result = await asyncio.to_thread(run_generation, request)
             if self._character_editor_session_token() != session_token:
                 logger.debug(
@@ -5178,12 +5186,36 @@ class PersonasScreen(BaseAppScreen):
         generate - one state's failure does not abort the sweep. A slot
         already claimed by an independent single-slot generate click
         (started just before this sweep) is skipped rather than raced.
-        Reports a single "k/4 generated" summary at the end.
+        Reports a single "k/4 generated" summary at the end - counting only
+        the slots that actually completed before any session-identity
+        mismatch stopped the sweep (see below).
+
+        Re-checks session identity at the TOP of every iteration (not just
+        once up front) and stops the sweep the moment it no longer matches
+        the character this sweep was launched for - the user may cancel the
+        editor and open a different character in the same widget between
+        slots, and each slot's own generation can take long enough for that
+        to happen mid-sweep. This deliberately does NOT reuse
+        ``_character_editor_session_token()`` for that check: the token's
+        generation counter is bumped by ``_apply_expression_upload`` on
+        every successful write (Task 1's staleness signal for OTHER
+        seams), so a token captured before the loop would already
+        mismatch after this sweep's own first successful slot. Comparing
+        the freshly-resolved editor's loaded character id is immune to
+        that self-inflicted bump.
         """
         style_template = getattr(self, "_expression_generate_style", None)
         succeeded = 0
         try:
             for state in ("avatar", "thinking", "speaking", "error"):
+                if not self._character_editor_is_active():
+                    break
+                try:
+                    editor = self.query_one(PersonasCharacterEditorWidget)
+                except QueryError:
+                    break
+                if editor.expression_character_id() != character_id:
+                    break
                 slot_key = (character_id, state)
                 if slot_key in self._expression_generate_inflight:
                     continue
@@ -5205,9 +5237,9 @@ class PersonasScreen(BaseAppScreen):
         it, mirroring how the Console's own style-insert flow refocuses
         its composer after the same modal closes. Mirrors
         ``_expression_upload_dialog_worker``'s own nested try/except around
-        ``push_screen_wait``: this worker's ``run_worker`` call does not set
-        ``exit_on_error=False``, so an uncaught exception here would crash
-        the app rather than just this dialog.
+        ``push_screen_wait``; the dispatching ``run_worker`` call also
+        passes ``exit_on_error=False`` (final review F5) so an uncaught
+        exception here only kills this dialog's worker instead of the app.
         """
         try:
             try:

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -32,12 +32,16 @@ from ...Character_Chat.Character_Chat_Lib import (
     list_character_tags,
     validate_character_book,
 )
+from ...Character_Chat.expression_generation import compose_expression_prompt
 from ...Character_Chat.persona_list_paging import page_user_profiles
 from ...Character_Chat.world_book_import import normalize_world_book_import
 from ...Character_Chat.world_book_manager import CHARACTER_WORLD_BOOKS_KEY
 from ...Chat.chat_handoff_models import ChatHandoffPayload
 from ...Chat.console_expression_state import EXPRESSION_IMAGE_STATES
 from ...DB.ChaChaNotes_DB import ConflictError
+from ...Image_Generation.config import get_image_generation_config
+from ...Image_Generation.listing import list_image_models_for_catalog
+from ...Image_Generation.worker import build_request, run_generation
 from ...tldw_api import UserProfileCreate, UserProfileUpdate
 from ...Utils.path_validation import validate_path_simple
 from ...Utils.paths import get_user_data_dir
@@ -88,6 +92,7 @@ from ...Widgets.Persona_Widgets.tag_filter_picker import TagFilterPicker
 from ...Widgets.Persona_Widgets.personas_pane_messages import (
     CharacterEditorCancelled,
     CharacterExpressionClearRequested,
+    CharacterExpressionGenerateRequested,
     CharacterExpressionSetExportRequested,
     CharacterExpressionSetImportRequested,
     CharacterExpressionUploadRequested,
@@ -565,6 +570,10 @@ class PersonasScreen(BaseAppScreen):
         # Same refuse-reentry idiom for the delete confirmation dialog.
         self._delete_dialog_active: bool = False
         self._character_editor_generation: int = 0
+        # Image-gen P3 Task 3: (character_id, state) pairs with an expression
+        # generation worker currently in flight - refuses a re-entrant
+        # generate click for the same slot rather than racing two writes.
+        self._expression_generate_inflight: set[tuple[int, str]] = set()
         self._profile_save_inflight: bool = False
         # Mirrors _profile_save_inflight for the character editor: guards
         # against a re-entrant Save (double-click/Ctrl+S) while an earlier
@@ -4735,6 +4744,66 @@ class PersonasScreen(BaseAppScreen):
             group="personas-io",
         )
 
+    @on(CharacterExpressionGenerateRequested)
+    def _handle_character_expression_generate_requested(
+        self, message: CharacterExpressionGenerateRequested
+    ) -> None:
+        """Dispatch an AI-generation worker for one expression-state slot.
+
+        Image-gen P3 Task 3: mirrors ``_handle_character_expression_upload_
+        requested``'s gate sequence (editor active -> saved character ->
+        not-already-busy) with two extra gates specific to generation: the
+        live description must be non-empty (there's nothing to prompt from
+        otherwise), and the configured backend must actually be usable
+        (same check + copy as the Console's ``/generate-image`` command).
+        """
+        message.stop()
+        if not self._character_editor_is_active():
+            self._notify(
+                "Open a character editor before generating an expression image.",
+                "warning",
+            )
+            return
+        editor = self.query_one(PersonasCharacterEditorWidget)
+        character_id = editor.expression_character_id()
+        if character_id is None:
+            self._notify("Save the character to add expressions.", "warning")
+            return
+        if not editor._area("description").text.strip():
+            self._notify("Add a description first.", "warning")
+            return
+        cfg = get_image_generation_config()
+        backend = cfg.default_backend
+        if not backend:
+            self._notify(
+                "No image generation backend configured. Set "
+                "[image_generation].default_backend.",
+                "warning",
+            )
+            return
+        catalog = list_image_models_for_catalog()
+        entry = next((item for item in catalog if item.get("name") == backend), None)
+        if entry is None or not entry.get("is_configured"):
+            self._notify(
+                f"Image backend '{backend}' is not enabled/configured. "
+                "Check [image_generation] settings.",
+                "warning",
+            )
+            return
+        key = (character_id, message.state)
+        if key in self._expression_generate_inflight:
+            self._notify(
+                f"Already generating the {message.state} expression image.",
+                "warning",
+            )
+            return
+        self._expression_generate_inflight.add(key)
+        self.run_worker(
+            self._generate_expression_image_worker(character_id, message.state),
+            group="personas-io",
+            exit_on_error=False,
+        )
+
     @on(CharacterExpressionClearRequested)
     def _handle_character_expression_clear_requested(
         self, message: CharacterExpressionClearRequested
@@ -4822,6 +4891,74 @@ class PersonasScreen(BaseAppScreen):
 
         mime = mimetypes.guess_type(path)[0]
         await self._apply_expression_upload(character_id, state, image_data, mime)
+
+    async def _generate_expression_image_worker(
+        self, character_id: int, state: str
+    ) -> None:
+        """Generate one expression-state image and write it through the
+        upload seam.
+
+        Image-gen P3 Task 3: reads live (unsaved) form values straight from
+        the editor's widgets - never ``_character_data`` - since the user
+        may be generating from text they haven't saved yet. The blocking
+        adapter call runs off-thread via ``asyncio.to_thread``; the session
+        token is captured immediately before that await and re-checked
+        immediately after, mirroring ``_stage_character_expression_from_
+        path``'s stale-write guard so a Cancel/new-session/save-in-place
+        that happens mid-generation drops the result instead of writing it
+        into the wrong (or no-longer-open) character. The whole body is
+        wrapped so a failure at any step (prompt composition, request
+        validation, adapter call, DB write) reports a single error notify
+        instead of propagating into the worker's default panic-on-
+        exception behavior.
+        """
+        key = (character_id, state)
+        try:
+            editor = self.query_one(PersonasCharacterEditorWidget)
+            name = editor._input("name").value
+            description = editor._area("description").text
+            personality = editor._area("personality").text
+            prompt, negative_prompt, params = compose_expression_prompt(
+                name=name,
+                description=description,
+                personality=personality,
+                state=state,
+                style_template=getattr(self, "_expression_generate_style", None),
+            )
+            cfg = get_image_generation_config()
+            request = build_request(
+                backend=cfg.default_backend,
+                prompt=prompt,
+                negative_prompt=negative_prompt or None,
+                seed=-1,
+                image_format="png",
+                width=params.get("width"),
+                height=params.get("height"),
+                steps=params.get("steps"),
+                cfg_scale=params.get("cfg_scale"),
+            )
+            session_token = self._character_editor_session_token()
+            result = await asyncio.to_thread(run_generation, request)
+            if self._character_editor_session_token() != session_token:
+                logger.debug(
+                    "Expression generation result ignored because the "
+                    f"character editor session changed. character_id="
+                    f"{character_id!r}, state={state!r}, "
+                    f"original_session={session_token!r}, "
+                    f"current_session={self._character_editor_session_token()!r}"
+                )
+                return
+            await self._apply_expression_upload(
+                character_id, state, result.content, result.content_type
+            )
+        except Exception as exc:
+            logger.opt(exception=True).error(
+                f"Expression image generation failed for character "
+                f"{character_id} state={state!r}: {exc}"
+            )
+            self._notify(f"Expression generation failed: {exc}", "error")
+        finally:
+            self._expression_generate_inflight.discard(key)
 
     # ===== Expression SET import/export (Roleplay P3d-2 Task 4) =====
     #

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -3791,6 +3791,9 @@ class PersonasScreen(BaseAppScreen):
 
     async def _begin_create_character(self) -> None:
         self._character_editor_generation += 1
+        # A picked image-gen style is scoped to the editor session that
+        # picked it (fix round 1) - must not bleed into this new one.
+        self._reset_expression_generate_style()
         self._edit_mode = "create"
         self.state.clear_selection()
         # A new session starts unclaimed - re-arms the save-in-place dedup
@@ -4176,6 +4179,10 @@ class PersonasScreen(BaseAppScreen):
             self._notify("Character data is not loaded yet.", severity="warning")
             return
         self._character_editor_generation += 1
+        # A picked image-gen style is scoped to the editor session that
+        # picked it (fix round 1) - opening this (possibly different)
+        # character must not silently inherit the previous session's style.
+        self._reset_expression_generate_style()
         self._edit_mode = "edit"
         # A new session starts unclaimed (see _begin_create_character).
         self._character_save_inflight = False
@@ -5231,6 +5238,28 @@ class PersonasScreen(BaseAppScreen):
         template = self._expression_generate_style
         text = f"Style: {template.name}" if template is not None else "Style: Custom"
         editor.set_style_readout(text)
+
+    def _reset_expression_generate_style(self) -> None:
+        """Clear the picked style template at a genuine editor-session
+        boundary (fix round 1).
+
+        The picked style is scoped to "this editor session, not persisted"
+        (Task 4's spec) - without this, a style picked while editing
+        character A silently bleeds into character B once opened in the
+        same screen session, since ``_expression_generate_style`` is
+        otherwise screen-lifetime state.
+
+        Called only from the 3 sites where ``_character_editor_generation``
+        bumps to mark a genuinely NEW/ended character-editor session
+        (``_begin_create_character``, ``_handle_edit_requested``,
+        ``_finish_cancel_edit``) - NOT from the other bump sites in this
+        file (avatar Remove, expression-set apply, expression upload/clear,
+        save-in-place), which bump the same counter merely to invalidate a
+        stale in-flight render within the SAME session and must leave a
+        picked style untouched.
+        """
+        self._expression_generate_style = None
+        self._update_expression_style_readout()
 
     # ===== Expression SET import/export (Roleplay P3d-2 Task 4) =====
     #
@@ -6624,6 +6653,9 @@ class PersonasScreen(BaseAppScreen):
 
     def _finish_cancel_edit(self) -> None:
         self._character_editor_generation += 1
+        # A picked image-gen style is scoped to the editor session that
+        # picked it (fix round 1) - the session just ended.
+        self._reset_expression_generate_style()
         self._edit_mode = "view"
         self.state.has_unsaved_changes = False
         inspector = self.query_one(PersonasInspectorPane)

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
@@ -29,6 +29,7 @@ from .personas_pane_messages import (
     CharacterExpressionGenerateRequested,
     CharacterExpressionSetExportRequested,
     CharacterExpressionSetImportRequested,
+    CharacterExpressionStylePickRequested,
     CharacterExpressionUploadRequested,
     CharacterImageRemoveRequested,
     CharacterImageUploadRequested,
@@ -142,7 +143,8 @@ class PersonasCharacterEditorWidget(Container):
 
     PersonasCharacterEditorWidget #personas-char-editor-expr-import,
     PersonasCharacterEditorWidget #personas-char-editor-expr-export,
-    PersonasCharacterEditorWidget #personas-char-editor-expr-generate-all {
+    PersonasCharacterEditorWidget #personas-char-editor-expr-generate-all,
+    PersonasCharacterEditorWidget #personas-char-editor-style-pick {
         width: auto;
         min-width: 0;
         height: 1;
@@ -150,6 +152,14 @@ class PersonasCharacterEditorWidget(Container):
         padding: 0 1;
         margin-left: 1;
         border: none;
+    }
+
+    /* Image-gen P3 Task 4: the current style-template readout, between the
+       "Expressions" header and its action buttons. */
+    PersonasCharacterEditorWidget #personas-char-editor-style-readout {
+        width: auto;
+        min-width: 0;
+        margin-left: 2;
     }
 
     /* Expression authoring slots (Roleplay P3d-1 Task 4) - one row per
@@ -368,6 +378,15 @@ class PersonasCharacterEditorWidget(Container):
             yield Container(id="personas-char-editor-avatar-thumb")
             with Horizontal(classes="personas-char-editor-expr-set-row"):
                 yield Static("Expressions", classes="destination-section")
+                yield Static(
+                    "Style: Custom",
+                    id="personas-char-editor-style-readout",
+                )
+                yield Button(
+                    "Style…",
+                    id="personas-char-editor-style-pick",
+                    classes="console-action-subdued",
+                )
                 yield Button(
                     "✨ Generate all",
                     id="personas-char-editor-expr-generate-all",
@@ -645,6 +664,17 @@ class PersonasCharacterEditorWidget(Container):
         from textual.widgets import Static as _S
 
         holder.mount(renderable if isinstance(renderable, _W) else _S(renderable))
+
+    def set_style_readout(self, text: str) -> None:
+        """Update the "Style: {name}" / "Style: Custom" readout Static.
+
+        Image-gen P3 Task 4: the screen owns resolving the picked style
+        template (or falling back to "Custom" on cancel/none-picked); this
+        method only mounts the finished text, mirroring
+        ``set_avatar_thumbnail``/``set_expression_thumbnail``'s
+        screen-decides/widget-mounts split.
+        """
+        self.query_one("#personas-char-editor-style-readout", Static).update(text)
 
     def validate(self) -> list[tuple[str, str, str]]:
         """Live per-field checks: name required, oversized avatar, blank greetings.
@@ -1120,6 +1150,11 @@ class PersonasCharacterEditorWidget(Container):
     def _expression_generate_all_pressed(self, event: Button.Pressed) -> None:
         event.stop()
         self.post_message(CharacterExpressionGenerateAllRequested())
+
+    @on(Button.Pressed, "#personas-char-editor-style-pick")
+    def _style_pick_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(CharacterExpressionStylePickRequested())
 
     @on(Button.Pressed, "#personas-char-editor-expr-import")
     def _expression_set_import_pressed(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
@@ -141,6 +141,15 @@ class PersonasCharacterEditorWidget(Container):
         min-height: 1;
     }
 
+    /* Static defaults to 1fr with no width set, which would otherwise let
+       this header claim the whole row and push every action button in it
+       (Style readout/pick, Generate all, Import/Export set) past the row's
+       right edge - permanently unreachable since Horizontal doesn't wrap. */
+    PersonasCharacterEditorWidget #personas-char-editor-expr-header {
+        width: auto;
+        min-width: 0;
+    }
+
     PersonasCharacterEditorWidget #personas-char-editor-expr-import,
     PersonasCharacterEditorWidget #personas-char-editor-expr-export,
     PersonasCharacterEditorWidget #personas-char-editor-expr-generate-all,
@@ -377,7 +386,11 @@ class PersonasCharacterEditorWidget(Container):
                 )
             yield Container(id="personas-char-editor-avatar-thumb")
             with Horizontal(classes="personas-char-editor-expr-set-row"):
-                yield Static("Expressions", classes="destination-section")
+                yield Static(
+                    "Expressions",
+                    id="personas-char-editor-expr-header",
+                    classes="destination-section",
+                )
                 yield Static(
                     "Style: Custom",
                     id="personas-char-editor-style-readout",

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
@@ -22,8 +22,11 @@ from textual.widgets import Button, DataTable, Input, Label, Static, TextArea
 from ...Character_Chat.world_book_manager import CHARACTER_WORLD_BOOKS_KEY
 from ...Chat.console_expression_state import EXPRESSION_IMAGE_STATES
 from .personas_pane_messages import (
+    CharacterAvatarGenerateRequested,
     CharacterEditorCancelled,
     CharacterExpressionClearRequested,
+    CharacterExpressionGenerateAllRequested,
+    CharacterExpressionGenerateRequested,
     CharacterExpressionSetExportRequested,
     CharacterExpressionSetImportRequested,
     CharacterExpressionUploadRequested,
@@ -110,7 +113,8 @@ class PersonasCharacterEditorWidget(Container):
     }
 
     PersonasCharacterEditorWidget #personas-char-editor-avatar-upload,
-    PersonasCharacterEditorWidget #personas-char-editor-avatar-remove {
+    PersonasCharacterEditorWidget #personas-char-editor-avatar-remove,
+    PersonasCharacterEditorWidget #personas-char-editor-avatar-generate {
         width: auto;
         min-width: 0;
         height: 1;
@@ -137,7 +141,8 @@ class PersonasCharacterEditorWidget(Container):
     }
 
     PersonasCharacterEditorWidget #personas-char-editor-expr-import,
-    PersonasCharacterEditorWidget #personas-char-editor-expr-export {
+    PersonasCharacterEditorWidget #personas-char-editor-expr-export,
+    PersonasCharacterEditorWidget #personas-char-editor-expr-generate-all {
         width: auto;
         min-width: 0;
         height: 1;
@@ -172,7 +177,8 @@ class PersonasCharacterEditorWidget(Container):
     }
 
     PersonasCharacterEditorWidget .personas-char-editor-expr-upload,
-    PersonasCharacterEditorWidget .personas-char-editor-expr-clear {
+    PersonasCharacterEditorWidget .personas-char-editor-expr-clear,
+    PersonasCharacterEditorWidget .personas-char-editor-expr-generate {
         width: auto;
         min-width: 0;
         height: 1;
@@ -350,6 +356,11 @@ class PersonasCharacterEditorWidget(Container):
                     classes="console-action-subdued",
                 )
                 yield Button(
+                    "✨ Generate",
+                    id="personas-char-editor-avatar-generate",
+                    classes="console-action-subdued",
+                )
+                yield Button(
                     "Remove",
                     id="personas-char-editor-avatar-remove",
                     classes="console-action-subdued",
@@ -357,6 +368,12 @@ class PersonasCharacterEditorWidget(Container):
             yield Container(id="personas-char-editor-avatar-thumb")
             with Horizontal(classes="personas-char-editor-expr-set-row"):
                 yield Static("Expressions", classes="destination-section")
+                yield Button(
+                    "✨ Generate all",
+                    id="personas-char-editor-expr-generate-all",
+                    classes="console-action-subdued",
+                    disabled=True,
+                )
                 yield Button(
                     "Import set…",
                     id="personas-char-editor-expr-import",
@@ -386,6 +403,12 @@ class PersonasCharacterEditorWidget(Container):
                             "Upload",
                             id=f"personas-char-editor-expr-{state}-upload",
                             classes="console-action-subdued personas-char-editor-expr-upload",
+                            disabled=True,
+                        )
+                        yield Button(
+                            "✨ Generate",
+                            id=f"personas-char-editor-expr-{state}-generate",
+                            classes="console-action-subdued personas-char-editor-expr-generate",
                             disabled=True,
                         )
                         yield Button(
@@ -585,9 +608,15 @@ class PersonasCharacterEditorWidget(Container):
         hint_text = "" if enabled else "Save the character to add expressions."
         self.query_one("#personas-char-editor-expr-import", Button).disabled = not enabled
         self.query_one("#personas-char-editor-expr-export", Button).disabled = not enabled
+        self.query_one(
+            "#personas-char-editor-expr-generate-all", Button
+        ).disabled = not enabled
         for state in EXPRESSION_IMAGE_STATES:
             self.query_one(
                 f"#personas-char-editor-expr-{state}-upload", Button
+            ).disabled = not enabled
+            self.query_one(
+                f"#personas-char-editor-expr-{state}-generate", Button
             ).disabled = not enabled
             self.query_one(
                 f"#personas-char-editor-expr-{state}-clear", Button
@@ -1047,6 +1076,11 @@ class PersonasCharacterEditorWidget(Container):
         event.stop()
         self.post_message(CharacterImageRemoveRequested())
 
+    @on(Button.Pressed, "#personas-char-editor-avatar-generate")
+    def _generate_avatar_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(CharacterAvatarGenerateRequested())
+
     @staticmethod
     def _expression_state_from_button_id(button_id: str | None, *, suffix: str) -> str | None:
         """Recover the ``state`` a per-slot upload/clear button id encodes.
@@ -1068,12 +1102,24 @@ class PersonasCharacterEditorWidget(Container):
         if state is not None:
             self.post_message(CharacterExpressionUploadRequested(state))
 
+    @on(Button.Pressed, ".personas-char-editor-expr-generate")
+    def _expression_generate_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        state = self._expression_state_from_button_id(event.button.id, suffix="-generate")
+        if state is not None:
+            self.post_message(CharacterExpressionGenerateRequested(state))
+
     @on(Button.Pressed, ".personas-char-editor-expr-clear")
     def _expression_clear_pressed(self, event: Button.Pressed) -> None:
         event.stop()
         state = self._expression_state_from_button_id(event.button.id, suffix="-clear")
         if state is not None:
             self.post_message(CharacterExpressionClearRequested(state))
+
+    @on(Button.Pressed, "#personas-char-editor-expr-generate-all")
+    def _expression_generate_all_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(CharacterExpressionGenerateAllRequested())
 
     @on(Button.Pressed, "#personas-char-editor-expr-import")
     def _expression_set_import_pressed(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py
@@ -114,6 +114,18 @@ class CharacterExpressionGenerateAllRequested(Message):
     slots (thinking/speaking/error) at once."""
 
 
+class CharacterExpressionStylePickRequested(Message):
+    """Image-gen P3: user requested to pick a style template used by
+    subsequent avatar/expression AI generations in the active character
+    editor.
+
+    Mirrors the Console's own style picker (``ConsoleStylePickerModal``)
+    but stores the resolved template on the screen instead of inserting a
+    token into a composer draft - the character editor has no draft text
+    for a token to live in.
+    """
+
+
 class EditUserProfileRequested(Message):
     """Edit was requested for the displayed user profile."""
 

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py
@@ -56,6 +56,16 @@ class CharacterImageRemoveRequested(Message):
     """User requested to remove the avatar image from the active character editor."""
 
 
+class CharacterAvatarGenerateRequested(Message):
+    """User requested AI generation of a new avatar image for the active
+    character editor.
+
+    Image-gen P3: distinct from ``CharacterImageUploadRequested`` (a manual
+    file pick) - this triggers a generation worker instead, staging the
+    result into the editor the same way an uploaded avatar would.
+    """
+
+
 class CharacterExpressionUploadRequested(Message):
     """User requested to choose an image for one expression-state slot
     (thinking/speaking/error) in the active character editor.
@@ -78,12 +88,30 @@ class CharacterExpressionClearRequested(Message):
         super().__init__()
 
 
+class CharacterExpressionGenerateRequested(Message):
+    """User requested AI generation of one expression-state slot
+    (thinking/speaking/error) in the active character editor.
+
+    Image-gen P3: mirrors ``CharacterExpressionUploadRequested`` but triggers
+    a generation worker instead of a file picker.
+    """
+
+    def __init__(self, state: str) -> None:
+        self.state = state
+        super().__init__()
+
+
 class CharacterExpressionSetImportRequested(Message):
     """Roleplay P3d-2: import a whole expression set from a .zip."""
 
 
 class CharacterExpressionSetExportRequested(Message):
     """Roleplay P3d-2: export the character's expression set to a .zip."""
+
+
+class CharacterExpressionGenerateAllRequested(Message):
+    """Image-gen P3: user requested AI generation of all expression-state
+    slots (thinking/speaking/error) at once."""
 
 
 class EditUserProfileRequested(Message):


### PR DESCRIPTION
## Image Generation P3 — Generate Character Avatar & Expression Images

Phase 3 of the in-chat image-generation program (P1 #800 engine, P2a #832 card+variants, P2b #850 speak/styles/context). This fills the **existing** character expression system with generated images — no new canvas, gallery, or mood states, **no schema or config changes**.

### What's included

- **✨ Generate** buttons beside Upload on the character editor's **avatar row** and all three **expression slots** (thinking / speaking / error), plus **✨ Generate all** — prompts auto-composed from the editor's *live* name + description (+ personality) with per-state modifiers, optionally wrapped in a preset via the existing style picker (a "Style: …" readout + picker button in the Expressions row; session-scoped, reset at editor-session boundaries).
- **Persistence matches each slot's existing rule**: generated avatar is *staged* (persists on Save, with an explicit 5 MB pre-check — the existing validator is path-based and unreachable for in-memory bytes); expression images write *immediately* through the existing `_apply_expression_upload` seam (DB upsert + notify + thumbnail refresh, all reused). Regenerate = click again.
- **Safety**: every worker uses the screen's `exit_on_error=False` + full try/except/finally convention; stale-write guards (session token + per-iteration character-identity checks) ensure switching characters or closing the editor mid-generation never writes into the wrong character; per-slot/all in-flight guards; graceful refusals for empty descriptions, unconfigured backends, and double-clicks.

### Review catches worth noting
- The **final whole-branch review found a confirmed High data-integrity bug** before merge: Generate-all re-captured its stale-token per slot (self-comparison), so a mid-sweep character switch wrote character A's expression rows with images prompted from character B's form. Fixed with a per-iteration character-identity guard + RED-verified regression tests (plus a sibling None-token guard hole).
- The **live TUI smoke found a pre-existing, already-shipped layout bug**: the Expressions header (`Static` defaulting to `1fr`, from the earlier Roleplay P3d-2 row, commit `99f1436fc` on dev) pushed the row's Import/Export buttons off-screen at every width. Drive-by fix (`width: auto`) + regression pin; the branch's new controls made the row more crowded but did not cause the bug.

### Testing
~60 new tests: composition table, button/message/gating, the core worker's six pins (happy/stale-token/empty-desc/in-flight/failure-cleanup/unsaved), avatar staging + oversized refusal, generate-all partial summary, style pick→params threading + session-boundary resets, the two final-review regression pins, and the width pin. Full sweeps green vs. baseline (3 unrelated pre-existing failures worktree-attributed at the plan base). Ruff clean (2 pre-existing F821s blamed to earlier commits); app boots; CSS bundle untouched. **Live tmux smoke green**: buttons render, generation fails gracefully without a backend (connection-refused notify, no crash), style picker end-to-end.

### Deferred follow-ups (triaged by the final review, none blocking)
Expressions-row overflow at narrow terminal widths (pre-existing); a "Generating…" in-slot hint; state-list unification; a confirm on the destructive Generate-all sweep; the k/4 summary over-count on a rare DB-write failure; 3 unrelated pre-existing test failures worth their own task.

⚠️ **Please do not merge without an explicit maintainer gate** (per repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds image generation to the character editor: Generate buttons for avatar and the three expression slots, plus Generate all. Prompts use live form text (+optional style) and write through existing upload paths; no schema or config changes.

- **New Features**
  - Generate buttons beside Upload for avatar, thinking, speaking, and error; plus Generate all.
  - Prompts auto-compose from live name/description (+personality) with per-state modifiers and an optional session-scoped style via the style picker and readout.
  - Persistence mirrors existing behavior: avatar is staged with a 5 MB pre-check; expressions write immediately through the existing apply seam. Guards handle empty descriptions, unconfigured backends, in-flight clicks, and stale sessions; workers use exit_on_error=False. Tests cover prompts, gating, workers, style resets, and layout.

- **Bug Fixes**
  - Generate all re-checks session identity on each iteration to prevent cross-character writes; added a None-token refusal. Also derives states/count from `EXPRESSION_PROMPT_STATES` and includes the slot in failure notifications.
  - Fixed Expressions header width so Style/Generate/Import/Export controls stay visible.
  - Reset the expression style at editor-session boundaries so a picked style does not carry over between characters.

<sup>Written for commit c63e81dc60b5fbc96752fb8e2c958bd7a392806d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

