### PR TITLE
feat(skills): make the script sandbox budget configurable (task-582)

### DIFF
--- a/Docs/Features/Skills-Script-Execution.md
+++ b/Docs/Features/Skills-Script-Execution.md
@@ -154,37 +154,52 @@ by absolute path are not.
 
 ### Current limits
 
-These are fixed defaults in `Skills_Interop/skill_script_runner.py`
-(`ScriptRunLimits`) and are **not** currently exposed as configuration:
+Defaults, all overridable from the `[skills]` config section (see below):
 
-| Limit | Default |
-|---|---|
-| CPU time | 10 s |
-| Address space | 512 MiB |
-| Open files | 128 |
-| Max single file size | 8 MiB |
-| Wall clock | 60 s |
-| Retained output (per stream) | 64 KiB |
+| Limit | Default | Config key |
+|---|---|---|
+| CPU time | 10 s | `script_cpu_seconds` |
+| Address space | 512 MiB | `script_address_space_bytes` |
+| Open files | 128 | `script_open_files` |
+| Max single file size | 8 MiB | `script_file_size_bytes` |
+| Wall clock | 60 s | `script_wall_clock_seconds` |
+| Retained output (per stream) | 64 KiB | `script_output_cap_bytes` |
 
 ## Configuration
 
-One knob exists today, under a `[skills]` section in `~/.config/tldw_cli/config.toml`:
+Under a `[skills]` section in `~/.config/tldw_cli/config.toml`:
 
 ```toml
 [skills]
 # Optional. Parent directory for the per-run scratch working directory.
 # Defaults to the OS temp directory when unset.
 script_scratch_root = "/path/to/scratch"
+
+# Optional sandbox budget. Any key you omit keeps its default.
+script_cpu_seconds = 10
+script_address_space_bytes = 536870912   # 512 MiB
+script_open_files = 128
+script_file_size_bytes = 8388608         # 8 MiB
+script_wall_clock_seconds = 60
+script_output_cap_bytes = 65536          # 64 KiB
 ```
 
-A configured root that resolves inside the skills store or the trust store is **rejected**
-and the OS temp directory is used instead — otherwise a script could be handed a working
-directory inside its own bundle.
+A configured `script_scratch_root` that resolves inside the skills store or the trust
+store is **rejected** and the OS temp directory is used instead — otherwise a script
+could be handed a working directory inside its own bundle.
 
-> **Implementation note:** read this setting with the three-argument form,
-> `get_cli_setting("skills", "script_scratch_root", default)`. The section-dict form
+A limit value that is non-numeric, non-positive, or non-finite is **rejected in favour of
+its default**, never applied. A misconfigured limit must not end up more permissive than
+the default: `script_cpu_seconds = 0` gives you the 10 s default, not an unlimited run.
+
+`script_wall_clock_seconds` is additionally clamped to 600 s. A run holds a worker thread
+and sits inside the agent's own run budget, so an unbounded value would strand the turn
+rather than merely permit a slow script.
+
+> **Implementation note:** read these with the three-argument form,
+> `get_cli_setting("skills", "<key>", default)`. The section-dict form
 > (`get_cli_setting("skills", {})`) silently returns `{}` for any section name without a
-> dot, which would make the setting permanently unreachable.
+> dot, which would make every key here permanently unreachable.
 
 ## Residual risks
 

