### PR TITLE
docs: User Guide scaffold (G0 — index, template, stubs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,9 @@ def _heavy_task(self):
 2. Implement the `name`, `description`, `parameters` properties and the async `execute(**kwargs)` method
 3. Register the instance via `ToolExecutor.register_tool()` (the singleton executor is obtained through `get_tool_executor()` in `tool_executor.py`); built-in registration is gated by the `[tools]` config section
 
+**UI changes:** PRs that change a screen's UI should update the matching
+`Docs/User_Guide/` page (or at least its "Verified against" stamp).
+
 ### Security Requirements
 
 - Validate all inputs via `input_validation.py`

--- a/Docs/User_Guide/_template.md
+++ b/Docs/User_Guide/_template.md
@@ -55,11 +55,9 @@ the [guide index](index.md))
 ## Capture recipe
 
 **Winner: Textual's built-in `App.save_screenshot()` SVG export**, driven
-headlessly through `run_test()`. This was the first of three candidates tried
-under the Step 1 timebox (tmux ANSI → rich SVG, and a textual-serve +
-Playwright PNG harness were the fallbacks) and it passed the fidelity bar on
-the first attempt, so the experiment stopped there — no need to try the other
-two.
+headlessly through `run_test()`. This approach passed the fidelity bar
+immediately under the Step 1 timebox, so the two fallback candidates (tmux ANSI → rich SVG, and a textual-serve +
+Playwright PNG harness) were never exercised.
 
 Fidelity bar: nav bar labels present and complete, box-drawing glyphs intact,
 theme colors rendered (not monochrome), no truncated right edge.
@@ -106,7 +104,7 @@ theme colors rendered (not monochrome), no truncated right edge.
 3. Run it against the scratch profile, writing straight into the page's image
    directory:
    ```bash
-   cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook   # repo root
+   cd "$(git rev-parse --show-toplevel)"   # your checkout of the branch being documented
    mkdir -p "Docs/User_Guide/images/<screen>"
    TLDW_CONFIG_PATH="$S/g0_profile/config.toml" \
      G0_CAPTURE_OUT="Docs/User_Guide/images/<screen>/<name>.svg" \

--- a/Docs/User_Guide/_template.md
+++ b/Docs/User_Guide/_template.md
@@ -95,7 +95,7 @@ theme colors rendered (not monochrome), no truncated right edge.
            # --- drive to the state being documented, e.g.: ---
            # await pilot.click("#some-nav-label")
            # await pilot.pause(0.5)
-           app.save_screenshot(os.environ["G0_CAPTURE_OUT"])
+           app.save_screenshot(os.environ["GUIDE_CAPTURE_OUT"])
 
    asyncio.run(main())
    EOF
@@ -107,7 +107,7 @@ theme colors rendered (not monochrome), no truncated right edge.
    cd "$(git rev-parse --show-toplevel)"   # your checkout of the branch being documented
    mkdir -p "Docs/User_Guide/images/<screen>"
    TLDW_CONFIG_PATH="$S/g0_profile/config.toml" \
-     G0_CAPTURE_OUT="Docs/User_Guide/images/<screen>/<name>.svg" \
+     GUIDE_CAPTURE_OUT="Docs/User_Guide/images/<screen>/<name>.svg" \
      .venv/bin/python "$S/capture_<screen>.py"
    ```
 
@@ -120,7 +120,11 @@ at 235×52; this recipe deliberately uses a smaller, fixed 200×50 so every
 page's captures are the same size. Verified during the Step 1 experiment
 that 200 columns does *not* clip the 13-item nav bar — every destination
 through "More: Ctrl+P" renders inside the frame. Always pass
-`size=(200, 50)` to `run_test()`.
+`size=(200, 50)` to `run_test()`. This margin is thin: at 200 columns the
+current 13-item nav bar has only about one column of slack before "More:
+Ctrl+P" gets clipped, so any future nav-label change (renamed/added/removed
+destination) needs a re-check against the fidelity bar for right-edge
+clipping.
 
 **Output path convention:** `Docs/User_Guide/images/<screen>/<name>.svg`,
 where `<screen>` is the same kebab-case slug used for that screen's guide

--- a/Docs/User_Guide/_template.md
+++ b/Docs/User_Guide/_template.md
@@ -1,0 +1,134 @@
+# Page template & authoring guide (not user-facing)
+
+Copy everything between the BEGIN/END markers into a new page and fill it in.
+Every page is written from a LIVE driving session: execute every claim and
+every how-to on-screen before writing it down.
+
+<!-- BEGIN TEMPLATE -->
+# <Screen> — <one-line purpose>
+
+## What this screen is for
+(2–4 sentences; when to reach for it)
+
+## Getting there
+(nav key/number, command palette entry, startup config)
+
+## Layout tour
+(capture + region-by-region walk; regions named exactly as labeled on screen)
+
+## Features & controls
+(reference table per region: control → what it does)
+
+## Common tasks
+(3–8 numbered step-by-step how-tos, imperative voice)
+
+## Keyboard & commands
+(table: key / slash command → action; SCREEN-SPECIFIC only — globals live in
+the [guide index](index.md))
+
+## Related settings & docs
+(Settings panes, config.toml keys, Docs/Features links)
+
+## Quirks & troubleshooting
+(honest limitations with backlog refs; common errors and their fixes)
+
+—
+*Verified against dev @ <short-sha> — <YYYY-MM-DD>*
+<!-- END TEMPLATE -->
+
+## Authoring rules
+
+- On-screen labels verbatim. No internal jargon (no "native id", "store",
+  "recompose").
+- No aspirational features. Limitations stated honestly with a backlog ref
+  where one exists.
+- Screen-specific keys only in "Keyboard & commands"; global keys live in
+  index.md.
+- Stub pages: first two sections + a "🚧 This page is a stub" banner + links
+  to any existing Docs/Features deep dive.
+- Form-heavy panes (chiefly Settings): self-describing form fields may be
+  summarized at field-group level; interactive/behavioral controls are always
+  enumerated individually.
+- Before the phase PR merges: re-check dev history for the documented
+  screen's modules; re-verify and re-stamp affected sections if it moved.
+
+## Capture recipe
+
+**Winner: Textual's built-in `App.save_screenshot()` SVG export**, driven
+headlessly through `run_test()`. This was the first of three candidates tried
+under the Step 1 timebox (tmux ANSI → rich SVG, and a textual-serve +
+Playwright PNG harness were the fallbacks) and it passed the fidelity bar on
+the first attempt, so the experiment stopped there — no need to try the other
+two.
+
+Fidelity bar: nav bar labels present and complete, box-drawing glyphs intact,
+theme colors rendered (not monochrome), no truncated right edge.
+
+1. Scratch profile (create once, reuse across every page's captures — never
+   point `TLDW_CONFIG_PATH` at a real profile):
+   ```bash
+   S=<scratch-root>            # any writable scratch dir, e.g. $TMPDIR/guide_capture
+   mkdir -p "$S/g0_profile"
+   cat > "$S/g0_profile/config.toml" <<'EOF'
+   [general]
+   users_name = "guide_g0"
+   default_tab = "chat"
+
+   [splash_screen]
+   enabled = false
+   EOF
+   ```
+
+2. Driver script — copy per page and add pilot actions (clicks, key presses,
+   `await pilot.pause(...)`) between entering `run_test()` and calling
+   `save_screenshot()` to drive to the state being documented:
+   ```bash
+   cat > "$S/capture_<screen>.py" <<'EOF'
+   """Drive the real app under run_test and export an SVG screenshot."""
+   import asyncio, os
+
+   if "TLDW_CONFIG_PATH" not in os.environ:
+       raise SystemExit("Refusing to run against the real profile: set TLDW_CONFIG_PATH")
+
+   async def main() -> None:
+       from tldw_chatbook.app import TldwCli
+       app = TldwCli()
+       async with app.run_test(size=(200, 50)) as pilot:
+           # --- drive to the state being documented, e.g.: ---
+           # await pilot.click("#some-nav-label")
+           # await pilot.pause(0.5)
+           app.save_screenshot(os.environ["G0_CAPTURE_OUT"])
+
+   asyncio.run(main())
+   EOF
+   ```
+
+3. Run it against the scratch profile, writing straight into the page's image
+   directory:
+   ```bash
+   cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook   # repo root
+   mkdir -p "Docs/User_Guide/images/<screen>"
+   TLDW_CONFIG_PATH="$S/g0_profile/config.toml" \
+     G0_CAPTURE_OUT="Docs/User_Guide/images/<screen>/<name>.svg" \
+     .venv/bin/python "$S/capture_<screen>.py"
+   ```
+
+4. Sanity-check before embedding: open the `.svg` in a browser, or thumbnail
+   it locally (macOS: `qlmanage -t -s 2458 -o /tmp/out file.svg`) and eyeball
+   it against the fidelity bar above.
+
+**Standard size: 200×50 cells.** The live nav survey (Task 1) drove the app
+at 235×52; this recipe deliberately uses a smaller, fixed 200×50 so every
+page's captures are the same size. Verified during the Step 1 experiment
+that 200 columns does *not* clip the 13-item nav bar — every destination
+through "More: Ctrl+P" renders inside the frame. Always pass
+`size=(200, 50)` to `run_test()`.
+
+**Output path convention:** `Docs/User_Guide/images/<screen>/<name>.svg`,
+where `<screen>` is the same kebab-case slug used for that screen's guide
+page (e.g. `console`, `library`) and `<name>` describes the specific view
+(e.g. `overview`, `get-started-card`).
+
+Demo-content rules: scratch profile only (TLDW_CONFIG_PATH), canned demo
+text, no personal data; local llama endpoint for live replies; delete the
+scratch data dir afterwards.

--- a/Docs/User_Guide/acp.md
+++ b/Docs/User_Guide/acp.md
@@ -13,4 +13,5 @@ Agents, Sessions, Runtimes, and Compatibility, scoped to Ready + Blocked.
 ## Getting there
 
 - Click **ACP** in the nav bar, or press **Ctrl+P** → "Switch to ACP".
-  (From most screens, you can also press **0**.)
+  (Pressing **0** can also work when no text field has focus — see the
+  [number-key note](index.md) in the index.)

