### PR TITLE
chore(backlog): file skills script-execution follow-ups (578-582)

### DIFF
--- a/backlog/tasks/task-578 - Gate-skill_file-reads-on-trust-manifest-membership.md
+++ b/backlog/tasks/task-578 - Gate-skill_file-reads-on-trust-manifest-membership.md
@@ -1,0 +1,33 @@
+---
+id: TASK-578
+title: Gate skill_file reads on trust-manifest membership
+status: To Do
+assignee: []
+created_date: '2026-07-25 14:35'
+labels:
+  - skills
+  - security
+  - trust
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Script execution now requires a bundle path to be present in the skill's trusted manifest, but `skill_file` reads still gate only on `validate_supporting_file_path`.
+
+The trust scanner deliberately prunes junk paths (`node_modules/`, `.git/`, `__pycache__/`, `*.tmp`, `*.part`, `*~`, `*.pyc`, `.DS_Store`) from fingerprinting, so a file on such a path is never fingerprinted and never shown in the human trust review — yet an agent can still read its contents. A shipped bundle can therefore carry agent-readable instructions the reviewer never saw, and a script running under a standing grant can write more of them without perturbing the skill's digest.
+
+This predates the script-execution work and is not a regression, and it cannot escalate into execution (only manifest-fingerprinted files can run). But it is the last place where "passes the path validator" still substitutes for "is trust material", so the two seams should agree.
+
+The open question this task must settle: some real bundles legitimately read their own vendored data from pruned paths. Tightening reads may be a breaking change for them, so the fix needs an explicit decision rather than a silent tightening.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Reading a bundle path that is not fingerprinted in the skill's trusted manifest is refused
+- [ ] #2 The refusal is indistinguishable from a genuinely missing file, so it cannot be used to probe what a bundle contains
+- [ ] #3 Reading a normal fingerprinted supporting file still works, including nested paths
+- [ ] #4 An explicit decision is recorded for bundles that legitimately read their own vendored/pruned data — either a documented allowance or a documented breaking change
+- [ ] #5 The residual-risk wording in Docs/Features/Skills-Script-Execution.md is updated to match the resulting behaviour
+<!-- AC:END -->

