### PR TITLE
fix(rag): first-run healing respects deliberate profile switches (task-639)

### DIFF
--- a/Tests/RAG/test_first_run_import.py
+++ b/Tests/RAG/test_first_run_import.py
@@ -3,13 +3,32 @@ from tldw_chatbook.RAG_Search.config_profiles import ConfigProfileManager, Profi
 
 
 def _wire(monkeypatch, tmp_path):
+    """Wire a real ConfigProfileManager plus fakes for the active-profile
+    pointer and the task-639 first-run-import-done marker.
+
+    `ptr["v"]` is the pointer ([rag.service].profile); `ptr["marker"]` is the
+    durable first-run marker ([rag.service].first_run_import_done, see
+    `_first_run_import_done`/`_mark_first_run_import_done`). Both are backed
+    by the SAME fake `save_setting_to_cli_config`, routed by `key` exactly
+    like the real TOML writes would be -- this catches a real bug class
+    (e.g. one write silently clobbering the other's tracked value) that a
+    single shared dict/lambda would have masked.
+    """
     mgr = ConfigProfileManager(profiles_dir=tmp_path / "profiles")
     import tldw_chatbook.RAG_Search.simplified.active_config as ac
     monkeypatch.setattr(ac, "_manager", lambda: mgr, raising=False)
-    ptr = {"v": None}
+    ptr = {"v": None, "marker": False}
     monkeypatch.setattr(ac, "_active_profile_id", lambda: ptr["v"] or "hybrid_basic", raising=False)
-    monkeypatch.setattr(ac, "save_setting_to_cli_config",
-                        lambda s, k, v: ptr.update(v=v) or True, raising=False)
+    monkeypatch.setattr(ac, "_first_run_import_done", lambda: ptr["marker"], raising=False)
+
+    def _fake_save_setting(section, key, value):
+        if section == "rag.service" and key == "profile":
+            ptr["v"] = value
+        elif section == "rag.service" and key == "first_run_import_done":
+            ptr["marker"] = value
+        return True
+
+    monkeypatch.setattr(ac, "save_setting_to_cli_config", _fake_save_setting, raising=False)
     monkeypatch.setattr(ac, "reset_shared_rag_service", lambda: None, raising=False)
     # task-635: ensure_imported_profile() now only imports when there is
     # genuine hand-set [AppRAGSearchConfig.rag.*] material (see
