### PR TITLE
Library ingest: UX, copy, defaults and performance from the UAT pass [TASK-678..683]

### DIFF
--- a/Tests/Library/test_ingest_preflight.py
+++ b/Tests/Library/test_ingest_preflight.py
@@ -327,3 +327,28 @@ class TestPublicApi:
         # importing a private name from local_file_ingestion.
         assert is_http_url("https://example.com") is True
         assert is_http_url("/local/path") is False
+
+
+class TestPathErrorsAreMarked:
+    """A path that cannot be found is not something to retry (task-666)."""
+
+    def test_missing_path_is_flagged_as_a_path_problem(self, tmp_path: Path) -> None:
+        result = analyze_path(str(tmp_path / "nope.txt"))
+        assert result.errors
+        assert result.path_invalid is True
+
+    def test_successful_analysis_is_not_flagged(self, tmp_path: Path) -> None:
+        (tmp_path / "a.txt").write_text("hello")
+        result = analyze_path(str(tmp_path / "a.txt"))
+        assert result.errors == []
+        assert result.path_invalid is False
+
+    def test_unreachable_url_is_not_a_path_problem(self) -> None:
+        """A URL that failed to respond is worth retrying; a typo'd path isn't."""
+        with patch(
+            "tldw_chatbook.Library.ingest_preflight.urlopen",
+            side_effect=URLError("connection refused"),
+        ):
+            result = analyze_path("https://example.com/document.pdf")
+        assert result.errors
+        assert result.path_invalid is False

--- a/Tests/Library/test_library_ingest_state.py
+++ b/Tests/Library/test_library_ingest_state.py
@@ -675,7 +675,9 @@ def test_build_warning_lines_empty():
 
 def test_build_warning_lines_label_and_hint():
     warnings = [{"label": "PDF processing", "hint": "PyMuPDF is not installed."}]
-    assert build_warning_lines(warnings) == ["PDF processing: PyMuPDF is not installed."]
+    assert build_warning_lines(warnings) == [
+        "PDF processing isn't installed — needed for PyMuPDF is not installed."
+    ]
 
 
 def test_build_warning_lines_falls_back_to_hint_only():
@@ -683,9 +685,35 @@ def test_build_warning_lines_falls_back_to_hint_only():
     assert build_warning_lines(warnings) == ["Something is missing."]
 
 
+def test_build_warning_lines_names_the_gap_and_the_fix():
+    """The composed line says what is missing, why it matters, and the fix.
+
+    The old shape pasted the label in front of a hint that already repeated
+    it, producing "PDF processing: PDF processing is unavailable: PDF
+    ingestion." (task-666).
+    """
+    warnings = [
+        {
+            "label": "PDF processing",
+            "hint": "PDF ingestion",
+            "command": 'pip install -e ".[pdf]"',
+        }
+    ]
+    assert build_warning_lines(warnings) == [
+        "PDF processing isn't installed — needed for PDF ingestion. "
+        'Install it with: pip install -e ".[pdf]"'
+    ]
+
+
+def test_build_warning_lines_does_not_repeat_the_label():
+    """When the label and the capability are the same words, say them once."""
+    warnings = [{"label": "Audio processing", "hint": "Audio processing"}]
+    assert build_warning_lines(warnings) == ["Audio processing isn't installed."]
+
+
 def test_build_warning_lines_label_only():
     warnings = [{"label": "PDF processing"}]
-    assert build_warning_lines(warnings) == ["PDF processing"]
+    assert build_warning_lines(warnings) == ["PDF processing isn't installed."]
 
 
 def test_build_warning_lines_empty_dict():
@@ -693,9 +721,12 @@ def test_build_warning_lines_empty_dict():
     assert build_warning_lines(warnings) == ["{}"]
 
 
-def test_build_warning_lines_ignores_command_key():
+def test_build_warning_lines_includes_the_install_command():
+    """The command is the actionable half; it belongs in the line."""
     warnings = [{"label": "PDF", "hint": "missing", "command": "pip install x"}]
-    assert build_warning_lines(warnings) == ["PDF: missing"]
+    assert build_warning_lines(warnings) == [
+        "PDF isn't installed — needed for missing. Install it with: pip install x"
+    ]
 
 
 # --- _human_size -----------------------------------------------------------
@@ -727,7 +758,7 @@ def test_canvas_state_preflight_fields_populated_from_parameter():
     state = build_library_ingest_state((), form=LibraryIngestFormState(), preflight=preflight)
     assert state.type_breakdown_line == "2 PDF documents"
     assert state.estimate_line == "2 files · 2.0 KB"
-    assert state.warning_lines == ["PDF: missing"]
+    assert state.warning_lines == ["PDF isn't installed — needed for missing."]
     assert state.errors == ["Path not found"]
     assert state.type_groups == ["pdf", "generic"]
     assert state.unsupported_files == []
@@ -842,3 +873,36 @@ def test_recent_jobs_limits_to_ten():
     )
     state = build_library_ingest_state(jobs, form=LibraryIngestFormState())
     assert len(state.recent_jobs) == 10
+
+
+def test_form_defaults_come_from_the_capability_declaration() -> None:
+    """One declaration of defaults, not two that disagree.
+
+    The capability layer declared ``analyze=True, chunk_size=1000`` while the
+    form shipped ``analyze=False, chunk=False, chunk_size=500``, and the two
+    ingest surfaces disagreed about chunking on top of that. Whichever was
+    authoritative, they could not both be (task-667).
+    """
+    from tldw_chatbook.Library.ingest_capabilities import get_capabilities
+
+    generic = {f.name: f.default for f in get_capabilities("generic").fields}
+    form = LibraryIngestFormState()
+
+    assert form.analyze is generic["analyze"]
+    assert form.chunk is generic["chunk"]
+    assert form.chunk_size == str(generic["chunk_size"])
+
+
+def test_chunking_is_on_by_default_and_analysis_is_off() -> None:
+    """Imports are chunked for retrieval; nothing calls an LLM unasked.
+
+    Chunking off by default meant imported documents were never chunked for
+    retrieval, quietly undermining search and RAG for anyone who never opened
+    the advanced panel. Analysis stays off because it costs an LLM call per
+    document at ingest time.
+    """
+    form = LibraryIngestFormState()
+
+    assert form.chunk is True
+    assert form.chunk_size == "1000"
+    assert form.analyze is False

--- a/Tests/UI/test_library_ingest_canvas.py
+++ b/Tests/UI/test_library_ingest_canvas.py
@@ -294,7 +294,9 @@ async def test_error_and_warning_markup_is_escaped():
         assert error_static.visual.plain == "[bold]not bold[/bold]"
 
         warning_static = pilot.app.query_one("#ingest-preflight-warning-0", Static)
-        assert warning_static.visual.plain == "⚠ Hint: [/bracket]"
+        assert warning_static.visual.plain == (
+            "⚠ Hint isn't installed — needed for [/bracket]."
+        )
 
 
 # --- Per-type options panels ------------------------------------------------
@@ -323,12 +325,14 @@ async def test_type_group_panels_render_for_detected_groups():
         pdf_panel = pilot.app.query_one("#type-group-pdf", Collapsible)
         generic_panel = pilot.app.query_one("#type-group-generic", Collapsible)
         assert "PDF documents" in str(pdf_panel.title)
-        assert "pdf_engine=" in str(pdf_panel.title)
+        assert "PDF engine: pymupdf4llm" in str(pdf_panel.title)
         assert "Plain text / documents / HTML" in str(generic_panel.title)
-        assert "chunk_size=" in str(generic_panel.title)
+        assert "Chunk size: 1000" in str(generic_panel.title)
 
         scope = pilot.app.query_one("#type-group-pdf .type-group-scope", Static)
-        assert "These options apply to all PDF documents files" in str(scope.renderable)
+        assert "Applies to all PDF documents in this import." in str(
+            scope.renderable
+        )
 
         assert pilot.app.query_one("#opt-pdf-reset", Button)
         assert pilot.app.query_one("#opt-generic-reset", Button)
@@ -411,7 +415,11 @@ async def test_non_dependent_controls_stay_enabled():
 async def test_chunk_size_disabled_when_chunk_unchecked():
     """Chunk size and overlap inputs are disabled until Chunk is checked."""
     form = _default_form()
+    # The panel renders from ``type_options``; the screen writes the scalar
+    # ``form.chunk`` mirror and this dict together on every toggle. Chunking
+    # is on by default now, so the off case has to be stated explicitly.
     form.chunk = False
