### PR TITLE
Console branching//rewind follow-ups, batch 2 (tasks 548, 501)

### DIFF
--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -2418,6 +2418,13 @@ async def test_build_context_snapshot_isolates_assembly_errors():
     assert payload["messages"][0]["content"] == "Hello"
     assert payload["messages"][1]["content"].startswith("Follow up")
     assert payload["system"] == []
+    # Qodo (PR #860): the failure here fires inside the annotate->strip
+    # window, so the degraded payload must strip the private id-threading
+    # key too -- it must never surface in the inspector snapshot.
+    assert all(
+        controller_module.NATIVE_MESSAGE_ID_KEY not in row
+        for row in payload["messages"]
+    )
 
 
 def test_annotate_skill_commands_multimodal_text_part():

--- a/Tests/Chat/test_console_rewind_summarize.py
+++ b/Tests/Chat/test_console_rewind_summarize.py
@@ -548,3 +548,78 @@ async def test_native_message_id_key_stripped_before_provider():
         and "[Summary of earlier conversation]" in row.get("content", "")
         for row in gateway.captured_messages
     )
+
+
+# ---------------------------------------------------------------------------
+# task-548: the inspector next-send preview mirrors boundary compaction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_snapshot_reflects_boundary_compaction():
+    """With an active summary, build_context_snapshot compacts like a real send."""
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=SummaryGateway())
+    session = store.ensure_session(title="Chat 1")
+
+    u1 = store.append_message(session.id, role=ConsoleMessageRole.USER, content="old-q")
+    store.append_message(session.id, role=ConsoleMessageRole.ASSISTANT, content="old-a")
+    u2 = store.append_message(session.id, role=ConsoleMessageRole.USER, content="new-q")
+    store.append_message(session.id, role=ConsoleMessageRole.ASSISTANT, content="new-a")
+    store.set_session_context_summary(session.id, "COMPACT-SUMMARY", u2.id)
+
+    snapshot = await controller.build_context_snapshot(draft="")
+    rows = snapshot.next_send_payload["messages"]
+
+    # Pre-boundary turns replaced; boundary tail intact.
+    contents = [row.get("content") or "" for row in rows]
+    assert not any("old-q" in c or "old-a" in c for c in contents)
+    assert any("new-q" in c for c in contents)
+    assert any("new-a" in c for c in contents)
+    # Summary folded into the leading system row AND the duplicated field.
+    assert rows[0]["role"] == "system"
+    assert "COMPACT-SUMMARY" in rows[0]["content"]
+    assert any(
+        "COMPACT-SUMMARY" in (row.get("content") or "")
+        for row in snapshot.next_send_payload["system"]
+    )
+    # AC #2: the private id-threading key never reaches the preview.
+    assert not any("_native_message_id" in row for row in rows)
+    _ = u1
+
+
+@pytest.mark.asyncio
+async def test_snapshot_without_summary_unchanged_and_key_free():
+    """No stored summary: preview shows full history and no private keys."""
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=SummaryGateway())
+    session = store.ensure_session(title="Chat 1")
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="q1")
+    store.append_message(session.id, role=ConsoleMessageRole.ASSISTANT, content="a1")
+
+    snapshot = await controller.build_context_snapshot(draft="next")
+    rows = snapshot.next_send_payload["messages"]
+
+    contents = [row.get("content") or "" for row in rows]
+    assert any("q1" in c for c in contents)
+    assert any("a1" in c for c in contents)
+    assert not any("_native_message_id" in row for row in rows)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_with_dangling_boundary_shows_full_history():
+    """A dangling boundary leaves the preview un-compacted (leak rule parity)."""
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=SummaryGateway())
+    session = store.ensure_session(title="Chat 1")
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="q1")
+    store.append_message(session.id, role=ConsoleMessageRole.ASSISTANT, content="a1")
+    store.set_session_context_summary(session.id, "GHOST-SUMMARY", "ghost-native-id")
+
+    snapshot = await controller.build_context_snapshot(draft="")
+    rows = snapshot.next_send_payload["messages"]
+
+    contents = [row.get("content") or "" for row in rows]
+    assert any("q1" in c for c in contents)
+    assert any("a1" in c for c in contents)
+    assert not any("GHOST-SUMMARY" in c for c in contents)

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -3774,17 +3774,40 @@ async def test_console_sibling_swipe_buttons_navigate_between_regenerated_siblin
             console.query_one(f"#console-message-{a1.id}", Static)
         )
         assert "(1/2)" in row_text