--- a/Docs/User_Guide/acp.md
+++ b/Docs/User_Guide/acp.md
@@ -13,5 +13,4 @@ Agents, Sessions, Runtimes, and Compatibility, scoped to Ready + Blocked.
 ## Getting there
 
 - Click **ACP** in the nav bar, or press **Ctrl+P** → "Switch to ACP".
-  (Pressing **0** can also work when no text field has focus — see the
-  [number-key note](index.md) in the index.)
+  (Or press **Ctrl+0** from anywhere.)

--- a/Docs/User_Guide/acp.md
+++ b/Docs/User_Guide/acp.md
@@ -1,0 +1,16 @@
+# ACP — Agent Client Protocol agents, sessions, runtimes, diffs, and terminals
+
+> 🚧 **This page is a stub.** The full write-up is planned; the sections
+> below cover orientation only. See the [guide index](index.md).
+
+## What this screen is for
+
+ACP covers Agent Client Protocol interoperability: agent sessions,
+runtimes, diffs, and terminals (on-screen header: "ACP | Agent protocol
+sessions and runtimes | Runtime needed | Local/Remote"). Views include
+Agents, Sessions, Runtimes, and Compatibility, scoped to Ready + Blocked.
+
+## Getting there
+
+- Click **ACP** in the nav bar, or press **Ctrl+P** → "Switch to ACP".
+  (From most screens, you can also press **0**.)

--- a/Docs/User_Guide/artifacts.md
+++ b/Docs/User_Guide/artifacts.md
@@ -1,0 +1,16 @@
+# Artifacts — Generated outputs, bundles, reports, datasets, and Chatbooks
+
+> 🚧 **This page is a stub.** The full write-up is planned; the sections
+> below cover orientation only. See the [guide index](index.md).
+
+## What this screen is for
+
+Artifacts is where generated outputs collect: bundles, reports, datasets,
+drafts, exports, and Chatbooks. The on-screen filter bar lets you narrow
+by type (All, Chatbooks, Reports, Datasets, Drafts, Exports) and sort
+(default: Recent).
+
+## Getting there
+
+- Click **Artifacts** in the nav bar, or press **Ctrl+P** → "Switch to
+  Artifacts". (From most screens, you can also press **4**.)

--- a/Docs/User_Guide/artifacts.md
+++ b/Docs/User_Guide/artifacts.md
@@ -13,4 +13,5 @@ by type (All, Chatbooks, Reports, Datasets, Drafts, Exports) and sort
 ## Getting there
 
 - Click **Artifacts** in the nav bar, or press **Ctrl+P** → "Switch to
-  Artifacts". (From most screens, you can also press **4**.)
+  Artifacts". (Pressing **4** can also work when no text field has focus —
+  see the [number-key note](index.md) in the index.)

--- a/Docs/User_Guide/artifacts.md
+++ b/Docs/User_Guide/artifacts.md
@@ -13,5 +13,4 @@ by type (All, Chatbooks, Reports, Datasets, Drafts, Exports) and sort
 ## Getting there
 
 - Click **Artifacts** in the nav bar, or press **Ctrl+P** → "Switch to
-  Artifacts". (Pressing **4** can also work when no text field has focus —
-  see the [number-key note](index.md) in the index.)
+  Artifacts". (Or press **Ctrl+4** from anywhere.)

--- a/Docs/User_Guide/index.md
+++ b/Docs/User_Guide/index.md
@@ -87,4 +87,4 @@ screen's own page for its "Keyboard & commands" table.
   than duplicate them.
 
 —
-*Verified against dev @ 9af99aba — 2026-07-25*
+*Verified against dev @ 8975c9b8 — 2026-07-25*

