### PR TITLE
Console branching follow-ups, batch 3 (tasks 573, 543, 572)

### DIFF
--- a/Tests/Chat/test_console_agent_swap.py
+++ b/Tests/Chat/test_console_agent_swap.py
@@ -1415,3 +1415,135 @@ async def test_mcp_review_hook_raise_fails_open_but_invoke_gate_still_refuses(tm
     assert (
         service.execute_calls == []
     )  # never invoked -- refused by invoke()'s own gate
+
+
+@pytest.mark.asyncio
+async def test_stopped_via_cancel_records_persisted_id_on_run(tmp_path):
+    """task-543: the dominant user-Stop path (``stop_active_run`` ->
+    ``task.cancel()``) raises ``CancelledError`` in the controller BEFORE
+    ``run_reply``'s ``(run_id, outcome)`` ever binds -- so the CancelledError
+    branch must recover the run id via the bridge's latest-unanchored-primary
+    lookup and record the stopped reply's PERSISTED id onto the run. Every
+    pre-existing stop test simulated the stop via a normally-returning
+    ``run_reply``, which made this gap invisible. RED pre-fix: the run row
+    stays NULL and falls to the ordinal fallback on resume.
+    """
+    from Tests.Chat.test_console_chat_store import FakePersistence
+
+    class _YieldThenParkGateway(_ParkingGateway):
+        """Streams ONE chunk before parking: a zero-chunk stop never persists
+        (empty rows defer -- the AC#3 NULL case, covered separately below), so
+        the persisted-id recording needs a partial reply in the buffer."""
+
+        async def stream_chat(self, _resolution, _messages):
+            yield "partial answer\n"
+            self.started.set()
+            self.release.wait(timeout=60)
+            yield "answered anyway."
+
+    gateway = _YieldThenParkGateway()
+    persistence = FakePersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    bridge = ConsoleAgentBridge(agent_runs_db=db, store=store, provider_gateway=gateway)
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        provider="llama_cpp",
+        model="test-model",
+        agent_bridge=bridge,
+        agent_runtime_enabled=True,
+    )
+
+    send_task = asyncio.ensure_future(controller.submit_draft("hello"))
+    for _ in range(3000):  # 30s deadline -- CI-contention headroom
+        if gateway.started.is_set():
+            break
+        await asyncio.sleep(0.01)
+    assert gateway.started.is_set(), (
+        "bridge thread never reached the parked gateway call"
+    )
+
+    # A REAL cross-task cancellation, exactly as the Stop button delivers it.
+    assert controller.stop_active_run() is True
+    result = await send_task
+    assert result.accepted is True
+
+    session_id = store.active_session_id
+    assistant = next(
+        m
+        for m in store.messages_for_session(session_id)
+        if m.role is ConsoleMessageRole.ASSISTANT
+    )
+    assert assistant.status == "stopped"
+    assert assistant.persisted_message_id is not None
+
+    gateway.release.set()
+    primary: dict | None = None
+    for _ in range(3000):  # 30s deadline -- CI-contention headroom
+        runs = [r for r in _all_runs(db) if r["agent_kind"] == "primary"]
+        if runs and runs[0]["status"] != "running":
+            primary = runs[0]
+            break
+        await asyncio.sleep(0.01)
+
+    assert primary is not None, "primary run never settled"
+    assert primary["assistant_message_id"] == assistant.persisted_message_id
+    assert primary["assistant_message_id"] != assistant.id
+
+
+@pytest.mark.asyncio
+async def test_stopped_via_cancel_without_persistence_stays_null(tmp_path):
+    """task-543 AC#3: with no persistence backend the stopped reply never gets
+    a persisted id, so the cancel-path recording must no-op and the run row
+    must stay NULL (ordinal fallback) -- never a stale/native id."""
+    gateway = _ParkingGateway()
+    store = ConsoleChatStore()
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    bridge = ConsoleAgentBridge(agent_runs_db=db, store=store, provider_gateway=gateway)
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        provider="llama_cpp",
+        model="test-model",
+        agent_bridge=bridge,
+        agent_runtime_enabled=True,
+    )
+
+    send_task = asyncio.ensure_future(controller.submit_draft("hello"))
+    for _ in range(3000):
+        if gateway.started.is_set():
+            break
+        await asyncio.sleep(0.01)
+    assert gateway.started.is_set()
+
+    assert controller.stop_active_run() is True
+    await send_task
+    gateway.release.set()
+
+    primary: dict | None = None
+    for _ in range(3000):
+        runs = [r for r in _all_runs(db) if r["agent_kind"] == "primary"]
+        if runs and runs[0]["status"] != "running":
+            primary = runs[0]
+            break
+        await asyncio.sleep(0.01)
+    assert primary is not None
+    assert primary["assistant_message_id"] is None
+
+
+def test_latest_unanchored_primary_run_id_guards_anchored_rows(tmp_path):
+    """task-543 mis-write guard: an ultra-early Stop (before create_run
+    committed) sees the PREVIOUS run as the newest primary -- but a finished
+    run is always anchored by a finalizer path, so the lookup must return
+    None for it rather than let the caller overwrite a good anchor."""
+    store = ConsoleChatStore()
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    bridge = ConsoleAgentBridge(agent_runs_db=db, store=store, provider_gateway=None)
+
+    run_id = db.create_run(conversation_id="conv-1", agent_kind="primary", task="t")
+    assert bridge.latest_unanchored_primary_run_id("conv-1") == run_id
+
+    db.set_run_assistant_message_id(run_id, "persisted-1")
+    assert bridge.latest_unanchored_primary_run_id("conv-1") is None
+    assert bridge.latest_unanchored_primary_run_id("conv-other") is None