+    form.type_options = {"generic": {"chunk": False}}
     state = build_library_ingest_state(
         (),
         form=form,
@@ -810,3 +818,160 @@ async def test_chunk_size_enabled_when_chunk_checked():
         assert (
             pilot.app.query_one("#opt-generic-chunk_overlap", Input).disabled is False
         )
+
+
+@pytest.mark.asyncio
+async def test_path_error_offers_a_way_to_pick_a_file_not_retry():
+    """A path that cannot be found offers correction, not Retry.
+
+    Re-running the same analysis against the same bad path fails identically,
+    so Retry was the wrong verb for the most common pre-flight error a
+    first-time user hits (task-666).
+    """
+    state = build_library_ingest_state(
+        (),
+        form=_default_form(),
+        preflight=PreflightResult(
+            type_groups={},
+            warnings=[],
+            errors=["Path not found: /tmp/nope.txt"],
+            total_size=0,
+            truncated=False,
+            total_files=0,
+            path_invalid=True,
+        ),
+    )
+    app = _CanvasHost(state)
+    async with app.run_test() as pilot:
+        assert len(pilot.app.query("#ingest-preflight-retry")) == 0
+        assert pilot.app.query_one("#ingest-preflight-choose", Button)
+
+
+@pytest.mark.asyncio
+async def test_retryable_error_still_offers_retry():
+    """A URL that failed to respond is worth another attempt."""
+    state = build_library_ingest_state(
+        (),
+        form=_default_form(),
+        preflight=PreflightResult(
+            type_groups={},
+            warnings=[],
+            errors=["URL unreachable: timed out"],
+            total_size=0,
+            truncated=False,
+            total_files=0,
+            path_invalid=False,
+        ),
+    )
+    app = _CanvasHost(state)
+    async with app.run_test() as pilot:
+        assert pilot.app.query_one("#ingest-preflight-retry", Button)
+        assert len(pilot.app.query("#ingest-preflight-choose")) == 0
+
+
+@pytest.mark.asyncio
+async def test_option_panel_title_reads_as_plain_language():
+    """The collapsed panel title describes settings, not internal field names."""
+    state = build_library_ingest_state(
+        (),
+        form=_default_form(),
+        preflight=PreflightResult(
+            type_groups={"pdf": ["/tmp/a.pdf"]},
+            warnings=[],
+            errors=[],
+            total_size=0,
+            truncated=False,
+            total_files=1,
+        ),
+    )
+    app = _CanvasHost(state)
+    with patch(
+        "tldw_chatbook.Widgets.Library.library_ingest_canvas._is_installed",
+        return_value=True,
+    ):
+        async with app.run_test() as pilot:
+            title = str(pilot.app.query_one("#type-group-pdf", Collapsible).title)
+
+    assert "pdf_engine=" not in title
+    assert "ocr=False" not in title
+    assert "PDF engine: pymupdf4llm" in title
+    assert "Enable OCR: off" in title
+
+
+def test_warning_line_does_not_repeat_itself():
+    """Warning copy names the gap once, then how to close it."""
+    from tldw_chatbook.Library.library_ingest_state import build_warning_lines
+
+    lines = build_warning_lines(
+        [
+            {
+                "feature": "pdf_processing",
+                "label": "PDF processing",
+                "hint": "PDF ingestion",
+                "command": 'pip install -e ".[pdf]"',
+            },
+            {
+                "feature": "audio_processing",
+                "label": "Audio processing",
+                "hint": "Audio processing",
+                "command": 'pip install -e ".[audio]"',
+            },
+        ]
+    )
+
+    assert lines[0] == (
+        "PDF processing isn't installed — needed for PDF ingestion. "
+        'Install it with: pip install -e ".[pdf]"'
+    )
+    # The label and the capability are the same words here, so say it once.
+    assert lines[1] == (
+        'Audio processing isn\'t installed. Install it with: pip install -e ".[audio]"'
+    )
+
+
+@pytest.mark.asyncio
+async def test_first_visit_explains_what_can_be_imported():
+    """An untouched form orients the user instead of showing blank space."""
+    state = build_library_ingest_state((), form=LibraryIngestFormState())
+    app = _CanvasHost(state)
+    async with app.run_test() as pilot:
+        first = str(pilot.app.query_one("#library-ingest-intro-0", Static).renderable)
+        second = str(pilot.app.query_one("#library-ingest-intro-1", Static).renderable)
+
+    assert "folder" in first and "URL" in first
+    assert "PDF documents" in first and "e-books" in first
+    assert "searchable" in second
+
+
+@pytest.mark.asyncio
+async def test_intro_gives_way_to_the_real_summary():
+    """Orientation never competes with an actual pre-flight result."""
+    state = build_library_ingest_state(
+        (),
+        form=_default_form(),
+        preflight=PreflightResult(
+            type_groups={"generic": ["/tmp/a.txt"]},
+            warnings=[],
+            errors=[],
+            total_size=10,
+            truncated=False,
+            total_files=1,
+        ),
+    )
+    app = _CanvasHost(state)
+    async with app.run_test() as pilot:
+        assert len(pilot.app.query("#library-ingest-intro-0")) == 0
+
+
+@pytest.mark.asyncio
+async def test_clear_button_appears_only_with_a_path():
+    """The path field can be emptied in one press once it has content."""
+    empty = build_library_ingest_state((), form=LibraryIngestFormState())
+    app = _CanvasHost(empty)
+    async with app.run_test() as pilot:
+        assert len(pilot.app.query("#library-ingest-clear-path")) == 0
+
+    filled = build_library_ingest_state((), form=_default_form())
+    app = _CanvasHost(filled)
+    async with app.run_test() as pilot:
+        assert pilot.app.query_one("#library-ingest-clear-path", Button)

--- a/Tests/UI/test_library_ingest_guardrail_modal.py
+++ b/Tests/UI/test_library_ingest_guardrail_modal.py
@@ -148,6 +148,10 @@ def _minimal_library_screen() -> LibraryScreen:
     """Return a LibraryScreen instance without mounting the full UI."""
     screen = object.__new__(LibraryScreen)
     screen._library_ingest_form = LibraryIngestFormState()
+    # Set by ``__init__``, which this shortcut bypasses; submit cancels any
+    # in-flight pre-flight so a late result cannot repopulate the summary it
+    # just cleared.
+    screen._library_ingest_preflight_worker = None
     screen._notify_library_ingest_warning = MagicMock()
     screen.refresh = MagicMock()
     screen.app_instance = MagicMock()
@@ -239,3 +243,32 @@ def test_submit_without_warnings_calls_submit(tmp_path: Path):
     screen.app_instance.submit_library_ingest_job.assert_called_once()
     call_kwargs = screen.app_instance.submit_library_ingest_job.call_args.kwargs
     assert call_kwargs["source_path"] == str(txt)
+
+
+def test_submit_clears_the_stale_preflight_summary(tmp_path: Path):
+    """Submitting must not leave the previous file's summary on screen.
+
+    The path and title clear on submit, but the pre-flight result did not, so
+    the form simultaneously said "Enter a file path to start." and "1 plain
+    text file - 333 B" for the file already submitted, which reads as though
+    a file is still staged (task-665).
+    """
+    txt = tmp_path / "file.txt"
+    txt.write_text("hello")
+
+    screen = _minimal_library_screen()
+    form = screen._library_ingest_form
+    form.path = str(txt)
+    form.title = "Some title"
+    form.preflight = _empty_preflight(
+        type_groups={"generic": [str(txt)]}, total_files=1
+    )
+
+    mock_app = MagicMock()
+    with patch.object(LibraryScreen, "app", new_callable=lambda: property(lambda self: mock_app)):
+        screen._submit_library_ingest_form()
+
+    assert form.path == ""
+    assert form.title == ""
+    assert form.preflight is None, "stale pre-flight summary survived the submit"
+    assert form.preflight_checking is False

--- a/Tests/UI/test_library_screen.py
+++ b/Tests/UI/test_library_screen.py
@@ -1,5 +1,7 @@
 """LibraryScreen rail-level UI tests."""
 
+from pathlib import Path
+
 import pytest
 import pytest_asyncio
 from textual.widgets import Button
@@ -48,6 +50,8 @@ def _minimal_ingest_screen() -> LibraryScreen:
     """Return a LibraryScreen instance without mounting the full UI."""
     screen = object.__new__(LibraryScreen)
     screen._library_ingest_form = LibraryIngestFormState()
+    # Set by ``__init__``, which this shortcut bypasses.
+    screen._library_ingest_preflight_worker = None
     return screen
 
 
@@ -140,13 +144,24 @@ def test_do_submit_ingest_persists_options(monkeypatch) -> None:
         "audio_video": {"transcription_model": "small"},
     }
 
