### PR TITLE
feat(agents): surface the sandboxed file tools to the agent loop (task-654)

### DIFF
--- a/Tests/Agents/test_builtin_file_tools.py
+++ b/Tests/Agents/test_builtin_file_tools.py
@@ -74,3 +74,32 @@ def test_gated_tool_names_are_covered_by_the_shadow_guard(tools_config):
     assert gated <= _SHADOWED_BUILTIN_NAMES, (
         f"gated builtin tool names not covered: {gated - _SHADOWED_BUILTIN_NAMES}"
     )
+
+
+@pytest.mark.asyncio
+async def test_list_directory_does_not_follow_symlinks_out_of_the_sandbox(
+    tmp_path, monkeypatch
+):
+    """Containment: a planted symlink must not enumerate outside the root.
+
+    Surfacing this tool to the agent loop makes the escape reachable by an
+    agent, so it is fixed here rather than left to the tool's own PR: a
+    symlink created inside file_sandbox_root previously let the recursive
+    walk list files anywhere on disk.
+    """
+    import tldw_chatbook.Tools.file_operation_tools as fot
+
+    sandbox = tmp_path / "sandbox"
+    outside = tmp_path / "outside"
+    sandbox.mkdir()
+    outside.mkdir()
+    (outside / "OUTSIDE_SECRET.txt").write_text("x", encoding="utf-8")
+    (sandbox / "escape").symlink_to(outside)
+    (sandbox / "legit").mkdir()
+    (sandbox / "legit" / "inside.txt").write_text("y", encoding="utf-8")
+
+    monkeypatch.setattr(fot, "_resolve_sandbox_config", lambda: str(sandbox))
+    listing = str(await fot.ListDirectoryTool().execute(directory_path=".", recursive=True))
+
+    assert "OUTSIDE_SECRET" not in listing, "symlink escaped the sandbox root"
+    assert "inside.txt" in listing, "legitimate nested listing must still work"

--- a/Tests/Agents/test_builtin_file_tools.py
+++ b/Tests/Agents/test_builtin_file_tools.py
@@ -1,0 +1,76 @@
+"""task-584: the file tools must be reachable from the Agents runtime.
+
+`BuiltinToolProvider` hardcoded Calculator + DateTime, so the app's existing
+sandbox-rooted ReadFileTool/ListDirectoryTool were registered on the global
+ToolExecutor but never surfaced to the agent loop. Retained script output is
+written under the file-tool sandbox root precisely so those tools can reach it.
+
+They stay behind the SAME config gates that already govern them, which default
+to disabled — wiring them in changes reachability, not the default posture.
+"""
+
+import pytest
+
+from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider
+
+
+@pytest.fixture
+def tools_config(monkeypatch):
+    """Drive the existing [tools] gates."""
+    values = {}
+    import tldw_chatbook.config as config_module
+
+    def fake(section, key=None, default=None):
+        if section != "tools" or not isinstance(key, str):
+            return default
+        return values.get(key, default)
+
+    monkeypatch.setattr(config_module, "get_cli_setting", fake)
+    return values
+
+
+def _names(provider):
+    return {entry.name for entry in provider.list_catalog()}
+
+
+def test_file_tools_absent_by_default(tools_config):
+    """Default posture is unchanged: the gates default to disabled."""
+    names = _names(BuiltinToolProvider())
+    assert "read_file" not in names
+    assert "list_directory" not in names
+    assert {"calculator", "get_current_datetime"} <= names
+
+
+def test_read_file_appears_when_enabled(tools_config):
+    tools_config["read_file_enabled"] = True
+    assert "read_file" in _names(BuiltinToolProvider())
+
+
+def test_list_directory_appears_when_enabled(tools_config):
+    tools_config["list_directory_enabled"] = True
+    assert "list_directory" in _names(BuiltinToolProvider())
+
+
+def test_each_gate_is_independent(tools_config):
+    tools_config["read_file_enabled"] = True
+    names = _names(BuiltinToolProvider())
+    assert "read_file" in names
+    assert "list_directory" not in names
+
+
+def test_gated_tool_names_are_covered_by_the_shadow_guard(tools_config):
+    """The drift guard has a blind spot for config-gated tools.
+
+    It constructs a BuiltinToolProvider with DEFAULT config, so a tool that
+    only appears when a gate is enabled is invisible to it. These names must
+    therefore be pinned explicitly: a skill named `read_file` shadows a real
+    builtin the moment someone turns the gate on.
+    """
+    from tldw_chatbook.Library.library_skills_state import _SHADOWED_BUILTIN_NAMES
+
+    tools_config["read_file_enabled"] = True
+    tools_config["list_directory_enabled"] = True
+    gated = _names(BuiltinToolProvider())
+    assert gated <= _SHADOWED_BUILTIN_NAMES, (
+        f"gated builtin tool names not covered: {gated - _SHADOWED_BUILTIN_NAMES}"
+    )

