### PR TITLE
feat(rag): merge legacy query-time keys into first-run imported profile (task-495)

### DIFF
--- a/Tests/RAG/test_first_run_import.py
+++ b/Tests/RAG/test_first_run_import.py
@@ -256,13 +256,60 @@ def test_imported_profile_preserves_hand_set_legacy_query_time_keys(monkeypatch,
 
     new_id = ensure_imported_profile()
 
-    imported = mgr.get_profile(new_id).rag_config
+    imported_profile = mgr.get_profile(new_id)
+    imported = imported_profile.rag_config
     assert imported.search.default_top_k == 25
     assert imported.search.score_threshold == 0.42
     assert imported.search.include_citations is False
     assert imported.search.enable_reranking is True
     assert imported.search.reranker_model == "cross-encoder/legacy"
     assert imported.search.reranker_top_k == 7
+    # PR #874 Qodo finding 2: rag_factory.create_rag_service() decides
+    # reranking enablement from `profile.reranking_config is not None`
+    # (rag_factory.py:65), NOT `rag_config.search.enable_reranking` -- that
+    # field only mirrors for UI display (see settings_rag_profile_adapter.py
+    # apply_defaults_to_profile). A legacy user with reranking enabled must
+    # therefore also get a populated `reranking_config`, or reranking stays
+    # silently OFF for them after import despite `search.enable_reranking`
+    # being True above.
+    assert imported_profile.reranking_config is not None
+    assert imported_profile.reranking_config.model_name == "cross-encoder/legacy"
+    assert imported_profile.reranking_config.top_k_to_rerank == 7
+
+
+def test_imported_profile_reranking_config_absent_when_legacy_reranking_unset(monkeypatch, tmp_path):
+    """No legacy `enable_reranking` key set -> no `reranking_config` is
+    fabricated (mirrors today's "nothing to merge" behavior for the other
+    legacy keys)."""
+    from tldw_chatbook.RAG_Search.simplified.active_config import ensure_imported_profile
+    mgr, ptr = _wire(monkeypatch, tmp_path)
+    _wire_legacy_rag_config(monkeypatch, {
+        "search": {"default_top_k": 25},
+    })
+
+    new_id = ensure_imported_profile()
+
+    assert mgr.get_profile(new_id).reranking_config is None
+
+
+def test_imported_profile_reranking_config_keeps_model_default_when_legacy_model_blank(monkeypatch, tmp_path):
+    """Legacy reranking enabled but no `reranker_model` hand-set -> the
+    fabricated `RerankingConfig`'s `model_name` keeps its own default rather
+    than being stomped with an empty/missing value (same "blank means leave
+    alone" convention as `apply_defaults_to_profile`)."""
+    from tldw_chatbook.RAG_Search.reranker import RerankingConfig
+    from tldw_chatbook.RAG_Search.simplified.active_config import ensure_imported_profile
+    mgr, ptr = _wire(monkeypatch, tmp_path)
+    _wire_legacy_rag_config(monkeypatch, {
+        "processor": {"enable_reranking": True, "reranker_top_k": 12},
+    })
+
+    new_id = ensure_imported_profile()
+
+    imported_profile = mgr.get_profile(new_id)
+    assert imported_profile.reranking_config is not None
+    assert imported_profile.reranking_config.model_name == RerankingConfig().model_name
+    assert imported_profile.reranking_config.top_k_to_rerank == 12
 
 
 def test_imported_profile_fingerprint_invariant_with_legacy_query_keys_set(monkeypatch, tmp_path):

--- a/Tests/RAG/test_first_run_import.py
+++ b/Tests/RAG/test_first_run_import.py
@@ -222,3 +222,109 @@ def test_first_run_import_runs_before_shared_service_lock_is_held(
     ii.get_shared_rag_service()  # no service pre-injected: exercises the real fast-path+lock flow up to construction
 
     assert acquired == [True]  # lock was free (not self-deadlocked) when the wiring call ran
+
+
+# --- Task-495: merge legacy query-time keys into the first-run snapshot --
+
+
+def _wire_legacy_rag_config(monkeypatch, rag_section):
+    """Monkeypatch active_config.get_cli_setting so
+    get_cli_setting("AppRAGSearchConfig", "rag", {}) resolves to `rag_section`
+    (shaped like the raw [AppRAGSearchConfig.rag.<subsection>].<key> TOML
+    tree), independent of whatever the test-bootstrap config on disk has."""
+    import tldw_chatbook.RAG_Search.simplified.active_config as ac
+
+    def _fake_get_cli_setting(section, key=None, default=None):
+        if section == "AppRAGSearchConfig" and key == "rag":
+            return rag_section
+        return default
+
+    monkeypatch.setattr(ac, "get_cli_setting", _fake_get_cli_setting, raising=False)
+
+
+def test_imported_profile_preserves_hand_set_legacy_query_time_keys(monkeypatch, tmp_path):
+    """AC #1: hand-set legacy query-time keys (top_k, score_threshold,
+    citations, reranking) from [AppRAGSearchConfig.rag.search] /
+    [AppRAGSearchConfig.rag.processor] survive into the imported profile
+    instead of being silently discarded."""
+    from tldw_chatbook.RAG_Search.simplified.active_config import ensure_imported_profile
+    mgr, ptr = _wire(monkeypatch, tmp_path)
+    _wire_legacy_rag_config(monkeypatch, {
+        "search": {"default_top_k": 25, "score_threshold": 0.42, "include_citations": False},
+        "processor": {"enable_reranking": True, "reranker_model": "cross-encoder/legacy", "reranker_top_k": 7},
+    })
+
+    new_id = ensure_imported_profile()
+
+    imported = mgr.get_profile(new_id).rag_config
+    assert imported.search.default_top_k == 25
+    assert imported.search.score_threshold == 0.42
+    assert imported.search.include_citations is False
+    assert imported.search.enable_reranking is True
+    assert imported.search.reranker_model == "cross-encoder/legacy"
+    assert imported.search.reranker_top_k == 7
+
+
+def test_imported_profile_fingerprint_invariant_with_legacy_query_keys_set(monkeypatch, tmp_path):
+    """AC #2 (verbatim): with those same legacy query-time keys set, the
+    imported profile's fingerprint still equals the fingerprint of the
+    unmodified built-in base (SP1's adopted legacy-collection fingerprint) --
+    merging query-time-only fields must never move the fingerprint."""
+    from tldw_chatbook.RAG_Search.simplified.active_config import ensure_imported_profile, resolve_active_rag_config
+    from tldw_chatbook.RAG_Search.simplified.collection_fingerprint import fingerprint_collection
+    mgr, ptr = _wire(monkeypatch, tmp_path)
+    _wire_legacy_rag_config(monkeypatch, {
+        "search": {"default_top_k": 25, "score_threshold": 0.42, "include_citations": False},
+        "processor": {"enable_reranking": True, "reranker_model": "cross-encoder/legacy", "reranker_top_k": 7},
+    })
+    # Captured BEFORE ensure_imported_profile() repoints the active pointer --
+    # same ordering rationale as test_imported_fingerprint_matches_sp1_adoption.
+    pre_fp = fingerprint_collection(resolve_active_rag_config())
+
+    new_id = ensure_imported_profile()
+
+    imported_fp = fingerprint_collection(mgr.get_profile(new_id).rag_config)
+    assert imported_fp == pre_fp
+
+
+def test_imported_profile_unchanged_when_no_legacy_keys_set(monkeypatch, tmp_path):
+    """No hand-set legacy keys -> the imported snapshot is byte-equal to
+    today's plain resolve_active_rag_config() capture (no regression when
+    there's nothing to merge)."""
+    from dataclasses import asdict
+    from tldw_chatbook.RAG_Search.simplified.active_config import ensure_imported_profile, resolve_active_rag_config
+    mgr, ptr = _wire(monkeypatch, tmp_path)
+    _wire_legacy_rag_config(monkeypatch, {})
+    expected = resolve_active_rag_config()
+
+    new_id = ensure_imported_profile()
+
+    imported = mgr.get_profile(new_id).rag_config
+    assert asdict(imported) == asdict(expected)
+
+
+def test_imported_profile_does_not_merge_legacy_index_determining_keys(monkeypatch, tmp_path):
+    """Legacy embedding/chunking/distance_metric keys must NEVER be merged
+    (that would move the fingerprint and orphan the legacy collection) --
+    only the allow-listed query-time keys are eligible, and the fingerprint
+    stays equal to the unmodified built-in base's even when those
+    index-determining legacy keys are hand-set."""
+    from tldw_chatbook.RAG_Search.simplified.active_config import ensure_imported_profile, resolve_active_rag_config
+    from tldw_chatbook.RAG_Search.simplified.collection_fingerprint import fingerprint_collection
+    mgr, ptr = _wire(monkeypatch, tmp_path)
+    _wire_legacy_rag_config(monkeypatch, {
+        "embedding": {"model": "legacy-embedding-model", "max_length": 9999},
+        "chunking": {"chunk_size": 1, "chunk_overlap": 0},
+        "vector_store": {"distance_metric": "l2"},
+        "search": {"default_top_k": 25},
+    })
+    pre_fp = fingerprint_collection(resolve_active_rag_config())
+
+    new_id = ensure_imported_profile()
+
+    imported = mgr.get_profile(new_id).rag_config
+    assert imported.embedding.model != "legacy-embedding-model"
+    assert imported.chunking.chunk_size != 1
+    assert imported.vector_store.distance_metric != "l2"
+    assert imported.search.default_top_k == 25  # query-time key still merged
+    assert fingerprint_collection(imported) == pre_fp

--- a/backlog/tasks/task-495 - Merge-legacy-query-time-RAG-keys-into-the-first-run-Imported-settings-profile.md
+++ b/backlog/tasks/task-495 - Merge-legacy-query-time-RAG-keys-into-the-first-run-Imported-settings-profile.md
@@ -1,11 +1,13 @@
 ---
 id: TASK-495
 title: >-
-  Merge legacy query-time RAG keys into the first-run "Imported settings" profile
-status: To Do
-assignee: []
+  Merge legacy query-time RAG keys into the first-run "Imported settings"
+  profile
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-23 02:00'
-updated_date: '2026-07-23 02:00'
+updated_date: '2026-07-25 14:35'
 labels:
   - rag
   - profiles
@@ -24,8 +26,57 @@ Enrich the first-run snapshot: merge such hand-set query-time legacy keys onto t
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
-- [ ] The "Imported settings" first-run profile preserves a user's hand-set query-time legacy keys (top_k, score_threshold, citations, reranking) from `[AppRAGSearchConfig.rag.*]`.
-- [ ] The imported profile's SP1 fingerprint still equals SP1's adopted legacy-collection fingerprint (only non-index-determining fields merged) — a test asserts this holds with legacy query-keys set.
+- [x] #1 The "Imported settings" first-run profile preserves a user's hand-set query-time legacy keys (top_k, score_threshold, citations, reranking) from `[AppRAGSearchConfig.rag.*]`.
+- [x] #2 The imported profile's SP1 fingerprint still equals SP1's adopted legacy-collection fingerprint (only non-index-determining fields merged) — a test asserts this holds with legacy query-keys set.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a private helper in active_config.py that reads the raw [AppRAGSearchConfig.rag.search] / [AppRAGSearchConfig.rag.processor] dicts via get_cli_setting and returns only the KEYS LITERALLY PRESENT (not defaulted) among the allow-listed query-time fields: search.default_top_k, search.score_threshold, search.include_citations, processor.enable_reranking, processor.reranker_model, processor.reranker_top_k.
+2. In ensure_imported_profile(), after snapshot = resolve_active_rag_config(), merge those hand-set values onto snapshot.search in place, before wrapping snapshot in the ProfileConfig. Never touch embedding/chunking/vector_store.distance_metric fields (fingerprint-determining, per collection_fingerprint._index_fields) -- confirmed exhaustively against that module.
+3. TDD in Tests/RAG/test_first_run_import.py (already covers ensure_imported_profile): RED tests for (a) hand-set legacy keys preserved in the imported profile, (b) fingerprint invariance with those same keys set (mirrors existing test_imported_fingerprint_matches_sp1_adoption pattern), (c) no legacy keys set -> import unchanged vs today, (d) legacy embedding/chunk keys set -> NOT merged, fingerprint still equal.
+4. Implement, get GREEN, run full Tests/RAG/ suite for regressions.
+5. Update task-495 ACs + Implementation Notes, set Done.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added `_hand_set_legacy_query_time_keys()` / `_merge_legacy_query_time_keys()` to
+`tldw_chatbook/RAG_Search/simplified/active_config.py` and call the latter from
+`ensure_imported_profile()` right after `snapshot = resolve_active_rag_config()`,
+before the snapshot is wrapped in the new `ProfileConfig`.
+
+`_hand_set_legacy_query_time_keys()` reads the raw
+`get_cli_setting("AppRAGSearchConfig", "rag", {})` dict directly and checks
+literal key **presence** (`key in search`/`key in processor`), not "differs
+from default" — an explicit value equal to the dataclass default is still
+honored, and nothing is synthesized for an absent key. Only a fixed
+allow-list is ever read: `_LEGACY_SEARCH_KEYS = (default_top_k,
+score_threshold, include_citations)` from `[AppRAGSearchConfig.rag.search]`
+and `_LEGACY_PROCESSOR_KEYS = (enable_reranking, reranker_model,
+reranker_top_k)` from `[AppRAGSearchConfig.rag.processor]` (per the TOML
+mapping documented in `simplified/config.py`'s `EXAMPLE_TOML_CONFIG`).
+Embedding/chunking/`vector_store.distance_metric` legacy keys are never read
+by this path at all — confirmed against `collection_fingerprint.
+_index_fields`' exhaustive list of fingerprint-input fields, so this merge
+can never move `fingerprint_collection()`'s output.
+
+TDD: extended `Tests/RAG/test_first_run_import.py` (the existing
+`ensure_imported_profile` test file) with 4 tests — preserved-hand-set-keys
+(RED before the change), fingerprint-invariance-with-those-keys-set (AC #2,
+already held pre-change since nothing was merged yet, kept as a regression
+guard), unchanged-with-no-legacy-keys (byte/asdict-equal to today's
+behavior), and legacy-index-determining-keys-NOT-merged (RED before the
+change: `default_top_k` wasn't merged; embedding/chunk/distance_metric
+assertions passed throughout since that path never touches them). All 12
+tests in the file pass; full `Tests/RAG/` suite: 541 passed, 8 skipped (was
+~537 passed, 8 skipped before this change — net +4 new tests, no
+regressions).
+
+Files modified:
+- `tldw_chatbook/RAG_Search/simplified/active_config.py`
+- `Tests/RAG/test_first_run_import.py`
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/RAG_Search/simplified/active_config.py
+++ b/tldw_chatbook/RAG_Search/simplified/active_config.py
@@ -23,6 +23,18 @@ from ..ingestion_indexing import reset_shared_rag_service
 DEFAULT_PROFILE = "hybrid_basic"
 _IMPORTED_ID = "imported_settings"
 
+# Legacy TOML keys (task-495): non-index-determining query-time settings a
+# user may have hand-set under the deprecated [AppRAGSearchConfig.rag.search]
+# / [AppRAGSearchConfig.rag.processor] sections. These are the ONLY legacy
+# keys ever merged into the first-run "Imported settings" snapshot -- NONE of
+# embedding.model/max_length, any chunking.* field, or vector_store.
+# distance_metric (collection_fingerprint._index_fields' exhaustive input
+# set) are read here, so merging can never move
+# collection_fingerprint.fingerprint_collection()'s output away from what
+# SP1 adopts the legacy collection under.
+_LEGACY_SEARCH_KEYS = ("default_top_k", "score_threshold", "include_citations")
+_LEGACY_PROCESSOR_KEYS = ("enable_reranking", "reranker_model", "reranker_top_k")
+
 
 def _manager():
     return get_profile_manager()
@@ -185,11 +197,80 @@ def set_active_profile(profile_id: str) -> None:
     reset_shared_rag_service()
 
 
+def _hand_set_legacy_query_time_keys() -> dict:
+    """Allow-listed query-time keys the user literally set in the deprecated
+    [AppRAGSearchConfig.rag.search] / [AppRAGSearchConfig.rag.processor]
+    TOML sections.
+
+    "Hand-set" means present as a key in the raw loaded config dict -- NOT
+    "differs from the dataclass default". An explicit value that happens to
+    equal the default is still honored; an absent key is never synthesized
+    from a default. Only keys in `_LEGACY_SEARCH_KEYS` / `_LEGACY_PROCESSOR_
+    KEYS` are ever considered (see their docstring for why: they're exactly
+    the non-index-determining fields).
+
+    Returns:
+        Dict of `{SearchConfig field name: value}` for every allow-listed
+        key present in the user's config; empty when none are set or the
+        legacy section can't be read (never raises).
+    """
+    try:
+        rag_section = get_cli_setting("AppRAGSearchConfig", "rag", {}) or {}
+        if not isinstance(rag_section, dict):
+            return {}
+    except Exception as e:
+        logger.debug(f"Could not read legacy AppRAGSearchConfig.rag section: {e}")
+        return {}
+
+    found: dict = {}
+    search = rag_section.get("search")
+    if isinstance(search, dict):
+        for key in _LEGACY_SEARCH_KEYS:
+            if key in search:
+                found[key] = search[key]
+    processor = rag_section.get("processor")
+    if isinstance(processor, dict):
+        for key in _LEGACY_PROCESSOR_KEYS:
+            if key in processor:
+                found[key] = processor[key]
+    return found
+
+
+def _merge_legacy_query_time_keys(config: RAGConfig) -> RAGConfig:
+    """Merge hand-set legacy query-time keys onto `config.search`, in place.
+
+    Only ever called from ensure_imported_profile()'s one-time first-run
+    snapshot -- this is a migration convenience, not part of the ongoing
+    resolve_active_rag_config() resolution path (legacy AppRAGSearchConfig.
+    rag.* value keys are otherwise dead per the module docstring above).
+
+    Args:
+        config: The RAGConfig to mutate (the first-run snapshot).
+
+    Returns:
+        The same `config` instance, mutated in place, for convenient
+        chaining at the call site.
+    """
+    for key, value in _hand_set_legacy_query_time_keys().items():
+        try:
+            setattr(config.search, key, value)
+        except Exception as e:
+            logger.debug(f"Could not apply legacy query-time key {key}={value!r}: {e}")
+    return config
+
+
 def ensure_imported_profile() -> Optional[str]:
     """On first run, capture the currently-resolved RAG config into a writable
     'Imported settings' profile and set it active. Idempotent (returns None if it
     already exists). The captured config's SP1 fingerprint matches what SP1 adopts
     the legacy collection under, so the user keeps their index on upgrade.
+
+    Also merges (task-495) any hand-set, non-index-determining legacy
+    query-time keys from the deprecated [AppRAGSearchConfig.rag.search] /
+    [AppRAGSearchConfig.rag.processor] TOML sections (top_k, score_threshold,
+    citations, reranking) onto the snapshot, so a user's query-time tuning
+    survives the import instead of being silently discarded. See
+    `_merge_legacy_query_time_keys` / `_LEGACY_SEARCH_KEYS`.
 
     Self-healing: existence of the profile is not enough to consider first-run
     import "done" -- if a previous run persisted the profile but failed before
@@ -216,6 +297,10 @@ def ensure_imported_profile() -> Optional[str]:
             return None
         # Snapshot the resolved config (active pointer may name a builtin default today).
         snapshot = resolve_active_rag_config()
+        # task-495: preserve a user's hand-tuned, non-index-determining
+        # query-time legacy keys instead of silently discarding them --
+        # never affects the fingerprint (see _LEGACY_SEARCH_KEYS docstring).
+        _merge_legacy_query_time_keys(snapshot)
         profile = ProfileConfig(id=_IMPORTED_ID, name="Imported settings",
                                 description="Snapshot of your active RAG profile (plus any RAG_* env "
                                             "overrides) captured on first run; edit freely.",

--- a/tldw_chatbook/RAG_Search/simplified/active_config.py
+++ b/tldw_chatbook/RAG_Search/simplified/active_config.py
@@ -19,6 +19,7 @@ from tldw_chatbook.config import get_cli_setting, save_setting_to_cli_config
 from .config import RAGConfig, _normalized_type_setting
 from ..config_profiles import get_profile_manager, ProfileConfig, _slugify
 from ..ingestion_indexing import reset_shared_rag_service
+from ..reranker import RerankingConfig
 
 DEFAULT_PROFILE = "hybrid_basic"
 _IMPORTED_ID = "imported_settings"
@@ -236,7 +237,7 @@ def _hand_set_legacy_query_time_keys() -> dict:
     return found
 
 
-def _merge_legacy_query_time_keys(config: RAGConfig) -> RAGConfig:
+def _merge_legacy_query_time_keys(config: RAGConfig) -> dict:
     """Merge hand-set legacy query-time keys onto `config.search`, in place.
 
     Only ever called from ensure_imported_profile()'s one-time first-run
@@ -248,15 +249,18 @@ def _merge_legacy_query_time_keys(config: RAGConfig) -> RAGConfig:
         config: The RAGConfig to mutate (the first-run snapshot).
 
     Returns:
-        The same `config` instance, mutated in place, for convenient
-        chaining at the call site.
+        The dict of hand-set legacy keys that were found (possibly empty),
+        so callers that need to act on a key `SearchConfig` alone can't
+        represent (e.g. reranking presence -- see `ensure_imported_profile`)
+        don't have to re-read the legacy TOML section a second time.
     """
-    for key, value in _hand_set_legacy_query_time_keys().items():
+    legacy = _hand_set_legacy_query_time_keys()
+    for key, value in legacy.items():
         try:
             setattr(config.search, key, value)
         except Exception as e:
             logger.debug(f"Could not apply legacy query-time key {key}={value!r}: {e}")
-    return config
+    return legacy
 
 
 def ensure_imported_profile() -> Optional[str]:
@@ -271,6 +275,15 @@ def ensure_imported_profile() -> Optional[str]:
     citations, reranking) onto the snapshot, so a user's query-time tuning
     survives the import instead of being silently discarded. See
     `_merge_legacy_query_time_keys` / `_LEGACY_SEARCH_KEYS`.
+
+    Legacy reranking enablement additionally populates the new profile's
+    `reranking_config` (not just `rag_config.search.enable_reranking`):
+    `rag_factory.create_rag_service()` decides reranking enablement from
+    `profile.reranking_config is not None` -- `search.enable_reranking` is
+    UI-display-only and ignored by the live service (see
+    `settings_rag_profile_adapter.py`'s `apply_defaults_to_profile`, the
+    established convention this mirrors). Without this, a legacy user with
+    reranking enabled would silently end up with it OFF after import.
 
     Self-healing: existence of the profile is not enough to consider first-run
     import "done" -- if a previous run persisted the profile but failed before
@@ -300,11 +313,23 @@ def ensure_imported_profile() -> Optional[str]:
         # task-495: preserve a user's hand-tuned, non-index-determining
         # query-time legacy keys instead of silently discarding them --
         # never affects the fingerprint (see _LEGACY_SEARCH_KEYS docstring).
-        _merge_legacy_query_time_keys(snapshot)
+        legacy = _merge_legacy_query_time_keys(snapshot)
         profile = ProfileConfig(id=_IMPORTED_ID, name="Imported settings",
                                 description="Snapshot of your active RAG profile (plus any RAG_* env "
                                             "overrides) captured on first run; edit freely.",
                                 profile_type="custom", rag_config=snapshot)
+        if legacy.get("enable_reranking"):
+            # Presence, not the mirrored search.enable_reranking flag, is
+            # what actually turns reranking on for the live service (see the
+            # docstring above) -- fabricate reranking_config here so a
+            # legacy user's setting actually takes effect post-import.
+            profile.reranking_config = RerankingConfig()
+            reranker_model = legacy.get("reranker_model")
+            if reranker_model:
+                profile.reranking_config.model_name = reranker_model
+            reranker_top_k = legacy.get("reranker_top_k")
+            if reranker_top_k is not None:
+                profile.reranking_config.top_k_to_rerank = int(reranker_top_k)
         mgr.save_profile(profile)
         set_active_profile(_IMPORTED_ID)
         return _IMPORTED_ID


### PR DESCRIPTION
SP2b follow-up: `ensure_imported_profile` now merges hand-set (literally present in the user's `[AppRAGSearchConfig.rag.*]` config sections) query-time keys — default_top_k, score_threshold, include_citations, enable_reranking, reranker_model, reranker_top_k — onto the built-in base. Index-determining fields (embedding model/max_length, chunking, distance_metric) are never merged, and a non-tautological test asserts the imported profile's collection fingerprint stays equal to SP1's adoption (AC #2). No-legacy-keys path is behavior-identical. Tests/RAG 541 passed / 8 skipped; RED/GREEN independently reproduced by the reviewer. Reviewer minor (informational, not fixed): merged values aren't type-coerced, so a quoted numeric in TOML passes through as str.

Held for owner approval — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Merges legacy query-time RAG settings into the first-run "Imported settings" profile and creates `reranking_config` when legacy reranking was enabled, so users keep tuned behavior without changing the collection fingerprint. Satisfies task-495 AC #1 and #2.

- **New Features**
  - `ensure_imported_profile()` merges hand-set keys from `AppRAGSearchConfig.rag.search` and `.processor`: `default_top_k`, `score_threshold`, `include_citations`, `enable_reranking`, `reranker_model`, `reranker_top_k`.
  - If `enable_reranking` is set, it also creates `reranking_config` (maps `reranker_model` → `model_name`, `reranker_top_k` → `top_k_to_rerank`; keeps defaults when blank). Index-determining fields are never merged, the fingerprint stays unchanged, and it's a no-op when no legacy keys are set.

<sup>Written for commit 894bb039fc5b42157afe2a7ae5050c83dce0dd29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