-    saved: list[tuple[str, str, object]] = []
+    batches: list[dict] = []
     monkeypatch.setattr(
-        "tldw_chatbook.UI.Screens.library_screen.save_setting_to_cli_config",
-        lambda section, key, value: saved.append((section, key, value)) or True,
+        "tldw_chatbook.UI.Screens.library_screen.save_settings_to_cli_config",
+        lambda section_values: batches.append(
+            {s: dict(v) for s, v in section_values.items()}
+        )
+        or True,
     )
 
     screen._do_submit_ingest("/tmp/test.pdf")
+
+    # One batched write, not one full config read/parse/reload per option key.
+    assert len(batches) == 1, f"expected a single batched save, got {len(batches)}"
+    saved = [
+        (section, key, value)
+        for section, values in batches[0].items()
+        for key, value in values.items()
+    ]
 
     assert screen.app_instance.submit_library_ingest_job.called
     assert ("library.ingest_options.pdf", "pdf_engine", "docling") in saved
@@ -327,3 +342,62 @@ async def test_handle_library_ingest_open_wires_to_open_job_in_library() -> None
 
     screen._library_ingest_job_by_id.assert_called_once_with("ingest-job-1")
     screen._open_job_in_library.assert_called_once_with(job)
+
+
+def test_ingest_browse_location_prefers_last_used_then_home(tmp_path, monkeypatch) -> None:
+    """The file browser opens somewhere the user actually keeps files.
+
+    It defaulted to ``"."`` -- whichever directory the process was started
+    from, which for anyone launching from a shell is arbitrary (task-668).
+    """
+    screen = _minimal_ingest_screen()
+
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.library_screen.get_cli_setting",
+        lambda *args, **kwargs: str(tmp_path),
+    )
+    assert screen._library_ingest_browse_location() == str(tmp_path)
+
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.library_screen.get_cli_setting",
+        lambda *args, **kwargs: None,
+    )
+    assert screen._library_ingest_browse_location() == str(Path.home())
+
+    # A remembered directory that no longer exists must not be handed back.
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.library_screen.get_cli_setting",
+        lambda *args, **kwargs: str(tmp_path / "deleted"),
+    )
+    assert screen._library_ingest_browse_location() == str(Path.home())
+
+
+def test_ingest_browse_remembers_the_directory_of_the_picked_file(
+    tmp_path, monkeypatch
+) -> None:
+    """Picking a file stores its folder, so the next Browse starts there."""
+    screen = _minimal_ingest_screen()
+    picked = tmp_path / "doc.txt"
+    picked.write_text("hi")
+
+    saved: list[tuple] = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.library_screen.save_setting_to_cli_config",
+        lambda section, key, value: saved.append((section, key, value)) or True,
+    )
+
+    screen._remember_library_ingest_location(picked)
+
+    assert saved == [("library.ingest", "last_directory", str(tmp_path))]
+
+
+def test_ingestible_file_filters_separate_importable_from_the_rest() -> None:
+    """The picker distinguishes files ingest can handle from ones it cannot."""
+    from tldw_chatbook.UI.Screens.library_screen import _ingestible_file_filters
+
+    filters = _ingestible_file_filters()
+    importable = filters[0]
+
+    assert importable(Path("/tmp/notes.txt")) is True
+    assert importable(Path("/tmp/paper.pdf")) is True
+    assert importable(Path("/tmp/cover.jpg")) is False

--- a/backlog/tasks/task-678 - Clear-the-ingest-pre-flight-summary-when-the-form-is-submitted.md
+++ b/backlog/tasks/task-678 - Clear-the-ingest-pre-flight-summary-when-the-form-is-submitted.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-678
 title: Clear the ingest pre-flight summary when the form is submitted
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-26 03:26'
+updated_date: '2026-07-26 04:09'
 labels:
   - ingest
   - ux
@@ -18,6 +19,16 @@ After a successful submit the path field empties and the form says a path is nee
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Submitting clears the pre-flight summary along with the path
-- [ ] #2 The gate line and the summary never describe different states at the same time
+- [x] #1 Submitting clears the pre-flight summary along with the path
+- [x] #2 The gate line and the summary never describe different states at the same time
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The path and title cleared on submit but the pre-flight result did not, so the canvas asserted two things at once: 'Enter a file path to start.' beside a summary of the file just submitted, reading as though something was still staged.
+
+Submit now clears the pre-flight result and its checking flag, and cancels any in-flight analysis worker first so a late result cannot repopulate what was just cleared. The cancel logic moved into its own helper shared with the trigger path.
+
+Changed: tldw_chatbook/UI/Screens/library_screen.py, Tests/UI/test_library_ingest_guardrail_modal.py, Tests/UI/test_library_screen.py
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-679 - Rewrite-ingest-option-and-warning-copy-for-end-users.md
+++ b/backlog/tasks/task-679 - Rewrite-ingest-option-and-warning-copy-for-end-users.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-679
 title: Rewrite ingest option and warning copy for end users
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-26 03:26'
+updated_date: '2026-07-26 04:25'
 labels:
   - ingest
   - ux
@@ -18,8 +19,20 @@ The per-type options panel titles the collapsible with a raw dump of internal fi
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The options panel title describes the settings in plain language rather than internal field names
-- [ ] #2 Missing-tooling hints read as complete sentences and name the install command
-- [ ] #3 A not-found path offers a correction affordance rather than Retry
-- [ ] #4 Retry remains available for failures that are genuinely retryable
+- [x] #1 The options panel title describes the settings in plain language rather than internal field names
+- [x] #2 Missing-tooling hints read as complete sentences and name the install command
+- [x] #3 A not-found path offers a correction affordance rather than Retry
+- [x] #4 Retry remains available for failures that are genuinely retryable
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Three copy defects. The collapsed options title was a dump of internal field names and repr'd values (analyze=False, chunk_size=500); it now reads 'PDF engine: pymupdf4llm, Enable OCR: off'. The scope line said 'all PDF documents files'. And missing-tooling hints were built by pasting a label in front of a hint that already contained it, giving 'PDF processing: PDF processing is unavailable: PDF ingestion.'
+
+The two metadata fields behind that hint are used inconsistently across extras -- for PDF, label/what are 'PDF processing'/'PDF ingestion'; for audio they are effectively swapped -- so any template combining both reads wrong for one of them. _install_hint now returns the capability at stake as a plain noun phrase and build_warning_lines composes the sentence, dropping the 'needed for' clause when it would merely repeat the label.
+
+Retry was also the wrong verb for the most common pre-flight error: re-running the same analysis on the same missing path fails identically. Path-shaped errors are now marked at the source (PreflightResult.path_invalid) rather than string-matched in the UI, and the canvas offers 'Choose a file…' for them while keeping Retry for genuinely retryable failures such as an unreachable URL.
+
+Changed: tldw_chatbook/Library/ingest_capabilities.py, tldw_chatbook/Library/ingest_types.py, tldw_chatbook/Library/ingest_preflight.py, tldw_chatbook/Library/library_ingest_state.py, tldw_chatbook/Widgets/Library/library_ingest_canvas.py, tldw_chatbook/UI/Screens/library_screen.py, and their tests
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-680 - Give-ingest-options-a-single-source-of-defaults-with-chunking-on.md
+++ b/backlog/tasks/task-680 - Give-ingest-options-a-single-source-of-defaults-with-chunking-on.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-680
 title: Give ingest options a single source of defaults with chunking on
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-26 03:26'
+updated_date: '2026-07-26 04:25'
 labels:
   - ingest
   - ux
