### PR TITLE
fix(llm): resolve local-llm config from api_settings, not a top-level key (task-625)

### DIFF
--- a/Tests/LLM/test_local_llm_provider_config.py
+++ b/Tests/LLM/test_local_llm_provider_config.py
@@ -1,0 +1,94 @@
+"""task-625: the local-llm provider must resolve its config from api_settings.
+
+`chat_with_local_llm` read a TOP-LEVEL "local-llm" settings key, while the
+provider's configuration lives at `api_settings.local-llm` — which is where the
+app's own documented example puts it, and where every sibling local provider in
+the same module looks. `load_settings()` does not preserve arbitrary top-level
+sections either, so the provider was unusable from configuration entirely.
+"""
+
+import pytest
+
+from tldw_chatbook.LLM_Calls import LLM_API_Calls_Local as local_calls
+
+
+@pytest.fixture
+def captured_call(monkeypatch):
+    """Intercept the outbound request so no network is touched."""
+    seen = {}
+
+    def fake_request(*args, **kwargs):
+        seen["args"] = args
+        seen["kwargs"] = kwargs
+        return {"choices": [{"message": {"role": "assistant", "content": "ok"}}]}
+
+    # `_chat_with_openai_compatible_local_server` is the shared transport every
+    # local provider funnels through; stubbing it keeps this a pure config test.
+    monkeypatch.setattr(
+        local_calls,
+        "_chat_with_openai_compatible_local_server",
+        fake_request,
+    )
+    return seen
+
+
+def _settings_with(api_settings_block):
+    return {"api_settings": {"local-llm": api_settings_block}}
+
+
+def test_resolves_api_url_from_api_settings(monkeypatch, captured_call):
+    """The documented location must work."""
+    monkeypatch.setattr(
+        local_calls,
+        "settings",
+        _settings_with({"api_url": "http://127.0.0.1:9099/v1/chat/completions"}),
+    )
+    local_calls.chat_with_local_llm(
+        input_data=[{"role": "user", "content": "hi"}],
+    )
+    assert captured_call["kwargs"].get("api_base_url") == (
+        "http://127.0.0.1:9099/v1/chat/completions"
+    )
+
+
+def test_legacy_api_ip_key_still_accepted(monkeypatch, captured_call):
+    """`api_ip` is what the code historically read; don't break anyone on it."""
+    monkeypatch.setattr(
+        local_calls,
+        "settings",
+        _settings_with({"api_ip": "http://127.0.0.1:9099/v1/chat/completions"}),
+    )
+    local_calls.chat_with_local_llm(
+        input_data=[{"role": "user", "content": "hi"}],
+    )
+    assert captured_call["kwargs"].get("api_base_url") == (
+        "http://127.0.0.1:9099/v1/chat/completions"
+    )
+
+
+def test_documented_key_wins_over_legacy(monkeypatch, captured_call):
+    monkeypatch.setattr(
+        local_calls,
+        "settings",
+        _settings_with(
+            {
+                "api_url": "http://documented:9099/v1/chat/completions",
+                "api_ip": "http://legacy:9099/v1/chat/completions",
+            }
+        ),
+    )
+    local_calls.chat_with_local_llm(
+        input_data=[{"role": "user", "content": "hi"}],
+    )
+    assert "documented" in captured_call["kwargs"].get("api_base_url", "")
+
+
+def test_missing_url_still_raises_a_clear_configuration_error(monkeypatch):
+    """A genuinely absent URL must stay a config error, not an opaque 502."""
+    monkeypatch.setattr(local_calls, "settings", _settings_with({}))
+    with pytest.raises(Exception) as excinfo:
+        local_calls.chat_with_local_llm(
+            input_data=[{"role": "user", "content": "hi"}],
+            custom_prompt_arg=None,
+        )
+    assert "url" in str(excinfo.value).lower()

--- a/backlog/tasks/task-625 - Fix-local-llm-provider-reading-the-wrong-settings-key.md
+++ b/backlog/tasks/task-625 - Fix-local-llm-provider-reading-the-wrong-settings-key.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-625
 title: Fix local-llm provider reading the wrong settings key
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-25 12:40'
+updated_date: '2026-07-25 20:04'
 labels:
   - llm
   - config
