### PR TITLE
task-634: media analysis surfaces LLM failures instead of sentinel false-success (+ 634 ID-collision renumber)

### DIFF
--- a/Tests/Event_Handlers/test_worker_events_contract.py
+++ b/Tests/Event_Handlers/test_worker_events_contract.py
@@ -1,0 +1,72 @@
+# test_worker_events_contract.py
+# Description: Regression coverage for worker_events.chat_wrapper_function's
+# error-handling contract (task-634).
+#
+# A failing LLM call previously fell through to an unconditional
+# `return "STREAMING_HANDLED_BY_EVENTS"` regardless of whether the caller
+# requested streaming. Non-streaming callers (e.g. media analysis) consume
+# the return value directly, so the sentinel string rendered as if it were a
+# valid (and successful) LLM response. Non-streaming failures must now
+# propagate instead. The streaming branch's existing contract (StreamDone
+# posted + sentinel returned) must remain byte-identical.
+#
+# Imports
+from unittest.mock import Mock, patch
+
+import pytest
+
+from tldw_chatbook.Event_Handlers.worker_events import (
+    StreamDone,
+    chat_wrapper_function,
+)
+
+
+def _mock_app() -> Mock:
+    app = Mock()
+    app.loguru_logger = Mock()
+    app.post_message = Mock()
+    app.current_chat_worker = None
+    return app
+
+
+def test_chat_wrapper_function_nonstreaming_failure_raises():
+    """A non-streaming caller must see the real exception, not a sentinel string."""
+    app = _mock_app()
+
+    with patch(
+        "tldw_chatbook.Event_Handlers.worker_events.core_chat_function",
+        side_effect=RuntimeError("boom"),
+    ):
+        with pytest.raises(RuntimeError, match="boom"):
+            chat_wrapper_function(
+                app,
+                streaming=False,
+                api_endpoint="test-endpoint",
+                model="test-model",
+            )
+
+    app.post_message.assert_not_called()
+
+
+def test_chat_wrapper_function_streaming_failure_keeps_sentinel_contract():
+    """The legacy streaming contract (StreamDone posted + sentinel returned) is untouched."""
+    app = _mock_app()
+
+    with patch(
+        "tldw_chatbook.Event_Handlers.worker_events.core_chat_function",
+        side_effect=RuntimeError("boom"),
+    ):
+        result = chat_wrapper_function(
+            app,
+            streaming=True,
+            api_endpoint="test-endpoint",
+            model="test-model",
+        )
+
+    assert result == "STREAMING_HANDLED_BY_EVENTS"
+    app.post_message.assert_called_once()
+    posted = app.post_message.call_args[0][0]
+    assert isinstance(posted, StreamDone)
+    assert posted.full_text == ""
+    assert posted.error is not None
+    assert "boom" in posted.error