--- a/backlog/tasks/task-579 - Live-TUI-verification-of-skill-script-confirm-and-revoke.md
+++ b/backlog/tasks/task-579 - Live-TUI-verification-of-skill-script-confirm-and-revoke.md
@@ -1,0 +1,34 @@
+---
+id: TASK-579
+title: Live TUI verification of skill-script confirm and revoke
+status: To Do
+assignee: []
+created_date: '2026-07-25 14:35'
+labels:
+  - skills
+  - qa
+  - ui
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The trust-gated skill script execution feature (PR #871) is covered by unit, widget and end-to-end tests, but no part of its UI has ever been driven in a running application. Two surfaces carry real risk if their wiring is subtly wrong, because both are security controls the user relies on:
+
+- the in-chat confirm card (Allow once / Always allow this skill / Deny), including the per-round `request_id` handshake — if the id is not echoed correctly the resolve is silently dropped by design, the card appears to do nothing, and the agent's worker thread blocks until its 120s timeout;
+- the Library ▸ Skills "Revoke script access" button, which is the user's only way to withdraw a skill's standing permission.
+
+A silently broken wire-up on either would leave every automated test passing while the control does nothing. This task is the live smoke pass that closes that gap.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 In a running app, an agent-initiated script run displays the confirm card with the correct skill name, script path, invocation mechanism and arguments
+- [ ] #2 "Allow once" runs the script and returns its output to the conversation; "Deny" refuses and the script does not execute
+- [ ] #3 "Always allow this skill" suppresses the prompt on a subsequent run of the same skill
+- [ ] #4 Editing the skill's content afterwards causes the next run to prompt again
+- [ ] #5 The Library ▸ Skills trust panel shows the grant state, and "Revoke script access" clears it so the next run prompts again
+- [ ] #6 Switching conversations while a confirm card is pending does not leave the run blocked
+- [ ] #7 Findings are captured with screenshots or a terminal capture under Docs/superpowers/qa/
+<!-- AC:END -->

--- a/backlog/tasks/task-580 - Restore-shadowed-builtin-name-drift-guard-parity.md
+++ b/backlog/tasks/task-580 - Restore-shadowed-builtin-name-drift-guard-parity.md
@@ -1,0 +1,30 @@
+---
+id: TASK-580
+title: Restore shadowed-builtin-name drift-guard parity
+status: To Do
+assignee: []
+created_date: '2026-07-25 14:35'
+labels:
+  - skills
+  - tests
+  - tech-debt
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`Tests/Library` has a failing drift-guard test: `_SHADOWED_BUILTIN_NAMES` in `tldw_chatbook/Library/library_skills_state.py` is missing the `rewind` and `generate-image` console commands, which arrived with other merged features (commits 73ed08aa8 and 62f0f918c).
+
+The guard exists so a user-installed skill cannot silently shadow a built-in command name. Every runtime tool that joined `RUNTIME_TOOL_NAMES` has correctly been added to this set, so the runtime side is in order — the gap is on the console-command side, where two commands were added without updating the list.
+
+This is a genuine (if small) correctness gap, not just a red test: a skill named `rewind` or `generate-image` would currently not be recognised as shadowing a built-in. It has been carried as an accepted baseline failure across several branches, which erodes the signal value of the suite.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 `rewind` and `generate-image` are present in `_SHADOWED_BUILTIN_NAMES`
+- [ ] #2 The drift-guard test in Tests/Library passes without any accepted-baseline caveat
+- [ ] #3 A skill named after either command is handled the same way as one shadowing any other built-in
+- [ ] #4 The guard's failure message points at what to update, so the next command addition fixes it rather than accepting it as a baseline
+<!-- AC:END -->

--- a/backlog/tasks/task-581 - Support-concurrent-skill-script-confirm-rounds.md
+++ b/backlog/tasks/task-581 - Support-concurrent-skill-script-confirm-rounds.md
@@ -1,0 +1,31 @@
+---
+id: TASK-581
+title: Support concurrent skill-script confirm rounds
+status: To Do
+assignee: []
+created_date: '2026-07-25 14:35'
+labels:
+  - skills
+  - chat
+  - reliability
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The skill-script confirm bridge in `console_chat_controller.py` holds a single pending slot (`_pending_skill_script_event` / `_pending_skill_script_decision` / `_pending_skill_script_request_id`). If two confirm rounds are ever armed at once, the second overwrites the first's state and both worker threads then block until their 120s timeout expires.
+
+This currently fails closed and is bounded, so it is not a security defect — and it is not reachable today, because the agent loop dispatches tool calls one at a time on a single worker thread. It becomes reachable the moment anything runs tool calls concurrently, or a second agent run overlaps the first.
+
+The same single-slot shape exists in the sibling MCP approval and skill-install confirm flows, so a fix is worth designing once and applying consistently rather than patching one seam.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Two confirm rounds armed concurrently each resolve to their own decision, with no cross-talk
+- [ ] #2 Neither round can be resolved by the other's decision (the per-round request_id remains authoritative)
+- [ ] #3 Teardown of one round does not clear another round's pending state
+- [ ] #4 A test pins the concurrent case, failing against the current single-slot implementation
+- [ ] #5 A decision is recorded on whether the sibling MCP-approval and skill-install flows adopt the same fix
+<!-- AC:END -->

--- a/backlog/tasks/task-581 - Support-concurrent-skill-script-confirm-rounds.md
+++ b/backlog/tasks/task-581 - Support-concurrent-skill-script-confirm-rounds.md
@@ -14,7 +14,7 @@ dependencies: []
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-The skill-script confirm bridge in `console_chat_controller.py` holds a single pending slot (`_pending_skill_script_event` / `_pending_skill_script_decision` / `_pending_skill_script_request_id`). If two confirm rounds are ever armed at once, the second overwrites the first's state and both worker threads then block until their 120s timeout expires.
+The skill-script confirm bridge in `tldw_chatbook/Chat/console_chat_controller.py` holds a single pending slot (`_pending_skill_script_event` / `_pending_skill_script_decision` / `_pending_skill_script_request_id`). If two confirm rounds are ever armed at once, the second overwrites the first's state and both worker threads then block until their 120s timeout expires.
 
 This currently fails closed and is bounded, so it is not a security defect — and it is not reachable today, because the agent loop dispatches tool calls one at a time on a single worker thread. It becomes reachable the moment anything runs tool calls concurrently, or a second agent run overlaps the first.
 

--- a/backlog/tasks/task-582 - Expose-skill-script-sandbox-limits-as-configuration.md
+++ b/backlog/tasks/task-582 - Expose-skill-script-sandbox-limits-as-configuration.md
@@ -13,7 +13,7 @@ dependencies: []
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-The skill-script sandbox budget (`ScriptRunLimits` in `Skills_Interop/skill_script_runner.py`) is a set of hardcoded defaults: 10s CPU, 512 MiB address space, 128 open files, 8 MiB max file size, 60s wall clock, 64 KiB retained output per stream. The design anticipated these being overridable from a `[skills]` config block, but only `script_scratch_root` was actually wired, and the feature documentation currently states plainly that the limits are not configurable.
+The skill-script sandbox budget (`ScriptRunLimits` in `tldw_chatbook/Skills_Interop/skill_script_runner.py`) is a set of hardcoded defaults: 10s CPU, 512 MiB address space, 128 open files, 8 MiB max file size, 60s wall clock, 64 KiB retained output per stream. The design anticipated these being overridable from a `[skills]` config block, but only `script_scratch_root` was actually wired, and the feature documentation currently states plainly that the limits are not configurable.
 
 The defaults are deliberately conservative, which means a legitimate long-running or output-heavy skill script has no way to be accommodated short of a code change. Conversely, a user who wants a tighter budget cannot impose one.
 

--- a/backlog/tasks/task-582 - Expose-skill-script-sandbox-limits-as-configuration.md
+++ b/backlog/tasks/task-582 - Expose-skill-script-sandbox-limits-as-configuration.md
@@ -1,0 +1,30 @@
+---
+id: TASK-582
+title: Expose skill-script sandbox limits as configuration
+status: To Do
+assignee: []
+created_date: '2026-07-25 14:35'
+labels:
+  - skills
+  - config
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The skill-script sandbox budget (`ScriptRunLimits` in `Skills_Interop/skill_script_runner.py`) is a set of hardcoded defaults: 10s CPU, 512 MiB address space, 128 open files, 8 MiB max file size, 60s wall clock, 64 KiB retained output per stream. The design anticipated these being overridable from a `[skills]` config block, but only `script_scratch_root` was actually wired, and the feature documentation currently states plainly that the limits are not configurable.
+
+The defaults are deliberately conservative, which means a legitimate long-running or output-heavy skill script has no way to be accommodated short of a code change. Conversely, a user who wants a tighter budget cannot impose one.
+
+Note the trap this must avoid: `get_cli_setting("skills", {})` silently returns `{}` for any section name without a dot (config.py), so the section-dict form would make every knob permanently unreachable. The three-argument form is required, and the existing `script_scratch_root` read is the working precedent.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Each ScriptRunLimits field can be overridden from a `[skills]` config section, falling back to the current default when unset
+- [ ] #2 Overrides are read via the three-argument get_cli_setting form, with a test that would fail if the unreachable section-dict form were used
+- [ ] #3 Out-of-range or non-numeric values are rejected in favour of the default rather than producing an unbounded or zero budget
+- [ ] #4 A wall-clock override cannot exceed the confirm/run-budget envelope in a way that strands the agent run
+- [ ] #5 Docs/Features/Skills-Script-Execution.md is updated: the limits table stops saying the values are not configurable, and documents each knob
+<!-- AC:END -->

--- a/backlog/tasks/task-583 - OS-level-sandbox-for-skill-script-execution.md
+++ b/backlog/tasks/task-583 - OS-level-sandbox-for-skill-script-execution.md
@@ -1,0 +1,39 @@
+---
+id: TASK-583
+title: OS-level sandbox for skill script execution
+status: To Do
+assignee: []
+created_date: '2026-07-25 15:05'
+labels:
+  - skills
+  - security
+  - sandbox
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Skill script execution currently runs under a best-effort sandbox: no shell, a scrubbed environment (no API keys), a fresh scratch working directory, RLIMITs applied via a Python trampoline, a wall-clock deadline with process-group kill, and bounded output. That is deliberately not a jail, and the feature documentation says so.
+
+Three residuals follow directly from the absence of real OS-level containment:
+
+- **network egress is not blocked** — a script may open sockets;
+- **reads and writes outside the scratch directory are possible** — only the working directory is scratch, and nothing stops an absolute path;
+- **memory is uncapped on macOS/BSD** — `RLIMIT_AS` cannot be lowered there, so peak memory is bounded only by CPU and wall-clock limits.
+
+The compensating control today is the human confirm card plus per-run trust re-verification. Real containment would let those residuals be closed rather than documented, and would make a standing "always allow" grant a much safer thing to give.
+
+This is a design project, not a patch: the mechanism differs per platform (macOS `sandbox-exec` — Apple-deprecated but widely used; Linux seccomp/namespaces or bubblewrap; containers add setup and latency cost that may be wrong for fast local helpers). Script execution is already POSIX-only, so Windows is out of scope here.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A containment mechanism is chosen per supported platform, with the trade-offs (deprecation risk, setup cost, latency, failure modes) written down
+- [ ] #2 A script cannot write outside its scratch directory, verified by a test that attempts an absolute-path write
+- [ ] #3 A decision is recorded on network egress — blocked by default, or opt-in per skill — and enforced if blocked
+- [ ] #4 Memory is genuinely capped on macOS, or the platform's limitation is re-documented as irreducible with evidence
+- [ ] #5 A script that the sandbox refuses to launch fails closed with a clear user-facing reason, never a partial spawn
+- [ ] #6 The residual-risk section of Docs/Features/Skills-Script-Execution.md is rewritten to match what is actually enforced
+- [ ] #7 Existing skill scripts that only read their own bundle and write to the scratch directory continue to work unchanged
+<!-- AC:END -->

--- a/backlog/tasks/task-584 - Retain-and-expose-skill-script-output-files.md
+++ b/backlog/tasks/task-584 - Retain-and-expose-skill-script-output-files.md
@@ -1,0 +1,34 @@
+---
+id: TASK-584
+title: Retain and expose skill script output files
+status: To Do
+assignee: []
+created_date: '2026-07-25 15:05'
+labels:
+  - skills
+  - agents
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Skill script execution returns only stdout, stderr and an exit code. The per-run scratch working directory is deleted afterwards, so any file a script produces is discarded.
+
+That was the deliberate v1 choice: it keeps the run fully bounded and avoids inventing a retention story before there was a consumer for one. But it blocks a whole class of legitimate skills — extract-then-process pipelines, format converters, report or chart generators — whose entire purpose is to produce an artifact.
+
+The reason this is not a small change is that there is no consumer today. The Agents runtime has no general file-read tool, and `skill_file` is deliberately contained to a skill's own bundle (and, after the trust-manifest work, to fingerprinted files only). So "keep the output" immediately raises: who reads it, through what contained seam, and with what lifetime?
+
+Sketch of the options to weigh: persist the scratch directory under the existing tool-sandbox root and merely *list* produced files in the tool result (the user can open them, the agent cannot read them); or add a bounded read-back path so the agent can consume its own output — a new read surface that needs its own containment, size caps, and probably its own trust story. Retention/cleanup policy is required either way.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A decision is recorded on whether the agent can read produced files, or only the user can, with the reasoning
+- [ ] #2 Files a script produces survive the run and are reachable at a documented location
+- [ ] #3 Retention and cleanup are defined and enforced, so output cannot accumulate without bound
+- [ ] #4 If the agent can read output, that read path is contained and size-capped, and cannot reach outside the run's own output directory
+- [ ] #5 Produced files cannot be written into a skill's own bundle, so a run cannot invalidate its own fingerprints or plant trust-invisible content
+- [ ] #6 The tool result reports what was produced without dumping file contents into the transcript
+- [ ] #7 Docs/Features/Skills-Script-Execution.md is updated — it currently states plainly that produced files are discarded
+<!-- AC:END -->


### PR DESCRIPTION
## Summary

Files the five deferred follow-ups from **#871** (trust-gated skill script execution) as backlog tasks. Docs-only — no code changes.

| Task | What |
|---|---|
| 578 | `skill_file` reads still gate on the path validator, not the trust manifest |
| 579 | Live TUI verification of the confirm card and Revoke button |
| 580 | `_SHADOWED_BUILTIN_NAMES` missing `rewind` / `generate-image` |
| 581 | Single-slot confirm state cannot support concurrent rounds |
| 582 | `ScriptRunLimits` are hardcoded, not configurable |

## Notes on the two worth prioritising

**578** is the one with a security flavour. #871 fixed the execution seam so a script must appear in the skill's trusted manifest to run — closing a hole where junk-pruned paths (`node_modules/`, `*.tmp`, …) were runnable but invisible to trust review. The *read* seam was deliberately left alone in that PR to avoid breaking bundles that read their own vendored data. It cannot escalate into execution, but a bundle can still carry agent-readable instructions the reviewer never saw, so the two seams should be made to agree deliberately rather than by omission.

**580** is small but has been carried as an accepted baseline failure across several branches, which erodes the suite's signal. It is also a real (if minor) correctness gap, not just a red test.

## ID assignment

Swept against **253 refs and 54 worktrees** before assigning. Worth flagging: the `backlog` CLI would have assigned **577**, which is already taken on the unmerged branch `claude/task-562-chat-tab-conversation-entry` — the CLI only sees the local checkout, so it cannot detect cross-branch collisions. Verified 578-582 are free everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filed backlog tasks 578–584 for follow-ups to PR #871 (trust‑gated skill script execution). Docs-only: covers trust‑gated file reads, live confirm/revoke, builtin-name guard, concurrent confirms, configurable limits, OS sandboxing, and output retention.

- **Bug Fixes**
  - Corrected package-qualified paths in tasks 581–583 to reference `tldw_chatbook/...` modules so contributors land in the right files.

<sup>Written for commit a5eb88c4e1670808cbee0fba6c854ac9308890f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

