### PR TITLE
fix(chat): key skill-script confirms by request_id, not a single slot (task-581)

### DIFF
--- a/Tests/Chat/test_console_skill_script_confirm.py
+++ b/Tests/Chat/test_console_skill_script_confirm.py
@@ -408,9 +408,9 @@ def test_allow_round_trip(make_controller):
 
     thread = threading.Thread(target=worker)
     thread.start()
-    _wait_until(lambda: controller._pending_skill_script_event is not None)
+    _wait_until(lambda: bool(controller.pending_skill_script_ids()))
     controller.resolve_pending_skill_script(
-        True, False, request_id=controller._pending_skill_script_request_id
+        True, False, request_id=controller.pending_skill_script_ids()[0]
     )
     thread.join(timeout=5)
     assert result["decision"] == {"allow": True, "remember": False}
@@ -425,9 +425,9 @@ def test_always_allow_round_trip(make_controller):
 
     thread = threading.Thread(target=worker)
     thread.start()
-    _wait_until(lambda: controller._pending_skill_script_event is not None)
+    _wait_until(lambda: bool(controller.pending_skill_script_ids()))
     controller.resolve_pending_skill_script(
-        True, True, request_id=controller._pending_skill_script_request_id
+        True, True, request_id=controller.pending_skill_script_ids()[0]
     )
     thread.join(timeout=5)
     assert result["decision"] == {"allow": True, "remember": True}
@@ -442,7 +442,7 @@ def test_context_change_denies_a_pending_confirm(make_controller):
 
     thread = threading.Thread(target=worker)
     thread.start()
-    _wait_until(lambda: controller._pending_skill_script_event is not None)
+    _wait_until(lambda: bool(controller.pending_skill_script_ids()))
     controller._deny_pending_skill_script_on_context_change()
     thread.join(timeout=5)
     assert result["decision"]["allow"] is False
@@ -461,7 +461,7 @@ def test_switch_session_denies_a_pending_skill_script_confirm(make_controller):
 
     thread = threading.Thread(target=worker)
     thread.start()
-    _wait_until(lambda: controller._pending_skill_script_event is not None)
+    _wait_until(lambda: bool(controller.pending_skill_script_ids()))
     controller.switch_session(other.id)
     thread.join(timeout=5)
     assert result["decision"]["allow"] is False
@@ -482,14 +482,14 @@ def test_confirm_payload_carries_timeout_and_request_id(make_controller):
 
     thread = threading.Thread(target=worker)
     thread.start()
-    _wait_until(lambda: controller._pending_skill_script_event is not None)
+    _wait_until(lambda: bool(controller.pending_skill_script_ids()))
     shown = controller.pending_skill_script_payloads[0]
     assert shown is not None
     assert shown["skill_name"] == "demo"
     assert shown["script_path"] == "scripts/hello.py"
     assert isinstance(shown["timeout_seconds"], float)
     assert shown["timeout_seconds"] > 0
-    assert shown["request_id"] == controller._pending_skill_script_request_id
+    assert shown["request_id"] == controller.pending_skill_script_ids()[0]
     assert shown["request_id"]  # non-empty
     controller.resolve_pending_skill_script(True, False, request_id=shown["request_id"])
     thread.join(timeout=5)
@@ -505,7 +505,7 @@ def test_stale_request_id_is_dropped_then_matching_id_resolves(make_controller):
     controller = make_controller()
 
     # Round 1: arm, capture its id, then deny it via context-change so it
-    # tears down (clearing _pending_skill_script_request_id) without ever
+    # tears down (dropping its round from the registry) without ever
     # being resolved by a matching id.
     round_one_result = {}
 
@@ -516,13 +516,13 @@ def test_stale_request_id_is_dropped_then_matching_id_resolves(make_controller):
 
     t1 = threading.Thread(target=round_one)
     t1.start()
-    _wait_until(lambda: controller._pending_skill_script_event is not None)
-    stale_id = controller._pending_skill_script_request_id
+    _wait_until(lambda: bool(controller.pending_skill_script_ids()))
+    stale_id = controller.pending_skill_script_ids()[0]
     assert stale_id
     controller._deny_pending_skill_script_on_context_change()
     t1.join(timeout=5)
     assert round_one_result["decision"]["allow"] is False
