### PR TITLE
fix(library): close the shadowed-builtin drift guard (task-580)

### DIFF
--- a/Tests/Library/test_library_skills_state.py
+++ b/Tests/Library/test_library_skills_state.py
@@ -216,19 +216,31 @@ def test_shadow_name_set_stays_in_sync_with_real_sources():
 
     # Assert RUNTIME_TOOL_NAMES (spawn_subagent, find_tools, load_tools) is a subset
     assert RUNTIME_TOOL_NAMES <= _SHADOWED_BUILTIN_NAMES, (
-        f"RUNTIME_TOOL_NAMES not covered: {RUNTIME_TOOL_NAMES - _SHADOWED_BUILTIN_NAMES}"
+        "RUNTIME_TOOL_NAMES not covered: "
+        f"{RUNTIME_TOOL_NAMES - _SHADOWED_BUILTIN_NAMES}. "
+        "Add them to _SHADOWED_BUILTIN_NAMES in "
+        "tldw_chatbook/Library/library_skills_state.py -- do not accept this "
+        "as a baseline failure (task-580)."
     )
 
     # Assert builtin tool names (calculator, get_current_datetime) are a subset
     builtin_names = {e.name for e in BuiltinToolProvider().list_catalog()}
     assert builtin_names <= _SHADOWED_BUILTIN_NAMES, (
-        f"BuiltinToolProvider names not covered: {builtin_names - _SHADOWED_BUILTIN_NAMES}"
+        "BuiltinToolProvider names not covered: "
+        f"{builtin_names - _SHADOWED_BUILTIN_NAMES}. "
+        "Add them to _SHADOWED_BUILTIN_NAMES in "
+        "tldw_chatbook/Library/library_skills_state.py -- do not accept this "
+        "as a baseline failure (task-580)."
     )
 
     # Assert console command names (prompt, system) are a subset
     command_names = set(default_console_registry().available_names())
     assert command_names <= _SHADOWED_BUILTIN_NAMES, (
-        f"ConsoleCommandRegistry names not covered: {command_names - _SHADOWED_BUILTIN_NAMES}"
+        "ConsoleCommandRegistry names not covered: "
+        f"{command_names - _SHADOWED_BUILTIN_NAMES}. "
+        "Add them to _SHADOWED_BUILTIN_NAMES in "
+        "tldw_chatbook/Library/library_skills_state.py -- do not accept this "
+        "as a baseline failure (task-580)."
     )
 
 
@@ -283,3 +295,18 @@ def test_skill_trust_header_line_maps_postures():
     assert "can't be verified" in skill_trust_header_line("error", 0)[0]
     # disabled/empty posture -> hidden
     assert skill_trust_header_line("", 0) is None
+
+
+def test_console_command_names_are_treated_as_shadowing(monkeypatch):
+    """task-580 (AC#3): a skill named after a console command shadows it.
+
+    `rewind` and `generate-image` were missing from the set, so a skill by
+    either name was silently NOT recognised as shadowing a built-in, unlike
+    every other command. Pinned by name rather than by re-deriving the
+    registry, so this keeps failing if someone removes them.
+    """
+    from tldw_chatbook.Library.library_skills_state import skill_name_shadows_builtin
+
+    for name in ("rewind", "generate-image"):
+        assert skill_name_shadows_builtin(name) == name
+        assert skill_name_shadows_builtin(f"  {name.upper()} ") == name

--- a/Tests/Library/test_library_skills_state.py
+++ b/Tests/Library/test_library_skills_state.py
@@ -297,7 +297,7 @@ def test_skill_trust_header_line_maps_postures():
     assert skill_trust_header_line("", 0) is None
 
 
