### PR TITLE
Follow-ups: task-504 Chat-tab conversation-load repair + task-551 server-backend {{user}} resolution

### DIFF
--- a/Docs/superpowers/plans/2026-07-24-followups-504-551.md
+++ b/Docs/superpowers/plans/2026-07-24-followups-504-551.md
@@ -1,0 +1,366 @@
+# Follow-ups 504 + 551 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Repair `display_conversation_in_chat_tab_ui` so a loaded conversation actually populates the live Chat tab (task-504), and add an async active-user-profile resolver so `{{user}}` substitutes for server-backend profiles (task-551).
+
+**Architecture:** task-504 removes the dead `#chat-right-sidebar` block, repoints conversation details to the live `EnhancedSettingsSidebar` ids (`#chat-chat-title`/`#chat-chat-id`), scopes the exception handling so sidebar-detail failures can't abort the message-log mount, and live-shapes the shared test fixture that masked the bug. task-551 adds `resolve_active_user_profile_name_async` (local mode delegates to the sync resolver unchanged; server mode validates against `CharacterPersonaScopeService.list_user_profiles(mode="server")`, never raising) and swaps the three task-442 substitution sites onto it.
+
+**Tech Stack:** Python 3.11, Textual 8.x, pytest (Tests/UI has `asyncio_mode=auto`).
+
+**Spec:** `Docs/superpowers/specs/2026-07-24-followups-504-551-design.md` (committed e4d3cd42c) — read it first; its "Scout-verified ground truths" sections are binding.
+
+## Global Constraints
+
+- Worktree: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/personas-redesign`, branch `claude/roleplay-followups-504-551`. Subagent shells start in the MAIN checkout and a hook strips a LEADING `cd` — prepend `true; cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/personas-redesign; ` to EVERY Bash command.
+- Test command prefix (venv lives in the main checkout; imports resolve to the worktree): `true; cd <worktree>; HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <paths> -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread`
+- Do NOT mix `Tests/UI/` with another test dir in one pytest invocation (asyncio_mode=auto is Tests/UI-local). Run them as separate invocations.
+- Stage ONLY your task's files. Never `git add -A`. Never touch `.superpowers/`. No background test runs; run pytest in the foreground.
+- Naming: "persona" NEVER refers to the app user. New identifiers are user-profile-named. `{{user}}` = the USER's name; `{{char}}`/`{{character}}`/`{{persona}}` = the character's.
+- Byte-compat: with no active-profile pointer set, all outputs stay byte-identical (the task-442 twin tests must pass unchanged).
+- Line numbers in this plan are from the branch point (dev 238ac3041) and can drift — re-locate by symbol/string, not by line.
+
+---
+
+### Task 1: task-504 — repair `display_conversation_in_chat_tab_ui` and live-shape the fixture
+
+**Files:**
+- Modify: `tldw_chatbook/Event_Handlers/Chat_Events/chat_events.py` (`display_conversation_in_chat_tab_ui` ~:4147-4423; `handle_chat_clear_active_character_button_pressed` dead block ~:4892-4933)
+- Modify: `tldw_chatbook/Chat/tabs/tab_context.py` (`GLOBAL_WIDGETS` ~:40-46)
+- Modify: `tldw_chatbook/Event_Handlers/Chat_Events/chat_events_tabs.py` (any `#chat-conversation-*` id references in the wrapper, def ~:319)
+- Modify: `Tests/fixtures/event_handler_mocks.py` (~:122-124, ~:153-158, ~:188, ~:265-269)
+- Modify: `Tests/Event_Handlers/Chat_Events/test_chat_events.py` (new regression tests), `Tests/Event_Handlers/Chat_Events/test_chat_events_tabs.py` (redirect pins if they name old ids)
+- Modify: `backlog/tasks/task-504 - Fix-chat-right-sidebar-QueryError-silently-aborting-conversation-load-in-Chat-tab.md`
+
+**Interfaces:**
+- Consumes: live sidebar ids `#chat-chat-title` (Input) and `#chat-chat-id` (Input, disabled) composed by `EnhancedSettingsSidebar._compose_chat_details()` with `id_prefix="chat"` (`enhanced_settings_sidebar.py:404-440`). Verified: no `Input.Changed` router matches these ids — programmatic writes are side-effect-free.
+- Produces: nothing later tasks depend on (Task 2/3 are independent of this task).
+
+- [ ] **Step 1: Amend task-504 AC #1 in the task file (before any code)** — replace the AC #1 line with:
+  `- [ ] #1 Loading a saved conversation through display_conversation_in_chat_tab_ui populates the live sidebar title (#chat-chat-title), the conversation id display (#chat-chat-id), and the full message log without hitting the #chat-right-sidebar QueryError path (keywords dropped: no live keywords field exists — user-approved amendment 2026-07-24)`
+  Commit message: `docs(backlog): amend task-504 AC1 — repoint to live sidebar ids, drop keywords (user-approved)`
+
+- [ ] **Step 2: Write the failing regression tests** in `Tests/Event_Handlers/Chat_Events/test_chat_events.py`, next to the existing `test_display_conversation_substitutes_active_profile_name` (~:777) and reusing its fixture idioms (`mock_app`, `_t4_conversation_fixture`-style DB stubbing). Three tests:
+
+```python
+@pytest.mark.asyncio
+async def test_display_conversation_populates_live_sidebar_and_log(mock_app):
+    """task-504 AC1/AC3: title, id display, and message log populate against the live-shaped tree."""
+    # Arrange a conversation exactly like the existing T4 tests do (same
+    # ccl.get_conversation_details_and_messages stub, title="My Chat",
+    # two messages), then:
+    await chat_events.display_conversation_in_chat_tab_ui(mock_app, "conv-1")
+    assert mock_app.query_one("#chat-chat-title", Input).value == "My Chat"
+    assert mock_app.query_one("#chat-chat-id", Input).value == "conv-1"
+    chat_log = mock_app.query_one("#chat-log", VerticalScroll)
+    assert chat_log.mount.await_count == len(stubbed_messages)  # every message mounted
+
+@pytest.mark.asyncio
+async def test_display_conversation_never_queries_dead_right_sidebar(mock_app):
+    """task-504 AC1: the dead #chat-right-sidebar id is never queried (fixture raises QueryError for unknown ids)."""
+    await chat_events.display_conversation_in_chat_tab_ui(mock_app, "conv-1")
+    queried = [c.args[0] for c in mock_app.query_one.call_args_list]
+    assert "#chat-right-sidebar" not in queried
+    assert not any(sel.startswith("#chat-character-") for sel in queried)
+    assert not any(sel.startswith("#chat-conversation-") for sel in queried)
+
+@pytest.mark.asyncio
+async def test_display_conversation_sidebar_failure_does_not_block_log(mock_app):
+    """task-504: a missing sidebar detail field must not abort the message-log mount (the original bug pattern)."""
+    # Remove #chat-chat-title from the fixture's widget dict so that query raises QueryError.
+    await chat_events.display_conversation_in_chat_tab_ui(mock_app, "conv-1")
+    chat_log = mock_app.query_one("#chat-log", VerticalScroll)
+    assert chat_log.mount.await_count == len(stubbed_messages)  # log still populated
+```
+
+  Adapt assertions to the fixture's actual mechanics (widgets are MagicMocks; `.value` is a plain attribute after assignment; the fixture's `query_one` side-effect records calls). The exact stubbed-conversation arrangement MUST be copied from the neighboring T4 tests — do not invent a new stubbing style.
+
+- [ ] **Step 3: Live-shape the fixture** in `Tests/fixtures/event_handler_mocks.py`: delete the `#chat-conversation-title-input` / `#chat-conversation-keywords-input` / `#chat-conversation-uuid-display` entries, the six `#chat-character-*-edit` entries, the `"#chat-right-sidebar": MagicMock(),` entry, and the `if "#chat-right-sidebar" in widgets:` wiring block. Add:
+```python
+        "#chat-chat-title": create_widget_mock(Input, value=""),
+        "#chat-chat-id": create_widget_mock(Input, value=""),
+```
+  (Keep `#chat-character-search-results-list` — it is a different family used elsewhere.)
+
+- [ ] **Step 4: Run the new tests to verify they FAIL** (the production code still queries dead ids):
+  `... -m pytest Tests/Event_Handlers/Chat_Events/test_chat_events.py -q ...`
+  Expected: the three new tests fail; note which PRE-EXISTING tests in the mock_app suites now fail because of removed dead ids — apply the spec's blast-radius rule: a failing test of some OTHER legacy handler gets its id restored with `# DEAD-ID: not in live tree; kept for legacy-handler test — see follow-up task` and is listed in your report; a failing test of the two functions THIS task fixes gets updated as part of this task.
+
+- [ ] **Step 5: Implement the repair** in `display_conversation_in_chat_tab_ui`:
+  1. Delete the whole `right_sidebar_chat_tab = app.query_one("#chat-right-sidebar")` block including both `if/else` branches of character-edit writes (~:4247-4285).
+  2. Replace the `#chat-conversation-*` writes (~:4287-4295) with a scoped guard:
+```python
+        try:
+            app.query_one("#chat-chat-title", Input).value = conv_metadata.get("title", "")
+            app.query_one("#chat-chat-id", Input).value = conversation_id
+        except QueryError as qe_sidebar:
+            loguru_logger.warning(
+                f"Sidebar chat-details fields unavailable while loading {conversation_id}: {qe_sidebar}"
+            )
+```
+     (No keywords write — no live field.)
+  3. Wrap the three `#chat-system-prompt` writes in the character-resolution section (~:4225-4245) with the same scoped-guard pattern (one small `try/except QueryError` around each write or a tiny local helper — a missing sidebar field must never abort the load).
+  4. In the not-found branch (~:4164-4171): replace the three dead-id writes with the same `#chat-chat-title` ("Error: Not Found") / `#chat-chat-id` (conversation_id) scoped-guard pattern; keep the `#chat-log` error-message mount as-is.
+  5. Move the closing `loguru_logger.info("Displayed conversation ...")` (~:4421-4423) inside the `try` success path (after the token-counter block), so it no longer logs success when the except path ran.
+  6. Keep the outer `except QueryError` (~:4416-4420) as last-resort for the load-bearing `#chat-log` / `#chat-input` queries.
+
+- [ ] **Step 6: Clean the twin** in `handle_chat_clear_active_character_button_pressed` (~:4892-4933): delete the `right_sidebar = app.query_one("#chat-right-sidebar")` line, the six field writes, and the commented-out block; keep the `app.notify("Active character cleared. ...")` success notify (now unconditional after the system-prompt reset) and delete the now-unreachable `except QueryError` arm of THIS block (keep `except Exception` if other statements remain that can raise). Update its log line to drop the `#chat-right-sidebar` mention.
+
+- [ ] **Step 7: Tabs surfaces:** in `tab_context.py` `GLOBAL_WIDGETS`, replace the three `#chat-conversation-*` entries with `"#chat-chat-title"` and `"#chat-chat-id"` (keep `#chat-system-prompt`). Grep `chat_events_tabs.py` and `test_chat_events_tabs.py` for `chat-conversation-` and update references/pins to the new ids (the wrapper has no production callers; keep it consistent, do not extend it).
+
+- [ ] **Step 8: Run the full affected suites** (foreground, separate invocations):
+  - `Tests/Event_Handlers/Chat_Events/` (all — the fixture is shared)
+  - `Tests/fixtures/` if it has its own tests; plus `grep -rl "event_handler_mocks" Tests/` and run every hit's directory
+  Expected: all pass (with any blast-radius restorations documented).
+
+- [ ] **Step 9: Update the task file**: check the AC boxes, add `## Implementation Plan` and `## Implementation Notes` sections, and set `status: Done` in the frontmatter — mirror the structure of a recently-Done task file under `backlog/tasks/` (program convention: the task file goes Done inside the task commit; the controller re-verifies at merge).
+
+- [ ] **Step 10: Commit** with message `fix(chat): task-504 — repoint conversation load to live sidebar ids, scope QueryError guards, live-shape event fixture`.
+
+---
+
+### Task 2: task-551 — `resolve_active_user_profile_name_async` + unit tests
+
+**Files:**
+- Modify: `tldw_chatbook/Character_Chat/active_user_profile.py`
+- Modify: `Tests/Character_Chat/test_active_user_profile.py`
+
+**Interfaces:**
+- Consumes: existing `get_active_user_profile_pointer()`, `resolve_active_user_profile_name(service)` (both in the same module).
+- Produces (Task 3 depends on these EXACT signatures):
+  - `async def resolve_active_user_profile_name_async(scope_service: Any, *, mode: Optional[str], local_service: Optional[_UserProfileLister] = None) -> Optional[str]`
+  - `def resolve_runtime_backend_mode(app_like: Any) -> str` (guarded reader of `get_authoritative_runtime_source`, returns `"local"` or `"server"`, never raises, default `"local"`)
+
+- [ ] **Step 1: Write the failing unit tests** in `Tests/Character_Chat/test_active_user_profile.py` (reuse the existing `_isolated_config` fixture and `_FakeService`; these tests are asyncio — this dir does NOT have asyncio_mode=auto, so mark each with `@pytest.mark.asyncio`):
+
+```python
+class _FakeScopeService:
+    def __init__(self, payload=None, exc=None):
+        self.payload = payload
+        self.exc = exc
+        self.calls: list[dict] = []
+
+    async def list_user_profiles(self, mode="local", **kwargs):
+        self.calls.append({"mode": mode, **kwargs})
+        if self.exc is not None:
+            raise self.exc
+        return self.payload
+
+
+@pytest.mark.asyncio
+async def test_async_resolver_server_mode_matches_server_profile(_isolated_config):
+    mod.set_active_user_profile("Sam")
+    scope = _FakeScopeService(payload=[{"name": "Sam"}, {"name": "Rae"}])
+    assert await mod.resolve_active_user_profile_name_async(scope, mode="server") == "Sam"
+    assert scope.calls == [{"mode": "server"}]
+
+@pytest.mark.asyncio
+async def test_async_resolver_server_mode_accepts_items_payload(_isolated_config):
+    mod.set_active_user_profile("Sam")
+    scope = _FakeScopeService(payload={"items": [{"name": "Sam"}]})
+    assert await mod.resolve_active_user_profile_name_async(scope, mode="server") == "Sam"
+
+@pytest.mark.asyncio
+async def test_async_resolver_server_dangling_resolves_none(_isolated_config):
+    mod.set_active_user_profile("Ghost")
+    scope = _FakeScopeService(payload=[{"name": "Sam"}])
+    assert await mod.resolve_active_user_profile_name_async(scope, mode="server") is None
+
+@pytest.mark.asyncio
+async def test_async_resolver_server_error_resolves_none(_isolated_config):
+    mod.set_active_user_profile("Sam")
+    scope = _FakeScopeService(exc=RuntimeError("connection refused"))
+    assert await mod.resolve_active_user_profile_name_async(scope, mode="server") is None
+
+@pytest.mark.asyncio
+async def test_async_resolver_server_without_scope_service_resolves_none(_isolated_config):
+    mod.set_active_user_profile("Sam")
+    assert await mod.resolve_active_user_profile_name_async(None, mode="server") is None
+
+@pytest.mark.asyncio
+async def test_async_resolver_local_and_unknown_modes_delegate_to_sync(_isolated_config):
+    mod.set_active_user_profile("Sam")
+    local = _FakeService([{"name": "Sam"}])
+    scope = _FakeScopeService(payload=[{"name": "SERVER-ONLY"}])
+    for mode in ("local", None, "", "LOCAL", "garbage"):
+        assert await mod.resolve_active_user_profile_name_async(
+            scope, mode=mode, local_service=local
+        ) == "Sam"
+    assert scope.calls == []  # scope service never consulted off server mode
+
+@pytest.mark.asyncio
+async def test_async_resolver_no_pointer_short_circuits(_isolated_config):
+    scope = _FakeScopeService(payload=[{"name": "Sam"}])
+    assert await mod.resolve_active_user_profile_name_async(scope, mode="server") is None
+    assert scope.calls == []  # byte-compat: no backend call without a pointer
+
+
+def test_resolve_runtime_backend_mode_guards():
+    class _App:
+        def get_authoritative_runtime_source(self):
+            return "SERVER"
+    assert mod.resolve_runtime_backend_mode(_App()) == "server"
+    class _Raises:
+        def get_authoritative_runtime_source(self):
+            raise RuntimeError("boom")
+    assert mod.resolve_runtime_backend_mode(_Raises()) == "local"
+    assert mod.resolve_runtime_backend_mode(object()) == "local"
+    assert mod.resolve_runtime_backend_mode(None) == "local"
+```
+
+  NOTE the no-pointer short-circuit test: the pointer check must come BEFORE the scope-service call.
+
+- [ ] **Step 2: Run to verify FAIL** (`AttributeError: ... has no attribute 'resolve_active_user_profile_name_async'`):
+  `... -m pytest Tests/Character_Chat/test_active_user_profile.py -q ...`
+
+- [ ] **Step 3: Implement** in `active_user_profile.py` (Google docstrings — Args/Returns; the module's existing style is the template):
+
+```python
+def resolve_runtime_backend_mode(app_like: Any) -> str:
+    """Return the app's authoritative runtime backend mode, never raising.
+
+    Args:
+        app_like: Object expected to expose ``get_authoritative_runtime_source()``.
+
+    Returns:
+        ``"local"`` or ``"server"``; ``"local"`` on any failure or unknown value.
+    """
+    getter = getattr(app_like, "get_authoritative_runtime_source", None)
+    if callable(getter):
+        try:
+            candidate = str(getter() or "").strip().lower()
+            if candidate in {"local", "server"}:
+                return candidate
+        except Exception as exc:  # Never raise into a send path.
+            logger.debug(f"Runtime backend mode read failed: {exc}")
+    return "local"
+
+
+async def resolve_active_user_profile_name_async(
+    scope_service: Any,
+    *,
+    mode: Optional[str],
+    local_service: Optional[_UserProfileLister] = None,
+) -> Optional[str]:
+    """Resolve the active user profile's name against the current backend.
+
+    Local (and unknown) modes delegate to the sync resolver unchanged; server
+    mode validates the config pointer against the scope service's server
+    backend. A dangling pointer and every backend failure resolve to ``None``
+    (no active profile) — this function never raises.
+
+    Args:
+        scope_service: ``CharacterPersonaScopeService``-like object with an
+            async ``list_user_profiles(mode=...)``; may be ``None``.
+        mode: Backend mode; anything other than ``"server"`` uses the local path.
+        local_service: Sync local profile service for the local path.
+
+    Returns:
+        The active profile's name, or ``None`` when unset/dangling/unavailable.
+    """
+    normalized = str(mode or "").strip().lower()
+    if normalized != "server":
+        return resolve_active_user_profile_name(local_service)
+    pointer = get_active_user_profile_pointer()
+    if not pointer or scope_service is None:
+        return None
+    try:
+        payload = await scope_service.list_user_profiles(mode="server")
+        records = payload.get("items", []) if isinstance(payload, dict) else (payload or [])
+        for record in records:
+            if isinstance(record, dict) and str(record.get("name") or "") == pointer:
+                return pointer
+    except Exception as exc:  # Fail closed: {{user}} falls back to its site default.
+        logger.debug(f"Server-side active user profile resolution failed: {exc}")
+    return None
+```
+
+  (Match the module's actual logger import — it uses loguru per the existing functions; keep imports consistent. Add `Any`/`Optional` to the typing imports if missing.)
+
+- [ ] **Step 4: Run to verify PASS**, plus the pre-existing resolver tests in the same file (all must stay green).
+
+- [ ] **Step 5: Commit**: `feat(roleplay): task-551 — async active-user-profile resolver for the server backend`.
+
+---
+
+### Task 3: task-551 — swap the three substitution sites + site tests
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` (`_start_character_console_session` resolver call ~:10430-10461)
+- Modify: `tldw_chatbook/Event_Handlers/Chat_Events/chat_events.py` (`display_conversation_in_chat_tab_ui` resolver call ~:4205-4207)
+- Modify: `tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py` (`_active_user_name` ~:69-84, `_load_greetings` ~:109-159, `reset_for_character` ~:161-180, `handle_character_loaded` ~:351-392)
+- Modify: `Tests/UI/test_chat_first_handoffs.py`, `Tests/Event_Handlers/Chat_Events/test_chat_events.py`, `Tests/UI/test_personas_preview.py` (one server-mode test each)
+- Modify: `backlog/tasks/task-551 - Active-user-profile-resolution-for-the-server-profile-backend.md`
+
+**Interfaces:**
+- Consumes (from Task 2, exact): `resolve_active_user_profile_name_async(scope_service, *, mode, local_service=None)` (async), `resolve_runtime_backend_mode(app_like) -> str`.
+- Produces: nothing downstream.
+
+- [ ] **Step 1: Write the failing server-mode site tests** — one per file, each a sibling of the existing task-442 substitution test in that file, copying its arrangement verbatim and changing ONLY the service/mode arrangement:
+  - `Tests/UI/test_chat_first_handoffs.py::test_native_start_chat_greeting_uses_server_backend_profile`: like `test_native_start_chat_greeting_uses_active_user_profile_name` (~:485) but: `app.local_character_persona_service = None`, `app.character_persona_scope_service = _FakeScopeService(payload=[{"name": "Sam"}])` (define the fake locally, async `list_user_profiles`), `app.get_authoritative_runtime_source = lambda: "server"`. Assert the greeting substitutes "Sam" and `session.settings.user_profile_label == "Sam"`.
+  - `Tests/Event_Handlers/Chat_Events/test_chat_events.py::test_display_conversation_substitutes_server_backend_profile`: like `test_display_conversation_substitutes_active_profile_name` (~:777) with the same swap on `mock_app` (`mock_app.get_authoritative_runtime_source = lambda: "server"`; `local_character_persona_service = None`; fake scope service).
+  - `Tests/UI/test_personas_preview.py::test_greeting_renders_server_backend_profile_name`: like `test_greeting_renders_active_profile_name_and_labels_user_lines` (~:613) but the `_ControllerScreen`'s `app_instance` gets `character_persona_scope_service=<fake>`, `local_character_persona_service=None`, and the screen gets a `persona_handler` stub whose `current_mode()` returns `"server"`. Assert the greeting renders "Sam" and the user line label is "Sam".
+  Run each file; expected: the three new tests FAIL (name falls back), all twins still PASS.
+
+- [ ] **Step 2: Swap site (b)** `chat_screen._start_character_console_session` — replace the sync call block:
+```python
+        active_user_name = resolve_active_user_profile_name(
+            getattr(self.app_instance, "local_character_persona_service", None)
+        )
+```
+  with:
+```python
+        active_user_name = await resolve_active_user_profile_name_async(
+            getattr(self.app_instance, "character_persona_scope_service", None),
+            mode=resolve_runtime_backend_mode(self.app_instance),
+            local_service=getattr(self.app_instance, "local_character_persona_service", None),
+        )
+```
+  Update the local import (~:10430-10432) to import both new names (keep the sync name only if still used elsewhere in the file — grep first).
+
+- [ ] **Step 3: Swap site (c)** `chat_events.display_conversation_in_chat_tab_ui` — same transformation, preserving the trailing `or app.app_config.get("USERS_NAME", "User")` byte-exact, `mode=resolve_runtime_backend_mode(app)`. Update the module import (~:71-73).
+
+- [ ] **Step 4: Swap site (a)** preview controller:
+  1. Module-level sentinel: `_UNSET: Any = object()`.
+  2. New method on the controller:
+```python
+    async def _resolve_user_name_async(self) -> Optional[str]:
+        """Resolve the active user profile name against the workbench's backend mode."""
+        mode = "local"
+        handler = getattr(self.screen, "persona_handler", None)
+        current_mode = getattr(handler, "current_mode", None)
+        if callable(current_mode):
+            try:
+                candidate = str(current_mode() or "").strip().lower()
+                if candidate in {"local", "server"}:
+                    mode = candidate
+            except Exception:
+                mode = "local"
+        app_instance = getattr(self.screen, "app_instance", None)
+        return await resolve_active_user_profile_name_async(
+            getattr(app_instance, "character_persona_scope_service", None),
+            mode=mode,
+            local_service=getattr(app_instance, "local_character_persona_service", None),
+        )
+```
+  3. `_load_greetings(self, ..., user_name: Any = _UNSET)`: at the top of the body, `user_name = self._active_user_name() if user_name is _UNSET else user_name`; the rest of the body consumes `user_name` exactly as it does today (delete the old inline `user_name = self._active_user_name()` line).
+  4. In `reset_for_character` and `handle_character_loaded` (both async), pass `user_name=await self._resolve_user_name_async()` into their `_load_greetings(...)` calls.
+  5. Keep `_active_user_name()` (it is the sync fallback for any other `_load_greetings` caller — grep for other callers first; if none besides these two, still keep the sentinel fallback as the safety default).
+
+- [ ] **Step 5: Run the three site-test files + resolver units + twins** (separate invocations; Tests/UI alone):
+  - `Tests/Character_Chat/test_active_user_profile.py`
+  - `Tests/Event_Handlers/Chat_Events/test_chat_events.py`
+  - `Tests/UI/test_chat_first_handoffs.py Tests/UI/test_personas_preview.py`
+  Expected: all PASS, twins untouched and green.
+
+- [ ] **Step 6: Update the task-551 file** (AC boxes, Implementation Plan/Notes sections per backlog conventions).
+
+- [ ] **Step 7: Commit**: `feat(roleplay): task-551 — server-backend {{user}} resolution at the three substitution sites`.
+
+---
+
+### Controller-level (not subagent tasks)
+
+- File the follow-up backlog task "Conversation load/save/clone entry points missing from live Chat tab UI" (reachability + residual dead surfaces per the spec) — with the backlog-ID collision check (dev max + archive + open branches), re-verified at merge.
+- Final whole-branch review (most capable available model; opus weekly limit until Jul 30 → sonnet), review-package over merge-base..HEAD.
+- PR to `dev` (both tasks), Qodo adjudication, STOP for user merge-go.

--- a/Docs/superpowers/specs/2026-07-24-followups-504-551-design.md
+++ b/Docs/superpowers/specs/2026-07-24-followups-504-551-design.md
@@ -1,0 +1,93 @@
+# Follow-ups 504 + 551 — Chat-load repair + server-backend user-profile resolution — Design
+
+**Date:** 2026-07-24
+**Program:** RP-UX follow-ups (post-sweep; B1 #815 / B2 #824 / B3 #830 / B4 #849 merged).
+**Branch:** `claude/roleplay-followups-504-551` off dev `238ac3041`.
+**Status:** design approved by user (with AC-1 keywords amendment + reachability-follow-up approach confirmed).
+
+## Part 1 — task-504: repair `display_conversation_in_chat_tab_ui`
+
+### Scout-verified ground truths
+
+- The function (`Event_Handlers/Chat_Events/chat_events.py:4147-4423`) is **currently unreachable from the live UI**: its three callers (save `:3323`, clone `:3592`, load-selected `:3797`) fire only from buttons composed in `settings_sidebar.py`, whose `create_settings_sidebar()` has no callers since task-412. The tabs wrapper (`chat_events_tabs.py:319`) has no production callers either.
+- The dead `#chat-right-sidebar` query (`:4247`) is the first failure; the title/UUID/keywords ids written at `:4287-4295` (`#chat-conversation-title-input`, `#chat-conversation-uuid-display`, `#chat-conversation-keywords-input`) are **composed nowhere** — they would raise QueryError even with `:4247` removed. Same for the six `#chat-character-*-edit` ids (`:4248-4285`).
+- The not-found branch (`:4158-4188`) writes the same dead ids inside its own guard.
+- Live equivalents in `EnhancedSettingsSidebar._compose_chat_details()` (prefix-composed, `id_prefix="chat"`): **`#chat-chat-title`** (`Input`, `enhanced_settings_sidebar.py:436-440`) and **`#chat-chat-id`** (`Input`, disabled, `:428-433`). Zero readers/writers today; no `Input.Changed` router anywhere matches these ids (sidebar's own `@on(Input.Changed)` filters on `"settings-search"`; `app.on_input_changed` matches exact other ids) → programmatic `.value` writes are side-effect-free. **There is no live keywords field.**
+- Twin dead pattern: `handle_chat_clear_active_character_button_pressed` queries `#chat-right-sidebar` + the six character-edit ids (`:4892-4907`); its success notify sits after the dead queries, so today it always degrades to the error notify.
+- The shared test fixture `Tests/fixtures/event_handler_mocks.py` registers `#chat-right-sidebar` (bare MagicMock, `:188`), the three `#chat-conversation-*` ids (`:122-124`) and the six `#chat-character-*-edit` ids (`:153-158`) — this is what masks the bug in the existing tests. Unknown selectors already raise `QueryError` (`:250-253`).
+- `TabContext.GLOBAL_WIDGETS` (`Chat/tabs/tab_context.py:~40-46`) enumerates the three dead `#chat-conversation-*` ids; `Tests/.../test_chat_events_tabs.py:868-874` pins that `#chat-conversation-title-input` is not redirected.
+- `:4421-4423` logs "Displayed conversation …" unconditionally, even when the except path ran.
+
+### Changes
+
+1. **`display_conversation_in_chat_tab_ui`:**
+   - Delete the `#chat-right-sidebar` block (`:4247-4285`) — container query + six character-edit writes (AC #2 "dead write attempt removed": no live equivalents exist).
+   - Repoint conversation details to the live sidebar ids: title → `#chat-chat-title` (`Input.value`), conversation id → `#chat-chat-id` (`Input.value`). **Drop the keywords write** (no live field; AC #1 amended accordingly).
+   - Wrap the sidebar-detail writes (title/id + `#chat-system-prompt` character branch) in **their own scoped `try/except QueryError`** (warning log, no notify) so a missing sidebar field can never again abort the message-log mount. The message-log population, `#chat-input` focus, and token counter run regardless of sidebar-detail outcome.
+   - Repoint the not-found branch (`:4164-4171`) the same way (title → `#chat-chat-title` "Error: Not Found", id → `#chat-chat-id`; keywords write dropped).
+   - Move the `"Displayed conversation"` info log into the success path.
+   - Keep the outer `except QueryError` as last-resort for the truly load-bearing queries (`#chat-log`, `#chat-input`).
+2. **`handle_chat_clear_active_character_button_pressed`:** remove the dead container + six field queries; keep the (live) `#chat-system-prompt` reset and the "Active character cleared." success notify.
+3. **Fixture honesty (`event_handler_mocks.py`):** remove `#chat-right-sidebar`, the three `#chat-conversation-*` entries, and the six `#chat-character-*-edit` entries; add `#chat-chat-title` (`Input`, `value=""`) and `#chat-chat-id` (`Input`, `value=""`). Also drop the `#chat-right-sidebar` `query_one` wiring block (`:265-269`). **Blast-radius rule:** run the suites that consume `mock_app`; if a test of some *other* legacy handler (outside 504's scope) breaks on a removed id, restore just that id with a `# DEAD-ID: not in live tree; kept for legacy-handler test — see follow-up task` comment and record it in the follow-up task.
+4. **Tabs surfaces:** in `TabContext.GLOBAL_WIDGETS` swap the three dead `#chat-conversation-*` ids for `#chat-chat-title` + `#chat-chat-id` (keep `#chat-system-prompt`); update `chat_events_tabs.py` wrapper id references and the `test_chat_events_tabs.py` redirect pins consistently. Tabs-mode raw-literal behavior of the inner function (`#chat-log`/`#chat-input` not routed through `_tabbed_chat_selector`) is pre-existing and unchanged.
+5. **Regression tests (AC #3):** against the live-shaped fixture — (a) load populates `#chat-chat-title`.value with the metadata title, `#chat-chat-id`.value with the conversation id, and mounts the message widgets into `#chat-log`; (b) a sidebar-detail QueryError does not prevent the message-log mount (scoped-guard pin); (c) the task-442 substitution twins keep passing unchanged.
+6. **Task hygiene:** amend task-504 AC #1 (title + UUID + message log; keywords dropped — no live field) with a note *before* implementation; file the follow-up task: "Conversation load/save/clone entry points missing from live Chat tab UI" (covers reachability + residual dead surfaces: `app.py` right-sidebar watchers `:8613/:8626`, dead button routers `app.py:6925/:9299/:9445`, orphan CSS, `settings_sidebar.py` module retirement). Backlog-ID collision protocol at file time AND merge time.
+
+### Boundaries (OUT of scope)
+
+- No new UI (no keywords field, no load/save/clone buttons — that is the follow-up task).
+- Other legacy handlers that query dead ids keep their behavior (only the `:4895` twin is cleaned, because it is the same audit family).
+- `chat_events_sidebar_resize.py`, `app.py` right-sidebar watchers, orphan CSS: follow-up task.
+- The live `toggle-chat-right-sidebar` *button* id family is a different id — untouched.
+
+## Part 2 — task-551: async active-user-profile resolution for the server backend
+
+### Scout-verified ground truths
+
+- `resolve_active_user_profile_name(service)` (`Character_Chat/active_user_profile.py:71-97`) validates the pointer against the **sync local** service only; server-only profiles fail validation → `{{user}}` silently falls back (Qodo #849-4; lenient variant would break the deliberate dangling→None).
+- `CharacterPersonaScopeService.list_user_profiles` (`character_persona_scope_service.py:637-661`) is **async**, `mode: str = "local"`, normalizes mode (`{"local","server"}` else ValueError), enforces policy `character.persona.list.<mode>`, delegates to the backend, `_maybe_await`s. Server backend → `TLDWAPIClient.list_persona_profiles` → GET `/api/v1/persona/profiles`, returns raw parsed JSON; **every failure raises** (`APIConnectionError`/`AuthenticationError`/`APIResponseError`/`ValueError`/`PolicyDeniedError`); no result caching. Payload may be a bare list or `{"items": [...]}` (CCP handler precedent `ccp_persona_handler.py:85-91`); records carry `"name"`.
+- Scope service instance: `app.character_persona_scope_service` (`app.py:3863`); its local backend wraps the SAME `local_character_persona_service` instance.
+- Backend-mode sources: app-authoritative `app.get_authoritative_runtime_source()` (`app.py:4961-4967`, default "local"; bootstrap downgrades server→local when unconfigured); workbench-local `persona_handler.current_mode()` (`ccp_persona_handler.py:28-43`, window state first, app fallback, default "local").
+- The three task-442 sites: (a) preview `_active_user_name` (`personas_preview_controller.py:69-84`, sync) consumed by sync `_load_greetings` (`:109-159`) whose two callers are async (`reset_for_character:178`, `handle_character_loaded:379`); (b) `chat_screen._start_character_console_session` (`:10398`, async, call `:10445-10447`); (c) `chat_events.display_conversation_in_chat_tab_ui` (`:4147`, async, call `:4205-4207`, preserves `USERS_NAME` fallback).
+- Existing tests: resolver units (`Tests/Character_Chat/test_active_user_profile.py`), site twins (`Tests/UI/test_personas_preview.py:613-716`, `Tests/UI/test_chat_first_handoffs.py:485-560`, `Tests/Event_Handlers/Chat_Events/test_chat_events.py:777-860`) — all set only `local_character_persona_service`, never a scope service.
+
+### Changes
+
+1. **New async resolver** in `active_user_profile.py`:
+   ```
+   async def resolve_active_user_profile_name_async(
+       scope_service, *, mode: str | None, local_service=None
+   ) -> str | None
+   ```
+   - Normalize mode (strip/lower; `None`/unknown → `"local"` — never raise on garbage).
+   - **mode ≠ "server" → return `resolve_active_user_profile_name(local_service)`** unchanged (zero new failure modes in local mode: no policy-enforcement hop, no scope-service dependency; existing semantics byte-identical).
+   - **server:** pointer `None` or `scope_service` `None` → `None`. Else `await scope_service.list_user_profiles(mode="server")`; accept bare-list or `{"items": [...]}` payloads; match `str(record.get("name") or "") == pointer` → pointer; no match → `None` (dangling→None preserved). **Any exception** (connection, auth, policy, ValueError) → debug log → `None` — never raises into a send path; `{{user}}` falls back exactly as today. No result caching (calls happen at selection/send cadence only). Server mode validates against the server only — no local fallback on server failure (a pointer is resolved by the backend the surface is using, or not at all).
+2. **Site (b) `chat_screen._start_character_console_session`:** swap to `await resolve_active_user_profile_name_async(getattr(app, "character_persona_scope_service", None), mode=<app mode>, local_service=getattr(app, "local_character_persona_service", None))` where `<app mode>` = guarded `app_instance.get_authoritative_runtime_source()` (fallback `"local"`). Greeting + `user_profile_label` consumption unchanged.
+3. **Site (c) `chat_events.display_conversation_in_chat_tab_ui`:** same swap with `app`; keep the `or app.app_config.get("USERS_NAME", "User")` fallback byte-exact.
+4. **Site (a) preview controller:** resolve at the async boundary — new `async def _resolve_user_name_async()` on the controller using the **workbench's** mode (`self.screen.persona_handler.current_mode()`, guarded, fallback `"local"` — the preview validates against the backend the workbench is browsing, mirroring what the list surfaces show); `reset_for_character` and `handle_character_loaded` await it and pass the result into `_load_greetings(user_name=...)` (new keyword arg, sentinel default falls back to the existing sync `_active_user_name()`); `set_speakers` logic unchanged. Sync internals stay sync.
+5. **Mode-source rule (one precedence rule per surface):** chat surfaces (b)(c) use the app-authoritative runtime source; the workbench preview (a) uses the workbench mode. Each surface validates against the backend it actually serves.
+
+### Byte-compat (AC #3)
+
+No pointer → the resolver returns `None` before any backend call → all fallbacks identical → the task-442 twins pass **untouched** (their fixtures set no scope service and no runtime source → guarded mode defaults to `"local"` → exact sync path).
+
+### Tests
+
+- Resolver units (`Tests/Character_Chat/test_active_user_profile.py`): server happy path (fake async scope service, bare list), `{"items": [...]}` shape, server dangling → None, scope-service raises → None, `mode="local"`/`None`/garbage delegates to sync path, `scope_service=None` in server mode → None, never-raises.
+- Per-site server-mode substitution test: fake scope service + mode source pinned to `"server"` → the profile name substitutes at each of the three surfaces. Existing twins unchanged.
+
+### Boundaries
+
+- No caching layer, no retry/backoff (selection-cadence network calls; client timeouts govern).
+- No policy-enforcement path added in front of local-mode resolution.
+- Naming: all new identifiers are user-profile-named; "persona" never refers to the user (the `character_persona_scope_service` attribute name is the sanctioned both-halves service name).
+- Preview label staleness on clear/switch and description-into-system-prompt residuals (task-442 archive) stay out.
+
+## Global constraints (carried from the program)
+
+- Test env prefix: `HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest ... -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread`; Tests/UI has `asyncio_mode=auto` — don't mix Tests/UI with other dirs in one invocation.
+- Implementers stage ONLY their task's files; never `git add -A`; never touch `.superpowers/`.
+- Subagents prepend a non-leading `cd` to every Bash call (`true; cd <worktree>; ...` — a hook strips a LEADING `cd`).
+- No background/broad test sweeps; never broad-pkill pytest.
+- Backlog-ID collision check (dev max + archive + open branches) at task-file time and re-verified at merge.
+- PR to `dev`; Qodo adjudication; STOP for explicit user merge-go.

--- a/Tests/Character_Chat/test_active_user_profile.py
+++ b/Tests/Character_Chat/test_active_user_profile.py
@@ -56,3 +56,91 @@ def test_resolver_never_raises_on_broken_service(_isolated_config):
         def list_user_profiles(self, active_only: bool = False):
             raise RuntimeError("store unreadable")
     assert resolve_active_user_profile_name(_Boom()) is None
+
+
+class _FakeScopeService:
+    def __init__(self, payload=None, exc=None):
+        self.payload = payload
+        self.exc = exc
+        self.calls: list[dict] = []
+
+    async def list_user_profiles(self, mode="local", **kwargs):
+        self.calls.append({"mode": mode, **kwargs})
+        if self.exc is not None:
+            raise self.exc
+        return self.payload
+
+
+@pytest.mark.asyncio
+async def test_async_resolver_server_mode_matches_server_profile(_isolated_config):
+    set_active_user_profile("Sam")
+    scope = _FakeScopeService(payload=[{"name": "Sam"}, {"name": "Rae"}])
+    import tldw_chatbook.Character_Chat.active_user_profile as mod
+    assert await mod.resolve_active_user_profile_name_async(scope, mode="server") == "Sam"
+    assert scope.calls == [{"mode": "server"}]
+
+
+@pytest.mark.asyncio
+async def test_async_resolver_server_mode_accepts_items_payload(_isolated_config):
+    set_active_user_profile("Sam")
+    scope = _FakeScopeService(payload={"items": [{"name": "Sam"}]})
+    import tldw_chatbook.Character_Chat.active_user_profile as mod
+    assert await mod.resolve_active_user_profile_name_async(scope, mode="server") == "Sam"
+
+
+@pytest.mark.asyncio
+async def test_async_resolver_server_dangling_resolves_none(_isolated_config):
+    set_active_user_profile("Ghost")
+    scope = _FakeScopeService(payload=[{"name": "Sam"}])
+    import tldw_chatbook.Character_Chat.active_user_profile as mod
+    assert await mod.resolve_active_user_profile_name_async(scope, mode="server") is None
+
+
+@pytest.mark.asyncio
+async def test_async_resolver_server_error_resolves_none(_isolated_config):
+    set_active_user_profile("Sam")
+    scope = _FakeScopeService(exc=RuntimeError("connection refused"))
+    import tldw_chatbook.Character_Chat.active_user_profile as mod
+    assert await mod.resolve_active_user_profile_name_async(scope, mode="server") is None
+
+
+@pytest.mark.asyncio
+async def test_async_resolver_server_without_scope_service_resolves_none(_isolated_config):
+    set_active_user_profile("Sam")
+    import tldw_chatbook.Character_Chat.active_user_profile as mod
+    assert await mod.resolve_active_user_profile_name_async(None, mode="server") is None
+
+
+@pytest.mark.asyncio
+async def test_async_resolver_local_and_unknown_modes_delegate_to_sync(_isolated_config):
+    set_active_user_profile("Sam")
+    local = _FakeService([{"name": "Sam"}])
+    scope = _FakeScopeService(payload=[{"name": "SERVER-ONLY"}])
+    import tldw_chatbook.Character_Chat.active_user_profile as mod
+    for mode in ("local", None, "", "LOCAL", "garbage"):
+        assert await mod.resolve_active_user_profile_name_async(
+            scope, mode=mode, local_service=local
+        ) == "Sam"
+    assert scope.calls == []  # scope service never consulted off server mode
+
+
+@pytest.mark.asyncio
+async def test_async_resolver_no_pointer_short_circuits(_isolated_config):
+    scope = _FakeScopeService(payload=[{"name": "Sam"}])
+    import tldw_chatbook.Character_Chat.active_user_profile as mod
+    assert await mod.resolve_active_user_profile_name_async(scope, mode="server") is None
+    assert scope.calls == []  # byte-compat: no backend call without a pointer
+
+
+def test_resolve_runtime_backend_mode_guards():
+    import tldw_chatbook.Character_Chat.active_user_profile as mod
+    class _App:
+        def get_authoritative_runtime_source(self):
+            return "SERVER"
+    assert mod.resolve_runtime_backend_mode(_App()) == "server"
+    class _Raises:
+        def get_authoritative_runtime_source(self):
+            raise RuntimeError("boom")
+    assert mod.resolve_runtime_backend_mode(_Raises()) == "local"
+    assert mod.resolve_runtime_backend_mode(object()) == "local"
+    assert mod.resolve_runtime_backend_mode(None) == "local"

--- a/Tests/Event_Handlers/Chat_Events/test_chat_events.py
+++ b/Tests/Event_Handlers/Chat_Events/test_chat_events.py
@@ -846,3 +846,131 @@ async def test_display_conversation_keeps_users_name_without_active_profile(
         mock_chat_msg_class.call_args.kwargs["message"]
         == "Hello Tester, I am Sherlock."
     )
+
+
+# ===== task-504: display_conversation_in_chat_tab_ui repointed to the live
+# sidebar ids (#chat-chat-title / #chat-chat-id); the dead #chat-right-sidebar
+# / #chat-conversation-* / #chat-character-*-edit families must never be
+# queried and a missing sidebar field must never abort the message-log mount
+# =====
+
+
+def _t504_conversation_fixture() -> dict:
+    """Two-message conversation, live-shaped (no dead-id dependent fields)."""
+    return {
+        "metadata": {"title": "My Chat", "keywords_display": "", "character_id": None},
+        "messages": [
+            {"content": "Hi there", "sender": "User", "id": "m1", "timestamp": "t1"},
+            {"content": "Hello!", "sender": "AI", "id": "m2", "timestamp": "t2"},
+        ],
+        "character_name": "AI",
+    }
+
+
+async def test_display_conversation_populates_live_sidebar_and_log(
+    mock_app, monkeypatch
+):
+    """task-504 AC1/AC3: title, id display, and message log populate against
+    the live-shaped tree."""
+    import tldw_chatbook.Event_Handlers.Chat_Events.chat_events as chat_events_module
+    from tldw_chatbook.Event_Handlers.Chat_Events.chat_events import (
+        display_conversation_in_chat_tab_ui,
+    )
+
+    conversation = _t504_conversation_fixture()
+    stubbed_messages = conversation["messages"]
+    monkeypatch.setattr(
+        chat_events_module.ccl,
+        "get_conversation_details_and_messages",
+        lambda db, conversation_id: conversation,
+    )
+    # Force the classic (non-enhanced) widget path deterministically.
+    monkeypatch.setattr(chat_events_module, "get_cli_setting", lambda *a, **k: False)
+
+    with patch(
+        "tldw_chatbook.Event_Handlers.Chat_Events.chat_events.ChatMessage"
+    ) as mock_chat_msg_class:
+        mock_chat_msg_class.return_value = MagicMock(spec=ChatMessage)
+        await display_conversation_in_chat_tab_ui(mock_app, "conv-1")
+
+    assert mock_app.query_one("#chat-chat-title", Input).value == "My Chat"
+    assert mock_app.query_one("#chat-chat-id", Input).value == "conv-1"
+    chat_log = mock_app.query_one("#chat-log", VerticalScroll)
+    assert chat_log.mount.await_count == len(stubbed_messages)
+
+
+async def test_display_conversation_never_queries_dead_right_sidebar(
+    mock_app, monkeypatch
+):
+    """task-504 AC1: the dead #chat-right-sidebar id (and the
+    #chat-character-*-edit / #chat-conversation-* dead-id families) are never
+    queried."""
+    import tldw_chatbook.Event_Handlers.Chat_Events.chat_events as chat_events_module
+    from tldw_chatbook.Event_Handlers.Chat_Events.chat_events import (
+        display_conversation_in_chat_tab_ui,
+    )
+
+    monkeypatch.setattr(
+        chat_events_module.ccl,
+        "get_conversation_details_and_messages",
+        lambda db, conversation_id: _t504_conversation_fixture(),
+    )
+    monkeypatch.setattr(chat_events_module, "get_cli_setting", lambda *a, **k: False)
+
+    with patch(
+        "tldw_chatbook.Event_Handlers.Chat_Events.chat_events.ChatMessage"
+    ) as mock_chat_msg_class:
+        mock_chat_msg_class.return_value = MagicMock(spec=ChatMessage)
+        await display_conversation_in_chat_tab_ui(mock_app, "conv-1")
+
+    queried = [
+        call.args[0] for call in mock_app.query_one.call_args_list if call.args
+    ]
+    assert "#chat-right-sidebar" not in queried
+    assert not any(
+        isinstance(sel, str) and sel.startswith("#chat-character-") for sel in queried
+    )
+    assert not any(
+        isinstance(sel, str) and sel.startswith("#chat-conversation-")
+        for sel in queried
+    )
+
+
+async def test_display_conversation_sidebar_failure_does_not_block_log(
+    mock_app, monkeypatch
+):
+    """task-504: a missing sidebar detail field must not abort the
+    message-log mount (the original bug pattern) -- simulate
+    #chat-chat-title being absent from the compose tree."""
+    import tldw_chatbook.Event_Handlers.Chat_Events.chat_events as chat_events_module
+    from tldw_chatbook.Event_Handlers.Chat_Events.chat_events import (
+        display_conversation_in_chat_tab_ui,
+    )
+
+    conversation = _t504_conversation_fixture()
+    stubbed_messages = conversation["messages"]
+    monkeypatch.setattr(
+        chat_events_module.ccl,
+        "get_conversation_details_and_messages",
+        lambda db, conversation_id: conversation,
+    )
+    monkeypatch.setattr(chat_events_module, "get_cli_setting", lambda *a, **k: False)
+
+    original_side_effect = mock_app.query_one.side_effect
+
+    def side_effect_missing_title(selector, widget_type=None):
+        if selector == "#chat-chat-title":
+            raise QueryError("#chat-chat-title")
+        return original_side_effect(selector, widget_type)
+
+    mock_app.query_one.side_effect = side_effect_missing_title
+
+    with patch(
+        "tldw_chatbook.Event_Handlers.Chat_Events.chat_events.ChatMessage"
+    ) as mock_chat_msg_class:
+        mock_chat_msg_class.return_value = MagicMock(spec=ChatMessage)
+        await display_conversation_in_chat_tab_ui(mock_app, "conv-1")
+
+    mock_app.query_one.side_effect = original_side_effect
+    chat_log = mock_app.query_one("#chat-log", VerticalScroll)
+    assert chat_log.mount.await_count == len(stubbed_messages)

--- a/Tests/Event_Handlers/Chat_Events/test_chat_events.py
+++ b/Tests/Event_Handlers/Chat_Events/test_chat_events.py
@@ -848,6 +848,58 @@ async def test_display_conversation_keeps_users_name_without_active_profile(
     )
 
 
+class _T4ServerScopeService:
+    """Async ``list_user_profiles`` double matching the T2 scope-service contract."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    async def list_user_profiles(self, **kwargs):
+        return self._payload
+
+
+async def test_display_conversation_substitutes_server_backend_profile(
+    mock_app, monkeypatch
+):
+    """task-551: with the server backend authoritative, the display path's
+    {{user}} resolves against the scope service's server profiles ("Sam"),
+    not the (unset) local persona service."""
+    import tldw_chatbook.Event_Handlers.Chat_Events.chat_events as chat_events_module
+    from tldw_chatbook.Event_Handlers.Chat_Events.chat_events import (
+        display_conversation_in_chat_tab_ui,
+    )
+
+    _t4_route_pointer(
+        monkeypatch, {("character_defaults", "active_user_profile"): "Sam"}
+    )
+    mock_app.local_character_persona_service = None
+    mock_app.character_persona_scope_service = _T4ServerScopeService(
+        [{"name": "Sam"}]
+    )
+    mock_app.get_authoritative_runtime_source = lambda: "server"
+    monkeypatch.setattr(
+        chat_events_module.ccl,
+        "get_conversation_details_and_messages",
+        lambda db, conversation_id: _t4_conversation_fixture(
+            "Hello {{user}}, I am {{char}}."
+        ),
+    )
+    monkeypatch.setattr(
+        chat_events_module, "get_cli_setting", lambda *a, **k: False
+    )
+
+    with patch(
+        "tldw_chatbook.Event_Handlers.Chat_Events.chat_events.ChatMessage"
+    ) as mock_chat_msg_class:
+        mock_chat_msg_class.return_value = MagicMock(spec=ChatMessage)
+        await display_conversation_in_chat_tab_ui(mock_app, "conv-t4")
+
+    assert (
+        mock_chat_msg_class.call_args.kwargs["message"]
+        == "Hello Sam, I am Sherlock."
+    )
+
+
 # ===== task-504: display_conversation_in_chat_tab_ui repointed to the live
 # sidebar ids (#chat-chat-title / #chat-chat-id); the dead #chat-right-sidebar
 # / #chat-conversation-* / #chat-character-*-edit families must never be

--- a/Tests/Event_Handlers/Chat_Events/test_chat_events_tabs.py
+++ b/Tests/Event_Handlers/Chat_Events/test_chat_events_tabs.py
@@ -589,7 +589,7 @@ class TestChatEventsTabsStateSynchronization:
 
         # Set up query_one to return appropriate widgets
         def query_one_side_effect(selector, widget_type=None):
-            if selector == "#chat-conversation-title-input":
+            if selector == "#chat-chat-title":
                 return mock_title_input
             elif selector == "#chat-window":
                 return mock_chat_window
@@ -671,7 +671,7 @@ class TestChatEventsTabsStateSynchronization:
         mock_chat_window.tab_container = mock_tab_container
 
         def query_one_side_effect(selector, widget_type=None):
-            if selector == "#chat-conversation-title-input":
+            if selector == "#chat-chat-title":
                 return mock_title_input
             if selector == "#chat-window":
                 return mock_chat_window
@@ -851,7 +851,7 @@ class TestChatEventsTabsEdgeCases:
                 # Query both tab-specific and global widgets
                 app.query_one("#chat-log")  # Should be redirected
                 app.query_one(
-                    "#chat-conversation-title-input"
+                    "#chat-chat-title"
                 )  # Should NOT be redirected
                 app.query_one("#chat-system-prompt")  # Should NOT be redirected
 
@@ -867,7 +867,7 @@ class TestChatEventsTabsEdgeCases:
             # Verify correct selectors were captured
             assert f"#chat-log-{session_data.tab_id}" in captured_selectors
             assert (
-                "#chat-conversation-title-input" in captured_selectors
+                "#chat-chat-title" in captured_selectors
             )  # Not modified
             assert "#chat-system-prompt" in captured_selectors  # Not modified
 

--- a/Tests/UI/test_chat_first_handoffs.py
+++ b/Tests/UI/test_chat_first_handoffs.py
@@ -570,6 +570,66 @@ async def test_native_start_chat_greeting_stays_user_without_active_profile(
         assert session.settings.user_profile_label == "General"
 
 
+class _StartChatServerScopeService:
+    """Async ``list_user_profiles`` double matching the T2 scope-service contract."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    async def list_user_profiles(self, **kwargs):
+        return self._payload
+
+
+@pytest.mark.asyncio
+async def test_native_start_chat_greeting_uses_server_backend_profile(monkeypatch):
+    """task-551: with the server backend authoritative, the Start-Chat handoff
+    greeting's {{user}} resolves against the scope service's server profiles
+    ("Sam"), not the (unset) local persona service."""
+    from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+        ConsoleHarness,
+    )
+    from Tests.UI.test_screen_navigation import _build_test_app
+    from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+
+    _route_active_profile_pointer(
+        monkeypatch, {("character_defaults", "active_user_profile"): "Sam"}
+    )
+
+    app = _build_test_app()
+    app.chachanotes_db = _StubCharacterCardDB(
+        {
+            "name": "Elara",
+            "first_message": "Greetings, {{user}}.",
+            "system_prompt": "You are Elara, a forest guide.",
+        }
+    )
+    app.local_character_persona_service = None
+    app.character_persona_scope_service = _StartChatServerScopeService(
+        [{"name": "Sam"}]
+    )
+    app.get_authoritative_runtime_source = lambda: "server"
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        await pilot.pause()
+        screen = host.screen_stack[-1]
+
+        app.pending_chat_handoff = _character_start_chat_payload(
+            character_id=7, name="Elara", first_message="Greetings, {{user}}."
+        )
+
+        await screen._consume_pending_chat_handoff()
+        await pilot.pause()
+
+        store = screen._ensure_console_chat_store()
+        session = store._sessions[store.active_session_id]
+        msgs = store.messages_for_session(session.id)
+        assert msgs[0].role is ConsoleMessageRole.ASSISTANT
+        assert msgs[0].content == "Greetings, Sam."
+        assert session.settings.user_profile_label == "Sam"
+        assert session.settings.character_label == "Elara"
+
+
 @pytest.mark.asyncio
 async def test_resume_restores_character_identity():
     """Resuming a saved character conversation after an app restart must

--- a/Tests/UI/test_personas_preview.py
+++ b/Tests/UI/test_personas_preview.py
@@ -639,6 +639,53 @@ async def test_greeting_renders_active_profile_name_and_labels_user_lines(
         assert "Sam: hi" in pane.transcript_text()
 
 
+class _ServerScopeService:
+    """Async ``list_user_profiles`` double matching the T2 scope-service contract."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    async def list_user_profiles(self, **kwargs):
+        return self._payload
+
+
+async def test_greeting_renders_server_backend_profile_name(
+    _isolated_active_profile_config,
+):
+    """task-551: with the workbench in server mode, {{user}} resolves against
+    the scope service's server profiles ("Sam") - the site (a) async callers
+    (``reset_for_character``/``handle_character_loaded``) thread the resolved
+    name into ``_load_greetings`` instead of the sync local-only fallback."""
+    from tldw_chatbook.Character_Chat.active_user_profile import (
+        set_active_user_profile,
+    )
+    from tldw_chatbook.UI.Persona_Modules.personas_preview_controller import (
+        PersonasPreviewController,
+    )
+
+    set_active_user_profile("Sam")
+    app = PreviewApp()
+    async with app.run_test() as pilot:
+        pane = app.query_one(PersonasPreviewPane)
+        screen = _ControllerScreen(app, None)
+        screen.app_instance.character_persona_scope_service = _ServerScopeService(
+            [{"name": "Sam"}]
+        )
+        screen.persona_handler = SimpleNamespace(current_mode=lambda: "server")
+        screen.workers = SimpleNamespace(cancel_group=lambda *a, **k: None)
+        controller = PersonasPreviewController(screen)
+
+        await controller.reset_for_character(
+            character_id="7",
+            character_name="Elara",
+            record={"first_message": "Hello {{user}}, I am {{char}}."},
+        )
+        await pilot.pause()
+
+        assert pane._user_label == "Sam"  # set_speakers(user="Sam") was called
+        assert "Hello Sam, I am Elara." in pane.transcript_text()
+
+
 async def test_greeting_falls_back_to_user_without_active_profile(
     _isolated_active_profile_config,
 ):

--- a/Tests/fixtures/event_handler_mocks.py
+++ b/Tests/fixtures/event_handler_mocks.py
@@ -31,6 +31,10 @@ def create_comprehensive_app_mock():
     # Add thread lock for chat state management
     app._chat_state_lock = MagicMock()
 
+    # Sync accessor read by resolve_runtime_backend_mode(); the blanket
+    # AsyncMock would hand back an unawaited coroutine (RuntimeWarning noise).
+    app.get_authoritative_runtime_source = MagicMock(return_value="local")
+
     # Mock services and DBs
     app.chachanotes_db = MagicMock()
     app.notes_service = MagicMock()

--- a/Tests/fixtures/event_handler_mocks.py
+++ b/Tests/fixtures/event_handler_mocks.py
@@ -120,9 +120,8 @@ def setup_mock_widgets(app):
             TextArea, text="User message", sync_methods=["clear"]
         ),
         "#chat-log": mock_chat_log,
-        "#chat-conversation-title-input": create_widget_mock(Input, value=""),
-        "#chat-conversation-keywords-input": create_widget_mock(TextArea, text=""),
-        "#chat-conversation-uuid-display": create_widget_mock(Static),
+        "#chat-chat-title": create_widget_mock(Input, value=""),
+        "#chat-chat-id": create_widget_mock(Input, value=""),
         # Chat settings
         "#chat-api-provider": create_widget_mock(Select, value="OpenAI"),
         "#chat-api-model": create_widget_mock(Select, value="gpt-4"),
@@ -150,6 +149,11 @@ def setup_mock_widgets(app):
         "#chat-character-search-results-list": create_widget_mock(
             ListView, async_methods=["clear", "append"]
         ),
+        # DEAD-ID: not in live tree; kept for legacy-handler test -- see
+        # follow-up task (task-504 blast-radius: handle_chat_load_character_button_pressed
+        # in chat_events.py still queries these six #chat-character-*-edit
+        # ids and test_handle_chat_load_character_with_greeting depends on
+        # them; that handler is out of scope for task-504's repair).
         "#chat-character-name-edit": create_widget_mock(Input),
         "#chat-character-description-edit": create_widget_mock(TextArea),
         "#chat-character-personality-edit": create_widget_mock(TextArea),
@@ -184,8 +188,6 @@ def setup_mock_widgets(app):
         # RAG checkboxes
         "#chat-rag-enabled-checkbox": create_widget_mock(Checkbox, value=False),
         "#chat-rag-search-results-checkbox": create_widget_mock(Checkbox, value=False),
-        # Sidebars
-        "#chat-right-sidebar": MagicMock(),
         # LLM Management
         "#llm-provider-select": create_widget_mock(Select, value="ollama"),
         "#llm-server-status": create_widget_mock(Static),
@@ -260,12 +262,6 @@ def setup_mock_widgets(app):
         )
     )
     app.screen.query = MagicMock(side_effect=lambda selector: app.query(selector))
-
-    # Setup sidebar query_one behavior
-    if "#chat-right-sidebar" in widgets:
-        widgets["#chat-right-sidebar"].query_one = MagicMock(
-            side_effect=lambda sel, _type=None: widgets.get(sel)
-        )
 
     # Add query method that returns multiple widgets
     def query_side_effect(selector):

--- a/backlog/tasks/task-504 - Fix-chat-right-sidebar-QueryError-silently-aborting-conversation-load-in-Chat-tab.md
+++ b/backlog/tasks/task-504 - Fix-chat-right-sidebar-QueryError-silently-aborting-conversation-load-in-Chat-tab.md
@@ -3,10 +3,10 @@ id: TASK-504
 title: >-
   Fix #chat-right-sidebar QueryError silently aborting conversation load in Chat
   tab
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-24 01:29'
-updated_date: '2026-07-25 03:01'
+updated_date: '2026-07-25 03:30'
 labels:
   - tech-debt
   - dead-code
@@ -23,7 +23,43 @@ display_conversation_in_chat_tab_ui() (Event_Handlers/Chat_Events/chat_events.py
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Loading a saved conversation through display_conversation_in_chat_tab_ui populates the live sidebar title (#chat-chat-title), the conversation id display (#chat-chat-id), and the full message log without hitting the #chat-right-sidebar QueryError path (keywords dropped: no live keywords field exists -- user-approved amendment 2026-07-24)
-- [ ] #2 The character-detail-edit fields this function tries to populate (chat-character-name-edit etc.) are either restored somewhere reachable in the live UI, or the dead write attempt is removed without regressing conversation loading
-- [ ] #3 A regression test loads a conversation through display_conversation_in_chat_tab_ui (or its tab-aware wrapper) against a live-shaped widget tree (no #chat-right-sidebar) and asserts the message log and title actually populate
+- [x] #1 Loading a saved conversation through display_conversation_in_chat_tab_ui populates the live sidebar title (#chat-chat-title), the conversation id display (#chat-chat-id), and the full message log without hitting the #chat-right-sidebar QueryError path (keywords dropped: no live keywords field exists -- user-approved amendment 2026-07-24)
+- [x] #2 The character-detail-edit fields this function tries to populate (chat-character-name-edit etc.) are either restored somewhere reachable in the live UI, or the dead write attempt is removed without regressing conversation loading
+- [x] #3 A regression test loads a conversation through display_conversation_in_chat_tab_ui (or its tab-aware wrapper) against a live-shaped widget tree (no #chat-right-sidebar) and asserts the message log and title actually populate
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Amend AC #1 to name the live sidebar ids (#chat-chat-title / #chat-chat-id) and drop the keywords requirement (user-approved, no live keywords field exists).
+2. Write three failing regression tests in Tests/Event_Handlers/Chat_Events/test_chat_events.py against display_conversation_in_chat_tab_ui: (a) live sidebar + log population, (b) dead #chat-right-sidebar/#chat-conversation-*/#chat-character-*-edit families never queried, (c) a missing sidebar field does not abort the message-log mount.
+3. Live-shape Tests/fixtures/event_handler_mocks.py: remove the #chat-right-sidebar bare mock and its wiring block, the three #chat-conversation-* entries, and the six #chat-character-*-edit entries; add #chat-chat-title / #chat-chat-id Input mocks.
+4. Run the new tests to confirm they fail against the unmodified production code (RED), and capture the blast radius against the rest of the shared-fixture consumer suites.
+5. Repair display_conversation_in_chat_tab_ui: delete the #chat-right-sidebar block and its six character-edit writes (no live equivalents); repoint conversation-detail writes to #chat-chat-title / #chat-chat-id behind a scoped try/except QueryError (keywords write dropped); scope-guard the #chat-system-prompt writes the same way; repoint the not-found branch to the same live ids; move the closing info log inside the try success path so it no longer fires when the except path ran.
+6. Clean the twin handle_chat_clear_active_character_button_pressed: remove the dead #chat-right-sidebar query and its six field writes; keep the live #chat-system-prompt reset and make the success notify unconditional.
+7. Update Chat/tabs/tab_context.py GLOBAL_WIDGETS and the chat_events_tabs.py wrapper's #chat-conversation-title-input read to the new live ids; update the matching test_chat_events_tabs.py pins.
+8. Run the full affected suites (Tests/Event_Handlers/Chat_Events/, plus every consumer of Tests/fixtures/event_handler_mocks.py) and apply the blast-radius rule: restore any dead id whose removal broke a pre-existing test of an out-of-scope legacy handler, with a DEAD-ID comment.
+9. Update this task file (AC checkboxes, plan, notes, status) and commit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Repaired display_conversation_in_chat_tab_ui() and its twin handle_chat_clear_active_character_button_pressed() in Event_Handlers/Chat_Events/chat_events.py, which both unconditionally queried the dead #chat-right-sidebar container (removed from the live compose tree since ChatWindowEnhanced replaced the legacy ChatWindow, task-412) followed by six #chat-character-*-edit fields with no live equivalents. Because the query sat mid-population inside one broad try/except QueryError, everything downstream (title, keywords, UUID, and the full message log) silently never populated.
+
+Approach:
+- Deleted the #chat-right-sidebar block and its six character-edit writes outright (no live equivalents to relocate to, per user-approved scope).
+- Repointed the conversation-detail writes to the live EnhancedSettingsSidebar ids #chat-chat-title and #chat-chat-id (id_prefix="chat"), wrapped in their own scoped try/except QueryError so a missing sidebar field warns and continues instead of aborting the message-log mount. The keywords write was dropped entirely -- no live keywords field exists (AC #1 amended, user-approved).
+- Wrapped the three #chat-system-prompt writes (character-branch, character-load-failure branch, no-character branch) in a small `_safe_set_system_prompt` local helper using the same scoped-guard pattern.
+- Repointed the not-found branch's dead-id writes to the same #chat-chat-title/#chat-chat-id pair behind the same guard.
+- Moved the closing "Displayed conversation ..." info log inside the try's success path so it no longer logs success when the outer except ran.
+- Cleaned handle_chat_clear_active_character_button_pressed the same way: removed the dead #chat-right-sidebar query and six field writes; the "Active character cleared." notify is now unconditional after the #chat-system-prompt reset (its own try/except is untouched).
+- Repointed Chat/tabs/tab_context.py's GLOBAL_WIDGETS and the chat_events_tabs.py wrapper's post-load title read from the dead #chat-conversation-title-input to #chat-chat-title; updated the corresponding test_chat_events_tabs.py pins (including the skipped edge-case tests, for consistency).
+- Live-shaped Tests/fixtures/event_handler_mocks.py: removed the bare #chat-right-sidebar mock and its query_one wiring block, the three #chat-conversation-* entries, and the six #chat-character-*-edit entries; added #chat-chat-title / #chat-chat-id Input mocks.
+
+Blast radius (spec's documented rule applied): removing the six #chat-character-*-edit ids broke a pre-existing test of a different, out-of-scope legacy handler -- test_handle_chat_load_character_with_greeting, which exercises handle_chat_load_character_button_pressed (not one of this task's two target functions; queries the same six ids at chat_events.py:4645-4686). Restored those six ids in the fixture with a `# DEAD-ID: not in live tree; kept for legacy-handler test -- see follow-up task` comment. The #chat-right-sidebar and #chat-conversation-* removals had no other consumers and needed no restoration. The two pre-existing task-442 T4 twins (test_display_conversation_substitutes_active_profile_name / test_display_conversation_keeps_users_name_without_active_profile) failed transiently once the fixture was live-shaped (old code still queried the now-gone #chat-right-sidebar) and self-healed once the production repair landed -- no test edits were needed for them.
+
+Added three new regression tests next to the existing T4 tests: population against the live-shaped tree, absence of any #chat-right-sidebar/#chat-conversation-*/#chat-character-*-edit query, and a forced #chat-chat-title QueryError that must not block the message-log mount. Verified RED (all three failing) against the unmodified production code with the live-shaped fixture before implementing the repair.
+
+Modified files: tldw_chatbook/Event_Handlers/Chat_Events/chat_events.py, tldw_chatbook/Event_Handlers/Chat_Events/chat_events_tabs.py, tldw_chatbook/Chat/tabs/tab_context.py, Tests/fixtures/event_handler_mocks.py, Tests/Event_Handlers/Chat_Events/test_chat_events.py, Tests/Event_Handlers/Chat_Events/test_chat_events_tabs.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-504 - Fix-chat-right-sidebar-QueryError-silently-aborting-conversation-load-in-Chat-tab.md
+++ b/backlog/tasks/task-504 - Fix-chat-right-sidebar-QueryError-silently-aborting-conversation-load-in-Chat-tab.md
@@ -6,6 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-07-24 01:29'
+updated_date: '2026-07-25 03:01'
 labels:
   - tech-debt
   - dead-code
@@ -22,7 +23,7 @@ display_conversation_in_chat_tab_ui() (Event_Handlers/Chat_Events/chat_events.py
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Loading a saved conversation in the live Chat tab (ChatWindowEnhanced) populates the title, keywords, UUID display, and full message log without hitting the #chat-right-sidebar QueryError path
+- [ ] #1 Loading a saved conversation through display_conversation_in_chat_tab_ui populates the live sidebar title (#chat-chat-title), the conversation id display (#chat-chat-id), and the full message log without hitting the #chat-right-sidebar QueryError path (keywords dropped: no live keywords field exists -- user-approved amendment 2026-07-24)
 - [ ] #2 The character-detail-edit fields this function tries to populate (chat-character-name-edit etc.) are either restored somewhere reachable in the live UI, or the dead write attempt is removed without regressing conversation loading
 - [ ] #3 A regression test loads a conversation through display_conversation_in_chat_tab_ui (or its tab-aware wrapper) against a live-shaped widget tree (no #chat-right-sidebar) and asserts the message log and title actually populate
 <!-- AC:END -->

--- a/backlog/tasks/task-551 - Active-user-profile-resolution-for-the-server-profile-backend.md
+++ b/backlog/tasks/task-551 - Active-user-profile-resolution-for-the-server-profile-backend.md
@@ -31,9 +31,9 @@ async substitution sites (`chat_screen._start_character_console_session`,
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [x] #1 #1 With the server profile backend active, a server-side active profile's name substitutes into {{user}} at the three task-442 send surfaces
-- [x] #2 #2 A dangling pointer (profile deleted on the resolving backend) still resolves to no-active (never a stale name, never an error)
-- [x] #3 #3 With no pointer set, behavior is byte-identical (the task-442 twins keep passing)
+- [x] #1 With the server profile backend active, a server-side active profile's name substitutes into {{user}} at the three task-442 send surfaces
+- [x] #2 A dangling pointer (profile deleted on the resolving backend) still resolves to no-active (never a stale name, never an error)
+- [x] #3 With no pointer set, behavior is byte-identical (the task-442 twins keep passing)
 <!-- AC:END -->
 
 ## Implementation Plan

--- a/backlog/tasks/task-551 - Active-user-profile-resolution-for-the-server-profile-backend.md
+++ b/backlog/tasks/task-551 - Active-user-profile-resolution-for-the-server-profile-backend.md
@@ -1,16 +1,19 @@
 ---
 id: TASK-551
 title: Active user profile resolution for the server profile backend
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-24 20:30'
+updated_date: '2026-07-25 06:35'
 labels:
   - roleplay
   - enhancement
 dependencies: []
 ---
+
 ## Description
 
+<!-- SECTION:DESCRIPTION:BEGIN -->
 Filed from Qodo review of PR #849 (task-442). `resolve_active_user_profile_name`
 validates the config pointer against the SYNC local file-backed profile service
 (`app.local_character_persona_service`) — by design (the task-442 spec scoped
@@ -24,9 +27,41 @@ so this needs the real fix: an ASYNC resolver that validates against
 `character_persona_scope_service.list_user_profiles(mode=...)`, used at the
 async substitution sites (`chat_screen._start_character_console_session`,
 `chat_events` display path, the preview controller's async flows).
+<!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 #1 With the server profile backend active, a server-side active profile's name substitutes into {{user}} at the three task-442 send surfaces
+- [x] #2 #2 A dangling pointer (profile deleted on the resolving backend) still resolves to no-active (never a stale name, never an error)
+- [x] #3 #3 With no pointer set, behavior is byte-identical (the task-442 twins keep passing)
+<!-- AC:END -->
 
-- [ ] #1 With the server profile backend active, a server-side active profile's name substitutes into {{user}} at the three task-442 send surfaces
-- [ ] #2 A dangling pointer (profile deleted on the resolving backend) still resolves to no-active (never a stale name, never an error)
-- [ ] #3 With no pointer set, behavior is byte-identical (the task-442 twins keep passing)
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Write three failing server-mode site tests (one per substitution site), siblings of the existing task-442 twins in the same files, arranged with a server-backend scope service + server mode instead of the local persona service; confirm all three FAIL against the unswapped sites while the task-442 twins stay green.
+2. Swap chat_screen._start_character_console_session's resolver call to the async resolver, mode sourced from resolve_runtime_backend_mode(app_instance).
+3. Swap chat_events.display_conversation_in_chat_tab_ui's resolver call the same way, mode sourced from resolve_runtime_backend_mode(app), preserving the trailing USERS_NAME fallback byte-exact.
+4. Swap the preview controller's site: add an async _resolve_user_name_async() that reads the workbench's own mode (persona_handler.current_mode(), guarded, default local), give _load_greetings a sentinel-defaulted user_name kwarg so the sync _active_user_name() fallback stays intact for any other caller, and thread the resolved name through reset_for_character/handle_character_loaded.
+5. Re-run the three new tests plus the resolver unit tests and the task-442 twins; confirm all green.
+6. Update this task file and commit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Swapped the three task-442 {{user}} substitution sites onto the task-2 async resolver (`resolve_active_user_profile_name_async` / `resolve_runtime_backend_mode`, `Character_Chat/active_user_profile.py`), so a server-backend active user profile now substitutes correctly instead of silently falling back (Qodo #849-4).
+
+Approach:
+- chat_screen._start_character_console_session and chat_events.display_conversation_in_chat_tab_ui both swap their sync resolve_active_user_profile_name(local_service) call for `await resolve_active_user_profile_name_async(character_persona_scope_service, mode=resolve_runtime_backend_mode(app), local_service=local_character_persona_service)`; both use the app-authoritative runtime source. chat_events preserves the trailing `or app.app_config.get("USERS_NAME", "User")` fallback byte-exact.
+- personas_preview_controller gets a new async `_resolve_user_name_async()` that reads the WORKBENCH's own mode (`persona_handler.current_mode()`, guarded, default "local") rather than the app-level source -- the preview validates against the backend it's actually browsing. `_load_greetings` gained a sentinel-defaulted `user_name` kwarg (`_UNSET` module constant) so it still falls back to the sync `_active_user_name()` for any caller that doesn't pass one; `reset_for_character` and `handle_character_loaded` (both already async) now await the resolver and pass the result in. `_active_user_name()` itself is untouched -- it stays as the sync fallback default.
+- Each site keeps a separate mode-source rule per the design's "one precedence rule per surface": chat surfaces use the app-authoritative runtime source, the workbench preview uses the workbench mode.
+
+Tests: added one new server-mode test per site, siblings of the existing task-442 twins, arranged with a fake async scope service + server mode instead of the (now-None) local persona service:
+- Tests/UI/test_chat_first_handoffs.py::test_native_start_chat_greeting_uses_server_backend_profile
+- Tests/Event_Handlers/Chat_Events/test_chat_events.py::test_display_conversation_substitutes_server_backend_profile
+- Tests/UI/test_personas_preview.py::test_greeting_renders_server_backend_profile_name (exercises the real site via `reset_for_character`, not the sync `_load_greetings` short-circuit, so the assertion actually depends on the swap)
+All three were verified RED (falling back to "User"/local-only resolution) against the unswapped sites before implementing the swap, then GREEN after. All existing task-442 twins and the resolver unit tests stayed green throughout, untouched.
+
+Modified files: tldw_chatbook/UI/Screens/chat_screen.py, tldw_chatbook/Event_Handlers/Chat_Events/chat_events.py, tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py, Tests/UI/test_chat_first_handoffs.py, Tests/Event_Handlers/Chat_Events/test_chat_events.py, Tests/UI/test_personas_preview.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-562 - Conversation-load-save-clone-entry-points-missing-from-live-Chat-tab-UI.md
+++ b/backlog/tasks/task-562 - Conversation-load-save-clone-entry-points-missing-from-live-Chat-tab-UI.md
@@ -1,0 +1,43 @@
+---
+id: TASK-562
+title: Conversation load/save/clone entry points missing from live Chat tab UI
+status: To Do
+assignee: []
+created_date: '2026-07-24 22:05'
+labels:
+  - chat
+  - ux
+  - dead-code
+dependencies: []
+---
+## Description
+
+Filed from task-504's scout (2026-07-24). `display_conversation_in_chat_tab_ui` was
+repaired in task-504 (repointed to the live sidebar ids, scoped QueryError guards,
+regression-tested), but the function remains unreachable from the live UI: its three
+callers (`handle_chat_save_current_chat_button_pressed`,
+`handle_chat_clone_current_chat_button_pressed`,
+`handle_chat_load_selected_button_pressed`) fire only from buttons composed in
+`Widgets/settings_sidebar.py`, whose `create_settings_sidebar()` has had no callers
+since task-412 retired the legacy ChatWindow. The live `EnhancedSettingsSidebar` has
+its own New Chat / Clone buttons but no conversation search/load surface. This is a
+product decision, not just a wiring fix: either restore load/save/clone entry points
+in the live Chat tab (e.g. a Conversations section in the enhanced sidebar), or record
+that Chat-tab conversation loading is retired in favor of the Console workspace and
+remove the dead handler chain accordingly.
+
+Residual dead right-sidebar surfaces to sweep with whichever direction is chosen:
+`app.py` watchers `watch_chat_right_sidebar_collapsed`/`watch_chat_right_sidebar_width`,
+dead button/input routers (`app.py` ~:6925/:9299/:9445 referencing
+`chat-conversation-*` / `chat-character-*` ids composed nowhere),
+`chat_events_sidebar_resize.py`, orphan `#chat-right-sidebar` CSS blocks
+(Constants.py + css/), `settings_sidebar.py` module retirement, and the
+`# DEAD-ID` fixture restorations in `Tests/fixtures/event_handler_mocks.py`
+(six `#chat-character-*-edit` mocks kept only for a legacy handler's tests).
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A product decision is recorded (task notes or decision doc): live Chat-tab conversation load/save/clone is either restored or explicitly retired in favor of the Console workspace
+- [ ] #2 If restored: a user can search for and load a saved conversation from the live Chat tab, and the loaded title/id/message log populate (task-504's repaired path)
+- [ ] #3 If retired: the dead handler chain (three handlers + tabs wrapper) and the residual dead right-sidebar surfaces listed in the description are removed, with tests updated and no live behavior regressed
+<!-- AC:END -->

--- a/tldw_chatbook/Character_Chat/active_user_profile.py
+++ b/tldw_chatbook/Character_Chat/active_user_profile.py
@@ -7,7 +7,7 @@ refers to the user in this app; the user-side concept is "user profile".
 """
 from __future__ import annotations
 
-from typing import Protocol
+from typing import Any, Optional, Protocol
 
 from loguru import logger
 
@@ -94,4 +94,63 @@ def resolve_active_user_profile_name(service: _UserProfileLister | None) -> str 
     except Exception:
         logger.opt(exception=True).debug("Active user profile resolution failed.")
         return None
+    return None
+
+
+def resolve_runtime_backend_mode(app_like: Any) -> str:
+    """Return the app's authoritative runtime backend mode, never raising.
+
+    Args:
+        app_like: Object expected to expose ``get_authoritative_runtime_source()``.
+
+    Returns:
+        ``"local"`` or ``"server"``; ``"local"`` on any failure or unknown value.
+    """
+    getter = getattr(app_like, "get_authoritative_runtime_source", None)
+    if callable(getter):
+        try:
+            candidate = str(getter() or "").strip().lower()
+            if candidate in {"local", "server"}:
+                return candidate
+        except Exception as exc:  # Never raise into a send path.
+            logger.debug(f"Runtime backend mode read failed: {exc}")
+    return "local"
+
+
+async def resolve_active_user_profile_name_async(
+    scope_service: Any,
+    *,
+    mode: Optional[str],
+    local_service: Optional[_UserProfileLister] = None,
+) -> Optional[str]:
+    """Resolve the active user profile's name against the current backend.
+
+    Local (and unknown) modes delegate to the sync resolver unchanged; server
+    mode validates the config pointer against the scope service's server
+    backend. A dangling pointer and every backend failure resolve to ``None``
+    (no active profile) — this function never raises.
+
+    Args:
+        scope_service: ``CharacterPersonaScopeService``-like object with an
+            async ``list_user_profiles(mode=...)``; may be ``None``.
+        mode: Backend mode; anything other than ``"server"`` uses the local path.
+        local_service: Sync local profile service for the local path.
+
+    Returns:
+        The active profile's name, or ``None`` when unset/dangling/unavailable.
+    """
+    normalized = str(mode or "").strip().lower()
+    if normalized != "server":
+        return resolve_active_user_profile_name(local_service)
+    pointer = get_active_user_profile_pointer()
+    if not pointer or scope_service is None:
+        return None
+    try:
+        payload = await scope_service.list_user_profiles(mode="server")
+        records = payload.get("items", []) if isinstance(payload, dict) else (payload or [])
+        for record in records:
+            if isinstance(record, dict) and str(record.get("name") or "") == pointer:
+                return pointer
+    except Exception as exc:  # Fail closed: {{user}} falls back to its site default.
+        logger.debug(f"Server-side active user profile resolution failed: {exc}")
     return None

--- a/tldw_chatbook/Chat/tabs/tab_context.py
+++ b/tldw_chatbook/Chat/tabs/tab_context.py
@@ -39,9 +39,8 @@ class TabContext:
 
     # Widget IDs that remain global (not tab-specific)
     GLOBAL_WIDGETS: Set[str] = {
-        "#chat-conversation-title-input",
-        "#chat-conversation-keywords-input",
-        "#chat-conversation-uuid-display",
+        "#chat-chat-title",
+        "#chat-chat-id",
         "#chat-system-prompt",
     }
 

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_events.py
@@ -69,7 +69,8 @@ from tldw_chatbook.Utils.Emoji_Handling import (
 )
 from tldw_chatbook.Character_Chat import Character_Chat_Lib as ccl
 from tldw_chatbook.Character_Chat.active_user_profile import (
-    resolve_active_user_profile_name,
+    resolve_active_user_profile_name_async,
+    resolve_runtime_backend_mode,
 )
 from tldw_chatbook.Character_Chat.Character_Chat_Lib import load_character_and_image
 from tldw_chatbook.DB.ChaChaNotes_DB import (
@@ -4207,13 +4208,17 @@ async def display_conversation_in_chat_tab_ui(app: "TldwCli", conversation_id: s
     try:
         character_id_from_conv = conv_metadata.get("character_id")
         loaded_char_data_for_ui_fields: Optional[Dict[str, Any]] = None
-        # task-442: {{user}} renders the active user profile's name; with no
+        # task-442/task-551: {{user}} renders the active user profile's name,
+        # resolved against the app-authoritative runtime backend (local
+        # persona service, or the scope service's server profiles); with no
         # active profile the pre-existing USERS_NAME fallback is preserved
         # byte-exact. The same resolved name threads into
         # load_character_and_image below, so card fields and message display
         # substitute consistently.
-        current_user_name = resolve_active_user_profile_name(
-            getattr(app, "local_character_persona_service", None)
+        current_user_name = await resolve_active_user_profile_name_async(
+            getattr(app, "character_persona_scope_service", None),
+            mode=resolve_runtime_backend_mode(app),
+            local_service=getattr(app, "local_character_persona_service", None),
         ) or app.app_config.get("USERS_NAME", "User")
 
         if (

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_events.py
@@ -4162,13 +4162,14 @@ async def display_conversation_in_chat_tab_ui(app: "TldwCli", conversation_id: s
         app.notify(f"Error: Could not load chat {conversation_id}.", severity="error")
         # Update UI to reflect error state
         try:
-            app.query_one(
-                "#chat-conversation-title-input", Input
-            ).value = "Error: Not Found"
-            app.query_one("#chat-conversation-keywords-input", TextArea).text = ""
-            app.query_one(
-                "#chat-conversation-uuid-display", Input
-            ).value = conversation_id
+            try:
+                app.query_one("#chat-chat-title", Input).value = "Error: Not Found"
+                app.query_one("#chat-chat-id", Input).value = conversation_id
+            except QueryError as qe_sidebar_err:
+                loguru_logger.warning(
+                    f"Sidebar chat-details fields unavailable while showing not-found "
+                    f"state for {conversation_id}: {qe_sidebar_err}"
+                )
             _update_console_session_title(app, "Error Loading")
             chat_log_err = app.query_one("#chat-log", VerticalScroll)
             await chat_log_err.remove_children()
@@ -4193,6 +4194,15 @@ async def display_conversation_in_chat_tab_ui(app: "TldwCli", conversation_id: s
 
     app.current_chat_conversation_id = conversation_id
     app.current_chat_is_ephemeral = False
+
+    def _safe_set_system_prompt(text: str) -> None:
+        """Scoped guard: a missing #chat-system-prompt must never abort the load."""
+        try:
+            app.query_one("#chat-system-prompt", TextArea).text = text
+        except QueryError as qe_sys_prompt:
+            loguru_logger.warning(
+                f"#chat-system-prompt unavailable while loading {conversation_id}: {qe_sys_prompt}"
+            )
 
     try:
         character_id_from_conv = conv_metadata.get("character_id")
@@ -4222,77 +4232,42 @@ async def display_conversation_in_chat_tab_ui(app: "TldwCli", conversation_id: s
                 loguru_logger.info(
                     f"Loaded char data for '{char_data_for_ui.get('name', 'Unknown')}' into app.current_chat_active_character_data."
                 )
-                app.query_one(
-                    "#chat-system-prompt", TextArea
-                ).text = char_data_for_ui.get("system_prompt", "")
+                _safe_set_system_prompt(char_data_for_ui.get("system_prompt", ""))
             else:
                 app.current_chat_active_character_data = None
                 loguru_logger.warning(
                     f"Could not load char data for char_id: {character_id_from_conv}. Active char set to None."
                 )
-                app.query_one(
-                    "#chat-system-prompt", TextArea
-                ).text = app.app_config.get("chat_defaults", {}).get(
-                    "system_prompt", "You are a helpful AI assistant."
+                _safe_set_system_prompt(
+                    app.app_config.get("chat_defaults", {}).get(
+                        "system_prompt", "You are a helpful AI assistant."
+                    )
                 )
         else:
             app.current_chat_active_character_data = None
             loguru_logger.debug(
                 f"Conversation {conversation_id} uses default/no character. Active char set to None."
             )
-            app.query_one("#chat-system-prompt", TextArea).text = app.app_config.get(
-                "chat_defaults", {}
-            ).get("system_prompt", "You are a helpful AI assistant.")
+            _safe_set_system_prompt(
+                app.app_config.get("chat_defaults", {}).get(
+                    "system_prompt", "You are a helpful AI assistant."
+                )
+            )
 
-        right_sidebar_chat_tab = app.query_one("#chat-right-sidebar")
-        if loaded_char_data_for_ui_fields:
-            right_sidebar_chat_tab.query_one(
-                "#chat-character-name-edit", Input
-            ).value = loaded_char_data_for_ui_fields.get("name") or ""
-            right_sidebar_chat_tab.query_one(
-                "#chat-character-description-edit", TextArea
-            ).text = loaded_char_data_for_ui_fields.get("description") or ""
-            right_sidebar_chat_tab.query_one(
-                "#chat-character-personality-edit", TextArea
-            ).text = loaded_char_data_for_ui_fields.get("personality") or ""
-            right_sidebar_chat_tab.query_one(
-                "#chat-character-scenario-edit", TextArea
-            ).text = loaded_char_data_for_ui_fields.get("scenario") or ""
-            right_sidebar_chat_tab.query_one(
-                "#chat-character-system-prompt-edit", TextArea
-            ).text = loaded_char_data_for_ui_fields.get("system_prompt") or ""
-            right_sidebar_chat_tab.query_one(
-                "#chat-character-first-message-edit", TextArea
-            ).text = loaded_char_data_for_ui_fields.get("first_message") or ""
-        else:
-            right_sidebar_chat_tab.query_one(
-                "#chat-character-name-edit", Input
-            ).value = ""
-            right_sidebar_chat_tab.query_one(
-                "#chat-character-description-edit", TextArea
-            ).text = ""
-            right_sidebar_chat_tab.query_one(
-                "#chat-character-personality-edit", TextArea
-            ).text = ""
-            right_sidebar_chat_tab.query_one(
-                "#chat-character-scenario-edit", TextArea
-            ).text = ""
-            right_sidebar_chat_tab.query_one(
-                "#chat-character-system-prompt-edit", TextArea
-            ).text = ""
-            right_sidebar_chat_tab.query_one(
-                "#chat-character-first-message-edit", TextArea
-            ).text = ""
-
-        app.query_one(
-            "#chat-conversation-title-input", Input
-        ).value = conv_metadata.get("title", "")
-        app.query_one("#chat-conversation-uuid-display", Input).value = conversation_id
-
-        keywords_input_disp = app.query_one(
-            "#chat-conversation-keywords-input", TextArea
-        )
-        keywords_input_disp.text = conv_metadata.get("keywords_display", "")
+        # task-504: the legacy #chat-right-sidebar + #chat-character-*-edit
+        # writes here queried ids that have not existed in the live compose
+        # tree since ChatWindowEnhanced replaced the legacy ChatWindow (no
+        # live equivalents exist -- removed, not relocated). Sidebar-detail
+        # writes are scoped so a missing field never aborts the message log.
+        try:
+            app.query_one("#chat-chat-title", Input).value = conv_metadata.get(
+                "title", ""
+            )
+            app.query_one("#chat-chat-id", Input).value = conversation_id
+        except QueryError as qe_sidebar:
+            loguru_logger.warning(
+                f"Sidebar chat-details fields unavailable while loading {conversation_id}: {qe_sidebar}"
+            )
 
         _update_console_session_title(
             app, conv_metadata.get("title", "Untitled Conversation")
@@ -4413,14 +4388,15 @@ async def display_conversation_in_chat_tab_ui(app: "TldwCli", conversation_id: s
         except Exception as e:
             loguru_logger.debug(f"Could not update token counter: {e}")
 
+        loguru_logger.info(
+            f"Displayed conversation '{conv_metadata.get('title', 'Untitled')}' (ID: {conversation_id}) in chat tab."
+        )
+
     except QueryError as qe_disp_main:
         loguru_logger.error(
             f"UI component missing during display_conversation for {conversation_id}: {qe_disp_main}"
         )
         app.notify("Error updating UI for loaded chat.", severity="error")
-    loguru_logger.info(
-        f"Displayed conversation '{conv_metadata.get('title', 'Untitled')}' (ID: {conversation_id}) in chat tab."
-    )
 
 
 async def load_branched_conversation_history_ui(
@@ -4889,53 +4865,16 @@ async def handle_chat_clear_active_character_button_pressed(
             "Could not find #chat-system-prompt to reset on clear active character."
         )
 
-    try:
-        # Get a reference to the chat tab's right sidebar
-        # This sidebar has the ID "chat-right-sidebar"
-        right_sidebar = app.query_one("#chat-right-sidebar")
-
-        # Now query within the right_sidebar for the specific character editing fields
-        right_sidebar.query_one("#chat-character-name-edit", Input).value = ""
-        right_sidebar.query_one("#chat-character-description-edit", TextArea).text = ""
-        right_sidebar.query_one("#chat-character-personality-edit", TextArea).text = ""
-        right_sidebar.query_one("#chat-character-scenario-edit", TextArea).text = ""
-        right_sidebar.query_one(
-            "#chat-character-system-prompt-edit", TextArea
-        ).text = ""
-        right_sidebar.query_one(
-            "#chat-character-first-message-edit", TextArea
-        ).text = ""
-
-        # Optional: Clear the character search input and list within the right sidebar
-        # search_input_char = right_sidebar.query_one("#chat-character-search-input", Input)
-        # search_input_char.value = ""
-        # results_list_char = right_sidebar.query_one("#chat-character-search-results-list", ListView)
-        # await results_list_char.clear()
-        # If you clear the list, you might want to repopulate it with the default characters:
-        # await _populate_chat_character_search_list(app) # Assuming _populate_chat_character_search_list is defined in this file or imported
-
-        app.notify(
-            "Active character cleared. Chat will use default settings.",
-            severity="information",
-        )
-        loguru_logger.debug(
-            "Cleared active character data and UI fields from within #chat-right-sidebar."
-        )
-
-    except QueryError as e:
-        loguru_logger.opt(exception=True).error(
-            f"UI component not found when clearing character fields within #chat-right-sidebar. "
-            f"Widget ID/Selector: {getattr(e, 'widget_id', getattr(e, 'selector', 'N/A'))}"
-        )
-        app.notify(
-            "Error clearing character fields (UI component not found).",
-            severity="error",
-        )
-    except Exception as e_unexp:
-        loguru_logger.opt(exception=True).error(
-            f"Unexpected error clearing active character: {e_unexp}"
-        )
-        app.notify("Error clearing active character.", severity="error")
+    # task-504: the #chat-right-sidebar container and its six
+    # #chat-character-*-edit fields have not existed in the live compose
+    # tree since ChatWindowEnhanced replaced the legacy ChatWindow (no live
+    # equivalents exist -- removed, not relocated). The success notify below
+    # is now unconditional after the system-prompt reset above.
+    app.notify(
+        "Active character cleared. Chat will use default settings.",
+        severity="information",
+    )
+    loguru_logger.debug("Cleared active character data on clear active character.")
 
 
 async def handle_chat_prompt_search_input_changed(

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_events_tabs.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_events_tabs.py
@@ -379,7 +379,7 @@ async def display_conversation_in_chat_tab_ui_with_tabs(
 
             # Update session title based on loaded conversation
             try:
-                conv_title_input = original_query_one("#chat-conversation-title-input")
+                conv_title_input = original_query_one("#chat-chat-title")
                 if conv_title_input and conv_title_input.value:
                     session_data.title = conv_title_input.value
                 else:

--- a/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
+++ b/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
@@ -8,12 +8,15 @@ through the same Console gateway boundary without writing to local storage.
 from __future__ import annotations
 
 import dataclasses
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import TYPE_CHECKING, Any, Mapping, Optional
 
 from loguru import logger
 from textual.css.query import QueryError
 
-from ...Character_Chat.active_user_profile import resolve_active_user_profile_name
+from ...Character_Chat.active_user_profile import (
+    resolve_active_user_profile_name,
+    resolve_active_user_profile_name_async,
+)
 from ...Character_Chat.Character_Chat_Lib import replace_placeholders
 from ...Chat.console_chat_models import ConsoleProviderSelection
 from ...Chat.console_provider_gateway import ConsoleProviderGateway
@@ -35,6 +38,11 @@ logger = logger.bind(module="PersonasPreviewController")
 
 # Cap on the preview transcript text staged into a Console handoff body.
 PREVIEW_HANDOFF_TRANSCRIPT_CHAR_LIMIT = 6000
+
+# Sentinel distinguishing "no user_name passed" (fall back to the sync
+# resolver) from an explicit ``None`` (task-551: async callers resolve first
+# and always pass a value, even when that value is ``None``).
+_UNSET: Any = object()
 
 
 class PersonasPreviewController:
@@ -83,6 +91,25 @@ class PersonasPreviewController:
         )
         return resolve_active_user_profile_name(service)
 
+    async def _resolve_user_name_async(self) -> Optional[str]:
+        """Resolve the active user profile name against the workbench's backend mode."""
+        mode = "local"
+        handler = getattr(self.screen, "persona_handler", None)
+        current_mode = getattr(handler, "current_mode", None)
+        if callable(current_mode):
+            try:
+                candidate = str(current_mode() or "").strip().lower()
+                if candidate in {"local", "server"}:
+                    mode = candidate
+            except Exception:
+                mode = "local"
+        app_instance = getattr(self.screen, "app_instance", None)
+        return await resolve_active_user_profile_name_async(
+            getattr(app_instance, "character_persona_scope_service", None),
+            mode=mode,
+            local_service=getattr(app_instance, "local_character_persona_service", None),
+        )
+
     async def reset(self, greeting: str, *, seeded_for: str | None = None) -> None:
         """Clear preview state and reseed the preview transcript.
 
@@ -107,7 +134,12 @@ class PersonasPreviewController:
         self.refresh_provider_readout()
 
     def _load_greetings(
-        self, record: dict[str, Any], name: str, *, keep_index: bool = False
+        self,
+        record: dict[str, Any],
+        name: str,
+        *,
+        keep_index: bool = False,
+        user_name: Any = _UNSET,
     ) -> str:
         """Store the processed greeting list, populate the selector, return the seed.
 
@@ -118,6 +150,10 @@ class PersonasPreviewController:
                 keep the user's chosen greeting (clamped to the new list) instead
                 of resetting to the primary — so Reset/the selector still reflect
                 the choice.
+            user_name: Pre-resolved active user profile name (task-551 async
+                callers resolve against the workbench's backend mode before
+                calling in). Defaults to the sentinel, which falls back to the
+                synchronous local-only resolver for any other caller.
 
         Returns:
             The greeting text for the current index (primary when not keeping).
@@ -128,10 +164,10 @@ class PersonasPreviewController:
             for g in (record.get("alternate_greetings") or [])
             if isinstance(g, str)
         ]
-        # task-442: {{user}} renders the active user profile's name. With no
-        # active profile the historical "User" literal is preserved byte-exact
-        # and the pane's user speaker label stays untouched.
-        user_name = self._active_user_name()
+        # task-442/task-551: {{user}} renders the active user profile's name.
+        # With no active profile the historical "User" literal is preserved
+        # byte-exact and the pane's user speaker label stays untouched.
+        user_name = self._active_user_name() if user_name is _UNSET else user_name
         self._greetings = [
             replace_placeholders(g, name, user_name or "User") for g in raw
         ]
@@ -175,7 +211,9 @@ class PersonasPreviewController:
         if record is None:
             await self.reset("")
             return
-        greeting = self._load_greetings(record, character_name)
+        greeting = self._load_greetings(
+            record, character_name, user_name=await self._resolve_user_name_async()
+        )
         await self.reset(greeting, seeded_for=character_id)
 
     async def restore_conversation(
@@ -376,7 +414,12 @@ class PersonasPreviewController:
         # chosen alternate greeting (else Reset/the selector silently revert to
         # the primary, task-438 review).
         preserve = self.seeded_for == character_id and bool(pane.transcript_text())
-        greeting = self._load_greetings(record, name, keep_index=preserve)
+        greeting = self._load_greetings(
+            record,
+            name,
+            keep_index=preserve,
+            user_name=await self._resolve_user_name_async(),
+        )
         # The speaker label is set once at selection (_select_character, from the
         # selection's display name) and must NOT be re-set here: set_speakers only
         # relabels FUTURE lines, so changing it on a same-character reload that

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -10411,7 +10411,8 @@ class ChatScreen(BaseAppScreen):
         # deferring Character_Chat submodule imports (they pull in Pillow
         # and CharactersRAGDB) rather than importing them at module scope.
         from ...Character_Chat.active_user_profile import (
-            resolve_active_user_profile_name,
+            resolve_active_user_profile_name_async,
+            resolve_runtime_backend_mode,
         )
         from ...Character_Chat.Character_Chat_Lib import replace_placeholders
 
@@ -10421,12 +10422,15 @@ class ChatScreen(BaseAppScreen):
             for key in ("system_prompt", "personality", "description", "scenario")
         ]
         system_prompt = "\n".join(p for p in parts if p) or "Stay in character."
-        # task-442: {{user}} renders the active user profile's name; the local
-        # persona service carries the sync list_user_profiles the resolver
-        # expects. No active profile keeps the historical "User" literal
-        # byte-exact and leaves the session's "General" label untouched.
-        active_user_name = resolve_active_user_profile_name(
-            getattr(self.app_instance, "local_character_persona_service", None)
+        # task-442/task-551: {{user}} renders the active user profile's name,
+        # resolved against the app-authoritative runtime backend (local
+        # persona service, or the scope service's server profiles). No
+        # active profile keeps the historical "User" literal byte-exact and
+        # leaves the session's "General" label untouched.
+        active_user_name = await resolve_active_user_profile_name_async(
+            getattr(self.app_instance, "character_persona_scope_service", None),
+            mode=resolve_runtime_backend_mode(self.app_instance),
+            local_service=getattr(self.app_instance, "local_character_persona_service", None),
         )
         greeting = replace_placeholders(
             str(card.get("first_message") or ""), name, active_user_name or "User"


### PR DESCRIPTION
## Summary

Two follow-up tasks from the RP-UX sweep, one filed follow-up.

### task-504 — repair `display_conversation_in_chat_tab_ui` (Chat tab conversation load)
- Removes the dead `#chat-right-sidebar` block (container query + six `#chat-character-*-edit` writes — those ids are composed nowhere since task-412 retired legacy ChatWindow).
- Repoints conversation details to the live `EnhancedSettingsSidebar` ids: title → `#chat-chat-title`, conversation id → `#chat-chat-id` (verified side-effect-free: no `Input.Changed` router matches them). Keywords write dropped — **no live keywords field exists; AC #1 amended accordingly (user-approved)**.
- Scopes the exception handling so a missing sidebar-detail field can never again silently abort the message-log mount (the original bug pattern); not-found branch repointed the same way; success log moved inside the success path.
- Cleans the same dead pattern in `handle_chat_clear_active_character_button_pressed` (its success notify was unreachable — always degraded to the error notify).
- Live-shapes the shared test fixture `event_handler_mocks.py` that masked the bug (it registered all the dead ids as MagicMocks). One documented `# DEAD-ID` restoration: six `#chat-character-*-edit` mocks kept solely for an out-of-scope legacy handler's pre-existing test.
- `TabContext.GLOBAL_WIDGETS` + tabs wrapper + their pins swapped to the live ids.
- 3 new regression tests (RED-confirmed against the old code): title/id/log populate; dead ids never queried; sidebar failure doesn't block the log.

**Honesty note:** the function's three callers (save/clone/load handlers) are triggered by buttons composed only in the retired `settings_sidebar.py`, so this path is repaired but not yet user-reachable — restoring (or formally retiring) the entry points is **task-562**, filed in this PR.

### task-551 — server-backend `{{user}}` resolution (Qodo #849-4 follow-up)
- New `resolve_active_user_profile_name_async(scope_service, *, mode, local_service=None)` + `resolve_runtime_backend_mode(app_like)` in `active_user_profile.py`:
  - mode ≠ "server" → delegates to the sync resolver unchanged (scope service never consulted; no new failure modes in local mode);
  - server → validates the pointer via `scope_service.list_user_profiles(mode="server")` (bare-list and `{"items": [...]}` payloads); dangling → None; **any** backend failure (connection/auth/policy) → None, never raises — `{{user}}` falls back exactly as today. No-pointer short-circuits before any backend call (byte-compat pinned).
- Three substitution sites swapped: `chat_screen._start_character_console_session` and `chat_events.display_conversation_in_chat_tab_ui` use the app-authoritative runtime source; the Personas preview controller uses the **workbench's** backend mode (`persona_handler.current_mode()`) — each surface validates against the backend it serves. `USERS_NAME` fallback at the chat_events site preserved byte-exact.
- 8 resolver unit tests + 3 server-mode site tests (all RED-first); the task-442 byte-compat twins are untouched and green.

## Review chain
Per-task implementer + reviewer per task (all Spec ✅ / Approved), final whole-branch review: READY FOR PR with zero Critical/Important findings. Rebased over 61 dev commits; grep-gates re-run clean; post-rebase: 113 passed + 26 skipped (Event_Handlers/Chat_Events + Character_Chat resolver + LLM_Management fixture-consumer), 79 passed (UI handoffs + personas preview).

## Backlog
- task-504: Done (AC #1 amended — user-approved keywords drop)
- task-551: Done
- task-562: filed (To Do) — Chat-tab load/save/clone reachability + residual dead right-sidebar surfaces (ID verified against dev max 561; 552 gap deliberately not reused)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs Chat tab conversation loading by wiring to live sidebar fields and hardening error handling, and adds async server-backend user profile resolution so `{{user}}` resolves correctly across chat and preview.

- **Bug Fixes**
  - Removed dead `#chat-right-sidebar` queries; now writes conversation details to `#chat-chat-title` and `#chat-chat-id` (keywords write dropped; no field exists).
  - Scoped sidebar writes so a missing field never blocks the message log; fixed the clear-character handler to always notify on success.
  - Updated tests/fixtures and added 3 regression tests; note: load/save/clone entry points are still missing in the live UI (tracked in task-562).

- **New Features**
  - Added `resolve_active_user_profile_name_async(scope_service, *, mode)` and `resolve_runtime_backend_mode(app)`; server mode validates via the scope service and safely falls back on any failure.
  - Switched `{{user}}` substitution to use the authoritative backend in chat start, conversation display, and personas preview, preserving local fallback behavior.
  - Added resolver and server-mode site tests.

<sup>Written for commit dda82be76512f085deed8cc6f9ae95db901bbeac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