-    assert controller._pending_skill_script_request_id is None  # torn down
+    assert controller.pending_skill_script_ids() == []  # torn down
 
     # Round 2: arms a fresh id. A resolve carrying round 1's stale id must
     # be dropped -- the round stays armed, unresolved.
@@ -535,14 +535,14 @@ def test_stale_request_id_is_dropped_then_matching_id_resolves(make_controller):
 
     t2 = threading.Thread(target=round_two)
     t2.start()
-    _wait_until(lambda: controller._pending_skill_script_event is not None)
-    fresh_id = controller._pending_skill_script_request_id
+    _wait_until(lambda: bool(controller.pending_skill_script_ids()))
+    fresh_id = controller.pending_skill_script_ids()[0]
     assert fresh_id and fresh_id != stale_id
 
     controller.resolve_pending_skill_script(True, False, request_id=stale_id)
     time.sleep(0.1)
     assert t2.is_alive(), "a stale request_id must not resolve the armed round"
-    assert controller._pending_skill_script_event is not None  # still armed
+    assert controller.pending_skill_script_ids()  # still armed
 
     # The matching (current) id resolves it correctly.
     controller.resolve_pending_skill_script(True, False, request_id=fresh_id)
@@ -561,14 +561,14 @@ def test_resolve_with_no_request_id_is_dropped(make_controller):
 
     thread = threading.Thread(target=worker)
     thread.start()
-    _wait_until(lambda: controller._pending_skill_script_event is not None)
+    _wait_until(lambda: bool(controller.pending_skill_script_ids()))
 
     controller.resolve_pending_skill_script(True, False)  # request_id omitted
     time.sleep(0.1)
     assert thread.is_alive(), "an id-less resolve must not resolve the armed round"
 
     controller.resolve_pending_skill_script(
-        True, False, request_id=controller._pending_skill_script_request_id
+        True, False, request_id=controller.pending_skill_script_ids()[0]
     )
     thread.join(timeout=5)
     assert result["decision"] == {"allow": True, "remember": False}