--- a/backlog/tasks/task-654 - Surface-sandboxed-file-tools-to-the-agent-loop.md
+++ b/backlog/tasks/task-654 - Surface-sandboxed-file-tools-to-the-agent-loop.md
@@ -30,6 +30,7 @@ This is a posture-relevant change even though the tools stay behind their existi
 - [x] #3 Each gate is independent; enabling one does not surface the other
 - [x] #4 A tool that cannot be constructed (missing module, bad config) is simply absent rather than breaking provider construction
 - [x] #5 The names are covered by the shadowed-builtin guard, so a skill cannot silently shadow them once a gate is enabled
+- [x] #6 `list_directory` cannot enumerate outside the sandbox root via a planted symlink
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -40,4 +41,6 @@ Extended `BuiltinToolProvider.__init__` to add `ReadFileTool`/`ListDirectoryTool
 
 `WriteFileTool` is deliberately **not** surfaced: granting the agent loop filesystem writes is a larger decision than making retained output readable, and nothing here needs it.
 
-Files: `tldw_chatbook/Agents/tool_catalog.py`, `tldw_chatbook/Library/library_skills_state.py`, `Tests/Agents/test_builtin_file_tools.py`
+**AC#6 was found by review and is the reason this split mattered.** A symlink planted inside `file_sandbox_root` let `ListDirectoryTool`'s recursive walk enumerate files anywhere on disk — reproduced before fixing (an out-of-sandbox file appeared in the listing). Latent while nothing in the agent loop could call the tool; reachable the moment this PR surfaces it, so it is fixed here rather than deferred. The walk now refuses to descend into symlinked directories and re-checks that each child resolves under the root.
+
+Files: `tldw_chatbook/Tools/file_operation_tools.py`, `tldw_chatbook/Agents/tool_catalog.py`, `tldw_chatbook/Library/library_skills_state.py`, `Tests/Agents/test_builtin_file_tools.py`

--- a/backlog/tasks/task-654 - Surface-sandboxed-file-tools-to-the-agent-loop.md
+++ b/backlog/tasks/task-654 - Surface-sandboxed-file-tools-to-the-agent-loop.md
@@ -1,0 +1,43 @@
+---
+id: TASK-654
+title: Surface sandboxed file tools to the agent loop
+status: Done
+assignee:
+  - '@claude'
+created_date: '2026-07-25 18:05'
+labels:
+  - agents
+  - tools
+  - security
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`Tools/file_operation_tools.py` provides `ReadFileTool`, `ListDirectoryTool` and `WriteFileTool`, all confined to a configurable `[tools] file_sandbox_root`. They are registered on the global `ToolExecutor`, but the Agents runtime's `BuiltinToolProvider` hardcodes only `CalculatorTool` and `DateTimeTool` — so the agent loop never sees them.
+
+That gap has a concrete cost: skill-script output is deliberately retained under the file-tool sandbox root (task-584) precisely so the app's existing contained tooling can reach it, and today nothing in the agent loop can.
+
+This is a posture-relevant change even though the tools stay behind their existing gates, so it is split from task-584 to be reviewed on its own merits rather than riding along with output retention.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [x] #1 `read_file` and `list_directory` are reachable from the agent loop when their existing `[tools]` gates are enabled
+- [x] #2 The default posture is unchanged — with no config, the agent sees exactly the tools it saw before
+- [x] #3 Each gate is independent; enabling one does not surface the other
+- [x] #4 A tool that cannot be constructed (missing module, bad config) is simply absent rather than breaking provider construction
+- [x] #5 The names are covered by the shadowed-builtin guard, so a skill cannot silently shadow them once a gate is enabled
+<!-- AC:END -->
+
+## Implementation Notes
+
+Extended `BuiltinToolProvider.__init__` to add `ReadFileTool`/`ListDirectoryTool` when `read_file_enabled` / `list_directory_enabled` are set, reusing the **same** `[tools]` gates that already govern their registration on the global `ToolExecutor`. Both default to disabled, so this changes *reachability*, not the default posture. Construction failures are swallowed per-tool, so an unavailable tool is absent rather than fatal.
+
+**AC#5 is the non-obvious one.** The shadowed-builtin drift guard (task-580) builds a `BuiltinToolProvider` with *default* config, so a config-gated tool is invisible to it — the guard would never have flagged these names. They are therefore pinned explicitly in `_SHADOWED_BUILTIN_NAMES`, with a test that enables both gates and asserts coverage. Without that, a skill named `read_file` would silently shadow a real builtin the moment a user turned the gate on.
+
+`WriteFileTool` is deliberately **not** surfaced: granting the agent loop filesystem writes is a larger decision than making retained output readable, and nothing here needs it.
+
+Files: `tldw_chatbook/Agents/tool_catalog.py`, `tldw_chatbook/Library/library_skills_state.py`, `Tests/Agents/test_builtin_file_tools.py`

--- a/tldw_chatbook/Agents/tool_catalog.py
+++ b/tldw_chatbook/Agents/tool_catalog.py
@@ -191,6 +191,27 @@ class BuiltinToolProvider:
 
     def __init__(self, gate: Any | None = None) -> None:
         self._tools = {t.name: t for t in (CalculatorTool(), DateTimeTool())}
+        # task-584: surface the app's existing sandbox-rooted file tools to the
+        # agent loop. They were registered on the global ToolExecutor but never
+        # reachable from here, so retained script output -- deliberately written
+        # under the file-tool sandbox root -- had no consumer. Behind the SAME
+        # [tools] gates that already govern them, which default to DISABLED:
+        # this changes reachability, not the default posture.
+        for gate_key, factory_name in (
+            ("read_file_enabled", "ReadFileTool"),
+            ("list_directory_enabled", "ListDirectoryTool"),
+        ):
+            try:
+                from ..config import get_cli_setting
+
+                if not get_cli_setting("tools", gate_key, False):
+                    continue
+                from ..Tools import file_operation_tools as _file_tools
+
+                tool = getattr(_file_tools, factory_name)()
+            except Exception:  # noqa: BLE001 — an unavailable tool is just absent
+                continue
+            self._tools[tool.name] = tool
         # `None` means "build the real gate on first use" -- NOT "ungated".
         # Every construction site (console_agent_bridge's default registry
         # and its per-run registry) passes nothing today, so an ungated

--- a/tldw_chatbook/Library/library_skills_state.py
+++ b/tldw_chatbook/Library/library_skills_state.py
@@ -65,6 +65,13 @@ _SHADOWED_BUILTIN_NAMES = frozenset(
         # signal-erosion the guard exists to prevent.
         "rewind",
         "generate-image",
+        # The sandbox-rooted file tools. These are CONFIG-GATED (off by
+        # default), so the drift guard -- which builds a BuiltinToolProvider
+        # with default config -- cannot see them and would not have caught
+        # their absence. Listed explicitly: a skill named after one of them
+        # still shadows a real builtin the moment a user enables the gate.
+        "read_file",
+        "list_directory",
     )
 )
 

--- a/tldw_chatbook/Tools/file_operation_tools.py
+++ b/tldw_chatbook/Tools/file_operation_tools.py
@@ -20,6 +20,24 @@ def _resolve_sandbox_config() -> str:
     return get_cli_setting("tools", "file_sandbox_root", default_root) or default_root
 
 
+def _is_within(candidate: Path, root: Path) -> bool:
+    """Return whether ``candidate`` resolves inside ``root``.
+
+    Args:
+        candidate: Path to test.
+        root: The sandbox root it must stay under.
+
+    Returns:
+        True only when the fully-resolved candidate is the root or below it.
+    """
+    try:
+        resolved = candidate.resolve()
+        root_resolved = root.resolve()
+    except OSError:
+        return False
+    return resolved == root_resolved or root_resolved in resolved.parents
+
+
 def _tool_sandbox_root() -> Path:
     """Resolve + create the file-tool sandbox root.
 
@@ -185,7 +203,8 @@ class ListDirectoryTool(Tool):
 
         try:
             # Validate the path
-            validated_path = validate_path(directory_path, _tool_sandbox_root())
+            sandbox_root = _tool_sandbox_root()
+            validated_path = validate_path(directory_path, sandbox_root)
             path = Path(validated_path)
 
             # Check if directory exists
@@ -227,11 +246,19 @@ class ListDirectoryTool(Tool):
                             }
                             entries.append(entry)
 
-                            # Recursively list subdirectories
+                            # Recursively list subdirectories, but NEVER
+                            # follow a symlink: a link planted inside the
+                            # sandbox would otherwise let the walk enumerate
+                            # files outside file_sandbox_root, breaking the
+                            # containment every other path here relies on.
+                            # Belt-and-braces, the resolved child must still
+                            # sit under the sandbox root.
                             if (
                                 recursive
                                 and item.is_dir()
+                                and not item.is_symlink()
                                 and current_depth < max_depth
+                                and _is_within(item, sandbox_root)
                             ):
                                 list_dir_contents(item, current_depth + 1)
 


### PR DESCRIPTION
## Summary

Split out of **#900** so the posture-relevant part is reviewed on its own merits.

`Tools/file_operation_tools.py` provides `ReadFileTool` and `ListDirectoryTool`, both confined to a configurable `[tools] file_sandbox_root` and registered on the global `ToolExecutor` — but `BuiltinToolProvider` hardcoded `CalculatorTool` + `DateTimeTool`, so **the agent loop never saw them**.

That gap has a concrete cost: skill-script output is retained under that same sandbox root (task-584) precisely so the app's existing contained tooling can reach it, and today nothing in the agent loop can.

## Scope of the change

| | |
|---|---|
| **Changes** | Reachability — the tools can now appear in the agent's catalog |
| **Does not change** | The default posture. Both gates (`read_file_enabled`, `list_directory_enabled`) already existed and already default to **disabled** |

With no config, the agent sees exactly what it saw before — pinned by a test. Gates are independent, and a tool that fails to construct is simply absent rather than breaking provider construction.

`WriteFileTool` is **deliberately not surfaced**: granting the agent loop filesystem writes is a larger decision than making retained output readable, and nothing here needs it.

## The non-obvious part

Both names are pinned in `_SHADOWED_BUILTIN_NAMES`, and this is worth reviewing carefully:

The shadowed-builtin drift guard (task-580) constructs a `BuiltinToolProvider` with **default** config — so a *config-gated* tool is invisible to it. The guard would never have flagged these names, and it stays green either way. Without the explicit pin, a skill named `read_file` would silently shadow a real builtin the moment a user enabled the gate.

A test enables both gates and asserts coverage, which is the only way to catch this class of gap.

## Testing

`Tests/Agents/test_builtin_file_tools.py` (5), RED-first — including one asserting the default posture is unchanged.

Tests/Agents + Tests/Library: **962 passed** · ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the sandboxed file tools to the agent loop behind existing `[tools]` gates so agents can read retained script output, and harden `ListDirectoryTool` to block symlink traversal outside the sandbox; default posture remains unchanged (task-654).

- **New Features**
  - `BuiltinToolProvider` now surfaces `ReadFileTool` and `ListDirectoryTool` when `read_file_enabled` / `list_directory_enabled` are enabled.
  - Tools construct defensively; pin `read_file`/`list_directory` in `_SHADOWED_BUILTIN_NAMES`; `WriteFileTool` is not surfaced.

- **Bug Fixes**
  - `ListDirectoryTool` no longer descends into symlinked directories and re-validates that children resolve under the sandbox root.

<sup>Written for commit 67cfff5151aca775898437359fbfa5867990c702. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