-def test_console_command_names_are_treated_as_shadowing(monkeypatch):
+def test_console_command_names_are_treated_as_shadowing():
     """task-580 (AC#3): a skill named after a console command shadows it.
 
     `rewind` and `generate-image` were missing from the set, so a skill by

--- a/backlog/tasks/task-580 - Restore-shadowed-builtin-name-drift-guard-parity.md
+++ b/backlog/tasks/task-580 - Restore-shadowed-builtin-name-drift-guard-parity.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-580
 title: Restore shadowed-builtin-name drift-guard parity
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-25 14:35'
+updated_date: '2026-07-25 20:20'
 labels:
   - skills
   - tests
@@ -23,8 +25,24 @@ This is a genuine (if small) correctness gap, not just a red test: a skill named
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `rewind` and `generate-image` are present in `_SHADOWED_BUILTIN_NAMES`
-- [ ] #2 The drift-guard test in Tests/Library passes without any accepted-baseline caveat
-- [ ] #3 A skill named after either command is handled the same way as one shadowing any other built-in
-- [ ] #4 The guard's failure message points at what to update, so the next command addition fixes it rather than accepting it as a baseline
+- [x] #1 `rewind` and `generate-image` are present in `_SHADOWED_BUILTIN_NAMES`
+- [x] #2 The drift-guard test in Tests/Library passes without any accepted-baseline caveat
+- [x] #3 A skill named after either command is handled the same way as one shadowing any other built-in
+- [x] #4 The guard's failure message points at what to update, so the next command addition fixes it rather than accepting it as a baseline
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added 'rewind' and 'generate-image' to _SHADOWED_BUILTIN_NAMES, clearing a drift-guard failure that had been carried as an accepted baseline across several branches.
+
+Not just a red test: the set is what skill_name_shadows_builtin consults, so a skill named after either command was silently NOT recognised as shadowing a built-in, unlike every other console command. Small, but a real correctness gap.
+
+AC#4 (make the guard self-service): all three assertions in the drift test now name the file to edit and say explicitly not to accept the failure as a baseline. The previous message named only the missing strings, which is what let it be waved through repeatedly — the guard fired correctly every time, it just did not tell anyone what to do about it.
+
+AC#3: added a behaviour test asserting skill_name_shadows_builtin() returns the normalized name for both commands, including the whitespace/case-normalizing path. Pinned by literal name rather than re-deriving from the registry, so it keeps failing if someone removes them — re-deriving would make the test tautological against the very set under test.
+
+Tests: Tests/Library 16 in the module and 1025 across Tests/Library + Tests/Skills, all green with no baseline caveat for the first time in this work stream. ruff clean.
+
+Files: tldw_chatbook/Library/library_skills_state.py, Tests/Library/test_library_skills_state.py
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Library/library_skills_state.py
+++ b/tldw_chatbook/Library/library_skills_state.py
@@ -58,6 +58,13 @@ _SHADOWED_BUILTIN_NAMES = frozenset(
         # The run_skill_script runtime tool (same drift-guard rationale as
         # skill_file/install_skill above).
         "run_skill_script",
+        # task-580: console commands from the /rewind and image-generation
+        # features. These were added to the command registry without updating
+        # this set, so the drift guard below failed and was carried as an
+        # accepted baseline across several branches -- which is exactly the
+        # signal-erosion the guard exists to prevent.
+        "rewind",
+        "generate-image",
     )
 )
 


### PR DESCRIPTION
## Summary

Closes **task-580**. Adds `rewind` and `generate-image` to `_SHADOWED_BUILTIN_NAMES`, clearing a drift-guard failure that had been carried as an *accepted baseline* across several branches — which is precisely the signal erosion the guard exists to prevent.

## Not just a red test

The set backs `skill_name_shadows_builtin()`, so a skill named `rewind` or `generate-image` was silently **not** recognised as shadowing a built-in, unlike every other console command. Small, but a real correctness gap rather than cosmetic test debt.

## Why it kept getting waved through

The guard fired correctly every single time. The problem was its message: it listed the missing strings and nothing else, so the cheapest response was always "known baseline, ignore."

All three assertions now name the file to edit and say explicitly not to accept the failure as a baseline:

```
ConsoleCommandRegistry names not covered: {'rewind', 'generate-image'}.
Add them to _SHADOWED_BUILTIN_NAMES in
tldw_chatbook/Library/library_skills_state.py -- do not accept this as a
baseline failure (task-580).
```

## Testing

Added a behaviour test asserting `skill_name_shadows_builtin()` returns the normalized name for both commands, including the whitespace/case path. It pins them by **literal name** rather than re-deriving from the registry — re-deriving would make the test tautological against the very set under test.

`Tests/Library` + `Tests/Skills`: **1025 passed**, green with no baseline caveat for the first time in this work stream. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the shadowed-builtin drift guard by adding `rewind` and `generate-image` to `_SHADOWED_BUILTIN_NAMES` and clarifying the guard message, so skills with those names correctly shadow console commands and future misses are easy to fix (task-580).

- **Bug Fixes**
  - Added `rewind` and `generate-image` to `_SHADOWED_BUILTIN_NAMES`.
  - Updated drift-guard assertions to name `tldw_chatbook/Library/library_skills_state.py` and say not to accept as a baseline.
  - Added a behavior test for `skill_name_shadows_builtin` covering both names and case/whitespace normalization.
  - Removed an unused `monkeypatch` parameter from the new shadowing test.

<sup>Written for commit 72bb6849f29d4c3d09e41102e5e9e93ac1e9a79a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

