### PR TITLE
feat(stts): complete external audio.cpp Playground vertical

### DIFF
--- a/Docs/Development/TTS/TTS_MODULE_GUIDE.md
+++ b/Docs/Development/TTS/TTS_MODULE_GUIDE.md
@@ -37,6 +37,7 @@ tldw_chatbook/TTS/
 ├── legacy_bridge.py         # Temporary provider-scoped compatibility adapters
 ├── audio_cpp_config.py      # Immutable external-server configuration
 ├── audio_cpp_contract.py    # Pinned JSON and PCM16 WAV validation
+├── playground_types.py      # Immutable Playground request/artifact contracts
 ├── adapters/
 │   └── audio_cpp.py         # Native external audio.cpp adapter
 ├── audio_schemas.py         # Pydantic schemas for requests/responses
@@ -160,9 +161,49 @@ overlap.
 
 Normal tests use fake HTTP transport and fixtures pinned to the reviewed
 upstream commit. They require neither an audio.cpp binary nor model downloads.
-The next ordered slice makes the STTS Playground catalog-driven for the
-external server. User-provided binary and user-provided `server.json`
-launch/supervision and its managed UI remain Slices 4–5.
+
+### Catalog-driven STTS Playground (Slice 3)
+
+TASK-569 implements the external audio.cpp Playground vertical. Opening the
+Playground reads sealed registry descriptors through `TTSService`; descriptor
+discovery does not resolve provider factories or materialize adapters. Only the
+selected provider is resolved. Selecting `audio_cpp` for the first time performs
+bounded readiness and model discovery against the saved external server.
+
+Catalog and voice discovery use independent Textual worker groups. Their result
+tokens include the canonical provider ID and configuration revision, plus the
+catalog revision and model ID where applicable. Results from an old selection,
+configuration, catalog, or model are discarded. Catalog refresh, generation,
+and playback cannot cancel one another, and a second generation cannot replace
+the active generation operation.
+
+One catalog-control projection drives provider, model, voice, format, and speed
+controls. For audio.cpp, the local **Server default** voice sentinel is initially
+selected and becomes `voice=None`; it is never sent as an identifier. Format is
+locked to WAV and speed to `1.0`. Switching to one of the six legacy providers
+restores that provider's prior model, voice, format, speed, and provider-specific
+control state. If refreshed metadata removes a selection, the Playground
+announces and selects a valid fallback. A stale catalog remains visible but
+disables new generation until readiness recovers.
+
+Generation captures an immutable provider-neutral request. `audio_cpp` is the
+native path and calls `TTSService.synthesize(TTSRequest)`; the six existing
+providers remain on the temporary `generate_audio_stream()` compatibility path.
+The validated complete WAV is stored as an immutable artifact containing its
+provider, model, optional voice, source-text snapshot, operation ID, actual
+format/content type, and safe response metadata. Playback and export use that
+artifact, so later selector changes cannot relabel the result or its filename.
+
+Stable adapter failures map to safe, actionable Playground messages and
+recovery actions. Cancellation remains cancellation, existing artifacts remain
+playable and exportable after discovery failures, and an audio.cpp generation
+never automatically falls back to another model or provider. The UI and logs
+do not expose submitted text, configured origins or values, credentials, raw
+remote bodies, or unsafe remote identifiers.
+
+Slice 3 connects only to an existing externally managed `audiocpp_server`.
+User-provided binary and user-provided `server.json` launch, supervision, and
+managed Playground controls remain deferred to Slices 4–5.
 
 #### 3. Audio Service (`audio_service.py`)
 Handles audio format conversion with:
@@ -408,9 +449,12 @@ Local TTS installs:
 The S/TT/S tab provides a comprehensive TTS testing environment:
 
 1. **Text Input**: Enter any text to synthesize
-2. **Provider Selection**: Choose from OpenAI, ElevenLabs, Kokoro, or Chatterbox
-3. **Voice Selection**: Provider-specific voices including custom uploads
+2. **Provider Selection**: Choose `audio_cpp` or one of the six legacy
+   providers from registry descriptors
+3. **Voice Selection**: Discovered audio.cpp voices with Server default, or
+   legacy provider-specific voices including custom uploads
 4. **Advanced Settings**:
+   - **audio.cpp**: Catalog-selected model, complete WAV, and speed `1.0`
    - **Chatterbox**: Exaggeration, CFG weight, temperature, candidates, validation
    - **ElevenLabs**: Stability, similarity boost, style, speaker boost
    - **Kokoro**: Language selection
@@ -765,7 +809,8 @@ pytest Tests/TTS/
 2. **Input Validation**: All text inputs are sanitized
 3. **File Paths**: Temporary files use secure generation
 4. **Network**: External audio.cpp accepts an explicit HTTP or HTTPS origin;
-   HTTPS certificate verification remains enabled and redirects are disabled
+   synthesis text is sent to that configured origin, HTTPS certificate
+   verification remains enabled, and redirects are disabled
 5. **Local Models**: Verify model file integrity
 6. **Voice Cloning**: Be aware of ethical implications
    - Only clone voices with permission

--- a/Docs/Features/Speech-Services-Guide.md
+++ b/Docs/Features/Speech-Services-Guide.md
@@ -44,7 +44,8 @@ The Speech Services feature in tldw_chatbook provides comprehensive Text-to-Spee
 The TTS Playground allows you to experiment with different voices and settings:
 
 - **Text Input**: Enter or paste the text you want to convert
-- **Provider Selection**: Choose from OpenAI, ElevenLabs, Kokoro (local), etc.
+- **Provider Selection**: Choose audio.cpp, OpenAI, ElevenLabs, Kokoro (local),
+  or another configured provider
 - **Voice Selection**: Pick from available voices for the selected provider
 - **Format**: Choose output format (MP3, WAV, etc.)
 - **Provider Settings**: Adjust provider-specific parameters
@@ -57,6 +58,48 @@ Configure default TTS options:
 - Audio format preferences
 - API key management
 - Voice blend creation (Kokoro only)
+
+### Using an Existing audio.cpp Server
+
+Chatbook can connect the Playground to one compatible `audiocpp_server` that
+you start and manage yourself:
+
+1. Start your compatible `audiocpp_server` and note its HTTP or HTTPS origin.
+2. Open **Speech Services → TTS Settings → audio.cpp External Server**.
+3. Enter the server's **Base URL**. Review the timeout and safety bounds, then
+   click **Save Settings**. Saving validates and persists the values but does
+   not connect to or launch a server.
+4. Click **Test Connection** or **Refresh Models**. These actions use the saved
+   settings and discover the server's TTS models.
+5. Return to **Playground**, select **audio.cpp**, then choose a discovered
+   model. Voice discovery happens when the model is selected.
+6. Leave **Server default** selected to omit the voice from the request, or
+   select an announced voice.
+7. Enter text and click **Generate Speech**. After the complete WAV is
+   validated, use **Play** or **Export**.
+
+audio.cpp currently returns one complete WAV per request and supports speed
+`1.0`; the Playground locks both controls while it is selected. This still uses
+the asynchronous adapter interface, but it is not incremental audio streaming.
+Switching to another provider restores that provider's previous model, voice,
+format, speed, and provider-specific controls.
+
+If discovery becomes stale or fails, the prior choices may remain visible but
+new generation stays disabled until a successful retry or model refresh.
+Already generated audio remains playable and exportable. If a selected model or
+voice disappears after refresh, the Playground announces and selects a valid
+fallback. A failed audio.cpp request never silently uses another model or
+provider.
+
+**Privacy:** the text submitted for synthesis is sent to the configured
+audio.cpp server. Chatbook avoids putting that text, the configured origin or
+settings values, credentials, raw remote responses, and unsafe remote
+identifiers in normal UI diagnostics or application logs.
+
+This release does not download, launch, monitor, restart, or stop audio.cpp and
+does not accept a binary path or `server.json` path. User-provided binary plus
+user-provided `server.json` launch and supervision are deferred to later
+managed-mode slices.
 
 ### AudioBook Generator
 
@@ -199,7 +242,8 @@ Example custom commands:
 ### Privacy-First Design
 
 - **Default Settings**: Privacy mode enabled by default
-- **No Cloud Storage**: Audio never uploaded without permission
+- **Explicit Service Boundary**: Cloud providers and an externally configured
+  audio.cpp server receive the content submitted to them
 - **Local Processing**: Prefer on-device transcription
 - **Encrypted History**: Optional history uses encryption
 
@@ -405,10 +449,22 @@ auto_clear_buffer = true
 
 ### TTS Settings
 ```toml
-[tts]
+[app_tts]
 default_provider = "openai"
 default_voice = "alloy"
 default_format = "mp3"
+
+[app_tts.audio_cpp]
+mode = "external"
+base_url = "http://127.0.0.1:8080"
+connect_timeout_seconds = 5
+synthesis_timeout_seconds = 600
+max_input_characters = 10000
+max_response_bytes = 134217728
+max_metadata_bytes = 1048576
+max_catalog_models = 1000
+max_voices_per_model = 1000
+max_identifier_characters = 256
 ```
 
 ## Support & Feedback
@@ -420,5 +476,5 @@ default_format = "mp3"
 
 ---
 
-**Last Updated**: 2025-07-30
-**Version**: 2.0 (Improved Speech Services)
+**Last Updated**: 2026-07-25
+**Version**: 2.1 (External audio.cpp Playground)

--- a/Docs/superpowers/plans/2026-07-25-audio-cpp-external-stts-playground.md
+++ b/Docs/superpowers/plans/2026-07-25-audio-cpp-external-stts-playground.md
@@ -1,0 +1,999 @@
+# External audio.cpp STTS Playground Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the existing STTS Playground catalog-driven and complete the end-to-end flow for one externally managed `audiocpp_server`, from configuration and discovery through validated complete-WAV generation, playback, and save.
+
+**Architecture:** Extend the app-owned `TTSService` with read-only provider descriptor and configuration-revision access, then place a small pure catalog-selection layer between provider metadata and Textual controls. The Playground resolves only the selected provider, uses independent catalog and voice workers with revision tokens, and sends immutable native requests to `audio_cpp`; the six existing providers retain their compatibility generation path. Generated audio is represented by an immutable provenance-bearing artifact so playback and export never depend on the current selectors.
+
+**Tech Stack:** Python 3.11+, Textual workers/widgets, frozen dataclasses, existing `TTSService`/`TTSAdapterRegistry`, Loguru, pytest/pytest-asyncio, Ruff, mypy.
+
+---
+
+## Global constraints
+
+- Implement only delivery Slice 3 from
+  `Docs/superpowers/specs/2026-07-23-audio-cpp-tts-adapter-registry-design.md`.
+- Do not add binary paths, `server.json` paths, subprocess use, launch,
+  supervision, restart, managed logs, process ownership, or managed-mode UI.
+- `audio_cpp` remains the exact canonical ID. Labels are display-only and are
+  never parsed to recover identity.
+- Opening STTS may inspect descriptors but must not materialize every adapter.
+  Only selecting or explicitly testing a provider may resolve it.
+- The `audio_cpp` native path uses `TTSService.synthesize(TTSRequest)`. Legacy
+  providers continue through `generate_audio_stream()` and the private bridge
+  metadata it owns.
+- The local Server-default sentinel is never sent to the adapter. It becomes
+  `voice=None`.
+- audio.cpp remains WAV-only, complete-response-only, and speed `1.0` only.
+- Catalog, voice, generation, and playback workers have independent groups.
+  Repeated generation cannot replace active generation.
+- Provider, configuration, catalog, and model revision tokens reject stale
+  asynchronous results.
+- Generated audio retains its own provider/model/voice/text/format/operation
+  metadata. Later selector changes cannot relabel it.
+- UI and application logs never include submitted text, configured origins or
+  values, credentials, raw remote bodies, or unescaped remote identifiers.
+- No new runtime dependency is added.
+
+## File map
+
+- Create `tldw_chatbook/TTS/playground_types.py`: immutable request snapshot and
+  generated-artifact contracts shared by the widget and event handler.
+- Create `tldw_chatbook/UI/stts_playground_catalog.py`: pure catalog selection,
+  Server-default, control restrictions, and stale-result token helpers.
+- Modify `tldw_chatbook/TTS/TTS_Generation.py`: read-only provider descriptor and
+  configuration-revision service methods.
+- Modify `tldw_chatbook/TTS/__init__.py`: export the provider-neutral Playground
+  contracts needed outside the TTS package.
+- Modify `tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py`: nested
+  audio.cpp settings persistence/reconfiguration, immutable request handling,
+  native complete-WAV generation, safe errors, and artifact delivery.
+- Modify `tldw_chatbook/UI/STTS_Window.py`: catalog-driven Playground controls,
+  external audio.cpp settings/actions, worker groups, safe status rendering,
+  and artifact-based playback/export.
+- Modify `Tests/TTS/test_tts_registry_service.py`: descriptor/revision service
+  seam coverage.
+- Create `Tests/TTS/test_stts_playground_types.py`: immutable request and
+  generated-artifact contract coverage.
+- Create `Tests/UI/test_stts_playground_catalog.py`: pure catalog-state tests.
+- Create `Tests/UI/test_stts_playground_audio_cpp.py`: Textual external
+  discovery/control/stale-result tests.
+- Create `Tests/TTS/test_stts_audio_cpp_generation.py`: event-handler native
+  generation, provenance, errors, and cancellation tests.
+- Modify `Tests/UI/test_stts_settings_widget.py`: external settings validation
+  and explicit action tests.
+- Modify `Tests/TTS/test_stts_settings_reconfiguration.py`: nested persistence
+  and exclusive audio.cpp reconfiguration tests.
+- Modify `Tests/TTS/test_stts_export_security.py`: generated-artifact export and
+  extension/provenance tests.
+- Modify `Docs/Development/TTS/TTS_MODULE_GUIDE.md`: landed Slice 3 service/UI
+  boundary and worker ownership.
+- Modify `Docs/Features/Speech-Services-Guide.md`: user-facing external server
+  setup, privacy boundary, discovery, generation, playback, and save.
+- Modify
+  `Docs/superpowers/specs/2026-07-23-audio-cpp-tts-adapter-registry-design.md`
+  and
+  `backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md`:
+  record Slice 3 as implemented without changing the managed-mode decision.
+- Modify
+  `backlog/tasks/task-569 - Complete-external-audio.cpp-STTS-Playground-vertical.md`:
+  plan, evidence, acceptance completion, and implementation notes.
+
+### Task 1: Add provider-neutral Playground contracts and service metadata access
+
+**Files:**
+
+- Create: `tldw_chatbook/TTS/playground_types.py`
+- Modify: `tldw_chatbook/TTS/TTS_Generation.py`
+- Modify: `tldw_chatbook/TTS/__init__.py`
+- Modify: `Tests/TTS/test_tts_registry_service.py`
+- Create: `Tests/TTS/test_stts_playground_types.py`
+
+- [ ] **Step 1: Write failing service metadata tests**
+
+Add tests proving:
+
+```python
+descriptors = service.provider_descriptors()
+
+assert tuple(item.provider_id for item in descriptors) == (
+    "audio_cpp",
+    "openai",
+    "elevenlabs",
+    "kokoro",
+    "chatterbox",
+    "higgs",
+    "alltalk",
+)
+assert factories.total_calls == 0
+assert service.configuration_revision("audio_cpp") == 1
+```
+
+Also prove the descriptor tuple is immutable, canonical, ordered, and does not
+acquire or materialize an adapter.
+
+- [ ] **Step 2: Write failing immutable request/artifact tests**
+
+Define the expected contracts in tests:
+
+```python
+snapshot = STTSPlaygroundRequest(
+    operation_id="local-op",
+    provider_id="audio_cpp",
+    model_id="kokoro",
+    text="hello",
+    voice_id=None,
+    response_format="wav",
+    speed=1.0,
+)
+artifact = STTSGeneratedAudio(
+    path=tmp_path / "result.wav",
+    provider_id="audio_cpp",
+    model_id="kokoro",
+    voice_id=None,
+    source_text="hello",
+    operation_id="local-op",
+    audio_format="wav",
+    content_type="audio/wav",
+    metadata={"delivery": "complete_wav"},
+)
+```
+
+Assert frozen mutation fails, options/metadata are defensive immutable copies,
+required identifiers are non-empty, and the artifact suffix is derived from
+`audio_format`, not from a current UI selection.
+
+- [ ] **Step 3: Run the focused tests and observe the missing APIs**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/TTS/test_tts_registry_service.py \
+  Tests/TTS/test_stts_playground_types.py -q
+```
+
+Expected: FAIL because the service methods and Playground contracts do not yet
+exist.
+
+- [ ] **Step 4: Implement the minimal contracts**
+
+In `TTSService` add synchronous read-only forwarding methods:
+
+```python
+def provider_descriptors(self) -> tuple[TTSProviderDescriptor, ...]:
+    """Return ordered provider metadata without materializing adapters."""
+    return self.registry.descriptors()
+
+def configuration_revision(self, provider_id: str) -> int:
+    """Return the selected provider's current registry revision."""
+    return self.registry.configuration_revision(provider_id)
+```
+
+Create frozen, slotted dataclasses in `playground_types.py`. Copy `options` and
+`metadata` into `MappingProxyType` in `__post_init__`, validate only structural
+invariants, and do not put Textual or adapter implementations in this module.
+Export the types through `tldw_chatbook.TTS`.
+
+- [ ] **Step 5: Run the focused tests**
+
+Run the Step 3 command.
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the provider-neutral seam**
+
+```bash
+git add \
+  tldw_chatbook/TTS/playground_types.py \
+  tldw_chatbook/TTS/TTS_Generation.py \
+  tldw_chatbook/TTS/__init__.py \
+  Tests/TTS/test_tts_registry_service.py \
+  Tests/TTS/test_stts_playground_types.py
+git commit -m "feat(tts): add playground request and result contracts"
+```
+
+### Task 2: Implement pure catalog selection and restriction state
+
+**Files:**
+
+- Create: `tldw_chatbook/UI/stts_playground_catalog.py`
+- Create: `Tests/UI/test_stts_playground_catalog.py`
+
+- [ ] **Step 1: Write failing catalog-state tests**
+
+Cover:
+
+- canonical provider options preserve descriptor order;
+- model fallback chooses the first valid model and reports when a removed
+  selection changed;
+- audio.cpp voices always begin with a local `Server default` sentinel;
+- the initial audio.cpp voice is Server default even when discovered voices
+  exist;
+- a retained explicitly selected voice remains selected while still valid;
+- Server default converts to `None` and is never returned as a literal request
+  voice;
+- audio.cpp format is exactly WAV and locked;
+- audio.cpp speed is exactly `1.0` and locked;
+- legacy model formats, voices, and speed support remain available;
+- unavailable or stale health keeps prior models visible but sets
+  `generation_allowed=False`;
+- request tokens compare provider ID, configuration revision, catalog revision,
+  and model ID;
+- model and voice labels containing Rich/Textual markup remain plain text when
+  converted at the rendering boundary.
+
+Use small real `TTSProviderCatalog` fixtures. Do not instantiate Textual apps or
+adapters in these tests.
+
+- [ ] **Step 2: Run tests and confirm the module is absent**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest Tests/UI/test_stts_playground_catalog.py -q
+```
+
+Expected: FAIL because `stts_playground_catalog` does not exist.
+
+- [ ] **Step 3: Implement the pure state module**
+
+Use focused contracts such as:
+
+```python
+SERVER_DEFAULT_VOICE_ID = "__server_default__"
+
+@dataclass(frozen=True, slots=True)
+class CatalogRequestToken:
+    provider_id: str
+    configuration_revision: int
+    catalog_revision: int | None = None
+    model_id: str | None = None
+
+@dataclass(frozen=True, slots=True)
+class PlaygroundControls:
+    provider_id: str
+    model_options: tuple[tuple[str, str], ...]
+    selected_model_id: str | None
+    voice_options: tuple[tuple[str, str], ...]
+    selected_voice_id: str | None
+    format_options: tuple[str, ...]
+    selected_format: str | None
+    format_locked: bool
+    speed: float
+    speed_locked: bool
+    generation_allowed: bool
+    selection_changed: bool
+```
+
+Keep selection, fallback, and restriction rules pure. Return strings from this
+module; construct Rich `Text` labels with markup disabled only in the UI.
+
+- [ ] **Step 4: Run the pure tests**
+
+Run the Step 2 command.
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit catalog state**
+
+```bash
+git add \
+  tldw_chatbook/UI/stts_playground_catalog.py \
+  Tests/UI/test_stts_playground_catalog.py
+git commit -m "feat(stts): add catalog driven control state"
+```
+
+### Task 3: Add external audio.cpp settings persistence and explicit discovery actions
+
+**Files:**
+
+- Modify: `tldw_chatbook/UI/STTS_Window.py`
+- Modify: `tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py`
+- Modify: `Tests/UI/test_stts_settings_widget.py`
+- Modify: `Tests/TTS/test_stts_settings_reconfiguration.py`
+
+- [ ] **Step 1: Write failing settings composition and validation tests**
+
+Mount `TTSSettingsWidget` and assert the external-only panel contains:
+
+- fixed mode `external`;
+- base URL;
+- connect and synthesis timeouts;
+- input, response, metadata, model, voice, and identifier bounds;
+- privacy copy stating submitted text is sent to the configured server;
+- Save, Test Connection, and Refresh Models actions;
+- no binary path, `server.json`, Start, Restart, managed log, or process control.
+
+Set all inputs to valid non-default values, call `_save_settings()`, and assert
+one defensively isolated ordinary `dict` appears under
+`settings["audio_cpp"]`. Mutating the original form/candidate after posting
+must not change the event snapshot.
+
+Parametrize invalid origins, credentials, paths, query/fragment components,
+non-positive numbers, booleans, non-integral limits, and oversized numeric
+strings. Assert no event is posted and neither the invalid value nor origin is
+logged or notified.
+
+- [ ] **Step 2: Write failing persistence/reconfiguration tests**
+
+Extend binding-table coverage with:
+
+```python
+"audio_cpp": _SettingBinding(
+    (("app_tts", "audio_cpp"),),
+    provider_id="audio_cpp",
+)
+```
+
+Prove one atomic save writes `[app_tts.audio_cpp]`, reloads effective settings,
+projects them with `project_audio_cpp_config()`, and calls:
+
+```python
+await service.reconfigure_provider(
+    "audio_cpp",
+    projected.to_mapping(),
+)
+```
+
+Assert the persisted value is a defensively copied ordinary nested `dict`, not
+a `MappingProxyType`, and inspect the written TOML/reloaded mapping to prove it
+has the `[app_tts.audio_cpp]` shape rather than an array of keys.
+
+Assert Save does not call `get_catalog`, `get_voices`, `synthesize`, or the
+adapter factory. An unchanged canonical config is a no-op. A changed config
+retires only audio.cpp and leaves all materialized legacy adapters untouched.
+Capture the `ReconfigureResult`: `UNCHANGED` emits no provider-state change;
+`CHANGED` emits one canonical `audio_cpp` configuration-changed notification
+containing the new service revision.
+
+- [ ] **Step 3: Run focused settings tests**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/UI/test_stts_settings_widget.py \
+  Tests/TTS/test_stts_settings_reconfiguration.py -q
+```
+
+Expected: FAIL for the missing panel, binding, and native config projection.
+
+- [ ] **Step 4: Implement nested settings and provider config dispatch**
+
+Add `audio_cpp` first in `_TTS_PROVIDER_ORDER`. Introduce a private helper:
+
+```python
+def _effective_provider_config(
+    provider_id: str,
+    effective_settings: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    if provider_id == "audio_cpp":
+        return project_audio_cpp_config(effective_settings).to_mapping()
+    return legacy_provider_config(provider_id, effective_settings)
+```
+
+Use `AudioCppConfig.from_mapping()` in `TTSSettingsWidget` to validate the
+complete form locally. The frozen `AudioCppConfig` is the validation snapshot;
+at the persistence boundary, call `to_mapping()` and defensively copy it into a
+plain nested `dict` accepted by the TOML writer. Never persist a mapping proxy.
+Error notifications are fixed safe copy and logs contain only setting
+names/outcomes.
+
+After successful reconfiguration, inspect each `ReconfigureResult`. For
+`CHANGED`, publish a provider-configuration-changed message with only the
+canonical provider ID and new integer revision. A mounted Playground handles
+that message by marking only that provider's catalog/voices stale, cancelling
+its discovery workers, and disabling Generate without reconnecting. Existing
+generated artifacts remain playable/exportable. `UNCHANGED` publishes nothing
+and leaves readiness state untouched.
+
+- [ ] **Step 5: Implement explicit Test Connection and Refresh Models workers**
+
+Use separate Textual worker group `stts-audio-cpp-settings-discovery`. Both
+actions operate on the currently saved/reconfigured app-owned service:
+
+```python
+service = await get_tts_service()
+catalog = await service.get_catalog("audio_cpp", refresh=True)
+```
+
+Test Connection reports compatible availability and model count; Refresh Models
+reports the refreshed count. Neither action displays the configured origin,
+remote diagnostic, raw exception, model identifiers, or values. Explain in the
+panel that form changes must be saved before testing. Capture
+`service.configuration_revision("audio_cpp")` before I/O and compare it again
+before applying either result; discard the result when the revision changed.
+
+- [ ] **Step 6: Run focused settings tests**
+
+Run the Step 3 command.
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit external settings**
+
+```bash
+git add \
+  tldw_chatbook/UI/STTS_Window.py \
+  tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py \
+  Tests/UI/test_stts_settings_widget.py \
+  Tests/TTS/test_stts_settings_reconfiguration.py
+git commit -m "feat(stts): add external audio cpp settings"
+```
+
+### Task 4: Make Playground provider, model, voice, format, and speed controls catalog-driven
+
+**Files:**
+
+- Modify: `tldw_chatbook/UI/STTS_Window.py`
+- Create: `Tests/UI/test_stts_playground_audio_cpp.py`
+- Modify: `Tests/UI/test_stts_capability_state.py`
+
+- [ ] **Step 1: Build a deterministic Textual host and fake service**
+
+The fake service records descriptor, catalog, voice, revision, and synthesis
+calls. Its descriptors list `audio_cpp` first and the six legacy providers. Its
+audio.cpp catalog includes multiple models, unsafe-looking opaque identifiers,
+WAV-only metadata, and `omit_voice_uses_server_default=True`.
+
+Mount `TTSPlaygroundWidget` without an app server or model download.
+
+- [ ] **Step 2: Write failing descriptor and lazy-materialization tests**
+
+Assert opening the widget:
+
+- calls only `provider_descriptors()`;
+- populates options as `(safe display label, canonical provider ID)`;
+- makes no catalog/voice/synthesis calls until the selected provider is
+  resolved;
+- accepts `audio_cpp` directly without label parsing;
+- leaves the six legacy provider options present and ordered.
+
+- [ ] **Step 3: Write failing catalog, voice, and stale-result tests**
+
+Cover:
+
+- selecting audio.cpp starts only the catalog worker;
+- selected-provider readiness populates TTS models;
+- model selection starts only the voice worker;
+- Server default is selected and becomes `None`;
+- missing voices leaves only Server default;
+- a removed model/voice selects a valid fallback and announces the change;
+- old provider, configuration-revision, catalog-revision, or model results are
+  discarded;
+- a successful `CHANGED` settings notification immediately marks the selected
+  audio.cpp catalog and voices stale, cancels only discovery workers, disables
+  Generate without connecting, and preserves the current generated artifact;
+- an `UNCHANGED` save emits no notification and leaves fresh state unchanged;
+- unsafe identifier text renders literally;
+- stale models remain visible but Generate is disabled;
+- unavailable, incompatible, not-configured, and reconfiguring states expose
+  fixed safe status/recovery copy.
+
+- [ ] **Step 4: Write failing control-restoration tests**
+
+Select a legacy provider, choose non-default model/voice/format/speed, switch to
+audio.cpp, then switch back. Assert:
+
+- audio.cpp forces WAV and disables Format;
+- audio.cpp forces `1.0` and disables Speed with an explanation;
+- legacy selection state is restored;
+- provider-specific legacy panels keep their existing visibility behavior;
+- no audio.cpp restriction remains sticky after switching.
+
+- [ ] **Step 5: Run the Textual tests and observe the static branches**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/UI/test_stts_playground_audio_cpp.py \
+  Tests/UI/test_stts_capability_state.py -q
+```
+
+Expected: FAIL because the Playground still hard-codes and parses provider
+labels, models, and voices.
+
+- [ ] **Step 6: Implement descriptor initialization and independent workers**
+
+Replace the Playground's static provider option list with an initially empty
+Select. On mount:
+
+1. retrieve the app-owned service;
+2. read descriptors synchronously without adapter acquisition;
+3. set safe Rich `Text` labels and canonical values;
+4. select the configured default if registered, otherwise the first descriptor;
+5. start `stts-catalog-discovery` only for that provider.
+
+Use `@work(exclusive=True, group="stts-catalog-discovery")` for catalogs and
+`@work(exclusive=True, group="stts-voice-discovery")` for voices. Capture
+`CatalogRequestToken` before I/O and verify all token fields before applying a
+result. Read the service configuration revision both before and after each
+await; a result applies only when both revisions and the current widget token
+match.
+
+- [ ] **Step 7: Implement one catalog-application path**
+
+Replace shared hard-coded model/voice/format/speed updates with one method that
+consumes `PlaygroundControls`. Keep small provider-specific legacy extensions
+(saved Chatterbox/Higgs profiles and Kokoro blends) layered on the catalog
+without changing canonical base options.
+
+Store per-provider control snapshots before switching. Disable Generate unless
+the selected catalog is fresh/available, the model is valid, text is non-empty,
+the cached configuration revision still equals the service revision, and no
+generation is active. Handle the canonical configuration-changed message by
+invalidating only matching catalog/voice state and workers; do not call the
+adapter from the message handler.
+
+- [ ] **Step 8: Run the Textual tests**
+
+Run the Step 5 command.
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit catalog-driven controls**
+
+```bash
+git add \
+  tldw_chatbook/UI/STTS_Window.py \
+  Tests/UI/test_stts_playground_audio_cpp.py \
+  Tests/UI/test_stts_capability_state.py
+git commit -m "feat(stts): drive playground controls from catalogs"
+```
+
+### Task 5: Route audio.cpp generation through the native service and retain provenance
+
+**Files:**
+
+- Modify: `tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py`
+- Modify: `tldw_chatbook/UI/STTS_Window.py`
+- Create: `Tests/TTS/test_stts_audio_cpp_generation.py`
+- Modify: `Tests/TTS/test_stts_export_security.py`
+
+- [ ] **Step 1: Write failing immutable request-snapshot tests**
+
+Assert `_generate_tts()` captures a single `STTSPlaygroundRequest` containing:
+
+- a local UUID operation ID;
+- canonical provider/model IDs;
+- source text snapshot;
+- `voice_id=None` for Server default;
+- WAV and speed `1.0` for audio.cpp;
+- an immutable copy of options.
+
+Change every selector and the TextArea after posting the event and prove the
+worker still receives the original snapshot.
+
+- [ ] **Step 2: Write failing native generation tests**
+
+With a fake `TTSService.synthesize()` response, assert the handler sends:
+
+```python
+TTSRequest(
+    provider_id="audio_cpp",
+    model_id=snapshot.model_id,
+    text=snapshot.text,
+    voice=snapshot.voice_id,
+    response_format="wav",
+    speed=1.0,
+    options={},
+)
+```
+
+Assert it consumes the async response exactly once, always calls `aclose()`,
+writes an owner-only `.wav` temporary file, and returns
+`STTSGeneratedAudio` with response provider/model/format/content type/metadata
+plus `voice_id=snapshot.voice_id`, the local source text, and operation ID.
+
+Prove audio.cpp never calls `generate_audio_stream()` or format conversion.
+Prove a legacy snapshot still calls the unchanged compatibility stream path and
+retains its requested conversion behavior.
+
+- [ ] **Step 3: Write failing error, cancellation, and privacy tests**
+
+Cover every stable audio.cpp operation code, retryability, recovery action,
+reconfiguring, registry closed, local configuration `ValueError`, and unknown
+exception fallback.
+
+Assert:
+
+- `str(TTSOperationError)` is treated as the established safe message contract
+  and escaped before Rich/Textual display;
+- unknown exception strings are not displayed or logged;
+- text, origin, config values, raw identifiers, and credentials do not appear
+  in logs or notices;
+- `CancelledError` propagates and closes the response without a failure notice;
+- repeated Generate while active is rejected without replacing the task.
+
+- [ ] **Step 4: Run focused generation tests**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/TTS/test_stts_audio_cpp_generation.py \
+  Tests/TTS/test_stts_export_security.py -q
+```
+
+Expected: FAIL because native request and artifact paths are absent.
+
+- [ ] **Step 5: Split native and legacy generation paths**
+
+Keep `handle_playground_generate()` as the retained owner. Refactor the worker
+into small helpers:
+
+```python
+async def _generate_audio_cpp(
+    self,
+    snapshot: STTSPlaygroundRequest,
+    progress_sink: ProgressSink,
+) -> STTSGeneratedAudio: ...
+
+async def _generate_legacy(
+    self,
+    snapshot: STTSPlaygroundRequest,
+    progress_sink: ProgressSink,
+) -> STTSGeneratedAudio: ...
+```
+
+Use `create_secure_temp_file()` for final bytes and track the file in
+`_playground_audio_files`. Preserve primary exceptions while closing native
+responses. Map only stable safe operation fields into the UI.
+
+- [ ] **Step 6: Deliver and store the immutable artifact**
+
+Change `_generation_complete()` to accept `STTSGeneratedAudio`. Store the
+artifact separately from selectors and set `current_audio_file=artifact.path`
+only as a compatibility convenience.
+
+Playback and export derive the path, extension, and status text from the
+artifact. Use the artifact's actual format even after provider/model/format
+selectors change.
+
+- [ ] **Step 7: Run focused generation tests**
+
+Run the Step 4 command.
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit native Playground generation**
+
+```bash
+git add \
+  tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py \
+  tldw_chatbook/UI/STTS_Window.py \
+  Tests/TTS/test_stts_audio_cpp_generation.py \
+  Tests/TTS/test_stts_export_security.py
+git commit -m "feat(stts): generate audio cpp wav through native service"
+```
+
+### Task 6: Harden worker ownership, recovery state, playback, and cleanup
+
+**Files:**
+
+- Modify: `tldw_chatbook/UI/STTS_Window.py`
+- Modify: `tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py`
+- Modify: `Tests/UI/test_stts_playground_audio_cpp.py`
+- Modify: `Tests/TTS/test_stts_audio_cpp_generation.py`
+
+- [ ] **Step 1: Write failing worker-isolation tests**
+
+Prove:
+
+- catalog refresh does not cancel generation;
+- voice discovery does not cancel catalog refresh for a different token until
+  its stale result is discarded;
+- repeated Generate cannot replace the active handler task;
+- playback uses its own `stts-playback` group;
+- leaving the Playground cancels widget-owned discovery/playback workers but
+  detaches, rather than cancels, the single app-handler-owned generation task;
+- generation completion after unmount never calls the removed widget, remains
+  available in handler-owned state, and is rehydrated by a newly mounted
+  Playground;
+- unmount after artifact creation preserves only the current delivered
+  artifact and never invokes global STTS cleanup or cancels settings/audiobook
+  work;
+- failed/cancelled generation deletes its partial files, successful replacement
+  securely deletes the superseded artifact and intermediates, and app shutdown
+  deletes the final retained artifact;
+- generation completion after a selector switch keeps original provenance;
+- progress callback/display failure cannot fail synthesis.
+
+- [ ] **Step 2: Write failing recovery-state tests**
+
+For stale/unavailable catalog state, assert:
+
+- prior models remain visible;
+- Generate is disabled;
+- Refresh remains available;
+- existing generated audio remains playable/exportable;
+- recovery action copy is local and fixed;
+- audio.cpp failure never auto-selects or invokes a legacy provider.
+
+- [ ] **Step 3: Run focused lifecycle tests**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/UI/test_stts_playground_audio_cpp.py \
+  Tests/TTS/test_stts_audio_cpp_generation.py -q
+```
+
+Expected: FAIL for the missing worker groups and recovery state.
+
+- [ ] **Step 4: Implement bounded worker and cleanup ownership**
+
+Use distinct worker groups:
+
+- `stts-catalog-discovery`
+- `stts-voice-discovery`
+- `stts-audio-cpp-settings-discovery`
+- retained event-handler generation task
+- `stts-playback`
+
+Make cleanup idempotent. Do not add a second generation worker inside the
+event-handler task. The retained generation task is app-handler-owned: widget
+unmount detaches it and cancels only widget-owned discovery/playback. Completion
+looks up a currently mounted Playground and checks the operation ID before any
+UI call; it never retains or calls the removed widget.
+
+Keep one read-only handler snapshot of active operation ID plus current
+`STTSGeneratedAudio`. A newly mounted Playground rehydrates generation/artifact
+state from that snapshot. Track in-flight files per operation. On failure or
+cancellation, securely delete that operation's partial files. On successful
+replacement, store the new artifact before securely deleting the superseded
+artifact and all intermediates. Preserve the current artifact after export and
+widget unmount so it remains playable; delete it only when replaced or during
+app-level STTS cleanup. App cleanup cancels and joins retained generation before
+deleting files. Never call global STTS cleanup merely because the Playground
+unmounted, and never cancel settings or audiobook tasks.
+
+- [ ] **Step 5: Implement safe recovery display**
+
+Map core recovery actions to fixed UI actions/copy without importing Textual
+into TTS core. Escape safe messages at the Rich boundary. Keep generated audio
+controls independent from current provider readiness.
+
+- [ ] **Step 6: Run focused lifecycle tests**
+
+Run the Step 3 command.
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit lifecycle hardening**
+
+```bash
+git add \
+  tldw_chatbook/UI/STTS_Window.py \
+  tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py \
+  Tests/UI/test_stts_playground_audio_cpp.py \
+  Tests/TTS/test_stts_audio_cpp_generation.py
+git commit -m "test(stts): harden audio cpp playground lifecycle"
+```
+
+### Task 7: Document the landed external Playground vertical
+
+**Files:**
+
+- Modify: `Docs/Development/TTS/TTS_MODULE_GUIDE.md`
+- Modify: `Docs/Features/Speech-Services-Guide.md`
+- Modify:
+  `Docs/superpowers/specs/2026-07-23-audio-cpp-tts-adapter-registry-design.md`
+- Modify:
+  `backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md`
+- Modify:
+  `backlog/tasks/task-569 - Complete-external-audio.cpp-STTS-Playground-vertical.md`
+
+- [ ] **Step 1: Update architecture and implementation status**
+
+Document:
+
+- Slice 3 is implemented and tracked by TASK-569;
+- descriptors do not materialize adapters;
+- catalog/voice workers and revision tokens;
+- native audio.cpp request boundary versus retained legacy compatibility path;
+- complete-WAV artifact provenance;
+- Server default omission;
+- WAV/speed restrictions and legacy restoration;
+- safe error/recovery behavior;
+- no automatic fallback.
+
+- [ ] **Step 2: Add user-facing external setup and privacy guidance**
+
+Explain:
+
+1. start the user's own compatible `audiocpp_server`;
+2. open STTS Settings and save the external origin/bounds;
+3. use Test Connection or Refresh Models;
+4. select audio.cpp in the Playground;
+5. select a discovered model and optional voice;
+6. generate, play, and export the complete WAV.
+
+State clearly that submitted text is sent to the configured server. Do not
+suggest Chatbook downloads, launches, or manages the server in Slice 3.
+
+- [ ] **Step 3: Preserve later-slice deferrals**
+
+Keep user-provided binary plus user-provided `server.json` launch/supervision in
+Slices 4–5. Do not document managed settings or actions as available.
+
+- [ ] **Step 4: Run documentation reference checks**
+
+Run:
+
+```bash
+rg -n "TASK-569|Slice 3|audio_cpp|Server default|complete WAV" \
+  Docs/Development/TTS/TTS_MODULE_GUIDE.md \
+  Docs/Features/Speech-Services-Guide.md \
+  Docs/superpowers/specs/2026-07-23-audio-cpp-tts-adapter-registry-design.md \
+  backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md \
+  "backlog/tasks/task-569 - Complete-external-audio.cpp-STTS-Playground-vertical.md"
+```
+
+Expected: all governing and user-facing files reference the landed behavior.
+
+- [ ] **Step 5: Commit documentation**
+
+```bash
+git add \
+  Docs/Development/TTS/TTS_MODULE_GUIDE.md \
+  Docs/Features/Speech-Services-Guide.md \
+  Docs/superpowers/specs/2026-07-23-audio-cpp-tts-adapter-registry-design.md \
+  backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md \
+  "backlog/tasks/task-569 - Complete-external-audio.cpp-STTS-Playground-vertical.md"
+git commit -m "docs(stts): document external audio cpp playground"
+```
+
+### Task 8: Run full verification and finish TASK-569
+
+**Files:**
+
+- Modify:
+  `backlog/tasks/task-569 - Complete-external-audio.cpp-STTS-Playground-vertical.md`
+
+- [ ] **Step 1: Run focused Slice 3 tests**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/TTS/test_stts_playground_types.py \
+  Tests/TTS/test_tts_registry_service.py \
+  Tests/TTS/test_stts_settings_reconfiguration.py \
+  Tests/TTS/test_stts_audio_cpp_generation.py \
+  Tests/TTS/test_stts_export_security.py \
+  Tests/UI/test_stts_playground_catalog.py \
+  Tests/UI/test_stts_playground_audio_cpp.py \
+  Tests/UI/test_stts_settings_widget.py \
+  Tests/UI/test_stts_capability_state.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run broad regressions**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/TTS \
+  Tests/UI/test_stts_capability_state.py \
+  Tests/UI/test_stts_settings_widget.py \
+  Tests/Audio_Services/test_local_audio_services_service.py \
+  Tests/Media/test_local_media_reading_service.py -q
+```
+
+Expected: PASS with only documented optional skips/warnings.
+
+- [ ] **Step 3: Run static, compilation, boundary, and diff checks**
+
+Run:
+
+```bash
+../../.venv/bin/python -m ruff check \
+  tldw_chatbook/TTS/playground_types.py \
+  tldw_chatbook/TTS/TTS_Generation.py \
+  tldw_chatbook/TTS/__init__.py \
+  tldw_chatbook/UI/stts_playground_catalog.py \
+  tldw_chatbook/UI/STTS_Window.py \
+  tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py \
+  Tests/TTS/test_stts_playground_types.py \
+  Tests/TTS/test_tts_registry_service.py \
+  Tests/TTS/test_stts_settings_reconfiguration.py \
+  Tests/TTS/test_stts_audio_cpp_generation.py \
+  Tests/TTS/test_stts_export_security.py \
+  Tests/UI/test_stts_playground_catalog.py \
+  Tests/UI/test_stts_playground_audio_cpp.py \
+  Tests/UI/test_stts_settings_widget.py \
+  Tests/UI/test_stts_capability_state.py
+
+../../.venv/bin/python -m ruff format --check \
+  tldw_chatbook/TTS/playground_types.py \
+  tldw_chatbook/TTS/TTS_Generation.py \
+  tldw_chatbook/TTS/__init__.py \
+  tldw_chatbook/UI/stts_playground_catalog.py \
+  tldw_chatbook/UI/STTS_Window.py \
+  tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py \
+  Tests/TTS/test_stts_playground_types.py \
+  Tests/TTS/test_tts_registry_service.py \
+  Tests/TTS/test_stts_settings_reconfiguration.py \
+  Tests/TTS/test_stts_audio_cpp_generation.py \
+  Tests/TTS/test_stts_export_security.py \
+  Tests/UI/test_stts_playground_catalog.py \
+  Tests/UI/test_stts_playground_audio_cpp.py \
+  Tests/UI/test_stts_settings_widget.py \
+  Tests/UI/test_stts_capability_state.py
+
+../../.venv/bin/python -m compileall -q \
+  tldw_chatbook/TTS \
+  tldw_chatbook/UI/stts_playground_catalog.py \
+  tldw_chatbook/UI/STTS_Window.py \
+  tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py
+
+../../.venv/bin/python -m mypy \
+  tldw_chatbook/TTS/playground_types.py \
+  tldw_chatbook/TTS/TTS_Generation.py \
+  tldw_chatbook/UI/stts_playground_catalog.py \
+  tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py
+
+git diff --unified=0 origin/dev -- \
+  tldw_chatbook/TTS/playground_types.py \
+  tldw_chatbook/UI/stts_playground_catalog.py \
+  tldw_chatbook/UI/STTS_Window.py \
+  tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py \
+  | rg '^\+[^+].*(subprocess|create_subprocess|binary_path|server_config_path|server\.json|restart_managed|managed_log)'
+
+git diff --check
+```
+
+Expected: static checks pass; the added-production-line boundary pipeline prints
+nothing and exits `1` because `rg` found no prohibited additions (the existing
+audiobook subprocess code is outside the added lines); `git diff --check`
+passes.
+
+- [ ] **Step 4: Perform security, privacy, and scope self-review**
+
+Confirm:
+
+- provider values are canonical IDs;
+- remote identifiers render as plain text;
+- only selected providers materialize;
+- stale async results are discarded;
+- Server default becomes `None`;
+- audio.cpp uses native `synthesize()` and one complete WAV;
+- legacy generation remains on the bridge;
+- no native POST retry or UI fallback exists;
+- logs/notices exclude text, config/origin/credential values, raw exceptions,
+  and unsafe identifiers;
+- generated artifacts retain immutable provenance;
+- no managed process or managed UI work entered the diff.
+
+- [ ] **Step 5: Complete Backlog evidence**
+
+Add exact verification counts and any documented warnings to TASK-569.
+Check every acceptance criterion and Definition-of-Done item only after its
+evidence passes, then move the task to Done.
+
+- [ ] **Step 6: Final commit**
+
+```bash
+git add \
+  "backlog/tasks/task-569 - Complete-external-audio.cpp-STTS-Playground-vertical.md"
+git commit -m "chore(stts): complete external audio cpp playground task"
+```
+
+## ADR check
+
+ADR required: yes
+
+ADR path:
+`backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md`
+
+Reason: ADR-023 already governs the catalog-driven Playground, external privacy
+boundary, complete-WAV interface, no-fallback policy, lifecycle, and ordered
+slice delivery. Slice 3 implements that accepted decision and updates its
+implementation status; no new ADR is required.

--- a/Docs/superpowers/specs/2026-07-23-audio-cpp-tts-adapter-registry-design.md
+++ b/Docs/superpowers/specs/2026-07-23-audio-cpp-tts-adapter-registry-design.md
@@ -2,7 +2,7 @@
 
 **Status:** approved by the user on 2026-07-23; review amendments approved on 2026-07-23
 **Date:** 2026-07-23
-**Related tasks:** [TASK-561](<../../../backlog/tasks/task-561 - Establish-TTS-adapter-registry-authority-and-legacy-bridge.md>) and [TASK-560](<../../../backlog/tasks/task-560 - Add-external-audio.cpp-native-TTS-adapter.md>)
+**Related tasks:** [TASK-561](<../../../backlog/tasks/task-561 - Establish-TTS-adapter-registry-authority-and-legacy-bridge.md>), [TASK-560](<../../../backlog/tasks/task-560 - Add-external-audio.cpp-native-TTS-adapter.md>), and [TASK-569](<../../../backlog/tasks/task-569 - Complete-external-audio.cpp-STTS-Playground-vertical.md>)
 **Canonical ADR:** [ADR-023](../../../backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md)
 **Upstream contract reviewed:** `0xShug0/audio.cpp` commit `d3d748179e5ace353386fbf17bcaedfacf482d75`
 
@@ -27,12 +27,14 @@ save it.
   adapter, bounded discovery, lazy voices, and complete-WAV synthesis. Its
   exact, alias-free, lazy, exclusive provider spec is registered before the six
   unchanged legacy entries.
-- Slice 3 remains the catalog-driven external STTS Playground vertical.
+- Slice 3, tracked by TASK-569, implements the catalog-driven external STTS
+  Playground from settings and lazy discovery through complete-WAV generation,
+  playback, and export.
 - Slices 4–5 remain user-provided binary plus user-provided `server.json`
   launch/supervision and its managed Playground UI.
 
 No process launching, supervision, binary handling, `server.json` ownership,
-or STTS UI behavior is part of the Slice 2 implementation.
+or managed-process UI behavior is part of Slices 1–3.
 
 ## Pre-implementation baseline
 
@@ -491,31 +493,36 @@ Cancellation closes Chatbook's HTTP operation but may not cancel native
 inference already running on the server. Cancellation does not restart the
 server or mark it unhealthy.
 
-## Future STTS Playground (Slices 3 and 5)
+## Landed external STTS Playground (Slice 3) and future managed UI (Slice 5)
 
 ### Provider and settings UI
 
 Opening STTS lists registry provider descriptors without initializing every
-provider. Only the selected provider is resolved. Selecting audio.cpp is a
-first use and may connect or lazily launch managed mode.
+provider. Descriptor enumeration does not resolve adapter factories. Only the
+selected provider is resolved. In Slice 3, selecting audio.cpp is a first use
+that performs bounded readiness and model discovery against the saved external
+origin.
 
-The audio.cpp settings panel contains:
+The landed external audio.cpp settings panel contains:
 
-- External or Managed mode.
+- External mode.
 - External base URL.
-- Managed binary path.
-- Managed `server.json` path.
-- Advanced timeout, input, audio-response, metadata, catalog, identifier, and
-  log bounds.
+- Advanced timeout, input, audio-response, metadata, catalog, voice, and
+  identifier bounds.
 - Test Connection and Refresh Models for external mode.
-- Start & Test and Restart & Rediscover for managed mode.
+- A notice that synthesis sends submitted text to the configured server.
 
 Save performs local validation and effective-configuration comparison. It does
-not connect or start a process. If configuration changed, the old adapter is
-retired safely. An active audio.cpp provider becomes `reconfiguring`; Generate,
-Test, Refresh, Start, and Restart report a retryable state until existing leases
-finish and the old adapter closes. A managed old child stops during that
-handoff. Save never launches the replacement or kills an in-flight operation.
+not connect. If configuration changed, the old adapter is retired safely. An
+active audio.cpp provider becomes `reconfiguring`; Generate, Test, and Refresh
+report a retryable state until existing leases finish and the old adapter
+closes. Save never materializes the replacement or interrupts an in-flight
+operation.
+
+Slice 5 will add the managed-mode selector, user-provided binary path,
+user-provided `server.json` path, bounded log settings, and ownership-aware
+Start & Test and Restart & Rediscover actions after the Slice 4 supervisor
+exists. None of those settings or actions is available in Slice 3.
 
 ### Catalog-driven controls
 
@@ -555,10 +562,14 @@ Catalog and voice results carry the selected IDs and configuration revision.
 They also carry the catalog revision used for voice discovery. Stale results are
 discarded. Generation captures a request snapshot.
 
-The generated result retains provider, model, voice, actual format, source text
-snapshot, and local operation ID. Switching providers does not relabel it.
-Playback and Save use response metadata, including the `.wav` extension, rather
-than current selector state.
+Generation crosses an immutable provider-neutral request boundary. audio.cpp
+uses native `TTSService.synthesize(TTSRequest)` while the six existing providers
+retain the temporary `generate_audio_stream()` compatibility path.
+
+The generated artifact retains provider, model, voice, actual format/content
+type, safe response metadata, source-text snapshot, and local operation ID.
+Switching providers does not relabel it. Playback and Save use artifact
+provenance, including the `.wav` extension, rather than current selector state.
 
 If a refresh fails, prior catalog data may remain visible and marked stale, but
 Generate is disabled until readiness returns. Existing generated audio remains
@@ -747,11 +758,11 @@ Unit tests use fakes rather than sleeps or real ports and cover:
 A separate small subprocess integration test verifies actual launch, readiness,
 and termination behavior without audio models.
 
-### Future Textual tests (Slices 3 and 5)
+### Landed Textual tests (Slice 3)
 
-- Save does not launch.
-- Selecting audio.cpp and Start & Test trigger lazy readiness.
-- External and managed actions differ.
+- Save does not connect or materialize audio.cpp.
+- Selecting audio.cpp and explicit Test Connection or Refresh Models trigger
+  lazy readiness.
 - Stale provider, model, voice, and configuration-revision results are ignored.
 - Server default remains the initial selection when discovered voices exist.
 - An explicitly selected Server-default sentinel becomes `None`.
@@ -765,6 +776,12 @@ and termination behavior without audio models.
   changes.
 - Stale catalogs remain visible while generation is disabled.
 - Recovery actions map from core action codes without core Textual imports.
+- A mounted Playground completes descriptor discovery, selection, generation,
+  playback/export artifact delivery, unmount/remount, and cleanup using service
+  fakes; normal CI needs no audio.cpp binary, server, or model download.
+
+Slice 5 adds separate Textual coverage for managed versus external actions,
+Start & Test, Restart & Rediscover, and owned-child recovery.
 
 ### Future optional live smoke test (Slice 4)
 
@@ -776,11 +793,11 @@ CI.
 
 ## Documentation and licensing
 
-Slice 2 documentation covers the external text boundary, Server default
-omission, WAV-only complete responses, configuration recovery, and safe
-failure behavior. Later user documentation will add the loopback-only managed
-boundary and the potentially sensitive nature of explicitly displayed managed
-child logs.
+Slices 2–3 documentation covers external setup, the external text boundary,
+Server default omission, WAV-only complete responses, configuration recovery,
+safe failure behavior, playback, and export. Later user documentation will add
+the loopback-only managed boundary and the potentially sensitive nature of
+explicitly displayed managed child logs.
 
 audio.cpp is Apache-2.0 licensed. This milestone links to and interoperates with
 a user-provided binary; it does not redistribute audio.cpp. Automatic download,
@@ -800,12 +817,12 @@ falls back.
 This feature-level design is delivered as five ordered, single-PR slices rather
 than one omnibus implementation task:
 
-1. Establish registry authority and contain existing providers in the legacy
-   bridge, including the compatibility generation and progress paths.
-2. Add the external audio.cpp contract and native adapter, proving discovery
-   and complete WAV synthesis through the service boundary.
-3. Make the STTS Playground catalog-driven and complete the external audio.cpp
-   end-to-end flow.
+1. Implemented: establish registry authority and contain existing providers in
+   the legacy bridge, including compatibility generation and progress paths.
+2. Implemented: add the external audio.cpp contract and native adapter, proving
+   discovery and complete WAV synthesis through the service boundary.
+3. Implemented by TASK-569: make the STTS Playground catalog-driven and
+   complete the external audio.cpp end-to-end flow.
 4. Add the managed audio.cpp supervisor for lazy launch, monitoring, restart,
    and owned-child shutdown.
 5. Add managed audio.cpp settings and actions to the STTS Playground, completing

--- a/Tests/TTS/test_audio_cpp_config.py
+++ b/Tests/TTS/test_audio_cpp_config.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from dataclasses import FrozenInstanceError
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from pydantic import BaseModel, ValidationError
 
 
 DEFAULT_CONFIG = {
@@ -43,6 +43,12 @@ def _config_api() -> tuple[Any, Any]:
     return AudioCppConfig, project_audio_cpp_config
 
 
+def test_audio_cpp_config_is_a_pydantic_validation_model() -> None:
+    AudioCppConfig, _ = _config_api()
+
+    assert issubclass(AudioCppConfig, BaseModel)
+
+
 def test_defaults_are_immutable_and_bounded() -> None:
     AudioCppConfig, project_audio_cpp_config = _config_api()
 
@@ -50,7 +56,7 @@ def test_defaults_are_immutable_and_bounded() -> None:
 
     assert config == AudioCppConfig()
     assert config.to_mapping() == DEFAULT_CONFIG
-    with pytest.raises(FrozenInstanceError):
+    with pytest.raises(ValidationError):
         config.base_url = "http://example.test"  # type: ignore[misc]
 
 

--- a/Tests/TTS/test_stts_audio_cpp_generation.py
+++ b/Tests/TTS/test_stts_audio_cpp_generation.py
@@ -1,0 +1,714 @@
+from __future__ import annotations
+
+import asyncio
+import stat
+from uuid import UUID
+from collections.abc import AsyncIterator, Mapping
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from loguru import logger
+from textual import on
+from textual.app import App, ComposeResult
+from textual.widgets import Button, Input, Select, Static, TextArea
+
+from tldw_chatbook.Event_Handlers.STTS_Events.stts_events import (
+    STTSEventHandler,
+    STTSPlaygroundGenerateEvent,
+)
+from tldw_chatbook.TTS import (
+    STTSGeneratedAudio,
+    STTSPlaygroundRequest,
+    ProviderHealth,
+    TTSOperationError,
+    TTSModelInfo,
+    TTSProviderCatalog,
+    TTSProviderDescriptor,
+    TTSRequest,
+)
+from tldw_chatbook.TTS.adapter_types import (
+    TTSProviderReconfiguringError,
+    TTSRegistryClosedError,
+)
+from tldw_chatbook.UI import STTS_Window
+from tldw_chatbook.UI.STTS_Window import TTSPlaygroundWidget
+
+
+def _snapshot(
+    *,
+    provider_id: str = "audio_cpp",
+    response_format: str = "wav",
+    options: Mapping[str, Any] | None = None,
+    model_id: str = "model-1",
+    text: str = "private source text",
+) -> STTSPlaygroundRequest:
+    return STTSPlaygroundRequest(
+        operation_id="local-operation-1",
+        provider_id=provider_id,
+        model_id=model_id,
+        text=text,
+        voice_id=None if provider_id == "audio_cpp" else "alloy",
+        response_format=response_format,
+        speed=1.0,
+        options=options or {},
+    )
+
+
+class _CountingStream:
+    def __init__(
+        self,
+        chunks: tuple[bytes, ...],
+        *,
+        failure: BaseException | None = None,
+        blocked: asyncio.Event | None = None,
+    ) -> None:
+        self.chunks = chunks
+        self.failure = failure
+        self.blocked = blocked
+        self.iterations = 0
+        self.close_calls = 0
+
+    def __aiter__(self) -> AsyncIterator[bytes]:
+        self.iterations += 1
+        return self._iterate()
+
+    async def _iterate(self) -> AsyncIterator[bytes]:
+        for chunk in self.chunks:
+            yield chunk
+        if self.blocked is not None:
+            await self.blocked.wait()
+        if self.failure is not None:
+            raise self.failure
+
+    async def aclose(self) -> None:
+        self.close_calls += 1
+
+
+class _Response:
+    def __init__(
+        self,
+        stream: _CountingStream,
+        *,
+        provider_id: str = "audio_cpp",
+        model_id: str = "server-model",
+        audio_format: str = "wav",
+        content_type: str = "audio/wav",
+        metadata: Mapping[str, str | int | float | bool | None] | None = None,
+    ) -> None:
+        self.provider_id = provider_id
+        self.model_id = model_id
+        self.audio_format = audio_format
+        self.content_type = content_type
+        self.byte_stream = stream
+        self.metadata = metadata or {}
+        self.close_calls = 0
+
+    async def aclose(self) -> None:
+        self.close_calls += 1
+        await self.byte_stream.aclose()
+
+
+class _NativeService:
+    def __init__(self, response: _Response) -> None:
+        self.response = response
+        self.requests: list[TTSRequest] = []
+        self.legacy_calls = 0
+
+    async def synthesize(
+        self,
+        request: TTSRequest,
+        progress_sink: object = None,
+    ) -> _Response:
+        del progress_sink
+        self.requests.append(request)
+        return self.response
+
+    async def generate_audio_stream(
+        self,
+        *_args: object,
+        **_kwargs: object,
+    ) -> AsyncIterator[bytes]:
+        self.legacy_calls += 1
+        raise AssertionError("audio.cpp must not use the legacy stream bridge")
+        yield b""  # pragma: no cover
+
+
+class _LegacyService:
+    def __init__(self) -> None:
+        self.stream_calls: list[tuple[object, str, object]] = []
+        self.native_calls = 0
+
+    async def synthesize(self, *_args: object, **_kwargs: object) -> None:
+        self.native_calls += 1
+        raise AssertionError("legacy generation must retain the bridge")
+
+    async def generate_audio_stream(
+        self,
+        request: object,
+        internal_model_id: str,
+        progress_sink: object = None,
+    ) -> AsyncIterator[bytes]:
+        self.stream_calls.append((request, internal_model_id, progress_sink))
+        yield b"RIFF"
+        yield b"legacy"
+
+
+class _DeliveryPlayground:
+    def __init__(self) -> None:
+        self.completions: list[STTSGeneratedAudio | None] = []
+        self.log = SimpleNamespace(write=Mock())
+        self.progress = SimpleNamespace(update=Mock())
+        self.container = SimpleNamespace(remove_class=Mock(), add_class=Mock())
+        self.status = SimpleNamespace(update=Mock())
+        self.button = SimpleNamespace(disabled=True)
+
+    def query_one(self, selector: str, _widget_type: object = None) -> object:
+        return {
+            "#generation-status-container": self.container,
+            "#generation-progress": self.progress,
+            "#generation-status-text": self.status,
+            "#tts-generation-log": self.log,
+            "#tts-generate-btn": self.button,
+        }[selector]
+
+    def call_from_thread(self, callback: object, *args: object) -> None:
+        assert callable(callback)
+        callback(*args)
+
+    def _generation_complete(
+        self,
+        artifact: STTSGeneratedAudio | None,
+    ) -> None:
+        self.completions.append(artifact)
+
+
+class _DeliveryApp:
+    def __init__(self, playground: _DeliveryPlayground | None = None) -> None:
+        self.playground = playground
+        self.notifications: list[tuple[str, str]] = []
+
+    def query_one(self, _widget_type: object) -> _DeliveryPlayground:
+        if self.playground is None:
+            raise LookupError("Playground is not mounted")
+        return self.playground
+
+    def notify(self, message: str, *, severity: str = "information") -> None:
+        self.notifications.append((message, severity))
+
+
+def _handler(service: object) -> STTSEventHandler:
+    handler = STTSEventHandler(
+        app=SimpleNamespace(notify=lambda *_args, **_kwargs: None)
+    )
+    handler._stts_service = service
+    return handler
+
+
+class _SnapshotService:
+    def provider_descriptors(self) -> tuple[TTSProviderDescriptor, ...]:
+        return (
+            TTSProviderDescriptor(
+                provider_id="audio_cpp",
+                display_name="audio.cpp",
+                native=True,
+            ),
+        )
+
+    def configuration_revision(self, _provider_id: str) -> int:
+        return 1
+
+    async def get_catalog(
+        self,
+        _provider_id: str,
+        refresh: bool = False,
+    ) -> TTSProviderCatalog:
+        del refresh
+        return TTSProviderCatalog(
+            provider_id="audio_cpp",
+            revision=1,
+            health=ProviderHealth(state="available", fresh=True),
+            models=(
+                TTSModelInfo(
+                    model_id="model-1",
+                    display_name="Model 1",
+                    family="test",
+                    upstream_mode="tts",
+                    formats=("wav",),
+                    voices=(),
+                    supports_speed=False,
+                    omit_voice_uses_server_default=True,
+                ),
+                TTSModelInfo(
+                    model_id="model-2",
+                    display_name="Model 2",
+                    family="test",
+                    upstream_mode="tts",
+                    formats=("wav",),
+                    voices=(),
+                    supports_speed=False,
+                    omit_voice_uses_server_default=True,
+                ),
+            ),
+        )
+
+    async def get_voices(
+        self,
+        _provider_id: str,
+        _model_id: str,
+        refresh: bool = False,
+    ) -> tuple[str, ...]:
+        del refresh
+        return ()
+
+
+class _SnapshotHost(App[None]):
+    def __init__(self) -> None:
+        super().__init__()
+        self.generation_events: list[STTSPlaygroundGenerateEvent] = []
+
+    def compose(self) -> ComposeResult:
+        yield TTSPlaygroundWidget()
+
+    @on(STTSPlaygroundGenerateEvent)
+    def capture_generation(self, event: STTSPlaygroundGenerateEvent) -> None:
+        self.generation_events.append(event)
+
+
+async def _resolved(value: object) -> object:
+    return value
+
+
+def test_generation_event_owns_one_immutable_request_snapshot() -> None:
+    request = _snapshot(options={"nested": {"value": 1}})
+
+    event = STTSPlaygroundGenerateEvent(request)
+
+    assert event.request is request
+    with pytest.raises(TypeError):
+        event.request.options["new"] = "value"  # type: ignore[index]
+    with pytest.raises(TypeError):
+        event.request.options["nested"]["value"] = 2  # type: ignore[index]
+
+
+@pytest.mark.asyncio
+async def test_playground_captures_audio_cpp_request_before_controls_change(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = _SnapshotService()
+    monkeypatch.setattr(
+        STTS_Window,
+        "get_cli_setting",
+        lambda section, key, default=None: (
+            "audio_cpp"
+            if (section, key) == ("app_tts", "default_provider")
+            else default
+        ),
+    )
+    monkeypatch.setattr(
+        STTS_Window,
+        "get_tts_service",
+        lambda: _resolved(service),
+    )
+    app = _SnapshotHost()
+
+    async with app.run_test(size=(160, 60)) as pilot:
+        await app.workers.wait_for_complete()
+        text_area = app.query_one("#tts-text-input", TextArea)
+        model_select = app.query_one("#tts-model-select", Select)
+        speed_input = app.query_one("#tts-speed-input", Input)
+        text_area.text = "original private text"
+        await pilot.pause()
+
+        app.query_one(TTSPlaygroundWidget)._generate_tts()
+        await pilot.pause()
+        assert len(app.generation_events) == 1
+        request = app.generation_events[0].request
+
+        text_area.text = "changed after post"
+        model_select.value = "model-2"
+        speed_input.value = "9.0"
+        await pilot.pause()
+
+        UUID(request.operation_id)
+        assert request.provider_id == "audio_cpp"
+        assert request.model_id == "model-1"
+        assert request.text == "original private text"
+        assert request.voice_id is None
+        assert request.response_format == "wav"
+        assert request.speed == 1.0
+        assert dict(request.options) == {}
+
+
+@pytest.mark.asyncio
+async def test_playground_stores_delivered_artifact_not_current_selectors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    service = _SnapshotService()
+    monkeypatch.setattr(
+        STTS_Window,
+        "get_cli_setting",
+        lambda section, key, default=None: (
+            "audio_cpp"
+            if (section, key) == ("app_tts", "default_provider")
+            else default
+        ),
+    )
+    monkeypatch.setattr(
+        STTS_Window,
+        "get_tts_service",
+        lambda: _resolved(service),
+    )
+    app = _SnapshotHost()
+    artifact_path = tmp_path / "actual-response.wav"
+    artifact_path.write_bytes(b"RIFF")
+    artifact = STTSGeneratedAudio(
+        path=artifact_path,
+        provider_id="audio_cpp",
+        model_id="response-model",
+        voice_id=None,
+        source_text="original text",
+        operation_id="operation-2",
+        audio_format="wav",
+        content_type="audio/wav",
+        metadata={"sample_rate": 24_000},
+    )
+
+    async with app.run_test(size=(160, 60)) as pilot:
+        await app.workers.wait_for_complete()
+        widget = app.query_one(TTSPlaygroundWidget)
+        app.query_one("#tts-model-select", Select).value = "model-2"
+        widget._generation_complete(artifact)
+        await pilot.pause()
+
+        assert widget.current_audio_artifact is artifact
+        assert widget.current_audio_file == artifact_path
+        assert app.query_one("#audio-play-btn", Button).disabled is False
+        assert app.query_one("#audio-export-btn", Button).disabled is False
+        assert (
+            str(app.query_one("#audio-player-status", Static).render())
+            == "WAV audio ready to play"
+        )
+
+
+@pytest.mark.asyncio
+async def test_audio_cpp_native_generation_consumes_and_closes_one_wav_response() -> (
+    None
+):
+    stream = _CountingStream((b"RIFF", b"audio"))
+    response = _Response(
+        stream,
+        metadata={"sample_rate": 24_000, "engine": "audio.cpp"},
+    )
+    service = _NativeService(response)
+    handler = _handler(service)
+    handler._convert_audio_format = AsyncMock(
+        side_effect=AssertionError("audio.cpp must not convert")
+    )
+    snapshot = _snapshot()
+
+    artifact = await handler._generate_audio_cpp(snapshot, None)
+
+    try:
+        assert service.requests == [
+            TTSRequest(
+                provider_id="audio_cpp",
+                model_id="model-1",
+                text="private source text",
+                voice=None,
+                response_format="wav",
+                speed=1.0,
+                options={},
+            )
+        ]
+        assert service.legacy_calls == 0
+        handler._convert_audio_format.assert_not_awaited()
+        assert stream.iterations == 1
+        assert stream.close_calls == 1
+        assert response.close_calls == 1
+        assert artifact == STTSGeneratedAudio(
+            path=artifact.path,
+            provider_id="audio_cpp",
+            model_id="server-model",
+            voice_id=None,
+            source_text="private source text",
+            operation_id="local-operation-1",
+            audio_format="wav",
+            content_type="audio/wav",
+            metadata={"sample_rate": 24_000, "engine": "audio.cpp"},
+        )
+        assert artifact.path.read_bytes() == b"RIFFaudio"
+        assert artifact.path.suffix == ".wav"
+        assert stat.S_IMODE(artifact.path.stat().st_mode) == 0o600
+        assert artifact.path in handler._playground_audio_files
+    finally:
+        artifact.path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_audio_cpp_native_generation_preserves_stream_error_and_closes() -> None:
+    primary = RuntimeError("primary stream failure")
+    stream = _CountingStream((b"partial",), failure=primary)
+
+    class CloseFailingResponse(_Response):
+        async def aclose(self) -> None:
+            await super().aclose()
+            raise RuntimeError("secondary close failure")
+
+    response = CloseFailingResponse(stream)
+    handler = _handler(_NativeService(response))
+
+    with pytest.raises(RuntimeError) as raised:
+        await handler._generate_audio_cpp(_snapshot(), None)
+
+    assert raised.value is primary
+    assert response.close_calls == 1
+    assert stream.close_calls == 1
+    assert handler._playground_audio_files == set()
+
+
+@pytest.mark.asyncio
+async def test_audio_cpp_native_generation_propagates_cancellation_and_closes() -> None:
+    blocked = asyncio.Event()
+    stream = _CountingStream((), blocked=blocked)
+    response = _Response(stream)
+    handler = _handler(_NativeService(response))
+    generation = asyncio.create_task(handler._generate_audio_cpp(_snapshot(), None))
+    await asyncio.sleep(0)
+
+    generation.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await generation
+
+    assert response.close_calls == 1
+    assert stream.close_calls == 1
+    assert handler._playground_audio_files == set()
+
+
+@pytest.mark.asyncio
+async def test_legacy_generation_retains_stream_bridge_and_requested_conversion(
+    tmp_path: Path,
+) -> None:
+    service = _LegacyService()
+    handler = _handler(service)
+
+    async def convert(input_path: Path, output_format: str) -> Path:
+        assert input_path.read_bytes() == b"RIFFlegacy"
+        assert output_format == "mp3"
+        output = input_path.with_suffix(".mp3")
+        output.write_bytes(b"converted")
+        return output
+
+    handler._convert_audio_format = AsyncMock(side_effect=convert)
+
+    artifact = await handler._generate_legacy(
+        _snapshot(provider_id="openai", response_format="mp3"),
+        None,
+    )
+
+    try:
+        assert len(service.stream_calls) == 1
+        request, internal_model_id, _progress_sink = service.stream_calls[0]
+        assert request.model == "model-1"
+        assert request.input == "private source text"
+        assert request.voice == "alloy"
+        assert request.response_format == "wav"
+        assert internal_model_id == "openai_official_model1"
+        assert service.native_calls == 0
+        handler._convert_audio_format.assert_awaited_once()
+        assert artifact.audio_format == "mp3"
+        assert artifact.path.read_bytes() == b"converted"
+        assert artifact.provider_id == "openai"
+        assert artifact.model_id == "model-1"
+        assert artifact.voice_id == "alloy"
+        assert artifact.path in handler._playground_audio_files
+    finally:
+        for path in tuple(handler._playground_audio_files):
+            path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_handler_dispatches_native_generation_and_delivers_artifact() -> None:
+    response = _Response(_CountingStream((b"RIFF", b"audio")))
+    playground = _DeliveryPlayground()
+    app = _DeliveryApp(playground)
+    handler = STTSEventHandler(app=app)
+    service = _NativeService(response)
+    handler._stts_service = service
+
+    await handler.handle_playground_generate(STTSPlaygroundGenerateEvent(_snapshot()))
+
+    artifact = handler._current_playground_artifact
+    try:
+        assert artifact is not None
+        assert handler._current_audio_file == artifact.path
+        assert playground.completions == [artifact]
+        assert app.notifications == [
+            ("TTS generation complete!", "information"),
+        ]
+        assert handler._is_generating is False
+    finally:
+        if artifact is not None:
+            artifact.path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "code",
+    (
+        "configuration_invalid",
+        "connection_unavailable",
+        "contract_incompatible",
+        "not_configured",
+        "request_invalid",
+        "model_invalid",
+        "server_busy",
+        "generation_failed",
+        "audio_response_invalid",
+        "generation_timeout",
+    ),
+)
+async def test_native_operation_errors_display_only_stable_safe_contract(
+    code: str,
+) -> None:
+    operation_error = TTSOperationError(
+        code=code,  # type: ignore[arg-type]
+        message="[safe provider message]",
+        retryable=True,
+        operation_id="provider-operation",
+        recovery_action="Retry from STTS",
+    )
+    service = SimpleNamespace(
+        synthesize=AsyncMock(side_effect=operation_error),
+    )
+    app = _DeliveryApp()
+    handler = STTSEventHandler(app=app)
+    handler._stts_service = service
+
+    await handler.handle_playground_generate(STTSPlaygroundGenerateEvent(_snapshot()))
+
+    assert app.notifications == [
+        (
+            "TTS generation failed: \\[safe provider message] Retry from STTS",
+            "error",
+        )
+    ]
+    assert handler._is_generating is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("failure", "expected"),
+    (
+        (
+            TTSProviderReconfiguringError("PRIVATE_RECONFIGURING"),
+            "TTS settings are being applied; retry shortly",
+        ),
+        (
+            TTSRegistryClosedError("PRIVATE_CLOSED"),
+            "The TTS service is unavailable",
+        ),
+        (
+            ValueError("PRIVATE_CONFIGURATION"),
+            "TTS is not configured; open STTS Settings",
+        ),
+    ),
+)
+async def test_native_local_failures_use_fixed_recovery_copy(
+    failure: Exception,
+    expected: str,
+) -> None:
+    service = SimpleNamespace(synthesize=AsyncMock(side_effect=failure))
+    app = _DeliveryApp()
+    handler = STTSEventHandler(app=app)
+    handler._stts_service = service
+
+    await handler.handle_playground_generate(STTSPlaygroundGenerateEvent(_snapshot()))
+
+    assert app.notifications == [(f"TTS generation failed: {expected}", "error")]
+    assert str(failure) not in app.notifications[0][0]
+
+
+@pytest.mark.asyncio
+async def test_unknown_native_failure_never_leaks_exception_or_request_details() -> (
+    None
+):
+    private_values = (
+        "UNKNOWN_FAILURE_SECRET",
+        "private source text",
+        "https://user:password@example.invalid",
+        "PRIVATE_MODEL_ID",
+    )
+    failure = RuntimeError(" ".join(private_values))
+    service = SimpleNamespace(synthesize=AsyncMock(side_effect=failure))
+    app = _DeliveryApp()
+    handler = STTSEventHandler(app=app)
+    handler._stts_service = service
+    messages: list[str] = []
+    sink_id = logger.add(messages.append, level="DEBUG", format="{message}")
+    try:
+        await handler.handle_playground_generate(
+            STTSPlaygroundGenerateEvent(
+                _snapshot(
+                    model_id=private_values[3],
+                    text=private_values[1],
+                    options={"origin": private_values[2]},
+                )
+            )
+        )
+    finally:
+        logger.remove(sink_id)
+
+    rendered = "\n".join(messages)
+    notices = "\n".join(message for message, _severity in app.notifications)
+    assert app.notifications == [
+        (
+            "TTS generation failed: Unexpected TTS generation failure; retry",
+            "error",
+        )
+    ]
+    for private_value in private_values:
+        assert private_value not in rendered
+        assert private_value not in notices
+
+
+@pytest.mark.asyncio
+async def test_cancelled_native_handler_closes_without_failure_notice() -> None:
+    blocked = asyncio.Event()
+    response = _Response(_CountingStream((), blocked=blocked))
+    service = _NativeService(response)
+    app = _DeliveryApp()
+    handler = STTSEventHandler(app=app)
+    handler._stts_service = service
+    generation = asyncio.create_task(
+        handler.handle_playground_generate(STTSPlaygroundGenerateEvent(_snapshot()))
+    )
+    await asyncio.sleep(0)
+
+    generation.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await generation
+
+    assert response.close_calls == 1
+    assert app.notifications == []
+    assert handler._is_generating is False
+
+
+@pytest.mark.asyncio
+async def test_repeated_generate_is_rejected_without_replacing_active_work() -> None:
+    service = SimpleNamespace(synthesize=AsyncMock())
+    app = _DeliveryApp()
+    handler = STTSEventHandler(app=app)
+    handler._stts_service = service
+    handler._is_generating = True
+
+    await handler.handle_playground_generate(STTSPlaygroundGenerateEvent(_snapshot()))
+
+    service.synthesize.assert_not_awaited()
+    assert handler._is_generating is True
+    assert app.notifications == [
+        ("TTS generation already in progress", "warning"),
+    ]

--- a/Tests/TTS/test_stts_audio_cpp_generation.py
+++ b/Tests/TTS/test_stts_audio_cpp_generation.py
@@ -277,6 +277,32 @@ class _SnapshotHost(App[None]):
         self.generation_events.append(event)
 
 
+class _EndToEndHost(App[None]):
+    def __init__(self, native_service: object) -> None:
+        super().__init__()
+        self.notifications: list[tuple[str, str]] = []
+        self._stts_handler = STTSEventHandler(app=self)
+        self._stts_handler._stts_service = native_service
+
+    def compose(self) -> ComposeResult:
+        yield TTSPlaygroundWidget()
+
+    @on(STTSPlaygroundGenerateEvent)
+    def generate(self, event: STTSPlaygroundGenerateEvent) -> None:
+        self._stts_handler.start_playground_generation(event)
+
+    def notify(
+        self,
+        message: str,
+        *,
+        title: str = "",
+        severity: str = "information",
+        timeout: float | None = None,
+    ) -> None:
+        del title, timeout
+        self.notifications.append((message, severity))
+
+
 async def _resolved(value: object) -> object:
     return value
 
@@ -392,6 +418,103 @@ async def test_playground_stores_delivered_artifact_not_current_selectors(
             str(app.query_one("#audio-player-status", Static).render())
             == "WAV audio ready to play"
         )
+
+
+@pytest.mark.asyncio
+async def test_audio_cpp_playground_runs_end_to_end_through_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog_service = _SnapshotService()
+    native_service = _NativeService(
+        _Response(_CountingStream((b"RIFF", b"end-to-end")))
+    )
+    monkeypatch.setattr(
+        STTS_Window,
+        "get_cli_setting",
+        lambda section, key, default=None: (
+            "audio_cpp"
+            if (section, key) == ("app_tts", "default_provider")
+            else default
+        ),
+    )
+    monkeypatch.setattr(
+        STTS_Window,
+        "get_tts_service",
+        lambda: _resolved(catalog_service),
+    )
+    app = _EndToEndHost(native_service)
+
+    async with app.run_test(size=(160, 60)) as pilot:
+        await app.workers.wait_for_complete()
+        widget = app.query_one(TTSPlaygroundWidget)
+        app.query_one("#tts-text-input", TextArea).text = "synthesize this"
+        await pilot.pause()
+
+        widget._generate_tts()
+        for _ in range(100):
+            if app._stts_handler.playground_state().artifact is not None:
+                break
+            await pilot.pause(0.02)
+        await pilot.pause()
+
+        artifact = app._stts_handler.playground_state().artifact
+        assert artifact is not None
+        assert artifact.path.read_bytes() == b"RIFFend-to-end"
+        assert widget.current_audio_artifact is artifact
+        assert widget.current_audio_file == artifact.path
+        assert app.query_one("#audio-play-btn", Button).disabled is False
+        assert app.query_one("#audio-export-btn", Button).disabled is False
+
+    await app._stts_handler.cleanup_tts_resources()
+
+
+@pytest.mark.asyncio
+async def test_catalog_refresh_does_not_cancel_handler_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog_service = _SnapshotService()
+    release = asyncio.Event()
+    native_service = _NativeService(_Response(_CountingStream((), blocked=release)))
+    monkeypatch.setattr(
+        STTS_Window,
+        "get_cli_setting",
+        lambda section, key, default=None: (
+            "audio_cpp"
+            if (section, key) == ("app_tts", "default_provider")
+            else default
+        ),
+    )
+    monkeypatch.setattr(
+        STTS_Window,
+        "get_tts_service",
+        lambda: _resolved(catalog_service),
+    )
+    app = _EndToEndHost(native_service)
+
+    async with app.run_test(size=(160, 60)) as pilot:
+        await app.workers.wait_for_complete()
+        widget = app.query_one(TTSPlaygroundWidget)
+        app.query_one("#tts-text-input", TextArea).text = "synthesize this"
+        await pilot.pause()
+        widget._generate_tts()
+        for _ in range(100):
+            if app._stts_handler.playground_state().generation_active:
+                break
+            await pilot.pause(0.02)
+        generation_task = app._stts_handler._generation_task
+        assert generation_task is not None
+
+        widget._load_provider_catalog("audio_cpp", refresh=True)
+        await app.workers.wait_for_complete()
+
+        assert app._stts_handler._generation_task is generation_task
+        assert generation_task.done() is False
+        assert generation_task.cancelled() is False
+
+        release.set()
+        await generation_task
+
+    await app._stts_handler.cleanup_tts_resources()
 
 
 @pytest.mark.asyncio
@@ -711,4 +834,174 @@ async def test_repeated_generate_is_rejected_without_replacing_active_work() -> 
     assert handler._is_generating is True
     assert app.notifications == [
         ("TTS generation already in progress", "warning"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_handler_retains_one_generation_task_and_exposes_read_only_state() -> (
+    None
+):
+    release = asyncio.Event()
+    first_response = _Response(_CountingStream((), blocked=release))
+    service = _NativeService(first_response)
+    app = _DeliveryApp()
+    handler = STTSEventHandler(app=app)
+    handler._stts_service = service
+    first_event = STTSPlaygroundGenerateEvent(_snapshot())
+    second_event = STTSPlaygroundGenerateEvent(
+        STTSPlaygroundRequest(
+            operation_id="local-operation-2",
+            provider_id="audio_cpp",
+            model_id="model-2",
+            text="second",
+            voice_id=None,
+            response_format="wav",
+        )
+    )
+
+    handler.start_playground_generation(first_event)
+    await asyncio.sleep(0)
+    retained_task = handler._generation_task
+    state = handler.playground_state()
+    handler.start_playground_generation(second_event)
+
+    assert retained_task is not None
+    assert handler._generation_task is retained_task
+    assert state.active_operation_id == "local-operation-1"
+    assert state.generation_active is True
+    assert state.artifact is None
+    assert app.notifications == [
+        ("TTS generation already in progress", "warning"),
+    ]
+
+    release.set()
+    await retained_task
+    finished_state = handler.playground_state()
+    try:
+        assert finished_state.active_operation_id is None
+        assert finished_state.generation_active is False
+        assert finished_state.artifact is not None
+        assert finished_state.artifact.operation_id == "local-operation-1"
+    finally:
+        await handler.cleanup_tts_resources()
+
+
+@pytest.mark.asyncio
+async def test_successful_replacement_and_shutdown_delete_owned_artifacts() -> None:
+    app = _DeliveryApp()
+    handler = STTSEventHandler(app=app)
+    handler._stts_service = _NativeService(
+        _Response(_CountingStream((b"RIFF", b"first")))
+    )
+    await handler.handle_playground_generate(STTSPlaygroundGenerateEvent(_snapshot()))
+    first = handler._current_playground_artifact
+    assert first is not None
+    assert first.path.exists()
+
+    handler._stts_service = _NativeService(
+        _Response(_CountingStream((b"RIFF", b"second")))
+    )
+    await handler.handle_playground_generate(
+        STTSPlaygroundGenerateEvent(
+            STTSPlaygroundRequest(
+                operation_id="local-operation-2",
+                provider_id="audio_cpp",
+                model_id="model-2",
+                text="second",
+                voice_id=None,
+                response_format="wav",
+            )
+        )
+    )
+    second = handler._current_playground_artifact
+
+    assert second is not None
+    assert second.path.exists()
+    assert second.path.read_bytes() == b"RIFFsecond"
+    assert not first.path.exists()
+    assert handler._playground_audio_files == {second.path}
+    assert handler._playground_operation_files == {
+        "local-operation-2": {second.path},
+    }
+
+    await handler.cleanup_tts_resources()
+
+    assert not second.path.exists()
+    assert handler._current_playground_artifact is None
+    assert handler._current_audio_file is None
+    assert handler._playground_audio_files == set()
+    assert handler._playground_operation_files == {}
+
+
+@pytest.mark.asyncio
+async def test_generation_survives_broken_or_removed_progress_view() -> None:
+    class BrokenPlayground:
+        def query_one(self, *_args: object, **_kwargs: object) -> object:
+            raise LookupError("PRIVATE_REMOVED_WIDGET")
+
+        def call_from_thread(self, callback: object, *args: object) -> None:
+            assert callable(callback)
+            callback(*args)
+
+    response = _Response(_CountingStream((b"RIFF", b"audio")))
+    app = _DeliveryApp(BrokenPlayground())  # type: ignore[arg-type]
+    handler = STTSEventHandler(app=app)
+    handler._stts_service = _NativeService(response)
+
+    await handler.handle_playground_generate(STTSPlaygroundGenerateEvent(_snapshot()))
+
+    artifact = handler._current_playground_artifact
+    try:
+        assert artifact is not None
+        assert artifact.path.read_bytes() == b"RIFFaudio"
+        assert app.notifications == [
+            ("TTS generation complete!", "information"),
+        ]
+    finally:
+        await handler.cleanup_tts_resources()
+
+
+@pytest.mark.asyncio
+async def test_unmounted_view_is_not_retained_or_called_on_completion() -> None:
+    release = asyncio.Event()
+    response = _Response(_CountingStream((), blocked=release))
+    first_view = _DeliveryPlayground()
+    app = _DeliveryApp(first_view)
+    handler = STTSEventHandler(app=app)
+    handler._stts_service = _NativeService(response)
+    handler.start_playground_generation(STTSPlaygroundGenerateEvent(_snapshot()))
+    await asyncio.sleep(0)
+    retained_task = handler._generation_task
+    assert retained_task is not None
+
+    app.playground = None
+    release.set()
+    await retained_task
+
+    state = handler.playground_state()
+    try:
+        assert first_view.completions == []
+        assert state.generation_active is False
+        assert state.active_operation_id is None
+        assert state.artifact is not None
+        assert state.artifact.path.exists()
+    finally:
+        await handler.cleanup_tts_resources()
+
+
+@pytest.mark.asyncio
+async def test_unavailable_service_releases_playground_generation_state() -> None:
+    playground = _DeliveryPlayground()
+    app = _DeliveryApp(playground)
+    handler = STTSEventHandler(app=app)
+
+    await handler.handle_playground_generate(STTSPlaygroundGenerateEvent(_snapshot()))
+
+    state = handler.playground_state()
+    assert playground.completions == [None]
+    assert state.active_operation_id is None
+    assert state.generation_active is False
+    assert state.artifact is None
+    assert app.notifications == [
+        ("TTS service not initialized", "error"),
     ]

--- a/Tests/TTS/test_stts_audio_cpp_generation.py
+++ b/Tests/TTS/test_stts_audio_cpp_generation.py
@@ -208,6 +208,9 @@ def _handler(service: object) -> STTSEventHandler:
 
 
 class _SnapshotService:
+    def __init__(self) -> None:
+        self.revision = 1
+
     def provider_descriptors(self) -> tuple[TTSProviderDescriptor, ...]:
         return (
             TTSProviderDescriptor(
@@ -218,7 +221,7 @@ class _SnapshotService:
         )
 
     def configuration_revision(self, _provider_id: str) -> int:
-        return 1
+        return self.revision
 
     async def get_catalog(
         self,
@@ -366,6 +369,80 @@ async def test_playground_captures_audio_cpp_request_before_controls_change(
         assert request.response_format == "wav"
         assert request.speed == 1.0
         assert dict(request.options) == {}
+
+
+@pytest.mark.asyncio
+async def test_playground_shortcut_does_not_replace_active_operation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = _SnapshotService()
+    monkeypatch.setattr(
+        STTS_Window,
+        "get_cli_setting",
+        lambda section, key, default=None: (
+            "audio_cpp"
+            if (section, key) == ("app_tts", "default_provider")
+            else default
+        ),
+    )
+    monkeypatch.setattr(
+        STTS_Window,
+        "get_tts_service",
+        lambda: _resolved(service),
+    )
+    app = _SnapshotHost()
+
+    async with app.run_test(size=(160, 60)) as pilot:
+        await app.workers.wait_for_complete()
+        widget = app.query_one(TTSPlaygroundWidget)
+        app.query_one("#tts-text-input", TextArea).text = "only once"
+        await pilot.pause()
+
+        widget._generate_tts()
+        await pilot.pause()
+        first_operation_id = widget._generation_operation_id
+
+        widget.action_generate_tts()
+        await pilot.pause()
+
+        assert first_operation_id is not None
+        assert widget._generation_operation_id == first_operation_id
+        assert len(app.generation_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_playground_shortcut_rejects_stale_configuration_revision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = _SnapshotService()
+    monkeypatch.setattr(
+        STTS_Window,
+        "get_cli_setting",
+        lambda section, key, default=None: (
+            "audio_cpp"
+            if (section, key) == ("app_tts", "default_provider")
+            else default
+        ),
+    )
+    monkeypatch.setattr(
+        STTS_Window,
+        "get_tts_service",
+        lambda: _resolved(service),
+    )
+    app = _SnapshotHost()
+
+    async with app.run_test(size=(160, 60)) as pilot:
+        await app.workers.wait_for_complete()
+        widget = app.query_one(TTSPlaygroundWidget)
+        app.query_one("#tts-text-input", TextArea).text = "stale request"
+        await pilot.pause()
+
+        service.revision = 2
+        widget.action_generate_tts()
+        await pilot.pause()
+
+        assert widget._generation_operation_id is None
+        assert app.generation_events == []
 
 
 @pytest.mark.asyncio
@@ -702,7 +779,7 @@ async def test_native_operation_errors_display_only_stable_safe_contract(
         message="[safe provider message]",
         retryable=True,
         operation_id="provider-operation",
-        recovery_action="Retry from STTS",
+        recovery_action="retry",
     )
     service = SimpleNamespace(
         synthesize=AsyncMock(side_effect=operation_error),
@@ -715,11 +792,44 @@ async def test_native_operation_errors_display_only_stable_safe_contract(
 
     assert app.notifications == [
         (
-            "TTS generation failed: \\[safe provider message] Retry from STTS",
+            "TTS generation failed: \\[safe provider message] "
+            "Retry from the STTS Playground.",
             "error",
         )
     ]
     assert handler._is_generating is False
+
+
+@pytest.mark.parametrize(
+    ("recovery_action", "expected"),
+    (
+        ("check_server", "Check the configured audio.cpp server and retry."),
+        (
+            "configure_server",
+            "Open STTS Settings and configure the audio.cpp server.",
+        ),
+        ("refresh_models", "Refresh models in the STTS Playground and retry."),
+        ("edit_request", "Adjust the text or selected options and retry."),
+        ("retry", "Retry from the STTS Playground."),
+        ("PRIVATE_UNKNOWN_ACTION", "Retry from the STTS Playground."),
+    ),
+)
+def test_native_recovery_identifiers_map_to_fixed_ui_copy(
+    recovery_action: str,
+    expected: str,
+) -> None:
+    error = TTSOperationError(
+        code="generation_failed",
+        message="Safe failure",
+        retryable=True,
+        operation_id="operation",
+        recovery_action=recovery_action,
+    )
+
+    copy = STTSEventHandler._generation_error_copy(error)
+
+    assert copy == f"Safe failure {expected}"
+    assert "PRIVATE_UNKNOWN_ACTION" not in copy
 
 
 @pytest.mark.asyncio
@@ -931,6 +1041,48 @@ async def test_successful_replacement_and_shutdown_delete_owned_artifacts() -> N
     assert handler._current_audio_file is None
     assert handler._playground_audio_files == set()
     assert handler._playground_operation_files == {}
+
+
+@pytest.mark.asyncio
+async def test_leased_artifact_survives_replacement_until_release() -> None:
+    app = _DeliveryApp()
+    handler = STTSEventHandler(app=app)
+    handler._stts_service = _NativeService(
+        _Response(_CountingStream((b"RIFF", b"first")))
+    )
+    await handler.handle_playground_generate(STTSPlaygroundGenerateEvent(_snapshot()))
+    first = handler._current_playground_artifact
+    assert first is not None
+    assert handler.lease_playground_artifact(first) is True
+
+    handler._stts_service = _NativeService(
+        _Response(_CountingStream((b"RIFF", b"second")))
+    )
+    await handler.handle_playground_generate(
+        STTSPlaygroundGenerateEvent(
+            STTSPlaygroundRequest(
+                operation_id="local-operation-2",
+                provider_id="audio_cpp",
+                model_id="model-2",
+                text="second",
+                voice_id=None,
+                response_format="wav",
+            )
+        )
+    )
+    second = handler._current_playground_artifact
+
+    assert second is not None
+    assert first.path.exists()
+    assert first.path in handler._playground_audio_files
+
+    handler.release_playground_artifact(first)
+
+    assert not first.path.exists()
+    assert first.path not in handler._playground_audio_files
+    assert second.path.exists()
+
+    await handler.cleanup_tts_resources()
 
 
 @pytest.mark.asyncio

--- a/Tests/TTS/test_stts_export_security.py
+++ b/Tests/TTS/test_stts_export_security.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 import pytest
 
 from tldw_chatbook.Event_Handlers.STTS_Events.stts_events import STTSEventHandler
+from tldw_chatbook.TTS import STTSGeneratedAudio
 
 
 class NotifyCaptureApp:
@@ -44,3 +45,30 @@ async def test_stts_export_current_audio_rejects_dangerous_destination_path(tmp_
     assert not target_path.exists()
     assert app.notifications[-1].severity == "error"
     assert "dangerous pattern" in app.notifications[-1].message
+
+
+@pytest.mark.asyncio
+async def test_stts_export_uses_delivered_artifact_path_and_actual_format(tmp_path):
+    app = NotifyCaptureApp()
+    handler = STTSEventHandler(app=app)
+    artifact_path = tmp_path / "native-response.wav"
+    artifact_path.write_bytes(b"native artifact")
+    stale_compatibility_path = tmp_path / "stale-selector.mp3"
+    stale_compatibility_path.write_bytes(b"wrong bytes")
+    handler._current_audio_file = stale_compatibility_path
+    handler._current_playground_artifact = STTSGeneratedAudio(
+        path=artifact_path,
+        provider_id="audio_cpp",
+        model_id="response-model",
+        voice_id=None,
+        source_text="source",
+        operation_id="operation",
+        audio_format="wav",
+        content_type="audio/wav",
+    )
+    target_path = tmp_path / "export.wav"
+
+    await handler.export_current_audio(target_path)
+
+    assert target_path.read_bytes() == b"native artifact"
+    assert app.notifications[-1].severity == "information"

--- a/Tests/TTS/test_stts_playground_types.py
+++ b/Tests/TTS/test_stts_playground_types.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any
+
+import pytest
+
+from tldw_chatbook.TTS import STTSGeneratedAudio, STTSPlaygroundRequest
+
+
+def test_playground_request_is_an_immutable_defensive_snapshot() -> None:
+    nested_options: dict[str, Any] = {
+        "language": "en",
+        "conditioning": {"temperature": 0.2},
+    }
+
+    snapshot = STTSPlaygroundRequest(
+        operation_id="local-op",
+        provider_id="audio_cpp",
+        model_id="kokoro",
+        text="hello",
+        voice_id=None,
+        response_format="wav",
+        speed=1.0,
+        options=nested_options,
+    )
+    nested_options["language"] = "fr"
+    nested_options["conditioning"]["temperature"] = 0.9
+
+    assert isinstance(snapshot.options, MappingProxyType)
+    assert snapshot.options == {
+        "language": "en",
+        "conditioning": {"temperature": 0.2},
+    }
+    with pytest.raises(TypeError):
+        snapshot.options["language"] = "es"  # type: ignore[index]
+    with pytest.raises(FrozenInstanceError):
+        snapshot.model_id = "replacement"  # type: ignore[misc]
+
+
+def test_generated_audio_retains_provenance_and_actual_format_suffix(
+    tmp_path: Path,
+) -> None:
+    response_metadata = {"delivery": "complete_wav", "sample_rate": 24_000}
+    artifact = STTSGeneratedAudio(
+        path=tmp_path / "result.legacy-selection",
+        provider_id="audio_cpp",
+        model_id="kokoro",
+        voice_id=None,
+        source_text="hello",
+        operation_id="local-op",
+        audio_format="wav",
+        content_type="audio/wav",
+        metadata=response_metadata,
+    )
+    response_metadata["delivery"] = "changed"
+
+    assert artifact.file_suffix == ".wav"
+    assert artifact.voice_id is None
+    assert artifact.source_text == "hello"
+    assert artifact.metadata == {
+        "delivery": "complete_wav",
+        "sample_rate": 24_000,
+    }
+    assert isinstance(artifact.metadata, MappingProxyType)
+    with pytest.raises(TypeError):
+        artifact.metadata["delivery"] = "stream"  # type: ignore[index]
+    with pytest.raises(FrozenInstanceError):
+        artifact.provider_id = "legacy"  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    (
+        ("operation_id", ""),
+        ("provider_id", " "),
+        ("model_id", ""),
+        ("response_format", ""),
+    ),
+)
+def test_playground_request_rejects_empty_required_identifiers(
+    field_name: str,
+    value: str,
+) -> None:
+    values = {
+        "operation_id": "local-op",
+        "provider_id": "audio_cpp",
+        "model_id": "kokoro",
+        "text": "hello",
+        "voice_id": None,
+        "response_format": "wav",
+        "speed": 1.0,
+    }
+    values[field_name] = value
+
+    with pytest.raises(ValueError, match=field_name):
+        STTSPlaygroundRequest(**values)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    (
+        ("operation_id", ""),
+        ("provider_id", ""),
+        ("model_id", " "),
+        ("audio_format", ""),
+        ("content_type", ""),
+    ),
+)
+def test_generated_audio_rejects_empty_required_identifiers(
+    tmp_path: Path,
+    field_name: str,
+    value: str,
+) -> None:
+    values = {
+        "path": tmp_path / "result.wav",
+        "provider_id": "audio_cpp",
+        "model_id": "kokoro",
+        "voice_id": None,
+        "source_text": "hello",
+        "operation_id": "local-op",
+        "audio_format": "wav",
+        "content_type": "audio/wav",
+    }
+    values[field_name] = value
+
+    with pytest.raises(ValueError, match=field_name):
+        STTSGeneratedAudio(**values)

--- a/Tests/TTS/test_stts_settings_reconfiguration.py
+++ b/Tests/TTS/test_stts_settings_reconfiguration.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import tomllib
 from collections.abc import Mapping
 from copy import deepcopy
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, Mock, call
@@ -12,10 +14,15 @@ from loguru import logger
 
 from Tests.TTS.adapter_fakes import FakeAdapter, FakeAdapterFactory, provider_spec
 from tldw_chatbook.Event_Handlers.STTS_Events.stts_events import (
+    STTSProviderConfigurationChanged,
     STTSEventHandler,
     STTSSettingsSaveEvent,
 )
-from tldw_chatbook.TTS.adapter_registry import TTSAdapterRegistry
+from tldw_chatbook.TTS.adapter_registry import ReconfigureResult, TTSAdapterRegistry
+from tldw_chatbook.TTS.audio_cpp_config import (
+    AudioCppConfig,
+    project_audio_cpp_config,
+)
 from tldw_chatbook.TTS.legacy_bridge import (
     legacy_provider_config,
     legacy_provider_specs,
@@ -36,9 +43,14 @@ class RecordingFactory(FakeAdapterFactory):
 class RecordingApp:
     def __init__(self) -> None:
         self.notifications: list[tuple[str, str]] = []
+        self.messages: list[object] = []
 
     def notify(self, message: str, *, severity: str) -> None:
         self.notifications.append((message, severity))
+
+    def post_message(self, message: object) -> bool:
+        self.messages.append(message)
+        return True
 
 
 PROVIDER_SETTING_KEYS = {
@@ -681,3 +693,177 @@ async def test_concurrent_settings_saves_are_serialized(
 
     assert saved_values == ["first", "second"]
     assert reconfigure_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_audio_cpp_save_persists_nested_plain_mapping_without_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candidate = AudioCppConfig(
+        base_url="https://voice.example.test:8443",
+        connect_timeout_seconds=2.5,
+        synthesis_timeout_seconds=45,
+        max_input_characters=1234,
+        max_response_bytes=1_048_576,
+        max_metadata_bytes=4096,
+        max_catalog_models=12,
+        max_voices_per_model=34,
+        max_identifier_characters=128,
+    ).to_mapping()
+    expected = deepcopy(candidate)
+    effective = {
+        "COMPREHENSIVE_CONFIG_RAW": {"app_tts": {"audio_cpp": deepcopy(expected)}}
+    }
+    saved_batches: list[dict[str, dict[str, object]]] = []
+    service = SimpleNamespace(
+        reconfigure_provider=AsyncMock(return_value=ReconfigureResult.CHANGED),
+        configuration_revision=Mock(return_value=2),
+        get_catalog=AsyncMock(side_effect=AssertionError("catalog requested")),
+        get_voices=AsyncMock(side_effect=AssertionError("voices requested")),
+        synthesize=AsyncMock(side_effect=AssertionError("synthesis requested")),
+    )
+    app = RecordingApp()
+    handler = STTSEventHandler(app)
+    handler._stts_service = service
+
+    def save_batch(
+        section_values: Mapping[str, Mapping[object, object]],
+    ) -> bool:
+        saved_batches.append(deepcopy(dict(section_values)))
+        return True
+
+    monkeypatch.setattr(
+        "tldw_chatbook.config.save_settings_to_cli_config",
+        save_batch,
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.config.load_settings",
+        Mock(return_value=effective),
+    )
+
+    event = STTSSettingsSaveEvent({"audio_cpp": candidate})
+    candidate["base_url"] = "http://mutated.invalid"
+    await handler.handle_settings_save(event)
+
+    assert type(saved_batches[0]["app_tts"]["audio_cpp"]) is dict
+    assert saved_batches == [{"app_tts": {"audio_cpp": expected}}]
+    service.reconfigure_provider.assert_awaited_once_with(
+        "audio_cpp",
+        project_audio_cpp_config(effective).to_mapping(),
+    )
+    service.get_catalog.assert_not_awaited()
+    service.get_voices.assert_not_awaited()
+    service.synthesize.assert_not_awaited()
+    assert len(app.messages) == 1
+    changed = app.messages[0]
+    assert isinstance(changed, STTSProviderConfigurationChanged)
+    assert changed.provider_id == "audio_cpp"
+    assert changed.configuration_revision == 2
+
+
+@pytest.mark.asyncio
+async def test_unchanged_audio_cpp_save_emits_no_configuration_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candidate = AudioCppConfig().to_mapping()
+    effective = {
+        "COMPREHENSIVE_CONFIG_RAW": {"app_tts": {"audio_cpp": deepcopy(candidate)}}
+    }
+    service = SimpleNamespace(
+        reconfigure_provider=AsyncMock(return_value=ReconfigureResult.UNCHANGED),
+        configuration_revision=Mock(side_effect=AssertionError("revision requested")),
+    )
+    app = RecordingApp()
+    handler = STTSEventHandler(app)
+    handler._stts_service = service
+    monkeypatch.setattr(
+        "tldw_chatbook.config.save_settings_to_cli_config",
+        Mock(return_value=True),
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.config.load_settings",
+        Mock(return_value=effective),
+    )
+
+    await handler.handle_settings_save(STTSSettingsSaveEvent({"audio_cpp": candidate}))
+
+    service.reconfigure_provider.assert_awaited_once()
+    service.configuration_revision.assert_not_called()
+    assert app.messages == []
+
+
+@pytest.mark.asyncio
+async def test_changed_audio_cpp_config_retires_only_audio_cpp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original = AudioCppConfig().to_mapping()
+    replacement = AudioCppConfig(base_url="http://127.0.0.1:18080").to_mapping()
+    audio_cpp_factory = RecordingFactory("audio_cpp")
+    legacy_factory = RecordingFactory("openai")
+    registry = TTSAdapterRegistry(
+        specs=(
+            provider_spec(
+                "audio_cpp",
+                audio_cpp_factory,
+                original,
+                exclusive=True,
+            ),
+            provider_spec("openai", legacy_factory, {}),
+        ),
+        aliases={},
+    )
+    service = TTSService(registry)
+    for provider_id in ("audio_cpp", "openai"):
+        lease = await registry.acquire(provider_id)
+        await lease.release()
+
+    app = RecordingApp()
+    handler = STTSEventHandler(app)
+    handler._stts_service = service
+    effective = {
+        "COMPREHENSIVE_CONFIG_RAW": {"app_tts": {"audio_cpp": deepcopy(replacement)}}
+    }
+    monkeypatch.setattr(
+        "tldw_chatbook.config.save_settings_to_cli_config",
+        Mock(return_value=True),
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.config.load_settings",
+        Mock(return_value=effective),
+    )
+
+    await handler.handle_settings_save(
+        STTSSettingsSaveEvent({"audio_cpp": replacement})
+    )
+
+    assert audio_cpp_factory.instances[0].close_calls == 1
+    assert audio_cpp_factory.calls == 1
+    assert legacy_factory.instances[0].close_calls == 0
+    assert registry.configuration_revision("audio_cpp") == 2
+    assert registry.configuration_revision("openai") == 1
+    assert len(app.messages) == 1
+    assert isinstance(app.messages[0], STTSProviderConfigurationChanged)
+
+    await service.close()
+    await service.wait_closed()
+
+
+def test_audio_cpp_mapping_serializes_as_nested_toml_table(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_chatbook import config as config_module
+
+    config_path = tmp_path / "config.toml"
+    candidate = AudioCppConfig(
+        base_url="http://127.0.0.1:18080",
+        max_catalog_models=42,
+    ).to_mapping()
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+
+    assert config_module.save_settings_to_cli_config(
+        {"app_tts": {"audio_cpp": dict(candidate)}}
+    )
+
+    persisted = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert persisted["app_tts"]["audio_cpp"] == candidate

--- a/Tests/TTS/test_tts_app_ownership.py
+++ b/Tests/TTS/test_tts_app_ownership.py
@@ -16,6 +16,7 @@ from Tests.UI.test_screen_navigation import _build_test_app
 from tldw_chatbook.Event_Handlers.STTS_Events.stts_events import (
     STTSEventHandler,
     STTSPlaygroundGenerateEvent,
+    STTSProviderConfigurationChanged,
     STTSSettingsSaveEvent,
 )
 from tldw_chatbook.TTS import STTSPlaygroundRequest
@@ -212,6 +213,20 @@ async def test_stts_initialization_only_retrieves_the_bound_service(
 
     get_service.assert_awaited_once_with()
     assert handler._stts_service is service
+
+
+def test_app_forwards_provider_configuration_change_to_stts_handler() -> None:
+    callback = Mock()
+    owner = SimpleNamespace(
+        _stts_handler=SimpleNamespace(
+            on_stts_provider_configuration_changed=callback,
+        )
+    )
+    event = STTSProviderConfigurationChanged("audio_cpp", 2)
+
+    TldwCli.handle_stts_provider_configuration_changed(owner, event)
+
+    callback.assert_called_once_with(event)
 
 
 def test_existing_mount_binds_before_screen_work() -> None:

--- a/Tests/TTS/test_tts_app_ownership.py
+++ b/Tests/TTS/test_tts_app_ownership.py
@@ -342,9 +342,10 @@ async def test_stts_forwards_typed_progress_sink_to_service(
         query_one=query_one,
         call_from_thread=call_from_thread,
     )
+    app.query_one = Mock(return_value=playground)
     event = _playground_event()
 
-    await handler._generate_tts_worker(event, playground)
+    await handler.handle_playground_generate(event)
 
     assert service.progress_sink is not None
     assert scheduled
@@ -381,7 +382,8 @@ async def test_stts_playground_generation_stays_in_the_owned_event_task(
 
     await handler.handle_playground_generate(event)
 
-    generation.assert_awaited_once_with(event, playground)
+    generation.assert_awaited_once_with(event)
+    app.query_one.assert_not_called()
     playground.run_worker.assert_not_called()
 
 
@@ -500,6 +502,7 @@ async def test_stts_conversion_cancellation_tracks_and_deletes_partial_output(
         assert process_terminated.is_set()
         assert process_waited.is_set()
         assert not output_path.exists()
+        assert handler._playground_operation_files == {}
     finally:
         if not generation.done():
             generation.cancel()

--- a/Tests/TTS/test_tts_app_ownership.py
+++ b/Tests/TTS/test_tts_app_ownership.py
@@ -18,6 +18,7 @@ from tldw_chatbook.Event_Handlers.STTS_Events.stts_events import (
     STTSPlaygroundGenerateEvent,
     STTSSettingsSaveEvent,
 )
+from tldw_chatbook.TTS import STTSPlaygroundRequest
 from tldw_chatbook.TTS.adapter_types import ProgressSink, TTSProgress
 from tldw_chatbook.TTS.TTS_Generation import (
     get_tts_service,
@@ -27,6 +28,23 @@ from tldw_chatbook.app import TldwCli
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _playground_event(
+    *,
+    response_format: str = "wav",
+) -> STTSPlaygroundGenerateEvent:
+    return STTSPlaygroundGenerateEvent(
+        STTSPlaygroundRequest(
+            operation_id="ownership-test-operation",
+            provider_id="openai",
+            model_id="tts-1",
+            text="hello",
+            voice_id="alloy",
+            response_format=response_format,
+            speed=1.0,
+        )
+    )
 
 
 class FakeOwnedService:
@@ -324,14 +342,7 @@ async def test_stts_forwards_typed_progress_sink_to_service(
         query_one=query_one,
         call_from_thread=call_from_thread,
     )
-    event = STTSPlaygroundGenerateEvent(
-        text="hello",
-        provider="openai",
-        voice="alloy",
-        model="tts-1",
-        speed=1.0,
-        format="wav",
-    )
+    event = _playground_event()
 
     await handler._generate_tts_worker(event, playground)
 
@@ -340,8 +351,7 @@ async def test_stts_forwards_typed_progress_sink_to_service(
     status_text.update.assert_called_with("Generating")
     progress_bar.update.assert_any_call(progress=50.0)
     generation_log.write.assert_any_call("[dim]Processed 1/2 item(s)[/dim]")
-    assert created_tasks
-    assert all(task.done() for task in created_tasks)
+    assert created_tasks == []
     assert handler._current_audio_file is not None
     audio_file = handler._current_audio_file
 
@@ -367,14 +377,7 @@ async def test_stts_playground_generation_stays_in_the_owned_event_task(
     handler._stts_service = object()
     generation = AsyncMock()
     monkeypatch.setattr(handler, "_generate_tts_worker", generation)
-    event = STTSPlaygroundGenerateEvent(
-        text="hello",
-        provider="openai",
-        voice="alloy",
-        model="tts-1",
-        speed=1.0,
-        format="wav",
-    )
+    event = _playground_event()
 
     await handler.handle_playground_generate(event)
 
@@ -480,14 +483,7 @@ async def test_stts_conversion_cancellation_tracks_and_deletes_partial_output(
     )
     handler = STTSEventHandler(app=SimpleNamespace(notify=Mock()))
     handler._stts_service = OneChunkService()
-    event = STTSPlaygroundGenerateEvent(
-        text="hello",
-        provider="openai",
-        voice="alloy",
-        model="tts-1",
-        speed=1.0,
-        format="mp3",
-    )
+    event = _playground_event(response_format="mp3")
     generation = asyncio.create_task(handler._generate_tts_worker(event))
 
     try:
@@ -588,14 +584,7 @@ async def test_stts_cleanup_seals_handler_against_late_generation(
     handler._stts_service = object()
     generate = AsyncMock()
     monkeypatch.setattr(handler, "_generate_tts_worker", generate)
-    event = STTSPlaygroundGenerateEvent(
-        text="hello",
-        provider="openai",
-        voice="alloy",
-        model="tts-1",
-        speed=1.0,
-        format="wav",
-    )
+    event = _playground_event()
 
     await handler.cleanup_tts_resources()
     await handler.handle_playground_generate(event)

--- a/Tests/TTS/test_tts_improvements.py
+++ b/Tests/TTS/test_tts_improvements.py
@@ -119,17 +119,26 @@ class TestTTSEventHandler:
             "default_speed": 1.0,
         }
 
-        # Generate TTS
-        await handler._generate_tts("Test text", "test_msg", "alloy")
+        generated_path = None
+        try:
+            # Generate TTS
+            await handler._generate_tts("Test text", "test_msg", "alloy")
+            generated_path = handler._audio_files["test_msg"]
 
-        # Check for progress events
-        progress_events = [
-            m for m in handler.messages if isinstance(m, TTSProgressEvent)
-        ]
-        assert len(progress_events) >= 2  # At least initial and final
-        assert progress_events[0].progress == 0.0
-        assert progress_events[-1].progress == 1.0
-        assert progress_events[-1].status == "Audio generation complete"
+            # Check for progress events
+            progress_events = [
+                m for m in handler.messages if isinstance(m, TTSProgressEvent)
+            ]
+            assert len(progress_events) >= 2  # At least initial and final
+            assert progress_events[0].progress == 0.0
+            assert progress_events[-1].progress == 1.0
+            assert progress_events[-1].status == "Audio generation complete"
+        finally:
+            await handler.cleanup_tts_resources()
+
+        assert handler._audio_files == {}
+        assert generated_path is not None
+        assert not generated_path.exists()
 
     @pytest.mark.asyncio
     async def test_export_functionality(self, handler, tmp_path):

--- a/Tests/TTS/test_tts_logging_privacy.py
+++ b/Tests/TTS/test_tts_logging_privacy.py
@@ -136,6 +136,8 @@ def test_tts_package_exports_only_stable_adapter_service_api() -> None:
         "OpenAISpeechRequest",
         "ProgressSink",
         "ProviderHealth",
+        "STTSGeneratedAudio",
+        "STTSPlaygroundRequest",
         "TTSAudioResponse",
         "TTSModelInfo",
         "TTSOperationCode",

--- a/Tests/TTS/test_tts_registry_service.py
+++ b/Tests/TTS/test_tts_registry_service.py
@@ -1325,7 +1325,7 @@ def test_default_bootstrap_prepends_audio_cpp_without_changing_legacy_specs(
     )
 
     service = build_default_tts_service({})
-    descriptors = service.registry.descriptors()
+    descriptors = service.provider_descriptors()
 
     assert tuple(item.provider_id for item in descriptors) == (
         "audio_cpp",
@@ -1337,7 +1337,9 @@ def test_default_bootstrap_prepends_audio_cpp_without_changing_legacy_specs(
         native=True,
     )
     assert service.registry.aliases() == {}
+    assert service.configuration_revision("audio_cpp") == 1
     assert service.registry._slots["audio_cpp"].spec.exclusive_reconfigure is True
+    assert all(slot.active is None for slot in service.registry._slots.values())
     assert all(factory.calls == 0 for factory in factories.values())
 
 

--- a/Tests/UI/test_stts_playground_audio_cpp.py
+++ b/Tests/UI/test_stts_playground_audio_cpp.py
@@ -100,6 +100,7 @@ class FakeTTSService:
         self.catalog_cancelled = False
         self.voice_started: asyncio.Event | None = None
         self.allow_voices: asyncio.Event | None = None
+        self.voice_error: Exception | None = None
 
     def provider_descriptors(self) -> tuple[TTSProviderDescriptor, ...]:
         self.descriptor_calls += 1
@@ -146,6 +147,8 @@ class FakeTTSService:
             self.voice_started.set()
         if self.allow_voices is not None:
             await self.allow_voices.wait()
+        if self.voice_error is not None:
+            raise self.voice_error
         return self.voices.get((provider_id, model_id), ())
 
     async def synthesize(self, *_args: Any, **_kwargs: Any) -> None:
@@ -218,6 +221,13 @@ def _option_labels(select: Select[Any]) -> tuple[str, ...]:
     for label, _value in select._options:
         labels.append(label.plain if isinstance(label, Text) else str(label))
     return tuple(labels)
+
+
+def _label_for_value(select: Select[Any], value: str) -> str:
+    for label, option_value in select._options:
+        if option_value == value:
+            return label.plain if isinstance(label, Text) else str(label)
+    raise AssertionError(f"Missing Select value: {value}")
 
 
 async def _wait_until(
@@ -379,6 +389,7 @@ async def test_catalog_revision_invalidates_old_voices_before_rediscovery(
         await app.workers.wait_for_complete()
         voice_select = app.query_one("#tts-voice-select", Select)
         voice_select.value = "[voice]"
+        app.query_one("#tts-text-input", TextArea).text = "pending voice"
         await pilot.pause()
 
         service.catalogs["audio_cpp"] = _audio_catalog(revision=12)
@@ -393,12 +404,24 @@ async def test_catalog_revision_invalidates_old_voices_before_rediscovery(
         assert _option_values(voice_select) == (SERVER_DEFAULT_VOICE_ID,)
         assert voice_select.value == SERVER_DEFAULT_VOICE_ID
         assert app.notices == notices_before
+        assert app.query_one("#tts-generate-btn", Button).disabled is True
+
+        widget.action_generate_tts()
+        await pilot.pause()
+
+        assert app.generation_events == []
+        pending_notices = [
+            *notices_before,
+            ("Voices are still loading; wait before generating", "warning"),
+        ]
+        assert app.notices == pending_notices
 
         service.allow_voices.set()
         await app.workers.wait_for_complete()
 
         assert voice_select.value == "[voice]"
-        assert app.notices == notices_before
+        assert app.notices == pending_notices
+        assert app.query_one("#tts-generate-btn", Button).disabled is False
 
 
 @pytest.mark.asyncio
@@ -437,6 +460,43 @@ async def test_catalog_revision_falls_back_only_after_refreshed_voice_is_removed
                 "warning",
             ),
         ]
+
+
+@pytest.mark.asyncio
+async def test_voice_discovery_failure_releases_pending_explicit_voice(
+    audio_cpp_playground: FakeTTSService,
+) -> None:
+    service = audio_cpp_playground
+    app = _PlaygroundHost()
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await app.workers.wait_for_complete()
+        voice_select = app.query_one("#tts-voice-select", Select)
+        voice_select.value = "[voice]"
+        app.query_one("#tts-text-input", TextArea).text = "fallback voice"
+        await pilot.pause()
+
+        service.catalogs["audio_cpp"] = _audio_catalog(revision=12)
+        service.voice_error = RuntimeError("untrusted upstream detail")
+        app.query_one(TTSPlaygroundWidget)._load_provider_catalog(
+            "audio_cpp",
+            refresh=True,
+        )
+        await app.workers.wait_for_complete()
+
+        assert voice_select.value == SERVER_DEFAULT_VOICE_ID
+        assert app.query_one("#tts-generate-btn", Button).disabled is False
+        assert (
+            str(app.query_one("#tts-provider-status", Static).render())
+            == "Voices are unavailable; the provider default remains available"
+        )
+
+        app.query_one(TTSPlaygroundWidget).action_generate_tts()
+        await pilot.pause()
+
+        assert len(app.generation_events) == 1
+        assert app.generation_events[0].request.voice_id is None
+        assert "untrusted upstream detail" not in str(app.notices)
 
 
 @pytest.mark.asyncio
@@ -490,6 +550,69 @@ async def test_legacy_control_state_is_restored_after_audio_cpp_switch(
         "audio_cpp",
         "openai",
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    (
+        "provider_id",
+        "model_id",
+        "model_label",
+        "voice_id",
+        "voice_label",
+    ),
+    (
+        ("openai", "tts-1", "TTS-1 (Standard)", "alloy", "Alloy"),
+        (
+            "elevenlabs",
+            "eleven_multilingual_v2",
+            "Eleven Multilingual v2 (Default)",
+            "21m00Tcm4TlvDq8ikWAM",
+            "Rachel",
+        ),
+        ("kokoro", "kokoro", "Kokoro 82M", "af_alloy", "Alloy (US Female)"),
+        (
+            "chatterbox",
+            "chatterbox",
+            "Chatterbox 0.5B",
+            "default",
+            "Default Voice",
+        ),
+        (
+            "higgs",
+            "higgs-audio-v2",
+            "Higgs Audio V2 3B",
+            "professional_female",
+            "Professional Female",
+        ),
+        ("alltalk", "alltalk", "AllTalk TTS", "female_01.wav", "Female 01"),
+    ),
+)
+async def test_legacy_provider_defaults_and_labels_are_preserved(
+    audio_cpp_playground: FakeTTSService,
+    provider_id: str,
+    model_id: str,
+    model_label: str,
+    voice_id: str,
+    voice_label: str,
+) -> None:
+    del audio_cpp_playground
+    app = _PlaygroundHost()
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await app.workers.wait_for_complete()
+        app.query_one("#tts-provider-select", Select).value = provider_id
+        await _wait_until(
+            pilot,
+            lambda: app.query_one("#tts-model-select", Select).value == model_id,
+        )
+
+        model_select = app.query_one("#tts-model-select", Select)
+        voice_select = app.query_one("#tts-voice-select", Select)
+        assert model_select.value == model_id
+        assert _label_for_value(model_select, model_id) == model_label
+        assert voice_select.value == voice_id
+        assert _label_for_value(voice_select, voice_id) == voice_label
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_stts_playground_audio_cpp.py
+++ b/Tests/UI/test_stts_playground_audio_cpp.py
@@ -20,6 +20,8 @@ from tldw_chatbook.TTS.adapter_types import (
     TTSModelInfo,
     TTSProviderCatalog,
     TTSProviderDescriptor,
+    TTSProviderReconfiguringError,
+    TTSRegistryClosedError,
 )
 from tldw_chatbook.TTS.playground_types import STTSGeneratedAudio
 from tldw_chatbook.TTS.legacy_catalogs import legacy_catalog
@@ -562,6 +564,58 @@ async def test_voice_discovery_failure_overrides_configured_explicit_default(
         assert len(app.generation_events) == 1
         assert app.generation_events[0].request.voice_id is None
         assert "untrusted upstream detail" not in str(app.notices)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("lifecycle_error", "expected_status"),
+    (
+        (
+            TTSProviderReconfiguringError("PRIVATE_RECONFIGURING"),
+            "settings are being applied",
+        ),
+        (
+            TTSRegistryClosedError("PRIVATE_REGISTRY_CLOSED"),
+            "tts service is unavailable",
+        ),
+    ),
+)
+async def test_voice_discovery_lifecycle_failure_preserves_pending_selection(
+    audio_cpp_playground: FakeTTSService,
+    monkeypatch: pytest.MonkeyPatch,
+    lifecycle_error: Exception,
+    expected_status: str,
+) -> None:
+    service = audio_cpp_playground
+
+    def get_setting(section: str, key: str, default: Any = None) -> Any:
+        configured = {
+            ("app_tts", "default_provider"): "audio_cpp",
+            ("app_tts", "default_voice"): "[voice]",
+        }
+        return configured.get((section, key), default)
+
+    monkeypatch.setattr(STTS_Window, "get_cli_setting", get_setting)
+    service.voice_error = lifecycle_error
+    app = _PlaygroundHost()
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await app.workers.wait_for_complete()
+        app.query_one("#tts-text-input", TextArea).text = "lifecycle pending"
+        await pilot.pause()
+
+        widget = app.query_one(TTSPlaygroundWidget)
+        status = str(app.query_one("#tts-provider-status", Static).render()).lower()
+        assert widget._pending_voice_selections == {"audio_cpp": "[voice]"}
+        assert app.query_one("#tts-generate-btn", Button).disabled is True
+        assert expected_status in status
+
+        widget.action_generate_tts()
+        await pilot.pause()
+
+        assert app.generation_events == []
+        assert "PRIVATE_" not in str(app.notices)
+        assert "PRIVATE_" not in status
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_stts_playground_audio_cpp.py
+++ b/Tests/UI/test_stts_playground_audio_cpp.py
@@ -488,6 +488,146 @@ async def test_superseded_catalog_failure_cannot_overwrite_newer_success(
 
 
 @pytest.mark.asyncio
+async def test_superseded_catalog_success_cannot_invalidate_newer_success(
+    audio_cpp_playground: FakeTTSService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = audio_cpp_playground
+    app = _PlaygroundHost()
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await app.workers.wait_for_complete()
+        widget = app.query_one(TTSPlaygroundWidget)
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        call_count = 0
+        older_catalog = _audio_catalog(revision=11)
+        newer_catalog = _audio_catalog(revision=12)
+
+        async def get_catalog(
+            provider_id: str,
+            refresh: bool = False,
+        ) -> TTSProviderCatalog:
+            nonlocal call_count
+            del refresh
+            assert provider_id == "audio_cpp"
+            call_count += 1
+            if call_count == 1:
+                first_started.set()
+                try:
+                    await release_first.wait()
+                except asyncio.CancelledError:
+                    await release_first.wait()
+                return older_catalog
+            return newer_catalog
+
+        monkeypatch.setattr(service, "get_catalog", get_catalog)
+
+        widget._load_provider_catalog("audio_cpp", refresh=True)
+        await first_started.wait()
+        widget._load_provider_catalog("audio_cpp", refresh=True)
+        await _wait_until(
+            pilot,
+            lambda: (
+                call_count == 2
+                and widget._catalogs.get("audio_cpp") is newer_catalog
+                and "ready"
+                in str(app.query_one("#tts-provider-status", Static).render()).lower()
+            ),
+        )
+
+        release_first.set()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert widget._catalogs["audio_cpp"] is newer_catalog
+        assert "audio_cpp" not in widget._stale_providers
+        assert widget._catalog_generation_allowed is True
+        assert (
+            "ready"
+            in str(app.query_one("#tts-provider-status", Static).render()).lower()
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("obsolete_fails", (False, True), ids=("success", "failure"))
+async def test_superseded_same_model_voice_result_cannot_overwrite_newer_success(
+    audio_cpp_playground: FakeTTSService,
+    monkeypatch: pytest.MonkeyPatch,
+    obsolete_fails: bool,
+) -> None:
+    service = audio_cpp_playground
+    app = _PlaygroundHost()
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await app.workers.wait_for_complete()
+        widget = app.query_one(TTSPlaygroundWidget)
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        call_count = 0
+        model_id = "<opaque:model>"
+        catalog_revision = service.catalogs["audio_cpp"].revision
+
+        async def get_voices(
+            provider_id: str,
+            requested_model_id: str,
+            refresh: bool = False,
+        ) -> tuple[str, ...]:
+            nonlocal call_count
+            del refresh
+            assert (provider_id, requested_model_id) == ("audio_cpp", model_id)
+            call_count += 1
+            if call_count == 1:
+                first_started.set()
+                try:
+                    await release_first.wait()
+                except asyncio.CancelledError:
+                    await release_first.wait()
+                if obsolete_fails:
+                    raise RuntimeError("obsolete voice request failed")
+                return ("obsolete-voice",)
+            return ("new-voice",)
+
+        monkeypatch.setattr(service, "get_voices", get_voices)
+
+        widget._load_provider_voices(
+            "audio_cpp",
+            model_id,
+            catalog_revision,
+            refresh=True,
+        )
+        await first_started.wait()
+        widget._load_provider_voices(
+            "audio_cpp",
+            model_id,
+            catalog_revision,
+            refresh=True,
+        )
+        await _wait_until(
+            pilot,
+            lambda: (
+                call_count == 2
+                and widget._discovered_voices.get(("audio_cpp", model_id))
+                == ("new-voice",)
+            ),
+        )
+
+        release_first.set()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert widget._discovered_voices[("audio_cpp", model_id)] == ("new-voice",)
+        assert _option_values(app.query_one("#tts-voice-select", Select)) == (
+            SERVER_DEFAULT_VOICE_ID,
+            "new-voice",
+        )
+        assert (
+            "voices are unavailable"
+            not in str(app.query_one("#tts-provider-status", Static).render()).lower()
+        )
+
+
+@pytest.mark.asyncio
 async def test_voice_discovery_does_not_cancel_inflight_catalog_refresh(
     audio_cpp_playground: FakeTTSService,
 ) -> None:

--- a/Tests/UI/test_stts_playground_audio_cpp.py
+++ b/Tests/UI/test_stts_playground_audio_cpp.py
@@ -13,8 +13,10 @@ from textual.app import App, ComposeResult
 from textual.widgets import Button, Input, Select, Static, TextArea
 
 from tldw_chatbook.Event_Handlers.STTS_Events.stts_events import (
+    STTSEventHandler,
     STTSPlaygroundGenerateEvent,
 )
+from tldw_chatbook.TTS.audio_player import PlaybackState
 from tldw_chatbook.TTS.adapter_types import (
     ProviderHealth,
     TTSModelInfo,
@@ -27,7 +29,10 @@ from tldw_chatbook.TTS.playground_types import STTSGeneratedAudio
 from tldw_chatbook.TTS.legacy_catalogs import legacy_catalog
 from tldw_chatbook.UI import STTS_Window
 from tldw_chatbook.UI.STTS_Window import TTSPlaygroundWidget
-from tldw_chatbook.UI.stts_playground_catalog import SERVER_DEFAULT_VOICE_ID
+from tldw_chatbook.UI.stts_playground_catalog import (
+    LOADING_SELECT_VALUE,
+    SERVER_DEFAULT_VOICE_ID,
+)
 
 
 PROVIDER_IDS = (
@@ -314,6 +319,56 @@ async def test_mount_uses_descriptors_and_resolves_only_selected_provider(
 
 
 @pytest.mark.asyncio
+async def test_playground_generates_with_sentinel_shaped_remote_ids(
+    audio_cpp_playground: FakeTTSService,
+) -> None:
+    service = audio_cpp_playground
+    remote_model_id = "__opaque_model__"
+    remote_voice_id = "__server_default__"
+    service.catalogs["audio_cpp"] = TTSProviderCatalog(
+        provider_id="audio_cpp",
+        revision=12,
+        health=ProviderHealth(state="available", fresh=True),
+        models=(
+            TTSModelInfo(
+                model_id=remote_model_id,
+                display_name="Opaque model",
+                family="test",
+                upstream_mode="tts",
+                formats=("wav",),
+                voices=(),
+                supports_speed=False,
+                omit_voice_uses_server_default=True,
+            ),
+        ),
+    )
+    service.voices[("audio_cpp", remote_model_id)] = (remote_voice_id,)
+    app = _PlaygroundHost()
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        widget = app.query_one(TTSPlaygroundWidget)
+        model_select = app.query_one("#tts-model-select", Select)
+        voice_select = app.query_one("#tts-voice-select", Select)
+
+        assert model_select.value == remote_model_id
+        assert service.voice_calls == [("audio_cpp", remote_model_id, False)]
+        assert _option_values(voice_select) == (
+            SERVER_DEFAULT_VOICE_ID,
+            remote_voice_id,
+        )
+
+        voice_select.value = remote_voice_id
+        await pilot.pause()
+        widget._generate_tts()
+
+        request = app.generation_events[-1].request
+        assert request.model_id == remote_model_id
+        assert request.voice_id == remote_voice_id
+
+
+@pytest.mark.asyncio
 async def test_configuration_change_marks_catalog_stale_without_connecting(
     audio_cpp_playground: FakeTTSService,
     tmp_path: Path,
@@ -365,11 +420,71 @@ async def test_catalog_result_is_discarded_when_configuration_revision_changes(
         await pilot.pause()
 
         assert _option_values(app.query_one("#tts-model-select", Select)) == (
-            "__loading__",
+            LOADING_SELECT_VALUE,
         )
         assert app.query_one("#tts-generate-btn", Button).disabled is True
         status = str(app.query_one("#tts-provider-status", Static).render()).lower()
         assert "settings changed" in status
+
+
+@pytest.mark.asyncio
+async def test_superseded_catalog_failure_cannot_overwrite_newer_success(
+    audio_cpp_playground: FakeTTSService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = audio_cpp_playground
+    app = _PlaygroundHost()
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await app.workers.wait_for_complete()
+        widget = app.query_one(TTSPlaygroundWidget)
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        call_count = 0
+        newer_catalog = _audio_catalog(revision=12)
+
+        async def get_catalog(
+            provider_id: str,
+            refresh: bool = False,
+        ) -> TTSProviderCatalog:
+            nonlocal call_count
+            del refresh
+            call_count += 1
+            if call_count == 1:
+                first_started.set()
+                try:
+                    await release_first.wait()
+                except asyncio.CancelledError:
+                    await release_first.wait()
+                raise RuntimeError("obsolete refresh failed")
+            assert provider_id == "audio_cpp"
+            return newer_catalog
+
+        monkeypatch.setattr(service, "get_catalog", get_catalog)
+
+        widget._load_provider_catalog("audio_cpp", refresh=True)
+        await first_started.wait()
+        widget._load_provider_catalog("audio_cpp", refresh=True)
+        await _wait_until(
+            pilot,
+            lambda: (
+                call_count == 2
+                and widget._catalogs.get("audio_cpp") is newer_catalog
+                and "ready"
+                in str(app.query_one("#tts-provider-status", Static).render()).lower()
+            ),
+        )
+
+        release_first.set()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert widget._catalogs["audio_cpp"] is newer_catalog
+        assert "audio_cpp" not in widget._stale_providers
+        assert (
+            "ready"
+            in str(app.query_one("#tts-provider-status", Static).render()).lower()
+        )
 
 
 @pytest.mark.asyncio
@@ -1059,6 +1174,123 @@ async def test_playback_uses_artifact_captured_before_worker_runs(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("pause_before_replacement", "terminal_action"),
+    (
+        (False, "stop"),
+        (True, "stop"),
+        (False, "finish"),
+        (False, "unmount"),
+    ),
+    ids=("playing-stop", "paused-stop", "natural-finish", "unmount"),
+)
+async def test_playback_lease_survives_replacement_until_playback_ends(
+    audio_cpp_playground: FakeTTSService,
+    tmp_path: Path,
+    pause_before_replacement: bool,
+    terminal_action: str,
+) -> None:
+    del audio_cpp_playground
+    old_path = tmp_path / "old.wav"
+    new_path = tmp_path / "new.wav"
+    old_path.write_bytes(b"old")
+    new_path.write_bytes(b"new")
+    old_artifact = STTSGeneratedAudio(
+        path=old_path,
+        provider_id="audio_cpp",
+        model_id="old-model",
+        voice_id=None,
+        source_text="old",
+        operation_id="old-operation",
+        audio_format="wav",
+        content_type="audio/wav",
+    )
+    new_artifact = STTSGeneratedAudio(
+        path=new_path,
+        provider_id="audio_cpp",
+        model_id="new-model",
+        voice_id=None,
+        source_text="new",
+        operation_id="new-operation",
+        audio_format="wav",
+        content_type="audio/wav",
+    )
+
+    class Player:
+        def __init__(self) -> None:
+            self.state = PlaybackState.IDLE
+
+        async def get_state(self) -> PlaybackState:
+            return self.state
+
+        async def stop(self) -> bool:
+            self.state = PlaybackState.IDLE
+            return True
+
+        async def play(self, _path: Path) -> bool:
+            self.state = PlaybackState.PLAYING
+            return True
+
+        async def is_playing(self) -> bool:
+            return self.state == PlaybackState.PLAYING
+
+        async def pause(self) -> bool:
+            self.state = PlaybackState.PAUSED
+            return True
+
+        async def resume(self) -> bool:
+            self.state = PlaybackState.PLAYING
+            return True
+
+        async def get_position(self) -> float:
+            return 0.0
+
+        async def get_duration(self) -> float:
+            return 1.0
+
+    app = _PlaygroundHost()
+    handler = STTSEventHandler(app)
+    handler._accept_playground_artifact(old_artifact)
+    app._stts_handler = handler
+    player = Player()
+    app.audio_player = player
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await app.workers.wait_for_complete()
+        widget = app.query_one(TTSPlaygroundWidget)
+
+        widget._play_audio()
+        await _wait_until(
+            pilot,
+            lambda: (
+                player.state == PlaybackState.PLAYING
+                and widget._play_worker_task is None
+            ),
+        )
+        if pause_before_replacement:
+            widget._pause_audio()
+            await _wait_until(
+                pilot,
+                lambda: player.state == PlaybackState.PAUSED,
+            )
+
+        handler._accept_playground_artifact(new_artifact)
+        widget._store_delivered_artifact(new_artifact, announce=False)
+
+        assert old_path.exists()
+        assert handler._playground_file_leases[old_path] == 1
+
+        if terminal_action == "stop":
+            await widget._stop_audio_async()
+        elif terminal_action == "finish":
+            player.state = PlaybackState.FINISHED
+            await _wait_until(pilot, lambda: not old_path.exists())
+
+    assert not old_path.exists()
+    assert old_path not in handler._playground_file_leases
+
+
+@pytest.mark.asyncio
 async def test_export_uses_artifact_captured_before_dialog_completes(
     audio_cpp_playground: FakeTTSService,
     monkeypatch: pytest.MonkeyPatch,
@@ -1161,6 +1393,31 @@ async def test_export_cancel_releases_captured_artifact(
         callbacks[0](None)
 
         lease_handler.release_playground_artifact.assert_called_once_with(artifact)
+
+
+@pytest.mark.asyncio
+async def test_audio_export_rejects_unsafe_dialog_destination(
+    audio_cpp_playground: FakeTTSService,
+    tmp_path: Path,
+) -> None:
+    del audio_cpp_playground
+    source = tmp_path / "source.wav"
+    unsafe_destination = tmp_path / "bad;name.wav"
+    source.write_bytes(b"audio")
+    app = _PlaygroundHost()
+
+    async with app.run_test(size=(180, 70)):
+        await app.workers.wait_for_complete()
+        widget = app.query_one(TTSPlaygroundWidget)
+
+        widget._handle_audio_export(
+            str(unsafe_destination),
+            source_path=source,
+        )
+
+    assert not unsafe_destination.exists()
+    assert app.notices[-1][1] == "error"
+    assert "dangerous pattern" in app.notices[-1][0]
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_stts_playground_audio_cpp.py
+++ b/Tests/UI/test_stts_playground_audio_cpp.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
 from rich.text import Text
@@ -16,6 +18,7 @@ from tldw_chatbook.TTS.adapter_types import (
     TTSProviderCatalog,
     TTSProviderDescriptor,
 )
+from tldw_chatbook.TTS.playground_types import STTSGeneratedAudio
 from tldw_chatbook.TTS.legacy_catalogs import legacy_catalog
 from tldw_chatbook.UI import STTS_Window
 from tldw_chatbook.UI.STTS_Window import TTSPlaygroundWidget
@@ -91,6 +94,7 @@ class FakeTTSService:
         }
         self.catalog_started: asyncio.Event | None = None
         self.allow_catalog: asyncio.Event | None = None
+        self.catalog_cancelled = False
 
     def provider_descriptors(self) -> tuple[TTSProviderDescriptor, ...]:
         self.descriptor_calls += 1
@@ -122,6 +126,7 @@ class FakeTTSService:
             try:
                 await self.allow_catalog.wait()
             except asyncio.CancelledError:
+                self.catalog_cancelled = True
                 await self.allow_catalog.wait()
         return self.catalogs[provider_id]
 
@@ -313,6 +318,41 @@ async def test_catalog_result_is_discarded_when_configuration_revision_changes(
 
 
 @pytest.mark.asyncio
+async def test_voice_discovery_does_not_cancel_inflight_catalog_refresh(
+    audio_cpp_playground: FakeTTSService,
+) -> None:
+    service = audio_cpp_playground
+    app = _PlaygroundHost()
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await app.workers.wait_for_complete()
+        service.catalog_started = asyncio.Event()
+        service.allow_catalog = asyncio.Event()
+        widget = app.query_one(TTSPlaygroundWidget)
+
+        widget._load_provider_catalog("audio_cpp", refresh=True)
+        await service.catalog_started.wait()
+        app.query_one("#tts-model-select", Select).value = "second-model"
+        await _wait_until(
+            pilot,
+            lambda: any(
+                provider_id == "audio_cpp" and model_id == "second-model"
+                for provider_id, model_id, _refresh in service.voice_calls
+            ),
+        )
+
+        assert service.catalog_cancelled is False
+        service.allow_catalog.set()
+        await _wait_until(
+            pilot,
+            lambda: (
+                "ready"
+                in str(app.query_one("#tts-provider-status", Static).render()).lower()
+            ),
+        )
+
+
+@pytest.mark.asyncio
 async def test_legacy_control_state_is_restored_after_audio_cpp_switch(
     audio_cpp_playground: FakeTTSService,
 ) -> None:
@@ -403,7 +443,167 @@ async def test_audio_cpp_health_states_use_fixed_safe_recovery_copy(
         status = str(app.query_one("#tts-provider-status", Static).render()).lower()
         assert expected_copy in status
         assert app.query_one("#tts-generate-btn", Button).disabled is True
+        assert app.query_one("#tts-refresh-catalog-btn", Button).disabled is False
+        assert app.query_one("#tts-provider-select", Select).value == "audio_cpp"
         assert _option_values(app.query_one("#tts-model-select", Select)) == (
             "<opaque:model>",
             "second-model",
         )
+        assert service.catalog_calls == [("audio_cpp", False)]
+
+
+@pytest.mark.asyncio
+async def test_playback_uses_dedicated_widget_worker_group(
+    audio_cpp_playground: FakeTTSService,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    del audio_cpp_playground
+    path = tmp_path / "artifact.wav"
+    path.write_bytes(b"RIFF")
+    artifact = STTSGeneratedAudio(
+        path=path,
+        provider_id="audio_cpp",
+        model_id="model",
+        voice_id=None,
+        source_text="source",
+        operation_id="operation",
+        audio_format="wav",
+        content_type="audio/wav",
+    )
+    captured: dict[str, object] = {}
+    worker_calls = 0
+
+    def run_worker(
+        _self: TTSPlaygroundWidget,
+        awaitable: object,
+        **kwargs: object,
+    ) -> SimpleNamespace:
+        nonlocal worker_calls
+        worker_calls += 1
+        captured.update(kwargs)
+        close = getattr(awaitable, "close", None)
+        if callable(close):
+            close()
+        return SimpleNamespace(is_finished=False, cancel=lambda: None)
+
+    app = _PlaygroundHost()
+
+    async with app.run_test(size=(180, 70)):
+        await app.workers.wait_for_complete()
+        monkeypatch.setattr(TTSPlaygroundWidget, "run_worker", run_worker)
+        monkeypatch.setattr(
+            TTSPlaygroundWidget,
+            "_ensure_audio_player",
+            lambda _self: True,
+        )
+        widget = app.query_one(TTSPlaygroundWidget)
+        widget.current_audio_artifact = artifact
+        widget.current_audio_file = artifact.path
+
+        widget._play_audio()
+        widget._play_audio()
+
+        assert captured["group"] == "stts-playback"
+        assert captured["exclusive"] is True
+        assert worker_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_unmount_cancels_only_widget_owned_worker_groups(
+    audio_cpp_playground: FakeTTSService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    del audio_cpp_playground
+    app = _PlaygroundHost()
+    cleanup = Mock()
+    app._stts_handler = SimpleNamespace(cleanup_tts_resources=cleanup)
+    cancelled_groups: list[str] = []
+
+    async with app.run_test(size=(180, 70)):
+        original_cancel_group = app.workers.cancel_group
+
+        def cancel_group(node: object, group: str) -> None:
+            cancelled_groups.append(group)
+            original_cancel_group(node, group)
+
+        monkeypatch.setattr(app.workers, "cancel_group", cancel_group)
+        await app.workers.wait_for_complete()
+
+    assert {
+        "stts-catalog-discovery",
+        "stts-voice-discovery",
+        "stts-playback",
+    }.issubset(cancelled_groups)
+    cleanup.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_new_mount_rehydrates_handler_owned_artifact(
+    audio_cpp_playground: FakeTTSService,
+    tmp_path: Path,
+) -> None:
+    del audio_cpp_playground
+    path = tmp_path / "retained.wav"
+    path.write_bytes(b"RIFF")
+    artifact = STTSGeneratedAudio(
+        path=path,
+        provider_id="audio_cpp",
+        model_id="response-model",
+        voice_id=None,
+        source_text="source",
+        operation_id="completed-operation",
+        audio_format="wav",
+        content_type="audio/wav",
+    )
+    state = SimpleNamespace(
+        active_operation_id=None,
+        artifact=artifact,
+        generation_active=False,
+    )
+    cleanup = Mock()
+    app = _PlaygroundHost()
+    app._stts_handler = SimpleNamespace(
+        playground_state=lambda: state,
+        cleanup_tts_resources=cleanup,
+    )
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        widget = app.query_one(TTSPlaygroundWidget)
+
+        assert widget.current_audio_artifact is artifact
+        assert widget.current_audio_file == path
+        assert app.query_one("#audio-play-btn", Button).disabled is False
+        assert app.query_one("#audio-export-btn", Button).disabled is False
+
+    assert path.exists()
+    cleanup.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_new_mount_rehydrates_active_generation_without_starting_another(
+    audio_cpp_playground: FakeTTSService,
+) -> None:
+    service = audio_cpp_playground
+    state = SimpleNamespace(
+        active_operation_id="active-operation",
+        artifact=None,
+        generation_active=True,
+    )
+    app = _PlaygroundHost()
+    app._stts_handler = SimpleNamespace(playground_state=lambda: state)
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        widget = app.query_one(TTSPlaygroundWidget)
+
+        assert widget._generation_operation_id == "active-operation"
+        assert app.query_one("#tts-generate-btn", Button).disabled is True
+        assert (
+            "in progress"
+            in str(app.query_one("#generation-status-text", Static).render()).lower()
+        )
+        assert service.synthesize_calls == 0

--- a/Tests/UI/test_stts_playground_audio_cpp.py
+++ b/Tests/UI/test_stts_playground_audio_cpp.py
@@ -101,6 +101,17 @@ class FakeTTSService:
         self.voice_started: asyncio.Event | None = None
         self.allow_voices: asyncio.Event | None = None
         self.voice_error: Exception | None = None
+        self.voice_started_by_request: dict[
+            tuple[str, str],
+            asyncio.Event,
+        ] = {}
+        self.voice_finished_by_request: dict[
+            tuple[str, str],
+            asyncio.Event,
+        ] = {}
+        self.voice_gates: dict[tuple[str, str], asyncio.Event] = {}
+        self.voice_errors: dict[tuple[str, str], Exception] = {}
+        self.voice_ignore_cancellation: set[tuple[str, str]] = set()
 
     def provider_descriptors(self) -> tuple[TTSProviderDescriptor, ...]:
         self.descriptor_calls += 1
@@ -143,13 +154,29 @@ class FakeTTSService:
         refresh: bool = False,
     ) -> tuple[str, ...]:
         self.voice_calls.append((provider_id, model_id, refresh))
+        request_key = (provider_id, model_id)
         if self.voice_started is not None:
             self.voice_started.set()
-        if self.allow_voices is not None:
-            await self.allow_voices.wait()
-        if self.voice_error is not None:
-            raise self.voice_error
-        return self.voices.get((provider_id, model_id), ())
+        request_started = self.voice_started_by_request.get(request_key)
+        if request_started is not None:
+            request_started.set()
+        try:
+            gate = self.voice_gates.get(request_key, self.allow_voices)
+            if gate is not None:
+                try:
+                    await gate.wait()
+                except asyncio.CancelledError:
+                    if request_key not in self.voice_ignore_cancellation:
+                        raise
+                    await gate.wait()
+            error = self.voice_errors.get(request_key, self.voice_error)
+            if error is not None:
+                raise error
+            return self.voices.get(request_key, ())
+        finally:
+            request_finished = self.voice_finished_by_request.get(request_key)
+            if request_finished is not None:
+                request_finished.set()
 
     async def synthesize(self, *_args: Any, **_kwargs: Any) -> None:
         self.synthesize_calls += 1
@@ -497,6 +524,145 @@ async def test_voice_discovery_failure_releases_pending_explicit_voice(
         assert len(app.generation_events) == 1
         assert app.generation_events[0].request.voice_id is None
         assert "untrusted upstream detail" not in str(app.notices)
+
+
+@pytest.mark.asyncio
+async def test_voice_discovery_failure_overrides_configured_explicit_default(
+    audio_cpp_playground: FakeTTSService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = audio_cpp_playground
+
+    def get_setting(section: str, key: str, default: Any = None) -> Any:
+        configured = {
+            ("app_tts", "default_provider"): "audio_cpp",
+            ("app_tts", "default_voice"): "[voice]",
+        }
+        return configured.get((section, key), default)
+
+    monkeypatch.setattr(STTS_Window, "get_cli_setting", get_setting)
+    service.voice_error = RuntimeError("untrusted upstream detail")
+    app = _PlaygroundHost()
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await app.workers.wait_for_complete()
+        app.query_one("#tts-text-input", TextArea).text = "configured fallback"
+        await pilot.pause()
+
+        widget = app.query_one(TTSPlaygroundWidget)
+        assert app.query_one("#tts-voice-select", Select).value == (
+            SERVER_DEFAULT_VOICE_ID
+        )
+        assert widget._pending_voice_selections == {}
+        assert app.query_one("#tts-generate-btn", Button).disabled is False
+
+        widget.action_generate_tts()
+        await pilot.pause()
+
+        assert len(app.generation_events) == 1
+        assert app.generation_events[0].request.voice_id is None
+        assert "untrusted upstream detail" not in str(app.notices)
+
+
+@pytest.mark.asyncio
+async def test_server_default_override_survives_provider_switch(
+    audio_cpp_playground: FakeTTSService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    del audio_cpp_playground
+
+    def get_setting(section: str, key: str, default: Any = None) -> Any:
+        configured = {
+            ("app_tts", "default_provider"): "audio_cpp",
+            ("app_tts", "default_voice"): "[voice]",
+        }
+        return configured.get((section, key), default)
+
+    monkeypatch.setattr(STTS_Window, "get_cli_setting", get_setting)
+    app = _PlaygroundHost()
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await app.workers.wait_for_complete()
+        provider_select = app.query_one("#tts-provider-select", Select)
+        voice_select = app.query_one("#tts-voice-select", Select)
+        assert voice_select.value == "[voice]"
+
+        voice_select.value = SERVER_DEFAULT_VOICE_ID
+        provider_select.value = "openai"
+        await _wait_until(
+            pilot,
+            lambda: app.query_one("#tts-model-select", Select).value == "tts-1",
+        )
+        provider_select.value = "audio_cpp"
+        await _wait_until(
+            pilot,
+            lambda: (
+                app.query_one("#tts-model-select", Select).value == "<opaque:model>"
+            ),
+        )
+
+        assert voice_select.value == SERVER_DEFAULT_VOICE_ID
+
+
+@pytest.mark.asyncio
+async def test_stale_model_voice_failure_cannot_release_current_pending_voice(
+    audio_cpp_playground: FakeTTSService,
+) -> None:
+    service = audio_cpp_playground
+    app = _PlaygroundHost()
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await app.workers.wait_for_complete()
+        widget = app.query_one(TTSPlaygroundWidget)
+        voice_select = app.query_one("#tts-voice-select", Select)
+        model_select = app.query_one("#tts-model-select", Select)
+        voice_select.value = "[voice]"
+        app.query_one("#tts-text-input", TextArea).text = "current pending voice"
+        await pilot.pause()
+
+        old_key = ("audio_cpp", "<opaque:model>")
+        current_key = ("audio_cpp", "second-model")
+        service.voice_started_by_request[old_key] = asyncio.Event()
+        service.voice_finished_by_request[old_key] = asyncio.Event()
+        service.voice_gates[old_key] = asyncio.Event()
+        service.voice_errors[old_key] = RuntimeError("late old-model failure")
+        service.voice_ignore_cancellation.add(old_key)
+        service.voice_started_by_request[current_key] = asyncio.Event()
+        service.voice_finished_by_request[current_key] = asyncio.Event()
+        service.voice_gates[current_key] = asyncio.Event()
+
+        widget._load_provider_voices(
+            "audio_cpp",
+            "<opaque:model>",
+            service.catalogs["audio_cpp"].revision,
+            refresh=True,
+        )
+        await service.voice_started_by_request[old_key].wait()
+
+        model_select.value = "second-model"
+        await service.voice_started_by_request[current_key].wait()
+        await pilot.pause()
+
+        assert widget._pending_voice_selections == {"audio_cpp": "[voice]"}
+        assert app.query_one("#tts-generate-btn", Button).disabled is True
+
+        service.voice_gates[old_key].set()
+        await service.voice_finished_by_request[old_key].wait()
+        await pilot.pause()
+
+        assert widget._pending_voice_selections == {"audio_cpp": "[voice]"}
+        assert app.query_one("#tts-generate-btn", Button).disabled is True
+        widget.action_generate_tts()
+        await pilot.pause()
+        assert app.generation_events == []
+        assert app.notices[-1] == (
+            "Voices are still loading; wait before generating",
+            "warning",
+        )
+
+        service.voice_gates[current_key].set()
+        await service.voice_finished_by_request[current_key].wait()
+        await _wait_until(pilot, lambda: widget._pending_voice_selections == {})
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_stts_playground_audio_cpp.py
+++ b/Tests/UI/test_stts_playground_audio_cpp.py
@@ -10,8 +10,11 @@ from unittest.mock import Mock
 import pytest
 from rich.text import Text
 from textual.app import App, ComposeResult
-from textual.widgets import Button, Input, Select, Static
+from textual.widgets import Button, Input, Select, Static, TextArea
 
+from tldw_chatbook.Event_Handlers.STTS_Events.stts_events import (
+    STTSPlaygroundGenerateEvent,
+)
 from tldw_chatbook.TTS.adapter_types import (
     ProviderHealth,
     TTSModelInfo,
@@ -154,6 +157,7 @@ class _PlaygroundHost(App[None]):
     def __init__(self) -> None:
         super().__init__()
         self.notices: list[tuple[str, str]] = []
+        self.generation_events: list[STTSPlaygroundGenerateEvent] = []
 
     def compose(self) -> ComposeResult:
         yield TTSPlaygroundWidget()
@@ -168,6 +172,12 @@ class _PlaygroundHost(App[None]):
     ) -> None:
         del title, timeout
         self.notices.append((message, severity))
+
+    def post_message(self, message: Any) -> bool:
+        if isinstance(message, STTSPlaygroundGenerateEvent):
+            self.generation_events.append(message)
+            return True
+        return super().post_message(message)
 
 
 @pytest.fixture
@@ -375,15 +385,58 @@ async def test_catalog_revision_invalidates_old_voices_before_rediscovery(
         service.voice_started = asyncio.Event()
         service.allow_voices = asyncio.Event()
         widget = app.query_one(TTSPlaygroundWidget)
+        notices_before = list(app.notices)
         widget._load_provider_catalog("audio_cpp", refresh=True)
         await service.voice_started.wait()
         await pilot.pause()
 
         assert _option_values(voice_select) == (SERVER_DEFAULT_VOICE_ID,)
         assert voice_select.value == SERVER_DEFAULT_VOICE_ID
+        assert app.notices == notices_before
 
         service.allow_voices.set()
         await app.workers.wait_for_complete()
+
+        assert voice_select.value == "[voice]"
+        assert app.notices == notices_before
+
+
+@pytest.mark.asyncio
+async def test_catalog_revision_falls_back_only_after_refreshed_voice_is_removed(
+    audio_cpp_playground: FakeTTSService,
+) -> None:
+    service = audio_cpp_playground
+    app = _PlaygroundHost()
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await app.workers.wait_for_complete()
+        voice_select = app.query_one("#tts-voice-select", Select)
+        voice_select.value = "[voice]"
+        await pilot.pause()
+
+        service.catalogs["audio_cpp"] = _audio_catalog(revision=12)
+        service.voices[("audio_cpp", "<opaque:model>")] = ("replacement",)
+        service.voice_started = asyncio.Event()
+        service.allow_voices = asyncio.Event()
+        notices_before = list(app.notices)
+        widget = app.query_one(TTSPlaygroundWidget)
+        widget._load_provider_catalog("audio_cpp", refresh=True)
+        await service.voice_started.wait()
+        await pilot.pause()
+
+        assert app.notices == notices_before
+
+        service.allow_voices.set()
+        await app.workers.wait_for_complete()
+
+        assert voice_select.value == SERVER_DEFAULT_VOICE_ID
+        assert app.notices == [
+            *notices_before,
+            (
+                "Available models or voices changed; a valid selection was chosen",
+                "warning",
+            ),
+        ]
 
 
 @pytest.mark.asyncio
@@ -437,6 +490,39 @@ async def test_legacy_control_state_is_restored_after_audio_cpp_switch(
         "audio_cpp",
         "openai",
     ]
+
+
+@pytest.mark.asyncio
+async def test_higgs_saved_profile_is_prefixed_exactly_once_in_request(
+    audio_cpp_playground: FakeTTSService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    del audio_cpp_playground
+    monkeypatch.setattr(
+        TTSPlaygroundWidget,
+        "_higgs_profile_choices",
+        staticmethod(lambda: [("Saved voice", "profile:saved-voice")]),
+    )
+    app = _PlaygroundHost()
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await app.workers.wait_for_complete()
+        app.query_one("#tts-provider-select", Select).value = "higgs"
+        await _wait_until(
+            pilot,
+            lambda: (
+                app.query_one("#tts-model-select", Select).value == "higgs-audio-v2"
+            ),
+        )
+        app.query_one("#tts-voice-select", Select).value = "profile:saved-voice"
+        app.query_one("#tts-text-input", TextArea).text = "use saved profile"
+        await pilot.pause()
+
+        app.query_one(TTSPlaygroundWidget)._generate_tts()
+        await pilot.pause()
+
+        assert len(app.generation_events) == 1
+        assert app.generation_events[0].request.voice_id == "profile:saved-voice"
 
 
 @pytest.mark.asyncio
@@ -541,6 +627,197 @@ async def test_playback_uses_dedicated_widget_worker_group(
         assert captured["group"] == "stts-playback"
         assert captured["exclusive"] is True
         assert worker_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_playback_uses_artifact_captured_before_worker_runs(
+    audio_cpp_playground: FakeTTSService,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    del audio_cpp_playground
+    old_path = tmp_path / "old.wav"
+    new_path = tmp_path / "new.wav"
+    old_path.write_bytes(b"old")
+    new_path.write_bytes(b"new")
+    old_artifact = STTSGeneratedAudio(
+        path=old_path,
+        provider_id="audio_cpp",
+        model_id="old-model",
+        voice_id=None,
+        source_text="old",
+        operation_id="old-operation",
+        audio_format="wav",
+        content_type="audio/wav",
+    )
+    new_artifact = STTSGeneratedAudio(
+        path=new_path,
+        provider_id="audio_cpp",
+        model_id="new-model",
+        voice_id=None,
+        source_text="new",
+        operation_id="new-operation",
+        audio_format="wav",
+        content_type="audio/wav",
+    )
+    jobs: list[object] = []
+
+    def run_worker(
+        _self: TTSPlaygroundWidget,
+        job: object,
+        **_kwargs: object,
+    ) -> SimpleNamespace:
+        jobs.append(job)
+        return SimpleNamespace(is_finished=False, cancel=lambda: None)
+
+    class Player:
+        def __init__(self) -> None:
+            self.played: list[Path] = []
+
+        async def get_state(self) -> str:
+            return "stopped"
+
+        async def stop(self) -> bool:
+            return True
+
+        async def play(self, path: Path) -> bool:
+            self.played.append(path)
+            return False
+
+    lease_handler = SimpleNamespace(
+        lease_playground_artifact=Mock(return_value=True),
+        release_playground_artifact=Mock(),
+    )
+    app = _PlaygroundHost()
+    app._stts_handler = lease_handler
+    player = Player()
+    app.audio_player = player
+
+    async with app.run_test(size=(180, 70)):
+        await app.workers.wait_for_complete()
+        monkeypatch.setattr(TTSPlaygroundWidget, "run_worker", run_worker)
+        widget = app.query_one(TTSPlaygroundWidget)
+        widget.current_audio_artifact = old_artifact
+        widget.current_audio_file = old_path
+
+        widget._play_audio()
+        widget.current_audio_artifact = new_artifact
+        widget.current_audio_file = new_path
+
+        job = jobs[0]
+        if callable(job):
+            await job()
+        else:
+            await job  # type: ignore[misc]
+
+        assert player.played == [old_path]
+        lease_handler.lease_playground_artifact.assert_called_once_with(old_artifact)
+        lease_handler.release_playground_artifact.assert_called_once_with(old_artifact)
+
+
+@pytest.mark.asyncio
+async def test_export_uses_artifact_captured_before_dialog_completes(
+    audio_cpp_playground: FakeTTSService,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    del audio_cpp_playground
+    old_path = tmp_path / "old.wav"
+    new_path = tmp_path / "new.wav"
+    destination = tmp_path / "export.wav"
+    old_path.write_bytes(b"old")
+    new_path.write_bytes(b"new")
+    old_artifact = STTSGeneratedAudio(
+        path=old_path,
+        provider_id="audio_cpp",
+        model_id="old-model",
+        voice_id=None,
+        source_text="old",
+        operation_id="old-operation",
+        audio_format="wav",
+        content_type="audio/wav",
+    )
+    new_artifact = STTSGeneratedAudio(
+        path=new_path,
+        provider_id="audio_cpp",
+        model_id="new-model",
+        voice_id=None,
+        source_text="new",
+        operation_id="new-operation",
+        audio_format="wav",
+        content_type="audio/wav",
+    )
+    callbacks: list[Callable[[str | None], None]] = []
+    lease_handler = SimpleNamespace(
+        lease_playground_artifact=Mock(return_value=True),
+        release_playground_artifact=Mock(),
+    )
+    app = _PlaygroundHost()
+    app._stts_handler = lease_handler
+
+    async with app.run_test(size=(180, 70)):
+        await app.workers.wait_for_complete()
+        monkeypatch.setattr(
+            app,
+            "push_screen",
+            lambda _screen, callback: callbacks.append(callback),
+        )
+        widget = app.query_one(TTSPlaygroundWidget)
+        widget.current_audio_artifact = old_artifact
+        widget.current_audio_file = old_path
+
+        widget._export_audio()
+        widget.current_audio_artifact = new_artifact
+        widget.current_audio_file = new_path
+        callbacks[0](str(destination))
+
+        assert destination.read_bytes() == b"old"
+        lease_handler.lease_playground_artifact.assert_called_once_with(old_artifact)
+        lease_handler.release_playground_artifact.assert_called_once_with(old_artifact)
+
+
+@pytest.mark.asyncio
+async def test_export_cancel_releases_captured_artifact(
+    audio_cpp_playground: FakeTTSService,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    del audio_cpp_playground
+    path = tmp_path / "artifact.wav"
+    path.write_bytes(b"audio")
+    artifact = STTSGeneratedAudio(
+        path=path,
+        provider_id="audio_cpp",
+        model_id="model",
+        voice_id=None,
+        source_text="source",
+        operation_id="operation",
+        audio_format="wav",
+        content_type="audio/wav",
+    )
+    callbacks: list[Callable[[str | None], None]] = []
+    lease_handler = SimpleNamespace(
+        lease_playground_artifact=Mock(return_value=True),
+        release_playground_artifact=Mock(),
+    )
+    app = _PlaygroundHost()
+    app._stts_handler = lease_handler
+
+    async with app.run_test(size=(180, 70)):
+        await app.workers.wait_for_complete()
+        monkeypatch.setattr(
+            app,
+            "push_screen",
+            lambda _screen, callback: callbacks.append(callback),
+        )
+        widget = app.query_one(TTSPlaygroundWidget)
+        widget.current_audio_artifact = artifact
+        widget.current_audio_file = path
+
+        widget._export_audio()
+        callbacks[0](None)
+
+        lease_handler.release_playground_artifact.assert_called_once_with(artifact)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_stts_playground_audio_cpp.py
+++ b/Tests/UI/test_stts_playground_audio_cpp.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+from rich.text import Text
+from textual.app import App, ComposeResult
+from textual.widgets import Button, Input, Select, Static
+
+from tldw_chatbook.TTS.adapter_types import (
+    ProviderHealth,
+    TTSModelInfo,
+    TTSProviderCatalog,
+    TTSProviderDescriptor,
+)
+from tldw_chatbook.TTS.legacy_catalogs import legacy_catalog
+from tldw_chatbook.UI import STTS_Window
+from tldw_chatbook.UI.STTS_Window import TTSPlaygroundWidget
+from tldw_chatbook.UI.stts_playground_catalog import SERVER_DEFAULT_VOICE_ID
+
+
+PROVIDER_IDS = (
+    "audio_cpp",
+    "openai",
+    "elevenlabs",
+    "kokoro",
+    "chatterbox",
+    "higgs",
+    "alltalk",
+)
+
+
+def _audio_catalog(
+    *,
+    health: ProviderHealth | None = None,
+    revision: int = 11,
+) -> TTSProviderCatalog:
+    return TTSProviderCatalog(
+        provider_id="audio_cpp",
+        revision=revision,
+        health=health or ProviderHealth(state="available", fresh=True),
+        models=(
+            TTSModelInfo(
+                model_id="<opaque:model>",
+                display_name="[bold red]Opaque model[/]",
+                family="test",
+                upstream_mode="tts",
+                formats=("wav",),
+                voices=(),
+                supports_speed=False,
+                omit_voice_uses_server_default=True,
+            ),
+            TTSModelInfo(
+                model_id="second-model",
+                display_name="Second model",
+                family="test",
+                upstream_mode="tts",
+                formats=("wav",),
+                voices=(),
+                supports_speed=False,
+                omit_voice_uses_server_default=True,
+            ),
+        ),
+    )
+
+
+class FakeTTSService:
+    def __init__(self) -> None:
+        self.descriptor_calls = 0
+        self.catalog_calls: list[tuple[str, bool]] = []
+        self.voice_calls: list[tuple[str, str, bool]] = []
+        self.synthesize_calls = 0
+        self.revisions = {provider_id: 1 for provider_id in PROVIDER_IDS}
+        self.catalogs = {
+            "audio_cpp": _audio_catalog(),
+            **{
+                provider_id: legacy_catalog(provider_id)
+                for provider_id in PROVIDER_IDS
+                if provider_id != "audio_cpp"
+            },
+        }
+        self.voices: dict[tuple[str, str], tuple[str, ...]] = {
+            ("audio_cpp", "<opaque:model>"): (
+                "[voice]",
+                "<script>alert(1)</script>",
+            ),
+            ("audio_cpp", "second-model"): ("second-voice",),
+        }
+        self.catalog_started: asyncio.Event | None = None
+        self.allow_catalog: asyncio.Event | None = None
+
+    def provider_descriptors(self) -> tuple[TTSProviderDescriptor, ...]:
+        self.descriptor_calls += 1
+        return tuple(
+            TTSProviderDescriptor(
+                provider_id=provider_id,
+                display_name=(
+                    "[b]audio.cpp[/]"
+                    if provider_id == "audio_cpp"
+                    else provider_id.title()
+                ),
+                native=provider_id == "audio_cpp",
+            )
+            for provider_id in PROVIDER_IDS
+        )
+
+    def configuration_revision(self, provider_id: str) -> int:
+        return self.revisions[provider_id]
+
+    async def get_catalog(
+        self,
+        provider_id: str,
+        refresh: bool = False,
+    ) -> TTSProviderCatalog:
+        self.catalog_calls.append((provider_id, refresh))
+        if self.catalog_started is not None:
+            self.catalog_started.set()
+        if self.allow_catalog is not None:
+            try:
+                await self.allow_catalog.wait()
+            except asyncio.CancelledError:
+                await self.allow_catalog.wait()
+        return self.catalogs[provider_id]
+
+    async def get_voices(
+        self,
+        provider_id: str,
+        model_id: str,
+        refresh: bool = False,
+    ) -> tuple[str, ...]:
+        self.voice_calls.append((provider_id, model_id, refresh))
+        return self.voices.get((provider_id, model_id), ())
+
+    async def synthesize(self, *_args: Any, **_kwargs: Any) -> None:
+        self.synthesize_calls += 1
+        raise AssertionError("Task 4 must not synthesize")
+
+
+class _PlaygroundHost(App[None]):
+    def __init__(self) -> None:
+        super().__init__()
+        self.notices: list[tuple[str, str]] = []
+
+    def compose(self) -> ComposeResult:
+        yield TTSPlaygroundWidget()
+
+    def notify(
+        self,
+        message: str,
+        *,
+        title: str = "",
+        severity: str = "information",
+        timeout: float | None = None,
+    ) -> None:
+        del title, timeout
+        self.notices.append((message, severity))
+
+
+@pytest.fixture
+def audio_cpp_playground(
+    monkeypatch: pytest.MonkeyPatch,
+) -> FakeTTSService:
+    service = FakeTTSService()
+
+    def get_setting(section: str, key: str, default: Any = None) -> Any:
+        if (section, key) == ("app_tts", "default_provider"):
+            return "audio_cpp"
+        return default
+
+    monkeypatch.setattr(STTS_Window, "get_cli_setting", get_setting)
+    monkeypatch.setattr(
+        STTS_Window,
+        "get_tts_service",
+        lambda: _resolved(service),
+    )
+    monkeypatch.setattr(
+        TTSPlaygroundWidget,
+        "_check_higgs_installation",
+        lambda self: None,
+    )
+    return service
+
+
+async def _resolved(value: Any) -> Any:
+    return value
+
+
+def _option_values(select: Select[Any]) -> tuple[Any, ...]:
+    return tuple(value for _label, value in select._options)
+
+
+def _option_labels(select: Select[Any]) -> tuple[str, ...]:
+    labels = []
+    for label, _value in select._options:
+        labels.append(label.plain if isinstance(label, Text) else str(label))
+    return tuple(labels)
+
+
+async def _wait_until(
+    pilot: Any,
+    predicate: Callable[[], bool],
+) -> None:
+    for _ in range(100):
+        if predicate():
+            return
+        await pilot.pause(0.02)
+    pytest.fail("Timed out waiting for Playground state")
+
+
+@pytest.mark.asyncio
+async def test_mount_uses_descriptors_and_resolves_only_selected_provider(
+    audio_cpp_playground: FakeTTSService,
+) -> None:
+    service = audio_cpp_playground
+    app = _PlaygroundHost()
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        provider_select = app.query_one("#tts-provider-select", Select)
+        assert _option_values(provider_select) == PROVIDER_IDS
+        assert provider_select.value == "audio_cpp"
+        assert _option_labels(provider_select)[0] == "[b]audio.cpp[/]"
+
+        model_select = app.query_one("#tts-model-select", Select)
+        voice_select = app.query_one("#tts-voice-select", Select)
+        assert model_select.value == "<opaque:model>"
+        assert _option_labels(model_select)[0] == "[bold red]Opaque model[/]"
+        assert voice_select.value == SERVER_DEFAULT_VOICE_ID
+        assert _option_values(voice_select) == (
+            SERVER_DEFAULT_VOICE_ID,
+            "[voice]",
+            "<script>alert(1)</script>",
+        )
+        assert _option_labels(voice_select)[2] == "<script>alert(1)</script>"
+
+        assert app.query_one("#tts-format-select", Select).value == "wav"
+        assert app.query_one("#tts-format-select", Select).disabled is True
+        assert app.query_one("#tts-speed-input", Input).value == "1.0"
+        assert app.query_one("#tts-speed-input", Input).disabled is True
+        restriction = app.query_one("#tts-audio-cpp-restrictions", Static)
+        assert "complete wav" in str(restriction.render()).lower()
+
+    assert service.descriptor_calls == 1
+    assert service.catalog_calls == [("audio_cpp", False)]
+    assert service.voice_calls == [
+        ("audio_cpp", "<opaque:model>", False),
+    ]
+    assert service.synthesize_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_configuration_change_marks_catalog_stale_without_connecting(
+    audio_cpp_playground: FakeTTSService,
+    tmp_path: Path,
+) -> None:
+    service = audio_cpp_playground
+    app = _PlaygroundHost()
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        widget = app.query_one(TTSPlaygroundWidget)
+        model_values = _option_values(app.query_one("#tts-model-select", Select))
+        calls_before = list(service.catalog_calls)
+
+        widget.current_audio_file = tmp_path / "existing.wav"
+        app.query_one("#audio-play-btn", Button).disabled = False
+        app.query_one("#audio-export-btn", Button).disabled = False
+        service.revisions["audio_cpp"] = 2
+        widget.mark_provider_configuration_changed("audio_cpp", 2)
+        await pilot.pause()
+
+        assert _option_values(app.query_one("#tts-model-select", Select)) == (
+            model_values
+        )
+        assert app.query_one("#tts-generate-btn", Button).disabled is True
+        assert app.query_one("#audio-play-btn", Button).disabled is False
+        assert app.query_one("#audio-export-btn", Button).disabled is False
+        assert (
+            "refresh"
+            in str(app.query_one("#tts-provider-status", Static).render()).lower()
+        )
+        assert service.catalog_calls == calls_before
+
+
+@pytest.mark.asyncio
+async def test_catalog_result_is_discarded_when_configuration_revision_changes(
+    audio_cpp_playground: FakeTTSService,
+) -> None:
+    service = audio_cpp_playground
+    service.catalog_started = asyncio.Event()
+    service.allow_catalog = asyncio.Event()
+    app = _PlaygroundHost()
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await service.catalog_started.wait()
+        service.revisions["audio_cpp"] = 2
+        service.allow_catalog.set()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert _option_values(app.query_one("#tts-model-select", Select)) == (
+            "__loading__",
+        )
+        assert app.query_one("#tts-generate-btn", Button).disabled is True
+        status = str(app.query_one("#tts-provider-status", Static).render()).lower()
+        assert "settings changed" in status
+
+
+@pytest.mark.asyncio
+async def test_legacy_control_state_is_restored_after_audio_cpp_switch(
+    audio_cpp_playground: FakeTTSService,
+) -> None:
+    service = audio_cpp_playground
+    app = _PlaygroundHost()
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await app.workers.wait_for_complete()
+        provider = app.query_one("#tts-provider-select", Select)
+        provider.value = "openai"
+        await _wait_until(
+            pilot,
+            lambda: app.query_one("#tts-model-select", Select).value == "tts-1",
+        )
+
+        model = app.query_one("#tts-model-select", Select)
+        voice = app.query_one("#tts-voice-select", Select)
+        response_format = app.query_one("#tts-format-select", Select)
+        speed = app.query_one("#tts-speed-input", Input)
+        model.value = "tts-1-hd"
+        voice.value = "nova"
+        response_format.value = "flac"
+        speed.value = "1.35"
+        await pilot.pause()
+
+        provider.value = "audio_cpp"
+        await _wait_until(pilot, lambda: response_format.disabled)
+        assert response_format.value == "wav"
+        assert response_format.disabled is True
+        assert speed.value == "1.0"
+        assert speed.disabled is True
+
+        provider.value = "openai"
+        await _wait_until(
+            pilot,
+            lambda: model.value == "tts-1-hd" and not response_format.disabled,
+        )
+        assert model.value == "tts-1-hd"
+        assert voice.value == "nova"
+        assert response_format.value == "flac"
+        assert response_format.disabled is False
+        assert speed.value == "1.35"
+        assert speed.disabled is False
+
+    assert [provider_id for provider_id, _refresh in service.catalog_calls] == [
+        "audio_cpp",
+        "openai",
+        "audio_cpp",
+        "openai",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("health", "expected_copy"),
+    (
+        (
+            ProviderHealth(state="unavailable", fresh=True),
+            "unavailable",
+        ),
+        (
+            ProviderHealth(state="not_configured", fresh=True),
+            "not configured",
+        ),
+        (
+            ProviderHealth(state="reconfiguring", fresh=False),
+            "settings are being applied",
+        ),
+        (
+            ProviderHealth(state="available", fresh=False),
+            "catalog is stale",
+        ),
+    ),
+)
+async def test_audio_cpp_health_states_use_fixed_safe_recovery_copy(
+    audio_cpp_playground: FakeTTSService,
+    health: ProviderHealth,
+    expected_copy: str,
+) -> None:
+    service = audio_cpp_playground
+    service.catalogs["audio_cpp"] = _audio_catalog(health=health)
+    app = _PlaygroundHost()
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        status = str(app.query_one("#tts-provider-status", Static).render()).lower()
+        assert expected_copy in status
+        assert app.query_one("#tts-generate-btn", Button).disabled is True
+        assert _option_values(app.query_one("#tts-model-select", Select)) == (
+            "<opaque:model>",
+            "second-model",
+        )

--- a/Tests/UI/test_stts_playground_audio_cpp.py
+++ b/Tests/UI/test_stts_playground_audio_cpp.py
@@ -628,6 +628,136 @@ async def test_superseded_same_model_voice_result_cannot_overwrite_newer_success
 
 
 @pytest.mark.asyncio
+async def test_catalog_generation_is_reserved_before_exclusive_worker_cancellation(
+    audio_cpp_playground: FakeTTSService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = audio_cpp_playground
+    app = _PlaygroundHost()
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await app.workers.wait_for_complete()
+        widget = app.query_one(TTSPlaygroundWidget)
+        baseline_catalog = widget._catalogs["audio_cpp"]
+        first_started = asyncio.Event()
+        first_returned_on_cancel = asyncio.Event()
+        second_started = asyncio.Event()
+        release_second = asyncio.Event()
+        call_count = 0
+        obsolete_catalog = _audio_catalog(revision=10)
+        newer_catalog = _audio_catalog(revision=12)
+
+        async def get_catalog(
+            provider_id: str,
+            refresh: bool = False,
+        ) -> TTSProviderCatalog:
+            nonlocal call_count
+            del refresh
+            assert provider_id == "audio_cpp"
+            call_count += 1
+            if call_count == 1:
+                first_started.set()
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    first_returned_on_cancel.set()
+                    return obsolete_catalog
+            second_started.set()
+            await release_second.wait()
+            return newer_catalog
+
+        monkeypatch.setattr(service, "get_catalog", get_catalog)
+
+        widget._load_provider_catalog("audio_cpp", refresh=True)
+        await first_started.wait()
+        first_generation = widget._catalog_request_generations["audio_cpp"]
+
+        widget._load_provider_catalog("audio_cpp", refresh=True)
+
+        assert widget._catalog_request_generations["audio_cpp"] == (
+            first_generation + 1
+        )
+        await first_returned_on_cancel.wait()
+        await second_started.wait()
+        await pilot.pause()
+        assert widget._catalogs["audio_cpp"] is baseline_catalog
+
+        release_second.set()
+        await app.workers.wait_for_complete()
+        assert widget._catalogs["audio_cpp"] is newer_catalog
+
+
+@pytest.mark.asyncio
+async def test_voice_generation_is_reserved_before_exclusive_worker_cancellation(
+    audio_cpp_playground: FakeTTSService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = audio_cpp_playground
+    app = _PlaygroundHost()
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await app.workers.wait_for_complete()
+        widget = app.query_one(TTSPlaygroundWidget)
+        model_id = "<opaque:model>"
+        request_key = ("audio_cpp", model_id)
+        baseline_voices = widget._discovered_voices[request_key]
+        catalog_revision = service.catalogs["audio_cpp"].revision
+        first_started = asyncio.Event()
+        first_returned_on_cancel = asyncio.Event()
+        second_started = asyncio.Event()
+        release_second = asyncio.Event()
+        call_count = 0
+
+        async def get_voices(
+            provider_id: str,
+            requested_model_id: str,
+            refresh: bool = False,
+        ) -> tuple[str, ...]:
+            nonlocal call_count
+            del refresh
+            assert (provider_id, requested_model_id) == request_key
+            call_count += 1
+            if call_count == 1:
+                first_started.set()
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    first_returned_on_cancel.set()
+                    return ("obsolete-on-cancel",)
+            second_started.set()
+            await release_second.wait()
+            return ("new-voice",)
+
+        monkeypatch.setattr(service, "get_voices", get_voices)
+
+        widget._load_provider_voices(
+            "audio_cpp",
+            model_id,
+            catalog_revision,
+            refresh=True,
+        )
+        await first_started.wait()
+        first_generation = widget._voice_request_generations[request_key]
+
+        widget._load_provider_voices(
+            "audio_cpp",
+            model_id,
+            catalog_revision,
+            refresh=True,
+        )
+
+        assert widget._voice_request_generations[request_key] == first_generation + 1
+        await first_returned_on_cancel.wait()
+        await second_started.wait()
+        await pilot.pause()
+        assert widget._discovered_voices[request_key] == baseline_voices
+
+        release_second.set()
+        await app.workers.wait_for_complete()
+        assert widget._discovered_voices[request_key] == ("new-voice",)
+
+
+@pytest.mark.asyncio
 async def test_voice_discovery_does_not_cancel_inflight_catalog_refresh(
     audio_cpp_playground: FakeTTSService,
 ) -> None:

--- a/Tests/UI/test_stts_playground_audio_cpp.py
+++ b/Tests/UI/test_stts_playground_audio_cpp.py
@@ -95,6 +95,8 @@ class FakeTTSService:
         self.catalog_started: asyncio.Event | None = None
         self.allow_catalog: asyncio.Event | None = None
         self.catalog_cancelled = False
+        self.voice_started: asyncio.Event | None = None
+        self.allow_voices: asyncio.Event | None = None
 
     def provider_descriptors(self) -> tuple[TTSProviderDescriptor, ...]:
         self.descriptor_calls += 1
@@ -137,6 +139,10 @@ class FakeTTSService:
         refresh: bool = False,
     ) -> tuple[str, ...]:
         self.voice_calls.append((provider_id, model_id, refresh))
+        if self.voice_started is not None:
+            self.voice_started.set()
+        if self.allow_voices is not None:
+            await self.allow_voices.wait()
         return self.voices.get((provider_id, model_id), ())
 
     async def synthesize(self, *_args: Any, **_kwargs: Any) -> None:
@@ -350,6 +356,34 @@ async def test_voice_discovery_does_not_cancel_inflight_catalog_refresh(
                 in str(app.query_one("#tts-provider-status", Static).render()).lower()
             ),
         )
+
+
+@pytest.mark.asyncio
+async def test_catalog_revision_invalidates_old_voices_before_rediscovery(
+    audio_cpp_playground: FakeTTSService,
+) -> None:
+    service = audio_cpp_playground
+    app = _PlaygroundHost()
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await app.workers.wait_for_complete()
+        voice_select = app.query_one("#tts-voice-select", Select)
+        voice_select.value = "[voice]"
+        await pilot.pause()
+
+        service.catalogs["audio_cpp"] = _audio_catalog(revision=12)
+        service.voice_started = asyncio.Event()
+        service.allow_voices = asyncio.Event()
+        widget = app.query_one(TTSPlaygroundWidget)
+        widget._load_provider_catalog("audio_cpp", refresh=True)
+        await service.voice_started.wait()
+        await pilot.pause()
+
+        assert _option_values(voice_select) == (SERVER_DEFAULT_VOICE_ID,)
+        assert voice_select.value == SERVER_DEFAULT_VOICE_ID
+
+        service.allow_voices.set()
+        await app.workers.wait_for_complete()
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_stts_playground_catalog.py
+++ b/Tests/UI/test_stts_playground_catalog.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from tldw_chatbook.TTS.adapter_types import (
+    ProviderHealth,
+    TTSModelInfo,
+    TTSProviderCatalog,
+    TTSProviderDescriptor,
+)
+from tldw_chatbook.UI.stts_playground_catalog import (
+    SERVER_DEFAULT_VOICE_ID,
+    CatalogRequestToken,
+    controls_from_catalog,
+    provider_options,
+    voice_id_for_request,
+)
+
+
+def _model(
+    *,
+    model_id: str = "model-a",
+    display_name: str = "Model A",
+    formats: tuple[str, ...] = ("wav",),
+    voices: tuple[str, ...] = ("voice-a", "voice-b"),
+    supports_speed: bool = True,
+    server_default: bool = True,
+) -> TTSModelInfo:
+    return TTSModelInfo(
+        model_id=model_id,
+        display_name=display_name,
+        family="test",
+        upstream_mode="tts",
+        formats=formats,
+        voices=voices,
+        supports_speed=supports_speed,
+        omit_voice_uses_server_default=server_default,
+    )
+
+
+def _catalog(
+    *,
+    provider_id: str = "audio_cpp",
+    health: ProviderHealth | None = None,
+    models: tuple[TTSModelInfo, ...] | None = None,
+    revision: int = 7,
+) -> TTSProviderCatalog:
+    return TTSProviderCatalog(
+        provider_id=provider_id,
+        revision=revision,
+        health=health or ProviderHealth(state="available", fresh=True),
+        models=models or (_model(),),
+    )
+
+
+def test_provider_options_preserve_descriptor_order_and_canonical_values() -> None:
+    descriptors = (
+        TTSProviderDescriptor("audio_cpp", "audio.cpp", True),
+        TTSProviderDescriptor("openai", "[bold]OpenAI[/]", False),
+        TTSProviderDescriptor("kokoro", "<Kokoro>", False),
+    )
+
+    assert provider_options(descriptors) == (
+        ("audio.cpp", "audio_cpp"),
+        ("[bold]OpenAI[/]", "openai"),
+        ("<Kokoro>", "kokoro"),
+    )
+
+
+def test_audio_cpp_initial_controls_force_wav_speed_and_server_default() -> None:
+    controls = controls_from_catalog(
+        _catalog(),
+        selected_model_id=None,
+        selected_voice_id=None,
+        discovered_voices=("voice-a", "voice-b"),
+        selected_format="mp3",
+        speed=1.75,
+    )
+
+    assert controls.selected_model_id == "model-a"
+    assert controls.voice_options == (
+        ("Server default", SERVER_DEFAULT_VOICE_ID),
+        ("voice-a", "voice-a"),
+        ("voice-b", "voice-b"),
+    )
+    assert controls.selected_voice_id == SERVER_DEFAULT_VOICE_ID
+    assert voice_id_for_request(controls.selected_voice_id) is None
+    assert controls.format_options == ("wav",)
+    assert controls.selected_format == "wav"
+    assert controls.format_locked is True
+    assert controls.speed == 1.0
+    assert controls.speed_locked is True
+    assert controls.generation_allowed is True
+    assert controls.selection_changed is False
+
+
+def test_audio_cpp_retains_valid_explicit_voice_and_falls_back_when_removed() -> None:
+    retained = controls_from_catalog(
+        _catalog(),
+        selected_model_id="model-a",
+        selected_voice_id="voice-b",
+        discovered_voices=("voice-a", "voice-b"),
+        selected_format="wav",
+        speed=1.0,
+    )
+    removed = controls_from_catalog(
+        _catalog(),
+        selected_model_id="model-a",
+        selected_voice_id="removed",
+        discovered_voices=("voice-a",),
+        selected_format="wav",
+        speed=1.0,
+    )
+
+    assert retained.selected_voice_id == "voice-b"
+    assert voice_id_for_request(retained.selected_voice_id) == "voice-b"
+    assert retained.selection_changed is False
+    assert removed.selected_voice_id == SERVER_DEFAULT_VOICE_ID
+    assert removed.selection_changed is True
+
+
+def test_audio_cpp_without_discovered_voices_keeps_only_server_default() -> None:
+    controls = controls_from_catalog(
+        _catalog(),
+        selected_model_id="model-a",
+        selected_voice_id=None,
+        discovered_voices=(),
+        selected_format="wav",
+        speed=1.0,
+    )
+
+    assert controls.voice_options == (("Server default", SERVER_DEFAULT_VOICE_ID),)
+    assert controls.selected_voice_id == SERVER_DEFAULT_VOICE_ID
+
+
+def test_removed_model_falls_back_and_stale_health_disables_generation() -> None:
+    catalog = _catalog(
+        models=(
+            _model(model_id="first", display_name="First"),
+            _model(model_id="second", display_name="Second"),
+        )
+    )
+    controls = controls_from_catalog(
+        catalog,
+        selected_model_id="removed",
+        selected_voice_id=None,
+        discovered_voices=(),
+        selected_format="wav",
+        speed=1.0,
+    )
+    stale = controls_from_catalog(
+        replace(catalog, health=ProviderHealth(state="available", fresh=False)),
+        selected_model_id="first",
+        selected_voice_id=None,
+        discovered_voices=(),
+        selected_format="wav",
+        speed=1.0,
+    )
+
+    assert controls.model_options == (("First", "first"), ("Second", "second"))
+    assert controls.selected_model_id == "first"
+    assert controls.selection_changed is True
+    assert stale.model_options == controls.model_options
+    assert stale.selected_model_id == "first"
+    assert stale.generation_allowed is False
+
+
+def test_legacy_controls_preserve_format_voice_and_speed_support() -> None:
+    catalog = _catalog(
+        provider_id="openai",
+        models=(
+            _model(
+                formats=("mp3", "flac", "wav"),
+                voices=("alloy", "nova"),
+                server_default=False,
+            ),
+        ),
+    )
+
+    controls = controls_from_catalog(
+        catalog,
+        selected_model_id="model-a",
+        selected_voice_id="nova",
+        discovered_voices=None,
+        selected_format="flac",
+        speed=1.25,
+    )
+
+    assert controls.voice_options == (("alloy", "alloy"), ("nova", "nova"))
+    assert controls.selected_voice_id == "nova"
+    assert controls.format_options == ("mp3", "flac", "wav")
+    assert controls.selected_format == "flac"
+    assert controls.format_locked is False
+    assert controls.speed == 1.25
+    assert controls.speed_locked is False
+    assert controls.generation_allowed is True
+
+
+def test_remote_model_and_voice_labels_remain_plain_unparsed_strings() -> None:
+    unsafe_model = "[bold red]model[/]"
+    unsafe_voice = "<script>alert(1)</script>"
+    controls = controls_from_catalog(
+        _catalog(models=(_model(model_id="opaque", display_name=unsafe_model),)),
+        selected_model_id=None,
+        selected_voice_id=None,
+        discovered_voices=(unsafe_voice,),
+        selected_format="wav",
+        speed=1.0,
+    )
+
+    assert controls.model_options == ((unsafe_model, "opaque"),)
+    assert controls.voice_options[1] == (unsafe_voice, unsafe_voice)
+
+
+def test_catalog_request_token_matches_every_revision_dimension() -> None:
+    token = CatalogRequestToken(
+        provider_id="audio_cpp",
+        configuration_revision=3,
+        catalog_revision=7,
+        model_id="model-a",
+    )
+    current = {
+        "provider_id": "audio_cpp",
+        "configuration_revision": 3,
+        "catalog_revision": 7,
+        "model_id": "model-a",
+    }
+
+    assert token.matches(**current) is True
+    for field, replacement_value in (
+        ("provider_id", "openai"),
+        ("configuration_revision", 4),
+        ("catalog_revision", 8),
+        ("model_id", "model-b"),
+    ):
+        changed = dict(current)
+        changed[field] = replacement_value
+        assert token.matches(**changed) is False

--- a/Tests/UI/test_stts_playground_catalog.py
+++ b/Tests/UI/test_stts_playground_catalog.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import replace
 
+import pytest
+
 from tldw_chatbook.TTS.adapter_types import (
     ProviderHealth,
     TTSModelInfo,
@@ -65,6 +67,19 @@ def test_provider_options_preserve_descriptor_order_and_canonical_values() -> No
         ("[bold]OpenAI[/]", "openai"),
         ("<Kokoro>", "kokoro"),
     )
+
+
+@pytest.mark.parametrize(
+    "public_callable",
+    (CatalogRequestToken.matches, provider_options),
+)
+def test_public_catalog_callables_have_google_style_docstrings(
+    public_callable: object,
+) -> None:
+    docstring = getattr(public_callable, "__doc__", "") or ""
+
+    assert "Args:" in docstring
+    assert "Returns:" in docstring
 
 
 def test_audio_cpp_initial_controls_force_wav_speed_and_server_default() -> None:
@@ -131,6 +146,28 @@ def test_audio_cpp_without_discovered_voices_keeps_only_server_default() -> None
 
     assert controls.voice_options == (("Server default", SERVER_DEFAULT_VOICE_ID),)
     assert controls.selected_voice_id == SERVER_DEFAULT_VOICE_ID
+
+
+def test_audio_cpp_preserves_sentinel_shaped_remote_ids() -> None:
+    remote_model_id = "__opaque_model__"
+    remote_voice_id = "__server_default__"
+    controls = controls_from_catalog(
+        _catalog(models=(_model(model_id=remote_model_id),)),
+        selected_model_id=remote_model_id,
+        selected_voice_id=remote_voice_id,
+        discovered_voices=(remote_voice_id,),
+        selected_format="wav",
+        speed=1.0,
+    )
+
+    assert controls.selected_model_id == remote_model_id
+    assert controls.voice_options == (
+        ("Server default", SERVER_DEFAULT_VOICE_ID),
+        (remote_voice_id, remote_voice_id),
+    )
+    assert controls.selected_voice_id == remote_voice_id
+    assert voice_id_for_request(remote_voice_id) == remote_voice_id
+    assert voice_id_for_request(SERVER_DEFAULT_VOICE_ID) is None
 
 
 def test_removed_model_falls_back_and_stale_health_disables_generation() -> None:
@@ -218,12 +255,14 @@ def test_catalog_request_token_matches_every_revision_dimension() -> None:
         configuration_revision=3,
         catalog_revision=7,
         model_id="model-a",
+        request_generation=9,
     )
     current = {
         "provider_id": "audio_cpp",
         "configuration_revision": 3,
         "catalog_revision": 7,
         "model_id": "model-a",
+        "request_generation": 9,
     }
 
     assert token.matches(**current) is True
@@ -232,6 +271,7 @@ def test_catalog_request_token_matches_every_revision_dimension() -> None:
         ("configuration_revision", 4),
         ("catalog_revision", 8),
         ("model_id", "model-b"),
+        ("request_generation", 10),
     ):
         changed = dict(current)
         changed[field] = replacement_value

--- a/Tests/UI/test_stts_settings_widget.py
+++ b/Tests/UI/test_stts_settings_widget.py
@@ -3,17 +3,25 @@ from __future__ import annotations
 import ast
 import inspect
 import textwrap
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock, Mock, call
 
 import pytest
 from loguru import logger
 from textual.app import App, ComposeResult
-from textual.widgets import Input, Select
+from textual.widgets import Button, Collapsible, Input, Select, Static
 
 from tldw_chatbook.Event_Handlers.STTS_Events.stts_events import (
     STTSSettingsSaveEvent,
     _TTS_SETTING_BINDINGS,
 )
+from tldw_chatbook.TTS.adapter_types import (
+    ProviderHealth,
+    TTSModelInfo,
+    TTSProviderCatalog,
+)
+from tldw_chatbook.TTS.audio_cpp_config import AudioCppConfig
 from tldw_chatbook.UI import STTS_Window
 from tldw_chatbook.UI.STTS_Window import TTSSettingsWidget
 
@@ -68,6 +76,7 @@ def test_settings_binding_table_classifies_every_widget_payload_key() -> None:
 def settings_config(monkeypatch: pytest.MonkeyPatch) -> None:
     overrides: dict[tuple[str, str], Any] = {
         ("app_tts", "OPENAI_ORG_ID"): "org-existing",
+        ("app_tts", "audio_cpp"): AudioCppConfig().to_mapping(),
     }
 
     def get_setting(section: str, key: str, default: Any = None) -> Any:
@@ -207,3 +216,224 @@ async def test_settings_widget_does_not_echo_collection_error_details(
     assert app.saved_events == []
     assert app.notices == [("Failed to save settings", "error")]
     assert secret not in rendered
+
+
+@pytest.mark.asyncio
+async def test_audio_cpp_settings_surface_is_external_only(
+    settings_config: None,
+) -> None:
+    del settings_config
+    app = _SettingsHost()
+
+    async with app.run_test(size=(180, 80)) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#audio-cpp-settings", Collapsible)
+
+        assert str(panel.query_one("#audio-cpp-mode-value", Static).render()) == (
+            "External"
+        )
+        assert {
+            widget.id for widget in panel.query(Input) if widget.id is not None
+        } == {
+            "audio-cpp-base-url-input",
+            "audio-cpp-connect-timeout-input",
+            "audio-cpp-synthesis-timeout-input",
+            "audio-cpp-max-input-characters-input",
+            "audio-cpp-max-response-bytes-input",
+            "audio-cpp-max-metadata-bytes-input",
+            "audio-cpp-max-catalog-models-input",
+            "audio-cpp-max-voices-per-model-input",
+            "audio-cpp-max-identifier-characters-input",
+        }
+        button_labels = {str(button.label) for button in panel.query(Button)}
+        assert button_labels == {"Test Connection", "Refresh Models"}
+        privacy_copy = str(
+            panel.query_one("#audio-cpp-privacy-notice", Static).render()
+        )
+        assert "submitted text" in privacy_copy.lower()
+        assert "configured server" in privacy_copy.lower()
+        rendered_panel = " ".join(
+            (
+                str(panel.title),
+                privacy_copy,
+                *button_labels,
+            )
+        ).lower()
+        for managed_term in (
+            "binary path",
+            "server.json",
+            "start server",
+            "restart",
+            "managed log",
+            "process control",
+        ):
+            assert managed_term not in rendered_panel
+
+
+@pytest.mark.asyncio
+async def test_audio_cpp_settings_save_posts_validated_defensive_plain_mapping(
+    settings_config: None,
+) -> None:
+    del settings_config
+    app = _SettingsHost()
+
+    async with app.run_test(size=(180, 80)) as pilot:
+        await pilot.pause()
+        values = {
+            "#audio-cpp-base-url-input": "https://voice.example.test:8443",
+            "#audio-cpp-connect-timeout-input": "2.5",
+            "#audio-cpp-synthesis-timeout-input": "45",
+            "#audio-cpp-max-input-characters-input": "1234",
+            "#audio-cpp-max-response-bytes-input": "1048576",
+            "#audio-cpp-max-metadata-bytes-input": "4096",
+            "#audio-cpp-max-catalog-models-input": "12",
+            "#audio-cpp-max-voices-per-model-input": "34",
+            "#audio-cpp-max-identifier-characters-input": "128",
+        }
+        for selector, value in values.items():
+            app.query_one(selector, Input).value = value
+
+        app.query_one(TTSSettingsWidget)._save_settings()
+        await pilot.pause()
+
+        assert len(app.saved_events) == 1
+        candidate = app.saved_events[0].settings["audio_cpp"]
+        assert type(candidate) is dict
+        assert candidate == {
+            "mode": "external",
+            "base_url": "https://voice.example.test:8443",
+            "connect_timeout_seconds": 2.5,
+            "synthesis_timeout_seconds": 45.0,
+            "max_input_characters": 1234,
+            "max_response_bytes": 1048576,
+            "max_metadata_bytes": 4096,
+            "max_catalog_models": 12,
+            "max_voices_per_model": 34,
+            "max_identifier_characters": 128,
+        }
+
+        app.query_one(
+            "#audio-cpp-base-url-input", Input
+        ).value = "http://changed.invalid"
+        assert candidate["base_url"] == "https://voice.example.test:8443"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("selector", "invalid_value"),
+    (
+        ("#audio-cpp-base-url-input", "relative/path"),
+        ("#audio-cpp-base-url-input", "https://user:secret@example.test"),
+        ("#audio-cpp-base-url-input", "https://example.test/path"),
+        ("#audio-cpp-base-url-input", "https://example.test?secret=query"),
+        ("#audio-cpp-base-url-input", "https://example.test#fragment"),
+        ("#audio-cpp-connect-timeout-input", "0"),
+        ("#audio-cpp-synthesis-timeout-input", "nan"),
+        ("#audio-cpp-max-catalog-models-input", "1.5"),
+        ("#audio-cpp-max-voices-per-model-input", "-1"),
+        ("#audio-cpp-max-identifier-characters-input", "9" * 5000),
+    ),
+)
+async def test_audio_cpp_settings_reject_invalid_values_without_echo(
+    settings_config: None,
+    selector: str,
+    invalid_value: str,
+) -> None:
+    del settings_config
+    app = _SettingsHost()
+    messages: list[str] = []
+    sink_id = logger.add(messages.append, level="DEBUG", format="{message}")
+    try:
+        async with app.run_test(size=(180, 80)) as pilot:
+            await pilot.pause()
+            app.query_one(selector, Input).value = invalid_value
+            app.query_one(TTSSettingsWidget)._save_settings()
+            await pilot.pause()
+    finally:
+        logger.remove(sink_id)
+
+    assert app.saved_events == []
+    assert app.notices == [("Failed to save settings", "error")]
+    rendered = "\n".join(messages + [message for message, _ in app.notices])
+    assert invalid_value not in rendered
+
+
+def _available_audio_cpp_catalog() -> TTSProviderCatalog:
+    return TTSProviderCatalog(
+        provider_id="audio_cpp",
+        revision=9,
+        health=ProviderHealth(state="available", fresh=True),
+        models=(
+            TTSModelInfo(
+                model_id="opaque-model",
+                display_name="Opaque model",
+                family="test",
+                upstream_mode="tts",
+                formats=("wav",),
+                voices=(),
+                supports_speed=False,
+                omit_voice_uses_server_default=True,
+            ),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_audio_cpp_test_and_refresh_are_explicit_saved_config_actions(
+    settings_config: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    del settings_config
+    service = SimpleNamespace(
+        configuration_revision=Mock(side_effect=(4, 4, 4, 4)),
+        get_catalog=AsyncMock(return_value=_available_audio_cpp_catalog()),
+    )
+    monkeypatch.setattr(
+        STTS_Window,
+        "get_tts_service",
+        AsyncMock(return_value=service),
+    )
+    app = _SettingsHost()
+
+    async with app.run_test(size=(180, 80)) as pilot:
+        await pilot.pause()
+        await pilot.click("#audio-cpp-test-connection-btn")
+        await app.workers.wait_for_complete()
+        await pilot.click("#audio-cpp-refresh-models-btn")
+        await app.workers.wait_for_complete()
+
+    assert service.get_catalog.await_args_list == [
+        call("audio_cpp", refresh=True),
+        call("audio_cpp", refresh=True),
+    ]
+    assert app.notices == [
+        ("audio.cpp connection is ready (1 model)", "information"),
+        ("audio.cpp models refreshed (1 model)", "information"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_audio_cpp_settings_discovery_discards_changed_revision(
+    settings_config: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    del settings_config
+    service = SimpleNamespace(
+        configuration_revision=Mock(side_effect=(7, 8)),
+        get_catalog=AsyncMock(return_value=_available_audio_cpp_catalog()),
+    )
+    monkeypatch.setattr(
+        STTS_Window,
+        "get_tts_service",
+        AsyncMock(return_value=service),
+    )
+    app = _SettingsHost()
+
+    async with app.run_test(size=(180, 80)) as pilot:
+        await pilot.pause()
+        await pilot.click("#audio-cpp-test-connection-btn")
+        await app.workers.wait_for_complete()
+
+    assert app.notices == [
+        ("audio.cpp settings changed; retry the check", "warning"),
+    ]

--- a/Tests/UI/test_stts_settings_widget.py
+++ b/Tests/UI/test_stts_settings_widget.py
@@ -24,6 +24,10 @@ from tldw_chatbook.TTS.adapter_types import (
 from tldw_chatbook.TTS.audio_cpp_config import AudioCppConfig
 from tldw_chatbook.UI import STTS_Window
 from tldw_chatbook.UI.STTS_Window import TTSSettingsWidget
+from tldw_chatbook.UI.stts_playground_catalog import (
+    FIRST_AVAILABLE_MODEL_ID,
+    SERVER_DEFAULT_VOICE_ID,
+)
 
 
 class _SettingsHost(App[None]):
@@ -108,6 +112,81 @@ async def test_settings_selects_mount_with_canonical_values(
         )
         assert app.query_one("#kokoro-device-select", Select).value == "cpu"
         assert app.query_one("#higgs-device-select", Select).value == "auto"
+
+
+@pytest.mark.asyncio
+async def test_audio_cpp_stored_defaults_mount_and_save_without_nulls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stored = {
+        ("app_tts", "default_provider"): "audio_cpp",
+        ("app_tts", "default_model"): "<opaque:model>",
+        ("app_tts", "default_voice"): "[voice]",
+        ("app_tts", "default_format"): "wav",
+        ("app_tts", "audio_cpp"): AudioCppConfig().to_mapping(),
+    }
+    monkeypatch.setattr(
+        STTS_Window,
+        "get_cli_setting",
+        lambda section, key, default=None: stored.get((section, key), default),
+    )
+    monkeypatch.setattr(
+        TTSSettingsWidget,
+        "_load_kokoro_voice_blends",
+        lambda self: None,
+    )
+    app = _SettingsHost()
+
+    async with app.run_test(size=(160, 60)) as pilot:
+        await pilot.pause()
+        widget = app.query_one(TTSSettingsWidget)
+
+        assert app.query_one("#default-provider-select", Select).value == "audio_cpp"
+        assert app.query_one("#default-model-select", Select).value == "<opaque:model>"
+        assert app.query_one("#default-voice-select", Select).value == "[voice]"
+
+        widget._save_settings()
+        await pilot.pause()
+
+        settings = app.saved_events[-1].settings
+        assert settings["default_provider"] == "audio_cpp"
+        assert settings["default_model"] == "<opaque:model>"
+        assert settings["default_voice"] == "[voice]"
+        assert settings["default_format"] == "wav"
+        assert settings["default_speed"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_selecting_audio_cpp_defaults_uses_non_materializing_sentinels(
+    settings_config: None,
+) -> None:
+    del settings_config
+    app = _SettingsHost()
+
+    async with app.run_test(size=(160, 60)) as pilot:
+        await pilot.pause()
+        provider = app.query_one("#default-provider-select", Select)
+        provider.value = "audio_cpp"
+        await pilot.pause()
+
+        assert app.query_one("#default-model-select", Select).value == (
+            FIRST_AVAILABLE_MODEL_ID
+        )
+        assert app.query_one("#default-voice-select", Select).value == (
+            SERVER_DEFAULT_VOICE_ID
+        )
+        assert app.query_one("#default-format-select", Select).value == "wav"
+        assert app.query_one("#default-format-select", Select).disabled is True
+        assert app.query_one("#default-speed-input", Input).value == "1.0"
+        assert app.query_one("#default-speed-input", Input).disabled is True
+
+        app.query_one(TTSSettingsWidget)._save_settings()
+        await pilot.pause()
+
+        settings = app.saved_events[-1].settings
+        assert settings["default_provider"] == "audio_cpp"
+        assert settings["default_model"] == FIRST_AVAILABLE_MODEL_ID
+        assert settings["default_voice"] == SERVER_DEFAULT_VOICE_ID
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_stts_settings_widget.py
+++ b/Tests/UI/test_stts_settings_widget.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import ast
 import inspect
 import textwrap
@@ -153,7 +154,52 @@ async def test_audio_cpp_stored_defaults_mount_and_save_without_nulls(
         assert settings["default_model"] == "<opaque:model>"
         assert settings["default_voice"] == "[voice]"
         assert settings["default_format"] == "wav"
-        assert settings["default_speed"] == 1.0
+    assert settings["default_speed"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_audio_cpp_settings_preserve_sentinel_shaped_remote_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    remote_model_id = "__opaque_model__"
+    remote_voice_id = "__server_default__"
+    stored = {
+        ("app_tts", "default_provider"): "audio_cpp",
+        ("app_tts", "default_model"): remote_model_id,
+        ("app_tts", "default_voice"): remote_voice_id,
+        ("app_tts", "default_format"): "wav",
+        ("app_tts", "audio_cpp"): AudioCppConfig().to_mapping(),
+    }
+    monkeypatch.setattr(
+        STTS_Window,
+        "get_cli_setting",
+        lambda section, key, default=None: stored.get((section, key), default),
+    )
+    monkeypatch.setattr(
+        TTSSettingsWidget,
+        "_load_kokoro_voice_blends",
+        lambda self: None,
+    )
+    app = _SettingsHost()
+
+    async with app.run_test(size=(160, 60)) as pilot:
+        await pilot.pause()
+        model_select = app.query_one("#default-model-select", Select)
+        voice_select = app.query_one("#default-voice-select", Select)
+
+        assert model_select.value == remote_model_id
+        assert voice_select.value == remote_voice_id
+        voice_values = tuple(value for _label, value in voice_select._options)
+        assert SERVER_DEFAULT_VOICE_ID in voice_values
+        assert remote_voice_id in voice_values
+        assert SERVER_DEFAULT_VOICE_ID != remote_voice_id
+
+        app.query_one(TTSSettingsWidget)._save_settings()
+        await pilot.pause()
+
+    settings = app.saved_events[-1].settings
+    assert settings["default_model"] == remote_model_id
+    assert settings["default_voice"] == remote_voice_id
 
 
 @pytest.mark.asyncio
@@ -185,8 +231,8 @@ async def test_selecting_audio_cpp_defaults_uses_non_materializing_sentinels(
 
         settings = app.saved_events[-1].settings
         assert settings["default_provider"] == "audio_cpp"
-        assert settings["default_model"] == FIRST_AVAILABLE_MODEL_ID
-        assert settings["default_voice"] == SERVER_DEFAULT_VOICE_ID
+        assert settings["default_model"] == ""
+        assert settings["default_voice"] == ""
 
 
 @pytest.mark.asyncio
@@ -515,4 +561,108 @@ async def test_audio_cpp_settings_discovery_discards_changed_revision(
 
     assert app.notices == [
         ("audio.cpp settings changed; retry the check", "warning"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_audio_cpp_settings_discovery_failure_rechecks_revision(
+    settings_config: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    del settings_config
+    request_started = asyncio.Event()
+    release_request = asyncio.Event()
+
+    async def get_catalog(
+        provider_id: str,
+        refresh: bool = False,
+    ) -> TTSProviderCatalog:
+        del provider_id, refresh
+        request_started.set()
+        await release_request.wait()
+        raise RuntimeError("obsolete settings failed")
+
+    service = SimpleNamespace(
+        configuration_revision=Mock(side_effect=(7, 8)),
+        get_catalog=get_catalog,
+    )
+    monkeypatch.setattr(
+        STTS_Window,
+        "get_tts_service",
+        AsyncMock(return_value=service),
+    )
+    app = _SettingsHost()
+
+    async with app.run_test(size=(180, 80)) as pilot:
+        await pilot.pause()
+        await pilot.click("#audio-cpp-test-connection-btn")
+        await request_started.wait()
+        release_request.set()
+        await app.workers.wait_for_complete()
+
+        status = str(app.query_one("#audio-cpp-discovery-status", Static).render())
+
+    assert status == "Settings changed; retry"
+    assert app.notices == [
+        ("audio.cpp settings changed; retry the check", "warning"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_superseded_settings_discovery_failure_cannot_overwrite_success(
+    settings_config: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    del settings_config
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    second_returned = asyncio.Event()
+    call_count = 0
+
+    async def get_catalog(
+        provider_id: str,
+        refresh: bool = False,
+    ) -> TTSProviderCatalog:
+        nonlocal call_count
+        del provider_id, refresh
+        call_count += 1
+        if call_count == 1:
+            first_started.set()
+            try:
+                await release_first.wait()
+            except asyncio.CancelledError:
+                await release_first.wait()
+            raise RuntimeError("superseded action failed")
+        second_returned.set()
+        return _available_audio_cpp_catalog()
+
+    service = SimpleNamespace(
+        configuration_revision=Mock(return_value=7),
+        get_catalog=get_catalog,
+    )
+    monkeypatch.setattr(
+        STTS_Window,
+        "get_tts_service",
+        AsyncMock(return_value=service),
+    )
+    app = _SettingsHost()
+
+    async with app.run_test(size=(180, 80)) as pilot:
+        await pilot.pause()
+        widget = app.query_one(TTSSettingsWidget)
+        widget._discover_audio_cpp("test")
+        await first_started.wait()
+        widget._discover_audio_cpp("refresh")
+        await second_returned.wait()
+        await pilot.pause()
+
+        release_first.set()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        status = str(app.query_one("#audio-cpp-discovery-status", Static).render())
+
+    assert status == "audio.cpp models refreshed (1 model)"
+    assert app.notices == [
+        ("audio.cpp models refreshed (1 model)", "information"),
     ]

--- a/backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md
+++ b/backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md
@@ -2,7 +2,7 @@
 
 Status: Accepted
 Date: 2026-07-23
-Related Tasks: TASK-561, TASK-560
+Related Tasks: TASK-561, TASK-560, TASK-569
 Supersedes: N/A
 
 ## Decision
@@ -50,7 +50,7 @@ but no longer governs new TTS provider integration.
 
 ## Implementation status
 
-Slices 1 and 2 are implemented. The sealed registry registers the exact native
+Slices 1–3 are implemented. The sealed registry registers the exact native
 provider `audio_cpp` first, with no provider alias and exclusive lazy
 reconfiguration, followed by the six unchanged legacy bridge entries.
 
@@ -76,9 +76,26 @@ They require `GET /health`, `GET /v1/models`, and complete-WAV
 `POST /v1/audio/speech`; per-model
 `GET /v1/audio/voices?model=<id>` remains optional.
 
-Slice 3 remains the catalog-driven external STTS Playground vertical. Slices
-4–5 remain user-provided prebuilt binary plus user-provided `server.json`
-launch/supervision and managed UI. No process or UI work is part of TASK-560.
+TASK-569 implements the catalog-driven external STTS Playground vertical.
+Descriptor discovery does not materialize adapters; only a selected provider is
+resolved. Independent catalog and voice workers carry configuration, catalog,
+provider, and model revisions so stale results are discarded. audio.cpp
+generation captures an immutable provider-neutral request and uses native
+`TTSService.synthesize()`, while the six existing providers retain the
+temporary compatibility generation path.
+
+The Playground maps Server default to an omitted voice, locks audio.cpp to WAV
+and speed `1.0`, and restores each legacy provider's prior controls when
+switching away. A successful complete-WAV artifact retains immutable provider,
+model, optional voice, source-text, operation, actual-format, content-type, and
+safe response provenance for playback and export. Safe failures expose bounded
+recovery actions; stale discovery disables new generation without invalidating
+an existing artifact; audio.cpp never automatically falls back.
+
+Slices 4–5 remain user-provided prebuilt binary plus user-provided
+`server.json` launch/supervision and managed UI. Slices 1–3 do not launch,
+monitor, restart, or stop audio.cpp and expose no managed process settings or
+actions.
 
 ## Context
 
@@ -156,7 +173,9 @@ policy, and a cross-module interface.
   Provider-neutral, operation-scoped progress prevents UI access to concrete
   backends; progress-sink failures never fail synthesis.
 - Slice 3 makes the Playground catalog-driven, while legacy catalogs remain
-  marked as approximate until migrated.
+  marked as approximate until migrated. Descriptor reads remain non-
+  materializing; independent catalog, voice, generation, and playback
+  ownership prevents one operation from cancelling another.
 - Future managed mode (Slices 4–5) launches only a user-provided executable and
   configuration using the pinned server's default or explicit `127.0.0.1`
   bind; `localhost` and `::1` are not accepted by that server version.
@@ -184,6 +203,9 @@ policy, and a cross-module interface.
   default is not identified by the voices endpoint. Discovered voices remain
   explicit alternatives; omitting `voice` is the only server-default request
   representation.
+- Slice 3 retains complete-WAV results as immutable artifacts with the request
+  and actual response provenance required for playback and export, independent
+  of later selector changes.
 - Readiness probes health and model discovery without generating hidden audio;
   speech-endpoint compatibility is established by the first user-requested
   generation or the future opt-in live smoke test.
@@ -240,6 +262,7 @@ policy, and a cross-module interface.
 
 - [Design spec](../../Docs/superpowers/specs/2026-07-23-audio-cpp-tts-adapter-registry-design.md)
 - [TASK-560](<../tasks/task-560 - Add-external-audio.cpp-native-TTS-adapter.md>)
+- [TASK-569](<../tasks/task-569 - Complete-external-audio.cpp-STTS-Playground-vertical.md>)
 - [Pinned audio.cpp server guide](https://github.com/0xShug0/audio.cpp/blob/d3d748179e5ace353386fbf17bcaedfacf482d75/app/server/README.md)
 - [Pinned audio.cpp server runtime](https://github.com/0xShug0/audio.cpp/blob/d3d748179e5ace353386fbf17bcaedfacf482d75/app/server/runtime.cpp)
 - [Pinned audio.cpp busy guard](https://github.com/0xShug0/audio.cpp/blob/d3d748179e5ace353386fbf17bcaedfacf482d75/app/server/busy_guard.h)

--- a/backlog/tasks/task-569 - Complete-external-audio.cpp-STTS-Playground-vertical.md
+++ b/backlog/tasks/task-569 - Complete-external-audio.cpp-STTS-Playground-vertical.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-569
 title: Complete external audio.cpp STTS Playground vertical
-status: Done
+status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-25 13:47'
-updated_date: '2026-07-25 16:30'
+updated_date: '2026-07-25 16:55'
 labels:
   - tts
   - audio-cpp

--- a/backlog/tasks/task-569 - Complete-external-audio.cpp-STTS-Playground-vertical.md
+++ b/backlog/tasks/task-569 - Complete-external-audio.cpp-STTS-Playground-vertical.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-569
 title: Complete external audio.cpp STTS Playground vertical
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-25 13:47'
-updated_date: '2026-07-25 13:54'
+updated_date: '2026-07-25 16:30'
 labels:
   - tts
   - audio-cpp
@@ -29,16 +29,16 @@ Make the STTS Playground catalog-driven through the application-owned TTS servic
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The STTS provider selector is populated from sealed registry descriptors using canonical provider IDs without materializing every adapter, and all six legacy providers retain their visible behavior.
-- [ ] #2 Selecting audio_cpp lazily resolves only that provider, performs bounded readiness and model discovery, discards stale provider/configuration/catalog results, and exposes safe unavailable, incompatible, stale, and reconfiguring states.
-- [ ] #3 The external audio.cpp settings surface validates and persists only the approved external configuration, Save does not connect, changed configuration retires only audio_cpp, and Test Connection plus Refresh Models are explicit actions.
-- [ ] #4 Audio.cpp model and lazy voice controls use catalog metadata, select a local Server default sentinel that becomes voice=None, render identifiers safely, and choose a valid announced fallback when refreshed metadata removes a selection.
-- [ ] #5 Audio.cpp forces WAV and speed 1.0 with disabled explanatory controls, while switching to a legacy provider restores that provider's model, voice, format, speed, and provider-specific control state.
-- [ ] #6 Generate uses an immutable provider-neutral request snapshot through TTSService, never falls back, prevents overlapping generation, and keeps discovery, generation, playback, and save worker ownership independent.
-- [ ] #7 Successful complete-WAV results retain provider, model, voice, source-text snapshot, operation ID, and actual response metadata so later selector changes cannot relabel playback or saved filenames.
-- [ ] #8 Stable adapter failures, retryability, and recovery actions produce safe actionable Playground state; cancellation remains cancellation, stale catalogs disable new generation, and existing generated audio remains playable and saveable.
-- [ ] #9 The Playground communicates that external synthesis sends submitted text to the configured server while UI diagnostics and logs reveal neither synthesis text, configuration values, credentials, origins, nor unsafe remote identifiers.
-- [ ] #10 Deterministic service-fake and Textual tests cover the external end-to-end flow without an audio.cpp binary, server, model download, or managed binary/server.json UI, and relevant legacy STTS regressions remain green.
+- [x] #1 The STTS provider selector is populated from sealed registry descriptors using canonical provider IDs without materializing every adapter, and all six legacy providers retain their visible behavior.
+- [x] #2 Selecting audio_cpp lazily resolves only that provider, performs bounded readiness and model discovery, discards stale provider/configuration/catalog results, and exposes safe unavailable, incompatible, stale, and reconfiguring states.
+- [x] #3 The external audio.cpp settings surface validates and persists only the approved external configuration, Save does not connect, changed configuration retires only audio_cpp, and Test Connection plus Refresh Models are explicit actions.
+- [x] #4 Audio.cpp model and lazy voice controls use catalog metadata, select a local Server default sentinel that becomes voice=None, render identifiers safely, and choose a valid announced fallback when refreshed metadata removes a selection.
+- [x] #5 Audio.cpp forces WAV and speed 1.0 with disabled explanatory controls, while switching to a legacy provider restores that provider's model, voice, format, speed, and provider-specific control state.
+- [x] #6 Generate uses an immutable provider-neutral request snapshot through TTSService, never falls back, prevents overlapping generation, and keeps discovery, generation, playback, and save worker ownership independent.
+- [x] #7 Successful complete-WAV results retain provider, model, voice, source-text snapshot, operation ID, and actual response metadata so later selector changes cannot relabel playback or saved filenames.
+- [x] #8 Stable adapter failures, retryability, and recovery actions produce safe actionable Playground state; cancellation remains cancellation, stale catalogs disable new generation, and existing generated audio remains playable and saveable.
+- [x] #9 The Playground communicates that external synthesis sends submitted text to the configured server while UI diagnostics and logs reveal neither synthesis text, configuration values, credentials, origins, nor unsafe remote identifiers.
+- [x] #10 Deterministic service-fake and Textual tests cover the external end-to-end flow without an audio.cpp binary, server, model download, or managed binary/server.json UI, and relevant legacy STTS regressions remain green.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -58,11 +58,32 @@ ADR path: backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-bound
 Reason: ADR-023 already governs the adapter registry, catalog-driven Playground, external privacy boundary, complete-WAV contract, no-fallback policy, lifecycle, and ordered delivery slices; Slice 3 implements that accepted decision, so no new ADR is required.
 <!-- SECTION:PLAN:END -->
 
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the catalog-driven external audio.cpp STTS Playground vertical through the application-owned TTS service. Added immutable request/artifact contracts, lazy descriptor/catalog/voice resolution, validated external settings and explicit discovery actions, native complete-WAV generation, provenance-safe playback/export, retained handler-owned generation, artifact leasing/cleanup, fixed safe recovery copy, and exact stale provider/configuration/catalog/model rejection. Preserved the six legacy providers behind the temporary bridge, including their original model/voice defaults and friendly labels. Hardened explicit-voice rediscovery so ordinary current voice failures can use Server default while stale and registry lifecycle failures cannot mutate or enable current generation. Updated ADR-023, the approved design, the TTS module guide, and user-facing external-server/privacy guidance; no new ADR was needed.
+
+Verification evidence:
+- Focused Slice 3 matrix after the final rebase: 185 passed, 1 existing RequestsDependencyWarning.
+- Broad TTS/STTS regressions after the final rebase: 892 passed, 14 expected optional skips, 6 existing dependency/SWIG deprecation warnings.
+- Full audio.cpp Playground file: 31 passed.
+- Ruff check passed and Ruff format confirmed 16 scoped files formatted.
+- compileall passed for TTS, STTS Window/catalog, and STTS event handler.
+- Scoped mypy passed for 5 changed typed source modules.
+- Managed-mode added-line boundary search returned no matches; git diff --check passed.
+- Documentation reference search passed.
+- Rebased without conflicts onto latest origin/dev 6ed2b9c00b355fa5b0344539cf7d944d97a5ac69; it is an ancestor of the feature head.
+- Range-diff marked all 15 rewritten commits patch-identical.
+- Final independent post-rebase review at e07287275 found no Critical or Important issues and declared the code merge-ready for correctness, races, lifecycle, security, privacy, compatibility, and integration with the new dev base.
+
+Core files changed include TTS/playground_types.py, TTS/TTS_Generation.py, TTS/legacy_catalogs.py, UI/stts_playground_catalog.py, UI/STTS_Window.py, Event_Handlers/STTS_Events/stts_events.py, focused TTS/UI tests, and the governing/user documentation. The deliberate tradeoff remains external-only, complete-WAV-first delivery through an async-stream-compatible interface; binary/server.json launch and supervision remain deferred.
+<!-- SECTION:NOTES:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Automated unit, service-integration, and Textual tests cover the new catalog, settings, worker, generation, playback, save, stale-result, cancellation, error, and privacy behavior.
-- [ ] #2 Ruff, formatting, compileall, scoped mypy, focused and broad regressions, boundary searches, and diff hygiene pass.
-- [ ] #3 ADR-023, the approved design, TTS module guide, and user-facing configuration guidance describe the landed external Playground flow and preserve managed-mode deferrals.
-- [ ] #4 Self-review confirms no binary handling, server.json ownership, process launch, supervision, restart, managed log display, or automatic fallback entered Slice 3.
-- [ ] #5 Every acceptance criterion is checked and implementation notes record exact verification evidence before the task moves to Done.
+- [x] #1 Automated unit, service-integration, and Textual tests cover the new catalog, settings, worker, generation, playback, save, stale-result, cancellation, error, and privacy behavior.
+- [x] #2 Ruff, formatting, compileall, scoped mypy, focused and broad regressions, boundary searches, and diff hygiene pass.
+- [x] #3 ADR-023, the approved design, TTS module guide, and user-facing configuration guidance describe the landed external Playground flow and preserve managed-mode deferrals.
+- [x] #4 Self-review confirms no binary handling, server.json ownership, process launch, supervision, restart, managed log display, or automatic fallback entered Slice 3.
+- [x] #5 Every acceptance criterion is checked and implementation notes record exact verification evidence before the task moves to Done.
 <!-- DOD:END -->

--- a/backlog/tasks/task-569 - Complete-external-audio.cpp-STTS-Playground-vertical.md
+++ b/backlog/tasks/task-569 - Complete-external-audio.cpp-STTS-Playground-vertical.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-569
 title: Complete external audio.cpp STTS Playground vertical
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-25 13:47'
-updated_date: '2026-07-25 16:55'
+updated_date: '2026-07-25 18:05'
 labels:
   - tts
   - audio-cpp
@@ -61,22 +61,21 @@ Reason: ADR-023 already governs the adapter registry, catalog-driven Playground,
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Implemented the catalog-driven external audio.cpp STTS Playground vertical through the application-owned TTS service. Added immutable request/artifact contracts, lazy descriptor/catalog/voice resolution, validated external settings and explicit discovery actions, native complete-WAV generation, provenance-safe playback/export, retained handler-owned generation, artifact leasing/cleanup, fixed safe recovery copy, and exact stale provider/configuration/catalog/model rejection. Preserved the six legacy providers behind the temporary bridge, including their original model/voice defaults and friendly labels. Hardened explicit-voice rediscovery so ordinary current voice failures can use Server default while stale and registry lifecycle failures cannot mutate or enable current generation. Updated ADR-023, the approved design, the TTS module guide, and user-facing external-server/privacy guidance; no new ADR was needed.
+Implemented the catalog-driven external audio.cpp STTS Playground vertical through the application-owned TTS service. Added immutable request/artifact contracts, lazy descriptor/catalog/voice resolution, validated external settings and explicit discovery actions, native complete-WAV generation, provenance-safe playback/export, retained handler-owned generation, artifact leasing/cleanup, fixed safe recovery copy, and exact stale provider/configuration/catalog/model rejection. Preserved the six legacy providers behind the temporary bridge, including their original model/voice defaults and friendly labels. Hardened review edges with final-destination export validation, a strict frozen Pydantic audio.cpp configuration model, out-of-band UI sentinels that cannot collide with opaque remote IDs, synchronously reserved catalog/voice request generations, settings action generations, and playback-lifetime artifact leases. Ordinary current voice failures can use Server default while superseded, stale, and registry lifecycle results cannot mutate current state. Updated ADR-023, the approved design, the TTS module guide, and user-facing external-server/privacy guidance; no new ADR was needed.
 
 Verification evidence:
-- Focused Slice 3 matrix after the final rebase: 185 passed, 1 existing RequestsDependencyWarning.
-- Broad TTS/STTS regressions after the final rebase: 892 passed, 14 expected optional skips, 6 existing dependency/SWIG deprecation warnings.
-- Full audio.cpp Playground file: 31 passed.
-- Ruff check passed and Ruff format confirmed 16 scoped files formatted.
+- Focused Slice 3 matrix after the final rebase: 203 passed, 1 existing RequestsDependencyWarning.
+- Broad TTS/STTS regressions on the final implementation: 896 passed, 14 expected optional skips, 6 existing dependency/SWIG deprecation warnings.
+- Full audio.cpp Playground and pure catalog files: 54 passed.
+- Ruff check passed and Ruff format confirmed 17 scoped files formatted.
 - compileall passed for TTS, STTS Window/catalog, and STTS event handler.
 - Scoped mypy passed for 5 changed typed source modules.
 - Managed-mode added-line boundary search returned no matches; git diff --check passed.
-- Documentation reference search passed.
-- Rebased without conflicts onto latest origin/dev 6ed2b9c00b355fa5b0344539cf7d944d97a5ac69; it is an ancestor of the feature head.
-- Range-diff marked all 15 rewritten commits patch-identical.
-- Final independent post-rebase review at e07287275 found no Critical or Important issues and declared the code merge-ready for correctness, races, lifecycle, security, privacy, compatibility, and integration with the new dev base.
+- Rebased without conflicts onto latest origin/dev 3d401a1e709576273b7f542c4ea747fc93ce94bf; it is an ancestor of the feature head.
+- The final base-only rebase changed unrelated Console/task-623 files; range-diff marked all 18 rewritten commits patch-identical.
+- Final independent review at d4ccdaa004b7b53bc47bbc987c2dcdcf69e4121d found no Critical, Important, or Minor issues and declared the code merge-ready for correctness, cancellation ordering, races, lifecycle, security, privacy, compatibility, and integration with the current dev base.
 
-Core files changed include TTS/playground_types.py, TTS/TTS_Generation.py, TTS/legacy_catalogs.py, UI/stts_playground_catalog.py, UI/STTS_Window.py, Event_Handlers/STTS_Events/stts_events.py, focused TTS/UI tests, and the governing/user documentation. The deliberate tradeoff remains external-only, complete-WAV-first delivery through an async-stream-compatible interface; binary/server.json launch and supervision remain deferred.
+Core files changed include TTS/playground_types.py, TTS/TTS_Generation.py, TTS/audio_cpp_config.py, TTS/legacy_catalogs.py, UI/stts_playground_catalog.py, UI/STTS_Window.py, Event_Handlers/STTS_Events/stts_events.py, focused TTS/UI tests, and the governing/user documentation. The deliberate tradeoff remains external-only, complete-WAV-first delivery through an async-stream-compatible interface; binary/server.json launch and supervision remain deferred.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-569 - Complete-external-audio.cpp-STTS-Playground-vertical.md
+++ b/backlog/tasks/task-569 - Complete-external-audio.cpp-STTS-Playground-vertical.md
@@ -1,0 +1,68 @@
+---
+id: TASK-569
+title: Complete external audio.cpp STTS Playground vertical
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-07-25 13:47'
+updated_date: '2026-07-25 13:54'
+labels:
+  - tts
+  - audio-cpp
+  - stts
+  - ui
+dependencies:
+  - TASK-560
+references:
+  - backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md
+documentation:
+  - Docs/superpowers/specs/2026-07-23-audio-cpp-tts-adapter-registry-design.md
+  - Docs/superpowers/plans/2026-07-25-audio-cpp-external-stts-playground.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make the STTS Playground catalog-driven through the application-owned TTS service so users can configure one external audiocpp_server, discover TTS models and voices, generate a validated complete WAV, and play or save the result without managed process behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The STTS provider selector is populated from sealed registry descriptors using canonical provider IDs without materializing every adapter, and all six legacy providers retain their visible behavior.
+- [ ] #2 Selecting audio_cpp lazily resolves only that provider, performs bounded readiness and model discovery, discards stale provider/configuration/catalog results, and exposes safe unavailable, incompatible, stale, and reconfiguring states.
+- [ ] #3 The external audio.cpp settings surface validates and persists only the approved external configuration, Save does not connect, changed configuration retires only audio_cpp, and Test Connection plus Refresh Models are explicit actions.
+- [ ] #4 Audio.cpp model and lazy voice controls use catalog metadata, select a local Server default sentinel that becomes voice=None, render identifiers safely, and choose a valid announced fallback when refreshed metadata removes a selection.
+- [ ] #5 Audio.cpp forces WAV and speed 1.0 with disabled explanatory controls, while switching to a legacy provider restores that provider's model, voice, format, speed, and provider-specific control state.
+- [ ] #6 Generate uses an immutable provider-neutral request snapshot through TTSService, never falls back, prevents overlapping generation, and keeps discovery, generation, playback, and save worker ownership independent.
+- [ ] #7 Successful complete-WAV results retain provider, model, voice, source-text snapshot, operation ID, and actual response metadata so later selector changes cannot relabel playback or saved filenames.
+- [ ] #8 Stable adapter failures, retryability, and recovery actions produce safe actionable Playground state; cancellation remains cancellation, stale catalogs disable new generation, and existing generated audio remains playable and saveable.
+- [ ] #9 The Playground communicates that external synthesis sends submitted text to the configured server while UI diagnostics and logs reveal neither synthesis text, configuration values, credentials, origins, nor unsafe remote identifiers.
+- [ ] #10 Deterministic service-fake and Textual tests cover the external end-to-end flow without an audio.cpp binary, server, model download, or managed binary/server.json UI, and relevant legacy STTS regressions remain green.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add immutable request/artifact contracts and read-only service descriptor/configuration-revision APIs.
+2. Add pure catalog selection, Server-default, restriction, fallback, and stale-token state with tests.
+3. Add validated external audio.cpp settings persistence/reconfiguration plus explicit Test Connection and Refresh Models actions.
+4. Make STTS Playground controls descriptor/catalog-driven with safe labels, lazy independent workers, audio.cpp restrictions, and legacy-state restoration.
+5. Route audio.cpp generation through native TTSService.synthesize(), retain immutable artifact provenance, and keep legacy generation on the temporary bridge.
+6. Harden worker ownership, cancellation, stale-result rejection, safe recovery, playback/export, cleanup, and privacy behavior.
+7. Update ADR-023, the approved design, module guide, and user documentation while preserving managed-mode deferrals.
+8. Run focused and broad tests, Ruff/format/compile/mypy/boundary/diff checks, self-review, record evidence, and finish TASK-569.
+
+ADR required: yes
+ADR path: backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md
+Reason: ADR-023 already governs the adapter registry, catalog-driven Playground, external privacy boundary, complete-WAV contract, no-fallback policy, lifecycle, and ordered delivery slices; Slice 3 implements that accepted decision, so no new ADR is required.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Automated unit, service-integration, and Textual tests cover the new catalog, settings, worker, generation, playback, save, stale-result, cancellation, error, and privacy behavior.
+- [ ] #2 Ruff, formatting, compileall, scoped mypy, focused and broad regressions, boundary searches, and diff hygiene pass.
+- [ ] #3 ADR-023, the approved design, TTS module guide, and user-facing configuration guidance describe the landed external Playground flow and preserve managed-mode deferrals.
+- [ ] #4 Self-review confirms no binary handling, server.json ownership, process launch, supervision, restart, managed log display, or automatic fallback entered Slice 3.
+- [ ] #5 Every acceptance criterion is checked and implementation notes record exact verification evidence before the task moves to Done.
+<!-- DOD:END -->

--- a/tldw_chatbook/Event_Handlers/STTS_Events/__init__.py
+++ b/tldw_chatbook/Event_Handlers/STTS_Events/__init__.py
@@ -2,6 +2,7 @@
 from .stts_events import (
     STTSEventHandler,
     STTSPlaygroundGenerateEvent,
+    STTSProviderConfigurationChanged,
     STTSSettingsSaveEvent,
     STTSAudioBookGenerateEvent,
 )
@@ -9,6 +10,7 @@ from .stts_events import (
 __all__ = [
     "STTSEventHandler",
     "STTSPlaygroundGenerateEvent",
+    "STTSProviderConfigurationChanged",
     "STTSSettingsSaveEvent",
     "STTSAudioBookGenerateEvent",
 ]

--- a/tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py
+++ b/tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py
@@ -249,6 +249,14 @@ _TTS_PROVIDER_ORDER = (
     "alltalk",
 )
 
+_RECOVERY_ACTION_COPY = {
+    "check_server": "Check the configured audio.cpp server and retry.",
+    "configure_server": "Open STTS Settings and configure the audio.cpp server.",
+    "edit_request": "Adjust the text or selected options and retry.",
+    "refresh_models": "Refresh models in the STTS Playground and retry.",
+    "retry": "Retry from the STTS Playground.",
+}
+
 
 def _effective_provider_config(
     provider_id: str,
@@ -334,6 +342,7 @@ class STTSEventHandler:
         self._active_playground_operation_id: str | None = None
         self._playground_audio_files: set[Path] = set()
         self._playground_operation_files: dict[str, set[Path]] = {}
+        self._playground_file_leases: dict[Path, int] = {}
         self._cleanup_task: asyncio.Task[None] | None = None
         self._settings_save_lock = asyncio.Lock()
 
@@ -410,8 +419,53 @@ class STTSEventHandler:
         for path in tuple(self._playground_operation_files.get(operation_id, ())):
             if path in keep:
                 continue
+            if self._playground_file_leases.get(path, 0) > 0:
+                continue
             if secure_delete_file(path) or not path.exists():
                 self._forget_operation_file(operation_id, path)
+
+    def lease_playground_artifact(self, artifact: STTSGeneratedAudio) -> bool:
+        """Pin a handler-owned artifact across a deferred UI action."""
+        path = Path(artifact.path)
+        operation_files = self._playground_operation_files.get(
+            artifact.operation_id,
+            set(),
+        )
+        if (
+            path not in self._playground_audio_files
+            or path not in operation_files
+            or not path.exists()
+        ):
+            return False
+        self._playground_file_leases[path] = (
+            self._playground_file_leases.get(path, 0) + 1
+        )
+        return True
+
+    def release_playground_artifact(self, artifact: STTSGeneratedAudio) -> None:
+        """Release one lease and retire the artifact when it is no longer current."""
+        path = Path(artifact.path)
+        count = self._playground_file_leases.get(path, 0)
+        if count <= 0:
+            return
+        if count == 1:
+            self._playground_file_leases.pop(path, None)
+        else:
+            self._playground_file_leases[path] = count - 1
+            return
+
+        current_path = (
+            self._current_playground_artifact.path
+            if self._current_playground_artifact is not None
+            else None
+        )
+        if current_path == path:
+            return
+        for operation_id, operation_files in tuple(
+            self._playground_operation_files.items()
+        ):
+            if path in operation_files:
+                self._delete_operation_files(operation_id)
 
     def _accept_playground_artifact(self, artifact: STTSGeneratedAudio) -> None:
         """Store the new artifact before securely retiring older files."""
@@ -853,10 +907,11 @@ class STTSEventHandler:
     def _generation_error_copy(error: Exception) -> str:
         if isinstance(error, TTSOperationError):
             parts = [str(error)]
-            if error.recovery_action:
-                parts.append(error.recovery_action)
+            recovery_copy = _RECOVERY_ACTION_COPY.get(error.recovery_action or "")
+            if recovery_copy is not None:
+                parts.append(recovery_copy)
             elif error.retryable:
-                parts.append("Retry from the STTS Playground")
+                parts.append(_RECOVERY_ACTION_COPY["retry"])
             return " ".join(parts)
         if isinstance(error, TTSProviderReconfiguringError):
             return "TTS settings are being applied; retry shortly"
@@ -1322,6 +1377,7 @@ class STTSEventHandler:
         self._active_tasks.difference_update(tasks)
 
         owned_paths = tuple(self._playground_audio_files)
+        self._playground_file_leases.clear()
         for path in owned_paths:
             if secure_delete_file(path) or not path.exists():
                 self._playground_audio_files.discard(path)

--- a/tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py
+++ b/tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py
@@ -5,6 +5,7 @@
 import asyncio
 from collections.abc import Coroutine, Mapping
 from copy import deepcopy
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional, Dict, Any, NamedTuple
 from pathlib import Path
@@ -286,6 +287,15 @@ class STTSProviderConfigurationChanged(Message):
         self.configuration_revision = configuration_revision
 
 
+@dataclass(frozen=True, slots=True)
+class _STTSPlaygroundState:
+    """Read-only handler-owned Playground lifecycle snapshot."""
+
+    active_operation_id: str | None
+    artifact: STTSGeneratedAudio | None
+    generation_active: bool
+
+
 class STTSAudioBookGenerateEvent(Message):
     """Event when audiobook generation is requested"""
 
@@ -320,7 +330,10 @@ class STTSEventHandler:
         self._current_playground_artifact: STTSGeneratedAudio | None = None
         self._is_generating = False
         self._active_tasks: set[asyncio.Task[Any]] = set()
+        self._generation_task: asyncio.Task[None] | None = None
+        self._active_playground_operation_id: str | None = None
         self._playground_audio_files: set[Path] = set()
+        self._playground_operation_files: dict[str, set[Path]] = {}
         self._cleanup_task: asyncio.Task[None] | None = None
         self._settings_save_lock = asyncio.Lock()
 
@@ -332,6 +345,88 @@ class STTSEventHandler:
         except Exception:
             logger.error("Failed to initialize S/TT/S service")
             self._stts_service = None
+
+    def playground_state(self) -> _STTSPlaygroundState:
+        """Return immutable handler-owned generation and artifact state."""
+        return _STTSPlaygroundState(
+            active_operation_id=self._active_playground_operation_id,
+            artifact=self._current_playground_artifact,
+            generation_active=self._is_generating,
+        )
+
+    def start_playground_generation(
+        self,
+        event: STTSPlaygroundGenerateEvent,
+    ) -> None:
+        """Start and retain exactly one handler-owned Playground task."""
+        if self._cleanup_task is not None:
+            logger.debug("Ignoring TTS generation after STTS cleanup started")
+            return
+        if self._generation_task is not None and not self._generation_task.done():
+            self.app.notify("TTS generation already in progress", severity="warning")
+            return
+        if self._is_generating:
+            self.app.notify("TTS generation already in progress", severity="warning")
+            return
+
+        task = asyncio.create_task(
+            self.handle_playground_generate(event),
+            name=f"stts_playground_{event.request.operation_id}",
+        )
+        self._generation_task = task
+        self._active_tasks.add(task)
+        task.add_done_callback(self._playground_generation_done)
+
+    def _playground_generation_done(self, task: asyncio.Task[None]) -> None:
+        self._active_tasks.discard(task)
+        if self._generation_task is task:
+            self._generation_task = None
+        try:
+            task.exception()
+        except BaseException:
+            pass
+
+    def _track_operation_file(self, operation_id: str, path: Path) -> None:
+        path = Path(path)
+        self._playground_audio_files.add(path)
+        self._playground_operation_files.setdefault(operation_id, set()).add(path)
+
+    def _forget_operation_file(self, operation_id: str, path: Path) -> None:
+        path = Path(path)
+        self._playground_audio_files.discard(path)
+        operation_files = self._playground_operation_files.get(operation_id)
+        if operation_files is None:
+            return
+        operation_files.discard(path)
+        if not operation_files:
+            self._playground_operation_files.pop(operation_id, None)
+
+    def _delete_operation_files(
+        self,
+        operation_id: str,
+        *,
+        keep: frozenset[Path] = frozenset(),
+    ) -> None:
+        for path in tuple(self._playground_operation_files.get(operation_id, ())):
+            if path in keep:
+                continue
+            if secure_delete_file(path) or not path.exists():
+                self._forget_operation_file(operation_id, path)
+
+    def _accept_playground_artifact(self, artifact: STTSGeneratedAudio) -> None:
+        """Store the new artifact before securely retiring older files."""
+        self._current_playground_artifact = artifact
+        self._current_audio_file = artifact.path
+        self._track_operation_file(artifact.operation_id, artifact.path)
+        for operation_id in tuple(self._playground_operation_files):
+            self._delete_operation_files(
+                operation_id,
+                keep=(
+                    frozenset({artifact.path})
+                    if operation_id == artifact.operation_id
+                    else frozenset()
+                ),
+            )
 
     async def _generate_audio_cpp(
         self,
@@ -378,7 +473,7 @@ class STTSEventHandler:
                 prefix="stts_playground_",
             )
         )
-        self._playground_audio_files.add(path)
+        self._track_operation_file(snapshot.operation_id, path)
         try:
             return STTSGeneratedAudio(
                 path=path,
@@ -393,7 +488,7 @@ class STTSEventHandler:
             )
         except BaseException:
             if secure_delete_file(path) or not path.exists():
-                self._playground_audio_files.discard(path)
+                self._forget_operation_file(snapshot.operation_id, path)
             raise
 
     async def _generate_legacy(
@@ -438,14 +533,17 @@ class STTSEventHandler:
                 )
             )
             created_paths.add(wav_file)
-            self._playground_audio_files.add(wav_file)
+            self._track_operation_file(snapshot.operation_id, wav_file)
             output_file = wav_file
             audio_format = "wav"
 
             if requested_format != "wav":
                 conversion_destination = wav_file.with_suffix(f".{requested_format}")
                 created_paths.add(conversion_destination)
-                self._playground_audio_files.add(conversion_destination)
+                self._track_operation_file(
+                    snapshot.operation_id,
+                    conversion_destination,
+                )
                 converted_file = await self._convert_audio_format(
                     wav_file,
                     requested_format,
@@ -453,16 +551,22 @@ class STTSEventHandler:
                 if converted_file is not None:
                     output_file = Path(converted_file)
                     created_paths.add(output_file)
-                    self._playground_audio_files.add(output_file)
+                    self._track_operation_file(snapshot.operation_id, output_file)
                     audio_format = requested_format
                     if secure_delete_file(wav_file) or not wav_file.exists():
-                        self._playground_audio_files.discard(wav_file)
+                        self._forget_operation_file(
+                            snapshot.operation_id,
+                            wav_file,
+                        )
                         created_paths.discard(wav_file)
                 elif (
                     secure_delete_file(conversion_destination)
                     or not conversion_destination.exists()
                 ):
-                    self._playground_audio_files.discard(conversion_destination)
+                    self._forget_operation_file(
+                        snapshot.operation_id,
+                        conversion_destination,
+                    )
                     created_paths.discard(conversion_destination)
 
             return STTSGeneratedAudio(
@@ -479,7 +583,7 @@ class STTSEventHandler:
         except BaseException:
             for path in created_paths:
                 if secure_delete_file(path) or not path.exists():
-                    self._playground_audio_files.discard(path)
+                    self._forget_operation_file(snapshot.operation_id, path)
             raise
 
     @staticmethod
@@ -527,39 +631,33 @@ class STTSEventHandler:
             return
 
         if not self._stts_service:
+            operation_id = event.request.operation_id
+            self._is_generating = True
+            self._active_playground_operation_id = operation_id
+            self._deliver_generation_failure(
+                operation_id,
+                "The TTS service is unavailable",
+            )
             self.app.notify("TTS service not initialized", severity="error")
+            self._is_generating = False
+            self._finish_generation_ui(operation_id)
+            self._active_playground_operation_id = None
             return
 
         self._is_generating = True
-
-        # Get playground widget first
-        try:
-            from tldw_chatbook.UI.STTS_Window import TTSPlaygroundWidget
-
-            playground = self.app.query_one(TTSPlaygroundWidget)
-            logger.debug("Found mounted TTS Playground")
-        except Exception as error:
-            logger.debug(
-                "TTS Playground is not mounted ({})",
-                type(error).__name__,
-            )
-            playground = None
-
-        # The Textual message hook already dispatches this coroutine through
-        # _start_event_task, so a nested worker would split task ownership.
-        await self._generate_tts_worker(event, playground)
+        self._active_playground_operation_id = event.request.operation_id
+        await self._generate_tts_worker(event)
 
     async def _generate_tts_worker(
         self,
         event: STTSPlaygroundGenerateEvent,
-        playground: Any | None = None,
     ) -> None:
         """Generate from one immutable request and deliver one artifact."""
         snapshot = event.request
-        self._show_generation_progress(playground)
+        self._show_generation_progress(snapshot.operation_id)
 
         async def progress_callback(info: TTSProgress) -> None:
-            self._update_generation_progress(playground, info)
+            self._update_generation_progress(snapshot.operation_id, info)
 
         try:
             if snapshot.provider_id == "audio_cpp":
@@ -572,13 +670,17 @@ class STTSEventHandler:
                     snapshot,
                     progress_callback,
                 )
-            self._current_playground_artifact = artifact
-            self._current_audio_file = artifact.path
-            self._deliver_generation_success(playground, artifact)
+            self._accept_playground_artifact(artifact)
+            self._deliver_generation_success(
+                snapshot.operation_id,
+                artifact,
+            )
             self.app.notify("TTS generation complete!", severity="information")
         except asyncio.CancelledError:
+            self._delete_operation_files(snapshot.operation_id)
             raise
         except Exception as error:
+            self._delete_operation_files(snapshot.operation_id)
             message = self._generation_error_copy(error)
             if isinstance(error, TTSOperationError):
                 logger.error(
@@ -591,16 +693,19 @@ class STTSEventHandler:
                     "TTS generation failed ({})",
                     type(error).__name__,
                 )
-            self._deliver_generation_failure(playground, message)
+            self._deliver_generation_failure(snapshot.operation_id, message)
             self.app.notify(
                 f"TTS generation failed: {escape(message)}",
                 severity="error",
             )
         finally:
-            self._is_generating = False
-            self._finish_generation_ui(playground)
+            if self._active_playground_operation_id == snapshot.operation_id:
+                self._is_generating = False
+                self._finish_generation_ui(snapshot.operation_id)
+                self._active_playground_operation_id = None
 
-    def _show_generation_progress(self, playground: Any | None) -> None:
+    def _show_generation_progress(self, operation_id: str) -> None:
+        playground = self._mounted_playground(operation_id)
         if playground is None:
             return
 
@@ -615,9 +720,10 @@ class STTSEventHandler:
 
     def _update_generation_progress(
         self,
-        playground: Any | None,
+        operation_id: str,
         info: TTSProgress,
     ) -> None:
+        playground = self._mounted_playground(operation_id)
         if playground is None:
             return
 
@@ -647,9 +753,10 @@ class STTSEventHandler:
 
     def _deliver_generation_success(
         self,
-        playground: Any | None,
+        operation_id: str,
         artifact: STTSGeneratedAudio,
     ) -> None:
+        playground = self._mounted_playground(operation_id)
         if playground is None:
             return
 
@@ -671,9 +778,10 @@ class STTSEventHandler:
 
     def _deliver_generation_failure(
         self,
-        playground: Any | None,
+        operation_id: str,
         message: str,
     ) -> None:
+        playground = self._mounted_playground(operation_id)
         if playground is None:
             return
 
@@ -687,7 +795,8 @@ class STTSEventHandler:
 
         self._invoke_playground(playground, deliver)
 
-    def _finish_generation_ui(self, playground: Any | None) -> None:
+    def _finish_generation_ui(self, operation_id: str) -> None:
+        playground = self._mounted_playground(operation_id)
         if playground is None:
             return
 
@@ -707,6 +816,20 @@ class STTSEventHandler:
             playground.query_one("#generation-status-container").add_class("hidden")
 
         self._invoke_playground(playground, finish)
+
+    def _mounted_playground(self, operation_id: str) -> Any | None:
+        if operation_id != self._active_playground_operation_id:
+            return None
+        try:
+            from tldw_chatbook.UI.STTS_Window import TTSPlaygroundWidget
+
+            return self.app.query_one(TTSPlaygroundWidget)
+        except Exception as error:
+            logger.debug(
+                "TTS Playground is not mounted ({})",
+                type(error).__name__,
+            )
+            return None
 
     @staticmethod
     def _invoke_playground(
@@ -1202,19 +1325,30 @@ class STTSEventHandler:
         for path in owned_paths:
             if secure_delete_file(path) or not path.exists():
                 self._playground_audio_files.discard(path)
+                for operation_id in tuple(self._playground_operation_files):
+                    self._forget_operation_file(operation_id, path)
 
         if (
             self._current_audio_file in owned_paths
             and self._current_audio_file not in self._playground_audio_files
         ):
             self._current_audio_file = None
+        if (
+            self._current_playground_artifact is not None
+            and self._current_playground_artifact.path
+            not in self._playground_audio_files
+        ):
+            self._current_playground_artifact = None
+        if self._generation_task is not None and self._generation_task.done():
+            self._generation_task = None
+        self._active_playground_operation_id = None
         self._is_generating = False
 
     def on_stts_playground_generate_event(
         self, event: STTSPlaygroundGenerateEvent
     ) -> None:
         """Start a retained async task for playground generation."""
-        self._start_event_task(self.handle_playground_generate(event))
+        self.start_playground_generation(event)
 
     def on_stts_settings_save_event(self, event: STTSSettingsSaveEvent) -> None:
         """Handle settings save event"""

--- a/tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py
+++ b/tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py
@@ -9,21 +9,37 @@ from datetime import datetime
 from typing import Optional, Dict, Any, NamedTuple
 from pathlib import Path
 from loguru import logger
+from rich.markup import escape
 
 #
 # Third-party imports
 from textual.message import Message
-from textual.widgets import Button, Select, RichLog, Static, ProgressBar
+from textual.widgets import Button, RichLog, Static, ProgressBar
 
 #
 # Local imports
-from tldw_chatbook.TTS import get_tts_service, OpenAISpeechRequest
+from tldw_chatbook.TTS import (
+    get_tts_service,
+    OpenAISpeechRequest,
+    STTSGeneratedAudio,
+    STTSPlaygroundRequest,
+    TTSRequest,
+)
 from tldw_chatbook.TTS.adapter_registry import ReconfigureResult
-from tldw_chatbook.TTS.adapter_types import TTSProgress
+from tldw_chatbook.TTS.adapter_types import (
+    ProgressSink,
+    TTSOperationError,
+    TTSProgress,
+    TTSProviderReconfiguringError,
+    TTSRegistryClosedError,
+)
 from tldw_chatbook.TTS.audio_cpp_config import project_audio_cpp_config
 from tldw_chatbook.TTS.legacy_bridge import legacy_provider_config
 from tldw_chatbook.TTS.TTS_Generation import _join_retained_task
-from tldw_chatbook.Utils.secure_temp_files import secure_delete_file
+from tldw_chatbook.Utils.secure_temp_files import (
+    create_secure_temp_file,
+    secure_delete_file,
+)
 #
 #######################################################################################################################
 #
@@ -244,26 +260,13 @@ def _effective_provider_config(
 
 
 class STTSPlaygroundGenerateEvent(Message):
-    """Event when TTS generation is requested from playground"""
+    """Event carrying one immutable Playground generation snapshot."""
 
-    def __init__(
-        self,
-        text: str,
-        provider: str,
-        voice: str,
-        model: str,
-        speed: float,
-        format: str,
-        extra_params: Optional[Dict[str, Any]] = None,
-    ):
+    def __init__(self, request: STTSPlaygroundRequest) -> None:
         super().__init__()
-        self.text = text
-        self.provider = provider
-        self.voice = voice
-        self.model = model
-        self.speed = speed
-        self.format = format
-        self.extra_params = extra_params or {}
+        if not isinstance(request, STTSPlaygroundRequest):
+            raise TypeError("request must be an STTSPlaygroundRequest")
+        self.request = request
 
 
 class STTSSettingsSaveEvent(Message):
@@ -314,6 +317,7 @@ class STTSEventHandler:
         self.app = app  # Reference to the main app
         self._stts_service = None
         self._current_audio_file = None
+        self._current_playground_artifact: STTSGeneratedAudio | None = None
         self._is_generating = False
         self._active_tasks: set[asyncio.Task[Any]] = set()
         self._playground_audio_files: set[Path] = set()
@@ -328,6 +332,188 @@ class STTSEventHandler:
         except Exception:
             logger.error("Failed to initialize S/TT/S service")
             self._stts_service = None
+
+    async def _generate_audio_cpp(
+        self,
+        snapshot: STTSPlaygroundRequest,
+        progress_sink: ProgressSink | None,
+    ) -> STTSGeneratedAudio:
+        """Generate one complete native audio.cpp WAV response."""
+        if self._stts_service is None:
+            raise RuntimeError("TTS service is not initialized")
+
+        request = TTSRequest(
+            provider_id="audio_cpp",
+            model_id=snapshot.model_id,
+            text=snapshot.text,
+            voice=snapshot.voice_id,
+            response_format="wav",
+            speed=1.0,
+            options={},
+        )
+        response = None
+        primary_error: BaseException | None = None
+        try:
+            response = await self._stts_service.synthesize(request, progress_sink)
+            chunks = [chunk async for chunk in response.byte_stream]
+        except BaseException as error:
+            primary_error = error
+            raise
+        finally:
+            if response is not None:
+                try:
+                    await response.aclose()
+                except BaseException:
+                    if primary_error is None:
+                        raise
+                    logger.warning(
+                        "Failed to close audio.cpp response after {}",
+                        type(primary_error).__name__,
+                    )
+
+        path = Path(
+            create_secure_temp_file(
+                b"".join(chunks),
+                suffix=f".{response.audio_format.removeprefix('.')}",
+                prefix="stts_playground_",
+            )
+        )
+        self._playground_audio_files.add(path)
+        try:
+            return STTSGeneratedAudio(
+                path=path,
+                provider_id=response.provider_id,
+                model_id=response.model_id,
+                voice_id=snapshot.voice_id,
+                source_text=snapshot.text,
+                operation_id=snapshot.operation_id,
+                audio_format=response.audio_format,
+                content_type=response.content_type,
+                metadata=response.metadata,
+            )
+        except BaseException:
+            if secure_delete_file(path) or not path.exists():
+                self._playground_audio_files.discard(path)
+            raise
+
+    async def _generate_legacy(
+        self,
+        snapshot: STTSPlaygroundRequest,
+        progress_sink: ProgressSink | None,
+    ) -> STTSGeneratedAudio:
+        """Retain the existing stream-and-convert path for legacy providers."""
+        if self._stts_service is None:
+            raise RuntimeError("TTS service is not initialized")
+
+        requested_format = snapshot.response_format.lower()
+        if requested_format not in {"mp3", "opus", "aac", "flac", "wav", "pcm"}:
+            requested_format = "mp3"
+        request = OpenAISpeechRequest(
+            model=snapshot.model_id,
+            input=snapshot.text,
+            voice=snapshot.voice_id or "default",
+            response_format="wav",
+            speed=snapshot.speed,
+        )
+        options = dict(snapshot.options)
+        if snapshot.provider_id in {"chatterbox", "higgs"} and options:
+            request.extra_params = options
+
+        internal_model_id = self._legacy_internal_model_id(snapshot, options)
+        created_paths: set[Path] = set()
+        try:
+            chunks = [
+                chunk
+                async for chunk in self._stts_service.generate_audio_stream(
+                    request,
+                    internal_model_id,
+                    progress_sink=progress_sink,
+                )
+            ]
+            wav_file = Path(
+                create_secure_temp_file(
+                    b"".join(chunks),
+                    suffix=".wav",
+                    prefix="stts_playground_",
+                )
+            )
+            created_paths.add(wav_file)
+            self._playground_audio_files.add(wav_file)
+            output_file = wav_file
+            audio_format = "wav"
+
+            if requested_format != "wav":
+                conversion_destination = wav_file.with_suffix(f".{requested_format}")
+                created_paths.add(conversion_destination)
+                self._playground_audio_files.add(conversion_destination)
+                converted_file = await self._convert_audio_format(
+                    wav_file,
+                    requested_format,
+                )
+                if converted_file is not None:
+                    output_file = Path(converted_file)
+                    created_paths.add(output_file)
+                    self._playground_audio_files.add(output_file)
+                    audio_format = requested_format
+                    if secure_delete_file(wav_file) or not wav_file.exists():
+                        self._playground_audio_files.discard(wav_file)
+                        created_paths.discard(wav_file)
+                elif (
+                    secure_delete_file(conversion_destination)
+                    or not conversion_destination.exists()
+                ):
+                    self._playground_audio_files.discard(conversion_destination)
+                    created_paths.discard(conversion_destination)
+
+            return STTSGeneratedAudio(
+                path=output_file,
+                provider_id=snapshot.provider_id,
+                model_id=snapshot.model_id,
+                voice_id=snapshot.voice_id,
+                source_text=snapshot.text,
+                operation_id=snapshot.operation_id,
+                audio_format=audio_format,
+                content_type=self._audio_content_type(audio_format),
+                metadata={},
+            )
+        except BaseException:
+            for path in created_paths:
+                if secure_delete_file(path) or not path.exists():
+                    self._playground_audio_files.discard(path)
+            raise
+
+    @staticmethod
+    def _legacy_internal_model_id(
+        snapshot: STTSPlaygroundRequest,
+        options: Mapping[str, Any],
+    ) -> str:
+        provider_id = snapshot.provider_id
+        if provider_id == "openai":
+            model_id = snapshot.model_id.lower().replace("-", "")
+            return f"openai_official_{model_id}"
+        if provider_id == "elevenlabs":
+            return f"elevenlabs_{snapshot.model_id}"
+        if provider_id == "kokoro":
+            engine = "onnx" if options.get("use_onnx", True) else "pytorch"
+            return f"local_kokoro_default_{engine}"
+        if provider_id == "chatterbox":
+            return "local_chatterbox_default"
+        if provider_id == "higgs":
+            return "local_higgs_v2"
+        if provider_id == "alltalk":
+            return f"alltalk_{snapshot.model_id}"
+        return snapshot.model_id
+
+    @staticmethod
+    def _audio_content_type(audio_format: str) -> str:
+        return {
+            "aac": "audio/aac",
+            "flac": "audio/flac",
+            "mp3": "audio/mpeg",
+            "opus": "audio/ogg",
+            "pcm": "audio/L16",
+            "wav": "audio/wav",
+        }.get(audio_format, "application/octet-stream")
 
     async def handle_playground_generate(
         self, event: STTSPlaygroundGenerateEvent
@@ -351,9 +537,12 @@ class STTSEventHandler:
             from tldw_chatbook.UI.STTS_Window import TTSPlaygroundWidget
 
             playground = self.app.query_one(TTSPlaygroundWidget)
-            logger.debug(f"Found playground widget: {playground}")
-        except Exception as e:
-            logger.warning(f"Could not find TTSPlaygroundWidget: {e}")
+            logger.debug("Found mounted TTS Playground")
+        except Exception as error:
+            logger.debug(
+                "TTS Playground is not mounted ({})",
+                type(error).__name__,
+            )
             playground = None
 
         # The Textual message hook already dispatches this coroutine through
@@ -361,418 +550,198 @@ class STTSEventHandler:
         await self._generate_tts_worker(event, playground)
 
     async def _generate_tts_worker(
-        self, event: STTSPlaygroundGenerateEvent, playground=None
+        self,
+        event: STTSPlaygroundGenerateEvent,
+        playground: Any | None = None,
     ) -> None:
-        """Worker function for TTS generation"""
+        """Generate from one immutable request and deliver one artifact."""
+        snapshot = event.request
+        self._show_generation_progress(playground)
+
+        async def progress_callback(info: TTSProgress) -> None:
+            self._update_generation_progress(playground, info)
+
         try:
-            # Show progress container if available
-            if playground:
-
-                def show_progress():
-                    try:
-                        status_container = playground.query_one(
-                            "#generation-status-container"
-                        )
-                        status_container.remove_class("hidden")
-                        progress_bar = playground.query_one("#generation-progress")
-                        progress_bar.update(total=100, progress=0)
-                    except Exception as e:
-                        logger.debug(f"Could not show progress container: {e}")
-
-                if hasattr(playground, "call_from_thread"):
-                    playground.call_from_thread(show_progress)
-                else:
-                    show_progress()
-            # Validate and clean format
-            format_value = event.format
-            if isinstance(format_value, tuple):
-                format_value = format_value[0]
-            elif (
-                not format_value
-                or format_value == Select.BLANK
-                or str(format_value) == "Select.BLANK"
-            ):
-                format_value = "mp3"
-
-            # Additional validation for allowed formats
-            valid_formats = ["mp3", "opus", "aac", "flac", "wav", "pcm"]
-            if format_value not in valid_formats:
-                logger.warning(
-                    f"Invalid format value '{format_value}', defaulting to mp3"
+            if snapshot.provider_id == "audio_cpp":
+                artifact = await self._generate_audio_cpp(
+                    snapshot,
+                    progress_callback,
                 )
-                format_value = "mp3"
-
-            # Store the requested format for later conversion
-            requested_format = format_value
-
-            # For non-WAV formats, generate WAV first to avoid choppiness
-            generation_format = "wav"
-            logger.debug(
-                f"TTS Request - requested format: {requested_format}, generation format: {generation_format}, provider: {event.provider}"
-            )
-
-            # Create TTS request with generation format (WAV for quality)
-            request = OpenAISpeechRequest(
-                model=event.model,
-                input=event.text,
-                voice=event.voice,
-                response_format=generation_format,
-                speed=event.speed,
-            )
-
-            # Map provider to internal model ID (handle case-insensitive)
-            provider_lower = event.provider.lower() if event.provider else ""
-
-            # Extract the actual provider key from display names
-            if "kokoro" in provider_lower:
-                provider_lower = "kokoro"
-            elif "elevenlabs" in provider_lower:
-                provider_lower = "elevenlabs"
-            elif "openai" in provider_lower:
-                provider_lower = "openai"
-            elif "chatterbox" in provider_lower:
-                provider_lower = "chatterbox"
-            elif "alltalk" in provider_lower:
-                provider_lower = "alltalk"
-            elif "higgs" in provider_lower:
-                provider_lower = "higgs"
-
-            if provider_lower == "openai":
-                # Also convert model to lowercase
-                model_lower = event.model.lower().replace(
-                    "-", ""
-                )  # Convert TTS-1 to tts1
-                internal_model_id = f"openai_official_{model_lower}"
-            elif provider_lower == "elevenlabs":
-                internal_model_id = f"elevenlabs_{event.model}"
-            elif provider_lower == "kokoro":
-                # Check if ONNX or PyTorch should be used
-                use_onnx = event.extra_params.get("use_onnx", True)
-                if use_onnx:
-                    internal_model_id = "local_kokoro_default_onnx"
-                else:
-                    internal_model_id = "local_kokoro_default_pytorch"
-                # Handle Kokoro language code
-                if event.extra_params.get("language"):
-                    # Kokoro voices include language code prefix
-                    lang_code = event.extra_params["language"]
-                    # Update voice to include language code if not already present
-                    if not event.voice.startswith(f"{lang_code}"):
-                        # Voice might need language adjustment
-                        pass  # The voice already includes the language prefix
-            elif provider_lower == "chatterbox":
-                internal_model_id = "local_chatterbox_default"
-                # Pass voice and extra params to the request
-                if event.voice.startswith("custom:"):
-                    # Voice contains reference audio path
-                    request.voice = event.voice
-                elif event.voice.startswith("profile:"):
-                    # Voice is a saved profile
-                    request.voice = event.voice
-                # Add extra params to request for Chatterbox
-                if event.extra_params:
-                    request.extra_params = event.extra_params
-            elif provider_lower == "higgs":
-                internal_model_id = "local_higgs_v2"
-                # Handle voice cloning reference
-                if event.voice.startswith("custom:"):
-                    # Voice contains reference audio path
-                    request.voice = event.voice
-                elif event.voice.startswith("profile:"):
-                    # Voice is a saved profile
-                    request.voice = event.voice
-                # Pass extra params for Higgs features
-                if event.extra_params:
-                    request.extra_params = event.extra_params
-            elif provider_lower == "alltalk":
-                internal_model_id = f"alltalk_{event.model}"
             else:
-                # Default case - use the model as-is
-                internal_model_id = event.model
-
-            # Log to playground
-            if playground:
-                # Use call_from_thread if we're in a worker thread
-                def update_log(msg):
-                    log = playground.query_one("#tts-generation-log", RichLog)
-                    log.write(msg)
-
-                if hasattr(playground, "call_from_thread"):
-                    playground.call_from_thread(
-                        update_log,
-                        f"[bold yellow]Starting generation with {event.provider}...[/bold yellow]",
-                    )
-                    if provider_lower in ["higgs", "chatterbox", "kokoro"]:
-                        playground.call_from_thread(
-                            update_log,
-                            "[dim]⚠️  First-time model loading may take 2-5 minutes...[/dim]",
-                        )
-                        playground.call_from_thread(
-                            update_log,
-                            "[dim]The model will be cached for faster subsequent generations.[/dim]",
-                        )
-                else:
-                    update_log(
-                        f"[bold yellow]Starting generation with {event.provider}...[/bold yellow]"
-                    )
-                    if provider_lower in ["higgs", "chatterbox", "kokoro"]:
-                        update_log(
-                            "[dim]⚠️  First-time model loading may take 2-5 minutes...[/dim]"
-                        )
-                        update_log(
-                            "[dim]The model will be cached for faster subsequent generations.[/dim]"
-                        )
-
-            # Define progress callback
-            async def progress_callback(info: TTSProgress) -> None:
-                """Update UI with generation progress"""
-                if playground:
-
-                    def update_progress():
-                        try:
-                            # Update status text
-                            status_text = playground.query_one(
-                                "#generation-status-text", Static
-                            )
-                            status_text.update(info.status or "Generating...")
-
-                            # Update progress bar
-                            progress_bar = playground.query_one(
-                                "#generation-progress", ProgressBar
-                            )
-                            if info.fraction is not None:
-                                progress_bar.update(progress=info.fraction * 100)
-
-                            # Log additional details
-                            log = playground.query_one("#tts-generation-log", RichLog)
-                            audio_duration = info.metrics.get("audio_duration")
-                            if isinstance(audio_duration, (int, float)):
-                                log.write(
-                                    f"[dim]Generated {audio_duration:.1f}s of audio[/dim]"
-                                )
-                            elif info.processed is not None:
-                                if info.total is None:
-                                    log.write(
-                                        f"[dim]Processed {info.processed} item(s)[/dim]"
-                                    )
-                                else:
-                                    log.write(
-                                        f"[dim]Processed {info.processed}/{info.total} item(s)[/dim]"
-                                    )
-                        except Exception as e:
-                            logger.debug(f"Progress update error: {e}")
-
-                    if hasattr(playground, "call_from_thread"):
-                        playground.call_from_thread(update_progress)
-                    else:
-                        update_progress()
-
-            # Generate audio with provider-specific settings
-            audio_data = b""
-            chunk_count = 0
-            total_size = 0
-            start_time = asyncio.get_event_loop().time()
-
-            # Pass extra params to the service if needed
-            if event.provider == "elevenlabs" and event.extra_params:
-                # For ElevenLabs, we need to pass these settings to the backend
-                # The TTS service should handle passing these to the appropriate backend
-                request_dict = request.dict()
-                request_dict.update(event.extra_params)
-                # Note: This requires the backend to support these extra parameters
-
-            # Create a task to show periodic status while waiting
-            async def show_waiting_status():
-                wait_count = 0
-                while chunk_count == 0:  # While we haven't received any chunks yet
-                    await asyncio.sleep(5)  # Check every 5 seconds
-                    wait_count += 1
-                    if playground and chunk_count == 0:  # Still waiting
-                        elapsed = int(asyncio.get_event_loop().time() - start_time)
-                        wait_msg = f"[yellow]⏳ Still loading model... ({elapsed}s elapsed)[/yellow]"
-                        if wait_count > 12:  # After 1 minute
-                            wait_msg += "\n[dim]This is taking longer than usual. Please be patient.[/dim]"
-
-                        def update_wait():
-                            log = playground.query_one("#tts-generation-log", RichLog)
-                            log.write(wait_msg)
-
-                        if hasattr(playground, "call_from_thread"):
-                            playground.call_from_thread(update_wait)
-                        else:
-                            update_wait()
-
-            # Start the waiting status task
-            status_task = asyncio.create_task(
-                show_waiting_status(),
-                name="stts_generation_status",
-            )
-
-            try:
-                async for chunk in self._stts_service.generate_audio_stream(
-                    request,
-                    internal_model_id,
-                    progress_sink=progress_callback,
-                ):
-                    audio_data += chunk
-                    chunk_count += 1
-                    total_size = len(audio_data)
-
-                    # Cancel the waiting status task once we start receiving data
-                    if chunk_count == 1:
-                        status_task.cancel()
-
-                # Update progress periodically (every 10 chunks)
-                if chunk_count % 10 == 0 and playground:
-                    progress_msg = f"[cyan]Streaming audio... {total_size / 1024:.1f} KB received[/cyan]"
-                    if hasattr(playground, "call_from_thread"):
-                        playground.call_from_thread(update_log, progress_msg)
-                    else:
-                        update_log(progress_msg)
-
-                # Also update for first chunk to show we're receiving data
-                if chunk_count == 1 and playground:
-                    first_msg = "[green]✓ Model loaded, receiving audio data...[/green]"
-                    if hasattr(playground, "call_from_thread"):
-                        playground.call_from_thread(update_log, first_msg)
-                    else:
-                        update_log(first_msg)
-
-            finally:
-                status_task.cancel()
-                await asyncio.gather(status_task, return_exceptions=True)
-
-            # Save to temporary WAV file first
-            import tempfile
-
-            wav_file = None
-            with tempfile.NamedTemporaryFile(
-                delete=False, suffix=".wav", prefix="stts_playground_"
-            ) as tmp_file:
-                tmp_file.write(audio_data)
-                wav_file = Path(tmp_file.name)
-            self._playground_audio_files.add(wav_file)
-
-            # Convert to requested format if needed
-            if requested_format != "wav":
-                if playground:
-
-                    def update_converting():
-                        log = playground.query_one("#tts-generation-log", RichLog)
-                        log.write(
-                            f"[yellow]Converting to {requested_format.upper()}...[/yellow]"
-                        )
-
-                    if hasattr(playground, "call_from_thread"):
-                        playground.call_from_thread(update_converting)
-                    else:
-                        update_converting()
-
-                # Convert audio format
-                conversion_destination = wav_file.with_suffix(f".{requested_format}")
-                self._playground_audio_files.add(conversion_destination)
-                converted_file = await self._convert_audio_format(
-                    wav_file, requested_format
+                artifact = await self._generate_legacy(
+                    snapshot,
+                    progress_callback,
                 )
-                if converted_file:
-                    if secure_delete_file(wav_file) or not wav_file.exists():
-                        self._playground_audio_files.discard(wav_file)
-                    else:
-                        logger.warning(
-                            f"Failed to delete temporary WAV file: {wav_file}"
-                        )
-                    self._current_audio_file = converted_file
-                else:
-                    if (
-                        secure_delete_file(conversion_destination)
-                        or not conversion_destination.exists()
-                    ):
-                        self._playground_audio_files.discard(conversion_destination)
-                    # Conversion failed, use WAV file
-                    logger.warning(
-                        f"Failed to convert to {requested_format}, using WAV"
-                    )
-                    self._current_audio_file = wav_file
-            else:
-                self._current_audio_file = wav_file
-
-            # Update UI
-            if playground:
-
-                def complete_generation():
-                    log = playground.query_one("#tts-generation-log", RichLog)
-                    log.write(
-                        f"[bold green]✓ Generation complete! File: {self._current_audio_file.name}[/bold green]"
-                    )
-                    log.write(f"Size: {len(audio_data) / 1024:.1f} KB")
-
-                    # Call the widget's completion method
-                    if hasattr(playground, "_generation_complete"):
-                        playground._generation_complete(True, self._current_audio_file)
-                    else:
-                        # Fallback to direct UI updates
-                        playground.query_one("#audio-play-btn", Button).disabled = False
-                        playground.query_one(
-                            "#audio-export-btn", Button
-                        ).disabled = False
-                        playground.query_one("#audio-player-status").update(
-                            f"Audio ready: {self._current_audio_file.name}"
-                        )
-
-                if hasattr(playground, "call_from_thread"):
-                    playground.call_from_thread(complete_generation)
-                else:
-                    complete_generation()
-
+            self._current_playground_artifact = artifact
+            self._current_audio_file = artifact.path
+            self._deliver_generation_success(playground, artifact)
             self.app.notify("TTS generation complete!", severity="information")
-
-        except Exception as e:
-            logger.error(f"TTS generation failed: {e}")
-            if playground:
-                exc = e
-
-                def handle_error():
-                    log = playground.query_one("#tts-generation-log", RichLog)
-                    log.write(f"[bold red]✗ Generation failed: {exc}[/bold red]")
-
-                    # Call the widget's completion method
-                    if hasattr(playground, "_generation_complete"):
-                        playground._generation_complete(False)
-
-                if hasattr(playground, "call_from_thread"):
-                    playground.call_from_thread(handle_error)
-                else:
-                    handle_error()
-
-            from rich.markup import escape
-
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            message = self._generation_error_copy(error)
+            if isinstance(error, TTSOperationError):
+                logger.error(
+                    "TTS generation failed (code={}, retryable={})",
+                    error.code,
+                    error.retryable,
+                )
+            else:
+                logger.error(
+                    "TTS generation failed ({})",
+                    type(error).__name__,
+                )
+            self._deliver_generation_failure(playground, message)
             self.app.notify(
-                f"TTS generation failed: {escape(str(e))}", severity="error"
+                f"TTS generation failed: {escape(message)}",
+                severity="error",
             )
         finally:
             self._is_generating = False
-            # Re-enable generate button is now handled in _generation_complete
-            # But ensure it's re-enabled as a fallback
-            if playground:
-                try:
-                    playground.query_one("#tts-generate-btn", Button).disabled = False
+            self._finish_generation_ui(playground)
 
-                    # Hide progress container
-                    def hide_progress():
-                        try:
-                            status_container = playground.query_one(
-                                "#generation-status-container"
-                            )
-                            status_container.add_class("hidden")
-                        except Exception:
-                            pass
+    def _show_generation_progress(self, playground: Any | None) -> None:
+        if playground is None:
+            return
 
-                    if hasattr(playground, "call_from_thread"):
-                        playground.call_from_thread(hide_progress)
-                    else:
-                        hide_progress()
-                except (OSError, FileNotFoundError):
-                    pass
+        def show() -> None:
+            playground.query_one("#generation-status-container").remove_class("hidden")
+            playground.query_one("#generation-progress").update(
+                total=100,
+                progress=0,
+            )
+
+        self._invoke_playground(playground, show)
+
+    def _update_generation_progress(
+        self,
+        playground: Any | None,
+        info: TTSProgress,
+    ) -> None:
+        if playground is None:
+            return
+
+        def update() -> None:
+            playground.query_one(
+                "#generation-status-text",
+                Static,
+            ).update(info.status or "Generating...")
+            if info.fraction is not None:
+                playground.query_one(
+                    "#generation-progress",
+                    ProgressBar,
+                ).update(progress=info.fraction * 100)
+            log = playground.query_one("#tts-generation-log", RichLog)
+            audio_duration = info.metrics.get("audio_duration")
+            if isinstance(audio_duration, (int, float)):
+                log.write(f"[dim]Generated {audio_duration:.1f}s of audio[/dim]")
+            elif info.processed is not None:
+                if info.total is None:
+                    log.write(f"[dim]Processed {info.processed} item(s)[/dim]")
+                else:
+                    log.write(
+                        f"[dim]Processed {info.processed}/{info.total} item(s)[/dim]"
+                    )
+
+        self._invoke_playground(playground, update)
+
+    def _deliver_generation_success(
+        self,
+        playground: Any | None,
+        artifact: STTSGeneratedAudio,
+    ) -> None:
+        if playground is None:
+            return
+
+        def deliver() -> None:
+            playground.query_one("#tts-generation-log", RichLog).write(
+                "[bold green]Generation complete[/bold green]"
+            )
+            callback = getattr(playground, "_generation_complete", None)
+            if callable(callback):
+                callback(artifact)
+                return
+            playground.query_one("#audio-play-btn", Button).disabled = False
+            playground.query_one("#audio-export-btn", Button).disabled = False
+            playground.query_one("#audio-player-status", Static).update(
+                "Audio ready to play"
+            )
+
+        self._invoke_playground(playground, deliver)
+
+    def _deliver_generation_failure(
+        self,
+        playground: Any | None,
+        message: str,
+    ) -> None:
+        if playground is None:
+            return
+
+        def deliver() -> None:
+            playground.query_one("#tts-generation-log", RichLog).write(
+                f"[bold red]Generation failed: {escape(message)}[/bold red]"
+            )
+            callback = getattr(playground, "_generation_complete", None)
+            if callable(callback):
+                callback(None)
+
+        self._invoke_playground(playground, deliver)
+
+    def _finish_generation_ui(self, playground: Any | None) -> None:
+        if playground is None:
+            return
+
+        def finish() -> None:
+            sync_generate_enabled = getattr(
+                playground,
+                "_sync_generate_enabled",
+                None,
+            )
+            if callable(sync_generate_enabled):
+                sync_generate_enabled()
+            else:
+                playground.query_one(
+                    "#tts-generate-btn",
+                    Button,
+                ).disabled = False
+            playground.query_one("#generation-status-container").add_class("hidden")
+
+        self._invoke_playground(playground, finish)
+
+    @staticmethod
+    def _invoke_playground(
+        playground: Any,
+        callback: object,
+        *args: object,
+    ) -> None:
+        try:
+            call_from_thread = getattr(playground, "call_from_thread", None)
+            if callable(call_from_thread):
+                call_from_thread(callback, *args)
+            elif callable(callback):
+                callback(*args)
+        except Exception as error:
+            logger.debug(
+                "Playground generation display update failed ({})",
+                type(error).__name__,
+            )
+
+    @staticmethod
+    def _generation_error_copy(error: Exception) -> str:
+        if isinstance(error, TTSOperationError):
+            parts = [str(error)]
+            if error.recovery_action:
+                parts.append(error.recovery_action)
+            elif error.retryable:
+                parts.append("Retry from the STTS Playground")
+            return " ".join(parts)
+        if isinstance(error, TTSProviderReconfiguringError):
+            return "TTS settings are being applied; retry shortly"
+        if isinstance(error, TTSRegistryClosedError):
+            return "The TTS service is unavailable"
+        if isinstance(error, ValueError):
+            return "TTS is not configured; open STTS Settings"
+        return "Unexpected TTS generation failure; retry"
 
     async def handle_settings_save(self, event: STTSSettingsSaveEvent) -> None:
         """Handle settings save"""
@@ -1141,7 +1110,8 @@ class STTSEventHandler:
 
     async def play_current_audio(self) -> None:
         """Play the current audio file"""
-        if not self._current_audio_file or not self._current_audio_file.exists():
+        audio_path = self._current_playground_audio_path()
+        if audio_path is None or not audio_path.exists():
             self.app.notify("No audio file to play", severity="warning")
             return
 
@@ -1151,7 +1121,7 @@ class STTSEventHandler:
                 play_audio_file,
             )
 
-            play_audio_file(self._current_audio_file)
+            play_audio_file(audio_path)
             self.app.notify("Playing audio...", severity="information")
         except Exception as e:
             logger.error(f"Failed to play audio: {e}")
@@ -1159,7 +1129,8 @@ class STTSEventHandler:
 
     async def export_current_audio(self, target_path: Path) -> None:
         """Export the current audio file"""
-        if not self._current_audio_file or not self._current_audio_file.exists():
+        audio_path = self._current_playground_audio_path()
+        if audio_path is None or not audio_path.exists():
             self.app.notify("No audio file to export", severity="warning")
             return
 
@@ -1178,13 +1149,21 @@ class STTSEventHandler:
             validated_filename = validate_filename(target_path.name)
             validated_target_path = validated_parent / validated_filename
 
-            shutil.copy2(self._current_audio_file, validated_target_path)
+            shutil.copy2(audio_path, validated_target_path)
             self.app.notify(
                 f"Audio exported to {validated_target_path}", severity="information"
             )
         except Exception as e:
             logger.error(f"Failed to export audio: {e}")
             self.app.notify(f"Failed to export audio: {e}", severity="error")
+
+    def _current_playground_audio_path(self) -> Path | None:
+        """Return artifact provenance before the compatibility path field."""
+        if self._current_playground_artifact is not None:
+            return self._current_playground_artifact.path
+        if self._current_audio_file is None:
+            return None
+        return Path(self._current_audio_file)
 
     def _start_event_task(self, coroutine: Coroutine[Any, Any, None]) -> None:
         """Start and retain an event task until it finishes."""

--- a/tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py
+++ b/tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py
@@ -3,7 +3,8 @@
 #
 # Imports
 import asyncio
-from collections.abc import Coroutine
+from collections.abc import Coroutine, Mapping
+from copy import deepcopy
 from datetime import datetime
 from typing import Optional, Dict, Any, NamedTuple
 from pathlib import Path
@@ -17,7 +18,9 @@ from textual.widgets import Button, Select, RichLog, Static, ProgressBar
 #
 # Local imports
 from tldw_chatbook.TTS import get_tts_service, OpenAISpeechRequest
+from tldw_chatbook.TTS.adapter_registry import ReconfigureResult
 from tldw_chatbook.TTS.adapter_types import TTSProgress
+from tldw_chatbook.TTS.audio_cpp_config import project_audio_cpp_config
 from tldw_chatbook.TTS.legacy_bridge import legacy_provider_config
 from tldw_chatbook.TTS.TTS_Generation import _join_retained_task
 from tldw_chatbook.Utils.secure_temp_files import secure_delete_file
@@ -40,6 +43,10 @@ def _app_tts_binding(
 
 
 _TTS_SETTING_BINDINGS = {
+    "audio_cpp": _SettingBinding(
+        (("app_tts", "audio_cpp"),),
+        "audio_cpp",
+    ),
     "default_provider": _SettingBinding(
         (
             ("app_tts", "default_provider"),
@@ -216,6 +223,7 @@ _TTS_SETTING_BINDINGS = {
     ),
 }
 _TTS_PROVIDER_ORDER = (
+    "audio_cpp",
     "openai",
     "elevenlabs",
     "kokoro",
@@ -223,6 +231,16 @@ _TTS_PROVIDER_ORDER = (
     "higgs",
     "alltalk",
 )
+
+
+def _effective_provider_config(
+    provider_id: str,
+    effective_settings: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    """Project one provider's effective registry configuration."""
+    if provider_id == "audio_cpp":
+        return project_audio_cpp_config(effective_settings).to_mapping()
+    return legacy_provider_config(provider_id, effective_settings)
 
 
 class STTSPlaygroundGenerateEvent(Message):
@@ -253,7 +271,16 @@ class STTSSettingsSaveEvent(Message):
 
     def __init__(self, settings: Dict[str, Any]):
         super().__init__()
-        self.settings = settings
+        self.settings = deepcopy(settings)
+
+
+class STTSProviderConfigurationChanged(Message):
+    """Signal that one provider's effective configuration revision changed."""
+
+    def __init__(self, provider_id: str, configuration_revision: int) -> None:
+        super().__init__()
+        self.provider_id = provider_id
+        self.configuration_revision = configuration_revision
 
 
 class STTSAudioBookGenerateEvent(Message):
@@ -774,7 +801,9 @@ class STTSEventHandler:
                 if binding is None:
                     continue
                 for section, setting_name in binding.destinations:
-                    section_values.setdefault(section, {})[setting_name] = value
+                    section_values.setdefault(section, {})[setting_name] = deepcopy(
+                        value
+                    )
                     saved_destinations.append((key, section, setting_name))
                 if binding.provider_id is not None:
                     candidate_provider_ids.add(binding.provider_id)
@@ -799,7 +828,10 @@ class STTSEventHandler:
                     *(
                         service.reconfigure_provider(
                             provider_id,
-                            legacy_provider_config(provider_id, effective_settings),
+                            _effective_provider_config(
+                                provider_id,
+                                effective_settings,
+                            ),
                         )
                         for provider_id in candidate_providers
                     ),
@@ -810,6 +842,14 @@ class STTSEventHandler:
                     for provider_id, result in zip(candidate_providers, results)
                     if isinstance(result, BaseException)
                 ]
+                for provider_id, result in zip(candidate_providers, results):
+                    if result is ReconfigureResult.CHANGED:
+                        self.app.post_message(
+                            STTSProviderConfigurationChanged(
+                                provider_id,
+                                service.configuration_revision(provider_id),
+                            )
+                        )
                 if failed_providers:
                     logger.error(
                         "Failed to reconfigure TTS providers: {}",

--- a/tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py
+++ b/tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py
@@ -7,24 +7,25 @@ from collections.abc import Coroutine, Mapping
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional, Dict, Any, NamedTuple
 from pathlib import Path
+from typing import Any, Dict, NamedTuple, Optional
+
 from loguru import logger
 from rich.markup import escape
 
 #
 # Third-party imports
 from textual.message import Message
-from textual.widgets import Button, RichLog, Static, ProgressBar
+from textual.widgets import Button, ProgressBar, RichLog, Static
 
 #
 # Local imports
 from tldw_chatbook.TTS import (
-    get_tts_service,
     OpenAISpeechRequest,
     STTSGeneratedAudio,
     STTSPlaygroundRequest,
     TTSRequest,
+    get_tts_service,
 )
 from tldw_chatbook.TTS.adapter_registry import ReconfigureResult
 from tldw_chatbook.TTS.adapter_types import (
@@ -41,6 +42,7 @@ from tldw_chatbook.Utils.secure_temp_files import (
     create_secure_temp_file,
     secure_delete_file,
 )
+
 #
 #######################################################################################################################
 #
@@ -1109,8 +1111,8 @@ class STTSEventHandler:
         try:
             from tldw_chatbook.TTS.audiobook_generator import (
                 AudioBookGenerator,
-                AudioBookRequest,
                 AudioBookProgress,
+                AudioBookRequest,
             )
 
             logger.info("AudioBook generation requested")
@@ -1314,6 +1316,7 @@ class STTSEventHandler:
 
         try:
             import shutil
+
             from tldw_chatbook.Utils.path_validation import (
                 validate_filename,
                 validate_path_simple,

--- a/tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py
+++ b/tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py
@@ -1241,6 +1241,16 @@ class STTSEventHandler:
         """Handle settings save event"""
         self._start_event_task(self.handle_settings_save(event))
 
+    def on_stts_provider_configuration_changed(
+        self,
+        event: STTSProviderConfigurationChanged,
+    ) -> None:
+        """Invalidate any mounted Playground for the changed provider."""
+        for widget in self.app.query("TTSPlaygroundWidget"):
+            callback = getattr(widget, "mark_provider_configuration_changed", None)
+            if callable(callback):
+                callback(event.provider_id, event.configuration_revision)
+
     def on_stts_audiobook_generate_event(
         self, event: STTSAudioBookGenerateEvent
     ) -> None:

--- a/tldw_chatbook/TTS/TTS_Generation.py
+++ b/tldw_chatbook/TTS/TTS_Generation.py
@@ -17,6 +17,7 @@ from tldw_chatbook.TTS.adapter_types import (
     TTSAudioResponse,
     TTSProgress,
     TTSProviderCatalog,
+    TTSProviderDescriptor,
     TTSRequest,
     TTSRegistryClosedError,
 )
@@ -273,6 +274,21 @@ class TTSService:
             raise
         else:
             await response.aclose()
+
+    def provider_descriptors(self) -> tuple[TTSProviderDescriptor, ...]:
+        """Return ordered provider metadata without materializing adapters."""
+        return self.registry.descriptors()
+
+    def configuration_revision(self, provider_id: str) -> int:
+        """Return the current registry configuration revision for a provider.
+
+        Args:
+            provider_id: Canonical provider identifier.
+
+        Returns:
+            The provider's monotonically increasing configuration revision.
+        """
+        return self.registry.configuration_revision(provider_id)
 
     async def get_catalog(
         self,

--- a/tldw_chatbook/TTS/__init__.py
+++ b/tldw_chatbook/TTS/__init__.py
@@ -11,6 +11,10 @@ from tldw_chatbook.TTS.adapter_types import (
     TTSRequest,
 )
 from tldw_chatbook.TTS.audio_schemas import OpenAISpeechRequest, NormalizationOptions
+from tldw_chatbook.TTS.playground_types import (
+    STTSGeneratedAudio,
+    STTSPlaygroundRequest,
+)
 from tldw_chatbook.TTS.TTS_Generation import (
     TTSService,
     bind_tts_service,
@@ -24,6 +28,8 @@ __all__ = [
     "OpenAISpeechRequest",
     "ProgressSink",
     "ProviderHealth",
+    "STTSGeneratedAudio",
+    "STTSPlaygroundRequest",
     "TTSAudioResponse",
     "TTSModelInfo",
     "TTSOperationCode",

--- a/tldw_chatbook/TTS/audio_cpp_config.py
+++ b/tldw_chatbook/TTS/audio_cpp_config.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import math
 from collections.abc import Mapping
 from copy import deepcopy
-from dataclasses import dataclass
 from ipaddress import AddressValueError, IPv4Address, IPv6Address
 from numbers import Real
 from typing import Any, Literal
@@ -11,6 +10,13 @@ from unicodedata import category
 from urllib.parse import urlsplit
 
 import idna
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    ValidationError,
+    ValidationInfo,
+    field_validator,
+)
 
 _CONFIG_DIAGNOSTIC = "audio.cpp configuration must be a mapping"
 _MODE_DIAGNOSTIC = "audio.cpp mode must be external"
@@ -155,9 +161,30 @@ def _validate_limit(field_name: str, value: object) -> int:
     return value
 
 
-@dataclass(frozen=True, slots=True)
-class AudioCppConfig:
+def _safe_validation_error(error: ValidationError) -> ValueError:
+    """Translate Pydantic failures into fixed value-independent diagnostics."""
+    details = error.errors(include_context=False, include_input=False)
+    field_name = details[0]["loc"][0] if details and details[0]["loc"] else None
+    if field_name == "mode":
+        return ValueError(_MODE_DIAGNOSTIC)
+    if field_name == "base_url":
+        return _invalid_url()
+    if field_name in _TIMEOUT_FIELDS:
+        return ValueError(f"audio.cpp {field_name} must be a finite positive number")
+    if field_name in _LIMIT_FIELDS:
+        return ValueError(f"audio.cpp {field_name} must be a positive integer")
+    return ValueError(_CONFIG_DIAGNOSTIC)
+
+
+class AudioCppConfig(BaseModel):
     """Validated external audio.cpp connection and safety limits."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        frozen=True,
+        hide_input_in_errors=True,
+        strict=True,
+    )
 
     mode: Literal["external"] = "external"
     base_url: str = "http://127.0.0.1:8080"
@@ -170,26 +197,35 @@ class AudioCppConfig:
     max_voices_per_model: int = 1000
     max_identifier_characters: int = 256
 
-    def __post_init__(self) -> None:
-        if self.mode != "external":
+    @field_validator("mode", mode="before")
+    @classmethod
+    def _validate_mode(cls, value: object) -> str:
+        if value != "external":
             raise ValueError(_MODE_DIAGNOSTIC)
-        object.__setattr__(
-            self,
-            "base_url",
-            _canonicalize_http_origin(self.base_url),
-        )
-        for field_name in _TIMEOUT_FIELDS:
-            object.__setattr__(
-                self,
-                field_name,
-                _validate_timeout(field_name, getattr(self, field_name)),
-            )
-        for field_name in _LIMIT_FIELDS:
-            object.__setattr__(
-                self,
-                field_name,
-                _validate_limit(field_name, getattr(self, field_name)),
-            )
+        return "external"
+
+    @field_validator("base_url", mode="before")
+    @classmethod
+    def _validate_base_url(cls, value: object) -> str:
+        return _canonicalize_http_origin(value)
+
+    @field_validator(*_TIMEOUT_FIELDS, mode="before")
+    @classmethod
+    def _validate_timeout_field(
+        cls,
+        value: object,
+        info: ValidationInfo,
+    ) -> float:
+        return _validate_timeout(info.field_name, value)
+
+    @field_validator(*_LIMIT_FIELDS, mode="before")
+    @classmethod
+    def _validate_limit_field(
+        cls,
+        value: object,
+        info: ValidationInfo,
+    ) -> int:
+        return _validate_limit(info.field_name, value)
 
     @classmethod
     def from_mapping(cls, values: Mapping[str, Any]) -> AudioCppConfig:
@@ -211,10 +247,18 @@ class AudioCppConfig:
             for field_name in _CONFIG_FIELDS
             if field_name in values
         }
-        return cls(**projected)
+        try:
+            return cls(**projected)
+        except ValidationError as error:
+            raise _safe_validation_error(error) from None
 
     def to_mapping(self) -> dict[str, AudioCppConfigValue]:
-        """Return an independent registry mapping of approved fields."""
+        """Return an independent registry mapping of approved fields.
+
+        Returns:
+            A plain mapping containing only approved configuration fields.
+
+        """
         return {
             "mode": self.mode,
             "base_url": self.base_url,

--- a/tldw_chatbook/TTS/legacy_catalogs.py
+++ b/tldw_chatbook/TTS/legacy_catalogs.py
@@ -25,6 +25,33 @@ LEGACY_MODELS = {
     "higgs": ("higgs-audio-v2",),
     "alltalk": ("alltalk",),
 }
+LEGACY_DEFAULT_MODELS = {
+    "openai": "tts-1",
+    "elevenlabs": "eleven_multilingual_v2",
+    "kokoro": "kokoro",
+    "chatterbox": "chatterbox",
+    "higgs": "higgs-audio-v2",
+    "alltalk": "alltalk",
+}
+LEGACY_MODEL_LABELS = {
+    "openai": {
+        "tts-1": "TTS-1 (Standard)",
+        "tts-1-hd": "TTS-1-HD (High Quality)",
+    },
+    "elevenlabs": {
+        "eleven_monolingual_v1": "Eleven Monolingual v1",
+        "eleven_multilingual_v1": "Eleven Multilingual v1",
+        "eleven_multilingual_v2": "Eleven Multilingual v2 (Default)",
+        "eleven_turbo_v2": "Eleven Turbo v2",
+        "eleven_turbo_v2_5": "Eleven Turbo v2.5",
+        "eleven_flash_v2": "Eleven Flash v2 (Low Latency)",
+        "eleven_flash_v2_5": "Eleven Flash v2.5 (Ultra Low Latency)",
+    },
+    "kokoro": {"kokoro": "Kokoro 82M"},
+    "chatterbox": {"chatterbox": "Chatterbox 0.5B"},
+    "higgs": {"higgs-audio-v2": "Higgs Audio V2 3B"},
+    "alltalk": {"alltalk": "AllTalk TTS"},
+}
 OPENAI_VOICES = (
     "alloy",
     "ash",
@@ -68,6 +95,70 @@ KOKORO_VOICES = (
     "bm_george",
     "bm_lewis",
 )
+LEGACY_DEFAULT_VOICES = {
+    "openai": "alloy",
+    "elevenlabs": "21m00Tcm4TlvDq8ikWAM",
+    "kokoro": "af_alloy",
+    "chatterbox": "default",
+    "higgs": "professional_female",
+    "alltalk": "female_01.wav",
+}
+LEGACY_VOICE_OPTIONS = {
+    "openai": tuple((voice.title(), voice) for voice in OPENAI_VOICES),
+    "elevenlabs": (
+        ("Rachel", "21m00Tcm4TlvDq8ikWAM"),
+        ("Domi", "AZnzlk1XvdvUeBnXmlld"),
+        ("Bella", "EXAVITQu4vr4xnSDxMaL"),
+        ("Antoni", "ErXwobaYiN019PkySvjV"),
+        ("Elli", "MF3mGyEYCl7XYWbV9V6O"),
+        ("Josh", "TxGEqnHWrfWFTfGW9XjX"),
+        ("Arnold", "VR6AewLTigWG4xSOukaG"),
+        ("Adam", "pNInz6obpgDQGcFmaJgB"),
+        ("Sam", "yoZ06aMxZJJ28mfd3POQ"),
+    ),
+    "kokoro": (
+        ("Alloy (US Female)", "af_alloy"),
+        ("Aoede (US Female)", "af_aoede"),
+        ("Bella (US Female)", "af_bella"),
+        ("Heart (US Female)", "af_heart"),
+        ("Jessica (US Female)", "af_jessica"),
+        ("Kore (US Female)", "af_kore"),
+        ("Nicole (US Female)", "af_nicole"),
+        ("Nova (US Female)", "af_nova"),
+        ("River (US Female)", "af_river"),
+        ("Sarah (US Female)", "af_sarah"),
+        ("Sky (US Female)", "af_sky"),
+        ("Adam (US Male)", "am_adam"),
+        ("Michael (US Male)", "am_michael"),
+        ("Emma (UK Female)", "bf_emma"),
+        ("Isabella (UK Female)", "bf_isabella"),
+        ("George (UK Male)", "bm_george"),
+        ("Lewis (UK Male)", "bm_lewis"),
+    ),
+    "chatterbox": (
+        ("Default Voice", "default"),
+        ("Upload Reference Audio", "custom"),
+    ),
+    "higgs": (
+        ("Professional Female", "professional_female"),
+        ("Warm Female", "warm_female"),
+        ("Storyteller Male", "storyteller_male"),
+        ("Deep Male", "deep_male"),
+        ("Energetic Female", "energetic_female"),
+        ("Soft Female", "soft_female"),
+        ("Upload Reference Audio", "custom"),
+    ),
+    "alltalk": (
+        ("Female 01", "female_01.wav"),
+        ("Female 02", "female_02.wav"),
+        ("Female 03", "female_03.wav"),
+        ("Female 04", "female_04.wav"),
+        ("Male 01", "male_01.wav"),
+        ("Male 02", "male_02.wav"),
+        ("Male 03", "male_03.wav"),
+        ("Male 04", "male_04.wav"),
+    ),
+}
 
 _ALL_VISIBLE_FORMATS = ("mp3", "opus", "aac", "flac", "wav", "pcm")
 _VOICES = {
@@ -115,7 +206,7 @@ def legacy_catalog(provider_id: str) -> TTSProviderCatalog:
         models=tuple(
             TTSModelInfo(
                 model_id=model_id,
-                display_name=model_id.replace("_", " ").title(),
+                display_name=LEGACY_MODEL_LABELS[provider_id][model_id],
                 family=provider_id,
                 upstream_mode="legacy",
                 formats=_ALL_VISIBLE_FORMATS,

--- a/tldw_chatbook/TTS/playground_types.py
+++ b/tldw_chatbook/TTS/playground_types.py
@@ -10,6 +10,22 @@ from typing import Any
 AudioMetadataValue = str | int | float | bool | None
 
 
+def _freeze_option(value: Any) -> Any:
+    """Recursively isolate mutable option containers."""
+    if isinstance(value, Mapping):
+        return MappingProxyType(
+            {
+                deepcopy(key): _freeze_option(nested_value)
+                for key, nested_value in value.items()
+            }
+        )
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_option(item) for item in value)
+    if isinstance(value, (set, frozenset)):
+        return frozenset(_freeze_option(item) for item in value)
+    return deepcopy(value)
+
+
 def _require_identifier(name: str, value: str) -> None:
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"{name} must not be empty")
@@ -34,7 +50,7 @@ class STTSPlaygroundRequest:
         object.__setattr__(
             self,
             "options",
-            MappingProxyType(deepcopy(dict(self.options))),
+            _freeze_option(self.options),
         )
 
 

--- a/tldw_chatbook/TTS/playground_types.py
+++ b/tldw_chatbook/TTS/playground_types.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any
+
+AudioMetadataValue = str | int | float | bool | None
+
+
+def _require_identifier(name: str, value: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must not be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class STTSPlaygroundRequest:
+    """Immutable snapshot of one Playground generation request."""
+
+    operation_id: str
+    provider_id: str
+    model_id: str
+    text: str
+    voice_id: str | None
+    response_format: str
+    speed: float = 1.0
+    options: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for name in ("operation_id", "provider_id", "model_id", "response_format"):
+            _require_identifier(name, getattr(self, name))
+        object.__setattr__(
+            self,
+            "options",
+            MappingProxyType(deepcopy(dict(self.options))),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class STTSGeneratedAudio:
+    """Immutable generated-audio artifact with request provenance."""
+
+    path: Path
+    provider_id: str
+    model_id: str
+    voice_id: str | None
+    source_text: str
+    operation_id: str
+    audio_format: str
+    content_type: str
+    metadata: Mapping[str, AudioMetadataValue] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for name in (
+            "operation_id",
+            "provider_id",
+            "model_id",
+            "audio_format",
+            "content_type",
+        ):
+            _require_identifier(name, getattr(self, name))
+        object.__setattr__(self, "path", Path(self.path))
+        object.__setattr__(
+            self,
+            "metadata",
+            MappingProxyType(deepcopy(dict(self.metadata))),
+        )
+
+    @property
+    def file_suffix(self) -> str:
+        """Return the suffix implied by the actual response format."""
+        return f".{self.audio_format.removeprefix('.')}"

--- a/tldw_chatbook/UI/STTS_Window.py
+++ b/tldw_chatbook/UI/STTS_Window.py
@@ -810,6 +810,18 @@ class TTSPlaygroundWidget(Widget):
         except asyncio.CancelledError:
             raise
         except Exception as error:
+            if isinstance(
+                error,
+                (TTSProviderReconfiguringError, TTSRegistryClosedError),
+            ):
+                if provider_id == self._selected_provider_id:
+                    self._stale_providers.add(provider_id)
+                    self._catalog_generation_allowed = False
+                    self._set_provider_status(
+                        self._catalog_error_copy(error, provider_id)
+                    )
+                    self._sync_generate_enabled()
+                return
             if not self._voice_token_is_current(token):
                 return
             logger.warning(
@@ -1278,20 +1290,28 @@ class TTSPlaygroundWidget(Widget):
             return "Please select a valid TTS provider"
         if not isinstance(model_id, str) or model_id.startswith("__"):
             return "Please select a valid TTS model"
-        if provider_id in self._pending_voice_selections:
-            return "Voices are still loading; wait before generating"
 
         service = self._tts_service
         catalog = self._catalogs.get(provider_id)
         if service is None or catalog is None:
             return "The selected provider catalog is not ready; refresh models"
+        revision_matches = self._catalog_configuration_revisions.get(
+            provider_id
+        ) == service.configuration_revision(provider_id)
+        if (
+            provider_id in self._pending_voice_selections
+            and provider_id not in self._stale_providers
+            and catalog.health.state == "available"
+            and catalog.health.fresh
+            and revision_matches
+        ):
+            return "Voices are still loading; wait before generating"
         if (
             provider_id in self._stale_providers
             or not self._catalog_generation_allowed
             or catalog.health.state != "available"
             or not catalog.health.fresh
-            or self._catalog_configuration_revisions.get(provider_id)
-            != service.configuration_revision(provider_id)
+            or not revision_matches
         ):
             return "The selected provider catalog is stale; refresh models"
         if not any(model.model_id == model_id for model in catalog.models):

--- a/tldw_chatbook/UI/STTS_Window.py
+++ b/tldw_chatbook/UI/STTS_Window.py
@@ -58,8 +58,12 @@ from tldw_chatbook.UI.stts_playground_catalog import (
     AUDIO_CPP_PROVIDER_ID,
     CatalogRequestToken,
     FIRST_AVAILABLE_MODEL_ID,
+    LOADING_SELECT_VALUE,
     PlaygroundControls,
     SERVER_DEFAULT_VOICE_ID,
+    UNAVAILABLE_SELECT_VALUE,
+    SelectSentinel,
+    SelectValue,
     controls_from_catalog,
     provider_options,
     voice_id_for_request,
@@ -235,6 +239,7 @@ class TTSPlaygroundWidget(Widget):
         self.higgs_reference_audio_path = None
         self._progress_timer_task = None
         self._play_worker_task = None
+        self._active_playback_release: Callable[[], None] | None = None
         self._tts_service = None
         self._provider_ids: frozenset[str] = frozenset()
         self._provider_display_names: dict[str, str] = {}
@@ -242,6 +247,7 @@ class TTSPlaygroundWidget(Widget):
         self._selected_provider_id: str | None = None
         self._catalogs: dict[str, TTSProviderCatalog] = {}
         self._catalog_configuration_revisions: dict[str, int] = {}
+        self._catalog_request_generations: dict[str, int] = {}
         self._discovered_voices: dict[tuple[str, str], tuple[str, ...]] = {}
         self._pending_voice_selections: dict[str, str] = {}
         self._provider_control_snapshots: dict[str, dict[str, Any]] = {}
@@ -249,7 +255,7 @@ class TTSPlaygroundWidget(Widget):
         self._catalog_generation_allowed = False
         self._applying_catalog_controls = False
         self._applied_model_id: str | None = None
-        self._applied_voice_id: str | None = None
+        self._applied_voice_id: SelectValue | None = None
         self._applied_format: str | None = None
         self._generation_operation_id: str | None = None
         self.example_texts = [
@@ -282,7 +288,7 @@ class TTSPlaygroundWidget(Widget):
             with Horizontal(classes="form-row"):
                 yield Label("Provider:", classes="form-label")
                 yield Select(
-                    options=[("Loading providers…", "__loading__")],
+                    options=[("Loading providers…", LOADING_SELECT_VALUE)],
                     id="tts-provider-select",
                     allow_blank=False,
                     disabled=True,
@@ -303,7 +309,7 @@ class TTSPlaygroundWidget(Widget):
             with Horizontal(classes="form-row"):
                 yield Label("Voice:", classes="form-label")
                 yield Select(
-                    options=[("Waiting for provider…", "__loading__")],
+                    options=[("Waiting for provider…", LOADING_SELECT_VALUE)],
                     id="tts-voice-select",
                     allow_blank=False,
                     disabled=True,
@@ -313,7 +319,7 @@ class TTSPlaygroundWidget(Widget):
             with Horizontal(classes="form-row"):
                 yield Label("Model:", classes="form-label")
                 yield Select(
-                    options=[("Waiting for provider…", "__loading__")],
+                    options=[("Waiting for provider…", LOADING_SELECT_VALUE)],
                     id="tts-model-select",
                     allow_blank=False,
                     disabled=True,
@@ -557,7 +563,7 @@ class TTSPlaygroundWidget(Widget):
             with Horizontal(classes="form-row"):
                 yield Label("Format:", classes="form-label")
                 yield Select(
-                    options=[("Waiting for provider…", "__loading__")],
+                    options=[("Waiting for provider…", LOADING_SELECT_VALUE)],
                     id="tts-format-select",
                     allow_blank=False,
                     disabled=True,
@@ -661,12 +667,15 @@ class TTSPlaygroundWidget(Widget):
             # Stop audio playback if active
             if hasattr(self.app, "audio_player"):
                 await self.app.audio_player.stop()
+                self._release_playback_artifact()
+            else:
+                self._release_playback_artifact()
 
             logger.debug("TTSPlaygroundWidget cleanup completed")
         except Exception as e:
             logger.error(f"Error during TTSPlaygroundWidget cleanup: {e}")
 
-    def _is_valid_voice(self, voice: str) -> bool:
+    def _is_valid_voice(self, voice: object) -> bool:
         """Check if a voice value is valid (not a separator)."""
         return bool(voice) and not str(voice).startswith("_separator")
 
@@ -683,6 +692,7 @@ class TTSPlaygroundWidget(Widget):
         initialize: bool = False,
     ) -> None:
         """Load descriptors and one selected provider catalog."""
+        token: CatalogRequestToken | None = None
         try:
             if self._tts_service is None:
                 self._tts_service = await get_tts_service()
@@ -729,9 +739,14 @@ class TTSPlaygroundWidget(Widget):
                 return
 
             configuration_revision = service.configuration_revision(provider_id)
+            request_generation = (
+                self._catalog_request_generations.get(provider_id, 0) + 1
+            )
+            self._catalog_request_generations[provider_id] = request_generation
             token = CatalogRequestToken(
                 provider_id=provider_id,
                 configuration_revision=configuration_revision,
+                request_generation=request_generation,
             )
             self._set_provider_status("Loading selected provider models…")
             catalog = await service.get_catalog(provider_id, refresh=refresh)
@@ -761,7 +776,7 @@ class TTSPlaygroundWidget(Widget):
             self._apply_catalog(provider_id, catalog)
 
             model_id = self._current_select_value("#tts-model-select")
-            if model_id is not None:
+            if isinstance(model_id, str):
                 self._load_provider_voices(
                     provider_id,
                     model_id,
@@ -772,6 +787,10 @@ class TTSPlaygroundWidget(Widget):
             raise
         except Exception as error:
             target = provider_id or self._selected_provider_id
+            if token is not None and not self._catalog_token_is_current(token):
+                if self._catalog_request_is_latest(token):
+                    self._mark_stale_catalog_result(token)
+                return
             if target is not None:
                 self._catalog_failure(
                     target,
@@ -855,7 +874,8 @@ class TTSPlaygroundWidget(Widget):
             return False
         catalog = self._catalogs.get(token.provider_id)
         current_revision = catalog.revision if catalog is not None else None
-        current_model = self._current_select_value("#tts-model-select")
+        selected_model = self._current_select_value("#tts-model-select")
+        current_model = selected_model if isinstance(selected_model, str) else None
         try:
             configuration_revision = service.configuration_revision(token.provider_id)
         except (KeyError, TTSRegistryClosedError):
@@ -865,17 +885,29 @@ class TTSPlaygroundWidget(Widget):
             configuration_revision=configuration_revision,
             catalog_revision=current_revision,
             model_id=current_model,
+            request_generation=None,
         )
 
     def _catalog_token_is_current(self, token: CatalogRequestToken) -> bool:
         service = self._tts_service
         if service is None:
             return False
+        try:
+            configuration_revision = service.configuration_revision(token.provider_id)
+        except (KeyError, TTSRegistryClosedError):
+            return False
         return token.matches(
             provider_id=self._selected_provider_id or "",
-            configuration_revision=service.configuration_revision(token.provider_id),
+            configuration_revision=configuration_revision,
             catalog_revision=None,
             model_id=None,
+            request_generation=self._catalog_request_generations.get(token.provider_id),
+        )
+
+    def _catalog_request_is_latest(self, token: CatalogRequestToken) -> bool:
+        """Return whether a catalog token is still its provider's newest request."""
+        return token.request_generation == self._catalog_request_generations.get(
+            token.provider_id
         )
 
     def _mark_stale_catalog_result(self, token: CatalogRequestToken) -> None:
@@ -897,18 +929,34 @@ class TTSPlaygroundWidget(Widget):
         snapshot = self._control_snapshot_for(provider_id)
         selected_model = snapshot.get("model_id")
         if selected_model is None:
-            selected_model = (
-                get_cli_setting("app_tts", "default_model", None)
-                if provider_id == AUDIO_CPP_PROVIDER_ID
-                else LEGACY_DEFAULT_MODELS.get(provider_id)
-            )
+            if provider_id == AUDIO_CPP_PROVIDER_ID:
+                configured_model = get_cli_setting(
+                    "app_tts",
+                    "default_model",
+                    None,
+                )
+                selected_model = (
+                    configured_model
+                    if isinstance(configured_model, str) and configured_model
+                    else None
+                )
+            else:
+                selected_model = LEGACY_DEFAULT_MODELS.get(provider_id)
         selected_voice = snapshot.get("voice_id")
         if selected_voice is None:
-            selected_voice = (
-                get_cli_setting("app_tts", "default_voice", None)
-                if provider_id == AUDIO_CPP_PROVIDER_ID
-                else LEGACY_DEFAULT_VOICES.get(provider_id)
-            )
+            if provider_id == AUDIO_CPP_PROVIDER_ID:
+                configured_voice = get_cli_setting(
+                    "app_tts",
+                    "default_voice",
+                    None,
+                )
+                selected_voice = (
+                    configured_voice
+                    if isinstance(configured_voice, str) and configured_voice
+                    else None
+                )
+            else:
+                selected_voice = LEGACY_DEFAULT_VOICES.get(provider_id)
         pending_voice = self._pending_voice_selections.get(provider_id)
         if pending_voice is not None:
             selected_voice = pending_voice
@@ -917,7 +965,7 @@ class TTSPlaygroundWidget(Widget):
             selected_format = get_cli_setting("app_tts", "default_format", None)
         speed = self._snapshot_speed(snapshot)
 
-        voice_choices: tuple[tuple[str, str], ...] | None = None
+        voice_choices: tuple[tuple[str, SelectValue], ...] | None = None
         discovered_voices: tuple[str, ...] | None
         if provider_id == AUDIO_CPP_PROVIDER_ID:
             model_for_voices = self._catalog_model_id(catalog, selected_model)
@@ -931,7 +979,6 @@ class TTSPlaygroundWidget(Widget):
                 voice_discovery_pending
                 and isinstance(selected_voice, str)
                 and selected_voice
-                and selected_voice != SERVER_DEFAULT_VOICE_ID
             ):
                 pending_voice = selected_voice
                 self._pending_voice_selections[provider_id] = selected_voice
@@ -1035,20 +1082,20 @@ class TTSPlaygroundWidget(Widget):
 
     @staticmethod
     def _safe_select_options(
-        options: tuple[tuple[str, str], ...],
-    ) -> list[tuple[Text, str]]:
+        options: tuple[tuple[str, SelectValue], ...],
+    ) -> list[tuple[Text, SelectValue]]:
         return [(Text(label, no_wrap=True), value) for label, value in options]
 
     def _set_select_state(
         self,
         select: Select,
-        options: tuple[tuple[str, str], ...],
-        selected: str | None,
+        options: tuple[tuple[str, SelectValue], ...],
+        selected: SelectValue | None,
         empty_label: str,
     ) -> None:
         if not options:
-            select.set_options([(empty_label, "__unavailable__")])
-            select.value = "__unavailable__"
+            select.set_options([(empty_label, UNAVAILABLE_SELECT_VALUE)])
+            select.value = UNAVAILABLE_SELECT_VALUE
             select.disabled = True
             return
         select.set_options(self._safe_select_options(options))
@@ -1083,13 +1130,11 @@ class TTSPlaygroundWidget(Widget):
         except (TypeError, ValueError):
             return 1.0
 
-    def _current_select_value(self, selector: str) -> str | None:
+    def _current_select_value(self, selector: str) -> SelectValue | None:
         value = self.query_one(selector, Select).value
-        if not isinstance(value, str):
+        if value is LOADING_SELECT_VALUE or value is UNAVAILABLE_SELECT_VALUE:
             return None
-        if value.startswith("__") and value != SERVER_DEFAULT_VOICE_ID:
-            return None
-        return value
+        return value if isinstance(value, (str, SelectSentinel)) else None
 
     @staticmethod
     def _catalog_model_id(
@@ -1288,7 +1333,7 @@ class TTSPlaygroundWidget(Widget):
             or provider_id not in self._provider_ids
         ):
             return "Please select a valid TTS provider"
-        if not isinstance(model_id, str) or model_id.startswith("__"):
+        if not isinstance(model_id, str):
             return "Please select a valid TTS model"
 
         service = self._tts_service
@@ -1385,7 +1430,7 @@ class TTSPlaygroundWidget(Widget):
             if catalog is not None:
                 self._apply_catalog(provider_id, catalog)
                 model_id = self._current_select_value("#tts-model-select")
-                if model_id is not None:
+                if isinstance(model_id, str):
                     self._load_provider_voices(
                         provider_id,
                         model_id,
@@ -1403,7 +1448,9 @@ class TTSPlaygroundWidget(Widget):
                 return
             if event.select.id == "tts-voice-select":
                 self._applied_voice_id = (
-                    event.value if isinstance(event.value, str) else None
+                    event.value
+                    if isinstance(event.value, (str, SelectSentinel))
+                    else None
                 )
             else:
                 self._applied_format = (
@@ -1426,10 +1473,14 @@ class TTSPlaygroundWidget(Widget):
     def on_tts_text_changed(self, _event: TextArea.Changed) -> None:
         self._sync_generate_enabled()
 
-    def _get_select_key(self, select_widget: Select) -> Optional[str]:
+    def _get_select_key(self, select_widget: Select) -> SelectValue | None:
         """Return exact canonical values for catalog-driven controls."""
         current = select_widget.value
-        if not isinstance(current, str) or current.startswith("__"):
+        if current is LOADING_SELECT_VALUE or current is UNAVAILABLE_SELECT_VALUE:
+            return None
+        if current is SERVER_DEFAULT_VOICE_ID:
+            return current
+        if not isinstance(current, str):
             return None
         if select_widget.id == "tts-language-select":
             for language_id, display_name in select_widget._options:
@@ -1684,13 +1735,13 @@ class TTSPlaygroundWidget(Widget):
         if not isinstance(provider, str) or provider not in self._provider_ids:
             self.app.notify("Please select a valid TTS provider", severity="warning")
             return
-        if not isinstance(model, str) or model.startswith("__"):
+        if not isinstance(model, str):
             self.app.notify("Please select a valid TTS model", severity="warning")
             return
         if not isinstance(format, str):
             self.app.notify("Please select a valid audio format", severity="warning")
             return
-        voice_id = voice_id_for_request(voice if isinstance(voice, str) else None)
+        voice_id = voice_id_for_request(voice)
         if provider == AUDIO_CPP_PROVIDER_ID:
             format = "wav"
             speed = 1.0
@@ -1831,6 +1882,13 @@ class TTSPlaygroundWidget(Widget):
 
         return audio_path, release_once
 
+    def _release_playback_artifact(self) -> None:
+        """Release the artifact retained by the active playback, if any."""
+        release = self._active_playback_release
+        self._active_playback_release = None
+        if release is not None:
+            release()
+
     def _play_audio(self) -> None:
         """Play the generated audio"""
         logger.debug(
@@ -1910,6 +1968,7 @@ class TTSPlaygroundWidget(Widget):
                     # Always force stop any existing playback first
                     stop_result = await self.app.audio_player.stop()
                     logger.debug(f"Stop result: {stop_result}")
+                    self._release_playback_artifact()
 
                     # Small delay to ensure clean state
                     import asyncio
@@ -1926,6 +1985,9 @@ class TTSPlaygroundWidget(Widget):
                     logger.debug(f"Play result: {success}")
 
                     if success:
+                        self._active_playback_release = release_artifact
+                        release_artifact = None
+
                         # Cancel any existing progress timer
                         if (
                             self._progress_timer_task
@@ -2083,6 +2145,7 @@ class TTSPlaygroundWidget(Widget):
             # Force stop any playback
             success = await self.app.audio_player.stop()
             logger.debug(f"Stop result: {success}")
+            self._release_playback_artifact()
 
             # Also ensure progress timer is cancelled
             if self._progress_timer_task and not self._progress_timer_task.done():
@@ -2174,6 +2237,10 @@ class TTSPlaygroundWidget(Widget):
 
         try:
             import shutil
+            from tldw_chatbook.Utils.path_validation import (
+                validate_filename,
+                validate_path_simple,
+            )
 
             dest_path = Path(path)
 
@@ -2185,6 +2252,14 @@ class TTSPlaygroundWidget(Widget):
                     severity="warning",
                 )
                 dest_path = dest_path.with_suffix(source_path.suffix)
+
+            validate_path_simple(dest_path, require_exists=False)
+            validated_parent = validate_path_simple(
+                dest_path.parent,
+                require_exists=True,
+            ).resolve()
+            validated_filename = validate_filename(dest_path.name)
+            dest_path = validated_parent / validated_filename
 
             # Copy the file
             shutil.copy2(source_path, dest_path)
@@ -2363,6 +2438,8 @@ class TTSPlaygroundWidget(Widget):
                         progress_bar.remove_class("hidden")
                         time_display.remove_class("hidden")
                 elif state in [PlaybackState.IDLE, PlaybackState.FINISHED]:
+                    self._release_playback_artifact()
+
                     # Hide progress elements
                     self.query_one("#audio-progress-bar").add_class("hidden")
                     self.query_one("#audio-time-display").add_class("hidden")
@@ -2415,6 +2492,10 @@ class TTSSettingsWidget(Widget):
     kokoro_model_path = reactive("")
     kokoro_voices_path = reactive("")
     chatterbox_voice_dir = reactive("")
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._audio_cpp_discovery_generation = 0
 
     DEFAULT_CSS = """
     TTSSettingsWidget {
@@ -3476,7 +3557,7 @@ class TTSSettingsWidget(Widget):
             self._browse_higgs_voices_dir()
             event.stop()
 
-    def _is_valid_voice(self, voice: str) -> bool:
+    def _is_valid_voice(self, voice: object) -> bool:
         """Check if a voice value is valid (not a separator)"""
         return bool(voice) and not str(voice).startswith("_separator")
 
@@ -3686,7 +3767,6 @@ class TTSSettingsWidget(Widget):
                 configured_provider == AUDIO_CPP_PROVIDER_ID
                 and isinstance(stored_model, str)
                 and stored_model
-                and not stored_model.startswith("__")
             ):
                 options.append(("Saved server model", stored_model))
                 selected = stored_model
@@ -3772,12 +3852,14 @@ class TTSSettingsWidget(Widget):
             settings["default_provider"] = self.query_one(
                 "#default-provider-select", Select
             ).value
-            settings["default_voice"] = self.query_one(
-                "#default-voice-select", Select
-            ).value
-            settings["default_model"] = self.query_one(
-                "#default-model-select", Select
-            ).value
+            default_voice = self.query_one("#default-voice-select", Select).value
+            settings["default_voice"] = (
+                default_voice if isinstance(default_voice, str) else ""
+            )
+            default_model = self.query_one("#default-model-select", Select).value
+            settings["default_model"] = (
+                default_model if isinstance(default_model, str) else ""
+            )
             settings["default_format"] = self.query_one(
                 "#default-format-select", Select
             ).value
@@ -4083,19 +4165,21 @@ class TTSSettingsWidget(Widget):
     )
     async def _discover_audio_cpp(self, action: str) -> None:
         """Test or refresh the currently saved external audio.cpp service."""
+        self._audio_cpp_discovery_generation += 1
+        request_generation = self._audio_cpp_discovery_generation
         status = self.query_one("#audio-cpp-discovery-status", Static)
         status.update("Checking saved settings…")
+        service = None
+        before_revision: int | None = None
         try:
             service = await get_tts_service()
             before_revision = service.configuration_revision("audio_cpp")
             catalog = await service.get_catalog("audio_cpp", refresh=True)
             after_revision = service.configuration_revision("audio_cpp")
+            if request_generation != self._audio_cpp_discovery_generation:
+                return
             if before_revision != after_revision:
-                status.update("Settings changed; retry")
-                self.app.notify(
-                    "audio.cpp settings changed; retry the check",
-                    severity="warning",
-                )
+                self._report_audio_cpp_settings_changed(status)
                 return
             if (
                 catalog.provider_id != "audio_cpp"
@@ -4120,12 +4204,32 @@ class TTSSettingsWidget(Widget):
         except asyncio.CancelledError:
             raise
         except Exception:
+            if request_generation != self._audio_cpp_discovery_generation:
+                return
+            if service is not None and before_revision is not None:
+                try:
+                    after_revision = service.configuration_revision("audio_cpp")
+                except Exception:
+                    after_revision = None
+                if request_generation != self._audio_cpp_discovery_generation:
+                    return
+                if after_revision is not None and before_revision != after_revision:
+                    self._report_audio_cpp_settings_changed(status)
+                    return
             logger.warning("audio.cpp settings discovery failed")
             status.update("Unavailable")
             self.app.notify(
                 "audio.cpp is not ready; check the saved settings",
                 severity="error",
             )
+
+    def _report_audio_cpp_settings_changed(self, status: Static) -> None:
+        """Report that an explicit discovery result is no longer authoritative."""
+        status.update("Settings changed; retry")
+        self.app.notify(
+            "audio.cpp settings changed; retry the check",
+            severity="warning",
+        )
 
     def _validate_numeric_input(
         self, value: str, min_val: float, max_val: float, default: float

--- a/tldw_chatbook/UI/STTS_Window.py
+++ b/tldw_chatbook/UI/STTS_Window.py
@@ -248,6 +248,7 @@ class TTSPlaygroundWidget(Widget):
         self._catalogs: dict[str, TTSProviderCatalog] = {}
         self._catalog_configuration_revisions: dict[str, int] = {}
         self._catalog_request_generations: dict[str, int] = {}
+        self._voice_request_generations: dict[tuple[str, str], int] = {}
         self._discovered_voices: dict[tuple[str, str], tuple[str, ...]] = {}
         self._pending_voice_selections: dict[str, str] = {}
         self._provider_control_snapshots: dict[str, dict[str, Any]] = {}
@@ -751,7 +752,8 @@ class TTSPlaygroundWidget(Widget):
             self._set_provider_status("Loading selected provider models…")
             catalog = await service.get_catalog(provider_id, refresh=refresh)
             if not self._catalog_token_is_current(token):
-                self._mark_stale_catalog_result(token)
+                if self._catalog_request_is_latest(token):
+                    self._mark_stale_catalog_result(token)
                 return
             if catalog.provider_id != provider_id:
                 self._catalog_failure(
@@ -814,11 +816,15 @@ class TTSPlaygroundWidget(Widget):
         service = self._tts_service
         if service is None:
             return
+        request_key = (provider_id, model_id)
+        request_generation = self._voice_request_generations.get(request_key, 0) + 1
+        self._voice_request_generations[request_key] = request_generation
         token = CatalogRequestToken(
             provider_id=provider_id,
             configuration_revision=service.configuration_revision(provider_id),
             catalog_revision=catalog_revision,
             model_id=model_id,
+            request_generation=request_generation,
         )
         try:
             voices = await service.get_voices(
@@ -829,6 +835,8 @@ class TTSPlaygroundWidget(Widget):
         except asyncio.CancelledError:
             raise
         except Exception as error:
+            if not self._voice_token_is_current(token):
+                return
             if isinstance(
                 error,
                 (TTSProviderReconfiguringError, TTSRegistryClosedError),
@@ -840,8 +848,6 @@ class TTSPlaygroundWidget(Widget):
                         self._catalog_error_copy(error, provider_id)
                     )
                     self._sync_generate_enabled()
-                return
-            if not self._voice_token_is_current(token):
                 return
             logger.warning(
                 "TTS voice discovery failed ({})",
@@ -885,7 +891,9 @@ class TTSPlaygroundWidget(Widget):
             configuration_revision=configuration_revision,
             catalog_revision=current_revision,
             model_id=current_model,
-            request_generation=None,
+            request_generation=self._voice_request_generations.get(
+                (token.provider_id, token.model_id or "")
+            ),
         )
 
     def _catalog_token_is_current(self, token: CatalogRequestToken) -> bool:

--- a/tldw_chatbook/UI/STTS_Window.py
+++ b/tldw_chatbook/UI/STTS_Window.py
@@ -49,6 +49,11 @@ from tldw_chatbook.TTS.adapter_types import (
     TTSRegistryClosedError,
 )
 from tldw_chatbook.TTS.audio_cpp_config import AudioCppConfig
+from tldw_chatbook.TTS.legacy_catalogs import (
+    LEGACY_DEFAULT_MODELS,
+    LEGACY_DEFAULT_VOICES,
+    LEGACY_VOICE_OPTIONS,
+)
 from tldw_chatbook.UI.stts_playground_catalog import (
     AUDIO_CPP_PROVIDER_ID,
     CatalogRequestToken,
@@ -823,6 +828,13 @@ class TTSPlaygroundWidget(Widget):
                 type(error).__name__,
             )
             if provider_id == self._selected_provider_id:
+                self._pending_voice_selections.pop(provider_id, None)
+                self._provider_control_snapshots.setdefault(provider_id, {})[
+                    "voice_id"
+                ] = SERVER_DEFAULT_VOICE_ID
+                catalog = self._catalogs.get(provider_id)
+                if catalog is not None:
+                    self._apply_catalog(provider_id, catalog)
                 self._set_provider_status(
                     "Voices are unavailable; the provider default remains available"
                 )
@@ -857,10 +869,18 @@ class TTSPlaygroundWidget(Widget):
         snapshot = self._control_snapshot_for(provider_id)
         selected_model = snapshot.get("model_id")
         if selected_model is None:
-            selected_model = get_cli_setting("app_tts", "default_model", None)
+            selected_model = (
+                get_cli_setting("app_tts", "default_model", None)
+                if provider_id == AUDIO_CPP_PROVIDER_ID
+                else LEGACY_DEFAULT_MODELS.get(provider_id)
+            )
         selected_voice = snapshot.get("voice_id")
         if selected_voice is None:
-            selected_voice = get_cli_setting("app_tts", "default_voice", None)
+            selected_voice = (
+                get_cli_setting("app_tts", "default_voice", None)
+                if provider_id == AUDIO_CPP_PROVIDER_ID
+                else LEGACY_DEFAULT_VOICES.get(provider_id)
+            )
         pending_voice = self._pending_voice_selections.get(provider_id)
         if pending_voice is not None:
             selected_voice = pending_voice
@@ -883,6 +903,7 @@ class TTSPlaygroundWidget(Widget):
                 voice_discovery_pending
                 and isinstance(selected_voice, str)
                 and selected_voice
+                and selected_voice != SERVER_DEFAULT_VOICE_ID
             ):
                 pending_voice = selected_voice
                 self._pending_voice_selections[provider_id] = selected_voice
@@ -914,6 +935,8 @@ class TTSPlaygroundWidget(Widget):
             self._provider_control_snapshots.setdefault(provider_id, {})["voice_id"] = (
                 pending_voice
             )
+            self._catalog_generation_allowed = False
+            self._sync_generate_enabled()
         elif provider_id == AUDIO_CPP_PROVIDER_ID and discovered_voices is not None:
             self._pending_voice_selections.pop(provider_id, None)
 
@@ -1064,42 +1087,17 @@ class TTSPlaygroundWidget(Widget):
         provider_id: str,
         base_voices: tuple[str, ...],
     ) -> tuple[tuple[str, str], ...]:
+        configured_choices = LEGACY_VOICE_OPTIONS.get(provider_id)
+        choices = (
+            list(configured_choices)
+            if configured_choices is not None
+            else [(voice.replace("_", " ").title(), voice) for voice in base_voices]
+        )
         if provider_id == "chatterbox":
-            choices = [
-                ("Default Voice", "default"),
-                ("Upload Reference Audio", "custom"),
-            ]
             choices.extend(self._chatterbox_profile_choices())
-            return tuple(choices)
-        if provider_id == "higgs":
-            choices = [
-                ("Professional Female", "professional_female"),
-                ("Warm Female", "warm_female"),
-                ("Storyteller Male", "storyteller_male"),
-                ("Deep Male", "deep_male"),
-                ("Energetic Female", "energetic_female"),
-                ("Soft Female", "soft_female"),
-                ("Upload Reference Audio", "custom"),
-            ]
+        elif provider_id == "higgs":
             choices.extend(self._higgs_profile_choices())
-            return tuple(choices)
-        if provider_id == "alltalk":
-            return tuple(
-                (name.replace("_", " ").replace(".wav", "").title(), name)
-                for name in (
-                    "female_01.wav",
-                    "female_02.wav",
-                    "female_03.wav",
-                    "female_04.wav",
-                    "male_01.wav",
-                    "male_02.wav",
-                    "male_03.wav",
-                    "male_04.wav",
-                )
-            )
-
-        choices = [(voice.replace("_", " ").title(), voice) for voice in base_voices]
-        if provider_id == "kokoro":
+        elif provider_id == "kokoro":
             choices.extend(self._kokoro_blend_choices())
         return tuple(choices)
 
@@ -1262,6 +1260,8 @@ class TTSPlaygroundWidget(Widget):
             return "Please select a valid TTS provider"
         if not isinstance(model_id, str) or model_id.startswith("__"):
             return "Please select a valid TTS model"
+        if provider_id in self._pending_voice_selections:
+            return "Voices are still loading; wait before generating"
 
         service = self._tts_service
         catalog = self._catalogs.get(provider_id)

--- a/tldw_chatbook/UI/STTS_Window.py
+++ b/tldw_chatbook/UI/STTS_Window.py
@@ -737,6 +737,16 @@ class TTSPlaygroundWidget(Widget):
                 )
                 return
 
+            previous_catalog = self._catalogs.get(provider_id)
+            if (
+                previous_catalog is not None
+                and previous_catalog.revision != catalog.revision
+            ):
+                self._discovered_voices = {
+                    key: value
+                    for key, value in self._discovered_voices.items()
+                    if key[0] != provider_id
+                }
             self._catalogs[provider_id] = catalog
             self._catalog_configuration_revisions[provider_id] = configuration_revision
             self._stale_providers.discard(provider_id)

--- a/tldw_chatbook/UI/STTS_Window.py
+++ b/tldw_chatbook/UI/STTS_Window.py
@@ -243,6 +243,7 @@ class TTSPlaygroundWidget(Widget):
         self._applied_model_id: str | None = None
         self._applied_voice_id: str | None = None
         self._applied_format: str | None = None
+        self._generation_operation_id: str | None = None
         self.example_texts = [
             "Welcome to the Text-to-Speech playground! This is where you can experiment with different voices, providers, and settings to create natural-sounding speech.",
             "The quick brown fox jumps over the lazy dog. This pangram contains all letters of the alphabet.",
@@ -626,6 +627,7 @@ class TTSPlaygroundWidget(Widget):
 
     def on_mount(self) -> None:
         """Load provider descriptors and only the selected provider catalog."""
+        self._rehydrate_handler_state()
         self._load_provider_catalog(initialize=True)
 
     async def on_unmount(self) -> None:
@@ -633,6 +635,7 @@ class TTSPlaygroundWidget(Widget):
         try:
             self.app.workers.cancel_group(self, "stts-catalog-discovery")
             self.app.workers.cancel_group(self, "stts-voice-discovery")
+            self.app.workers.cancel_group(self, "stts-playback")
             # Cancel any active progress timer
             if self._progress_timer_task and not self._progress_timer_task.done():
                 self._progress_timer_task.cancel()
@@ -642,7 +645,7 @@ class TTSPlaygroundWidget(Widget):
             if (
                 hasattr(self, "_play_worker_task")
                 and self._play_worker_task
-                and not self._play_worker_task.done()
+                and not self._play_worker_task.is_finished
             ):
                 self._play_worker_task.cancel()
                 await asyncio.sleep(0.05)
@@ -1192,6 +1195,7 @@ class TTSPlaygroundWidget(Widget):
             text_present
             and self._catalog_generation_allowed
             and revision_matches
+            and self._generation_operation_id is None
             and not getattr(self.app, "_is_generating", False)
         )
 
@@ -1563,51 +1567,86 @@ class TTSPlaygroundWidget(Widget):
         # Disable generate button
         self.query_one("#tts-generate-btn", Button).disabled = True
 
-        # Post event to generate TTS
-        self.app.post_message(
-            STTSPlaygroundGenerateEvent(
-                STTSPlaygroundRequest(
-                    operation_id=str(uuid4()),
-                    provider_id=provider,
-                    model_id=model,
-                    text=text,
-                    voice_id=voice_id,
-                    response_format=format,
-                    speed=speed,
-                    options=extra_params,
-                )
-            )
+        request = STTSPlaygroundRequest(
+            operation_id=str(uuid4()),
+            provider_id=provider,
+            model_id=model,
+            text=text,
+            voice_id=voice_id,
+            response_format=format,
+            speed=speed,
+            options=extra_params,
         )
+        self._generation_operation_id = request.operation_id
+        self.app.post_message(STTSPlaygroundGenerateEvent(request))
 
     def _generation_complete(
         self,
         artifact: STTSGeneratedAudio | None,
     ) -> None:
         """Store one delivered artifact independently of current selectors."""
+        if (
+            artifact is not None
+            and self._generation_operation_id is not None
+            and artifact.operation_id != self._generation_operation_id
+        ):
+            return
+        self._generation_operation_id = None
         self._sync_generate_enabled()
 
         if artifact is not None:
-            self.current_audio_artifact = artifact
-            self.current_audio_file = artifact.path
-
-            log = self.query_one("#tts-generation-log", RichLog)
-            log.write("[bold green]✓ TTS generation complete![/bold green]")
-
-            # Enable audio controls
-            self.query_one("#audio-play-btn", Button).disabled = False
-            self.query_one(
-                "#pause-audio-btn", Button
-            ).disabled = True  # Disabled until playing
-            self.query_one(
-                "#stop-audio-btn", Button
-            ).disabled = True  # Disabled until playing
-            self.query_one("#audio-export-btn", Button).disabled = False
-            self.query_one("#audio-player-status", Static).update(
-                f"{artifact.audio_format.upper()} audio ready to play"
-            )
+            self._store_delivered_artifact(artifact, announce=True)
         else:
             log = self.query_one("#tts-generation-log", RichLog)
             log.write("[bold red]✗ TTS generation failed![/bold red]")
+
+    def _store_delivered_artifact(
+        self,
+        artifact: STTSGeneratedAudio,
+        *,
+        announce: bool,
+    ) -> None:
+        self.current_audio_artifact = artifact
+        self.current_audio_file = artifact.path
+        if announce:
+            self.query_one("#tts-generation-log", RichLog).write(
+                "[bold green]✓ TTS generation complete![/bold green]"
+            )
+        self.query_one("#audio-play-btn", Button).disabled = False
+        self.query_one("#pause-audio-btn", Button).disabled = True
+        self.query_one("#stop-audio-btn", Button).disabled = True
+        self.query_one("#audio-export-btn", Button).disabled = False
+        self.query_one("#audio-player-status", Static).update(
+            f"{artifact.audio_format.upper()} audio ready to play"
+        )
+
+    def _rehydrate_handler_state(self) -> None:
+        handler = getattr(self.app, "_stts_handler", None)
+        snapshot_getter = getattr(handler, "playground_state", None)
+        if not callable(snapshot_getter):
+            return
+        try:
+            state = snapshot_getter()
+        except Exception as error:
+            logger.debug(
+                "Could not rehydrate TTS Playground state ({})",
+                type(error).__name__,
+            )
+            return
+        artifact = getattr(state, "artifact", None)
+        if isinstance(artifact, STTSGeneratedAudio) and artifact.path.exists():
+            self._store_delivered_artifact(artifact, announce=False)
+        active_operation_id = getattr(state, "active_operation_id", None)
+        if getattr(state, "generation_active", False) and isinstance(
+            active_operation_id,
+            str,
+        ):
+            self._generation_operation_id = active_operation_id
+            self.query_one("#generation-status-container").remove_class("hidden")
+            self.query_one("#generation-status-text", Static).update(
+                "Generation in progress…"
+            )
+            self.query_one("#tts-generate-btn", Button).disabled = True
 
     def _current_generated_audio_path(self) -> Path | None:
         """Return the delivered artifact path, with legacy path fallback."""
@@ -1627,7 +1666,7 @@ class TTSPlaygroundWidget(Widget):
         if (
             hasattr(self, "_play_worker_task")
             and self._play_worker_task
-            and not self._play_worker_task.done()
+            and not self._play_worker_task.is_finished
         ):
             logger.debug("Play already in progress, ignoring request")
             return
@@ -1662,7 +1701,9 @@ class TTSPlaygroundWidget(Widget):
             # Use the new audio player method
             # Store the worker task so we can check if it's running
             self._play_worker_task = self.run_worker(
-                self._play_audio_async, exclusive=False
+                self._play_audio_async,
+                group="stts-playback",
+                exclusive=True,
             )
         else:
             self.app.notify("Audio playback not available", severity="warning")
@@ -1770,8 +1811,11 @@ class TTSPlaygroundWidget(Widget):
         logger.debug("_pause_audio called")
         if self._ensure_audio_player():
             logger.debug("Audio player available, running pause worker")
-            # Don't use exclusive worker for pause - it needs to interrupt play
-            self.run_worker(self._pause_audio_async, exclusive=False)
+            self.run_worker(
+                self._pause_audio_async,
+                group="stts-playback",
+                exclusive=True,
+            )
         else:
             logger.debug("Audio player not available")
             self.app.notify("Audio player not available", severity="warning")
@@ -1826,8 +1870,11 @@ class TTSPlaygroundWidget(Widget):
         logger.debug("_stop_audio called")
         if self._ensure_audio_player():
             logger.debug("Audio player available, running stop worker")
-            # Don't use exclusive worker for stop - it needs to interrupt play
-            self.run_worker(self._stop_audio_async, exclusive=False)
+            self.run_worker(
+                self._stop_audio_async,
+                group="stts-playback",
+                exclusive=True,
+            )
         else:
             logger.debug("Audio player not available")
             self.app.notify("Audio player not available", severity="warning")

--- a/tldw_chatbook/UI/STTS_Window.py
+++ b/tldw_chatbook/UI/STTS_Window.py
@@ -792,52 +792,68 @@ class TTSPlaygroundWidget(Widget):
         refresh: bool = False,
     ) -> None:
         """Load voices for only the selected provider model."""
+        service = self._tts_service
+        if service is None:
+            return
+        token = CatalogRequestToken(
+            provider_id=provider_id,
+            configuration_revision=service.configuration_revision(provider_id),
+            catalog_revision=catalog_revision,
+            model_id=model_id,
+        )
         try:
-            service = self._tts_service
-            if service is None:
-                return
-            token = CatalogRequestToken(
-                provider_id=provider_id,
-                configuration_revision=service.configuration_revision(provider_id),
-                catalog_revision=catalog_revision,
-                model_id=model_id,
-            )
             voices = await service.get_voices(
                 provider_id,
                 model_id,
                 refresh=refresh,
             )
-            catalog = self._catalogs.get(provider_id)
-            current_revision = catalog.revision if catalog is not None else None
-            current_model = self._current_select_value("#tts-model-select")
-            if not token.matches(
-                provider_id=self._selected_provider_id or "",
-                configuration_revision=service.configuration_revision(provider_id),
-                catalog_revision=current_revision,
-                model_id=current_model,
-            ):
-                return
-            self._discovered_voices[(provider_id, model_id)] = tuple(voices)
-            if catalog is not None:
-                self._apply_catalog(provider_id, catalog)
         except asyncio.CancelledError:
             raise
         except Exception as error:
+            if not self._voice_token_is_current(token):
+                return
             logger.warning(
                 "TTS voice discovery failed ({})",
                 type(error).__name__,
             )
-            if provider_id == self._selected_provider_id:
-                self._pending_voice_selections.pop(provider_id, None)
-                self._provider_control_snapshots.setdefault(provider_id, {})[
-                    "voice_id"
-                ] = SERVER_DEFAULT_VOICE_ID
-                catalog = self._catalogs.get(provider_id)
-                if catalog is not None:
-                    self._apply_catalog(provider_id, catalog)
-                self._set_provider_status(
-                    "Voices are unavailable; the provider default remains available"
-                )
+            self._discovered_voices[(provider_id, model_id)] = ()
+            self._pending_voice_selections.pop(provider_id, None)
+            self._provider_control_snapshots.setdefault(provider_id, {})["voice_id"] = (
+                SERVER_DEFAULT_VOICE_ID
+            )
+            catalog = self._catalogs.get(provider_id)
+            if catalog is not None:
+                self._apply_catalog(provider_id, catalog)
+            self._set_provider_status(
+                "Voices are unavailable; the provider default remains available"
+            )
+            return
+
+        if not self._voice_token_is_current(token):
+            return
+        self._discovered_voices[(provider_id, model_id)] = tuple(voices)
+        catalog = self._catalogs.get(provider_id)
+        if catalog is not None:
+            self._apply_catalog(provider_id, catalog)
+
+    def _voice_token_is_current(self, token: CatalogRequestToken) -> bool:
+        """Return whether a voice result still targets the displayed model."""
+        service = self._tts_service
+        if service is None or not self.is_mounted:
+            return False
+        catalog = self._catalogs.get(token.provider_id)
+        current_revision = catalog.revision if catalog is not None else None
+        current_model = self._current_select_value("#tts-model-select")
+        try:
+            configuration_revision = service.configuration_revision(token.provider_id)
+        except (KeyError, TTSRegistryClosedError):
+            return False
+        return token.matches(
+            provider_id=self._selected_provider_id or "",
+            configuration_revision=configuration_revision,
+            catalog_revision=current_revision,
+            model_id=current_model,
+        )
 
     def _catalog_token_is_current(self, token: CatalogRequestToken) -> bool:
         service = self._tts_service
@@ -1057,7 +1073,9 @@ class TTSPlaygroundWidget(Widget):
 
     def _current_select_value(self, selector: str) -> str | None:
         value = self.query_one(selector, Select).value
-        if not isinstance(value, str) or value.startswith("__"):
+        if not isinstance(value, str):
+            return None
+        if value.startswith("__") and value != SERVER_DEFAULT_VOICE_ID:
             return None
         return value
 

--- a/tldw_chatbook/UI/STTS_Window.py
+++ b/tldw_chatbook/UI/STTS_Window.py
@@ -4,6 +4,7 @@
 # Imports
 import asyncio
 from collections.abc import Mapping
+from dataclasses import replace
 from typing import Optional, Dict, Any, List
 from pathlib import Path
 from urllib.parse import urlsplit
@@ -26,6 +27,7 @@ from textual.reactive import reactive
 from textual.binding import Binding
 from textual import on, work
 from loguru import logger
+from rich.text import Text
 
 # Local imports
 from tldw_chatbook.config import get_cli_setting
@@ -35,7 +37,20 @@ from tldw_chatbook.Event_Handlers.STTS_Events.stts_events import (
     STTSAudioBookGenerateEvent,
 )
 from tldw_chatbook.TTS import get_tts_service
+from tldw_chatbook.TTS.adapter_types import (
+    TTSOperationError,
+    TTSProviderCatalog,
+    TTSProviderReconfiguringError,
+    TTSRegistryClosedError,
+)
 from tldw_chatbook.TTS.audio_cpp_config import AudioCppConfig
+from tldw_chatbook.UI.stts_playground_catalog import (
+    AUDIO_CPP_PROVIDER_ID,
+    CatalogRequestToken,
+    PlaygroundControls,
+    controls_from_catalog,
+    provider_options,
+)
 from tldw_chatbook.UI.destination_recovery import optional_dependency_recovery_state
 from tldw_chatbook.Widgets.voice_blend_dialog import VoiceBlendDialog
 from tldw_chatbook.Widgets.enhanced_file_picker import (
@@ -206,6 +221,21 @@ class TTSPlaygroundWidget(Widget):
         self.higgs_reference_audio_path = None
         self._progress_timer_task = None
         self._play_worker_task = None
+        self._tts_service = None
+        self._provider_ids: frozenset[str] = frozenset()
+        self._provider_display_names: dict[str, str] = {}
+        self._displayed_provider_id: str | None = None
+        self._selected_provider_id: str | None = None
+        self._catalogs: dict[str, TTSProviderCatalog] = {}
+        self._catalog_configuration_revisions: dict[str, int] = {}
+        self._discovered_voices: dict[tuple[str, str], tuple[str, ...]] = {}
+        self._provider_control_snapshots: dict[str, dict[str, Any]] = {}
+        self._stale_providers: set[str] = set()
+        self._catalog_generation_allowed = False
+        self._applying_catalog_controls = False
+        self._applied_model_id: str | None = None
+        self._applied_voice_id: str | None = None
+        self._applied_format: str | None = None
         self.example_texts = [
             "Welcome to the Text-to-Speech playground! This is where you can experiment with different voices, providers, and settings to create natural-sounding speech.",
             "The quick brown fox jumps over the lazy dog. This pangram contains all letters of the alphabet.",
@@ -236,31 +266,41 @@ class TTSPlaygroundWidget(Widget):
             with Horizontal(classes="form-row"):
                 yield Label("Provider:", classes="form-label")
                 yield Select(
-                    options=[
-                        ("openai", "OpenAI"),
-                        ("elevenlabs", "ElevenLabs"),
-                        ("kokoro", "Kokoro (Local)"),
-                        ("chatterbox", "Chatterbox (Local)"),
-                        ("higgs", "Higgs Audio (Local)"),
-                        ("alltalk", "AllTalk (Local)"),
-                    ],
+                    options=[("Loading providers…", "__loading__")],
                     id="tts-provider-select",
+                    allow_blank=False,
+                    disabled=True,
                 )
+                yield Button(
+                    "Refresh Models",
+                    id="tts-refresh-catalog-btn",
+                    disabled=True,
+                )
+
+            yield Static(
+                "Loading TTS providers…",
+                id="tts-provider-status",
+                classes="status-text",
+            )
 
             # Voice selection (will be populated based on provider)
             with Horizontal(classes="form-row"):
                 yield Label("Voice:", classes="form-label")
                 yield Select(
-                    options=[],  # Will be populated on mount
+                    options=[("Waiting for provider…", "__loading__")],
                     id="tts-voice-select",
+                    allow_blank=False,
+                    disabled=True,
                 )
 
             # Model selection
             with Horizontal(classes="form-row"):
                 yield Label("Model:", classes="form-label")
                 yield Select(
-                    options=[],  # Will be populated on mount
+                    options=[("Waiting for provider…", "__loading__")],
                     id="tts-model-select",
+                    allow_blank=False,
+                    disabled=True,
                 )
 
             # Language selection (for Kokoro)
@@ -299,6 +339,7 @@ class TTSPlaygroundWidget(Widget):
                     value="1.0",
                     placeholder="0.25-4.0",
                     type="number",
+                    disabled=True,
                 )
 
             # ElevenLabs-specific settings
@@ -500,21 +541,24 @@ class TTSPlaygroundWidget(Widget):
             with Horizontal(classes="form-row"):
                 yield Label("Format:", classes="form-label")
                 yield Select(
-                    options=[
-                        ("mp3", "MP3"),
-                        ("opus", "Opus"),
-                        ("aac", "AAC"),
-                        ("flac", "FLAC"),
-                        ("wav", "WAV"),
-                        ("pcm", "PCM"),
-                    ],
+                    options=[("Waiting for provider…", "__loading__")],
                     id="tts-format-select",
+                    allow_blank=False,
+                    disabled=True,
                 )
+            yield Static(
+                "audio.cpp returns one complete WAV and currently uses speed 1.0.",
+                id="tts-audio-cpp-restrictions",
+                classes="status-text hidden",
+            )
 
             # Generate button and quick actions
             with Horizontal(classes="form-row"):
                 yield Button(
-                    "🔊 Generate Speech", id="tts-generate-btn", variant="primary"
+                    "🔊 Generate Speech",
+                    id="tts-generate-btn",
+                    variant="primary",
+                    disabled=True,
                 )
                 yield Button(
                     "🎲 Random Text", id="tts-random-text-btn", variant="default"
@@ -574,13 +618,14 @@ class TTSPlaygroundWidget(Widget):
             )
 
     def on_mount(self) -> None:
-        """Initialize default values on mount"""
-        # Delay initialization to ensure widgets are ready
-        self.set_timer(0.1, self._initialize_defaults)
+        """Load provider descriptors and only the selected provider catalog."""
+        self._load_provider_catalog(initialize=True)
 
     async def on_unmount(self) -> None:
         """Clean up resources when widget is unmounted"""
         try:
+            self.app.workers.cancel_group(self, "stts-catalog-discovery")
+            self.app.workers.cancel_group(self, "stts-voice-discovery")
             # Cancel any active progress timer
             if self._progress_timer_task and not self._progress_timer_task.done():
                 self._progress_timer_task.cancel()
@@ -603,481 +648,664 @@ class TTSPlaygroundWidget(Widget):
         except Exception as e:
             logger.error(f"Error during TTSPlaygroundWidget cleanup: {e}")
 
-    def _initialize_defaults(self) -> None:
-        """Initialize default values after mount"""
+    def _is_valid_voice(self, voice: str) -> bool:
+        """Check if a voice value is valid (not a separator)."""
+        return bool(voice) and not str(voice).startswith("_separator")
+
+    @work(
+        exclusive=True,
+        group="stts-catalog-discovery",
+        exit_on_error=False,
+    )
+    async def _load_provider_catalog(
+        self,
+        provider_id: str | None = None,
+        *,
+        refresh: bool = False,
+        initialize: bool = False,
+    ) -> None:
+        """Load descriptors and one selected provider catalog."""
         try:
-            # Set default provider
-            provider_select = self.query_one("#tts-provider-select", Select)
-            default_provider = get_cli_setting("app_tts", "default_provider", "openai")
+            if self._tts_service is None:
+                self._tts_service = await get_tts_service()
 
-            # Try to set the provider value
-            if default_provider in [
-                "openai",
-                "elevenlabs",
-                "kokoro",
-                "chatterbox",
-                "higgs",
-                "alltalk",
-            ]:
+            service = self._tts_service
+            if initialize:
+                descriptors = service.provider_descriptors()
+                options = provider_options(descriptors)
+                if not options:
+                    self._set_provider_status("No TTS providers are registered")
+                    return
+                self._provider_ids = frozenset(value for _label, value in options)
+                self._provider_display_names = {
+                    value: label for label, value in options
+                }
+                provider_select = self.query_one("#tts-provider-select", Select)
+                provider_select.set_options(self._safe_select_options(options))
+                provider_select.disabled = False
+                configured_default = get_cli_setting(
+                    "app_tts",
+                    "default_provider",
+                    options[0][1],
+                )
+                selected = (
+                    configured_default
+                    if configured_default in self._provider_ids
+                    else options[0][1]
+                )
+                self._selected_provider_id = selected
+                self._applying_catalog_controls = True
                 try:
-                    provider_select.value = default_provider
-                    current_provider = default_provider
-                except Exception as e:
-                    logger.debug(f"Could not set provider immediately: {e}")
-                    current_provider = provider_select.value or "openai"
-            else:
-                current_provider = provider_select.value or "openai"
+                    provider_select.value = selected
+                finally:
+                    self._applying_catalog_controls = False
+                self.query_one("#tts-refresh-catalog-btn", Button).disabled = False
+                self._show_provider_specific_controls(selected)
+                provider_id = selected
 
-            # If no value selected (shouldn't happen with options), default to openai
-            if current_provider is None or current_provider == Select.BLANK:
-                current_provider = "openai"
+            if provider_id is None:
+                provider_id = self._selected_provider_id
+            if provider_id is None or provider_id not in getattr(
+                self, "_provider_ids", ()
+            ):
+                return
 
-            logger.debug(f"Initializing with provider: {current_provider}")
+            configuration_revision = service.configuration_revision(provider_id)
+            token = CatalogRequestToken(
+                provider_id=provider_id,
+                configuration_revision=configuration_revision,
+            )
+            self._set_provider_status("Loading selected provider models…")
+            catalog = await service.get_catalog(provider_id, refresh=refresh)
+            if not self._catalog_token_is_current(token):
+                self._mark_stale_catalog_result(token)
+                return
+            if catalog.provider_id != provider_id:
+                self._catalog_failure(
+                    provider_id,
+                    "The selected provider returned an incompatible catalog",
+                )
+                return
 
-            # Always update voice and model options based on current provider
-            if current_provider != Select.BLANK:
-                self._update_voice_options(current_provider)
-                self._update_model_options(current_provider)
+            self._catalogs[provider_id] = catalog
+            self._catalog_configuration_revisions[provider_id] = configuration_revision
+            self._stale_providers.discard(provider_id)
+            self._apply_catalog(provider_id, catalog)
 
-            # Set default format
-            format_select = self.query_one("#tts-format-select", Select)
-            default_format = get_cli_setting("app_tts", "default_format", "mp3")
-            if default_format in ["mp3", "opus", "aac", "flac", "wav", "pcm"]:
-                try:
-                    format_select.value = default_format
-                except Exception as e:
-                    logger.debug(f"Could not set format immediately: {e}")
+            model_id = self._current_select_value("#tts-model-select")
+            if model_id is not None:
+                self._load_provider_voices(
+                    provider_id,
+                    model_id,
+                    catalog.revision,
+                    refresh=refresh,
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            target = provider_id or self._selected_provider_id
+            if target is not None:
+                self._catalog_failure(
+                    target,
+                    self._catalog_error_copy(error, target),
+                )
 
-        except Exception as e:
-            logger.warning(f"Error initializing defaults: {e}")
+    @work(
+        exclusive=True,
+        group="stts-voice-discovery",
+        exit_on_error=False,
+    )
+    async def _load_provider_voices(
+        self,
+        provider_id: str,
+        model_id: str,
+        catalog_revision: int,
+        *,
+        refresh: bool = False,
+    ) -> None:
+        """Load voices for only the selected provider model."""
+        try:
+            service = self._tts_service
+            if service is None:
+                return
+            token = CatalogRequestToken(
+                provider_id=provider_id,
+                configuration_revision=service.configuration_revision(provider_id),
+                catalog_revision=catalog_revision,
+                model_id=model_id,
+            )
+            voices = await service.get_voices(
+                provider_id,
+                model_id,
+                refresh=refresh,
+            )
+            catalog = self._catalogs.get(provider_id)
+            current_revision = catalog.revision if catalog is not None else None
+            current_model = self._current_select_value("#tts-model-select")
+            if not token.matches(
+                provider_id=self._selected_provider_id or "",
+                configuration_revision=service.configuration_revision(provider_id),
+                catalog_revision=current_revision,
+                model_id=current_model,
+            ):
+                return
+            self._discovered_voices[(provider_id, model_id)] = tuple(voices)
+            if catalog is not None:
+                self._apply_catalog(provider_id, catalog)
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            logger.warning(
+                "TTS voice discovery failed ({})",
+                type(error).__name__,
+            )
+            if provider_id == self._selected_provider_id:
+                self._set_provider_status(
+                    "Voices are unavailable; the provider default remains available"
+                )
+
+    def _catalog_token_is_current(self, token: CatalogRequestToken) -> bool:
+        service = self._tts_service
+        if service is None:
+            return False
+        return token.matches(
+            provider_id=self._selected_provider_id or "",
+            configuration_revision=service.configuration_revision(token.provider_id),
+            catalog_revision=None,
+            model_id=None,
+        )
+
+    def _mark_stale_catalog_result(self, token: CatalogRequestToken) -> None:
+        if token.provider_id != self._selected_provider_id:
+            return
+        self._stale_providers.add(token.provider_id)
+        self._catalog_generation_allowed = False
+        display_name = self._provider_display_name(token.provider_id)
+        self._set_provider_status(f"{display_name} settings changed; refresh models")
+        self._sync_generate_enabled()
+
+    def _apply_catalog(
+        self,
+        provider_id: str,
+        catalog: TTSProviderCatalog,
+    ) -> None:
+        if provider_id != self._selected_provider_id:
+            return
+        snapshot = self._control_snapshot_for(provider_id)
+        selected_model = snapshot.get("model_id")
+        if selected_model is None:
+            selected_model = get_cli_setting("app_tts", "default_model", None)
+        selected_voice = snapshot.get("voice_id")
+        if selected_voice is None:
+            selected_voice = get_cli_setting("app_tts", "default_voice", None)
+        selected_format = snapshot.get("response_format")
+        if selected_format is None:
+            selected_format = get_cli_setting("app_tts", "default_format", None)
+        speed = self._snapshot_speed(snapshot)
+
+        voice_choices: tuple[tuple[str, str], ...] | None = None
+        discovered_voices: tuple[str, ...] | None
+        if provider_id == AUDIO_CPP_PROVIDER_ID:
+            model_for_voices = self._catalog_model_id(catalog, selected_model)
+            discovered_voices = (
+                self._discovered_voices.get((provider_id, model_for_voices))
+                if model_for_voices is not None
+                else None
+            )
+        else:
+            model_for_voices = self._catalog_model_id(catalog, selected_model)
+            base_voices = self._catalog_model_voices(catalog, model_for_voices)
+            voice_choices = self._legacy_voice_choices(provider_id, base_voices)
+            discovered_voices = tuple(value for _label, value in voice_choices)
+
+        controls = controls_from_catalog(
+            catalog,
+            selected_model_id=selected_model,
+            selected_voice_id=selected_voice,
+            discovered_voices=discovered_voices,
+            selected_format=selected_format,
+            speed=speed,
+        )
+        if voice_choices is not None:
+            controls = replace(controls, voice_options=voice_choices)
+        self._apply_controls(controls)
+
+    def _apply_controls(self, controls: PlaygroundControls) -> None:
+        model_select = self.query_one("#tts-model-select", Select)
+        voice_select = self.query_one("#tts-voice-select", Select)
+        format_select = self.query_one("#tts-format-select", Select)
+        speed_input = self.query_one("#tts-speed-input", Input)
+        self._applied_model_id = controls.selected_model_id
+        self._applied_voice_id = controls.selected_voice_id
+        self._applied_format = controls.selected_format
+        self._applying_catalog_controls = True
+        try:
+            self._set_select_state(
+                model_select,
+                controls.model_options,
+                controls.selected_model_id,
+                "No models available",
+            )
+            self._set_select_state(
+                voice_select,
+                controls.voice_options,
+                controls.selected_voice_id,
+                "No voices available",
+            )
+            format_options = tuple(
+                (audio_format.upper(), audio_format)
+                for audio_format in controls.format_options
+            )
+            self._set_select_state(
+                format_select,
+                format_options,
+                controls.selected_format,
+                "No formats available",
+            )
+            format_select.disabled = controls.format_locked
+            speed_input.value = str(controls.speed)
+            speed_input.disabled = controls.speed_locked
+        finally:
+            self._applying_catalog_controls = False
+
+        restriction = self.query_one("#tts-audio-cpp-restrictions", Static)
+        if controls.provider_id == AUDIO_CPP_PROVIDER_ID:
+            restriction.remove_class("hidden")
+            format_select.tooltip = "audio.cpp returns one complete WAV response"
+            speed_input.tooltip = "audio.cpp currently supports speed 1.0"
+        else:
+            restriction.add_class("hidden")
+            format_select.tooltip = None
+            speed_input.tooltip = None
+
+        catalog = self._catalogs[controls.provider_id]
+        self._displayed_provider_id = controls.provider_id
+        self._catalog_generation_allowed = (
+            controls.generation_allowed
+            and controls.provider_id not in self._stale_providers
+            and self._catalog_configuration_revisions.get(controls.provider_id)
+            == self._tts_service.configuration_revision(controls.provider_id)
+        )
+        self._set_provider_status(self._catalog_health_copy(catalog))
+        self._remember_current_controls(controls.provider_id)
+        self._sync_generate_enabled()
+        if controls.selection_changed:
+            self.app.notify(
+                "Available models or voices changed; a valid selection was chosen",
+                severity="warning",
+            )
+
+    @staticmethod
+    def _safe_select_options(
+        options: tuple[tuple[str, str], ...],
+    ) -> list[tuple[Text, str]]:
+        return [(Text(label, no_wrap=True), value) for label, value in options]
+
+    def _set_select_state(
+        self,
+        select: Select,
+        options: tuple[tuple[str, str], ...],
+        selected: str | None,
+        empty_label: str,
+    ) -> None:
+        if not options:
+            select.set_options([(empty_label, "__unavailable__")])
+            select.value = "__unavailable__"
+            select.disabled = True
+            return
+        select.set_options(self._safe_select_options(options))
+        select.disabled = False
+        select.value = selected or options[0][1]
+
+    def _control_snapshot_for(self, provider_id: str) -> dict[str, Any]:
+        if getattr(self, "_displayed_provider_id", None) == provider_id:
+            self._remember_current_controls(provider_id)
+        return dict(self._provider_control_snapshots.get(provider_id, {}))
+
+    def _remember_current_controls(self, provider_id: str) -> None:
+        if getattr(self, "_displayed_provider_id", None) != provider_id:
+            return
+        speed_value = self.query_one("#tts-speed-input", Input).value
+        try:
+            speed = float(speed_value)
+        except ValueError:
+            speed = 1.0
+        self._provider_control_snapshots[provider_id] = {
+            "model_id": self._current_select_value("#tts-model-select"),
+            "voice_id": self._current_select_value("#tts-voice-select"),
+            "response_format": self._current_select_value("#tts-format-select"),
+            "speed": speed,
+        }
+
+    @staticmethod
+    def _snapshot_speed(snapshot: Mapping[str, Any]) -> float:
+        speed = snapshot.get("speed", 1.0)
+        try:
+            return float(speed)
+        except (TypeError, ValueError):
+            return 1.0
+
+    def _current_select_value(self, selector: str) -> str | None:
+        value = self.query_one(selector, Select).value
+        if not isinstance(value, str) or value.startswith("__"):
+            return None
+        return value
+
+    @staticmethod
+    def _catalog_model_id(
+        catalog: TTSProviderCatalog,
+        selected_model_id: object,
+    ) -> str | None:
+        if isinstance(selected_model_id, str) and any(
+            model.model_id == selected_model_id for model in catalog.models
+        ):
+            return selected_model_id
+        return catalog.models[0].model_id if catalog.models else None
+
+    @staticmethod
+    def _catalog_model_voices(
+        catalog: TTSProviderCatalog,
+        model_id: str | None,
+    ) -> tuple[str, ...]:
+        for model in catalog.models:
+            if model.model_id == model_id:
+                return model.voices
+        return ()
+
+    def _legacy_voice_choices(
+        self,
+        provider_id: str,
+        base_voices: tuple[str, ...],
+    ) -> tuple[tuple[str, str], ...]:
+        if provider_id == "chatterbox":
+            choices = [
+                ("Default Voice", "default"),
+                ("Upload Reference Audio", "custom"),
+            ]
+            choices.extend(self._chatterbox_profile_choices())
+            return tuple(choices)
+        if provider_id == "higgs":
+            choices = [
+                ("Professional Female", "professional_female"),
+                ("Warm Female", "warm_female"),
+                ("Storyteller Male", "storyteller_male"),
+                ("Deep Male", "deep_male"),
+                ("Energetic Female", "energetic_female"),
+                ("Soft Female", "soft_female"),
+                ("Upload Reference Audio", "custom"),
+            ]
+            choices.extend(self._higgs_profile_choices())
+            return tuple(choices)
+        if provider_id == "alltalk":
+            return tuple(
+                (name.replace("_", " ").replace(".wav", "").title(), name)
+                for name in (
+                    "female_01.wav",
+                    "female_02.wav",
+                    "female_03.wav",
+                    "female_04.wav",
+                    "male_01.wav",
+                    "male_02.wav",
+                    "male_03.wav",
+                    "male_04.wav",
+                )
+            )
+
+        choices = [(voice.replace("_", " ").title(), voice) for voice in base_voices]
+        if provider_id == "kokoro":
+            choices.extend(self._kokoro_blend_choices())
+        return tuple(choices)
+
+    @staticmethod
+    def _kokoro_blend_choices() -> list[tuple[str, str]]:
+        blend_file = Path.home() / ".config" / "tldw_cli" / "kokoro_voice_blends.json"
+        if not blend_file.is_file():
+            return []
+        try:
+            payload = json.loads(blend_file.read_text(encoding="utf-8"))
+        except (OSError, ValueError, TypeError):
+            logger.warning("Saved Kokoro voice blends could not be loaded")
+            return []
+        if not isinstance(payload, Mapping):
+            return []
+        return [
+            (f"Voice blend: {name}", f"blend:{name}")
+            for name in payload
+            if isinstance(name, str) and name
+        ]
+
+    @staticmethod
+    def _chatterbox_profile_choices() -> list[tuple[str, str]]:
+        try:
+            from tldw_chatbook.TTS.backends.chatterbox_voice_manager import (
+                ChatterboxVoiceManager,
+            )
+
+            voice_dir = Path.home() / ".config" / "tldw_cli" / "chatterbox_voices"
+            if not voice_dir.is_dir():
+                return []
+            profiles = ChatterboxVoiceManager(voice_dir).list_profiles()
+            return [
+                (str(profile.get("display_name") or profile["name"]), profile["name"])
+                for profile in profiles
+                if isinstance(profile, Mapping)
+                and isinstance(profile.get("name"), str)
+                and profile["name"]
+            ]
+        except Exception:
+            logger.warning("Saved Chatterbox voice profiles could not be loaded")
+            return []
+
+    @staticmethod
+    def _higgs_profile_choices() -> list[tuple[str, str]]:
+        try:
+            from tldw_chatbook.TTS.backends.higgs_voice_manager import (
+                HiggsVoiceProfileManager,
+            )
+
+            voice_dir = Path.home() / ".config" / "tldw_cli" / "higgs_voices"
+            if not voice_dir.is_dir():
+                return []
+            profiles = HiggsVoiceProfileManager(voice_dir).list_profiles()
+            return [
+                (
+                    str(profile.get("display_name") or profile["name"]),
+                    f"profile:{profile['name']}",
+                )
+                for profile in profiles
+                if isinstance(profile, Mapping)
+                and isinstance(profile.get("name"), str)
+                and profile["name"]
+            ]
+        except Exception:
+            logger.warning("Saved Higgs voice profiles could not be loaded")
+            return []
+
+    def _catalog_health_copy(self, catalog: TTSProviderCatalog) -> str:
+        display_name = self._provider_display_name(catalog.provider_id)
+        if catalog.provider_id in self._stale_providers:
+            return f"{display_name} settings changed; refresh models"
+        health = catalog.health
+        if health.state == "available" and health.fresh:
+            return f"{display_name} is ready"
+        if health.state == "available":
+            return f"{display_name} catalog is stale; refresh models"
+        if health.state == "not_configured":
+            return f"{display_name} is not configured; open STTS Settings"
+        if health.state == "reconfiguring":
+            return f"{display_name} settings are being applied; retry shortly"
+        if health.state == "closed":
+            return "The TTS service is unavailable"
+        return f"{display_name} is unavailable; check STTS Settings"
+
+    def _provider_display_name(self, provider_id: str) -> str:
+        return self._provider_display_names.get(provider_id, "TTS provider")
+
+    def _catalog_error_copy(self, error: Exception, provider_id: str) -> str:
+        display_name = self._provider_display_name(provider_id)
+        if isinstance(error, TTSProviderReconfiguringError):
+            return f"{display_name} settings are being applied; retry shortly"
+        if isinstance(error, TTSRegistryClosedError):
+            return "The TTS service is unavailable"
+        if isinstance(error, TTSOperationError):
+            if error.code in {"configuration_invalid", "not_configured"}:
+                return f"{display_name} is not configured; open STTS Settings"
+            if error.code == "contract_incompatible":
+                return f"The configured {display_name} service is incompatible"
+            return f"{display_name} is unavailable; check STTS Settings"
+        if isinstance(error, ValueError):
+            return f"{display_name} is not configured; open STTS Settings"
+        return f"{display_name} is unavailable; check STTS Settings"
+
+    def _catalog_failure(self, provider_id: str, copy: str) -> None:
+        logger.warning("TTS catalog discovery failed for {}", provider_id)
+        if provider_id != self._selected_provider_id:
+            return
+        self._stale_providers.add(provider_id)
+        self._catalog_generation_allowed = False
+        self._set_provider_status(copy)
+        self._sync_generate_enabled()
+
+    def _set_provider_status(self, copy: str) -> None:
+        self.query_one("#tts-provider-status", Static).update(Text(copy))
+
+    def _sync_generate_enabled(self) -> None:
+        text_present = bool(self.query_one("#tts-text-input", TextArea).text.strip())
+        provider_id = self._selected_provider_id
+        revision_matches = False
+        if (
+            provider_id is not None
+            and self._tts_service is not None
+            and provider_id in self._catalog_configuration_revisions
+        ):
+            revision_matches = self._catalog_configuration_revisions[
+                provider_id
+            ] == self._tts_service.configuration_revision(provider_id)
+        self.query_one("#tts-generate-btn", Button).disabled = not (
+            text_present
+            and self._catalog_generation_allowed
+            and revision_matches
+            and not getattr(self.app, "_is_generating", False)
+        )
+
+    def _show_provider_specific_controls(self, provider_id: str) -> None:
+        language_row = self.query_one("#kokoro-language-row", Horizontal)
+        kokoro_settings = self.query_one("#kokoro-settings", Vertical)
+        elevenlabs_settings = self.query_one("#elevenlabs-settings", Vertical)
+        chatterbox_settings = self.query_one("#chatterbox-settings", Vertical)
+        higgs_settings = self.query_one("#higgs-settings", Vertical)
+        language_row.set_class(provider_id == "kokoro", "visible")
+        kokoro_settings.set_class(provider_id == "kokoro", "visible")
+        elevenlabs_settings.set_class(provider_id == "elevenlabs", "visible")
+        chatterbox_settings.set_class(provider_id == "chatterbox", "visible")
+        higgs_settings.set_class(provider_id == "higgs", "visible")
+        if provider_id == "higgs":
+            self._check_higgs_installation()
+
+    def mark_provider_configuration_changed(
+        self,
+        provider_id: str,
+        configuration_revision: int,
+    ) -> None:
+        """Invalidate cached controls after a changed provider configuration."""
+        del configuration_revision
+        self._stale_providers.add(provider_id)
+        self._discovered_voices = {
+            key: value
+            for key, value in self._discovered_voices.items()
+            if key[0] != provider_id
+        }
+        if provider_id != self._selected_provider_id:
+            return
+        self.app.workers.cancel_group(self, "stts-catalog-discovery")
+        self.app.workers.cancel_group(self, "stts-voice-discovery")
+        self._catalog_generation_allowed = False
+        display_name = self._provider_display_name(provider_id)
+        self._set_provider_status(f"{display_name} settings changed; refresh models")
+        self._sync_generate_enabled()
 
     @on(Select.Changed)
     def on_tts_provider_select_changed(self, event: Select.Changed) -> None:
-        """Handle provider/model selection changes"""
+        """Handle canonical provider/model/voice/format selections."""
+        if self._applying_catalog_controls:
+            return
         if event.select.id == "tts-provider-select":
-            # Get the provider select widget
-            provider_select = self.query_one("#tts-provider-select", Select)
-
-            # The event.value might be the display text, so we need to find the key
-            # by matching against the options
-            provider_value = None
-            for option_value, option_label in [
-                ("openai", "OpenAI"),
-                ("elevenlabs", "ElevenLabs"),
-                ("kokoro", "Kokoro (Local)"),
-                ("chatterbox", "Chatterbox (Local)"),
-                ("higgs", "Higgs Audio (Local)"),
-                ("alltalk", "AllTalk (Local)"),
-            ]:
-                if event.value == option_label or event.value == option_value:
-                    provider_value = option_value
-                    break
-
-            logger.info(f"Provider select changed - event.value: {event.value!r}")
-            logger.info(f"Resolved provider key: {provider_value!r}")
-            logger.debug(f"Provider widget value is: {provider_select.value}")
-
-            # The widget value should be the key (e.g., "kokoro")
-            if provider_value and provider_value != Select.BLANK:
-                self._update_voice_options(provider_value)
-                self._update_model_options(provider_value)
-
-            # Show/hide provider-specific settings
-            if provider_value and provider_value != Select.BLANK:
-                # Show/hide Kokoro language row
-                language_row = self.query_one("#kokoro-language-row", Horizontal)
-                if provider_value == "kokoro":
-                    logger.debug("Showing Kokoro language selection row")
-                    language_row.add_class("visible")
-                else:
-                    logger.debug("Hiding Kokoro language selection row")
-                    language_row.remove_class("visible")
-
-                # Show/hide Kokoro settings
-                kokoro_settings = self.query_one("#kokoro-settings", Vertical)
-                if provider_value == "kokoro":
-                    logger.debug("Showing Kokoro settings")
-                    kokoro_settings.add_class("visible")
-                else:
-                    logger.debug("Hiding Kokoro settings")
-                    kokoro_settings.remove_class("visible")
-
-                # Show/hide ElevenLabs settings
-                elevenlabs_settings = self.query_one("#elevenlabs-settings", Vertical)
-                if provider_value == "elevenlabs":
-                    elevenlabs_settings.add_class("visible")
-                else:
-                    elevenlabs_settings.remove_class("visible")
-
-                # Show/hide Chatterbox settings
-                chatterbox_settings = self.query_one("#chatterbox-settings", Vertical)
-                if provider_value == "chatterbox":
-                    chatterbox_settings.add_class("visible")
-                else:
-                    chatterbox_settings.remove_class("visible")
-
-                # Show/hide Higgs settings
-                higgs_settings = self.query_one("#higgs-settings", Vertical)
-                if provider_value == "higgs":
-                    higgs_settings.add_class("visible")
-                    # Check if Higgs is installed
-                    self._check_higgs_installation()
-                else:
-                    higgs_settings.remove_class("visible")
-
-        elif event.select.id == "tts-voice-select":
-            # Validate voice selection (prevent selecting separators)
-            if not self._is_valid_voice(event.value):
-                # Find and select the first valid voice
-                voice_select = event.select
-                for value, _ in voice_select._options:
-                    if self._is_valid_voice(value):
-                        voice_select.value = value
-                        break
-
-    def _is_valid_voice(self, voice: str) -> bool:
-        """Check if a voice value is valid (not a separator)"""
-        return bool(voice) and not str(voice).startswith("_separator")
-
-    def _set_valid_voice(self, voice_select, voice_options, fallback="af_bella"):
-        """Set a valid voice from options, skipping separators"""
-        # Find first valid voice option (skip separators)
-        valid_voice = None
-        for value, label in voice_options:
-            if self._is_valid_voice(value):
-                valid_voice = value
-                logger.debug(f"Found valid voice: {value} ({label})")
-                break
-
-        # Try to set the value with error handling
-        try:
-            if valid_voice:
-                logger.info(f"Setting voice to: {valid_voice}")
-                voice_select.value = valid_voice
+            if not isinstance(event.value, str) or event.value not in getattr(
+                self, "_provider_ids", ()
+            ):
+                return
+            if event.value == self._selected_provider_id:
+                return
+            if self._selected_provider_id is not None:
+                self._remember_current_controls(self._selected_provider_id)
+            self._selected_provider_id = event.value
+            self._show_provider_specific_controls(event.value)
+            self._catalog_generation_allowed = False
+            self._sync_generate_enabled()
+            self._load_provider_catalog(event.value)
+            return
+        if event.select.id == "tts-model-select":
+            provider_id = self._selected_provider_id
+            if provider_id is None or not isinstance(event.value, str):
+                return
+            if event.value == self._applied_model_id:
+                return
+            self._remember_current_controls(provider_id)
+            catalog = self._catalogs.get(provider_id)
+            if catalog is not None:
+                self._apply_catalog(provider_id, catalog)
+                model_id = self._current_select_value("#tts-model-select")
+                if model_id is not None:
+                    self._load_provider_voices(
+                        provider_id,
+                        model_id,
+                        catalog.revision,
+                    )
+            return
+        if event.select.id in {"tts-voice-select", "tts-format-select"}:
+            if (
+                event.select.id == "tts-voice-select"
+                and event.value == self._applied_voice_id
+            ) or (
+                event.select.id == "tts-format-select"
+                and event.value == self._applied_format
+            ):
+                return
+            if event.select.id == "tts-voice-select":
+                self._applied_voice_id = (
+                    event.value if isinstance(event.value, str) else None
+                )
             else:
-                logger.warning(f"No valid voice found, using fallback: {fallback}")
-                voice_select.value = fallback
-
-            # Log final state only if successfully set
-            logger.info(f"Voice select final value: {voice_select.value}")
-        except Exception as e:
-            logger.debug(f"Could not set voice value immediately: {e}")
-            # The value will be set later when the widget is ready
-
-    def _safe_set_select_value(
-        self, select_widget, value: str, widget_name: str = "widget"
-    ) -> None:
-        """Safely set a Select widget value with error handling"""
-        try:
-            select_widget.value = value
-            logger.debug(f"Successfully set {widget_name} to: {value}")
-        except Exception as e:
-            logger.debug(f"Could not set {widget_name} value immediately: {e}")
-
-    def _get_select_key(self, select_widget) -> Optional[str]:
-        """Get the actual key from a Select widget, not the display text"""
-        if not hasattr(select_widget, "_options") or not select_widget._options:
-            return None
-
-        current_value = select_widget.value
-        if current_value == Select.BLANK:
-            return None
-
-        # Find the key that matches the current value
-        for key, label in select_widget._options:
-            if label == current_value or key == current_value:
-                return key
-
-        return None
-
-    def _update_voice_options(self, provider: str) -> None:
-        """Update voice options based on provider"""
-        logger.info(
-            f"_update_voice_options called with provider: '{provider}' (type: {type(provider)})"
-        )
-
-        # Handle Select.BLANK
-        if provider == Select.BLANK or str(provider) == "Select.BLANK":
-            logger.debug("Provider is Select.BLANK, skipping update")
-            return
-
-        try:
-            voice_select = self.query_one("#tts-voice-select", Select)
-            logger.debug(
-                f"Found voice select widget, current value: {voice_select.value}, options: {len(voice_select._options) if hasattr(voice_select, '_options') else 'unknown'}"
-            )
-        except Exception as e:
-            logger.error(f"Failed to find voice select widget: {e}")
-            return
-
-        if provider == "openai":
-            voice_select.set_options(
-                [
-                    ("alloy", "Alloy"),
-                    ("ash", "Ash"),
-                    ("ballad", "Ballad"),
-                    ("coral", "Coral"),
-                    ("echo", "Echo"),
-                    ("fable", "Fable"),
-                    ("onyx", "Onyx"),
-                    ("nova", "Nova"),
-                    ("sage", "Sage"),
-                    ("shimmer", "Shimmer"),
-                    ("verse", "Verse"),
-                ]
-            )
-            # Don't set value directly - let Select handle it
-            try:
-                voice_select.value = "alloy"
-            except Exception as e:
-                logger.debug(f"Could not set default voice value: {e}")
-        elif provider == "elevenlabs":
-            voice_select.set_options(
-                [
-                    ("21m00Tcm4TlvDq8ikWAM", "Rachel"),
-                    ("AZnzlk1XvdvUeBnXmlld", "Domi"),
-                    ("EXAVITQu4vr4xnSDxMaL", "Bella"),
-                    ("ErXwobaYiN019PkySvjV", "Antoni"),
-                    ("MF3mGyEYCl7XYWbV9V6O", "Elli"),
-                    ("TxGEqnHWrfWFTfGW9XjX", "Josh"),
-                    ("VR6AewLTigWG4xSOukaG", "Arnold"),
-                    ("pNInz6obpgDQGcFmaJgB", "Adam"),
-                    ("yoZ06aMxZJJ28mfd3POQ", "Sam"),
-                ]
-            )
-            try:
-                voice_select.value = "21m00Tcm4TlvDq8ikWAM"
-            except Exception as e:
-                logger.debug(f"Could not set default ElevenLabs voice value: {e}")
-        elif provider == "kokoro":
-            logger.info(f"Setting up Kokoro voices for provider: {provider}")
-            logger.debug(
-                f"Voice select widget state - value: {voice_select.value}, enabled: {not voice_select.disabled}"
-            )
-            voice_options = [
-                # American Female voices
-                ("af_alloy", "Alloy (US Female)"),
-                ("af_aoede", "Aoede (US Female)"),
-                ("af_bella", "Bella (US Female)"),
-                ("af_heart", "Heart (US Female)"),
-                ("af_jessica", "Jessica (US Female)"),
-                ("af_kore", "Kore (US Female)"),
-                ("af_nicole", "Nicole (US Female)"),
-                ("af_nova", "Nova (US Female)"),
-                ("af_river", "River (US Female)"),
-                ("af_sarah", "Sarah (US Female)"),
-                ("af_sky", "Sky (US Female)"),
-                # American Male voices
-                ("am_adam", "Adam (US Male)"),
-                ("am_michael", "Michael (US Male)"),
-                # British Female voices
-                ("bf_emma", "Emma (UK Female)"),
-                ("bf_isabella", "Isabella (UK Female)"),
-                # British Male voices
-                ("bm_george", "George (UK Male)"),
-                ("bm_lewis", "Lewis (UK Male)"),
-                # Note: Additional voices for other languages (Japanese, Chinese, Spanish, etc.)
-                # can be added here with proper voice codes
-            ]
-
-            # Add saved voice blends
-            blend_file = (
-                Path.home() / ".config" / "tldw_cli" / "kokoro_voice_blends.json"
-            )
-            if blend_file.exists():
-                try:
-                    import json
-
-                    with open(blend_file, "r") as f:
-                        blends = json.load(f)
-                        if blends:
-                            # Add separator
-                            voice_options.append(
-                                ("_separator", "──── Voice Blends ────")
-                            )
-                            # Add each blend
-                            for blend_name, blend_data in blends.items():
-                                display_name = f"🎭 {blend_name}"
-                                if blend_data.get("description"):
-                                    display_name += (
-                                        f" - {blend_data['description'][:30]}"
-                                    )
-                                voice_options.append(
-                                    (f"blend:{blend_name}", display_name)
-                                )
-                except Exception as e:
-                    logger.error(f"Failed to load voice blends: {e}")
-
-            voice_select.set_options(voice_options)
-            logger.debug(f"Set {len(voice_options)} voice options for Kokoro")
-
-            # Use helper method to set valid voice
-            self._set_valid_voice(voice_select, voice_options, fallback="af_bella")
-        elif provider == "chatterbox":
-            logger.info(f"Setting up Chatterbox voices for provider: {provider}")
-            voice_options = [
-                ("default", "Default Voice"),
-                ("_separator", "──── Custom Voices ────"),
-                ("custom", "Upload Reference Audio"),
-            ]
-
-            # Add saved voice profiles
-            try:
-                from tldw_chatbook.TTS.backends.chatterbox_voice_manager import (
-                    ChatterboxVoiceManager,
+                self._applied_format = (
+                    event.value if isinstance(event.value, str) else None
                 )
+            if self._selected_provider_id is not None:
+                self._remember_current_controls(self._selected_provider_id)
+            self._sync_generate_enabled()
 
-                voice_dir = Path.home() / ".config" / "tldw_cli" / "chatterbox_voices"
-                if voice_dir.exists():
-                    manager = ChatterboxVoiceManager(voice_dir)
-                    profiles = manager.list_profiles()
-                    if profiles:
-                        voice_options.append(
-                            ("_separator2", "──── Saved Profiles ────")
-                        )
-                        for profile in profiles:
-                            voice_options.append(
-                                (profile["name"], profile["display_name"])
-                            )
-                    logger.info(f"Loaded {len(profiles)} Chatterbox voice profiles")
-            except Exception as e:
-                logger.warning(f"Could not load Chatterbox voice profiles: {e}")
+    @on(Input.Changed)
+    def on_tts_speed_changed(self, event: Input.Changed) -> None:
+        if (
+            not self._applying_catalog_controls
+            and event.input.id == "tts-speed-input"
+            and self._selected_provider_id is not None
+        ):
+            self._remember_current_controls(self._selected_provider_id)
 
-            voice_select.set_options(voice_options)
-            self._safe_set_select_value(voice_select, "default", "Chatterbox voice")
-        elif provider == "higgs":
-            logger.info(f"Setting up Higgs voices for provider: {provider}")
-            voice_options = [
-                # Default Higgs voices
-                ("professional_female", "Professional Female"),
-                ("warm_female", "Warm Female"),
-                ("storyteller_male", "Storyteller Male"),
-                ("deep_male", "Deep Male"),
-                ("energetic_female", "Energetic Female"),
-                ("soft_female", "Soft Female"),
-                # Separator for custom voices
-                ("_separator", "──── Custom Voices ────"),
-                ("custom", "Upload Reference Audio"),
-            ]
+    @on(TextArea.Changed)
+    def on_tts_text_changed(self, _event: TextArea.Changed) -> None:
+        self._sync_generate_enabled()
 
-            # Add saved voice profiles
-            try:
-                from tldw_chatbook.TTS.backends.higgs_voice_manager import (
-                    HiggsVoiceProfileManager,
-                )
-
-                voice_dir = Path.home() / ".config" / "tldw_cli" / "higgs_voices"
-                if voice_dir.exists():
-                    manager = HiggsVoiceProfileManager(voice_dir)
-                    profiles = manager.list_profiles()
-                    if profiles:
-                        # Add separator
-                        voice_options.append(
-                            ("_separator2", "──── Saved Profiles ────")
-                        )
-                        # Add each profile
-                        for profile in profiles:
-                            display_name = f"📎 {profile['display_name']}"
-                            if profile.get("description"):
-                                display_name += f" - {profile['description'][:30]}"
-                            voice_options.append(
-                                (f"profile:{profile['name']}", display_name)
-                            )
-            except Exception as e:
-                logger.debug(f"Could not load Higgs voice profiles: {e}")
-
-            voice_select.set_options(voice_options)
-            self._set_valid_voice(
-                voice_select, voice_options, fallback="professional_female"
-            )
-        elif provider == "alltalk":
-            voice_select.set_options(
-                [
-                    ("female_01.wav", "Female 01"),
-                    ("female_02.wav", "Female 02"),
-                    ("female_03.wav", "Female 03"),
-                    ("female_04.wav", "Female 04"),
-                    ("male_01.wav", "Male 01"),
-                    ("male_02.wav", "Male 02"),
-                    ("male_03.wav", "Male 03"),
-                    ("male_04.wav", "Male 04"),
-                    # AllTalk typically supports more voices, these are common defaults
-                ]
-            )
-            self._safe_set_select_value(voice_select, "female_01.wav", "AllTalk voice")
-        else:
-            logger.warning(f"Unknown TTS provider: {provider}")
-            voice_select.set_options([("default", "Default")])
-
-    def _update_model_options(self, provider: str) -> None:
-        """Update model options based on provider"""
-        logger.debug(f"Updating model options for provider: {provider}")
-
-        # Handle Select.BLANK
-        if provider == Select.BLANK or str(provider) == "Select.BLANK":
-            logger.debug("Provider is Select.BLANK, skipping model update")
-            return
-
-        model_select = self.query_one("#tts-model-select", Select)
-
-        if provider == "openai":
-            model_select.set_options(
-                [
-                    ("tts-1", "TTS-1 (Standard)"),
-                    ("tts-1-hd", "TTS-1-HD (High Quality)"),
-                ]
-            )
-            self._safe_set_select_value(model_select, "tts-1", "OpenAI model")
-        elif provider == "elevenlabs":
-            model_select.set_options(
-                [
-                    ("eleven_monolingual_v1", "Eleven Monolingual v1"),
-                    ("eleven_multilingual_v1", "Eleven Multilingual v1"),
-                    ("eleven_multilingual_v2", "Eleven Multilingual v2 (Default)"),
-                    ("eleven_turbo_v2", "Eleven Turbo v2"),
-                    ("eleven_turbo_v2_5", "Eleven Turbo v2.5"),
-                    ("eleven_flash_v2", "Eleven Flash v2 (Low Latency)"),
-                    ("eleven_flash_v2_5", "Eleven Flash v2.5 (Ultra Low Latency)"),
-                ]
-            )
-            self._safe_set_select_value(
-                model_select, "eleven_multilingual_v2", "ElevenLabs model"
-            )
-        elif provider == "kokoro":
-            logger.info("Setting Kokoro model options")
-            model_select.set_options(
-                [
-                    ("kokoro", "Kokoro 82M"),
-                ]
-            )
-            self._safe_set_select_value(model_select, "kokoro", "Kokoro model")
-            logger.info("Kokoro model options configured")
-        elif provider == "chatterbox":
-            model_select.set_options(
-                [
-                    ("chatterbox", "Chatterbox 0.5B"),
-                ]
-            )
-            self._safe_set_select_value(model_select, "chatterbox", "Chatterbox model")
-        elif provider == "higgs":
-            logger.info("Setting Higgs model options")
-            model_select.set_options(
-                [
-                    ("higgs-audio-v2", "Higgs Audio V2 3B"),
-                ]
-            )
-            self._safe_set_select_value(model_select, "higgs-audio-v2", "Higgs model")
-            logger.info("Higgs model options configured")
-        elif provider == "alltalk":
-            model_select.set_options(
-                [
-                    ("alltalk", "AllTalk TTS"),
-                ]
-            )
-            self._safe_set_select_value(model_select, "alltalk", "AllTalk model")
-        else:
-            logger.warning(f"Unknown TTS provider for model: {provider}")
-            model_select.set_options([("default", "Default Model")])
+    def _get_select_key(self, select_widget: Select) -> Optional[str]:
+        """Return exact canonical values for catalog-driven controls."""
+        current = select_widget.value
+        if not isinstance(current, str) or current.startswith("__"):
+            return None
+        if select_widget.id == "tts-language-select":
+            for language_id, display_name in select_widget._options:
+                if display_name == current:
+                    return str(language_id)
+        return current
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """Handle button presses"""
@@ -1085,6 +1313,13 @@ class TTSPlaygroundWidget(Widget):
         if event.button.id == "tts-generate-btn":
             self._generate_tts()
             event.stop()  # Prevent event from bubbling up
+        elif event.button.id == "tts-refresh-catalog-btn":
+            if self._selected_provider_id is not None:
+                self._load_provider_catalog(
+                    self._selected_provider_id,
+                    refresh=True,
+                )
+            event.stop()
         elif event.button.id == "tts-random-text-btn":
             self._insert_random_text()
             event.stop()

--- a/tldw_chatbook/UI/STTS_Window.py
+++ b/tldw_chatbook/UI/STTS_Window.py
@@ -3,7 +3,7 @@
 #
 # Imports
 import asyncio
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import replace
 from typing import Optional, Dict, Any, List
 from pathlib import Path
@@ -52,7 +52,9 @@ from tldw_chatbook.TTS.audio_cpp_config import AudioCppConfig
 from tldw_chatbook.UI.stts_playground_catalog import (
     AUDIO_CPP_PROVIDER_ID,
     CatalogRequestToken,
+    FIRST_AVAILABLE_MODEL_ID,
     PlaygroundControls,
+    SERVER_DEFAULT_VOICE_ID,
     controls_from_catalog,
     provider_options,
     voice_id_for_request,
@@ -236,6 +238,7 @@ class TTSPlaygroundWidget(Widget):
         self._catalogs: dict[str, TTSProviderCatalog] = {}
         self._catalog_configuration_revisions: dict[str, int] = {}
         self._discovered_voices: dict[tuple[str, str], tuple[str, ...]] = {}
+        self._pending_voice_selections: dict[str, str] = {}
         self._provider_control_snapshots: dict[str, dict[str, Any]] = {}
         self._stale_providers: set[str] = set()
         self._catalog_generation_allowed = False
@@ -858,6 +861,9 @@ class TTSPlaygroundWidget(Widget):
         selected_voice = snapshot.get("voice_id")
         if selected_voice is None:
             selected_voice = get_cli_setting("app_tts", "default_voice", None)
+        pending_voice = self._pending_voice_selections.get(provider_id)
+        if pending_voice is not None:
+            selected_voice = pending_voice
         selected_format = snapshot.get("response_format")
         if selected_format is None:
             selected_format = get_cli_setting("app_tts", "default_format", None)
@@ -872,11 +878,20 @@ class TTSPlaygroundWidget(Widget):
                 if model_for_voices is not None
                 else None
             )
+            voice_discovery_pending = discovered_voices is None
+            if (
+                voice_discovery_pending
+                and isinstance(selected_voice, str)
+                and selected_voice
+            ):
+                pending_voice = selected_voice
+                self._pending_voice_selections[provider_id] = selected_voice
         else:
             model_for_voices = self._catalog_model_id(catalog, selected_model)
             base_voices = self._catalog_model_voices(catalog, model_for_voices)
             voice_choices = self._legacy_voice_choices(provider_id, base_voices)
             discovered_voices = tuple(value for _label, value in voice_choices)
+            voice_discovery_pending = False
 
         controls = controls_from_catalog(
             catalog,
@@ -888,7 +903,19 @@ class TTSPlaygroundWidget(Widget):
         )
         if voice_choices is not None:
             controls = replace(controls, voice_options=voice_choices)
+        if voice_discovery_pending and pending_voice is not None:
+            model_changed = (
+                selected_model is not None
+                and selected_model != controls.selected_model_id
+            )
+            controls = replace(controls, selection_changed=model_changed)
         self._apply_controls(controls)
+        if voice_discovery_pending and pending_voice is not None:
+            self._provider_control_snapshots.setdefault(provider_id, {})["voice_id"] = (
+                pending_voice
+            )
+        elif provider_id == AUDIO_CPP_PROVIDER_ID and discovered_voices is not None:
+            self._pending_voice_selections.pop(provider_id, None)
 
     def _apply_controls(self, controls: PlaygroundControls) -> None:
         model_select = self.query_one("#tts-model-select", Select)
@@ -1209,6 +1236,50 @@ class TTSPlaygroundWidget(Widget):
             and not getattr(self.app, "_is_generating", False)
         )
 
+    def _generation_readiness_error(
+        self,
+        provider_id: object,
+        model_id: object,
+    ) -> str | None:
+        """Return fixed UI copy when a generation snapshot is not authoritative."""
+        if self._generation_operation_id is not None:
+            return "TTS generation is already in progress"
+
+        handler = getattr(self.app, "_stts_handler", None)
+        state_getter = getattr(handler, "playground_state", None)
+        if callable(state_getter):
+            try:
+                if getattr(state_getter(), "generation_active", False):
+                    return "TTS generation is already in progress"
+            except Exception:
+                return "The TTS service is unavailable"
+
+        if (
+            not isinstance(provider_id, str)
+            or provider_id != self._selected_provider_id
+            or provider_id not in self._provider_ids
+        ):
+            return "Please select a valid TTS provider"
+        if not isinstance(model_id, str) or model_id.startswith("__"):
+            return "Please select a valid TTS model"
+
+        service = self._tts_service
+        catalog = self._catalogs.get(provider_id)
+        if service is None or catalog is None:
+            return "The selected provider catalog is not ready; refresh models"
+        if (
+            provider_id in self._stale_providers
+            or not self._catalog_generation_allowed
+            or catalog.health.state != "available"
+            or not catalog.health.fresh
+            or self._catalog_configuration_revisions.get(provider_id)
+            != service.configuration_revision(provider_id)
+        ):
+            return "The selected provider catalog is stale; refresh models"
+        if not any(model.model_id == model_id for model in catalog.models):
+            return "The selected model is no longer available; refresh models"
+        return None
+
     def _show_provider_specific_controls(self, provider_id: str) -> None:
         language_row = self.query_one("#kokoro-language-row", Horizontal)
         kokoro_settings = self.query_one("#kokoro-settings", Vertical)
@@ -1376,6 +1447,13 @@ class TTSPlaygroundWidget(Widget):
 
     def _generate_tts(self) -> None:
         """Generate TTS audio"""
+        if self._generation_operation_id is not None:
+            self.app.notify(
+                "TTS generation is already in progress",
+                severity="warning",
+            )
+            return
+
         # Get form values
         text_area = self.query_one("#tts-text-input", TextArea)
         text = text_area.text.strip()
@@ -1392,6 +1470,12 @@ class TTSPlaygroundWidget(Widget):
         provider = self._get_select_key(provider_select) or provider_select.value
         voice = self._get_select_key(voice_select) or voice_select.value
         model = self._get_select_key(model_select) or model_select.value
+
+        readiness_error = self._generation_readiness_error(provider, model)
+        if readiness_error is not None:
+            self._sync_generate_enabled()
+            self.app.notify(readiness_error, severity="warning")
+            return
 
         # Validate voice selection
         if not self._is_valid_voice(voice):
@@ -1495,7 +1579,7 @@ class TTSPlaygroundWidget(Widget):
                 "custom",
                 "_separator",
                 "_separator2",
-            ] and not voice.startswith("custom:"):
+            ] and not voice.startswith(("custom:", "profile:")):
                 # This is a saved profile - format it as profile:name
                 voice = f"profile:{voice}"
         elif provider == "higgs":
@@ -1548,7 +1632,7 @@ class TTSPlaygroundWidget(Widget):
                 "custom",
                 "_separator",
                 "_separator2",
-            ] and not voice.startswith("custom:"):
+            ] and not voice.startswith(("custom:", "profile:")):
                 # This is a saved profile - format it as profile:name
                 voice = f"profile:{voice}"
 
@@ -1666,6 +1750,49 @@ class TTSPlaygroundWidget(Widget):
             return None
         return Path(self.current_audio_file)
 
+    def _capture_audio_for_action(
+        self,
+    ) -> tuple[Path, Callable[[], None]] | None:
+        """Capture and, when handler-owned, lease the current artifact."""
+        artifact = self.current_audio_artifact
+        audio_path = self._current_generated_audio_path()
+        if audio_path is None:
+            return None
+        if artifact is None or artifact.path != audio_path:
+            return audio_path, lambda: None
+
+        handler = getattr(self.app, "_stts_handler", None)
+        acquire = getattr(handler, "lease_playground_artifact", None)
+        release = getattr(handler, "release_playground_artifact", None)
+        if not callable(acquire) or not callable(release):
+            return audio_path, lambda: None
+        try:
+            if not acquire(artifact):
+                return None
+        except Exception as error:
+            logger.debug(
+                "Could not lease Playground artifact ({})",
+                type(error).__name__,
+            )
+            return None
+
+        released = False
+
+        def release_once() -> None:
+            nonlocal released
+            if released:
+                return
+            released = True
+            try:
+                release(artifact)
+            except Exception as error:
+                logger.debug(
+                    "Could not release Playground artifact ({})",
+                    type(error).__name__,
+                )
+
+        return audio_path, release_once
+
     def _play_audio(self) -> None:
         """Play the generated audio"""
         logger.debug(
@@ -1681,16 +1808,18 @@ class TTSPlaygroundWidget(Widget):
             logger.debug("Play already in progress, ignoring request")
             return
 
-        audio_path = self._current_generated_audio_path()
-        if audio_path is None:
+        captured = self._capture_audio_for_action()
+        if captured is None:
             self.app.notify("No audio file to play", severity="warning")
             return
+        audio_path, release_artifact = captured
 
         logger.debug(
             f"Audio path: {audio_path}, exists: {audio_path.exists() if audio_path else False}"
         )
 
         if not audio_path.exists():
+            release_artifact()
             self.app.notify(
                 f"Audio file not found: {audio_path.name}", severity="warning"
             )
@@ -1710,18 +1839,30 @@ class TTSPlaygroundWidget(Widget):
 
             # Use the new audio player method
             # Store the worker task so we can check if it's running
-            self._play_worker_task = self.run_worker(
-                self._play_audio_async,
-                group="stts-playback",
-                exclusive=True,
-            )
+            playback = self._play_audio_async(audio_path, release_artifact)
+            try:
+                self._play_worker_task = self.run_worker(
+                    playback,
+                    group="stts-playback",
+                    exclusive=True,
+                )
+            except Exception:
+                playback.close()
+                release_artifact()
+                raise
         else:
+            release_artifact()
             self.app.notify("Audio playback not available", severity="warning")
 
-    async def _play_audio_async(self) -> None:
+    async def _play_audio_async(
+        self,
+        audio_path: Path | None = None,
+        release_artifact: Callable[[], None] | None = None,
+    ) -> None:
         """Play audio asynchronously using the audio player"""
         try:
-            audio_path = self._current_generated_audio_path()
+            if audio_path is None:
+                audio_path = self._current_generated_audio_path()
             if audio_path is not None:
                 if audio_path.exists():
                     # Get current player state before stopping
@@ -1800,6 +1941,9 @@ class TTSPlaygroundWidget(Widget):
             self.query_one("#pause-audio-btn", Button).disabled = True
             self.query_one("#stop-audio-btn", Button).disabled = True
             self.query_one("#audio-player-status", Static).update("Playback error")
+        finally:
+            if release_artifact is not None:
+                release_artifact()
 
     def _ensure_audio_player(self) -> bool:
         """Ensure audio player is initialized (lazy loading)"""
@@ -1935,8 +2079,13 @@ class TTSPlaygroundWidget(Widget):
 
     def _export_audio(self) -> None:
         """Export the generated audio"""
-        original_path = self._current_generated_audio_path()
-        if original_path is None:
+        captured = self._capture_audio_for_action()
+        if captured is None:
+            self.app.notify("No audio file to export", severity="warning")
+            return
+        original_path, release_artifact = captured
+        if not original_path.exists():
+            release_artifact()
             self.app.notify("No audio file to export", severity="warning")
             return
 
@@ -1961,11 +2110,27 @@ class TTSPlaygroundWidget(Widget):
             context="audio_export",
         )
 
-        self.app.push_screen(file_picker, self._handle_audio_export)
+        def handle_export(path: Optional[str]) -> None:
+            try:
+                self._handle_audio_export(path, source_path=original_path)
+            finally:
+                release_artifact()
 
-    def _handle_audio_export(self, path: Optional[str]) -> None:
+        try:
+            self.app.push_screen(file_picker, handle_export)
+        except Exception:
+            release_artifact()
+            raise
+
+    def _handle_audio_export(
+        self,
+        path: Optional[str],
+        *,
+        source_path: Path | None = None,
+    ) -> None:
         """Handle audio file export"""
-        source_path = self._current_generated_audio_path()
+        if source_path is None:
+            source_path = self._current_generated_audio_path()
         if not path or source_path is None:
             return
 
@@ -2289,6 +2454,7 @@ class TTSSettingsWidget(Widget):
                     yield Select(
                         options=[
                             ("OpenAI", "openai"),
+                            ("audio.cpp (External Server)", "audio_cpp"),
                             ("ElevenLabs", "elevenlabs"),
                             ("Kokoro (Local)", "kokoro"),
                             ("Chatterbox (Local)", "chatterbox"),
@@ -3054,6 +3220,7 @@ class TTSSettingsWidget(Widget):
             default_provider = get_cli_setting("app_tts", "default_provider", "openai")
             if default_provider in [
                 "openai",
+                "audio_cpp",
                 "elevenlabs",
                 "kokoro",
                 "chatterbox",
@@ -3110,6 +3277,7 @@ class TTSSettingsWidget(Widget):
             default_format = get_cli_setting("app_tts", "default_format", "mp3")
             if default_format in ["mp3", "opus", "aac", "flac", "wav"]:
                 format_select.value = default_format
+            self._update_audio_cpp_default_constraints(default_provider)
 
             # Set Kokoro device
             try:
@@ -3281,6 +3449,7 @@ class TTSSettingsWidget(Widget):
             # Update voice and model options when provider changes
             self._update_default_voice_options(event.value)
             self._update_default_model_options(event.value)
+            self._update_audio_cpp_default_constraints(event.value)
         elif event.select.id == "default-voice-select":
             # Validate voice selection (prevent selecting separators)
             if not self._is_valid_voice(event.value):
@@ -3295,7 +3464,26 @@ class TTSSettingsWidget(Widget):
         """Update default voice options based on provider"""
         voice_select = self.query_one("#default-voice-select", Select)
 
-        if provider == "openai":
+        if provider == AUDIO_CPP_PROVIDER_ID:
+            options = [("Server default", SERVER_DEFAULT_VOICE_ID)]
+            selected = SERVER_DEFAULT_VOICE_ID
+            configured_provider = get_cli_setting(
+                "app_tts",
+                "default_provider",
+                "openai",
+            )
+            stored_voice = get_cli_setting("app_tts", "default_voice", None)
+            if (
+                configured_provider == AUDIO_CPP_PROVIDER_ID
+                and isinstance(stored_voice, str)
+                and stored_voice
+                and stored_voice != SERVER_DEFAULT_VOICE_ID
+            ):
+                options.append(("Saved server voice", stored_voice))
+                selected = stored_voice
+            voice_select.set_options(options)
+            voice_select.value = selected
+        elif provider == "openai":
             voice_select.set_options(
                 [
                     ("Alloy", "alloy"),
@@ -3445,7 +3633,28 @@ class TTSSettingsWidget(Widget):
         """Update default model options based on provider"""
         model_select = self.query_one("#default-model-select", Select)
 
-        if provider == "openai":
+        if provider == AUDIO_CPP_PROVIDER_ID:
+            options = [
+                ("First available server model", FIRST_AVAILABLE_MODEL_ID),
+            ]
+            selected = FIRST_AVAILABLE_MODEL_ID
+            configured_provider = get_cli_setting(
+                "app_tts",
+                "default_provider",
+                "openai",
+            )
+            stored_model = get_cli_setting("app_tts", "default_model", None)
+            if (
+                configured_provider == AUDIO_CPP_PROVIDER_ID
+                and isinstance(stored_model, str)
+                and stored_model
+                and not stored_model.startswith("__")
+            ):
+                options.append(("Saved server model", stored_model))
+                selected = stored_model
+            model_select.set_options(options)
+            model_select.value = selected
+        elif provider == "openai":
             model_select.set_options(
                 [
                     ("TTS-1 (Standard)", "tts-1"),
@@ -3503,6 +3712,17 @@ class TTSSettingsWidget(Widget):
                 ]
             )
             model_select.value = "alltalk"
+
+    def _update_audio_cpp_default_constraints(self, provider: object) -> None:
+        """Mirror native audio.cpp's fixed format and speed without discovery."""
+        format_select = self.query_one("#default-format-select", Select)
+        speed_input = self.query_one("#default-speed-input", Input)
+        is_audio_cpp = provider == AUDIO_CPP_PROVIDER_ID
+        format_select.disabled = is_audio_cpp
+        speed_input.disabled = is_audio_cpp
+        if is_audio_cpp:
+            format_select.value = "wav"
+            speed_input.value = "1.0"
 
     def _save_settings(self) -> None:
         """Save TTS settings"""

--- a/tldw_chatbook/UI/STTS_Window.py
+++ b/tldw_chatbook/UI/STTS_Window.py
@@ -8,6 +8,7 @@ from dataclasses import replace
 from typing import Optional, Dict, Any, List
 from pathlib import Path
 from urllib.parse import urlsplit
+from uuid import uuid4
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, ScrollableContainer, Container
 from textual.widgets import (
@@ -36,7 +37,11 @@ from tldw_chatbook.Event_Handlers.STTS_Events.stts_events import (
     STTSSettingsSaveEvent,
     STTSAudioBookGenerateEvent,
 )
-from tldw_chatbook.TTS import get_tts_service
+from tldw_chatbook.TTS import (
+    STTSGeneratedAudio,
+    STTSPlaygroundRequest,
+    get_tts_service,
+)
 from tldw_chatbook.TTS.adapter_types import (
     TTSOperationError,
     TTSProviderCatalog,
@@ -50,6 +55,7 @@ from tldw_chatbook.UI.stts_playground_catalog import (
     PlaygroundControls,
     controls_from_catalog,
     provider_options,
+    voice_id_for_request,
 )
 from tldw_chatbook.UI.destination_recovery import optional_dependency_recovery_state
 from tldw_chatbook.Widgets.voice_blend_dialog import VoiceBlendDialog
@@ -217,6 +223,7 @@ class TTSPlaygroundWidget(Widget):
     def __init__(self):
         super().__init__()
         self.current_audio_file = None
+        self.current_audio_artifact: STTSGeneratedAudio | None = None
         self.reference_audio_path = None
         self.higgs_reference_audio_path = None
         self._progress_timer_task = None
@@ -1380,10 +1387,6 @@ class TTSPlaygroundWidget(Widget):
         format_select = self.query_one("#tts-format-select", Select)
         format = format_select.value
 
-        # Debug logging
-        logger.debug(f"Format select value: {format!r}, type: {type(format)}")
-        logger.debug(f"Format select options: {format_select._options}")
-
         # Ensure format has a valid value
         if not format or format == Select.BLANK or str(format) == "Select.BLANK":
             format = "mp3"
@@ -1391,7 +1394,6 @@ class TTSPlaygroundWidget(Widget):
         elif isinstance(format, tuple):
             # If it's a tuple, take the first element
             format = format[0]
-            logger.debug(f"Format was tuple, extracted: {format}")
 
         # Additional validation - also handle uppercase
         valid_formats = ["mp3", "opus", "aac", "flac", "wav", "pcm"]
@@ -1399,7 +1401,7 @@ class TTSPlaygroundWidget(Widget):
         if format_lower in valid_formats:
             format = format_lower
         else:
-            logger.warning(f"Invalid format '{format}', defaulting to mp3")
+            logger.warning("Invalid Playground audio format; using mp3")
             format = "mp3"
 
         # Collect provider-specific settings
@@ -1539,21 +1541,24 @@ class TTSPlaygroundWidget(Widget):
         # Log the request
         log = self.query_one("#tts-generation-log", RichLog)
         log.write("[bold blue]Generating TTS...[/bold blue]")
-        log.write(f"Provider: {provider}")
-        log.write(f"Voice: {voice}")
-        log.write(f"Model: {model}")
         log.write(f"Speed: {speed}")
         log.write(f"Format: {format}")
         log.write(f"Text length: {len(text)} characters")
 
-        # Debug log the actual values
-        logger.debug(
-            f"TTS generation - provider: {provider!r}, voice: {voice!r}, model: {model!r}"
-        )
-
-        # Log provider-specific settings
-        if extra_params:
-            log.write(f"Extra settings: {extra_params}")
+        if not isinstance(provider, str) or provider not in self._provider_ids:
+            self.app.notify("Please select a valid TTS provider", severity="warning")
+            return
+        if not isinstance(model, str) or model.startswith("__"):
+            self.app.notify("Please select a valid TTS model", severity="warning")
+            return
+        if not isinstance(format, str):
+            self.app.notify("Please select a valid audio format", severity="warning")
+            return
+        voice_id = voice_id_for_request(voice if isinstance(voice, str) else None)
+        if provider == AUDIO_CPP_PROVIDER_ID:
+            format = "wav"
+            speed = 1.0
+            extra_params = {}
 
         # Disable generate button
         self.query_one("#tts-generate-btn", Button).disabled = True
@@ -1561,25 +1566,29 @@ class TTSPlaygroundWidget(Widget):
         # Post event to generate TTS
         self.app.post_message(
             STTSPlaygroundGenerateEvent(
-                text=text,
-                provider=provider,
-                voice=voice,
-                model=model,
-                speed=speed,
-                format=format,
-                extra_params=extra_params,
+                STTSPlaygroundRequest(
+                    operation_id=str(uuid4()),
+                    provider_id=provider,
+                    model_id=model,
+                    text=text,
+                    voice_id=voice_id,
+                    response_format=format,
+                    speed=speed,
+                    options=extra_params,
+                )
             )
         )
 
     def _generation_complete(
-        self, success: bool, audio_file: Optional[Path] = None
+        self,
+        artifact: STTSGeneratedAudio | None,
     ) -> None:
-        """Handle TTS generation completion"""
-        self.query_one("#tts-generate-btn", Button).disabled = False
+        """Store one delivered artifact independently of current selectors."""
+        self._sync_generate_enabled()
 
-        if success and audio_file:
-            # Store the audio file path
-            self.current_audio_file = audio_file
+        if artifact is not None:
+            self.current_audio_artifact = artifact
+            self.current_audio_file = artifact.path
 
             log = self.query_one("#tts-generation-log", RichLog)
             log.write("[bold green]✓ TTS generation complete![/bold green]")
@@ -1593,13 +1602,20 @@ class TTSPlaygroundWidget(Widget):
                 "#stop-audio-btn", Button
             ).disabled = True  # Disabled until playing
             self.query_one("#audio-export-btn", Button).disabled = False
-            self.query_one("#audio-player-status", Static).update("Audio ready to play")
-
-            self.app.notify("TTS generation complete!", severity="information")
+            self.query_one("#audio-player-status", Static).update(
+                f"{artifact.audio_format.upper()} audio ready to play"
+            )
         else:
             log = self.query_one("#tts-generation-log", RichLog)
             log.write("[bold red]✗ TTS generation failed![/bold red]")
-            self.app.notify("TTS generation failed", severity="error")
+
+    def _current_generated_audio_path(self) -> Path | None:
+        """Return the delivered artifact path, with legacy path fallback."""
+        if self.current_audio_artifact is not None:
+            return self.current_audio_artifact.path
+        if self.current_audio_file is None:
+            return None
+        return Path(self.current_audio_file)
 
     def _play_audio(self) -> None:
         """Play the generated audio"""
@@ -1616,15 +1632,10 @@ class TTSPlaygroundWidget(Widget):
             logger.debug("Play already in progress, ignoring request")
             return
 
-        if not self.current_audio_file:
+        audio_path = self._current_generated_audio_path()
+        if audio_path is None:
             self.app.notify("No audio file to play", severity="warning")
             return
-
-        # Convert to Path if it's a string
-        if isinstance(self.current_audio_file, str):
-            audio_path = Path(self.current_audio_file)
-        else:
-            audio_path = self.current_audio_file
 
         logger.debug(
             f"Audio path: {audio_path}, exists: {audio_path.exists() if audio_path else False}"
@@ -1659,14 +1670,8 @@ class TTSPlaygroundWidget(Widget):
     async def _play_audio_async(self) -> None:
         """Play audio asynchronously using the audio player"""
         try:
-            # Use the stored audio file path - ensure it's a Path object
-            if self.current_audio_file:
-                # Convert to Path if it's a string
-                if isinstance(self.current_audio_file, str):
-                    audio_path = Path(self.current_audio_file)
-                else:
-                    audio_path = self.current_audio_file
-
+            audio_path = self._current_generated_audio_path()
+            if audio_path is not None:
                 if audio_path.exists():
                     # Get current player state before stopping
                     current_state = await self.app.audio_player.get_state()
@@ -1873,7 +1878,8 @@ class TTSPlaygroundWidget(Widget):
 
     def _export_audio(self) -> None:
         """Export the generated audio"""
-        if not self.current_audio_file:
+        original_path = self._current_generated_audio_path()
+        if original_path is None:
             self.app.notify("No audio file to export", severity="warning")
             return
 
@@ -1889,7 +1895,6 @@ class TTSPlaygroundWidget(Widget):
         )
 
         # Get original filename and extension
-        original_path = Path(self.current_audio_file)
         default_name = f"tts_export_{original_path.stem}{original_path.suffix}"
 
         file_picker = FileSave(
@@ -1903,13 +1908,13 @@ class TTSPlaygroundWidget(Widget):
 
     def _handle_audio_export(self, path: Optional[str]) -> None:
         """Handle audio file export"""
-        if not path or not self.current_audio_file:
+        source_path = self._current_generated_audio_path()
+        if not path or source_path is None:
             return
 
         try:
             import shutil
 
-            source_path = Path(self.current_audio_file)
             dest_path = Path(path)
 
             # If different format requested, we need conversion
@@ -5116,13 +5121,16 @@ class AudioBookGenerationWidget(Widget):
             # Post event to generate preview
             self.post_message(
                 STTSPlaygroundGenerateEvent(
-                    text=preview_text,
-                    provider=provider,
-                    voice=narrator_voice,
-                    model=self._get_model_for_provider(provider),
-                    speed=1.0,
-                    format="mp3",
-                    extra_params={"preview_chapter": chapter.title},
+                    STTSPlaygroundRequest(
+                        operation_id=str(uuid4()),
+                        provider_id=provider,
+                        model_id=self._get_model_for_provider(provider),
+                        text=preview_text,
+                        voice_id=narrator_voice,
+                        response_format="mp3",
+                        speed=1.0,
+                        options={"preview_chapter": chapter.title},
+                    )
                 )
             )
 

--- a/tldw_chatbook/UI/STTS_Window.py
+++ b/tldw_chatbook/UI/STTS_Window.py
@@ -3,6 +3,7 @@
 #
 # Imports
 import asyncio
+from collections.abc import Mapping
 from typing import Optional, Dict, Any, List
 from pathlib import Path
 from urllib.parse import urlsplit
@@ -23,7 +24,7 @@ from textual.widgets import (
 from textual.widget import Widget
 from textual.reactive import reactive
 from textual.binding import Binding
-from textual import on
+from textual import on, work
 from loguru import logger
 
 # Local imports
@@ -33,6 +34,8 @@ from tldw_chatbook.Event_Handlers.STTS_Events.stts_events import (
     STTSSettingsSaveEvent,
     STTSAudioBookGenerateEvent,
 )
+from tldw_chatbook.TTS import get_tts_service
+from tldw_chatbook.TTS.audio_cpp_config import AudioCppConfig
 from tldw_chatbook.UI.destination_recovery import optional_dependency_recovery_state
 from tldw_chatbook.Widgets.voice_blend_dialog import VoiceBlendDialog
 from tldw_chatbook.Widgets.enhanced_file_picker import (
@@ -1963,8 +1966,20 @@ class TTSSettingsWidget(Widget):
     }
     """
 
+    @staticmethod
+    def _load_audio_cpp_config() -> AudioCppConfig:
+        """Load a safe external audio.cpp form snapshot."""
+        candidate = get_cli_setting("app_tts", "audio_cpp", {})
+        try:
+            values = candidate if isinstance(candidate, Mapping) else {}
+            return AudioCppConfig.from_mapping(values)
+        except (TypeError, ValueError):
+            logger.warning("Stored audio.cpp settings are invalid; using defaults")
+            return AudioCppConfig()
+
     def compose(self) -> ComposeResult:
         """Compose the TTS Settings UI"""
+        audio_cpp_config = self._load_audio_cpp_config()
         with ScrollableContainer(classes="tts-settings-container"):
             yield Label("⚙️ TTS Settings", classes="section-title")
 
@@ -2025,6 +2040,107 @@ class TTSSettingsWidget(Widget):
                         placeholder="0.25-4.0",
                         type="number",
                     )
+
+            with Collapsible(
+                title="audio.cpp External Server",
+                id="audio-cpp-settings",
+                classes="settings-section",
+                collapsed=False,
+            ):
+                with Horizontal(classes="form-row"):
+                    yield Label("Mode:", classes="form-label")
+                    yield Static("External", id="audio-cpp-mode-value")
+
+                with Horizontal(classes="form-row"):
+                    yield Label("Base URL:", classes="form-label")
+                    yield Input(
+                        id="audio-cpp-base-url-input",
+                        value=audio_cpp_config.base_url,
+                        placeholder="http://127.0.0.1:8080",
+                    )
+
+                with Horizontal(classes="form-row"):
+                    yield Label("Connect timeout:", classes="form-label")
+                    yield Input(
+                        id="audio-cpp-connect-timeout-input",
+                        value=str(audio_cpp_config.connect_timeout_seconds),
+                        type="number",
+                    )
+
+                with Horizontal(classes="form-row"):
+                    yield Label("Synthesis timeout:", classes="form-label")
+                    yield Input(
+                        id="audio-cpp-synthesis-timeout-input",
+                        value=str(audio_cpp_config.synthesis_timeout_seconds),
+                        type="number",
+                    )
+
+                with Horizontal(classes="form-row"):
+                    yield Label("Max input characters:", classes="form-label")
+                    yield Input(
+                        id="audio-cpp-max-input-characters-input",
+                        value=str(audio_cpp_config.max_input_characters),
+                        type="integer",
+                    )
+
+                with Horizontal(classes="form-row"):
+                    yield Label("Max response bytes:", classes="form-label")
+                    yield Input(
+                        id="audio-cpp-max-response-bytes-input",
+                        value=str(audio_cpp_config.max_response_bytes),
+                        type="integer",
+                    )
+
+                with Horizontal(classes="form-row"):
+                    yield Label("Max metadata bytes:", classes="form-label")
+                    yield Input(
+                        id="audio-cpp-max-metadata-bytes-input",
+                        value=str(audio_cpp_config.max_metadata_bytes),
+                        type="integer",
+                    )
+
+                with Horizontal(classes="form-row"):
+                    yield Label("Max catalog models:", classes="form-label")
+                    yield Input(
+                        id="audio-cpp-max-catalog-models-input",
+                        value=str(audio_cpp_config.max_catalog_models),
+                        type="integer",
+                    )
+
+                with Horizontal(classes="form-row"):
+                    yield Label("Max voices per model:", classes="form-label")
+                    yield Input(
+                        id="audio-cpp-max-voices-per-model-input",
+                        value=str(audio_cpp_config.max_voices_per_model),
+                        type="integer",
+                    )
+
+                with Horizontal(classes="form-row"):
+                    yield Label("Max identifier chars:", classes="form-label")
+                    yield Input(
+                        id="audio-cpp-max-identifier-characters-input",
+                        value=str(audio_cpp_config.max_identifier_characters),
+                        type="integer",
+                    )
+
+                yield Static(
+                    "External synthesis sends submitted text to the configured "
+                    "server. Save changes before testing.",
+                    id="audio-cpp-privacy-notice",
+                )
+                with Horizontal(classes="form-row"):
+                    yield Button(
+                        "Test Connection",
+                        id="audio-cpp-test-connection-btn",
+                    )
+                    yield Button(
+                        "Refresh Models",
+                        id="audio-cpp-refresh-models-btn",
+                    )
+                yield Static(
+                    "Not checked",
+                    id="audio-cpp-discovery-status",
+                )
 
             # OpenAI settings
             with Collapsible(title="OpenAI Settings", classes="settings-section"):
@@ -2829,6 +2945,12 @@ class TTSSettingsWidget(Widget):
         if event.button.id == "save-settings-btn":
             self._save_settings()
             event.stop()  # Prevent event from bubbling up
+        elif event.button.id == "audio-cpp-test-connection-btn":
+            self._discover_audio_cpp("test")
+            event.stop()
+        elif event.button.id == "audio-cpp-refresh-models-btn":
+            self._discover_audio_cpp("refresh")
+            event.stop()
         elif event.button.id == "add-voice-blend-btn":
             self.run_worker(self._show_add_voice_blend_dialog)
             event.stop()
@@ -3108,6 +3230,8 @@ class TTSSettingsWidget(Widget):
                 self.query_one("#default-speed-input", Input).value, 0.25, 4.0, 1.0
             )
 
+            settings["audio_cpp"] = self._collect_audio_cpp_config().to_mapping()
+
             # OpenAI settings
             openai_key = self.query_one("#openai-api-key-input", Input).value
             if openai_key:
@@ -3359,6 +3483,94 @@ class TTSSettingsWidget(Widget):
         except Exception:
             logger.error("Failed to collect TTS settings")
             self.app.notify("Failed to save settings", severity="error")
+
+    def _collect_audio_cpp_config(self) -> AudioCppConfig:
+        """Validate the complete external audio.cpp settings form."""
+        return AudioCppConfig.from_mapping(
+            {
+                "mode": "external",
+                "base_url": self.query_one("#audio-cpp-base-url-input", Input).value,
+                "connect_timeout_seconds": float(
+                    self.query_one("#audio-cpp-connect-timeout-input", Input).value
+                ),
+                "synthesis_timeout_seconds": float(
+                    self.query_one("#audio-cpp-synthesis-timeout-input", Input).value
+                ),
+                "max_input_characters": self._audio_cpp_integer(
+                    "#audio-cpp-max-input-characters-input"
+                ),
+                "max_response_bytes": self._audio_cpp_integer(
+                    "#audio-cpp-max-response-bytes-input"
+                ),
+                "max_metadata_bytes": self._audio_cpp_integer(
+                    "#audio-cpp-max-metadata-bytes-input"
+                ),
+                "max_catalog_models": self._audio_cpp_integer(
+                    "#audio-cpp-max-catalog-models-input"
+                ),
+                "max_voices_per_model": self._audio_cpp_integer(
+                    "#audio-cpp-max-voices-per-model-input"
+                ),
+                "max_identifier_characters": self._audio_cpp_integer(
+                    "#audio-cpp-max-identifier-characters-input"
+                ),
+            }
+        )
+
+    def _audio_cpp_integer(self, selector: str) -> int:
+        """Parse one audio.cpp integer field without coercing fractions."""
+        return int(self.query_one(selector, Input).value)
+
+    @work(
+        exclusive=True,
+        group="stts-audio-cpp-settings-discovery",
+        exit_on_error=False,
+    )
+    async def _discover_audio_cpp(self, action: str) -> None:
+        """Test or refresh the currently saved external audio.cpp service."""
+        status = self.query_one("#audio-cpp-discovery-status", Static)
+        status.update("Checking saved settings…")
+        try:
+            service = await get_tts_service()
+            before_revision = service.configuration_revision("audio_cpp")
+            catalog = await service.get_catalog("audio_cpp", refresh=True)
+            after_revision = service.configuration_revision("audio_cpp")
+            if before_revision != after_revision:
+                status.update("Settings changed; retry")
+                self.app.notify(
+                    "audio.cpp settings changed; retry the check",
+                    severity="warning",
+                )
+                return
+            if (
+                catalog.provider_id != "audio_cpp"
+                or catalog.health.state != "available"
+                or not catalog.health.fresh
+            ):
+                status.update("Unavailable")
+                self.app.notify(
+                    "audio.cpp is not ready; check the saved settings",
+                    severity="error",
+                )
+                return
+
+            model_count = len(catalog.models)
+            noun = "model" if model_count == 1 else "models"
+            if action == "test":
+                message = f"audio.cpp connection is ready ({model_count} {noun})"
+            else:
+                message = f"audio.cpp models refreshed ({model_count} {noun})"
+            status.update(message)
+            self.app.notify(message, severity="information")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("audio.cpp settings discovery failed")
+            status.update("Unavailable")
+            self.app.notify(
+                "audio.cpp is not ready; check the saved settings",
+                severity="error",
+            )
 
     def _validate_numeric_input(
         self, value: str, min_val: float, max_val: float, default: float

--- a/tldw_chatbook/UI/STTS_Window.py
+++ b/tldw_chatbook/UI/STTS_Window.py
@@ -680,17 +680,43 @@ class TTSPlaygroundWidget(Widget):
         """Check if a voice value is valid (not a separator)."""
         return bool(voice) and not str(voice).startswith("_separator")
 
-    @work(
-        exclusive=True,
-        group="stts-catalog-discovery",
-        exit_on_error=False,
-    )
-    async def _load_provider_catalog(
+    def _load_provider_catalog(
         self,
         provider_id: str | None = None,
         *,
         refresh: bool = False,
         initialize: bool = False,
+    ) -> None:
+        """Reserve request identity before starting exclusive catalog work."""
+        target = provider_id or self._selected_provider_id
+        request_generation = (
+            self._reserve_catalog_request(target) if isinstance(target, str) else None
+        )
+        self._load_provider_catalog_worker(
+            provider_id,
+            refresh=refresh,
+            initialize=initialize,
+            request_generation=request_generation,
+        )
+
+    def _reserve_catalog_request(self, provider_id: str) -> int:
+        """Reserve and return the next catalog request generation."""
+        generation = self._catalog_request_generations.get(provider_id, 0) + 1
+        self._catalog_request_generations[provider_id] = generation
+        return generation
+
+    @work(
+        exclusive=True,
+        group="stts-catalog-discovery",
+        exit_on_error=False,
+    )
+    async def _load_provider_catalog_worker(
+        self,
+        provider_id: str | None = None,
+        *,
+        refresh: bool = False,
+        initialize: bool = False,
+        request_generation: int | None = None,
     ) -> None:
         """Load descriptors and one selected provider catalog."""
         token: CatalogRequestToken | None = None
@@ -740,10 +766,8 @@ class TTSPlaygroundWidget(Widget):
                 return
 
             configuration_revision = service.configuration_revision(provider_id)
-            request_generation = (
-                self._catalog_request_generations.get(provider_id, 0) + 1
-            )
-            self._catalog_request_generations[provider_id] = request_generation
+            if request_generation is None:
+                request_generation = self._reserve_catalog_request(provider_id)
             token = CatalogRequestToken(
                 provider_id=provider_id,
                 configuration_revision=configuration_revision,
@@ -799,12 +823,7 @@ class TTSPlaygroundWidget(Widget):
                     self._catalog_error_copy(error, target),
                 )
 
-    @work(
-        exclusive=True,
-        group="stts-voice-discovery",
-        exit_on_error=False,
-    )
-    async def _load_provider_voices(
+    def _load_provider_voices(
         self,
         provider_id: str,
         model_id: str,
@@ -812,13 +831,36 @@ class TTSPlaygroundWidget(Widget):
         *,
         refresh: bool = False,
     ) -> None:
+        """Reserve request identity before starting exclusive voice work."""
+        request_key = (provider_id, model_id)
+        request_generation = self._voice_request_generations.get(request_key, 0) + 1
+        self._voice_request_generations[request_key] = request_generation
+        self._load_provider_voices_worker(
+            provider_id,
+            model_id,
+            catalog_revision,
+            refresh=refresh,
+            request_generation=request_generation,
+        )
+
+    @work(
+        exclusive=True,
+        group="stts-voice-discovery",
+        exit_on_error=False,
+    )
+    async def _load_provider_voices_worker(
+        self,
+        provider_id: str,
+        model_id: str,
+        catalog_revision: int,
+        *,
+        refresh: bool = False,
+        request_generation: int,
+    ) -> None:
         """Load voices for only the selected provider model."""
         service = self._tts_service
         if service is None:
             return
-        request_key = (provider_id, model_id)
-        request_generation = self._voice_request_generations.get(request_key, 0) + 1
-        self._voice_request_generations[request_key] = request_generation
         token = CatalogRequestToken(
             provider_id=provider_id,
             configuration_revision=service.configuration_revision(provider_id),

--- a/tldw_chatbook/UI/Voice_Cloning_Window.py
+++ b/tldw_chatbook/UI/Voice_Cloning_Window.py
@@ -5,6 +5,7 @@
 from typing import Optional, Dict, Any, List
 from pathlib import Path
 import asyncio
+from uuid import uuid4
 from loguru import logger
 
 # Textual imports
@@ -39,6 +40,7 @@ from ..Widgets.enhanced_file_picker import (
 )
 from ..Third_Party.textual_fspicker import Filters
 from ..Event_Handlers.STTS_Events.stts_events import STTSPlaygroundGenerateEvent
+from ..TTS import STTSPlaygroundRequest
 
 #######################################################################################################################
 #
@@ -632,13 +634,16 @@ Tags: {", ".join(profile["tags"]) if profile["tags"] else "None"}
         voice = f"profile:{test_profile}"
 
         event = STTSPlaygroundGenerateEvent(
-            text=test_text,
-            provider=provider,
-            voice=voice,
-            model="default",
-            speed=1.0,
-            format="mp3",
-            extra_params={"source": "voice_cloning_test"},
+            STTSPlaygroundRequest(
+                operation_id=str(uuid4()),
+                provider_id=provider,
+                model_id="default",
+                text=test_text,
+                voice_id=voice,
+                response_format="mp3",
+                speed=1.0,
+                options={"source": "voice_cloning_test"},
+            )
         )
 
         # Post the event to be handled by the main app

--- a/tldw_chatbook/UI/stts_playground_catalog.py
+++ b/tldw_chatbook/UI/stts_playground_catalog.py
@@ -1,7 +1,10 @@
+"""Pure projection helpers for catalog-driven STTS Playground controls."""
+
 from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass
+from enum import Enum, auto
 
 from tldw_chatbook.TTS.adapter_types import (
     TTSModelInfo,
@@ -10,11 +13,25 @@ from tldw_chatbook.TTS.adapter_types import (
 )
 
 AUDIO_CPP_PROVIDER_ID = "audio_cpp"
-FIRST_AVAILABLE_MODEL_ID = "__first_available_model__"
-SERVER_DEFAULT_VOICE_ID = "__server_default__"
 SERVER_DEFAULT_VOICE_LABEL = "Server default"
 
-SelectOption = tuple[str, str]
+
+class SelectSentinel(Enum):
+    """Out-of-band values owned by local STTS Select controls."""
+
+    FIRST_AVAILABLE_MODEL = auto()
+    SERVER_DEFAULT_VOICE = auto()
+    LOADING = auto()
+    UNAVAILABLE = auto()
+
+
+FIRST_AVAILABLE_MODEL_ID = SelectSentinel.FIRST_AVAILABLE_MODEL
+SERVER_DEFAULT_VOICE_ID = SelectSentinel.SERVER_DEFAULT_VOICE
+LOADING_SELECT_VALUE = SelectSentinel.LOADING
+UNAVAILABLE_SELECT_VALUE = SelectSentinel.UNAVAILABLE
+
+SelectValue = str | SelectSentinel
+SelectOption = tuple[str, SelectValue]
 
 
 @dataclass(frozen=True, slots=True)
@@ -25,6 +42,7 @@ class CatalogRequestToken:
     configuration_revision: int
     catalog_revision: int | None = None
     model_id: str | None = None
+    request_generation: int | None = None
 
     def matches(
         self,
@@ -33,13 +51,27 @@ class CatalogRequestToken:
         configuration_revision: int,
         catalog_revision: int | None,
         model_id: str | None,
+        request_generation: int | None = None,
     ) -> bool:
-        """Return whether every captured request dimension is still current."""
+        """Return whether every captured request dimension is still current.
+
+        Args:
+            provider_id: Currently selected canonical provider identifier.
+            configuration_revision: Current provider configuration revision.
+            catalog_revision: Current provider catalog revision, when applicable.
+            model_id: Currently selected opaque model identifier, when applicable.
+            request_generation: Latest request generation, when applicable.
+
+        Returns:
+            ``True`` when every captured dimension matches current state.
+
+        """
         return (
             self.provider_id == provider_id
             and self.configuration_revision == configuration_revision
             and self.catalog_revision == catalog_revision
             and self.model_id == model_id
+            and self.request_generation == request_generation
         )
 
 
@@ -51,7 +83,7 @@ class PlaygroundControls:
     model_options: tuple[SelectOption, ...]
     selected_model_id: str | None
     voice_options: tuple[SelectOption, ...]
-    selected_voice_id: str | None
+    selected_voice_id: SelectValue | None
     format_options: tuple[str, ...]
     selected_format: str | None
     format_locked: bool
@@ -64,29 +96,58 @@ class PlaygroundControls:
 def provider_options(
     descriptors: Iterable[TTSProviderDescriptor],
 ) -> tuple[SelectOption, ...]:
-    """Return display labels paired with exact canonical provider IDs."""
+    """Return display labels paired with exact canonical provider IDs.
+
+    Args:
+        descriptors: Sealed registry descriptors in display order.
+
+    Returns:
+        Select options containing display labels and canonical provider IDs.
+
+    """
     return tuple(
         (descriptor.display_name, descriptor.provider_id) for descriptor in descriptors
     )
 
 
-def voice_id_for_request(selected_voice_id: str | None) -> str | None:
-    """Translate the local Server-default sentinel into adapter omission."""
-    if selected_voice_id == SERVER_DEFAULT_VOICE_ID:
+def voice_id_for_request(selected_voice_id: object) -> str | None:
+    """Translate the local Server-default sentinel into adapter omission.
+
+    Args:
+        selected_voice_id: Selected remote voice ID or local default sentinel.
+
+    Returns:
+        The exact remote voice ID, or ``None`` to request the server default.
+
+    """
+    if selected_voice_id is SERVER_DEFAULT_VOICE_ID:
         return None
-    return selected_voice_id
+    return selected_voice_id if isinstance(selected_voice_id, str) else None
 
 
 def controls_from_catalog(
     catalog: TTSProviderCatalog,
     *,
     selected_model_id: str | None,
-    selected_voice_id: str | None,
+    selected_voice_id: SelectValue | None,
     discovered_voices: tuple[str, ...] | None,
     selected_format: str | None,
     speed: float,
 ) -> PlaygroundControls:
-    """Resolve one provider catalog into deterministic control state."""
+    """Resolve one provider catalog into deterministic control state.
+
+    Args:
+        catalog: Current provider catalog.
+        selected_model_id: Previously selected opaque model ID.
+        selected_voice_id: Previously selected opaque voice ID.
+        discovered_voices: Lazily discovered voice IDs, when available.
+        selected_format: Previously selected response format.
+        speed: Previously selected synthesis speed.
+
+    Returns:
+        Provider-neutral state for the Playground controls.
+
+    """
     model_options = tuple(
         (model.display_name or model.model_id, model.model_id)
         for model in catalog.models
@@ -98,7 +159,7 @@ def controls_from_catalog(
     )
 
     voice_options: tuple[SelectOption, ...]
-    resolved_voice_id: str | None
+    resolved_voice_id: SelectValue | None
     format_options: tuple[str, ...]
     resolved_format: str | None
     if catalog.provider_id == AUDIO_CPP_PROVIDER_ID:
@@ -161,12 +222,11 @@ def _selected_model(
 
 def _audio_cpp_voices(
     voices: tuple[str, ...],
-    selected_voice_id: str | None,
-) -> tuple[tuple[SelectOption, ...], str, bool]:
-    remote_voices = tuple(voice for voice in voices if voice != SERVER_DEFAULT_VOICE_ID)
-    options = (
+    selected_voice_id: SelectValue | None,
+) -> tuple[tuple[SelectOption, ...], SelectValue, bool]:
+    options: tuple[SelectOption, ...] = (
         (SERVER_DEFAULT_VOICE_LABEL, SERVER_DEFAULT_VOICE_ID),
-        *((voice, voice) for voice in remote_voices),
+        *((voice, voice) for voice in voices),
     )
     valid_ids = {value for _, value in options}
     if selected_voice_id is None:
@@ -179,7 +239,7 @@ def _audio_cpp_voices(
 def _legacy_voices(
     catalog_voices: tuple[str, ...],
     discovered_voices: tuple[str, ...] | None,
-    selected_voice_id: str | None,
+    selected_voice_id: SelectValue | None,
 ) -> tuple[tuple[SelectOption, ...], str | None, bool]:
     voices = catalog_voices if discovered_voices is None else discovered_voices
     options = tuple((voice, voice) for voice in voices)
@@ -189,7 +249,7 @@ def _legacy_voices(
 
 
 def _retain_or_first(
-    selected: str | None,
+    selected: SelectValue | None,
     values: tuple[str, ...],
 ) -> str | None:
     if selected in values:

--- a/tldw_chatbook/UI/stts_playground_catalog.py
+++ b/tldw_chatbook/UI/stts_playground_catalog.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from tldw_chatbook.TTS.adapter_types import (
+    TTSModelInfo,
+    TTSProviderCatalog,
+    TTSProviderDescriptor,
+)
+
+AUDIO_CPP_PROVIDER_ID = "audio_cpp"
+SERVER_DEFAULT_VOICE_ID = "__server_default__"
+SERVER_DEFAULT_VOICE_LABEL = "Server default"
+
+SelectOption = tuple[str, str]
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogRequestToken:
+    """Identity and revision snapshot for one catalog or voice request."""
+
+    provider_id: str
+    configuration_revision: int
+    catalog_revision: int | None = None
+    model_id: str | None = None
+
+    def matches(
+        self,
+        *,
+        provider_id: str,
+        configuration_revision: int,
+        catalog_revision: int | None,
+        model_id: str | None,
+    ) -> bool:
+        """Return whether every captured request dimension is still current."""
+        return (
+            self.provider_id == provider_id
+            and self.configuration_revision == configuration_revision
+            and self.catalog_revision == catalog_revision
+            and self.model_id == model_id
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PlaygroundControls:
+    """Provider-neutral state used to populate Playground controls."""
+
+    provider_id: str
+    model_options: tuple[SelectOption, ...]
+    selected_model_id: str | None
+    voice_options: tuple[SelectOption, ...]
+    selected_voice_id: str | None
+    format_options: tuple[str, ...]
+    selected_format: str | None
+    format_locked: bool
+    speed: float
+    speed_locked: bool
+    generation_allowed: bool
+    selection_changed: bool
+
+
+def provider_options(
+    descriptors: Iterable[TTSProviderDescriptor],
+) -> tuple[SelectOption, ...]:
+    """Return display labels paired with exact canonical provider IDs."""
+    return tuple(
+        (descriptor.display_name, descriptor.provider_id) for descriptor in descriptors
+    )
+
+
+def voice_id_for_request(selected_voice_id: str | None) -> str | None:
+    """Translate the local Server-default sentinel into adapter omission."""
+    if selected_voice_id == SERVER_DEFAULT_VOICE_ID:
+        return None
+    return selected_voice_id
+
+
+def controls_from_catalog(
+    catalog: TTSProviderCatalog,
+    *,
+    selected_model_id: str | None,
+    selected_voice_id: str | None,
+    discovered_voices: tuple[str, ...] | None,
+    selected_format: str | None,
+    speed: float,
+) -> PlaygroundControls:
+    """Resolve one provider catalog into deterministic control state."""
+    model_options = tuple(
+        (model.display_name or model.model_id, model.model_id)
+        for model in catalog.models
+    )
+    model = _selected_model(catalog.models, selected_model_id)
+    resolved_model_id = model.model_id if model is not None else None
+    selection_changed = (
+        selected_model_id is not None and selected_model_id != resolved_model_id
+    )
+
+    voice_options: tuple[SelectOption, ...]
+    resolved_voice_id: str | None
+    format_options: tuple[str, ...]
+    resolved_format: str | None
+    if catalog.provider_id == AUDIO_CPP_PROVIDER_ID:
+        voice_options, resolved_voice_id, voice_changed = _audio_cpp_voices(
+            discovered_voices or (),
+            selected_voice_id,
+        )
+        format_options = ("wav",)
+        resolved_format = "wav"
+        format_locked = True
+        resolved_speed = 1.0
+        speed_locked = True
+        format_compatible = model is not None and "wav" in model.formats
+    else:
+        voice_options, resolved_voice_id, voice_changed = _legacy_voices(
+            () if model is None else model.voices,
+            discovered_voices,
+            selected_voice_id,
+        )
+        format_options = () if model is None else model.formats
+        resolved_format = _retain_or_first(selected_format, format_options)
+        format_locked = model is None or len(format_options) <= 1
+        speed_locked = model is None or not model.supports_speed
+        resolved_speed = 1.0 if speed_locked else speed
+        format_compatible = resolved_format is not None
+
+    health = catalog.health
+    generation_allowed = bool(
+        model is not None
+        and health.state == "available"
+        and health.fresh
+        and format_compatible
+    )
+    return PlaygroundControls(
+        provider_id=catalog.provider_id,
+        model_options=model_options,
+        selected_model_id=resolved_model_id,
+        voice_options=voice_options,
+        selected_voice_id=resolved_voice_id,
+        format_options=format_options,
+        selected_format=resolved_format,
+        format_locked=format_locked,
+        speed=resolved_speed,
+        speed_locked=speed_locked,
+        generation_allowed=generation_allowed,
+        selection_changed=selection_changed or voice_changed,
+    )
+
+
+def _selected_model(
+    models: tuple[TTSModelInfo, ...],
+    selected_model_id: str | None,
+) -> TTSModelInfo | None:
+    if selected_model_id is not None:
+        for model in models:
+            if model.model_id == selected_model_id:
+                return model
+    return models[0] if models else None
+
+
+def _audio_cpp_voices(
+    voices: tuple[str, ...],
+    selected_voice_id: str | None,
+) -> tuple[tuple[SelectOption, ...], str, bool]:
+    remote_voices = tuple(voice for voice in voices if voice != SERVER_DEFAULT_VOICE_ID)
+    options = (
+        (SERVER_DEFAULT_VOICE_LABEL, SERVER_DEFAULT_VOICE_ID),
+        *((voice, voice) for voice in remote_voices),
+    )
+    valid_ids = {value for _, value in options}
+    if selected_voice_id is None:
+        return options, SERVER_DEFAULT_VOICE_ID, False
+    if selected_voice_id in valid_ids:
+        return options, selected_voice_id, False
+    return options, SERVER_DEFAULT_VOICE_ID, True
+
+
+def _legacy_voices(
+    catalog_voices: tuple[str, ...],
+    discovered_voices: tuple[str, ...] | None,
+    selected_voice_id: str | None,
+) -> tuple[tuple[SelectOption, ...], str | None, bool]:
+    voices = catalog_voices if discovered_voices is None else discovered_voices
+    options = tuple((voice, voice) for voice in voices)
+    resolved = _retain_or_first(selected_voice_id, voices)
+    changed = selected_voice_id is not None and selected_voice_id != resolved
+    return options, resolved, changed
+
+
+def _retain_or_first(
+    selected: str | None,
+    values: tuple[str, ...],
+) -> str | None:
+    if selected in values:
+        return selected
+    return values[0] if values else None

--- a/tldw_chatbook/UI/stts_playground_catalog.py
+++ b/tldw_chatbook/UI/stts_playground_catalog.py
@@ -10,6 +10,7 @@ from tldw_chatbook.TTS.adapter_types import (
 )
 
 AUDIO_CPP_PROVIDER_ID = "audio_cpp"
+FIRST_AVAILABLE_MODEL_ID = "__first_available_model__"
 SERVER_DEFAULT_VOICE_ID = "__server_default__"
 SERVER_DEFAULT_VOICE_LABEL = "Server default"
 

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -265,6 +265,7 @@ from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
 from tldw_chatbook.Event_Handlers.STTS_Events.stts_events import (
     STTSEventHandler,
     STTSPlaygroundGenerateEvent,
+    STTSProviderConfigurationChanged,
     STTSSettingsSaveEvent,
     STTSAudioBookGenerateEvent,
 )
@@ -6060,6 +6061,16 @@ class TldwCli(
         handler = await self._ensure_stts_handler()
         if handler:
             await handler.handle_settings_save(event)
+
+    @on(STTSProviderConfigurationChanged)
+    def handle_stts_provider_configuration_changed(
+        self,
+        event: STTSProviderConfigurationChanged,
+    ) -> None:
+        """Forward provider invalidation to the retained STTS handler."""
+        handler = getattr(self, "_stts_handler", None)
+        if handler is not None:
+            handler.on_stts_provider_configuration_changed(event)
 
     @on(STTSAudioBookGenerateEvent)
     async def handle_stts_audiobook_generate_event(

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -6042,7 +6042,8 @@ class TldwCli(
     ) -> None:
         """Handle S/TT/S playground generation request."""
         self.loguru_logger.info(
-            f"S/TT/S generation request: provider={event.provider}, model={event.model}"
+            "S/TT/S generation request accepted for provider={}",
+            event.request.provider_id,
         )
         handler = await self._ensure_stts_handler()
         if handler:

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -6047,7 +6047,7 @@ class TldwCli(
         )
         handler = await self._ensure_stts_handler()
         if handler:
-            await handler.handle_playground_generate(event)
+            handler.start_playground_generation(event)
         else:
             self.loguru_logger.error("S/TT/S handler not initialized")
             self.notify("S/TT/S service not available", severity="error")


### PR DESCRIPTION
## Summary

- make the STTS Playground registry/catalog-driven and lazily resolve the selected provider, with audio.cpp as the first native adapter
- add validated external audio.cpp settings, explicit model/voice discovery, complete-WAV generation, immutable provenance, playback/export, and hardened worker/lifecycle ownership
- preserve all six existing providers behind the temporary legacy bridge, including their prior defaults and labels, and document the external-only privacy/runtime boundary

## Verification

- [x] Focused Slice 3 matrix: 185 passed
- [x] Broad TTS/STTS regression matrix: 892 passed, 14 expected optional skips
- [x] Ruff check and format check
- [x] compileall and scoped mypy
- [x] managed-mode boundary scan and diff hygiene
- [x] independent post-rebase review: no Critical or Important findings

## Architecture and scope

- Backlog: TASK-569 (Done)
- Governing decision: ADR-023
- Rebased onto dev at 6ed2b9c00b355fa5b0344539cf7d944d97a5ac69
- External-only in this slice: no binary handling, server.json ownership, launch, supervision, restart, managed logs, or automatic provider fallback
- Complete WAV responses are exposed through the preserved async-stream adapter interface

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the catalog-driven STTS Playground and connects the native external `audio_cpp` adapter for model/voice discovery and validated complete-WAV generation with playback and export. Preserves all six legacy providers with their prior defaults and labels; fulfills TASK-569 and aligns with ADR-023.

- New Features
  - Catalog-driven provider selection with lazy resolution; UI controls derive from catalogs with a server-default voice option.
  - External `audio_cpp` settings now use a Pydantic model with strict validation.
  - Added immutable `STTSPlaygroundRequest` and `STTSGeneratedAudio`; export uses the delivered artifact path with safe paths.
  - TTS service exposes `provider_descriptors()` and `configuration_revision()` to keep UI state fresh and invalidate caches.
  - Event flow updated: `STTSPlaygroundGenerateEvent` carries the request; lifecycle hardened; stale/superseded discoveries are rejected.

- Migration
  - No changes required for existing providers.
  - To use `audio_cpp`: start your `audiocpp_server`, set its origin in Speech Services settings, then select models/voices in the Playground.

<sup>Written for commit 4e6ea3d5d01cc6924d46c9cd5949ae241c165c3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