--- a/Docs/User_Guide/index.md
+++ b/Docs/User_Guide/index.md
@@ -1,0 +1,78 @@
+# tldw_chatbook User Guide
+
+tldw_chatbook is a terminal (TUI) app for working with LLMs: chat with local
+or cloud providers, manage conversations/notes/media in a local library,
+run roleplay characters with lorebooks, schedule watchlists, and drive
+agent/tool workflows — all stored locally in SQLite.
+
+> This guide tracks the **dev** branch. Each page carries a
+> "Verified against dev @ `<sha>`" stamp; if your build is older, screens
+> may differ slightly.
+
+## Quick start — your first five minutes
+
+1. Install and launch — see the [README](../../README.md#installation).
+2. Open **Settings** (coming in G4) and set a provider + model (or point at
+   a local server).
+3. Press **2** to open **Console** (coming in G1) and send your first
+   message.
+4. Press **F1** anywhere for contextual help; **Ctrl+P** opens the command
+   palette.
+
+## The screens
+
+| Key | Screen | What it's for |
+|-----|--------|----------------|
+| 1 | Home (coming in G5) | Dashboard, notifications, status, and next actions. |
+| 2 | Console (coming in G1) | Live agent conversations, approvals, tools, RAG, and runs. |
+| 3 | Library (coming in G2) | Workspaces, source material, imports, notes, media, conversations, Study, flashcards, quizzes, and Search/RAG. |
+| 4 | [Artifacts](artifacts.md) 🚧 | Generated outputs, bundles, reports, datasets, and Chatbooks. |
+| 5 | Roleplay & Chat Dictionaries (coming in G3) | Characters, user profiles, dictionaries, and behavior profiles. |
+| 6 | [Watchlists](watchlists.md) 🚧 | Monitored sources, runs, alerts, and recovery. |
+| 7 | [Schedules](schedules.md) 🚧 | When jobs, watchlists, and workflows run. |
+| 8 | [Workflows](workflows.md) 🚧 | Reusable procedures, recipes, dry-runs, and outputs. |
+| 9 | [MCP](mcp.md) 🚧 | MCP servers, tools, permissions, auth, and audit. |
+| 0 | [ACP](acp.md) 🚧 | Agent Client Protocol agents, sessions, runtimes, diffs, and terminals. |
+| — | [Lab](lab.md) 🚧 | Opens the **Models** screen — providers, models, speech, and evaluation runs. |
+| — | [Logs](logs.md) 🚧 | Application logs and diagnostics. |
+| — | Settings (coming in G4) | Global app preferences, appearance, accounts, and storage. |
+
+Lab, Logs, and Settings have no dedicated number key — reach them by
+clicking the nav label or via the command palette (**Ctrl+P**).
+
+\* Number keys switch tabs from most screens right after launch, but not
+once a text field (composer, search box) — or in at least one observed
+case, another auto-focused widget — has focus; that keystroke is consumed
+by the field instead of the app shell. Click the nav label or use
+**Ctrl+P** as the dependable way to switch screens.
+
+## Global keyboard shortcuts
+
+| Key | Action |
+|-----|--------|
+| F1 | Open the current screen's shortcuts help (the list shown is screen-specific) |
+| Ctrl+P | Open the command palette — search and jump to any screen or command from anywhere |
+| Ctrl+Q | Quit the app |
+
+Everything else (F6/Shift+F6 pane-cycling, Enter/Ctrl+K/Ctrl+T in Console,
+and the single-letter mnemonics like `s`/`r`/`t` on Settings) is
+screen-specific — see that screen's own page for its "Keyboard &
+commands" table.
+
+## Where did … go? (legacy names)
+
+| Old name | Now lives in |
+|----------|--------------|
+| Notes | Library (coming in G2) |
+| Prompts | Library (coming in G2) |
+| Subscriptions | [Watchlists](watchlists.md) 🚧 |
+| Coding | Console (coming in G1) |
+| Conversations / CCP | Roleplay & Chat Dictionaries (coming in G3) |
+| LLM management | [Lab](lab.md) 🚧 |
+
+## Conventions
+
+- Keys are shown as `Ctrl+P`; slash commands as `/rewind`.
+- 🚧 marks stub pages awaiting a full write-up.
+- Deep dives live in [Docs/Features](../Features/); pages link out rather
+  than duplicate them.

--- a/Docs/User_Guide/index.md
+++ b/Docs/User_Guide/index.md
@@ -14,8 +14,7 @@ agent/tool workflows — all stored locally in SQLite.
 1. Install and launch — see the [README](../../README.md#installation).
 2. Open **Settings** (coming in G4) and set a provider + model (or point at
    a local server).
-3. Press **2** to open **Console** (coming in G1) and send your first
-   message.
+3. Open **Console** (coming in G1) by clicking "Console" in the nav bar, or use **Ctrl+P** → "Switch to Console"; then send your first message. (From most screens, you can also press **2**.)
 4. Press **F1** anywhere for contextual help; **Ctrl+P** opens the command
    palette.
 
@@ -33,14 +32,14 @@ agent/tool workflows — all stored locally in SQLite.
 | 8 | [Workflows](workflows.md) 🚧 | Reusable procedures, recipes, dry-runs, and outputs. |
 | 9 | [MCP](mcp.md) 🚧 | MCP servers, tools, permissions, auth, and audit. |
 | 0 | [ACP](acp.md) 🚧 | Agent Client Protocol agents, sessions, runtimes, diffs, and terminals. |
-| — | [Lab](lab.md) 🚧 | Opens the **Models** screen — providers, models, speech, and evaluation runs. |
+| — | [Lab](lab.md) 🚧 | Models, speech, and evaluation runs. |
 | — | [Logs](logs.md) 🚧 | Application logs and diagnostics. |
 | — | Settings (coming in G4) | Global app preferences, appearance, accounts, and storage. |
 
 Lab, Logs, and Settings have no dedicated number key — reach them by
 clicking the nav label or via the command palette (**Ctrl+P**).
 
-\* Number keys switch tabs from most screens right after launch, but not
+**Note:** Number keys switch tabs from most screens right after launch, but not
 once a text field (composer, search box) — or in at least one observed
 case, another auto-focused widget — has focus; that keystroke is consumed
 by the field instead of the app shell. Click the nav label or use
@@ -65,6 +64,7 @@ commands" table.
 |----------|--------------|
 | Notes | Library (coming in G2) |
 | Prompts | Library (coming in G2) |
+| Skills | Library ▸ Skills (coming in G2) |
 | Subscriptions | [Watchlists](watchlists.md) 🚧 |
 | Coding | Console (coming in G1) |
 | Conversations / CCP | Roleplay & Chat Dictionaries (coming in G3) |

--- a/Docs/User_Guide/index.md
+++ b/Docs/User_Guide/index.md
@@ -3,30 +3,37 @@
 tldw_chatbook is a terminal (TUI) app for working with LLMs: chat with local
 or cloud providers, manage conversations/notes/media in a local library,
 run roleplay characters with lorebooks, schedule watchlists, and drive
-agent/tool workflows — all stored locally in SQLite.
+agent/tool workflows — stored locally in SQLite by default (some surfaces
+can sync with a tldw server you configure).
 
-> This guide tracks the **dev** branch. Each page carries a
-> "Verified against dev @ `<sha>`" stamp; if your build is older, screens
-> may differ slightly.
+> This guide tracks the **dev** branch. Each fully written page carries a
+> "Verified against dev @ `<sha>`" stamp (stub pages are marked 🚧 instead);
+> if your build is older, screens may differ slightly.
 
 ## Quick start — your first five minutes
 
-1. Install and launch — see the [README](../../README.md#installation).
-2. Open **Settings** (coming in G4) and set a provider + model (or point at
-   a local server).
-3. Open **Console** (coming in G1) by clicking "Console" in the nav bar, or use **Ctrl+P** → "Switch to Console"; then send your first message. (From most screens, you can also press **2**.)
-4. Press **F1** anywhere for contextual help; **Ctrl+P** opens the command
-   palette.
+1. Install and launch — see the [README](../../README.md#installation). On
+   first launch, a "Get started" onboarding card appears and the composer
+   stays locked; sending unlocks once you've set up a provider in step 2.
+2. Open **Settings** (not yet written) — click **Settings** in the nav bar
+   (or **Ctrl+P** → "Switch to Settings") — and set a provider + model (or
+   point at a local server).
+3. Open **Console** (not yet written) by clicking "Console" in the nav bar,
+   or use **Ctrl+P** → "Switch to Console"; then send your first message.
+   (Pressing **2** can also work when no text field has focus — see the
+   number-key note below.)
+4. Press **F1** anywhere to open the current screen's keyboard-shortcuts
+   list; **Ctrl+P** opens the command palette.
 
 ## The screens
 
 | Key | Screen | What it's for |
 |-----|--------|----------------|
-| 1 | Home (coming in G5) | Dashboard, notifications, status, and next actions. |
-| 2 | Console (coming in G1) | Live agent conversations, approvals, tools, RAG, and runs. |
-| 3 | Library (coming in G2) | Workspaces, source material, imports, notes, media, conversations, Study, flashcards, quizzes, and Search/RAG. |
+| 1 | Home (not yet written) | Dashboard, notifications, status, and next actions. |
+| 2 | Console (not yet written) | Live agent conversations, approvals, tools, RAG, and runs. |
+| 3 | Library (not yet written) | Workspaces, source material, imports, notes, media, conversations, Study, flashcards, quizzes, and Search/RAG. |
 | 4 | [Artifacts](artifacts.md) 🚧 | Generated outputs, bundles, reports, datasets, and Chatbooks. |
-| 5 | Roleplay & Chat Dictionaries (coming in G3) | Characters, user profiles, dictionaries, and behavior profiles. |
+| 5 | Roleplay & Chat Dictionaries (not yet written) | Characters, user profiles, dictionaries, and behavior profiles. |
 | 6 | [Watchlists](watchlists.md) 🚧 | Monitored sources, runs, alerts, and recovery. |
 | 7 | [Schedules](schedules.md) 🚧 | When jobs, watchlists, and workflows run. |
 | 8 | [Workflows](workflows.md) 🚧 | Reusable procedures, recipes, dry-runs, and outputs. |
@@ -34,22 +41,24 @@ agent/tool workflows — all stored locally in SQLite.
 | 0 | [ACP](acp.md) 🚧 | Agent Client Protocol agents, sessions, runtimes, diffs, and terminals. |
 | — | [Lab](lab.md) 🚧 | Models, speech, and evaluation runs. |
 | — | [Logs](logs.md) 🚧 | Application logs and diagnostics. |
-| — | Settings (coming in G4) | Global app preferences, appearance, accounts, and storage. |
+| — | Settings (not yet written) | Global app preferences, appearance, accounts, and storage. |
 
 Lab, Logs, and Settings have no dedicated number key — reach them by
 clicking the nav label or via the command palette (**Ctrl+P**).
 
-**Note:** Number keys switch tabs from most screens right after launch, but not
-once a text field (composer, search box) — or in at least one observed
-case, another auto-focused widget — has focus; that keystroke is consumed
-by the field instead of the app shell. Click the nav label or use
-**Ctrl+P** as the dependable way to switch screens.
+**Note:** Number keys can switch tabs, but only when no text field
+(composer, search box) — or, in at least one observed case, another
+auto-focused widget — has focus; once something else has focus, that
+keystroke is consumed by the field instead of the app shell. They're most
+likely to work right after launch, before anything has grabbed focus.
+Click the nav label or use **Ctrl+P** as the dependable way to switch
+screens.
 
 ## Global keyboard shortcuts
 
 | Key | Action |
 |-----|--------|
-| F1 | Open the current screen's shortcuts help (the list shown is screen-specific) |
+| F1 | Open the current screen's keyboard-shortcuts list (content is screen-specific) |
 | Ctrl+P | Open the command palette — search and jump to any screen or command from anywhere |
 | Ctrl+Q | Quit the app |
 
@@ -62,13 +71,15 @@ commands" table.
 
 | Old name | Now lives in |
 |----------|--------------|
-| Notes | Library (coming in G2) |
-| Prompts | Library (coming in G2) |
-| Skills | Library ▸ Skills (coming in G2) |
+| Notes | Library ▸ Notes (not yet written) |
+| Prompts | Library ▸ Prompts (not yet written) |
+| Skills | Library ▸ Skills (not yet written) |
 | Subscriptions | [Watchlists](watchlists.md) 🚧 |
-| Coding | Console (coming in G1) |
-| Conversations / CCP | Roleplay & Chat Dictionaries (coming in G3) |
+| Coding | Console (not yet written) |
+| Conversations / CCP | Roleplay & Chat Dictionaries (not yet written) |
 | LLM management | [Lab](lab.md) 🚧 |
+| Research | Library (not yet written) |
+| Customize | Settings (not yet written) |
 
 ## Conventions
 
@@ -76,3 +87,6 @@ commands" table.
 - 🚧 marks stub pages awaiting a full write-up.
 - Deep dives live in [Docs/Features](../Features/); pages link out rather
   than duplicate them.
+
+—
+*Verified against dev @ 9af99aba — 2026-07-25*

--- a/Docs/User_Guide/index.md
+++ b/Docs/User_Guide/index.md
@@ -18,41 +18,38 @@ can sync with a tldw server you configure).
 2. Open **Settings** (not yet written) — click **Settings** in the nav bar
    (or **Ctrl+P** → "Switch to Settings") — and set a provider + model (or
    point at a local server).
-3. Open **Console** (not yet written) by clicking "Console" in the nav bar,
-   or use **Ctrl+P** → "Switch to Console"; then send your first message.
-   (Pressing **2** can also work when no text field has focus — see the
-   number-key note below.)
+3. Open **Console** (not yet written) — press **Ctrl+2**, click "Console"
+   in the nav bar, or use **Ctrl+P** → "Switch to Console"; then send your
+   first message.
 4. Press **F1** anywhere to open the current screen's keyboard-shortcuts
    list; **Ctrl+P** opens the command palette.
 
 ## The screens
 
-| Key | Screen | What it's for |
+| Hotkey | Screen | What it's for |
 |-----|--------|----------------|
-| 1 | Home (not yet written) | Dashboard, notifications, status, and next actions. |
-| 2 | Console (not yet written) | Live agent conversations, approvals, tools, RAG, and runs. |
-| 3 | Library (not yet written) | Workspaces, source material, imports, notes, media, conversations, Study, flashcards, quizzes, and Search/RAG. |
-| 4 | [Artifacts](artifacts.md) 🚧 | Generated outputs, bundles, reports, datasets, and Chatbooks. |
-| 5 | Roleplay & Chat Dictionaries (not yet written) | Characters, user profiles, dictionaries, and behavior profiles. |
-| 6 | [Watchlists](watchlists.md) 🚧 | Monitored sources, runs, alerts, and recovery. |
-| 7 | [Schedules](schedules.md) 🚧 | When jobs, watchlists, and workflows run. |
-| 8 | [Workflows](workflows.md) 🚧 | Reusable procedures, recipes, dry-runs, and outputs. |
-| 9 | [MCP](mcp.md) 🚧 | MCP servers, tools, permissions, auth, and audit. |
-| 0 | [ACP](acp.md) 🚧 | Agent Client Protocol agents, sessions, runtimes, diffs, and terminals. |
+| Ctrl+1 | Home (not yet written) | Dashboard, notifications, status, and next actions. |
+| Ctrl+2 | Console (not yet written) | Live agent conversations, approvals, tools, RAG, and runs. |
+| Ctrl+3 | Library (not yet written) | Workspaces, source material, imports, notes, media, conversations, Study, flashcards, quizzes, and Search/RAG. |
+| Ctrl+4 | [Artifacts](artifacts.md) 🚧 | Generated outputs, bundles, reports, datasets, and Chatbooks. |
+| Ctrl+5 | Roleplay & Chat Dictionaries (not yet written) | Characters, user profiles, dictionaries, and behavior profiles. |
+| Ctrl+6 | [Watchlists](watchlists.md) 🚧 | Monitored sources, runs, alerts, and recovery. |
+| Ctrl+7 | [Schedules](schedules.md) 🚧 | When jobs, watchlists, and workflows run. |
+| Ctrl+8 | [Workflows](workflows.md) 🚧 | Reusable procedures, recipes, dry-runs, and outputs. |
+| Ctrl+9 | [MCP](mcp.md) 🚧 | MCP servers, tools, permissions, auth, and audit. |
+| Ctrl+0 | [ACP](acp.md) 🚧 | Agent Client Protocol agents, sessions, runtimes, diffs, and terminals. |
 | — | [Lab](lab.md) 🚧 | Models, speech, and evaluation runs. |
 | — | [Logs](logs.md) 🚧 | Application logs and diagnostics. |
 | — | Settings (not yet written) | Global app preferences, appearance, accounts, and storage. |
 
-Lab, Logs, and Settings have no dedicated number key — reach them by
-clicking the nav label or via the command palette (**Ctrl+P**).
+Lab, Logs, and Settings have no hotkey — reach them by clicking the nav
+label or via the command palette (**Ctrl+P**).
 
-**Note:** Number keys can switch tabs, but only when no text field
-(composer, search box) — or, in at least one observed case, another
-auto-focused widget — has focus; once something else has focus, that
-keystroke is consumed by the field instead of the app shell. They're most
-likely to work right after launch, before anything has grabbed focus.
-Click the nav label or use **Ctrl+P** as the dependable way to switch
-screens.
+**Note:** The digit shown before each nav label is that screen's hotkey
+digit: press **Ctrl+digit** (Ctrl+1 … Ctrl+9, Ctrl+0) to switch to it from
+anywhere — the chord works even while a text field has focus. Bare digit
+keys are not navigation shortcuts (typing `2` in the composer just types
+"2"). Clicking the nav label and **Ctrl+P** work everywhere too.
 
 ## Global keyboard shortcuts
 
@@ -61,11 +58,12 @@ screens.
 | F1 | Open the current screen's keyboard-shortcuts list (content is screen-specific) |
 | Ctrl+P | Open the command palette — search and jump to any screen or command from anywhere |
 | Ctrl+Q | Quit the app |
+| Ctrl+1 … Ctrl+9, Ctrl+0 | Switch to the screen with that hotkey digit (see the nav map above) |
+| F6 / Shift+F6 | Cycle forward/backward through the current screen's panes (on screens without multiple panes it only shows a notice) |
 
-Everything else (F6/Shift+F6 pane-cycling, Enter/Ctrl+K/Ctrl+T in Console,
-and the single-letter mnemonics like `s`/`r`/`t` on Settings) is
-screen-specific — see that screen's own page for its "Keyboard &
-commands" table.
+Everything else (Enter/Ctrl+K/Ctrl+T in Console, and the single-letter
+mnemonics like `s`/`r`/`t` on Settings) is screen-specific — see that
+screen's own page for its "Keyboard & commands" table.
 
 ## Where did … go? (legacy names)
 

--- a/Docs/User_Guide/lab.md
+++ b/Docs/User_Guide/lab.md
@@ -1,0 +1,16 @@
+# Lab — Models, speech, and evaluation runs
+
+> 🚧 **This page is a stub.** The full write-up is planned; the sections
+> below cover orientation only. See the [guide index](index.md).
+
+## What this screen is for
+
+Lab is the nav label for Models, speech, and evaluation runs. Opening it
+lands on a screen titled **"Models"** ("Manage providers, models, and
+endpoints.") — its default sub-area; the other sub-areas (speech,
+evaluation runs) are reached from within that screen.
+
+## Getting there
+
+- Click **Lab** in the nav bar, or press **Ctrl+P** → "Switch to Lab".
+  There is no dedicated number key for Lab.

--- a/Docs/User_Guide/lab.md
+++ b/Docs/User_Guide/lab.md
@@ -13,4 +13,4 @@ evaluation runs) are reached from within that screen.
 ## Getting there
 
 - Click **Lab** in the nav bar, or press **Ctrl+P** → "Switch to Lab".
-  There is no dedicated number key for Lab.
+  There is no hotkey digit for Lab.

--- a/Docs/User_Guide/logs.md
+++ b/Docs/User_Guide/logs.md
@@ -11,4 +11,4 @@ Logs shows application logs and diagnostics (on-screen subtitle:
 ## Getting there
 
 - Click **Logs** in the nav bar, or press **Ctrl+P** → "Switch to Logs".
-  There is no dedicated number key for Logs.
+  There is no hotkey digit for Logs.

--- a/Docs/User_Guide/logs.md
+++ b/Docs/User_Guide/logs.md
@@ -1,0 +1,14 @@
+# Logs — Application logs and diagnostics
+
+> 🚧 **This page is a stub.** The full write-up is planned; the sections
+> below cover orientation only. See the [guide index](index.md).
+
+## What this screen is for
+
+Logs shows application logs and diagnostics (on-screen subtitle:
+"Application logs and diagnostics.").
+
+## Getting there
+
+- Click **Logs** in the nav bar, or press **Ctrl+P** → "Switch to Logs".
+  There is no dedicated number key for Logs.

--- a/Docs/User_Guide/mcp.md
+++ b/Docs/User_Guide/mcp.md
@@ -1,0 +1,16 @@
+# MCP — MCP servers, tools, permissions, auth, and audit
+
+> 🚧 **This page is a stub.** The full write-up is planned; the sections
+> below cover orientation only. See the [guide index](index.md).
+
+## What this screen is for
+
+MCP manages MCP servers, scoped tools, permissions, and audit readiness
+(on-screen subtitle: "Manage MCP servers, scoped tools, permissions, and
+audit readiness."). It's organized into four modes: Servers, Tools,
+Permissions, and Audit.
+
+## Getting there
+
+- Click **MCP** in the nav bar, or press **Ctrl+P** → "Switch to MCP".
+  (From most screens, you can also press **9**.)

--- a/Docs/User_Guide/mcp.md
+++ b/Docs/User_Guide/mcp.md
@@ -13,5 +13,4 @@ Permissions, and Audit.
 ## Getting there
 
 - Click **MCP** in the nav bar, or press **Ctrl+P** → "Switch to MCP".
-  (Pressing **9** can also work when no text field has focus — see the
-  [number-key note](index.md) in the index.)
+  (Or press **Ctrl+9** from anywhere.)

--- a/Docs/User_Guide/mcp.md
+++ b/Docs/User_Guide/mcp.md
@@ -13,4 +13,5 @@ Permissions, and Audit.
 ## Getting there
 
 - Click **MCP** in the nav bar, or press **Ctrl+P** → "Switch to MCP".
-  (From most screens, you can also press **9**.)
+  (Pressing **9** can also work when no text field has focus — see the
+  [number-key note](index.md) in the index.)

--- a/Docs/User_Guide/schedules.md
+++ b/Docs/User_Guide/schedules.md
@@ -13,5 +13,4 @@ panels for the Schedule Queue, Task Detail, and Inspector.
 ## Getting there
 
 - Click **Schedules** in the nav bar, or press **Ctrl+P** → "Switch to
-  Schedules". (Pressing **7** can also work when no text field has focus —
-  see the [number-key note](index.md) in the index.)
+  Schedules". (Or press **Ctrl+7** from anywhere.)

--- a/Docs/User_Guide/schedules.md
+++ b/Docs/User_Guide/schedules.md
@@ -1,0 +1,16 @@
+# Schedules — When jobs, watchlists, and workflows run
+
+> 🚧 **This page is a stub.** The full write-up is planned; the sections
+> below cover orientation only. See the [guide index](index.md).
+
+## What this screen is for
+
+Schedules controls when jobs, watchlists, and workflows run. The screen
+has no single on-screen title; it opens on a sync status bar (Local /
+Server, last pull/push) above **Queue** and **Conflicts** tabs, with
+panels for the Schedule Queue, Task Detail, and Inspector.
+
+## Getting there
+
+- Click **Schedules** in the nav bar, or press **Ctrl+P** → "Switch to
+  Schedules". (From most screens, you can also press **7**.)

--- a/Docs/User_Guide/schedules.md
+++ b/Docs/User_Guide/schedules.md
@@ -13,4 +13,5 @@ panels for the Schedule Queue, Task Detail, and Inspector.
 ## Getting there
 
 - Click **Schedules** in the nav bar, or press **Ctrl+P** → "Switch to
-  Schedules". (From most screens, you can also press **7**.)
+  Schedules". (Pressing **7** can also work when no text field has focus —
+  see the [number-key note](index.md) in the index.)

--- a/Docs/User_Guide/watchlists.md
+++ b/Docs/User_Guide/watchlists.md
@@ -5,12 +5,12 @@
 
 ## What this screen is for
 
-Watchlists tracks monitored sources, their runs, alerts, and recovery
-(on-screen header: "Watchlists | Monitored sources, runs, alerts,
-recovery | Mixed | Local/Server"). Storage is Mixed, local and server.
-This screen was previously called "Subscriptions."
+Watchlists tracks monitored sources, their runs, alerts, and recovery. The
+header shows "Watchlists | Monitored sources, runs, alerts, recovery |
+Mixed | Local/Server". This screen was previously called "Subscriptions."
 
 ## Getting there
 
 - Click **Watchlists** in the nav bar, or press **Ctrl+P** → "Switch to
-  Watchlists". (From most screens, you can also press **6**.)
+  Watchlists". (Pressing **6** can also work when no text field has focus —
+  see the [number-key note](index.md) in the index.)

--- a/Docs/User_Guide/watchlists.md
+++ b/Docs/User_Guide/watchlists.md
@@ -12,5 +12,4 @@ Mixed | Local/Server". This screen was previously called "Subscriptions."
 ## Getting there
 
 - Click **Watchlists** in the nav bar, or press **Ctrl+P** → "Switch to
-  Watchlists". (Pressing **6** can also work when no text field has focus —
-  see the [number-key note](index.md) in the index.)
+  Watchlists". (Or press **Ctrl+6** from anywhere.)

--- a/Docs/User_Guide/watchlists.md
+++ b/Docs/User_Guide/watchlists.md
@@ -1,0 +1,16 @@
+# Watchlists — Monitored sources, runs, alerts, and recovery
+
+> 🚧 **This page is a stub.** The full write-up is planned; the sections
+> below cover orientation only. See the [guide index](index.md).
+
+## What this screen is for
+
+Watchlists tracks monitored sources, their runs, alerts, and recovery
+(on-screen header: "Watchlists | Monitored sources, runs, alerts,
+recovery | Mixed | Local/Server"). Storage is Mixed, local and server.
+This screen was previously called "Subscriptions."
+
+## Getting there
+
+- Click **Watchlists** in the nav bar, or press **Ctrl+P** → "Switch to
+  Watchlists". (From most screens, you can also press **6**.)

--- a/Docs/User_Guide/workflows.md
+++ b/Docs/User_Guide/workflows.md
@@ -1,0 +1,16 @@
+# Workflows — Reusable procedures, recipes, dry-runs, and outputs
+
+> 🚧 **This page is a stub.** The full write-up is planned; the sections
+> below cover orientation only. See the [guide index](index.md).
+
+## What this screen is for
+
+Workflows manages reusable procedures: runs, dry-runs, and approvals
+(on-screen header: "Workflows | Procedures, runs, dry-runs, approvals |
+Local | Console handoff"). It's organized into modes: Recipes, Inputs,
+Steps, Dry Run, Approvals, and Outputs.
+
+## Getting there
+
+- Click **Workflows** in the nav bar, or press **Ctrl+P** → "Switch to
+  Workflows". (From most screens, you can also press **8**.)

--- a/Docs/User_Guide/workflows.md
+++ b/Docs/User_Guide/workflows.md
@@ -13,5 +13,4 @@ Steps, Dry Run, Approvals, and Outputs.
 ## Getting there
 
 - Click **Workflows** in the nav bar, or press **Ctrl+P** → "Switch to
-  Workflows". (Pressing **8** can also work when no text field has focus —
-  see the [number-key note](index.md) in the index.)
+  Workflows". (Or press **Ctrl+8** from anywhere.)

--- a/Docs/User_Guide/workflows.md
+++ b/Docs/User_Guide/workflows.md
@@ -13,4 +13,5 @@ Steps, Dry Run, Approvals, and Outputs.
 ## Getting there
 
 - Click **Workflows** in the nav bar, or press **Ctrl+P** → "Switch to
-  Workflows". (From most screens, you can also press **8**.)
+  Workflows". (Pressing **8** can also work when no text field has focus —
+  see the [number-key note](index.md) in the index.)

--- a/Docs/superpowers/plans/2026-07-25-user-guide-g0-scaffold.md
+++ b/Docs/superpowers/plans/2026-07-25-user-guide-g0-scaffold.md
@@ -1,0 +1,459 @@
+# User Guide G0 (Scaffold) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create the `Docs/User_Guide/` scaffold — index with Quick Start/nav map/global shortcuts/legacy pointers, the authoring template with a decided capture recipe, eight stub pages, the README link, and the CLAUDE.md maintenance hook — per the approved spec `Docs/superpowers/specs/2026-07-25-user-guide-by-screen-design.md`.
+
+**Architecture:** Pure-docs change plus two bounded investigations (live nav survey; capture-pipeline timebox). No app code changes. Everything lands on branch `claude/user-guide-program` (worktree `.claude/worktrees/console-branching`) and ships as one PR at the user merge gate.
+
+**Tech Stack:** Markdown; tmux-driven live app (`.venv/bin/python -m tldw_chatbook.app` with `TLDW_CONFIG_PATH` scratch profile); Textual SVG export OR textual-serve+Playwright PNG (decided in Task 2).
+
+## Global Constraints
+
+- Spec is authoritative: `Docs/superpowers/specs/2026-07-25-user-guide-by-screen-design.md`.
+- On-screen labels quoted verbatim; no internal jargon (no "native id", "store", "recompose").
+- No aspirational features; limitations carry backlog refs where they exist.
+- Stub pages = first two template sections + "🚧 This page is a stub" banner + Docs/Features links where relevant.
+- File names follow visible nav labels, lowercased/kebab-cased.
+- Every commit message ends with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- Run everything from the worktree root `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/console-branching` (background Bash resets cwd — re-`cd` in every shell block).
+- The live app writes real user data unless `TLDW_CONFIG_PATH` points at a scratch profile — ALWAYS use the scratch profile; delete `~/.local/share/tldw_cli/<scratch users_name>` afterwards.
+
+---
+
+### Task 1: Live nav survey (labels, screen titles, footers, RP&CD naming)
+
+**Files:**
+- Create: `/private/tmp/claude-501/-Users-macbook-dev-Documents-GitHub-tldw-chatbook/1d048b3f-6ca0-42a3-99c4-ad0cb7b73ac0/scratchpad/g0_survey.md` (working notes, NOT committed)
+
+**Interfaces:**
+- Produces: the verified nav inventory consumed by Tasks 3–5: exact nav-bar labels for all 13 destinations, each screen's on-screen title line, the footer key list per visited screen, the intersection = GLOBAL shortcuts set, and the resolved RP&CD expansion + chosen file naming (`roleplay.md` vs other).
+
+- [ ] **Step 1: Write the scratch profile config**
+
+```bash
+S=/private/tmp/claude-501/-Users-macbook-dev-Documents-GitHub-tldw-chatbook/1d048b3f-6ca0-42a3-99c4-ad0cb7b73ac0/scratchpad
+mkdir -p "$S/g0_profile"
+cat > "$S/g0_profile/config.toml" <<'EOF'
+[general]
+users_name = "guide_g0"
+default_tab = "chat"
+
+[splash_screen]
+enabled = false
+EOF
+```
+
+- [ ] **Step 2: Launch the app in tmux and confirm boot**
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/console-branching
+S=/private/tmp/claude-501/-Users-macbook-dev-Documents-GitHub-tldw-chatbook/1d048b3f-6ca0-42a3-99c4-ad0cb7b73ac0/scratchpad
+tmux -L g0 kill-server 2>/dev/null
+tmux -L g0 new-session -d -x 235 -y 52 "TLDW_CONFIG_PATH=$S/g0_profile/config.toml .venv/bin/python -m tldw_chatbook.app"
+sleep 14
+tmux -L g0 capture-pane -p | head -3
+```
+
+Expected: nav bar line showing `1 Home │ 2 Console │ 3 Library …`.
+
+- [ ] **Step 3: Record the full nav bar and Console footer**
+
+```bash
+tmux -L g0 capture-pane -p | sed -n '1,3p'  >> "$S/g0_survey.md"
+tmux -L g0 capture-pane -p | tail -3        >> "$S/g0_survey.md"
+```
+
+- [ ] **Step 4: Visit each of the 13 destinations; record title + footer for each**
+
+Navigation: click each nav label with an SGR click pair sent to row 2 at the label's column (find COL from a fresh `capture-pane` dump; click = `tmux -L g0 send-keys -l $'\x1b[<0;COL;2M'` then the same with `m`). Locate the label column and click IN ONE Bash invocation (atomic locate+click — separate calls drift). For each screen append to `$S/g0_survey.md`: the nav label, the screen's own title/header line, and the footer line.
+
+Special attention on **RP&CD**: record the full screen title/header text — this resolves the page/directory name. Also record LAB, LOGS, SETTINGS (they have no number key — note how they open).
+
+- [ ] **Step 5: Derive the global-shortcuts set**
+
+In `$S/g0_survey.md`, list footer keys seen on EVERY visited screen (the intersection) as GLOBAL; everything else is screen-specific. Explicitly check: `F6`/`Shift+F6`, `F1`, `Ctrl+P`, number keys `1–0`.
+
+- [ ] **Step 6: Extract the legacy-route alias table from code**
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/console-branching
+.venv/bin/python -c "
+from tldw_chatbook.UI.Navigation import screen_registry as sr
+for alias, target in sorted(sr._SCREEN_ALIASES.items()):
+    print(f'{alias} -> {target}')
+" >> /private/tmp/claude-501/-Users-macbook-dev-Documents-GitHub-tldw-chatbook/1d048b3f-6ca0-42a3-99c4-ad0cb7b73ac0/scratchpad/g0_survey.md
+```
+
+Expected: at least `notes -> library`, `prompts -> library`, `subscriptions -> watchlists_collections`, plus TAB_CCP/TAB_LLM entries.
+
+- [ ] **Step 7: Quit the app; decide and record the RP&CD file naming**
+
+```bash
+tmux -L g0 send-keys C-q; sleep 3; tmux -L g0 kill-server 2>/dev/null
+```
+
+In `$S/g0_survey.md` write one line: `RP&CD naming decision: <file/dir name> because on-screen title is "<verbatim>"`. Rule from spec: match what users see, lowercased/kebab-cased; if the title is just "RP&CD", use its expanded form from the screen header; if genuinely only "RP&CD" appears anywhere, use `rp-and-cd`.
+
+(No commit — survey notes are scratchpad-only. The next tasks consume them.)
+
+### Task 2: Capture-recipe timebox (SVG attempt → PNG fallback) + `_template.md`
+
+**Files:**
+- Create: `Docs/User_Guide/_template.md`
+- Create: `Docs/User_Guide/images/.gitkeep`
+
+**Interfaces:**
+- Consumes: nothing from Task 1 (independent).
+- Produces: the decided capture recipe (format + exact commands) inside `_template.md`; later phases follow it verbatim.
+
+- [ ] **Step 1: Timeboxed SVG attempt (max ~30 minutes wall clock)**
+
+Try, in order, stopping at the first that yields a faithful full-screen image of the running app:
+
+(a) Textual built-in export — check availability, then drive it:
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/console-branching
+grep -rn "save_screenshot\|deliver_screenshot" .venv/lib/python3.12/site-packages/textual/app.py | head -5
+```
+If `save_screenshot` exists (it does in Textual 8.x), test SVG export headlessly with a pilot script:
+```bash
+S=/private/tmp/claude-501/-Users-macbook-dev-Documents-GitHub-tldw-chatbook/1d048b3f-6ca0-42a3-99c4-ad0cb7b73ac0/scratchpad
+cat > "$S/svg_probe.py" <<'EOF'
+"""Probe: boot the real app under run_test and export an SVG screenshot."""
+import asyncio, os
+
+if "TLDW_CONFIG_PATH" not in os.environ:
+    raise SystemExit("Refusing to run against the real profile: set TLDW_CONFIG_PATH")
+
+async def main() -> None:
+    from tldw_chatbook.app import TldwCli
+    app = TldwCli()
+    async with app.run_test(size=(200, 50)):
+        app.save_screenshot(os.environ["G0_PROBE_OUT"])
+
+asyncio.run(main())
+EOF
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/console-branching
+TLDW_CONFIG_PATH="$S/g0_profile/config.toml" G0_PROBE_OUT="$S/g0_probe.svg" .venv/bin/python "$S/svg_probe.py" && ls -la "$S/g0_probe.svg"
+```
+Inspect the SVG (open in browser or read the text) — accept only if the full screen renders faithfully (theme colors, box glyphs intact).
+
+(b) If (a) fails: tmux ANSI → rich SVG:
+```bash
+tmux -L g0 capture-pane -e -p > "$S/screen.ansi"
+.venv/bin/python -c "
+from rich.console import Console
+c = Console(record=True, width=235)
+with open('$S/screen.ansi') as f:
+    c.print_ansi = getattr(c, 'print_ansi', None)
+    text = f.read()
+from rich.text import Text
+c.print(Text.from_ansi(text))
+c.save_svg('$S/screen.svg', title='tldw_chatbook')
+"
+```
+Accept under the same fidelity bar.
+
+(c) If both fail within the timebox: PNG via the proven textual-serve + Playwright harness (templates in the session scratchpad `harness/` folder per the UX-review program; browser page screenshot at a fixed viewport). Record which option won and why in the recipe.
+
+- [ ] **Step 2: Write `Docs/User_Guide/_template.md`**
+
+Content — the spec's template plus authoring rules plus the WINNING recipe from Step 1 (replace the `<capture recipe>` block with the actual commands that worked, and state the standard size chosen — use the size that rendered best in Step 1, candidate 200×50):
+
+```markdown
+# Page template & authoring guide (not user-facing)
+
+Copy everything between the BEGIN/END markers into a new page and fill it in.
+Every page is written from a LIVE driving session: execute every claim and
+every how-to on-screen before writing it down.
+
+<!-- BEGIN TEMPLATE -->
+# <Screen> — <one-line purpose>
+
+## What this screen is for
+(2–4 sentences; when to reach for it)
+
+## Getting there
+(nav key/number, command palette entry, startup config)
+
+## Layout tour
+(capture + region-by-region walk; regions named exactly as labeled on screen)
+
+## Features & controls
+(reference table per region: control → what it does)
+
+## Common tasks
+(3–8 numbered step-by-step how-tos, imperative voice)
+
+## Keyboard & commands
+(table: key / slash command → action; SCREEN-SPECIFIC only — globals live in
+the [guide index](index.md))
+
+## Related settings & docs
+(Settings panes, config.toml keys, Docs/Features links)
+
+## Quirks & troubleshooting
+(honest limitations with backlog refs; common errors and their fixes)
+
+—
+*Verified against dev @ <short-sha> — <YYYY-MM-DD>*
+<!-- END TEMPLATE -->
+
+## Authoring rules
+
+- On-screen labels verbatim. No internal jargon (no "native id", "store",
+  "recompose").
+- No aspirational features. Limitations stated honestly with a backlog ref
+  where one exists.
+- Screen-specific keys only in "Keyboard & commands"; global keys live in
+  index.md.
+- Stub pages: first two sections + a "🚧 This page is a stub" banner + links
+  to any existing Docs/Features deep dive.
+- Form-heavy panes (chiefly Settings): self-describing form fields may be
+  summarized at field-group level; interactive/behavioral controls are always
+  enumerated individually.
+- Before the phase PR merges: re-check dev history for the documented
+  screen's modules; re-verify and re-stamp affected sections if it moved.
+
+## Capture recipe
+
+<the exact winning commands from Task 2 Step 1: scratch profile setup,
+launch, drive-to-state notes, export command, standard size, output path
+convention Docs/User_Guide/images/<screen>/<name>.<ext>>
+
+Demo-content rules: scratch profile only (TLDW_CONFIG_PATH), canned demo
+text, no personal data; local llama endpoint for live replies; delete the
+scratch data dir afterwards.
+```
+
+- [ ] **Step 3: Verify and commit**
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/console-branching
+ls Docs/User_Guide/_template.md Docs/User_Guide/images/.gitkeep
+grep -c "BEGIN TEMPLATE" Docs/User_Guide/_template.md   # expect 1
+grep -n "TBD\|TODO\|<the exact winning" Docs/User_Guide/_template.md  # expect NO matches (recipe filled in)
+git add Docs/User_Guide/_template.md Docs/User_Guide/images/.gitkeep
+git commit -m "docs(guide): authoring template + decided capture recipe (G0)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+### Task 3: `index.md`
+
+**Files:**
+- Create: `Docs/User_Guide/index.md`
+
+**Interfaces:**
+- Consumes: Task 1's survey (nav labels, screen one-liners, global shortcuts, legacy aliases, RP&CD naming).
+- Produces: the guide's front door; every other page links back to it as `index.md`.
+
+- [ ] **Step 1: Write `Docs/User_Guide/index.md`**
+
+Structure (fill the bracketed slots from `g0_survey.md` — every table row must match the live survey verbatim; do not invent):
+
+```markdown
+# tldw_chatbook User Guide
+
+tldw_chatbook is a terminal (TUI) app for working with LLMs: chat with local
+or cloud providers, manage conversations/notes/media in a local library,
+run roleplay characters with lorebooks, schedule watchlists, and drive
+agent/tool workflows — all stored locally in SQLite.
+
+> This guide tracks the **dev** branch. Each page carries a
+> "Verified against dev @ <sha>" stamp; if your build is older, screens may
+> differ slightly.
+
+## Quick start — your first five minutes
+
+1. Install and launch — see the [README](../../README.md#installation).
+2. Open **Settings** (…as recorded in survey…) and set a provider + model
+   (or point at a local server). <link to settings.md#provider-setup>
+3. Press **2** to open **Console** and send your first message.
+   <link to console.md>
+4. Press **F1** anywhere for contextual help; **Ctrl+P** opens the command
+   palette.
+
+## The screens
+
+| Key | Screen | What it's for |
+|----|--------|----------------|
+| 1 | [Home](home.md) | <one-liner from survey> |
+| 2 | [Console](console.md) | <one-liner> |
+| 3 | [Library](library.md) | <one-liner> |
+| … | … (all 13 rows, stub pages linked too, 🚧 marked) | |
+
+## Global keyboard shortcuts
+
+| Key | Action |
+|-----|--------|
+| <rows = the INTERSECTION set from the survey — globals only> | |
+
+## Where did … go? (legacy names)
+
+| Old name | Now lives in |
+|----------|--------------|
+| Notes | [Library ▸ Notes](library.md) |
+| Prompts | [Library ▸ Prompts](library.md) |
+| Subscriptions | [Watchlists](watchlists.md) |
+| <remaining rows from the alias table, user-recognizable names only> | |
+
+## Conventions
+
+- Keys are shown as `Ctrl+P`; slash commands as `/rewind`.
+- 🚧 marks stub pages awaiting a full write-up.
+- Deep dives live in [Docs/Features](../Features/); pages link out rather
+  than duplicate them.
+```
+
+- [ ] **Step 2: Verify links resolve and commit**
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/console-branching
+.venv/bin/python - <<'EOF'
+import re, pathlib
+page = pathlib.Path("Docs/User_Guide/index.md")
+base = page.parent
+bad = []
+for target in re.findall(r"\]\(([^)#]+)(?:#[^)]*)?\)", page.read_text()):
+    if target.startswith("http"):
+        continue
+    if not (base / target).exists():
+        bad.append(target)
+print("BROKEN:", bad)
+EOF
+```
+Expected: `BROKEN: []` — note deep-page targets (console.md etc.) do NOT exist yet in G0; link the stubs that DO exist, and write not-yet-written deep pages as plain text with "(coming in G1)" instead of links. Re-run until empty.
+
+```bash
+git add Docs/User_Guide/index.md
+git commit -m "docs(guide): index — quick start, nav map, global shortcuts, legacy pointers (G0)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+### Task 4: Eight stub pages
+
+**Files:**
+- Create: `Docs/User_Guide/artifacts.md`, `watchlists.md`, `schedules.md`, `workflows.md`, `mcp.md`, `acp.md`, `lab.md`, `logs.md`
+
+**Interfaces:**
+- Consumes: Task 1's survey (each screen's one-liner + how to open it); Task 2's stub rules.
+- Produces: link targets for index.md's nav map.
+
+- [ ] **Step 1: Write all eight stubs from the shared skeleton**
+
+Skeleton (fill both sections from the survey; keep each file under ~25 lines):
+
+```markdown
+# <Screen> — <one-line purpose from survey>
+
+> 🚧 **This page is a stub.** The full write-up is planned; the sections
+> below cover orientation only. See the [guide index](index.md).
+
+## What this screen is for
+
+<2–4 verified sentences>
+
+## Getting there
+
+- Press **<key>** from anywhere (or: open via **Ctrl+P** → "<palette name>").
+
+<optional: "Deep dive: [<title>](../Features/<file>.md)" where one exists —
+e.g. watchlists → SUBSCRIPTION_IMPLEMENTATION_PLAN is internal, skip;
+speech/transcription links belong to future media pages, not these stubs>
+```
+
+- [ ] **Step 2: Verify and commit**
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/console-branching
+ls Docs/User_Guide/{artifacts,watchlists,schedules,workflows,mcp,acp,lab,logs}.md
+grep -L "🚧" Docs/User_Guide/{artifacts,watchlists,schedules,workflows,mcp,acp,lab,logs}.md  # expect NO output
+git add Docs/User_Guide/*.md
+git commit -m "docs(guide): stub pages for the eight non-deep screens (G0)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+### Task 5: README link + CLAUDE.md maintenance hook
+
+**Files:**
+- Modify: `README.md` (immediately after the opening description, before "Project Status")
+- Modify: `CLAUDE.md` (in "Development Guidelines")
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: discoverability + the refresh hook required by the spec.
+
+- [ ] **Step 1: Add the README link**
+
+Insert after the first paragraph of `README.md`:
+
+```markdown
+> 📖 **New here?** The [User Guide](Docs/User_Guide/index.md) walks through
+> every screen — what it does and how to use it.
+```
+
+- [ ] **Step 2: Add the CLAUDE.md hook**
+
+Insert as the last bullet of "### Adding Features" in `CLAUDE.md`:
+
+```markdown
+- **UI changes:** PRs that change a screen's UI should update the matching
+  `Docs/User_Guide/` page (or at least its "Verified against" stamp).
+```
+
+- [ ] **Step 3: Verify and commit**
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/console-branching
+grep -n "User Guide" README.md | head -2
+grep -n "Docs/User_Guide" CLAUDE.md | head -2
+git add README.md CLAUDE.md
+git commit -m "docs(guide): README entry point + CLAUDE.md maintenance hook (G0)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+### Task 6: Whole-scaffold check + PR
+
+**Files:**
+- None new (verification + PR only).
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: PR at the user merge gate.
+
+- [ ] **Step 1: Full link sweep across the guide**
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/console-branching
+.venv/bin/python - <<'EOF'
+import re, pathlib
+bad = []
+for page in pathlib.Path("Docs/User_Guide").glob("*.md"):
+    for target in re.findall(r"\]\(([^)#]+)(?:#[^)]*)?\)", page.read_text()):
+        if target.startswith("http"):
+            continue
+        if not (page.parent / target).exists():
+            bad.append(f"{page.name}: {target}")
+print("BROKEN:", bad)
+EOF
+```
+Expected: `BROKEN: []`.
+
+- [ ] **Step 2: Spec-conformance sweep**
+
+Check against the spec's G0 bullet: index (Quick Start + globals) ✓, _template (template + decided recipe) ✓, eight stubs ✓, README link ✓, CLAUDE.md hook ✓, RP&CD naming recorded ✓ (the decision line from Task 1 goes into the PR body). Fix anything missing before the PR.
+
+- [ ] **Step 3: Push and open the PR (leave at user gate)**
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/console-branching
+git push -u origin claude/user-guide-program
+gh pr create --base dev --title "docs: User Guide scaffold (G0 — index, template, stubs)" --body "<summary of the six deliverables, the RP&CD naming decision + evidence, the capture-recipe decision (SVG vs PNG + why), spec + plan links; footer: 🤖 Generated with [Claude Code](https://claude.com/claude-code)>"
+```
+
+Do NOT merge — user gate.

--- a/Docs/superpowers/specs/2026-07-25-user-guide-by-screen-design.md
+++ b/Docs/superpowers/specs/2026-07-25-user-guide-by-screen-design.md
@@ -39,8 +39,12 @@ README, `FAQs.md`, and eight deep-dive docs in `Docs/Features/`.
 
 ```
 Docs/User_Guide/
-  index.md                         # app intro, nav map, conventions, stub notice,
-                                   # legacy-route pointers ("Notes → Library ▸ Notes")
+  index.md                         # app intro, Quick Start (first five minutes:
+                                   # launch -> provider setup -> first chat), nav map,
+                                   # GLOBAL shortcuts table (F6, Ctrl+P, number-key nav),
+                                   # conventions ("guide tracks the dev branch"),
+                                   # stub notice, legacy-route pointers
+                                   # ("Notes → Library ▸ Notes")
   _template.md                     # canonical page template + capture recipe (authoring aid)
   images/<screen>/*.svg            # fresh captures, one folder per screen
   home.md
@@ -69,6 +73,11 @@ on-screen expansion in the live app and name the page/directory to match what
 users actually see (candidate: `roleplay.md` + `roleplay/`). File names
 otherwise follow visible nav labels, lowercased/kebab-cased.
 
+**Child-page lists above are PROVISIONAL.** They were drafted from program
+memory, not a live survey. Every phase (G1–G5) begins with a live IA survey
+of the actual screen; the survey's sub-surface inventory wins over this
+spec's tree, and the phase plan records any delta.
+
 ## Page template (fixed section order)
 
 ```markdown
@@ -80,7 +89,8 @@ otherwise follow visible nav labels, lowercased/kebab-cased.
                                  exactly as labeled on screen)
 ## Features & controls          (reference table per region: control → what it does)
 ## Common tasks                 (3–8 numbered step-by-step how-tos, imperative voice)
-## Keyboard & commands          (table: key / slash command → action)
+## Keyboard & commands          (table: key / slash command → action;
+                                 SCREEN-SPECIFIC only — globals live in index.md)
 ## Related settings & docs      (Settings panes, config.toml keys, Docs/Features links)
 ## Quirks & troubleshooting     (honest limitations with backlog refs, common errors
                                  and their fixes)
@@ -104,11 +114,14 @@ Authoring rules:
   content, no personal data; local llama endpoint when a live reply is needed.
 - One standard terminal size for all captures (fixed in `_template.md` during
   G0 after checking what renders best; candidate 200×50).
-- SVG preferred (crisp, diffable, text-searchable); the exact end-to-end
-  recipe (launch command, profile, sizing, export mechanism) is written into
-  `_template.md` in G0 so refreshing a stale image is minutes, not
-  archaeology. Capture tooling reuses the existing verification harness
-  (tmux / textual-serve pipeline already used for UX reviews).
+- Format: SVG preferred (crisp, diffable, text-searchable) — but the SVG
+  pipeline is UNPROVEN here. G0 gives it ONE timeboxed attempt (Textual's
+  own SVG export, or tmux ANSI -> rich `export_svg`); if it does not work
+  cleanly, fall back without ceremony to PNG via the PROVEN
+  textual-serve + Playwright harness used by the UX-review program. The
+  chosen recipe (launch command, profile, sizing, export mechanism) is
+  written into `_template.md` in G0 so refreshing a stale image is minutes,
+  not archaeology.
 
 ## Cross-linking and de-duplication
 
@@ -124,11 +137,16 @@ Authoring rules:
 
 ## Phasing (six PRs, each at the user merge gate)
 
-- **G0 — scaffold:** `index.md`, `_template.md` (template + capture recipe),
-  all eight stub pages, README link, RP&CD naming resolved. No captures.
+- **G0 — scaffold:** `index.md` (incl. Quick Start + global shortcuts),
+  `_template.md` (template + capture recipe, incl. the timeboxed SVG-vs-PNG
+  decision), all eight stub pages, README link, RP&CD naming resolved, and a
+  one-line maintenance hook in CLAUDE.md ("UI-changing PRs should update the
+  matching Docs/User_Guide page or its stamp"). No captures.
 - **G1 — Console:** `console.md` + five child pages + captures. (Largest;
   Console is where every new user lands and where the most undocumented
-  capability sits.)
+  capability sits.) The phase plan MAY split this into two PRs (parent +
+  chat-basics, then the four deeper children) if the single-PR review load
+  looks too heavy.
 - **G2 — Library:** `library.md` + five child pages.
 - **G3 — RP&CD:** parent + three child pages.
 - **G4 — Settings:** `settings.md`.
@@ -139,11 +157,18 @@ Authoring rules:
 
 1. Every control visible on the screen appears in *Features & controls*
    (swept against the live screen during the verification session).
+   Exception for form-heavy panes (chiefly Settings): self-describing form
+   fields may be summarized at field-group level; interactive/behavioral
+   controls are always enumerated individually.
 2. Every *Common task* was executed end-to-end live before being written.
 3. All links resolve; captures render; the verification stamp is present.
 4. No claim contradicts current dev behavior; known limitations carry backlog
    refs.
 5. Terminology matches on-screen labels exactly.
+6. Merge-time drift check: before the phase PR merges, confirm dev has not
+   changed the documented screen since the verification session (diff dev
+   history for the screen's modules); re-verify and re-stamp affected
+   sections if it has. (Concurrent sessions merge UI changes here daily.)
 
 ## Non-goals
 

--- a/Docs/superpowers/specs/2026-07-25-user-guide-by-screen-design.md
+++ b/Docs/superpowers/specs/2026-07-25-user-guide-by-screen-design.md
@@ -1,0 +1,154 @@
+# User Guide, screen-by-screen — design
+
+Date: 2026-07-25
+Status: approved (brainstorm 2026-07-25, delivery/scope/template/captures/accuracy
+decided by the user; Approach A structure + Console-first ordering approved)
+
+## Goal
+
+Give tldw_chatbook a real user guide: a `Docs/User_Guide/` tree where each
+screen (and each major sub-screen of the composite screens) has its own page
+describing what it is for, what every visible feature/control does, and how to
+accomplish common tasks on it. Today no user guide exists — `Docs/` is
+developer-facing, and the only user-facing material is the install-centric
+README, `FAQs.md`, and eight deep-dive docs in `Docs/Features/`.
+
+## Decisions (user-locked)
+
+- **D1 Delivery:** in-repo Markdown under a new `Docs/User_Guide/` directory,
+  one file per screen with an `index.md`, linked prominently from the README.
+  No docs site, no in-app Help wiring in this program (both are explicit
+  non-goals; the per-screen file layout keeps them cheap to add later).
+- **D2 Scope:** deep pages for the five core screens — **Home, Console,
+  Library, RP&CD (Roleplay), Settings** — and real-but-tiny stub pages for the
+  other eight nav destinations (Artifacts, Watchlists, Schedules, Workflows,
+  MCP, ACP, Lab, Logs). Legacy/hidden route names get "now lives in…" pointers
+  in the index only.
+- **D3 Page shape:** one fixed hybrid template per page (reference AND
+  task-oriented; section list below).
+- **D4 Screenshots:** fresh captures of current dev taken by the author in the
+  same verification session as the prose, stored under
+  `Docs/User_Guide/images/<screen>/`. The reproducible capture recipe is
+  documented in `_template.md`.
+- **D5 Accuracy:** every page is written from a live driving session of the
+  real app; every claim and every how-to is executed on-screen before being
+  written down; each page footer carries
+  `Verified against dev @ <short-sha> — <YYYY-MM-DD>`.
+
+## Structure (Approach A: parent page + child pages for composite screens)
+
+```
+Docs/User_Guide/
+  index.md                         # app intro, nav map, conventions, stub notice,
+                                   # legacy-route pointers ("Notes → Library ▸ Notes")
+  _template.md                     # canonical page template + capture recipe (authoring aid)
+  images/<screen>/*.svg            # fresh captures, one folder per screen
+  home.md
+  console.md                       # orientation, layout tour, sessions/tabs/workspaces
+  console/chat-basics.md           # send/stream/stop, message actions, selection, keyboard
+  console/branching-and-rewind.md  # regenerate/swipe siblings, Edit & resend, /rewind menu
+  console/attachments-and-images.md# attach/paste, inline images, image generation, speak/TTS
+  console/agent-runs.md            # agent mode, tool markers, approvals, skills, MCP tools
+  console/context-and-rag.md       # inspector/next-send preview, RAG scoping, prefill,
+                                   # dictionaries & world books in the payload
+  library.md
+  library/notes.md
+  library/media.md
+  library/skills.md
+  library/prompts.md
+  library/collections.md
+  <roleplay>.md + <roleplay>/{characters,lorebooks,chat-dictionaries}.md
+  settings.md                      # one page, one section per pane (split later only if
+                                   # a pane outgrows it)
+  artifacts.md  watchlists.md  schedules.md  workflows.md
+  mcp.md  acp.md  lab.md  logs.md  # stubs with a visible "🚧 stub" banner
+```
+
+Open naming item (resolve in G0): the nav label is "RP&CD" — confirm its
+on-screen expansion in the live app and name the page/directory to match what
+users actually see (candidate: `roleplay.md` + `roleplay/`). File names
+otherwise follow visible nav labels, lowercased/kebab-cased.
+
+## Page template (fixed section order)
+
+```markdown
+# <Screen> — <one-line purpose>
+
+## What this screen is for      (2–4 sentences; when to reach for it)
+## Getting there                (nav key/number, command palette, startup config)
+## Layout tour                  (capture + region-by-region walk, regions named
+                                 exactly as labeled on screen)
+## Features & controls          (reference table per region: control → what it does)
+## Common tasks                 (3–8 numbered step-by-step how-tos, imperative voice)
+## Keyboard & commands          (table: key / slash command → action)
+## Related settings & docs      (Settings panes, config.toml keys, Docs/Features links)
+## Quirks & troubleshooting     (honest limitations with backlog refs, common errors
+                                 and their fixes)
+
+—
+*Verified against dev @ <short-sha> — <date>*
+```
+
+Authoring rules:
+- On-screen labels quoted verbatim; no internal jargon (no "native id",
+  "store", "recompose").
+- No aspirational features. Limitations stated honestly with a backlog ref
+  where one exists (e.g. `/rewind` restore-to-before-first does not survive an
+  app restart — task-574).
+- Stub pages use only the first two template sections plus a "🚧 This page is
+  a stub" banner and links to any existing `Docs/Features/` deep dive.
+
+## Captures
+
+- Scratch profile (`TLDW_CONFIG_PATH`, throwaway `users_name`), canned demo
+  content, no personal data; local llama endpoint when a live reply is needed.
+- One standard terminal size for all captures (fixed in `_template.md` during
+  G0 after checking what renders best; candidate 200×50).
+- SVG preferred (crisp, diffable, text-searchable); the exact end-to-end
+  recipe (launch command, profile, sizing, export mechanism) is written into
+  `_template.md` in G0 so refreshing a stale image is minutes, not
+  archaeology. Capture tooling reuses the existing verification harness
+  (tmux / textual-serve pipeline already used for UX reviews).
+
+## Cross-linking and de-duplication
+
+- `Docs/Features/*` remain the deep dives. Guide pages give 2–3 orienting
+  sentences and link out; they never duplicate deep-dive content.
+- `FAQs.md` entries that are really screen how-tos migrate into the relevant
+  page; genuine FAQs stay put.
+- README gains a prominent "📖 User Guide" link near the top.
+- `index.md` carries a legacy-route table (notes, prompts, subscriptions,
+  coding, …) pointing at the surviving screen.
+- Child pages cross-link laterally where behavior spans pages (e.g.
+  branching page ↔ context page for what regenerate does to provider context).
+
+## Phasing (six PRs, each at the user merge gate)
+
+- **G0 — scaffold:** `index.md`, `_template.md` (template + capture recipe),
+  all eight stub pages, README link, RP&CD naming resolved. No captures.
+- **G1 — Console:** `console.md` + five child pages + captures. (Largest;
+  Console is where every new user lands and where the most undocumented
+  capability sits.)
+- **G2 — Library:** `library.md` + five child pages.
+- **G3 — RP&CD:** parent + three child pages.
+- **G4 — Settings:** `settings.md`.
+- **G5 — Home** + index polish pass (promote any stub that turned out trivial
+  to complete; fix cross-links discovered along the way).
+
+## Done criteria (per deep page)
+
+1. Every control visible on the screen appears in *Features & controls*
+   (swept against the live screen during the verification session).
+2. Every *Common task* was executed end-to-end live before being written.
+3. All links resolve; captures render; the verification stamp is present.
+4. No claim contradicts current dev behavior; known limitations carry backlog
+   refs.
+5. Terminology matches on-screen labels exactly.
+
+## Non-goals
+
+- No docs website / mkdocs tooling.
+- No in-app Help (F1) wiring to these pages (layout keeps it cheap later).
+- No CI drift-checking tooling (CI is intentionally cancelled in this repo;
+  the verification stamp is the staleness signal).
+- No rewriting of `Docs/Features/*` deep dives beyond adding cross-links.

--- a/Docs/superpowers/specs/2026-07-25-user-guide-by-screen-design.md
+++ b/Docs/superpowers/specs/2026-07-25-user-guide-by-screen-design.md
@@ -61,16 +61,20 @@ Docs/User_Guide/
   library/skills.md
   library/prompts.md
   library/collections.md
-  <roleplay>.md + <roleplay>/{characters,lorebooks,chat-dictionaries}.md
+  roleplay-chat-dictionaries.md + roleplay-chat-dictionaries/{characters,lorebooks,chat-dictionaries}.md
   settings.md                      # one page, one section per pane (split later only if
                                    # a pane outgrows it)
   artifacts.md  watchlists.md  schedules.md  workflows.md
   mcp.md  acp.md  lab.md  logs.md  # stubs with a visible "🚧 stub" banner
 ```
 
-Open naming item (resolve in G0): the nav label is "RP&CD" — confirm its
-on-screen expansion in the live app and name the page/directory to match what
-users actually see (candidate: `roleplay.md` + `roleplay/`). File names
+RESOLVED (G0): the nav label "RP&CD" expands on-screen to "Roleplay & Chat
+Dictionaries" — confirmed identically in both the screen's own banner header
+("Roleplay & Chat Dictionaries" / "Author the pieces that shape a chat") and
+the Ctrl+P command-palette entry ("Tab Navigation: Switch to Roleplay & Chat
+Dictionaries"). Per the file-naming rule (match what users see, lowercased/
+kebab-cased, "&" treated as a separator), the page and directory are named
+`roleplay-chat-dictionaries.md` + `roleplay-chat-dictionaries/`. File names
 otherwise follow visible nav labels, lowercased/kebab-cased.
 
 **Child-page lists above are PROVISIONAL.** They were drafted from program

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 A sophisticated Terminal User Interface (TUI) application built with the Textual framework for interacting with various Large Language Model APIs. The product is organized around a chat-first **master shell**: the **Console** is the main work surface, with **Home** (triage/status) and **Library** (notes, media, study, ingestion, search) as the other top-priority destinations, alongside supporting surfaces (Personas, Artifacts, Watchlists, and model/agent tools) that hand context back into the active conversation.
 
+> 📖 **New here?** The [User Guide](Docs/User_Guide/index.md) walks through
+> every screen — what it does and how to use it.
+
 ![Screenshot](https://github.com/rmusser01/tldw_chatbook/blob/main/static/PoC-Frontpage.PNG?raw=true)
 
 ## Project Status & Recent UI Overhaul


### PR DESCRIPTION
First phase of the screen-by-screen User Guide program (spec + plan included in this PR under Docs/superpowers/).

## What this adds
- **`Docs/User_Guide/index.md`** — app intro, Quick Start (first five minutes, honest about the first-run "Get started" card and locked composer), the 13-screen nav map with palette-verbatim one-liners, the behaviorally-verified global shortcuts table (F1 / Ctrl+P / Ctrl+Q — the footer intersection across screens is literally empty, so these were verified by pressing them), a "Where did … go?" legacy table, and conventions. Stamped `Verified against dev @ 9af99aba`.
- **`Docs/User_Guide/_template.md`** — the fixed page template all later phases copy, authoring rules, and the **decided capture recipe**: Textual's built-in `save_screenshot()` SVG export via headless `run_test()` at 200×50 (probe SVG verified: full nav bar, box glyphs, theme colors, no clipping). The two fallback pipelines were never needed.
- **Eight stub pages** (Artifacts, Watchlists, Schedules, Workflows, MCP, ACP, Lab, Logs) — 🚧-bannered, every sentence traced to the live survey (palette one-liners, on-screen subtitles, empty-state copy). lab.md tells users the screen is titled "Models"; schedules.md honestly notes the screen has no title line.
- **README** gains the User Guide entry point (byte-safe 3-line insertion, zero line-ending churn) and **CLAUDE.md** gains the maintenance hook: UI-changing PRs should update the matching guide page or its stamp.
- **Spec updated in-repo:** the RP&CD naming question is RESOLVED — on-screen title "Roleplay & Chat Dictionaries" (screen banner + palette entry) → future pages `roleplay-chat-dictionaries.md`/`…/`.

## Process
Built subagent-driven from the approved spec: live nav survey of all 13 destinations on a scratch profile → per-task review loops (2 Important + assorted minors fixed along the way) → final whole-branch review (opus) which caught 6 more Importants (README CRLF churn, stamp over-promise, number-key over-claim vs the survey's own evidence, stale spec naming item, local-storage contradiction, Quick Start gaps) — all fixed and re-verified. Final verdict: pure-additions branch, every user-facing claim traces to the survey, link sweep clean.

Next phases (each its own gated PR): G1 Console → G2 Library → G3 Roleplay & Chat Dictionaries → G4 Settings → G5 Home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scaffolded the screen‑by‑screen User Guide (G0): added the index with Quick Start, a 13‑screen map, and updated global shortcuts; a fixed authoring template with a reproducible SVG capture recipe; eight stub pages; plus a README entry point and a maintenance hook.

- **New Features**
  - `Docs/User_Guide/index.md`: intro, Quick Start, 13‑screen nav map, and global shortcuts updated to Ctrl+1…Ctrl+0, F1, Ctrl+P, Ctrl+Q, and F6/Shift+F6 (note: bare digits aren’t shortcuts; Ctrl+digit works even in text fields); legacy name pointers; stamped “Verified against dev @ 8975c9b8”.
  - `Docs/User_Guide/_template.md`: fixed page template and authoring rules; decided capture recipe using Textual `save_screenshot()` SVG via headless `run_test(size=(200, 50))`; standard image paths under `Docs/User_Guide/images/`.
  - Stubs: `artifacts.md`, `watchlists.md`, `schedules.md`, `workflows.md`, `mcp.md`, `acp.md`, `lab.md`, `logs.md` (each with orientation and updated “Getting there” including Ctrl+digit).
  - README: adds a top‑level link to the User Guide.
  - `CLAUDE.md`: adds a maintenance rule to update the matching guide page or its verification stamp on UI changes.
  - Spec and plan: `Docs/superpowers/specs/2026-07-25-user-guide-by-screen-design.md` and `Docs/superpowers/plans/2026-07-25-user-guide-g0-scaffold.md` define scope, phased delivery, and the timeboxed SVG‑vs‑PNG capture decision.

<sup>Written for commit 95d118ff78d14f6d4799d6048b13fc94c9a37033. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