--- a/Tests/Chat/test_console_edit_resend.py
+++ b/Tests/Chat/test_console_edit_resend.py
@@ -318,3 +318,133 @@ async def test_edit_and_resend_skill_refusal_leaves_no_pending_node():
     assert all(
         m.status != "pending" for m in store.messages_for_session(session.id)
     )
+
+
+class _RecordingStreamingGateway(StreamingGateway):
+    """StreamingGateway that records the provider payload it was handed."""
+
+    def __init__(self):
+        self.messages_seen = None
+
+    async def stream_chat(self, resolution, messages):
+        self.messages_seen = [dict(m) for m in messages]
+        for chunk in ("edi", "ted-reply"):
+            yield chunk
+
+
+def _anchor_attachment():
+    from tldw_chatbook.Chat.console_chat_models import MessageAttachment
+
+    return MessageAttachment(
+        data=b"png-bytes",
+        mime_type="image/png",
+        display_name="photo.png",
+        position=0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_edit_and_resend_carries_anchor_attachments(monkeypatch):
+    """task-573: the resent sibling keeps the anchor's attachments -- on the
+    persisted node AND embedded in the provider payload (multimodal parts),
+    instead of silently re-sending text-only."""
+    from tldw_chatbook.Chat import console_chat_controller as controller_module
+
+    monkeypatch.setattr(controller_module, "is_vision_capable", lambda p, m: True)
+    store = ConsoleChatStore()
+    gateway = _RecordingStreamingGateway()
+    controller = ConsoleChatController(
+        store=store, provider_gateway=gateway, model="vision-model"
+    )
+    session = store.create_session(title="t")
+    store.active_session_id = session.id
+    u1 = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="look at this",
+        attachments=(_anchor_attachment(),),
+    )
+    store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content="old reply"
+    )
+
+    result = await controller.edit_and_resend_message(u1.id, "edited caption")
+
+    assert result.accepted is True
+    siblings, _index, count = store.siblings_at(u1.id)
+    assert count == 2
+    new_user_id = next(iter({s.id for s in siblings} - {u1.id}))
+    new_user = store.get_message(new_user_id)
+    assert len(new_user.attachments) == 1
+    assert new_user.attachments[0].data == b"png-bytes"
+    assert new_user.attachments[0].mime_type == "image/png"
+
+    user_rows = [m for m in gateway.messages_seen if m["role"] == "user"]
+    last_user = user_rows[-1]
+    assert isinstance(last_user["content"], list)
+    assert last_user["content"][0] == {"type": "text", "text": "edited caption"}
+    assert last_user["content"][1]["image_url"]["url"].startswith(
+        "data:image/png;base64,"
+    )
+
+
+@pytest.mark.asyncio
+async def test_edit_and_resend_blocks_attachments_on_non_vision_model(monkeypatch):
+    """task-573 AC#2: the vision gate applies exactly as on a fresh send, and
+    the block fires BEFORE any node is created (mutate-last discipline)."""
+    from tldw_chatbook.Chat import console_chat_controller as controller_module
+
+    monkeypatch.setattr(controller_module, "is_vision_capable", lambda p, m: False)
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(
+        store=store, provider_gateway=StreamingGateway(), model="text-model"
+    )
+    session = store.create_session(title="t")
+    store.active_session_id = session.id
+    u1 = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="look at this",
+        attachments=(_anchor_attachment(),),
+    )
+    a1 = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content="old reply"
+    )
+
+    result = await controller.edit_and_resend_message(u1.id, "edited caption")
+
+    assert result.accepted is False
+    assert "can't accept images" in result.visible_copy
+    siblings, _index, count = store.siblings_at(u1.id)
+    assert count == 1
+    # The block appends only the SYSTEM block-row (standard _block behavior);
+    # no forked USER sibling and no stuck "pending" assistant node exist.
+    assert all(
+        m.status != "pending" for m in store.messages_for_session(session.id)
+    )
+    active_leaf = store.get_message(store.active_leaf(session.id))
+    assert active_leaf.role is ConsoleMessageRole.SYSTEM
+    assert a1.id in store.active_path_message_ids(session.id)
+
+
+@pytest.mark.asyncio
+async def test_edit_and_resend_text_only_anchor_stays_text_payload():
+    """A text-only anchor keeps the pre-task-573 payload shape (plain string
+    content), so no provider sees a gratuitous multimodal list."""
+    store = ConsoleChatStore()
+    gateway = _RecordingStreamingGateway()
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+    session = store.create_session(title="t")
+    store.active_session_id = session.id
+    u1 = store.append_message(
+        session.id, role=ConsoleMessageRole.USER, content="original"
+    )
+    store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content="original-reply"
+    )
+
+    result = await controller.edit_and_resend_message(u1.id, "edited")
+
+    assert result.accepted is True
+    user_rows = [m for m in gateway.messages_seen if m["role"] == "user"]
+    assert user_rows[-1]["content"] == "edited"