--- a/Tests/Skills/test_script_limits_config.py
+++ b/Tests/Skills/test_script_limits_config.py
@@ -1,0 +1,113 @@
+"""task-582: ScriptRunLimits must be overridable from the [skills] config.
+
+The sandbox budget was a set of hardcoded defaults, so a legitimately
+long-running or output-heavy skill script had no accommodation short of a code
+change, and a user wanting a *tighter* budget could not impose one.
+
+The trap these tests guard: `get_cli_setting("skills", {})` silently returns
+`{}` for any section name without a dot (config.py), so the section-dict form
+would make every knob permanently unreachable. Only the three-argument form
+works.
+"""
+
+import pytest
+
+from tldw_chatbook.Skills_Interop.skill_script_runner import ScriptRunLimits
+from tldw_chatbook.Skills_Interop import local_skills_service as svc_module
+
+
+@pytest.fixture
+def config(monkeypatch):
+    """Serve a fake [skills] table through the real 3-arg accessor shape."""
+    values = {}
+
+    def fake_get_cli_setting(section, key=None, default=None):
+        # A caller using the section-dict form passes key as a dict/None; that
+        # form cannot reach these values, so return the default and let the
+        # assertion fail loudly rather than silently succeeding.
+        if section != "skills" or not isinstance(key, str):
+            return default
+        return values.get(key, default)
+
+    import tldw_chatbook.config as config_module
+
+    monkeypatch.setattr(config_module, "get_cli_setting", fake_get_cli_setting)
+    return values
+
+
+def test_defaults_apply_when_nothing_is_configured(config):
+    limits = svc_module.resolve_script_run_limits()
+    assert limits == ScriptRunLimits()
+
+
+def test_every_field_can_be_overridden(config):
+    config.update(
+        {
+            "script_cpu_seconds": 3,
+            "script_address_space_bytes": 128 * 1024 * 1024,
+            "script_open_files": 32,
+            "script_file_size_bytes": 1024 * 1024,
+            "script_wall_clock_seconds": 12.5,
+            "script_output_cap_bytes": 4096,
+        }
+    )
+    limits = svc_module.resolve_script_run_limits()
+    assert limits.cpu_seconds == 3
+    assert limits.address_space_bytes == 128 * 1024 * 1024
+    assert limits.open_files == 32
+    assert limits.file_size_bytes == 1024 * 1024
+    assert limits.wall_clock_seconds == 12.5
+    assert limits.output_cap_bytes == 4096
+
+
+def test_partial_override_keeps_other_defaults(config):
+    config["script_cpu_seconds"] = 5
+    limits = svc_module.resolve_script_run_limits()
+    assert limits.cpu_seconds == 5
+    assert limits.output_cap_bytes == ScriptRunLimits().output_cap_bytes
+
+
+@pytest.mark.parametrize(
+    "value",
+    [0, -1, "banana", None, 3.5e400],
+)
+def test_invalid_values_fall_back_to_the_default(config, value):
+    """AC#3: never let a bad value produce an unbounded or zero budget."""
+    config["script_cpu_seconds"] = value
+    limits = svc_module.resolve_script_run_limits()
+    assert limits.cpu_seconds == ScriptRunLimits().cpu_seconds
+
+
+def test_wall_clock_is_capped_to_the_run_budget_envelope(config):
+    """AC#4: an over-large wall clock must not strand the agent run."""
+    config["script_wall_clock_seconds"] = 100_000.0
+    limits = svc_module.resolve_script_run_limits()
+    assert limits.wall_clock_seconds <= svc_module.MAX_SCRIPT_WALL_CLOCK_SECONDS
+    assert limits.wall_clock_seconds > 0
+
+
+def test_section_dict_form_would_not_reach_these_values(monkeypatch):
+    """AC#2: pin the reachability trap itself.
+
+    If the implementation ever switches to `get_cli_setting("skills", {})`,
+    this fake — which mirrors config.py's real behaviour of returning the
+    default for a non-str key — makes it silently see nothing, so the
+    override assertion below fails.
+    """
+    import tldw_chatbook.config as config_module
+
+    calls = []
+
+    def fake_get_cli_setting(section, key=None, default=None):
+        calls.append((section, key))
+        if section != "skills" or not isinstance(key, str):
+            return default
+        return 7 if key == "script_cpu_seconds" else default
+
+    monkeypatch.setattr(config_module, "get_cli_setting", fake_get_cli_setting)
+    limits = svc_module.resolve_script_run_limits()
+    assert limits.cpu_seconds == 7, (
+        "the resolver must use the 3-arg get_cli_setting form; the "
+        "section-dict form cannot reach [skills] values at all"
+    )
+    assert any(isinstance(key, str) for _section, key in calls)

--- a/backlog/tasks/task-582 - Expose-skill-script-sandbox-limits-as-configuration.md
+++ b/backlog/tasks/task-582 - Expose-skill-script-sandbox-limits-as-configuration.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-582
 title: Expose skill-script sandbox limits as configuration
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-25 14:35'
+updated_date: '2026-07-25 20:54'
 labels:
   - skills
   - config