--- a/Tests/Chat/test_skill_script_concurrent_confirms.py
+++ b/Tests/Chat/test_skill_script_concurrent_confirms.py
@@ -1,0 +1,120 @@
+"""task-581: concurrent skill-script confirm rounds must not clobber each other.
+
+The confirm bridge held a SINGLE pending slot, so if two rounds were ever armed
+at once the second overwrote the first's event/decision and both worker threads
+blocked until their 120s deadline. It fails closed and is not reachable while
+the agent loop dispatches tool calls one at a time on one worker thread — but it
+becomes reachable the moment anything runs tool calls concurrently, or a second
+agent run overlaps the first.
+"""
+
+import threading
+import time
+
+import pytest
+
+from .test_console_skill_script_confirm import make_controller as make_controller  # noqa: F401
+
+
+def _wait_until(predicate, timeout=5.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.02)
+    return False
+
+
+@pytest.fixture
+def controller(make_controller):
+    """A controller with a fake UI already wired (see the sibling module)."""
+    return make_controller()
+
+
+def _arm(ctrl, skill_name, results, key):
+    def worker():
+        results[key] = ctrl.request_skill_script_confirm({"skill_name": skill_name})
+
+    t = threading.Thread(target=worker, daemon=True)
+    t.start()
+    return t
+
+
+def test_two_concurrent_rounds_each_get_their_own_decision(controller):
+    """AC#1: no cross-talk — each round resolves to what the user chose for it."""
+    results = {}
+    t1 = _arm(controller, "skill-one", results, "one")
+    assert _wait_until(lambda: len(controller.pending_skill_script_ids()) == 1)
+    id1 = controller.pending_skill_script_ids()[0]
+
+    t2 = _arm(controller, "skill-two", results, "two")
+    assert _wait_until(lambda: len(controller.pending_skill_script_ids()) == 2), (
+        "arming a second round must not evict the first"
+    )
+    id2 = [i for i in controller.pending_skill_script_ids() if i != id1][0]
+
+    controller.resolve_pending_skill_script(True, False, request_id=id2)
+    t2.join(timeout=5)
+    controller.resolve_pending_skill_script(False, False, request_id=id1)
+    t1.join(timeout=5)
+
+    assert results["two"] == {"allow": True, "remember": False}
+    assert results["one"] == {"allow": False, "remember": False}
+
+
+def test_a_decision_cannot_resolve_the_other_round(controller):
+    """AC#2: the per-round request_id stays authoritative."""
+    results = {}
+    t1 = _arm(controller, "skill-one", results, "one")
+    assert _wait_until(lambda: len(controller.pending_skill_script_ids()) == 1)
+
+    t2 = _arm(controller, "skill-two", results, "two")
+    assert _wait_until(lambda: len(controller.pending_skill_script_ids()) == 2)
+
+    # Resolving with a bogus id must release neither round.
+    controller.resolve_pending_skill_script(True, True, request_id="not-a-real-id")
+    time.sleep(0.2)
+    assert "one" not in results and "two" not in results
+
+    for rid in list(controller.pending_skill_script_ids()):
+        controller.resolve_pending_skill_script(False, False, request_id=rid)
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+
+
+def test_teardown_of_one_round_leaves_the_other_armed(controller):
+    """AC#3: finishing round A must not clear round B's pending state."""
+    results = {}
+    t1 = _arm(controller, "skill-one", results, "one")
+    assert _wait_until(lambda: len(controller.pending_skill_script_ids()) == 1)
+    id1 = controller.pending_skill_script_ids()[0]
+
+    t2 = _arm(controller, "skill-two", results, "two")
+    assert _wait_until(lambda: len(controller.pending_skill_script_ids()) == 2)
+    id2 = [i for i in controller.pending_skill_script_ids() if i != id1][0]
+
+    controller.resolve_pending_skill_script(True, False, request_id=id1)
+    t1.join(timeout=5)
+
+    assert controller.pending_skill_script_ids() == [id2], (
+        "round A's teardown must not evict round B"
+    )
+    controller.resolve_pending_skill_script(False, False, request_id=id2)
+    t2.join(timeout=5)
+    assert results["two"]["allow"] is False
+
+
+def test_context_change_denies_every_armed_round(controller):
+    """A conversation switch must release all of them, not just the newest."""
+    results = {}
+    t1 = _arm(controller, "skill-one", results, "one")
+    assert _wait_until(lambda: len(controller.pending_skill_script_ids()) == 1)
+    t2 = _arm(controller, "skill-two", results, "two")
+    assert _wait_until(lambda: len(controller.pending_skill_script_ids()) == 2)
+
+    controller._deny_pending_skill_script_on_context_change()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+    assert results["one"]["allow"] is False
+    assert results["two"]["allow"] is False
+    assert controller.pending_skill_script_ids() == []

--- a/backlog/tasks/task-581 - Support-concurrent-skill-script-confirm-rounds.md
+++ b/backlog/tasks/task-581 - Support-concurrent-skill-script-confirm-rounds.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-581
 title: Support concurrent skill-script confirm rounds
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-25 14:35'
+updated_date: '2026-07-25 20:41'
 labels:
   - skills
   - chat
