### PR TITLE
docs(backlog): record task-583 sandbox feasibility prototype (paused)

### DIFF
--- a/backlog/tasks/task-583 - OS-level-sandbox-for-skill-script-execution.md
+++ b/backlog/tasks/task-583 - OS-level-sandbox-for-skill-script-execution.md
@@ -4,6 +4,7 @@ title: OS-level sandbox for skill script execution
 status: To Do
 assignee: []
 created_date: '2026-07-25 15:05'
+updated_date: '2026-07-25 23:25'
 labels:
   - skills
   - security
@@ -37,3 +38,24 @@ This is a design project, not a patch: the mechanism differs per platform (macOS
 - [ ] #6 The residual-risk section of Docs/Features/Skills-Script-Execution.md is rewritten to match what is actually enforced
 - [ ] #7 Existing skill scripts that only read their own bundle and write to the scratch directory continue to work unchanged
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+PAUSED by user 2026-07-25, before any implementation. Recording the feasibility prototype so it is not re-derived.
+
+FEASIBILITY: PROVEN on macOS 15.6. sandbox-exec exists at /usr/bin/sandbox-exec and a deny-default profile genuinely blocks both network egress and writes outside an allowed subpath. Full-stack prototype composed cleanly with the EXISTING runner: RLIMITs from our Python trampoline still applied (verified CPU 7 / NOFILE 64 inside the sandbox), network blocked, scratch write allowed, write outside blocked, and start_new_session still gave the child its own process group (so killpg teardown is unaffected). Exit 0.
+
+TWO CONSTRAINTS LEARNED THE HARD WAY:
+1. subpath rules MUST use the RESOLVED path. mktemp -d yields /var/folders/... but the sandbox matches /private/var/folders/...; the unresolved form silently denies writes to the very directory you meant to allow.
+2. A malformed profile makes sandbox-exec fail LOUDLY (it errored on a deliberate typo) rather than silently running unsandboxed — the failure direction you want from a containment layer.
+
+USER DECISIONS TAKEN DURING THE BRAINSTORM (carry these into the eventual spec):
+- Network: blocked by default with a per-skill opt-in.
+- The opt-in is a DECLARE/GRANT PAIR (user answered '1+2'): the skill declares  in SKILL.md frontmatter (so the request rides in reviewed, fingerprinted content — adding it later changes the digest, re-triggering review and dropping any standing script grant) AND the user grants it via a per-skill toggle in the Library trust panel. Network is permitted only when BOTH hold, so a skill cannot self-grant and a user cannot accidentally grant to a skill that never asked.
+- Fail mode: refuse to run when the sandbox cannot be applied, with a config knob permitting degraded best-effort execution for someone who knowingly wants it.
+
+RISKS TO ACCEPT KNOWINGLY: sandbox-exec is Apple-deprecated, so a future macOS could remove it and the fail-closed default would then turn script execution off until a replacement lands. Linux needs a different mechanism entirely (seccomp/namespaces/bubblewrap), so this ships macOS-first with Linux refusing-unless-opted-in.
+
+SCOPE NOTE: this is a multi-task layer (frontmatter key, second grant dimension, UI toggle, profile generation, fail-mode config), not a single PR.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
Task-583 is **paused before implementation** at the user's request. This records the feasibility work so it does not have to be re-derived.

**Feasibility: proven on macOS 15.6.** A deny-default `sandbox-exec` profile genuinely blocks network egress and out-of-scratch writes, and composes cleanly with the *existing* runner — RLIMITs from the Python trampoline still apply, `start_new_session` still gives the child its own process group, so killpg teardown is unaffected.

**Two constraints learned the hard way**, both easy to lose a day to:
- `subpath` rules must use the **resolved** path — `/var/folders/…` silently denies writes to the directory you meant to allow; `/private/var/folders/…` works.
- A malformed profile makes `sandbox-exec` fail **loudly** rather than silently running unsandboxed, which is the failure direction you want.

Also records the design decisions taken during the brainstorm (network blocked by default; the opt-in as a **declare/grant pair** across frontmatter and the Library trust panel; fail-closed with an opt-in escape hatch) and the risks to accept knowingly (`sandbox-exec` is Apple-deprecated; Linux needs a different mechanism).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record the sandbox feasibility for Task-583, confirming `/usr/bin/sandbox-exec` on macOS 15.6 blocks network egress and out‑of‑scratch writes while composing with the existing RLIMIT/process‑group runner; documents two constraints (use resolved paths for `subpath`; malformed profiles fail loudly), the declare+UI‑grant network opt‑in with a fail‑closed default, and risks (Apple deprecation, Linux mechanism TBD); implementation is paused.

<sup>Written for commit 1de9720f734316fa14e5dd1f8297e1bfadf12a30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