@@ -22,9 +24,27 @@ Note the trap this must avoid: `get_cli_setting("skills", {})` silently returns 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Each ScriptRunLimits field can be overridden from a `[skills]` config section, falling back to the current default when unset
-- [ ] #2 Overrides are read via the three-argument get_cli_setting form, with a test that would fail if the unreachable section-dict form were used
-- [ ] #3 Out-of-range or non-numeric values are rejected in favour of the default rather than producing an unbounded or zero budget
-- [ ] #4 A wall-clock override cannot exceed the confirm/run-budget envelope in a way that strands the agent run
-- [ ] #5 Docs/Features/Skills-Script-Execution.md is updated: the limits table stops saying the values are not configurable, and documents each knob
+- [x] #1 Each ScriptRunLimits field can be overridden from a `[skills]` config section, falling back to the current default when unset
+- [x] #2 Overrides are read via the three-argument get_cli_setting form, with a test that would fail if the unreachable section-dict form were used
+- [x] #3 Out-of-range or non-numeric values are rejected in favour of the default rather than producing an unbounded or zero budget
+- [x] #4 A wall-clock override cannot exceed the confirm/run-budget envelope in a way that strands the agent run
+- [x] #5 Docs/Features/Skills-Script-Execution.md is updated: the limits table stops saying the values are not configurable, and documents each knob
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added resolve_script_run_limits(), which builds the sandbox budget from ScriptRunLimits defaults plus any [skills] overrides, and wired run_skill_script to use it instead of a bare default.
+
+Six knobs, one per field: script_cpu_seconds, script_address_space_bytes, script_open_files, script_file_size_bytes, script_wall_clock_seconds, script_output_cap_bytes. Omitting any key keeps its default.
+
+AC#3, the part that matters: a value that is non-numeric, non-positive, or non-finite is REJECTED in favour of the default rather than applied. The governing rule is that a misconfigured limit must never end up MORE permissive than the default — script_cpu_seconds = 0 yields the 10s default, not an unlimited run. bool is excluded explicitly since it is an int subclass and 'true' is a config mistake, not a budget of 1.
+
+AC#4: script_wall_clock_seconds is clamped to MAX_SCRIPT_WALL_CLOCK_SECONDS = 600. A run holds a worker thread and sits inside the agent's own run budget, so an unbounded value would strand the turn rather than merely permit a slow script.
+
+AC#2: the reachability trap is pinned by a test whose fake get_cli_setting mirrors config.py's real behaviour of returning the default for a non-str key — so if the implementation ever switches to the section-dict form (get_cli_setting('skills', {})), which silently returns {} for any section without a dot, the override assertion fails rather than the knobs going quietly dead.
+
+Tests: Tests/Skills/test_script_limits_config.py (10) written RED-first, all 10 failing before the resolver existed. Tests/Skills 369 passed, ruff clean (also removed a local ScriptRunLimits import that the change made unused).
+
+Files: tldw_chatbook/Skills_Interop/local_skills_service.py, Tests/Skills/test_script_limits_config.py, Docs/Features/Skills-Script-Execution.md
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Skills_Interop/local_skills_service.py
+++ b/tldw_chatbook/Skills_Interop/local_skills_service.py
@@ -9,7 +9,7 @@ import re
 import shutil
 import zipfile
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
@@ -64,6 +64,71 @@ _TEXT_FIELD_LIMITS = {
 _TRUST_STATUS_SERVICE_UNAVAILABLE = "trust_locked"
 _TRUST_REASON_SERVICE_UNAVAILABLE = "trust_service_unavailable"
 SKILL_FILE_READ_CAP_CHARS = 100_000
+
+#: task-582: ceiling for a configured script wall clock. A run holds a worker
+#: thread and sits inside the agent's own run budget, so an unbounded override
+#: would strand the turn rather than merely allow a slow script.
+MAX_SCRIPT_WALL_CLOCK_SECONDS = 600.0
+
+#: [skills] config key -> (ScriptRunLimits field, coercion) for the sandbox
+#: budget. Read with the THREE-argument get_cli_setting form: the section-dict
+#: form (`get_cli_setting("skills", {})`) silently returns {} for any section
+#: name without a dot (config.py), which would make every knob here
+#: permanently unreachable.
+_SCRIPT_LIMIT_KEYS = (
+    ("script_cpu_seconds", "cpu_seconds", int),
+    ("script_address_space_bytes", "address_space_bytes", int),
+    ("script_open_files", "open_files", int),
+    ("script_file_size_bytes", "file_size_bytes", int),
+    ("script_wall_clock_seconds", "wall_clock_seconds", float),
+    ("script_output_cap_bytes", "output_cap_bytes", int),
+)
+
+
+def resolve_script_run_limits() -> "ScriptRunLimits":
+    """Build the sandbox budget, applying any [skills] config overrides.
+
+    Every field falls back to its ScriptRunLimits default. A value that is
+    non-numeric, non-positive, or non-finite is REJECTED in favour of that
+    default rather than allowed to produce a zero or unbounded budget -- a
+    misconfigured limit must never be more permissive than the default.
+
+    Returns:
+        A ScriptRunLimits with configured overrides applied and the wall
+        clock clamped to MAX_SCRIPT_WALL_CLOCK_SECONDS.
+    """
+    import math
+
+    from .skill_script_runner import ScriptRunLimits
+
+    defaults = ScriptRunLimits()
+    overrides: dict[str, Any] = {}
+    try:
+        from ..config import get_cli_setting
+    except Exception:  # noqa: BLE001 — no config is just "use the defaults"
+        return defaults
+
+    for config_key, field, coerce in _SCRIPT_LIMIT_KEYS:
+        try:
+            raw = get_cli_setting("skills", config_key, None)
+        except Exception:  # noqa: BLE001
+            continue
+        if raw is None or isinstance(raw, bool):
+            # bool is an int subclass; a `true` here is a config mistake, not
+            # a budget of 1.
+            continue
+        try:
+            value = coerce(raw)
+        except (TypeError, ValueError, OverflowError):
+            continue
+        if not math.isfinite(value) or value <= 0:
+            continue
+        overrides[field] = value
+
+    wall = overrides.get("wall_clock_seconds", defaults.wall_clock_seconds)
+    overrides["wall_clock_seconds"] = min(wall, MAX_SCRIPT_WALL_CLOCK_SECONDS)
+    return replace(defaults, **overrides)
+
 
 #: Pruned directories a bundle may still READ its own data out of (task-578).
 #: The trust scanner prunes vendored dependency trees so a real bundle's
@@ -1843,7 +1908,7 @@ class LocalSkillsService:
         import shutil as _shutil
         import tempfile
 
-        from .skill_script_runner import ScriptRunLimits, run_script_subprocess
+        from .skill_script_runner import run_script_subprocess
 
         self._enforce("skills.run_script.launch.local")
         self._require_trusted_skill(skill_name)
@@ -1859,7 +1924,7 @@ class LocalSkillsService:
         plan = self._plan_for_script(
             self._canonical_skill_name(skill_name), script_path, path
         )
-        effective_limits = limits or ScriptRunLimits()
+        effective_limits = limits or resolve_script_run_limits()
         target_argv = (
             [str(path), *args]
             if plan.mechanism == "direct-exec"


### PR DESCRIPTION
## Summary

Closes **task-582**. The sandbox budget (`ScriptRunLimits`) was hardcoded, so a legitimately long-running or output-heavy skill script had no accommodation short of a code change — and a user wanting a *tighter* budget could not impose one either.

`resolve_script_run_limits()` now applies `[skills]` overrides over the defaults, and `run_skill_script` uses it.

| Limit | Default | Config key |
|---|---|---|
| CPU time | 10 s | `script_cpu_seconds` |
| Address space | 512 MiB | `script_address_space_bytes` |
| Open files | 128 | `script_open_files` |
| Max single file size | 8 MiB | `script_file_size_bytes` |
| Wall clock | 60 s | `script_wall_clock_seconds` |
| Retained output (per stream) | 64 KiB | `script_output_cap_bytes` |

## The rule that governs validation (AC#3)

**A misconfigured limit must never end up more permissive than the default.**

A value that is non-numeric, non-positive, or non-finite is *rejected* in favour of its default rather than applied — `script_cpu_seconds = 0` gives you the 10 s default, not an unlimited run. `bool` is excluded explicitly, since it is an `int` subclass and a stray `true` is a config mistake, not a budget of 1.

## Wall-clock ceiling (AC#4)

`script_wall_clock_seconds` is clamped to **600 s**. A run holds a worker thread and sits inside the agent's own run budget, so an unbounded value would strand the whole turn rather than merely permit a slow script.

## The reachability trap, pinned (AC#2)

`get_cli_setting("skills", {})` silently returns `{}` for any section name without a dot, which would make every one of these keys permanently dead. A dedicated test uses a fake that mirrors that real behaviour, so if the implementation ever switches to the section-dict form the override assertion **fails** rather than the knobs going quietly inert.

## Testing

`Tests/Skills/test_script_limits_config.py` (10 tests) written RED-first — all 10 failed before the resolver existed.

Tests/Skills: **369 passed** · ruff clean (also removed a local `ScriptRunLimits` import the change made unused).

Docs updated: the limits table no longer claims the values are not configurable, and each knob is documented alongside the validation and clamping rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes skill script sandbox limits configurable via the `[skills]` config. Uses a safe resolver during execution, addressing task-582.

- **New Features**
  - Added `resolve_script_run_limits()` to apply `[skills]` overrides over `ScriptRunLimits` defaults.
  - Keys: `script_cpu_seconds`, `script_address_space_bytes`, `script_open_files`, `script_file_size_bytes`, `script_wall_clock_seconds`, `script_output_cap_bytes`.
  - Invalid or non-positive values fall back to defaults; `bool` is rejected; overrides never end up more permissive than defaults.
  - Clamped `script_wall_clock_seconds` to 600s to avoid stranding runs.
  - `run_skill_script` now uses the resolver; docs updated; tests cover overrides and enforce `get_cli_setting("skills", "<key>", default)` usage.

<sup>Written for commit 4016e1bfc124d3ccef724e01f5c82ee34658d67d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