@@ -41,9 +43,29 @@ Found during live UAT of skill script execution (task-579), where it blocked dri
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] A `local-llm` provider configured under `[api_settings.local-llm]` in config.toml is usable for a chat completion
-- [ ] The key the code reads and the key the documented example writes agree (`api_url` vs `api_ip` reconciled, with the legacy name still accepted if it was ever functional)
-- [ ] The failure mode when the URL genuinely is missing remains a clear configuration error, not an HTTP 502
-- [ ] Other local providers in the same module are checked for the same top-level-vs-api_settings mistake and fixed if present
-- [ ] A test pins that the provider resolves its base URL from `[api_settings.local-llm]`, failing against the current code
+- [ ] #1 A `local-llm` provider configured under `[api_settings.local-llm]` in config.toml is usable for a chat completion
+- [ ] #2 The key the code reads and the key the documented example writes agree (`api_url` vs `api_ip` reconciled, with the legacy name still accepted if it was ever functional)
+- [ ] #3 The failure mode when the URL genuinely is missing remains a clear configuration error, not an HTTP 502
+- [ ] #4 Other local providers in the same module are checked for the same top-level-vs-api_settings mistake and fixed if present
+- [ ] #5 A test pins that the provider resolves its base URL from `[api_settings.local-llm]`, failing against the current code
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+One-line root cause, verified end to end.
+
+chat_with_local_llm resolved its config with settings.get('local-llm', {}) — a TOP-LEVEL key. The provider's config lives at api_settings.local-llm, which is where the app's own documented example puts it and where every sibling local provider in the same module looks. load_settings() does not preserve arbitrary top-level sections either, so no config.toml could ever populate that key: the provider was unusable from configuration, always failing with 'API URL is required' and surfacing in the Console as an opaque HTTP 502.
+
+Fix: read cli_api_settings = settings.get('api_settings', {}) then cfg = cli_api_settings.get('local-llm', {}), matching the siblings exactly.
+
+Key-name reconciliation (AC#2): the documented block uses api_url while the code read api_ip, so resolution is now cfg.get('api_url') or cfg.get('api_ip') — the documented key wins, the historical one still works so nobody with a functioning setup breaks.
+
+Sweep (AC#4): grepped every settings.get(' call across LLM_Calls/. Line 503 was the ONLY offender; koboldcpp, ooba_api, tabby_api, aphrodite_api, llama_cpp, vllm and the rest all correctly go through settings['api_settings'].
+
+Verified beyond unit tests: a config.toml with the documented [api_settings.local-llm] block now completes a real chat_api_call against a live llama.cpp server — the exact case that failed during the task-579 UAT.
+
+Tests: Tests/LLM/test_local_llm_provider_config.py (4) written RED-first — 3 failed against the old code, and the missing-URL case passed throughout, proving the error path was untouched. Tests/LLM + Tests/Chat 2189 passed / 69 skipped, ruff clean.
+
+Files: tldw_chatbook/LLM_Calls/LLM_API_Calls_Local.py, Tests/LLM/test_local_llm_provider_config.py
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls_Local.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls_Local.py
@@ -500,8 +500,18 @@ def chat_with_local_llm(
         model = None
 
     # --- Settings Load ---
-    cfg = settings.get("local-llm", {})
-    api_base_url = cfg.get("api_ip")  # api_url passed via chat_api_call or from config
+    # task-625: read from the [api_settings] table, like every sibling local
+    # provider in this module. This previously read a TOP-LEVEL "local-llm"
+    # key, which config.toml has no way to produce -- load_settings() does not
+    # preserve arbitrary top-level sections -- so the provider was unusable
+    # from its own documented configuration and always failed with the
+    # "API URL is required" error below.
+    cli_api_settings = settings.get("api_settings", {})  # Get the [api_settings] table
+    cfg = cli_api_settings.get("local-llm", {})
+    # `api_url` is the documented key (see the [api_settings.local-llm] example
+    # in config.py); `api_ip` is what this function historically read, kept as a
+    # fallback so an existing working setup does not break.
+    api_base_url = cfg.get("api_url") or cfg.get("api_ip")
     if not api_base_url:
         raise ChatConfigurationError(
             provider="local-llm",


### PR DESCRIPTION
## Summary

Closes **task-625**. The `local-llm` provider could not be configured at all.

`chat_with_local_llm` resolved its config with:

```python
cfg = settings.get("local-llm", {})      # a TOP-LEVEL key
```

The provider's configuration lives at `api_settings.local-llm` — its documented home (the commented `[api_settings.local-llm]` block in `config.py`) and where **every** sibling local provider in the same module looks. `load_settings()` does not preserve arbitrary top-level sections either, so no `config.toml` could ever populate that key.

The result: any user configuring `local-llm` as documented hit

```
ChatConfigurationError: Llamafile/Local LLM API URL (api_url) is required …
```

surfaced in the Console as an opaque *"Agent run failed: provider returned HTTP 502 … configuration error"*.

## Fix

Read `settings["api_settings"]["local-llm"]`, exactly like the siblings.

**Key-name reconciliation:** the documented block writes `api_url` while the code read `api_ip`, so resolution is now `api_url or api_ip` — the documented key wins, and anyone with a working `api_ip` setup is not broken.

**Sweep (AC#4):** grepped every `settings.get(` call across `LLM_Calls/`. This was the **only** offender — `koboldcpp`, `ooba_api`, `tabby_api`, `aphrodite_api`, `llama_cpp`, `vllm` and the rest all correctly go through `settings["api_settings"]`.

## Verification

Beyond the unit tests, a `config.toml` containing the documented `[api_settings.local-llm]` block now completes a real `chat_api_call` against a live llama.cpp server — the exact case that failed during the task-579 UAT and forced that run onto a different provider.

`Tests/LLM/test_local_llm_provider_config.py` (4 tests) written RED-first: 3 failed against the old code, while the missing-URL case passed throughout, proving the error path is untouched and the tests aren't vacuous.

Tests/LLM + Tests/Chat: 2189 passed / 69 skipped · ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `local-llm` provider by reading config from `api_settings.local-llm` in `config.toml`, so it can be configured as documented. Addresses task-625 and avoids opaque 502s from misconfiguration.

- **Bug Fixes**
  - Read config from `api_settings.local-llm`, not a top-level key; matches docs and other local providers.
  - Support `api_url` (preferred) with `api_ip` as fallback to preserve existing setups.
  - Kept clear config error when URL is missing; added tests for both keys and the error path.

<sup>Written for commit 79f56de8c58617a3152b1a6bc16f47ca37bafac2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