--- a/Tests/UI/test_media_window_v2_parity.py
+++ b/Tests/UI/test_media_window_v2_parity.py
@@ -9,6 +9,7 @@ from textual.app import App, ComposeResult
 from textual.widgets import Button, Collapsible, Label, Select, Static
 
 from tldw_chatbook.Event_Handlers.media_events import (
+    MediaAnalysisRequestEvent,
     MediaAnalysisSaveEvent,
     MediaReadingHighlightCreateEvent,
     MediaReadingHighlightDeleteEvent,
@@ -1363,3 +1364,65 @@ async def test_media_viewer_analysis_actions_explain_disabled_and_available_stat
         assert "Select a saved analysis version before deleting it" in str(
             delete_button.tooltip
         )
+
+
+@pytest.mark.asyncio
+async def test_media_analysis_llm_failure_surfaces_error_not_sentinel():
+    """task-634: a failing LLM call during media analysis must notify an error
+    and reset the analysis display -- it must never render the internal
+    "STREAMING_HANDLED_BY_EVENTS" sentinel or claim success."""
+    window, app = _build_media_window()
+    app.chat_wrapper = Mock(side_effect=RuntimeError("LLM exploded"))
+    app.app_config = {"api_settings": {}}
+    window._record_for_event = Mock(
+        return_value={
+            "title": "Doc",
+            "content": "some content",
+            "author": "Someone",
+            "type": "article",
+        }
+    )
+
+    analysis_display = AsyncMock()
+
+    def _query_one(selector, expect_type=None):
+        if selector == "#analysis-display":
+            return analysis_display
+        raise AssertionError(f"Unexpected selector: {selector}")
+
+    window.viewer_panel = Mock()
+    window.viewer_panel.query_one = Mock(side_effect=_query_one)
+    window.viewer_panel.all_analyses = []
+
+    captured = {}
+
+    def _run_worker(coro, exclusive=True):
+        captured["coro"] = coro
+
+    window.run_worker = _run_worker
+
+    event = MediaAnalysisRequestEvent(
+        media_id="local:media:1",
+        provider="Local",
+        model="test-model",
+        system_prompt="",
+        user_prompt="Summarize this",
+        type_slug="article",
+    )
+
+    window.handle_analysis_request(event)
+    await captured["coro"]
+
+    notified_messages = [call.args[0] for call in app.notify.call_args_list]
+    assert any("Error" in message for message in notified_messages)
+    assert not any(
+        "Analysis generated successfully" in message for message in notified_messages
+    )
+    assert not any(
+        "STREAMING_HANDLED_BY_EVENTS" in message for message in notified_messages
+    )
+
+    analysis_display.update.assert_awaited()
+    updated_text = analysis_display.update.await_args.args[0]
+    assert "STREAMING_HANDLED_BY_EVENTS" not in updated_text
+    assert "failed" in updated_text.lower()

--- a/Tests/UI/test_media_window_v2_parity.py
+++ b/Tests/UI/test_media_window_v2_parity.py
@@ -1393,6 +1393,9 @@ async def test_media_analysis_llm_failure_surfaces_error_not_sentinel():
     window.viewer_panel = Mock()
     window.viewer_panel.query_one = Mock(side_effect=_query_one)
     window.viewer_panel.all_analyses = []
+    # Simulate a prior successful analysis still parked on the viewer panel --
+    # the failure path must not leave this stale content actionable.
+    window.viewer_panel.current_analysis = "Stale prior analysis"
 
     captured = {}
 
@@ -1426,3 +1429,70 @@ async def test_media_analysis_llm_failure_surfaces_error_not_sentinel():
     updated_text = analysis_display.update.await_args.args[0]
     assert "STREAMING_HANDLED_BY_EVENTS" not in updated_text
     assert "failed" in updated_text.lower()
+
+    # task-634 Qodo follow-up: the stale current_analysis pointer must be
+    # cleared and button states refreshed so Save/Edit can't act on a prior
+    # successful analysis while the panel is showing a failure message.
+    assert window.viewer_panel.current_analysis is None
+    window.viewer_panel._update_analysis_button_states.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_media_analysis_missing_response_text_clears_stale_analysis_state():
+    """task-634 Qodo follow-up: the "no valid response text" branch (LLM
+    returns a response but no extractable text) must reset the same way as
+    the outer-exception branch -- clearing the stale current_analysis
+    pointer and refreshing button states, not just the display text."""
+    window, app = _build_media_window()
+    # Response has no usable text under any of the extraction branches.
+    app.chat_wrapper = Mock(return_value={"unexpected": "shape"})
+    app.app_config = {"api_settings": {}}
+    window._record_for_event = Mock(
+        return_value={
+            "title": "Doc",
+            "content": "some content",
+            "author": "Someone",
+            "type": "article",
+        }
+    )
+
+    analysis_display = AsyncMock()
+
+    def _query_one(selector, expect_type=None):
+        if selector == "#analysis-display":
+            return analysis_display
+        raise AssertionError(f"Unexpected selector: {selector}")
+
+    window.viewer_panel = Mock()
+    window.viewer_panel.query_one = Mock(side_effect=_query_one)
+    window.viewer_panel.all_analyses = []
+    window.viewer_panel.current_analysis = "Stale prior analysis"
+
+    captured = {}
+
+    def _run_worker(coro, exclusive=True):
+        captured["coro"] = coro
+
+    window.run_worker = _run_worker
+
+    event = MediaAnalysisRequestEvent(
+        media_id="local:media:2",
+        provider="Local",
+        model="test-model",
+        system_prompt="",
+        user_prompt="Summarize this",
+        type_slug="article",
+    )
+
+    window.handle_analysis_request(event)
+    await captured["coro"]
+
+    notified_messages = [call.args[0] for call in app.notify.call_args_list]
+    assert any("Failed to generate analysis" in message for message in notified_messages)
+
+    analysis_display.update.assert_awaited()
+    updated_text = analysis_display.update.await_args.args[0]
+    assert "failed" in updated_text.lower()
+
+    assert window.viewer_panel.current_analysis is None
+    window.viewer_panel._update_analysis_button_states.assert_called()

--- a/backlog/tasks/task-634 - Media-analysis-shows-false-success-with-sentinel-text-on-LLM-failure.md
+++ b/backlog/tasks/task-634 - Media-analysis-shows-false-success-with-sentinel-text-on-LLM-failure.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-634
 title: Media analysis shows false success with sentinel text on LLM failure
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-25 22:40'
 labels:
@@ -37,7 +37,69 @@ either way.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A failing LLM call during media analysis surfaces an error to the user (no success toast, no sentinel text rendered as analysis)
-- [ ] #2 A successful analysis is unaffected (return-value contract for the success path unchanged)
-- [ ] #3 A regression test drives the failure path (LLM call raising) and pins the error surfacing
+- [x] #1 A failing LLM call during media analysis surfaces an error to the user (no success toast, no sentinel text rendered as analysis)
+- [x] #2 A successful analysis is unaffected (return-value contract for the success path unchanged)
+- [x] #3 A regression test drives the failure path (LLM call raising) and pins the error surfacing
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. `worker_events.chat_wrapper_function`'s single `except Exception` block (non-streaming
+   path) currently posts `StreamDone` and unconditionally returns the
+   `"STREAMING_HANDLED_BY_EVENTS"` sentinel, regardless of whether the caller requested
+   streaming. Branch on the already-bound `streaming` kwarg: keep the streaming branch's
+   `StreamDone` post + sentinel return byte-identical (nothing else consumes it, but it's
+   the documented legacy contract); for the non-streaming branch, `raise` (bare, to
+   preserve the traceback) so the caller gets the real exception instead of a string that
+   gets rendered as if it were a valid LLM response.
+2. `MediaWindow_v2.py`'s `perform_analysis()` outer `except Exception` (the only live
+   non-streaming caller of `chat_wrapper`) already notifies the user with
+   `f"Error: {str(e)[:100]}"`, but leaves the analysis display untouched — so a failure
+   right after a prior successful analysis would leave stale content on screen. Mirror the
+   existing falsy-response else-branch exactly: reset `#analysis-display` to
+   `"*Analysis generation failed - no valid response text*"`, guarded by its own
+   try/except.
+3. Add regression tests first (TDD): a unit test pinning the non-streaming failure now
+   raises (RED against current code, which returns the sentinel), a twin test pinning the
+   streaming branch's untouched contract, and a media-seam test driving
+   `handle_analysis_request` with `chat_wrapper` patched to raise, asserting an error
+   notification, no success notification, no sentinel text anywhere, and the analysis
+   display reset to a failure message.
+
+## Implementation Notes
+
+Approach taken: exactly the two production edits described in the plan, TDD'd with a RED
+proof first for both new/extended test homes.
+
+- `tldw_chatbook/Event_Handlers/worker_events.py` (`chat_wrapper_function`'s single
+  `except Exception as e:` block, non-streaming path): the error logging/metrics
+  (`logger.exception`, `log_counter`, `log_histogram`) stayed byte-identical. Below that,
+  branched on `streaming` (already bound before the `try`, so safe to read in the `except`):
+  the streaming branch keeps the original `StreamDone` post + `"STREAMING_HANDLED_BY_EVENTS"`
+  return byte-identical (pinned by
+  `test_chat_wrapper_function_streaming_failure_keeps_sentinel_contract`); the non-streaming
+  branch now does a bare `raise` instead of swallowing the exception into the sentinel
+  string (pinned by `test_chat_wrapper_function_nonstreaming_failure_raises`, which was RED
+  against the pre-fix code with `Failed: DID NOT RAISE <class 'RuntimeError'>`).
+- `tldw_chatbook/UI/MediaWindow_v2.py` (`handle_analysis_request`'s `perform_analysis()`
+  outer `except Exception as e:`): after the existing `self.app_instance.notify(f"Error:
+  {str(e)[:100]}", severity="error")` (left unchanged), added a try/except-guarded
+  `#analysis-display` reset to `"*Analysis generation failed - no valid response text*"`,
+  mirroring the falsy-response else-branch a few lines above verbatim. New test
+  `test_media_analysis_llm_failure_surfaces_error_not_sentinel` in
+  `Tests/UI/test_media_window_v2_parity.py` drives `handle_analysis_request` with
+  `app_instance.chat_wrapper` patched to raise; it was RED against pre-fix code
+  (`AssertionError: Expected update to have been awaited` — the display reset didn't exist
+  yet) and is GREEN post-fix. It also asserts no "Analysis generated successfully" notify
+  and no literal sentinel text anywhere in the notify calls or the display update text.
+- Both edits are strictly additive to the failure paths; the success-path return-value
+  contract (`return result` for non-streaming, the streaming generator-consumption branch,
+  and the `response_text` success branch in `MediaWindow_v2.py`) is untouched, satisfying
+  AC #2. Verified via the full existing `Tests/UI/test_media_window_v2_parity.py` +
+  `Tests/UI/test_media_handoffs.py` + `Tests/Event_Handlers/` + `Tests/test_smoke.py` suites
+  passing, plus pyflakes and `import tldw_chatbook.app` clean.
+- Files modified: `tldw_chatbook/Event_Handlers/worker_events.py`,
+  `tldw_chatbook/UI/MediaWindow_v2.py`,
+  `Tests/UI/test_media_window_v2_parity.py` (new test + import).
+- File added: `Tests/Event_Handlers/test_worker_events_contract.py` (new test home — none
+  existed for `worker_events.py` before this task).