--- a/Tests/DB/test_agent_runs_db.py
+++ b/Tests/DB/test_agent_runs_db.py
@@ -419,3 +419,30 @@ def test_memory_db_skips_wal():
     with db.connection() as conn:
         assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "memory"
         assert conn.execute("PRAGMA busy_timeout").fetchone()[0] == 5000
+
+
+def test_latest_primary_run_targets_newest_primary_only(tmp_path):
+    """Qodo (PR #872): the Stop-path lookup must be a single bounded query,
+    and interleaved newer SUBAGENT runs must not hide the newest primary."""
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+
+    old_primary = db.create_run(conversation_id="c1", agent_kind="primary", task="a")
+    newer_primary = db.create_run(conversation_id="c1", agent_kind="primary", task="b")
+    db.create_run(
+        conversation_id="c1",
+        agent_kind="subagent",
+        task="sub",
+        parent_run_id=newer_primary,
+    )
+
+    record = db.latest_primary_run("c1")
+    assert record is not None
+    assert record["id"] == newer_primary
+    assert record["agent_kind"] == "primary"
+
+    # Superseded newest primary falls back to the next non-superseded one.
+    db.set_status(newer_primary, "superseded")
+    record = db.latest_primary_run("c1")
+    assert record is not None and record["id"] == old_primary
+
+    assert db.latest_primary_run("no-such-conversation") is None

--- a/Tests/UI/test_console_resume_active_path.py
+++ b/Tests/UI/test_console_resume_active_path.py
@@ -481,3 +481,59 @@ def test_resume_leaves_valid_persisted_summary_boundary_untouched():
         )
     finally:
         db.close_connection()
+
+
+def _persist_degenerate_all_user_legacy_conversation(db: CharactersRAGDB):
+    """Legacy FLAT conversation whose user turns got NO assistant reply.
+
+    Reachable in the flat era via repeated failed/blocked sends: every row is
+    a NULL-parent USER root with no children. task-572's target shape -- the
+    role-homogeneity signal alone mistakes it for a genuine Phase-B root fork
+    and leaves it un-chained (phantom counter, truncated view).
+    """
+    service = ChatConversationService(db)
+    conversation_id = service.create_conversation(
+        id="degenerate-flat-conv-1",
+        title="Degenerate",
+        scope_type="global",
+        state="in-progress",
+    )
+    for i, content in enumerate(["u1", "u2", "u3"]):
+        db.add_message(
+            {
+                "id": f"m-degen-{i}",
+                "conversation_id": conversation_id,
+                "sender": "user",
+                "role": "user",
+                "content": content,
+                "timestamp": f"2026-01-01T00:00:0{i}.000000+00:00",
+            }
+        )
+    return conversation_id
+
+
+def test_resume_chains_degenerate_all_user_legacy_conversation():
+    """task-572: a degenerate all-USER legacy conversation (multiple
+    parentless user rows, no replies anywhere) resumes as the full ordered
+    sequence with no phantom sibling counter.
+
+    The stronger fingerprint: an all-USER root set whose roots are ALL
+    childless is degenerate legacy (a genuine first-message edit-&-resend
+    fork always carries at least one reply subtree under a root) and is
+    chained; an all-USER root set with any subtree stays un-chained (pinned
+    by ``test_resume_second_root_loads_off_path_but_is_not_shown``).
+    """
+    db = CharactersRAGDB(":memory:", "test_client")
+    try:
+        conversation_id = _persist_degenerate_all_user_legacy_conversation(db)
+        assert db.get_conversation_active_leaf(conversation_id) is None
+
+        store, session = _resume_into_store(db, conversation_id)
+
+        view = store.messages_for_session(session.id)
+        assert [m.content for m in view] == ["u1", "u2", "u3"]
+        for message in view:
+            _snapshots, _index, count = store.siblings_at(message.id)
+            assert count == 1
+    finally:
+        db.close_connection()

--- a/backlog/tasks/task-543 - Console-branching-record-run-id-on-stopped-via-cancel-agent-runs.md
+++ b/backlog/tasks/task-543 - Console-branching-record-run-id-on-stopped-via-cancel-agent-runs.md
@@ -3,8 +3,9 @@ id: TASK-543
 title: >-
   Console branching: record the persisted reply id for stopped-via-cancel agent
   runs
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-24'
 labels:
   - console
