### PR TITLE
fix(roleplay): restore character memory, honest readiness, correct chips and avatars

### DIFF
--- a/Tests/Chat/test_console_display_state.py
+++ b/Tests/Chat/test_console_display_state.py
@@ -25,14 +25,14 @@ def test_console_control_state_exposes_provider_model_and_context_labels():
 
     assert state.provider_label == "Provider: OpenAI"
     assert state.model_label == "Model: gpt-5.5"
-    assert state.user_profile_label == "As: Researcher"
+    assert state.user_profile_label == "You: Researcher"
     assert state.rag_label == "RAG: on"
     assert state.sources_label == "Sources: 3 staged"
     assert state.tools_label == "Tools: 4 ready"
     assert state.approvals_label == "Approvals: 1 pending"
 
 
-def test_console_control_state_preserves_falsy_labels_and_general_assistant_fallback():
+def test_console_control_state_preserves_falsy_labels_and_default_profile_fallback():
     state = ConsoleControlState.from_values(
         provider=0,
         model=False,
@@ -41,7 +41,7 @@ def test_console_control_state_preserves_falsy_labels_and_general_assistant_fall
 
     assert state.provider_label == "Provider: 0"
     assert state.model_label == "Model: False"
-    assert state.user_profile_label == "Assistant: General"
+    assert state.user_profile_label == "You: default"
 
 
 def test_console_control_state_counter_activity_flags():
@@ -261,3 +261,40 @@ def test_console_inspector_state_enables_pending_approval_tools_and_chatbook_act
     assert actions_by_id[CONSOLE_INSPECTOR_SAVE_CHATBOOK_ID].enabled is True
     rows_by_label = {row.label: row for row in state.rows}
     assert rows_by_label["Approvals"].status == "blocked"
+
+
+# --- Roleplay UAT: the "Assistant" chip named neither the assistant nor a truth ---
+# Live repro (origin/dev @ f384a2807): the chip read "Assistant: General" in every
+# session, including while actively roleplaying with a character. It was built
+# from the USER-PROFILE label (`persona`), which Console always passed as None,
+# so it was a constant that described nothing. For a roleplay user the AI side
+# (the character) is the thing that must be visible; the user profile is a
+# separate fact and gets its own chip.
+
+
+def test_character_chip_names_the_active_character():
+    state = ConsoleControlState.from_values(
+        provider="llama_cpp", model="m", character="Seraphina"
+    )
+
+    assert state.character_label == "Character: Seraphina"
+
+
+def test_character_chip_reports_none_without_a_character():
+    state = ConsoleControlState.from_values(provider="llama_cpp", model="m")
+
+    assert state.character_label == "Character: none"
+
+
+def test_user_profile_chip_is_labelled_for_the_user_not_the_assistant():
+    state = ConsoleControlState.from_values(
+        provider="llama_cpp", model="m", persona="Corvin"
+    )
+
+    assert state.user_profile_label == "You: Corvin"
+
+
+def test_user_profile_chip_defaults_without_claiming_an_assistant():
+    state = ConsoleControlState.from_values(provider="llama_cpp", model="m")
+
+    assert state.user_profile_label == "You: default"

--- a/Tests/Chat/test_console_history_budget.py
+++ b/Tests/Chat/test_console_history_budget.py
@@ -168,3 +168,56 @@ def test_long_history_drops_exact_turns_via_binary_search():
 
 def test_default_response_reservation_value():
     assert DEFAULT_RESPONSE_RESERVATION == 1024
+
+
+# --- Roleplay UAT regression: reservation must never consume the whole window ---
+# Live repro (origin/dev @ f384a2807): a local llama.cpp model resolved to the
+# 4096 fallback window while Console's default max_tokens (4096) was passed as
+# the response reservation, making the history budget negative
+# (4096 - 4096 - 512 = -512). Every prior turn was dropped on EVERY send, so the
+# character had no memory: one turn after being told "my favorite color is teal"
+# the model answered "I don't know your favorite color yet".
+
+
+def test_reservation_equal_to_window_still_keeps_recent_history():
+    """A reservation as large as the window must not zero out the history budget.
+
+    Without the clamp the budget goes negative and every prior turn is dropped,
+    which is the roleplay amnesia bug.
+    """
+    msgs = [
+        _msg("system", "you are Seraphina"),
+        _msg("user", "my favorite color is teal"),
+        _msg("assistant", "I will remember that"),
+        _msg("user", "what is my favorite color"),
+    ]
+    result = bound_messages_to_window(
+        msgs,
+        model="m",
+        provider="p",
+        response_reservation=4096,
+        window=4096,
+        count_fn=_wordcount,
+    )
+    assert result.dropped_count == 0
+    assert result.messages == msgs
+
+
+def test_reservation_larger_than_window_still_keeps_recent_history():
+    """An over-large reservation must be clamped, not allowed to starve history."""
+    msgs = [
+        _msg("system", "sys"),
+        _msg("user", "remember this fact"),
+        _msg("assistant", "noted"),
+        _msg("user", "recall the fact"),
+    ]
+    result = bound_messages_to_window(
+        msgs,
+        model="m",
+        provider="p",
+        response_reservation=999_999,
+        window=4096,
+        count_fn=_wordcount,
+    )
+    assert result.dropped_count == 0
+    assert result.messages == msgs

--- a/Tests/Chat/test_console_image_view.py
+++ b/Tests/Chat/test_console_image_view.py
@@ -310,3 +310,50 @@ def test_resolve_show_character_avatar_live_shape():
     assert resolve_show_character_avatar(
         {"COMPREHENSIVE_CONFIG_RAW": {"chat": {"images": {"show_character_avatar": False}}}}
     ) is False
+
+
+# --- Roleplay UAT regression: the chat character avatar showed only its corner ---
+# Live repro (origin/dev @ f384a2807): the avatar spec reused the shared
+# transcript render cache, which builds Pixels at PIXELS_MAX_COLS x
+# PIXELS_MAX_LINES (80x40 cells). That renderable was then placed in the rail's
+# 16x8 avatar box, so Rich simply clipped it -- the user saw the top-left ~1/5
+# of their character's portrait instead of a scaled-down whole image.
+
+
+def test_scale_image_for_cell_box_fits_avatar_box():
+    """A large portrait must be scaled to fit the box, never left oversized."""
+    from PIL import Image as PILImage
+
+    from tldw_chatbook.Chat.console_image_view import scale_image_for_cell_box
+
+    source = PILImage.new("RGB", (512, 512))
+    scaled = scale_image_for_cell_box(source, 16, 8)
+
+    # A terminal cell is ~2x taller than wide, so an N-line box shows 2N pixel
+    # rows. Anything larger than the box in either axis gets clipped, not fitted.
+    assert scaled.width <= 16
+    assert scaled.height <= 16
+
+
+def test_scale_image_for_cell_box_preserves_aspect_ratio():
+    """Scaling must not distort the portrait."""
+    from PIL import Image as PILImage
+
+    from tldw_chatbook.Chat.console_image_view import scale_image_for_cell_box
+
+    source = PILImage.new("RGB", (400, 200))
+    scaled = scale_image_for_cell_box(source, 16, 8)
+
+    assert scaled.width / scaled.height == 400 / 200
+
+
+def test_scale_image_for_cell_box_leaves_source_unmodified():
+    """The cached source image must not be mutated in place by scaling."""
+    from PIL import Image as PILImage
+
+    from tldw_chatbook.Chat.console_image_view import scale_image_for_cell_box
+
+    source = PILImage.new("RGB", (512, 512))
+    scale_image_for_cell_box(source, 16, 8)
+
+    assert source.size == (512, 512)

--- a/Tests/Chat/test_console_run_status_surfaces.py
+++ b/Tests/Chat/test_console_run_status_surfaces.py
@@ -22,7 +22,8 @@ def _ready_control_state() -> ConsoleControlState:
     return ConsoleControlState(
         provider_label="Provider: llama_cpp",
         model_label="Model: local-gemma",
-        user_profile_label="Assistant: General",
+        character_label="Character: none",
+        user_profile_label="You: default",
         rag_label="RAG: off",
         sources_label="Sources: 0",
         tools_label="Tools: 0",

--- a/Tests/Chat/test_local_server_discovery.py
+++ b/Tests/Chat/test_local_server_discovery.py
@@ -416,3 +416,35 @@ async def test_probe_keeps_only_chat_capable_models_from_mixed_server() -> None:
 
     assert result.ok is True
     assert result.model_ids == ("chat-1",)
+
+
+@pytest.mark.asyncio
+async def test_probe_keeps_a_server_whose_other_entries_are_merely_unrecognized() -> None:
+    """A non-chat entry beside odd-shaped entries must not condemn the server.
+
+    Review finding: the reject condition was "no ids AND saw a non-chat entry",
+    which also rejected listings whose remaining entries simply failed to yield
+    an id (non-string ids, unexpected shapes). That turned an
+    unrecognized-but-plausible server into "no models endpoint" and hid a
+    possibly chat-capable host. Only an ALL-non-chat listing is a rejection.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "data": [
+                    {"id": "voice-1", "task": "tts"},
+                    {"id": 12345},  # non-string id: unrecognized, not non-chat
+                ],
+            },
+        )
+
+    async with _client(handler) as client:
+        result = await probe_models_endpoint(
+            "http://127.0.0.1:9099", provider_key="llama_cpp", http_client=client
+        )
+
+    assert result.ok is True
+    assert result.model_ids == ()

--- a/Tests/Chat/test_local_server_discovery.py
+++ b/Tests/Chat/test_local_server_discovery.py
@@ -331,3 +331,88 @@ async def test_probe_sanitizes_hostile_model_ids() -> None:
         assert len(model_id) <= 120
         assert all(ch.isprintable() for ch in model_id)
         assert "\x1b" not in model_id
+
+
+# --- Roleplay UAT regression: non-chat engines must not register as chat servers ---
+# Live repro (origin/dev @ f384a2807): a TTS-only engine was listening on the
+# hardcoded llama.cpp discovery port (127.0.0.1:8080) and answered /v1/models
+# with a 2xx payload. Discovery treated any 2xx models listing as a chat-capable
+# llama.cpp, so first-run onboarding offered "Use detected llama.cpp
+# (127.0.0.1:8080)", declared the app Ready, and the user's first message failed
+# with HTTP 404 (unknown endpoint: /v1/chat/completions). The payload itself
+# declared `"task": "tts"` -- the data needed to reject it was already present.
+
+
+def _tts_models_payload() -> dict:
+    """The real payload shape served by the TTS engine seen in the UAT."""
+    return {
+        "object": "list",
+        "data": [
+            {
+                "id": "supertonic-3",
+                "object": "model",
+                "owned_by": "engine",
+                "family": "supertonic",
+                "task": "tts",
+                "mode": "offline",
+            }
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_probe_rejects_tts_only_server() -> None:
+    """A models listing whose every entry declares a non-chat task is not a hit."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_tts_models_payload())
+
+    async with _client(handler) as client:
+        result = await probe_models_endpoint(
+            "http://127.0.0.1:8080", provider_key="llama_cpp", http_client=client
+        )
+
+    assert result.ok is False
+    assert result.model_ids == ()
+
+
+@pytest.mark.asyncio
+async def test_probe_keeps_server_whose_models_declare_no_task() -> None:
+    """llama.cpp does not declare `task`; absence must never mean 'not chat'."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_openai_models_payload("gemma-4-26B.gguf"))
+
+    async with _client(handler) as client:
+        result = await probe_models_endpoint(
+            "http://127.0.0.1:9099", provider_key="llama_cpp", http_client=client
+        )
+
+    assert result.ok is True
+    assert result.model_ids == ("gemma-4-26B.gguf",)
+
+
+@pytest.mark.asyncio
+async def test_probe_keeps_only_chat_capable_models_from_mixed_server() -> None:
+    """A server serving both chat and non-chat models offers only the chat ones."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "data": [
+                    {"id": "voice-1", "task": "tts"},
+                    {"id": "embed-1", "task": "embedding"},
+                    {"id": "chat-1"},
+                ],
+            },
+        )
+
+    async with _client(handler) as client:
+        result = await probe_models_endpoint(
+            "http://127.0.0.1:9099", provider_key="llama_cpp", http_client=client
+        )
+
+    assert result.ok is True
+    assert result.model_ids == ("chat-1",)

