### PR TITLE
Image-gen backends: fal.ai + Gemini (nano-banana) + reference-image engine seam

### DIFF
--- a/Docs/superpowers/plans/2026-07-26-imagegen-fal-gemini-fireworks.md
+++ b/Docs/superpowers/plans/2026-07-26-imagegen-fal-gemini-fireworks.md
@@ -1,0 +1,193 @@
+# fal.ai / Gemini / Fireworks Image Backends Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Three new image-generation backends (`fal`, `gemini`, `fireworks`) on the established adapter contract, plus the engine-level reference-image seam, wired through config, listing, registry, and the Settings page.
+
+**Architecture:** One adapter file per service; everything else is rows in existing tables (`_SECRETS`/`_NON_SECRET`, registry lazy-map, `BACKEND_IDS`/`FIELD_SCHEMA`, probe dispatch). One new guarded HTTP helper (`fetch_bytes_via_post`) for Fireworks' bytes-returning POST. Reference images open the dormant `ResolvedReferenceImage` seam with per-backend capability flags and fail-loudly choke-point validation. Spec: `Docs/superpowers/specs/2026-07-26-imagegen-fal-gemini-fireworks-design.md` — read it before any task.
+
+**Tech Stack:** Python 3.11+, httpx (sync, via the package's guarded helpers), pytest with fake clients.
+
+## Global Constraints
+
+- All HTTP through the package's guarded helpers (`http_client.fetch_json`, `image_format_utils.fetch_image_bytes`, and Task 1's `fetch_bytes_via_post`): egress `check_url_or_raise` pre-request, self-built URLs carry `trusted_origins=origin_set(url)`, response-extracted URLs are fully enforced (no trust, no credentials), no auto-redirects.
+- **Never follow server-provided URLs with credentials attached** (fal poll URLs are self-built; response URLs are cross-check only).
+- **Model ids are validated before URL construction**: gemini/fireworks `^[A-Za-z0-9._-]+$`; fal additionally allows `/` but rejects `..` segments, leading/trailing `/`, and any of `?#%` or whitespace.
+- API keys never in logs, error text, or URLs (gemini key goes in the `x-goog-api-key` HEADER, never `?key=`).
+- 404/400-model-unknown errors name the attempted model id and the config key (`[image_generation.<backend>] default_model`) — the task-620 pattern; copy `openrouter_image_adapter.py`'s enrichment shape.
+- Negative prompt is appended to the prompt text (openrouter precedent), never dropped.
+- `ImageGenResult.resolved_model`/`resolved_seed` only where the backend genuinely reports them — never fabricate.
+- Defaults (exact): fal base `https://queue.fal.run`, model `fal-ai/flux/schnell`, poll 2s, timeout 120; gemini base `https://generativelanguage.googleapis.com/v1beta`, model `gemini-2.5-flash-image`, timeout 120; fireworks base `https://api.fireworks.ai/inference/v1/workflows/accounts/fireworks/models`, model `flux-1-schnell-fp8`, timeout 120.
+- Env precedence: `FAL_KEY`; `GEMINI_API_KEY` then `GOOGLE_API_KEY`; `FIREWORKS_API_KEY`. Keyring ids: `fal`, `gemini`, `fireworks`.
+- Reference images: bytes-in-memory only (`ResolvedReferenceImage.content`), mime allowlist `{image/png, image/jpeg, image/webp}`, cap `IMAGE_GEN_REFERENCE_MAX_BYTES = 10 * 1024 * 1024`, unsupported-backend requests REFUSED at the `run_generation` choke point.
+- Where the spec says "implementer verifies from the API reference" (fal image_size field, gemini responseModalities requirement, fireworks body field names + image-input route, fireworks/fal probe endpoints): verify against the LIVE vendor docs via WebFetch during the task, record the verified shape + doc URL in your report, and pin it in a test. Do not guess from training data (task-620 lesson).
+- Tests FOREGROUND only (background pytest notifications never reach subagents). venv: `source /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/activate`; run from the worktree. TDD red-then-green per behavior. `ruff check` touched files; `python -c "import tldw_chatbook.app"` clean. Explicit-path staging.
+- Baseline flake (NOT yours): `test_console_conversation_browser_search_ignores_stale_results`.
+
+---
+
+### Task 1: `fetch_bytes_via_post` guarded helper
+
+**Files:**
+- Modify: `tldw_chatbook/Image_Generation/http_client.py`
+- Test: `Tests/Image_Generation/test_http_client.py`
+
+**Interfaces:**
+- Consumes: existing module internals — `_validate_egress_or_raise`, `create_client`, `egress.same_origin`/`egress._hop_headers`, `DEFAULT_MAX_REDIRECTS`, `_DEFAULT_TIMEOUT` (read `fetch_json` at :126 end-to-end first; mirror its structure).
+- Produces: `fetch_bytes_via_post(url: str, *, headers: dict | None = None, json: Any = None, timeout: float | None = None, trusted_origins: frozenset = frozenset(), max_bytes: int = 32 * 1024 * 1024) -> tuple[bytes, str]` — returns `(body_bytes, content_type_header_value)`. Raises the module's existing egress/HTTP error types exactly like `fetch_json`.
+
+- [ ] **Step 1: Failing tests** (append to `test_http_client.py`, reusing its fake-client fixtures — read the `hc` fixture and the fake-response helpers first):
+
+```python
+def test_fetch_bytes_via_post_returns_body_and_content_type(monkeypatch, hc):
+    """Happy path: POST returns bytes + the content-type header."""
+    # fake client returns 200, content=b"\x89PNG...", headers={"content-type": "image/png"}
+    body, ctype = hc.fetch_bytes_via_post("https://api.example.com/gen", json={"prompt": "x"})
+    assert body.startswith(b"\x89PNG") and ctype == "image/png"
+
+def test_fetch_bytes_via_post_validates_egress_first(monkeypatch, hc):
+    # private IP without trusted_origins -> egress error, fake client NEVER called
+
+def test_fetch_bytes_via_post_strips_credentials_on_cross_origin_redirect(monkeypatch, hc):
+    # 307 to another host: Authorization absent on hop 2; same-origin keeps it
+    # (mirror test_fetch_json_strips_authorization_on_cross_origin_redirect's fake shape)
+
+def test_fetch_bytes_via_post_redirect_to_private_ip_blocked(monkeypatch, hc):
+    # 307 Location -> 10.0.0.1 raises egress error
+
+def test_fetch_bytes_via_post_max_bytes_exceeded_raises(monkeypatch, hc):
+    # content longer than max_bytes -> clear error naming the cap, not a truncated return
+
+def test_fetch_bytes_via_post_respects_explicit_zero_timeout(monkeypatch, hc):
+    # timeout=0 passed through (the task-497 lesson), None -> _DEFAULT_TIMEOUT
+```
+
+- [ ] **Step 2: Run** `python -m pytest Tests/Image_Generation/test_http_client.py -q` → new tests FAIL (attribute missing).
+- [ ] **Step 3: Implement** by mirroring `fetch_json`'s manual redirect loop verbatim in structure: per-hop `_validate_egress_or_raise(current, trusted_origins=...)`, `same_origin` computed against the FIRST url, `egress._hop_headers(headers, is_same_origin)` on hops, json body re-sent per the module's documented redirect semantics, `raise_for_status()`, then length check against `max_bytes` before returning `(resp.content, resp.headers.get("content-type", ""))`. Google docstring stating the fireworks-shaped use case and the cap semantics.
+- [ ] **Step 4: Run** the full file green; `ruff check tldw_chatbook/Image_Generation/http_client.py`.
+- [ ] **Step 5: Commit** `feat(imagegen): guarded fetch_bytes_via_post helper`.
+
+---
+
+### Task 2: Config + listing rows for the three backends
+
+**Files:**
+- Modify: `tldw_chatbook/Image_Generation/config.py` (defaults constants ~line 40s; `_SECRETS` ~:64; `_NON_SECRET` ~:76; `ImageGenerationConfig` fields ~:190s; builder ~:380s), `tldw_chatbook/Image_Generation/listing.py`, `tldw_chatbook/config.py` (shipped default-TOML example block for `[image_generation]` — add commented sections for the three)
+- Test: `Tests/Image_Generation/test_config_loader.py`, `Tests/Image_Generation/test_listing.py` (or the file that tests is_configured — find it)
+
+**Interfaces:**
+- Produces (exact names later tasks rely on): constants `DEFAULT_FAL_IMAGE_BASE_URL/MODEL/POLL_INTERVAL_SECONDS/TIMEOUT_SECONDS`, `DEFAULT_GEMINI_IMAGE_BASE_URL/MODEL/TIMEOUT_SECONDS`, `DEFAULT_FIREWORKS_IMAGE_BASE_URL/MODEL/TIMEOUT_SECONDS` (values from Global Constraints); cfg fields `fal_image_base_url/api_key/default_model/poll_interval_seconds/timeout_seconds`, `gemini_image_base_url/api_key/default_model/timeout_seconds`, `fireworks_image_base_url/api_key/default_model/timeout_seconds`; `_SECRETS` rows `("fal", ("fal_image_api_key", ["FAL_KEY"], "fal"))` etc. per Global Constraints (use the table's existing tuple shape — note swarmui's row also carries a config-key name after the #901 fix; new rows use `"api_key"` there); `_NON_SECRET` rows mapping `("fal","base_url")→"fal_image_base_url"` etc.; `key_sources` covers the three automatically (verify).
+- `listing.py`: `_is_fal_configured`/`_is_gemini_configured`/`_is_fireworks_configured` following the sibling shape (key present ⇒ configured), registered wherever the sibling functions are dispatched.
+
+- [ ] **Step 1: Failing tests**: loader round-trip per backend (nested `[image_generation.fal] api_key/default_model/...` → flat fields + `key_sources["fal"]=="config"`); env precedence (`GEMINI_API_KEY` beats `GOOGLE_API_KEY`; each env var name surfaces as `env:<VAR>`); defaults when unset (exact constants); listing is_configured true/false per key presence for all three.
+- [ ] **Step 2: Run** → FAIL. **Step 3: Implement** the rows + listing functions + the commented default-TOML sections. **Step 4:** `Tests/Image_Generation/ -q` green (the #901 drift test in `Tests/UI/test_settings_image_gen_defaults.py` will fail ONLY after Task 7 adds schema rows — do NOT touch settings files here; run that file to confirm it still passes since `BACKEND_IDS` is unchanged so far).
+- [ ] **Step 5: Commit** `feat(imagegen): config + listing rows for fal/gemini/fireworks`.
+
+---
+
+### Task 3: Reference-image engine seam
+
+**Files:**
+- Modify: `tldw_chatbook/Image_Generation/capabilities.py` (per-backend `supports_reference_image` — read `resolve_backend_reference_image_capability` at :97 first and extend ITS mechanism rather than adding a parallel one), `tldw_chatbook/Image_Generation/request_validation.py`, `tldw_chatbook/Image_Generation/worker.py` (`build_request` optional param; `run_generation` already calls `validate_image_generation_request` at :82 — the new checks land inside the validator)
+- Test: `Tests/Image_Generation/test_request_validation.py` (or the validator's existing test file), `Tests/Image_Generation/test_worker.py`
+
+**Interfaces:**
+- Consumes: `ResolvedReferenceImage` (capabilities.py:17 — `content: bytes | None`, `mime_type`, `bytes_len`).
+- Produces: `REFERENCE_IMAGE_CAPABLE_BACKENDS: frozenset[str] = frozenset({"fal", "gemini", "fireworks"})` (in capabilities.py); `IMAGE_GEN_REFERENCE_MAX_BYTES = 10 * 1024 * 1024` and `REFERENCE_IMAGE_ALLOWED_MIMES = frozenset({"image/png", "image/jpeg", "image/webp"})` (in request_validation.py); `build_request(..., reference_image: ResolvedReferenceImage | None = None)`; validator issues (exact user-facing strings): `"backend '<id>' does not support reference images"`, `"reference image mime '<mime>' is not supported (png/jpeg/webp)"`, `"reference image exceeds the 10MB limit"`, `"reference image has no content bytes"`.
+
+- [ ] **Step 1: Failing tests**: refusal for each of the six legacy backend ids with a reference set; acceptance for the three new ids (validator passes; adapter not reached); mime matrix (webp ok, image/gif refused); oversize (10MB+1) refused; `content=None` refused; `build_request(reference_image=...)` threads to `ImageGenRequest.reference_image`.
+- [ ] **Step 2: Run** → FAIL. **Step 3: Implement** — capability set + validator checks (only when `request.reference_image is not None`), keeping every existing validation behavior untouched. **Step 4:** validator + worker files green; full `Tests/Image_Generation/ -q` green.
+- [ ] **Step 5: Commit** `feat(imagegen): reference-image capability flags + choke-point validation`.
+
+---
+
+### Task 4: Gemini adapter
+
+**Files:**
+- Create: `tldw_chatbook/Image_Generation/adapters/gemini_image_adapter.py`
+- Modify: `tldw_chatbook/Image_Generation/adapter_registry.py` (row: `"gemini": "...adapters.gemini_image_adapter.GeminiImageAdapter"`)
+- Test: `Tests/Image_Generation/test_gemini_adapter.py` (new)
+
+**Interfaces:**
+- Consumes: `fetch_json` (http_client), cfg fields from Task 2, `ImageGenRequest`/`ImageGenResult`/adapter base contract (copy `openrouter_image_adapter.py`'s class skeleton, config access, and error types — it is the closest sibling), `ResolvedReferenceImage`.
+- Produces: `GeminiImageAdapter.generate(request) -> ImageGenResult`; module-level `_validate_model_id(model: str) -> str` (raises the adapter config-error type on charset violation — regex `^[A-Za-z0-9._-]+$`).
+
+Behavior (spec §gemini, all pinned by tests):
+- URL `{base}/models/{validated_model}:generateContent`; headers `{"x-goog-api-key": key, "Content-Type": "application/json"}` — assert the key appears in NO url and NO query param.
+- Body: `{"contents": [{"parts": [<optional inlineData part>, {"text": prompt_with_negative}]}], "generationConfig": {"responseModalities": [...]}}` — VERIFY the exact responseModalities requirement for `gemini-2.5-flash-image` from https://ai.google.dev/gemini-api/docs/image-generation via WebFetch; record in report; pin in test.
+- Reference image (when set): `{"inline_data": {"mime_type": ref.mime_type, "data": base64(ref.content)}}` part BEFORE the text part.
+- Response: iterate all `candidates[*].content.parts[*]`; first part with `inlineData`/`inline_data` → b64decode. No image → error mapping: `promptFeedback.blockReason` present → `"Gemini blocked the prompt (<blockReason>)"`; candidate `finishReason` not STOP → `"Gemini returned no image (<finishReason>)"`; else `"Gemini returned no image"`. Never include response text or the prompt.
+- 400/404 naming the model → task-620 enrichment: message contains the model id and `[image_generation.gemini] default_model`.
+- Self-built URL is the only URL — `trusted_origins=origin_set(url)` on the fetch_json call.
+
+- [ ] **Step 1: Failing tests** (fake `fetch_json` patched on the adapter module, capturing kwargs): payload shape incl. header-not-query pin + responseModalities; negative-prompt appended; reference-image part shape + ordering; parts iteration across a text-then-image response; blockReason/finishReason/no-parts error matrix (sanitization: a response containing marker text must not leak into the error); model-id validation matrix (`good-model_1.0` ok; `../evil`, `a?b`, `a b` refused); 404 enrichment; trusted_origins passed.
+- [ ] **Step 2: Run** → FAIL (module missing). **Step 3: Implement.** **Step 3b (spec §gemini.4):** CONFIRM `fetch_json`'s guarded path has no byte-cap that truncates image-sized JSON (~3-8MB base64): read the redirect loop + response handling for any size limit; if one exists, ensure it accommodates image payloads or raises a CLEAR error (never a silent truncation) — record the finding in your report (OpenRouter's base64 data-URLs already traverse this path, so expected answer is "no cap"; verify, don't assume). **Step 4:** file + `Tests/Image_Generation/ -q` green; registry resolves `get_adapter("gemini")`.
+- [ ] **Step 5: Commit** `feat(imagegen): Gemini (AI Studio) image adapter`.
+
+---
+
+### Task 5: Fireworks adapter
+
+**Files:**
+- Create: `tldw_chatbook/Image_Generation/adapters/fireworks_image_adapter.py`
+- Modify: `tldw_chatbook/Image_Generation/adapter_registry.py` (row `"fireworks"`)
+- Test: `Tests/Image_Generation/test_fireworks_adapter.py` (new)
+
+**Interfaces:**
+- Consumes: Task 1's `fetch_bytes_via_post` (this is its consumer); cfg fields; base contract (openrouter skeleton); Task 3's reference validation guarantees (adapter may assume a present reference is mime/size-valid).
+- Produces: `FireworksImageAdapter.generate(request) -> ImageGenResult`; `_validate_model_id` with `^[A-Za-z0-9._-]+$`.
+
+Behavior:
+- VERIFY from https://docs.fireworks.ai/api-reference/generate-a-new-image-from-a-text-prompt via WebFetch: exact body field names (prompt/negative_prompt/width/height/steps/cfg_scale/seed spellings) and the image-input route for reference images (Kontext-family or `image_to_image` workflow); record in report, pin in tests.
+- URL `{base}/{validated_model}/text_to_image` (or the verified reference route when `request.reference_image` is set); headers `Authorization: Bearer {key}`, `Content-Type: application/json`, `Accept` from `request.format` (`png`→`image/png`, `jpeg`/`jpg`→`image/jpeg`, else `image/png`).
+- Response: `(bytes, content_type)` from `fetch_bytes_via_post`; content_type starting `image/` → success (`ImageGenResult` with those bytes + content type); JSON content_type or non-2xx → sanitized error (status + short category; never raw body), 404 → task-620 enrichment naming model + `[image_generation.fireworks] default_model`.
+- `trusted_origins=origin_set(url)` (self-built only).
+
+- [ ] **Step 1: Failing tests**: Accept mapping matrix; body field spellings (as verified — the test IS the pin); bytes-success path; JSON-error-on-same-endpoint branch (sanitized); 404 enrichment; model-id matrix; reference-image route/field selection when set; trusted_origins.
+- [ ] **Step 2: Run** → FAIL. **Step 3: Implement.** **Step 4:** green + registry resolves. **Step 5: Commit** `feat(imagegen): Fireworks image adapter`.
+
+---
+
+### Task 6: fal adapter
+
+**Files:**
+- Create: `tldw_chatbook/Image_Generation/adapters/fal_image_adapter.py`
+- Modify: `tldw_chatbook/Image_Generation/adapter_registry.py` (row `"fal"`)
+- Test: `Tests/Image_Generation/test_fal_adapter.py` (new)
+
+**Interfaces:**
+- Consumes: `fetch_json` (submit/poll), `image_format_utils.fetch_image_bytes` (result image, ENFORCED — no trust, no credentials), cfg fields incl. `fal_image_poll_interval_seconds`; Task 3's reference guarantees.
+- Produces: `FalImageAdapter.generate(request) -> ImageGenResult`; `_validate_model_path(path: str) -> str` (allows `/`; rejects `..` segments, leading/trailing `/`, `?#%` and whitespace); `_app_id(model_path: str) -> str` (first two `/`-segments; raises the config-error type if fewer than two segments).
+
+Behavior (spec §fal):
+- Submit `POST {base}/{validated_model_path}` with `Authorization: Key {key}`, body `{"prompt": prompt_with_negative, "seed": ... when set, "image_size": {"width": w, "height": h} when both set}` — VERIFY the image_size generic-object form against https://docs.fal.ai (queue + any flux schnell schema page) via WebFetch; when `request.reference_image` set add `"image_url": "data:{mime};base64,{b64}"`.
+- Extract `request_id` (validate `^[A-Za-z0-9-]+$`). Self-build `status_url = {base}/{app_id}/requests/{request_id}/status` and `result_url = {base}/{app_id}/requests/{request_id}`. **Cross-check**: if the response carries `status_url`, compare against the self-built value (exact string or parsed origin+path); mismatch → error `"fal queue URL shape changed — expected <self-built>, vendor sent a different location"` (include NEITHER credentials nor the vendor URL beyond its origin). NEVER request the vendor-provided URL.
+- Poll `status_url` with the auth header + `trusted_origins=origin_set(...)` every `poll_interval_seconds` until status COMPLETED (or IN_PROGRESS/IN_QUEUE continue; anything else → sanitized error) within `timeout_seconds` total; then GET `result_url` (auth, trusted) → `images[0].url` → `fetch_image_bytes(url)` with NO trusted_origins and NO auth header.
+- 404 on submit → task-620 enrichment naming the model path + `[image_generation.fal] default_model`.
+
+- [ ] **Step 1: Failing tests** (fake `fetch_json`/`fetch_image_bytes` capturing every call): submit payload shape (+data-URI reference; +image_size); **the self-built-URL pin** — fake submit response carries a DIFFERENT `status_url`; assert the poll call used the self-built URL and the adapter errored on the cross-check (two tests: matching status_url → polls fine; mismatching → loud error, zero polls to the vendor URL); app-id derivation (`fal-ai/flux/schnell` → polls hit `/fal-ai/flux/requests/...`; single-segment model refused); poll lifecycle (IN_QUEUE→IN_PROGRESS→COMPLETED), timeout path, FAILED status sanitized; result image fetched WITHOUT auth/trust (assert the fake fetch_image_bytes got no Authorization and no trusted_origins); request_id charset refusal; model-path matrix (`fal-ai/flux/schnell` ok, `../x` refused, `a//b` handling per the validator, trailing `/` refused); 404 enrichment.
+- [ ] **Step 2: Run** → FAIL. **Step 3: Implement** (poll sleep via `time.sleep` — blocking adapter, worker-driven; make the sleep injectable/monkeypatchable for tests). **Step 4:** green + registry resolves + full `Tests/Image_Generation/ -q` green.
+- [ ] **Step 5: Commit** `feat(imagegen): fal.ai queue image adapter with self-built poll URLs`.
+
+---
+
+### Task 7: Settings rows, probes, live tests
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/settings_image_gen_defaults.py` (`BACKEND_IDS` → nine, canonical order: existing six then `fal`, `gemini`, `fireworks`; `BACKEND_LABELS` += `"fal": "fal.ai"`, `"gemini": "Gemini (AI Studio)"`, `"fireworks": "Fireworks"`; `FIELD_SCHEMA` rows per backend: `base_url`[url], `default_model`[text], `timeout_seconds`[int,min 1], `api_key`[secret]; probe dispatch for the three), `Tests/Image_Generation/test_live_backends.py` (three opt-in live suites)
+- Test: `Tests/UI/test_settings_image_gen_defaults.py` (extend), `Tests/UI/test_settings_image_gen_panel.py` (update any nine-backend-count assertions honestly)
+
+**Interfaces:**
+- Consumes: everything from Tasks 2–6; the probe module's existing badge set and `_guarded_get` (NO new badge strings).
+- Produces: probes — gemini: `GET {base}/models` with `x-goog-api-key` → 2xx `Reachable` / 401,403 `Auth failed` / other `Unreachable: HTTP <n>`; fireworks: VERIFY via WebFetch whether `https://api.fireworks.ai/inference/v1/models` (OpenAI-compat, Bearer) exists as a cheap authed list — if yes, full auth probe; if unverifiable, reachability-only → `Reachable (auth unverified)` (record which in the report); fal: reachability-only on the configured base → `Reachable (auth unverified)`.
+
+- [ ] **Step 1: Failing tests**: drift test passes UNMODIFIED once schema rows land (it round-trips secret+non-secret keys through the real loader — Task 2 made the loader ready; if it fails, the schema/loader keys drifted — fix the ROWS, never the test); `build_backend_rows` returns nine with the new labels/key_sources; probe branches per backend (fake `_guarded_get`: gemini 200→Reachable, 401→Auth failed; fal → auth-unverified; fireworks per verified route); panel tests asserting six updated to nine (each updated assertion listed in the report).
+- [ ] **Step 2: Run** → FAIL. **Step 3: Implement** rows + probe branches + live tests (`TLDW_LIVE_FAL_API_KEY`+`TLDW_LIVE_FAL_MODEL?`, `TLDW_LIVE_GEMINI_API_KEY`, `TLDW_LIVE_FIREWORKS_API_KEY` — mirror the existing per-backend gating in `test_live_backends.py`, markers integration/optional/slow; each live test: tiny prompt, asserts non-empty image bytes; gemini additionally a reference-image edit case gated on the same key).
+- [ ] **Step 4:** `Tests/UI/test_settings_image_gen_defaults.py` + `test_settings_image_gen_panel.py` + `Tests/Image_Generation/ -q` green; `python -c "import tldw_chatbook.app"`.
+- [ ] **Step 5: Commit** `feat(settings): fal/gemini/fireworks rows, probes, opt-in live tests`.
+
+---
+
+## Post-plan (controller)
+
+Final whole-branch review (most capable model; secret-lifecycle + spec audit + the fal self-built-URL property end-to-end), then live UAT with the user's three keys (Settings probe + Console `/generate-image :backend` per backend + one nano-banana reference-image edit), then PR per the finishing flow. Backlog task filing for the program + follow-ups at PR time, IDs swept across all refs at assignment.

--- a/Docs/superpowers/plans/2026-07-26-imagegen-fal-gemini-fireworks.md
+++ b/Docs/superpowers/plans/2026-07-26-imagegen-fal-gemini-fireworks.md
@@ -1,10 +1,18 @@
 # fal.ai / Gemini / Fireworks Image Backends Implementation Plan
 
+> **2026-07-26: Fireworks DROPPED** — vendor deprecated image generation
+> 2026-06-10 (changelog; endpoints 401); user-approved. Program ships fal +
+> gemini. Task 5 (Fireworks adapter) is marked DROPPED below; its commit was
+> implemented then reset away. Task 7's rows/probe/live-test items become
+> fal+gemini only — eight backends total, not nine. The rest of this plan is
+> kept as-written for historical context; fireworks-specific items are
+> annotated rather than deleted or rewritten.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Three new image-generation backends (`fal`, `gemini`, `fireworks`) on the established adapter contract, plus the engine-level reference-image seam, wired through config, listing, registry, and the Settings page.
+**Goal:** Three new image-generation backends (`fal`, `gemini`, `fireworks`) on the established adapter contract, plus the engine-level reference-image seam, wired through config, listing, registry, and the Settings page. *(2026-07-26: fireworks dropped — see note at top of doc; goal is now two new backends, fal + gemini.)*
 
-**Architecture:** One adapter file per service; everything else is rows in existing tables (`_SECRETS`/`_NON_SECRET`, registry lazy-map, `BACKEND_IDS`/`FIELD_SCHEMA`, probe dispatch). One new guarded HTTP helper (`fetch_bytes_via_post`) for Fireworks' bytes-returning POST. Reference images open the dormant `ResolvedReferenceImage` seam with per-backend capability flags and fail-loudly choke-point validation. Spec: `Docs/superpowers/specs/2026-07-26-imagegen-fal-gemini-fireworks-design.md` — read it before any task.
+**Architecture:** One adapter file per service; everything else is rows in existing tables (`_SECRETS`/`_NON_SECRET`, registry lazy-map, `BACKEND_IDS`/`FIELD_SCHEMA`, probe dispatch). One new guarded HTTP helper (`fetch_bytes_via_post`) for Fireworks' bytes-returning POST. Reference images open the dormant `ResolvedReferenceImage` seam with per-backend capability flags and fail-loudly choke-point validation. Spec: `Docs/superpowers/specs/2026-07-26-imagegen-fal-gemini-fireworks-design.md` — read it before any task. *(`fetch_bytes_via_post` shipped in Task 1 before the drop decision and remains in the codebase, unused by any adapter now.)*
 
 **Tech Stack:** Python 3.11+, httpx (sync, via the package's guarded helpers), pytest with fake clients.
 
@@ -17,8 +25,8 @@
 - 404/400-model-unknown errors name the attempted model id and the config key (`[image_generation.<backend>] default_model`) — the task-620 pattern; copy `openrouter_image_adapter.py`'s enrichment shape.
 - Negative prompt is appended to the prompt text (openrouter precedent), never dropped.
 - `ImageGenResult.resolved_model`/`resolved_seed` only where the backend genuinely reports them — never fabricate.
-- Defaults (exact): fal base `https://queue.fal.run`, model `fal-ai/flux/schnell`, poll 2s, timeout 120; gemini base `https://generativelanguage.googleapis.com/v1beta`, model `gemini-2.5-flash-image`, timeout 120; fireworks base `https://api.fireworks.ai/inference/v1/workflows/accounts/fireworks/models`, model `flux-1-schnell-fp8`, timeout 120.
-- Env precedence: `FAL_KEY`; `GEMINI_API_KEY` then `GOOGLE_API_KEY`; `FIREWORKS_API_KEY`. Keyring ids: `fal`, `gemini`, `fireworks`.
+- Defaults (exact): fal base `https://queue.fal.run`, model `fal-ai/flux/schnell`, poll 2s, timeout 120; gemini base `https://generativelanguage.googleapis.com/v1beta`, model `gemini-2.5-flash-image`, timeout 120; fireworks base `https://api.fireworks.ai/inference/v1/workflows/accounts/fireworks/models`, model `flux-1-schnell-fp8`, timeout 120. *(fireworks defaults were implemented in Task 2 then removed when the backend was dropped.)*
+- Env precedence: `FAL_KEY`; `GEMINI_API_KEY` then `GOOGLE_API_KEY`; `FIREWORKS_API_KEY`. Keyring ids: `fal`, `gemini`, `fireworks`. *(fireworks env var/keyring id removed with the backend.)*
 - Reference images: bytes-in-memory only (`ResolvedReferenceImage.content`), mime allowlist `{image/png, image/jpeg, image/webp}`, cap `IMAGE_GEN_REFERENCE_MAX_BYTES = 10 * 1024 * 1024`, unsupported-backend requests REFUSED at the `run_generation` choke point.
 - Where the spec says "implementer verifies from the API reference" (fal image_size field, gemini responseModalities requirement, fireworks body field names + image-input route, fireworks/fal probe endpoints): verify against the LIVE vendor docs via WebFetch during the task, record the verified shape + doc URL in your report, and pin it in a test. Do not guess from training data (task-620 lesson).
 - Tests FOREGROUND only (background pytest notifications never reach subagents). venv: `source /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/activate`; run from the worktree. TDD red-then-green per behavior. `ruff check` touched files; `python -c "import tldw_chatbook.app"` clean. Explicit-path staging.
@@ -71,6 +79,8 @@ def test_fetch_bytes_via_post_respects_explicit_zero_timeout(monkeypatch, hc):
 
 ### Task 2: Config + listing rows for the three backends
 
+*(2026-07-26: implemented for all three as written below, then the fireworks rows/constants/dataclass fields/listing dispatch were surgically removed in a follow-up commit when the backend was dropped — see decision note at top of doc. fal + gemini rows are unaffected and remain exactly as specified.)*
+
 **Files:**
 - Modify: `tldw_chatbook/Image_Generation/config.py` (defaults constants ~line 40s; `_SECRETS` ~:64; `_NON_SECRET` ~:76; `ImageGenerationConfig` fields ~:190s; builder ~:380s), `tldw_chatbook/Image_Generation/listing.py`, `tldw_chatbook/config.py` (shipped default-TOML example block for `[image_generation]` — add commented sections for the three)
 - Test: `Tests/Image_Generation/test_config_loader.py`, `Tests/Image_Generation/test_listing.py` (or the file that tests is_configured — find it)
@@ -93,7 +103,7 @@ def test_fetch_bytes_via_post_respects_explicit_zero_timeout(monkeypatch, hc):
 
 **Interfaces:**
 - Consumes: `ResolvedReferenceImage` (capabilities.py:17 — `content: bytes | None`, `mime_type`, `bytes_len`).
-- Produces: `REFERENCE_IMAGE_CAPABLE_BACKENDS: frozenset[str] = frozenset({"fal", "gemini", "fireworks"})` (in capabilities.py); `IMAGE_GEN_REFERENCE_MAX_BYTES = 10 * 1024 * 1024` and `REFERENCE_IMAGE_ALLOWED_MIMES = frozenset({"image/png", "image/jpeg", "image/webp"})` (in request_validation.py); `build_request(..., reference_image: ResolvedReferenceImage | None = None)`; validator issues (exact user-facing strings): `"backend '<id>' does not support reference images"`, `"reference image mime '<mime>' is not supported (png/jpeg/webp)"`, `"reference image exceeds the 10MB limit"`, `"reference image has no content bytes"`.
+- Produces: `REFERENCE_IMAGE_CAPABLE_BACKENDS: frozenset[str] = frozenset({"fal", "gemini", "fireworks"})` (in capabilities.py); `IMAGE_GEN_REFERENCE_MAX_BYTES = 10 * 1024 * 1024` and `REFERENCE_IMAGE_ALLOWED_MIMES = frozenset({"image/png", "image/jpeg", "image/webp"})` (in request_validation.py); `build_request(..., reference_image: ResolvedReferenceImage | None = None)`; validator issues (exact user-facing strings): `"backend '<id>' does not support reference images"`, `"reference image mime '<mime>' is not supported (png/jpeg/webp)"`, `"reference image exceeds the 10MB limit"`, `"reference image has no content bytes"`. *(2026-07-26: `fireworks` removed from `REFERENCE_IMAGE_CAPABLE_BACKENDS` when the backend was dropped — the frozenset is now `{"fal", "gemini"}`.)*
 
 - [ ] **Step 1: Failing tests**: refusal for each of the six legacy backend ids with a reference set; acceptance for the three new ids (validator passes; adapter not reached); mime matrix (webp ok, image/gif refused); oversize (10MB+1) refused; `content=None` refused; `build_request(reference_image=...)` threads to `ImageGenRequest.reference_image`.
 - [ ] **Step 2: Run** → FAIL. **Step 3: Implement** — capability set + validator checks (only when `request.reference_image is not None`), keeping every existing validation behavior untouched. **Step 4:** validator + worker files green; full `Tests/Image_Generation/ -q` green.
@@ -126,7 +136,9 @@ Behavior (spec §gemini, all pinned by tests):
 
 ---
 
-### Task 5: Fireworks adapter
+### Task 5: Fireworks adapter — **DROPPED 2026-07-26**
+
+> Vendor deprecated image generation 2026-06-10 (changelog; endpoints 401); user-approved. The adapter commit was implemented then reset away — no `fireworks_image_adapter.py`, no `"fireworks"` registry row, no `test_fireworks_adapter.py` exist on the branch. The task body below is kept as-written for historical context only; do not implement it.
 
 **Files:**
 - Create: `tldw_chatbook/Image_Generation/adapters/fireworks_image_adapter.py`
@@ -173,6 +185,8 @@ Behavior (spec §fal):
 
 ### Task 7: Settings rows, probes, live tests
 
+> *2026-07-26 update: fireworks dropped — this task now adds `fal`+`gemini` only. `BACKEND_IDS` → **eight**, not nine (existing six + `fal` + `gemini`); no fireworks label/schema rows/probe branch/live-test entry. The task body below is kept as originally planned (three backends) for historical context; treat every "three"/"nine" below as "two"/"eight" and drop every fireworks-specific bullet.*
+
 **Files:**
 - Modify: `tldw_chatbook/UI/Screens/settings_image_gen_defaults.py` (`BACKEND_IDS` → nine, canonical order: existing six then `fal`, `gemini`, `fireworks`; `BACKEND_LABELS` += `"fal": "fal.ai"`, `"gemini": "Gemini (AI Studio)"`, `"fireworks": "Fireworks"`; `FIELD_SCHEMA` rows per backend: `base_url`[url], `default_model`[text], `timeout_seconds`[int,min 1], `api_key`[secret]; probe dispatch for the three), `Tests/Image_Generation/test_live_backends.py` (three opt-in live suites)
 - Test: `Tests/UI/test_settings_image_gen_defaults.py` (extend), `Tests/UI/test_settings_image_gen_panel.py` (update any nine-backend-count assertions honestly)
@@ -190,4 +204,4 @@ Behavior (spec §fal):
 
 ## Post-plan (controller)
 
-Final whole-branch review (most capable model; secret-lifecycle + spec audit + the fal self-built-URL property end-to-end), then live UAT with the user's three keys (Settings probe + Console `/generate-image :backend` per backend + one nano-banana reference-image edit), then PR per the finishing flow. Backlog task filing for the program + follow-ups at PR time, IDs swept across all refs at assignment.
+Final whole-branch review (most capable model; secret-lifecycle + spec audit + the fal self-built-URL property end-to-end), then live UAT with the user's three keys (Settings probe + Console `/generate-image :backend` per backend + one nano-banana reference-image edit), then PR per the finishing flow. Backlog task filing for the program + follow-ups at PR time, IDs swept across all refs at assignment. *(2026-07-26: "three keys"/"per backend" now means fal + gemini only — see decision note at top of doc.)*

--- a/Docs/superpowers/specs/2026-07-26-imagegen-fal-gemini-fireworks-design.md
+++ b/Docs/superpowers/specs/2026-07-26-imagegen-fal-gemini-fireworks-design.md
@@ -1,9 +1,17 @@
 # Image-gen backends: fal.ai, Gemini (AI Studio), Fireworks — design
 
+> **2026-07-26: Fireworks DROPPED** — vendor deprecated image generation
+> 2026-06-10 (changelog; endpoints 401); user-approved. Program ships fal +
+> gemini. The rest of this document is kept as-written for historical
+> context (it was the approved design at the time); sections that are now
+> Fireworks-only are annotated below rather than deleted or rewritten.
+
 Date: 2026-07-26. Status: approved pending user review.
 Adds three backends to `tldw_chatbook/Image_Generation/` on the established adapter contract. API shapes verified against live vendor docs 2026-07-26 (the task-620 stale-model lesson): fal queue API at `queue.fal.run` with `Authorization: Key`; Gemini `generateContent` with `x-goog-api-key` returning base64 `inlineData` (Imagen is deprecated, shutdown 2026-08-17 — not used); Fireworks workflows `text_to_image` returning raw bytes with Bearer auth.
 
 ## Decisions (user-approved)
+
+> *2026-07-26 update: Fireworks entries below are historical — the backend was dropped (see note at top of doc). Live scope is fal + gemini only.*
 
 - Backend ids: `fal`, `gemini`, `fireworks`. Labels: "fal.ai", "Gemini (AI Studio)", "Fireworks".
 - Defaults: fal `fal-ai/flux/schnell`; gemini `gemini-2.5-flash-image` (nano-banana); fireworks `flux-1-schnell-fp8`.
@@ -14,10 +22,10 @@ Adds three backends to `tldw_chatbook/Image_Generation/` on the established adap
 
 One adapter file per service under `Image_Generation/adapters/` implementing the existing base contract (`generate(request) -> ImageGenResult`, sync/blocking, worker-driven). Everything else is table rows:
 - Registry lazy-map entry per backend.
-- `Image_Generation/config.py`: defaults constants, `ImageGenerationConfig` fields, `_SECRETS` rows (`fal`: `fal_image_api_key`, env `["FAL_KEY"]`, keyring `fal`; `gemini`: `gemini_image_api_key`, env `["GEMINI_API_KEY", "GOOGLE_API_KEY"]` (order = precedence, the modelstudio two-var pattern), keyring `gemini`; `fireworks`: `fireworks_image_api_key`, env `["FIREWORKS_API_KEY"]`, keyring `fireworks`), `_NON_SECRET` rows (`base_url`, `default_model`, `timeout_seconds` each; fal also `poll_interval_seconds`), `key_sources` picks the new rows up automatically.
-- Defaults: fal base `https://queue.fal.run`, poll interval 2s, timeout 120s; gemini base `https://generativelanguage.googleapis.com/v1beta`, timeout 120s; fireworks base `https://api.fireworks.ai/inference/v1/workflows/accounts/fireworks/models`, timeout 120s.
+- `Image_Generation/config.py`: defaults constants, `ImageGenerationConfig` fields, `_SECRETS` rows (`fal`: `fal_image_api_key`, env `["FAL_KEY"]`, keyring `fal`; `gemini`: `gemini_image_api_key`, env `["GEMINI_API_KEY", "GOOGLE_API_KEY"]` (order = precedence, the modelstudio two-var pattern), keyring `gemini`; `fireworks`: `fireworks_image_api_key`, env `["FIREWORKS_API_KEY"]`, keyring `fireworks`), `_NON_SECRET` rows (`base_url`, `default_model`, `timeout_seconds` each; fal also `poll_interval_seconds`), `key_sources` picks the new rows up automatically. *(2026-07-26: the fireworks `_SECRETS`/`_NON_SECRET` rows and dataclass fields were implemented then removed when the backend was dropped — see decision note.)*
+- Defaults: fal base `https://queue.fal.run`, poll interval 2s, timeout 120s; gemini base `https://generativelanguage.googleapis.com/v1beta`, timeout 120s; fireworks base `https://api.fireworks.ai/inference/v1/workflows/accounts/fireworks/models`, timeout 120s. *(fireworks defaults removed with the backend.)*
 - `listing.py`: is_configured per backend (key present; same non-critical-exception envelope as siblings).
-- Settings (`settings_image_gen_defaults.py`): `BACKEND_IDS` += 3 (canonical order: existing six, then `fal`, `gemini`, `fireworks`), `BACKEND_LABELS`, `FIELD_SCHEMA` rows mirroring openrouter's (`base_url`[url], `default_model`[text], `timeout_seconds`[int,min 1], `api_key`[secret]); probe table below. The panel, draft/save, key UX, and drift test pick the rows up with no panel code changes (that is the point of the schema-driven design; any test asserting six backends updates honestly to nine).
+- Settings (`settings_image_gen_defaults.py`): `BACKEND_IDS` += 3 (canonical order: existing six, then `fal`, `gemini`, `fireworks`), `BACKEND_LABELS`, `FIELD_SCHEMA` rows mirroring openrouter's (`base_url`[url], `default_model`[text], `timeout_seconds`[int,min 1], `api_key`[secret]); probe table below. The panel, draft/save, key UX, and drift test pick the rows up with no panel code changes (that is the point of the schema-driven design; any test asserting six backends updates honestly to nine). *(2026-07-26: Task 7 (not yet implemented as of the Fireworks-drop decision) now adds only `fal`+`gemini` — `BACKEND_IDS` += 2, eight backends total, not nine.)*
 
 ## Adapters
 
@@ -33,47 +41,49 @@ One adapter file per service under `Image_Generation/adapters/` implementing the
 3. Response: iterate ALL `candidates[].content.parts[]`; first `inlineData` part wins → base64-decode with its `mimeType`. **No-image responses are a first-class error path**: safety blocks / text-only answers (`promptFeedback.blockReason`, `finishReason` SAFETY etc.) map to a clear sanitized error naming only the reason CATEGORY (never response text, never the prompt) — no index crashes on missing parts.
 4. Response size: the base64 image arrives inside the JSON body (~3MB+ at 1024²). OpenRouter already receives base64 data-URLs through the same guarded `fetch_json` path, so this works today — the implementer CONFIRMS no byte-cap in the guarded path truncates image-sized JSON rather than assuming (and raises a clear error if a cap is hit).
 
-**fireworks (`fireworks_image_adapter.py`)** — single call, bytes back:
+**fireworks (`fireworks_image_adapter.py`)** — single call, bytes back — **DROPPED 2026-07-26** (see decision note at top of doc; the adapter commit was implemented then reset away when the backend was dropped, and this section is kept for historical context only):
 1. `POST {base}/{model}/text_to_image`, `Authorization: Bearer {api_key}`, `Content-Type: application/json`, `Accept` derived from `ImageGenRequest.format` (`png`→`image/png`, `jpeg`→`image/jpeg`; pinned by test); body maps `prompt`/`negative_prompt`/`width`/`height`/`steps`/`cfg_scale`/`seed` directly (implementer verifies current field names from the API reference).
 2. Response is RAW IMAGE BYTES on success; error responses arrive as JSON on the same endpoint — the adapter distinguishes by status + content-type and surfaces sanitized errors (never raw response bodies; a 404 gets the task-620 enriched message naming the attempted model id and `[image_generation.fireworks] default_model`).
 
 **Shared requirements (all three):**
-- **Model-id shape validation before URL construction** — NEW attack surface unique to these adapters: the model id becomes part of the URL path (existing six carry it in the JSON body). Charset allowlists per backend: gemini/fireworks `[A-Za-z0-9._-]+`; fal additionally allows `/` (path-shaped ids) but rejects `..` segments, leading/trailing `/`, and any of `?#%\s`. Violations raise the adapter's config-error type naming the offending id.
+- **Model-id shape validation before URL construction** — NEW attack surface unique to these adapters: the model id becomes part of the URL path (existing six carry it in the JSON body). Charset allowlists per backend: gemini/fireworks `[A-Za-z0-9._-]+`; fal additionally allows `/` (path-shaped ids) but rejects `..` segments, leading/trailing `/`, and any of `?#%\s`. Violations raise the adapter's config-error type naming the offending id. *(fireworks dropped 2026-07-26 — only gemini's allowlist applies going forward.)*
 - All HTTP through the package's guarded helpers; the task-620 enriched not-found messaging pattern applied per backend (404/400-model-unknown names the model id + config key).
 - `api_key` never logged, never in error text; negative prompt appended not dropped; `ImageGenResult` populated per contract (resolved_model only where genuinely reported — do not fabricate).
 
 ## http_client addition
 
-`fetch_bytes_via_post(url, *, headers, json, timeout, trusted_origins) -> tuple[bytes, str]` (bytes + content-type): fireworks' shape (POST returning bytes) fits neither `fetch_json` (JSON-only) nor `fetch_image_bytes` (GET-shaped). Same discipline as both: egress `check_url_or_raise` with trusted_origins pre-request, no auto-redirects, per-hop revalidation with `same_origin`-gated credential stripping on any redirect, explicit timeout honoring `timeout=0`, size-bounded read. Unit-tested with the same fake-client matrix as the existing helpers (incl. the cross-origin cred-strip and redirect-to-private cases).
+`fetch_bytes_via_post(url, *, headers, json, timeout, trusted_origins) -> tuple[bytes, str]` (bytes + content-type): fireworks' shape (POST returning bytes) fits neither `fetch_json` (JSON-only) nor `fetch_image_bytes` (GET-shaped). Same discipline as both: egress `check_url_or_raise` with trusted_origins pre-request, no auto-redirects, per-hop revalidation with `same_origin`-gated credential stripping on any redirect, explicit timeout honoring `timeout=0`, size-bounded read. Unit-tested with the same fake-client matrix as the existing helpers (incl. the cross-origin cred-strip and redirect-to-private cases). *(2026-07-26: the helper (Task 1) shipped and stays in the codebase — it was fireworks' original motivation but is generic and harmless to keep; it is simply unused by any adapter now that fireworks is dropped.)*
 
 ## Settings probes
 
 - gemini: `GET {base}/models` with `x-goog-api-key` → 2xx `Reachable` / 401,403 `Auth failed` / other mapping — full auth-verified probe (cheap list endpoint exists).
-- fireworks: implementer checks for the OpenAI-compat `GET .../inference/v1/models` with Bearer on the api.fireworks.ai host; if confirmed cheap+authed, full probe; else reachability-only → `Reachable (auth unverified)`.
+- fireworks: implementer checks for the OpenAI-compat `GET .../inference/v1/models` with Bearer on the api.fireworks.ai host; if confirmed cheap+authed, full probe; else reachability-only → `Reachable (auth unverified)`. *(dropped 2026-07-26 — never implemented.)*
 - fal: reachability-only on the configured base (no confirmed cheap authed endpoint) → `Reachable (auth unverified)`.
 - All through the existing probe module's closed badge set and sanitization; no new badge strings.
 
 ## Testing
 
-- Per-adapter unit suites (`Tests/Image_Generation/test_{fal,gemini,fireworks}_adapter.py`) with fake clients patched on the real module: payload shape incl. auth-header placement (gemini: header-not-query pinned), model-id validation matrix (incl. fal `..` rejection), response parsing (gemini all-parts iteration + no-image/safety mapping; fireworks bytes-vs-JSON-error branch; fal poll lifecycle with SELF-BUILT URL assertion — the fake asserts the poll URL was constructed from config base + request_id, NOT taken from the response's status_url), error sanitization, egress trust threading (self-built trusted; extracted enforced).
+- Per-adapter unit suites (`Tests/Image_Generation/test_{fal,gemini,fireworks}_adapter.py`) with fake clients patched on the real module: payload shape incl. auth-header placement (gemini: header-not-query pinned), model-id validation matrix (incl. fal `..` rejection), response parsing (gemini all-parts iteration + no-image/safety mapping; fireworks bytes-vs-JSON-error branch; fal poll lifecycle with SELF-BUILT URL assertion — the fake asserts the poll URL was constructed from config base + request_id, NOT taken from the response's status_url), error sanitization, egress trust threading (self-built trusted; extracted enforced). *(2026-07-26: no `test_fireworks_adapter.py` exists — the adapter commit was reset away before merge.)*
 - `fetch_bytes_via_post` helper suite as above.
 - Config loader: new `_SECRETS`/`_NON_SECRET` rows, key_sources for the gemini two-var precedence.
-- Settings: the existing drift test must pass unmodified (it validates schema-vs-loader automatically); backend-count-sensitive tests updated to nine; probe tests for the two/three new probe branches.
-- Opt-in live tests per backend in `test_live_backends.py` style (`TLDW_LIVE_FAL_API_KEY` etc., markers integration/optional/slow).
-- Live UAT (post merge-readiness, user keys): per backend — Settings probe, then Console `/generate-image :backend <prompt>` end-to-end with card verification; the OpenRouter UAT recipe.
+- Settings: the existing drift test must pass unmodified (it validates schema-vs-loader automatically); backend-count-sensitive tests updated to nine; probe tests for the two/three new probe branches. *(2026-07-26: eight backends total, not nine — see Architecture section note.)*
+- Opt-in live tests per backend in `test_live_backends.py` style (`TLDW_LIVE_FAL_API_KEY` etc., markers integration/optional/slow). *(fireworks live-test entry dropped with the backend.)*
+- Live UAT (post merge-readiness, user keys): per backend — Settings probe, then Console `/generate-image :backend <prompt>` end-to-end with card verification; the OpenRouter UAT recipe. *(fireworks UAT case dropped with the backend.)*
 
 ## Reference images (engine seam — user-approved scope addition)
 
+> *2026-07-26 update: implemented for fal + gemini only — `REFERENCE_IMAGE_CAPABLE_BACKENDS` is `frozenset({"fal", "gemini"})` (fireworks removed post-drop).*
+
 The P1 port left a dormant seam that this program opens at the ENGINE level for the three new backends (Console attach UX is a follow-up spec — engine first, surface second):
 - `ImageGenRequest.reference_image: ResolvedReferenceImage | None` already exists (`capabilities.py`: bytes `content`, `mime_type`, dims) — the request shape needs no change. `worker.build_request` gains an optional `reference_image` param that populates it.
-- **Per-backend capability flags**: `supports_reference_image` — True for `fal`, `gemini`, `fireworks`; False for the existing six (modelstudio's dormant per-model map stays dormant; per-model gating remains v2). Exposed via the existing `resolve_backend_reference_image_capability` seam so callers can query it.
+- **Per-backend capability flags**: `supports_reference_image` — True for `fal`, `gemini`, `fireworks`; False for the existing six (modelstudio's dormant per-model map stays dormant; per-model gating remains v2). Exposed via the existing `resolve_backend_reference_image_capability` seam so callers can query it. *(fireworks entry removed 2026-07-26.)*
 - **Fail loudly, never silently ignore**: `run_generation`'s validation choke point rejects a request carrying a reference image for a backend whose flag is False ("backend X does not support reference images") — the silent no-op contract of the dormant seam ends with this program.
 - **Validation at the choke point**: mime allowlist (png/jpeg/webp), size cap `IMAGE_GEN_REFERENCE_MAX_BYTES = 10 * 1024 * 1024`, non-empty content bytes required (file_id/temp_path variants are NOT accepted by the engine — bytes-in-memory only, preserving the P1 no-media-DB-coupling decision).
 - **Per-adapter encoding**:
   - gemini: an `inlineData` part (`{inline_data: {mime_type, data: <b64>}}`) alongside the text part — nano-banana's native editing input.
   - fal: `image_url` field as a base64 data URI (`data:{mime};base64,...`) — fal accepts data URIs, avoiding any fal-storage upload scope. When a reference is present the model is used as-is (choosing an image-capable fal model is the caller's job; a model that ignores image_url is vendor behavior, not adapter error).
-  - fireworks: implementer verifies the current image-input field/route from the API reference (Kontext-family workflows; possibly a distinct `image_to_image`/kontext endpoint) — if the configured model's workflow does not accept an image input the adapter surfaces the vendor error sanitized; if a distinct route exists the adapter selects it when a reference is present.
-- **Tests**: per-adapter encoding shape (gemini part structure; fal data-URI; fireworks field/route selection); choke-point refusal for unsupported backends (all six legacy ids); mime/size validation matrix; capability-flag exposure.
+  - fireworks: implementer verifies the current image-input field/route from the API reference (Kontext-family workflows; possibly a distinct `image_to_image`/kontext endpoint) — if the configured model's workflow does not accept an image input the adapter surfaces the vendor error sanitized; if a distinct route exists the adapter selects it when a reference is present. *(dropped 2026-07-26 — never implemented.)*
+- **Tests**: per-adapter encoding shape (gemini part structure; fal data-URI; fireworks field/route selection); choke-point refusal for unsupported backends (all six legacy ids); mime/size validation matrix; capability-flag exposure. *(fireworks encoding-shape test never existed; the choke-point/mime/size/capability tests cover fal+gemini.)*
 - **Live UAT addition**: one nano-banana edit case (tiny reference image + edit instruction) alongside the text-to-image cases.
 
 ## Non-goals

--- a/Docs/superpowers/specs/2026-07-26-imagegen-fal-gemini-fireworks-design.md
+++ b/Docs/superpowers/specs/2026-07-26-imagegen-fal-gemini-fireworks-design.md
@@ -23,7 +23,7 @@ One adapter file per service under `Image_Generation/adapters/` implementing the
 
 **fal (`fal_image_adapter.py`)** — queue + poll, the novita/modelstudio precedent:
 1. Submit `POST {base}/{model_path}` with header `Authorization: Key {api_key}`, JSON body: `prompt` (negative prompt appended as a suffix line, the openrouter precedent), `seed` when set, size mapping when width/height set (fal `image_size` enum or `{width,height}` object — implementer verifies exact field from the model schema and uses the generic form).
-2. **Poll URLs are SELF-BUILT, never response-followed**: the submit response's `request_id` is combined with the CONFIGURED base into `{base}/{model_path}/requests/{request_id}/status` and `/requests/{request_id}` (fal's documented deterministic queue shapes). The response's `status_url`/`response_url` fields are IGNORED — following server-provided URLs while attaching `Authorization` is a credential-exfiltration primitive our egress posture exists to prevent. `request_id` is validated (UUID-ish charset) before URL use.
+2. **Poll URLs are SELF-BUILT, never response-followed**: the submit response's `request_id` is combined with the CONFIGURED base into `{base}/{app_id}/requests/{request_id}/status` and `/requests/{request_id}` — where **`app_id` is the first two segments of the model path** (`fal-ai/flux/schnell` → app `fal-ai/flux`; fal's queue addresses requests by app, not full model path — a naive full-path build 404s for our own default model). The response's `status_url`/`response_url` fields are NEVER followed (following server-provided URLs while attaching `Authorization` is a credential-exfiltration primitive) but ARE used as a cross-check: assert the response-provided status_url matches the self-built URL (origin + path); on mismatch fail loudly with a clear "fal queue URL shape changed" error so vendor drift surfaces as a diagnosis, not silent 404s. `request_id` is validated (UUID-ish charset) before URL use.
 3. Poll with the auth header at `poll_interval_seconds` until COMPLETED/timeout; result `images[0].url` (fal CDN, different origin) is fetched via the shared `fetch_image_bytes` as an ENFORCED-untrusted URL (no trusted_origins, no credentials — exactly the openrouter image-link pattern).
 - Self-built submit/poll URLs carry `trusted_origins=origin_set(url)` (allows operator-pointed private bases; metadata IPs still hard-blocked).
 
@@ -34,7 +34,7 @@ One adapter file per service under `Image_Generation/adapters/` implementing the
 4. Response size: the base64 image arrives inside the JSON body (~3MB+ at 1024²). OpenRouter already receives base64 data-URLs through the same guarded `fetch_json` path, so this works today — the implementer CONFIRMS no byte-cap in the guarded path truncates image-sized JSON rather than assuming (and raises a clear error if a cap is hit).
 
 **fireworks (`fireworks_image_adapter.py`)** — single call, bytes back:
-1. `POST {base}/{model}/text_to_image`, `Authorization: Bearer {api_key}`, `Content-Type: application/json`, `Accept: image/png` (or the vendor's documented accept for format selection); body maps `prompt`/`negative_prompt`/`width`/`height`/`steps`/`cfg_scale`/`seed` directly (implementer verifies current field names from the API reference).
+1. `POST {base}/{model}/text_to_image`, `Authorization: Bearer {api_key}`, `Content-Type: application/json`, `Accept` derived from `ImageGenRequest.format` (`png`→`image/png`, `jpeg`→`image/jpeg`; pinned by test); body maps `prompt`/`negative_prompt`/`width`/`height`/`steps`/`cfg_scale`/`seed` directly (implementer verifies current field names from the API reference).
 2. Response is RAW IMAGE BYTES on success; error responses arrive as JSON on the same endpoint — the adapter distinguishes by status + content-type and surfaces sanitized errors (never raw response bodies; a 404 gets the task-620 enriched message naming the attempted model id and `[image_generation.fireworks] default_model`).
 
 **Shared requirements (all three):**
@@ -62,9 +62,23 @@ One adapter file per service under `Image_Generation/adapters/` implementing the
 - Opt-in live tests per backend in `test_live_backends.py` style (`TLDW_LIVE_FAL_API_KEY` etc., markers integration/optional/slow).
 - Live UAT (post merge-readiness, user keys): per backend — Settings probe, then Console `/generate-image :backend <prompt>` end-to-end with card verification; the OpenRouter UAT recipe.
 
+## Reference images (engine seam — user-approved scope addition)
+
+The P1 port left a dormant seam that this program opens at the ENGINE level for the three new backends (Console attach UX is a follow-up spec — engine first, surface second):
+- `ImageGenRequest.reference_image: ResolvedReferenceImage | None` already exists (`capabilities.py`: bytes `content`, `mime_type`, dims) — the request shape needs no change. `worker.build_request` gains an optional `reference_image` param that populates it.
+- **Per-backend capability flags**: `supports_reference_image` — True for `fal`, `gemini`, `fireworks`; False for the existing six (modelstudio's dormant per-model map stays dormant; per-model gating remains v2). Exposed via the existing `resolve_backend_reference_image_capability` seam so callers can query it.
+- **Fail loudly, never silently ignore**: `run_generation`'s validation choke point rejects a request carrying a reference image for a backend whose flag is False ("backend X does not support reference images") — the silent no-op contract of the dormant seam ends with this program.
+- **Validation at the choke point**: mime allowlist (png/jpeg/webp), size cap `IMAGE_GEN_REFERENCE_MAX_BYTES = 10 * 1024 * 1024`, non-empty content bytes required (file_id/temp_path variants are NOT accepted by the engine — bytes-in-memory only, preserving the P1 no-media-DB-coupling decision).
+- **Per-adapter encoding**:
+  - gemini: an `inlineData` part (`{inline_data: {mime_type, data: <b64>}}`) alongside the text part — nano-banana's native editing input.
+  - fal: `image_url` field as a base64 data URI (`data:{mime};base64,...`) — fal accepts data URIs, avoiding any fal-storage upload scope. When a reference is present the model is used as-is (choosing an image-capable fal model is the caller's job; a model that ignores image_url is vendor behavior, not adapter error).
+  - fireworks: implementer verifies the current image-input field/route from the API reference (Kontext-family workflows; possibly a distinct `image_to_image`/kontext endpoint) — if the configured model's workflow does not accept an image input the adapter surfaces the vendor error sanitized; if a distinct route exists the adapter selects it when a reference is present.
+- **Tests**: per-adapter encoding shape (gemini part structure; fal data-URI; fireworks field/route selection); choke-point refusal for unsupported backends (all six legacy ids); mime/size validation matrix; capability-flag exposure.
+- **Live UAT addition**: one nano-banana edit case (tiny reference image + edit instruction) alongside the text-to-image cases.
+
 ## Non-goals
 
-Image-to-image / editing modes (Kontext, gemini image inputs); fal websocket/realtime; LoRA/ControlNet params; per-backend `allowed_extra_params` curation beyond the existing config-only mechanism; Vertex-AI service-account auth for Gemini (AI-Studio API keys only, per the request).
+Console/UI reference-image attach UX (follow-up spec); per-MODEL reference gating (the dormant `reference_image_supported_models` map stays dormant); reference images for the six existing backends; fal websocket/realtime; LoRA/ControlNet params; per-backend `allowed_extra_params` curation beyond the existing config-only mechanism; Vertex-AI service-account auth for Gemini (AI-Studio API keys only, per the request).
 
 ## Risks
 

--- a/Docs/superpowers/specs/2026-07-26-imagegen-fal-gemini-fireworks-design.md
+++ b/Docs/superpowers/specs/2026-07-26-imagegen-fal-gemini-fireworks-design.md
@@ -1,0 +1,73 @@
+# Image-gen backends: fal.ai, Gemini (AI Studio), Fireworks — design
+
+Date: 2026-07-26. Status: approved pending user review.
+Adds three backends to `tldw_chatbook/Image_Generation/` on the established adapter contract. API shapes verified against live vendor docs 2026-07-26 (the task-620 stale-model lesson): fal queue API at `queue.fal.run` with `Authorization: Key`; Gemini `generateContent` with `x-goog-api-key` returning base64 `inlineData` (Imagen is deprecated, shutdown 2026-08-17 — not used); Fireworks workflows `text_to_image` returning raw bytes with Bearer auth.
+
+## Decisions (user-approved)
+
+- Backend ids: `fal`, `gemini`, `fireworks`. Labels: "fal.ai", "Gemini (AI Studio)", "Fireworks".
+- Defaults: fal `fal-ai/flux/schnell`; gemini `gemini-2.5-flash-image` (nano-banana); fireworks `flux-1-schnell-fp8`.
+- Live UAT with user-provided keys for all three after merge-readiness; opt-in live tests (`TLDW_LIVE_*` pattern) regardless.
+- Per-service adapters (no generic REST abstraction, no OpenAI-compat shims — response shapes differ too much; codebase precedent is per-service).
+
+## Architecture
+
+One adapter file per service under `Image_Generation/adapters/` implementing the existing base contract (`generate(request) -> ImageGenResult`, sync/blocking, worker-driven). Everything else is table rows:
+- Registry lazy-map entry per backend.
+- `Image_Generation/config.py`: defaults constants, `ImageGenerationConfig` fields, `_SECRETS` rows (`fal`: `fal_image_api_key`, env `["FAL_KEY"]`, keyring `fal`; `gemini`: `gemini_image_api_key`, env `["GEMINI_API_KEY", "GOOGLE_API_KEY"]` (order = precedence, the modelstudio two-var pattern), keyring `gemini`; `fireworks`: `fireworks_image_api_key`, env `["FIREWORKS_API_KEY"]`, keyring `fireworks`), `_NON_SECRET` rows (`base_url`, `default_model`, `timeout_seconds` each; fal also `poll_interval_seconds`), `key_sources` picks the new rows up automatically.
+- Defaults: fal base `https://queue.fal.run`, poll interval 2s, timeout 120s; gemini base `https://generativelanguage.googleapis.com/v1beta`, timeout 120s; fireworks base `https://api.fireworks.ai/inference/v1/workflows/accounts/fireworks/models`, timeout 120s.
+- `listing.py`: is_configured per backend (key present; same non-critical-exception envelope as siblings).
+- Settings (`settings_image_gen_defaults.py`): `BACKEND_IDS` += 3 (canonical order: existing six, then `fal`, `gemini`, `fireworks`), `BACKEND_LABELS`, `FIELD_SCHEMA` rows mirroring openrouter's (`base_url`[url], `default_model`[text], `timeout_seconds`[int,min 1], `api_key`[secret]); probe table below. The panel, draft/save, key UX, and drift test pick the rows up with no panel code changes (that is the point of the schema-driven design; any test asserting six backends updates honestly to nine).
+
+## Adapters
+
+**fal (`fal_image_adapter.py`)** — queue + poll, the novita/modelstudio precedent:
+1. Submit `POST {base}/{model_path}` with header `Authorization: Key {api_key}`, JSON body: `prompt` (negative prompt appended as a suffix line, the openrouter precedent), `seed` when set, size mapping when width/height set (fal `image_size` enum or `{width,height}` object — implementer verifies exact field from the model schema and uses the generic form).
+2. **Poll URLs are SELF-BUILT, never response-followed**: the submit response's `request_id` is combined with the CONFIGURED base into `{base}/{model_path}/requests/{request_id}/status` and `/requests/{request_id}` (fal's documented deterministic queue shapes). The response's `status_url`/`response_url` fields are IGNORED — following server-provided URLs while attaching `Authorization` is a credential-exfiltration primitive our egress posture exists to prevent. `request_id` is validated (UUID-ish charset) before URL use.
+3. Poll with the auth header at `poll_interval_seconds` until COMPLETED/timeout; result `images[0].url` (fal CDN, different origin) is fetched via the shared `fetch_image_bytes` as an ENFORCED-untrusted URL (no trusted_origins, no credentials — exactly the openrouter image-link pattern).
+- Self-built submit/poll URLs carry `trusted_origins=origin_set(url)` (allows operator-pointed private bases; metadata IPs still hard-blocked).
+
+**gemini (`gemini_image_adapter.py`)** — single call:
+1. `POST {base}/models/{model}:generateContent`, key ONLY in the `x-goog-api-key` header — never the `?key=` query form Gemini also accepts (URLs land in logs; headers do not).
+2. Body: `contents=[{parts:[{text: prompt(+appended negative)}]}]`, `generationConfig.responseModalities` including `"IMAGE"` (implementer verifies the exact current requirement for `gemini-2.5-flash-image` from the docs and pins it in a test).
+3. Response: iterate ALL `candidates[].content.parts[]`; first `inlineData` part wins → base64-decode with its `mimeType`. **No-image responses are a first-class error path**: safety blocks / text-only answers (`promptFeedback.blockReason`, `finishReason` SAFETY etc.) map to a clear sanitized error naming only the reason CATEGORY (never response text, never the prompt) — no index crashes on missing parts.
+4. Response size: the base64 image arrives inside the JSON body (~3MB+ at 1024²). OpenRouter already receives base64 data-URLs through the same guarded `fetch_json` path, so this works today — the implementer CONFIRMS no byte-cap in the guarded path truncates image-sized JSON rather than assuming (and raises a clear error if a cap is hit).
+
+**fireworks (`fireworks_image_adapter.py`)** — single call, bytes back:
+1. `POST {base}/{model}/text_to_image`, `Authorization: Bearer {api_key}`, `Content-Type: application/json`, `Accept: image/png` (or the vendor's documented accept for format selection); body maps `prompt`/`negative_prompt`/`width`/`height`/`steps`/`cfg_scale`/`seed` directly (implementer verifies current field names from the API reference).
+2. Response is RAW IMAGE BYTES on success; error responses arrive as JSON on the same endpoint — the adapter distinguishes by status + content-type and surfaces sanitized errors (never raw response bodies; a 404 gets the task-620 enriched message naming the attempted model id and `[image_generation.fireworks] default_model`).
+
+**Shared requirements (all three):**
+- **Model-id shape validation before URL construction** — NEW attack surface unique to these adapters: the model id becomes part of the URL path (existing six carry it in the JSON body). Charset allowlists per backend: gemini/fireworks `[A-Za-z0-9._-]+`; fal additionally allows `/` (path-shaped ids) but rejects `..` segments, leading/trailing `/`, and any of `?#%\s`. Violations raise the adapter's config-error type naming the offending id.
+- All HTTP through the package's guarded helpers; the task-620 enriched not-found messaging pattern applied per backend (404/400-model-unknown names the model id + config key).
+- `api_key` never logged, never in error text; negative prompt appended not dropped; `ImageGenResult` populated per contract (resolved_model only where genuinely reported — do not fabricate).
+
+## http_client addition
+
+`fetch_bytes_via_post(url, *, headers, json, timeout, trusted_origins) -> tuple[bytes, str]` (bytes + content-type): fireworks' shape (POST returning bytes) fits neither `fetch_json` (JSON-only) nor `fetch_image_bytes` (GET-shaped). Same discipline as both: egress `check_url_or_raise` with trusted_origins pre-request, no auto-redirects, per-hop revalidation with `same_origin`-gated credential stripping on any redirect, explicit timeout honoring `timeout=0`, size-bounded read. Unit-tested with the same fake-client matrix as the existing helpers (incl. the cross-origin cred-strip and redirect-to-private cases).
+
+## Settings probes
+
+- gemini: `GET {base}/models` with `x-goog-api-key` → 2xx `Reachable` / 401,403 `Auth failed` / other mapping — full auth-verified probe (cheap list endpoint exists).
+- fireworks: implementer checks for the OpenAI-compat `GET .../inference/v1/models` with Bearer on the api.fireworks.ai host; if confirmed cheap+authed, full probe; else reachability-only → `Reachable (auth unverified)`.
+- fal: reachability-only on the configured base (no confirmed cheap authed endpoint) → `Reachable (auth unverified)`.
+- All through the existing probe module's closed badge set and sanitization; no new badge strings.
+
+## Testing
+
+- Per-adapter unit suites (`Tests/Image_Generation/test_{fal,gemini,fireworks}_adapter.py`) with fake clients patched on the real module: payload shape incl. auth-header placement (gemini: header-not-query pinned), model-id validation matrix (incl. fal `..` rejection), response parsing (gemini all-parts iteration + no-image/safety mapping; fireworks bytes-vs-JSON-error branch; fal poll lifecycle with SELF-BUILT URL assertion — the fake asserts the poll URL was constructed from config base + request_id, NOT taken from the response's status_url), error sanitization, egress trust threading (self-built trusted; extracted enforced).
+- `fetch_bytes_via_post` helper suite as above.
+- Config loader: new `_SECRETS`/`_NON_SECRET` rows, key_sources for the gemini two-var precedence.
+- Settings: the existing drift test must pass unmodified (it validates schema-vs-loader automatically); backend-count-sensitive tests updated to nine; probe tests for the two/three new probe branches.
+- Opt-in live tests per backend in `test_live_backends.py` style (`TLDW_LIVE_FAL_API_KEY` etc., markers integration/optional/slow).
+- Live UAT (post merge-readiness, user keys): per backend — Settings probe, then Console `/generate-image :backend <prompt>` end-to-end with card verification; the OpenRouter UAT recipe.
+
+## Non-goals
+
+Image-to-image / editing modes (Kontext, gemini image inputs); fal websocket/realtime; LoRA/ControlNet params; per-backend `allowed_extra_params` curation beyond the existing config-only mechanism; Vertex-AI service-account auth for Gemini (AI-Studio API keys only, per the request).
+
+## Risks
+
+- Vendor model-id drift (mitigated: enriched errors, live tests, Settings model field with resolved-default placeholder).
+- fal queue URL shape is vendor-documented-but-unversioned; the self-built-URL decision trades a hypothetical shape change (loud, easy fix) for closing a real credential-exfiltration channel — correct trade.
+- Settings backends list grows to nine rows; fine at ≥120 cols (sub-120 remains task-653).

--- a/Tests/Image_Generation/test_adapter_registry.py
+++ b/Tests/Image_Generation/test_adapter_registry.py
@@ -26,6 +26,6 @@ def test_nothing_enabled_by_default():
 def test_default_adapters_point_at_local_package():
     from tldw_chatbook.Image_Generation.adapter_registry import DEFAULT_ADAPTERS
     assert set(DEFAULT_ADAPTERS) == {
-        "stable_diffusion_cpp", "swarmui", "openrouter", "novita", "together", "modelstudio"
+        "stable_diffusion_cpp", "swarmui", "openrouter", "novita", "together", "modelstudio", "gemini"
     }
     assert all(v.startswith("tldw_chatbook.Image_Generation.adapters.") for v in DEFAULT_ADAPTERS.values())

--- a/Tests/Image_Generation/test_adapter_registry.py
+++ b/Tests/Image_Generation/test_adapter_registry.py
@@ -26,6 +26,6 @@ def test_nothing_enabled_by_default():
 def test_default_adapters_point_at_local_package():
     from tldw_chatbook.Image_Generation.adapter_registry import DEFAULT_ADAPTERS
     assert set(DEFAULT_ADAPTERS) == {
-        "stable_diffusion_cpp", "swarmui", "openrouter", "novita", "together", "modelstudio", "gemini"
+        "stable_diffusion_cpp", "swarmui", "openrouter", "novita", "together", "modelstudio", "gemini", "fal"
     }
     assert all(v.startswith("tldw_chatbook.Image_Generation.adapters.") for v in DEFAULT_ADAPTERS.values())

--- a/Tests/Image_Generation/test_capabilities.py
+++ b/Tests/Image_Generation/test_capabilities.py
@@ -1,0 +1,64 @@
+import pytest
+
+
+def test_reference_image_capable_backends_frozenset():
+    from tldw_chatbook.Image_Generation.capabilities import REFERENCE_IMAGE_CAPABLE_BACKENDS
+    assert REFERENCE_IMAGE_CAPABLE_BACKENDS == frozenset({"fal", "gemini", "fireworks"})
+    assert isinstance(REFERENCE_IMAGE_CAPABLE_BACKENDS, frozenset)
+
+
+@pytest.mark.parametrize("backend", ["fal", "gemini", "fireworks"])
+def test_resolve_backend_reference_image_capability_new_backends_supported(backend):
+    from tldw_chatbook.Image_Generation.capabilities import resolve_backend_reference_image_capability
+    capability = resolve_backend_reference_image_capability(backend)
+    assert capability.supported is True
+    assert capability.reason is None
+
+
+@pytest.mark.parametrize(
+    "backend",
+    ["stable_diffusion_cpp", "swarmui", "openrouter", "novita", "together", "modelstudio"],
+)
+def test_resolve_backend_reference_image_capability_legacy_backends_unsupported(backend):
+    # The new REFERENCE_IMAGE_CAPABLE_BACKENDS frozenset is the primary gate
+    # here -- even modelstudio, which has a (dormant) per-model reference
+    # image map, is unsupported at this backend-level query.
+    from tldw_chatbook.Image_Generation.capabilities import resolve_backend_reference_image_capability
+    capability = resolve_backend_reference_image_capability(backend)
+    assert capability.supported is False
+
+
+def test_resolve_backend_reference_image_capability_unknown_backend_unsupported():
+    from tldw_chatbook.Image_Generation.capabilities import resolve_backend_reference_image_capability
+    assert resolve_backend_reference_image_capability("not-a-real-backend").supported is False
+    assert resolve_backend_reference_image_capability(None).supported is False
+
+
+def test_resolve_backend_reference_image_capability_case_insensitive():
+    from tldw_chatbook.Image_Generation.capabilities import resolve_backend_reference_image_capability
+    assert resolve_backend_reference_image_capability("FAL").supported is True
+    assert resolve_backend_reference_image_capability(" Gemini ").supported is True
+
+
+def test_resolve_reference_image_capability_new_backends_ignore_model():
+    # fal/gemini/fireworks have no per-model gating -- any model (or None)
+    # is accepted once the backend itself is in the capable set.
+    from tldw_chatbook.Image_Generation.capabilities import resolve_reference_image_capability
+    assert resolve_reference_image_capability("fal", "any-model").supported is True
+    assert resolve_reference_image_capability("gemini", None).supported is True
+    assert resolve_reference_image_capability("fireworks", "").supported is True
+
+
+def test_resolve_reference_image_capability_modelstudio_dormant_map_unchanged():
+    # The dormant per-model map is still fully intact and reachable through
+    # this model-aware function (used directly by the Model Studio adapter)
+    # -- task-3 must not remove or further restrict it there.
+    from tldw_chatbook.Image_Generation.capabilities import resolve_reference_image_capability
+    assert resolve_reference_image_capability("modelstudio", "qwen-image-2.0").supported is True
+    assert resolve_reference_image_capability("modelstudio", "qwen-image-edit").supported is True
+    assert resolve_reference_image_capability("modelstudio", "some-unrelated-model").supported is False
+
+
+def test_resolve_reference_image_capability_legacy_non_modelstudio_backend_unsupported():
+    from tldw_chatbook.Image_Generation.capabilities import resolve_reference_image_capability
+    assert resolve_reference_image_capability("swarmui", "anything").supported is False

--- a/Tests/Image_Generation/test_capabilities.py
+++ b/Tests/Image_Generation/test_capabilities.py
@@ -3,11 +3,11 @@ import pytest
 
 def test_reference_image_capable_backends_frozenset():
     from tldw_chatbook.Image_Generation.capabilities import REFERENCE_IMAGE_CAPABLE_BACKENDS
-    assert REFERENCE_IMAGE_CAPABLE_BACKENDS == frozenset({"fal", "gemini", "fireworks"})
+    assert REFERENCE_IMAGE_CAPABLE_BACKENDS == frozenset({"fal", "gemini"})
     assert isinstance(REFERENCE_IMAGE_CAPABLE_BACKENDS, frozenset)
 
 
-@pytest.mark.parametrize("backend", ["fal", "gemini", "fireworks"])
+@pytest.mark.parametrize("backend", ["fal", "gemini"])
 def test_resolve_backend_reference_image_capability_new_backends_supported(backend):
     from tldw_chatbook.Image_Generation.capabilities import resolve_backend_reference_image_capability
     capability = resolve_backend_reference_image_capability(backend)
@@ -41,12 +41,11 @@ def test_resolve_backend_reference_image_capability_case_insensitive():
 
 
 def test_resolve_reference_image_capability_new_backends_ignore_model():
-    # fal/gemini/fireworks have no per-model gating -- any model (or None)
-    # is accepted once the backend itself is in the capable set.
+    # fal/gemini have no per-model gating -- any model (or None) is accepted
+    # once the backend itself is in the capable set.
     from tldw_chatbook.Image_Generation.capabilities import resolve_reference_image_capability
     assert resolve_reference_image_capability("fal", "any-model").supported is True
     assert resolve_reference_image_capability("gemini", None).supported is True
-    assert resolve_reference_image_capability("fireworks", "").supported is True
 
 
 def test_resolve_reference_image_capability_modelstudio_dormant_map_unchanged():

--- a/Tests/Image_Generation/test_config_loader.py
+++ b/Tests/Image_Generation/test_config_loader.py
@@ -180,7 +180,7 @@ def test_key_sources_missing(monkeypatch):
     assert cfg.key_sources["openrouter"] == "missing"
     assert set(cfg.key_sources) == {
         "stable_diffusion_cpp", "swarmui", "openrouter", "novita", "together", "modelstudio",
-        "fal", "gemini", "fireworks",
+        "fal", "gemini",
     }
 
 
@@ -336,11 +336,14 @@ def test_other_backends_config_key_unaffected_by_swarmui_fix(monkeypatch):
     assert cfg.openrouter_image_api_key == "fake-openrouter-key"
 
 
-# --- task-2 (fal/Gemini/Fireworks image backends) ---------------------------
+# --- task-2 (fal/Gemini image backends) --------------------------------
+# Fireworks was dropped 2026-07-26 -- vendor deprecated image generation
+# (see Docs/superpowers/specs/2026-07-26-imagegen-fal-gemini-fireworks-design.md
+# and the sibling plan doc for the decision note).
 
 
 def _delenv_new_backend_vars(monkeypatch):
-    for var in ("FAL_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY", "FIREWORKS_API_KEY"):
+    for var in ("FAL_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"):
         monkeypatch.delenv(var, raising=False)
 
 
@@ -432,42 +435,3 @@ def test_gemini_env_fallback_to_google_api_key(monkeypatch):
     cfg = _load_config_with_section(monkeypatch, {})
     assert cfg.gemini_image_api_key == "fake-google-key"
     assert cfg.key_sources["gemini"] == "env:GOOGLE_API_KEY"
-
-
-def test_fireworks_defaults_when_unset(monkeypatch):
-    from tldw_chatbook.Image_Generation import config as c
-    _delenv_new_backend_vars(monkeypatch)
-    cfg = _load_config_with_section(monkeypatch, {})
-    assert cfg.fireworks_image_base_url == c.DEFAULT_FIREWORKS_IMAGE_BASE_URL == (
-        "https://api.fireworks.ai/inference/v1/workflows/accounts/fireworks/models"
-    )
-    assert cfg.fireworks_image_default_model == c.DEFAULT_FIREWORKS_IMAGE_MODEL == "flux-1-schnell-fp8"
-    assert cfg.fireworks_image_timeout_seconds == c.DEFAULT_FIREWORKS_IMAGE_TIMEOUT_SECONDS == 120
-    assert cfg.fireworks_image_api_key in (None, "")
-    assert cfg.key_sources["fireworks"] == "missing"
-
-
-def test_fireworks_nested_toml_round_trip(monkeypatch):
-    _delenv_new_backend_vars(monkeypatch)
-    fake = {
-        "fireworks": {
-            "base_url": "https://api.example.fireworks.ai/v1",
-            "api_key": "fake-fireworks-key",
-            "default_model": "flux-other-model",
-            "timeout_seconds": 60,
-        }
-    }
-    cfg = _load_config_with_section(monkeypatch, fake)
-    assert cfg.fireworks_image_base_url == "https://api.example.fireworks.ai/v1"
-    assert cfg.fireworks_image_api_key == "fake-fireworks-key"
-    assert cfg.fireworks_image_default_model == "flux-other-model"
-    assert cfg.fireworks_image_timeout_seconds == 60
-    assert cfg.key_sources["fireworks"] == "config"
-
-
-def test_fireworks_env_key_precedence(monkeypatch):
-    _delenv_new_backend_vars(monkeypatch)
-    monkeypatch.setenv("FIREWORKS_API_KEY", "fake-fireworks-env-key")
-    cfg = _load_config_with_section(monkeypatch, {"fireworks": {"api_key": "fake-fireworks-config-key"}})
-    assert cfg.fireworks_image_api_key == "fake-fireworks-env-key"
-    assert cfg.key_sources["fireworks"] == "env:FIREWORKS_API_KEY"

--- a/Tests/Image_Generation/test_config_loader.py
+++ b/Tests/Image_Generation/test_config_loader.py
@@ -178,7 +178,10 @@ def test_key_sources_missing(monkeypatch):
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     cfg = _load_config_with_section(monkeypatch, {})
     assert cfg.key_sources["openrouter"] == "missing"
-    assert set(cfg.key_sources) == {"stable_diffusion_cpp", "swarmui", "openrouter", "novita", "together", "modelstudio"}
+    assert set(cfg.key_sources) == {
+        "stable_diffusion_cpp", "swarmui", "openrouter", "novita", "together", "modelstudio",
+        "fal", "gemini", "fireworks",
+    }
 
 
 def test_key_sources_modelstudio_names_winning_env(monkeypatch):
@@ -331,3 +334,140 @@ def test_other_backends_config_key_unaffected_by_swarmui_fix(monkeypatch):
     )
     assert cfg.key_sources["openrouter"] == "config"
     assert cfg.openrouter_image_api_key == "fake-openrouter-key"
+
+
+# --- task-2 (fal/Gemini/Fireworks image backends) ---------------------------
+
+
+def _delenv_new_backend_vars(monkeypatch):
+    for var in ("FAL_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY", "FIREWORKS_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_fal_defaults_when_unset(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as c
+    _delenv_new_backend_vars(monkeypatch)
+    cfg = _load_config_with_section(monkeypatch, {})
+    assert cfg.fal_image_base_url == c.DEFAULT_FAL_IMAGE_BASE_URL == "https://queue.fal.run"
+    assert cfg.fal_image_default_model == c.DEFAULT_FAL_IMAGE_MODEL == "fal-ai/flux/schnell"
+    assert cfg.fal_image_poll_interval_seconds == c.DEFAULT_FAL_IMAGE_POLL_INTERVAL_SECONDS == 2
+    assert cfg.fal_image_timeout_seconds == c.DEFAULT_FAL_IMAGE_TIMEOUT_SECONDS == 120
+    assert cfg.fal_image_api_key in (None, "")
+    assert cfg.key_sources["fal"] == "missing"
+
+
+def test_fal_nested_toml_round_trip(monkeypatch):
+    _delenv_new_backend_vars(monkeypatch)
+    fake = {
+        "fal": {
+            "base_url": "https://queue.example.fal.run",
+            "api_key": "fake-fal-key",
+            "default_model": "fal-ai/other-model",
+            "poll_interval_seconds": 5,
+            "timeout_seconds": 30,
+        }
+    }
+    cfg = _load_config_with_section(monkeypatch, fake)
+    assert cfg.fal_image_base_url == "https://queue.example.fal.run"
+    assert cfg.fal_image_api_key == "fake-fal-key"
+    assert cfg.fal_image_default_model == "fal-ai/other-model"
+    assert cfg.fal_image_poll_interval_seconds == 5
+    assert cfg.fal_image_timeout_seconds == 30
+    assert cfg.key_sources["fal"] == "config"
+
+
+def test_fal_env_key_precedence(monkeypatch):
+    _delenv_new_backend_vars(monkeypatch)
+    monkeypatch.setenv("FAL_KEY", "fake-fal-env-key")
+    cfg = _load_config_with_section(monkeypatch, {"fal": {"api_key": "fake-fal-config-key"}})
+    assert cfg.fal_image_api_key == "fake-fal-env-key"
+    assert cfg.key_sources["fal"] == "env:FAL_KEY"
+
+
+def test_gemini_defaults_when_unset(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as c
+    _delenv_new_backend_vars(monkeypatch)
+    cfg = _load_config_with_section(monkeypatch, {})
+    assert cfg.gemini_image_base_url == c.DEFAULT_GEMINI_IMAGE_BASE_URL == "https://generativelanguage.googleapis.com/v1beta"
+    assert cfg.gemini_image_default_model == c.DEFAULT_GEMINI_IMAGE_MODEL == "gemini-2.5-flash-image"
+    assert cfg.gemini_image_timeout_seconds == c.DEFAULT_GEMINI_IMAGE_TIMEOUT_SECONDS == 120
+    assert cfg.gemini_image_api_key in (None, "")
+    assert cfg.key_sources["gemini"] == "missing"
+
+
+def test_gemini_nested_toml_round_trip(monkeypatch):
+    _delenv_new_backend_vars(monkeypatch)
+    fake = {
+        "gemini": {
+            "base_url": "https://example.googleapis.com/v1beta",
+            "api_key": "fake-gemini-key",
+            "default_model": "gemini-other-model",
+            "timeout_seconds": 45,
+        }
+    }
+    cfg = _load_config_with_section(monkeypatch, fake)
+    assert cfg.gemini_image_base_url == "https://example.googleapis.com/v1beta"
+    assert cfg.gemini_image_api_key == "fake-gemini-key"
+    assert cfg.gemini_image_default_model == "gemini-other-model"
+    assert cfg.gemini_image_timeout_seconds == 45
+    assert cfg.key_sources["gemini"] == "config"
+
+
+def test_gemini_env_precedence_gemini_key_wins_over_google_key(monkeypatch):
+    """GEMINI_API_KEY is listed first in the precedence order, so when both
+    env vars are set it must win over GOOGLE_API_KEY."""
+    _delenv_new_backend_vars(monkeypatch)
+    monkeypatch.setenv("GOOGLE_API_KEY", "fake-google-key")
+    monkeypatch.setenv("GEMINI_API_KEY", "fake-gemini-key")
+    cfg = _load_config_with_section(monkeypatch, {})
+    assert cfg.gemini_image_api_key == "fake-gemini-key"
+    assert cfg.key_sources["gemini"] == "env:GEMINI_API_KEY"
+
+
+def test_gemini_env_fallback_to_google_api_key(monkeypatch):
+    """When only GOOGLE_API_KEY is set (no GEMINI_API_KEY), it must be used
+    and named explicitly as the source."""
+    _delenv_new_backend_vars(monkeypatch)
+    monkeypatch.setenv("GOOGLE_API_KEY", "fake-google-key")
+    cfg = _load_config_with_section(monkeypatch, {})
+    assert cfg.gemini_image_api_key == "fake-google-key"
+    assert cfg.key_sources["gemini"] == "env:GOOGLE_API_KEY"
+
+
+def test_fireworks_defaults_when_unset(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as c
+    _delenv_new_backend_vars(monkeypatch)
+    cfg = _load_config_with_section(monkeypatch, {})
+    assert cfg.fireworks_image_base_url == c.DEFAULT_FIREWORKS_IMAGE_BASE_URL == (
+        "https://api.fireworks.ai/inference/v1/workflows/accounts/fireworks/models"
+    )
+    assert cfg.fireworks_image_default_model == c.DEFAULT_FIREWORKS_IMAGE_MODEL == "flux-1-schnell-fp8"
+    assert cfg.fireworks_image_timeout_seconds == c.DEFAULT_FIREWORKS_IMAGE_TIMEOUT_SECONDS == 120
+    assert cfg.fireworks_image_api_key in (None, "")
+    assert cfg.key_sources["fireworks"] == "missing"
+
+
+def test_fireworks_nested_toml_round_trip(monkeypatch):
+    _delenv_new_backend_vars(monkeypatch)
+    fake = {
+        "fireworks": {
+            "base_url": "https://api.example.fireworks.ai/v1",
+            "api_key": "fake-fireworks-key",
+            "default_model": "flux-other-model",
+            "timeout_seconds": 60,
+        }
+    }
+    cfg = _load_config_with_section(monkeypatch, fake)
+    assert cfg.fireworks_image_base_url == "https://api.example.fireworks.ai/v1"
+    assert cfg.fireworks_image_api_key == "fake-fireworks-key"
+    assert cfg.fireworks_image_default_model == "flux-other-model"
+    assert cfg.fireworks_image_timeout_seconds == 60
+    assert cfg.key_sources["fireworks"] == "config"
+
+
+def test_fireworks_env_key_precedence(monkeypatch):
+    _delenv_new_backend_vars(monkeypatch)
+    monkeypatch.setenv("FIREWORKS_API_KEY", "fake-fireworks-env-key")
+    cfg = _load_config_with_section(monkeypatch, {"fireworks": {"api_key": "fake-fireworks-config-key"}})
+    assert cfg.fireworks_image_api_key == "fake-fireworks-env-key"
+    assert cfg.key_sources["fireworks"] == "env:FIREWORKS_API_KEY"

--- a/Tests/Image_Generation/test_fal_adapter.py
+++ b/Tests/Image_Generation/test_fal_adapter.py
@@ -1,0 +1,695 @@
+"""Tests for the fal.ai queue image generation adapter (task-6 of the
+fal/Gemini/Fireworks image-backends plan).
+
+Pinned behaviors (see .superpowers/sdd/2026-07-26-imagegen-fal-gemini-fireworks/task-6-brief.md):
+- Submit: POST {base}/{validated_model_path}, Authorization: Key {api_key},
+  body {"prompt": ..., "seed": ... when set, "image_size": {"width", "height"}
+  when both set, "image_url": data URI when a reference image is set}.
+- app_id is the first two "/"-segments of the model path (verified against
+  fal's own fal_client SDK -- see task-6-report.md); the poll/result URLs
+  are ALWAYS self-built from base_url + app_id + request_id, never taken
+  from the API response.
+- A submit response's own status_url (when present) is a CROSS-CHECK ONLY:
+  a mismatch is a loud, sanitized error and the vendor URL is NEVER
+  requested.
+- Poll status_url until COMPLETED (IN_QUEUE/IN_PROGRESS continue, anything
+  else is a sanitized error) within timeout_seconds; then GET result_url
+  and fetch images[0].url via fetch_image_bytes with NO trusted_origins and
+  NO Authorization header.
+- 404 on submit gets task-620 enrichment naming the model path + the
+  [image_generation.fal] default_model config key.
+"""
+import base64
+import io
+
+import httpx
+import pytest
+from PIL import Image
+
+
+def _b64_png():
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8), (200, 100, 0)).save(buf, "PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+def _image_bytes_png():
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8), (200, 100, 0)).save(buf, "PNG")
+    return buf.getvalue()
+
+
+def _req(**overrides):
+    from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest
+
+    defaults = dict(
+        backend="fal",
+        prompt="a whale in space",
+        negative_prompt=None,
+        width=None,
+        height=None,
+        steps=None,
+        cfg_scale=None,
+        seed=None,
+        sampler=None,
+        model=None,
+        format="png",
+        extra_params={},
+    )
+    defaults.update(overrides)
+    return ImageGenRequest(**defaults)
+
+
+def _reset_and_import(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as _c
+
+    _c.reset_image_generation_config_cache()
+    monkeypatch.setenv("FAL_KEY", "test-fal-key")
+    from tldw_chatbook.Image_Generation.adapters import fal_image_adapter as m
+
+    return m
+
+
+def _submit_response(request_id="req-1", status_url=None):
+    resp = {"request_id": request_id}
+    if status_url is not None:
+        resp["status_url"] = status_url
+    return resp
+
+
+def _status_response(status):
+    return {"status": status}
+
+
+def _result_response(url="https://cdn.fal.media/files/output.png"):
+    return {"images": [{"url": url}]}
+
+
+def _make_fake_fetch_json(calls, *, submit_response, statuses=("COMPLETED",), result_response=None):
+    """A fetch_json fake that distinguishes submit/status/result calls by URL shape."""
+    status_iter = iter(statuses)
+    if result_response is None:
+        result_response = _result_response()
+
+    def fake(method, url, **kw):
+        calls.append({"method": method, "url": url, **kw})
+        if method.upper() == "POST":
+            return submit_response
+        if url.endswith("/status"):
+            return _status_response(next(status_iter))
+        return result_response
+
+    return fake
+
+
+def _patch_no_op_sleep(monkeypatch, m):
+    monkeypatch.setattr(m.time, "sleep", lambda *_: None)
+
+
+# ---------------------------------------------------------------------------
+# Submit payload shape
+# ---------------------------------------------------------------------------
+
+
+def test_fal_submit_url_and_headers(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    _patch_no_op_sleep(monkeypatch, m)
+
+    calls = []
+    fake = _make_fake_fetch_json(calls, submit_response=_submit_response())
+    monkeypatch.setattr(m, "fetch_json", fake)
+    monkeypatch.setattr(m, "fetch_image_bytes", lambda *a, **kw: (_image_bytes_png(), "image/png"))
+
+    req = _req(model="fal-ai/flux/schnell")
+    m.FalImageAdapter().generate(req)
+
+    submit_call = calls[0]
+    assert submit_call["method"] == "POST"
+    assert submit_call["url"] == "https://queue.fal.run/fal-ai/flux/schnell"
+    assert submit_call["headers"]["Authorization"] == "Key test-fal-key"
+    assert submit_call["headers"]["Content-Type"] == "application/json"
+    assert submit_call["trusted_origins"] == frozenset({"queue.fal.run"})
+
+
+def test_fal_submit_body_basic_shape(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    _patch_no_op_sleep(monkeypatch, m)
+
+    calls = []
+    fake = _make_fake_fetch_json(calls, submit_response=_submit_response())
+    monkeypatch.setattr(m, "fetch_json", fake)
+    monkeypatch.setattr(m, "fetch_image_bytes", lambda *a, **kw: (_image_bytes_png(), "image/png"))
+
+    req = _req(model="fal-ai/flux/schnell")
+    m.FalImageAdapter().generate(req)
+
+    assert calls[0]["json"] == {"prompt": "a whale in space"}
+
+
+def test_fal_submit_includes_seed_when_set(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    _patch_no_op_sleep(monkeypatch, m)
+
+    calls = []
+    fake = _make_fake_fetch_json(calls, submit_response=_submit_response())
+    monkeypatch.setattr(m, "fetch_json", fake)
+    monkeypatch.setattr(m, "fetch_image_bytes", lambda *a, **kw: (_image_bytes_png(), "image/png"))
+
+    req = _req(model="fal-ai/flux/schnell", seed=42)
+    m.FalImageAdapter().generate(req)
+
+    assert calls[0]["json"]["seed"] == 42
+
+
+def test_fal_submit_includes_image_size_when_width_and_height_set(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    _patch_no_op_sleep(monkeypatch, m)
+
+    calls = []
+    fake = _make_fake_fetch_json(calls, submit_response=_submit_response())
+    monkeypatch.setattr(m, "fetch_json", fake)
+    monkeypatch.setattr(m, "fetch_image_bytes", lambda *a, **kw: (_image_bytes_png(), "image/png"))
+
+    req = _req(model="fal-ai/flux/schnell", width=768, height=512)
+    m.FalImageAdapter().generate(req)
+
+    assert calls[0]["json"]["image_size"] == {"width": 768, "height": 512}
+
+
+def test_fal_submit_omits_image_size_when_only_one_dimension_set(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    _patch_no_op_sleep(monkeypatch, m)
+
+    calls = []
+    fake = _make_fake_fetch_json(calls, submit_response=_submit_response())
+    monkeypatch.setattr(m, "fetch_json", fake)
+    monkeypatch.setattr(m, "fetch_image_bytes", lambda *a, **kw: (_image_bytes_png(), "image/png"))
+
+    req = _req(model="fal-ai/flux/schnell", width=768, height=None)
+    m.FalImageAdapter().generate(req)
+
+    assert "image_size" not in calls[0]["json"]
+
+
+def test_fal_negative_prompt_appended(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    _patch_no_op_sleep(monkeypatch, m)
+
+    calls = []
+    fake = _make_fake_fetch_json(calls, submit_response=_submit_response())
+    monkeypatch.setattr(m, "fetch_json", fake)
+    monkeypatch.setattr(m, "fetch_image_bytes", lambda *a, **kw: (_image_bytes_png(), "image/png"))
+
+    req = _req(model="fal-ai/flux/schnell", negative_prompt="blurry, low quality")
+    m.FalImageAdapter().generate(req)
+
+    prompt = calls[0]["json"]["prompt"]
+    assert "a whale in space" in prompt
+    assert "blurry, low quality" in prompt
+
+
+def test_fal_submit_includes_reference_image_data_url(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    from tldw_chatbook.Image_Generation.capabilities import ResolvedReferenceImage
+
+    _patch_no_op_sleep(monkeypatch, m)
+
+    calls = []
+    fake = _make_fake_fetch_json(calls, submit_response=_submit_response())
+    monkeypatch.setattr(m, "fetch_json", fake)
+    monkeypatch.setattr(m, "fetch_image_bytes", lambda *a, **kw: (_image_bytes_png(), "image/png"))
+
+    ref = ResolvedReferenceImage(
+        file_id=1,
+        filename="ref.png",
+        mime_type="image/png",
+        width=8,
+        height=8,
+        bytes_len=3,
+        content=b"abc",
+        temp_path=None,
+    )
+    req = _req(model="fal-ai/flux/schnell", reference_image=ref)
+    m.FalImageAdapter().generate(req)
+
+    expected = "data:image/png;base64," + base64.b64encode(b"abc").decode("ascii")
+    assert calls[0]["json"]["image_url"] == expected
+
+
+# ---------------------------------------------------------------------------
+# app_id derivation
+# ---------------------------------------------------------------------------
+
+
+def test_app_id_drops_third_segment(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    assert m._app_id("fal-ai/flux/schnell") == "fal-ai/flux"
+
+
+def test_app_id_keeps_two_segments_unchanged(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    assert m._app_id("fal-ai/flux") == "fal-ai/flux"
+
+
+def test_app_id_rejects_single_segment(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    from tldw_chatbook.Image_Generation.exceptions import ImageBackendUnavailableError
+
+    with pytest.raises(ImageBackendUnavailableError):
+        m._app_id("onlyone")
+
+
+def test_fal_polls_two_segment_app_id_url_for_three_segment_model(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    _patch_no_op_sleep(monkeypatch, m)
+
+    calls = []
+    fake = _make_fake_fetch_json(
+        calls,
+        submit_response=_submit_response(request_id="req-xyz"),
+        statuses=("IN_QUEUE", "IN_PROGRESS", "COMPLETED"),
+    )
+    monkeypatch.setattr(m, "fetch_json", fake)
+    monkeypatch.setattr(m, "fetch_image_bytes", lambda *a, **kw: (_image_bytes_png(), "image/png"))
+
+    req = _req(model="fal-ai/flux/schnell")
+    m.FalImageAdapter().generate(req)
+
+    poll_urls = [c["url"] for c in calls if c["url"].endswith("/status")]
+    assert poll_urls
+    for url in poll_urls:
+        assert url == "https://queue.fal.run/fal-ai/flux/requests/req-xyz/status"
+    result_calls = [c for c in calls if c["method"].upper() == "GET" and not c["url"].endswith("/status")]
+    assert result_calls[0]["url"] == "https://queue.fal.run/fal-ai/flux/requests/req-xyz"
+
+
+def test_fal_single_segment_model_refused_before_network(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    from tldw_chatbook.Image_Generation.exceptions import ImageBackendUnavailableError
+
+    def _boom(*a, **kw):
+        raise AssertionError("fetch_json must not be called for an unresolvable app id")
+
+    monkeypatch.setattr(m, "fetch_json", _boom)
+    req = _req(model="onlyone")
+    with pytest.raises(ImageBackendUnavailableError):
+        m.FalImageAdapter().generate(req)
+
+
+# ---------------------------------------------------------------------------
+# Self-built poll URL cross-check
+# ---------------------------------------------------------------------------
+
+
+def test_fal_matching_status_url_polls_fine(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    _patch_no_op_sleep(monkeypatch, m)
+
+    expected_status_url = "https://queue.fal.run/fal-ai/flux/requests/req-1/status"
+    calls = []
+    fake = _make_fake_fetch_json(
+        calls,
+        submit_response=_submit_response(request_id="req-1", status_url=expected_status_url),
+    )
+    monkeypatch.setattr(m, "fetch_json", fake)
+    monkeypatch.setattr(m, "fetch_image_bytes", lambda *a, **kw: (_image_bytes_png(), "image/png"))
+
+    req = _req(model="fal-ai/flux/schnell")
+    res = m.FalImageAdapter().generate(req)
+    assert res.bytes_len > 0
+    poll_calls = [c for c in calls if c["url"].endswith("/status")]
+    assert len(poll_calls) == 1
+    assert poll_calls[0]["url"] == expected_status_url
+
+
+def test_fal_mismatching_status_url_raises_and_never_polls_vendor_url(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+    _patch_no_op_sleep(monkeypatch, m)
+
+    vendor_status_url = "https://evil.example/steal/status"
+    calls = []
+    fake = _make_fake_fetch_json(
+        calls,
+        submit_response=_submit_response(request_id="req-1", status_url=vendor_status_url),
+    )
+    monkeypatch.setattr(m, "fetch_json", fake)
+    monkeypatch.setattr(m, "fetch_image_bytes", lambda *a, **kw: (_image_bytes_png(), "image/png"))
+
+    req = _req(model="fal-ai/flux/schnell")
+    with pytest.raises(ImageGenerationError) as exc_info:
+        m.FalImageAdapter().generate(req)
+
+    message = str(exc_info.value)
+    assert "fal queue URL shape changed" in message
+    assert "https://queue.fal.run/fal-ai/flux/requests/req-1/status" in message
+    # Origin only -- never the full vendor URL/path, never credentials.
+    assert "steal" not in message
+    assert vendor_status_url not in message
+    # Only the submit call happened -- no poll request of any kind (self-built
+    # or vendor) was ever issued.
+    assert len(calls) == 1
+    urls_requested = {c["url"] for c in calls}
+    assert vendor_status_url not in urls_requested
+
+
+def test_fal_mismatching_status_url_different_path_same_host(monkeypatch):
+    # Same host, different path -- still a mismatch (path is part of the check).
+    m = _reset_and_import(monkeypatch)
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+    _patch_no_op_sleep(monkeypatch, m)
+
+    vendor_status_url = "https://queue.fal.run/fal-ai/other-app/requests/req-1/status"
+    calls = []
+    fake = _make_fake_fetch_json(
+        calls,
+        submit_response=_submit_response(request_id="req-1", status_url=vendor_status_url),
+    )
+    monkeypatch.setattr(m, "fetch_json", fake)
+
+    req = _req(model="fal-ai/flux/schnell")
+    with pytest.raises(ImageGenerationError, match="fal queue URL shape changed"):
+        m.FalImageAdapter().generate(req)
+    assert len(calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Poll lifecycle / timeout / failure
+# ---------------------------------------------------------------------------
+
+
+def test_fal_poll_lifecycle_in_queue_then_in_progress_then_completed(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    _patch_no_op_sleep(monkeypatch, m)
+
+    calls = []
+    fake = _make_fake_fetch_json(
+        calls,
+        submit_response=_submit_response(),
+        statuses=("IN_QUEUE", "IN_PROGRESS", "COMPLETED"),
+    )
+    monkeypatch.setattr(m, "fetch_json", fake)
+    monkeypatch.setattr(m, "fetch_image_bytes", lambda *a, **kw: (_image_bytes_png(), "image/png"))
+
+    req = _req(model="fal-ai/flux/schnell")
+    res = m.FalImageAdapter().generate(req)
+    assert res.bytes_len > 0
+    poll_calls = [c for c in calls if c["url"].endswith("/status")]
+    assert len(poll_calls) == 3
+
+
+def test_fal_poll_timeout(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+    fake_now = {"t": 0.0}
+
+    def fake_monotonic():
+        return fake_now["t"]
+
+    def fake_sleep(interval):
+        fake_now["t"] += interval
+
+    monkeypatch.setattr(m.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(m.time, "sleep", fake_sleep)
+
+    calls = []
+
+    def fake_fetch_json(method, url, **kw):
+        calls.append({"method": method, "url": url, **kw})
+        if method.upper() == "POST":
+            return _submit_response()
+        return _status_response("IN_QUEUE")  # never completes
+
+    monkeypatch.setattr(m, "fetch_json", fake_fetch_json)
+
+    req = _req(model="fal-ai/flux/schnell")
+    with pytest.raises(ImageGenerationError, match="timed out"):
+        m.FalImageAdapter().generate(req)
+
+
+def test_fal_failed_status_raises_sanitized_error(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+    _patch_no_op_sleep(monkeypatch, m)
+
+    secret_marker = "SUPER_SECRET_INTERNAL_DETAIL_9182"
+
+    def fake_fetch_json(method, url, **kw):
+        if method.upper() == "POST":
+            return _submit_response()
+        if url.endswith("/status"):
+            return {"status": "FAILED", "error": {"message": secret_marker}}
+        raise AssertionError("result URL should never be requested after a FAILED status")
+
+    monkeypatch.setattr(m, "fetch_json", fake_fetch_json)
+
+    req = _req(model="fal-ai/flux/schnell")
+    with pytest.raises(ImageGenerationError) as exc_info:
+        m.FalImageAdapter().generate(req)
+    message = str(exc_info.value)
+    assert "FAILED" in message
+    assert secret_marker not in message
+
+
+# ---------------------------------------------------------------------------
+# Result image fetch: no auth, no trust
+# ---------------------------------------------------------------------------
+
+
+def test_fal_result_image_fetched_without_auth_or_trust(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    _patch_no_op_sleep(monkeypatch, m)
+
+    calls = []
+    fake = _make_fake_fetch_json(
+        calls,
+        submit_response=_submit_response(),
+        result_response=_result_response(url="https://cdn.fal.media/files/whale.png"),
+    )
+    monkeypatch.setattr(m, "fetch_json", fake)
+
+    fetch_image_calls = []
+
+    def fake_fetch_image_bytes(url, **kw):
+        fetch_image_calls.append({"url": url, **kw})
+        return _image_bytes_png(), "image/png"
+
+    monkeypatch.setattr(m, "fetch_image_bytes", fake_fetch_image_bytes)
+
+    req = _req(model="fal-ai/flux/schnell")
+    m.FalImageAdapter().generate(req)
+
+    assert len(fetch_image_calls) == 1
+    image_call = fetch_image_calls[0]
+    assert image_call["url"] == "https://cdn.fal.media/files/whale.png"
+    assert image_call.get("headers") is None
+    assert image_call.get("trusted_origins", frozenset()) == frozenset()
+    assert "Authorization" not in (image_call.get("headers") or {})
+
+
+def test_fal_result_missing_image_url_raises(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+    _patch_no_op_sleep(monkeypatch, m)
+
+    def fake_fetch_json(method, url, **kw):
+        if method.upper() == "POST":
+            return _submit_response()
+        if url.endswith("/status"):
+            return _status_response("COMPLETED")
+        return {"images": []}
+
+    monkeypatch.setattr(m, "fetch_json", fake_fetch_json)
+
+    req = _req(model="fal-ai/flux/schnell")
+    with pytest.raises(ImageGenerationError):
+        m.FalImageAdapter().generate(req)
+
+
+# ---------------------------------------------------------------------------
+# request_id validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_request_id", ["abc/def", "abc def", "abc?def", "", "abc#def"])
+def test_fal_request_id_charset_refusal(monkeypatch, bad_request_id):
+    m = _reset_and_import(monkeypatch)
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+    def fake_fetch_json(method, url, **kw):
+        if method.upper() == "POST":
+            return _submit_response(request_id=bad_request_id) if bad_request_id else {}
+        raise AssertionError("polling must never be reached with an invalid/missing request_id")
+
+    monkeypatch.setattr(m, "fetch_json", fake_fetch_json)
+
+    req = _req(model="fal-ai/flux/schnell")
+    with pytest.raises(ImageGenerationError):
+        m.FalImageAdapter().generate(req)
+
+
+def test_fal_request_id_valid_charset_accepted(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    _patch_no_op_sleep(monkeypatch, m)
+
+    calls = []
+    fake = _make_fake_fetch_json(calls, submit_response=_submit_response(request_id="Req-ID-123"))
+    monkeypatch.setattr(m, "fetch_json", fake)
+    monkeypatch.setattr(m, "fetch_image_bytes", lambda *a, **kw: (_image_bytes_png(), "image/png"))
+
+    req = _req(model="fal-ai/flux/schnell")
+    res = m.FalImageAdapter().generate(req)
+    assert res.bytes_len > 0
+
+
+# ---------------------------------------------------------------------------
+# Model-path validation matrix
+# ---------------------------------------------------------------------------
+
+
+def test_validate_model_path_accepts_valid(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    assert m._validate_model_path("fal-ai/flux/schnell") == "fal-ai/flux/schnell"
+
+
+@pytest.mark.parametrize(
+    "bad_path",
+    [
+        "../x",
+        "a//b",
+        "/fal-ai/flux",
+        "fal-ai/flux/",
+        "fal-ai/flux?x=1",
+        "fal-ai/flux#frag",
+        "fal-ai/flux%2e%2e",
+        "fal ai/flux",
+        "",
+        "fal-ai/../flux",
+    ],
+)
+def test_validate_model_path_rejects_invalid(monkeypatch, bad_path):
+    m = _reset_and_import(monkeypatch)
+    from tldw_chatbook.Image_Generation.exceptions import ImageBackendUnavailableError
+
+    with pytest.raises(ImageBackendUnavailableError):
+        m._validate_model_path(bad_path)
+
+
+def test_fal_generate_rejects_invalid_model_path_before_network(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    from tldw_chatbook.Image_Generation.exceptions import ImageBackendUnavailableError
+
+    def _boom(*a, **kw):
+        raise AssertionError("fetch_json must not be called for an invalid model path")
+
+    monkeypatch.setattr(m, "fetch_json", _boom)
+    req = _req(model="../evil")
+    with pytest.raises(ImageBackendUnavailableError):
+        m.FalImageAdapter().generate(req)
+
+
+# ---------------------------------------------------------------------------
+# 404 enrichment
+# ---------------------------------------------------------------------------
+
+
+def test_fal_404_names_model_path_and_config_key(monkeypatch):
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+    m = _reset_and_import(monkeypatch)
+
+    def _raise_404(method, url, **kw):
+        request = httpx.Request(method, url)
+        response = httpx.Response(404, request=request, text="Not Found")
+        raise httpx.HTTPStatusError(
+            "Client error '404 Not Found' for url '{}'".format(url), request=request, response=response
+        )
+
+    monkeypatch.setattr(m, "fetch_json", _raise_404)
+    req = _req(model="fal-ai/nonexistent/model")
+    with pytest.raises(ImageGenerationError) as exc_info:
+        m.FalImageAdapter().generate(req)
+    message = str(exc_info.value)
+    assert "fal-ai/nonexistent/model" in message
+    assert "[image_generation.fal] default_model" in message
+    assert "404" in message
+
+
+def test_fal_non_404_status_keeps_generic_message(monkeypatch):
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+    m = _reset_and_import(monkeypatch)
+
+    def _raise_500(method, url, **kw):
+        request = httpx.Request(method, url)
+        response = httpx.Response(500, request=request, text="Internal Server Error")
+        raise httpx.HTTPStatusError(
+            "Server error '500 Internal Server Error' for url '{}'".format(url), request=request, response=response
+        )
+
+    monkeypatch.setattr(m, "fetch_json", _raise_500)
+    req = _req(model="fal-ai/flux/schnell")
+    with pytest.raises(ImageGenerationError) as exc_info:
+        m.FalImageAdapter().generate(req)
+    assert "default_model" not in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Missing api key
+# ---------------------------------------------------------------------------
+
+
+def test_fal_missing_api_key_raises_backend_unavailable(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as _c
+
+    _c.reset_image_generation_config_cache()
+    monkeypatch.delenv("FAL_KEY", raising=False)
+    monkeypatch.setattr(_c, "_read_image_generation_toml", lambda: {}, raising=False)
+    monkeypatch.setattr(_c, "_keyring_get", lambda backend: None, raising=False)
+
+    from tldw_chatbook.Image_Generation.adapters import fal_image_adapter as m
+    from tldw_chatbook.Image_Generation.exceptions import ImageBackendUnavailableError
+
+    req = _req(model="fal-ai/flux/schnell")
+    with pytest.raises(ImageBackendUnavailableError):
+        m.FalImageAdapter().generate(req)
+
+
+# ---------------------------------------------------------------------------
+# Registry wiring
+# ---------------------------------------------------------------------------
+
+
+def test_fal_registered_in_default_adapters():
+    from tldw_chatbook.Image_Generation.adapter_registry import DEFAULT_ADAPTERS
+
+    assert DEFAULT_ADAPTERS["fal"] == (
+        "tldw_chatbook.Image_Generation.adapters.fal_image_adapter.FalImageAdapter"
+    )
+
+
+def test_fal_registry_resolves_adapter(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as _c
+    from tldw_chatbook.Image_Generation import adapter_registry as reg
+
+    _c.reset_image_generation_config_cache()
+    reg.reset_registry()
+    monkeypatch.setattr(
+        reg,
+        "get_image_generation_config",
+        lambda: type(
+            "Cfg",
+            (),
+            {"default_backend": "fal", "enabled_backends": ["fal"]},
+        )(),
+    )
+    registry = reg.ImageAdapterRegistry()
+    adapter = registry.get_adapter("fal")
+    assert adapter is not None
+    assert adapter.name == "fal"
+    reg.reset_registry()

--- a/Tests/Image_Generation/test_gemini_adapter.py
+++ b/Tests/Image_Generation/test_gemini_adapter.py
@@ -349,20 +349,26 @@ def test_gemini_reference_image_part_before_text(monkeypatch):
     assert "text" in parts[1]
 
 
-def test_gemini_reference_image_via_temp_path(monkeypatch, tmp_path):
+def test_gemini_reference_image_content_none_raises_contract_violation(monkeypatch, tmp_path):
+    # Qodo PR #915 FIX 1: the engine's choke-point contract is bytes-in-memory
+    # ONLY -- file_id/temp_path variants are never accepted by the engine, and
+    # the validator refuses content=None before any adapter runs. So a
+    # reference_image reaching the adapter with content=None is a contract
+    # violation, not a "fall back to reading temp_path" case: the adapter
+    # must refuse it and must never touch the filesystem, even when
+    # temp_path happens to be populated (as the dataclass invariant requires
+    # when content is None).
     m = _reset_and_import(monkeypatch)
     from tldw_chatbook.Image_Generation.capabilities import ResolvedReferenceImage
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
 
     ref_file = tmp_path / "ref.png"
-    ref_file.write_bytes(b"xyz123")
+    ref_file.write_bytes(b"should never be read")
 
-    seen = {}
+    def _boom(*a, **kw):
+        raise AssertionError("fetch_json must not be called when the reference image violates the contract")
 
-    def _capture(method, url, *, headers=None, json=None, params=None, timeout=None, trusted_origins=frozenset()):
-        seen["json"] = json
-        return _gemini_response()
-
-    monkeypatch.setattr(m, "fetch_json", _capture)
+    monkeypatch.setattr(m, "fetch_json", _boom)
     ref = ResolvedReferenceImage(
         file_id=1,
         filename="ref.png",
@@ -374,11 +380,9 @@ def test_gemini_reference_image_via_temp_path(monkeypatch, tmp_path):
         temp_path=str(ref_file),
     )
     req = _req(model="gemini-2.5-flash-image", reference_image=ref)
-    m.GeminiImageAdapter().generate(req)
-
-    parts = seen["json"]["contents"][0]["parts"]
-    assert parts[0]["inline_data"]["mime_type"] == "image/jpeg"
-    assert parts[0]["inline_data"]["data"] == base64.b64encode(b"xyz123").decode("ascii")
+    with pytest.raises(ImageGenerationError) as exc_info:
+        m.GeminiImageAdapter().generate(req)
+    assert "choke-point contract violation" in str(exc_info.value)
 
 
 # ---------------------------------------------------------------------------

--- a/Tests/Image_Generation/test_gemini_adapter.py
+++ b/Tests/Image_Generation/test_gemini_adapter.py
@@ -1,0 +1,536 @@
+"""Tests for the Gemini (AI Studio) image generation adapter (task-4 of the
+fal/Gemini/Fireworks image-backends plan).
+
+Pinned behaviors (see .superpowers/sdd/2026-07-26-imagegen-fal-gemini-fireworks/task-4-brief.md):
+- URL: {base}/models/{validated_model}:generateContent
+- Auth: x-goog-api-key header ONLY -- never in the URL or query params.
+- generationConfig.responseModalities == ["TEXT", "IMAGE"] (verified live against
+  Google's docs -- gemini-2.5-flash-image silently returns an empty parts array
+  if only ["IMAGE"] is requested; see task-4-report.md for sources).
+- Reference image (when set) is an inline_data part BEFORE the text part.
+- Response parsing iterates every candidates[*].content.parts[*], accepting
+  both inlineData and inline_data spellings defensively.
+- No-image error mapping: blockReason > candidate finishReason != STOP > generic.
+- 400/404 enrichment names the model id and the config key to check.
+- trusted_origins is the self-built URL's own origin only.
+"""
+import base64
+import io
+
+import httpx
+import pytest
+from PIL import Image
+
+
+def _b64_png():
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8), (0, 180, 0)).save(buf, "PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+def _gemini_response(mime_type="image/png", data=None, key="inlineData"):
+    return {
+        "candidates": [
+            {
+                "content": {"parts": [{key: {"mimeType": mime_type, "data": data or _b64_png()}}]},
+                "finishReason": "STOP",
+            }
+        ]
+    }
+
+
+def _req(**overrides):
+    from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest
+
+    defaults = dict(
+        backend="gemini",
+        prompt="a fox in a forest",
+        negative_prompt=None,
+        width=None,
+        height=None,
+        steps=None,
+        cfg_scale=None,
+        seed=None,
+        sampler=None,
+        model=None,
+        format="png",
+        extra_params={},
+    )
+    defaults.update(overrides)
+    return ImageGenRequest(**defaults)
+
+
+def _reset_and_import(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as _c
+
+    _c.reset_image_generation_config_cache()
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    from tldw_chatbook.Image_Generation.adapters import gemini_image_adapter as m
+
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Payload shape / headers / URL / trusted_origins
+# ---------------------------------------------------------------------------
+
+
+def test_gemini_url_and_headers_key_only_in_header(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+
+    seen = {}
+
+    def _capture(method, url, *, headers=None, json=None, params=None, timeout=None, trusted_origins=frozenset()):
+        seen.update(method=method, url=url, headers=headers, json=json, params=params, trusted_origins=trusted_origins)
+        return _gemini_response()
+
+    monkeypatch.setattr(m, "fetch_json", _capture)
+    req = _req(model="gemini-2.5-flash-image")
+    m.GeminiImageAdapter().generate(req)
+
+    assert seen["method"] == "POST"
+    assert seen["url"] == "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-image:generateContent"
+    assert "test-key" not in seen["url"]
+    assert not seen["params"]
+    assert seen["headers"]["x-goog-api-key"] == "test-key"
+    assert seen["headers"]["Content-Type"] == "application/json"
+    # never in a query string form either
+    assert "key=" not in seen["url"]
+
+
+def test_gemini_trusted_origins_is_self_built_url_origin(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+
+    seen = {}
+
+    def _capture(method, url, *, headers=None, json=None, params=None, timeout=None, trusted_origins=frozenset()):
+        seen["trusted_origins"] = trusted_origins
+        seen["url"] = url
+        return _gemini_response()
+
+    monkeypatch.setattr(m, "fetch_json", _capture)
+    req = _req(model="gemini-2.5-flash-image")
+    m.GeminiImageAdapter().generate(req)
+
+    assert seen["trusted_origins"] == frozenset({"generativelanguage.googleapis.com"})
+
+
+def test_gemini_response_modalities_pinned(monkeypatch):
+    # task-620 lesson: verified live against docs, not guessed. See report.
+    m = _reset_and_import(monkeypatch)
+
+    seen = {}
+
+    def _capture(method, url, *, headers=None, json=None, params=None, timeout=None, trusted_origins=frozenset()):
+        seen["json"] = json
+        return _gemini_response()
+
+    monkeypatch.setattr(m, "fetch_json", _capture)
+    req = _req(model="gemini-2.5-flash-image")
+    m.GeminiImageAdapter().generate(req)
+
+    assert seen["json"]["generationConfig"] == {"responseModalities": ["TEXT", "IMAGE"]}
+
+
+def test_gemini_negative_prompt_appended(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+
+    seen = {}
+
+    def _capture(method, url, *, headers=None, json=None, params=None, timeout=None, trusted_origins=frozenset()):
+        seen["json"] = json
+        return _gemini_response()
+
+    monkeypatch.setattr(m, "fetch_json", _capture)
+    req = _req(model="gemini-2.5-flash-image", negative_prompt="blurry, low quality")
+    m.GeminiImageAdapter().generate(req)
+
+    parts = seen["json"]["contents"][0]["parts"]
+    text_part = parts[-1]
+    assert "a fox in a forest" in text_part["text"]
+    assert "blurry, low quality" in text_part["text"]
+
+
+def test_gemini_body_shape_no_reference(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+
+    seen = {}
+
+    def _capture(method, url, *, headers=None, json=None, params=None, timeout=None, trusted_origins=frozenset()):
+        seen["json"] = json
+        return _gemini_response()
+
+    monkeypatch.setattr(m, "fetch_json", _capture)
+    req = _req(model="gemini-2.5-flash-image")
+    m.GeminiImageAdapter().generate(req)
+
+    assert seen["json"] == {
+        "contents": [{"parts": [{"text": "a fox in a forest"}]}],
+        "generationConfig": {"responseModalities": ["TEXT", "IMAGE"]},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Reference image part shape + ordering
+# ---------------------------------------------------------------------------
+
+
+def test_gemini_reference_image_part_before_text(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    from tldw_chatbook.Image_Generation.capabilities import ResolvedReferenceImage
+
+    seen = {}
+
+    def _capture(method, url, *, headers=None, json=None, params=None, timeout=None, trusted_origins=frozenset()):
+        seen["json"] = json
+        return _gemini_response()
+
+    monkeypatch.setattr(m, "fetch_json", _capture)
+    ref = ResolvedReferenceImage(
+        file_id=1,
+        filename="ref.png",
+        mime_type="image/png",
+        width=8,
+        height=8,
+        bytes_len=3,
+        content=b"abc",
+        temp_path=None,
+    )
+    req = _req(model="gemini-2.5-flash-image", reference_image=ref)
+    m.GeminiImageAdapter().generate(req)
+
+    parts = seen["json"]["contents"][0]["parts"]
+    assert len(parts) == 2
+    assert parts[0] == {
+        "inline_data": {
+            "mime_type": "image/png",
+            "data": base64.b64encode(b"abc").decode("ascii"),
+        }
+    }
+    assert "text" in parts[1]
+
+
+def test_gemini_reference_image_via_temp_path(monkeypatch, tmp_path):
+    m = _reset_and_import(monkeypatch)
+    from tldw_chatbook.Image_Generation.capabilities import ResolvedReferenceImage
+
+    ref_file = tmp_path / "ref.png"
+    ref_file.write_bytes(b"xyz123")
+
+    seen = {}
+
+    def _capture(method, url, *, headers=None, json=None, params=None, timeout=None, trusted_origins=frozenset()):
+        seen["json"] = json
+        return _gemini_response()
+
+    monkeypatch.setattr(m, "fetch_json", _capture)
+    ref = ResolvedReferenceImage(
+        file_id=1,
+        filename="ref.png",
+        mime_type="image/jpeg",
+        width=8,
+        height=8,
+        bytes_len=6,
+        content=None,
+        temp_path=str(ref_file),
+    )
+    req = _req(model="gemini-2.5-flash-image", reference_image=ref)
+    m.GeminiImageAdapter().generate(req)
+
+    parts = seen["json"]["contents"][0]["parts"]
+    assert parts[0]["inline_data"]["mime_type"] == "image/jpeg"
+    assert parts[0]["inline_data"]["data"] == base64.b64encode(b"xyz123").decode("ascii")
+
+
+# ---------------------------------------------------------------------------
+# Response parsing: parts iteration across candidates
+# ---------------------------------------------------------------------------
+
+
+def test_gemini_extracts_image_text_then_image_parts(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+
+    response = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"text": "Here is your fox:"},
+                        {"inlineData": {"mimeType": "image/png", "data": _b64_png()}},
+                    ]
+                },
+                "finishReason": "STOP",
+            }
+        ]
+    }
+    monkeypatch.setattr(m, "fetch_json", lambda *a, **kw: response)
+    req = _req(model="gemini-2.5-flash-image")
+    res = m.GeminiImageAdapter().generate(req)
+    assert res.bytes_len > 0
+    assert res.content_type == "image/png"
+
+
+def test_gemini_extracts_image_from_second_candidate(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+
+    response = {
+        "candidates": [
+            {"content": {"parts": [{"text": "no image here"}]}, "finishReason": "STOP"},
+            {
+                "content": {"parts": [{"inline_data": {"mime_type": "image/png", "data": _b64_png()}}]},
+                "finishReason": "STOP",
+            },
+        ]
+    }
+    monkeypatch.setattr(m, "fetch_json", lambda *a, **kw: response)
+    req = _req(model="gemini-2.5-flash-image")
+    res = m.GeminiImageAdapter().generate(req)
+    assert res.bytes_len > 0
+
+
+def test_gemini_snake_case_inline_data_spelling_accepted(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+
+    response = _gemini_response(key="inline_data")
+    monkeypatch.setattr(m, "fetch_json", lambda *a, **kw: response)
+    req = _req(model="gemini-2.5-flash-image")
+    res = m.GeminiImageAdapter().generate(req)
+    assert res.bytes_len > 0
+
+
+# ---------------------------------------------------------------------------
+# No-image error matrix
+# ---------------------------------------------------------------------------
+
+
+def test_gemini_no_image_block_reason(monkeypatch):
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+    m = _reset_and_import(monkeypatch)
+    response = {"promptFeedback": {"blockReason": "SAFETY"}, "candidates": []}
+    monkeypatch.setattr(m, "fetch_json", lambda *a, **kw: response)
+    req = _req(model="gemini-2.5-flash-image")
+    with pytest.raises(ImageGenerationError) as exc_info:
+        m.GeminiImageAdapter().generate(req)
+    assert str(exc_info.value) == "Gemini blocked the prompt (SAFETY)"
+
+
+def test_gemini_no_image_finish_reason_not_stop(monkeypatch):
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+    m = _reset_and_import(monkeypatch)
+    response = {"candidates": [{"content": {"parts": []}, "finishReason": "SAFETY"}]}
+    monkeypatch.setattr(m, "fetch_json", lambda *a, **kw: response)
+    req = _req(model="gemini-2.5-flash-image")
+    with pytest.raises(ImageGenerationError) as exc_info:
+        m.GeminiImageAdapter().generate(req)
+    assert str(exc_info.value) == "Gemini returned no image (SAFETY)"
+
+
+def test_gemini_no_image_generic_fallback(monkeypatch):
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+    m = _reset_and_import(monkeypatch)
+    response = {"candidates": [{"content": {"parts": []}, "finishReason": "STOP"}]}
+    monkeypatch.setattr(m, "fetch_json", lambda *a, **kw: response)
+    req = _req(model="gemini-2.5-flash-image")
+    with pytest.raises(ImageGenerationError) as exc_info:
+        m.GeminiImageAdapter().generate(req)
+    assert str(exc_info.value) == "Gemini returned no image"
+
+
+def test_gemini_no_image_error_never_leaks_response_text_or_prompt(monkeypatch):
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+    m = _reset_and_import(monkeypatch)
+    marker = "SUPER_SECRET_MARKER_TEXT_1234"
+    response = {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": marker}]},
+                "finishReason": "SAFETY",
+            }
+        ]
+    }
+    monkeypatch.setattr(m, "fetch_json", lambda *a, **kw: response)
+    req = _req(model="gemini-2.5-flash-image", prompt="a very unique prompt marker XYZ987")
+    with pytest.raises(ImageGenerationError) as exc_info:
+        m.GeminiImageAdapter().generate(req)
+    message = str(exc_info.value)
+    assert marker not in message
+    assert "XYZ987" not in message
+    assert message == "Gemini returned no image (SAFETY)"
+
+
+def test_gemini_block_reason_takes_priority_over_finish_reason(monkeypatch):
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+    m = _reset_and_import(monkeypatch)
+    response = {
+        "promptFeedback": {"blockReason": "OTHER"},
+        "candidates": [{"content": {"parts": []}, "finishReason": "SAFETY"}],
+    }
+    monkeypatch.setattr(m, "fetch_json", lambda *a, **kw: response)
+    req = _req(model="gemini-2.5-flash-image")
+    with pytest.raises(ImageGenerationError) as exc_info:
+        m.GeminiImageAdapter().generate(req)
+    assert str(exc_info.value) == "Gemini blocked the prompt (OTHER)"
+
+
+# ---------------------------------------------------------------------------
+# Model-id validation matrix
+# ---------------------------------------------------------------------------
+
+
+def test_validate_model_id_accepts_valid_charset(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    assert m._validate_model_id("good-model_1.0") == "good-model_1.0"
+
+
+@pytest.mark.parametrize("bad_id", ["../evil", "a?b", "a b", "", "a/b"])
+def test_validate_model_id_rejects_invalid_charset(monkeypatch, bad_id):
+    m = _reset_and_import(monkeypatch)
+    from tldw_chatbook.Image_Generation.exceptions import ImageBackendUnavailableError
+
+    with pytest.raises(ImageBackendUnavailableError) as exc_info:
+        m._validate_model_id(bad_id)
+    assert bad_id in str(exc_info.value)
+
+
+def test_gemini_generate_rejects_invalid_model_id_before_network(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    from tldw_chatbook.Image_Generation.exceptions import ImageBackendUnavailableError
+
+    def _boom(*a, **kw):
+        raise AssertionError("fetch_json must not be called for an invalid model id")
+
+    monkeypatch.setattr(m, "fetch_json", _boom)
+    req = _req(model="../evil")
+    with pytest.raises(ImageBackendUnavailableError):
+        m.GeminiImageAdapter().generate(req)
+
+
+# ---------------------------------------------------------------------------
+# 404 / 400 enrichment (task-620 lesson)
+# ---------------------------------------------------------------------------
+
+
+def test_gemini_404_names_model_and_config_path(monkeypatch):
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+    m = _reset_and_import(monkeypatch)
+
+    def _raise_404(method, url, **kw):
+        request = httpx.Request(method, url)
+        response = httpx.Response(404, request=request, text="Not Found")
+        raise httpx.HTTPStatusError(
+            "Client error '404 Not Found' for url '{}'".format(url), request=request, response=response
+        )
+
+    monkeypatch.setattr(m, "fetch_json", _raise_404)
+    req = _req(model="gemini-nonexistent-model")
+    with pytest.raises(ImageGenerationError) as exc_info:
+        m.GeminiImageAdapter().generate(req)
+    message = str(exc_info.value)
+    assert "gemini-nonexistent-model" in message
+    assert "[image_generation.gemini] default_model" in message
+    assert "404" in message
+
+
+def test_gemini_400_names_model_and_config_path(monkeypatch):
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+    m = _reset_and_import(monkeypatch)
+
+    def _raise_400(method, url, **kw):
+        request = httpx.Request(method, url)
+        response = httpx.Response(400, request=request, text="Bad Request")
+        raise httpx.HTTPStatusError(
+            "Client error '400 Bad Request' for url '{}'".format(url), request=request, response=response
+        )
+
+    monkeypatch.setattr(m, "fetch_json", _raise_400)
+    req = _req(model="gemini-nonexistent-model")
+    with pytest.raises(ImageGenerationError) as exc_info:
+        m.GeminiImageAdapter().generate(req)
+    message = str(exc_info.value)
+    assert "gemini-nonexistent-model" in message
+    assert "[image_generation.gemini] default_model" in message
+    assert "400" in message
+
+
+def test_gemini_non_404_400_status_keeps_generic_message(monkeypatch):
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+    m = _reset_and_import(monkeypatch)
+
+    def _raise_500(method, url, **kw):
+        request = httpx.Request(method, url)
+        response = httpx.Response(500, request=request, text="Internal Server Error")
+        raise httpx.HTTPStatusError(
+            "Server error '500 Internal Server Error' for url '{}'".format(url), request=request, response=response
+        )
+
+    monkeypatch.setattr(m, "fetch_json", _raise_500)
+    req = _req(model="gemini-2.5-flash-image")
+    with pytest.raises(ImageGenerationError) as exc_info:
+        m.GeminiImageAdapter().generate(req)
+    message = str(exc_info.value)
+    assert "default_model" not in message
+
+
+# ---------------------------------------------------------------------------
+# Missing api key
+# ---------------------------------------------------------------------------
+
+
+def test_gemini_missing_api_key_raises_backend_unavailable(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as _c
+
+    _c.reset_image_generation_config_cache()
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.setattr(_c, "_read_image_generation_toml", lambda: {}, raising=False)
+    monkeypatch.setattr(_c, "_keyring_get", lambda backend: None, raising=False)
+
+    from tldw_chatbook.Image_Generation.adapters import gemini_image_adapter as m
+    from tldw_chatbook.Image_Generation.exceptions import ImageBackendUnavailableError
+
+    req = _req(model="gemini-2.5-flash-image")
+    with pytest.raises(ImageBackendUnavailableError):
+        m.GeminiImageAdapter().generate(req)
+
+
+# ---------------------------------------------------------------------------
+# Registry wiring
+# ---------------------------------------------------------------------------
+
+
+def test_gemini_registered_in_default_adapters():
+    from tldw_chatbook.Image_Generation.adapter_registry import DEFAULT_ADAPTERS
+
+    assert DEFAULT_ADAPTERS["gemini"] == (
+        "tldw_chatbook.Image_Generation.adapters.gemini_image_adapter.GeminiImageAdapter"
+    )
+
+
+def test_gemini_registry_resolves_adapter(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as _c
+    from tldw_chatbook.Image_Generation import adapter_registry as reg
+
+    _c.reset_image_generation_config_cache()
+    reg.reset_registry()
+    monkeypatch.setattr(
+        reg,
+        "get_image_generation_config",
+        lambda: type(
+            "Cfg",
+            (),
+            {"default_backend": "gemini", "enabled_backends": ["gemini"]},
+        )(),
+    )
+    registry = reg.ImageAdapterRegistry()
+    adapter = registry.get_adapter("gemini")
+    assert adapter is not None
+    assert adapter.name == "gemini"
+    reg.reset_registry()

--- a/Tests/Image_Generation/test_gemini_adapter.py
+++ b/Tests/Image_Generation/test_gemini_adapter.py
@@ -115,6 +115,145 @@ def test_gemini_trusted_origins_is_self_built_url_origin(monkeypatch):
     assert seen["trusted_origins"] == frozenset({"generativelanguage.googleapis.com"})
 
 
+def _patch_dns_public(monkeypatch, hc):
+    """Make every hostname resolve to a fixed public IP (mirrors test_http_client.py's
+    _policy_env fixture) so the real egress DNS-resolution branch doesn't hit the network."""
+    monkeypatch.setattr(hc.egress, "_resolve", lambda host: ["93.184.216.34"])
+
+    async def _resolve_async(host):
+        return ["93.184.216.34"]
+
+    monkeypatch.setattr(hc.egress, "_resolve_async", _resolve_async)
+    monkeypatch.setattr(hc.egress, "get_cli_setting", lambda s, k=None, d=None: d)
+
+
+def test_gemini_cross_origin_redirect_strips_api_key(monkeypatch):
+    # Fix-round-1 (reviewer IMPORTANT finding): x-goog-api-key must be
+    # stripped on a cross-origin redirect exactly like Authorization/Cookie.
+    # This exercises the REAL fetch_json redirect machinery (fetch_json is
+    # NOT monkeypatched here) so the fix is proven end-to-end through the
+    # adapter, not just at the egress unit level.
+    from tldw_chatbook.Image_Generation import config as _c
+    from tldw_chatbook.Image_Generation import http_client as hc
+
+    _c.reset_image_generation_config_cache()
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    _patch_dns_public(monkeypatch, hc)
+
+    from tldw_chatbook.Image_Generation.adapters import gemini_image_adapter as m
+
+    seen = []
+    start_url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-image:generateContent"
+
+    class RedirResp:
+        is_redirect = True
+        headers = {"location": "https://attacker.example/steal"}
+        url = start_url
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {}
+
+    class FinalResp:
+        is_redirect = False
+        status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return _gemini_response()
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def request(self, method, url, *, headers=None, **k):
+            seen.append((url, dict(headers or {})))
+            return FinalResp() if url == "https://attacker.example/steal" else RedirResp()
+
+    monkeypatch.setattr(hc.httpx, "Client", FakeClient)
+    req = _req(model="gemini-2.5-flash-image")
+    m.GeminiImageAdapter().generate(req)
+
+    assert len(seen) == 2
+    first_url, first_headers = seen[0]
+    assert first_url == start_url
+    assert first_headers.get("x-goog-api-key") == "test-key"
+    second_url, second_headers = seen[1]
+    assert second_url == "https://attacker.example/steal"
+    assert "x-goog-api-key" not in second_headers
+
+
+def test_gemini_same_origin_redirect_keeps_api_key(monkeypatch):
+    # Companion to the cross-origin test above: a same-origin redirect must
+    # NOT strip the key (only cross-origin hops are stripped).
+    from tldw_chatbook.Image_Generation import config as _c
+    from tldw_chatbook.Image_Generation import http_client as hc
+
+    _c.reset_image_generation_config_cache()
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    _patch_dns_public(monkeypatch, hc)
+
+    from tldw_chatbook.Image_Generation.adapters import gemini_image_adapter as m
+
+    seen = []
+    start_url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-image:generateContent"
+    same_origin_url = "https://generativelanguage.googleapis.com/v1beta/models/other:generateContent"
+
+    class RedirResp:
+        is_redirect = True
+        headers = {"location": same_origin_url}
+        url = start_url
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {}
+
+    class FinalResp:
+        is_redirect = False
+        status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return _gemini_response()
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def request(self, method, url, *, headers=None, **k):
+            seen.append((url, dict(headers or {})))
+            return FinalResp() if url == same_origin_url else RedirResp()
+
+    monkeypatch.setattr(hc.httpx, "Client", FakeClient)
+    req = _req(model="gemini-2.5-flash-image")
+    m.GeminiImageAdapter().generate(req)
+
+    assert len(seen) == 2
+    second_url, second_headers = seen[1]
+    assert second_url == same_origin_url
+    assert second_headers.get("x-goog-api-key") == "test-key"
+
+
 def test_gemini_response_modalities_pinned(monkeypatch):
     # task-620 lesson: verified live against docs, not guessed. See report.
     m = _reset_and_import(monkeypatch)
@@ -296,6 +435,49 @@ def test_gemini_snake_case_inline_data_spelling_accepted(monkeypatch):
     req = _req(model="gemini-2.5-flash-image")
     res = m.GeminiImageAdapter().generate(req)
     assert res.bytes_len > 0
+
+
+def test_gemini_malformed_base64_in_first_candidate_does_not_abort_scan(monkeypatch):
+    # Fix-round-1 (reviewer MINOR finding): corrupted base64 in candidate[0]
+    # must not raise out of the scan and mask a valid image in candidate[1].
+    m = _reset_and_import(monkeypatch)
+
+    response = {
+        "candidates": [
+            {
+                "content": {"parts": [{"inlineData": {"mimeType": "image/png", "data": "not-valid-base64!!!"}}]},
+                "finishReason": "STOP",
+            },
+            {
+                "content": {"parts": [{"inlineData": {"mimeType": "image/png", "data": _b64_png()}}]},
+                "finishReason": "STOP",
+            },
+        ]
+    }
+    monkeypatch.setattr(m, "fetch_json", lambda *a, **kw: response)
+    req = _req(model="gemini-2.5-flash-image")
+    res = m.GeminiImageAdapter().generate(req)
+    assert res.bytes_len > 0
+
+
+def test_gemini_all_parts_undecodable_raises_dedicated_error(monkeypatch):
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+    m = _reset_and_import(monkeypatch)
+
+    response = {
+        "candidates": [
+            {
+                "content": {"parts": [{"inlineData": {"mimeType": "image/png", "data": "not-valid-base64!!!"}}]},
+                "finishReason": "STOP",
+            }
+        ]
+    }
+    monkeypatch.setattr(m, "fetch_json", lambda *a, **kw: response)
+    req = _req(model="gemini-2.5-flash-image")
+    with pytest.raises(ImageGenerationError) as exc_info:
+        m.GeminiImageAdapter().generate(req)
+    assert str(exc_info.value) == "Gemini returned image data that could not be decoded"
 
 
 # ---------------------------------------------------------------------------

--- a/Tests/Image_Generation/test_http_client.py
+++ b/Tests/Image_Generation/test_http_client.py
@@ -412,7 +412,15 @@ def test_create_client_defaults_when_timeout_omitted(hc):
         client.close()
 
 
-# --- fetch_bytes_via_post --------------------------------------------------
+# --- fetch_bytes_via_post ---------------------------------------------------
+#
+# fetch_bytes_via_post streams the final hop's response (client.stream(), not
+# client.request()) so a body larger than max_bytes is never fully buffered
+# before being rejected -- httpx has no built-in body-size limit, so a
+# read-then-check on resp.content would defeat the cap (fix round 1). Fake
+# response objects below therefore act as their own context manager
+# (__enter__/__exit__) and expose iter_bytes() instead of .content, matching
+# what `with client.stream(...) as resp:` yields.
 
 
 def test_fetch_bytes_via_post_returns_body_and_content_type(monkeypatch, hc):
@@ -420,14 +428,18 @@ def test_fetch_bytes_via_post_returns_body_and_content_type(monkeypatch, hc):
     class FakeResp:
         status_code = 200
         is_redirect = False
-        content = b"\x89PNG\r\n\x1a\nrest-of-file"
         headers = {"content-type": "image/png"}
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
         def raise_for_status(self): pass
+        def iter_bytes(self):
+            yield b"\x89PNG\r\n\x1a\n"
+            yield b"rest-of-file"
     class FakeClient:
         def __init__(self, *a, **k): pass
         def __enter__(self): return self
         def __exit__(self, *a): return False
-        def request(self, method, url, *, json=None, **k):
+        def stream(self, method, url, *, json=None, **k):
             assert method == "POST"
             return FakeResp()
     monkeypatch.setattr(hc.httpx, "Client", FakeClient)
@@ -445,7 +457,7 @@ def test_fetch_bytes_via_post_validates_egress_first(monkeypatch, hc):
         def __init__(self, *a, **k): pass
         def __enter__(self): return self
         def __exit__(self, *a): return False
-        def request(self, *a, **k):
+        def stream(self, *a, **k):
             raise AssertionError("must not reach the transport when the URL is blocked")
     monkeypatch.setattr(hc.httpx, "Client", FakeClient)
     with pytest.raises(ImageGenerationError):
@@ -462,20 +474,25 @@ def test_fetch_bytes_via_post_strips_credentials_on_cross_origin_redirect(monkey
         status_code = 307
         headers = {"location": "https://attacker.example/steal"}
         url = "https://api.example.com/x"
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
         def raise_for_status(self): pass
 
     class FinalResp:
         is_redirect = False
         status_code = 200
-        content = b"bytes-payload"
         headers = {"content-type": "application/octet-stream"}
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
         def raise_for_status(self): pass
+        def iter_bytes(self):
+            yield b"bytes-payload"
 
     class FakeClient:
         def __init__(self, *a, **k): pass
         def __enter__(self): return self
         def __exit__(self, *a): return False
-        def request(self, method, url, *, headers=None, **k):
+        def stream(self, method, url, *, headers=None, **k):
             seen.append((url, dict(headers or {})))
             return RedirResp() if url == "https://api.example.com/x" else FinalResp()
 
@@ -506,13 +523,15 @@ def test_fetch_bytes_via_post_redirect_to_private_ip_blocked(monkeypatch, hc):
         status_code = 307
         headers = {"location": "http://10.0.0.1/steal"}
         url = "https://api.example.com/x"
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
         def raise_for_status(self): pass
 
     class FakeClient:
         def __init__(self, *a, **k): pass
         def __enter__(self): return self
         def __exit__(self, *a): return False
-        def request(self, *a, **k): return RedirResp()
+        def stream(self, *a, **k): return RedirResp()
 
     monkeypatch.setattr(hc.httpx, "Client", FakeClient)
     with pytest.raises(ImageGenerationError):
@@ -522,30 +541,79 @@ def test_fetch_bytes_via_post_redirect_to_private_ip_blocked(monkeypatch, hc):
         )
 
 
-def test_fetch_bytes_via_post_max_bytes_exceeded_raises(monkeypatch, hc):
-    # Content longer than max_bytes -> clear error naming the cap, not a
-    # silently truncated return.
+def test_fetch_bytes_via_post_max_bytes_exceeded_aborts_mid_stream(monkeypatch, hc):
+    # A running total that exceeds max_bytes partway through the stream must
+    # abort THERE (not read the rest of the body first) and raise a clear,
+    # cap-naming error -- proven by asserting the chunk source was not fully
+    # consumed.
     from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+    consumed = []
+
+    def chunk_source():
+        for i in range(5):
+            consumed.append(i)
+            yield b"x" * 10  # 5 chunks * 10 bytes = 50 bytes if fully read
 
     class FakeResp:
         status_code = 200
         is_redirect = False
-        content = b"x" * 100
-        headers = {"content-type": "application/octet-stream"}
+        headers = {"content-type": "application/octet-stream"}  # no Content-Length
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
         def raise_for_status(self): pass
+        def iter_bytes(self): return chunk_source()
+
     class FakeClient:
         def __init__(self, *a, **k): pass
         def __enter__(self): return self
         def __exit__(self, *a): return False
-        def request(self, *a, **k): return FakeResp()
+        def stream(self, *a, **k): return FakeResp()
+
     monkeypatch.setattr(hc.httpx, "Client", FakeClient)
     with pytest.raises(ImageGenerationError) as exc_info:
         hc.fetch_bytes_via_post(
             "https://api.example.com/gen", json={"prompt": "x"},
             trusted_origins=frozenset({"api.example.com"}),
-            max_bytes=10,
+            max_bytes=25,  # exceeded partway through chunk 3 (30 > 25)
         )
-    assert "10" in str(exc_info.value)
+    assert "25" in str(exc_info.value)
+    assert len(consumed) < 5, "stream must abort as soon as the cap is exceeded, not read to the end"
+
+
+def test_fetch_bytes_via_post_declared_oversize_rejected_without_reading(monkeypatch, hc):
+    # A Content-Length that already exceeds max_bytes is rejected before a
+    # single chunk is read -- the declared-oversize pre-check.
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+    iter_bytes_started = []
+
+    class FakeResp:
+        status_code = 200
+        is_redirect = False
+        headers = {"content-type": "application/octet-stream", "content-length": "1000"}
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def raise_for_status(self): pass
+        def iter_bytes(self):
+            iter_bytes_started.append(True)
+            yield b"x" * 1000
+
+    class FakeClient:
+        def __init__(self, *a, **k): pass
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def stream(self, *a, **k): return FakeResp()
+
+    monkeypatch.setattr(hc.httpx, "Client", FakeClient)
+    with pytest.raises(ImageGenerationError) as exc_info:
+        hc.fetch_bytes_via_post(
+            "https://api.example.com/gen", json={"prompt": "x"},
+            trusted_origins=frozenset({"api.example.com"}),
+            max_bytes=100,
+        )
+    assert "100" in str(exc_info.value)
+    assert iter_bytes_started == [], "declared-oversize body must never be read, not even one chunk"
 
 
 def test_fetch_bytes_via_post_respects_explicit_zero_timeout(monkeypatch, hc):
@@ -556,15 +624,18 @@ def test_fetch_bytes_via_post_respects_explicit_zero_timeout(monkeypatch, hc):
     class FakeResp:
         status_code = 200
         is_redirect = False
-        content = b"bytes"
         headers = {"content-type": "application/octet-stream"}
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
         def raise_for_status(self): pass
+        def iter_bytes(self):
+            yield b"bytes"
     class FakeClient:
         def __init__(self, *a, **k):
             captured.append(k.get("timeout"))
         def __enter__(self): return self
         def __exit__(self, *a): return False
-        def request(self, *a, **k): return FakeResp()
+        def stream(self, *a, **k): return FakeResp()
 
     monkeypatch.setattr(hc.httpx, "Client", FakeClient)
     hc.fetch_bytes_via_post(

--- a/Tests/Image_Generation/test_http_client.py
+++ b/Tests/Image_Generation/test_http_client.py
@@ -410,3 +410,172 @@ def test_create_client_defaults_when_timeout_omitted(hc):
         assert client.timeout == httpx.Timeout(timeout=hc._DEFAULT_TIMEOUT)
     finally:
         client.close()
+
+
+# --- fetch_bytes_via_post --------------------------------------------------
+
+
+def test_fetch_bytes_via_post_returns_body_and_content_type(monkeypatch, hc):
+    """Happy path: POST returns bytes + the content-type header."""
+    class FakeResp:
+        status_code = 200
+        is_redirect = False
+        content = b"\x89PNG\r\n\x1a\nrest-of-file"
+        headers = {"content-type": "image/png"}
+        def raise_for_status(self): pass
+    class FakeClient:
+        def __init__(self, *a, **k): pass
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def request(self, method, url, *, json=None, **k):
+            assert method == "POST"
+            return FakeResp()
+    monkeypatch.setattr(hc.httpx, "Client", FakeClient)
+    body, ctype = hc.fetch_bytes_via_post(
+        "https://api.example.com/gen", json={"prompt": "x"},
+        trusted_origins=frozenset({"api.example.com"}),
+    )
+    assert body.startswith(b"\x89PNG") and ctype == "image/png"
+
+
+def test_fetch_bytes_via_post_validates_egress_first(monkeypatch, hc):
+    # Private IP without trusted_origins -> egress error, fake client never called.
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+    class FakeClient:
+        def __init__(self, *a, **k): pass
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def request(self, *a, **k):
+            raise AssertionError("must not reach the transport when the URL is blocked")
+    monkeypatch.setattr(hc.httpx, "Client", FakeClient)
+    with pytest.raises(ImageGenerationError):
+        hc.fetch_bytes_via_post("http://127.0.0.1:7801/gen", json={"prompt": "x"})
+
+
+def test_fetch_bytes_via_post_strips_credentials_on_cross_origin_redirect(monkeypatch, hc):
+    # 307 to another host: Authorization absent on hop 2; same-origin keeps it
+    # on hop 1 (mirrors test_fetch_json_strips_authorization_on_cross_origin_redirect).
+    seen = []
+
+    class RedirResp:
+        is_redirect = True
+        status_code = 307
+        headers = {"location": "https://attacker.example/steal"}
+        url = "https://api.example.com/x"
+        def raise_for_status(self): pass
+
+    class FinalResp:
+        is_redirect = False
+        status_code = 200
+        content = b"bytes-payload"
+        headers = {"content-type": "application/octet-stream"}
+        def raise_for_status(self): pass
+
+    class FakeClient:
+        def __init__(self, *a, **k): pass
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def request(self, method, url, *, headers=None, **k):
+            seen.append((url, dict(headers or {})))
+            return RedirResp() if url == "https://api.example.com/x" else FinalResp()
+
+    monkeypatch.setattr(hc.httpx, "Client", FakeClient)
+    body, ctype = hc.fetch_bytes_via_post(
+        "https://api.example.com/x",
+        headers={"Authorization": "Bearer secret", "X-Other": "keep"},
+        json={"prompt": "x"},
+        trusted_origins=frozenset({"api.example.com"}),
+    )
+    assert body == b"bytes-payload" and ctype == "application/octet-stream"
+    assert len(seen) == 2
+    first_url, first_headers = seen[0]
+    assert first_headers.get("Authorization") == "Bearer secret"
+    second_url, second_headers = seen[1]
+    assert second_url == "https://attacker.example/steal"
+    assert "Authorization" not in second_headers
+    assert second_headers.get("X-Other") == "keep"
+
+
+def test_fetch_bytes_via_post_redirect_to_private_ip_blocked(monkeypatch, hc):
+    # 307 Location -> 10.0.0.1 raises an egress error, even though the first
+    # hop was fine.
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+    class RedirResp:
+        is_redirect = True
+        status_code = 307
+        headers = {"location": "http://10.0.0.1/steal"}
+        url = "https://api.example.com/x"
+        def raise_for_status(self): pass
+
+    class FakeClient:
+        def __init__(self, *a, **k): pass
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def request(self, *a, **k): return RedirResp()
+
+    monkeypatch.setattr(hc.httpx, "Client", FakeClient)
+    with pytest.raises(ImageGenerationError):
+        hc.fetch_bytes_via_post(
+            "https://api.example.com/x", json={"prompt": "x"},
+            trusted_origins=frozenset({"api.example.com"}),
+        )
+
+
+def test_fetch_bytes_via_post_max_bytes_exceeded_raises(monkeypatch, hc):
+    # Content longer than max_bytes -> clear error naming the cap, not a
+    # silently truncated return.
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+    class FakeResp:
+        status_code = 200
+        is_redirect = False
+        content = b"x" * 100
+        headers = {"content-type": "application/octet-stream"}
+        def raise_for_status(self): pass
+    class FakeClient:
+        def __init__(self, *a, **k): pass
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def request(self, *a, **k): return FakeResp()
+    monkeypatch.setattr(hc.httpx, "Client", FakeClient)
+    with pytest.raises(ImageGenerationError) as exc_info:
+        hc.fetch_bytes_via_post(
+            "https://api.example.com/gen", json={"prompt": "x"},
+            trusted_origins=frozenset({"api.example.com"}),
+            max_bytes=10,
+        )
+    assert "10" in str(exc_info.value)
+
+
+def test_fetch_bytes_via_post_respects_explicit_zero_timeout(monkeypatch, hc):
+    # timeout=0 is passed through to the client as-is (the task-497 lesson);
+    # None falls back to _DEFAULT_TIMEOUT.
+    captured = []
+
+    class FakeResp:
+        status_code = 200
+        is_redirect = False
+        content = b"bytes"
+        headers = {"content-type": "application/octet-stream"}
+        def raise_for_status(self): pass
+    class FakeClient:
+        def __init__(self, *a, **k):
+            captured.append(k.get("timeout"))
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def request(self, *a, **k): return FakeResp()
+
+    monkeypatch.setattr(hc.httpx, "Client", FakeClient)
+    hc.fetch_bytes_via_post(
+        "https://api.example.com/gen", json={"prompt": "x"}, timeout=0,
+        trusted_origins=frozenset({"api.example.com"}),
+    )
+    assert captured[-1] == 0
+
+    captured.clear()
+    hc.fetch_bytes_via_post(
+        "https://api.example.com/gen", json={"prompt": "x"}, timeout=None,
+        trusted_origins=frozenset({"api.example.com"}),
+    )
+    assert captured[-1] == hc._DEFAULT_TIMEOUT

--- a/Tests/Image_Generation/test_listing.py
+++ b/Tests/Image_Generation/test_listing.py
@@ -31,3 +31,71 @@ def test_disabled_backends_excluded(monkeypatch):
     c.get_image_generation_config(reload=True)
     names = {e["name"] for e in L.list_image_models_for_catalog()}
     assert "novita" not in names and "swarmui" in names
+
+
+# --- task-2 (fal/Gemini/Fireworks image backends): _is_*_configured --------
+#
+# These three backends have no adapter registered yet (adapters land in a
+# later task), so they never appear via list_image_models_for_catalog()'s
+# registry-driven enumeration here -- exercise the dispatch helpers directly,
+# same shape as the sibling _is_openrouter_configured/etc. functions.
+
+def test_is_fal_configured_true_when_key_present(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as c, listing as L
+    monkeypatch.delenv("FAL_KEY", raising=False)
+    monkeypatch.setattr(c, "_read_image_generation_toml",
+                        lambda: {"fal": {"api_key": "fake-fal-key"}}, raising=False)
+    cfg = c.get_image_generation_config(reload=True)
+    assert L._is_fal_configured(cfg, True) is True
+
+
+def test_is_fal_configured_false_when_key_missing(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as c, listing as L
+    monkeypatch.delenv("FAL_KEY", raising=False)
+    monkeypatch.setattr(c, "_read_image_generation_toml", lambda: {}, raising=False)
+    cfg = c.get_image_generation_config(reload=True)
+    assert L._is_fal_configured(cfg, True) is False
+
+
+def test_is_fal_configured_false_when_disabled_even_with_key(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as c, listing as L
+    monkeypatch.setattr(c, "_read_image_generation_toml",
+                        lambda: {"fal": {"api_key": "fake-fal-key"}}, raising=False)
+    cfg = c.get_image_generation_config(reload=True)
+    assert L._is_fal_configured(cfg, False) is False
+
+
+def test_is_gemini_configured_true_when_key_present(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as c, listing as L
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.setattr(c, "_read_image_generation_toml",
+                        lambda: {"gemini": {"api_key": "fake-gemini-key"}}, raising=False)
+    cfg = c.get_image_generation_config(reload=True)
+    assert L._is_gemini_configured(cfg, True) is True
+
+
+def test_is_gemini_configured_false_when_key_missing(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as c, listing as L
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.setattr(c, "_read_image_generation_toml", lambda: {}, raising=False)
+    cfg = c.get_image_generation_config(reload=True)
+    assert L._is_gemini_configured(cfg, True) is False
+
+
+def test_is_fireworks_configured_true_when_key_present(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as c, listing as L
+    monkeypatch.delenv("FIREWORKS_API_KEY", raising=False)
+    monkeypatch.setattr(c, "_read_image_generation_toml",
+                        lambda: {"fireworks": {"api_key": "fake-fireworks-key"}}, raising=False)
+    cfg = c.get_image_generation_config(reload=True)
+    assert L._is_fireworks_configured(cfg, True) is True
+
+
+def test_is_fireworks_configured_false_when_key_missing(monkeypatch):
+    from tldw_chatbook.Image_Generation import config as c, listing as L
+    monkeypatch.delenv("FIREWORKS_API_KEY", raising=False)
+    monkeypatch.setattr(c, "_read_image_generation_toml", lambda: {}, raising=False)
+    cfg = c.get_image_generation_config(reload=True)
+    assert L._is_fireworks_configured(cfg, True) is False

--- a/Tests/Image_Generation/test_listing.py
+++ b/Tests/Image_Generation/test_listing.py
@@ -33,10 +33,12 @@ def test_disabled_backends_excluded(monkeypatch):
     assert "novita" not in names and "swarmui" in names
 
 
-# --- task-2 (fal/Gemini/Fireworks image backends): _is_*_configured --------
+# --- task-2 (fal/Gemini image backends): _is_*_configured ------------------
+# Fireworks was dropped 2026-07-26 -- vendor deprecated image generation
+# (see the design spec/plan docs' 2026-07-26 decision notes).
 #
-# These three backends have no adapter registered yet (adapters land in a
-# later task), so they never appear via list_image_models_for_catalog()'s
+# These backends have no adapter registered yet (adapters land in a later
+# task), so they never appear via list_image_models_for_catalog()'s
 # registry-driven enumeration here -- exercise the dispatch helpers directly,
 # same shape as the sibling _is_openrouter_configured/etc. functions.
 
@@ -82,20 +84,3 @@ def test_is_gemini_configured_false_when_key_missing(monkeypatch):
     monkeypatch.setattr(c, "_read_image_generation_toml", lambda: {}, raising=False)
     cfg = c.get_image_generation_config(reload=True)
     assert L._is_gemini_configured(cfg, True) is False
-
-
-def test_is_fireworks_configured_true_when_key_present(monkeypatch):
-    from tldw_chatbook.Image_Generation import config as c, listing as L
-    monkeypatch.delenv("FIREWORKS_API_KEY", raising=False)
-    monkeypatch.setattr(c, "_read_image_generation_toml",
-                        lambda: {"fireworks": {"api_key": "fake-fireworks-key"}}, raising=False)
-    cfg = c.get_image_generation_config(reload=True)
-    assert L._is_fireworks_configured(cfg, True) is True
-
-
-def test_is_fireworks_configured_false_when_key_missing(monkeypatch):
-    from tldw_chatbook.Image_Generation import config as c, listing as L
-    monkeypatch.delenv("FIREWORKS_API_KEY", raising=False)
-    monkeypatch.setattr(c, "_read_image_generation_toml", lambda: {}, raising=False)
-    cfg = c.get_image_generation_config(reload=True)
-    assert L._is_fireworks_configured(cfg, True) is False

--- a/Tests/Image_Generation/test_live_backends.py
+++ b/Tests/Image_Generation/test_live_backends.py
@@ -15,6 +15,16 @@ Env vars, one group per backend:
     modelstudio:            DASHSCOPE_API_KEY
     swarmui:                TLDW_LIVE_SWARMUI_BASE_URL (a reachable SwarmUI server)
     stable_diffusion_cpp:   TLDW_LIVE_SD_CPP_BINARY + TLDW_LIVE_SD_CPP_MODEL_PATH
+    fal:                    TLDW_LIVE_FAL_API_KEY (+ optional TLDW_LIVE_FAL_MODEL)
+    gemini:                 TLDW_LIVE_GEMINI_API_KEY (+ optional TLDW_LIVE_GEMINI_MODEL)
+
+fal/gemini deliberately use their own ``TLDW_LIVE_*`` opt-in var, distinct
+from the production secret env vars their adapters otherwise fall back to
+(``FAL_KEY``, ``GEMINI_API_KEY``/``GOOGLE_API_KEY``) -- so a developer who
+happens to have one of those exported for unrelated reasons never
+accidentally triggers a paid live call just by running the suite. The key is
+fed to the backend via a crafted config section (like the sd.cpp/swarmui
+groups above), never by relying on the adapter's own env fallback.
 """
 from __future__ import annotations
 
@@ -66,11 +76,11 @@ def _enable_backend(monkeypatch, backend: str, *, toml: dict | None = None) -> N
     monkeypatch.setattr(c, "_read_image_generation_toml", lambda: section, raising=False)
 
 
-def _generate(backend: str, **kwargs):
+def _generate(backend: str, *, prompt: str = _PROMPT, **kwargs):
     from tldw_chatbook.Image_Generation.worker import build_request, run_generation
 
     req = build_request(
-        backend=backend, prompt=_PROMPT, seed=1, image_format="png", **kwargs
+        backend=backend, prompt=prompt, seed=1, image_format="png", **kwargs
     )
     return run_generation(req)
 
@@ -79,6 +89,19 @@ def _assert_real_image(res) -> None:
     assert res.bytes_len > 0
     assert res.content_type.startswith("image/")
     assert len(res.content) == res.bytes_len
+
+
+def _tiny_png_bytes() -> bytes:
+    """A real (not merely well-formed-looking) 1x1 PNG, for the gemini
+    reference-image edit test -- Gemini actually decodes the inline data, so
+    an arbitrary placeholder byte string would get rejected server-side
+    (mirrors ``Tests/Image_Generation/test_demo_screen.py``'s own helper)."""
+    import io
+    from PIL import Image as PILImage
+
+    buf = io.BytesIO()
+    PILImage.new("RGB", (1, 1), color=(255, 0, 0)).save(buf, format="PNG")
+    return buf.getvalue()
 
 
 def test_live_openrouter_generates_image(monkeypatch):
@@ -128,3 +151,57 @@ def test_live_stable_diffusion_cpp_generates_image(monkeypatch):
     )
     # Keep the run fast -- this is a smoke test, not a quality check.
     _assert_real_image(_generate("stable_diffusion_cpp", steps=4, width=64, height=64))
+
+
+def test_live_fal_generates_image(monkeypatch):
+    env = _required_env("TLDW_LIVE_FAL_API_KEY")
+    model = os.environ.get("TLDW_LIVE_FAL_MODEL", "").strip()
+    _enable_backend(
+        monkeypatch, "fal", toml={"api_key": env["TLDW_LIVE_FAL_API_KEY"]}
+    )
+    kwargs = {"model": model} if model else {}
+    _assert_real_image(_generate("fal", **kwargs))
+
+
+def test_live_gemini_generates_image(monkeypatch):
+    env = _required_env("TLDW_LIVE_GEMINI_API_KEY")
+    model = os.environ.get("TLDW_LIVE_GEMINI_MODEL", "").strip()
+    _enable_backend(
+        monkeypatch, "gemini", toml={"api_key": env["TLDW_LIVE_GEMINI_API_KEY"]}
+    )
+    kwargs = {"model": model} if model else {}
+    _assert_real_image(_generate("gemini", **kwargs))
+
+
+def test_live_gemini_reference_image_edit(monkeypatch):
+    """gemini additionally supports a reference-image edit request (a tiny
+    in-memory PNG + an edit instruction) -- gated on the same
+    TLDW_LIVE_GEMINI_API_KEY as the plain generation test above."""
+    from tldw_chatbook.Image_Generation.capabilities import ResolvedReferenceImage
+
+    env = _required_env("TLDW_LIVE_GEMINI_API_KEY")
+    model = os.environ.get("TLDW_LIVE_GEMINI_MODEL", "").strip()
+    _enable_backend(
+        monkeypatch, "gemini", toml={"api_key": env["TLDW_LIVE_GEMINI_API_KEY"]}
+    )
+
+    ref_bytes = _tiny_png_bytes()
+    reference_image = ResolvedReferenceImage(
+        file_id=1,
+        filename="ref.png",
+        mime_type="image/png",
+        width=1,
+        height=1,
+        bytes_len=len(ref_bytes),
+        content=ref_bytes,
+        temp_path=None,
+    )
+    kwargs = {"reference_image": reference_image}
+    if model:
+        kwargs["model"] = model
+    result = _generate(
+        "gemini",
+        prompt="Recolor this reference image's background to solid blue.",
+        **kwargs,
+    )
+    _assert_real_image(result)

--- a/Tests/Image_Generation/test_request_validation.py
+++ b/Tests/Image_Generation/test_request_validation.py
@@ -74,7 +74,7 @@ def test_reference_image_refused_for_legacy_backends(rv, backend):
     ]
 
 
-@pytest.mark.parametrize("backend", ["fal", "gemini", "fireworks"])
+@pytest.mark.parametrize("backend", ["fal", "gemini"])
 def test_reference_image_accepted_for_new_backends(rv, backend):
     ok = {"backend": backend, "prompt": "cat", "extra_params": {}, "reference_image": _ref()}
     assert rv.validate_image_generation_request(ok) == []

--- a/Tests/Image_Generation/test_request_validation.py
+++ b/Tests/Image_Generation/test_request_validation.py
@@ -1,5 +1,7 @@
 import pytest
 
+from tldw_chatbook.Image_Generation.capabilities import ResolvedReferenceImage
+
 @pytest.fixture
 def rv():
     from tldw_chatbook.Image_Generation import request_validation as m
@@ -7,6 +9,23 @@ def rv():
 
 def _codes(issues):
     return {i.path for i in issues}
+
+def _messages(issues):
+    return {i.message for i in issues}
+
+def _ref(**overrides):
+    defaults = dict(
+        file_id=1,
+        filename="ref.png",
+        mime_type="image/png",
+        width=64,
+        height=64,
+        bytes_len=4,
+        content=b"1234",
+        temp_path=None,
+    )
+    defaults.update(overrides)
+    return ResolvedReferenceImage(**defaults)
 
 def test_valid_request_has_no_issues(rv):
     ok = {"backend": "swarmui", "prompt": "cat", "width": 512, "height": 512, "steps": 20, "cfg_scale": 7.0, "extra_params": {}}
@@ -25,3 +44,103 @@ def test_extra_params_not_in_allowlist_flagged(rv):
     bad = {"backend": "swarmui", "prompt": "cat", "extra_params": {"totally_unknown": 1}}
     issues = rv.validate_image_generation_request(bad)
     assert any("extra_params" in p for p in _codes(issues))
+
+
+def test_reference_image_absent_key_no_issues(rv):
+    # Existing callers that never populate "reference_image" at all must be
+    # completely unaffected by the new choke-point checks.
+    ok = {"backend": "swarmui", "prompt": "cat", "extra_params": {}}
+    assert rv.validate_image_generation_request(ok) == []
+
+
+def test_reference_image_none_no_issues(rv):
+    ok = {"backend": "swarmui", "prompt": "cat", "extra_params": {}, "reference_image": None}
+    assert rv.validate_image_generation_request(ok) == []
+
+
+@pytest.mark.parametrize(
+    "backend",
+    ["stable_diffusion_cpp", "swarmui", "openrouter", "novita", "together", "modelstudio"],
+)
+def test_reference_image_refused_for_legacy_backends(rv, backend):
+    bad = {"backend": backend, "prompt": "cat", "extra_params": {}, "reference_image": _ref()}
+    issues = rv.validate_image_generation_request(bad)
+    assert issues == [
+        rv.ImageGenerationValidationIssue(
+            code="image_params_invalid",
+            message=f"backend {backend!r} does not support reference images",
+            path="reference_image",
+        )
+    ]
+
+
+@pytest.mark.parametrize("backend", ["fal", "gemini", "fireworks"])
+def test_reference_image_accepted_for_new_backends(rv, backend):
+    ok = {"backend": backend, "prompt": "cat", "extra_params": {}, "reference_image": _ref()}
+    assert rv.validate_image_generation_request(ok) == []
+
+
+def test_reference_image_webp_accepted(rv):
+    ok = {"backend": "fal", "prompt": "cat", "extra_params": {}, "reference_image": _ref(mime_type="image/webp")}
+    assert rv.validate_image_generation_request(ok) == []
+
+
+def test_reference_image_gif_refused(rv):
+    bad = {"backend": "fal", "prompt": "cat", "extra_params": {}, "reference_image": _ref(mime_type="image/gif")}
+    issues = rv.validate_image_generation_request(bad)
+    assert "reference image mime 'image/gif' is not supported (png/jpeg/webp)" in _messages(issues)
+
+
+def test_reference_image_oversize_refused(rv):
+    bad = {
+        "backend": "fal",
+        "prompt": "cat",
+        "extra_params": {},
+        "reference_image": _ref(bytes_len=rv.IMAGE_GEN_REFERENCE_MAX_BYTES + 1),
+    }
+    issues = rv.validate_image_generation_request(bad)
+    assert "reference image exceeds the 10MB limit" in _messages(issues)
+
+
+def test_reference_image_at_exact_cap_not_refused(rv):
+    ok = {
+        "backend": "fal",
+        "prompt": "cat",
+        "extra_params": {},
+        "reference_image": _ref(bytes_len=rv.IMAGE_GEN_REFERENCE_MAX_BYTES),
+    }
+    assert rv.validate_image_generation_request(ok) == []
+
+
+def test_reference_image_no_content_refused(rv):
+    bad = {
+        "backend": "fal",
+        "prompt": "cat",
+        "extra_params": {},
+        "reference_image": _ref(content=None, temp_path="/tmp/ref.png"),
+    }
+    issues = rv.validate_image_generation_request(bad)
+    assert "reference image has no content bytes" in _messages(issues)
+
+
+def test_reference_image_multiple_problems_all_reported(rv):
+    # Unsupported backend + bad mime + oversize + no content, all at once --
+    # the checks must not short-circuit each other.
+    bad = {
+        "backend": "swarmui",
+        "prompt": "cat",
+        "extra_params": {},
+        "reference_image": _ref(
+            mime_type="image/gif",
+            bytes_len=rv.IMAGE_GEN_REFERENCE_MAX_BYTES + 1,
+            content=None,
+            temp_path="/tmp/ref.gif",
+        ),
+    }
+    issues = rv.validate_image_generation_request(bad)
+    messages = _messages(issues)
+    assert "backend 'swarmui' does not support reference images" in messages
+    assert "reference image mime 'image/gif' is not supported (png/jpeg/webp)" in messages
+    assert "reference image exceeds the 10MB limit" in messages
+    assert "reference image has no content bytes" in messages
+    assert len(issues) == 4

--- a/Tests/Image_Generation/test_worker.py
+++ b/Tests/Image_Generation/test_worker.py
@@ -43,6 +43,80 @@ def test_run_generation_dispatches_to_adapter(monkeypatch):
     assert res.bytes_len == 1
 
 
+def _make_reference_image(**overrides):
+    from tldw_chatbook.Image_Generation.capabilities import ResolvedReferenceImage
+    defaults = dict(
+        file_id=1,
+        filename="ref.png",
+        mime_type="image/png",
+        width=64,
+        height=64,
+        bytes_len=4,
+        content=b"1234",
+        temp_path=None,
+    )
+    defaults.update(overrides)
+    return ResolvedReferenceImage(**defaults)
+
+
+def test_build_request_reference_image_defaults_none():
+    from tldw_chatbook.Image_Generation.worker import build_request
+    req = build_request(backend="swarmui", prompt="cat")
+    assert req.reference_image is None
+
+
+def test_build_request_threads_reference_image():
+    from tldw_chatbook.Image_Generation.worker import build_request
+    ref = _make_reference_image()
+    req = build_request(backend="fal", prompt="cat", reference_image=ref)
+    assert req.reference_image is ref
+
+
+def test_run_generation_reference_image_unsupported_backend_raises_before_adapter(monkeypatch):
+    # A legacy backend with a reference image attached must be refused at the
+    # validation choke point in run_generation() -- the adapter must never be
+    # reached (get_adapter() would raise if it were called).
+    from tldw_chatbook.Image_Generation import worker
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+    class FakeReg:
+        def resolve_backend(self, name):
+            return "swarmui" if name == "swarmui" else None
+
+        def get_adapter(self, name):
+            raise AssertionError("adapter must not be reached when validation fails")
+
+    monkeypatch.setattr(worker, "get_registry", lambda: FakeReg())
+    req = worker.build_request(backend="swarmui", prompt="cat", reference_image=_make_reference_image())
+    with pytest.raises(ImageGenerationError, match="does not support reference images"):
+        worker.run_generation(req)
+
+
+def test_run_generation_reference_image_supported_backend_dispatches(monkeypatch):
+    from tldw_chatbook.Image_Generation import worker
+    from tldw_chatbook.Image_Generation.adapters.base import ImageGenResult
+
+    class FakeAdapter:
+        name = "fal"
+        supported_formats = {"png"}
+
+        def generate(self, req):
+            assert req.reference_image is not None
+            return ImageGenResult(content=b"x", content_type="image/png", bytes_len=1)
+
+    class FakeReg:
+        def resolve_backend(self, name):
+            return "fal" if name == "fal" else None
+
+        def get_adapter(self, name):
+            return FakeAdapter()
+
+    monkeypatch.setattr(worker, "get_registry", lambda: FakeReg())
+    req = worker.build_request(backend="fal", prompt="cat", reference_image=_make_reference_image())
+    res = worker.run_generation(req)
+    assert res.bytes_len == 1
+
+
 def test_run_generation_adapter_load_failure_raises(monkeypatch):
     # resolve_backend() says the backend is enabled, but get_adapter() failed
     # to construct it (e.g. a bad adapter spec / import error swallowed by the

--- a/Tests/UI/test_settings_image_gen_defaults.py
+++ b/Tests/UI/test_settings_image_gen_defaults.py
@@ -734,6 +734,61 @@ def test_probe_modelstudio_unauthenticated_reachability_only(monkeypatch):
     assert result == ImageGenProbeResult(ok=True, badge="Reachable (auth unverified)")
 
 
+def test_probe_fal_unauthenticated_reachability_only(monkeypatch):
+    """fal's queue API has no models-listing route -- reachability-only,
+    same treatment as novita/modelstudio, even when a key is present."""
+    calls = []
+    monkeypatch.setattr(sigd.httpx, "Client", _fake_client_cls(response=200, calls=calls))
+    result = probe_backend("fal", {"base_url": "http://127.0.0.1:9900"}, "some-key")
+    assert result == ImageGenProbeResult(ok=True, badge="Reachable (auth unverified)")
+    # Reachability-only means the base_url itself is hit -- no /models path,
+    # no Authorization header built from the key.
+    assert calls[0][0] == "http://127.0.0.1:9900"
+    assert calls[0][1] == {}
+
+
+def test_probe_fal_any_answer_counts_even_non_2xx(monkeypatch):
+    monkeypatch.setattr(sigd.httpx, "Client", _fake_client_cls(response=404))
+    result = probe_backend("fal", {"base_url": "http://127.0.0.1:9900"}, None)
+    assert result == ImageGenProbeResult(ok=True, badge="Reachable (auth unverified)")
+
+
+def test_probe_gemini_reachable_2xx(monkeypatch):
+    calls = []
+    monkeypatch.setattr(sigd.httpx, "Client", _fake_client_cls(response=200, calls=calls))
+    result = probe_backend("gemini", {"base_url": "http://127.0.0.1:9900"}, "goog-real-key")
+    assert result == ImageGenProbeResult(ok=True, badge="Reachable")
+    url, headers = calls[0]
+    assert url == "http://127.0.0.1:9900/models"
+    assert headers == {"x-goog-api-key": "goog-real-key"}
+
+
+def test_probe_gemini_auth_failed_401_with_key(monkeypatch):
+    monkeypatch.setattr(sigd.httpx, "Client", _fake_client_cls(response=401))
+    result = probe_backend("gemini", {"base_url": "http://127.0.0.1:9900"}, "goog-bad-key")
+    assert result == ImageGenProbeResult(ok=False, badge="Auth failed")
+
+
+def test_probe_gemini_auth_failed_403_with_key(monkeypatch):
+    monkeypatch.setattr(sigd.httpx, "Client", _fake_client_cls(response=403))
+    result = probe_backend("gemini", {"base_url": "http://127.0.0.1:9900"}, "goog-bad-key")
+    assert result == ImageGenProbeResult(ok=False, badge="Auth failed")
+
+
+def test_probe_gemini_other_http_status_with_key(monkeypatch):
+    monkeypatch.setattr(sigd.httpx, "Client", _fake_client_cls(response=500))
+    result = probe_backend("gemini", {"base_url": "http://127.0.0.1:9900"}, "goog-real-key")
+    assert result == ImageGenProbeResult(ok=False, badge="Unreachable: HTTP 500")
+
+
+def test_probe_no_key_gemini_reachable_auth_unverified(monkeypatch):
+    calls = []
+    monkeypatch.setattr(sigd.httpx, "Client", _fake_client_cls(response=200, calls=calls))
+    result = probe_backend("gemini", {"base_url": "http://127.0.0.1:9900"}, None)
+    assert result == ImageGenProbeResult(ok=True, badge="Reachable (auth unverified)")
+    assert calls[0][1] == {}  # no x-goog-api-key header sent
+
+
 def test_probe_unknown_backend_id_raises():
     with pytest.raises(ValueError):
         probe_backend("not-a-real-backend", {}, None)

--- a/Tests/UI/test_settings_image_gen_panel.py
+++ b/Tests/UI/test_settings_image_gen_panel.py
@@ -37,6 +37,7 @@ from tldw_chatbook.Image_Generation.config import (
 from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
 from tldw_chatbook.UI.Screens.settings_config_models import SettingsCategoryId
 from tldw_chatbook.UI.Screens.settings_image_gen_defaults import (
+    BACKEND_IDS,
     ImageGenProbeResult,
     effective_placeholder,
 )
@@ -254,7 +255,7 @@ async def test_env_key_shows_env_source_line(scratch_config, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_save_revert_disabled_test_buttons_enabled(scratch_config):
-    """Save/Revert stay disabled with nothing staged, but the six Test
+    """Save/Revert stay disabled with nothing staged, but the eight Test
     buttons (task 6: wired to `probe_backend`) are clickable regardless of
     dirty state -- a probe reads the CURRENT form values, so it is useful
     even with no unsaved edits at all."""
@@ -268,14 +269,7 @@ async def test_save_revert_disabled_test_buttons_enabled(scratch_config):
 
         assert panel.query_one("#settings-imagegen-save", Button).disabled
         assert panel.query_one("#settings-imagegen-revert", Button).disabled
-        for backend_id in (
-            "stable_diffusion_cpp",
-            "swarmui",
-            "openrouter",
-            "novita",
-            "together",
-            "modelstudio",
-        ):
+        for backend_id in BACKEND_IDS:
             assert not panel.query_one(
                 f"#settings-imagegen-test-{backend_id}", Button
             ).disabled
@@ -769,14 +763,11 @@ _PROBE_BACKEND_PATCH_TARGET = (
     "tldw_chatbook.UI.Screens.settings_screen.image_gen_probe_backend"
 )
 
-_ALL_BACKEND_IDS = (
-    "stable_diffusion_cpp",
-    "swarmui",
-    "openrouter",
-    "novita",
-    "together",
-    "modelstudio",
-)
+# The real BACKEND_IDS -- aliased here (rather than a hand-copied tuple) so
+# this file can't silently under-cover a future backend addition the way it
+# did for fal/gemini (task-7 fix: this used to be a hardcoded six-entry
+# tuple that never grew when the schema did).
+_ALL_BACKEND_IDS = BACKEND_IDS
 
 
 @pytest.mark.asyncio
@@ -920,7 +911,7 @@ api_key = "sk-saved-key"
 
 @pytest.mark.asyncio
 async def test_probe_renders_badge_and_reenables_buttons(scratch_config, monkeypatch):
-    """All six Test buttons disable for the duration of one probe (gated
+    """All eight Test buttons disable for the duration of one probe (gated
     via a real `threading.Event` on the probe's own worker thread) and
     re-enable once it completes; the result badge lands on the right
     backend's status Static."""
@@ -1224,19 +1215,20 @@ enabled_backends = ["openrouter", "swarmui"]
         screen._select_category("image_generation")
         await pilot.pause(0.2)
 
-        for backend_id in (
-            "stable_diffusion_cpp",
-            "swarmui",
-            "openrouter",
-            "novita",
-            "together",
-            "modelstudio",
-        ):
+        for backend_id in BACKEND_IDS:
             row = screen.query_one(f"#settings-imagegen-backend-{backend_id}")
             test_btn = screen.query_one(f"#settings-imagegen-test-{backend_id}", Button)
             cb = screen.query_one(
                 f"#settings-imagegen-enabled-{backend_id}", Checkbox
             )
+            # task-7: eight rows (was six) no longer all fit within these
+            # small terminal sizes without scrolling -- scroll each row into
+            # view first (same pattern already used below for save_btn)
+            # before checking its click target, so a row pushed off-screen
+            # by the two new backends isn't mistaken for "something else
+            # intercepts the click."
+            row.scroll_visible(animate=False)
+            await pilot.pause(0.1)
             row_right = row.region.x + row.region.width
             test_right = test_btn.region.x + test_btn.region.width
             assert test_right <= row_right, (
@@ -1309,14 +1301,7 @@ enabled_backends = ["openrouter"]
         select.value = Select.NULL
         await pilot.pause()
 
-        for backend_id in (
-            "stable_diffusion_cpp",
-            "swarmui",
-            "openrouter",
-            "novita",
-            "together",
-            "modelstudio",
-        ):
+        for backend_id in BACKEND_IDS:
             marker = panel.query_one(
                 f"#settings-imagegen-default-marker-{backend_id}", Static
             )

--- a/Tests/Utils/test_egress.py
+++ b/Tests/Utils/test_egress.py
@@ -931,3 +931,24 @@ async def test_validate_navigation_chain_async(monkeypatch):
         ["http://internal.example/"],
         trusted_origins=frozenset({"internal.example"}),
     )
+
+
+def test_hop_headers_strips_x_goog_api_key_cross_origin():
+    # Gemini's custom auth header (Image_Generation/adapters/gemini_image_adapter.py)
+    # must be stripped on a cross-origin hop exactly like Authorization/Cookie --
+    # otherwise a redirect from the configured Gemini base to a different public
+    # host would forward the real API key verbatim.
+    from tldw_chatbook.Utils.egress import _hop_headers
+
+    headers = {"x-goog-api-key": "secret-key", "X-Keep": "y"}
+    stripped = _hop_headers(headers, False)
+    assert "x-goog-api-key" not in stripped
+    assert stripped.get("X-Keep") == "y"
+
+
+def test_hop_headers_keeps_x_goog_api_key_same_origin():
+    from tldw_chatbook.Utils.egress import _hop_headers
+
+    headers = {"x-goog-api-key": "secret-key"}
+    kept = _hop_headers(headers, True)
+    assert kept.get("x-goog-api-key") == "secret-key"

--- a/backlog/tasks/task-686 - fal-Gemini-image-backends-follow-ups.md
+++ b/backlog/tasks/task-686 - fal-Gemini-image-backends-follow-ups.md
@@ -27,7 +27,7 @@ Non-blocking follow-ups from the fal.ai + Gemini image-backend program's final w
 - [ ] Pre-existing (out of this program's diff): the chat-side Google path (`LLM_Calls/LLM_API_Calls.py` ~:2906) sends `x-goog-api-key` through a redirect-following `requests.Session` — outside the guarded-helper credential-strip net that now protects the image path. Route it through guarded transport or strip on redirect.
 - [ ] Per-backend keyring-source loader tests for `fal`/`gemini` (generic keyring path is covered; sibling backends share the same gap).
 - [ ] `fetch_bytes_via_post`'s docstring cites Fireworks (dropped) as its example consumer — reword to a generic bytes-returning-POST description. Note the helper currently has NO production consumer (kept: tested, guarded, and the class of API it serves recurs).
-- [ ] Gemini 429 (quota) surfaces the generic httpx text — add a friendlier enriched message ("rate limited / image quota exhausted — free-tier caps apply") alongside the 404 enrichment pattern (live-UAT observation).
+- [ ] Gemini 429 (quota) and fal 403 (locked/exhausted-balance) surface generic httpx text — add friendlier enriched messages ("rate limited / image quota exhausted — free-tier caps apply"; "fal account locked or out of balance — top up at fal.ai") alongside the 404 enrichment pattern (live-UAT observations; both raw bodies carry actionable detail our sanitization rightly drops — the enrichment can name the CATEGORY without echoing bodies).
 <!-- AC:END -->
 
 ## Implementation Plan

--- a/backlog/tasks/task-686 - fal-Gemini-image-backends-follow-ups.md
+++ b/backlog/tasks/task-686 - fal-Gemini-image-backends-follow-ups.md
@@ -1,0 +1,41 @@
+---
+id: TASK-686
+title: >-
+  fal/Gemini image backends follow-ups
+status: To Do
+assignee: []
+created_date: '2026-07-26 03:30'
+updated_date: '2026-07-26 03:30'
+labels:
+  - image-generation
+  - followup
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Non-blocking follow-ups from the fal.ai + Gemini image-backend program's final whole-branch review and live UAT (spec `Docs/superpowers/specs/2026-07-26-imagegen-fal-gemini-fireworks-design.md`; Fireworks was dropped mid-program — vendor deprecated image generation 2026-06-10). None are shipped defects.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] Reference-image size cap validates `len(content)` rather than trusting the caller-supplied `bytes_len` field, and empty `content=b""` is refused at the choke point (harden BEFORE the Console attach-UX program opens a real production constructor; today both adapters fail loudly anyway).
+- [ ] fal `_app_id` handles fal's `APP_NAMESPACES` endpoint grammar (`workflows/...`, `comfy/...` prefixes shift the owner/app segments by one) — today a namespaced model would misdiagnose as "fal queue URL shape changed" (loud, but wrong diagnosis).
+- [ ] Pre-existing (out of this program's diff): the chat-side Google path (`LLM_Calls/LLM_API_Calls.py` ~:2906) sends `x-goog-api-key` through a redirect-following `requests.Session` — outside the guarded-helper credential-strip net that now protects the image path. Route it through guarded transport or strip on redirect.
+- [ ] Per-backend keyring-source loader tests for `fal`/`gemini` (generic keyring path is covered; sibling backends share the same gap).
+- [ ] `fetch_bytes_via_post`'s docstring cites Fireworks (dropped) as its example consumer — reword to a generic bytes-returning-POST description. Note the helper currently has NO production consumer (kept: tested, guarded, and the class of API it serves recurs).
+- [ ] Gemini 429 (quota) surfaces the generic httpx text — add a friendlier enriched message ("rate limited / image quota exhausted — free-tier caps apply") alongside the 404 enrichment pattern (live-UAT observation).
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Image_Generation/adapter_registry.py
+++ b/tldw_chatbook/Image_Generation/adapter_registry.py
@@ -22,6 +22,7 @@ class ImageAdapterRegistry:
         "novita": "tldw_chatbook.Image_Generation.adapters.novita_image_adapter.NovitaImageAdapter",
         "together": "tldw_chatbook.Image_Generation.adapters.together_image_adapter.TogetherImageAdapter",
         "modelstudio": "tldw_chatbook.Image_Generation.adapters.modelstudio_image_adapter.ModelStudioImageAdapter",
+        "gemini": "tldw_chatbook.Image_Generation.adapters.gemini_image_adapter.GeminiImageAdapter",
     }
 
     def __init__(self, config_override: dict[str, Any] | None = None) -> None:

--- a/tldw_chatbook/Image_Generation/adapter_registry.py
+++ b/tldw_chatbook/Image_Generation/adapter_registry.py
@@ -23,6 +23,7 @@ class ImageAdapterRegistry:
         "together": "tldw_chatbook.Image_Generation.adapters.together_image_adapter.TogetherImageAdapter",
         "modelstudio": "tldw_chatbook.Image_Generation.adapters.modelstudio_image_adapter.ModelStudioImageAdapter",
         "gemini": "tldw_chatbook.Image_Generation.adapters.gemini_image_adapter.GeminiImageAdapter",
+        "fal": "tldw_chatbook.Image_Generation.adapters.fal_image_adapter.FalImageAdapter",
     }
 
     def __init__(self, config_override: dict[str, Any] | None = None) -> None:

--- a/tldw_chatbook/Image_Generation/adapters/fal_image_adapter.py
+++ b/tldw_chatbook/Image_Generation/adapters/fal_image_adapter.py
@@ -1,0 +1,383 @@
+"""fal.ai queue image-generation backend adapter.
+
+Task 6 of the fal/Gemini/Fireworks image-backends plan (see
+``.superpowers/sdd/2026-07-26-imagegen-fal-gemini-fireworks/task-6-brief.md``).
+Modeled on ``novita_image_adapter.py`` (the closest sibling with a
+submit/poll queue shape) for the polling loop, and on
+``gemini_image_adapter.py`` (``_validate_model_id`` precedent) for
+model-path validation and 404 enrichment.
+
+fal's queue API (verified live 2026-07-25, see task-6-report.md for
+sources):
+
+- Submit: ``POST {base}/{model_path}`` (e.g.
+  ``https://queue.fal.run/fal-ai/flux/schnell``), ``Authorization: Key
+  $FAL_KEY``, returns ``{"request_id": ..., "status_url": ..., ...}``.
+- The ``image_size`` field accepts either a string enum OR a generic
+  object form ``{"width": int, "height": int}`` -- confirmed against the
+  live ``fal-ai/flux/schnell`` schema page (fal.ai/models/fal-ai/flux/schnell/api).
+- The "app id" used to build the polling/result URLs is NOT the full
+  submitted model path -- it is only the first two ``/``-segments
+  (``owner/app``), with any further segments (e.g. a variant like
+  ``schnell``) dropped. This is confirmed against fal's own
+  ``fal_client`` Python SDK source (``AppId.from_endpoint_id`` in
+  ``fal-ai/fal``'s ``projects/fal_client/src/fal_client/client.py``),
+  which splits an endpoint id into ``owner``/``alias``/``path`` and uses
+  only ``owner/alias`` to build the queue status/result base URL --
+  exactly the two-segment rule this adapter's ``_app_id`` implements.
+
+Because the polling/result URLs are self-built from validated inputs
+(never taken from the API response), a submit response's own
+``status_url`` -- when present -- is used ONLY as a cross-check: a
+mismatch names the drift as a loud, sanitized error instead of silently
+trusting (and fetching) a vendor-controlled URL.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+from tldw_chatbook.Image_Generation.http_client import fetch_json
+from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest, ImageGenResult
+from tldw_chatbook.Image_Generation.adapters.image_format_utils import (
+    fetch_image_bytes,
+    reference_image_data_url,
+    validate_and_convert_image_output,
+)
+from tldw_chatbook.Image_Generation.config import (
+    DEFAULT_FAL_IMAGE_BASE_URL,
+    DEFAULT_FAL_IMAGE_MODEL,
+    DEFAULT_FAL_IMAGE_POLL_INTERVAL_SECONDS,
+    DEFAULT_FAL_IMAGE_TIMEOUT_SECONDS,
+    get_image_generation_config,
+)
+from tldw_chatbook.Image_Generation.exceptions import ImageBackendUnavailableError, ImageGenerationError
+from tldw_chatbook.Image_Generation.request_validation import effective_inline_max_bytes
+from tldw_chatbook.Utils.egress import origin_set
+
+# fal model paths (e.g. "fal-ai/flux/schnell") are path-segment-interpolated
+# directly into the submit URL, and their first two segments are used to
+# build the poll/result URLs -- this charset match (plus the segment checks
+# in `_validate_model_path`) keeps a misconfigured/malicious path from ever
+# reaching URL construction. `/` is allowed (unlike Gemini's flat model
+# ids) since fal paths are inherently multi-segment.
+_MODEL_PATH_CHARSET_RE = re.compile(r"^[A-Za-z0-9._\-/]+$")
+
+# The submit response's `request_id` is interpolated into the self-built
+# poll/result URLs -- charset-validated for the same reason as the model
+# path above.
+_REQUEST_ID_RE = re.compile(r"^[A-Za-z0-9-]+$")
+
+
+def _validate_model_path(path: str) -> str:
+    """Validate a fal model path's charset and segment shape, returning it stripped.
+
+    Args:
+        path: The candidate model path (from the request or config default),
+            e.g. ``"fal-ai/flux/schnell"``.
+
+    Returns:
+        The stripped path, unchanged, when it passes validation.
+
+    Raises:
+        ImageBackendUnavailableError: If ``path`` is empty, contains any
+            character outside ``[A-Za-z0-9._-/]``, has a leading/trailing
+            ``/``, or has an empty (``a//b``) or ``..`` path segment --
+            naming the offending path so a misconfigured ``default_model``
+            is diagnosable.
+    """
+    candidate = (path or "").strip()
+    if not candidate or not _MODEL_PATH_CHARSET_RE.match(candidate):
+        raise ImageBackendUnavailableError(
+            f"invalid fal model path {candidate!r} -- check [image_generation.fal] default_model"
+        )
+    if candidate.startswith("/") or candidate.endswith("/"):
+        raise ImageBackendUnavailableError(
+            f"invalid fal model path {candidate!r} -- check [image_generation.fal] default_model"
+        )
+    for segment in candidate.split("/"):
+        if not segment or segment == "..":
+            raise ImageBackendUnavailableError(
+                f"invalid fal model path {candidate!r} -- check [image_generation.fal] default_model"
+            )
+    return candidate
+
+
+def _app_id(model_path: str) -> str:
+    """Derive fal's queue "app id" (owner/app) from an already-validated model path.
+
+    Only the first two ``/``-segments are used -- any further segments (a
+    model variant, e.g. ``schnell`` in ``fal-ai/flux/schnell``) are dropped.
+    See the module docstring for how this was verified against fal's own
+    client SDK.
+
+    Args:
+        model_path: An already ``_validate_model_path``-validated path.
+
+    Returns:
+        The first two segments joined by ``/`` (e.g. ``"fal-ai/flux"``).
+
+    Raises:
+        ImageBackendUnavailableError: If ``model_path`` has fewer than two
+            ``/``-segments.
+    """
+    segments = model_path.split("/")
+    if len(segments) < 2:
+        raise ImageBackendUnavailableError(
+            f"invalid fal model path {model_path!r} -- expected at least two "
+            "path segments (e.g. 'owner/app') -- check [image_generation.fal] default_model"
+        )
+    return "/".join(segments[:2])
+
+
+class FalImageAdapter:
+    name = "fal"
+    supported_formats = {"png", "jpg", "webp"}
+    _PENDING_STATUSES = {"IN_QUEUE", "IN_PROGRESS"}
+    _COMPLETED_STATUS = "COMPLETED"
+
+    def __init__(self) -> None:
+        self._config = get_image_generation_config()
+
+    def generate(self, request: ImageGenRequest) -> ImageGenResult:
+        output_format = request.format.lower()
+        if output_format not in self.supported_formats:
+            raise ImageGenerationError(f"unsupported output format: {output_format}")
+
+        api_key = self._resolve_api_key()
+        base_url = self._resolve_base_url()
+        model_path = self._resolve_model_path(request)
+        app_id = _app_id(model_path)
+
+        submit_data = self._submit(base_url, model_path, api_key, request)
+        request_id = self._extract_request_id(submit_data)
+        status_url = f"{base_url}/{app_id}/requests/{request_id}/status"
+        result_url = f"{base_url}/{app_id}/requests/{request_id}"
+        self._cross_check_status_url(submit_data, status_url)
+
+        self._poll_until_complete(status_url, api_key)
+        result_data = self._fetch_result(result_url, api_key)
+        image_url = self._extract_image_url(result_data)
+
+        # image_url came from the vendor's result payload (untrusted, a CDN
+        # link) -- no trusted_origins, no Authorization header, fully
+        # subject to the egress policy, mirroring novita/openrouter's
+        # API-returned-URL fetches.
+        content, content_type = fetch_image_bytes(
+            image_url,
+            timeout=self._timeout(),
+            max_bytes=self._max_output_bytes(),
+        )
+        content, content_type = validate_and_convert_image_output(
+            content,
+            content_type,
+            output_format,
+            max_bytes=self._max_output_bytes(),
+        )
+        return ImageGenResult(content=content, content_type=content_type, bytes_len=len(content))
+
+    def _max_output_bytes(self) -> int:
+        return effective_inline_max_bytes(self._config)
+
+    def _timeout(self) -> int:
+        return self._config.fal_image_timeout_seconds or DEFAULT_FAL_IMAGE_TIMEOUT_SECONDS
+
+    def _resolve_api_key(self) -> str:
+        api_key = (self._config.fal_image_api_key or "").strip()
+        if not api_key:
+            api_key = (os.getenv("FAL_KEY") or "").strip()
+        if not api_key:
+            raise ImageBackendUnavailableError("fal image api key is not configured")
+        return api_key
+
+    def _resolve_base_url(self) -> str:
+        raw = self._config.fal_image_base_url or DEFAULT_FAL_IMAGE_BASE_URL
+        cleaned = str(raw).strip()
+        if not cleaned:
+            raise ImageBackendUnavailableError("fal image base URL is not configured")
+        if not cleaned.startswith("http://") and not cleaned.startswith("https://"):
+            cleaned = f"https://{cleaned}"
+        return cleaned.rstrip("/")
+
+    def _resolve_model_path(self, request: ImageGenRequest) -> str:
+        model = request.model or self._config.fal_image_default_model or DEFAULT_FAL_IMAGE_MODEL
+        return _validate_model_path(model)
+
+    @staticmethod
+    def _headers(api_key: str) -> dict[str, str]:
+        return {
+            "Authorization": f"Key {api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _build_submit_payload(self, request: ImageGenRequest) -> dict[str, Any]:
+        prompt = request.prompt.strip()
+        if request.negative_prompt:
+            prompt = f"{prompt}\n\nNegative prompt: {request.negative_prompt.strip()}"
+
+        payload: dict[str, Any] = {"prompt": prompt}
+        if request.seed is not None:
+            payload["seed"] = request.seed
+        if request.width is not None and request.height is not None:
+            payload["image_size"] = {"width": request.width, "height": request.height}
+        if request.reference_image is not None:
+            payload["image_url"] = reference_image_data_url(request.reference_image)
+        return payload
+
+    def _submit(
+        self, base_url: str, model_path: str, api_key: str, request: ImageGenRequest
+    ) -> Any:
+        submit_url = f"{base_url}/{model_path}"
+        payload = self._build_submit_payload(request)
+        try:
+            return fetch_json(
+                method="POST",
+                url=submit_url,
+                headers=self._headers(api_key),
+                json=payload,
+                timeout=self._timeout(),
+                # submit_url is built from the configured base_url plus a
+                # charset/segment-validated model path, not API-returned
+                # data, so its host is trusted.
+                trusted_origins=origin_set(submit_url),
+            )
+        except httpx.HTTPStatusError as exc:
+            # task-620: a bare httpx status error doesn't say *why* -- for
+            # fal this is almost always an invalid/retired model path. Name
+            # the path and point at the config key so the user isn't left
+            # guessing.
+            if exc.response is not None and exc.response.status_code == 404:
+                raise ImageGenerationError(
+                    f"model {model_path!r} was rejected by fal (404) -- check "
+                    "[image_generation.fal] default_model"
+                ) from exc
+            raise ImageGenerationError(f"fal submit request failed: {exc}") from exc
+        except ImageGenerationError:
+            raise
+        except Exception as exc:
+            raise ImageGenerationError(f"fal submit request failed: {exc}") from exc
+
+    @staticmethod
+    def _extract_request_id(data: Any) -> str:
+        if not isinstance(data, dict):
+            raise ImageGenerationError("fal submit response was not JSON")
+        request_id = data.get("request_id")
+        if not isinstance(request_id, str) or not request_id.strip():
+            raise ImageGenerationError("fal submit response did not include a request_id")
+        request_id = request_id.strip()
+        if not _REQUEST_ID_RE.match(request_id):
+            raise ImageGenerationError("fal submit response returned an invalid request_id")
+        return request_id
+
+    @staticmethod
+    def _cross_check_status_url(submit_data: Any, self_built_status_url: str) -> None:
+        """Cross-check (never follow) a submit response's own ``status_url``.
+
+        The adapter always polls its own self-built URL -- this only
+        verifies the vendor's claimed location still matches the shape this
+        adapter assumes, so an undetected API change (or a compromised
+        response) can't silently go unnoticed. The vendor URL itself is
+        NEVER requested.
+        """
+        if not isinstance(submit_data, dict):
+            return
+        vendor_status_url = submit_data.get("status_url")
+        if not isinstance(vendor_status_url, str) or not vendor_status_url.strip():
+            return
+        vendor_status_url = vendor_status_url.strip()
+        if vendor_status_url == self_built_status_url:
+            return
+
+        self_parsed = urlparse(self_built_status_url)
+        vendor_parsed = urlparse(vendor_status_url)
+        if (
+            self_parsed.scheme == vendor_parsed.scheme
+            and self_parsed.netloc == vendor_parsed.netloc
+            and self_parsed.path == vendor_parsed.path
+        ):
+            return
+
+        vendor_origin = (
+            f"{vendor_parsed.scheme}://{vendor_parsed.netloc}"
+            if vendor_parsed.scheme and vendor_parsed.netloc
+            else "unknown"
+        )
+        # Never include the full vendor URL (only its origin) and never any
+        # credentials -- this message may end up in logs/UI.
+        raise ImageGenerationError(
+            "fal queue URL shape changed -- expected "
+            f"{self_built_status_url!r}, vendor sent a different location (origin: {vendor_origin})"
+        )
+
+    def _poll_until_complete(self, status_url: str, api_key: str) -> None:
+        timeout_seconds = float(self._config.fal_image_timeout_seconds or DEFAULT_FAL_IMAGE_TIMEOUT_SECONDS)
+        poll_interval = max(
+            1.0, float(self._config.fal_image_poll_interval_seconds or DEFAULT_FAL_IMAGE_POLL_INTERVAL_SECONDS)
+        )
+        deadline = time.monotonic() + timeout_seconds
+        # status_url is self-built from the configured base_url plus
+        # validated app_id/request_id -- never from API-returned data -- so
+        # its host is trusted.
+        trusted = origin_set(status_url)
+
+        while time.monotonic() < deadline:
+            try:
+                data = fetch_json(
+                    method="GET",
+                    url=status_url,
+                    headers=self._headers(api_key),
+                    timeout=timeout_seconds,
+                    trusted_origins=trusted,
+                )
+            except Exception as exc:
+                raise ImageGenerationError(f"fal status polling failed: {exc}") from exc
+
+            status = self._extract_status(data)
+            if status == self._COMPLETED_STATUS:
+                return
+            if status in self._PENDING_STATUSES:
+                time.sleep(poll_interval)
+                continue
+            # Anything else (FAILED, an error status, or an unrecognized/
+            # missing status) is a hard stop -- only the sanitized status
+            # label is included, never the raw response payload.
+            raise ImageGenerationError(f"fal task did not complete (status: {status or 'unknown'})")
+
+        raise ImageGenerationError("timed out waiting for fal image task result")
+
+    @staticmethod
+    def _extract_status(data: Any) -> str | None:
+        if not isinstance(data, dict):
+            return None
+        value = data.get("status")
+        if isinstance(value, str) and value.strip():
+            return value.strip().upper()
+        return None
+
+    def _fetch_result(self, result_url: str, api_key: str) -> Any:
+        try:
+            return fetch_json(
+                method="GET",
+                url=result_url,
+                headers=self._headers(api_key),
+                timeout=self._timeout(),
+                trusted_origins=origin_set(result_url),
+            )
+        except Exception as exc:
+            raise ImageGenerationError(f"fal result request failed: {exc}") from exc
+
+    @staticmethod
+    def _extract_image_url(data: Any) -> str:
+        if isinstance(data, dict):
+            images = data.get("images")
+            if isinstance(images, list) and images and isinstance(images[0], dict):
+                url = images[0].get("url")
+                if isinstance(url, str) and url.strip():
+                    return url.strip()
+        raise ImageGenerationError("fal result response did not include an image URL")

--- a/tldw_chatbook/Image_Generation/adapters/fal_image_adapter.py
+++ b/tldw_chatbook/Image_Generation/adapters/fal_image_adapter.py
@@ -137,6 +137,16 @@ def _app_id(model_path: str) -> str:
 
 
 class FalImageAdapter:
+    """Image-generation adapter for fal.ai's queue-based generation API.
+
+    Implements the ``ImageGenerationAdapter`` protocol (``base.py``):
+    ``name``/``supported_formats``/``generate()``. Submits a job, polls its
+    status until completion (or timeout), fetches the result payload, then
+    downloads the resulting image from its (untrusted, vendor-returned) CDN
+    URL. See the module docstring for the verified submit/poll/result URL
+    shapes and the app-id derivation rule.
+    """
+
     name = "fal"
     supported_formats = {"png", "jpg", "webp"}
     _PENDING_STATUSES = {"IN_QUEUE", "IN_PROGRESS"}
@@ -146,6 +156,31 @@ class FalImageAdapter:
         self._config = get_image_generation_config()
 
     def generate(self, request: ImageGenRequest) -> ImageGenResult:
+        """Submit a fal generation job, poll it to completion, and fetch the image.
+
+        Args:
+            request: The normalized generation request. ``request.model``
+                overrides the configured default model path (validated via
+                ``_validate_model_path``); ``request.negative_prompt``, when
+                set, is appended to the prompt text; ``request.seed``/
+                ``request.width``/``request.height``, when set, are passed
+                through; ``request.reference_image``, when set, is encoded
+                as a data URL and sent as ``image_url``; ``request.format``
+                must be one of ``supported_formats``.
+
+        Returns:
+            The decoded, format-converted image result.
+
+        Raises:
+            ImageGenerationError: If ``request.format`` is unsupported, the
+                submit/poll/result requests fail, the job doesn't reach
+                ``COMPLETED`` before the configured timeout, the result
+                payload has no image URL, or the vendor's ``status_url``
+                cross-check (see ``_cross_check_status_url``) detects an
+                unexpected queue URL shape.
+            ImageBackendUnavailableError: If the API key, base URL, or the
+                resolved model path is missing or fails validation.
+        """
         output_format = request.format.lower()
         if output_format not in self.supported_formats:
             raise ImageGenerationError(f"unsupported output format: {output_format}")

--- a/tldw_chatbook/Image_Generation/adapters/gemini_image_adapter.py
+++ b/tldw_chatbook/Image_Generation/adapters/gemini_image_adapter.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import base64
 import os
 import re
-from pathlib import Path
 from typing import Any
 
 import httpx
@@ -74,6 +73,16 @@ def _validate_model_id(model: str) -> str:
 
 
 class GeminiImageAdapter:
+    """Image-generation adapter for Google's Gemini (AI Studio) API.
+
+    Implements the ``ImageGenerationAdapter`` protocol (``base.py``):
+    ``name``/``supported_formats``/``generate()``. Submits a single-shot
+    ``generateContent`` request (no polling) and extracts the first decodable
+    inline-data image part from the response. See the module docstring for
+    the verified request/response shape and the ``responseModalities``
+    requirement.
+    """
+
     name = "gemini"
     supported_formats = {"png", "jpg", "webp"}
 
@@ -81,6 +90,29 @@ class GeminiImageAdapter:
         self._config = get_image_generation_config()
 
     def generate(self, request: ImageGenRequest) -> ImageGenResult:
+        """Generate one image via Gemini's ``models/{model}:generateContent`` endpoint.
+
+        Args:
+            request: The normalized generation request. ``request.model``
+                overrides the configured default model (validated via
+                ``_validate_model_id``); ``request.negative_prompt``, when
+                set, is appended to the prompt text; ``request.reference_image``,
+                when set, is threaded in as an ``inline_data`` part before the
+                text part (see ``_reference_image_part``); ``request.format``
+                must be one of ``supported_formats``.
+
+        Returns:
+            The decoded, format-converted image result.
+
+        Raises:
+            ImageGenerationError: If ``request.format`` is unsupported,
+                the request to Gemini fails, Gemini returns no usable image
+                (blocked prompt, a non-``STOP`` finish reason, an empty
+                response, or undecodable inline data), or the reference
+                image violates the engine's bytes-in-memory contract.
+            ImageBackendUnavailableError: If the API key, base URL, or the
+                resolved model id is missing or fails validation.
+        """
         output_format = request.format.lower()
         if output_format not in self.supported_formats:
             raise ImageGenerationError(f"unsupported output format: {output_format}")
@@ -185,18 +217,33 @@ class GeminiImageAdapter:
 
     @staticmethod
     def _reference_image_part(reference_image: ResolvedReferenceImage) -> dict[str, Any]:
-        # task-3's choke point already validated mime/size/content before
-        # this reaches the adapter -- this just reads whichever of
-        # content/temp_path is populated (ResolvedReferenceImage guarantees
-        # exactly one), mirroring image_format_utils.reference_image_data_url.
+        """Build the Gemini ``inline_data`` part for a validated reference image.
+
+        Args:
+            reference_image: The reference image, already checked by the
+                engine's choke point (task-3) for backend capability,
+                allowed mime type, size cap, and non-empty content before
+                this adapter ever runs.
+
+        Returns:
+            The ``{"inline_data": {"mime_type": ..., "data": ...}}`` part,
+            placed before the text part in the request body.
+
+        Raises:
+            ImageGenerationError: If ``reference_image.content`` is ``None``
+                or empty. The engine's contract is bytes-in-memory ONLY --
+                ``file_id``/``temp_path`` variants are never accepted by the
+                choke-point validator, so this should be unreachable in
+                practice; it exists as a defensive contract check, not a
+                recoverable code path. Unlike ``file_id``/``temp_path``
+                inputs, this adapter never reads from disk.
+        """
         content = reference_image.content
         if content is None:
-            if not reference_image.temp_path:
-                raise ImageGenerationError("invalid reference image data")
-            try:
-                content = Path(reference_image.temp_path).read_bytes()
-            except Exception as exc:
-                raise ImageGenerationError("invalid reference image data") from exc
+            raise ImageGenerationError(
+                "reference image reached the adapter without content bytes "
+                "(choke-point contract violation)"
+            )
         if not content:
             raise ImageGenerationError("invalid reference image data")
 

--- a/tldw_chatbook/Image_Generation/adapters/gemini_image_adapter.py
+++ b/tldw_chatbook/Image_Generation/adapters/gemini_image_adapter.py
@@ -1,0 +1,268 @@
+"""Gemini (AI Studio) image-generation backend adapter.
+
+Task 4 of the fal/Gemini/Fireworks image-backends plan (see
+``.superpowers/sdd/2026-07-26-imagegen-fal-gemini-fireworks/task-4-brief.md``).
+Modeled on ``openrouter_image_adapter.py`` (closest sibling): same config
+access pattern, error types, and task-620 404-enrichment shape.
+
+``generationConfig.responseModalities`` is pinned to ``["TEXT", "IMAGE"]`` --
+verified live against Google's docs (see task-4-report.md for sources):
+``gemini-2.5-flash-image`` is a conversational multimodal model that returns
+an empty ``parts`` array (HTTP 200, no error) if only ``["IMAGE"]`` is
+requested; both modalities must be requested even though this adapter
+discards any text part in the response.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from tldw_chatbook.Image_Generation.http_client import fetch_json
+from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest, ImageGenResult
+from tldw_chatbook.Image_Generation.adapters.image_format_utils import (
+    decode_base64_image,
+    validate_and_convert_image_output,
+)
+from tldw_chatbook.Image_Generation.capabilities import ResolvedReferenceImage
+from tldw_chatbook.Image_Generation.config import (
+    DEFAULT_GEMINI_IMAGE_BASE_URL,
+    DEFAULT_GEMINI_IMAGE_MODEL,
+    DEFAULT_GEMINI_IMAGE_TIMEOUT_SECONDS,
+    get_image_generation_config,
+)
+from tldw_chatbook.Image_Generation.exceptions import ImageBackendUnavailableError, ImageGenerationError
+from tldw_chatbook.Image_Generation.request_validation import effective_inline_max_bytes
+from tldw_chatbook.Utils.egress import origin_set
+
+# Gemini model ids are path-segment-interpolated into the request URL
+# (`.../models/{model}:generateContent`); this charset match keeps a
+# misconfigured/malicious id (e.g. containing `/`, `..`, `?`, whitespace)
+# from ever reaching URL construction.
+_MODEL_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+# See module docstring: verified requirement for gemini-2.5-flash-image.
+_RESPONSE_MODALITIES = ["TEXT", "IMAGE"]
+
+
+def _validate_model_id(model: str) -> str:
+    """Validate a Gemini model id's charset, returning it stripped.
+
+    Args:
+        model: The candidate model id (from the request or config default).
+
+    Returns:
+        The stripped model id, unchanged, when it passes validation.
+
+    Raises:
+        ImageBackendUnavailableError: If ``model`` is empty or contains any
+            character outside ``[A-Za-z0-9._-]`` -- naming the offending id
+            so a misconfigured ``default_model`` is diagnosable.
+    """
+    candidate = (model or "").strip()
+    if not candidate or not _MODEL_ID_RE.match(candidate):
+        raise ImageBackendUnavailableError(
+            f"invalid gemini model id {candidate!r} -- check [image_generation.gemini] default_model"
+        )
+    return candidate
+
+
+class GeminiImageAdapter:
+    name = "gemini"
+    supported_formats = {"png", "jpg", "webp"}
+
+    def __init__(self) -> None:
+        self._config = get_image_generation_config()
+
+    def generate(self, request: ImageGenRequest) -> ImageGenResult:
+        output_format = request.format.lower()
+        if output_format not in self.supported_formats:
+            raise ImageGenerationError(f"unsupported output format: {output_format}")
+
+        api_key = self._resolve_api_key()
+        base_url = self._resolve_base_url()
+        model = self._resolve_model(request)
+        url = self._generate_content_url(base_url, model)
+        payload = self._build_payload(request)
+
+        try:
+            data = fetch_json(
+                method="POST",
+                url=url,
+                headers=self._headers(api_key),
+                json=payload,
+                timeout=self._config.gemini_image_timeout_seconds or DEFAULT_GEMINI_IMAGE_TIMEOUT_SECONDS,
+                # url is built from the configured base_url plus a
+                # charset-validated model id, not API-returned data, so its
+                # host is trusted.
+                trusted_origins=origin_set(url),
+            )
+        except httpx.HTTPStatusError as exc:
+            # task-620: a bare httpx status error ("404 Not Found for url
+            # '...:generateContent'") doesn't say *why* -- for Gemini this is
+            # almost always an invalid/retired model id. Name the model and
+            # point at the config key so the user isn't left guessing.
+            if exc.response is not None and exc.response.status_code in (400, 404):
+                status = exc.response.status_code
+                raise ImageGenerationError(
+                    f"model {model!r} was rejected by Gemini ({status}) — check "
+                    "[image_generation.gemini] default_model"
+                ) from exc
+            raise ImageGenerationError(f"Gemini request failed: {exc}") from exc
+        except ImageGenerationError:
+            raise
+        except Exception as exc:
+            raise ImageGenerationError(f"Gemini request failed: {exc}") from exc
+
+        content, content_type = self._extract_image(data)
+        content, content_type = validate_and_convert_image_output(
+            content,
+            content_type,
+            output_format,
+            max_bytes=self._max_output_bytes(),
+        )
+        return ImageGenResult(content=content, content_type=content_type, bytes_len=len(content))
+
+    def _max_output_bytes(self) -> int:
+        return effective_inline_max_bytes(self._config)
+
+    def _resolve_api_key(self) -> str:
+        api_key = (self._config.gemini_image_api_key or "").strip()
+        if not api_key:
+            api_key = (os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY") or "").strip()
+        if not api_key:
+            raise ImageBackendUnavailableError("gemini image api key is not configured")
+        return api_key
+
+    def _resolve_base_url(self) -> str:
+        raw = self._config.gemini_image_base_url or DEFAULT_GEMINI_IMAGE_BASE_URL
+        cleaned = str(raw).strip()
+        if not cleaned:
+            raise ImageBackendUnavailableError("gemini image base URL is not configured")
+        if not cleaned.startswith("http://") and not cleaned.startswith("https://"):
+            cleaned = f"https://{cleaned}"
+        return cleaned.rstrip("/")
+
+    def _resolve_model(self, request: ImageGenRequest) -> str:
+        model = request.model or self._config.gemini_image_default_model or DEFAULT_GEMINI_IMAGE_MODEL
+        return _validate_model_id(model)
+
+    @staticmethod
+    def _generate_content_url(base_url: str, model: str) -> str:
+        return f"{base_url}/models/{model}:generateContent"
+
+    @staticmethod
+    def _headers(api_key: str) -> dict[str, str]:
+        # The key is carried ONLY in this header -- Gemini also accepts a
+        # `?key=` query param, but URLs are far more likely to be logged
+        # (access logs, error messages, redirect chains) than headers, so
+        # the query-param form is deliberately never used here.
+        return {
+            "x-goog-api-key": api_key,
+            "Content-Type": "application/json",
+        }
+
+    def _build_payload(self, request: ImageGenRequest) -> dict[str, Any]:
+        prompt = request.prompt.strip()
+        if request.negative_prompt:
+            prompt = f"{prompt}\n\nNegative prompt: {request.negative_prompt.strip()}"
+
+        parts: list[dict[str, Any]] = []
+        if request.reference_image is not None:
+            parts.append(self._reference_image_part(request.reference_image))
+        parts.append({"text": prompt})
+
+        return {
+            "contents": [{"parts": parts}],
+            "generationConfig": {"responseModalities": list(_RESPONSE_MODALITIES)},
+        }
+
+    @staticmethod
+    def _reference_image_part(reference_image: ResolvedReferenceImage) -> dict[str, Any]:
+        # task-3's choke point already validated mime/size/content before
+        # this reaches the adapter -- this just reads whichever of
+        # content/temp_path is populated (ResolvedReferenceImage guarantees
+        # exactly one), mirroring image_format_utils.reference_image_data_url.
+        content = reference_image.content
+        if content is None:
+            if not reference_image.temp_path:
+                raise ImageGenerationError("invalid reference image data")
+            try:
+                content = Path(reference_image.temp_path).read_bytes()
+            except Exception as exc:
+                raise ImageGenerationError("invalid reference image data") from exc
+        if not content:
+            raise ImageGenerationError("invalid reference image data")
+
+        mime_type = (reference_image.mime_type or "application/octet-stream").split(";", 1)[0].strip().lower()
+        return {
+            "inline_data": {
+                "mime_type": mime_type,
+                "data": base64.b64encode(content).decode("ascii"),
+            }
+        }
+
+    def _extract_image(self, data: Any) -> tuple[bytes, str]:
+        if isinstance(data, dict):
+            candidates = data.get("candidates")
+            if isinstance(candidates, list):
+                for candidate in candidates:
+                    if not isinstance(candidate, dict):
+                        continue
+                    content = candidate.get("content")
+                    if not isinstance(content, dict):
+                        continue
+                    parts = content.get("parts")
+                    if not isinstance(parts, list):
+                        continue
+                    for part in parts:
+                        extracted = self._extract_inline_data(part)
+                        if extracted is not None:
+                            return extracted
+        raise ImageGenerationError(self._no_image_message(data))
+
+    def _extract_inline_data(self, part: Any) -> tuple[bytes, str] | None:
+        if not isinstance(part, dict):
+            return None
+        # Defensive against both spellings: the canonical REST/JSON response
+        # field is camelCase `inlineData`, but proto-JSON also round-trips
+        # the original `inline_data` field name.
+        inline = part.get("inlineData")
+        if not isinstance(inline, dict):
+            inline = part.get("inline_data")
+        if not isinstance(inline, dict):
+            return None
+        b64data = inline.get("data")
+        if not isinstance(b64data, str) or not b64data.strip():
+            return None
+        mime_type = inline.get("mimeType") or inline.get("mime_type") or "image/png"
+        return decode_base64_image(b64data.strip(), max_bytes=self._max_output_bytes()), str(mime_type)
+
+    @staticmethod
+    def _no_image_message(data: Any) -> str:
+        """Map a no-image Gemini response to a fixed, sanitized message.
+
+        Never includes response text or the request prompt (only
+        `blockReason`/`finishReason` enum-ish values, which come from
+        Gemini's own moderation/control fields, not free text).
+        """
+        if isinstance(data, dict):
+            prompt_feedback = data.get("promptFeedback")
+            if isinstance(prompt_feedback, dict):
+                block_reason = prompt_feedback.get("blockReason")
+                if block_reason:
+                    return f"Gemini blocked the prompt ({block_reason})"
+            candidates = data.get("candidates")
+            if isinstance(candidates, list):
+                for candidate in candidates:
+                    if not isinstance(candidate, dict):
+                        continue
+                    finish_reason = candidate.get("finishReason")
+                    if finish_reason and finish_reason != "STOP":
+                        return f"Gemini returned no image ({finish_reason})"
+        return "Gemini returned no image"

--- a/tldw_chatbook/Image_Generation/adapters/gemini_image_adapter.py
+++ b/tldw_chatbook/Image_Generation/adapters/gemini_image_adapter.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any
 
 import httpx
+from loguru import logger
 
 from tldw_chatbook.Image_Generation.http_client import fetch_json
 from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest, ImageGenResult
@@ -208,6 +209,13 @@ class GeminiImageAdapter:
         }
 
     def _extract_image(self, data: Any) -> tuple[bytes, str]:
+        # Fix-round-1 (reviewer MINOR finding): a decode failure in one part
+        # must not abort the scan -- candidate[1] can still carry a valid
+        # image even if candidate[0]'s inline data is corrupt. `saw_undecodable`
+        # distinguishes "no inline-data part existed at all" (falls through to
+        # the normal blockReason/finishReason mapping) from "at least one did,
+        # but every one of them failed to decode" (a clearer, dedicated error).
+        saw_undecodable = False
         if isinstance(data, dict):
             candidates = data.get("candidates")
             if isinstance(candidates, list):
@@ -221,14 +229,26 @@ class GeminiImageAdapter:
                     if not isinstance(parts, list):
                         continue
                     for part in parts:
-                        extracted = self._extract_inline_data(part)
+                        extracted, undecodable = self._extract_inline_data(part)
                         if extracted is not None:
                             return extracted
+                        saw_undecodable = saw_undecodable or undecodable
+        if saw_undecodable:
+            raise ImageGenerationError("Gemini returned image data that could not be decoded")
         raise ImageGenerationError(self._no_image_message(data))
 
-    def _extract_inline_data(self, part: Any) -> tuple[bytes, str] | None:
+    def _extract_inline_data(self, part: Any) -> tuple[tuple[bytes, str] | None, bool]:
+        """Try to pull a decoded image out of one response ``part``.
+
+        Returns ``(result, undecodable)``: ``result`` is the decoded
+        ``(bytes, mime_type)`` on success, else ``None``; ``undecodable`` is
+        ``True`` only when the part *had* an inline-data payload that failed
+        to decode (malformed base64 / oversize) -- the caller uses this to
+        pick a more specific error than the generic no-image mapping when
+        every part with inline data failed this way.
+        """
         if not isinstance(part, dict):
-            return None
+            return None, False
         # Defensive against both spellings: the canonical REST/JSON response
         # field is camelCase `inlineData`, but proto-JSON also round-trips
         # the original `inline_data` field name.
@@ -236,12 +256,19 @@ class GeminiImageAdapter:
         if not isinstance(inline, dict):
             inline = part.get("inline_data")
         if not isinstance(inline, dict):
-            return None
+            return None, False
         b64data = inline.get("data")
         if not isinstance(b64data, str) or not b64data.strip():
-            return None
+            return None, False
         mime_type = inline.get("mimeType") or inline.get("mime_type") or "image/png"
-        return decode_base64_image(b64data.strip(), max_bytes=self._max_output_bytes()), str(mime_type)
+        try:
+            content = decode_base64_image(b64data.strip(), max_bytes=self._max_output_bytes())
+        except ImageGenerationError as exc:
+            # Never log the b64 payload itself -- only the decoder's generic
+            # failure reason (e.g. "invalid base64 image data").
+            logger.debug(f"Gemini image adapter: skipping undecodable inline-data part ({exc})")
+            return None, True
+        return (content, str(mime_type)), False
 
     @staticmethod
     def _no_image_message(data: Any) -> str:

--- a/tldw_chatbook/Image_Generation/adapters/image_format_utils.py
+++ b/tldw_chatbook/Image_Generation/adapters/image_format_utils.py
@@ -10,6 +10,9 @@ from typing import Any
 
 from tldw_chatbook.Image_Generation.http_client import (
     DEFAULT_MAX_REDIRECTS,
+    _positive_byte_limit,
+    _read_stream_with_limit,
+    _reject_declared_oversize,
     _resolve_redirect_url,
     _validate_egress_or_raise,
     create_client,
@@ -264,46 +267,14 @@ def _enforce_base64_encoded_limit(encoded: str, max_bytes: int | None) -> None:
         raise ImageGenerationError("image content too large")
 
 
-def _reject_declared_oversize(headers: Any, max_bytes: int | None) -> None:
-    limit = _positive_byte_limit(max_bytes)
-    if limit is None:
-        return
-    content_length = headers.get("content-length") or headers.get("Content-Length")
-    if content_length is None:
-        return
-    try:
-        declared_size = int(str(content_length).strip())
-    except ValueError:
-        return
-    if declared_size > limit:
-        raise ImageGenerationError("image content too large")
-
-
-def _read_stream_with_limit(chunks: Any, max_bytes: int | None) -> bytes:
-    limit = _positive_byte_limit(max_bytes)
-    total = 0
-    parts: list[bytes] = []
-    for chunk in chunks:
-        if not chunk:
-            continue
-        total += len(chunk)
-        if limit is not None and total > limit:
-            raise ImageGenerationError("image content too large")
-        parts.append(chunk)
-    return b"".join(parts)
-
-
 def _enforce_max_bytes(content: bytes, max_bytes: int | None) -> None:
     limit = _positive_byte_limit(max_bytes)
     if limit is not None and len(content) > limit:
         raise ImageGenerationError("image content too large")
 
 
-def _positive_byte_limit(max_bytes: int | None) -> int | None:
-    if max_bytes is None:
-        return None
-    try:
-        limit = int(max_bytes)
-    except (TypeError, ValueError):
-        return None
-    return limit if limit > 0 else None
+# _positive_byte_limit, _reject_declared_oversize, and _read_stream_with_limit
+# used to be defined here; they now live in http_client.py (task-1 fix round
+# 1) so fetch_bytes_via_post's POST byte-fetch path and this module's GET
+# fetch_image_bytes share one implementation instead of duplicating the
+# size-cap logic. Imported at the top of this file.

--- a/tldw_chatbook/Image_Generation/capabilities.py
+++ b/tldw_chatbook/Image_Generation/capabilities.py
@@ -27,7 +27,7 @@ _DEFAULT_REFERENCE_IMAGE_SUPPORT: dict[str, set[str]] = {
 #: this set and does not grant capability through the functions below for
 #: any backend outside it. Extending reference-image support to another
 #: backend means adding its id here, not repurposing the per-model map.
-REFERENCE_IMAGE_CAPABLE_BACKENDS: frozenset[str] = frozenset({"fal", "gemini", "fireworks"})
+REFERENCE_IMAGE_CAPABLE_BACKENDS: frozenset[str] = frozenset({"fal", "gemini"})
 
 
 @dataclass(frozen=True)
@@ -142,7 +142,7 @@ def resolve_reference_image_capability(
 ) -> ReferenceImageCapability:
     """Resolve whether a backend/model pair supports reference-image input.
 
-    Backends in ``REFERENCE_IMAGE_CAPABLE_BACKENDS`` (fal/Gemini/Fireworks)
+    Backends in ``REFERENCE_IMAGE_CAPABLE_BACKENDS`` (fal/Gemini)
     support reference images unconditionally -- these adapters have no
     per-model restriction, so ``model`` is not consulted for them. Backends
     outside that set fall back to the dormant per-model

--- a/tldw_chatbook/Image_Generation/capabilities.py
+++ b/tldw_chatbook/Image_Generation/capabilities.py
@@ -12,6 +12,23 @@ _DEFAULT_REFERENCE_IMAGE_SUPPORT: dict[str, set[str]] = {
     "modelstudio": {"qwen-image-2.0", "qwen-image-edit"},
 }
 
+#: Backends whose adapters accept a reference image unconditionally (no
+#: per-model gating). This is the *primary* capability gate consulted by the
+#: engine-level choke point (``request_validation.validate_image_generation_request``)
+#: and by :func:`resolve_backend_reference_image_capability` /
+#: :func:`resolve_reference_image_capability` below -- a backend outside this
+#: set is treated as reference-image-incapable regardless of what the dormant
+#: ``reference_image_supported_models`` config map (see
+#: ``_DEFAULT_REFERENCE_IMAGE_SUPPORT`` / ``_resolve_supported_models`` above)
+#: says about it. That per-model map remains intentionally dormant: it is
+#: still exercised directly by the Model Studio adapter (which calls
+#: :func:`resolve_reference_image_capability("modelstudio", model, ...)`
+#: itself to gate specific Qwen model families) but it is *not* wired into
+#: this set and does not grant capability through the functions below for
+#: any backend outside it. Extending reference-image support to another
+#: backend means adding its id here, not repurposing the per-model map.
+REFERENCE_IMAGE_CAPABLE_BACKENDS: frozenset[str] = frozenset({"fal", "gemini", "fireworks"})
+
 
 @dataclass(frozen=True)
 class ResolvedReferenceImage:
@@ -99,16 +116,22 @@ def resolve_backend_reference_image_capability(
     *,
     config: ImageGenerationConfig | None = None,
 ) -> ReferenceImageCapability:
-    """Resolve whether a backend exposes any reference-image support."""
+    """Resolve whether a backend exposes any reference-image support.
+
+    ``REFERENCE_IMAGE_CAPABLE_BACKENDS`` is the primary gate: a backend
+    outside that set is unsupported here even if the dormant
+    ``reference_image_supported_models`` map (consulted only by
+    :func:`resolve_reference_image_capability` below) would otherwise list
+    per-model support for it (e.g. Model Studio's Qwen models) -- that map
+    is kept dormant and does not leak into this backend-level query.
+    """
 
     backend_key = _normalize_key(backend)
     if not backend_key:
         return ReferenceImageCapability(supported=False, reason="unsupported_model")
-    supported_models = _resolve_supported_models(backend_key, config=config)
-    return ReferenceImageCapability(
-        supported=bool(supported_models),
-        reason=None if supported_models else "unsupported_model",
-    )
+    if backend_key not in REFERENCE_IMAGE_CAPABLE_BACKENDS:
+        return ReferenceImageCapability(supported=False, reason="unsupported_backend")
+    return ReferenceImageCapability(supported=True)
 
 
 def resolve_reference_image_capability(
@@ -117,11 +140,26 @@ def resolve_reference_image_capability(
     *,
     config: ImageGenerationConfig | None = None,
 ) -> ReferenceImageCapability:
-    """Resolve whether a backend/model pair supports reference-image input."""
+    """Resolve whether a backend/model pair supports reference-image input.
+
+    Backends in ``REFERENCE_IMAGE_CAPABLE_BACKENDS`` (fal/Gemini/Fireworks)
+    support reference images unconditionally -- these adapters have no
+    per-model restriction, so ``model`` is not consulted for them. Backends
+    outside that set fall back to the dormant per-model
+    ``reference_image_supported_models`` config map (default:
+    ``_DEFAULT_REFERENCE_IMAGE_SUPPORT``), which today only lists Model
+    Studio's Qwen models and is consulted directly by the Model Studio
+    adapter itself.
+    """
 
     backend_key = _normalize_key(backend)
+    if not backend_key:
+        return ReferenceImageCapability(supported=False, reason="unsupported_model")
+    if backend_key in REFERENCE_IMAGE_CAPABLE_BACKENDS:
+        return ReferenceImageCapability(supported=True)
+
     model_key = _normalize_key(model)
-    if not backend_key or not model_key:
+    if not model_key:
         return ReferenceImageCapability(supported=False, reason="unsupported_model")
 
     supported_models = _resolve_supported_models(backend_key, config=config)

--- a/tldw_chatbook/Image_Generation/config.py
+++ b/tldw_chatbook/Image_Generation/config.py
@@ -66,9 +66,6 @@ DEFAULT_FAL_IMAGE_TIMEOUT_SECONDS = 120
 DEFAULT_GEMINI_IMAGE_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
 DEFAULT_GEMINI_IMAGE_MODEL = "gemini-2.5-flash-image"
 DEFAULT_GEMINI_IMAGE_TIMEOUT_SECONDS = 120
-DEFAULT_FIREWORKS_IMAGE_BASE_URL = "https://api.fireworks.ai/inference/v1/workflows/accounts/fireworks/models"
-DEFAULT_FIREWORKS_IMAGE_MODEL = "flux-1-schnell-fp8"
-DEFAULT_FIREWORKS_IMAGE_TIMEOUT_SECONDS = 120
 
 # Secret fields: backend -> (flat_field_name, [env vars in precedence
 # order], keyring_backend_id, nested [image_generation.<backend>] TOML
@@ -90,7 +87,6 @@ _SECRETS = {
     "modelstudio": ("modelstudio_image_api_key",  ["DASHSCOPE_API_KEY", "QWEN_API_KEY"],   "modelstudio", "api_key"),
     "fal":         ("fal_image_api_key",          ["FAL_KEY"],                             "fal",         "api_key"),
     "gemini":      ("gemini_image_api_key",       ["GEMINI_API_KEY", "GOOGLE_API_KEY"],    "gemini",      "api_key"),
-    "fireworks":   ("fireworks_image_api_key",    ["FIREWORKS_API_KEY"],                   "fireworks",   "api_key"),
 }
 # Non-secret nested keys: (backend, toml_key) -> flat_field_name
 # NOTE: `reference_image_supported_models` is intentionally NOT mapped here —
@@ -140,9 +136,6 @@ _NON_SECRET = {
     ("gemini", "base_url"):           "gemini_image_base_url",
     ("gemini", "default_model"):      "gemini_image_default_model",
     ("gemini", "timeout_seconds"):    "gemini_image_timeout_seconds",
-    ("fireworks", "base_url"):        "fireworks_image_base_url",
-    ("fireworks", "default_model"):   "fireworks_image_default_model",
-    ("fireworks", "timeout_seconds"): "fireworks_image_timeout_seconds",
 }
 _GLOBAL_KEYS = [
     "default_backend", "enabled_backends", "max_width", "max_height",
@@ -338,10 +331,6 @@ class ImageGenerationConfig:
     gemini_image_api_key: str | None
     gemini_image_default_model: str | None
     gemini_image_timeout_seconds: int
-    fireworks_image_base_url: str | None
-    fireworks_image_api_key: str | None
-    fireworks_image_default_model: str | None
-    fireworks_image_timeout_seconds: int
     reference_image_supported_models: dict[str, list[str]] = field(default_factory=dict)
     # backend id -> "env:<VAR>" | "config" | "keyring" | "missing" (task-1,
     # Settings ▸ Image Gen plan). Purely additive/read-only metadata about
@@ -595,15 +584,6 @@ def get_image_generation_config(*, reload: bool = False) -> ImageGenerationConfi
         gemini_image_timeout_seconds=_coerce_int(
             section.get("gemini_image_timeout_seconds"),
             DEFAULT_GEMINI_IMAGE_TIMEOUT_SECONDS,
-        ),
-        fireworks_image_base_url=_get_config_value(section, "fireworks_image_base_url")
-        or DEFAULT_FIREWORKS_IMAGE_BASE_URL,
-        fireworks_image_api_key=_get_config_value(section, "fireworks_image_api_key"),
-        fireworks_image_default_model=_get_config_value(section, "fireworks_image_default_model")
-        or DEFAULT_FIREWORKS_IMAGE_MODEL,
-        fireworks_image_timeout_seconds=_coerce_int(
-            section.get("fireworks_image_timeout_seconds"),
-            DEFAULT_FIREWORKS_IMAGE_TIMEOUT_SECONDS,
         ),
         reference_image_supported_models=_parse_mapping_of_lists(section.get("reference_image_supported_models")),
         key_sources=key_sources,

--- a/tldw_chatbook/Image_Generation/config.py
+++ b/tldw_chatbook/Image_Generation/config.py
@@ -59,6 +59,16 @@ DEFAULT_MODELSTUDIO_IMAGE_REGION = "sg"
 DEFAULT_MODELSTUDIO_IMAGE_MODE = "auto"
 DEFAULT_MODELSTUDIO_IMAGE_POLL_INTERVAL_SECONDS = 2
 DEFAULT_MODELSTUDIO_IMAGE_TIMEOUT_SECONDS = 180
+DEFAULT_FAL_IMAGE_BASE_URL = "https://queue.fal.run"
+DEFAULT_FAL_IMAGE_MODEL = "fal-ai/flux/schnell"
+DEFAULT_FAL_IMAGE_POLL_INTERVAL_SECONDS = 2
+DEFAULT_FAL_IMAGE_TIMEOUT_SECONDS = 120
+DEFAULT_GEMINI_IMAGE_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+DEFAULT_GEMINI_IMAGE_MODEL = "gemini-2.5-flash-image"
+DEFAULT_GEMINI_IMAGE_TIMEOUT_SECONDS = 120
+DEFAULT_FIREWORKS_IMAGE_BASE_URL = "https://api.fireworks.ai/inference/v1/workflows/accounts/fireworks/models"
+DEFAULT_FIREWORKS_IMAGE_MODEL = "flux-1-schnell-fp8"
+DEFAULT_FIREWORKS_IMAGE_TIMEOUT_SECONDS = 120
 
 # Secret fields: backend -> (flat_field_name, [env vars in precedence
 # order], keyring_backend_id, nested [image_generation.<backend>] TOML
@@ -78,6 +88,9 @@ _SECRETS = {
     "novita":      ("novita_image_api_key",       ["NOVITA_API_KEY"],                      "novita",      "api_key"),
     "together":    ("together_image_api_key",     ["TOGETHER_API_KEY"],                    "together",    "api_key"),
     "modelstudio": ("modelstudio_image_api_key",  ["DASHSCOPE_API_KEY", "QWEN_API_KEY"],   "modelstudio", "api_key"),
+    "fal":         ("fal_image_api_key",          ["FAL_KEY"],                             "fal",         "api_key"),
+    "gemini":      ("gemini_image_api_key",       ["GEMINI_API_KEY", "GOOGLE_API_KEY"],    "gemini",      "api_key"),
+    "fireworks":   ("fireworks_image_api_key",    ["FIREWORKS_API_KEY"],                   "fireworks",   "api_key"),
 }
 # Non-secret nested keys: (backend, toml_key) -> flat_field_name
 # NOTE: `reference_image_supported_models` is intentionally NOT mapped here —
@@ -120,6 +133,16 @@ _NON_SECRET = {
     ("modelstudio", "poll_interval_seconds"): "modelstudio_image_poll_interval_seconds",
     ("modelstudio", "timeout_seconds"):       "modelstudio_image_timeout_seconds",
     ("modelstudio", "allowed_extra_params"):  "modelstudio_image_allowed_extra_params",
+    ("fal", "base_url"):              "fal_image_base_url",
+    ("fal", "default_model"):         "fal_image_default_model",
+    ("fal", "poll_interval_seconds"): "fal_image_poll_interval_seconds",
+    ("fal", "timeout_seconds"):       "fal_image_timeout_seconds",
+    ("gemini", "base_url"):           "gemini_image_base_url",
+    ("gemini", "default_model"):      "gemini_image_default_model",
+    ("gemini", "timeout_seconds"):    "gemini_image_timeout_seconds",
+    ("fireworks", "base_url"):        "fireworks_image_base_url",
+    ("fireworks", "default_model"):   "fireworks_image_default_model",
+    ("fireworks", "timeout_seconds"): "fireworks_image_timeout_seconds",
 }
 _GLOBAL_KEYS = [
     "default_backend", "enabled_backends", "max_width", "max_height",
@@ -306,6 +329,19 @@ class ImageGenerationConfig:
     modelstudio_image_poll_interval_seconds: int
     modelstudio_image_timeout_seconds: int
     modelstudio_image_allowed_extra_params: list[str]
+    fal_image_base_url: str | None
+    fal_image_api_key: str | None
+    fal_image_default_model: str | None
+    fal_image_poll_interval_seconds: int
+    fal_image_timeout_seconds: int
+    gemini_image_base_url: str | None
+    gemini_image_api_key: str | None
+    gemini_image_default_model: str | None
+    gemini_image_timeout_seconds: int
+    fireworks_image_base_url: str | None
+    fireworks_image_api_key: str | None
+    fireworks_image_default_model: str | None
+    fireworks_image_timeout_seconds: int
     reference_image_supported_models: dict[str, list[str]] = field(default_factory=dict)
     # backend id -> "env:<VAR>" | "config" | "keyring" | "missing" (task-1,
     # Settings ▸ Image Gen plan). Purely additive/read-only metadata about
@@ -538,6 +574,37 @@ def get_image_generation_config(*, reload: bool = False) -> ImageGenerationConfi
             DEFAULT_MODELSTUDIO_IMAGE_TIMEOUT_SECONDS,
         ),
         modelstudio_image_allowed_extra_params=_parse_list(section.get("modelstudio_image_allowed_extra_params")),
+        fal_image_base_url=_get_config_value(section, "fal_image_base_url") or DEFAULT_FAL_IMAGE_BASE_URL,
+        fal_image_api_key=_get_config_value(section, "fal_image_api_key"),
+        fal_image_default_model=_get_config_value(section, "fal_image_default_model") or DEFAULT_FAL_IMAGE_MODEL,
+        fal_image_poll_interval_seconds=max(
+            1,
+            _coerce_int(
+                section.get("fal_image_poll_interval_seconds"),
+                DEFAULT_FAL_IMAGE_POLL_INTERVAL_SECONDS,
+            ),
+        ),
+        fal_image_timeout_seconds=_coerce_int(
+            section.get("fal_image_timeout_seconds"),
+            DEFAULT_FAL_IMAGE_TIMEOUT_SECONDS,
+        ),
+        gemini_image_base_url=_get_config_value(section, "gemini_image_base_url") or DEFAULT_GEMINI_IMAGE_BASE_URL,
+        gemini_image_api_key=_get_config_value(section, "gemini_image_api_key"),
+        gemini_image_default_model=_get_config_value(section, "gemini_image_default_model")
+        or DEFAULT_GEMINI_IMAGE_MODEL,
+        gemini_image_timeout_seconds=_coerce_int(
+            section.get("gemini_image_timeout_seconds"),
+            DEFAULT_GEMINI_IMAGE_TIMEOUT_SECONDS,
+        ),
+        fireworks_image_base_url=_get_config_value(section, "fireworks_image_base_url")
+        or DEFAULT_FIREWORKS_IMAGE_BASE_URL,
+        fireworks_image_api_key=_get_config_value(section, "fireworks_image_api_key"),
+        fireworks_image_default_model=_get_config_value(section, "fireworks_image_default_model")
+        or DEFAULT_FIREWORKS_IMAGE_MODEL,
+        fireworks_image_timeout_seconds=_coerce_int(
+            section.get("fireworks_image_timeout_seconds"),
+            DEFAULT_FIREWORKS_IMAGE_TIMEOUT_SECONDS,
+        ),
         reference_image_supported_models=_parse_mapping_of_lists(section.get("reference_image_supported_models")),
         key_sources=key_sources,
         default_batch=default_batch,

--- a/tldw_chatbook/Image_Generation/http_client.py
+++ b/tldw_chatbook/Image_Generation/http_client.py
@@ -200,6 +200,67 @@ def fetch_json(
     raise ImageGenerationError("request failed: too many redirects")
 
 
+def _positive_byte_limit(max_bytes: int | None) -> int | None:
+    """Normalize a byte cap: ``None``/non-int/non-positive values mean "no cap".
+
+    Relocated from ``Image_Generation/adapters/image_format_utils.py`` (task-1
+    fix round 1) so both ``fetch_bytes_via_post`` (this module) and
+    ``fetch_image_bytes`` (image_format_utils, which imports it back from
+    here) share one implementation instead of duplicating the cap logic.
+    """
+    if max_bytes is None:
+        return None
+    try:
+        limit = int(max_bytes)
+    except (TypeError, ValueError):
+        return None
+    return limit if limit > 0 else None
+
+
+def _reject_declared_oversize(headers: Any, max_bytes: int | None) -> None:
+    """Reject a response whose declared ``Content-Length`` already exceeds the cap.
+
+    Runs before any body bytes are read, so a server that honestly declares
+    an oversized body is rejected without buffering it at all. A missing or
+    unparsable ``Content-Length`` is not itself an error here -- the running
+    total check in ``_read_stream_with_limit`` is the backstop for a body
+    that is unbounded or lies about its declared size.
+    """
+    limit = _positive_byte_limit(max_bytes)
+    if limit is None:
+        return
+    content_length = headers.get("content-length") or headers.get("Content-Length")
+    if content_length is None:
+        return
+    try:
+        declared_size = int(str(content_length).strip())
+    except ValueError:
+        return
+    if declared_size > limit:
+        raise ImageGenerationError("image content too large")
+
+
+def _read_stream_with_limit(chunks: Any, max_bytes: int | None) -> bytes:
+    """Read a byte-chunk iterator, aborting mid-stream once the running total exceeds the cap.
+
+    This is the backstop against a body that is unbounded or that lies about
+    its declared ``Content-Length`` (or omits it): each chunk is only
+    buffered after confirming the running total is still within the cap, so
+    a body that blows the cap is never fully read into memory.
+    """
+    limit = _positive_byte_limit(max_bytes)
+    total = 0
+    parts: list[bytes] = []
+    for chunk in chunks:
+        if not chunk:
+            continue
+        total += len(chunk)
+        if limit is not None and total > limit:
+            raise ImageGenerationError("image content too large")
+        parts.append(chunk)
+    return b"".join(parts)
+
+
 def fetch_bytes_via_post(
     url: str,
     *,
@@ -214,11 +275,28 @@ def fetch_bytes_via_post(
     For backends that return image bytes directly from a POST (e.g. Fireworks'
     image-generation endpoint) rather than a JSON envelope carrying a URL or
     base64 payload. Mirrors ``fetch_json``'s manual, per-hop-validated
-    redirect loop verbatim: egress is re-validated on every hop,
+    redirect loop: egress is re-validated on every hop,
     ``Authorization``/``Cookie``/``Proxy-Authorization`` are stripped on any
     hop whose origin differs from the original request's (see ``fetch_json``'s
     docstring for the full same-origin rationale), and redirects are never
     auto-followed by the transport.
+
+    Unlike ``fetch_json``, the final hop's response is streamed
+    (``client.stream()``) rather than eagerly buffered: ``httpx`` has no
+    built-in body-size limit, so reading the whole body via ``resp.content``
+    before checking it against ``max_bytes`` would let a hostile or broken
+    endpoint force an unbounded in-memory buffer regardless of the cap. Two
+    guards apply instead, mirroring ``image_format_utils.fetch_image_bytes``
+    (whose ``_reject_declared_oversize``/``_read_stream_with_limit`` helpers
+    live in this module and are imported back by that module, so both GET and
+    POST byte-fetch paths share one implementation):
+
+    1. ``_reject_declared_oversize`` rejects a response whose declared
+       ``Content-Length`` already exceeds ``max_bytes`` -- before a single
+       chunk is read.
+    2. ``_read_stream_with_limit`` reads the body chunk-by-chunk, aborting as
+       soon as the running total exceeds ``max_bytes`` -- the backstop for a
+       body with no (or an inaccurate) ``Content-Length``.
 
     Args:
         url: Absolute request URL (validated before each hop).
@@ -233,7 +311,8 @@ def fetch_bytes_via_post(
             for URLs sourced from a remote API's response body.
         max_bytes: Maximum allowed response body size in bytes. A response
             body larger than this raises ``ImageGenerationError`` naming the
-            cap -- the body is never silently truncated and returned partial.
+            cap -- the body is never silently truncated and returned partial,
+            nor fully buffered in memory before being rejected.
 
     Returns:
         A ``(body_bytes, content_type_header_value)`` tuple.
@@ -242,7 +321,8 @@ def fetch_bytes_via_post(
         ImageGenerationError: On a blocked URL (see
             ``_validate_egress_or_raise``), a redirect without a
             ``Location``, exceeding the redirect cap, or the response body
-            exceeding ``max_bytes``.
+            exceeding ``max_bytes`` (declared via ``Content-Length`` or
+            discovered mid-stream).
     """
     current = url
     with create_client(timeout=timeout) as client:
@@ -253,23 +333,25 @@ def fetch_bytes_via_post(
             # origin must not carry Authorization/Cookie/Proxy-Authorization
             # along with it.
             same_origin = egress.same_origin(url, current)
-            resp = client.request(
+            with client.stream(
                 "POST",
                 current,
                 headers=egress._hop_headers(headers, same_origin),
                 json=json,
-            )
-            if resp.is_redirect:
-                location = resp.headers.get("location") or resp.headers.get("Location")
-                if not location:
-                    raise ImageGenerationError("request failed: redirect without location")
-                current = _resolve_redirect_url(str(resp.url), str(location))
-                continue
-            resp.raise_for_status()
-            content = resp.content
-            if len(content) > max_bytes:
-                raise ImageGenerationError(
-                    f"response body exceeds max_bytes cap ({max_bytes} bytes)"
-                )
-            return content, resp.headers.get("content-type", "")
+            ) as resp:
+                if resp.is_redirect:
+                    location = resp.headers.get("location") or resp.headers.get("Location")
+                    if not location:
+                        raise ImageGenerationError("request failed: redirect without location")
+                    current = _resolve_redirect_url(str(resp.url), str(location))
+                    continue
+                resp.raise_for_status()
+                try:
+                    _reject_declared_oversize(resp.headers, max_bytes)
+                    content = _read_stream_with_limit(resp.iter_bytes(), max_bytes)
+                except ImageGenerationError as exc:
+                    raise ImageGenerationError(
+                        f"response body exceeds max_bytes cap ({max_bytes} bytes)"
+                    ) from exc
+                return content, resp.headers.get("content-type", "")
     raise ImageGenerationError("request failed: too many redirects")

--- a/tldw_chatbook/Image_Generation/http_client.py
+++ b/tldw_chatbook/Image_Generation/http_client.py
@@ -198,3 +198,78 @@ def fetch_json(
             resp.raise_for_status()
             return resp.json()
     raise ImageGenerationError("request failed: too many redirects")
+
+
+def fetch_bytes_via_post(
+    url: str,
+    *,
+    headers: dict | None = None,
+    json: Any = None,
+    timeout: float | None = None,
+    trusted_origins: frozenset = frozenset(),
+    max_bytes: int = 32 * 1024 * 1024,
+) -> tuple[bytes, str]:
+    """Issue a POST request and return the raw response body, not parsed JSON.
+
+    For backends that return image bytes directly from a POST (e.g. Fireworks'
+    image-generation endpoint) rather than a JSON envelope carrying a URL or
+    base64 payload. Mirrors ``fetch_json``'s manual, per-hop-validated
+    redirect loop verbatim: egress is re-validated on every hop,
+    ``Authorization``/``Cookie``/``Proxy-Authorization`` are stripped on any
+    hop whose origin differs from the original request's (see ``fetch_json``'s
+    docstring for the full same-origin rationale), and redirects are never
+    auto-followed by the transport.
+
+    Args:
+        url: Absolute request URL (validated before each hop).
+        headers: Optional request headers; credential headers are dropped on
+            cross-origin hops (see ``fetch_json``).
+        json: Optional JSON body, re-sent on every hop.
+        timeout: Per-request timeout in seconds. ``None`` uses
+            ``_DEFAULT_TIMEOUT``; an explicit ``0`` is honored as given
+            (fail-fast), not silently replaced by the default.
+        trusted_origins: Hostnames trusted to resolve to a private/internal
+            IP (e.g. a configured backend ``base_url``'s host). Leave empty
+            for URLs sourced from a remote API's response body.
+        max_bytes: Maximum allowed response body size in bytes. A response
+            body larger than this raises ``ImageGenerationError`` naming the
+            cap -- the body is never silently truncated and returned partial.
+
+    Returns:
+        A ``(body_bytes, content_type_header_value)`` tuple.
+
+    Raises:
+        ImageGenerationError: On a blocked URL (see
+            ``_validate_egress_or_raise``), a redirect without a
+            ``Location``, exceeding the redirect cap, or the response body
+            exceeding ``max_bytes``.
+    """
+    current = url
+    with create_client(timeout=timeout) as client:
+        for hop in range(DEFAULT_MAX_REDIRECTS + 1):
+            _validate_egress_or_raise(current, trusted_origins=trusted_origins)
+            # Same credential-exfiltration rationale as fetch_json: a
+            # redirect to a still-public (so not SSRF-blocked) different
+            # origin must not carry Authorization/Cookie/Proxy-Authorization
+            # along with it.
+            same_origin = egress.same_origin(url, current)
+            resp = client.request(
+                "POST",
+                current,
+                headers=egress._hop_headers(headers, same_origin),
+                json=json,
+            )
+            if resp.is_redirect:
+                location = resp.headers.get("location") or resp.headers.get("Location")
+                if not location:
+                    raise ImageGenerationError("request failed: redirect without location")
+                current = _resolve_redirect_url(str(resp.url), str(location))
+                continue
+            resp.raise_for_status()
+            content = resp.content
+            if len(content) > max_bytes:
+                raise ImageGenerationError(
+                    f"response body exceeds max_bytes cap ({max_bytes} bytes)"
+                )
+            return content, resp.headers.get("content-type", "")
+    raise ImageGenerationError("request failed: too many redirects")

--- a/tldw_chatbook/Image_Generation/listing.py
+++ b/tldw_chatbook/Image_Generation/listing.py
@@ -100,13 +100,6 @@ def _is_gemini_configured(cfg, enabled: bool) -> bool:
     return bool(api_key)
 
 
-def _is_fireworks_configured(cfg, enabled: bool) -> bool:
-    if not enabled:
-        return False
-    api_key = (getattr(cfg, "fireworks_image_api_key", None) or os.getenv("FIREWORKS_API_KEY") or "").strip()
-    return bool(api_key)
-
-
 def _resolve_supported_formats(name: str) -> list[str] | None:
     registry = get_registry()
     try:
@@ -184,13 +177,6 @@ def list_image_models_for_catalog() -> list[dict[str, Any]]:
             except _IMAGE_LISTING_NONCRITICAL_EXCEPTIONS as exc:
                 logger.debug("Image backend config check failed for {}: {}", name, exc)
                 is_configured = False
-        if name == "fireworks":
-            try:
-                is_configured = _is_fireworks_configured(cfg, enabled)
-            except _IMAGE_LISTING_NONCRITICAL_EXCEPTIONS as exc:
-                logger.debug("Image backend config check failed for {}: {}", name, exc)
-                is_configured = False
-
         entry: dict[str, Any] = {
             "provider": "image",
             "id": f"image/{name}",

--- a/tldw_chatbook/Image_Generation/listing.py
+++ b/tldw_chatbook/Image_Generation/listing.py
@@ -81,6 +81,32 @@ def _is_modelstudio_configured(cfg, enabled: bool) -> bool:
     return bool(api_key)
 
 
+def _is_fal_configured(cfg, enabled: bool) -> bool:
+    if not enabled:
+        return False
+    api_key = (getattr(cfg, "fal_image_api_key", None) or os.getenv("FAL_KEY") or "").strip()
+    return bool(api_key)
+
+
+def _is_gemini_configured(cfg, enabled: bool) -> bool:
+    if not enabled:
+        return False
+    api_key = (
+        getattr(cfg, "gemini_image_api_key", None)
+        or os.getenv("GEMINI_API_KEY")
+        or os.getenv("GOOGLE_API_KEY")
+        or ""
+    ).strip()
+    return bool(api_key)
+
+
+def _is_fireworks_configured(cfg, enabled: bool) -> bool:
+    if not enabled:
+        return False
+    api_key = (getattr(cfg, "fireworks_image_api_key", None) or os.getenv("FIREWORKS_API_KEY") or "").strip()
+    return bool(api_key)
+
+
 def _resolve_supported_formats(name: str) -> list[str] | None:
     registry = get_registry()
     try:
@@ -143,6 +169,24 @@ def list_image_models_for_catalog() -> list[dict[str, Any]]:
         if name == "modelstudio":
             try:
                 is_configured = _is_modelstudio_configured(cfg, enabled)
+            except _IMAGE_LISTING_NONCRITICAL_EXCEPTIONS as exc:
+                logger.debug("Image backend config check failed for {}: {}", name, exc)
+                is_configured = False
+        if name == "fal":
+            try:
+                is_configured = _is_fal_configured(cfg, enabled)
+            except _IMAGE_LISTING_NONCRITICAL_EXCEPTIONS as exc:
+                logger.debug("Image backend config check failed for {}: {}", name, exc)
+                is_configured = False
+        if name == "gemini":
+            try:
+                is_configured = _is_gemini_configured(cfg, enabled)
+            except _IMAGE_LISTING_NONCRITICAL_EXCEPTIONS as exc:
+                logger.debug("Image backend config check failed for {}: {}", name, exc)
+                is_configured = False
+        if name == "fireworks":
+            try:
+                is_configured = _is_fireworks_configured(cfg, enabled)
             except _IMAGE_LISTING_NONCRITICAL_EXCEPTIONS as exc:
                 logger.debug("Image backend config check failed for {}: {}", name, exc)
                 is_configured = False

--- a/tldw_chatbook/Image_Generation/request_validation.py
+++ b/tldw_chatbook/Image_Generation/request_validation.py
@@ -6,6 +6,7 @@ import math
 from dataclasses import dataclass
 from typing import Any
 
+from tldw_chatbook.Image_Generation.capabilities import resolve_backend_reference_image_capability
 from tldw_chatbook.Image_Generation.config import (
     DEFAULT_INLINE_MAX_BYTES,
     DEFAULT_MAX_HEIGHT,
@@ -15,6 +16,14 @@ from tldw_chatbook.Image_Generation.config import (
     DEFAULT_MAX_WIDTH,
     get_image_generation_config,
 )
+
+#: Choke-point bounds for the reference-image seam (task-3 of the
+#: fal/Gemini/Fireworks plan). Adapters (Tasks 4-6) can assume that any
+#: ``ImageGenRequest.reference_image`` that reaches them has already been
+#: validated against these here -- backend capability, allowed mime, size
+#: cap, and non-empty content.
+IMAGE_GEN_REFERENCE_MAX_BYTES = 10 * 1024 * 1024
+REFERENCE_IMAGE_ALLOWED_MIMES = frozenset({"image/png", "image/jpeg", "image/webp"})
 
 
 @dataclass(frozen=True)
@@ -90,6 +99,7 @@ def validate_image_generation_request(
 
     _validate_positive_finite_float(issues, structured.get("cfg_scale"), path="cfg_scale")
     _validate_extra_params(structured, config, issues)
+    _validate_reference_image(structured, config, issues)
     return issues
 
 
@@ -176,3 +186,46 @@ def _validate_extra_params(
         cli_args = extra_params.get("cli_args")
         if not isinstance(cli_args, (list, tuple)):
             issues.append(_issue("cli_args must be a list", "extra_params.cli_args"))
+
+
+def _validate_reference_image(
+    structured: dict[str, Any],
+    config: Any,
+    issues: list[ImageGenerationValidationIssue],
+) -> None:
+    """Choke-point validation for ``ImageGenRequest.reference_image``.
+
+    Runs only when a reference image is actually present on the request, so
+    every existing (non-reference) validation path is untouched. Checks fire
+    independently (they don't short-circuit each other) so a caller sees
+    every problem with the reference image at once, matching the accumulate-
+    all-issues style of the rest of this validator.
+    """
+
+    reference_image = structured.get("reference_image")
+    if reference_image is None:
+        return
+
+    backend = structured.get("backend")
+    capability = resolve_backend_reference_image_capability(backend, config=config)
+    if not capability.supported:
+        issues.append(
+            _issue(f"backend {backend!r} does not support reference images", "reference_image")
+        )
+
+    mime_type = getattr(reference_image, "mime_type", None)
+    if mime_type not in REFERENCE_IMAGE_ALLOWED_MIMES:
+        issues.append(
+            _issue(
+                f"reference image mime {mime_type!r} is not supported (png/jpeg/webp)",
+                "reference_image",
+            )
+        )
+
+    bytes_len = getattr(reference_image, "bytes_len", None)
+    if isinstance(bytes_len, int) and not isinstance(bytes_len, bool) and bytes_len > IMAGE_GEN_REFERENCE_MAX_BYTES:
+        issues.append(_issue("reference image exceeds the 10MB limit", "reference_image"))
+
+    content = getattr(reference_image, "content", None)
+    if content is None:
+        issues.append(_issue("reference image has no content bytes", "reference_image"))

--- a/tldw_chatbook/Image_Generation/worker.py
+++ b/tldw_chatbook/Image_Generation/worker.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import Any
 from tldw_chatbook.Image_Generation.adapter_registry import get_registry
 from tldw_chatbook.Image_Generation.adapters.base import ImageGenRequest, ImageGenResult
+from tldw_chatbook.Image_Generation.capabilities import ResolvedReferenceImage
 from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
 from tldw_chatbook.Image_Generation.request_validation import validate_image_generation_request
 
@@ -24,6 +25,7 @@ def build_request(
     model: str | None = None,
     image_format: str = "png",
     extra_params: dict[str, Any] | None = None,
+    reference_image: ResolvedReferenceImage | None = None,
 ) -> ImageGenRequest:
     """Build an :class:`ImageGenRequest` from caller/UI inputs.
 
@@ -40,6 +42,9 @@ def build_request(
         model: Optional model override.
         image_format: Output format (defaults to ``"png"``).
         extra_params: Backend-specific passthrough params (coerced to ``{}`` if None).
+        reference_image: Optional resolved reference image. Validated at the
+            ``run_generation`` choke point (backend capability, mime, size,
+            content) before any adapter sees it.
 
     Returns:
         A frozen :class:`ImageGenRequest`.
@@ -49,6 +54,7 @@ def build_request(
         width=width, height=height, steps=steps, cfg_scale=cfg_scale, seed=seed,
         sampler=sampler, model=model, format=image_format,
         extra_params=dict(extra_params or {}),
+        reference_image=reference_image,
     )
 
 
@@ -56,9 +62,12 @@ def run_generation(request: ImageGenRequest) -> ImageGenResult:
     """Validate, resolve the backend, and invoke its adapter. Blocking.
 
     Enforces the request-validation layer (bounds + per-backend ``extra_params``
-    allowlist) at this single entry point *before* dispatch, so a caller that
-    constructs an :class:`ImageGenRequest` directly cannot bypass it (e.g. the
-    stable-diffusion.cpp ``cli_args`` passthrough).
+    allowlist, plus reference-image backend-capability/mime/size/content
+    checks when ``request.reference_image`` is set) at this single entry
+    point *before* dispatch, so a caller that constructs an
+    :class:`ImageGenRequest` directly cannot bypass it (e.g. the
+    stable-diffusion.cpp ``cli_args`` passthrough, or an unsupported
+    backend receiving a reference image).
 
     Must run on a thread — the adapters are synchronous and blocking.
 
@@ -88,6 +97,7 @@ def run_generation(request: ImageGenRequest) -> ImageGenResult:
             "steps": request.steps,
             "cfg_scale": request.cfg_scale,
             "extra_params": request.extra_params,
+            "reference_image": request.reference_image,
         }
     )
     if issues:

--- a/tldw_chatbook/UI/Screens/settings_image_gen_defaults.py
+++ b/tldw_chatbook/UI/Screens/settings_image_gen_defaults.py
@@ -36,6 +36,8 @@ from tldw_chatbook.Image_Generation.config import (
 )
 from tldw_chatbook.Image_Generation.listing import (
     _IMAGE_LISTING_NONCRITICAL_EXCEPTIONS,
+    _is_fal_configured,
+    _is_gemini_configured,
     _is_modelstudio_configured,
     _is_novita_configured,
     _is_openrouter_configured,
@@ -54,6 +56,8 @@ BACKEND_IDS: tuple[str, ...] = (
     "novita",
     "together",
     "modelstudio",
+    "fal",
+    "gemini",
 )
 
 BACKEND_LABELS: dict[str, str] = {
@@ -63,6 +67,8 @@ BACKEND_LABELS: dict[str, str] = {
     "novita": "Novita",
     "together": "Together",
     "modelstudio": "ModelStudio",
+    "fal": "fal.ai",
+    "gemini": "Gemini (AI Studio)",
 }
 
 # backend_id -> the listing.py is_configured check to reuse (never
@@ -74,6 +80,8 @@ _CONFIGURED_CHECKS = {
     "novita": _is_novita_configured,
     "together": _is_together_configured,
     "modelstudio": _is_modelstudio_configured,
+    "fal": _is_fal_configured,
+    "gemini": _is_gemini_configured,
 }
 
 
@@ -125,6 +133,21 @@ FIELD_SCHEMA: dict[str, tuple[FieldSpec, ...]] = {
         FieldSpec("base_url", "Base URL", "url"),
         FieldSpec("default_model", "Default model", "text"),
         FieldSpec("region", "Region", "text"),
+        FieldSpec("timeout_seconds", "Timeout (seconds)", "int", min_value=1),
+        FieldSpec("api_key", "API key", "secret"),
+    ),
+    # fal's `poll_interval_seconds` stays config-only in v1 (matches
+    # novita/modelstudio's own poll_interval_seconds precedent -- neither is
+    # in the curated editor either).
+    "fal": (
+        FieldSpec("base_url", "Base URL", "url"),
+        FieldSpec("default_model", "Default model", "text"),
+        FieldSpec("timeout_seconds", "Timeout (seconds)", "int", min_value=1),
+        FieldSpec("api_key", "API key", "secret"),
+    ),
+    "gemini": (
+        FieldSpec("base_url", "Base URL", "url"),
+        FieldSpec("default_model", "Default model", "text"),
         FieldSpec("timeout_seconds", "Timeout (seconds)", "int", min_value=1),
         FieldSpec("api_key", "API key", "secret"),
     ),
@@ -716,9 +739,13 @@ def _probe_swarmui(base_url: str) -> ImageGenProbeResult:
 
 
 def _probe_reachability_only(base_url: str) -> ImageGenProbeResult:
-    """novita/modelstudio: neither has a confirmed cheap authenticated GET
-    (see ``probe_backend``'s docstring) -- unauthenticated reachability
-    only, so auth is never actually verified."""
+    """novita/modelstudio/fal: none of these has a confirmed cheap
+    authenticated GET (see ``probe_backend``'s docstring) -- unauthenticated
+    reachability only, so auth is never actually verified. fal's queue API
+    (``queue.fal.run``) has no models-listing route either -- this is a
+    plain reachability GET on the configured base, same shape as
+    ``_probe_swarmui`` but reporting the honest "auth unverified" badge
+    (unlike swarmui, which has no auth concept at all)."""
     _response, blocked_badge = _guarded_get(base_url)
     if blocked_badge is not None:
         return ImageGenProbeResult(ok=False, badge=blocked_badge)
@@ -729,6 +756,27 @@ def _probe_openai_compatible(base_url: str, secret: str | None) -> ImageGenProbe
     """openrouter/together: OpenAI-compatible ``GET {base_url}/models``."""
     url = f"{base_url.rstrip('/')}/models"
     headers = {"Authorization": f"Bearer {secret}"} if secret else None
+    response, blocked_badge = _guarded_get(url, headers=headers)
+    if blocked_badge is not None:
+        return ImageGenProbeResult(ok=False, badge=blocked_badge)
+    if not secret:
+        return ImageGenProbeResult(ok=True, badge="Reachable (auth unverified)")
+    if response.status_code in (401, 403):
+        return ImageGenProbeResult(ok=False, badge="Auth failed")
+    if 200 <= response.status_code < 300:
+        return ImageGenProbeResult(ok=True, badge="Reachable")
+    return ImageGenProbeResult(ok=False, badge=f"Unreachable: HTTP {response.status_code}")
+
+
+def _probe_gemini(base_url: str, secret: str | None) -> ImageGenProbeResult:
+    """gemini: authenticated ``GET {base_url}/models``, key in the
+    ``x-goog-api-key`` header -- Google's models-listing route is cheap and
+    exists on the same base as the image-generation endpoint, so (unlike
+    novita/modelstudio/fal) this is a full auth-verified probe, mirroring
+    ``_probe_openai_compatible``'s shape with Gemini's own header/auth
+    semantics."""
+    url = f"{base_url.rstrip('/')}/models"
+    headers = {"x-goog-api-key": secret} if secret else None
     response, blocked_badge = _guarded_get(url, headers=headers)
     if blocked_badge is not None:
         return ImageGenProbeResult(ok=False, badge=blocked_badge)
@@ -785,12 +833,19 @@ def probe_backend(
     - ``openrouter``/``together``: OpenAI-compatible ``GET
       {base_url}/models``, authenticated when a secret is available -- see
       ``_probe_openai_compatible``.
-    - ``novita``/``modelstudio``: unauthenticated reachability only.
-      Novita's adapter (``novita_image_adapter.py``) only exposes the
+    - ``novita``/``modelstudio``/``fal``: unauthenticated reachability
+      only. Novita's adapter (``novita_image_adapter.py``) only exposes the
       async submit/poll routes (``/v3/async/txt2img``,
       ``/v3/async/task-result``) -- no cheap authenticated GET was
       confirmed in this codebase's adapter, so novita is probed the same
       way as modelstudio rather than guessing at an unconfirmed endpoint.
+      fal's queue API (``queue.fal.run``) has no models-listing route
+      either -- same reachability-only treatment.
+    - ``gemini``: authenticated ``GET {base_url}/models`` with the key in
+      ``x-goog-api-key`` -- Google's models-listing route is a cheap,
+      confirmed authenticated GET on the same base as image generation, so
+      gemini gets a full auth-verified probe like openrouter/together
+      rather than reachability-only.
 
     Every network probe runs the SSRF egress check
     (``Utils.egress.check_url_or_raise``) before any request.
@@ -822,6 +877,8 @@ def probe_backend(
         return _probe_swarmui(base_url)
     if backend_id in ("openrouter", "together"):
         return _probe_openai_compatible(base_url, secret)
-    if backend_id in ("novita", "modelstudio"):
+    if backend_id == "gemini":
+        return _probe_gemini(base_url, secret)
+    if backend_id in ("novita", "modelstudio", "fal"):
         return _probe_reachability_only(base_url)
     raise ValueError(f"unknown backend_id: {backend_id!r}")

--- a/tldw_chatbook/Utils/egress.py
+++ b/tldw_chatbook/Utils/egress.py
@@ -237,7 +237,16 @@ async def check_url_or_raise_async(url: str, *, trusted_origins=frozenset()) -> 
 # ---------------------------------------------------------------------------
 # Guarded transport helpers
 # ---------------------------------------------------------------------------
-_STRIP_HEADERS = ("authorization", "cookie", "proxy-authorization")
+#: Header names stripped on any cross-origin redirect hop (see
+#: ``_hop_headers`` / ``guarded_fetch_httpx``). ``x-goog-api-key`` is Gemini's
+#: custom auth header (``Image_Generation/adapters/gemini_image_adapter.py``)
+#: -- the first adapter in this app to authenticate via a header other than
+#: ``Authorization``. Without listing it here, a redirect from the Gemini
+#: base (or any user-configured base_url) to a different public host would
+#: forward the real API key verbatim; every ``Authorization``-based adapter
+#: is already protected by this tuple. There is no legitimate cross-origin
+#: use of this header, so adding it is strictly tightening.
+_STRIP_HEADERS = ("authorization", "cookie", "proxy-authorization", "x-goog-api-key")
 
 
 class EgressFetchError(Exception):

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -2843,6 +2843,27 @@ timeout_seconds = 180
 allowed_extra_params = []
 api_key = "<API_KEY_HERE>"
 
+# fal.ai, Gemini, and Fireworks backends -- uncomment and add
+# enabled_backends/default_backend above to use.
+# [image_generation.fal]
+# base_url = "https://queue.fal.run"
+# default_model = "fal-ai/flux/schnell"
+# poll_interval_seconds = 2
+# timeout_seconds = 120
+# api_key = "<API_KEY_HERE>"          # or set FAL_KEY in the environment
+
+# [image_generation.gemini]
+# base_url = "https://generativelanguage.googleapis.com/v1beta"
+# default_model = "gemini-2.5-flash-image"
+# timeout_seconds = 120
+# api_key = "<API_KEY_HERE>"          # or set GEMINI_API_KEY / GOOGLE_API_KEY
+
+# [image_generation.fireworks]
+# base_url = "https://api.fireworks.ai/inference/v1/workflows/accounts/fireworks/models"
+# default_model = "flux-1-schnell-fp8"
+# timeout_seconds = 120
+# api_key = "<API_KEY_HERE>"          # or set FIREWORKS_API_KEY
+
 # User-defined `/generate-image` @style templates, layered over the 13
 # built-ins (Media_Creation/generation_templates.py). A user template with
 # the same id as a builtin overrides it; new ids extend the set. Fields

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -2843,8 +2843,8 @@ timeout_seconds = 180
 allowed_extra_params = []
 api_key = "<API_KEY_HERE>"
 
-# fal.ai, Gemini, and Fireworks backends -- uncomment and add
-# enabled_backends/default_backend above to use.
+# fal.ai and Gemini backends -- uncomment and add enabled_backends/
+# default_backend above to use.
 # [image_generation.fal]
 # base_url = "https://queue.fal.run"
 # default_model = "fal-ai/flux/schnell"
@@ -2857,12 +2857,6 @@ api_key = "<API_KEY_HERE>"
 # default_model = "gemini-2.5-flash-image"
 # timeout_seconds = 120
 # api_key = "<API_KEY_HERE>"          # or set GEMINI_API_KEY / GOOGLE_API_KEY
-
-# [image_generation.fireworks]
-# base_url = "https://api.fireworks.ai/inference/v1/workflows/accounts/fireworks/models"
-# default_model = "flux-1-schnell-fp8"
-# timeout_seconds = 120
-# api_key = "<API_KEY_HERE>"          # or set FIREWORKS_API_KEY
 
 # User-defined `/generate-image` @style templates, layered over the 13
 # built-ins (Media_Creation/generation_templates.py). A user template with


### PR DESCRIPTION
## Summary

Two new image-generation backends on the established adapter contract — **fal.ai** (queue+poll, default `fal-ai/flux/schnell`) and **Gemini / AI Studio** (`generateContent`, default `gemini-2.5-flash-image` — nano-banana) — plus the **engine-level reference-image seam** (image-to-image input for the new backends). Spec and plan under `Docs/superpowers/` (user-approved); built as SDD tasks with per-task adversarial review, a whole-branch final review (merge-ready, zero Critical/Important), and live UAT to the extent current keys allow.

**Fireworks was requested and then dropped mid-program**: the implementer discovered — and I verified from two independent sources — that Fireworks deprecated its image-generation API entirely on 2026-06-10 (endpoints 401 for everyone). The adapter built against the last-known schema was reverted; spec/plan carry dated drop annotations. FLUX remains served by the existing Together backend.

### Security decisions the branch is built around
- **fal never requests a server-provided URL.** Its queue poll/result URLs are self-built from the configured base + app id (first two model-path segments, cross-verified against fal's own client SDK source) + a charset-validated request id; the vendor's `status_url` is used only as a parsed cross-check that fails loudly on shape drift. This closes the credential-exfiltration channel that naively following queue responses would open.
- **Model ids are validated before URL construction** (new attack surface — the six existing adapters carry the model in the JSON body; these put it in the URL path). Charset allowlists with `..`/query rejection, per backend.
- **Gemini's key lives in the `x-goog-api-key` header only** (never the `?key=` query form Google also accepts — URLs get logged, headers don't; the live-UAT 429 confirmed the error text carries no credential). The header was also added to the central egress `_STRIP_HEADERS` — it's the app's first non-`Authorization` auth header and was silently outside the cross-origin credential-strip net.
- **Reference images validated at the choke point** — capability flags (`fal`/`gemini` true, six legacy false), mime allowlist, 10MB cap, bytes-in-memory only; unsupported backends refuse loudly. Gemini encodes as an `inline_data` part, fal as a base64 data URI. Console attach UX is a follow-up spec; the seam is engine-complete.
- New guarded `fetch_bytes_via_post` helper with a **streaming byte cap** (Content-Length pre-check + mid-read abort — review rejected read-then-check because httpx eagerly buffers with no default limit); the existing streaming helpers were relocated to `http_client` as the shared home.

### Verified-from-live-docs discipline (the task-620 lesson)
Every vendor shape was verified against live documentation during implementation and pinned in tests — including the non-obvious `responseModalities: ["TEXT","IMAGE"]` requirement (image-only silently returns empty parts) and fal's `image_size` object form. Reviewers independently re-verified the claims (one fetched fal's client source to confirm the app-id rule byte-for-byte).

### Live UAT so far (user keys, continuing post-merge)
Settings page renders all eight backends; Gemini auto-configures from `GOOGLE_API_KEY` (the designed env fallback) and its **auth-verified probe returned Reachable against the live models endpoint**; fal's reachability probe returned its exact spec'd badge. Gemini generation reached Google correctly but the key's image-quota bucket is exhausted (429) — full generation + nano-banana reference-edit UAT completes when a quota-bearing key is available; fal end-to-end awaits its key. Opt-in live suites (`TLDW_LIVE_FAL_API_KEY`/`TLDW_LIVE_GEMINI_API_KEY`) are in the tree for exactly that.

## Testing
- `Tests/Image_Generation/`: 237 passed / 9 skipped (the skips are the opt-in live suites) — includes 43 fal tests (poll lifecycle with the self-built-URL pins), 32 Gemini tests (parts iteration, safety-block mapping, header-not-query pin), the streaming-cap matrix, reference-seam validation matrix, and config/key_sources rows.
- Settings suites 113 passed (drift test passed **unmodified** when the new rows landed — the schema-driven design working as intended); egress suite 70 passed (central strip addition, pre-existing tests untouched).
- Follow-ups filed as **task-686** (cap hardening before Console attach UX, fal namespace grammar, the pre-existing chat-side `x-goog-api-key` redirect gap, keyring tests, docstring reword, friendlier 429).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two new image-generation backends — fal.ai and Gemini (`gemini-2.5-flash-image`) — with engine-level reference-image support. Drops Fireworks (vendor deprecated), updates settings/config, adds a streaming-safe HTTP helper, and hardens Gemini reference-image handling.

- **New Features**
  - `fal` and `gemini` adapters on the existing contract; registered in the adapter registry.
  - Reference-image seam: backend capability flags, mime allowlist (png/jpeg/webp), and a 10MB cap enforced at the engine choke point.
  - Settings: new rows and reachability/auth probes; env fallbacks (`FAL_KEY`, `GEMINI_API_KEY`/`GOOGLE_API_KEY`).
  - Config defaults and listing checks added; live test opt-ins (`TLDW_LIVE_FAL_API_KEY`, `TLDW_LIVE_GEMINI_API_KEY`).
  - `fetch_bytes_via_post` with streaming byte cap for safe large responses.

- **Security**
  - fal: self-built poll/result URLs (never follow vendor-provided URLs); strict model-id validation.
  - Gemini: `x-goog-api-key` header only; stripped on cross-origin redirects; added to central `_STRIP_HEADERS`.
  - Reference images validated centrally (capability, mime, size, non-empty) before adapter dispatch.
  - Gemini: enforces the bytes-only reference-image contract (no disk reads); raises on contract violations.

<sup>Written for commit 040aa4de31b111fe502807c600f1c63abb12b651. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