@@ -18,8 +19,18 @@ Ingest option defaults are declared in two places that disagree, and the two ing
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Option defaults come from one declaration used by every ingest surface
-- [ ] #2 Chunking defaults to on with a chunk size of 1000
-- [ ] #3 Analysis defaults to off so ingest does not make LLM calls unless asked
-- [ ] #4 A user who previously saved option values keeps them
+- [x] #1 Option defaults come from one declaration used by every ingest surface
+- [x] #2 Chunking defaults to on with a chunk size of 1000
+- [x] #3 Analysis defaults to off so ingest does not make LLM calls unless asked
+- [x] #4 A user who previously saved option values keeps them
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The capability schema declared analyze=True/chunk_size=1000 while the form hard-coded analyze=False/chunk=False/chunk_size=500, and the second ingest surface defaulted chunking the other way -- so which defaults a user got depended on which screen they opened.
+
+The capability schema is now the single declaration and the form derives from it. Per the agreed product call, chunking is on with a size of 1000 (local, cheap, and without it imported documents are never chunked for retrieval) while analysis stays off (an LLM call per document that the user has not asked for). Previously saved option values still win, since they are loaded over the defaults.
+
+Changed: tldw_chatbook/Library/ingest_capabilities.py, tldw_chatbook/Library/library_ingest_state.py, Tests/Library/test_library_ingest_state.py, Tests/UI/test_library_ingest_canvas.py
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-681 - Open-the-ingest-file-browser-somewhere-useful.md
+++ b/backlog/tasks/task-681 - Open-the-ingest-file-browser-somewhere-useful.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-681
 title: Open the ingest file browser somewhere useful
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-26 03:27'
+updated_date: '2026-07-26 04:25'
 labels:
   - ingest
   - ux
@@ -18,7 +19,15 @@ The Browse action opens wherever the process happens to have been started, which
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The browser opens at the last used ingest location, falling back to the user's home directory
-- [ ] #2 The last used location survives a restart
-- [ ] #3 Files that cannot be ingested are visually distinguished from ones that can
+- [x] #1 The browser opens at the last used ingest location, falling back to the user's home directory
+- [x] #2 The last used location survives a restart
+- [x] #3 Files that cannot be ingested are visually distinguished from ones that can
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+FileOpen's location defaulted to '.', the directory the process happened to be started from, which for anyone launching from a shell has none of their documents in it. The browser now opens at the directory of the last source imported, falling back to the user's home; the location is persisted so it survives a restart. The picker also gained an 'Importable files' filter derived from the ingest capability layer, so it cannot drift from what the pipeline accepts.
+
+Changed: tldw_chatbook/UI/Screens/library_screen.py, Tests/UI/test_library_screen.py
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-682 - Stop-rewriting-the-whole-config-file-on-every-ingest-submit.md
+++ b/backlog/tasks/task-682 - Stop-rewriting-the-whole-config-file-on-every-ingest-submit.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-682
 title: Stop rewriting the whole config file on every ingest submit
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-26 03:27'
+updated_date: '2026-07-26 04:09'
 labels:
   - ingest
   - performance
@@ -18,7 +19,17 @@ Each ingest submission saves its options one key at a time, and every save re-re
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Submitting an ingest writes its options in a single batched save
-- [ ] #2 The global settings cache is invalidated at most once per submission
-- [ ] #3 Saved option values are unchanged from the previous behaviour
+- [x] #1 Submitting an ingest writes its options in a single batched save
+- [x] #2 The global settings cache is invalidated at most once per submission
+- [x] #3 Saved option values are unchanged from the previous behaviour
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Each submission looped save_setting_to_cli_config once per option key, and every call re-read and re-parsed the entire config file and invalidated the global settings cache -- about six full reload cycles for one submitted file, growing with every option and every submission.
+
+save_settings_to_cli_config already existed and does exactly one read/write and one cache reload for a whole mapping, so the submit path now builds the per-group mapping and calls it once. Saved values are unchanged; the existing persist-options test was rewritten to assert a single batched write rather than a stream of individual ones.
+
+Changed: tldw_chatbook/UI/Screens/library_screen.py, Tests/UI/test_library_screen.py
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-683 - Make-the-ingest-canvas-usable-on-a-first-visit.md
+++ b/backlog/tasks/task-683 - Make-the-ingest-canvas-usable-on-a-first-visit.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-683
 title: Make the ingest canvas usable on a first visit
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-26 03:27'
+updated_date: '2026-07-26 04:25'
 labels:
   - ingest
   - ux
@@ -18,8 +19,18 @@ On first run the ingest pane is mostly empty space with no indication of what ca
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The empty state names the kinds of content that can be imported
-- [ ] #2 The user can tell what will happen to a file after it is imported
-- [ ] #3 The path field can be cleared in one action
-- [ ] #4 The pane does not leave the majority of its area blank on first visit
+- [x] #1 The empty state names the kinds of content that can be imported
+- [x] #2 The user can tell what will happen to a file after it is imported
+- [x] #3 The path field can be cleared in one action
+- [x] #4 The pane does not leave the majority of its area blank on first visit
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+On first visit the pane was mostly empty with no indication of what could be imported or what importing would do, and a long path could only be cleared by selecting it by hand.
+
+An orientation block now names the accepted sources (file, folder, URL) and types, and says imported items become searchable and usable as chat context. The supported-type list is derived from the same labels the pre-flight breakdown uses, so the promise and the analysis cannot drift. It is shown only while the form is untouched, so it never competes with a real summary. A Clear button appears beside Browse once the field has content.
+
+Changed: tldw_chatbook/Library/library_ingest_state.py, tldw_chatbook/Widgets/Library/library_ingest_canvas.py, tldw_chatbook/UI/Screens/library_screen.py, and their tests
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-684 - Retire-the-second-ingestion-window-in-favour-of-the-Library-ingest-canvas.md
+++ b/backlog/tasks/task-684 - Retire-the-second-ingestion-window-in-favour-of-the-Library-ingest-canvas.md
@@ -4,6 +4,7 @@ title: Retire the second ingestion window in favour of the Library ingest canvas
 status: To Do
 assignee: []
 created_date: '2026-07-26 03:27'
+updated_date: '2026-07-26 04:33'
 labels:
   - ingest
   - cleanup
@@ -13,7 +14,7 @@ dependencies: []
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-The app ships two independently built ingestion interfaces with different layouts, different defaults and different selection models, reachable from different places. The second one adds files to a batch with no way to remove one, ignores a repeat click, and applies a single title to every file in the batch. Maintaining two answers to the same job doubles the bug surface and guarantees they drift.
+The app ships two ingestion interfaces. Only the second one's Local Files tab duplicates the Library ingest canvas; its Server Sources, Server Jobs and Web Clipper tabs are server-backed capabilities the canvas has no equivalent for, and the canvas states outright that ingest runs on Local. Retiring the window outright would therefore delete working features, so the three capabilities are ported into the canvas first and the window is deleted last. Tracked as an umbrella over its subtasks.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -23,4 +24,5 @@ The app ships two independently built ingestion interfaces with different layout
 - [ ] #3 Any capability the retired window had that the canvas lacked is available in the canvas
 - [ ] #4 The retired window and its now-unused event handlers are deleted
 - [ ] #5 The full test suite passes with the window removed
+- [ ] #6 Server-backed ingestion is available from the Library ingest canvas,Remote ingest job status is visible alongside local jobs,Web clipping is available from the Library ingest canvas,Import sources opens the Library ingest canvas,No route or button reaches the retired window,The retired window and its now-unused event handlers are deleted,The full test suite passes with the window removed
 <!-- AC:END -->