@@ -23,9 +25,29 @@ The same single-slot shape exists in the sibling MCP approval and skill-install 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Two confirm rounds armed concurrently each resolve to their own decision, with no cross-talk
-- [ ] #2 Neither round can be resolved by the other's decision (the per-round request_id remains authoritative)
-- [ ] #3 Teardown of one round does not clear another round's pending state
-- [ ] #4 A test pins the concurrent case, failing against the current single-slot implementation
-- [ ] #5 A decision is recorded on whether the sibling MCP-approval and skill-install flows adopt the same fix
+- [x] #1 Two confirm rounds armed concurrently each resolve to their own decision, with no cross-talk
+- [x] #2 Neither round can be resolved by the other's decision (the per-round request_id remains authoritative)
+- [x] #3 Teardown of one round does not clear another round's pending state
+- [x] #4 A test pins the concurrent case, failing against the current single-slot implementation
+- [x] #5 A decision is recorded on whether the sibling MCP-approval and skill-install flows adopt the same fix
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Replaced the single pending slot with a request_id-keyed registry guarded by a lock.
+
+Before: _pending_skill_script_event / _decision / _request_id were one slot, so a second armed round overwrote the first and BOTH worker threads then blocked to their 120s deadline. Fails closed, and not reachable today because the agent loop dispatches tool calls one at a time on one worker thread — but reachable the moment anything runs them concurrently.
+
+After: self._pending_skill_script_rounds maps request_id -> {event, decision}. Arming inserts; resolving looks up by id and sets only that round's event; teardown pops only its own round. The card surface is cleared only when NO round remains armed — clearing unconditionally would have hidden a sibling round's card, which is the same clobbering bug in a different coat.
+
+_deny_pending_skill_script_on_context_change now denies EVERY armed round rather than just the newest: a conversation switch invalidates the context all of them were raised in.
+
+Added a public pending_skill_script_ids() accessor. This also let me migrate the sibling test module off four private attributes it had been poking (_pending_skill_script_event/_request_id) onto a supported contract — those tests now assert behaviour rather than internals.
+
+AC#5 DECISION: the sibling MCP-approval and skill-install flows keep their single-slot design for now. They share the shape but are equally unreachable today, and changing three HITL surfaces in one pass would widen the blast radius well past what this task justifies. The keyed pattern now exists here as the reference if either becomes concurrent — recorded rather than silently skipped.
+
+Tests: Tests/Chat/test_skill_script_concurrent_confirms.py (4) written RED-first, all four failing against the single-slot implementation. Tests/Chat + the card module: 2208 passed / 69 skipped. ruff clean.
+
+Files: tldw_chatbook/Chat/console_chat_controller.py, Tests/Chat/test_skill_script_concurrent_confirms.py, Tests/Chat/test_console_skill_script_confirm.py
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -651,14 +651,16 @@ class ConsoleChatController:
         self.skill_script_confirm_timeout_seconds: Callable[[], float] | None = None
         #: The active script-confirm round's release Event + shared
         #: decision box ({"allow": bool, "remember": bool}).
-        self._pending_skill_script_event: threading.Event | None = None
-        self._pending_skill_script_decision: dict[str, bool] | None = None
+        #: task-581: rounds keyed by request_id, not a single slot. Two rounds
+        #: armed at once previously clobbered each other's event/decision and
+        #: both worker threads then blocked to their full deadline.
+        self._pending_skill_script_rounds: dict[str, dict[str, Any]] = {}
+        self._pending_skill_script_lock = threading.Lock()
         #: The currently-armed round's unique id (see `request_skill_script_
         #: confirm` / `resolve_pending_skill_script`). A resolve carrying any
         #: other id (including None) is dropped -- this is what stops a
         #: late button press from a torn-down round 1 from authorizing
         #: round 2's script. `None` whenever no round is armed.
-        self._pending_skill_script_request_id: str | None = None
 
     async def submit_draft(self, draft: str) -> ConsoleSubmitResult:
         """Submit a composer draft through native Console validation and provider resolution."""
@@ -1456,9 +1458,11 @@ class ConsoleChatController:
         event = threading.Event()
         decision: dict[str, bool] = {}
         request_id = str(uuid4())
-        self._pending_skill_script_event = event
-        self._pending_skill_script_decision = decision
-        self._pending_skill_script_request_id = request_id
+        with self._pending_skill_script_lock:
+            self._pending_skill_script_rounds[request_id] = {
+                "event": event,
+                "decision": decision,
+            }
 
         timeout_seconds = (
             self.skill_script_confirm_timeout_seconds()
@@ -1484,11 +1488,14 @@ class ConsoleChatController:
                 "remember": bool(decision.get("remember", False)),
             }
         finally:
-            self._pending_skill_script_event = None
-            self._pending_skill_script_decision = None
-            self._pending_skill_script_request_id = None
+            with self._pending_skill_script_lock:
+                self._pending_skill_script_rounds.pop(request_id, None)
+                still_armed = bool(self._pending_skill_script_rounds)
             try:
