### PR TITLE
feat(agents): raise per-message tool-calling round cap 8 -> 20

### DIFF
--- a/Tests/Agents/test_agent_models.py
+++ b/Tests/Agents/test_agent_models.py
@@ -72,18 +72,21 @@ def test_budget_defaults():
     ) == (8, 240.0, 2, 8, 4000)
 
 
-def test_run_budget_default_model_turns_equal_steps_and_child_clamp_carries():
+def test_run_budget_default_model_turns_unreachable_and_child_clamp_carries():
     """Pin the engine-default unreachability invariant and child passthrough.
 
-    At ``RunBudget()`` the model-turn cap must equal ``max_steps`` (so the
-    new check can never fire before the step check), and
+    At ``RunBudget()`` the model-turn cap must be at least ``max_steps`` (so
+    the model-turn check can never fire before the step check), and
     ``clamp_child_budget`` must carry ``max_model_turns`` through unclamped.
     """
     b = RunBudget()
     # Unreachability invariant: each model turn appends >=1 step, so with
-    # max_model_turns == max_steps the step check always fires first (or
-    # ties) at defaults -> engine-default behavior byte-identical.
-    assert b.max_model_turns == b.max_steps == 8
+    # max_model_turns >= max_steps the step check always fires first (or
+    # ties) at defaults -> engine-default behavior unchanged. The cap was
+    # raised to 20 for callers that raise max_steps to match (the Console
+    # bridge); it must never drop below max_steps here.
+    assert b.max_model_turns >= b.max_steps
+    assert (b.max_model_turns, b.max_steps) == (20, 8)
     child = clamp_child_budget(
         RunBudget(max_model_turns=3), parent_remaining_seconds=30.0
     )

--- a/Tests/Agents/test_agent_runtime.py
+++ b/Tests/Agents/test_agent_runtime.py
@@ -252,6 +252,49 @@ def test_console_budget_floor_plus_two_extra_rounds_completes():
     assert len(out.steps) == 16
 
 