--- a/backlog/tasks/task-684.1 - Bring-server-backed-ingestion-into-the-Library-ingest-canvas.md
+++ b/backlog/tasks/task-684.1 - Bring-server-backed-ingestion-into-the-Library-ingest-canvas.md
@@ -1,0 +1,38 @@
+---
+id: TASK-684.1
+title: Bring server-backed ingestion into the Library ingest canvas
+status: To Do
+assignee: []
+created_date: '2026-07-26 04:33'
+updated_date: '2026-07-26 04:45'
+labels:
+  - ingest
+  - consolidation
+dependencies: []
+parent_task_id: TASK-684
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Server Sources is the only way to start a server-backed ingest, and it lives in a window the Library canvas is meant to replace. The canvas currently tells the user ingest runs on Local, with no way to target a server.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A server-backed ingest can be started from the Library ingest canvas
+- [ ] #2 The canvas shows which backend an ingest will run on and lets the user choose when both are available
+- [ ] #3 The Local-only quiet line no longer appears when a server backend is configured
+- [ ] #4 Starting a server ingest with no server configured explains what to configure
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reuse the existing server seam rather than extracting one. ServerMediaReadingService already wraps TLDWAPIClient.submit_media_ingest_jobs / list_media_ingest_jobs / cancel_media_ingest_jobs_batch, with tests in Tests/Media/test_server_media_ingest_jobs_service.py and Tests/tldw_api/test_media_ingest_jobs_client.py. The 700-line widget-coupled handler in tldw_api_events.py does NOT need untangling to get a server submit -- it can be left to die with the window in 671.4.
+2. Map the Library ingest form to MediaIngestSubmitRequest / MediaIngestJobSubmitRequest, driven by the type group pre-flight already detects.
+3. Give the ingest form a real backend choice. build_library_ingest_state takes runtime_source today and, per its own docstring, uses it for nothing but a quiet line, so the choice, its gating and its copy all belong here.
+4. Route submit through the chosen backend; keep the local path exactly as it is.
+5. Gate honestly: with no server configured the option explains what to configure rather than failing at submit.
+6. Tests at the mapping and routing seams, then a live pass against a configured server.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-684.2 - Show-remote-ingest-jobs-in-the-Library-ingest-queue.md
+++ b/backlog/tasks/task-684.2 - Show-remote-ingest-jobs-in-the-Library-ingest-queue.md
@@ -1,0 +1,38 @@
+---
+id: TASK-684.2
+title: Show remote ingest jobs in the Library ingest queue
+status: To Do
+assignee: []
+created_date: '2026-07-26 04:33'
+updated_date: '2026-07-26 04:45'
+labels:
+  - ingest
+  - consolidation
+dependencies: []
+parent_task_id: TASK-684
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Remote ingest jobs are monitored in a separate window from local ones, so a user running both has to look in two places to answer one question: what is happening to my imports.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Remote jobs appear in the same queue as local ones
+- [ ] #2 A queue row makes clear whether the job is running locally or on a server
+- [ ] #3 Remote job state changes are reflected without leaving the screen
+- [ ] #4 Queue actions behave sensibly for remote jobs or are hidden for them
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Use the existing client APIs: list_media_ingest_jobs(batch_id), get_media_ingest_job(job_id) and cancel_media_ingest_jobs_batch already exist on TLDWAPIClient and are surfaced by ServerMediaReadingService.
+2. Mirror remote jobs into LibraryIngestJobRegistry rather than merging two sources at render time, so queue rows, counts and Home's active-work adapter keep one source of truth.
+3. Give LibraryIngestJob an origin (local/server) and surface it on the row.
+4. Poll remote state on a worker and marshal updates onto the UI thread the way the parse-pool coordinator already does.
+5. Map queue actions: cancel maps to cancel_media_ingest_jobs_batch; hide the ones with no remote equivalent.
+6. Tests for row rendering, origin labelling and state transitions.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-684.3 - Bring-web-clipping-into-the-Library-ingest-canvas.md
+++ b/backlog/tasks/task-684.3 - Bring-web-clipping-into-the-Library-ingest-canvas.md
@@ -1,0 +1,36 @@
+---
+id: TASK-684.3
+title: Bring web clipping into the Library ingest canvas
+status: To Do
+assignee: []
+created_date: '2026-07-26 04:33'
+updated_date: '2026-07-26 04:45'
+labels:
+  - ingest
+  - consolidation
+dependencies: []
+parent_task_id: TASK-684
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Web clipping is a distinct way to get content into the Library and is only reachable from the window being retired.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A web page can be clipped into the Library from the ingest canvas
+- [ ] #2 Clipped pages land in the queue like any other import
+- [ ] #3 Clipper scope and destination settings remain available
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Use TLDWAPIClient.ingest_web_content (with web_clipper_schemas.py) rather than porting WebClipperPanel's internals; ServerWebClipperService and WebClipperScopeService are already constructed in app.py and survive the window's deletion.
+2. Treat a URL as what it already is in this form -- a valid ingest source -- so clipping is a behaviour of the existing path field, not a fourth mode.
+3. Route clipped pages through the job registry so they land in the queue like any other import.
+4. Preserve scope and destination settings.
+5. Tests plus a live clip.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-684.4 - Delete-the-retired-ingestion-window-and-its-dead-wiring.md
+++ b/backlog/tasks/task-684.4 - Delete-the-retired-ingestion-window-and-its-dead-wiring.md
@@ -1,0 +1,39 @@
+---
+id: TASK-684.4
+title: Delete the retired ingestion window and its dead wiring
+status: To Do
+assignee: []
+created_date: '2026-07-26 04:33'
+updated_date: '2026-07-26 04:35'
+labels:
+  - ingest
+  - cleanup
+dependencies: []
+parent_task_id: TASK-684
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Once every capability has an equivalent in the Library ingest canvas, the second window and everything that exists only to serve it should go, so the two cannot drift apart again.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Import sources opens the Library ingest canvas
+- [ ] #2 No route, button or command reaches the retired window
+- [ ] #3 The window, its panels and its now-unused event handlers are deleted
+- [ ] #4 The full test suite passes with the window removed
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Re-verify every capability of the retired window has a canvas equivalent (the gate for this task).
+2. Point #library-workspace-import-sources at the Library ingest canvas instead of NavigateToScreen('ingest').
+3. Remove the 'ingest' ScreenRoute and MediaIngestScreen.
+4. Delete MediaIngestWindowRebuilt and its four panels.
+5. Delete the handlers that existed only for it -- check local_ingest_events.py and tldw_api_events.py for callers first; both import the window directly today.
+6. Delete Tests/UI/test_media_ingest_window_rebuilt.py and any other tests of the removed surface.
+7. Full suite plus a live pass over every path that used to reach the window.
+<!-- SECTION:PLAN:END -->

--- a/tldw_chatbook/Library/ingest_capabilities.py
+++ b/tldw_chatbook/Library/ingest_capabilities.py
@@ -263,13 +263,20 @@ def _install_hint(feature_id: str) -> dict[str, str]:
     info = OPTIONAL_FEATURES.get(extra)
 
     if info is not None:
+        # ``hint`` is the *capability at stake*, not a sentence: the two
+        # metadata fields are used inconsistently across extras (for PDF,
+        # label="PDF processing"/what="PDF ingestion"; for audio they are
+        # effectively swapped), so any template combining both reads wrong for
+        # one of them. Callers compose the final line -- see
+        # ``build_warning_lines``, which pairs this with the specific missing
+        # feature's own label and drops it when the two would just repeat.
         return {
-            "hint": f"{info.label} is unavailable: {info.unavailable_what}.",
+            "hint": info.unavailable_what,
             "command": info.source_install_command,
         }
 
     return {
-        "hint": f"Optional dependency '{feature_id}' is not installed.",
+        "hint": "",
         "command": f'pip install -e ".[{feature_id}]"',
     }
 
@@ -380,14 +387,21 @@ _TYPE_GROUPS: dict[str, TypeGroupCapabilities] = {
                 name="analyze",
                 label="Analyze after ingest",
                 type="checkbox",
-                default=True,
+                # Off by default: analysis costs an LLM call per document at
+                # ingest time, which a user importing a folder has not asked
+                # for and may not have a provider configured for.
+                default=False,
                 depends_on=None,
             ),
             OptionField(
                 name="chunk",
                 label="Chunk content",
                 type="checkbox",
-                default=False,
+                # On by default: chunking is local and cheap, and without it
+                # imported documents are never chunked for retrieval, which
+                # quietly undermines search and RAG for anyone who never
+                # opens this panel.
+                default=True,
                 depends_on=None,
             ),
             OptionField(

--- a/tldw_chatbook/Library/ingest_preflight.py
+++ b/tldw_chatbook/Library/ingest_preflight.py
@@ -148,6 +148,7 @@ def analyze_path(path_or_url: str, scan_limit: int = 1000) -> PreflightResult:
     total_size = 0
     truncated = False
     total_files = 0
+    path_invalid = False
 
     if is_http_url(path_or_url):
         error = _probe_url(path_or_url)
@@ -170,9 +171,11 @@ def analyze_path(path_or_url: str, scan_limit: int = 1000) -> PreflightResult:
                 total_size=total_size,
                 truncated=truncated,
                 total_files=total_files,
+                path_invalid=True,
             )
         if not p.exists():
             errors.append(f"Path not found: {path_or_url}")
+            path_invalid = True
         elif p.is_file():
             group = get_type_group(str(p))
             type_groups.setdefault(group, []).append(str(p))
@@ -195,6 +198,7 @@ def analyze_path(path_or_url: str, scan_limit: int = 1000) -> PreflightResult:
                 warnings.extend(get_tooling_warnings(group))
         else:
             errors.append(f"Path is neither a file nor a directory: {path_or_url}")
+            path_invalid = True
 
     return PreflightResult(
         type_groups=type_groups,
@@ -203,4 +207,5 @@ def analyze_path(path_or_url: str, scan_limit: int = 1000) -> PreflightResult:
         total_size=total_size,
         truncated=truncated,
         total_files=total_files,
+        path_invalid=path_invalid,
     )