-        # a2 drops off the active path, so its id is no longer in the
-        # transcript's message set and selection clears (same rule an
-        # existing test already pins for "continue": selection tracks a
-        # message ID, and that ID vanishing from view resets it -- swiping
-        # again requires re-selecting the now-active row, exactly like any
-        # other action that swaps which message is active).
-        assert transcript.selected_message_id is None
-        assert not list(console.query(f"#console-message-actions-{a1.id}"))
+        # task-501: the selection FOLLOWS the swipe onto the landed sibling
+        # (a2 dropped off the active path, which would have cleared the old
+        # selection), so the action row stays available and repeated `<`/`>`
+        # presses work without re-clicking the row. Other selection-clearing
+        # actions ("continue" etc.) keep their existing clear-on-swap rule.
+        # Re-query the transcript: a recompose may have remounted it since
+        # the pre-click capture (the handoff is remount-proof; a stale widget
+        # reference in the test would not be).
+        await pilot.pause()
+        transcript = console.query_one("#console-native-transcript", ConsoleTranscript)
+        assert transcript.selected_message_id == a1.id
+        await _wait_for_selector(
+            console, pilot, f"#console-message-action-variant-next-{a1.id}"
+        )
 
-        transcript.select_message(a1.id)
-        await console._sync_native_console_chat_ui()
+        # Repeated swipe with NO re-click: `>` from the still-selected a1 row
+        # returns to a2 and the selection follows again.
+        await pilot.click(f"#console-message-action-variant-next-{a1.id}")
+        await _wait_for_text(console, pilot, "updated answer")
+        await pilot.pause()
+        transcript = console.query_one("#console-native-transcript", ConsoleTranscript)
+        assert transcript.selected_message_id == a2.id
+        await _wait_for_selector(
+            console, pilot, f"#console-message-action-variant-previous-{a2.id}"
+        )
+
+        # Swipe back to the FIRST sibling (again without a re-click -- the
+        # selection is sitting on a2 from the swipe above) and pin the
+        # boundary disabled states on a1's action row.
+        await pilot.click(f"#console-message-action-variant-previous-{a2.id}")
+        await _wait_for_text(console, pilot, "seed")
+        await pilot.pause()
+        transcript = console.query_one("#console-native-transcript", ConsoleTranscript)
+        assert transcript.selected_message_id == a1.id
         await _wait_for_selector(
             console, pilot, f"#console-message-action-variant-next-{a1.id}"
         )
@@ -3803,7 +3826,11 @@ async def test_console_sibling_swipe_buttons_navigate_between_regenerated_siblin
             console.query_one(f"#console-message-{a2.id}", Static)
         )
         assert "(2/2)" in row_text