--- a/Tests/Chat/test_token_counter.py
+++ b/Tests/Chat/test_token_counter.py
@@ -252,3 +252,28 @@ class TestEstimator:
 #
 # End of test_token_counter.py
 ########################################################################################################################
+
+
+# --- Roleplay UAT regression: the unknown-model fallback window ---
+# A local llama.cpp GGUF resolved to the legacy 4096 fallback even though the
+# server advertised n_ctx=64000, so history was trimmed almost immediately.
+# Modern local models are >= 16k; the fallback now reflects that.
+
+
+def test_unknown_local_model_falls_back_to_16k_window():
+    """An unknown local model must not resolve to the legacy 4k window."""
+    from tldw_chatbook.Utils.token_counter import get_model_token_limit
+
+    assert (
+        get_model_token_limit(
+            "gemma-4-26B-A4B-it-ultra-uncensored-heretic-Q4_K_M.gguf", "llama_cpp"
+        )
+        == 16384
+    )
+
+
+def test_unknown_provider_and_model_falls_back_to_16k_window():
+    """The generic default applies to any unrecognized provider/model pair."""
+    from tldw_chatbook.Utils.token_counter import get_model_token_limit
+
+    assert get_model_token_limit("some-unknown-model", "some-unknown-provider") == 16384

--- a/Tests/UI/test_console_session_settings.py
+++ b/Tests/UI/test_console_session_settings.py
@@ -4113,7 +4113,16 @@ async def test_console_settings_modal_save_as_default_writes_through_config(
     # Streaming persists on the canonical chat_defaults key (bridged legacy key),
     # and the provider itself becomes the default (PR #606 review finding:
     # chat_defaults.provider is the ONLY source of the default provider).
-    assert sections["chat_defaults"] == {"streaming": False, "provider": "llama_cpp"}
+    # The model is written here as well as into api_settings: chat_defaults.model
+    # is what `resolve_effective_provider_model` feeds to the session builder as
+    # an explicit override, so omitting it left a stale model winning in every
+    # new session (roleplay UAT: character "Start Chat" silently reverted to the
+    # model onboarding had auto-picked).
+    assert sections["chat_defaults"] == {
+        "streaming": False,
+        "provider": "llama_cpp",
+        "model": "model-a",
+    }
     # Never persist None-valued optionals.
     assert "min_p" not in saved_section
     assert "seed" not in saved_section
@@ -4675,3 +4684,53 @@ async def test_console_settings_modal_discover_rejects_invalid_endpoint_url() ->
         await _wait_for_discover_status(app, pilot, MODEL_DISCOVER_INVALID_URL_COPY)
 
     assert prober.calls == []
+
+
+# --- Roleplay UAT regression: Save as default must not leave a stale model ---
+# Live repro (origin/dev @ f384a2807): onboarding auto-selected a wrong model and
+# wrote it to [chat_defaults].model. Correcting the model in Console Settings and
+# pressing "Save as default" wrote the new model ONLY to
+# [api_settings.<provider>].model, leaving [chat_defaults].model stale. Because
+# `resolve_effective_provider_model` reads chat_defaults.model and passes it as an
+# explicit override into `build_default_console_session_settings` (where it
+# outranks api_settings), every NEW session -- new tab, character "Start Chat",
+# app relaunch -- silently reverted to the old model.
+
+
+def test_save_as_default_persists_model_to_chat_defaults() -> None:
+    """The chosen model must land in chat_defaults, the section Console reads."""
+    modal = ConsoleSettingsModal(
+        settings=ConsoleSessionSettings(provider="llama_cpp", model="good-model"),
+        app_config={},
+        providers_models={"llama_cpp": ["good-model"]},
+        context_estimate=ConsoleSettingsContextEstimate(
+            used_tokens=10, token_limit=16384, label="10 / 16k"
+        ),
+        can_save=True,
+    )
+    sections = modal._default_persist_sections(
+        ConsoleSessionSettings(provider="llama_cpp", model="good-model")
+    )
+
+    assert sections["chat_defaults"]["model"] == "good-model"
+
+
+def test_save_as_default_model_agrees_across_config_sections() -> None:
+    """chat_defaults and api_settings must not disagree about the active model."""
+    modal = ConsoleSettingsModal(
+        settings=ConsoleSessionSettings(provider="llama_cpp", model="good-model"),
+        app_config={},
+        providers_models={"llama_cpp": ["good-model"]},
+        context_estimate=ConsoleSettingsContextEstimate(
+            used_tokens=10, token_limit=16384, label="10 / 16k"
+        ),
+        can_save=True,
+    )
+    sections = modal._default_persist_sections(
+        ConsoleSessionSettings(provider="llama_cpp", model="good-model")
+    )
+
+    assert (
+        sections["chat_defaults"]["model"]
+        == sections["api_settings.llama_cpp"]["model"]
+    )

--- a/Tests/UI/test_console_status_chips.py
+++ b/Tests/UI/test_console_status_chips.py
@@ -119,3 +119,29 @@ async def test_status_chips_sync_updates_character_chip():
 
         chip = app.query_one("#console-character-chip")
         assert "Seraphina" in str(chip.render())
+
+
+@pytest.mark.asyncio
+async def test_status_chips_do_not_parse_markup_in_names():
+    """A character or profile name must never be parsed as Rich markup.
+
+    Names are user data (imported cards included). Rendering them through a
+    markup-enabled Static lets `[red]...[/]` restyle the chip strip, or raise
+    MarkupError on an unbalanced tag, from nothing more than a character name.
+    """
+    app = _ChipsApp(
+        ConsoleControlState.from_values(
+            provider="llama_cpp",
+            model="m",
+            character="[red]Seraphina[/]",
+            persona="[bold]Corvin[/]",
+        )
+    )
+    async with app.run_test(size=(200, 6)) as pilot:
+        await pilot.pause()
+
+        character_chip = app.query_one("#console-character-chip")
+        profile_chip = app.query_one("#console-persona-chip")
+
+        assert "[red]Seraphina[/]" in str(character_chip.render())
+        assert "[bold]Corvin[/]" in str(profile_chip.render())

--- a/Tests/UI/test_console_status_chips.py
+++ b/Tests/UI/test_console_status_chips.py
@@ -96,3 +96,26 @@ async def test_approvals_chip_posts_review_requested():
         assert any(
             isinstance(m, ConsoleApprovalsChip.ReviewRequested) for m in posted
         )
+
+
+@pytest.mark.asyncio
+async def test_status_chips_sync_updates_character_chip():
+    """The character chip must refresh on sync, not stay at its compose value.
+
+    Live repro: starting a chat from a character rendered "Character: none"
+    forever, because the chip was painted once at compose (before any character
+    existed) and `sync_state` never touched it again.
+    """
+    app = _ChipsApp(_state())
+    async with app.run_test(size=(160, 6)) as pilot:
+        await pilot.pause()
+        chips = app.query_one("#console-status-chips", ConsoleStatusChips)
+        chips.sync_state(
+            ConsoleControlState.from_values(
+                provider="llama_cpp", model="m", character="Seraphina"
+            )
+        )
+        await pilot.pause()
+
+        chip = app.query_one("#console-character-chip")
+        assert "Seraphina" in str(chip.render())

--- a/Tests/UI/test_console_status_chips.py
+++ b/Tests/UI/test_console_status_chips.py
@@ -14,7 +14,8 @@ def _state(**overrides) -> ConsoleControlState:
     base = dict(
         provider_label="Provider: Anthropic",
         model_label="Model: claude-3-haiku",
-        user_profile_label="Assistant: General",
+        character_label="Character: none",
+        user_profile_label="You: default",
         rag_label="RAG: off",
         sources_label="Sources: 0 staged",
         tools_label="Tools: 0 ready",
@@ -37,14 +38,15 @@ class _ChipsApp(App):
 
 
 @pytest.mark.asyncio
-async def test_status_chips_render_all_seven_labels():
+async def test_status_chips_render_all_eight_labels():
     app = _ChipsApp(_state())
     async with app.run_test(size=(160, 6)) as pilot:
         await pilot.pause()
         for selector, expected in (
             ("#console-provider-chip", "Provider:"),
             ("#console-model-chip", "Model:"),
-            ("#console-persona-chip", "Assistant:"),
+            ("#console-character-chip", "Character:"),
+            ("#console-persona-chip", "You:"),
             ("#console-rag-chip", "RAG:"),
             ("#console-sources-chip", "Sources:"),
             ("#console-tools-chip", "Tools:"),

--- a/Tests/UI/test_console_workbench_contract.py
+++ b/Tests/UI/test_console_workbench_contract.py
@@ -173,7 +173,8 @@ def _control_state() -> ConsoleControlState:
     return ConsoleControlState(
         provider_label="Provider: llama.cpp",
         model_label="Model: local-model",
-        user_profile_label="Assistant: General",
+        character_label="Character: none",
+        user_profile_label="You: default",
         rag_label="RAG: off",
         sources_label="Sources: 0",
         tools_label="Tools: 0",
@@ -274,6 +275,7 @@ async def test_console_control_bar_renders_visible_state_chips():
         expected_selectors = (
             "#console-provider-chip",
             "#console-model-chip",
+            "#console-character-chip",
             "#console-persona-chip",
             "#console-rag-chip",
             "#console-sources-chip",
@@ -290,9 +292,10 @@ async def test_console_control_bar_renders_visible_state_chips():
 
         assert any("Provider:" in text for text in visible_chip_text)
         assert any("Model:" in text for text in visible_chip_text)
-        assert any(
-            "Assistant:" in text or "Persona:" in text for text in visible_chip_text
-        )
+        # The AI side (character) and the human side (user profile) are now
+        # separate chips; the old single "Assistant:" chip named neither.
+        assert any("Character:" in text for text in visible_chip_text)
+        assert any("You:" in text for text in visible_chip_text)
         assert any("RAG:" in text for text in visible_chip_text)
         assert any("Sources:" in text for text in visible_chip_text)
         assert any("Tools:" in text for text in visible_chip_text)
@@ -333,6 +336,7 @@ async def test_console_control_chips_are_focusable_and_reveal_full_label_on_focu
         chip_ids = (
             "#console-provider-chip",
             "#console-model-chip",
+            "#console-character-chip",
             "#console-persona-chip",
             "#console-rag-chip",
             "#console-sources-chip",
@@ -910,7 +914,8 @@ def test_console_workbench_state_hides_recovery_banner_when_provider_blocked():
         control_state=ConsoleControlState(
             provider_label="Provider: OpenAI",
             model_label="Model: --",
-            user_profile_label="Assistant: General",
+            character_label="Character: none",
+        user_profile_label="You: default",
             rag_label="RAG: off",
             sources_label="Sources: 0",
             tools_label="Tools: 0",

--- a/tldw_chatbook/Chat/console_display_state.py
+++ b/tldw_chatbook/Chat/console_display_state.py
@@ -289,6 +289,7 @@ class ConsoleControlState:
 
     provider_label: str
     model_label: str
+    character_label: str
     user_profile_label: str
     rag_label: str
     sources_label: str
@@ -305,6 +306,7 @@ class ConsoleControlState:
         provider: Any = None,
         model: Any = None,
         persona: Any = None,
+        character: Any = None,
         rag_enabled: bool = False,
         staged_source_count: int = 0,
         tool_count: int = 0,
@@ -329,10 +331,14 @@ class ConsoleControlState:
             can actually run (built-in + MCP) and whose ``*_active`` flags drive
             chip emphasis.
         """
+        # Two distinct facts, two chips. The old single chip rendered
+        # "Assistant: General" from the USER-PROFILE value, which Console always
+        # passed as None -- so it was a constant that named neither side of the
+        # conversation. `{{user}}` is the human; the character is the AI side.
+        character_text = _clean(character, "")
+        character_label = f"Character: {character_text or 'none'}"
         persona_text = _clean(persona, "")
-        user_profile_label = (
-            f"As: {persona_text}" if persona_text else "Assistant: General"
-        )
+        user_profile_label = f"You: {persona_text or 'default'}"
         # TASK-350: the chip must reflect the tools that can ACTUALLY run — built-in
         # AND MCP. Counting only built-in read "Tools: 0 ready" while the inspector
         # showed "MCP: 10 tools ready". `mcp_tool_count is None` means no MCP seam
@@ -341,6 +347,7 @@ class ConsoleControlState:
         return cls(
             provider_label=f"Provider: {_clean(provider, 'not selected')}",
             model_label=f"Model: {_clean(model, 'not selected')}",
+            character_label=character_label,
             user_profile_label=user_profile_label,
             rag_label=f"RAG: {'on' if rag_enabled else 'off'}",
             sources_label=f"Sources: {staged_source_count} staged",

--- a/tldw_chatbook/Chat/console_display_state.py
+++ b/tldw_chatbook/Chat/console_display_state.py
@@ -318,7 +318,10 @@ class ConsoleControlState:
         Args:
             provider: Active provider name, or falsy for "not selected".
             model: Active model name, or falsy for "not selected".
-            persona: Persona/assistant label; falsy falls back to "General".
+            persona: The user's own profile label (the human side of the
+                conversation); falsy renders as "You: default".
+            character: Active character driving replies (the AI side);
+                falsy renders as "Character: none".
             rag_enabled: Whether RAG is on for this send.
             staged_source_count: Number of staged context sources.
             tool_count: Built-in tools that can run.

--- a/tldw_chatbook/Chat/console_history_budget.py
+++ b/tldw_chatbook/Chat/console_history_budget.py
@@ -135,7 +135,18 @@ def bound_messages_to_window(
         )
     )
     win = window if window is not None else get_model_token_limit(model, provider)
-    budget = win - response_reservation - max(_MIN_SAFETY_MARGIN, win // 50)
+    margin = max(_MIN_SAFETY_MARGIN, win // 50)
+    # The reply reservation may never consume the whole window. `max_tokens` is
+    # user-facing and routinely set to the full context size (Console's own
+    # default did exactly that), which made `budget` negative and silently
+    # dropped ALL history on EVERY send -- the model then had no memory of the
+    # conversation while still sounding in-character, because the system prefix
+    # is always preserved. Clamping to half the usable window guarantees history
+    # always keeps a share; a caller asking to reserve more just gets less reply
+    # room than requested, which is recoverable, unlike total amnesia.
+    usable = max(0, win - margin)
+    effective_reservation = min(max(0, response_reservation), usable // 2)
+    budget = win - effective_reservation - margin
 
     # System prefix = contiguous leading system rows.
     sys_end = 0

--- a/tldw_chatbook/Chat/console_image_view.py
+++ b/tldw_chatbook/Chat/console_image_view.py
@@ -79,6 +79,33 @@ def fit_image_cell_size(
     return w_cells, h_cells
 
 
+def scale_image_for_cell_box(
+    image: "PILImage.Image", box_cols: int, box_lines: int
+) -> "PILImage.Image":
+    """Return a copy of ``image`` scaled to fit a character-cell box.
+
+    ``Pixels.from_image`` bakes one cell per source pixel row-pair, so a Pixels
+    renderable built for a *large* box and then placed in a *small* widget is
+    clipped by Rich, not scaled -- the viewer sees the image's top-left corner.
+    Sizing the source to the destination box before building Pixels is what
+    makes the whole image visible.
+
+    Args:
+        image: Source PIL image; never modified.
+        box_cols: Destination box width in character columns.
+        box_lines: Destination box height in character lines.
+
+    Returns:
+        A scaled copy that fits within ``box_cols`` x ``box_lines * 2`` pixels
+        (terminal cells are ~2x taller than wide), preserving aspect ratio.
+    """
+    scaled = image.copy()
+    scaled.thumbnail(
+        (max(1, box_cols), max(1, box_lines) * 2), PILImage.Resampling.LANCZOS
+    )
+    return scaled
+
+
 def next_view_mode(current: ConsoleImageViewMode) -> ConsoleImageViewMode:
     """Return the next mode in the pixels -> graphics -> hidden cycle.
 

--- a/tldw_chatbook/Chat/local_server_discovery.py
+++ b/tldw_chatbook/Chat/local_server_discovery.py
@@ -310,10 +310,12 @@ def _model_ids_from_payload(payload: object) -> tuple[str, ...] | None:
         return None
     model_ids: list[str] = []
     saw_non_chat_entry = False
+    chat_candidate_count = 0
     for entry in entries:
         if _entry_declares_non_chat_task(entry):
             saw_non_chat_entry = True
             continue
+        chat_candidate_count += 1
         model_id: object = entry
         if isinstance(entry, Mapping):
             model_id = entry.get("id") or entry.get("name") or entry.get("model")
@@ -324,9 +326,12 @@ def _model_ids_from_payload(payload: object) -> tuple[str, ...] | None:
             model_ids.append(sanitized)
         if len(model_ids) >= MODEL_IDS_MAX_COUNT:
             break
-    if not model_ids and saw_non_chat_entry:
-        # The server listed models and every one of them is a non-chat
-        # workload: this endpoint is a real API, just not a chat API.
+    if not model_ids and saw_non_chat_entry and chat_candidate_count == 0:
+        # EVERY entry was explicitly non-chat: this endpoint is a real API,
+        # just not a chat API. A listing that merely failed to yield ids (odd
+        # shapes, non-string ids) alongside a non-chat entry is NOT rejected --
+        # that would turn an unrecognized-but-plausible server into "no models
+        # endpoint" and hide a chat-capable host from discovery.
         return None
     return tuple(model_ids)
 

--- a/tldw_chatbook/Chat/local_server_discovery.py
+++ b/tldw_chatbook/Chat/local_server_discovery.py
@@ -219,20 +219,88 @@ def _sanitize_model_id(raw: str) -> str:
     return cleaned[:MODEL_ID_MAX_CHARS]
 
 
-def _model_ids_from_payload(payload: object) -> tuple[str, ...] | None:
-    """Extract model id strings from a models-endpoint JSON payload.
+#: Declared model tasks that cannot serve `/v1/chat/completions`. Matched only
+#: against an EXPLICIT task/type field: llama.cpp and most OpenAI-compatible
+#: servers declare no task at all, so absence must always mean "assume chat"
+#: or discovery would stop finding real chat servers.
+NON_CHAT_MODEL_TASKS = frozenset(
+    {
+        "asr",
+        "classification",
+        "embed",
+        "embedding",
+        "embeddings",
+        "image",
+        "moderation",
+        "rerank",
+        "reranking",
+        "speech",
+        "stt",
+        "transcription",
+        "tts",
+    }
+)
 
-    Accepts the OpenAI ``{"data": [{"id": ...}]}`` shape, the Ollama
-    ``{"models": [{"name": ...}]}`` shape, and bare lists of entries.
+
+def _entry_declares_non_chat_task(entry: object) -> bool:
+    """Return whether a models-listing entry explicitly declares a non-chat task.
+
+    Args:
+        entry: One element of a models listing, of any shape.
+
+    Returns:
+        ``True`` only when the entry carries a recognizable task/type field
+        naming a non-chat workload (``"task": "tts"`` and friends). Entries
+        with no such field are never rejected.
+    """
+    if not isinstance(entry, Mapping):
+        return False
+    for key in ("task", "task_type", "model_type"):
+        value = entry.get(key)
+        if isinstance(value, str) and value.strip().lower() in NON_CHAT_MODEL_TASKS:
+            return True
+    return False
+
+
+def _payload_lists_only_non_chat_models(payload: object) -> bool:
+    """Return whether a models listing contained entries, all of them non-chat.
 
     Args:
         payload: Decoded JSON payload of any shape.
 
     Returns:
-        Ordered unique sanitized model ids (possibly empty) when the payload
-        carries a recognizable models container, or ``None`` when it does not
-        look like a models endpoint at all — a JSON page from some unrelated
-        local service must not count as a detected LLM server (PR #608 review).
+        ``True`` when the payload is a recognizable models listing whose every
+        entry explicitly declares a non-chat task; used to pick honest failure
+        copy rather than the generic "unrecognized payload" message.
+    """
+    entries: object = payload
+    if isinstance(payload, Mapping):
+        data = payload.get("data")
+        entries = data if isinstance(data, list) else payload.get("models")
+    if not isinstance(entries, list) or not entries:
+        return False
+    return all(_entry_declares_non_chat_task(entry) for entry in entries)
+
+
+def _model_ids_from_payload(payload: object) -> tuple[str, ...] | None:
+    """Extract chat-capable model id strings from a models-endpoint payload.
+
+    Accepts the OpenAI ``{"data": [{"id": ...}]}`` shape, the Ollama
+    ``{"models": [{"name": ...}]}`` shape, and bare lists of entries. Entries
+    that explicitly declare a non-chat task (TTS/STT/embedding/rerank/...) are
+    dropped: a text-to-speech engine listening on the well-known llama.cpp port
+    answers ``/v1/models`` with a perfectly valid 2xx listing but 404s every
+    chat completion, and used to be offered as a detected chat server.
+
+    Args:
+        payload: Decoded JSON payload of any shape.
+
+    Returns:
+        Ordered unique sanitized chat-capable model ids (possibly empty) when
+        the payload carries a recognizable models container, or ``None`` when
+        it does not look like a models endpoint at all — a JSON page from some
+        unrelated local service must not count as a detected LLM server
+        (PR #608 review) — or when every listed model is explicitly non-chat.
     """
     entries: object = payload
     if isinstance(payload, Mapping):
@@ -241,7 +309,11 @@ def _model_ids_from_payload(payload: object) -> tuple[str, ...] | None:
     if not isinstance(entries, list):
         return None
     model_ids: list[str] = []
+    saw_non_chat_entry = False
     for entry in entries:
+        if _entry_declares_non_chat_task(entry):
+            saw_non_chat_entry = True
+            continue
         model_id: object = entry
         if isinstance(entry, Mapping):
             model_id = entry.get("id") or entry.get("name") or entry.get("model")
@@ -252,6 +324,10 @@ def _model_ids_from_payload(payload: object) -> tuple[str, ...] | None:
             model_ids.append(sanitized)
         if len(model_ids) >= MODEL_IDS_MAX_COUNT:
             break
+    if not model_ids and saw_non_chat_entry:
+        # The server listed models and every one of them is a non-chat
+        # workload: this endpoint is a real API, just not a chat API.
+        return None
     return tuple(model_ids)
 
 
@@ -292,6 +368,11 @@ async def _get_models_payload(
         return None, f"No models endpoint at {display} (not a JSON API)."
     model_ids = _model_ids_from_payload(payload)
     if model_ids is None:
+        if _payload_lists_only_non_chat_models(payload):
+            # Honest, specific copy: this IS a working model API, it just cannot
+            # serve chat. Saying "unrecognized payload" would send the user
+            # hunting for the wrong problem.
+            return None, f"{display} serves no chat models (non-chat engine)."
         return None, f"No models endpoint at {display} (unrecognized API payload)."
     return model_ids, ""
 

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -212,6 +212,7 @@ from ...Chat.console_image_view import (
     resolve_default_mode,
     resolve_react_character_expressions,
     resolve_show_character_avatar,
+    scale_image_for_cell_box,
 )
 from ...Chat.console_paste_attach import (
     extract_dropped_path,
@@ -3599,12 +3600,20 @@ class ChatScreen(BaseAppScreen):
         pending_launch: Optional[ConsoleLiveWorkLaunch],
     ) -> ConsoleControlState:
         """Build Console-owned control/readiness labels."""
-        provider, model, _settings = self._active_console_provider_model_display()
+        provider, model, settings = self._active_console_provider_model_display()
         source = pending_launch.source if pending_launch else None
         return ConsoleControlState.from_values(
             provider=provider,
             model=model,
-            persona=None,
+            # The AI side of the conversation: whatever character this session is
+            # actually roleplaying, so the chip stops being a constant. The
+            # session's `character_label` is set by the character handoff; the
+            # rail name covers resumed conversations.
+            character=(
+                getattr(settings, "character_label", None)
+                or self._current_console_rail_character_name()
+            ),
+            persona=getattr(settings, "user_profile_label", None),
             rag_enabled=_source_mentions_rag(source),
             staged_source_count=1 if pending_launch else 0,
             tool_count=self._console_tool_count(),
@@ -4247,10 +4256,15 @@ class ChatScreen(BaseAppScreen):
             if image:
                 ok = await asyncio.to_thread(cache.prepare, key, image)
                 if ok:
-                    if mode == "graphics":
-                        spec["pil"] = cache.get_pil(key)
-                    else:
-                        spec["pixels"] = cache.get_pixels(key)
+                    # Always carry the PIL, never the cache's pre-baked Pixels.
+                    # `cache.get_pixels` bakes at the TRANSCRIPT box
+                    # (PIXELS_MAX_COLS x PIXELS_MAX_LINES = 80x40 cells); the
+                    # avatar rail is 16x8, and Rich clips an oversized Pixels
+                    # renderable rather than scaling it -- which showed the
+                    # user only the top-left corner of their character's
+                    # portrait. The render path scales the PIL to the avatar
+                    # box before building Pixels.
+                    spec["pil"] = cache.get_pil(key)
         except Exception:
             logger.opt(exception=True).debug("avatar: expression decode failed")
         # Post-await staleness re-check on the FULL (character_id, state)
@@ -4344,8 +4358,9 @@ class ChatScreen(BaseAppScreen):
         try:
             pixels = spec.get("pixels")
             if pixels is None and spec.get("pil") is not None:
-                scaled = spec["pil"].copy()
-                scaled.thumbnail((CHARACTER_AVATAR_COLS, CHARACTER_AVATAR_LINES * 2))
+                scaled = scale_image_for_cell_box(
+                    spec["pil"], CHARACTER_AVATAR_COLS, CHARACTER_AVATAR_LINES
+                )
                 from rich_pixels import Pixels
                 pixels = Pixels.from_image(scaled)
             widget = Static(pixels if pixels is not None else "", id="console-character-avatar-image")
@@ -7997,14 +8012,14 @@ class ChatScreen(BaseAppScreen):
             value = label.partition(":")[2].strip()
             return value.split(maxsplit=1)[0] if value else "0"
 
-        persona = str(control_state.user_profile_label or "General")
-        if persona.startswith("Assistant: "):
-            persona = persona.removeprefix("Assistant: ").strip() or "General"
-        elif persona.startswith("As: "):
-            persona = persona.removeprefix("As: ").strip() or "User Profile"
+        # The mode summary names the AI side: in a roleplay session that is the
+        # character, which is what the user is actually tracking.
+        character = str(control_state.character_label or "")
+        if character.startswith("Character: "):
+            character = character.removeprefix("Character: ").strip()
         return (
             "Chat/RAG/Follow"
-            f" | {persona}"
+            f" | {character or 'no character'}"
             f" | Sources {readiness_count(control_state.sources_label)}"
             f" | Tools {readiness_count(control_state.tools_label)}"
             f" | Approvals {readiness_count(control_state.approvals_label)}"

--- a/tldw_chatbook/Utils/token_counter.py
+++ b/tldw_chatbook/Utils/token_counter.py
@@ -198,8 +198,13 @@ MODEL_TOKEN_LIMITS = {
     "mistral-medium": 32000,
     "mistral-small": 32000,
     "mixtral-8x7b": 32000,
-    # Default for unknown models
-    "default": 4096,
+    # Default for unknown models. 16k, not the historical 4k: this value is what
+    # every local provider (llama.cpp/ollama/vllm/koboldcpp) resolves to, since
+    # their GGUF/model names never match the table above. 4k was far below what
+    # modern local models actually serve -- a llama.cpp server advertising
+    # n_ctx=64000 was being budgeted at 4096 -- which trimmed conversation
+    # history almost immediately and cost characters their memory.
+    "default": 16384,
 }
 
 

--- a/tldw_chatbook/Widgets/Console/console_control_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_control_bar.py
@@ -62,6 +62,7 @@ def _summary_line(state: ConsoleControlState) -> str:
         (
             state.provider_label,
             state.model_label,
+            state.character_label,
             state.user_profile_label,
             state.rag_label,
             state.sources_label,

--- a/tldw_chatbook/Widgets/Console/console_settings_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_settings_modal.py
@@ -768,6 +768,17 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
         chat_defaults: dict[str, object] = {"streaming": bool(draft.streaming)}
         if provider_key:
             chat_defaults["provider"] = provider_key
+        if model:
+            # The model must be written here too, not only into
+            # [api_settings.<provider>]. `resolve_effective_provider_model`
+            # reads `chat_defaults.model` and hands it to
+            # `build_default_console_session_settings` as an EXPLICIT override,
+            # where it outranks the api_settings value. Writing only
+            # api_settings therefore left a stale `chat_defaults.model`
+            # winning in every new session -- new tab, character "Start Chat",
+            # and app relaunch all silently reverted to the previously
+            # selected model after the user had corrected it here.
+            chat_defaults["model"] = model
         sections["chat_defaults"] = chat_defaults
         return sections
 

--- a/tldw_chatbook/Widgets/Console/console_status_chips.py
+++ b/tldw_chatbook/Widgets/Console/console_status_chips.py
@@ -267,6 +267,7 @@ class ConsoleStatusChips(Horizontal):
         label_values = {
             "#console-provider-chip": state.provider_label,
             "#console-model-chip": state.model_label,
+            "#console-character-chip": state.character_label,
             "#console-persona-chip": state.user_profile_label,
             "#console-rag-chip": state.rag_label,
             "#console-sources-chip": state.sources_label,

--- a/tldw_chatbook/Widgets/Console/console_status_chips.py
+++ b/tldw_chatbook/Widgets/Console/console_status_chips.py
@@ -140,7 +140,10 @@ class ConsoleStatusChips(Horizontal):
             classes += " console-chip-dim"
         elif emphasis is True:
             classes += " console-chip-alert"
-        chip = chip_class(label, id=id, classes=classes)
+        # markup=False: chip labels carry user data (character and profile
+        # names, model ids). A name containing `[red]...[/]` would otherwise
+        # restyle the chip strip, or raise MarkupError when unbalanced.
+        chip = chip_class(label, id=id, classes=classes, markup=False)
         chip.tooltip = label
         return chip
 

--- a/tldw_chatbook/Widgets/Console/console_status_chips.py
+++ b/tldw_chatbook/Widgets/Console/console_status_chips.py
@@ -147,6 +147,7 @@ class ConsoleStatusChips(Horizontal):
     def compose(self) -> ComposeResult:
         yield self._chip(self.state.provider_label, id="console-provider-chip")
         yield self._chip(self.state.model_label, id="console-model-chip")
+        yield self._chip(self.state.character_label, id="console-character-chip")
         yield self._chip(self.state.user_profile_label, id="console-persona-chip")
         yield self._chip(self.state.rag_label, id="console-rag-chip")
         yield self._chip(


### PR DESCRIPTION
Correctness fixes found by a live new-user roleplay UAT against `origin/dev` @ `f384a2807`
(fresh profile, local llama.cpp, journey: setup → character creation → chat → search/resume).

## S1 — characters had no memory (critical)

Two causes multiplied:

| term | value | source |
|---|---|---|
| assumed context window | 4096 | `get_model_token_limit` blanket fallback for **every** local model |
| response reservation | 4096 | `resolution.max_tokens`, i.e. Console's own default |
| safety margin | 512 | `max(_MIN_SAFETY_MARGIN, win // 50)` |
| **history budget** | **−512** | negative → all history dropped on **every** send |

The system prefix is always preserved, so the character kept *sounding* right while
having zero episodic memory — this reads as "the model is dumb", not as a config bug.
The only signal was a passive transcript line. Meanwhile the server advertised
`n_ctx = 64000` at `/props`, a 15× underestimate.

- Unknown-model fallback window **4096 → 16384**.
- Reservation clamped to half the usable window, so it can never starve history.
  `max_tokens` is user-facing and routinely set to the full context size; over-reserving
  now costs reply room, not the conversation.

**Live before/after**, same character and machine:

| | before | after |
|---|---|---|
| recall of prior turn | *"I don't know your favorite color yet"* | recalled **Corvin**, **Tidewater**, **Codex** |
| trim notices | every send (1 → 3 → 5 dropped) | **zero** |

## S2 — onboarding offered a server that cannot chat

Discovery probed the hardcoded llama.cpp port and treated any 2xx `/v1/models` listing as
chat-capable. A TTS-only engine on that port was offered as *"Use detected llama.cpp"*, the
app declared itself **Ready**, and the first message failed with
`HTTP 404 (unknown endpoint: /v1/chat/completions)` — while the payload itself declared
`"task": "tts"`.

Entries explicitly declaring a non-chat task are filtered; an all-non-chat listing is not a
hit; failure copy says so instead of "unrecognized payload". **Absence of a task field still
means chat**, so real llama.cpp servers are unaffected.

Verified against both live servers:
- `:8080` → `ok=False`, *"serves no chat models (non-chat engine)"*
- `:9099` → `ok=True`, gemma discovered

## S3 — "Save as default" silently reverted the model

The model was written only to `[api_settings.<provider>]`, but `resolve_effective_provider_model`
reads `chat_defaults.model` and passes it to the session builder as an **explicit override**,
where it outranks api_settings. Every new tab, character *Start Chat*, and relaunch reverted to
the model onboarding had auto-picked, after the user had corrected it.

(Worth noting: a direct probe of the builder *looked* correct — only tracing the override
revealed the real chain.)

## Chips — "Assistant: General" named nothing true

It was built from the user-profile label, which Console always passed as `None`, so it was a
constant. Split into two honest chips: `Character: <name>` (AI side, wired to the session) and
`You: <profile>` (human side).

## Avatars — portrait showed only its top-left corner

The avatar spec reused the shared transcript render cache, which bakes Pixels at 80×40 cells;
dropped into the 16×8 avatar box, Rich clipped rather than scaled it. The avatar now carries the
PIL and scales to its own box via a new `scale_image_for_cell_box` helper.

## Tests

- `Tests/Chat` full suite: **2215 passed, 60 skipped**
- `test_console_session_settings` 131, `test_console_workbench_contract` 59, chip/display/budget/discovery suites 124
- Every fix is TDD'd: test written, watched fail for the right reason, then fixed.
- Three existing tests asserted the old label/config contracts and were updated, with the reason recorded inline.

A second commit fixes a bug **live verification caught that the unit tests could not**: the new
character chip was added to `compose` but not to `sync_state`, so it read `Character: none` for
the whole session while its construction test passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores roleplay chat memory and honest readiness. Fixes discovery, default model persistence, chip accuracy and safety, and avatar scaling so first‑run chats work as expected.

- **Bug Fixes**
  - Preserve history: raise unknown‑model fallback window to 16k and clamp reply reservation to ≤ half the usable context so it can’t starve history.
  - Discovery: ignore `/v1/models` entries that declare non‑chat tasks; only an all‑non‑chat listing is rejected; missing task still means chat with clear failure copy when needed.
  - Defaults: persist the chosen model to both `chat_defaults.model` and `api_settings.<provider>.model` so new sessions keep the user’s selection.
  - Chips: replace “Assistant: General” with `Character: <name>` and `You: <profile>`, refresh the character chip on state sync, and render labels without markup to prevent name‑based styling/errors.
  - Avatars: carry the PIL image and scale it to the 16×8 rail using `scale_image_for_cell_box` to prevent clipping; readiness summary and control bar now include the character.

<sup>Written for commit 365e5401e759b0fbef8a5b194c3796e9810347e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