--- a/tldw_chatbook/Library/ingest_types.py
+++ b/tldw_chatbook/Library/ingest_types.py
@@ -26,6 +26,11 @@ class PreflightResult:
             is not known from the probe.
         truncated: ``True`` when a directory scan reached ``scan_limit``.
         total_files: Number of files discovered (``1`` for a reachable URL).
+        path_invalid: ``True`` when the errors are about the *path itself* --
+            missing, malformed, or neither a file nor a directory. Those are
+            not worth retrying: the same path will fail the same way, and the
+            fix is to correct it. A URL that failed to respond, by contrast,
+            may well succeed on a second attempt.
     """
 
     type_groups: dict[str, list[str]]
@@ -34,3 +39,4 @@ class PreflightResult:
     total_size: int
     truncated: bool
     total_files: int
+    path_invalid: bool = False

--- a/tldw_chatbook/Library/library_ingest_state.py
+++ b/tldw_chatbook/Library/library_ingest_state.py
@@ -14,12 +14,28 @@ from dataclasses import dataclass, field
 from pathlib import PurePath
 from typing import Any, Sequence
 
+from tldw_chatbook.Library.ingest_capabilities import get_capabilities
 from tldw_chatbook.Library.ingest_types import PreflightResult
 from tldw_chatbook.Library.library_ingest_jobs import (
     DEFAULT_CHUNK_SIZE,
     IngestJobState,
     LibraryIngestJob,
 )
+
+
+def _generic_default(name: str, fallback: Any) -> Any:
+    """Return the ``generic`` group's declared default for ``name``.
+
+    The capability schema is the single source of ingest option defaults.
+    This form echo used to hard-code its own, which disagreed with it
+    (``analyze``, ``chunk_size``) and with the other ingest surface
+    (``chunk``) -- three answers to the same question, so a user's actual
+    defaults depended on which screen they happened to open.
+    """
+    for field_spec in get_capabilities("generic").fields:
+        if field_spec.name == name:
+            return field_spec.default
+    return fallback
 
 # Exact copy values (binding -- see the L3b plan's Global Constraints).
 INGEST_HEADER_COPY = "Import media"
@@ -29,6 +45,17 @@ INGEST_UNAVAILABLE_COPY = "Ingest is unavailable in this runtime."
 QUEUE_HEADING_COPY = "Queue"
 QUEUE_EMPTY_COPY = "No ingest jobs yet."
 START_QUIET_LINE_COPY = "Enter a file path to start."
+
+# First-visit orientation. Shown only while the form is untouched, so it fills
+# the otherwise-blank pane a new user lands on without ever competing with a
+# real pre-flight summary.
+INGEST_INTRO_WHAT_COPY = (
+    "Import a file, a whole folder, or a URL. Supported: {types}."
+)
+INGEST_INTRO_NEXT_COPY = (
+    "Imported items are searchable in your Library and can be used as "
+    "context in chat."
+)
 
 # Re-exported from library_ingest_jobs.py (the lowest-level pure module in
 # the Library ingest stack) rather than redefined here -- kept as a module
@@ -153,6 +180,20 @@ def build_estimate_line(total_files: int, total_size: int, truncated: bool) -> s
     return line
 
 
+def build_intro_lines() -> tuple[str, ...]:
+    """Return the first-visit orientation lines for the ingest canvas.
+
+    The supported-type list is derived from the same labels the pre-flight
+    breakdown uses, so what the empty state promises and what the analysis
+    reports cannot drift apart.
+    """
+    types = ", ".join(plural for _singular, plural in _TYPE_GROUP_LABELS.values())
+    return (
+        INGEST_INTRO_WHAT_COPY.format(types=types),
+        INGEST_INTRO_NEXT_COPY,
+    )
+
+
 def build_warning_lines(warnings: list[dict[str, Any]]) -> list[str]:
     """Build human-readable warning lines from pre-flight warning dicts.
 
@@ -162,21 +203,40 @@ def build_warning_lines(warnings: list[dict[str, Any]]) -> list[str]:
             and optionally ``command``.
 
     Returns:
-        A list of display strings such as ``"PDF processing: PyMuPDF is not
-        installed."``.
+        A list of display strings such as ``"PDF processing isn't installed —
+        needed for PDF ingestion. Install it with: pip install -e \\".[pdf]\\""``.
+
+        Each line names the missing thing, what it costs the user, and the
+        command that fixes it. The old shape pasted a label in front of a hint
+        that already contained it, producing "PDF processing: PDF processing is
+        unavailable: PDF ingestion." -- so the "needed for" clause is dropped
+        whenever it would merely repeat the label.
     """
     lines: list[str] = []
     for warning in warnings:
-        label = warning.get("label", "")
-        hint = warning.get("hint", "")
-        if label and hint:
-            lines.append(f"{label}: {hint}")
+        label = (warning.get("label") or "").strip()
+        hint = (warning.get("hint") or "").strip()
+        command = (warning.get("command") or "").strip()
+
+        # ``hint`` is normally a noun phrase ("PDF ingestion"), but a caller
+        # may hand over a whole sentence; trimming the terminator keeps the
+        # composed line from ending in "..".
+        hint = hint.rstrip(".").strip()
+
+        if label:
+            sentence = f"{label} isn't installed"
+            if hint and hint.casefold() != label.casefold():
+                sentence += f" — needed for {hint}"
+            sentence += "."
         elif hint:
-            lines.append(hint)
-        elif label:
-            lines.append(label)
+            sentence = f"{hint}."
         else:
             lines.append(str(warning))
+            continue
+
+        if command:
+            sentence += f" Install it with: {command}"
+        lines.append(sentence)
     return lines
 
 
@@ -227,9 +287,13 @@ class LibraryIngestFormState:
     title: str = ""
     author: str = ""
     keywords: str = ""
-    analyze: bool = False
-    chunk: bool = False
-    chunk_size: str = str(DEFAULT_CHUNK_SIZE)
+    analyze: bool = field(
+        default_factory=lambda: bool(_generic_default("analyze", False))
+    )
+    chunk: bool = field(default_factory=lambda: bool(_generic_default("chunk", False)))
+    chunk_size: str = field(
+        default_factory=lambda: str(_generic_default("chunk_size", DEFAULT_CHUNK_SIZE))
+    )
     advanced_open: bool = False
     expanded_type_groups: set[str] = field(default_factory=set)
     type_options: dict[str, dict[str, Any]] = field(default_factory=dict)
@@ -361,6 +425,15 @@ class LibraryIngestCanvasState:
     queue_rows: tuple[IngestQueueRow, ...]
     queue_show_clear_finished: bool
     errors: list[str]
+    #: ``True`` when the errors are about the path itself, so the canvas
+    #: offers a way to pick a different one instead of a Retry that would
+    #: fail identically.
+    errors_are_path_problem: bool
+    #: Orientation copy for a first visit; empty once the user has
+    #: typed a path or an analysis has produced a summary.
+    intro_lines: tuple[str, ...]
+    #: Whether to offer a one-press way to empty the path field.
+    show_clear_path: bool
     type_breakdown_line: str
     estimate_line: str
     warning_lines: list[str]
@@ -632,11 +705,15 @@ def build_library_ingest_state(
             active_preflight.truncated,
         )
         warning_lines = build_warning_lines(active_preflight.warnings)
+        errors_are_path_problem = bool(
+            errors and getattr(active_preflight, "path_invalid", False)
+        )
         type_groups_list = list(type_groups.keys())
     else:
         type_groups = {}
         unsupported_files = []
         errors = []
+        errors_are_path_problem = False
         type_breakdown_line = ""
         estimate_line = ""
         warning_lines = []
@@ -646,6 +723,12 @@ def build_library_ingest_state(
     # reachable even when no plain-text files are in the selection.
     if "generic" not in type_groups_list:
         type_groups_list.append("generic")
+
+    # Orientation is for an untouched form only: once there is a path or a
+    # summary to read, it would just be noise above the real content.
+    intro_lines: tuple[str, ...] = ()
+    if not form.path.strip() and active_preflight is None:
+        intro_lines = build_intro_lines()
 
     recent_jobs = [
         job
@@ -665,6 +748,9 @@ def build_library_ingest_state(
         queue_rows=queue_rows,
         queue_show_clear_finished=queue_show_clear_finished,
         errors=errors,
+        errors_are_path_problem=errors_are_path_problem,
+        intro_lines=intro_lines,
+        show_clear_path=bool(form.path.strip()),
         type_breakdown_line=type_breakdown_line,
         estimate_line=estimate_line,
         warning_lines=warning_lines,

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -29,7 +29,11 @@ from textual.widgets import Button, Collapsible, Input, Static, TextArea
 
 from ...Chat.chat_handoff_models import ChatHandoffPayload
 from ...Chatbooks.chatbook_models import ContentType
-from ...config import get_cli_setting, save_setting_to_cli_config
+from ...config import (
+    get_cli_setting,
+    save_setting_to_cli_config,
+    save_settings_to_cli_config,
+)
 from ...Constants import (
     LIBRARY_MODE_CONVERSATIONS,
     LIBRARY_NAV_CONTEXT_CONVERSATION_ID,
@@ -175,7 +179,7 @@ from ...Sync_Interop.sync_readiness import (
     DEFAULT_SYNC_ELIGIBILITY_REGISTRY,
     build_sync_readiness_report,
 )
-from ...Third_Party.textual_fspicker import FileOpen, FileSave, SelectDirectory
+from ...Third_Party.textual_fspicker import FileOpen, FileSave, Filters, SelectDirectory
 from ...Utils.input_validation import sanitize_string, validate_text_input, validate_url
 from ...Utils.path_validation import validate_path_simple
 from ...Workspaces import (
@@ -385,6 +389,28 @@ LIBRARY_STUDY_HANDOFF_OWNERSHIP_COPY = "Generation and review run in Study."
 # How many carried-forward source titles the handoff canvas names before
 # collapsing the rest into an "and N more" count.
 LIBRARY_STUDY_HANDOFF_TITLES_CAP = 3
+
+
+def _ingestible_file_filters() -> Filters:
+    """Filters that separate importable files from the rest.
+
+    The picker previously listed every file regardless of whether ingest
+    could do anything with it, so a user could pick something that was only
+    ever going to fail. The supported set is taken from the ingest capability
+    layer, so it cannot drift from what the pipeline actually accepts.
+    """
+    from ...Library.ingest_capabilities import UNSUPPORTED_GROUP, get_type_group
+
+    def _is_ingestible(path: Path) -> bool:
+        try:
+            return get_type_group(str(path)) != UNSUPPORTED_GROUP
+        except Exception:
+            return False
+
+    return Filters(
+        ("Importable files", _is_ingestible),
+        ("All files", lambda _path: True),
+    )
 
 
 def _library_carries_forward_line(titles: Sequence[str]) -> str:
@@ -11618,6 +11644,25 @@ class LibraryScreen(BaseAppScreen):
         event.stop()
         self._library_ingest_form.keywords = event.value
 
+    @on(Button.Pressed, "#library-ingest-clear-path")
+    def handle_library_ingest_clear_path(self, event: Button.Pressed) -> None:
+        """Empty the ingest path field in one press.
+
+        Clearing a long path by hand meant selecting it first; there was no
+        affordance for the most common correction on the screen.
+
+        Args:
+            event: Button press event emitted by the "Clear" action.
+        """
+        event.stop()
+        self._cancel_library_ingest_preflight()
+        form = self._library_ingest_form
+        form.path = ""
+        form.preflight = None
+        form.preflight_checking = False
+        self.refresh(recompose=True)
+
+    @on(Button.Pressed, "#ingest-preflight-choose")
     @on(Button.Pressed, "#library-ingest-browse")
     def handle_library_ingest_browse(self, event: Button.Pressed) -> None:
         """Push a ``FileOpen`` dialog to pick a local file to ingest.