@@ -33,6 +52,7 @@ def test_first_run_creates_imported_profile_and_sets_active(monkeypatch, tmp_pat
     imported = mgr.get_profile(new_id)
     assert imported is not None and imported.read_only is False
     assert ptr["v"] == new_id  # set active
+    assert ptr["marker"] is True  # task-639: first-run-import-done marker recorded
     # Idempotent: a second call is a no-op (no duplicate).
     assert ensure_imported_profile() is None
 
@@ -120,12 +140,14 @@ def test_ensure_imported_profile_heals_half_done_first_run(monkeypatch, tmp_path
                               rag_config=ac.resolve_active_rag_config())
     mgr.save_profile(half_done)
     assert ptr["v"] is None  # pointer was never flipped -- simulates the half-done crash
+    assert ptr["marker"] is False  # task-639: no marker either -- the new gate condition
 
     result = ac.ensure_imported_profile()
 
     assert result is None  # idempotent: no new profile id returned
     assert [p for p in mgr.list_profiles() if p == ac._IMPORTED_ID] == [ac._IMPORTED_ID]  # no duplicate created
     assert ptr["v"] == ac._IMPORTED_ID  # healed: pointer now activates the existing profile
+    assert ptr["marker"] is True  # task-639: marker recorded, so this can't recur
 
 
 def test_ensure_imported_profile_swallows_save_failure(monkeypatch, tmp_path):
@@ -149,6 +171,7 @@ def test_ensure_imported_profile_swallows_save_failure(monkeypatch, tmp_path):
     assert result is None
     assert mgr.get_profile(ac._IMPORTED_ID) is None
     assert ptr["v"] is None  # never activated a profile that failed to save
+    assert ptr["marker"] is False  # task-639: no activation happened, so no marker either
 
 
 # --- Task 6: wiring into get_shared_rag_service --------------------------
@@ -440,7 +463,7 @@ def test_imported_profile_does_not_merge_legacy_index_determining_keys(monkeypat
 
 
 # --- Task-639: healing must not undo a deliberate profile switch, and must --
-# --- clean up configs already damaged by the pre-635 always-import bug -----
+# --- never delete a profile on a content guess (review: marker-based fix) --
 
 
 def test_ensure_imported_profile_does_not_reflip_deliberate_switch(monkeypatch, tmp_path):
@@ -449,13 +472,16 @@ def test_ensure_imported_profile_does_not_reflip_deliberate_switch(monkeypatch, 
     ensure_imported_profile() call (e.g. the next process's first RAG touch)
     must leave that pointer alone -- the old healing branch treated "pointer
     != imported_settings" as proof of a half-done first run, which silently
-    undid a real user choice on every subsequent launch."""
+    undid a real user choice on every subsequent launch. The fresh import
+    above already recorded the first-run-import-done marker, so the healing
+    branch's "not marker" gate is skipped entirely on the later call."""
     import tldw_chatbook.RAG_Search.simplified.active_config as ac
     mgr, ptr = _wire(monkeypatch, tmp_path)
     _wire_legacy_rag_config(monkeypatch, {"search": {"default_top_k": 10}})
 
     new_id = ac.ensure_imported_profile()
     assert ptr["v"] == new_id  # sanity: import activated it, as before
+    assert ptr["marker"] is True
 
     # The user later, deliberately, switches to a different builtin.
     ptr["v"] = "fast_search"
@@ -468,12 +494,11 @@ def test_ensure_imported_profile_does_not_reflip_deliberate_switch(monkeypatch, 
 
 def test_ensure_imported_profile_still_heals_when_pointer_is_default(monkeypatch, tmp_path):
     """AC #3 (restated for task-639's narrower gate): the healing branch must
-    still fire for the one case it exists for -- the pointer never having
-    been successfully written by anyone, i.e. it still names the default
-    builtin. This is the same scenario
+    still fire for the one case it exists for -- no marker recorded yet AND
+    the pointer never having been successfully written by anyone, i.e. it
+    still names the default builtin. This is the same scenario
     test_ensure_imported_profile_heals_half_done_first_run covers; kept here
-    too as an explicit task-639 lock on the new gating condition itself
-    (`_active_profile_id() == DEFAULT_PROFILE`, not `!= _IMPORTED_ID`)."""
+    too as an explicit task-639 lock on the new gating condition itself."""
     import tldw_chatbook.RAG_Search.simplified.active_config as ac
     mgr, ptr = _wire(monkeypatch, tmp_path)
     half_done = ProfileConfig(id=ac._IMPORTED_ID,
@@ -483,18 +508,63 @@ def test_ensure_imported_profile_still_heals_when_pointer_is_default(monkeypatch
                               rag_config=ac.resolve_active_rag_config())
     mgr.save_profile(half_done)
     assert ptr["v"] is None  # pointer still resolves to the default builtin
+    assert ptr["marker"] is False
 
     result = ac.ensure_imported_profile()
 
     assert result is None
     assert ptr["v"] == ac._IMPORTED_ID  # healed
+    assert ptr["marker"] is True  # recorded, so this can never recur
+
+
+def test_ensure_imported_profile_marker_present_never_touches_pointer_even_back_to_default(monkeypatch, tmp_path):
+    """Closes the previously-disclosed gap: once the marker is set, the
+    pointer is NEVER touched again -- including a user switching all the way
+    back to the default builtin itself, which is otherwise indistinguishable
+    from "never written" using the pointer alone. With the marker recording
+    that the activation was deliberate, that ambiguity no longer matters:
+    the healing branch is skipped entirely regardless of what the pointer
+    currently names."""
+    import tldw_chatbook.RAG_Search.simplified.active_config as ac
+    mgr, ptr = _wire(monkeypatch, tmp_path)
+    imported = _pre635_damage_snapshot(mgr, ac)
+    mgr.save_profile(imported)
+    ptr["marker"] = True  # a prior run already recorded a deliberate activation
+    ptr["v"] = None  # the user has since switched all the way back to the default builtin
+
+    result = ac.ensure_imported_profile()
+
+    assert result is None
+    assert ptr["v"] is None  # NOT flipped back to imported_settings -- stays on the default
+    assert mgr.get_profile(ac._IMPORTED_ID) is not None  # untouched either way
+
+
+def test_fresh_user_leaves_marker_unset(monkeypatch, tmp_path):
+    """A truly fresh install (task-635 no-op path) never creates the imported
+    profile, so there is nothing to mark done either -- the marker stays
+    absent. This must not, by itself, trigger any different behavior on a
+    later call (still a no-op, still no marker)."""
+    import tldw_chatbook.RAG_Search.simplified.active_config as ac
+    mgr, ptr = _wire(monkeypatch, tmp_path)
+
+    result = ac.ensure_imported_profile()
+
+    assert result is None
+    assert ptr["marker"] is False
+    assert ptr["v"] is None
+    # Idempotent, still no marker.
+    assert ac.ensure_imported_profile() is None
+    assert ptr["marker"] is False
 
 
 def _pre635_damage_snapshot(mgr, ac):
     """A profile shaped exactly like what the pre-635 always-import bug would
     have created+activated for a truly fresh install: a snapshot of the
     default builtin (the active pointer a fresh user starts with), no legacy
-    merge, no reranking."""
+    merge, no reranking. Also stands in generically for "an imported_settings
+    profile that predates the first-run-import-done marker" in the tests
+    below, whether or not its content happens to look default-equivalent --
+    the marker-based fix no longer cares which."""
     return ProfileConfig(
         id=ac._IMPORTED_ID,
         name="Imported settings",
@@ -505,92 +575,64 @@ def _pre635_damage_snapshot(mgr, ac):
     )
 
 
-def test_ensure_imported_profile_heals_pre635_damage_artifact_back_to_default(monkeypatch, tmp_path):
-    """AC #2: a config whose pointer is imported_settings AND whose imported
-    profile is provably indistinguishable from the default builtin (same
-    index fingerprint, no hand-set query-time/reranking differences) is a
-    damage artifact from the pre-635 always-import bug on what would now be
-    classified as a fresh install -- clean it up by deleting the profile and
-    repointing to the default builtin, so the user is no longer silently
-    parked on a profile they never chose.
-
-    Must actually DELETE the profile (not just repoint the pointer): if it
-    were left on disk, the very next ensure_imported_profile() call would see
-    `existing is not None` with the pointer now on the default builtin and
-    re-activate it via the healing branch, undoing the cleanup immediately.
-    """
+def test_ensure_imported_profile_never_deletes_settings_screen_customization(monkeypatch, tmp_path):
+    """Critical (task-639 review, reviewer-reproduced): the Settings screen
+    editor (apply_defaults_to_profile, settings_rag_profile_adapter.py:150-
+    167) can hand-tune SearchConfig fields the prior fingerprint + allow-list
+    damage heuristic never checked at all -- e.g. `search.hybrid_alpha`
+    (default 0.7), `default_search_mode`, `citation_style`,
+    `snippet_max_chars`, `max_context_size`, `fts_top_k`, `vector_top_k`, or
+    `embedding.batch_size`. None of those are index-determining (the
+    fingerprint still matched the default) and none were in the old
+    allow-list, so a profile with ONLY one of these fields customized still
+    looked "provably safe to delete" and was PERMANENTLY DESTROYED. No finite
+    content allow-list can close this for good -- there is always another
+    field it doesn't know about -- so the fix must never delete a profile
+    based on comparing its content at all, no matter what differs (or
+    doesn't). "Survives every subsequent ensure call": exercised 3x."""
     import tldw_chatbook.RAG_Search.simplified.active_config as ac
     mgr, ptr = _wire(monkeypatch, tmp_path)
-    damaged = _pre635_damage_snapshot(mgr, ac)
-    mgr.save_profile(damaged)
-    ptr["v"] = ac._IMPORTED_ID  # pre-635 bug already activated it
+    customized = _pre635_damage_snapshot(mgr, ac)
+    customized.rag_config.search.hybrid_alpha = 0.95  # real hand-set tuning, default is 0.7
+    mgr.save_profile(customized)
+    ptr["v"] = ac._IMPORTED_ID  # already active; no marker (predates the marker fix)
+    assert ptr["marker"] is False
+
+    for _ in range(3):
+        result = ac.ensure_imported_profile()
+        assert result is None
+
+    imported = mgr.get_profile(ac._IMPORTED_ID)
+    assert imported is not None  # NEVER deleted
+    assert imported.rag_config.search.hybrid_alpha == 0.95  # customization intact
+    assert ptr["v"] == ac._IMPORTED_ID  # left active
+    assert ptr["marker"] is True  # adopted as settled after the first call
+
+
+def test_ensure_imported_profile_adopts_preexisting_imported_pointer_without_deleting(monkeypatch, tmp_path):
+    """task-639 AC #2 (revised per review): a config whose pointer is ALREADY
+    imported_settings with no marker yet -- whether a pre-635 damage artifact
+    or a genuine, deliberately-kept import from before the marker existed,
+    indistinguishable from config contents alone (see the Critical finding
+    above) -- is NEVER deleted, even when its content happens to look
+    identical to the default builtin. It is simply adopted as settled: the
+    marker is set, and both the profile and the pointer are left completely
+    untouched."""
+    import tldw_chatbook.RAG_Search.simplified.active_config as ac
+    mgr, ptr = _wire(monkeypatch, tmp_path)
+    imported = _pre635_damage_snapshot(mgr, ac)  # content-identical to the default builtin
+    mgr.save_profile(imported)
+    ptr["v"] = ac._IMPORTED_ID  # already active, no marker (pre-marker world)
+    assert ptr["marker"] is False
 
     result = ac.ensure_imported_profile()
 
     assert result is None
-    assert ptr["v"] == ac.DEFAULT_PROFILE  # repointed back to the default builtin
-    assert mgr.get_profile(ac._IMPORTED_ID) is None  # deleted, not just repointed
-
-    # Idempotent from here on: the next call is a true fresh-install no-op
-    # (no legacy material was ever wired in this test).
-    assert ac.ensure_imported_profile() is None
-    assert ptr["v"] == ac.DEFAULT_PROFILE
-    assert mgr.get_profile(ac._IMPORTED_ID) is None
-
-
-def test_ensure_imported_profile_does_not_delete_hand_set_query_time_difference(monkeypatch, tmp_path):
-    """Negative case: the imported profile has a real, hand-set difference
-    from the default builtin (a non-fingerprint, query-time field) -- this is
-    NOT provably a damage artifact (it could be a genuine legacy import or
-    later customization), so it must be left completely alone."""
-    import tldw_chatbook.RAG_Search.simplified.active_config as ac
-    mgr, ptr = _wire(monkeypatch, tmp_path)
-    damaged = _pre635_damage_snapshot(mgr, ac)
-    damaged.rag_config.search.default_top_k = 999  # real hand-set difference
-    mgr.save_profile(damaged)
-    ptr["v"] = ac._IMPORTED_ID
-
-    result = ac.ensure_imported_profile()
-
-    assert result is None
-    assert ptr["v"] == ac._IMPORTED_ID  # left active, untouched
+    assert ptr["v"] == ac._IMPORTED_ID  # untouched
     assert mgr.get_profile(ac._IMPORTED_ID) is not None  # NOT deleted
+    assert ptr["marker"] is True  # adopted as settled -- never re-evaluated again
 
-
-def test_ensure_imported_profile_does_not_delete_fingerprint_mismatch(monkeypatch, tmp_path):
-    """Negative case: the imported profile's index-determining config (here,
-    embedding model) diverges from the default builtin's -- a genuine legacy
-    upgrade, not a damage artifact -- so it must be left alone even though no
-    query-time key differs."""
-    import tldw_chatbook.RAG_Search.simplified.active_config as ac
-    mgr, ptr = _wire(monkeypatch, tmp_path)
-    damaged = _pre635_damage_snapshot(mgr, ac)
-    damaged.rag_config.embedding.model = "a-genuinely-different-embedding-model"
-    mgr.save_profile(damaged)
-    ptr["v"] = ac._IMPORTED_ID
-
-    result = ac.ensure_imported_profile()
-
-    assert result is None
-    assert ptr["v"] == ac._IMPORTED_ID
-    assert mgr.get_profile(ac._IMPORTED_ID) is not None
-
-
-def test_ensure_imported_profile_does_not_delete_when_reranking_config_present(monkeypatch, tmp_path):
-    """Negative case: a fabricated `reranking_config` (task-495's legacy-
-    reranking-enabled path) is a real customization even when every other
-    field matches the default builtin and the fingerprint is identical (
-    reranking is not an index-determining field) -- must not be deleted."""
-    from tldw_chatbook.RAG_Search.reranker import RerankingConfig
-    import tldw_chatbook.RAG_Search.simplified.active_config as ac
-    mgr, ptr = _wire(monkeypatch, tmp_path)
-    damaged = _pre635_damage_snapshot(mgr, ac)
-    damaged.reranking_config = RerankingConfig()
-    mgr.save_profile(damaged)
-    ptr["v"] = ac._IMPORTED_ID
-
-    result = ac.ensure_imported_profile()
-
-    assert result is None
+    # Idempotent: a further call changes nothing further.
+    assert ac.ensure_imported_profile() is None
     assert ptr["v"] == ac._IMPORTED_ID
     assert mgr.get_profile(ac._IMPORTED_ID) is not None

--- a/Tests/RAG/test_first_run_import.py
+++ b/Tests/RAG/test_first_run_import.py
@@ -636,3 +636,112 @@ def test_ensure_imported_profile_adopts_preexisting_imported_pointer_without_del
     assert ac.ensure_imported_profile() is None
     assert ptr["v"] == ac._IMPORTED_ID
     assert mgr.get_profile(ac._IMPORTED_ID) is not None
+
+
+# --- Task-639 review round 3: don't mark "done" on an unconfirmed pointer --
+# --- write (set_active_profile swallows a failed write) --------------------
+
+
+def _wire_pointer_write_fails(monkeypatch, ac, ptr):
+    """Make the pointer write ([rag.service].profile) always fail (return
+    False, as save_setting_to_cli_config does on an I/O failure -- see its
+    real implementation) while the marker write
+    ([rag.service].first_run_import_done) keeps succeeding normally. Models
+    set_active_profile()'s documented failure mode: it swallows a failed
+    write (logs a warning, leaves the pointer untouched) instead of raising."""
+
+    def _fake_save_setting(section, key, value):
+        if section == "rag.service" and key == "profile":
+            return False  # simulated failure -- ptr["v"] deliberately NOT updated
+        if section == "rag.service" and key == "first_run_import_done":
+            ptr["marker"] = value
+            return True
+        return True
+
+    monkeypatch.setattr(ac, "save_setting_to_cli_config", _fake_save_setting, raising=False)
+
+
+def _wire_pointer_write_succeeds(monkeypatch, ac, ptr):
+    """Restore normal (successful) writes for both keys -- the same routing
+    _wire()'s own fake uses, exposed here so a test can flip a previously-
+    failing pointer write back to succeeding mid-test."""
+
+    def _fake_save_setting(section, key, value):
+        if section == "rag.service" and key == "profile":
+            ptr["v"] = value
+        elif section == "rag.service" and key == "first_run_import_done":
+            ptr["marker"] = value
+        return True
+
+    monkeypatch.setattr(ac, "save_setting_to_cli_config", _fake_save_setting, raising=False)
+
+
+def test_ensure_imported_profile_does_not_mark_when_healing_pointer_write_fails(monkeypatch, tmp_path):
+    """Important (task-639 review round 3, reviewer-reproduced): the healing
+    branch used to call _mark_first_run_import_done() unconditionally right
+    after set_active_profile(_IMPORTED_ID), but set_active_profile() itself
+    swallows a failed pointer write (logs a warning and returns without
+    resetting the shared service -- see its docstring). If the pointer write
+    fails while the marker write succeeds, the user would be permanently
+    parked on the default profile with NO future retry: the marker is
+    exactly what stops this branch from ever running again. Must instead
+    only mark once _active_profile_id() is confirmed to read back as
+    _IMPORTED_ID, and a later call (once the write starts succeeding) must
+    retry the activation rather than being permanently blocked."""
+    import tldw_chatbook.RAG_Search.simplified.active_config as ac
+    mgr, ptr = _wire(monkeypatch, tmp_path)
+    half_done = ProfileConfig(id=ac._IMPORTED_ID,
+                              name="Imported settings",
+                              description="Captured from your existing RAG configuration on first run.",
+                              profile_type="custom",
+                              rag_config=ac.resolve_active_rag_config())
+    mgr.save_profile(half_done)
+    assert ptr["v"] is None  # pointer still resolves to the default builtin
+
+    _wire_pointer_write_fails(monkeypatch, ac, ptr)
+
+    result = ac.ensure_imported_profile()
+
+    assert result is None
+    assert ptr["v"] is None  # pointer write failed -- never actually activated
+    assert ptr["marker"] is False  # MUST NOT be set: the activation never actually happened
+
+    # A later call, once the pointer write starts succeeding again, must
+    # RETRY the activation -- not be permanently blocked by a marker that
+    # was never legitimately earned.
+    _wire_pointer_write_succeeds(monkeypatch, ac, ptr)
+
+    result2 = ac.ensure_imported_profile()
+
+    assert result2 is None
+    assert ptr["v"] == ac._IMPORTED_ID  # retried and succeeded this time
+    assert ptr["marker"] is True
+
+
+def test_ensure_imported_profile_does_not_mark_when_fresh_import_pointer_write_fails(monkeypatch, tmp_path):
+    """Mirrors the fix at the fresh-import call site (task-639 review round
+    3): if set_active_profile() fails right after a brand-new "Imported
+    settings" profile is created, the marker must not be set either --
+    otherwise the next process's first RAG touch would see `existing is not
+    None`, the marker already True, and skip retrying the failed activation
+    forever, even though the pointer was never actually updated."""
+    import tldw_chatbook.RAG_Search.simplified.active_config as ac
+    mgr, ptr = _wire(monkeypatch, tmp_path)
+    _wire_legacy_rag_config(monkeypatch, {"search": {"default_top_k": 10}})
+    _wire_pointer_write_fails(monkeypatch, ac, ptr)
+
+    new_id = ac.ensure_imported_profile()
+
+    assert new_id == ac._IMPORTED_ID  # the profile WAS created
+    assert ptr["v"] is None  # but the pointer write failed -- never activated
+    assert ptr["marker"] is False  # MUST NOT be set
+
+    # A later call must retry activation via the healing branch (the profile
+    # already exists now), not skip it because of a falsely-set marker.
+    _wire_pointer_write_succeeds(monkeypatch, ac, ptr)
+
+    result2 = ac.ensure_imported_profile()
+
+    assert result2 is None  # profile already exists -- this is the healing path now
+    assert ptr["v"] == ac._IMPORTED_ID
+    assert ptr["marker"] is True

--- a/Tests/RAG/test_first_run_import.py
+++ b/Tests/RAG/test_first_run_import.py
@@ -437,3 +437,160 @@ def test_imported_profile_does_not_merge_legacy_index_determining_keys(monkeypat
     assert imported.vector_store.distance_metric != "l2"
     assert imported.search.default_top_k == 25  # query-time key still merged
     assert fingerprint_collection(imported) == pre_fp
+
+
+# --- Task-639: healing must not undo a deliberate profile switch, and must --
+# --- clean up configs already damaged by the pre-635 always-import bug -----
+
+
+def test_ensure_imported_profile_does_not_reflip_deliberate_switch(monkeypatch, tmp_path):
+    """AC #1: once a user has deliberately activated a DIFFERENT profile
+    (neither the default builtin nor imported_settings), a later
+    ensure_imported_profile() call (e.g. the next process's first RAG touch)
+    must leave that pointer alone -- the old healing branch treated "pointer
+    != imported_settings" as proof of a half-done first run, which silently
+    undid a real user choice on every subsequent launch."""
+    import tldw_chatbook.RAG_Search.simplified.active_config as ac
+    mgr, ptr = _wire(monkeypatch, tmp_path)
+    _wire_legacy_rag_config(monkeypatch, {"search": {"default_top_k": 10}})
+
+    new_id = ac.ensure_imported_profile()
+    assert ptr["v"] == new_id  # sanity: import activated it, as before
+
+    # The user later, deliberately, switches to a different builtin.
+    ptr["v"] = "fast_search"
+
+    result = ac.ensure_imported_profile()
+
+    assert result is None  # idempotent, no duplicate profile
+    assert ptr["v"] == "fast_search"  # NOT flipped back to imported_settings
+
+
+def test_ensure_imported_profile_still_heals_when_pointer_is_default(monkeypatch, tmp_path):
+    """AC #3 (restated for task-639's narrower gate): the healing branch must
+    still fire for the one case it exists for -- the pointer never having
+    been successfully written by anyone, i.e. it still names the default
+    builtin. This is the same scenario
+    test_ensure_imported_profile_heals_half_done_first_run covers; kept here
+    too as an explicit task-639 lock on the new gating condition itself
+    (`_active_profile_id() == DEFAULT_PROFILE`, not `!= _IMPORTED_ID`)."""
+    import tldw_chatbook.RAG_Search.simplified.active_config as ac
+    mgr, ptr = _wire(monkeypatch, tmp_path)
+    half_done = ProfileConfig(id=ac._IMPORTED_ID,
+                              name="Imported settings",
+                              description="Captured from your existing RAG configuration on first run.",
+                              profile_type="custom",
+                              rag_config=ac.resolve_active_rag_config())
+    mgr.save_profile(half_done)
+    assert ptr["v"] is None  # pointer still resolves to the default builtin
+
+    result = ac.ensure_imported_profile()
+
+    assert result is None
+    assert ptr["v"] == ac._IMPORTED_ID  # healed
+
+
+def _pre635_damage_snapshot(mgr, ac):
+    """A profile shaped exactly like what the pre-635 always-import bug would
+    have created+activated for a truly fresh install: a snapshot of the
+    default builtin (the active pointer a fresh user starts with), no legacy
+    merge, no reranking."""
+    return ProfileConfig(
+        id=ac._IMPORTED_ID,
+        name="Imported settings",
+        description="Snapshot of your active RAG profile (plus any RAG_* env "
+                    "overrides) captured on first run; edit freely.",
+        profile_type="custom",
+        rag_config=ac.resolve_active_rag_config(),  # pointer is still default here
+    )
+
+
+def test_ensure_imported_profile_heals_pre635_damage_artifact_back_to_default(monkeypatch, tmp_path):
+    """AC #2: a config whose pointer is imported_settings AND whose imported
+    profile is provably indistinguishable from the default builtin (same
+    index fingerprint, no hand-set query-time/reranking differences) is a
+    damage artifact from the pre-635 always-import bug on what would now be
+    classified as a fresh install -- clean it up by deleting the profile and
+    repointing to the default builtin, so the user is no longer silently
+    parked on a profile they never chose.
+
+    Must actually DELETE the profile (not just repoint the pointer): if it
+    were left on disk, the very next ensure_imported_profile() call would see
+    `existing is not None` with the pointer now on the default builtin and
+    re-activate it via the healing branch, undoing the cleanup immediately.
+    """
+    import tldw_chatbook.RAG_Search.simplified.active_config as ac
+    mgr, ptr = _wire(monkeypatch, tmp_path)
+    damaged = _pre635_damage_snapshot(mgr, ac)
+    mgr.save_profile(damaged)
+    ptr["v"] = ac._IMPORTED_ID  # pre-635 bug already activated it
+
+    result = ac.ensure_imported_profile()
+
+    assert result is None
+    assert ptr["v"] == ac.DEFAULT_PROFILE  # repointed back to the default builtin
+    assert mgr.get_profile(ac._IMPORTED_ID) is None  # deleted, not just repointed
+
+    # Idempotent from here on: the next call is a true fresh-install no-op
+    # (no legacy material was ever wired in this test).
+    assert ac.ensure_imported_profile() is None
+    assert ptr["v"] == ac.DEFAULT_PROFILE
+    assert mgr.get_profile(ac._IMPORTED_ID) is None
+
+
+def test_ensure_imported_profile_does_not_delete_hand_set_query_time_difference(monkeypatch, tmp_path):
+    """Negative case: the imported profile has a real, hand-set difference
+    from the default builtin (a non-fingerprint, query-time field) -- this is
+    NOT provably a damage artifact (it could be a genuine legacy import or
+    later customization), so it must be left completely alone."""
+    import tldw_chatbook.RAG_Search.simplified.active_config as ac
+    mgr, ptr = _wire(monkeypatch, tmp_path)
+    damaged = _pre635_damage_snapshot(mgr, ac)
+    damaged.rag_config.search.default_top_k = 999  # real hand-set difference
+    mgr.save_profile(damaged)
+    ptr["v"] = ac._IMPORTED_ID
+
+    result = ac.ensure_imported_profile()
+
+    assert result is None
+    assert ptr["v"] == ac._IMPORTED_ID  # left active, untouched
+    assert mgr.get_profile(ac._IMPORTED_ID) is not None  # NOT deleted
+
+
+def test_ensure_imported_profile_does_not_delete_fingerprint_mismatch(monkeypatch, tmp_path):
+    """Negative case: the imported profile's index-determining config (here,
+    embedding model) diverges from the default builtin's -- a genuine legacy
+    upgrade, not a damage artifact -- so it must be left alone even though no
+    query-time key differs."""
+    import tldw_chatbook.RAG_Search.simplified.active_config as ac
+    mgr, ptr = _wire(monkeypatch, tmp_path)
+    damaged = _pre635_damage_snapshot(mgr, ac)
+    damaged.rag_config.embedding.model = "a-genuinely-different-embedding-model"
+    mgr.save_profile(damaged)
+    ptr["v"] = ac._IMPORTED_ID
+
+    result = ac.ensure_imported_profile()
+
+    assert result is None
+    assert ptr["v"] == ac._IMPORTED_ID
+    assert mgr.get_profile(ac._IMPORTED_ID) is not None
+
+
+def test_ensure_imported_profile_does_not_delete_when_reranking_config_present(monkeypatch, tmp_path):
+    """Negative case: a fabricated `reranking_config` (task-495's legacy-
+    reranking-enabled path) is a real customization even when every other
+    field matches the default builtin and the fingerprint is identical (
+    reranking is not an index-determining field) -- must not be deleted."""
+    from tldw_chatbook.RAG_Search.reranker import RerankingConfig
+    import tldw_chatbook.RAG_Search.simplified.active_config as ac
+    mgr, ptr = _wire(monkeypatch, tmp_path)
+    damaged = _pre635_damage_snapshot(mgr, ac)
+    damaged.reranking_config = RerankingConfig()
+    mgr.save_profile(damaged)
+    ptr["v"] = ac._IMPORTED_ID
+
+    result = ac.ensure_imported_profile()
+
+    assert result is None
+    assert ptr["v"] == ac._IMPORTED_ID
+    assert mgr.get_profile(ac._IMPORTED_ID) is not None

--- a/backlog/tasks/task-639 - First-run-healing-branch-re-flips-deliberate-profile-switches-away-from-Imported-settings.md
+++ b/backlog/tasks/task-639 - First-run-healing-branch-re-flips-deliberate-profile-switches-away-from-Imported-settings.md
@@ -7,7 +7,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-07-25 21:54'
-updated_date: '2026-07-26 00:34'
+updated_date: '2026-07-26 00:58'
 labels:
   - followup
   - uat
@@ -106,6 +106,79 @@ non-reflip (RED before the fix, GREEN after), half-done-first-run still heals
 fingerprint mismatch, fabricated reranking_config) proving the cleanup never
 guesses. Tests/RAG/test_first_run_import.py: 22 passed (16 baseline + 6 new).
 Tests/RAG/: 574 passed, 8 skipped (baseline 568/8 + 6 new).
+
+Files: tldw_chatbook/RAG_Search/simplified/active_config.py,
+Tests/RAG/test_first_run_import.py.
+
+--- Review round 2 (Critical, reviewer-reproduced) ---
+
+Finding: _is_pre635_damage_artifact()'s "no hand-set difference" allow-list
+(_LEGACY_SEARCH_KEYS + _LEGACY_PROCESSOR_KEYS) did not cover every field the
+Settings screen editor (apply_defaults_to_profile,
+settings_rag_profile_adapter.py:150-167) can hand-tune -- e.g.
+search.hybrid_alpha (default 0.7), default_search_mode, citation_style,
+snippet_max_chars, max_context_size, fts_top_k, vector_top_k,
+embedding.batch_size. None of those are index-determining (fingerprint
+still matched the default) and none were in the allow-list, so a profile
+customized in ONLY one of those fields still looked "provably safe" and was
+PERMANENTLY DELETED. Reproduced with a RED test
+(test_ensure_imported_profile_never_deletes_settings_screen_customization)
+confirmed failing against the round-1 code before applying the fix below.
+
+Decision: replaced the content-comparison heuristic entirely with a durable
+marker, [rag.service].first_run_import_done (_first_run_import_done /
+_mark_first_run_import_done), written at BOTH places
+ensure_imported_profile() ever deliberately activates imported_settings (the
+fresh-import path and the half-done-first-run healing path). Once set, the
+pointer is never re-evaluated again, regardless of what it names -- this
+also closes the previously-disclosed "switch back to the default builtin"
+gap from round 1, since the marker (not the pointer's current value) is now
+the source of truth for "was this deliberate".
+
+For a config whose imported_settings pointer/profile predates the marker
+(marker absent, existing profile, pointer != DEFAULT_PROFILE): chose
+reviewer's option (b) -- NEVER delete. The marker is simply set and both the
+profile and pointer are left completely untouched. Rationale: no finite
+content check can prove "no customization exists" (that's exactly what broke
+in round 1), so a compare-and-maybe-delete strategy can always be defeated by
+some field nobody thought to check; leaving it as-is is unconditionally safe
+(zero risk of destroying real user data) and reaches the same practical
+end-state (the flapping stops, the pointer is confirmed and never
+reconsidered again). Only the true half-done case (existing profile, no
+marker, pointer STILL the default builtin -- i.e. never successfully written
+by anyone) completes the activation, matching AC#1's own framing of that
+condition.
+
+_LEGACY_MERGED_SEARCH_FIELDS and _is_pre635_damage_artifact() were removed
+entirely (no longer needed -- nothing compares content anymore); the
+`fingerprint_collection` import in active_config.py was removed along with
+it (dead post-removal).
+
+Tests: replaced the 3 round-1 "does_not_delete_*" negative tests and the
+delete-based "heals_pre635_damage_artifact" test (now factually wrong) with:
+test_ensure_imported_profile_never_deletes_settings_screen_customization
+(the reviewer's repro, RED-then-GREEN),
+test_ensure_imported_profile_adopts_preexisting_imported_pointer_without_deleting,
+test_ensure_imported_profile_marker_present_never_touches_pointer_even_back_to_default,
+test_fresh_user_leaves_marker_unset. Added marker assertions to the 3
+existing tests that activate imported_settings
+(test_first_run_creates_imported_profile_and_sets_active,
+test_ensure_imported_profile_heals_half_done_first_run,
+test_ensure_imported_profile_swallows_save_failure). Updated the shared
+_wire() fixture's save_setting_to_cli_config fake to route by `key` (profile
+vs first_run_import_done) into separate ptr["v"]/ptr["marker"] slots instead
+of one shared value, so the two writes can no longer silently clobber each
+other in tests.
+
+Gates: Tests/RAG/test_first_run_import.py: 22 passed. Tests/RAG/: 574 passed,
+8 skipped (same totals as round 1 -- test count is unchanged, only which
+scenarios are covered).
+
+Known accepted gap (unchanged from round 1, now narrower): a config that
+predates the marker AND whose pointer happens to already read as the default
+builtin is still indistinguishable from "never completed" -- this can only
+occur once, on the first marker-aware run, since the marker is written at
+every activation site from then on.
 
 Files: tldw_chatbook/RAG_Search/simplified/active_config.py,
 Tests/RAG/test_first_run_import.py.

--- a/backlog/tasks/task-639 - First-run-healing-branch-re-flips-deliberate-profile-switches-away-from-Imported-settings.md
+++ b/backlog/tasks/task-639 - First-run-healing-branch-re-flips-deliberate-profile-switches-away-from-Imported-settings.md
@@ -3,9 +3,11 @@ id: TASK-639
 title: >-
   First-run healing branch re-flips deliberate profile switches away from
   Imported settings
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-25 21:54'
+updated_date: '2026-07-26 00:34'
 labels:
   - followup
   - uat
@@ -21,7 +23,90 @@ task-641/635 review (Minor): ensure_imported_profile()'s self-healing branch (ac
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The healing branch only re-activates imported_settings when the active pointer is still the default builtin (i.e. a genuine half-done first run), never when the user has since deliberately activated a different profile
-- [ ] #2 A migration/cleanup path exists (or is explicitly scoped out with rationale) for configs already carrying an unwanted imported_settings profile + pointer from before task-635 shipped
-- [ ] #3 Existing half-done-first-run healing regression coverage (test_ensure_imported_profile_heals_half_done_first_run) still passes
+- [x] #1 The healing branch only re-activates imported_settings when the active pointer is still the default builtin (i.e. a genuine half-done first run), never when the user has since deliberately activated a different profile
+- [x] #2 A migration/cleanup path exists (or is explicitly scoped out with rationale) for configs already carrying an unwanted imported_settings profile + pointer from before task-635 shipped
+- [x] #3 Existing half-done-first-run healing regression coverage (test_ensure_imported_profile_heals_half_done_first_run) still passes
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce root cause in active_config.py:ensure_imported_profile() -- the
+   healing branch fires whenever the existing imported_settings profile's
+   pointer differs from imported_settings, with no way to tell a half-done
+   first run apart from a deliberate later switch.
+2. TDD: add a RED test proving a deliberate switch to a different (non-
+   default) profile survives a later ensure_imported_profile() call
+   unchanged (currently fails: gets flipped back).
+3. Fix AC#1: gate the healing branch on `_active_profile_id() == DEFAULT_PROFILE`
+   (pointer never successfully written by anyone) instead of `!= _IMPORTED_ID`.
+   Verify the existing half-done-first-run regression test
+   (test_ensure_imported_profile_heals_half_done_first_run) and the fresh-user
+   no-op test stay green.
+4. AC#2 cleanup: add a provable-damage-artifact detector (fingerprint-
+   identical to the builtin default + no hand-set legacy search/reranking
+   differences) for configs whose pointer is ALREADY imported_settings from
+   the pre-635 always-import bug on a fresh install. When detected, delete
+   the imported_settings profile and repoint to the default builtin (must
+   delete, not just repoint, or the healing branch would recreate the
+   flip-flop on the next call). Add positive (damage artifact -> healed) and
+   negative (real hand-set difference / fingerprint mismatch -> left alone)
+   regression tests.
+5. Run Tests/RAG/test_first_run_import.py, then the full Tests/RAG/ suite;
+   fix any regressions.
+6. Update task ACs + Implementation Notes, mark Done.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause: ensure_imported_profile()'s healing branch gated re-activation on
+`_active_profile_id() != _IMPORTED_ID` -- true for BOTH a half-done first run
+(pointer never written) and a user who deliberately activated a different
+profile after import completed, so it silently re-flipped deliberate switches
+back to "Imported settings" on every process's first RAG touch.
+
+Fix (AC#1): narrowed the gate to `_active_profile_id() == DEFAULT_PROFILE`
+(hybrid_basic) -- the one condition unique to "the pointer was never
+successfully written by anyone yet." Any other pointer value (builtin or
+user profile) is left completely alone, per the task's own AC#1 wording,
+which explicitly frames "still the default builtin" as the definition of a
+genuine half-done first run. No new state file was needed.
+
+Damage cleanup (AC#2): added `_is_pre635_damage_artifact()` -- true only when
+an existing "Imported settings" profile is index-fingerprint-identical to
+the default builtin AND carries none of the non-fingerprint legacy
+query-time/reranking fields (_LEGACY_SEARCH_KEYS + _LEGACY_PROCESSOR_KEYS,
+reranking_config). When the pointer is already imported_settings and this
+holds, the profile is DELETED (not just repointed -- leaving it on disk
+would let the pointer==DEFAULT_PROFILE healing branch re-activate it on the
+very next call, a flip-flop) and the pointer is reset to DEFAULT_PROFILE.
+This only fires for configs provably damaged by the pre-635 always-import
+bug on what would now be a fresh install (no legacy material, so the
+snapshot is byte-for-byte the default); anything with a real hand-set
+difference, a different fingerprint, or a fabricated reranking_config is
+left untouched -- can't distinguish genuine choice from damage there, so it
+doesn't guess (documented in the function's docstring).
+
+Known accepted gap: a user who, after being on "Imported settings",
+deliberately switches BACK to the default builtin profile is indistinguishable
+from "pointer never written" using only the pointer -- they would get healed
+back to Imported settings on the next first-touch. This is the same
+conflation AC#1 itself defines ("pointer still default" == "genuine half-done
+first run"), and the task explicitly scopes the never-flip guarantee to
+"non-default profile." Avoiding it would require a separate persisted
+first-run-complete marker, which the task said to avoid unless a hole was
+found; this one is inherent to "no new state file" and is called out here
+rather than silently accepted.
+
+Tests: 6 new cases in Tests/RAG/test_first_run_import.py -- deliberate-switch
+non-reflip (RED before the fix, GREEN after), half-done-first-run still heals
+(explicit task-639 lock on the new gate condition), damage-artifact cleanup
+(positive), and three negative cases (hand-set search-key difference,
+fingerprint mismatch, fabricated reranking_config) proving the cleanup never
+guesses. Tests/RAG/test_first_run_import.py: 22 passed (16 baseline + 6 new).
+Tests/RAG/: 574 passed, 8 skipped (baseline 568/8 + 6 new).
+
+Files: tldw_chatbook/RAG_Search/simplified/active_config.py,
+Tests/RAG/test_first_run_import.py.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/RAG_Search/simplified/active_config.py
+++ b/tldw_chatbook/RAG_Search/simplified/active_config.py
@@ -83,10 +83,27 @@ def _mark_first_run_import_done() -> None:
     ``imported_settings`` (a fresh import, and healing a half-done run) so
     that, from then on, the pointer is never second-guessed again -- even if
     the user later switches to a different profile, or back to the default
-    builtin itself. Best-effort: a failure here is logged and swallowed, same
-    as the rest of ``ensure_imported_profile`` -- it must never block RAG
-    service creation. A failed write just means the next call may re-evaluate
-    the healing branch once more, which is safe (idempotent), not corrupting.
+    builtin itself.
+
+    Callers on a path that just called ``set_active_profile(_IMPORTED_ID)``
+    MUST re-read ``_active_profile_id()`` and only call this when it now
+    reads ``_IMPORTED_ID``, confirming the pointer write actually took
+    effect, before calling this (task-639 review): ``set_active_profile``
+    swallows a failed write (``save_setting_to_cli_config`` returning
+    ``False`` just logs a warning and returns -- see its docstring), so
+    marking unconditionally right after it would record "done" even though
+    the pointer was never actually updated. Since the marker is what stops
+    the healing branch from ever retrying, that combination would
+    permanently strand the user on the default profile with no way to
+    recover. A path that never attempted a pointer write in the first place
+    (the "adopt an already-settled pointer as-is" branch) has nothing to
+    confirm and calls this unconditionally.
+
+    Best-effort: a failure here (the marker write itself failing) is logged
+    and swallowed, same as the rest of ``ensure_imported_profile`` -- it must
+    never block RAG service creation. A failed write just means the next
+    call may re-evaluate the healing branch once more, which is safe
+    (idempotent), not corrupting.
     """
     try:
         save_setting_to_cli_config("rag.service", "first_run_import_done", True)
@@ -415,18 +432,27 @@ def ensure_imported_profile() -> Optional[str]:
     - Pointer still names the default builtin (``DEFAULT_PROFILE`` ==
       ``hybrid_basic``, i.e. it was never successfully written by anyone) --
       this is the one condition a genuine half-done first run and "the
-      marker predates this profile" share, so the healing here always
-      completes the activation and sets the marker.
+      marker predates this profile" share, so the healing here attempts the
+      activation and, ONLY if ``_active_profile_id()`` reads back as
+      ``_IMPORTED_ID`` afterward (the write is confirmed, not assumed),
+      records the marker. A failed pointer write (``set_active_profile``
+      swallows it -- logs a warning, leaves the pointer untouched) leaves
+      the marker unset too, so the very next call retries instead of being
+      permanently stuck: marking on an unconfirmed write would otherwise
+      strand the user on the default profile forever, since the marker is
+      exactly what stops this branch from ever running again.
     - Pointer already names anything else (``imported_settings`` from a
       pre-635/pre-marker activation, or a different profile entirely) -- the
-      pointer is left completely untouched (never deleted, never repointed)
-      and the marker is simply set, adopting whatever is already active as
-      confirmed going forward. Deliberately does NOT delete the profile even
-      when it happens to look identical to the default: unlike a marker, no
-      finite content comparison can prove a Settings-screen customization is
-      absent, so guessing "safe to delete" risks real, irreversible data
-      loss -- doing nothing here has no such risk and reaches the same
-      settled state (the marker stops any further automatic handling).
+      pointer is left completely untouched (never deleted, never repointed,
+      no write attempted) and the marker is simply set unconditionally
+      (nothing to confirm when nothing was written), adopting whatever is
+      already active as confirmed going forward. Deliberately does NOT
+      delete the profile even when it happens to look identical to the
+      default: unlike a marker, no finite content comparison can prove a
+      Settings-screen customization is absent, so guessing "safe to delete"
+      risks real, irreversible data loss -- doing nothing here has no such
+      risk and reaches the same settled state (the marker stops any further
+      automatic handling).
 
     One inherent, bounded gap: for a config that predates the marker (an
     existing pointer that happens to already read as the default builtin,
@@ -458,14 +484,25 @@ def ensure_imported_profile() -> Optional[str]:
             if not _first_run_import_done():
                 if _active_profile_id() == DEFAULT_PROFILE:
                     # Never successfully written by anyone -- heal a
-                    # half-done first run.
+                    # half-done first run. Only record the marker once the
+                    # pointer write is CONFIRMED to have taken effect
+                    # (task-639 review): set_active_profile() swallows a
+                    # failed write (save_setting_to_cli_config returning
+                    # False just logs a warning and returns -- see its
+                    # docstring), so marking unconditionally here could
+                    # permanently strand the user on the default profile
+                    # with the marker now blocking every future retry.
                     set_active_profile(_IMPORTED_ID)
-                # else: pointer already names imported_settings (a
-                # pre-marker activation, possibly pre-635 damage) or some
-                # other profile entirely -- leave it exactly as-is (never
-                # delete, never repoint; see docstring for why) and just
-                # adopt it as settled.
-                _mark_first_run_import_done()
+                    if _active_profile_id() == _IMPORTED_ID:
+                        _mark_first_run_import_done()
+                else:
+                    # Pointer already names imported_settings (a pre-marker
+                    # activation, possibly pre-635 damage) or some other
+                    # profile entirely -- leave it exactly as-is (never
+                    # delete, never repoint; see docstring for why). No
+                    # write is attempted on this path, so there is nothing
+                    # to confirm -- adopt it as settled unconditionally.
+                    _mark_first_run_import_done()
             return None
         if not _has_legacy_rag_config_material():
             # task-635: nothing legacy to preserve continuity for -- leave a
@@ -495,7 +532,12 @@ def ensure_imported_profile() -> Optional[str]:
                 profile.reranking_config.top_k_to_rerank = int(reranker_top_k)
         mgr.save_profile(profile)
         set_active_profile(_IMPORTED_ID)
-        _mark_first_run_import_done()
+        if _active_profile_id() == _IMPORTED_ID:
+            # Only confirmed pointer writes get the marker (see the healing
+            # branch above for why) -- if this fails, the next call falls
+            # through to the healing branch (existing is not None, no
+            # marker, pointer still the default) and retries.
+            _mark_first_run_import_done()
         return _IMPORTED_ID
     except Exception as e:
         logger.warning(f"ensure_imported_profile: first-run import failed, continuing without it: {e}")

--- a/tldw_chatbook/RAG_Search/simplified/active_config.py
+++ b/tldw_chatbook/RAG_Search/simplified/active_config.py
@@ -16,6 +16,7 @@ from typing import Optional, Union
 from loguru import logger
 
 from tldw_chatbook.config import get_cli_setting, save_setting_to_cli_config
+from .collection_fingerprint import fingerprint_collection
 from .config import RAGConfig, _normalized_type_setting, validate_chroma_persist_directory
 from ..config_profiles import get_profile_manager, ProfileConfig, _slugify
 from ..ingestion_indexing import reset_shared_rag_service
@@ -307,6 +308,63 @@ def _merge_legacy_query_time_keys(config: RAGConfig) -> dict:
     return legacy
 
 
+#: Every SearchConfig field a legacy import can ever hand-set (task-495) --
+#: the full set _merge_legacy_query_time_keys() may setattr() onto a
+#: snapshot's `.search`. Used by _is_pre635_damage_artifact() to prove an
+#: existing "Imported settings" profile carries none of them.
+_LEGACY_MERGED_SEARCH_FIELDS = _LEGACY_SEARCH_KEYS + _LEGACY_PROCESSOR_KEYS
+
+
+def _is_pre635_damage_artifact(mgr, imported: ProfileConfig) -> bool:
+    """True when `imported` (the "Imported settings" profile) is provably
+    indistinguishable from the default builtin profile -- i.e. it can only be
+    a snapshot the pre-635 always-import bug took of a fresh install that had
+    nothing to import, not a genuine legacy upgrade or later customization
+    (task-639 AC #2).
+
+    Two independent conditions must BOTH hold, or this returns False (never
+    guesses):
+
+    - Index fingerprint identity: `fingerprint_collection(imported.rag_config)
+      == fingerprint_collection(default.rag_config)`. This is exactly the set
+      of fields SP1 keys a vector collection under, so identity here proves
+      reverting the pointer changes zero observable indexing behavior -- the
+      active collection stays the same collection either way.
+    - No hand-set query-time/reranking difference: none of the
+      `_LEGACY_MERGED_SEARCH_FIELDS` differ from the default's, and no
+      `reranking_config` was fabricated. These fields are NOT part of the
+      fingerprint, so a real customization here (task-495 legacy merge, or a
+      later hand-edit in the Settings screen) would otherwise be silently
+      discarded by treating fingerprint identity alone as proof.
+
+    Deliberately does NOT compare `embedding.device`: `resolve_active_rag_
+    config()`'s env-overlay layer concretizes an "auto" device into a real
+    "cpu"/"cuda"/"mps" value (see `_apply_env_overrides`), so an untouched
+    fresh-install snapshot legitimately differs from the default profile's
+    own stored "auto" on that one field. `device` is not a
+    `fingerprint_collection` input, so this has no bearing on the check.
+
+    Args:
+        mgr: The profile manager to resolve the default builtin profile from.
+        imported: The existing "Imported settings" profile to evaluate.
+
+    Returns:
+        True only when reverting `imported` to the default builtin pointer
+        (and discarding the profile) is provably lossless.
+    """
+    default = mgr.get_profile(DEFAULT_PROFILE)
+    if default is None:
+        return False  # nothing to prove equivalence against
+    if fingerprint_collection(imported.rag_config) != fingerprint_collection(default.rag_config):
+        return False
+    if imported.reranking_config is not None:
+        return False
+    for key in _LEGACY_MERGED_SEARCH_FIELDS:
+        if getattr(imported.rag_config.search, key, None) != getattr(default.rag_config.search, key, None):
+            return False
+    return True
+
+
 def ensure_imported_profile() -> Optional[str]:
     """On first run, capture the currently-resolved RAG config into a writable
     'Imported settings' profile and set it active -- but ONLY for a user
@@ -341,14 +399,40 @@ def ensure_imported_profile() -> Optional[str]:
     established convention this mirrors). Without this, a legacy user with
     reranking enabled would silently end up with it OFF after import.
 
-    Self-healing: existence of the profile is not enough to consider first-run
-    import "done" -- if a previous run persisted the profile but failed before
-    (or otherwise never got to) activating it, that leaves it created-but-never-
-    active forever with no retry. So every call also checks the active pointer
-    and (re)activates the imported profile if it isn't already active. This
-    healing path runs regardless of ``_has_legacy_rag_config_material()`` --
-    once the profile exists, healing its activation is not a fresh-install
-    concern.
+    Self-healing (narrowed, task-639): existence of the profile is not enough
+    to consider first-run import "done" -- if a previous run persisted the
+    profile but failed before (or otherwise never got to) activating it, that
+    leaves it created-but-never-active forever with no retry. So every call
+    also checks the active pointer, and (re)activates the imported profile
+    ONLY when the pointer still names the default builtin (``DEFAULT_PROFILE``
+    == ``hybrid_basic``) -- i.e. the pointer was never successfully written by
+    *anyone* yet, which is the one condition a genuine half-done first run and
+    "no one has ever written this pointer" share. A pointer naming ANY other
+    profile (builtin or user, including one the user switched to and then
+    later switched away from Imported settings) is left completely alone: the
+    prior behavior treated "pointer != imported_settings" as proof of a
+    half-done run, which cannot distinguish that from a user who deliberately
+    activated a different profile after import completed, and silently flipped
+    them back to Imported settings on their next launch. This healing path
+    runs regardless of ``_has_legacy_rag_config_material()`` -- once the
+    profile exists, healing its activation is not a fresh-install concern.
+
+    Damage cleanup (task-639 AC #2): the pre-635 bug ran this unconditionally,
+    so a fresh install that touched RAG before that fix shipped got "Imported
+    settings" created AND activated even though it had nothing legacy to
+    import -- its snapshot is, by construction, just a copy of the default
+    builtin. When the pointer is ALREADY imported_settings and the profile is
+    provably indistinguishable from the default builtin (see
+    ``_is_pre635_damage_artifact``: identical index fingerprint, no hand-set
+    query-time/reranking difference), that is treated as proof the activation
+    was the pre-635 bug rather than a real choice, and it is reverted: the
+    profile is deleted (not just repointed -- leaving it on disk would let the
+    healing branch above re-activate it on the very next call, since the
+    pointer would then again read as the default) and the pointer is set back
+    to ``DEFAULT_PROFILE``. Anything that cannot be proven this way (a real
+    hand-set difference, a different fingerprint, or a fabricated
+    ``reranking_config``) is left untouched -- when it can't tell a genuine
+    import/choice apart from damage, it does not guess.
 
     Exception-safe: any failure here must never block RAG service creation, so
     every error is caught and logged, returning None (as if already imported /
@@ -365,8 +449,21 @@ def ensure_imported_profile() -> Optional[str]:
         mgr = _manager()
         existing = mgr.get_profile(_IMPORTED_ID)
         if existing is not None:
-            if _active_profile_id() != _IMPORTED_ID:
-                set_active_profile(_IMPORTED_ID)  # heal a half-done first run
+            pointer = _active_profile_id()
+            if pointer == DEFAULT_PROFILE:
+                # The pointer was never successfully written by anyone --
+                # heal a half-done first run (task-639: narrowed from
+                # "!= _IMPORTED_ID" so a deliberate later switch to a
+                # different profile is never undone).
+                set_active_profile(_IMPORTED_ID)
+            elif pointer == _IMPORTED_ID and _is_pre635_damage_artifact(mgr, existing):
+                # task-639 AC #2: provably a pre-635 always-import-bug
+                # artifact on what would now be a fresh install -- revert.
+                # Delete first: leaving the profile on disk would let the
+                # branch above re-activate it next call (pointer now reads
+                # as the default).
+                mgr.delete_profile(_IMPORTED_ID)
+                set_active_profile(DEFAULT_PROFILE)
             return None
         if not _has_legacy_rag_config_material():
             # task-635: nothing legacy to preserve continuity for -- leave a

--- a/tldw_chatbook/RAG_Search/simplified/active_config.py
+++ b/tldw_chatbook/RAG_Search/simplified/active_config.py
@@ -16,7 +16,6 @@ from typing import Optional, Union
 from loguru import logger
 
 from tldw_chatbook.config import get_cli_setting, save_setting_to_cli_config
-from .collection_fingerprint import fingerprint_collection
 from .config import RAGConfig, _normalized_type_setting, validate_chroma_persist_directory
 from ..config_profiles import get_profile_manager, ProfileConfig, _slugify
 from ..ingestion_indexing import reset_shared_rag_service
@@ -51,6 +50,48 @@ def _active_profile_id() -> str:
     except Exception as e:
         logger.debug(f"Could not read active profile pointer: {e}")
     return DEFAULT_PROFILE
+
+
+def _first_run_import_done() -> bool:
+    """The durable first-run-import marker: [rag.service].first_run_import_done.
+
+    True once ensure_imported_profile() has deliberately activated
+    ``imported_settings`` — either by completing a fresh import or by healing
+    a half-done one (see ``_mark_first_run_import_done``, called at both
+    sites). This is the proof `ensure_imported_profile`'s healing branch uses
+    to tell "the pointer was never successfully settled" apart from "the
+    pointer is settled, whatever it currently names" -- unlike comparing
+    config *contents*, it can never be fooled by a customization it doesn't
+    happen to check for (task-639 review: the prior fingerprint + allow-list
+    heuristic missed several Settings-screen-editable fields, e.g.
+    ``search.hybrid_alpha``, and could delete a genuinely customized
+    profile).
+    """
+    try:
+        svc = get_cli_setting("rag", "service", {}) or {}
+        if isinstance(svc, dict):
+            return bool(svc.get("first_run_import_done"))
+    except Exception as e:
+        logger.debug(f"Could not read first_run_import_done marker: {e}")
+    return False
+
+
+def _mark_first_run_import_done() -> None:
+    """Persist [rag.service].first_run_import_done = True.
+
+    Called at both places ``ensure_imported_profile`` activates
+    ``imported_settings`` (a fresh import, and healing a half-done run) so
+    that, from then on, the pointer is never second-guessed again -- even if
+    the user later switches to a different profile, or back to the default
+    builtin itself. Best-effort: a failure here is logged and swallowed, same
+    as the rest of ``ensure_imported_profile`` -- it must never block RAG
+    service creation. A failed write just means the next call may re-evaluate
+    the healing branch once more, which is safe (idempotent), not corrupting.
+    """
+    try:
+        save_setting_to_cli_config("rag.service", "first_run_import_done", True)
+    except Exception as e:
+        logger.debug(f"Could not persist first_run_import_done marker: {e}")
 
 
 def _apply_env_overrides(config: RAGConfig,
@@ -308,63 +349,6 @@ def _merge_legacy_query_time_keys(config: RAGConfig) -> dict:
     return legacy
 
 
-#: Every SearchConfig field a legacy import can ever hand-set (task-495) --
-#: the full set _merge_legacy_query_time_keys() may setattr() onto a
-#: snapshot's `.search`. Used by _is_pre635_damage_artifact() to prove an
-#: existing "Imported settings" profile carries none of them.
-_LEGACY_MERGED_SEARCH_FIELDS = _LEGACY_SEARCH_KEYS + _LEGACY_PROCESSOR_KEYS
-
-
-def _is_pre635_damage_artifact(mgr, imported: ProfileConfig) -> bool:
-    """True when `imported` (the "Imported settings" profile) is provably
-    indistinguishable from the default builtin profile -- i.e. it can only be
-    a snapshot the pre-635 always-import bug took of a fresh install that had
-    nothing to import, not a genuine legacy upgrade or later customization
-    (task-639 AC #2).
-
-    Two independent conditions must BOTH hold, or this returns False (never
-    guesses):
-
-    - Index fingerprint identity: `fingerprint_collection(imported.rag_config)
-      == fingerprint_collection(default.rag_config)`. This is exactly the set
-      of fields SP1 keys a vector collection under, so identity here proves
-      reverting the pointer changes zero observable indexing behavior -- the
-      active collection stays the same collection either way.
-    - No hand-set query-time/reranking difference: none of the
-      `_LEGACY_MERGED_SEARCH_FIELDS` differ from the default's, and no
-      `reranking_config` was fabricated. These fields are NOT part of the
-      fingerprint, so a real customization here (task-495 legacy merge, or a
-      later hand-edit in the Settings screen) would otherwise be silently
-      discarded by treating fingerprint identity alone as proof.
-
-    Deliberately does NOT compare `embedding.device`: `resolve_active_rag_
-    config()`'s env-overlay layer concretizes an "auto" device into a real
-    "cpu"/"cuda"/"mps" value (see `_apply_env_overrides`), so an untouched
-    fresh-install snapshot legitimately differs from the default profile's
-    own stored "auto" on that one field. `device` is not a
-    `fingerprint_collection` input, so this has no bearing on the check.
-
-    Args:
-        mgr: The profile manager to resolve the default builtin profile from.
-        imported: The existing "Imported settings" profile to evaluate.
-
-    Returns:
-        True only when reverting `imported` to the default builtin pointer
-        (and discarding the profile) is provably lossless.
-    """
-    default = mgr.get_profile(DEFAULT_PROFILE)
-    if default is None:
-        return False  # nothing to prove equivalence against
-    if fingerprint_collection(imported.rag_config) != fingerprint_collection(default.rag_config):
-        return False
-    if imported.reranking_config is not None:
-        return False
-    for key in _LEGACY_MERGED_SEARCH_FIELDS:
-        if getattr(imported.rag_config.search, key, None) != getattr(default.rag_config.search, key, None):
-            return False
-    return True
-
-
 def ensure_imported_profile() -> Optional[str]:
     """On first run, capture the currently-resolved RAG config into a writable
     'Imported settings' profile and set it active -- but ONLY for a user
@@ -399,40 +383,62 @@ def ensure_imported_profile() -> Optional[str]:
     established convention this mirrors). Without this, a legacy user with
     reranking enabled would silently end up with it OFF after import.
 
-    Self-healing (narrowed, task-639): existence of the profile is not enough
-    to consider first-run import "done" -- if a previous run persisted the
-    profile but failed before (or otherwise never got to) activating it, that
-    leaves it created-but-never-active forever with no retry. So every call
-    also checks the active pointer, and (re)activates the imported profile
-    ONLY when the pointer still names the default builtin (``DEFAULT_PROFILE``
-    == ``hybrid_basic``) -- i.e. the pointer was never successfully written by
-    *anyone* yet, which is the one condition a genuine half-done first run and
-    "no one has ever written this pointer" share. A pointer naming ANY other
-    profile (builtin or user, including one the user switched to and then
-    later switched away from Imported settings) is left completely alone: the
-    prior behavior treated "pointer != imported_settings" as proof of a
-    half-done run, which cannot distinguish that from a user who deliberately
-    activated a different profile after import completed, and silently flipped
-    them back to Imported settings on their next launch. This healing path
-    runs regardless of ``_has_legacy_rag_config_material()`` -- once the
-    profile exists, healing its activation is not a fresh-install concern.
+    Self-healing (task-639, marker-based): existence of the profile is not
+    enough to consider first-run import "done" -- if a previous run persisted
+    the profile but failed before (or otherwise never got to) activating it,
+    that leaves it created-but-never-active forever with no retry. The guard
+    used to be "the active pointer differs from imported_settings", which
+    cannot distinguish that half-done state from a user who deliberately
+    activated a different profile afterward -- it silently flipped a
+    deliberate switch back to Imported settings on the user's next launch. A
+    second attempt compared the profile's *contents* against the default
+    builtin (fingerprint + an allow-listed field set) to prove "nothing to
+    lose", but that heuristic could itself be fooled: the Settings screen
+    lets a user hand-tune fields the allow-list never checked (e.g.
+    ``search.hybrid_alpha``, `default_search_mode`, `citation_style`,
+    `embedding.batch_size`, ...), so a real customization outside that list
+    passed the "provably safe" check and got permanently deleted.
 
-    Damage cleanup (task-639 AC #2): the pre-635 bug ran this unconditionally,
-    so a fresh install that touched RAG before that fix shipped got "Imported
-    settings" created AND activated even though it had nothing legacy to
-    import -- its snapshot is, by construction, just a copy of the default
-    builtin. When the pointer is ALREADY imported_settings and the profile is
-    provably indistinguishable from the default builtin (see
-    ``_is_pre635_damage_artifact``: identical index fingerprint, no hand-set
-    query-time/reranking difference), that is treated as proof the activation
-    was the pre-635 bug rather than a real choice, and it is reverted: the
-    profile is deleted (not just repointed -- leaving it on disk would let the
-    healing branch above re-activate it on the very next call, since the
-    pointer would then again read as the default) and the pointer is set back
-    to ``DEFAULT_PROFILE``. Anything that cannot be proven this way (a real
-    hand-set difference, a different fingerprint, or a fabricated
-    ``reranking_config``) is left untouched -- when it can't tell a genuine
-    import/choice apart from damage, it does not guess.
+    The fix is a durable marker instead of a content guess:
+    ``[rag.service].first_run_import_done`` (``_first_run_import_done`` /
+    ``_mark_first_run_import_done``), written every time this function
+    deliberately activates ``imported_settings`` (both the fresh-import path
+    below and the healing branch here). Once set, the pointer is NEVER
+    second-guessed again, no matter what it currently names -- including the
+    user switching back to the default builtin itself, which the pointer-only
+    approach could not tell apart from "never written". While the marker is
+    still absent (a config from before this function ever set it -- either a
+    genuine half-done first run, or a pre-existing "Imported settings"
+    activation from before the marker existed, task-639 AC #2), exactly one
+    thing happens:
+
+    - Pointer still names the default builtin (``DEFAULT_PROFILE`` ==
+      ``hybrid_basic``, i.e. it was never successfully written by anyone) --
+      this is the one condition a genuine half-done first run and "the
+      marker predates this profile" share, so the healing here always
+      completes the activation and sets the marker.
+    - Pointer already names anything else (``imported_settings`` from a
+      pre-635/pre-marker activation, or a different profile entirely) -- the
+      pointer is left completely untouched (never deleted, never repointed)
+      and the marker is simply set, adopting whatever is already active as
+      confirmed going forward. Deliberately does NOT delete the profile even
+      when it happens to look identical to the default: unlike a marker, no
+      finite content comparison can prove a Settings-screen customization is
+      absent, so guessing "safe to delete" risks real, irreversible data
+      loss -- doing nothing here has no such risk and reaches the same
+      settled state (the marker stops any further automatic handling).
+
+    One inherent, bounded gap: for a config that predates the marker (an
+    existing pointer that happens to already read as the default builtin,
+    with no marker yet) there is no way to tell "never completed" apart from
+    "the user deliberately switched back to the default sometime before this
+    code shipped" -- this can only occur once, on the first run under
+    marker-aware code, since the marker is written at every activation site
+    from then on and this ambiguity can never arise again afterward.
+
+    This healing path runs regardless of ``_has_legacy_rag_config_material()``
+    -- once the profile exists, healing its activation is not a fresh-install
+    concern.
 
     Exception-safe: any failure here must never block RAG service creation, so
     every error is caught and logged, returning None (as if already imported /
@@ -441,29 +447,25 @@ def ensure_imported_profile() -> Optional[str]:
     Returns:
         The new profile's id (``"imported_settings"``) on the run that
         creates and activates it; ``None`` when it already existed (no-op,
-        after healing the active pointer if needed), when there is no
-        genuine legacy material to import (fresh install), or when import
+        after healing the active pointer / marker if needed), when there is
+        no genuine legacy material to import (fresh install), or when import
         failed (logged, swallowed).
     """
     try:
         mgr = _manager()
         existing = mgr.get_profile(_IMPORTED_ID)
         if existing is not None:
-            pointer = _active_profile_id()
-            if pointer == DEFAULT_PROFILE:
-                # The pointer was never successfully written by anyone --
-                # heal a half-done first run (task-639: narrowed from
-                # "!= _IMPORTED_ID" so a deliberate later switch to a
-                # different profile is never undone).
-                set_active_profile(_IMPORTED_ID)
-            elif pointer == _IMPORTED_ID and _is_pre635_damage_artifact(mgr, existing):
-                # task-639 AC #2: provably a pre-635 always-import-bug
-                # artifact on what would now be a fresh install -- revert.
-                # Delete first: leaving the profile on disk would let the
-                # branch above re-activate it next call (pointer now reads
-                # as the default).
-                mgr.delete_profile(_IMPORTED_ID)
-                set_active_profile(DEFAULT_PROFILE)
+            if not _first_run_import_done():
+                if _active_profile_id() == DEFAULT_PROFILE:
+                    # Never successfully written by anyone -- heal a
+                    # half-done first run.
+                    set_active_profile(_IMPORTED_ID)
+                # else: pointer already names imported_settings (a
+                # pre-marker activation, possibly pre-635 damage) or some
+                # other profile entirely -- leave it exactly as-is (never
+                # delete, never repoint; see docstring for why) and just
+                # adopt it as settled.
+                _mark_first_run_import_done()
             return None
         if not _has_legacy_rag_config_material():
             # task-635: nothing legacy to preserve continuity for -- leave a
@@ -493,6 +495,7 @@ def ensure_imported_profile() -> Optional[str]:
                 profile.reranking_config.top_k_to_rerank = int(reranker_top_k)
         mgr.save_profile(profile)
         set_active_profile(_IMPORTED_ID)
+        _mark_first_run_import_done()
         return _IMPORTED_ID
     except Exception as e:
         logger.warning(f"ensure_imported_profile: first-run import failed, continuing without it: {e}")


### PR DESCRIPTION
Closes the last member of the silent-pointer-flip family. The first-run healing branch re-activated "Imported settings" whenever the pointer differed — flipping every legacy upgrader who deliberately switched profiles back on next launch.

Three review-driven rounds: (1) heal gate narrowed to pointer-still-default; (2) review caught a Critical in the round-1 damage-cleanup heuristic (it could DELETE a profile the user had customized via the settings editor — reproduced with a hybrid_alpha edit) → replaced entirely with a durable `[rag.service].first_run_import_done` marker written at both activation sites; pre-marker states are adopted as-is, NEVER deleted; the marker also closes the switch-back-to-default gap; (3) marker write now gated on confirmed pointer-write success so a transient I/O failure can't permanently strand a user on the default with no retry.

One bounded, self-terminating migration artifact documented: a pre-marker config whose pointer already reads as the default is indistinguishable from half-done on exactly one launch. Gates: first-run 24 passed, Tests/RAG 576 passed / 8 skipped. RED evidence revert-verified by the reviewer both rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes first-run healing so it only re-activates `imported_settings` when the active pointer is still the default, and stops re-flipping deliberate profile switches. Adds a durable `[rag.service].first_run_import_done` marker and writes it only after a confirmed pointer update; pre-marker setups are adopted as-is without deleting profiles. Meets Linear task-639 ACs.

- **Bug Fixes**
  - Gate healing to `_active_profile_id() == DEFAULT_PROFILE` with no marker; never flip deliberate switches.
  - Add `_first_run_import_done`/`_mark_first_run_import_done`; once set, the pointer is never re-evaluated.
  - Write the marker only after `_active_profile_id()` confirms `_IMPORTED_ID`; if the write fails, do not mark so a later run can retry.
  - For pre-marker configs, leave the pointer/profile (including `imported_settings`) untouched and set the marker; never delete based on content.
  - Updated `tldw_chatbook/RAG_Search/simplified/active_config.py`; expanded tests in `Tests/RAG/test_first_run_import.py` to cover the new gate, marker semantics, and failure cases.

<sup>Written for commit 25dec2e12d55494f12d1940ba170e55cdfd8b72a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