-        assert transcript.selected_message_id is None
+        # task-501: the swipe keeps the selection on the landed sibling (the
+        # pre-task-501 rule cleared it, forcing a re-click between swipes).
+        await pilot.pause()
+        transcript = console.query_one("#console-native-transcript", ConsoleTranscript)
+        assert transcript.selected_message_id == a2.id
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-501 - Console-branching-keep-transcript-selection-across-sibling-swipe.md
+++ b/backlog/tasks/task-501 - Console-branching-keep-transcript-selection-across-sibling-swipe.md
@@ -1,0 +1,70 @@
+---
+id: TASK-501
+title: >-
+  Console branching: keep transcript selection across sibling swipe for
+  back-to-back comparison
+status: Done
+assignee:
+  - '@claude'
+created_date: '2026-07-23'
+updated_date: '2026-07-24'
+labels:
+  - console
+  - ux
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+With Console branching (Phase A, PR #799), pressing `<` / `>` to navigate sibling branches moves the active leaf and re-syncs the transcript, which clears the selected message (pre-existing precedent from PR #359: `selected_message_id` is dropped whenever the message no longer occupies a transcript slot, shared with the "continue" action). Consequence: the action row disappears after each swipe, so comparing branches back-to-back requires re-selecting the message and re-opening the action row before each `<` / `>`. Since rapid branch comparison is the primary reason this feature exists, the swipe path should keep the selection anchored (e.g. re-select the new active node at the same turn position) so repeated `<` / `>` works without a re-click.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 After a `<` / `>` sibling swipe, the transcript keeps a selection at the swiped turn so the `<` / `>` action row stays available
+- [x] #2 Repeated `<` / `>` presses navigate siblings without an intervening row re-click
+- [x] #3 The "continue"/other-action selection-clear behavior is not regressed
+- [x] #4 Verified in the live TUI
+<!-- AC:END -->
+
+## Implementation Plan
+
+1. Hand the swiped-to sibling's id from the `variant-previous`/`variant-next`
+   action handler to the transcript as a PENDING selection (not an eager
+   `select_message`) so it is applied at ingest time, after the post-swipe
+   view actually reaches the widget.
+2. Hold the handoff on the SCREEN (`_pending_console_swipe_selection`) and
+   transfer it onto whichever transcript instance receives the next push —
+   a recompose can remount the transcript between the swipe and the push.
+3. Apply the pending id inside `set_messages` BEFORE the stale-selection
+   clear, so the swipe that removed the old selection lands directly on the
+   swiped-to sibling.
+4. Extend the swipe UI test to pin selection-follow + repeated no-re-click
+   swipes; leave "continue"/other actions on the existing clear rule.
+
+## Implementation Notes
+
+- `_select_console_message_variant` now returns the landed sibling's native
+  id (None on boundary no-ops); the action handler stores it in
+  `_pending_console_swipe_selection` (screen-held, remount-proof) and the
+  sync transfers it to `ConsoleTranscript.pending_selection_id`, which
+  `set_messages` applies once the id is present in the ingested set —
+  selecting eagerly would either miss the membership guard or be cleared by
+  reconciliation against the stale message set.
+- Only the `variant-previous`/`variant-next` branch of
+  `handle_console_message_action` sets the handoff; "continue" and every
+  other selection-clearing action keep the PR #359 clear-on-swap rule
+  (AC #3), pinned by the untouched selection-contract suite.
+- The pre-existing test tail was written for the old clear-on-swipe world
+  (it re-selected a1 while the view sat on a1's path); with the new
+  second-swipe coverage the view rests on a2, so the tail now swipes back
+  to a1 via the followed selection and asserts the boundary disabled states
+  there, ending on selection == a2 after the final swipe (was: None).
+- Verified live in the real TUI (tmux, local llama_cpp @9099, scratch
+  profile): regenerate to 3 siblings, `<`/`<`/`>` back-to-back with NO row
+  re-clicks — counter walked (3/3)→(2/3)→(1/3)→(2/3) with the action row
+  and guide persistent throughout.
+- Files: `tldw_chatbook/UI/Screens/chat_screen.py`,
+  `tldw_chatbook/Widgets/Console/console_transcript.py`,
+  `Tests/UI/test_console_native_chat_flow.py`.

--- a/backlog/tasks/task-548 - Console-rewind-inspector-next-send-preview-should-reflect-compaction.md
+++ b/backlog/tasks/task-548 - Console-rewind-inspector-next-send-preview-should-reflect-compaction.md
@@ -3,7 +3,7 @@ id: TASK-548
 title: >-
   Console /rewind: inspector next-send preview should reflect boundary
   compaction
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-24'
 labels:
@@ -21,7 +21,11 @@ With `/rewind`'s "Summarize up to here" (PR #844), the actual send path compacts
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 With an active boundary summary, the inspector's next-send preview matches the actually-dispatched payload shape (summary in system prefix, pre-boundary turns absent) or is explicitly labeled pre-compaction with the compaction effect shown
-- [ ] #2 No `NATIVE_MESSAGE_ID_KEY` (or other private keys) appear in the previewed rows
-- [ ] #3 Preview behavior unchanged when no summary is active
+- [x] #1 With an active boundary summary, the inspector's next-send preview matches the actually-dispatched payload shape (summary in system prefix, pre-boundary turns absent) or is explicitly labeled pre-compaction with the compaction effect shown
+- [x] #2 No `NATIVE_MESSAGE_ID_KEY` (or other private keys) appear in the previewed rows
+- [x] #3 Preview behavior unchanged when no summary is active
 <!-- AC:END -->
+
+## Implementation Notes
+
+`build_context_snapshot` now mirrors the dispatch choke point: the payload is built with `annotate_ids=True`, `_apply_context_summary_compaction` runs after the dictionary transform (exactly like the send path), and the private `NATIVE_MESSAGE_ID_KEY` is stripped immediately after — so with an active boundary summary the preview shows the compacted payload (summary folded into the leading system row) and the duplicated `system` field is now derived from the payload's own leading system row (falling back to the bare session prompt). Tests: compacted preview (pre-boundary rows gone, summary in messages[0] + system field, no private keys), no-summary unchanged, dangling-boundary un-compacted (leak-rule parity).

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -2049,9 +2049,16 @@ class ConsoleChatController:
             )
             # Preserve whatever was assembled before the failure so the viewer
             # still sees the transcript-derived payload and effective system
-            # prompt rather than an empty placeholder.
+            # prompt rather than an empty placeholder. A failure inside the
+            # annotate->strip window leaves the private id-threading key on the
+            # assembled rows, so strip it here too (Qodo, PR #860).
             degraded_messages = self._replace_image_data_with_placeholders(
-                self._redact_secrets(provider_messages)
+                self._redact_secrets(
+                    [
+                        {k: v for k, v in row.items() if k != NATIVE_MESSAGE_ID_KEY}
+                        for row in provider_messages
+                    ]
+                )
             )
             degraded_system = self._redact_secrets(self._leading_system_message())
             return ConsoleContextSnapshot(

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1923,7 +1923,12 @@ class ConsoleChatController:
 
         try:
             # Build the next-send payload as submit_draft would, but do not persist.
-            provider_messages = self._provider_messages_for_session(session_id)
+            # task-548: annotate native ids so the boundary-summary compaction
+            # below can anchor by identity, exactly like the real dispatch path
+            # (the keys are stripped again before the snapshot is returned).
+            provider_messages = self._provider_messages_for_session(
+                session_id, annotate_ids=True
+            )
 
             # Append a synthetic user turn for the draft so the preview matches what would be sent.
             attachment_tuple = tuple(attachments or ())
@@ -1952,6 +1957,22 @@ class ConsoleChatController:
             # Chat dictionaries are safe to apply (string replacements only).
             provider_messages = await self._apply_chat_dictionaries(provider_messages, session_id)
 
+            # task-548: mirror the dispatch choke point's boundary-summary
+            # compaction so the preview matches what is actually sent when a
+            # `/rewind` summary is active (pre-boundary turns replaced by the
+            # summary folded into the leading system row). Applied after the
+            # transforms, exactly like the send path; a payload without the
+            # boundary row (or no stored summary) is untouched. The private
+            # id-threading key is stripped immediately after, so it can never
+            # appear in the preview rows.
+            provider_messages = self._apply_context_summary_compaction(
+                session_id, provider_messages
+            )
+            provider_messages = [
+                {k: v for k, v in row.items() if k != NATIVE_MESSAGE_ID_KEY}
+                for row in provider_messages
+            ]
+
             # task-401: mirror the send path's response prefill exactly --
             # same resolution (one-shot wins over pinned) and same trailing
             # assistant turn -- WITHOUT consuming the one-shot (this is a
@@ -1976,7 +1997,17 @@ class ConsoleChatController:
 
             # Redact secrets before returning.
             redacted_messages = self._redact_secrets(provider_messages)
-            redacted_system = self._redact_secrets(self._leading_system_message())
+            # task-548: derive the duplicated `system` field from the payload's
+            # own leading system row when present, so a folded boundary summary
+            # shows there too (falling back to the bare session prompt when the
+            # payload carries no system row).
+            leading_system: list[dict[str, Any]] = (
+                [provider_messages[0]]
+                if provider_messages
+                and provider_messages[0].get("role") == ConsoleMessageRole.SYSTEM.value
+                else self._leading_system_message()
+            )
+            redacted_system = self._redact_secrets(leading_system)
 
             # Deep-copy messages so the snapshot is independent of the store.
             copied_messages = copy.deepcopy(current_messages)

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -2023,6 +2023,12 @@ class ChatScreen(BaseAppScreen):
         self._console_model_option_warnings: dict[tuple[str, str], str] = {}
         self._last_console_action: ConsoleActionResult | None = None
         self._pending_console_delete_message_id: str | None = None
+        #: task-501: sibling-swipe selection handoff. Held on the SCREEN (not
+        #: the transcript widget) because the transcript can be remounted by a
+        #: recompose between the swipe and the next message push — the sync
+        #: transfers this onto whichever transcript instance is current when
+        #: it pushes the post-swipe messages.
+        self._pending_console_swipe_selection: str | None = None
         self._console_transcript_sync_timer: Any | None = None
         self._console_sync_in_progress = False
         self._console_sync_requested = False
@@ -10715,6 +10721,15 @@ class ChatScreen(BaseAppScreen):
 
         messages = self._native_console_messages()
         if transcript is not None:
+            # task-501: transfer a sibling-swipe selection handoff onto the
+            # CURRENT transcript instance right before the push — the widget
+            # applies it at ingest time once the landed sibling's id is in
+            # the pushed set (see ConsoleTranscript.pending_selection_id).
+            if self._pending_console_swipe_selection is not None:
+                transcript.pending_selection_id = (
+                    self._pending_console_swipe_selection
+                )
+                self._pending_console_swipe_selection = None
             transcript.set_messages(messages)
             # SP2 /rewind: derive the "summarize up to here" banner boundary
             # from the active session's stored summary state. Render-derived
@@ -13142,10 +13157,25 @@ class ChatScreen(BaseAppScreen):
             action_id in {"variant-previous", "variant-next"}
             and result.status == "completed"
         ):
+            landed_sibling_id: str | None = None
             if message.generation_metadata:
                 self._select_console_generation_variant(message, direction=action_id)
             else:
-                self._select_console_message_variant(message_id, direction=action_id)
+                landed_sibling_id = self._select_console_message_variant(
+                    message_id, direction=action_id
+                )
+            # task-501: keep the selection (and its action row) on the swapped
+            # sibling so repeated `<`/`>` presses work without re-clicking the
+            # row. The post-swipe view reaches the transcript asynchronously
+            # (possibly coalesced), so hand the target off as a PENDING
+            # selection the transcript applies at ingest time — selecting
+            # eagerly here would either miss its membership guard or be
+            # cleared by reconciliation against the stale set. Other
+            # selection-clearing actions ("continue" etc.) are untouched.
+            if landed_sibling_id is not None:
+                # Held on the screen (remount-proof); the sync below transfers
+                # it onto whichever transcript instance receives the push.
+                self._pending_console_swipe_selection = landed_sibling_id
             await self._sync_native_console_chat_ui()
             return True
         if action_id == "keep" and result.status == "completed":
@@ -13858,8 +13888,13 @@ class ChatScreen(BaseAppScreen):
 
     def _select_console_message_variant(
         self, message_id: str, *, direction: str
-    ) -> None:
+    ) -> str | None:
         """Move the active leaf across ``message_id``'s persisted siblings.
+
+        Returns the target sibling's native id when the swipe moved (so the
+        caller can re-select that row after the UI sync — task-501: repeated
+        ``<``/``>`` presses must not require re-clicking the row), or ``None``
+        on a no-op at either end of the sibling list.
 
         ``message_id`` identifies the transcript ROW the swipe control was
         clicked on -- this may be off the CURRENT active leaf's own subtree
@@ -13881,12 +13916,13 @@ class ChatScreen(BaseAppScreen):
         elif direction == "variant-next":
             target_index = index + 1
         else:
-            return
+            return None
         if target_index < 0 or target_index >= count:
-            return
+            return None
         target_sibling_id = siblings[target_index].id
         session_id = store.session_id_for_message(message_id)
         store.set_active_leaf(session_id, store._leaf_under(target_sibling_id))
+        return target_sibling_id
 
     def _select_console_generation_variant(
         self, message: ConsoleChatMessage, *, direction: str

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -536,6 +536,14 @@ class ConsoleTranscript(VerticalScroll):
         super().__init__(**kwargs)
         self._messages: list[ConsoleChatMessage] = []
         self.selected_message_id: str | None = None
+        #: task-501: a selection to apply on the NEXT message ingest that
+        #: contains this id. Set by the screen's sibling-swipe handler, which
+        #: runs BEFORE the (possibly coalesced) post-swipe view reaches this
+        #: widget -- selecting eagerly would either miss the membership guard
+        #: or be cleared by reconciliation against the stale set. Applying it
+        #: at ingest time keeps the swiped-to sibling selected so repeated
+        #: `<`/`>` presses need no re-click.
+        self.pending_selection_id: str | None = None
         #: SP2 /rewind: native id of the "summarize up to here" boundary message.
         #: Render-derived only -- a banner row is emitted above this message when
         #: it is among the rendered messages; ``None`` (or a dangling id) shows
@@ -730,6 +738,16 @@ class ConsoleTranscript(VerticalScroll):
             # scrolled back.
             self.anchor()
         self._seen_message_ids = message_ids
+        # task-501: apply a swipe-handoff selection once its id is actually in
+        # the ingested set (see ``pending_selection_id``); checked BEFORE the
+        # clear below so a swipe that removed the old selection lands directly
+        # on the swiped-to sibling instead of clearing to None.
+        if (
+            self.pending_selection_id is not None
+            and self.pending_selection_id in message_ids
+        ):
+            self.selected_message_id = self.pending_selection_id
+            self.pending_selection_id = None
         if self.selected_message_id not in message_ids:
             self.selected_message_id = None
         for stale_id in [


### PR DESCRIPTION
Second batch of Console branching//rewind follow-ups.

## task-548 — inspector next-send preview reflects boundary compaction
`build_context_snapshot` now annotates ids, applies the same `_apply_context_summary_compaction` as the dispatch choke point (after the dictionary transform), strips the private key, and derives the duplicated `system` field from the payload's own leading system row — so the inspector preview matches the actually-dispatched payload when a /rewind summary is active.

## task-501 — keep transcript selection across sibling swipe
A `<`/`>` sibling swipe now hands the landed sibling's id off as a PENDING selection: the screen holds it (remount-proof across recomposes) and transfers it onto whichever transcript instance receives the post-swipe push; `set_messages` applies it at ingest, before the stale-selection clear. The action row therefore stays available and repeated `<`/`>` presses compare branches back-to-back with no intervening row re-click — the primary use case branching was built for. "continue" and every other selection-clearing action keep the PR #359 clear-on-swap rule.

## Verification
- `test_console_sibling_swipe_buttons_navigate_between_regenerated_siblings` extended: selection follows both swipe directions, repeated swipe with no re-click, boundary disabled states re-pinned under the new resting state.
- 177 passed across the swipe test + console store (base/sibling/tree) + transcript selection-contract suites; full `test_console_native_chat_flow.py` at 196 passed with only the 4 pre-existing baseline failures (identical on clean HEAD).
- task-501 live-verified in the real TUI (tmux, local llama_cpp): regenerate to 3 siblings, `<`/`<`/`>` back-to-back with no row re-clicks — counter walked (3/3)→(2/3)→(1/3)→(2/3) with the action row and guide persistent throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the inspector next-send preview with `/rewind` boundary compaction and keeps transcript selection across sibling swipes. Improves preview accuracy and removes re-clicks when comparing branches.

- **Bug Fixes**
  - task-548: Preview mirrors dispatch compaction. Annotates ids, compacts after dictionary transform, strips `NATIVE_MESSAGE_ID_KEY` (also in degraded snapshots), and derives `system` from the payload’s leading system row. Covers no-summary and dangling-boundary cases. Tests updated.
  - task-501: Selection follows `<`/`>` swipes. Landed sibling id is handed off as a pending selection, moved to the active transcript, and applied in `set_messages` before the stale-selection clear. Repeated swipes need no re-click; "continue" still clears.

<sup>Written for commit c841802baf5a7aa41baebb413c742af1489f3765. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