+def test_console_budget_step_cap_admits_a_full_model_turn_run():
+    """The Console budget's three caps must be sized together.
+
+    ``max_model_turns`` is meant to be the PRIMARY limiter, so ``max_steps``
+    must be large enough for a full run of fence tool rounds to reach it.
+    A fence round costs 3 steps (STEP_MODEL + STEP_TOOL_CALL +
+    STEP_TOOL_RESULT) and the wrap-up reply costs 1 more, so N model turns
+    need 3*(N-1)+1 steps. Raising the turn cap without raising the step cap
+    would silently move the wall back to the step check.
+    """
+    from tldw_chatbook.Chat.console_agent_bridge import CONSOLE_RUN_BUDGET
+
+    turns = CONSOLE_RUN_BUDGET.max_model_turns
+    assert CONSOLE_RUN_BUDGET.max_steps >= 3 * (turns - 1) + 1
+
+
+def test_console_budget_reaches_its_model_turn_cap_before_step_cap():
+    """Drive a real run to the Console turn cap: it must stop on the
+    model-turn budget, not the step budget."""
+    from tldw_chatbook.Chat.console_agent_bridge import CONSOLE_RUN_BUDGET
+
+    turns = CONSOLE_RUN_BUDGET.max_model_turns
+    # Never-ending distinct tool calls: only a budget can stop this run.
+    # Distinct args keep loop detection out of it.
+    scripted = [
+        ModelTurn(text=fence("calculator", {"expression": f"{i}+{i}"}))
+        for i in range(turns + 5)
+    ]
+    tick = iter(float(i) for i in range(1000))
+    out = run(
+        scripted,
+        config=AgentConfig(
+            model="m",
+            system_prompt="s",
+            allowed_tools=("calculator",),
+            budget=CONSOLE_RUN_BUDGET,
+        ),
+        clock=lambda: next(tick),
+    )
+    assert out.steps[-1].summary == "model-turn budget exhausted"
+    assert sum(1 for s in out.steps if s.kind == STEP_MODEL) == turns
+
+
 def test_identical_consecutive_calls_trip_loop_detection():
     same = ModelTurn(text=fence("calculator", {"expression": "6*7"}))
     out = run(

--- a/tldw_chatbook/Agents/agent_models.py
+++ b/tldw_chatbook/Agents/agent_models.py
@@ -47,6 +47,11 @@ RUNTIME_TOOL_NAMES = frozenset(
 
 DIRECT_DISCLOSE_THRESHOLD = 8
 LOOP_DETECTION_N = 3
+#: Default ceiling on provider turns (STEP_MODEL steps) in one run. Stays
+#: >= the default max_steps so it is provably unreachable at engine
+#: defaults; it only becomes the operative limiter for a caller that raises
+#: max_steps to match (see console_agent_bridge.CONSOLE_MAX_MODEL_TURNS).
+DEFAULT_MAX_MODEL_TURNS = 20
 # Longest tool-call cycle period the runtime detects (A->B->A->B is period 2).
 MAX_LOOP_PERIOD = 4
 
@@ -144,7 +149,7 @@ class RunBudget:
     # step, so the step check fires first) — engine-default behavior is
     # unchanged. It bites only where max_steps is raised to match; the
     # Console bridge sizes both together (CONSOLE_RUN_BUDGET).
-    max_model_turns: int = 20
+    max_model_turns: int = DEFAULT_MAX_MODEL_TURNS
     # task-326: cumulative prompt+completion token spend ceiling for one run.
     # 0 = unlimited (default), keeping existing runs byte-identical. This is a
     # SPEND ceiling (the growing prompt is re-sent each call), not a window size.
@@ -206,6 +211,16 @@ class RunOutcome:
 
 def clamp_child_budget(child: RunBudget, parent_remaining_seconds: float) -> RunBudget:
     """Clamp a sub-agent's budget so it cannot outlive its parent.
+
+    Sub-agents deliberately INHERIT ``max_model_turns`` and ``max_steps``
+    rather than being clamped down (operator decision, 2026-07-25, when the
+    Console cap was raised 8 -> 20). A child therefore gets the same
+    round budget as its parent, so one Console message can reach
+    ``max_model_turns * (1 + max_subagents)`` provider turns in the worst
+    case — 60 at the Console's current 20/2. That worst case is bounded in
+    TIME by the wall-clock clamp below (a child can never outlive its
+    parent's remaining budget), not in spend. Do not "fix" this by
+    clamping turns without checking that decision.
 
     Wall-clock is clamped to the parent's remainder (floored at 1s);
     ``max_subagents`` is zeroed — depth-1 sub-agents never spawn.

--- a/tldw_chatbook/Agents/agent_models.py
+++ b/tldw_chatbook/Agents/agent_models.py
@@ -122,11 +122,14 @@ class RunBudget:
 
     ``max_model_turns`` counts ``STEP_MODEL`` steps and is checked in
     ``agent_runtime.run_agent_loop`` immediately after the step-budget
-    check. At the defaults below it equals ``max_steps``, which makes it
-    provably unreachable: every model turn appends at least one step (the
-    ``STEP_MODEL`` step itself), so the step-budget check always fires
-    first (or ties) before the model-turn check can — engine-default
-    behavior is therefore byte-identical to the pre-task-244 loop.
+    check. At the defaults below it EXCEEDS ``max_steps``, which makes it
+    provably unreachable *at engine defaults*: every model turn appends at
+    least one step (the ``STEP_MODEL`` step itself), so with
+    ``max_model_turns >= max_steps`` the step-budget check always fires
+    first — engine-default behavior stays byte-identical to the
+    pre-task-244 loop. The cap only becomes the operative limiter for a
+    caller that also raises ``max_steps`` (the Console bridge does; see
+    ``console_agent_bridge.CONSOLE_RUN_BUDGET``).
     """
 
     max_steps: int = 8
@@ -135,10 +138,13 @@ class RunBudget:
     max_active_tools: int = 8
     max_subagent_result_chars: int = 4000
     # Primary provider-call limiter (task-244): counts STEP_MODEL turns.
-    # At defaults it equals max_steps, which makes it provably unreachable
-    # (every model turn appends >=1 step, so the step check fires first) —
-    # engine-default behavior is byte-identical to the pre-task-244 loop.
-    max_model_turns: int = 8
+    # Raised 8 -> 20 so an agent gets ~20 tool-calling rounds per user
+    # message rather than ~8. It stays >= max_steps at engine defaults, so
+    # it remains provably unreachable here (every model turn appends >=1
+    # step, so the step check fires first) — engine-default behavior is
+    # unchanged. It bites only where max_steps is raised to match; the
+    # Console bridge sizes both together (CONSOLE_RUN_BUDGET).
+    max_model_turns: int = 20
     # task-326: cumulative prompt+completion token spend ceiling for one run.
     # 0 = unlimited (default), keeping existing runs byte-identical. This is a
     # SPEND ceiling (the growing prompt is re-sent each call), not a window size.

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -113,8 +113,26 @@ _KNOWN_SUBAGENT_PREFIXES: set[str] = {SUBAGENT_SYSTEM_PROMPT}
 # bare max_steps=8, so this override applies only at the Console bridge's
 # own config-assembly site (run_reply below); other callers of
 # RunBudget()/AgentConfig keep the conservative engine default.
+#: Tool-calling rounds the Console agent gets per user message. THE primary
+#: limiter -- the two constants below exist to keep it reachable.
+CONSOLE_MAX_MODEL_TURNS = 20
+
+#: Step backstop. A fence round costs 3 steps (STEP_MODEL + STEP_TOOL_CALL +
+#: STEP_TOOL_RESULT) and the wrap-up reply costs 1, so N turns need
+#: 3*(N-1)+1 steps -- 58 at N=20. 64 clears that while staying a real
+#: backstop for native multi-call batches (1 + 2N steps per turn).
+#: `test_console_budget_step_cap_admits_a_full_model_turn_run` fails if this
+#: ever drops below the derived minimum.
+CONSOLE_MAX_STEPS = 64
+
+#: Wall-clock backstop for the whole run, at the slow local-model pace this
+#: gate exercises (25-50s per turn x CONSOLE_MAX_MODEL_TURNS).
+CONSOLE_MAX_WALL_SECONDS = 1200.0
+
 CONSOLE_RUN_BUDGET = RunBudget(
-    max_steps=64, max_wall_seconds=1200.0, max_model_turns=20
+    max_steps=CONSOLE_MAX_STEPS,
+    max_wall_seconds=CONSOLE_MAX_WALL_SECONDS,
+    max_model_turns=CONSOLE_MAX_MODEL_TURNS,
 )
 
 _QUIET_STEP_TOOLS = {FIND_TOOLS_NAME, LOAD_TOOLS_NAME}

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -86,22 +86,36 @@ _KNOWN_SUBAGENT_PREFIXES: set[str] = {SUBAGENT_SYSTEM_PROMPT}
 # task-244 adds a model-turn budget tier (agent_models.RunBudget.
 # max_model_turns) and makes IT, not the raw step count, this run's PRIMARY
 # limiter. Two additional real tool rounds beyond the 4-turn/10-step floor
-# cost 2 more turns / 6 more steps (6 turns / 16 steps total); under
-# max_model_turns=8 the floor plus those two extra rounds fits with 2 turns
-# to spare. max_steps=32 is a backstop, not a derived worst case: fence
-# turns cost at most 3 steps (one tool call per reply), but a NATIVE
-# multi-call batch (task-243) costs 1 + 2N steps per turn, so a run of
-# heavy parallel batches can legitimately hit the step backstop before the
-# 8-turn cap — that is the backstop doing its job. Either way it can no
-# longer starve a discovery run one step short of its wrap-up the way the
-# bare step default once did.
-# max_wall_seconds stays at the prior 480s (25-50s/turn x up to 8 model
-# turns at the slow local-model pace this gate exercises). The engine's own
-# RunBudget defaults (agent_models.RunBudget) are left UNCHANGED -- this
-# override applies only at the Console bridge's own config-assembly site
-# (run_reply below); other callers of RunBudget()/AgentConfig keep the bare
-# engine default.
-CONSOLE_RUN_BUDGET = RunBudget(max_steps=32, max_wall_seconds=480.0, max_model_turns=8)
+# cost 2 more turns / 6 more steps (6 turns / 16 steps total), so even the
+# old 8-turn cap cleared the floor with room to spare.
+#
+# The three numbers below are sized TOGETHER so that max_model_turns stays
+# the primary limiter -- raising it alone would just move the wall to
+# whichever of the other two binds first:
+#   * max_model_turns=20 gives ~20 tool-calling rounds per user message
+#     (raised from 8).
+#   * max_steps=64: a fence tool round costs 3 steps (STEP_MODEL +
+#     STEP_TOOL_CALL + STEP_TOOL_RESULT), so 19 rounds + 1 wrap-up
+#     STEP_MODEL = 3*19 + 1 = 58 steps. At the old 32 the step check would
+#     have fired around round 10, never letting the 20-turn cap be reached.
+#     64 clears 58 while staying a real backstop: a NATIVE multi-call batch
+#     (task-243) costs 1 + 2N steps per turn, so a run of heavy parallel
+#     batches can still legitimately hit the step backstop before the turn
+#     cap -- that is the backstop doing its job.
+#   * max_wall_seconds=1200: the prior 480s was derived as 25-50s/turn x up
+#     to 8 model turns at the slow local-model pace this gate exercises; at
+#     20 turns that same pace needs ~500-1000s, so 480 would have become
+#     the new binding limit around turn 10. 1200s covers the 20-turn worst
+#     case. This is a backstop, not a target -- fast cloud models finish 20
+#     turns in a fraction of it, and the user can Stop at any point (the
+#     tool-call wrapper polls cancellation every 0.5s, task-327).
+# The engine's own RunBudget defaults (agent_models.RunBudget) keep the
+# bare max_steps=8, so this override applies only at the Console bridge's
+# own config-assembly site (run_reply below); other callers of
+# RunBudget()/AgentConfig keep the conservative engine default.
+CONSOLE_RUN_BUDGET = RunBudget(
+    max_steps=64, max_wall_seconds=1200.0, max_model_turns=20
+)
 
 _QUIET_STEP_TOOLS = {FIND_TOOLS_NAME, LOAD_TOOLS_NAME}
 


### PR DESCRIPTION
Direct user request: raise the per-message tool-calling limit from 8 to 20. No backlog task filed.

## What "8" actually was

There is no per-turn tool-call cap in the codebase. Three things default to 8, and only one of them produces the observed behavior:

- **`RunBudget.max_model_turns = 8`** — a Console run alternates model → tool → model → tool, so this cap is what yields ~8 tool calls per user message. `console_agent_bridge`'s own comment calls it "this run's **PRIMARY** limiter". **This is the one raised.**
- `RunBudget.max_steps = 8` — the engine default, but Console overrides it to 32, so changing it alone would not affect the app.
- `RunBudget.max_active_tools = 8` — how many tool *schemas* are disclosed to the model (`schemas[:budget.max_active_tools]`), not a call limit.

## Why three numbers changed, not one

Raising the turn cap alone just moves the wall to whichever of the other Console caps binds first, so they are sized together:

| Cap | Was | Now | Why |
|---|---|---|---|
| `max_model_turns` | 8 | **20** | the requested change — ~20 tool-calling rounds per message |
| `max_steps` | 32 | **64** | a fence round costs 3 steps (`STEP_MODEL` + `STEP_TOOL_CALL` + `STEP_TOOL_RESULT`), so 19 rounds + wrap-up = **58**. At 32 the step check fired around round 10 and the 20-turn cap would never have been reachable. 64 clears 58 while staying a real backstop — a native multi-call batch costs `1 + 2N` steps per turn, so heavy parallel batches can still hit it, which is the backstop doing its job. |
| `max_wall_seconds` | 480 | **1200** | 480 was derived as "25-50s/turn × up to 8 model turns" at the slow local-model pace this gate exercises; 20 turns at that pace needs ~500-1000s, so 480 would have become the new binding limit around turn 10. A backstop, not a target — fast cloud models finish well inside it, and Stop is honored within ~0.5s (task-327's cancellation polling). |

## Engine defaults are unchanged

`RunBudget()` keeps `max_steps=8`, so `max_model_turns=20` stays **provably unreachable** at engine defaults (every model turn appends ≥1 step, so with `max_model_turns >= max_steps` the step check always fires first). The raised cap bites only for callers that raise `max_steps` to match — today, only the Console bridge.

## Tests

`test_run_budget_default_model_turns_equal_steps_and_child_clamp_carries` pinned `max_model_turns == max_steps == 8` as "the unreachability invariant". Equality was never the property that mattered — `>=` is — so it is renamed and re-asserts the real invariant plus the new concrete values.

Two guards added, because the failure mode here is a future edit raising one cap without the others:
- `test_console_budget_step_cap_admits_a_full_model_turn_run` — asserts `max_steps >= 3*(max_model_turns-1)+1`. Verified discriminating: the half-change (turns→20, steps left at 32) fails it.
- `test_console_budget_reaches_its_model_turn_cap_before_step_cap` — drives a real run to the cap and asserts it stops on `"model-turn budget exhausted"`, not the step budget.

`Tests/Agents/` → **253 passed**, 3 pre-existing warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised the per-message tool-calling round cap in the Console from ~8 to ~20 by making the model-turn budget the primary limiter and sizing step/time backstops to match. Engine-default behavior is unchanged.

- **New Features**
  - `CONSOLE_RUN_BUDGET`: `max_model_turns` 8→20, `max_steps` 32→64, `max_wall_seconds` 480→1200.
  - `RunBudget.max_model_turns` default 8→20; still unreachable at engine defaults (`max_steps` stays 8). Tests ensure `max_model_turns >= max_steps`, the step cap admits a full 20-turn run, and real runs stop on the model-turn budget first.

- **Refactors**
  - Replaced literals with named Console constants: `CONSOLE_MAX_MODEL_TURNS`, `CONSOLE_MAX_STEPS`, `CONSOLE_MAX_WALL_SECONDS`; added `DEFAULT_MAX_MODEL_TURNS` in `agent_models`.
  - Documented sub-agent policy: children inherit `max_model_turns` and `max_steps` (no clamping); lifetime is bounded by the parent’s wall-clock clamp.

<sup>Written for commit 8ded47a0bb31a22255997d2e67b6b18d44d3a410. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