-                self._marshal_pending_skill_script(None)
+                # Clearing unconditionally would hide a sibling round's card;
+                # only blank the surface when nothing is left pending.
+                if not still_armed:
+                    self._marshal_pending_skill_script(None)
             except Exception:  # noqa: BLE001
                 logger.opt(exception=True).debug(
                     "Failed to clear skill-script confirm during teardown"
@@ -1532,21 +1539,37 @@ class ConsoleChatController:
                 ``None`` (the default) never matches an armed round, so an
                 un-migrated or malformed caller fails closed by omission.
         """
-        decision = self._pending_skill_script_decision
-        event = self._pending_skill_script_event
-        if decision is None or event is None:
+        if request_id is None:
             return
-        if request_id is None or request_id != self._pending_skill_script_request_id:
+        with self._pending_skill_script_lock:
+            round_state = self._pending_skill_script_rounds.get(request_id)
+        if round_state is None:
             return
-        decision["allow"] = bool(allow)
-        decision["remember"] = bool(remember)
-        event.set()
+        round_state["decision"]["allow"] = bool(allow)
+        round_state["decision"]["remember"] = bool(remember)
+        round_state["event"].set()
 
     def _deny_pending_skill_script_on_context_change(self) -> None:
-        """Force-deny a pending script confirm (Event set, decision left False)."""
-        event = self._pending_skill_script_event
-        if event is not None:
-            event.set()
+        """Force-deny every armed script confirm (Events set, decisions left False).
+
+        Denies ALL rounds, not just the newest: a conversation switch
+        invalidates the context every pending confirm was raised in.
+        """
+        with self._pending_skill_script_lock:
+            rounds = list(self._pending_skill_script_rounds.values())
+        for round_state in rounds:
+            round_state["event"].set()
+
+    def pending_skill_script_ids(self) -> list[str]:
+        """Return the request ids of every currently-armed confirm round.
+
+        Returns:
+            The armed round ids, in insertion order. Empty when none is
+            pending. Exposed for tests and for any surface that needs to
+            know whether a decision is outstanding.
+        """
+        with self._pending_skill_script_lock:
+            return list(self._pending_skill_script_rounds)
 
     def stop_active_run(self, *, record_user_stop: bool = True) -> bool:
         """Request the active stream to stop at the next safe boundary.


### PR DESCRIPTION
## Summary

Closes **task-581**. The skill-script confirm bridge held a **single** pending slot, so two rounds armed at once overwrote each other's event/decision and *both* worker threads then blocked to their full 120s deadline.

It fails closed and is not reachable today — the agent loop dispatches tool calls one at a time on one worker thread — but it becomes reachable the moment anything runs tool calls concurrently, or a second agent run overlaps the first.

## Change

Rounds now live in a lock-guarded dict keyed by `request_id`:

- **arming** inserts rather than overwrites;
- **resolving** looks up by id and sets only that round's event;
- **teardown** pops only its own round;
- the card surface is cleared **only when no round remains armed** — clearing unconditionally would hide a sibling round's card, which is the same clobbering bug wearing a different coat;
- `_deny_pending_skill_script_on_context_change` now denies **every** armed round, not just the newest: a conversation switch invalidates the context all of them were raised in.

Adds a public `pending_skill_script_ids()` accessor. That also let me migrate the sibling test module off four private attributes it had been poking (`_pending_skill_script_event`, `_pending_skill_script_request_id`) onto a supported contract — those tests now assert behaviour instead of internals.

## AC#5 decision, recorded rather than skipped

The sibling **MCP-approval** and **skill-install** flows keep their single-slot design for now. They share the shape and are equally unreachable today, and changing three HITL surfaces in one pass would widen the blast radius well past what this task justifies. The keyed pattern now exists here as the reference implementation if either becomes concurrent.

## Testing

`Tests/Chat/test_skill_script_concurrent_confirms.py` (4 tests) written RED-first — **all four fail** against the single-slot implementation, covering no-cross-talk, id-authority, independent teardown, and deny-all-on-context-change.

Tests/Chat + the confirm-card module: **2208 passed** / 69 skipped · ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes concurrent skill-script confirmations by keying pending rounds by request_id instead of a single slot. Closes task-581 and prevents cross-talk and blocking when multiple confirms are armed.

- **Bug Fixes**
  - Store pending rounds in a lock-guarded dict keyed by request_id; arming inserts, resolving matches by id (id-less resolves are dropped), teardown pops only its own round.
  - Clear the confirm card only when no rounds remain, so a sibling round’s UI stays visible.
  - Context changes now deny all armed rounds, not just the newest.
  - Added public `pending_skill_script_ids()`; migrated tests off private attributes. New tests cover independence, id authority, teardown isolation, and deny-all on context change.
  - AC#5: MCP-approval and skill-install flows remain single-slot for now; this keyed pattern is the reference if they go concurrent.

<sup>Written for commit edddd37a3a0fedbf7432d54e7ff0de52597e0da9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

