### PR TITLE
Image-gen follow-ups: P3 expression-generation polish (task-563)

### DIFF
--- a/Tests/UI/test_personas_expression_generate.py
+++ b/Tests/UI/test_personas_expression_generate.py
@@ -1129,6 +1129,77 @@ async def test_generate_all_worker_declining_confirmation_aborts_with_no_writes(
     assert not any("generated" in msg.lower() for msg, _sev in notifications)
 
 
+async def test_generate_all_worker_unreadable_expression_state_fails_closed_into_confirmation(
+    personas_editor_with_saved_character, monkeypatch
+):
+    """A DB read failure while checking for existing images must fail CLOSED:
+    when overwrite status is unknown, the confirmation dialog is forced
+    rather than silently skipped (Qodo PR #865 — consent gate must not fail
+    open on the exception path)."""
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    _set_description(screen, "A cheerful adventurer.")
+
+    def _raise(*args, **kwargs):
+        raise RuntimeError("db unavailable")
+
+    monkeypatch.setattr(db, "get_character_expression_image", _raise)
+
+    push_calls: list = []
+
+    async def _fake_push_screen_wait(dialog):
+        push_calls.append(dialog)
+        return False  # Cancel — sweep must abort without writes
+
+    monkeypatch.setattr(app, "push_screen_wait", _fake_push_screen_wait)
+    run_calls: list = []
+    monkeypatch.setattr(
+        personas_screen_module,
+        "run_generation",
+        lambda request: run_calls.append(request),
+    )
+    screen._expression_generate_inflight.add((char_id, "all"))
+
+    await screen._generate_all_expression_images_worker(char_id)
+
+    assert len(push_calls) == 1  # unknown overwrite state ⇒ dialog forced
+    assert run_calls == []
+
+
+async def test_generate_all_worker_confirm_dialog_failure_notifies_user(
+    personas_editor_with_saved_character, monkeypatch
+):
+    """When the overwrite-confirmation dialog itself fails to show, the
+    aborted sweep must tell the user instead of silently doing nothing
+    (Qodo PR #865 — the feature otherwise appears broken with only a log
+    line as evidence)."""
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    editor = _set_description(screen, "A cheerful adventurer.")
+    editor.set_avatar_image(b"already-staged-avatar")
+
+    async def _broken_push_screen_wait(dialog):
+        raise RuntimeError("screen stack unavailable")
+
+    monkeypatch.setattr(app, "push_screen_wait", _broken_push_screen_wait)
+    run_calls: list = []
+    monkeypatch.setattr(
+        personas_screen_module,
+        "run_generation",
+        lambda request: run_calls.append(request),
+    )
+    notifications = _capture_notifications(app)
+    screen._expression_generate_inflight.add((char_id, "all"))
+
+    await screen._generate_all_expression_images_worker(char_id)
+
+    assert run_calls == []
+    assert any(
+        "confirmation" in msg.lower() and "cancel" in msg.lower()
+        for msg, _sev in notifications
+    ), f"expected a user-facing abort notification, got: {notifications}"
+
+
 # ----- Mandatory (c): Generate-all, one failing state -----------------------
 
 

--- a/Tests/UI/test_personas_expression_generate.py
+++ b/Tests/UI/test_personas_expression_generate.py
@@ -46,6 +46,8 @@ from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
     CharacterAvatarGenerateRequested,
     CharacterExpressionGenerateAllRequested,
     CharacterExpressionGenerateRequested,
+    CharacterExpressionSetExportRequested,
+    CharacterExpressionSetImportRequested,
     CharacterExpressionStylePickRequested,
 )
 
@@ -69,6 +71,8 @@ class _CaptureApp(App):
         self.expr_generate: list[CharacterExpressionGenerateRequested] = []
         self.expr_generate_all: list[CharacterExpressionGenerateAllRequested] = []
         self.style_pick: list[CharacterExpressionStylePickRequested] = []
+        self.expr_import: list[CharacterExpressionSetImportRequested] = []
+        self.expr_export: list[CharacterExpressionSetExportRequested] = []
 
     def compose(self) -> ComposeResult:
         yield PersonasCharacterEditorWidget()
@@ -93,6 +97,16 @@ class _CaptureApp(App):
     ) -> None:
         self.style_pick.append(message)
 
+    def on_character_expression_set_import_requested(
+        self, message: CharacterExpressionSetImportRequested
+    ) -> None:
+        self.expr_import.append(message)
+
+    def on_character_expression_set_export_requested(
+        self, message: CharacterExpressionSetExportRequested
+    ) -> None:
+        self.expr_export.append(message)
+
 
 # ===== Buttons exist =====
 
@@ -112,39 +126,85 @@ async def test_generate_buttons_present_in_compose():
             )
 
 
-async def test_expressions_header_does_not_push_siblings_off_row():
-    """Regression (P3 verification sweep): a bare ``Static`` defaults to
-    Textual's ``1fr`` width when nothing constrains it, so the "Expressions"
-    section header - sharing its row with the Style readout/pick, Generate
-    all, and Import/Export set controls - would otherwise claim the entire
-    row and render every sibling past the row's right edge. The row is a
-    plain ``Horizontal`` (no wrap, no horizontal scrollbar), so those five
-    controls would be unreachable by mouse click. Live tmux verification
-    caught this; this pins the fix (an explicit ``width: auto`` on the
-    header) at the compose level.
+@pytest.mark.parametrize("width", [80, 120, 200])
+async def test_expr_set_row_buttons_reachable_and_functional_at_width(width):
+    """task-563 AC1: supersedes the original 200-col-only regression test
+    below this docstring's history - a bare ``Static`` used to default to
+    Textual's ``1fr`` width, letting the "Expressions" section header claim
+    the whole row and push every sibling control off it (fixed by the
+    ``width: auto`` on the header, still in effect). That fix only proved
+    reachability at a 200-column viewport; live tmux verification separately
+    found the row's four action buttons (Style pick, Generate all, Import
+    set, Export set) still overflow and become unreachable at realistic
+    narrower widths (120 cols: Import/Export; 80 cols: Generate all too),
+    since a plain ``Horizontal`` has no wrap and (until this fix) no
+    horizontal scrollbar either.
 
-    Scope: this only proves the fix at the 200-column viewport tested here -
-    the 1fr-header defect is fixed and the five controls are reachable at
-    that width. It does NOT prove reachability at narrower terminal widths;
-    full narrow-terminal reachability of this row is a separate, already-
-    known issue, independent of the 1fr-header defect fixed here."""
+    The fix makes the row horizontally scrollable (``overflow-x: auto`` on
+    ``.personas-char-editor-expr-set-row``, mirroring ``MainNavigationBar``'s
+    own ``.main-nav`` idiom) instead of hard-clipping. This proves the fix
+    at all three widths in two parts:
+
+    - Reachable: after ``scroll_visible()`` (what a real user's mouse
+      wheel/shift-wheel, or Tab - which auto-scrolls the focused widget into
+      view - would do), the button's rendered region must fall entirely
+      within the actual terminal viewport (``0 <= region.x`` and
+      ``region.x + region.width <= width``). This is the assertion that
+      actually discriminates the fix: ``Pilot.click`` itself was found to
+      dispatch successfully even at an off-screen region (headless-mode
+      leniency a real terminal's mouse-reporting protocol cannot replicate,
+      since it cannot report coordinates beyond its own dimensions), so a
+      raw click-succeeds check alone does not prove real-terminal
+      reachability - the in-bounds region check does.
+    - Functional: a still-independent proof the button itself works, via
+      the same ``Button.press()`` this file's other tests already use.
+    """
     app = _CaptureApp()