@@ -11638,13 +11683,53 @@ class LibraryScreen(BaseAppScreen):
         async def browse_callback(selected_path: Path | None) -> None:
             if selected_path is None:
                 return
+            self._remember_library_ingest_location(selected_path)
             self._library_ingest_form.path = str(selected_path)
             self.refresh(recompose=True)
             self._trigger_library_ingest_preflight(str(selected_path))
 
         self.app.push_screen(
-            FileOpen(title="Import Media"),
+            FileOpen(
+                location=self._library_ingest_browse_location(),
+                title="Import Media",
+                filters=_ingestible_file_filters(),
+            ),
             browse_callback,
+        )
+
+    def _library_ingest_browse_location(self) -> str:
+        """Return where the ingest file browser should open.
+
+        The picker defaulted to ``"."`` -- whatever directory the process
+        happened to be started from, which for anyone launching from a shell
+        is an arbitrary place with none of their documents in it. Prefer the
+        directory they last imported from, then their home directory.
+
+        Returns:
+            A directory path suitable for ``FileOpen(location=...)``.
+        """
+        remembered = get_cli_setting("library.ingest", "last_directory")
+        if remembered:
+            try:
+                candidate = Path(str(remembered)).expanduser()
+                if candidate.is_dir():
+                    return str(candidate)
+            except OSError:
+                pass
+        return str(Path.home())
+
+    def _remember_library_ingest_location(self, selected_path: Path) -> None:
+        """Persist the directory a source was picked from, for next time."""
+        try:
+            directory = (
+                selected_path
+                if selected_path.is_dir()
+                else selected_path.parent
+            )
+        except OSError:
+            return
+        save_setting_to_cli_config(
+            "library.ingest", "last_directory", str(directory)
         )
 
     @on(LibraryIngestCanvas.OptionPanelToggled)
@@ -11692,6 +11777,18 @@ class LibraryScreen(BaseAppScreen):
         if field is not None and field.type not in ("text", "number"):
             self.refresh(recompose=True)
 
+    def _cancel_library_ingest_preflight(self) -> None:
+        """Cancel any in-flight pre-flight worker, ignoring a finished one."""
+        worker = self._library_ingest_preflight_worker
+        if worker is None:
+            return
+        try:
+            if not worker.is_finished:
+                worker.cancel()
+        except Exception:
+            pass
+        self._library_ingest_preflight_worker = None
+
     def _trigger_library_ingest_preflight(self, path: str) -> None:
         """Start (or restart) the pre-flight worker for ``path``.
 
@@ -11701,12 +11798,7 @@ class LibraryScreen(BaseAppScreen):
         if not path.strip():
             self._library_ingest_form.preflight_checking = False
             return
-        if self._library_ingest_preflight_worker is not None:
-            try:
-                if not self._library_ingest_preflight_worker.is_finished:
-                    self._library_ingest_preflight_worker.cancel()
-            except Exception:
-                pass
+        self._cancel_library_ingest_preflight()
         self._library_ingest_form.preflight_checking = True
         self.refresh(recompose=True)
         self._library_ingest_preflight_worker = self._run_library_ingest_preflight(path)
@@ -11886,11 +11978,27 @@ class LibraryScreen(BaseAppScreen):
             chunk_enabled=form.chunk,
             chunk_size=clamp_chunk_size(form.chunk_size),
         )
-        for group, values in snapshot.items():
-            for key, val in values.items():
-                save_setting_to_cli_config(f"library.ingest_options.{group}", key, val)
+        # One batched write. Saving key-by-key re-read and re-parsed the whole
+        # config file and invalidated the global settings cache once per
+        # option -- roughly six full reload cycles for a single submitted file,
+        # growing with every option and every submission.
+        option_settings = {
+            f"library.ingest_options.{group}": dict(values)
+            for group, values in snapshot.items()
+            if values
+        }
+        if option_settings:
+            save_settings_to_cli_config(option_settings)
         form.path = ""
         form.title = ""
+        # The summary described the file that just left the form, so keeping
+        # it would leave the canvas asserting two things at once: "Enter a
+        # file path to start." next to "1 plain text file - 333 B", which
+        # reads as though something is still staged. Any in-flight analysis is
+        # cancelled too, so a late result cannot repopulate what was cleared.
+        self._cancel_library_ingest_preflight()
+        form.preflight = None
+        form.preflight_checking = False
         self.refresh(recompose=True)
 
     def _load_library_ingest_options_from_config(self) -> None:

--- a/tldw_chatbook/Widgets/Library/library_ingest_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_ingest_canvas.py
@@ -22,6 +22,18 @@ from tldw_chatbook.Library.library_ingest_state import (
 )
 
 
+def _summarise_option(field: Any, value: Any) -> str:
+    """Describe one option for the collapsed panel title, in plain language.
+
+    The title used to be a dump of internal field names and repr'd values
+    (``analyze=False, chunk=False, chunk_size=500, chunk_overlap=100``), which
+    told a first-time user nothing about what any of it does.
+    """
+    if field.type == "checkbox":
+        return f"{field.label}: {'on' if value else 'off'}"
+    return f"{field.label}: {value}"
+
+
 def _toggle_label(*, enabled: bool, text: str) -> str:
     """Return a toggle Button's visible label, ``✓``/``○`` convention."""
     marker = "✓" if enabled else "○"