--- a/backlog/tasks/task-635 - Agent-and-subagent-settings-screen-general-and-per-workspace.md
+++ b/backlog/tasks/task-635 - Agent-and-subagent-settings-screen-general-and-per-workspace.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-634
+id: TASK-635
 title: Agent and sub-agent settings screen (general and per-workspace)
 status: To Do
 assignee: []

--- a/tldw_chatbook/Event_Handlers/worker_events.py
+++ b/tldw_chatbook/Event_Handlers/worker_events.py
@@ -416,14 +416,18 @@ def chat_wrapper_function(
             },
         )
 
-        # To ensure consistent error handling through StreamDone for the UI:
-        app_instance.post_message(
-            StreamDone(
-                full_text="", error=f"Chat wrapper error: {str(e)}", response_data=None
+        if streaming:
+            # Legacy streaming contract: report the failure through the (now unhandled)
+            # StreamDone event and return the sentinel.
+            app_instance.post_message(
+                StreamDone(
+                    full_text="", error=f"Chat wrapper error: {str(e)}", response_data=None
+                )
             )
-        )
-        return "STREAMING_HANDLED_BY_EVENTS"  # Signal that this path also used an event to report error
-        # Alternative for WorkerState.ERROR: raise e
+            return "STREAMING_HANDLED_BY_EVENTS"  # Exit the worker function
+        # task-634: non-streaming callers consume the return value directly -- a swallowed
+        # exception rendered the sentinel as the response. Propagate instead.
+        raise
 
 
 #

--- a/tldw_chatbook/UI/MediaWindow_v2.py
+++ b/tldw_chatbook/UI/MediaWindow_v2.py
@@ -58,6 +58,8 @@ MEDIA_EMPTY_STATE_COPY = (
     "Details, analysis, save/export, and Use in Chat actions appear after a media item is selected."
 )
 
+ANALYSIS_FAILED_MESSAGE = "*Analysis generation failed - no valid response text*"
+
 
 class MediaWindow(Container):
     """
@@ -1402,6 +1404,28 @@ class MediaWindow(Container):
         except Exception:
             pass
 
+    async def _reset_analysis_failure_state(self, media_id: Optional[str]) -> None:
+        """Reset the analysis viewer after a failed analysis generation.
+
+        Updates the analysis display to the shared failure message and clears
+        the viewer panel's ``current_analysis`` pointer so Save/Edit can't act
+        on a prior successful analysis while the panel shows a failure
+        message, then refreshes the button states to match. Saved history in
+        ``all_analyses`` is left untouched -- only the current (unsaved)
+        pointer resets.
+        """
+        try:
+            analysis_display = self.viewer_panel.query_one(
+                "#analysis-display", Markdown
+            )
+            await analysis_display.update(ANALYSIS_FAILED_MESSAGE)
+            self.viewer_panel.current_analysis = None
+            self.viewer_panel._update_analysis_button_states()
+        except Exception as e:
+            logger.opt(exception=True).error(
+                f"Error resetting analysis display for media_id={media_id}: {e}"
+            )
+
     @on(MediaAnalysisRequestEvent)
     def handle_analysis_request(self, event: MediaAnalysisRequestEvent) -> None:
         """Handle media analysis request."""
@@ -1691,30 +1715,14 @@ class MediaWindow(Container):
                     self.app_instance.notify(
                         "Failed to generate analysis", severity="error"
                     )
-                    # Reset analysis display on failure
-                    try:
-                        analysis_display = self.viewer_panel.query_one(
-                            "#analysis-display", Markdown
-                        )
-                        await analysis_display.update(
-                            "*Analysis generation failed - no valid response text*"
-                        )
-                    except Exception as e:
-                        logger.error(f"Error resetting analysis display: {e}")
+                    # Reset analysis display and viewer state on failure
+                    await self._reset_analysis_failure_state(event.media_id)
 
             except Exception as e:
                 logger.opt(exception=True).error(f"Error performing analysis: {e}")
                 self.app_instance.notify(f"Error: {str(e)[:100]}", severity="error")
-                # Reset analysis display on failure
-                try:
-                    analysis_display = self.viewer_panel.query_one(
-                        "#analysis-display", Markdown
-                    )
-                    await analysis_display.update(
-                        "*Analysis generation failed - no valid response text*"
-                    )
-                except Exception as e:
-                    logger.error(f"Error resetting analysis display: {e}")
+                # Reset analysis display and viewer state on failure
+                await self._reset_analysis_failure_state(event.media_id)
 
         # Run the analysis in a worker
         self.run_worker(perform_analysis(), exclusive=True)

--- a/tldw_chatbook/UI/MediaWindow_v2.py
+++ b/tldw_chatbook/UI/MediaWindow_v2.py
@@ -1705,6 +1705,16 @@ class MediaWindow(Container):
             except Exception as e:
                 logger.opt(exception=True).error(f"Error performing analysis: {e}")
                 self.app_instance.notify(f"Error: {str(e)[:100]}", severity="error")
+                # Reset analysis display on failure
+                try:
+                    analysis_display = self.viewer_panel.query_one(
+                        "#analysis-display", Markdown
+                    )
+                    await analysis_display.update(
+                        "*Analysis generation failed - no valid response text*"
+                    )
+                except Exception as e:
+                    logger.error(f"Error resetting analysis display: {e}")
 
         # Run the analysis in a worker
         self.run_worker(perform_analysis(), exclusive=True)


### PR DESCRIPTION
## Summary

**task-634 — media analysis no longer shows a false success on LLM failure.** Pre-existing bug surfaced by task-577 PR2's review trace: `worker_events.chat_wrapper_function` swallowed every exception and returned the sentinel string `"STREAMING_HANDLED_BY_EVENTS"`; the Media library's Analysis tab (the function's only live caller, `streaming=False`, consumes the return value) rendered that sentinel as the analysis text and toasted "Analysis generated successfully".

### The fix (two surgical edits)
1. **`worker_events.py` except block — contract split**: error logging/metrics unchanged; `if streaming:` keeps the legacy StreamDone-post + sentinel byte-equivalent (dead-path consistency); non-streaming now does a bare `raise` (traceback preserved — the original author's own inline comment anticipated exactly this alternative). MediaWindow's existing error plumbing (`call_llm` re-raise → outer except → `"Error: …"` notify) now actually fires.
2. **`MediaWindow_v2.py` outer except**: also resets `#analysis-display` to a failure message, mirroring the sibling falsy-response branch verbatim — the panel shows the failure, not stale content.

Success paths byte-identical; the only other parties to the contract change are six grep-proven-dead CCP generator handlers.

### Tests (all RED-proven against the base commit, reviewer-reproduced in a detached worktree)
- `test_chat_wrapper_function_nonstreaming_failure_raises` (was: `DID NOT RAISE`)
- `test_chat_wrapper_function_streaming_failure_keeps_sentinel_contract` (twin pinning the untouched branch)
- `test_media_analysis_llm_failure_surfaces_error_not_sentinel` (media seam: error notify, no success notify, sentinel never rendered)

### Also in this PR: backlog ID-collision repair
A second `task-634` ("Agent and sub-agent settings screen") landed on dev via #895 after our media-bug task-634 merged via #894. Per the merged-first-keeps convention (ancestry-verified), the agent-settings task is renumbered to **task-635** (file rename + `id:` only, body byte-identical, no dangling references). Note for the next merger: two unmerged branches have independently claimed 635 — re-verify at their merge time.

### Verification
Implementer + independent reviewer (zero findings): 101 passed across the contract/media/Event_Handlers/smoke suites; pyflakes clean; import smoke clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
LLM failures in Media Analysis now surface an error and fully reset the viewer state, instead of rendering the `STREAMING_HANDLED_BY_EVENTS` sentinel as a false success. Streaming behavior is unchanged; also resolves the ID collision by renumbering the agent-settings backlog item to `TASK-635` (per `TASK-634`).

- **Bug Fixes**
  - `worker_events.chat_wrapper_function`: non-streaming errors now re-raise; streaming still posts `StreamDone` and returns `STREAMING_HANDLED_BY_EVENTS`.
  - `MediaWindow_v2`: added `_reset_analysis_failure_state` to update `#analysis-display` with `ANALYSIS_FAILED_MESSAGE`, clear `current_analysis`, and refresh button states; used on exceptions and when no valid response text is returned so stale analyses can’t be saved/edited.
  - Backlog: duplicate `task-634` renumbered to `TASK-635`; `TASK-634` marked Done.

<sup>Written for commit 2a1978d2f1c500ab16d35b943ea126f06109a357. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