-    async with app.run_test(size=(200, 50)):
+    async with app.run_test(size=(width, 50)) as pilot:
         editor = app.query_one(PersonasCharacterEditorWidget)
-        row = editor.query_one(".personas-char-editor-expr-set-row")
-        row_right_edge = row.region.x + row.region.width
-        for widget_id in (
-            "personas-char-editor-style-readout",
-            "personas-char-editor-style-pick",
-            "personas-char-editor-expr-generate-all",
-            "personas-char-editor-expr-import",
-            "personas-char-editor-expr-export",
+        editor.load_character({"id": 1, "name": "A"})  # saved -> row's buttons enabled
+        await pilot.pause()
+
+        for widget_id, captured, message_type in (
+            (
+                "personas-char-editor-style-pick",
+                app.style_pick,
+                CharacterExpressionStylePickRequested,
+            ),
+            (
+                "personas-char-editor-expr-generate-all",
+                app.expr_generate_all,
+                CharacterExpressionGenerateAllRequested,
+            ),
+            (
+                "personas-char-editor-expr-import",
+                app.expr_import,
+                CharacterExpressionSetImportRequested,
+            ),
+            (
+                "personas-char-editor-expr-export",
+                app.expr_export,
+                CharacterExpressionSetExportRequested,
+            ),
         ):
-            node = editor.query_one(f"#{widget_id}")
-            assert node.region.x < row_right_edge, (
-                f"{widget_id} rendered at x={node.region.x}, at/past the "
-                f"row's right edge ({row_right_edge}) - unreachable by mouse "
-                "click."
+            node = editor.query_one(f"#{widget_id}", Button)
+            node.scroll_visible(animate=False)
+            await pilot.pause()
+            await pilot.pause()  # let the (possibly animated-off) scroll settle
+            region = node.region
+            assert 0 <= region.x and region.x + region.width <= width, (
+                f"{widget_id} rendered at x={region.x}, width={region.width} "
+                f"- outside the {width}-column viewport even after "
+                "scroll_visible(), so a real terminal's mouse could never "
+                "reach it."
+            )
+
+            before = len(captured)
+            node.press()
+            await pilot.pause()
+            assert len(captured) == before + 1, (
+                f"{widget_id} did not post {message_type.__name__} at "
+                f"width={width}."
             )
 
 
@@ -533,6 +593,176 @@ async def test_generate_requested_backend_not_configured_notifies(
     )
 
 
+# ===== task-563 AC2: in-slot "Generating…" affordance =====
+#
+# Spec §1 promised a per-slot busy indicator while a generation runs; today
+# the only feedback is the completion/failure notify or the "already
+# generating" refusal on a second click. These tests pin the widget-level
+# setters (PersonasCharacterEditorWidget.set_expression_generating /
+# set_avatar_generating) and the screen-level wiring: set at dispatch,
+# cleared on success AND failure (both flow through _generate_one_slot's
+# existing ``finally``), and never leaked onto a DIFFERENT character's
+# same-named slot after a mid-generation editor switch.
+
+
+async def test_set_expression_generating_shows_and_clears_hint():
+    app = _CaptureApp()
+    async with app.run_test():
+        editor = app.query_one(PersonasCharacterEditorWidget)
+        editor.load_character({"id": 1, "name": "A"})  # saved -> enabled ("" hint)
+        hint = editor.query_one("#personas-char-editor-expr-thinking-hint", Static)
+        assert str(hint.renderable) == ""
+
+        editor.set_expression_generating("thinking", True)
+        assert str(hint.renderable) == "Generating…"
+
+        editor.set_expression_generating("thinking", False)
+        assert str(hint.renderable) == ""
+
+
+async def test_set_expression_generating_clear_restores_unsaved_hint():
+    app = _CaptureApp()
+    async with app.run_test():
+        editor = app.query_one(PersonasCharacterEditorWidget)
+        editor.load_character({"name": "A"})  # no id -> unsaved
+        editor.set_expression_generating("thinking", True)
+        hint = editor.query_one("#personas-char-editor-expr-thinking-hint", Static)
+        assert str(hint.renderable) == "Generating…"
+
+        editor.set_expression_generating("thinking", False)
+        assert str(hint.renderable) == "Save the character to add expressions."
+
+
+async def test_set_avatar_generating_shows_and_clears_status():
+    app = _CaptureApp()
+    async with app.run_test():
+        editor = app.query_one(PersonasCharacterEditorWidget)
+        editor.load_character({"id": 1, "name": "A"})
+        status = editor.query_one("#personas-char-editor-avatar-status", Static)
+        assert str(status.renderable) == "Avatar: none"
+
+        editor.set_avatar_generating(True)
+        assert str(status.renderable) == "Avatar: generating…"
+
+        editor.set_avatar_generating(False)
+        assert str(status.renderable) == "Avatar: none"
+
+
+async def test_generate_worker_shows_and_clears_in_slot_generating_hint(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    editor = _set_description(screen, "A cheerful adventurer.")
+    hint = editor.query_one("#personas-char-editor-expr-thinking-hint", Static)
+
+    seen: dict = {}
+
+    def _run_generation(request):
+        seen["during"] = str(hint.renderable)
+        return SimpleNamespace(content=b"png-bytes", content_type="image/png")
+
+    monkeypatch.setattr(personas_screen_module, "run_generation", _run_generation)
+    screen._expression_generate_inflight.add((char_id, "thinking"))
+    editor.set_expression_generating("thinking", True)  # what the handler does at dispatch
+
+    await screen._generate_expression_image_worker(char_id, "thinking")
+
+    assert seen["during"] == "Generating…"
+    assert str(hint.renderable) == ""
+
+
+async def test_generate_worker_failure_clears_in_slot_generating_hint(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    editor = _set_description(screen, "A cheerful adventurer.")
+    hint = editor.query_one("#personas-char-editor-expr-error-hint", Static)
+
+    def _boom(request):
+        raise RuntimeError("backend exploded")
+
+    monkeypatch.setattr(personas_screen_module, "run_generation", _boom)
+    screen._expression_generate_inflight.add((char_id, "error"))
+    editor.set_expression_generating("error", True)
+
+    await screen._generate_expression_image_worker(char_id, "error")
+
+    assert str(hint.renderable) == ""
+
+
+async def test_avatar_generate_worker_shows_and_clears_generating_status(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    editor = _set_description(screen, "A cheerful adventurer.")
+    status = editor.query_one("#personas-char-editor-avatar-status", Static)
+
+    seen: dict = {}
+
+    def _run_generation(request):
+        seen["during"] = str(status.renderable)
+        return SimpleNamespace(content=b"png-bytes", content_type="image/png")
+
+    monkeypatch.setattr(personas_screen_module, "run_generation", _run_generation)
+    _capture_avatar_render_worker(screen)
+    screen._expression_generate_inflight.add((char_id, "avatar"))
+    editor.set_avatar_generating(True)
+
+    await screen._generate_expression_image_worker(char_id, "avatar")
+
+    assert seen["during"] == "Avatar: generating…"
+    assert str(status.renderable) == "Avatar: embedded"
+
+
+async def test_generate_worker_does_not_clear_generating_hint_of_switched_to_character(
+    personas_editor_with_saved_character, monkeypatch
+):
+    """The leak guard: while A's "thinking" generation is in flight, the
+    user switches the SAME editor widget to a DIFFERENT character B, which
+    happens to have its own INDEPENDENT "thinking" generation already
+    showing "Generating…" (started via a separate click after the switch).
+    A's stale completion must not clear B's legitimately-in-flight
+    indicator - the clear must only ever touch the (character_id, state)
+    pair it was set for."""
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    editor = _set_description(screen, "CHARACTER A: a cheerful adventurer.")
+    other_id = db.add_character_card({"name": "Grim"})
+    hint = editor.query_one("#personas-char-editor-expr-thinking-hint", Static)
+
+    def _run_generation(request):
+        # Mid-flight for A's request: the user cancels and opens a
+        # DIFFERENT character (B) in the same editor widget.
+        screen._finish_cancel_edit()
+        screen._character_editor_generation += 1
+        screen._edit_mode = "edit"
+        screen.state.select_entity(
+            entity_kind="character", entity_id=str(other_id), entity_name="Grim"
+        )
+        screen._show_center("#ccp-character-editor-view")
+        editor.load_character(
+            {"id": other_id, "name": "Grim", "description": "B", "version": 1}
+        )
+        # B has its own, unrelated "thinking" generation already in flight.
+        editor.set_expression_generating("thinking", True)
+        return SimpleNamespace(content=b"png-bytes", content_type="image/png")
+
+    monkeypatch.setattr(personas_screen_module, "run_generation", _run_generation)
+    apply_mock = AsyncMock()
+    monkeypatch.setattr(screen, "_apply_expression_upload", apply_mock)
+    screen._expression_generate_inflight.add((char_id, "thinking"))
+    editor.set_expression_generating("thinking", True)
+
+    await screen._generate_expression_image_worker(char_id, "thinking")
+
+    apply_mock.assert_not_awaited()  # A's stale write is dropped, as before
+    # B's own (unrelated) "Generating…" must survive A's stale completion.
+    assert str(hint.renderable) == "Generating…"
+
+
 # ===== Image-gen P3 Task 4: avatar generate, Generate-all, style picker =====
 #
 # The refactor's own proof is above: this file's 14 original Task 3 tests
@@ -714,6 +944,191 @@ async def test_avatar_generate_requested_inflight_second_click_single_generation
     assert "already generating" in notifications[-1][0].lower()
 
 
+async def test_generate_requested_refused_while_generate_all_in_flight(
+    personas_editor_with_saved_character, monkeypatch
+):
+    """task-563 AC5: a per-slot key is freed the instant that slot's own
+    generation finishes inside the Generate-all sweep (``_generate_one_
+    slot``'s ``finally``), while the sweep itself keeps running the
+    remaining states. Without an explicit guard, a single-slot click for
+    that just-finished (or not-yet-started) state during the same sweep
+    would dispatch an independent, redundant regeneration. Closing this at
+    the "all" key's full lifetime (held for the whole sweep) is simpler and
+    stronger than trying to reason about per-slot timing windows."""
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    _set_description(screen, "A cheerful adventurer.")
+    screen._expression_generate_inflight.add((char_id, "all"))
+
+    calls: list = []
+    monkeypatch.setattr(screen, "run_worker", lambda *a, **k: calls.append(1))
+    notifications = _capture_notifications(app)
+
+    screen._handle_character_expression_generate_requested(
+        CharacterExpressionGenerateRequested("thinking")
+    )
+
+    assert calls == []
+    assert notifications
+    assert notifications[-1][1] == "warning"
+    assert "generate all" in notifications[-1][0].lower()
+
+
+async def test_avatar_generate_requested_refused_while_generate_all_in_flight(
+    personas_editor_with_saved_character, monkeypatch
+):
+    """task-563 AC5: same guard as the expression-slot case, for the avatar
+    generate button - the avatar is itself one of the sweep's four states."""
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    _set_description(screen, "A cheerful adventurer.")
+    screen._expression_generate_inflight.add((char_id, "all"))
+
+    calls: list = []
+    monkeypatch.setattr(screen, "run_worker", lambda *a, **k: calls.append(1))
+    notifications = _capture_notifications(app)
+
+    screen._handle_character_avatar_generate_requested(CharacterAvatarGenerateRequested())
+
+    assert calls == []
+    assert notifications
+    assert notifications[-1][1] == "warning"
+    assert "generate all" in notifications[-1][0].lower()
+
+
+# ----- task-563 AC3: Generate-all overwrite confirmation --------------------
+#
+# The sweep's blast radius (avatar + 3 expression states) exceeds the
+# per-slot regenerate-by-click contract, so it must confirm first whenever
+# it would actually overwrite something. Uses the same ConfirmationDialog /
+# push_screen_wait idiom as _confirm_delete / _confirm_dictionary_revert
+# (monkeypatch app.push_screen_wait, mirroring this file's own style-pick
+# tests above).
+
+
+async def test_generate_all_worker_no_confirmation_when_nothing_would_be_overwritten(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    _set_description(screen, "A cheerful adventurer.")
+
+    push_calls: list = []
+
+    async def _fake_push_screen_wait(dialog):
+        push_calls.append(dialog)
+        return True
+
+    monkeypatch.setattr(app, "push_screen_wait", _fake_push_screen_wait)
+    monkeypatch.setattr(
+        personas_screen_module,
+        "run_generation",
+        lambda request: SimpleNamespace(content=b"png-bytes", content_type="image/png"),
+    )
+    apply_mock = AsyncMock()
+    monkeypatch.setattr(screen, "_apply_expression_upload", apply_mock)
+    _capture_avatar_render_worker(screen)
+    screen._expression_generate_inflight.add((char_id, "all"))
+
+    await screen._generate_all_expression_images_worker(char_id)
+
+    assert push_calls == []  # nothing to overwrite -> no dialog
+    assert apply_mock.await_count == 3  # the sweep still ran normally
+
+
+async def test_generate_all_worker_confirms_before_overwriting_staged_avatar(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    editor = _set_description(screen, "A cheerful adventurer.")
+    editor.set_avatar_image(b"already-staged-avatar")
+
+    push_calls: list = []
+
+    async def _fake_push_screen_wait(dialog):
+        push_calls.append(dialog)
+        return True  # user confirms
+
+    monkeypatch.setattr(app, "push_screen_wait", _fake_push_screen_wait)
+    monkeypatch.setattr(
+        personas_screen_module,
+        "run_generation",
+        lambda request: SimpleNamespace(content=b"png-bytes", content_type="image/png"),
+    )
+    apply_mock = AsyncMock()
+    monkeypatch.setattr(screen, "_apply_expression_upload", apply_mock)
+    _capture_avatar_render_worker(screen)
+    screen._expression_generate_inflight.add((char_id, "all"))
+
+    await screen._generate_all_expression_images_worker(char_id)
+
+    assert len(push_calls) == 1
+    assert editor.current_avatar_bytes() == b"png-bytes"  # sweep proceeded
+    assert apply_mock.await_count == 3
+
+
+async def test_generate_all_worker_confirms_before_overwriting_existing_expression_image(
+    personas_editor_with_saved_character, monkeypatch
+):
+    """An existing expression-state image (not the avatar) also counts as
+    "would overwrite"."""
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    _set_description(screen, "A cheerful adventurer.")
+    db.set_character_expression_image(char_id, "thinking", b"already-there")
+
+    push_calls: list = []
+
+    async def _fake_push_screen_wait(dialog):
+        push_calls.append(dialog)
+        return True
+
+    monkeypatch.setattr(app, "push_screen_wait", _fake_push_screen_wait)
+    monkeypatch.setattr(
+        personas_screen_module,
+        "run_generation",
+        lambda request: SimpleNamespace(content=b"png-bytes", content_type="image/png"),
+    )
+    _capture_avatar_render_worker(screen)
+    screen._expression_generate_inflight.add((char_id, "all"))
+
+    await screen._generate_all_expression_images_worker(char_id)
+
+    assert len(push_calls) == 1
+    assert db.get_character_expression_image(char_id, "thinking") == b"png-bytes"
+
+
+async def test_generate_all_worker_declining_confirmation_aborts_with_no_writes(
+    personas_editor_with_saved_character, monkeypatch
+):
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    editor = _set_description(screen, "A cheerful adventurer.")
+    editor.set_avatar_image(b"already-staged-avatar")
+
+    async def _fake_push_screen_wait(dialog):
+        return False  # Cancel
+
+    monkeypatch.setattr(app, "push_screen_wait", _fake_push_screen_wait)
+    run_calls: list = []
+
+    def _run_generation(request):
+        run_calls.append(request)
+        return SimpleNamespace(content=b"png-bytes", content_type="image/png")
+
+    monkeypatch.setattr(personas_screen_module, "run_generation", _run_generation)
+    notifications = _capture_notifications(app)
+    screen._expression_generate_inflight.add((char_id, "all"))
+
+    await screen._generate_all_expression_images_worker(char_id)
+
+    assert run_calls == []  # nothing generated
+    assert editor.current_avatar_bytes() == b"already-staged-avatar"  # untouched
+    assert (char_id, "all") not in screen._expression_generate_inflight
+    assert not any("generated" in msg.lower() for msg, _sev in notifications)
+
+
 # ----- Mandatory (c): Generate-all, one failing state -----------------------
 
 
@@ -747,6 +1162,47 @@ async def test_generate_all_worker_one_failing_state_reports_partial_summary(
     for state in ("avatar", "thinking", "speaking", "error"):
         assert (char_id, state) not in screen._expression_generate_inflight
     assert notifications
+    assert notifications[-1] == ("3/4 generated.", "information")
+
+
+async def test_generate_all_worker_counts_only_genuinely_persisted_slots(
+    personas_editor_with_saved_character, monkeypatch
+):
+    """task-563 AC4: exercises the REAL ``_apply_expression_upload`` (not a
+    mock) so a DB-write failure for one state - generation itself
+    succeeded, only the persist step failed - must not be counted as a
+    success in the final summary, even though it already got its own
+    per-slot error notify."""
+    app, screen, db, char_id = personas_editor_with_saved_character
+    _configure_backend(monkeypatch)
+    _set_description(screen, "A cheerful adventurer.")
+
+    monkeypatch.setattr(
+        personas_screen_module,
+        "run_generation",
+        lambda request: SimpleNamespace(content=b"png-bytes", content_type="image/png"),
+    )
+    original_write = db.set_character_expression_image
+
+    def _flaky_write(character_id, state, image, mime=None):
+        if state == "speaking":
+            raise RuntimeError("disk full")
+        return original_write(character_id, state, image, mime)
+
+    monkeypatch.setattr(db, "set_character_expression_image", _flaky_write)
+    _capture_avatar_render_worker(screen)
+    notifications = _capture_notifications(app)
+    screen._expression_generate_inflight.add((char_id, "all"))
+
+    await screen._generate_all_expression_images_worker(char_id)
+
+    # avatar (staged) + thinking + error persisted; speaking's DB write
+    # failed, so it must not count despite generation itself succeeding.
+    assert db.get_character_expression_image(char_id, "speaking") is None
+    assert db.get_character_expression_image(char_id, "thinking") is not None
+    assert db.get_character_expression_image(char_id, "error") is not None
+    severities = [severity for _msg, severity in notifications]
+    assert "error" in severities  # the per-slot failure notify still fires
     assert notifications[-1] == ("3/4 generated.", "information")
 
 

--- a/Tests/UI/test_personas_expression_slots.py
+++ b/Tests/UI/test_personas_expression_slots.py
@@ -104,10 +104,36 @@ async def test_upload_writes_expression_row(personas_editor_with_saved_character
     app, screen, db, char_id = personas_editor_with_saved_character
     buf = BytesIO()
     Image.new("RGB", (16, 16)).save(buf, format="PNG")
-    await screen._apply_expression_upload(
+    result = await screen._apply_expression_upload(
         char_id, "speaking", buf.getvalue(), "image/png"
     )
     assert db.get_character_expression_image(char_id, "speaking") is not None
+    # task-563 AC4: callers that aggregate multiple slots (Generate-all)
+    # need an honest success signal, not just "this call didn't raise".
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_apply_expression_upload_returns_false_on_db_write_failure(
+    personas_editor_with_saved_character, monkeypatch
+):
+    """task-563 AC4: a DB-write failure inside _apply_expression_upload must
+    be reported to the caller (not just swallowed behind an error notify) so
+    an aggregating caller (the Generate-all sweep) doesn't count this slot as
+    a success."""
+    app, screen, db, char_id = personas_editor_with_saved_character
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(db, "set_character_expression_image", _boom)
+
+    result = await screen._apply_expression_upload(
+        char_id, "speaking", b"not-really-png", "image/png"
+    )
+
+    assert result is False
+    assert db.get_character_expression_image(char_id, "speaking") is None
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-563 - Image-gen-P3-polish-follow-ups.md
+++ b/backlog/tasks/task-563 - Image-gen-P3-polish-follow-ups.md
@@ -2,10 +2,10 @@
 id: TASK-563
 title: >-
   Image-gen P3 polish follow-ups
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-24 23:34'
-updated_date: '2026-07-24 23:34'
+updated_date: '2026-07-25 01:30'
 labels:
   - image-generation
   - personas

--- a/backlog/tasks/task-563 - Image-gen-P3-polish-follow-ups.md
+++ b/backlog/tasks/task-563 - Image-gen-P3-polish-follow-ups.md
@@ -1,11 +1,10 @@
 ---
 id: TASK-563
-title: >-
-  Image-gen P3 polish follow-ups
-status: In Progress
+title: Image-gen P3 polish follow-ups
+status: Done
 assignee: []
 created_date: '2026-07-24 23:34'
-updated_date: '2026-07-25 01:30'
+updated_date: '2026-07-25 08:48'
 labels:
   - image-generation
   - personas
@@ -21,21 +20,41 @@ Deferred polish from the image-gen P3 whole-branch review (PR #859: ✨Generate 
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
-- [ ] The Expressions action row remains usable at narrow terminal widths (at 120 cols Import/Export currently overflow the row; at 80 cols Generate-all does too — pre-existing since the row shipped). Wrap, scroll, or fold the set-actions into a menu; pin with a width-parameterized test replacing the current 200-col-only claim.
-- [ ] A generation in progress shows an in-slot "Generating…" affordance (spec §1 promised it; today the only feedback is the completion/failure notify or the "already generating" refusal on a second click).
-- [ ] "✨ Generate all" asks for confirmation when it would overwrite existing images (staged avatar or populated expression slots) — the sweep's blast radius exceeds the per-slot regenerate-by-click contract.
-- [ ] The Generate-all summary counts only genuinely persisted slots (today `_apply_expression_upload` swallows its own DB-write failure and the sweep counts that slot as a success — user sees both the per-slot error AND an inflated "k/4").
-- [ ] Cosmetics: a one-line comment at `_after_character_save`'s record-reread-failure fallback noting the style-reset invariant holds via the closed editor gates; the generate-all narrow race (per-slot key freed mid-loop allowing a duplicate regeneration) either guarded or documented as accepted last-write-wins.
+- [x] #1 The Expressions action row remains usable at narrow terminal widths (at 120 cols Import/Export currently overflow the row; at 80 cols Generate-all does too — pre-existing since the row shipped). Wrap, scroll, or fold the set-actions into a menu; pin with a width-parameterized test replacing the current 200-col-only claim.
+- [x] #2 A generation in progress shows an in-slot "Generating…" affordance (spec §1 promised it; today the only feedback is the completion/failure notify or the "already generating" refusal on a second click).
+- [x] #3 "✨ Generate all" asks for confirmation when it would overwrite existing images (staged avatar or populated expression slots) — the sweep's blast radius exceeds the per-slot regenerate-by-click contract.
+- [x] #4 The Generate-all summary counts only genuinely persisted slots (today `_apply_expression_upload` swallows its own DB-write failure and the sweep counts that slot as a success — user sees both the per-slot error AND an inflated "k/4").
+- [x] #5 Cosmetics: a one-line comment at `_after_character_save`'s record-reread-failure fallback noting the style-reset invariant holds via the closed editor gates; the generate-all narrow race (per-slot key freed mid-loop allowing a duplicate regeneration) either guarded or documented as accepted last-write-wins.
 <!-- AC:END -->
 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
+1. AC1 (narrow-width row): add overflow-x: auto; scrollbar-size-horizontal: 0; to .personas-char-editor-expr-set-row (mirrors MainNavigationBar's .main-nav idiom, tldw_chatbook/UI/Navigation/main_navigation.py:94) - the row becomes horizontally scrollable instead of hard-clipping past its right edge, so every button stays reachable (scroll/keyboard-tab) at any width. Replace test_expressions_header_does_not_push_siblings_off_row's 200-col-only claim with a width-parameterized test (80/120/200) that scroll_visible()s + pilot.click()s each action button and asserts the correct message posts - proving reachable AND functional, not just positioned. This is DEFAULT_CSS inside the widget's Python file, not the generated tldw_cli_modular.tcss bundle, so no build_css.sh run is needed.
+2. AC2 (in-slot Generating... affordance): add PersonasCharacterEditorWidget.set_expression_generating(state, busy) (overwrites the per-state -hint Static) and set_avatar_generating(busy) (overwrites avatar-status Static), both self-healing on clear (recompute the real default rather than remembering one). Screen sets busy=True at the same three sites that already add an in-flight key (_handle_character_expression_generate_requested, _handle_character_avatar_generate_requested, and inside _generate_all_expression_images_worker's loop). Clear busy=False from one place - _generate_one_slot's existing finally - via a new _clear_slot_generating_indicator(character_id, state) helper that re-checks _character_editor_is_active() + editor.expression_character_id() == character_id first (mirrors the sweep's own per-iteration identity guard) so a mid-generation character switch never paints a stale "Generating..." onto whatever now-different character is loaded - the switch's own _sync_expression_slots_enabled/_set_avatar_status_from_record already reset the widget for real.
+3. AC3 (Generate-all overwrite confirmation): add editor.has_avatar_image() (factored out of _set_avatar_status_from_record) and a screen helper that also checks the 3 DB-backed expression states via db.get_character_expression_image (mirrors _render_character_expression_slot's read). When any exist, _generate_all_expression_images_worker awaits a new _confirm_generate_all_overwrite() (same ConfirmationDialog/push_screen_wait idiom as _confirm_delete/_confirm_dictionary_revert) before the loop; Cancel aborts silently (no notify, no writes, in-flight key still released via the existing finally). No dialog when everything is empty.
+4. AC4 (honest k/N summary): _apply_expression_upload returns bool (True on persisted write, False on the already-notified DB-write failure); _generate_one_slot's expression branch returns that value instead of a hardcoded True, so _generate_all_expression_images_worker's succeeded counter (already `if await self._generate_one_slot(...): succeeded += 1`) only counts genuinely persisted slots.
+5. AC5 (cosmetics): one-line comment at _after_character_save's saved_record is None fallback explaining why leaving _expression_generate_style un-reset there is still safe (editor closes to view mode; the next genuine session-open resets it before any button is reachable). For the generate-all narrow race, GUARD it: _handle_character_expression_generate_requested and _handle_character_avatar_generate_requested additionally refuse when (character_id, "all") is in-flight, closing the window where a per-slot key freed mid-sweep let an independent single-slot click regenerate a slot the sweep already (or is about to) touch - documented as the chosen approach (not last-write-wins) in Implementation Notes.
+6. TDD per AC: write/adjust failing tests first in Tests/UI/test_personas_expression_generate.py (screen/worker level) and Tests/UI/test_personas_expression_slots.py or a new widget test as needed, confirm red, implement, confirm green. Run ruff + import-clean check. Update task file ACs/Notes, commit.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
+All 5 ACs implemented with TDD (failing test confirmed red, then implementation, then green) in `tldw_chatbook/UI/Screens/personas_screen.py` and `tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py`.
+
+**AC1 (narrow-width row).** Added `overflow-x: auto; scrollbar-size-horizontal: 0;` to `.personas-char-editor-expr-set-row`'s `DEFAULT_CSS` (widget-scoped Python CSS, not the generated `tldw_cli_modular.tcss` bundle — no `build_css.sh` needed), mirroring `MainNavigationBar`'s `.main-nav` idiom. The row becomes horizontally scrollable instead of hard-clipping. Replaced the 200-col-only `test_expressions_header_does_not_push_siblings_off_row` with `test_expr_set_row_buttons_reachable_and_functional_at_width` parametrized over 80/120/200 cols. Discovered mid-implementation that `Pilot.click()` dispatches successfully even at an off-screen region (headless-mode leniency a real terminal can't replicate), so the test instead asserts the button's region falls entirely within the viewport after `scroll_visible()` (the assertion that actually discriminates the fix — verified red at width=80 without the CSS change, green with it) plus a separate `Button.press()` functional check.
+
+**AC2 (in-slot "Generating…" affordance).** Added `PersonasCharacterEditorWidget.set_expression_generating(state, busy)` and `set_avatar_generating(busy)`, both self-healing on clear (recompute the real default text rather than remembering one). Screen sets busy=True at the three dispatch sites that already add an in-flight key; clears via one path — `_generate_one_slot`'s existing `finally` — through a new `_clear_slot_generating_indicator(character_id, state)` that re-checks `_character_editor_is_active()` + `editor.expression_character_id() == character_id` before touching the widget, so a mid-generation character switch never paints a stale indicator onto a different now-loaded character. Pinned with a dedicated leak test simulating a switch to a character with its own independent "thinking" generation in flight, proving the stale clear does not clobber it.
+
+**AC3 (Generate-all overwrite confirmation).** Added `editor.has_avatar_image()` (factored out of `_set_avatar_status_from_record`) and `_generate_all_would_overwrite()` (avatar + the 3 DB-backed expression states via `db.get_character_expression_image`, mirroring `_render_character_expression_slot`'s read). `_generate_all_expression_images_worker` now confirms via `_confirm_generate_all_overwrite()` (same `ConfirmationDialog`/`push_screen_wait` idiom as `_confirm_delete`/`_confirm_dictionary_revert`) before the loop, only when something would actually be overwritten; a decline aborts with no writes and no summary notify (a "0/4 generated" notify on an explicit decline would misleadingly read as an under-performing attempt rather than a withdrawn request).
+
+**AC4 (honest k/N summary).** `_apply_expression_upload` now returns `bool` (`True` on a persisted write, `False` on the already-notified DB-write failure); `_generate_one_slot`'s expression branch returns that value instead of a hardcoded `True`. `_generate_all_expression_images_worker`'s existing `if await self._generate_one_slot(...): succeeded += 1` now only counts genuinely persisted slots. Pinned with a test that exercises the real (unmocked) `_apply_expression_upload` with a flaky DB write for one state, proving the summary reads "3/4" (not "4/4") while the per-slot error notify still fires.
+
+**AC5 (cosmetics + narrow race).** Added a one-line comment at `_after_character_save`'s `saved_record is None` fallback explaining the style-reset invariant still holds (editor closes to view mode; the next genuine session-open resets the style before any button is reachable). Chose to **guard** (not document as accepted) the generate-all narrow race: `_handle_character_expression_generate_requested` and `_handle_character_avatar_generate_requested` now also refuse when `(character_id, "all")` is in-flight, closing the window where a per-slot key freed mid-sweep let an independent single-slot click race a redundant regeneration against the still-running sweep. This is simpler and stronger than reasoning about per-slot timing windows, since the "all" key's lifetime spans the sweep's entire duration.
+
+**Testing:** `Tests/UI/test_personas_expression_generate.py` (net +~430 lines; the old 200-col-only test was replaced by a 3x-parametrized one) and `Tests/UI/test_personas_expression_slots.py` (+2 tests). Full targeted suite: 69 passed (was 52 baseline). Broader regression sweep `Tests/UI/ -k personas` (all 26 persona-related files, 620+ tests): 3 pre-existing failures reproduced identically on the base commit (`test_import_offpage_name_conflict_message`, `test_character_book_errors_render_in_editor_footer`, `test_export_json_rejects_hidden_directory_destination` — task-564's scope, not touched here), everything else green. `ruff check` on touched files shows only pre-existing findings at unchanged line positions (verified against `git show HEAD`). `python -c "import tldw_chatbook.app"` clean.
+
+**Files modified:** `tldw_chatbook/UI/Screens/personas_screen.py`, `tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py`, `Tests/UI/test_personas_expression_generate.py`, `Tests/UI/test_personas_expression_slots.py`.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -4694,12 +4694,24 @@ class PersonasScreen(BaseAppScreen):
 
     async def _apply_expression_upload(
         self, character_id: int, state: str, image: bytes, mime: str | None = None
-    ) -> None:
-        """Write an uploaded expression-state image and re-render its slot."""
+    ) -> bool:
+        """Write an uploaded expression-state image and re-render its slot.
+
+        Returns:
+            ``True`` when the DB write actually persisted, ``False`` on a
+            missing-database or write failure (already notified here).
+            Task-563 AC4: a caller that aggregates multiple slots (the
+            Generate-all sweep) must count only genuinely persisted slots
+            rather than treating "this call didn't raise" as success -
+            without this return value, a swallowed DB-write failure here
+            was invisible to the caller and the sweep's summary silently
+            overstated its count even though the user already saw this
+            method's own error notify.
+        """
         db = getattr(self.app_instance, "chachanotes_db", None)
         if db is None:
             self._notify("Database is not available.", "error")
-            return
+            return False
         try:
             await asyncio.to_thread(
                 db.set_character_expression_image, character_id, state, image, mime
@@ -4710,10 +4722,11 @@ class PersonasScreen(BaseAppScreen):
                 f"{character_id}: {exc}"
             )
             self._notify(f"Expression upload failed: {exc}", "error")
-            return
+            return False
         self._character_editor_generation += 1
         self._notify(f"{state.capitalize()} expression image saved.", "information")
         await self._render_character_expression_slot(character_id, state)
+        return True
 
     async def _clear_expression_slot(self, character_id: int, state: str) -> None:
         """Soft-delete an expression-state image and clear its slot's thumbnail."""
@@ -4831,7 +4844,24 @@ class PersonasScreen(BaseAppScreen):
                 "warning",
             )
             return
+        # task-563 AC5: the "all" key is held for the sweep's ENTIRE
+        # duration (added at dispatch, discarded in the sweep worker's own
+        # finally after the loop) - unlike a per-slot key, which is freed
+        # the instant THAT slot's own generation finishes while the sweep
+        # keeps going. Without this check, a click here for a state the
+        # sweep just finished (or hasn't reached yet) would race an
+        # independent, redundant regeneration against the still-running
+        # sweep instead of being refused outright.
+        if (character_id, "all") in self._expression_generate_inflight:
+            self._notify(
+                "Generate all is already running for this character.", "warning"
+            )
+            return
         self._expression_generate_inflight.add(key)
+        # task-563 AC2: the in-slot busy affordance (spec §1) - set here,
+        # at the same moment the in-flight key is claimed; cleared from
+        # _generate_one_slot's own finally (success AND failure alike).
+        editor.set_expression_generating(message.state, True)
         self.run_worker(
             self._generate_expression_image_worker(character_id, message.state),
             group="personas-io",
@@ -4873,7 +4903,16 @@ class PersonasScreen(BaseAppScreen):
         if key in self._expression_generate_inflight:
             self._notify("Already generating the avatar image.", "warning")
             return
+        # task-563 AC5: same narrow-race guard as the expression-slot
+        # handler above - the avatar is itself one of the sweep's four
+        # states, so it must also be refused while a sweep is running.
+        if (character_id, "all") in self._expression_generate_inflight:
+            self._notify(
+                "Generate all is already running for this character.", "warning"
+            )
+            return
         self._expression_generate_inflight.add(key)
+        editor.set_avatar_generating(True)  # task-563 AC2
         self.run_worker(
             self._generate_expression_image_worker(character_id, "avatar"),
             group="personas-io",
@@ -5151,10 +5190,13 @@ class PersonasScreen(BaseAppScreen):
                     "Avatar image generated — Save to keep it.", "information"
                 )
                 return True
-            await self._apply_expression_upload(
+            # Propagate the write's real outcome (task-563 AC4) - a DB-write
+            # failure here already notified via _apply_expression_upload's
+            # own error path and must not be double-counted as a success by
+            # an aggregating caller (the Generate-all sweep's k/N summary).
+            return await self._apply_expression_upload(
                 character_id, state, result.content, result.content_type
             )
-            return True
         except Exception as exc:
             logger.opt(exception=True).error(
                 f"Image generation failed for character {character_id!r} "
@@ -5164,6 +5206,53 @@ class PersonasScreen(BaseAppScreen):
             return False
         finally:
             self._expression_generate_inflight.discard(key)
+            # task-563 AC2: clear the busy affordance on BOTH the success
+            # and failure paths above (this finally runs either way).
+            self._clear_slot_generating_indicator(character_id, state)
+
+    def _set_slot_generating(
+        self, editor: "PersonasCharacterEditorWidget", state: str, busy: bool
+    ) -> None:
+        """Route to the avatar or per-state expression busy-indicator
+        setter (task-563 AC2) - ``"avatar"`` is one of
+        ``EXPRESSION_PROMPT_STATES`` but has its own Static
+        (``avatar-status``), not a per-state ``-hint``.
+        """
+        if state == "avatar":
+            editor.set_avatar_generating(busy)
+        else:
+            editor.set_expression_generating(state, busy)
+
+    def _clear_slot_generating_indicator(
+        self, character_id: int | None, state: str
+    ) -> None:
+        """Clear the in-slot "Generating…" affordance set at dispatch
+        (task-563 AC2), but only into the still-open editor session for the
+        SAME character.
+
+        Mirrors ``_generate_all_expression_images_worker``'s own per-
+        iteration identity re-check (character id, not the session token -
+        the token's generation counter is bumped by ``_apply_expression_
+        upload`` on every successful write, which would make a token
+        captured before this call already look stale for this call's own
+        success). Without this guard, a character switch mid-generation
+        (the same race ``_generate_all_expression_images_worker`` already
+        defends the DB writes against) could paint this slot's stale busy
+        state onto whatever a DIFFERENT character now has loaded in the
+        same-named slot; the switch's own ``_sync_expression_slots_enabled``/
+        ``_set_avatar_status_from_record`` call already reset the widget for
+        real, and a currently-generating slot on that OTHER character must
+        not be clobbered either.
+        """
+        if not self._character_editor_is_active():
+            return
+        try:
+            editor = self.query_one(PersonasCharacterEditorWidget)
+        except QueryError:
+            return
+        if editor.expression_character_id() != character_id:
+            return
+        self._set_slot_generating(editor, state, False)
 
     async def _generate_expression_image_worker(
         self, character_id: int | None, state: str
@@ -5207,10 +5296,29 @@ class PersonasScreen(BaseAppScreen):
         mismatch after this sweep's own first successful slot. Comparing
         the freshly-resolved editor's loaded character id is immune to
         that self-inflicted bump.
+
+        Task-563 AC3: before the loop, checks whether the sweep would
+        overwrite anything already present (a staged avatar or any of the
+        3 DB-backed expression states) and, only then, confirms via
+        ``_confirm_generate_all_overwrite`` - the sweep's blast radius (up
+        to 4 slots) exceeds the per-slot regenerate-by-click contract, so a
+        single click here should not silently clobber existing images. A
+        decline aborts with no writes and no "k/N generated" summary
+        (which would misleadingly read as an attempt that under-performed
+        rather than a request the user actively withdrew).
         """
         style_template = getattr(self, "_expression_generate_style", None)
         succeeded = 0
+        cancelled = False
         try:
+            try:
+                editor = self.query_one(PersonasCharacterEditorWidget)
+            except QueryError:
+                return
+            if await self._generate_all_would_overwrite(character_id, editor):
+                if not await self._confirm_generate_all_overwrite():
+                    cancelled = True
+                    return
             for state in EXPRESSION_PROMPT_STATES:
                 if not self._character_editor_is_active():
                     break
@@ -5224,13 +5332,70 @@ class PersonasScreen(BaseAppScreen):
                 if slot_key in self._expression_generate_inflight:
                     continue
                 self._expression_generate_inflight.add(slot_key)
+                self._set_slot_generating(editor, state, True)  # task-563 AC2
                 if await self._generate_one_slot(character_id, state, style_template):
                     succeeded += 1
         finally:
             self._expression_generate_inflight.discard((character_id, "all"))
-        self._notify(
-            f"{succeeded}/{len(EXPRESSION_PROMPT_STATES)} generated.", "information"
+        if not cancelled:
+            self._notify(
+                f"{succeeded}/{len(EXPRESSION_PROMPT_STATES)} generated.",
+                "information",
+            )
+
+    async def _generate_all_would_overwrite(
+        self, character_id: int, editor: "PersonasCharacterEditorWidget"
+    ) -> bool:
+        """True when a Generate-all sweep would overwrite an existing
+        avatar or expression image (task-563 AC3).
+
+        Checks the editor's staged/persisted avatar first (cheap, no DB
+        round trip), then each of the 3 DB-backed expression states
+        (mirrors ``_render_character_expression_slot``'s own read) -
+        stopping at the first hit.
+        """
+        if editor.has_avatar_image():
+            return True
+        db = getattr(self.app_instance, "chachanotes_db", None)
+        if db is None:
+            return False
+        for state in EXPRESSION_IMAGE_STATES:
+            try:
+                data = await asyncio.to_thread(
+                    db.get_character_expression_image, character_id, state
+                )
+            except Exception:
+                logger.opt(exception=True).debug(
+                    f"Could not check the existing {state} expression image "
+                    f"for character {character_id} before a Generate-all "
+                    "overwrite confirmation."
+                )
+                continue
+            if data:
+                return True
+        return False
+
+    async def _confirm_generate_all_overwrite(self) -> bool:
+        """True when the user confirmed overwriting existing images
+        (task-563 AC3; requires a worker context, same as ``_confirm_
+        delete``/``_confirm_dictionary_revert``)."""
+        dialog = ConfirmationDialog(
+            title="Generate all",
+            message=(
+                "This will overwrite the existing avatar and/or expression "
+                "images. Continue?"
+            ),
+            confirm_label="Generate all",
+            cancel_label="Cancel",
         )
+        try:
+            return bool(await self.app.push_screen_wait(dialog))
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Could not show the Generate-all overwrite confirmation "
+                "dialog; skipping the sweep."
+            )
+            return False
 
     async def _expression_style_pick_dialog_worker(self) -> None:
         """Show the style picker; store the choice and refresh the readout.
@@ -6496,6 +6661,14 @@ class PersonasScreen(BaseAppScreen):
         if saved_record is None:
             # Could not re-read -> fall back to today's flip-to-card so we
             # never leave the editor holding a stale version.
+            # (task-563 AC5: this path does NOT call
+            # _reset_expression_generate_style(), unlike _begin_create_
+            # character/_handle_edit_requested/_finish_cancel_edit - but the
+            # invariant those calls protect ("a picked style never bleeds
+            # into a DIFFERENT editor session") still holds here: the editor
+            # is now closed to view mode, so no Generate button is reachable
+            # against the stale style, and the next genuine session-open
+            # resets it before any button in that new session is reachable.)
             self._edit_mode = "view"
             self._show_center("#ccp-character-card-view")
             self.call_after_refresh(self._focus_library_list)

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -5365,12 +5365,14 @@ class PersonasScreen(BaseAppScreen):
                     db.get_character_expression_image, character_id, state
                 )
             except Exception:
+                # Fail CLOSED: unknown overwrite status must force the
+                # confirmation, never silently skip a consent gate.
                 logger.opt(exception=True).debug(
                     f"Could not check the existing {state} expression image "
-                    f"for character {character_id} before a Generate-all "
+                    f"for character {character_id}; forcing the Generate-all "
                     "overwrite confirmation."
                 )
-                continue
+                return True
             if data:
                 return True
         return False
@@ -5394,6 +5396,11 @@ class PersonasScreen(BaseAppScreen):
             logger.opt(exception=True).warning(
                 "Could not show the Generate-all overwrite confirmation "
                 "dialog; skipping the sweep."
+            )
+            self._notify(
+                "Could not show the overwrite confirmation; "
+                "Generate-all cancelled.",
+                "warning",
             )
             return False
 

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
@@ -135,10 +135,22 @@ class PersonasCharacterEditorWidget(Container):
     }
 
     /* Import/export set buttons (Roleplay P3d-2 Task 4) - the "Expressions"
-       section header plus its two whole-set actions on one line. */
+       section header plus its two whole-set actions on one line. Task-563
+       AC1: at narrow terminal widths (120 cols: Import/Export overflow;
+       80 cols: Generate all overflows too) a plain Horizontal hard-clips
+       past its right edge with no way to reach the clipped buttons -
+       Textual has no flex-wrap for a horizontal layout. overflow-x: auto
+       makes the row horizontally scrollable instead (mouse wheel/shift-
+       wheel, or Tab, which auto-scrolls the focused button into view) -
+       the same idiom MainNavigationBar's .main-nav uses for its own
+       button row (UI/Navigation/main_navigation.py). The hidden scrollbar
+       keeps the row's height at 1 line rather than reserving a visible
+       scrollbar track. */
     PersonasCharacterEditorWidget .personas-char-editor-expr-set-row {
         height: auto;
         min-height: 1;
+        overflow-x: auto;
+        scrollbar-size-horizontal: 0;
     }
 
     /* Static defaults to 1fr with no width set, which would otherwise let
@@ -891,15 +903,60 @@ class PersonasCharacterEditorWidget(Container):
             "Advanced ▾" if open_ else "Advanced ▸"
         )
 
+    def has_avatar_image(self) -> bool:
+        """True when the editor holds any avatar image data (embedded bytes
+        or a legacy URL/path string).
+
+        Factored out of ``_set_avatar_status_from_record`` (task-563 AC3):
+        the screen reuses this same truthiness check to decide whether a
+        Generate-all sweep would overwrite an existing avatar and needs to
+        confirm first.
+        """
+        return bool(self._character_data.get("image") or self._character_data.get("avatar"))
+
     def _set_avatar_status_from_record(self) -> None:
-        avatar = (
-            "embedded"
-            if (self._character_data.get("image") or self._character_data.get("avatar"))
-            else "none"
-        )
+        avatar = "embedded" if self.has_avatar_image() else "none"
         self.query_one("#personas-char-editor-avatar-status", Static).update(
             f"Avatar: {avatar}"
         )
+
+    def set_expression_generating(self, state: str, busy: bool) -> None:
+        """Show/clear the in-slot "Generating…" affordance for one
+        expression state (task-563 AC2; spec §1 promised this).
+
+        Overwrites the same Static ``_sync_expression_slots_enabled`` uses
+        for the "Save the character…" hint. Clearing recomputes that same
+        enabled/disabled default from scratch rather than restoring a
+        remembered value, so it self-heals regardless of call order (and a
+        stale clear that lands after a genuine character switch just
+        re-asserts whatever the CURRENTLY loaded character's real hint
+        already is, touching only this one state's Static - never a
+        sibling's).
+
+        Args:
+            state: One of ``EXPRESSION_IMAGE_STATES``.
+            busy: ``True`` to show "Generating…", ``False`` to restore the
+                normal hint text.
+        """
+        hint = self.query_one(f"#personas-char-editor-expr-{state}-hint", Static)
+        if busy:
+            hint.update("Generating…")
+            return
+        enabled = self.expression_character_id() is not None
+        hint.update("" if enabled else "Save the character to add expressions.")
+
+    def set_avatar_generating(self, busy: bool) -> None:
+        """Show/clear the avatar row's "Generating…" affordance (task-563
+        AC2). Mirrors ``set_expression_generating``: clearing recomputes the
+        real status from ``_set_avatar_status_from_record`` rather than
+        restoring a remembered value.
+        """
+        if busy:
+            self.query_one("#personas-char-editor-avatar-status", Static).update(
+                "Avatar: generating…"
+            )
+            return
+        self._set_avatar_status_from_record()
 
     def _mark_dirty(self) -> None:
         if self._loading or self._dirty_posted or self._loaded_snapshot is None:


### PR DESCRIPTION
## Summary

Personas-cluster follow-up from the image-gen program: the deferred polish minors from the P3 whole-branch review (#859, ✨Generate for avatar + expression slots). One backlog task, SDD-reviewed, approved with zero findings.

### task-563 — P3 expression polish (`ef2c8d9bf`)
- **Narrow-width Expressions row** (pre-existing since the row shipped): the action row is now horizontally scrollable (same idiom as `MainNavigationBar`), so Import/Export/Generate-all stay reachable at 80 and 120 cols; Tab-focus auto-scrolls buttons into view. The old 200-col-only test claim is replaced by an 80/120/200 width-parameterized reachability test — reviewer reverted the fix locally and confirmed the 80-col case genuinely fails without it.
- **In-slot "Generating…" affordance** (spec §1 had promised it): set at all three dispatch sites, cleared in a `finally` that re-checks editor identity — a stale clear from character A cannot clobber character B's in-flight indicator after a mid-generation switch (dedicated leak test).
- **Generate-all overwrite confirmation**: when a staged avatar or populated expression slot exists, Generate-all asks first via the screen's existing `ConfirmationDialog`/`push_screen_wait` idiom; no dialog when everything is empty. The modal is awaited from an async worker, not a thread.
- **Honest k/N summary**: `_apply_expression_upload` now returns whether the DB write actually persisted; the sweep counts only genuine writes, so a slot that errors no longer inflates the "k/4 generated" summary (per-slot error notify preserved).
- **Cosmetics**: comment at `_after_character_save`'s record-reread fallback documenting the style-reset invariant; the generate-all narrow race is now guarded (an `(character_id, "all")` in-flight key blocks duplicate single-slot dispatches during a sweep, symmetric both directions, no starvation).

One disclosed micro-nuance: the sweep worker's pre-loop editor lookup silently aborts on an editor-unmount race instead of the old misleading "0/4 generated" notify — reviewer assessed the window as vanishingly narrow and the new behavior no worse.

## Testing
- `Tests/UI/test_personas_expression_generate.py` + `test_personas_expression_slots.py`: 69 passed (baseline 52). All TDD'd red→green; all foreground.
- Broader personas UI sweep: only the three known pre-existing failures (task-564's scope), reproduced identically on the base commit.
- `ruff` byte-identical to base on touched files; `python -c "import tldw_chatbook.app"` clean; no TCSS bundle impact (grep-verified).

Also carries the task-563/564 backlog filings (duplicated from #862 so merge order doesn't matter; rebase-before-merge collapses the duplicate add).

Sibling PRs: #862 (engine: 497+498), #864 (Console: 558). All three are independent against dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes Personas image generation UX: the Expressions row works at narrow widths, shows per-slot “Generating…” hints, confirms overwrite for Generate all, fixes the k/N summary, and blocks redundant clicks. Also forces confirmation when overwrite status can’t be read, suppresses the k/N summary on user cancel, and notifies if the dialog can’t be shown. Satisfies Linear task-563 (AC1–AC5).

- **New Features**
  - Expressions action row is horizontally scrollable at 80/120/200 cols; Tab focus auto-scrolls buttons into view.
  - In-slot “Generating…” indicator for avatar and each expression; set on dispatch and cleared on success/failure without leaking across character switches.
  - Generate all asks before overwriting a staged avatar or populated expression slots; no dialog when everything is empty.

- **Bug Fixes**
  - Accurate k/N summary: `_apply_expression_upload` returns `bool`; the sweep counts only persisted writes.
  - Guard narrow race: refuse single-slot or avatar generate while `(character_id, "all")` is in-flight to prevent duplicates.
  - Consent gate hardens: unreadable overwrite state forces confirmation; user-declined confirmation aborts with no writes and no summary; dialog failure cancels the sweep and notifies the user.

<sup>Written for commit 81879296faea010cfc54998950678f462697fc47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