@@ -74,14 +86,14 @@ class LibraryIngestCanvas(VerticalScroll):
         expanded: bool,
     ) -> Collapsible:
         """Build a collapsible options panel for one detected type group."""
-        scope_label = f"These options apply to all {cap.label} files in this selection."
+        scope_label = f"Applies to all {cap.label} in this import."
         children: list[Any] = [Static(scope_label, classes="type-group-scope")]
         summary_parts: list[str] = []
         cap_fields_by_name = {f.name: f for f in cap.fields}
 
         for field in cap.fields:
             value = values.get(field.name, field.default)
-            summary_parts.append(f"{field.name}={value}")
+            summary_parts.append(_summarise_option(field, value))
             # Two independent reasons a field can be uneditable: its tooling
             # is not installed, or the sibling field that gates it is off.
             disabled = field.depends_on is not None and not _is_installed(
@@ -178,12 +190,27 @@ class LibraryIngestCanvas(VerticalScroll):
             id="library-ingest-path",
             classes="library-ingest-field",
         )
-        yield Button(
-            "Browse…",
-            id="library-ingest-browse",
-            classes="library-canvas-action",
-            compact=True,
-        )
+        with Horizontal(classes="library-ingest-path-actions"):
+            yield Button(
+                "Browse…",
+                id="library-ingest-browse",
+                classes="library-canvas-action",
+                compact=True,
+            )
+            if state.show_clear_path:
+                yield Button(
+                    "Clear",
+                    id="library-ingest-clear-path",
+                    classes="library-canvas-action",
+                    compact=True,
+                )
+        for index, line in enumerate(state.intro_lines):
+            yield Static(
+                line,
+                id=f"library-ingest-intro-{index}",
+                classes="library-ingest-quiet-line",
+                markup=False,
+            )
         # Pre-flight summary replaces the old always-visible supported-types
         # line. All copy is taken straight from ``state``; this widget stays
         # render-only and does not compute pre-flight results itself.
@@ -202,12 +229,22 @@ class LibraryIngestCanvas(VerticalScroll):
                         id=f"ingest-preflight-error-{index}",
                         classes="library-ingest-quiet-line",
                     )
-                yield Button(
-                    "Retry",
-                    id="ingest-preflight-retry",
-                    classes="library-canvas-action",
-                    compact=True,
-                )
+                if state.errors_are_path_problem:
+                    # Re-running the same analysis on the same bad path fails
+                    # identically; the useful action is picking a real one.
+                    yield Button(
+                        "Choose a file…",
+                        id="ingest-preflight-choose",
+                        classes="library-canvas-action",
+                        compact=True,
+                    )
+                else:
+                    yield Button(
+                        "Retry",
+                        id="ingest-preflight-retry",
+                        classes="library-canvas-action",
+                        compact=True,
+                    )
             if state.warning_lines:
                 for index, warning in enumerate(state.warning_lines):
                     yield Static(


### PR DESCRIPTION
Second of two PRs from the Library ingest UAT. Stacked on #907 (P0/P1) — review that first; this PR's base is that branch, so the diff here is only the UX batch.

Tasks 678, 679, 680, 681, 682, 683.

## Changes

**Stale summary after submit (665).** The path and title cleared on submit but the pre-flight result did not, so the canvas said "Enter a file path to start." directly above a summary of the file just submitted. Cleared now, and any in-flight analysis is cancelled first so a late result cannot repopulate it.

**Copy (666).** Three defects:
- The collapsed options title was a dump of internal field names and repr'd values (`analyze=False, chunk=False, chunk_size=500, chunk_overlap=100`). It now reads `Analyze after ingest: off, Chunk content: on, Chunk size: 1000`.
- Missing-tooling hints pasted a label in front of a hint that already contained it: `PDF processing: PDF processing is unavailable: PDF ingestion.` The two metadata fields behind that hint are used inconsistently across extras (for PDF they are label/what = "PDF processing"/"PDF ingestion"; for audio they are effectively swapped), so any template combining both reads wrong for one of them. The hint is now a plain noun phrase and the sentence is composed, dropping the "needed for" clause when it would merely repeat the label.
- "Retry" was the wrong verb for a path that cannot be found — the same analysis fails identically. Path-shaped errors are marked at the source (`PreflightResult.path_invalid`) rather than string-matched in the UI, and the canvas offers "Choose a file…" for them while keeping Retry for genuinely retryable failures such as an unreachable URL.

**Defaults (667).** The capability schema declared `analyze=True, chunk_size=1000` while the form hard-coded `analyze=False, chunk=False, chunk_size=500`, and the second ingest surface defaulted chunking the other way — so which defaults a user got depended on which screen they opened. The schema is now the single declaration. Per the product call: chunking on at 1000 (local and cheap, and without it imported documents are never chunked for retrieval), analysis off (an LLM call per document nobody asked for). Previously saved values still win.

**File browser (668).** Opened at `"."` — the directory the process happened to be started from. Now opens at the last-used import directory, falling back to home, persisted across restarts, and filters to importable files using the ingest capability layer so it cannot drift from what the pipeline accepts.

**Config write storm (669).** Each submission saved its options one key at a time, and every save re-read and re-parsed the whole config file and invalidated the global settings cache — about six full reload cycles for a single file. Uses the existing batched save.

**First visit (670).** The pane was mostly blank with no indication of what could be imported or what importing does. An orientation block now names the accepted sources and types (derived from the same labels the pre-flight breakdown uses) and says imported items become searchable and usable as chat context. It appears only while the form is untouched. The path field gained a Clear button.

## Verification

`Tests/Library/`, `Tests/Local_Ingestion/`, `Tests/UI/test_library_ingest_canvas.py`, `test_library_screen.py`, `test_library_ingest_guardrail_modal.py`, `test_library_url_ingest_submit.py`: 826 passed. Live-verified on a fresh profile.

Several existing tests asserted the old copy verbatim; those assertions were updated to the new strings rather than the behaviour being weakened.

## Not included: task-684

684 asked to retire `MediaIngestWindowRebuilt` as a duplicate. It has four tabs, and only "Local Files" duplicates the Library canvas — Server Sources, Server Jobs and Web Clipper are server-backed features with no equivalent in the canvas, which states outright that "ingest runs on Local". Retiring it as written would delete three working features, so it is being phased: port the three panels first, then delete. Filed as 684.1-684.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Library ingest UX with clearer copy, first‑visit guidance, unified defaults, and a smarter file picker; fixes stale summaries and noisy config writes. Addresses TASK‑678..683 and splits `TASK-684` into `TASK-684.1..684.4` to port server-backed features before retiring the old window.

- **New Features**
  - Single defaults source from capabilities: chunking on (1000), analysis off; applied across ingest surfaces (TASK‑680).
  - First-visit intro explains sources (file/folder/URL) and supported types; shows only on an untouched form. Added a Clear button for the path (TASK‑683).
  - File picker opens at last-used directory (fallback to home), persists across restarts, and adds an “Importable files” filter from capabilities (TASK‑681).
  - Options panel titles use plain language (e.g., “PDF engine: pymupdf4llm”, “Enable OCR: off”); scope copy simplified (TASK‑679).

- **Bug Fixes**
  - Clearing stale preflight summary on submit; cancels any in-flight analysis to prevent late repopulation (TASK‑678).
  - Path errors are flagged at the source (`PreflightResult.path_invalid`); UI offers “Choose a file…” for them and keeps Retry for retryable URL failures (TASK‑679).
  - Batched option saves with `save_settings_to_cli_config` to stop config reload storms; saved values are unchanged (TASK‑682).

<sup>Written for commit b48e259ad2c248ba839fa07b0f6e27dd54f3c3fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

**Renumbered:** dev's dedup-round4 (#912) claimed 660-663 and 670-672 while this batch was unmerged, so it moved to 673-685 (this PR covers 678-683). Rebuilt on the rebased #907 by re-applying the source diff, so the renumbered task files and the code references agree.

**Local verification:** `Tests/Library/`, `Tests/Local_Ingestion/`, `test_library_ingest_canvas.py`, `test_library_screen.py`, `test_library_ingest_guardrail_modal.py`, `test_library_url_ingest_submit.py` -- 826 passed, 0 failed.