@@ -23,7 +24,35 @@ Fix direction (final-review recommendation): expose the most-recent primary run 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A user Stop delivered via task cancellation records the stopped reply's persisted id on the run (id-anchored + off-path-hidden on resume, same as other terminal paths)
-- [ ] #2 A test exercises the real `stop_active_run` → `task.cancel()` path and asserts the run's `assistant_message_id`
-- [ ] #3 A never-persisted stopped reply still leaves the run NULL (ordinal fallback), never a stale id
+- [x] #1 A user Stop delivered via task cancellation records the stopped reply's persisted id on the run (id-anchored + off-path-hidden on resume, same as other terminal paths)
+- [x] #2 A test exercises the real `stop_active_run` → `task.cancel()` path and asserts the run's `assistant_message_id`
+- [x] #3 A never-persisted stopped reply still leaves the run NULL (ordinal fallback), never a stale id
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Bridge seam `latest_unanchored_primary_run_id(conversation_id)`: newest
+   non-superseded PRIMARY run's id, returned ONLY while its
+   `assistant_message_id` is still NULL (the mis-write guard for a Stop that
+   beats `create_run` -- a finished run is always anchored by a finalizer
+   path, so an anchored newest row means record nothing).
+2. Controller CancelledError branch: after `_mark_stream_stopped`, call
+   `_record_run_assistant_message` with the recovered id (defensive wrapper;
+   the existing helper already no-ops on a never-persisted stop -> AC#3).
+3. Tests exercising the REAL `stop_active_run` -> `task.cancel()` path via
+   the parked-bridge-thread scaffolding (yield-then-park gateway so the gate
+   flushes a chunk and the stopped reply persists), plus the NULL guard.
+
+## Implementation Notes
+
+- The run ROW exists long before a user can Stop (`create_run` at loop
+  start), so the newest non-superseded primary IS the active run; the
+  NULL-anchor guard turns the one racy exception into a safe no-op instead
+  of overwriting the previous run's good anchor.
+- Test detail discovered en route: the agent stream's fence-gate is
+  line-buffered -- a chunk without a newline never flushes to the store, so
+  a zero-chunk (or newline-less) stop legitimately never persists and stays
+  NULL -> ordinal fallback (pinned by the no-persistence test).
+- Files: `tldw_chatbook/Chat/console_agent_bridge.py`,
+  `tldw_chatbook/Chat/console_chat_controller.py`,
+  `Tests/Chat/test_console_agent_swap.py`.

--- a/backlog/tasks/task-572 - Console-branching-stronger-legacy-flat-fingerprint-for-root-chaining.md
+++ b/backlog/tasks/task-572 - Console-branching-stronger-legacy-flat-fingerprint-for-root-chaining.md
@@ -3,8 +3,9 @@ id: TASK-572
 title: >-
   Console branching: stronger legacy-flat fingerprint for resume root-chaining
   (all-USER-legacy phantom counter)
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-24'
 labels:
   - console
@@ -23,7 +24,30 @@ dependencies: []
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A degenerate all-USER legacy conversation (multiple parentless user rows, no replies) resumes showing the full sequence in order with no phantom sibling counter
-- [ ] #2 A genuine first-message edit-&-resend root fork is still left un-chained (both branches navigable)
-- [ ] #3 Existing legacy-flat and flat-prefix chaining tests still pass
+- [x] #1 A degenerate all-USER legacy conversation (multiple parentless user rows, no replies) resumes showing the full sequence in order with no phantom sibling counter
+- [x] #2 A genuine first-message edit-&-resend root fork is still left un-chained (both branches navigable)
+- [x] #3 Existing legacy-flat and flat-prefix chaining tests still pass
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Strengthen `_chain_legacy_flat_roots`'s all-USER decision: chain when any
+   root is an ASSISTANT row (true legacy signature -- a genuine tree never
+   roots an assistant) OR when every root is childless (degenerate legacy;
+   a genuine first-message fork always carries at least one reply subtree).
+2. TDD at the real-DB resume level: degenerate all-USER legacy resumes as
+   the full ordered sequence with no phantom counter; genuine fork and
+   flat-prefix behaviors pinned by the existing suite.
+
+## Implementation Notes
+
+- Signal changed from role-homogeneity alone to
+  `root_has_assistant OR all_roots_childless`; flat-prefix and mixed-role
+  legacy keep chaining exactly as before, genuine all-USER forks with any
+  subtree stay un-chained.
+- Documented residual edge (narrower than the closed gap): a genuine
+  first-message fork whose BOTH branches are childless (anchor never
+  replied AND the resent reply never persisted) now chains -- non-data-loss,
+  provably indistinguishable from degenerate legacy from the tree alone.
+- Files: `tldw_chatbook/Chat/console_chat_store.py`,
+  `Tests/UI/test_console_resume_active_path.py`.

--- a/backlog/tasks/task-573 - Console-branching-carry-attachments-on-Edit-and-resend.md
+++ b/backlog/tasks/task-573 - Console-branching-carry-attachments-on-Edit-and-resend.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-573
 title: 'Console branching: carry attachments across Edit & resend'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-24'
 labels:
   - console
@@ -21,7 +22,37 @@ Phase B's "Edit & resend" (PR #811) forks a new user-message branch from an edit
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Edit & resend on a user message with attachments carries the attachments onto the new sibling (persisted) and into the provider payload, or clearly informs the user they will be dropped
-- [ ] #2 The vision-capability block applies the same way it does on a fresh send
-- [ ] #3 Plain in-place Save continues to leave attachments untouched
+- [x] #1 Edit & resend on a user message with attachments carries the attachments onto the new sibling (persisted) and into the provider payload, or clearly informs the user they will be dropped
+- [x] #2 The vision-capability block applies the same way it does on a fresh send
+- [x] #3 Plain in-place Save continues to leave attachments untouched
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Vision gate in `edit_and_resend_message` before any mutation, identical to
+   `submit_draft` (fires only when the anchor carries data-bearing attachments).
+2. Replace the hand-rolled text-only synthesized dict with ONE
+   `_provider_message_payloads` pass over ancestors + a synthesized
+   `ConsoleChatMessage` carrying the anchor's attachments, so image budget /
+   vision degradation / mime fallback all apply exactly as on a fresh send.
+3. `ConsoleChatStore.create_sibling` gains `attachments=` (same
+   `_set_message_attachments` seam as `append_message`); the resent sibling is
+   created with the anchor's tuple and persists through the existing path.
+4. TDD: carry-over (node + multimodal payload), non-vision block with no
+   orphan nodes (mutate-last), text-only anchor keeps plain-string payload.
+
+## Implementation Notes
+
+- The synthesized turn is now a `ConsoleChatMessage` (not a bare dict) run
+  through the same payload builder as everything else -- newest-first image
+  budget reservation covers the resent turn, and a non-vision model that
+  slipped past the gate degrades identically to a fresh send.
+- The vision gate reuses `vision_block_reason(..., is_capable=is_vision_capable)`
+  (the documented monkeypatch seam), fires pre-mutation, and produces the same
+  copy as `submit_draft` -- blocked resends leave no forked sibling and no
+  pending assistant node.
+- Plain in-place Save is untouched (`update_message_content` without
+  `attachments=`), pinned by the existing wiring/persistence tests.
+- Files: `tldw_chatbook/Chat/console_chat_controller.py`,
+  `tldw_chatbook/Chat/console_chat_store.py`,
+  `Tests/Chat/test_console_edit_resend.py`.

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -1476,14 +1476,7 @@ class ConsoleAgentBridge:
             The newest non-superseded primary run's id when its
             ``assistant_message_id`` is still NULL, else ``None``.
         """
-        record = next(
-            (
-                r
-                for r in self._db.list_runs(conversation_id, include_superseded=False)
-                if r["agent_kind"] == AGENT_KIND_PRIMARY
-            ),
-            None,
-        )
+        record = self._db.latest_primary_run(conversation_id)
         if record is None or record.get("assistant_message_id") is not None:
             return None
         return record["id"]

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -1452,6 +1452,42 @@ class ConsoleAgentBridge:
         """
         self._db.set_run_assistant_message_id(run_id, persisted_message_id)
 
+    def latest_unanchored_primary_run_id(self, conversation_id: str) -> str | None:
+        """Return the newest non-superseded PRIMARY run's id while unanchored.
+
+        task-543 seam for the stopped-via-cancel path: ``stop_active_run``'s
+        ``task.cancel()`` raises ``CancelledError`` in the controller before
+        ``run_reply``'s ``(run_id, outcome)`` ever binds, so the controller
+        cannot learn the run id from the return value -- but the run ROW
+        already exists (``create_run`` runs at loop start, long before the
+        first chunk can stream), and the newest non-superseded primary is by
+        construction the active run. The ``assistant_message_id IS NULL``
+        guard covers the one exception: a Stop delivered before
+        ``create_run`` committed would surface the PREVIOUS run here, and a
+        finished run always has its anchor recorded by a finalizer terminal
+        path -- so an already-anchored newest row means "record nothing"
+        (row stays NULL -> ordinal fallback, the pre-fix behavior), never
+        "overwrite a good anchor".
+
+        Args:
+            conversation_id: Durable conversation id whose runs to inspect.
+
+        Returns:
+            The newest non-superseded primary run's id when its
+            ``assistant_message_id`` is still NULL, else ``None``.
+        """
+        record = next(
+            (
+                r
+                for r in self._db.list_runs(conversation_id, include_superseded=False)
+                if r["agent_kind"] == AGENT_KIND_PRIMARY
+            ),
+            None,
+        )
+        if record is None or record.get("assistant_message_id") is not None:
+            return None
+        return record["id"]
+
     def subagent_count(self, conversation_id: str) -> int:
         return self._db.count_subagent_runs(conversation_id)
 

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1963,6 +1963,18 @@ class ConsoleChatController:
         if validation_error is not None:
             return self._block(session_id, validation_error)
 
+        # task-573: the resend carries the anchor's attachments, so the same
+        # vision gate a fresh send applies (see ``submit_draft``) must fire
+        # here too -- BEFORE any node is created (mutate-last discipline).
+        anchor_attachments = tuple(message.attachments)
+        if any(a.data is not None for a in anchor_attachments):
+            vision_model = self.model or self.configured_model
+            block_reason = vision_block_reason(
+                self.provider, vision_model, is_capable=is_vision_capable
+            )
+            if block_reason is not None:
+                return self._block(session_id, block_reason)
+
         self._set_run_state(
             ConsoleRunState(ConsoleRunStatus.VALIDATING, "Validating provider.")
         )
@@ -1976,18 +1988,31 @@ class ConsoleChatController:
             return self._block(session_id, visible_copy)
 
         # Build + transform the payload BEFORE creating either new node
-        # (task-2 review fix): the edited text is synthesized as a plain
-        # dict standing in for the not-yet-created sibling, so a
-        # skill-substitution refusal (or any other transform failure) has
-        # nothing to clean up -- no orphan sibling, no stuck "pending"
-        # assistant node.
-        provider_messages = self._provider_messages_for_session(
-            session_id,
-            before_message_id=message_id,
-            annotate_ids=True,
+        # (task-2 review fix): the edited turn is synthesized as a
+        # not-yet-stored ``ConsoleChatMessage`` standing in for the sibling,
+        # so a skill-substitution refusal (or any other transform failure)
+        # has nothing to clean up -- no orphan sibling, no stuck "pending"
+        # assistant node. task-573: running ancestors + the synthesized turn
+        # through ONE ``_provider_message_payloads`` pass gives the carried
+        # attachments the same image-budget/vision/mime treatment as a fresh
+        # send (newest-first reservation included), instead of a hand-rolled
+        # text-only dict.
+        ancestors: list[ConsoleChatMessage] = []
+        for candidate in self.store.messages_for_session(session_id):
+            if candidate.id == message_id:
+                break
+            ancestors.append(candidate)
+        ancestors.append(
+            ConsoleChatMessage(
+                role=ConsoleMessageRole.USER,
+                content=clean_content,
+                attachments=anchor_attachments,
+            )
         )
-        provider_messages.append(
-            {"role": ConsoleMessageRole.USER.value, "content": clean_content}
+        provider_messages = self._leading_system_message() + (
+            self._provider_message_payloads(
+                ancestors, skip_failed=True, annotate_ids=True
+            )
         )
         self._ensure_user_continuation_instruction(provider_messages)
         (
@@ -2020,6 +2045,7 @@ class ConsoleChatController:
             role=ConsoleMessageRole.USER,
             content=clean_content,
             persist=self.store.persistence is not None,
+            attachments=anchor_attachments,
         )
         assistant = self.store.append_message(
             session_id,

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -3515,6 +3515,17 @@ class ConsoleChatController:
                     )
                 except KeyError:
                     return self._session_closed_result()
+                # task-543: this is the dominant user-Stop path --
+                # ``task.cancel()`` raised before ``(run_id, outcome)`` ever
+                # bound, so recover the active run's id via the bridge's
+                # latest-unanchored-primary lookup and record the stopped
+                # reply's persisted id, same as every finalizer terminal
+                # path. A never-persisted stop (or an anchored/missing row)
+                # no-ops and leaves the row NULL -> ordinal fallback.
+                self._record_run_assistant_message(
+                    self._latest_unanchored_primary_run_id(conversation_id),
+                    stopped,
+                )
                 return ConsoleSubmitResult(True, True, stopped.content)
             raise
         except Exception as exc:
@@ -3820,6 +3831,34 @@ class ConsoleChatController:
                 run_id=run_id,
                 persisted_message_id=persisted,
             )
+
+    def _latest_unanchored_primary_run_id(self, conversation_id: str) -> str | None:
+        """Return the active run's id for the stopped-via-cancel path.
+
+        task-543: thin defensive wrapper over the bridge's
+        ``latest_unanchored_primary_run_id`` (see its docstring for the
+        NULL-anchor guard) -- a bookkeeping lookup on the Stop path must
+        never fail the stop itself.
+
+        Args:
+            conversation_id: Durable conversation id whose runs to inspect.
+
+        Returns:
+            The recoverable run id, or ``None`` when there is no bridge, no
+            matching unanchored primary run, or the lookup fails.
+        """
+        if self._agent_bridge is None:
+            return None
+        try:
+            return self._agent_bridge.latest_unanchored_primary_run_id(
+                conversation_id
+            )
+        except Exception:  # noqa: BLE001 -- bookkeeping must never fail the stop
+            logger.opt(exception=True).warning(
+                "failed to look up unanchored primary run for stop recording",
+                conversation_id=conversation_id,
+            )
+            return None
 
     def _append_failed_assistant(
         self, session_id: str, visible_copy: str,

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -2491,18 +2491,25 @@ class ConsoleChatStore:
         the older as a fake parent-child link, corrupting the tree so a
         swipe/resume shows the wrong content).
 
-        KNOWN LIMITATION (not airtight): legacy flat data with at least one
-        assistant reply mixes roles and is chained correctly, but a DEGENERATE
-        legacy conversation whose 2+ user turns each got NO assistant reply
-        loads as all-USER roots and is (wrongly) left un-chained -- it resumes
-        showing only the last user message with a phantom sibling counter. This
-        is a narrow, non-data-loss regression (every message stays navigable via
-        ``siblings_at``/``set_active_leaf``): the all-USER-legacy and all-USER
-        genuine-fork shapes are provably indistinguishable from the persisted
-        tree alone, so no local heuristic can be perfect, and always-chaining
-        (the alternative) corrupts the common first-message-edit feature -- the
-        worse trade. A stronger legacy fingerprint (e.g. "conversation contains
-        a NULL-parent ASSISTANT row") is a filed follow-up.
+        task-572 strengthens the fingerprint for the all-USER root set: a
+        DEGENERATE legacy conversation whose 2+ user turns each got NO
+        assistant reply (reachable in the flat era via repeated
+        failed/blocked sends) also loads as all-USER roots -- but its roots
+        are ALL CHILDLESS, whereas a genuine first-message edit-&-resend
+        fork always hangs at least one reply subtree under a root (the
+        anchor's old tail, and/or the resent branch's own reply). So an
+        all-USER root set is chained when every root is childless, and left
+        alone when any root has a subtree.
+
+        RESIDUAL EDGE (not airtight, narrower than the pre-task-572 gap): a
+        genuine first-message fork whose BOTH branches ended up childless --
+        the anchor never got a reply AND the resent branch's reply never
+        persisted (killed mid-stream before the first flushed chunk) -- is
+        indistinguishable from degenerate legacy and now chains. Non-data-
+        loss (both user rows stay visible, linearly), and strictly rarer
+        than the all-USER-legacy shape this fixes; the two shapes are
+        provably indistinguishable from the persisted tree alone, so no
+        local heuristic can be perfect.
 
         Roots are chained in their existing insertion order, which is the DB's
         timestamp-ASC order (``get_root_messages_for_conversation`` orders roots
@@ -2527,12 +2534,18 @@ class ConsoleChatStore:
         if len(roots) <= 1:
             return
         nodes = self._nodes_by_session.get(session_id, {})
-        root_roles = {nodes[root_id].role for root_id in roots if root_id in nodes}
-        if len(root_roles) <= 1:
-            # Every root-level node shares one role: a genuine Phase-B
-            # root-level branch (all USER), not legacy flat data (which
-            # always mixes USER and ASSISTANT rows at the root). Leave each
-            # root independently navigable via `siblings_at`/`set_active_leaf`.
+        root_has_assistant = any(
+            nodes[root_id].role is ConsoleMessageRole.ASSISTANT
+            for root_id in roots
+            if root_id in nodes
+        )
+        all_roots_childless = all(not children.get(root_id) for root_id in roots)
+        if not root_has_assistant and not all_roots_childless:
+            # All-USER roots with at least one reply subtree: a genuine
+            # Phase-B root-level fork (an ASSISTANT node's parent is never
+            # None, so any root assistant row is the legacy signature; and a
+            # real fork always carries a subtree). Leave each root
+            # independently navigable via `siblings_at`/`set_active_leaf`.
             return
         # Keep only the first root under None; chain the rest onto their
         # predecessor, preserving each root's own existing subtree.

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -886,6 +886,9 @@ class ConsoleChatStore:
             anchor_message_id: Native id of the node to fork alongside
                 (typically the assistant message being regenerated).
             role: Role for the new sibling message.
+            attachments: Attachments to set on the new sibling (task-573:
+                Edit & resend carries the anchor's attachments onto the
+                fork). Same seam ``append_message`` uses; empty by default.
             content: Initial content. An empty-content assistant sibling
                 starts ``"pending"`` (mirrors ``append_message``), ready to
                 receive stream chunks via ``append_stream_chunk``.

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -864,6 +864,7 @@ class ConsoleChatStore:
         role: ConsoleMessageRole,
         content: str = "",
         persist: bool = False,
+        attachments: Sequence[MessageAttachment] = (),
     ) -> ConsoleChatMessage:
         """Fork a new node alongside ``anchor_message_id`` and make it active.
 
@@ -915,6 +916,9 @@ class ConsoleChatStore:
             content=content,
             status=self._initial_status(role=role, content=content),
         )
+        # task-573: a fork can carry the anchor's attachments (Edit & resend
+        # of an image-bearing user turn); same seam ``append_message`` uses.
+        self._set_message_attachments(message, tuple(attachments))
         self._sessions[session_id].updated_at = _utc_now_iso()
         self._register_tree_node(session_id, message, parent_native_id=parent_native_id)
         # Retarget the active leaf and rematerialize the active-path view

--- a/tldw_chatbook/DB/AgentRuns_DB.py
+++ b/tldw_chatbook/DB/AgentRuns_DB.py
@@ -348,6 +348,31 @@ class AgentRunsDB(BaseDB):
             ).fetchone()
         return self._row_to_dict(row) if row else None
 
+    def latest_primary_run(self, conversation_id: str) -> dict | None:
+        """Fetch the newest non-superseded PRIMARY run for a conversation.
+
+        A single bounded query (``LIMIT 1``) so hot callers (the user-Stop
+        path's run-anchor lookup) never materialize the whole run history;
+        interleaved newer sub-agent runs cannot hide the newest primary
+        because the kind filter is in the SQL.
+
+        Args:
+            conversation_id: The conversation whose runs to inspect.
+
+        Returns:
+            The newest matching run as a dict (``steps``/``budget``
+            JSON-decoded), or ``None`` when the conversation has no
+            non-superseded primary run.
+        """
+        with self.connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM agent_runs WHERE conversation_id = ? "
+                "AND agent_kind = 'primary' AND status != 'superseded' "
+                "ORDER BY created_at DESC, id DESC LIMIT 1",
+                (conversation_id,),
+            ).fetchone()
+        return self._row_to_dict(row) if row else None
+
     def list_runs(
         self,
         conversation_id: str,


### PR DESCRIPTION
Third batch of Console branching follow-ups, implementing the three remaining To-Do tasks in the stream (IDs per the #803 collision rework).

## task-573 — carry attachments across Edit & resend
Edit & resend silently re-sent text-only when the anchor user message carried an image. The resend now applies the same vision gate as a fresh send BEFORE any node is created; builds the payload by running ancestors + a synthesized `ConsoleChatMessage` (carrying the anchor's attachments) through the one shared `_provider_message_payloads` pass (image budget / vision degradation / mime fallback identical to `submit_draft`); and forks the sibling with the attachments via `create_sibling`'s new `attachments=` parameter. Plain in-place Save unchanged.

## task-543 — record run id for stopped-via-cancel agent runs
The dominant user-Stop path (`stop_active_run` → `task.cancel()`) raised `CancelledError` before `run_reply`'s `(run_id, outcome)` ever bound, so the stopped reply's persisted id was never recorded and the run fell to the ordinal marker fallback on resume. The CancelledError branch now recovers the active run via the bridge's new `latest_unanchored_primary_run_id` seam — newest non-superseded primary, returned only while its `assistant_message_id` is still NULL, so a Stop that beats `create_run` can never overwrite the previous run's good anchor — and records the persisted id exactly like the finalizer terminal paths. New tests exercise the REAL `task.cancel()` path via a parked bridge thread (every prior stop test simulated the stop through a normally-returning `run_reply`).

## task-572 — stronger legacy-flat fingerprint for resume root-chaining
A degenerate all-USER legacy conversation (2+ parentless user rows, no replies) was mistaken for a genuine Phase-B root fork and left un-chained — resuming truncated to the last row with a phantom sibling counter. The all-USER decision now also chains when every root is childless (a genuine first-message edit-&-resend fork always hangs at least one reply subtree under a root); any root ASSISTANT row keeps chaining as the true legacy signature. The narrower residual edge is documented in the method docstring.

## Verification
- TDD throughout (red confirmed before each fix).
- 500 tests green across the edit-resend / agent-swap / controller / store / stop-reliability / resume-active-path suites plus the full `test_console_native_chat_flow.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three console branching gaps: Edit & resend now carries image attachments with the same vision gating as new sends; canceled runs record the stopped reply’s persisted id; resume chains degenerate all-USER legacy roots to remove phantom counters. Covers tasks 573, 543, and 572.

- **Bug Fixes**
  - Edit & resend (task-573): carries the anchor’s attachments onto the new sibling and into the provider payload; builds ancestors + a synthesized `ConsoleChatMessage` through the shared `_provider_message_payloads`; applies the same vision gate before any mutation; `create_sibling(attachments=...)` persists attachments; text-only anchors keep string payloads.
  - Stop via cancel (task-543): on `CancelledError`, recovers the active run via the bridge’s `latest_unanchored_primary_run_id` (DB’s bounded `latest_primary_run`) and records the stopped reply’s persisted id; anchored newest rows are guarded; never-persisted stops leave the run NULL (ordinal fallback); tests exercise real `stop_active_run` → `task.cancel()`.
  - Resume root-chaining (task-572): chains legacy roots when any root is ASSISTANT or when all USER roots are childless; prevents phantom sibling counters and truncation; genuine first-message forks with any subtree remain un-chained; residual edge documented.

<sup>Written for commit 5c74fd79c5f9edaefbff3df72756647c605d86d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

