### PR TITLE
Watchlists rebuild Phase A: data foundation

### DIFF
--- a/Docs/superpowers/plans/2026-07-25-watchlists-rebuild-phase-a-data-foundation.md
+++ b/Docs/superpowers/plans/2026-07-25-watchlists-rebuild-phase-a-data-foundation.md
@@ -12,7 +12,7 @@
 
 - Spec: `Docs/superpowers/specs/2026-07-25-watchlists-console-rebuild-design.md`. Every requirement below is traceable to it.
 - All schema changes are **idempotent** — running twice is a no-op — and live in `SubscriptionsDB`: table creation in `_initialize_schema`, additive migration in `_ensure_watchlists_schema`. No table is created lazily from a service. (Ruling, 2026-07-25: this is why Task 2 relocates `local_watchlist_runs`.)
-- `PRAGMA foreign_keys = ON` is already set (`Subscriptions_DB.py:82`). Cascades are live; do not disable.
+- Foreign-key enforcement is enabled by **Task 1a**. It was previously off at runtime — see that task. Do not disable it.
 - `SubscriptionsDB` uses `threading.local()` connections (`:75`, `:368-370`). Never share a connection across threads.
 - Use `db.transaction()` (`:373`) for writes; it commits on success and rolls back on exception.
 - `subscriptions.tags` is **comma-joined**, not JSON (`:422`). `watchlists.tags` matches.
@@ -45,6 +45,108 @@ Phase A ships as its own PR and is independently testable — it has no UI surfa
 | `Tests/DB/test_subscriptions_db_watchlists.py` | **New.** Schema, FTS, backfill, counts | 1, 3, 7 |
 | `Tests/Subscriptions/test_item_persist.py` | **New.** Full-column-set persistence | 4 |
 | `Tests/Subscriptions/test_watchlist_bundle_service.py` | **New.** CRUD, membership, collisions, migration | 5, 6 |
+
+---
+
+### Task 1a: Enable foreign-key enforcement
+
+**Files:**
+- Modify: `tldw_chatbook/DB/Subscriptions_DB.py` — add a `_get_connection` override
+- Modify: `Tests/DB/test_subscriptions_db.py` — fix one test that depends on enforcement being off
+- Test: `Tests/DB/test_subscriptions_db.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: every `SubscriptionsDB` connection has `PRAGMA foreign_keys = ON`. Task 1's cascade behaviour depends on this.
+
+**Why this exists (ruling, 2026-07-25):** the spec originally claimed enforcement was already on, citing `Subscriptions_DB.py:82`. That pragma runs inside `_initialize_schema`'s `with closing(self._get_connection())` block, on a connection closed immediately afterwards. The pragma is per-connection, and `BaseDB._get_connection` (`base_db.py:104-110`) sets only `row_factory`. So enforcement has been **off** at runtime, and `subscription_items`' declared `ON DELETE CASCADE` has never fired — deleting a subscription silently orphaned its items.
+
+This ships as its own commit because it fixes a pre-existing bug with database-wide effect and must be revertable independently of the feature work. Cleaning up already-orphaned rows is out of scope.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `Tests/DB/test_subscriptions_db.py`:
+
+```python
+def test_foreign_keys_enforced_on_runtime_connection(db):
+    # PRAGMA foreign_keys is per-connection and defaults to OFF. The pragma in
+    # _initialize_schema runs on a connection that is closed immediately after,
+    # so it does not cover the thread-local connection everything else uses.
+    assert db.conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+
+
+def test_deleting_subscription_cascades_to_its_items(db):
+    source_id = db.add_subscription(
+        name="ArXiv", type="rss", source="https://a.example/feed"
+    )
+    with db.transaction() as conn:
+        conn.execute(
+            "INSERT INTO subscription_items (subscription_id, url, title) VALUES (?, ?, ?)",
+            (source_id, "https://a.example/1", "An item"),
+        )
+
+    with db.transaction() as conn:
+        conn.execute("DELETE FROM subscriptions WHERE id = ?", (source_id,))
+
+    orphans = db.conn.execute("SELECT COUNT(*) FROM subscription_items").fetchone()[0]
+    assert orphans == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest Tests/DB/test_subscriptions_db.py -k "foreign_keys or cascades" -v`
+Expected: FAIL — the pragma reads `0`, and the orphaned item survives the parent delete.
+
+- [ ] **Step 3: Write the implementation**
+
+In `tldw_chatbook/DB/Subscriptions_DB.py`, add this method to `SubscriptionsDB` directly after `__init__`:
+
+```python
+    def _get_connection(self) -> sqlite3.Connection:
+        """Return a connection with foreign-key enforcement enabled.
+
+        ``PRAGMA foreign_keys`` is per-connection and defaults to OFF, and
+        ``BaseDB._get_connection`` sets only ``row_factory``. Without this
+        override every ``ON DELETE CASCADE`` in this schema is inert, which
+        silently orphaned ``subscription_items`` whenever a subscription was
+        deleted. Matches ``ChaChaNotes_DB`` and ``Client_Media_DB_v2``, which
+        each enable it per connection.
+        """
+        conn = super()._get_connection()
+        conn.execute("PRAGMA foreign_keys = ON;")
+        return conn
+```
+
+Confirm `import sqlite3` is already present at the top of the file; add it if not.
+
+- [ ] **Step 4: Fix the test that depended on enforcement being off**
+
+`test_subscription_filters_action_constraint_allows_include` inserts a `subscription_filters` row with `subscription_id=1` when no such subscription exists. It passes today only because enforcement is off — it asserts an invalid state. Give it a real parent row:
+
+```python
+def test_subscription_filters_action_constraint_allows_include(db):
+    source_id = db.add_subscription(
+        name="ArXiv", type="rss", source="https://a.example/feed"
+    )
+    cursor = db.conn.cursor()
+    cursor.execute(
+        "INSERT INTO subscription_filters (subscription_id, name, conditions, action) VALUES (?, ?, ?, ?)",
+        (source_id, "include ai", "{}", "include"),
+    )
+    db.conn.commit()
+```
+
+- [ ] **Step 5: Run the affected suites**
+
+Run: `source .venv/bin/activate && pytest Tests/DB/test_subscriptions_db.py Tests/Subscriptions Tests/Watchlists -q`
+Expected: all pass except the pre-existing, unrelated failure `Tests/Watchlists/test_watchlists_navigator.py::test_navigator_has_all_section_buttons`, which fails on this branch before any of your changes. If anything else fails, enabling enforcement surfaced another latent orphan — report it as DONE_WITH_CONCERNS with the specifics rather than working around it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/DB/Subscriptions_DB.py Tests/DB/test_subscriptions_db.py
+git commit -m "fix(db): enable foreign-key enforcement on SubscriptionsDB connections"
+```
 
 ---
 

--- a/Docs/superpowers/plans/2026-07-25-watchlists-rebuild-phase-a-data-foundation.md
+++ b/Docs/superpowers/plans/2026-07-25-watchlists-rebuild-phase-a-data-foundation.md
@@ -11,14 +11,14 @@
 ## Global Constraints
 
 - Spec: `Docs/superpowers/specs/2026-07-25-watchlists-console-rebuild-design.md`. Every requirement below is traceable to it.
-- All schema changes go through `SubscriptionsDB._ensure_watchlists_schema` and must be **idempotent** — running twice is a no-op.
+- All schema changes are **idempotent** — running twice is a no-op — and live in `SubscriptionsDB`: table creation in `_initialize_schema`, additive migration in `_ensure_watchlists_schema`. No table is created lazily from a service. (Ruling, 2026-07-25: this is why Task 2 relocates `local_watchlist_runs`.)
 - `PRAGMA foreign_keys = ON` is already set (`Subscriptions_DB.py:82`). Cascades are live; do not disable.
 - `SubscriptionsDB` uses `threading.local()` connections (`:75`, `:368-370`). Never share a connection across threads.
 - Use `db.transaction()` (`:373`) for writes; it commits on success and rolls back on exception.
 - `subscriptions.tags` is **comma-joined**, not JSON (`:422`). `watchlists.tags` matches.
 - `subscription_items.status` CHECK allows only `new`, `reviewed`, `ingested`, `ignored`, `error` (`:156`). Do not add values. "read" means `reviewed`; flag is the separate `is_flagged` column.
 - Tests run from the venv: `source .venv/bin/activate && pytest`. The `timeout` command is unavailable in this environment.
-- Parameterized queries only. Never interpolate values into SQL.
+- Parameterized queries only for **values in production code**. `PRAGMA` statements cannot take parameters; test helpers may interpolate a hardcoded, non-user-derived identifier. (Ruling, 2026-07-25.)
 
 ## Phase Map
 
@@ -238,38 +238,86 @@ git commit -m "feat(watchlists): add watchlist tables and item content columns"
 
 ---
 
-### Task 2: batch_id on the lazily-created run table
+### Task 2: Relocate the run table and add batch_id
 
 **Files:**
-- Modify: `tldw_chatbook/Subscriptions/local_watchlists_service.py:949-968` (`_ensure_run_schema`)
-- Modify: `tldw_chatbook/DB/Subscriptions_DB.py` — `_ensure_watchlists_schema`
+- Modify: `tldw_chatbook/DB/Subscriptions_DB.py` — `_initialize_schema` executescript, and `_ensure_watchlists_schema`
+- Modify: `tldw_chatbook/Subscriptions/local_watchlists_service.py` — delete `_ensure_run_schema` (`:948-968`) and its seven call sites (`:176`, `:202`, `:261`, `:288`, `:304`, `:319`, `:347`)
 - Test: `Tests/DB/test_subscriptions_db_watchlists.py`
 
 **Interfaces:**
 - Consumes: Task 1's `_ensure_watchlists_schema` block.
-- Produces: `local_watchlist_runs.batch_id TEXT`, present whether the table is created fresh or already exists.
+- Produces: `local_watchlist_runs` owned by `SubscriptionsDB`, with `batch_id TEXT`. `LocalWatchlistsService._ensure_run_schema` no longer exists.
 
-**Why this is delicate:** `local_watchlist_runs` is created **lazily** by `LocalWatchlistsService._ensure_run_schema`, not by `SubscriptionsDB._initialize_schema`. An unconditional `ALTER TABLE local_watchlist_runs` inside `_ensure_watchlists_schema` fails on a fresh database because the table does not exist yet. The column must therefore be added in **both** places: the lazy `CREATE TABLE` for new databases, and a **conditional** `ALTER` for databases where the table already exists.
+**Why this changed shape (ruling, 2026-07-25):** `local_watchlist_runs` was created **lazily** by `LocalWatchlistsService._ensure_run_schema`, which meant an `ALTER TABLE` in `_ensure_watchlists_schema` would fail on a fresh database. The original plan worked around that with a conditional `ALTER`. The ruling was to fix the cause instead: move table creation into `SubscriptionsDB._initialize_schema` so one place owns schema.
+
+`BaseDB.__init__` calls `_initialize_schema()` (`base_db.py:76`) before anything else can touch the database, and `_initialize_schema` calls `_ensure_watchlists_schema` at its end. So by the time the migration runs, the table always exists — the existence guard is unnecessary. Only the column-presence check remains, for databases created before `batch_id`.
+
+All seven `_ensure_run_schema` call sites are inside `local_watchlists_service.py`; nothing outside it, and no test, calls it.
 
 - [ ] **Step 1: Write the failing test**
 
 Append to `Tests/DB/test_subscriptions_db_watchlists.py`:
 
 ```python
-def test_batch_id_migration_skips_missing_run_table(db):
-    # Fresh DB: local_watchlist_runs does not exist yet. The migration must not raise.
-    assert "local_watchlist_runs" not in _tables(db)
-    db._ensure_watchlists_schema()
+def test_run_table_owned_by_db_with_batch_id(db):
+    # No service call needed — SubscriptionsDB owns this table now.
+    assert "local_watchlist_runs" in _tables(db)
+    assert "batch_id" in _columns(db, "local_watchlist_runs")
 
 
-def test_batch_id_added_to_existing_run_table(db):
-    # Simulate a DB created before batch_id existed.
-    with db.transaction() as conn:
-        conn.execute("""
-            CREATE TABLE local_watchlist_runs (
+def test_batch_id_added_to_preexisting_run_table(tmp_path):
+    import sqlite3
+
+    # A database created before batch_id existed, with the old table shape.
+    path = tmp_path / "legacy.db"
+    legacy_conn = sqlite3.connect(path)
+    legacy_conn.executescript("""
+        CREATE TABLE local_watchlist_runs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            source_id INTEGER NOT NULL,
+            job_id INTEGER,
+            status TEXT NOT NULL,
+            started_at TEXT,
+            finished_at TEXT,
+            stats_json TEXT,
+            error_msg TEXT,
+            log_text TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+    """)
+    legacy_conn.commit()
+    legacy_conn.close()
+
+    migrated = SubscriptionsDB(str(path), client_id="test")
+    assert "batch_id" in _columns(migrated, "local_watchlist_runs")
+
+
+def test_lazy_run_schema_helper_is_gone():
+    from tldw_chatbook.Subscriptions.local_watchlists_service import LocalWatchlistsService
+
+    assert not hasattr(LocalWatchlistsService, "_ensure_run_schema")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest Tests/DB/test_subscriptions_db_watchlists.py -k "run_table or batch_id or lazy_run" -v`
+Expected: FAIL — all three fail: the table is not created by `SubscriptionsDB`, `batch_id` does not exist, and `_ensure_run_schema` is still present.
+
+- [ ] **Step 3: Move the table into `_initialize_schema`**
+
+In `tldw_chatbook/DB/Subscriptions_DB.py`, inside the `conn.executescript(...)` block in `_initialize_schema`, add this **after** the `subscription_templates` table and **before** the `CREATE INDEX` statements (it references `subscriptions`, which must already be declared):
+
+```sql
+            -- Local watchlist run history. Owned here rather than created
+            -- lazily by LocalWatchlistsService, so one place owns schema and
+            -- additive migrations can ALTER it unconditionally.
+            CREATE TABLE IF NOT EXISTS local_watchlist_runs (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 source_id INTEGER NOT NULL,
                 job_id INTEGER,
+                batch_id TEXT,
                 status TEXT NOT NULL,
                 started_at TEXT,
                 finished_at TEXT,
@@ -277,79 +325,56 @@ def test_batch_id_added_to_existing_run_table(db):
                 error_msg TEXT,
                 log_text TEXT,
                 created_at TEXT NOT NULL,
-                updated_at TEXT NOT NULL
-            )
-        """)
-
-    db._ensure_watchlists_schema()
-    assert "batch_id" in _columns(db, "local_watchlist_runs")
-
-
-def test_batch_id_present_on_lazily_created_run_table(db):
-    from tldw_chatbook.Subscriptions.local_watchlists_service import LocalWatchlistsService
-
-    LocalWatchlistsService._ensure_run_schema(db)
-    assert "batch_id" in _columns(db, "local_watchlist_runs")
+                updated_at TEXT NOT NULL,
+                FOREIGN KEY (source_id) REFERENCES subscriptions(id) ON DELETE CASCADE
+            );
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 4: Add the batch_id migration for pre-existing databases**
 
-Run: `source .venv/bin/activate && pytest Tests/DB/test_subscriptions_db_watchlists.py -k batch_id -v`
-Expected: FAIL — `test_batch_id_added_to_existing_run_table` and `test_batch_id_present_on_lazily_created_run_table` fail because `batch_id` does not exist.
-
-- [ ] **Step 3: Add the column to the lazy CREATE TABLE**
-
-In `tldw_chatbook/Subscriptions/local_watchlists_service.py`, in `_ensure_run_schema`, add `batch_id` after `job_id`:
+`CREATE TABLE IF NOT EXISTS` will not add a column to a table that already exists, so databases created before `batch_id` still need an `ALTER`. In `_ensure_watchlists_schema`, immediately before the final `conn.commit()` added in Task 1:
 
 ```python
-                CREATE TABLE IF NOT EXISTS local_watchlist_runs (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    source_id INTEGER NOT NULL,
-                    job_id INTEGER,
-                    batch_id TEXT,
-                    status TEXT NOT NULL,
-                    started_at TEXT,
-                    finished_at TEXT,
-                    stats_json TEXT,
-                    error_msg TEXT,
-                    log_text TEXT,
-                    created_at TEXT NOT NULL,
-                    updated_at TEXT NOT NULL,
-                    FOREIGN KEY (source_id) REFERENCES subscriptions(id) ON DELETE CASCADE
-                )
+        # local_watchlist_runs is guaranteed to exist: BaseDB.__init__ runs
+        # _initialize_schema (base_db.py:76), which creates it and then calls
+        # this method. Only the column needs checking, for databases created
+        # before batch_id existed.
+        run_cols = {row[1] for row in cursor.execute("PRAGMA table_info(local_watchlist_runs)")}
+        if "batch_id" not in run_cols:
+            cursor.execute("ALTER TABLE local_watchlist_runs ADD COLUMN batch_id TEXT")
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_local_watchlist_runs_batch "
+            "ON local_watchlist_runs(batch_id)"
+        )
 ```
 
-- [ ] **Step 4: Add the conditional ALTER**
+- [ ] **Step 5: Delete the lazy helper and its call sites**
 
-In `tldw_chatbook/DB/Subscriptions_DB.py`, inside `_ensure_watchlists_schema`, immediately before the final `conn.commit()` added in Task 1:
+In `tldw_chatbook/Subscriptions/local_watchlists_service.py`:
 
-```python
-        # local_watchlist_runs is created lazily by LocalWatchlistsService, so it
-        # may not exist yet. ALTER only when it does; new databases get batch_id
-        # from that service's CREATE TABLE instead.
-        run_table_exists = cursor.execute(
-            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='local_watchlist_runs'"
-        ).fetchone()
-        if run_table_exists:
-            run_cols = {row[1] for row in cursor.execute("PRAGMA table_info(local_watchlist_runs)")}
-            if "batch_id" not in run_cols:
-                cursor.execute("ALTER TABLE local_watchlist_runs ADD COLUMN batch_id TEXT")
-            cursor.execute(
-                "CREATE INDEX IF NOT EXISTS idx_local_watchlist_runs_batch "
-                "ON local_watchlist_runs(batch_id)"
-            )
+1. Delete the `_ensure_run_schema` staticmethod entirely (`:948-968`, the `@staticmethod` decorator line through the closing of its `CREATE TABLE` block).
+2. Delete all seven `self._ensure_run_schema(db)` call lines: `:176`, `:202`, `:261`, `:288`, `:304`, `:319`, `:347`. Delete the whole line each time — none is part of a larger expression.
+
+Work bottom-up (highest line number first) so earlier deletions do not shift the line numbers of later ones. After editing, confirm nothing remains:
+
+```bash
+grep -rn "_ensure_run_schema" tldw_chatbook Tests
 ```
 
-- [ ] **Step 5: Run tests to verify they pass**
+Expected: no output.
 
-Run: `source .venv/bin/activate && pytest Tests/DB/test_subscriptions_db_watchlists.py -v && pytest Tests/Watchlists -v`
-Expected: PASS, no failures.
+Leave `_ensure_alert_rule_schema` alone. Relocating `local_watchlist_alert_rules` is the same pattern but is out of scope for this task.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && pytest Tests/DB/test_subscriptions_db_watchlists.py -v && pytest Tests/Watchlists -v && pytest Tests/Subscriptions -v`
+Expected: PASS, no failures. The watchlists and subscriptions suites exercise run creation and listing, which is what the relocation could break.
+
+- [ ] **Step 7: Commit**
 
 ```bash
 git add tldw_chatbook/DB/Subscriptions_DB.py tldw_chatbook/Subscriptions/local_watchlists_service.py Tests/DB/test_subscriptions_db_watchlists.py
-git commit -m "feat(watchlists): add batch_id to run table with conditional migration"
+git commit -m "refactor(watchlists): move run table into SubscriptionsDB, add batch_id"
 ```
 
 ---

--- a/Docs/superpowers/plans/2026-07-25-watchlists-rebuild-phase-a-data-foundation.md
+++ b/Docs/superpowers/plans/2026-07-25-watchlists-rebuild-phase-a-data-foundation.md
@@ -652,7 +652,7 @@ Add as a public method on `SubscriptionsDB`, directly after `_ensure_watchlists_
                 """
                 SELECT id, title, content, author
                 FROM subscription_items
-                WHERE id NOT IN (SELECT rowid FROM subscription_items_fts)
+                WHERE id NOT IN (SELECT rowid FROM subscription_items_fts_docsize)
                 ORDER BY id
                 LIMIT ?
                 """,

--- a/Docs/superpowers/plans/2026-07-25-watchlists-rebuild-phase-a-data-foundation.md
+++ b/Docs/superpowers/plans/2026-07-25-watchlists-rebuild-phase-a-data-foundation.md
@@ -695,6 +695,10 @@ git commit -m "feat(watchlists): add FTS5 index over items with chunked backfill
 
 **The bug being fixed:** two INSERT paths write disjoint column sets. `Subscriptions_DB.py:1322` writes `canonical_url`, `previous_hash`, `change_percentage`, `diff_summary`, `change_type` but drops `status`/`run_id`/`alert_matches`. `local_watchlists_service.py:1301` does the reverse. Neither writes body text, even though `local_watchlists_service.py:878` normalizes a `content` value before discarding it.
 
+**Both paths must be routed, not just one** (ruling, 2026-07-25 — the original steps wired only `local_watchlists_service`). `Subscriptions_DB._add_subscription_item` is reachable from `record_check_result`, which `Scheduling/scheduler/handlers/watchlist_check_handler.py:108` calls, and ADR-019 makes that handler the future execution authority for watchlist checks. Left unrouted, flipping `scheduling.watchlist_checks_enabled` would silently write items with no body text and no run linkage.
+
+Its existing `SELECT` guard on canonical_url + content_hash **stays**; only the raw `INSERT` delegates. The two paths deduplicate differently — the old one on a canonicalised URL, the shared function on raw `url` via `ON CONFLICT` — and keeping the guard preserves canonicalisation-based dedup exactly. Standardising the two rules was considered and rejected: it would silently split URLs differing only by trailing slash or case into separate rows.
+
 - [ ] **Step 1: Write the failing test**
 
 Create `Tests/Subscriptions/test_item_persist.py`:
@@ -837,8 +841,12 @@ def persist_subscription_item(
 ) -> None:
     """Insert or update one item, writing the full column set.
 
-    Existing ``reviewed`` and ``ignored`` statuses are preserved across
-    re-fetches; anything else resets to ``new``.
+    Existing ``reviewed``, ``ignored`` and ``ingested`` statuses are preserved
+    across re-fetches; anything else resets to ``new``. ``ingested`` is
+    included because it is set by a user action and ``execute_run`` re-upserts
+    every kept item on every run — without it, handled items resurface as
+    unread on the next poll. ``error`` deliberately resets, since a successful
+    re-fetch should clear a prior error.
 
     Args:
         conn: An open connection inside a transaction.
@@ -882,7 +890,7 @@ def persist_subscription_item(
             diff_summary = excluded.diff_summary,
             change_type = excluded.change_type,
             status = CASE
-                WHEN subscription_items.status IN ('reviewed', 'ignored')
+                WHEN subscription_items.status IN ('reviewed', 'ignored', 'ingested')
                 THEN subscription_items.status
                 ELSE 'new'
             END,

--- a/Docs/superpowers/plans/2026-07-25-watchlists-rebuild-phase-a-data-foundation.md
+++ b/Docs/superpowers/plans/2026-07-25-watchlists-rebuild-phase-a-data-foundation.md
@@ -1,0 +1,1423 @@
+# Watchlists Rebuild — Phase A: Data Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the storage and service layer the Watchlists screen rebuild needs — the watchlist bundle entity, durable item body text, full-text search, and a single item-persist path — with no UI changes.
+
+**Architecture:** Everything extends `SubscriptionsDB`'s existing idempotent `_ensure_watchlists_schema` helper rather than introducing migration machinery. A new `WatchlistBundleService` owns the watchlist entity and membership. The two divergent item INSERT paths collapse into one shared function. No UI file is touched in this phase.
+
+**Tech Stack:** Python ≥3.11, SQLite with FTS5, pytest. No new dependencies.
+
+## Global Constraints
+
+- Spec: `Docs/superpowers/specs/2026-07-25-watchlists-console-rebuild-design.md`. Every requirement below is traceable to it.
+- All schema changes go through `SubscriptionsDB._ensure_watchlists_schema` and must be **idempotent** — running twice is a no-op.
+- `PRAGMA foreign_keys = ON` is already set (`Subscriptions_DB.py:82`). Cascades are live; do not disable.
+- `SubscriptionsDB` uses `threading.local()` connections (`:75`, `:368-370`). Never share a connection across threads.
+- Use `db.transaction()` (`:373`) for writes; it commits on success and rolls back on exception.
+- `subscriptions.tags` is **comma-joined**, not JSON (`:422`). `watchlists.tags` matches.
+- `subscription_items.status` CHECK allows only `new`, `reviewed`, `ingested`, `ignored`, `error` (`:156`). Do not add values. "read" means `reviewed`; flag is the separate `is_flagged` column.
+- Tests run from the venv: `source .venv/bin/activate && pytest`. The `timeout` command is unavailable in this environment.
+- Parameterized queries only. Never interpolate values into SQL.
+
+## Phase Map
+
+This plan is Phase A of five. Later phases get their own plans, written against merged code rather than speculation:
+
+| Phase | Scope | Depends on |
+|---|---|---|
+| **A (this plan)** | Schema, unified persist, FTS, bundle service, counts | — |
+| B | `watchlists_workbench.py` container + five-region collapse (`region_layout.py`) + shell rewrite | A |
+| C | Tree, feeds pane, items pane, Inspector breadcrumb stack | B |
+| D | Content pane: article + change renderers, `content_render.py`, escaping | C |
+| E | Sources / Runs / Rules / Artifacts tabs | C |
+
+Phase A ships as its own PR and is independently testable — it has no UI surface.
+
+## File Structure
+
+| Path | Responsibility | Task |
+|---|---|---|
+| `tldw_chatbook/DB/Subscriptions_DB.py` | Schema additions, FTS, backfill, count query | 1, 3, 7 |
+| `tldw_chatbook/Subscriptions/local_watchlists_service.py` | `batch_id` on lazy run table; delegate persist | 2, 4 |
+| `tldw_chatbook/Subscriptions/item_persist.py` | **New.** Single item-persist function for both callers | 4 |
+| `tldw_chatbook/Subscriptions/watchlist_bundle_service.py` | **New.** Watchlist CRUD, membership, folder migration | 5, 6 |
+| `Tests/DB/test_subscriptions_db_watchlists.py` | **New.** Schema, FTS, backfill, counts | 1, 3, 7 |
+| `Tests/Subscriptions/test_item_persist.py` | **New.** Full-column-set persistence | 4 |
+| `Tests/Subscriptions/test_watchlist_bundle_service.py` | **New.** CRUD, membership, collisions, migration | 5, 6 |
+
+---
+
+### Task 1: Watchlist tables and item columns
+
+**Files:**
+- Modify: `tldw_chatbook/DB/Subscriptions_DB.py` — inside `_ensure_watchlists_schema`, after the existing index creation at `:361-362`
+- Test: `Tests/DB/test_subscriptions_db_watchlists.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: tables `watchlists`, `watchlist_sources`, `watchlist_migration_state`; columns `subscription_items.content`, `.content_format`, `.content_kind`, `.is_flagged`. Tasks 3-7 all depend on these.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/DB/test_subscriptions_db_watchlists.py`:
+
+```python
+import pytest
+
+from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SubscriptionsDB(str(tmp_path / "subs.db"), client_id="test")
+
+
+def _columns(db, table):
+    cursor = db.conn.cursor()
+    return {row[1] for row in cursor.execute(f"PRAGMA table_info({table})")}
+
+
+def _tables(db):
+    cursor = db.conn.cursor()
+    return {
+        row[0]
+        for row in cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+
+
+def test_watchlist_tables_created(db):
+    tables = _tables(db)
+    assert "watchlists" in tables
+    assert "watchlist_sources" in tables
+    assert "watchlist_migration_state" in tables
+
+
+def test_item_content_columns_created(db):
+    cols = _columns(db, "subscription_items")
+    assert "content" in cols
+    assert "content_format" in cols
+    assert "content_kind" in cols
+    assert "is_flagged" in cols
+
+
+def test_membership_cascades_on_source_delete(db):
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+    with db.transaction() as conn:
+        conn.execute("INSERT INTO watchlists (name) VALUES ('Morning')")
+        watchlist_id = conn.execute("SELECT id FROM watchlists").fetchone()[0]
+        conn.execute(
+            "INSERT INTO watchlist_sources (watchlist_id, subscription_id) VALUES (?, ?)",
+            (watchlist_id, source_id),
+        )
+
+    with db.transaction() as conn:
+        conn.execute("DELETE FROM subscriptions WHERE id = ?", (source_id,))
+
+    remaining = db.conn.execute("SELECT COUNT(*) FROM watchlist_sources").fetchone()[0]
+    assert remaining == 0
+
+
+def test_membership_cascades_on_watchlist_delete(db):
+    source_id = db.add_subscription(name="HN", type="rss", source="https://b.example/f")
+    with db.transaction() as conn:
+        conn.execute("INSERT INTO watchlists (name) VALUES ('Security')")
+        watchlist_id = conn.execute("SELECT id FROM watchlists").fetchone()[0]
+        conn.execute(
+            "INSERT INTO watchlist_sources (watchlist_id, subscription_id) VALUES (?, ?)",
+            (watchlist_id, source_id),
+        )
+        conn.execute("DELETE FROM watchlists WHERE id = ?", (watchlist_id,))
+
+    remaining = db.conn.execute("SELECT COUNT(*) FROM watchlist_sources").fetchone()[0]
+    assert remaining == 0
+    # The source itself survives — only membership is removed.
+    assert db.conn.execute("SELECT COUNT(*) FROM subscriptions").fetchone()[0] == 1
+
+
+def test_schema_migration_is_idempotent(db):
+    db._ensure_watchlists_schema()
+    db._ensure_watchlists_schema()
+    assert "watchlists" in _tables(db)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest Tests/DB/test_subscriptions_db_watchlists.py -v`
+Expected: FAIL — `test_watchlist_tables_created` asserts `"watchlists" in tables` and the table does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `tldw_chatbook/DB/Subscriptions_DB.py`, inside `_ensure_watchlists_schema`, **replace** the two index lines at `:361-362` with the block below (keeping those two `CREATE INDEX` statements at the top of it):
+
+```python
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_subscription_items_run_id ON subscription_items(run_id)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_subscription_items_queued ON subscription_items(queued_for_briefing, status)")
+
+        # Reader/body columns. `content` holds the renderable body: article text
+        # for feed items, diff text for site changes. `url_snapshots` remains the
+        # authority for full-page and previous-snapshot views.
+        if "content" not in items_cols:
+            cursor.execute("ALTER TABLE subscription_items ADD COLUMN content TEXT")
+        if "content_format" not in items_cols:
+            cursor.execute("ALTER TABLE subscription_items ADD COLUMN content_format TEXT")
+        if "content_kind" not in items_cols:
+            cursor.execute("ALTER TABLE subscription_items ADD COLUMN content_kind TEXT")
+        # Flag is a separate boolean, not a status: the status CHECK has no
+        # 'flagged' value, and an item can be flagged *and* reviewed at once.
+        if "is_flagged" not in items_cols:
+            cursor.execute("ALTER TABLE subscription_items ADD COLUMN is_flagged BOOLEAN DEFAULT 0")
+
+        # Watchlist bundle entity. `name` is intentionally not UNIQUE — uniqueness
+        # is enforced case-insensitively in WatchlistBundleService with
+        # auto-suffixing, because a SQL constraint would raise mid-migration.
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS watchlists (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                description TEXT,
+                tags TEXT,
+                is_active BOOLEAN DEFAULT 1,
+                sort_order INTEGER DEFAULT 0,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS watchlist_sources (
+                watchlist_id    INTEGER NOT NULL REFERENCES watchlists(id)     ON DELETE CASCADE,
+                subscription_id INTEGER NOT NULL REFERENCES subscriptions(id)  ON DELETE CASCADE,
+                added_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (watchlist_id, subscription_id)
+            )
+        """)
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_watchlist_sources_subscription "
+            "ON watchlist_sources(subscription_id)"
+        )
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_subscription_items_flagged "
+            "ON subscription_items(is_flagged, status)"
+        )
+        cursor.execute("""
+            CREATE TRIGGER IF NOT EXISTS update_watchlists_timestamp
+            AFTER UPDATE ON watchlists
+            BEGIN
+                UPDATE watchlists SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
+            END
+        """)
+        # Per-migration markers. schema_version cannot be reused: it is a single
+        # INTEGER PRIMARY KEY column with no room for keys.
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS watchlist_migration_state (
+                key TEXT PRIMARY KEY,
+                applied_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        conn.commit()
+```
+
+Delete the now-duplicated trailing `conn.commit()` that followed the original index lines.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `source .venv/bin/activate && pytest Tests/DB/test_subscriptions_db_watchlists.py -v`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Run the existing DB suite for regressions**
+
+Run: `source .venv/bin/activate && pytest Tests/DB/test_subscriptions_db.py -v`
+Expected: PASS, no failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/DB/Subscriptions_DB.py Tests/DB/test_subscriptions_db_watchlists.py
+git commit -m "feat(watchlists): add watchlist tables and item content columns"
+```
+
+---
+
+### Task 2: batch_id on the lazily-created run table
+
+**Files:**
+- Modify: `tldw_chatbook/Subscriptions/local_watchlists_service.py:949-968` (`_ensure_run_schema`)
+- Modify: `tldw_chatbook/DB/Subscriptions_DB.py` — `_ensure_watchlists_schema`
+- Test: `Tests/DB/test_subscriptions_db_watchlists.py`
+
+**Interfaces:**
+- Consumes: Task 1's `_ensure_watchlists_schema` block.
+- Produces: `local_watchlist_runs.batch_id TEXT`, present whether the table is created fresh or already exists.
+
+**Why this is delicate:** `local_watchlist_runs` is created **lazily** by `LocalWatchlistsService._ensure_run_schema`, not by `SubscriptionsDB._initialize_schema`. An unconditional `ALTER TABLE local_watchlist_runs` inside `_ensure_watchlists_schema` fails on a fresh database because the table does not exist yet. The column must therefore be added in **both** places: the lazy `CREATE TABLE` for new databases, and a **conditional** `ALTER` for databases where the table already exists.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `Tests/DB/test_subscriptions_db_watchlists.py`:
+
+```python
+def test_batch_id_migration_skips_missing_run_table(db):
+    # Fresh DB: local_watchlist_runs does not exist yet. The migration must not raise.
+    assert "local_watchlist_runs" not in _tables(db)
+    db._ensure_watchlists_schema()
+
+
+def test_batch_id_added_to_existing_run_table(db):
+    # Simulate a DB created before batch_id existed.
+    with db.transaction() as conn:
+        conn.execute("""
+            CREATE TABLE local_watchlist_runs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                source_id INTEGER NOT NULL,
+                job_id INTEGER,
+                status TEXT NOT NULL,
+                started_at TEXT,
+                finished_at TEXT,
+                stats_json TEXT,
+                error_msg TEXT,
+                log_text TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+        """)
+
+    db._ensure_watchlists_schema()
+    assert "batch_id" in _columns(db, "local_watchlist_runs")
+
+
+def test_batch_id_present_on_lazily_created_run_table(db):
+    from tldw_chatbook.Subscriptions.local_watchlists_service import LocalWatchlistsService
+
+    LocalWatchlistsService._ensure_run_schema(db)
+    assert "batch_id" in _columns(db, "local_watchlist_runs")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest Tests/DB/test_subscriptions_db_watchlists.py -k batch_id -v`
+Expected: FAIL — `test_batch_id_added_to_existing_run_table` and `test_batch_id_present_on_lazily_created_run_table` fail because `batch_id` does not exist.
+
+- [ ] **Step 3: Add the column to the lazy CREATE TABLE**
+
+In `tldw_chatbook/Subscriptions/local_watchlists_service.py`, in `_ensure_run_schema`, add `batch_id` after `job_id`:
+
+```python
+                CREATE TABLE IF NOT EXISTS local_watchlist_runs (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    source_id INTEGER NOT NULL,
+                    job_id INTEGER,
+                    batch_id TEXT,
+                    status TEXT NOT NULL,
+                    started_at TEXT,
+                    finished_at TEXT,
+                    stats_json TEXT,
+                    error_msg TEXT,
+                    log_text TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    FOREIGN KEY (source_id) REFERENCES subscriptions(id) ON DELETE CASCADE
+                )
+```
+
+- [ ] **Step 4: Add the conditional ALTER**
+
+In `tldw_chatbook/DB/Subscriptions_DB.py`, inside `_ensure_watchlists_schema`, immediately before the final `conn.commit()` added in Task 1:
+
+```python
+        # local_watchlist_runs is created lazily by LocalWatchlistsService, so it
+        # may not exist yet. ALTER only when it does; new databases get batch_id
+        # from that service's CREATE TABLE instead.
+        run_table_exists = cursor.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='local_watchlist_runs'"
+        ).fetchone()
+        if run_table_exists:
+            run_cols = {row[1] for row in cursor.execute("PRAGMA table_info(local_watchlist_runs)")}
+            if "batch_id" not in run_cols:
+                cursor.execute("ALTER TABLE local_watchlist_runs ADD COLUMN batch_id TEXT")
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_local_watchlist_runs_batch "
+                "ON local_watchlist_runs(batch_id)"
+            )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && pytest Tests/DB/test_subscriptions_db_watchlists.py -v && pytest Tests/Watchlists -v`
+Expected: PASS, no failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/DB/Subscriptions_DB.py tldw_chatbook/Subscriptions/local_watchlists_service.py Tests/DB/test_subscriptions_db_watchlists.py
+git commit -m "feat(watchlists): add batch_id to run table with conditional migration"
+```
+
+---
+
+### Task 3: FTS5 index over items
+
+**Files:**
+- Modify: `tldw_chatbook/DB/Subscriptions_DB.py` — `_ensure_watchlists_schema`, plus a new `backfill_items_fts` method
+- Test: `Tests/DB/test_subscriptions_db_watchlists.py`
+
+**Interfaces:**
+- Consumes: Task 1's `content` column. The FTS triggers reference `new.content`, so the column must exist before the triggers are created — keep this block **after** Task 1's.
+- Produces: `subscription_items_fts` virtual table; `SubscriptionsDB.backfill_items_fts(chunk_size: int = 500) -> int` returning the number of rows indexed in this call, `0` when complete.
+
+**Trigger caution:** an `update_subscription_items_timestamp` trigger already exists (`Subscriptions_DB.py:274-278`) and issues its own `UPDATE subscription_items`. SQLite's `recursive_triggers` pragma is off by default, so that nested update does **not** re-fire the FTS trigger. Do not enable `recursive_triggers`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `Tests/DB/test_subscriptions_db_watchlists.py`:
+
+```python
+def _insert_item(db, subscription_id, url, title, content):
+    with db.transaction() as conn:
+        conn.execute(
+            "INSERT INTO subscription_items "
+            "(subscription_id, url, title, content, content_kind, content_format) "
+            "VALUES (?, ?, ?, ?, 'article', 'text')",
+            (subscription_id, url, title, content),
+        )
+
+
+def test_fts_table_created(db):
+    assert "subscription_items_fts" in _tables(db)
+
+
+def test_fts_indexes_inserted_items(db):
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+    _insert_item(db, source_id, "https://a.example/1", "RAG Evaluation", "retrieval quality rubric")
+
+    rows = db.conn.execute(
+        "SELECT rowid FROM subscription_items_fts WHERE subscription_items_fts MATCH ?",
+        ("rubric",),
+    ).fetchall()
+    assert len(rows) == 1
+
+
+def test_fts_follows_updates_and_deletes(db):
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+    _insert_item(db, source_id, "https://a.example/1", "First", "alpha content")
+
+    with db.transaction() as conn:
+        conn.execute("UPDATE subscription_items SET content = 'beta content' WHERE url = ?",
+                     ("https://a.example/1",))
+
+    assert db.conn.execute(
+        "SELECT COUNT(*) FROM subscription_items_fts WHERE subscription_items_fts MATCH ?",
+        ("alpha",),
+    ).fetchone()[0] == 0
+    assert db.conn.execute(
+        "SELECT COUNT(*) FROM subscription_items_fts WHERE subscription_items_fts MATCH ?",
+        ("beta",),
+    ).fetchone()[0] == 1
+
+    with db.transaction() as conn:
+        conn.execute("DELETE FROM subscription_items WHERE url = ?", ("https://a.example/1",))
+
+    assert db.conn.execute(
+        "SELECT COUNT(*) FROM subscription_items_fts WHERE subscription_items_fts MATCH ?",
+        ("beta",),
+    ).fetchone()[0] == 0
+
+
+def test_backfill_is_chunked_and_resumable(db):
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+    with db.transaction() as conn:
+        conn.execute("DROP TRIGGER subscription_items_fts_ai")
+        for index in range(7):
+            conn.execute(
+                "INSERT INTO subscription_items (subscription_id, url, title, content) "
+                "VALUES (?, ?, ?, ?)",
+                (source_id, f"https://a.example/{index}", f"Item {index}", "searchable body"),
+            )
+
+    assert db.conn.execute("SELECT COUNT(*) FROM subscription_items_fts").fetchone()[0] == 0
+
+    first = db.backfill_items_fts(chunk_size=3)
+    assert first == 3
+    total = first
+    while True:
+        indexed = db.backfill_items_fts(chunk_size=3)
+        if indexed == 0:
+            break
+        total += indexed
+    assert total == 7
+
+    assert db.conn.execute(
+        "SELECT COUNT(*) FROM subscription_items_fts WHERE subscription_items_fts MATCH ?",
+        ("searchable",),
+    ).fetchone()[0] == 7
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest Tests/DB/test_subscriptions_db_watchlists.py -k "fts or backfill" -v`
+
+The `-k` expression must be quoted — unquoted, the shell parses `or` as a separate argument.
+
+Expected: FAIL — `test_fts_table_created` fails, `subscription_items_fts` does not exist.
+
+- [ ] **Step 3: Create the FTS table and triggers**
+
+In `tldw_chatbook/DB/Subscriptions_DB.py`, inside `_ensure_watchlists_schema`, after Task 2's block and before the final `conn.commit()`:
+
+```python
+        # External-content FTS over items, matching the pattern used by
+        # character_cards_fts / conversations_fts / media_fts. Triggers rather
+        # than explicit index writes, so every INSERT path stays indexed.
+        cursor.execute("""
+            CREATE VIRTUAL TABLE IF NOT EXISTS subscription_items_fts USING fts5(
+                title,
+                content,
+                author,
+                content='subscription_items',
+                content_rowid='id'
+            )
+        """)
+        cursor.execute("""
+            CREATE TRIGGER IF NOT EXISTS subscription_items_fts_ai
+            AFTER INSERT ON subscription_items BEGIN
+                INSERT INTO subscription_items_fts(rowid, title, content, author)
+                VALUES (new.id, new.title, new.content, new.author);
+            END
+        """)
+        cursor.execute("""
+            CREATE TRIGGER IF NOT EXISTS subscription_items_fts_ad
+            AFTER DELETE ON subscription_items BEGIN
+                INSERT INTO subscription_items_fts(subscription_items_fts, rowid, title, content, author)
+                VALUES ('delete', old.id, old.title, old.content, old.author);
+            END
+        """)
+        cursor.execute("""
+            CREATE TRIGGER IF NOT EXISTS subscription_items_fts_au
+            AFTER UPDATE ON subscription_items BEGIN
+                INSERT INTO subscription_items_fts(subscription_items_fts, rowid, title, content, author)
+                VALUES ('delete', old.id, old.title, old.content, old.author);
+                INSERT INTO subscription_items_fts(rowid, title, content, author)
+                VALUES (new.id, new.title, new.content, new.author);
+            END
+        """)
+```
+
+- [ ] **Step 4: Add the chunked backfill method**
+
+Add as a public method on `SubscriptionsDB`, directly after `_ensure_watchlists_schema`:
+
+```python
+    def backfill_items_fts(self, chunk_size: int = 500) -> int:
+        """Index one chunk of items that are missing from the FTS table.
+
+        Runs in a background worker, never inline in migration — a synchronous
+        backfill of a large subscription_items table would block app boot.
+        Resumes by rowid, so an interrupted backfill continues rather than
+        restarting.
+
+        Args:
+            chunk_size: Maximum rows to index in this call.
+
+        Returns:
+            Number of rows indexed. ``0`` means the backfill is complete.
+        """
+        with self.transaction() as conn:
+            rows = conn.execute(
+                """
+                SELECT id, title, content, author
+                FROM subscription_items
+                WHERE id NOT IN (SELECT rowid FROM subscription_items_fts)
+                ORDER BY id
+                LIMIT ?
+                """,
+                (chunk_size,),
+            ).fetchall()
+            if not rows:
+                return 0
+            conn.executemany(
+                "INSERT INTO subscription_items_fts(rowid, title, content, author) "
+                "VALUES (?, ?, ?, ?)",
+                [(row[0], row[1], row[2], row[3]) for row in rows],
+            )
+            return len(rows)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && pytest Tests/DB/test_subscriptions_db_watchlists.py -v`
+Expected: PASS, all tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/DB/Subscriptions_DB.py Tests/DB/test_subscriptions_db_watchlists.py
+git commit -m "feat(watchlists): add FTS5 index over items with chunked backfill"
+```
+
+---
+
+### Task 4: Unified item persistence
+
+**Files:**
+- Create: `tldw_chatbook/Subscriptions/item_persist.py`
+- Modify: `tldw_chatbook/Subscriptions/local_watchlists_service.py:1296-1340`
+- Test: `Tests/Subscriptions/test_item_persist.py`
+
+**Interfaces:**
+- Consumes: Task 1's `content`, `content_format`, `content_kind` columns.
+- Produces: `persist_subscription_item(conn, subscription_id: int, item: Mapping[str, Any], run_id: int | None, now: str) -> None`.
+
+**The bug being fixed:** two INSERT paths write disjoint column sets. `Subscriptions_DB.py:1322` writes `canonical_url`, `previous_hash`, `change_percentage`, `diff_summary`, `change_type` but drops `status`/`run_id`/`alert_matches`. `local_watchlists_service.py:1301` does the reverse. Neither writes body text, even though `local_watchlists_service.py:878` normalizes a `content` value before discarding it.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/Subscriptions/test_item_persist.py`:
+
+```python
+import pytest
+
+from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
+from tldw_chatbook.Subscriptions.item_persist import persist_subscription_item
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SubscriptionsDB(str(tmp_path / "subs.db"), client_id="test")
+
+
+@pytest.fixture
+def source_id(db):
+    return db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+
+
+def test_persists_full_column_set(db, source_id):
+    item = {
+        "url": "https://a.example/1",
+        "title": "RAG Evaluation",
+        "content": "retrieval quality rubric",
+        "content_kind": "article",
+        "content_format": "text",
+        "content_hash": "hash-1",
+        "author": "A. Author",
+        "canonical_url": "https://a.example/1",
+        "change_percentage": 12.5,
+        "diff_summary": "+2 -1",
+        "change_type": "content",
+        "alert_matches": [7],
+    }
+    with db.transaction() as conn:
+        persist_subscription_item(conn, source_id, item, run_id=42, now="2026-07-25T00:00:00Z")
+
+    row = db.conn.execute(
+        "SELECT content, content_kind, content_format, status, run_id, alert_matches, "
+        "canonical_url, change_percentage, diff_summary, change_type "
+        "FROM subscription_items WHERE url = ?",
+        ("https://a.example/1",),
+    ).fetchone()
+
+    assert row[0] == "retrieval quality rubric"
+    assert row[1] == "article"
+    assert row[2] == "text"
+    assert row[3] == "new"
+    assert row[4] == 42
+    assert row[5] == "[7]"
+    assert row[6] == "https://a.example/1"
+    assert row[7] == 12.5
+    assert row[8] == "+2 -1"
+    assert row[9] == "content"
+
+
+def test_upsert_preserves_reviewed_status(db, source_id):
+    item = {"url": "https://a.example/1", "title": "T", "content_hash": "h", "content": "body"}
+    with db.transaction() as conn:
+        persist_subscription_item(conn, source_id, item, run_id=1, now="2026-07-25T00:00:00Z")
+        conn.execute("UPDATE subscription_items SET status = 'reviewed' WHERE url = ?",
+                     ("https://a.example/1",))
+        persist_subscription_item(conn, source_id, item, run_id=2, now="2026-07-25T01:00:00Z")
+
+    row = db.conn.execute(
+        "SELECT status, run_id FROM subscription_items WHERE url = ?", ("https://a.example/1",)
+    ).fetchone()
+    assert row[0] == "reviewed"
+    assert row[1] == 2
+
+
+def test_rejects_invalid_kind_format_pairing(db, source_id):
+    item = {
+        "url": "https://a.example/1",
+        "title": "T",
+        "content_hash": "h",
+        "content_kind": "change",
+        "content_format": "markdown",
+    }
+    with pytest.raises(ValueError, match="content_kind"):
+        with db.transaction() as conn:
+            persist_subscription_item(conn, source_id, item, run_id=1, now="2026-07-25T00:00:00Z")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest Tests/Subscriptions/test_item_persist.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'tldw_chatbook.Subscriptions.item_persist'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `tldw_chatbook/Subscriptions/item_persist.py`:
+
+```python
+"""Single persistence path for scraped subscription items.
+
+Replaces two divergent INSERT statements that wrote disjoint column sets:
+``Subscriptions_DB`` wrote the change/dedup fields but dropped run linkage and
+status, while ``LocalWatchlistsService`` did the reverse. Neither wrote body
+text. Every caller now routes through :func:`persist_subscription_item`.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+
+_VALID_PAIRINGS = {
+    ("article", "text"),
+    ("article", "markdown"),
+    ("change", "diff"),
+}
+
+
+def _json_or_none(value: Any) -> str | None:
+    return json.dumps(value) if value is not None else None
+
+
+def _validate_content_pairing(kind: Any, fmt: Any) -> None:
+    """Reject impossible kind/format combinations at the persist boundary."""
+    if kind is None and fmt is None:
+        return
+    if (kind, fmt) not in _VALID_PAIRINGS:
+        raise ValueError(
+            f"invalid content_kind/content_format pairing: {kind!r}/{fmt!r}. "
+            f"Valid pairings: {sorted(_VALID_PAIRINGS)}"
+        )
+
+
+def persist_subscription_item(
+    conn: Any,
+    subscription_id: int,
+    item: Mapping[str, Any],
+    run_id: int | None,
+    now: str,
+) -> None:
+    """Insert or update one item, writing the full column set.
+
+    Existing ``reviewed`` and ``ignored`` statuses are preserved across
+    re-fetches; anything else resets to ``new``.
+
+    Args:
+        conn: An open connection inside a transaction.
+        subscription_id: Owning source id.
+        item: Normalized item mapping.
+        run_id: Run that produced this item, if any.
+        now: ISO-8601 timestamp for created_at/updated_at.
+
+    Raises:
+        ValueError: If content_kind and content_format are an invalid pairing.
+    """
+    content_kind = item.get("content_kind")
+    content_format = item.get("content_format")
+    _validate_content_pairing(content_kind, content_format)
+
+    conn.execute(
+        """
+        INSERT INTO subscription_items (
+            subscription_id, url, title, content, content_kind, content_format,
+            content_hash, published_date, author, categories, enclosures,
+            extracted_data, status, run_id, alert_matches, canonical_url,
+            previous_hash, change_percentage, diff_summary, change_type,
+            created_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(subscription_id, url, content_hash) DO UPDATE SET
+            title = excluded.title,
+            content = excluded.content,
+            content_kind = excluded.content_kind,
+            content_format = excluded.content_format,
+            published_date = excluded.published_date,
+            author = excluded.author,
+            categories = excluded.categories,
+            enclosures = excluded.enclosures,
+            extracted_data = excluded.extracted_data,
+            run_id = excluded.run_id,
+            alert_matches = excluded.alert_matches,
+            canonical_url = excluded.canonical_url,
+            previous_hash = excluded.previous_hash,
+            change_percentage = excluded.change_percentage,
+            diff_summary = excluded.diff_summary,
+            change_type = excluded.change_type,
+            status = CASE
+                WHEN subscription_items.status IN ('reviewed', 'ignored')
+                THEN subscription_items.status
+                ELSE 'new'
+            END,
+            updated_at = excluded.updated_at
+        """,
+        (
+            subscription_id,
+            item.get("url"),
+            item.get("title"),
+            item.get("content"),
+            content_kind,
+            content_format,
+            item.get("content_hash"),
+            item.get("published_date"),
+            item.get("author"),
+            _json_or_none(item.get("categories")),
+            _json_or_none(item.get("enclosures")),
+            _json_or_none(item.get("extracted_data")),
+            "new",
+            run_id,
+            _json_or_none(item.get("alert_matches")),
+            item.get("canonical_url"),
+            item.get("previous_hash"),
+            item.get("change_percentage"),
+            item.get("diff_summary"),
+            item.get("change_type"),
+            now,
+            now,
+        ),
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `source .venv/bin/activate && pytest Tests/Subscriptions/test_item_persist.py -v`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Route LocalWatchlistsService through it**
+
+In `tldw_chatbook/Subscriptions/local_watchlists_service.py`, add the import near the other local imports:
+
+```python
+from .item_persist import persist_subscription_item
+```
+
+Then replace the whole `cursor.execute("""INSERT INTO subscription_items …""", (...))` call spanning `:1301-1340` with:
+
+```python
+                persist_subscription_item(
+                    conn,
+                    source_id,
+                    {
+                        **item,
+                        "alert_matches": alert_matches,
+                    },
+                    run_id=run_id,
+                    now=now,
+                )
+```
+
+The enclosing method is `_upsert_subscription_items(db, source_id, run_id, items)`, whose body is
+`with db.transaction() as conn:` → `cursor = conn.cursor()` → `for item in items:`. So `conn` is in
+scope. `persist_subscription_item` takes the **connection**, not the cursor — pass `conn`.
+
+That INSERT is the last statement in the file, so several locals become dead once it is gone.
+Delete all of these:
+
+- `title = item.get("title")`
+- `published_date = item.get("published_date")`
+- `author = item.get("author")`
+- `categories = item.get("categories")`
+- `enclosures = item.get("enclosures")`
+- `extracted_data = item.get("extracted_data")`
+- `cursor = conn.cursor()` — nothing else in the method uses it
+
+Keep `url`, `content_hash` (both feed the `if not url or not content_hash: continue` guard) and
+`alert_matches` (passed through in the mapping above).
+
+- [ ] **Step 6: Verify no regressions in the watchlists suites**
+
+Run: `source .venv/bin/activate && pytest Tests/Subscriptions -v && pytest Tests/Watchlists -v`
+Expected: PASS. If a test asserts on dropped columns, that test was encoding the bug — update it to assert the full set.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tldw_chatbook/Subscriptions/item_persist.py tldw_chatbook/Subscriptions/local_watchlists_service.py Tests/Subscriptions/test_item_persist.py
+git commit -m "fix(watchlists): unify item persistence into one full-column path"
+```
+
+---
+
+### Task 5: WatchlistBundleService
+
+**Files:**
+- Create: `tldw_chatbook/Subscriptions/watchlist_bundle_service.py`
+- Test: `Tests/Subscriptions/test_watchlist_bundle_service.py`
+
+**Interfaces:**
+- Consumes: Task 1's `watchlists` / `watchlist_sources` tables.
+- Produces: `WatchlistBundleService(db)` with `create(name, description=None, tags=None) -> dict`, `rename(watchlist_id, name) -> dict`, `delete(watchlist_id) -> None`, `list_watchlists() -> list[dict]`, `add_source(watchlist_id, subscription_id) -> None`, `remove_source(watchlist_id, subscription_id) -> None`, `list_sources(watchlist_id) -> list[int]`. Tasks 6 and 7 and all of Phase C consume these.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/Subscriptions/test_watchlist_bundle_service.py`:
+
+```python
+import pytest
+
+from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
+from tldw_chatbook.Subscriptions.watchlist_bundle_service import WatchlistBundleService
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SubscriptionsDB(str(tmp_path / "subs.db"), client_id="test")
+
+
+@pytest.fixture
+def service(db):
+    return WatchlistBundleService(db)
+
+
+def test_create_and_list(service):
+    created = service.create("Morning AI Brief", tags=["ai", "daily"])
+    assert created["name"] == "Morning AI Brief"
+    assert created["tags"] == ["ai", "daily"]
+
+    listed = service.list_watchlists()
+    assert [row["name"] for row in listed] == ["Morning AI Brief"]
+
+
+def test_name_collision_is_case_insensitive_and_suffixes(service):
+    service.create("Unsorted")
+    second = service.create("unsorted")
+    third = service.create("UNSORTED")
+    assert second["name"] == "unsorted (2)"
+    assert third["name"] == "UNSORTED (3)"
+
+
+def test_rename_also_avoids_collision(service):
+    service.create("Security")
+    other = service.create("Papers")
+    renamed = service.rename(other["id"], "security")
+    assert renamed["name"] == "security (2)"
+
+
+def test_membership_add_remove_and_idempotent_add(service, db):
+    watchlist = service.create("Morning")
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+
+    service.add_source(watchlist["id"], source_id)
+    service.add_source(watchlist["id"], source_id)  # idempotent
+    assert service.list_sources(watchlist["id"]) == [source_id]
+
+    service.remove_source(watchlist["id"], source_id)
+    assert service.list_sources(watchlist["id"]) == []
+
+
+def test_source_can_belong_to_multiple_watchlists(service, db):
+    first = service.create("Morning")
+    second = service.create("Security")
+    source_id = db.add_subscription(name="HN", type="rss", source="https://b.example/f")
+
+    service.add_source(first["id"], source_id)
+    service.add_source(second["id"], source_id)
+
+    assert service.list_sources(first["id"]) == [source_id]
+    assert service.list_sources(second["id"]) == [source_id]
+
+
+def test_delete_removes_membership_but_not_sources(service, db):
+    watchlist = service.create("Morning")
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+    service.add_source(watchlist["id"], source_id)
+
+    service.delete(watchlist["id"])
+
+    assert service.list_watchlists() == []
+    assert db.conn.execute("SELECT COUNT(*) FROM subscriptions").fetchone()[0] == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest Tests/Subscriptions/test_watchlist_bundle_service.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'tldw_chatbook.Subscriptions.watchlist_bundle_service'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `tldw_chatbook/Subscriptions/watchlist_bundle_service.py`:
+
+```python
+"""Watchlist bundle CRUD and source membership.
+
+A watchlist is a named bundle of sources — the unit of organization and
+checking, and (in a later slice) of briefing generation. Membership is
+many-to-many: a source may belong to any number of watchlists.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from loguru import logger
+
+from ..DB.Subscriptions_DB import SubscriptionsDB
+
+
+logger = logger.bind(module="WatchlistBundleService")
+
+
+class WatchlistBundleService:
+    """Local watchlist bundles backed by ``SubscriptionsDB``."""
+
+    def __init__(self, db: SubscriptionsDB) -> None:
+        self._db = db
+
+    # --- Helpers ---
+
+    @staticmethod
+    def _split_tags(raw: Any) -> list[str]:
+        """Parse the comma-joined tags column used by subscriptions.tags."""
+        if not raw:
+            return []
+        return [part.strip() for part in str(raw).split(",") if part.strip()]
+
+    @staticmethod
+    def _join_tags(tags: Sequence[str] | None) -> str | None:
+        if not tags:
+            return None
+        cleaned = [str(tag).strip() for tag in tags if str(tag).strip()]
+        return ",".join(cleaned) if cleaned else None
+
+    @staticmethod
+    def _row_to_dict(row: Any) -> dict[str, Any]:
+        return {
+            "id": row[0],
+            "name": row[1],
+            "description": row[2],
+            "tags": WatchlistBundleService._split_tags(row[3]),
+            "is_active": bool(row[4]),
+            "sort_order": row[5],
+        }
+
+    def _unique_name(self, conn: Any, name: str, exclude_id: int | None = None) -> str:
+        """Return ``name``, suffixed if it collides case-insensitively.
+
+        Uniqueness lives here rather than in a SQL UNIQUE constraint because a
+        constraint would raise mid-migration on case-variant folder values or
+        OPML re-imports.
+        """
+        base = name.strip()
+        params: list[Any] = []
+        query = "SELECT LOWER(name) FROM watchlists"
+        if exclude_id is not None:
+            query += " WHERE id != ?"
+            params.append(exclude_id)
+        taken = {row[0] for row in conn.execute(query, params)}
+
+        if base.lower() not in taken:
+            return base
+        suffix = 2
+        while f"{base.lower()} ({suffix})" in taken:
+            suffix += 1
+        return f"{base} ({suffix})"
+
+    def _get(self, conn: Any, watchlist_id: int) -> dict[str, Any]:
+        row = conn.execute(
+            "SELECT id, name, description, tags, is_active, sort_order "
+            "FROM watchlists WHERE id = ?",
+            (watchlist_id,),
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"no watchlist with id {watchlist_id}")
+        return self._row_to_dict(row)
+
+    # --- CRUD ---
+
+    def create(
+        self,
+        name: str,
+        description: str | None = None,
+        tags: Sequence[str] | None = None,
+    ) -> dict[str, Any]:
+        """Create a watchlist, auto-suffixing the name on collision."""
+        with self._db.transaction() as conn:
+            resolved = self._unique_name(conn, name)
+            cursor = conn.execute(
+                "INSERT INTO watchlists (name, description, tags) VALUES (?, ?, ?)",
+                (resolved, description, self._join_tags(tags)),
+            )
+            return self._get(conn, cursor.lastrowid)
+
+    def rename(self, watchlist_id: int, name: str) -> dict[str, Any]:
+        """Rename a watchlist, auto-suffixing on collision with another row."""
+        with self._db.transaction() as conn:
+            resolved = self._unique_name(conn, name, exclude_id=watchlist_id)
+            conn.execute(
+                "UPDATE watchlists SET name = ? WHERE id = ?", (resolved, watchlist_id)
+            )
+            return self._get(conn, watchlist_id)
+
+    def delete(self, watchlist_id: int) -> None:
+        """Delete a watchlist. Membership cascades; sources are untouched."""
+        with self._db.transaction() as conn:
+            conn.execute("DELETE FROM watchlists WHERE id = ?", (watchlist_id,))
+
+    def list_watchlists(self) -> list[dict[str, Any]]:
+        """All watchlists in display order."""
+        rows = self._db.conn.execute(
+            "SELECT id, name, description, tags, is_active, sort_order "
+            "FROM watchlists ORDER BY sort_order, LOWER(name)"
+        ).fetchall()
+        return [self._row_to_dict(row) for row in rows]
+
+    # --- Membership ---
+
+    def add_source(self, watchlist_id: int, subscription_id: int) -> None:
+        """Add a source to a watchlist. Idempotent."""
+        with self._db.transaction() as conn:
+            conn.execute(
+                "INSERT OR IGNORE INTO watchlist_sources (watchlist_id, subscription_id) "
+                "VALUES (?, ?)",
+                (watchlist_id, subscription_id),
+            )
+
+    def remove_source(self, watchlist_id: int, subscription_id: int) -> None:
+        """Remove a source from a watchlist. The source itself survives."""
+        with self._db.transaction() as conn:
+            conn.execute(
+                "DELETE FROM watchlist_sources "
+                "WHERE watchlist_id = ? AND subscription_id = ?",
+                (watchlist_id, subscription_id),
+            )
+
+    def list_sources(self, watchlist_id: int) -> list[int]:
+        """Subscription ids belonging to a watchlist."""
+        rows = self._db.conn.execute(
+            "SELECT subscription_id FROM watchlist_sources "
+            "WHERE watchlist_id = ? ORDER BY added_at, subscription_id",
+            (watchlist_id,),
+        ).fetchall()
+        return [row[0] for row in rows]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `source .venv/bin/activate && pytest Tests/Subscriptions/test_watchlist_bundle_service.py -v`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Subscriptions/watchlist_bundle_service.py Tests/Subscriptions/test_watchlist_bundle_service.py
+git commit -m "feat(watchlists): add WatchlistBundleService with membership"
+```
+
+---
+
+### Task 6: Folder migration
+
+**Files:**
+- Modify: `tldw_chatbook/Subscriptions/watchlist_bundle_service.py`
+- Test: `Tests/Subscriptions/test_watchlist_bundle_service.py`
+
+**Interfaces:**
+- Consumes: Task 5's `create`/`add_source`; Task 1's `watchlist_migration_state`.
+- Produces: `WatchlistBundleService.migrate_folders() -> bool` — `True` if it ran, `False` if already applied.
+
+**Expectation-setting:** this migration will do almost nothing for real users. `subscriptions.folder` is never written by any live path — `_subscription_config_fields` (`local_watchlists_service.py:567`) allowlists ten fields and `folder` is not among them, and nothing in `Subscriptions/` calls `add_subscription(folder=…)`. It is retained for hand-seeded databases. First-run assumes an empty watchlist set; the permanent "All sources" and "Unassigned" tree roots in Phase C are what make sources reachable.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `Tests/Subscriptions/test_watchlist_bundle_service.py`:
+
+```python
+MIGRATION_KEY = "folders_to_watchlists"
+
+
+def test_migrate_folders_groups_by_folder(service, db):
+    first = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f",
+                                folder="Research")
+    second = db.add_subscription(name="HN", type="rss", source="https://b.example/f",
+                                 folder="Research")
+    third = db.add_subscription(name="Krebs", type="rss", source="https://c.example/f",
+                                folder="Security")
+
+    assert service.migrate_folders() is True
+
+    names = {row["name"] for row in service.list_watchlists()}
+    assert names == {"Research", "Security"}
+
+    by_name = {row["name"]: row["id"] for row in service.list_watchlists()}
+    assert sorted(service.list_sources(by_name["Research"])) == sorted([first, second])
+    assert service.list_sources(by_name["Security"]) == [third]
+
+
+def test_migrate_folders_puts_folderless_sources_in_unsorted(service, db):
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+
+    service.migrate_folders()
+
+    by_name = {row["name"]: row["id"] for row in service.list_watchlists()}
+    assert "Unsorted" in by_name
+    assert service.list_sources(by_name["Unsorted"]) == [source_id]
+
+
+def test_migrate_folders_runs_once(service, db):
+    db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f", folder="Research")
+
+    assert service.migrate_folders() is True
+    assert service.migrate_folders() is False
+    assert len(service.list_watchlists()) == 1
+
+    marker = db.conn.execute(
+        "SELECT COUNT(*) FROM watchlist_migration_state WHERE key = ?", (MIGRATION_KEY,)
+    ).fetchone()[0]
+    assert marker == 1
+
+
+def test_migrate_folders_is_noop_with_no_sources(service):
+    assert service.migrate_folders() is True
+    assert service.list_watchlists() == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest Tests/Subscriptions/test_watchlist_bundle_service.py -k migrate -v`
+Expected: FAIL — `AttributeError: 'WatchlistBundleService' object has no attribute 'migrate_folders'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `WatchlistBundleService`, after `list_sources`:
+
+```python
+    MIGRATION_KEY = "folders_to_watchlists"
+
+    def migrate_folders(self) -> bool:
+        """Turn distinct ``subscriptions.folder`` values into watchlists.
+
+        Sources with no folder join a single ``Unsorted`` watchlist. The
+        ``folder`` column is left in place and untouched, so this is reversible.
+
+        In practice this migrates almost nothing: no live code path writes
+        ``folder``. It exists for hand-seeded databases.
+
+        Returns:
+            ``True`` if the migration ran, ``False`` if it had already been
+            applied.
+        """
+        with self._db.transaction() as conn:
+            already = conn.execute(
+                "SELECT 1 FROM watchlist_migration_state WHERE key = ?",
+                (self.MIGRATION_KEY,),
+            ).fetchone()
+            if already:
+                return False
+
+            rows = conn.execute(
+                "SELECT id, folder FROM subscriptions ORDER BY id"
+            ).fetchall()
+
+            buckets: dict[str, list[int]] = {}
+            for subscription_id, folder in rows:
+                label = (folder or "").strip() or "Unsorted"
+                buckets.setdefault(label, []).append(subscription_id)
+
+            for label, source_ids in buckets.items():
+                resolved = self._unique_name(conn, label)
+                cursor = conn.execute(
+                    "INSERT INTO watchlists (name) VALUES (?)", (resolved,)
+                )
+                watchlist_id = cursor.lastrowid
+                conn.executemany(
+                    "INSERT OR IGNORE INTO watchlist_sources "
+                    "(watchlist_id, subscription_id) VALUES (?, ?)",
+                    [(watchlist_id, source_id) for source_id in source_ids],
+                )
+
+            conn.execute(
+                "INSERT INTO watchlist_migration_state (key) VALUES (?)",
+                (self.MIGRATION_KEY,),
+            )
+            logger.info(
+                "Migrated {} folder group(s) into watchlists.", len(buckets)
+            )
+            return True
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && pytest Tests/Subscriptions/test_watchlist_bundle_service.py -v`
+Expected: PASS, 10 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Subscriptions/watchlist_bundle_service.py Tests/Subscriptions/test_watchlist_bundle_service.py
+git commit -m "feat(watchlists): migrate subscription folders into watchlists"
+```
+
+---
+
+### Task 7: Single-query tree counts
+
+**Files:**
+- Modify: `tldw_chatbook/DB/Subscriptions_DB.py` — new `get_watchlist_item_counts` method
+- Test: `Tests/DB/test_subscriptions_db_watchlists.py`
+
+**Interfaces:**
+- Consumes: Tasks 1 and 5.
+- Produces: `SubscriptionsDB.get_watchlist_item_counts() -> dict[int, dict[str, int]]`, keyed by watchlist id plus two sentinels: `-1` = Unassigned, `-2` = All sources. Each value is `{"total": int, "unread": int}`. Phase C's tree consumes this.
+
+**Why this matters:** counting per tree node would issue one query per watchlist on every refresh. No per-subscription count helper exists today — `Subscriptions_DB` has only `get_new_items` and a single `COUNT(*)` in the whole file. This repo has form here: the performance audit found the Console's 0.2s tick running SQLite on the event loop. A `UNION ALL` keeps all three bucket shapes in one statement.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `Tests/DB/test_subscriptions_db_watchlists.py`:
+
+```python
+class _CountingConnection:
+    """Wraps a connection to count execute() calls."""
+
+    def __init__(self, inner):
+        self._inner = inner
+        self.execute_count = 0
+
+    def execute(self, *args, **kwargs):
+        self.execute_count += 1
+        return self._inner.execute(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
+def test_counts_bucket_by_watchlist_unassigned_and_all(db):
+    from tldw_chatbook.Subscriptions.watchlist_bundle_service import WatchlistBundleService
+
+    service = WatchlistBundleService(db)
+    morning = service.create("Morning")
+    security = service.create("Security")
+
+    shared = db.add_subscription(name="HN", type="rss", source="https://b.example/f")
+    lonely = db.add_subscription(name="Orphan", type="rss", source="https://c.example/f")
+
+    service.add_source(morning["id"], shared)
+    service.add_source(security["id"], shared)
+
+    _insert_item(db, shared, "https://b.example/1", "Shared unread", "body")
+    _insert_item(db, lonely, "https://c.example/1", "Orphan unread", "body")
+    with db.transaction() as conn:
+        conn.execute("UPDATE subscription_items SET status = 'reviewed' WHERE url = ?",
+                     ("https://c.example/1",))
+
+    counts = db.get_watchlist_item_counts()
+
+    assert counts[morning["id"]] == {"total": 1, "unread": 1}
+    assert counts[security["id"]] == {"total": 1, "unread": 1}
+    assert counts[-1] == {"total": 1, "unread": 0}   # Unassigned
+    assert counts[-2] == {"total": 2, "unread": 1}   # All sources
+
+
+def test_counts_use_a_single_query_regardless_of_watchlist_count(db, monkeypatch):
+    from tldw_chatbook.Subscriptions.watchlist_bundle_service import WatchlistBundleService
+
+    service = WatchlistBundleService(db)
+    for index in range(12):
+        service.create(f"List {index}")
+
+    counting = _CountingConnection(db.conn)
+    monkeypatch.setattr(type(db), "conn", property(lambda self: counting))
+
+    db.get_watchlist_item_counts()
+
+    assert counting.execute_count == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest Tests/DB/test_subscriptions_db_watchlists.py -k counts -v`
+Expected: FAIL — `AttributeError: 'SubscriptionsDB' object has no attribute 'get_watchlist_item_counts'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `SubscriptionsDB`, after `backfill_items_fts`:
+
+```python
+    # Sentinel bucket ids for the watchlists tree roots.
+    UNASSIGNED_BUCKET = -1
+    ALL_SOURCES_BUCKET = -2
+
+    def get_watchlist_item_counts(self) -> Dict[int, Dict[str, int]]:
+        """Item totals and unread counts for every watchlists tree node.
+
+        Returned in a single query so that adding watchlists never adds
+        round-trips. ``SUM(CASE …)`` is used rather than ``COUNT(*) FILTER``
+        to avoid depending on a newer SQLite than the bundled one.
+
+        Returns:
+            Mapping of bucket id to ``{"total": int, "unread": int}``. Bucket
+            ``-1`` is Unassigned (sources in no watchlist) and ``-2`` is All
+            sources. Real watchlist ids are positive.
+        """
+        rows = self.conn.execute(
+            """
+            SELECT ws.watchlist_id AS bucket,
+                   COUNT(si.id) AS total,
+                   SUM(CASE WHEN si.status = 'new' THEN 1 ELSE 0 END) AS unread
+            FROM watchlist_sources ws
+            JOIN subscription_items si ON si.subscription_id = ws.subscription_id
+            GROUP BY ws.watchlist_id
+
+            UNION ALL
+
+            SELECT ?, COUNT(si.id),
+                   SUM(CASE WHEN si.status = 'new' THEN 1 ELSE 0 END)
+            FROM subscription_items si
+            WHERE NOT EXISTS (
+                SELECT 1 FROM watchlist_sources ws
+                WHERE ws.subscription_id = si.subscription_id
+            )
+
+            UNION ALL
+
+            SELECT ?, COUNT(si.id),
+                   SUM(CASE WHEN si.status = 'new' THEN 1 ELSE 0 END)
+            FROM subscription_items si
+            """,
+            (self.UNASSIGNED_BUCKET, self.ALL_SOURCES_BUCKET),
+        ).fetchall()
+
+        return {
+            row[0]: {"total": row[1] or 0, "unread": row[2] or 0}
+            for row in rows
+            if row[0] is not None
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && pytest Tests/DB/test_subscriptions_db_watchlists.py -v`
+Expected: PASS, all tests.
+
+- [ ] **Step 5: Run the full affected suites**
+
+Run: `source .venv/bin/activate && pytest Tests/DB Tests/Subscriptions Tests/Watchlists -v`
+Expected: PASS, no failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/DB/Subscriptions_DB.py Tests/DB/test_subscriptions_db_watchlists.py
+git commit -m "feat(watchlists): add single-query tree item counts"
+```
+
+---
+
+## Phase A Completion Checklist
+
+- [ ] All seven tasks committed.
+- [ ] `pytest Tests/DB Tests/Subscriptions Tests/Watchlists` passes.
+- [ ] `_ensure_watchlists_schema` is still idempotent — run it twice against an existing DB and confirm no error.
+- [ ] No UI file was modified. `git diff --stat origin/dev -- tldw_chatbook/UI` is empty.
+- [ ] Phase B plan written against merged Phase A code.

--- a/Docs/superpowers/plans/2026-07-25-watchlists-rebuild-phase-b-workbench-shell.md
+++ b/Docs/superpowers/plans/2026-07-25-watchlists-rebuild-phase-b-workbench-shell.md
@@ -1,0 +1,1031 @@
+# Watchlists Rebuild — Phase B: Workbench & Shell Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Watchlists screen's placeholder three-column shell with a Console-styled workbench — two collapsible rails around a vertically-stacked, independently collapsible centre — leaving the panes themselves as stubs for Phase C.
+
+**Architecture:** A pure state machine (`region_layout.py`) owns collapse/solo/restore across five regions and is unit-testable with no Textual pilot. A purpose-built container (`watchlists_workbench.py`) renders it, because the shared `DestinationWorkbench` is a fixed equal-width `Horizontal` with no collapse, resize, or stacking. The screen shell becomes thin routing over those two, with Console handoff extracted to its own module.
+
+**Tech Stack:** Python ≥3.11, Textual ≥3.3.0, pytest. No new dependencies.
+
+## Global Constraints
+
+- Spec: `Docs/superpowers/specs/2026-07-25-watchlists-console-rebuild-design.md`. Every requirement below traces to it.
+- **No data-layer changes.** Phase A (PR #917) owns `SubscriptionsDB`, `item_persist.py`, and `watchlist_bundle_service.py`. Do not modify them.
+- **Panes stay stubs.** Phase B builds the container and the collapse behaviour. Real tables, the tree, and the reader are Phase C/D. A stub renders its title and a placeholder line — nothing more.
+- The screen class name, route (`watchlists_collections`), and existing stable widget selectors are preserved so Console handoffs and route tests keep passing.
+- `DestinationModeStrip` and the `$ds-*` token set are reused. `DestinationWorkbench` is **not** — verified: fixed `width: 1fr` panes composed once from a frozen tuple, no collapse, no stacking.
+- Reuse Console's vocabulary: `ConsoleRailHandle` (`Widgets/Console/console_rail_handle.py`) is the model for a collapsed rail's focusable handle.
+- **Config lookups are flat, not dotted.** `get_cli_setting("watchlists.layout", …)` silently returns the default — this repo has already shipped that bug with `chat.images`. Use `get_cli_setting("watchlists", "collapsed_regions", …)`.
+- Tests run from the venv: `source .venv/bin/activate && pytest …`. The `timeout` command does not exist here.
+- **Run one test file at a time, in the foreground.** Anything past ~90 seconds is auto-backgrounded by this environment and appears to hang.
+
+## Phase Map
+
+| Phase | Scope | Status |
+|---|---|---|
+| A | Schema, unified persist, FTS5, bundle service, counts | **merged — PR #917** |
+| **B (this plan)** | Region state machine, workbench container, shell rewrite, Console-handoff extraction | this plan |
+| C | Tree, feeds pane, items pane, Inspector breadcrumb stack | next |
+| D | Content pane: article + change renderers, escaping, HTML fallback | after C |
+| E | Sources / Runs / Rules / Artifacts tabs | after C |
+
+## File Structure
+
+| Path | Responsibility | Task |
+|---|---|---|
+| `tldw_chatbook/UI/Watchlists_Modules/region_layout.py` | Five-region collapse/solo/restore. Pure, no Textual import | 1 |
+| `tldw_chatbook/UI/Watchlists_Modules/region_layout_store.py` | Load/save collapse state to config | 2 |
+| `tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py` | Rails + stacked collapsible centre container | 3 |
+| `tldw_chatbook/UI/Watchlists_Modules/watchlists_console_handoff.py` | Console staging/follow, extracted from the shell | 4 |
+| `tldw_chatbook/UI/Screens/watchlists_collections_screen.py` | Thin shell: rails, tabs, bindings, routing | 5 |
+| `tldw_chatbook/css/features/_watchlists.tcss` | Workbench and region styling | 3 |
+| `Tests/Watchlists/test_region_layout.py` | Pure state machine — no pilot | 1 |
+| `Tests/Watchlists/test_region_layout_store.py` | Config round-trip | 2 |
+| `Tests/Watchlists/test_watchlists_workbench.py` | Container rendering and collapse | 3 |
+| `Tests/UI/test_watchlists_destination_shell.py` | Extended: bindings, tabs, route stability | 5 |
+
+---
+
+### Task 1: Region layout state machine
+
+**Files:**
+- Create: `tldw_chatbook/UI/Watchlists_Modules/region_layout.py`
+- Test: `Tests/Watchlists/test_region_layout.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `Region` (str enum: `LEFT_RAIL`, `FEEDS`, `ITEMS`, `CONTENT`, `RIGHT_RAIL`), `CENTRE_REGIONS` tuple, and `RegionLayout` — a frozen dataclass with `collapsed: frozenset[Region]`, `solo_region: Region | None`, and methods `is_collapsed(region) -> bool`, `toggle(region) -> RegionLayout`, `solo(region) -> RegionLayout`, `visible() -> tuple[Region, ...]`. Tasks 2, 3, and 5 all consume these.
+
+This is a pure module so the fiddliest interaction in the screen is testable without a Textual pilot. It must not import Textual.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/Watchlists/test_region_layout.py`:
+
+```python
+import pytest
+
+from tldw_chatbook.UI.Watchlists_Modules.region_layout import (
+    CENTRE_REGIONS,
+    Region,
+    RegionLayout,
+)
+
+
+def test_default_layout_has_everything_visible():
+    layout = RegionLayout()
+    assert layout.collapsed == frozenset()
+    assert layout.solo_region is None
+    assert layout.visible() == (
+        Region.LEFT_RAIL, Region.FEEDS, Region.ITEMS, Region.CONTENT, Region.RIGHT_RAIL,
+    )
+
+
+def test_toggle_collapses_then_expands():
+    layout = RegionLayout().toggle(Region.CONTENT)
+    assert layout.is_collapsed(Region.CONTENT)
+    assert Region.CONTENT not in layout.visible()
+
+    layout = layout.toggle(Region.CONTENT)
+    assert not layout.is_collapsed(Region.CONTENT)
+
+
+def test_toggle_returns_a_new_instance_and_leaves_the_original_alone():
+    original = RegionLayout()
+    changed = original.toggle(Region.ITEMS)
+    assert original.collapsed == frozenset()
+    assert changed is not original
+
+
+def test_rails_collapse_independently_of_the_centre():
+    layout = RegionLayout().toggle(Region.LEFT_RAIL).toggle(Region.RIGHT_RAIL)
+    assert layout.is_collapsed(Region.LEFT_RAIL)
+    assert layout.is_collapsed(Region.RIGHT_RAIL)
+    for region in CENTRE_REGIONS:
+        assert not layout.is_collapsed(region)
+
+
+def test_solo_collapses_the_other_centre_regions_only():
+    layout = RegionLayout().solo(Region.ITEMS)
+    assert layout.solo_region == Region.ITEMS
+    assert not layout.is_collapsed(Region.ITEMS)
+    assert layout.is_collapsed(Region.FEEDS)
+    assert layout.is_collapsed(Region.CONTENT)
+    # Rails are untouched by solo.
+    assert not layout.is_collapsed(Region.LEFT_RAIL)
+    assert not layout.is_collapsed(Region.RIGHT_RAIL)
+
+
+def test_solo_twice_restores_the_prior_layout():
+    before = RegionLayout().toggle(Region.FEEDS).toggle(Region.LEFT_RAIL)
+    after = before.solo(Region.ITEMS).solo(Region.ITEMS)
+    assert after.collapsed == before.collapsed
+    assert after.solo_region is None
+
+
+def test_solo_on_a_different_region_re_solos_without_stacking():
+    layout = RegionLayout().solo(Region.ITEMS).solo(Region.CONTENT)
+    assert layout.solo_region == Region.CONTENT
+    assert layout.is_collapsed(Region.ITEMS)
+    assert not layout.is_collapsed(Region.CONTENT)
+    # Restoring from here returns to the ORIGINAL pre-solo layout, not to the ITEMS solo.
+    restored = layout.solo(Region.CONTENT)
+    assert restored.collapsed == frozenset()
+    assert restored.solo_region is None
+
+
+def test_manual_toggle_while_soloed_clears_solo():
+    # Otherwise a later Z would "restore" a layout the user has since edited by hand.
+    layout = RegionLayout().solo(Region.ITEMS).toggle(Region.FEEDS)
+    assert layout.solo_region is None
+    assert not layout.is_collapsed(Region.FEEDS)
+
+
+def test_solo_rejects_rails():
+    with pytest.raises(ValueError, match="centre region"):
+        RegionLayout().solo(Region.LEFT_RAIL)
+
+
+def test_all_three_centre_regions_may_collapse_at_once():
+    # Legal: each collapses to a one-line header that stays clickable, so this is recoverable.
+    layout = RegionLayout()
+    for region in CENTRE_REGIONS:
+        layout = layout.toggle(region)
+    assert all(layout.is_collapsed(region) for region in CENTRE_REGIONS)
+    assert layout.visible() == (Region.LEFT_RAIL, Region.RIGHT_RAIL)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest Tests/Watchlists/test_region_layout.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'tldw_chatbook.UI.Watchlists_Modules.region_layout'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `tldw_chatbook/UI/Watchlists_Modules/region_layout.py`:
+
+```python
+"""Collapse and solo state for the Watchlists workbench's five regions.
+
+Pure state: no Textual import, no I/O. The screen's fiddliest interaction —
+five independently collapsible regions plus a solo/restore toggle — lives
+here so it can be tested without a Textual pilot.
+
+Every mutator returns a new instance; the type is frozen and hashable, so a
+Textual reactive can hold it and equality comparison decides whether to
+re-render.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class Region(str, Enum):
+    """One collapsible region of the Watchlists workbench."""
+
+    LEFT_RAIL = "left_rail"
+    FEEDS = "feeds"
+    ITEMS = "items"
+    CONTENT = "content"
+    RIGHT_RAIL = "right_rail"
+
+
+#: Display order, left rail through right rail.
+REGION_ORDER: tuple[Region, ...] = (
+    Region.LEFT_RAIL,
+    Region.FEEDS,
+    Region.ITEMS,
+    Region.CONTENT,
+    Region.RIGHT_RAIL,
+)
+
+#: The vertically stacked centre panes. Only these may be soloed.
+CENTRE_REGIONS: tuple[Region, ...] = (Region.FEEDS, Region.ITEMS, Region.CONTENT)
+
+
+@dataclass(frozen=True)
+class RegionLayout:
+    """Which regions are collapsed, and whether one centre pane is soloed."""
+
+    collapsed: frozenset[Region] = frozenset()
+    solo_region: Region | None = None
+    _pre_solo: frozenset[Region] | None = None
+
+    def is_collapsed(self, region: Region) -> bool:
+        """Whether ``region`` is currently collapsed to its header."""
+        return region in self.collapsed
+
+    def visible(self) -> tuple[Region, ...]:
+        """Expanded regions, in display order."""
+        return tuple(r for r in REGION_ORDER if r not in self.collapsed)
+
+    def toggle(self, region: Region) -> RegionLayout:
+        """Collapse ``region`` if expanded, expand it if collapsed.
+
+        A manual toggle clears any solo: the user has edited the layout by
+        hand, so a later solo-restore must not resurrect a stale snapshot.
+        """
+        collapsed = set(self.collapsed)
+        if region in collapsed:
+            collapsed.discard(region)
+        else:
+            collapsed.add(region)
+        return RegionLayout(collapsed=frozenset(collapsed))
+
+    def solo(self, region: Region) -> RegionLayout:
+        """Collapse the other centre panes around ``region``; call again to restore.
+
+        Rails are unaffected — solo is about the centre stack only.
+
+        Args:
+            region: The centre region to isolate.
+
+        Returns:
+            A layout with the other centre regions collapsed, or the
+            pre-solo layout if ``region`` is already soloed.
+
+        Raises:
+            ValueError: If ``region`` is a rail rather than a centre region.
+        """
+        if region not in CENTRE_REGIONS:
+            raise ValueError(f"{region!r} is not a centre region; solo applies to {CENTRE_REGIONS}")
+
+        if self.solo_region == region:
+            return RegionLayout(collapsed=self._pre_solo or frozenset())
+
+        # Re-soloing a different pane keeps the ORIGINAL pre-solo snapshot, so
+        # restore always returns to what the user had before soloing at all.
+        baseline = self._pre_solo if self.solo_region is not None else self.collapsed
+        rails = {r for r in self.collapsed if r not in CENTRE_REGIONS}
+        others = {r for r in CENTRE_REGIONS if r != region}
+        return RegionLayout(
+            collapsed=frozenset(rails | others),
+            solo_region=region,
+            _pre_solo=baseline,
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `source .venv/bin/activate && pytest Tests/Watchlists/test_region_layout.py -v`
+Expected: PASS, 10 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Watchlists_Modules/region_layout.py Tests/Watchlists/test_region_layout.py
+git commit -m "feat(watchlists): add pure five-region collapse/solo state machine"
+```
+
+---
+
+### Task 2: Persist collapse state to config
+
+**Files:**
+- Create: `tldw_chatbook/UI/Watchlists_Modules/region_layout_store.py`
+- Test: `Tests/Watchlists/test_region_layout_store.py`
+
+**Interfaces:**
+- Consumes: `Region`, `RegionLayout` from Task 1.
+- Produces: `load_region_layout() -> RegionLayout` and `save_region_layout(layout: RegionLayout) -> None`. Task 5 calls both.
+
+**The trap this task exists to avoid.** `get_cli_setting` performs a **flat** section lookup. Passing a dotted section like `"watchlists.layout"` silently returns the default and the setting never round-trips — this repo has already shipped that exact bug with `chat.images`. Use section `"watchlists"`, key `"collapsed_regions"`.
+
+Solo state is deliberately **not** persisted: it is a transient view mode, and restoring "soloed" across restarts would strand a user in a layout they did not choose.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/Watchlists/test_region_layout_store.py`:
+
+```python
+from tldw_chatbook.UI.Watchlists_Modules import region_layout_store
+from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region, RegionLayout
+
+
+def test_round_trips_collapsed_regions(monkeypatch):
+    saved = {}
+
+    def fake_save(section, key, value):
+        saved[(section, key)] = value
+        return True
+
+    monkeypatch.setattr(region_layout_store, "save_setting_to_cli_config", fake_save)
+    region_layout_store.save_region_layout(
+        RegionLayout(collapsed=frozenset({Region.CONTENT, Region.RIGHT_RAIL}))
+    )
+
+    # Flat section, not "watchlists.layout" — a dotted section silently no-ops.
+    assert ("watchlists", "collapsed_regions") in saved
+    assert sorted(saved[("watchlists", "collapsed_regions")]) == ["content", "right_rail"]
+
+    monkeypatch.setattr(
+        region_layout_store, "get_cli_setting",
+        lambda section, key, default=None: saved.get((section, key), default),
+    )
+    loaded = region_layout_store.load_region_layout()
+    assert loaded.collapsed == frozenset({Region.CONTENT, Region.RIGHT_RAIL})
+
+
+def test_load_defaults_to_everything_expanded(monkeypatch):
+    monkeypatch.setattr(
+        region_layout_store, "get_cli_setting", lambda section, key, default=None: default
+    )
+    assert region_layout_store.load_region_layout() == RegionLayout()
+
+
+def test_load_ignores_unknown_region_names(monkeypatch):
+    # A config hand-edited or written by a newer version must not crash the screen.
+    monkeypatch.setattr(
+        region_layout_store, "get_cli_setting",
+        lambda section, key, default=None: ["content", "nonsense", "left_rail"],
+    )
+    loaded = region_layout_store.load_region_layout()
+    assert loaded.collapsed == frozenset({Region.CONTENT, Region.LEFT_RAIL})
+
+
+def test_load_tolerates_a_non_list_value(monkeypatch):
+    monkeypatch.setattr(
+        region_layout_store, "get_cli_setting", lambda section, key, default=None: "content"
+    )
+    assert region_layout_store.load_region_layout().collapsed == frozenset({Region.CONTENT})
+
+
+def test_save_never_persists_solo(monkeypatch):
+    saved = {}
+    monkeypatch.setattr(
+        region_layout_store, "save_setting_to_cli_config",
+        lambda section, key, value: saved.__setitem__((section, key), value) or True,
+    )
+    region_layout_store.save_region_layout(RegionLayout().solo(Region.ITEMS))
+    assert sorted(saved[("watchlists", "collapsed_regions")]) == ["content", "feeds"]
+    assert ("watchlists", "solo_region") not in saved
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest Tests/Watchlists/test_region_layout_store.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named '...region_layout_store'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `tldw_chatbook/UI/Watchlists_Modules/region_layout_store.py`:
+
+```python
+"""Persist Watchlists workbench collapse state to the user's config.
+
+Collapse state is UI preference, not data, so it belongs in config rather
+than SubscriptionsDB. Solo is deliberately not persisted — it is a transient
+view mode, and restoring it across restarts would strand the user in a
+layout they did not choose.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from loguru import logger
+
+from ...config import get_cli_setting, save_setting_to_cli_config
+from .region_layout import Region, RegionLayout
+
+
+logger = logger.bind(module="WatchlistsRegionLayoutStore")
+
+#: Flat section. `get_cli_setting` does NOT resolve dotted sections — passing
+#: "watchlists.layout" silently returns the default and the setting never
+#: round-trips. This repo has shipped that bug before with "chat.images".
+_SECTION = "watchlists"
+_KEY = "collapsed_regions"
+
+
+def load_region_layout() -> RegionLayout:
+    """Read collapse state from config, defaulting to everything expanded."""
+    raw = get_cli_setting(_SECTION, _KEY, [])
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, Sequence):
+        logger.debug("Ignoring non-sequence watchlists collapse state: {!r}", raw)
+        return RegionLayout()
+
+    collapsed = set()
+    for value in raw:
+        try:
+            collapsed.add(Region(str(value)))
+        except ValueError:
+            logger.debug("Ignoring unknown watchlists region {!r} from config.", value)
+    return RegionLayout(collapsed=frozenset(collapsed))
+
+
+def save_region_layout(layout: RegionLayout) -> None:
+    """Write collapse state to config. Solo state is not persisted."""
+    values = sorted(region.value for region in layout.collapsed)
+    try:
+        save_setting_to_cli_config(_SECTION, _KEY, values)
+    except Exception:
+        logger.opt(exception=True).debug("Failed to persist watchlists collapse state.")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `source .venv/bin/activate && pytest Tests/Watchlists/test_region_layout_store.py -v`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Watchlists_Modules/region_layout_store.py Tests/Watchlists/test_region_layout_store.py
+git commit -m "feat(watchlists): persist workbench collapse state to config"
+```
+
+---
+
+### Task 3: Workbench container
+
+**Files:**
+- Create: `tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py`
+- Modify: `tldw_chatbook/css/features/_watchlists.tcss`
+- Test: `Tests/Watchlists/test_watchlists_workbench.py`
+
+**Interfaces:**
+- Consumes: `Region`, `CENTRE_REGIONS`, `RegionLayout` from Task 1.
+- Produces: `WatchlistsWorkbench(Horizontal)` with constructor `WatchlistsWorkbench(layout: RegionLayout, *, id: str | None = None)`, a `layout` reactive, and the message `RegionToggled(region: Region)` posted when a collapsed header or rail handle is activated. Task 5 mounts it and handles `RegionToggled`.
+
+Each region renders a titled body when expanded and a single-line header when collapsed. **A collapsed region's header stays focusable and clickable** — otherwise collapse is one-way when focus cannot return to it.
+
+Panes are stubs in this phase: a title and one placeholder line. Phase C replaces their bodies.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/Watchlists/test_watchlists_workbench.py`:
+
+```python
+import pytest
+from textual.app import App, ComposeResult
+
+from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region, RegionLayout
+from tldw_chatbook.UI.Watchlists_Modules.watchlists_workbench import (
+    RegionToggled,
+    WatchlistsWorkbench,
+)
+
+
+class _WorkbenchApp(App):
+    def __init__(self, layout: RegionLayout) -> None:
+        super().__init__()
+        self._layout = layout
+        self.toggles: list[Region] = []
+
+    def compose(self) -> ComposeResult:
+        yield WatchlistsWorkbench(self._layout, id="wl-workbench")
+
+    def on_region_toggled(self, message: RegionToggled) -> None:
+        self.toggles.append(message.region)
+
+
+@pytest.mark.asyncio
+async def test_all_regions_render_expanded_by_default():
+    app = _WorkbenchApp(RegionLayout())
+    async with app.run_test():
+        for region in Region:
+            assert app.query(f"#wl-region-{region.value}")
+            assert not app.query(f"#wl-header-{region.value}")
+
+
+@pytest.mark.asyncio
+async def test_collapsed_region_renders_a_header_instead_of_a_body():
+    app = _WorkbenchApp(RegionLayout(collapsed=frozenset({Region.CONTENT})))
+    async with app.run_test():
+        assert app.query("#wl-header-content")
+        assert not app.query("#wl-region-content")
+
+
+@pytest.mark.asyncio
+async def test_collapsed_header_is_focusable_so_collapse_is_not_one_way():
+    app = _WorkbenchApp(RegionLayout(collapsed=frozenset({Region.ITEMS})))
+    async with app.run_test():
+        header = app.query_one("#wl-header-items")
+        assert header.focusable, "a collapsed region must be reachable by keyboard"
+
+
+@pytest.mark.asyncio
+async def test_clicking_a_collapsed_header_posts_region_toggled():
+    app = _WorkbenchApp(RegionLayout(collapsed=frozenset({Region.FEEDS})))
+    async with app.run_test() as pilot:
+        await pilot.click("#wl-header-feeds")
+        await pilot.pause()
+        assert app.toggles == [Region.FEEDS]
+
+
+@pytest.mark.asyncio
+async def test_updating_the_layout_reactive_re_renders():
+    app = _WorkbenchApp(RegionLayout())
+    async with app.run_test() as pilot:
+        workbench = app.query_one(WatchlistsWorkbench)
+        workbench.layout = RegionLayout(collapsed=frozenset({Region.LEFT_RAIL}))
+        await pilot.pause()
+        assert app.query("#wl-header-left_rail")
+        assert not app.query("#wl-region-left_rail")
+
+
+@pytest.mark.asyncio
+async def test_every_centre_region_may_be_collapsed_at_once():
+    app = _WorkbenchApp(RegionLayout(collapsed=frozenset(CENTRE := {Region.FEEDS, Region.ITEMS, Region.CONTENT})))
+    async with app.run_test():
+        for region in CENTRE:
+            assert app.query(f"#wl-header-{region.value}")
+        # The rails survive, so the screen is never empty.
+        assert app.query("#wl-region-left_rail")
+        assert app.query("#wl-region-right_rail")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest Tests/Watchlists/test_watchlists_workbench.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named '...watchlists_workbench'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py`:
+
+```python
+"""Watchlists workbench: two collapsible rails around a stacked centre.
+
+The shared ``DestinationWorkbench`` cannot express this layout — it is a
+fixed ``Horizontal`` of equal-width panes composed once from a frozen tuple,
+with no collapse, resize, or vertical stacking. If the collapse behaviour
+here proves useful to a second screen, it graduates into the shared widget
+then; generalising ahead of a second consumer is not worth it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.message import Message
+from textual.reactive import reactive
+from textual.widgets import Button, Static
+
+from .region_layout import CENTRE_REGIONS, Region, RegionLayout
+
+
+#: Human-readable titles, used for both expanded bodies and collapsed headers.
+REGION_TITLES: dict[Region, str] = {
+    Region.LEFT_RAIL: "Watchlists",
+    Region.FEEDS: "Feeds",
+    Region.ITEMS: "Items",
+    Region.CONTENT: "Content",
+    Region.RIGHT_RAIL: "Inspector",
+}
+
+#: Placeholder body copy. Phase C and D replace these with real panes.
+REGION_PLACEHOLDERS: dict[Region, str] = {
+    Region.LEFT_RAIL: "Watchlist tree arrives in the next slice.",
+    Region.FEEDS: "Feeds table arrives in the next slice.",
+    Region.ITEMS: "Items table arrives in the next slice.",
+    Region.CONTENT: "Reader arrives in the next slice.",
+    Region.RIGHT_RAIL: "Inspector arrives in the next slice.",
+}
+
+
+class RegionToggled(Message):
+    """A collapsed region's header or rail handle was activated."""
+
+    def __init__(self, region: Region) -> None:
+        super().__init__()
+        self.region = region
+
+
+class WatchlistsWorkbench(Horizontal):
+    """Renders a :class:`RegionLayout` as rails plus a stacked centre."""
+
+    layout: reactive[RegionLayout] = reactive(RegionLayout(), recompose=True)
+
+    def __init__(self, layout: RegionLayout, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.add_class("watchlists-workbench")
+        self.set_reactive(WatchlistsWorkbench.layout, layout)
+
+    def compose(self) -> ComposeResult:
+        yield from self._compose_region(Region.LEFT_RAIL)
+
+        centre = Vertical(id="wl-centre", classes="watchlists-centre")
+        with centre:
+            for region in CENTRE_REGIONS:
+                yield from self._compose_region(region)
+
+        yield from self._compose_region(Region.RIGHT_RAIL)
+
+    def _compose_region(self, region: Region) -> ComposeResult:
+        """Render one region: a titled body, or a focusable one-line header."""
+        if self.layout.is_collapsed(region):
+            # A Button, not a Static: a collapsed region must stay focusable and
+            # clickable, or collapsing it is one-way.
+            header = Button(
+                f"▸ {REGION_TITLES[region]}",
+                id=f"wl-header-{region.value}",
+                compact=True,
+            )
+            header.add_class("watchlists-region-header")
+            header.tooltip = f"Expand {REGION_TITLES[region]}"
+            yield header
+            return
+
+        body = Vertical(
+            id=f"wl-region-{region.value}",
+            classes=f"watchlists-region watchlists-region-{region.value}",
+        )
+        with body:
+            yield Static(REGION_TITLES[region], classes="watchlists-region-title")
+            yield Static(REGION_PLACEHOLDERS[region], classes="watchlists-region-placeholder")
+        yield body
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        button_id = event.button.id or ""
+        prefix = "wl-header-"
+        if not button_id.startswith(prefix):
+            return
+        event.stop()
+        self.post_message(RegionToggled(Region(button_id[len(prefix):])))
+```
+
+- [ ] **Step 4: Add the styling**
+
+Append to `tldw_chatbook/css/features/_watchlists.tcss`:
+
+```css
+/* Workbench: rails around a vertically stacked centre */
+.watchlists-workbench {
+    width: 100%;
+    height: 1fr;
+    min-height: 0;
+}
+
+.watchlists-region-left_rail,
+.watchlists-region-right_rail {
+    width: 28;
+    min-width: 0;
+    height: 100%;
+    border: round $ds-grid-line;
+}
+
+.watchlists-centre {
+    width: 1fr;
+    min-width: 0;
+    height: 100%;
+    min-height: 0;
+}
+
+.watchlists-region-feeds,
+.watchlists-region-items,
+.watchlists-region-content {
+    width: 100%;
+    height: 1fr;
+    min-height: 0;
+    border: round $ds-grid-line;
+}
+
+.watchlists-region-title {
+    height: 1;
+    text-style: bold;
+    color: $ds-text-primary;
+}
+
+.watchlists-region-placeholder {
+    color: $ds-text-muted;
+}
+
+/* Collapsed regions keep a one-line, focusable header so nothing vanishes */
+.watchlists-region-header {
+    height: 1;
+    min-height: 1;
+    width: 100%;
+    color: $ds-text-muted;
+}
+```
+
+If this project builds a bundled stylesheet, regenerate it rather than hand-editing the bundle — run `python -m tldw_chatbook.css.build_css` if that entry point exists, and never edit `tldw_cli_modular.tcss` directly.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && pytest Tests/Watchlists/test_watchlists_workbench.py -v`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py tldw_chatbook/css/features/_watchlists.tcss Tests/Watchlists/test_watchlists_workbench.py
+git commit -m "feat(watchlists): add collapsible workbench container"
+```
+
+---
+
+### Task 4: Extract Console handoff from the shell
+
+**Files:**
+- Create: `tldw_chatbook/UI/Watchlists_Modules/watchlists_console_handoff.py`
+- Modify: `tldw_chatbook/UI/Screens/watchlists_collections_screen.py`
+- Test: `Tests/UI/test_watchlists_destination_shell.py` (existing — must keep passing)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `WatchlistsConsoleHandoff(app_instance)` with the staging and follow methods moved off the screen. Task 5's rewritten shell delegates to it.
+
+**Why first, and separately.** The shell is 1,219 lines and Task 5 rewrites it. Extracting the Console handoff in its own commit means the rewrite is reviewable as a rewrite, rather than as a rewrite tangled with a move. It also makes Task 5's target of a thin shell achievable rather than aspirational.
+
+**This task must not change behaviour.** It is a pure move: same logic, same messages, same stable selectors. The existing shell tests are the guard — they must pass unchanged, and you must not edit them to accommodate the move.
+
+- [ ] **Step 1: Establish the baseline**
+
+Run: `source .venv/bin/activate && pytest Tests/UI/test_watchlists_destination_shell.py -v`
+
+Record the pass/fail counts. Every test passing now must still pass at the end of this task. Note any that already fail — those are pre-existing and not yours to fix.
+
+- [ ] **Step 2: Identify exactly what moves**
+
+In `tldw_chatbook/UI/Screens/watchlists_collections_screen.py`, the Console handoff surface is the `@on(Button.Pressed, "#wc-attach-to-console")` handler, the `@on(Button.Pressed, "#watchlists-follow-in-console")` handler, the `@on(StageInConsoleRequested)` handler, and the private helpers they call (the `_latest_console_follow_*` state on `__init__` and the methods that populate it).
+
+List them before editing. Moving a partial set leaves the shell holding half a feature, which is worse than not moving it.
+
+- [ ] **Step 3: Create the module with the moved logic**
+
+Create `tldw_chatbook/UI/Watchlists_Modules/watchlists_console_handoff.py` in this shape:
+
+```python
+"""Console staging and follow for the Watchlists screen.
+
+Extracted from the screen shell so the shell stays thin. This is a pure
+move: the logic, messages, and stable selectors are unchanged from when it
+lived on the screen.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+
+
+logger = logger.bind(module="WatchlistsConsoleHandoff")
+
+
+class WatchlistsConsoleHandoff:
+    """Owns the Watchlists screen's Console staging and follow state."""
+
+    def __init__(self, app_instance: Any) -> None:
+        self.app_instance = app_instance
+        self._latest_console_follow_item_id = None
+        self._latest_console_follow_item_cache = None
+        self._latest_console_follow_loaded = False
+        self._latest_console_follow_error_logged = False
+
+    # Each method below is moved verbatim from the screen. Keep the bodies
+    # byte-identical apart from `self.app_instance` resolution.
+```
+
+Move the bodies **verbatim** — do not rewrite logic, rename variables, reorder branches, or "improve" anything while moving. A behaviour change made during a move is indistinguishable from a bug in review, and the tests guarding this are the only thing standing between you and a silently broken Console handoff.
+
+The screen keeps its `@on(...)` decorators — Textual needs them on the widget receiving the event — and each body becomes a one-line delegation. In the screen's `__init__`, replace the four `_latest_console_follow_*` assignments with:
+
+```python
+        self._console_handoff = WatchlistsConsoleHandoff(app_instance)
+```
+
+and each handler becomes, for example:
+
+```python
+    @on(Button.Pressed, "#watchlists-follow-in-console")
+    def _on_follow_in_console(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._console_handoff.follow_in_console()
+```
+
+- [ ] **Step 4: Verify no behaviour changed**
+
+Run: `source .venv/bin/activate && pytest Tests/UI/test_watchlists_destination_shell.py -v`
+Expected: identical results to Step 1. If a test now fails, the move was not faithful — fix the move, not the test.
+
+Then: `source .venv/bin/activate && pytest Tests/Watchlists -v`
+Expected: no new failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Watchlists_Modules/watchlists_console_handoff.py tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+git commit -m "refactor(watchlists): extract Console handoff from the screen shell"
+```
+
+---
+
+### Task 5: Rewrite the shell over the workbench
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/watchlists_collections_screen.py`
+- Test: `Tests/UI/test_watchlists_destination_shell.py`
+
+**Interfaces:**
+- Consumes: `RegionLayout`, `Region` (Task 1); `load_region_layout`, `save_region_layout` (Task 2); `WatchlistsWorkbench`, `RegionToggled` (Task 3); `WatchlistsConsoleHandoff` (Task 4).
+- Produces: the rebuilt screen. Phase C mounts real panes into the workbench's regions.
+
+**What changes:** `compose_content` yields the `DestinationModeStrip`, a tab strip, and the `WatchlistsWorkbench` instead of the three placeholder columns. Collapse bindings are added. The section-navigator rail is replaced by centre tabs.
+
+**What must not change:** the class name `WatchlistsCollectionsScreen`, the route `watchlists_collections`, the existing recovery-state behaviour, and every stable widget selector the existing tests assert on. Console handoffs and route tests must keep passing.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `Tests/UI/test_watchlists_destination_shell.py`, following the fixture style already in that file:
+
+```python
+@pytest.mark.asyncio
+async def test_workbench_replaces_the_placeholder_columns(watchlists_app):
+    async with watchlists_app.run_test() as pilot:
+        await pilot.pause()
+        screen = watchlists_app.screen
+        assert screen.query("#wl-workbench"), "the workbench container should be mounted"
+        # The literal placeholder labels from the old shell are gone.
+        text = " ".join(str(node.renderable) for node in screen.query(Static))
+        assert "Column 1: Watchlist List" not in text
+        assert "Column 3: Status Inspector" not in text
+
+
+@pytest.mark.asyncio
+async def test_z_collapses_the_focused_region_and_persists(watchlists_app, monkeypatch):
+    saved = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.watchlists_collections_screen.save_region_layout",
+        lambda layout: saved.append(layout),
+    )
+    async with watchlists_app.run_test() as pilot:
+        await pilot.pause()
+        screen = watchlists_app.screen
+        screen.focused_region = Region.CONTENT
+        await pilot.press("z")
+        await pilot.pause()
+        assert screen.region_layout.is_collapsed(Region.CONTENT)
+        assert saved, "collapse state must persist across visits"
+
+
+@pytest.mark.asyncio
+async def test_shift_z_solos_and_restores(watchlists_app):
+    async with watchlists_app.run_test() as pilot:
+        await pilot.pause()
+        screen = watchlists_app.screen
+        screen.focused_region = Region.ITEMS
+        await pilot.press("Z")
+        await pilot.pause()
+        assert screen.region_layout.is_collapsed(Region.FEEDS)
+        assert screen.region_layout.is_collapsed(Region.CONTENT)
+        await pilot.press("Z")
+        await pilot.pause()
+        assert screen.region_layout.collapsed == frozenset()
+
+
+@pytest.mark.asyncio
+async def test_bracket_keys_toggle_the_rails(watchlists_app):
+    async with watchlists_app.run_test() as pilot:
+        await pilot.pause()
+        screen = watchlists_app.screen
+        await pilot.press("[")
+        await pilot.pause()
+        assert screen.region_layout.is_collapsed(Region.LEFT_RAIL)
+        await pilot.press("]")
+        await pilot.pause()
+        assert screen.region_layout.is_collapsed(Region.RIGHT_RAIL)
+
+
+@pytest.mark.asyncio
+async def test_clicking_a_collapsed_header_expands_it(watchlists_app):
+    async with watchlists_app.run_test() as pilot:
+        await pilot.pause()
+        screen = watchlists_app.screen
+        screen.region_layout = RegionLayout(collapsed=frozenset({Region.FEEDS}))
+        await pilot.pause()
+        await pilot.click("#wl-header-feeds")
+        await pilot.pause()
+        assert not screen.region_layout.is_collapsed(Region.FEEDS)
+
+
+@pytest.mark.asyncio
+async def test_route_and_class_name_are_unchanged(watchlists_app):
+    async with watchlists_app.run_test():
+        screen = watchlists_app.screen
+        assert type(screen).__name__ == "WatchlistsCollectionsScreen"
+        # BaseAppScreen stores the route as `screen_name` (base_app_screen.py:23),
+        # not `route_name` — the screen passes "watchlists_collections" to super().
+        assert screen.screen_name == "watchlists_collections"
+```
+
+These tests need `from textual.widgets import Static`, plus `Region` and `RegionLayout` from `tldw_chatbook.UI.Watchlists_Modules.region_layout`. Add them to the file's existing import block rather than a second one.
+
+If the existing file has no `watchlists_app` fixture, reuse whatever fixture its current tests use and adapt these accordingly — do not invent a second app harness alongside an existing one.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest Tests/UI/test_watchlists_destination_shell.py -v`
+Expected: the six new tests FAIL (no `#wl-workbench`, no `region_layout` attribute); the pre-existing tests still pass.
+
+- [ ] **Step 3: Add layout state and bindings to the screen**
+
+In `WatchlistsCollectionsScreen`, add the imports and reactive state:
+
+```python
+from ..Watchlists_Modules.region_layout import CENTRE_REGIONS, Region, RegionLayout
+from ..Watchlists_Modules.region_layout_store import load_region_layout, save_region_layout
+from ..Watchlists_Modules.watchlists_workbench import RegionToggled, WatchlistsWorkbench
+```
+
+```python
+    region_layout = reactive(RegionLayout())
+    focused_region = reactive(Region.FEEDS)
+```
+
+Extend `BINDINGS` with the collapse keys, keeping the existing entries:
+
+```python
+        ("z", "toggle_region", "Collapse"),
+        ("Z", "solo_region", "Solo"),
+        ("left_square_bracket", "toggle_left_rail", "Left rail"),
+        ("right_square_bracket", "toggle_right_rail", "Right rail"),
+```
+
+Load persisted state in `on_mount`, before the first render:
+
+```python
+        self.region_layout = load_region_layout()
+```
+
+- [ ] **Step 4: Implement the actions**
+
+```python
+    def _apply_layout(self, layout: RegionLayout) -> None:
+        """Set the layout, push it to the workbench, and persist it."""
+        self.region_layout = layout
+        try:
+            self.query_one(WatchlistsWorkbench).layout = layout
+        except Exception:
+            logger.debug("Workbench not mounted yet; layout will apply on compose.")
+        save_region_layout(layout)
+
+    def action_toggle_region(self) -> None:
+        """Collapse or expand whichever region currently has focus."""
+        self._apply_layout(self.region_layout.toggle(self.focused_region))
+
+    def action_solo_region(self) -> None:
+        """Isolate the focused centre pane; press again to restore."""
+        if self.focused_region not in CENTRE_REGIONS:
+            self.notify("Solo applies to the Feeds, Items, or Content panes.")
+            return
+        self._apply_layout(self.region_layout.solo(self.focused_region))
+
+    def action_toggle_left_rail(self) -> None:
+        self._apply_layout(self.region_layout.toggle(Region.LEFT_RAIL))
+
+    def action_toggle_right_rail(self) -> None:
+        self._apply_layout(self.region_layout.toggle(Region.RIGHT_RAIL))
+
+    @on(RegionToggled)
+    def _on_region_toggled(self, event: RegionToggled) -> None:
+        event.stop()
+        self._apply_layout(self.region_layout.toggle(event.region))
+```
+
+- [ ] **Step 5: Replace the three placeholder columns in `compose_content`**
+
+Replace the three-column body (the `Column 1: Watchlist List` / `Column 2: …` / `Column 3: Status Inspector` containers) with the workbench, keeping the destination header, the backend selector, and the recovery-state rendering exactly as they are:
+
+```python
+            yield WatchlistsWorkbench(self.region_layout, id="wl-workbench")
+```
+
+Delete the now-unused `WatchlistsNavigator` import and its section-rail composition — section switching becomes centre tabs in Phase C/E. Leave the `_SECTION_DETAIL_TITLE` mapping and `active_section` reactive in place; Phase E's tabs consume them.
+
+- [ ] **Step 6: Run the tests**
+
+Run: `source .venv/bin/activate && pytest Tests/UI/test_watchlists_destination_shell.py -v`
+Expected: PASS, including every pre-existing test.
+
+Then, one at a time: `pytest Tests/Watchlists -v`, then `pytest Tests/UI -v`.
+Expected: no new failures. `Tests/Watchlists/test_watchlists_navigator.py::test_navigator_has_all_section_buttons` fails on this branch already — it asserts on the section rail this task removes, so it becomes legitimately obsolete. Delete that test file if the navigator is gone, and say so in your report rather than leaving a test asserting on deleted UI.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/watchlists_collections_screen.py Tests/UI/test_watchlists_destination_shell.py
+git commit -m "feat(watchlists): rebuild the screen shell over the collapsible workbench"
+```
+
+---
+
+## Phase B Completion Checklist
+
+- [ ] All five tasks committed.
+- [ ] `pytest Tests/Watchlists` and `pytest Tests/UI` pass with no new failures.
+- [ ] No data-layer file modified: `git diff --stat origin/dev -- tldw_chatbook/DB tldw_chatbook/Subscriptions` is empty.
+- [ ] The literal strings `Column 1: Watchlist List` and `Column 3: Status Inspector` no longer appear anywhere in the repo.
+- [ ] Collapse state survives a screen revisit and an app restart.
+- [ ] Every collapsed region can be re-expanded by keyboard alone.
+- [ ] Phase C plan written against merged Phase B code.

--- a/Docs/superpowers/specs/2026-07-25-watchlists-console-rebuild-design.md
+++ b/Docs/superpowers/specs/2026-07-25-watchlists-console-rebuild-design.md
@@ -20,8 +20,15 @@ its scheduled delivery. This spec designs the space those features occupy but im
 
 ## Goals
 
-- Rebuild the screen at Console-level information density, reusing `DestinationWorkbench`,
-  `DestinationModeStrip`, and the `$ds-*` token set.
+- Rebuild the screen at Console-level information density, reusing `DestinationModeStrip` and the
+  `$ds-*` token set.
+
+**`DestinationWorkbench` is deliberately not reused.** It is a fixed `Horizontal` of equal-width
+(`width: 1fr`) panes composed once from a frozen tuple set at construction, with no collapse, no
+resize, and no vertical stacking. That is the opposite of what this screen needs — two rails around
+a vertically-stacked, independently collapsible centre. A purpose-built `watchlists_workbench.py`
+container is used instead. If the collapse behaviour proves generally useful, it graduates into the
+shared widget later; it is not worth generalising ahead of a second consumer.
 - Introduce the watchlist bundle entity with many-to-many source membership.
 - Provide a real feed-reader path: collection → feeds → items → readable content.
 - Render scraped sites as first-class reader content, not second-class rows.
@@ -80,6 +87,11 @@ CREATE INDEX IF NOT EXISTS idx_watchlist_sources_subscription
 
 `PRAGMA foreign_keys = ON` is already set (`Subscriptions_DB.py:82`), so these cascades take effect.
 
+`watchlists.tags` is **comma-joined**, matching how `subscriptions.tags` is stored
+(`Subscriptions_DB.py:422` does `",".join(tags)`) — not JSON. This inherits the existing wart that
+a tag containing a comma will split; consistency with the sibling column is worth more than fixing
+it unilaterally here.
+
 **`watchlists.name` is deliberately not `UNIQUE`.** Uniqueness is enforced case-insensitively in
 `WatchlistBundleService` with auto-suffixing (`Unsorted (2)`). A raw SQL constraint would raise
 mid-migration on case-variant folder values or OPML re-imports.
@@ -91,10 +103,21 @@ Added to `subscription_items`:
 | `content` | `TEXT` | Renderable body: article text for feed items, diff text for site changes |
 | `content_kind` | `TEXT` | `article` \| `change` — selects which renderer the Content pane uses |
 | `content_format` | `TEXT` | `text` \| `markdown` \| `diff` — how to format within that renderer |
+| `is_flagged` | `BOOLEAN DEFAULT 0` | User flag, orthogonal to `status` |
 
 The two are orthogonal but constrained: `content_kind='change'` always pairs with
 `content_format='diff'`; `content_kind='article'` pairs with `text` or `markdown` depending on what
 the fetcher produced. Any other combination is a bug and is rejected at the persist boundary.
+
+**Flag needs its own column; it cannot be a status.** `subscription_items.status` carries a CHECK
+constraint allowing only `new`, `reviewed`, `ingested`, `ignored`, `error`
+(`Subscriptions_DB.py:156`) — there is no `flagged` value, and SQLite cannot drop a CHECK without
+the full table-rebuild dance. More importantly a single status column *cannot* express the real
+state: an item can be flagged **and** reviewed at once. `is_flagged` as a separate boolean follows
+the precedent ADR-018 already set with `queued_for_briefing`.
+
+**Read maps to `reviewed`.** The reader's "read/unread" language is a UI affordance over the
+existing `status` values; `new` is unread, `reviewed` is read. No new status value is introduced.
 
 Added to `local_watchlist_runs`:
 
@@ -187,6 +210,7 @@ The shell stays thin. `chat_screen.py` is 13,082 lines and is the failure mode t
 | `Subscriptions/watchlist_bundle_service.py` | Watchlist CRUD, membership, name collision handling, folder migration | new |
 | `UI/Screens/watchlists_collections_screen.py` | Shell: rails, tab routing, recovery state | rewrite; <400 LOC is a guideline, not an acceptance criterion |
 | `UI/Watchlists_Modules/watchlists_console_handoff.py` | Console staging/follow, extracted from the shell | new |
+| `UI/Watchlists_Modules/watchlists_workbench.py` | Rails + vertically-stacked collapsible centre container | new |
 | `UI/Watchlists_Modules/watchlist_tree.py` | Left rail: roots, watchlists, sources, tag + status filters | new |
 | `UI/Watchlists_Modules/feeds_pane.py` | Centre pane 1 — feeds table scoped by tree selection | new |
 | `UI/Watchlists_Modules/items_pane.py` | Centre pane 2 — items table | replaces placeholder |
@@ -258,7 +282,11 @@ the left and right rails, matching Console's rail handles.
 
 Collapsed panes become a one-line header showing their count, so nothing vanishes without a trace.
 Collapsed panes are skipped by `F6` pane cycling, but their header remains focusable and clickable
-so expansion is always reachable. Collapse state persists per user across visits.
+so expansion is always reachable.
+
+Collapse state persists across visits in the user's config under a `[watchlists.layout]` section —
+five booleans plus the solo-restore stack. It is UI preference, not data, so it belongs in config
+rather than `SubscriptionsDB`.
 
 ### Tabs
 
@@ -267,8 +295,15 @@ current screen. Only **Read** uses the three-pane split. Sources, Runs, Rules, a
 the full centre width — they have no collection→feed→item relationship.
 
 **Artifacts is empty-state-only in spec #1**, stating plainly that generation arrives in the next
-slice. It lists artifacts produced by the selected watchlist and navigates to the Artifacts screen
-via `NavigateToScreen`; it never stores or renders artifacts itself.
+slice. It lists artifacts produced by the selected watchlist and navigates to the Artifacts screen;
+it never stores or renders artifacts itself.
+
+Deep-linking needs care. `NavigateToScreen` does accept a `screen_context` dict
+(`main_navigation.py:47`), but the Artifacts screen does not read it — it consumes an app attribute,
+`pending_artifacts_chatbook_target_id` (`artifacts_screen.py:72-85`), and that attribute is
+**chatbook-specific**. Selecting a watchlist artifact therefore requires a parallel pending
+attribute and a consumer on the Artifacts screen. That work belongs to spec #2, since spec #1 has no
+artifacts to link to; it is recorded here so spec #2 does not discover it late.
 
 ### Action scopes
 
@@ -455,7 +490,7 @@ Feed titles, authors, and bodies are attacker-controllable. Two requirements:
 | UI | `Tests/Watchlists/test_watchlists_read_tab.py` | drill-down, both content renderers (article and change), auto-mark-read |
 | UI | `Tests/Watchlists/test_watchlists_inspector.py` | breadcrumb stack targeting, cadence overlap warning, Restore only on server |
 | Security | `Tests/Watchlists/test_watchlists_escaping.py` | a feed title containing `[bold]…[/]` renders literally |
-| Perf | `Tests/Watchlists/test_watchlists_counts.py` | tree counts issue exactly one query (N+1 guard) |
+| Perf | `Tests/Watchlists/test_watchlists_counts.py` | tree counts issue exactly one query (N+1 guard), asserted via a connection wrapper counting `execute` calls across a tree refresh |
 | Integration | `Tests/UI/test_watchlists_destination_shell.py` (extend) | backend switch, capability banners, Console handoff, route stability |
 
 ## Migration and cleanup
@@ -473,6 +508,8 @@ Feed titles, authors, and bodies are attacker-controllable. Two requirements:
 | Item | Owner |
 |---|---|
 | Server membership endpoint (`group_ids` on source update, or group member endpoints) | follow-up task |
+| Artifact→watchlist provenance. No link exists between a generated artifact and the watchlist that produced it, so the Artifacts tab has nothing to query even once generation ships. Reserve the shape early — retrofitting provenance after artifacts exist is materially harder | spec #2, decide before generation lands |
+| Artifacts deep-link: a watchlist-aware pending attribute plus consumer, alongside today's chatbook-only `pending_artifacts_chatbook_target_id` | spec #2 |
 | Briefing / podcast generation, template authoring, 2-speaker script + audio | spec #2 |
 | Recurring delivery scheduling for artifacts | spec #2, Schedules screen |
 | Fate of the ~4,600 unimported LOC in `Subscriptions/` (briefing, aggregation, distribution, export, RSS generation, recursive summarization) | spec #2 |

--- a/Docs/superpowers/specs/2026-07-25-watchlists-console-rebuild-design.md
+++ b/Docs/superpowers/specs/2026-07-25-watchlists-console-rebuild-design.md
@@ -85,7 +85,18 @@ CREATE INDEX IF NOT EXISTS idx_watchlist_sources_subscription
     ON watchlist_sources(subscription_id);
 ```
 
-`PRAGMA foreign_keys = ON` is already set (`Subscriptions_DB.py:82`), so these cascades take effect.
+**Foreign-key enforcement must be switched on first; it is currently off at runtime.** The
+`PRAGMA foreign_keys = ON` at `Subscriptions_DB.py:82` runs inside `_initialize_schema`'s
+`with closing(self._get_connection())` block, and that connection is closed immediately after. The
+pragma is per-connection, and `BaseDB._get_connection` (`base_db.py:104-110`) sets only
+`row_factory` — `Subscriptions_DB` never overrides it. Sibling databases do set it per connection
+(`ChaChaNotes_DB.py:2678`, `Client_Media_DB_v2.py:691`); this one is the exception.
+
+Consequence beyond this feature: `subscription_items` already declares
+`FOREIGN KEY (subscription_id) REFERENCES subscriptions(id) ON DELETE CASCADE`, which has never
+fired. Deleting a subscription has been silently orphaning its items. Implementation enables
+enforcement in its own commit before any of this schema lands. Cleaning up already-orphaned rows is
+deliberately **out of scope** — deleting user data deserves its own spec and a backup story.
 
 `watchlists.tags` is **comma-joined**, matching how `subscriptions.tags` is stored
 (`Subscriptions_DB.py:422` does `",".join(tags)`) — not JSON. This inherits the existing wart that

--- a/Docs/superpowers/specs/2026-07-25-watchlists-console-rebuild-design.md
+++ b/Docs/superpowers/specs/2026-07-25-watchlists-console-rebuild-design.md
@@ -1,0 +1,490 @@
+# Watchlists Console-Style Rebuild Design
+
+Date: 2026-07-25
+Status: Draft (pending spec review)
+Supersedes (partially): [ADR-018](../../../backlog/decisions/018-watchlists-tui-screen.md) — the section IA and pane set
+Related: [ADR-019](../../../backlog/decisions/019-watchlist-scheduler-migration.md), [2026-07-18 watchlists TUI screen design](2026-07-18-watchlists-tui-screen-design.md)
+
+## Summary
+
+Rebuild the Watchlists screen as an information-dense, Console-styled feed reader and source manager.
+A **watchlist** becomes a first-class entity: a named bundle of sources (RSS feeds and scraped
+sites) that is the unit of organization, checking, and — in a later slice — briefing and podcast
+generation.
+
+The screen's centre becomes a three-level drill-down (feeds → items → content) with every region
+independently collapsible. The service layer beneath the UI does not move.
+
+This is **spec #1 of two**. Spec #2 covers artifact generation (briefings, 2-speaker podcasts) and
+its scheduled delivery. This spec designs the space those features occupy but implements none of it.
+
+## Goals
+
+- Rebuild the screen at Console-level information density, reusing `DestinationWorkbench`,
+  `DestinationModeStrip`, and the `$ds-*` token set.
+- Introduce the watchlist bundle entity with many-to-many source membership.
+- Provide a real feed-reader path: collection → feeds → items → readable content.
+- Render scraped sites as first-class reader content, not second-class rows.
+- Give items durable body text and full-text search, neither of which exists today.
+- Keep every existing `Subscriptions/` service, the scheduler, and the route contract intact.
+
+## Non-goals
+
+- Briefing, podcast, or any artifact generation (spec #2).
+- Artifact storage or rendering — artifacts live on the Artifacts screen; Watchlists links to them.
+- Recurring delivery scheduling — that lives on the Schedules screen.
+- Nested watchlists. Server groups support `parent_group_id`; local watchlists are flat.
+- Syncing local watchlists to server groups.
+- Reviving `briefing_generator.py`, `aggregation_engine.py`, `distribution_manager.py`,
+  `export_manager.py`, `rss_feed_generator.py`, or `recursive_summarizer.py`. All are currently
+  unimported outside `Subscriptions/` and untested; their fate is spec #2's decision.
+
+## Entity model
+
+| Entity | Meaning | Storage |
+|---|---|---|
+| **Source** | One RSS feed or scraped site | `subscriptions` (existing) |
+| **Watchlist** | Named bundle of sources; unit of organization and checking | `watchlists` (new) |
+| **Membership** | Many-to-many source ↔ watchlist | `watchlist_sources` (new) |
+| **Item** | One fetched entry or detected site change | `subscription_items` (existing, extended) |
+| **Run** | One check execution, per source, grouped into batches | `local_watchlist_runs` (existing, extended) |
+
+A source may belong to any number of watchlists, matching the server's many-to-many `group_ids`.
+
+### Schema changes
+
+All changes go through the existing idempotent `_ensure_watchlists_schema` helper in
+`Subscriptions_DB.py` that ADR-018 established. No new migration machinery.
+
+```sql
+CREATE TABLE IF NOT EXISTS watchlists (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    description TEXT,
+    tags TEXT,
+    is_active BOOLEAN DEFAULT 1,
+    sort_order INTEGER DEFAULT 0,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS watchlist_sources (
+    watchlist_id    INTEGER NOT NULL REFERENCES watchlists(id)     ON DELETE CASCADE,
+    subscription_id INTEGER NOT NULL REFERENCES subscriptions(id)  ON DELETE CASCADE,
+    added_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (watchlist_id, subscription_id)
+);
+CREATE INDEX IF NOT EXISTS idx_watchlist_sources_subscription
+    ON watchlist_sources(subscription_id);
+```
+
+`PRAGMA foreign_keys = ON` is already set (`Subscriptions_DB.py:82`), so these cascades take effect.
+
+**`watchlists.name` is deliberately not `UNIQUE`.** Uniqueness is enforced case-insensitively in
+`WatchlistBundleService` with auto-suffixing (`Unsorted (2)`). A raw SQL constraint would raise
+mid-migration on case-variant folder values or OPML re-imports.
+
+Added to `subscription_items`:
+
+| Column | Type | Purpose |
+|---|---|---|
+| `content` | `TEXT` | Renderable body: article text for feed items, diff text for site changes |
+| `content_kind` | `TEXT` | `article` \| `change` — selects which renderer the Content pane uses |
+| `content_format` | `TEXT` | `text` \| `markdown` \| `diff` — how to format within that renderer |
+
+The two are orthogonal but constrained: `content_kind='change'` always pairs with
+`content_format='diff'`; `content_kind='article'` pairs with `text` or `markdown` depending on what
+the fetcher produced. Any other combination is a bug and is rejected at the persist boundary.
+
+Added to `local_watchlist_runs`:
+
+| Column | Type | Purpose |
+|---|---|---|
+| `batch_id` | `TEXT` | Groups the per-source runs produced by one watchlist-level check |
+
+**Ordering constraint:** `local_watchlist_runs` is created lazily at
+`local_watchlists_service.py:953`, *not* in `Subscriptions_DB`'s schema init. Therefore `batch_id`
+must be added to that lazy `CREATE TABLE` statement, and the `ALTER TABLE` in
+`_ensure_watchlists_schema` must be conditional on the table already existing. An unconditional
+`ALTER` fails on a fresh database.
+
+### Full-text search
+
+`subscription_items_fts` is an external-content FTS5 table over `title, content, author`, with
+insert/update/delete triggers — the same pattern as `character_cards_fts`, `conversations_fts`,
+`messages_fts`, and `media_fts`.
+
+Because two code paths insert items today (see below), triggers rather than explicit index writes
+are required so both paths stay indexed.
+
+**Backfill runs chunked in a background worker, not inline in migration.** Backfilling a large
+`subscription_items` table synchronously would block app boot. Default chunk size 500 rows per
+transaction, resuming from the highest indexed rowid so an interrupted backfill continues rather
+than restarting.
+
+### Body text: where it lives
+
+| Content | Store | Notes |
+|---|---|---|
+| Renderable body (what the reader shows, what FTS indexes) | `subscription_items.content` | New |
+| Full page snapshot, previous snapshot | `url_snapshots.extracted_content` / `raw_html` | Already exists, keyed `(subscription_id, url, created_at)` |
+
+Full pages are not duplicated per item. `[full page]` and `[previous snapshot]` in the reader read
+from `url_snapshots`.
+
+**Known limitation, must be surfaced in the UI:** `content` is `NULL` for every pre-existing item
+and cannot be recovered without re-fetching, because no code path has ever persisted a body. For
+historical items the reader and search are title-only until the source is re-checked. The reader's
+empty state says so explicitly ("no body captured — re-check this source").
+
+### Unified item persistence
+
+Two divergent INSERT paths exist today and write different column sets:
+
+| Path | Writes | Drops |
+|---|---|---|
+| `Subscriptions_DB.py:1322` | `canonical_url`, `previous_hash`, `change_percentage`, `diff_summary`, `change_type` | `status`, `run_id`, `alert_matches` |
+| `local_watchlists_service.py:1301` | `status`, `run_id`, `alert_matches` | all five change/dedup fields |
+
+Neither writes body text, though `local_watchlists_service.py:878` normalizes a `content` value
+before discarding it.
+
+Both are replaced by a single persist function writing the full column set, including the new
+`content`, `content_format`, and `content_kind`. This is a prerequisite for the reader, not a
+cleanup.
+
+### Migration of existing data
+
+1. Each distinct non-empty `subscriptions.folder` becomes a watchlist; sources with no folder join
+   one `Unsorted` watchlist. `folder` is left in place and untouched, so migration is re-runnable
+   and reversible.
+2. Completion is recorded in a dedicated marker table, and the whole migration executes inside one
+   transaction so two app instances cannot double-apply it:
+
+```sql
+CREATE TABLE IF NOT EXISTS watchlist_migration_state (
+    key TEXT PRIMARY KEY,
+    applied_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+   The existing `schema_version` table is not reused: it holds a single integer column
+   (`Subscriptions_DB.py:85-88`) with no room for per-migration keys, and bumping it would change a
+   value other code may read.
+
+**This migration will do almost nothing for real users.** `folder` is never written by any live
+path: `_subscription_config_fields` (`local_watchlists_service.py:567`) allowlists ten fields and
+`folder` is not among them, and nothing in `Subscriptions/` calls `add_subscription(folder=…)`.
+It is retained only for hand-seeded databases. First-run design therefore assumes an empty
+watchlist set — see "All sources" below.
+
+## Module layout
+
+The shell stays thin. `chat_screen.py` is 13,082 lines and is the failure mode to avoid.
+
+| Path | Role | Status |
+|---|---|---|
+| `Subscriptions/watchlist_bundle_service.py` | Watchlist CRUD, membership, name collision handling, folder migration | new |
+| `UI/Screens/watchlists_collections_screen.py` | Shell: rails, tab routing, recovery state | rewrite; <400 LOC is a guideline, not an acceptance criterion |
+| `UI/Watchlists_Modules/watchlists_console_handoff.py` | Console staging/follow, extracted from the shell | new |
+| `UI/Watchlists_Modules/watchlist_tree.py` | Left rail: roots, watchlists, sources, tag + status filters | new |
+| `UI/Watchlists_Modules/feeds_pane.py` | Centre pane 1 — feeds table scoped by tree selection | new |
+| `UI/Watchlists_Modules/items_pane.py` | Centre pane 2 — items table | replaces placeholder |
+| `UI/Watchlists_Modules/content_pane.py` | Centre pane 3 — article and change renderers | new |
+| `UI/Watchlists_Modules/content_render.py` | HTML→text, diff formatting, markup escaping | new |
+| `UI/Watchlists_Modules/region_layout.py` | Five-region collapse/solo/restore state; pure, no Textual | new |
+| `UI/Watchlists_Modules/inspector_pane.py` | Right rail — breadcrumb stack + actions | rewrite |
+| `UI/Watchlists_Modules/sources_tab.py` | Source CRUD, OPML, health | replaces `sources_pane` |
+| `UI/Watchlists_Modules/runs_tab.py` | Run history, batches, logs | replaces `runs_pane` |
+| `UI/Watchlists_Modules/rules_tab.py` | Filters + alert rules | replaces `rules_pane` |
+| `UI/Watchlists_Modules/artifacts_tab.py` | Artifacts produced by this watchlist → Artifacts screen | new |
+| `UI/Watchlists_Modules/watchlists_backend_controller.py` | Local/server routing, capability reporting | keep, extended |
+| `UI/Watchlists_Modules/overview_pane.py` | Root-node dashboard | keep, re-scoped |
+| `UI/Watchlists_Modules/opml_dialogs.py` | OPML import/export dialogs | keep |
+
+`region_layout.py` is a pure state machine so the fiddliest interaction in the screen is testable
+without a Textual pilot.
+
+The screen class name, route (`watchlists_collections`), and stable widget selectors are preserved
+so Console handoffs, shell destinations, and route tests keep working.
+
+## Layout and interaction
+
+```
+┌ Watchlists ─────────────────────────────── Local ▾ ─ Ready ────────────┐
+│ Sources 52  Unread 37  Runs 1  Alerts 2 │ Check now  New  Import OPML  │
+├────────────┬─────────────────────────────────────────┬─────────────────┤
+│ ▸ All srcs │ [1 Read] 2 Sources 3 Runs 4 Rules 5 Art.│ INSPECTOR       │
+│ ▸ Unassign │┌ Feeds in Morning AI Brief (3) ────  z ─┐│ Morning AI Brief│
+│ ▾ Morning  ││ Feed        Type Last  New Status      ││  ▸ ArXiv: AI    │
+│    ArXiv ◀ ││ ArXiv: AI   rss  2m     24 Healthy     ││    ▸ RAG Eval   │
+│    HN Top  ││ HN Top      rss  5m     15 Healthy     ││ ─────────────── │
+│    anthro… ││ anthropic…  site 7m      3 Healthy     ││ ArXiv: AI       │
+│ ▸ Security │├ Items · ArXiv: AI (24) ───── / ── z ───┤│ 2025-04-25      │
+│ ▸ Papers   ││ # Title             Date   Status      ││ 1,240 words     │
+│            ││ 1 RAG Evaluation    04-25  New   ◀     ││ New             │
+│ #daily #ai ││ 2 Reliable LLM Apps 04-24  New         ││ ─────────────── │
+│ #sec       │├ Content ──────────────────────── z ────┤│ [Open       o]  │
+│            ││ An Introduction to RAG Evaluation      ││ [Stage      s]  │
+│ Unread  37 ││ ArXiv: AI · 2025-04-25 · 1,240 words   ││ [Ingest     i]  │
+│ Today    9 ││                                        ││ [Discuss    D]  │
+│ Flagged  2 ││ Retrieval quality is usually measured  ││ [Mark read  m]  │
+│ Errors   1 ││ with recall@k, but that misses the …   ││                 │
+├────────────┴─────────────────────────────────────────┴─────────────────┤
+│ c check  i ingest  s stage  / search  z collapse  Z solo  ? help       │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+### The tree
+
+Two permanent roots sit above the flat watchlist list:
+
+- **All sources** — every source regardless of membership.
+- **Unassigned** — sources belonging to no watchlist.
+
+These are not conveniences. Without them, deleting a watchlist would orphan its sources into
+invisibility, and first-run would show an empty tree given that folder migration is effectively a
+no-op. Tags filter across watchlists; status filters (Unread / Today / Flagged / Errors) filter
+items within the current scope.
+
+Selecting the **collection node itself** shows the merged item stream across all its sources — the
+normal feed-reader default. Selecting a **source** narrows to that source.
+
+### Five collapsible regions
+
+`z` collapses or expands the focused region. `Z` solos it, collapsing the other two centre panes;
+a second `Z` restores the prior layout from a stack held in `region_layout.py`. `[` and `]` toggle
+the left and right rails, matching Console's rail handles.
+
+Collapsed panes become a one-line header showing their count, so nothing vanishes without a trace.
+Collapsed panes are skipped by `F6` pane cycling, but their header remains focusable and clickable
+so expansion is always reachable. Collapse state persists per user across visits.
+
+### Tabs
+
+`1`–`5` select Read / Sources / Runs / Rules / Artifacts, preserving the digit muscle memory of the
+current screen. Only **Read** uses the three-pane split. Sources, Runs, Rules, and Artifacts take
+the full centre width — they have no collection→feed→item relationship.
+
+**Artifacts is empty-state-only in spec #1**, stating plainly that generation arrives in the next
+slice. It lists artifacts produced by the selected watchlist and navigates to the Artifacts screen
+via `NavigateToScreen`; it never stores or renders artifacts itself.
+
+### Action scopes
+
+Three surfaces, three scopes, no overlap:
+
+| Surface | Scope |
+|---|---|
+| Header strip | Screen-scope actions on the current tree selection (Check now, New, Import OPML) |
+| Inspector | Selection-scope actions for the deepest current selection |
+| Key bindings | Accelerators for whatever the Inspector currently shows |
+
+### Inspector
+
+The Inspector shows a **breadcrumb stack** — watchlist ▸ source ▸ item — with the deepest selection
+expanded and shallower levels collapsed to one line each. This is deterministic: it does not depend
+on which widget last held focus, which would break the moment a user clicks an Inspector button.
+
+The action buttons always belong to the **deepest expanded level**. Clicking a collapsed breadcrumb
+level promotes it to deepest, swapping the detail and the actions together — so the actions on
+screen can never belong to a different level than the detail above them.
+
+| Level | Shows | Actions |
+|---|---|---|
+| Watchlist | tags, source count, unread, cadence (bulk) | Check now, Add source, Rename, Delete |
+| Source | URL, type, health, last check, dedup, cadence | Check now, Preview, Edit, Pause, Remove from watchlist, Delete, Restore* |
+| Item | source, date, author, word count, status | Open, Stage, Ingest, Discuss in Console, Mark read, Flag |
+| Run | status, duration, counts, filter tallies, log tail | Cancel, Re-run |
+
+\* Restore appears only on the server backend, which returns `restore_window_seconds` and
+`restore_expires_at` on `SourceDeleteResponse`. The local backend has no undo-delete; the spec names
+the asymmetry rather than hiding it.
+
+The **Delivery** row is hidden entirely in spec #1 — there is no delivery to show until spec #2.
+
+### Cadence editing
+
+`subscriptions.check_frequency` remains the single authority; it is what `WatchlistProjection` and
+the scheduler already read. No new cadence column exists.
+
+The Inspector's "Check every 6h" on a watchlist is a **bulk editor** over member sources. It shows
+the shared value when member sources agree and `mixed` when they do not.
+
+**It must warn about overlap before writing.** Because sources are shared across watchlists, setting
+a cadence on one watchlist silently changes it as seen from another. The confirmation names the
+overlap: "3 of 5 sources are also in Security."
+
+### Content pane
+
+`content_kind` selects the renderer.
+
+**Article** (feed items) — title, source, date, word count, body.
+
+**Change** (site items) — percent changed, change type, added/removed lines, with `[full page]` and
+`[previous snapshot]` reading from `url_snapshots`:
+
+```
+┌ Content ───────────────────────────────────────┐
+│ anthropic.com/news        site · changed 7m ago │
+│ 12% changed · structural                        │
+│ ─────────────────────────────────────────────── │
+│ + Claude Opus 4.5 is now available in the API   │
+│ + Pricing updated for long-context requests     │
+│ - Claude Opus 4.1 is now available in the API   │
+│                                                 │
+│ [full page]  [previous snapshot]                │
+└─────────────────────────────────────────────────┘
+```
+
+Both kinds share the same pane, keys, and Stage/Ingest/Discuss actions, so sites behave like feeds
+throughout the workflow while showing what was honestly captured.
+
+### Reading behaviour
+
+- Opening an item in Content marks it read, with an explicit unread toggle since marking read
+  destroys the unread list.
+- **Item status is global.** An item marked read from "All sources" is read in every watchlist that
+  contains its source. This is correct — it is the same article — but it is stated so it is not
+  discovered as a bug.
+- `/` opens FTS search scoped to the current tree selection. An active query persists across tree
+  selection changes; the scope follows the selection and is shown in the search bar.
+
+### Key bindings
+
+Preserved from today: `1`–`5`, `?`, `n`, `d`, `c`, `p`.
+Added: `e` edit, `s` stage, `i` ingest, `P` pause, `z` collapse, `Z` solo, `/` search, `j`/`k`
+next/previous item, `[` / `]` rail toggles.
+
+Implementation must run a conflict audit against `BaseAppScreen` and app-level bindings. Roughly
+fifteen bare letters plus shifted variants is not a set to assume is free, and shifted-letter
+bindings are weakly discoverable — the footer hint bar carries them.
+
+### Empty states
+
+First run has no watchlists. The tree shows **All sources** with an inline "Add your first feed"
+affordance rather than an empty box. Items with no captured body explain why and how to fix it.
+The Artifacts tab names the next slice instead of showing a bare empty table.
+
+## Data flow
+
+1. Mount resolves the backend, then **one grouped query** populates every tree count off the event
+   loop. `Subscriptions_DB` uses `threading.local()` connections (`:75`, `:368-370`), so worker
+   threads hold their own connection and this is safe.
+2. Tree selection scopes Feeds; Feeds selection scopes Items; Items selection loads Content.
+3. Tabs lazy-load on first open.
+4. Every fetch carries a backend token; results are discarded if the backend changed in flight.
+5. Mutations go pane → controller → scope service → worker → reactive update.
+
+### Counts must be one query
+
+No per-subscription count helper exists in `Subscriptions_DB` — only `get_new_items` and a single
+`COUNT(*)` in the entire file. Counting per tree node per refresh would issue one query per
+watchlist on every refresh. Tree counts are computed by a single grouped query, cached, and
+invalidated on run completion or item status change.
+
+This repo has form here: the performance audit found the Console's 0.2s tick running SQLite on the
+event loop.
+
+### Two polling cadences
+
+- **Screen-level status poll**, low frequency, always active while the screen is mounted: drives the
+  header strip counts and tree run status.
+- **Run detail poll**, higher frequency, only while the Runs tab is visible and a run is
+  non-terminal.
+
+### Backend routing
+
+| Operation | Local | Server |
+|---|---|---|
+| List watchlists | `WatchlistBundleService` | `list_watchlist_groups` |
+| Create / rename / delete watchlist | `WatchlistBundleService` | **disabled** — see below |
+| Source ↔ watchlist membership | `WatchlistBundleService` | **unsupported** — capability banner |
+| Source CRUD | `WatchlistScopeService` | `WatchlistScopeService` |
+| Check now | `LocalWatchlistsService.launch_run` | `check_watchlist_sources_now` |
+| Runs, run detail, cancel | `WatchlistScopeService` | `WatchlistScopeService` |
+| Item read / search | local only | local only |
+| OPML import / export | local OPML service | `import/export_watchlist_sources` |
+
+**Membership cannot be set from this client.** `SourceResponse` exposes `group_ids` for reading, but
+`SourceUpdateRequest` has no `group_ids` field and neither `WatchlistGroupCreateRequest` nor
+`WatchlistGroupUpdateRequest` carries members — all three are `extra="forbid"`, so nothing can be
+smuggled through. There is no wire path for "add this source to this watchlist" on the server.
+
+Consequently **watchlist creation is also disabled on the server backend**, not merely membership
+editing. Group creation would otherwise succeed and produce a node that can never contain anything.
+A capability banner explains this, following the pattern ADR-018 used for content-alert rules. A
+follow-up task covers adding the membership endpoint.
+
+`WatchlistGroupCreateRequest.parent_group_id` exists, so the server supports nested groups while
+local watchlists are flat. Server nesting is displayed flattened, with the path in the name.
+
+Item bodies, read state, and search are local-only in both modes — the server exposes no item
+content API in this client.
+
+## Error handling and security
+
+- `DestinationRecoveryState` for service-level failures; `policy_denied_recovery_state` for policy
+  denials — both already established on this screen.
+- `@work(exclusive=True, group=…)` per pane to prevent duplicate fetches.
+- Backend-unsupported operations show a capability banner explaining why, never a disabled control
+  with no explanation.
+- Inline field-level validation on forms.
+
+### Untrusted remote content
+
+Feed titles, authors, and bodies are attacker-controllable. Two requirements:
+
+1. **Escape on output.** Every remote-derived string rendered into Textual markup passes through
+   `escape_markup`. The existing panes sanitize *inputs* (`sources_pane.py:224-244`) but nothing
+   escapes *outputs*. This repo has shipped this exact bug before, in tooltips rendering markup.
+2. **Guaranteed HTML degradation.** BeautifulSoup and html2text sit behind `optional_deps` in the
+   fetch layer, and RSS bodies are HTML. `content_render.py` provides a dependency-free fallback —
+   tag strip plus entity unescape — so an install without those extras renders plain text rather
+   than markup soup.
+
+## Testing
+
+| Layer | File | Covers |
+|---|---|---|
+| Pure | `Tests/Watchlists/test_region_layout.py` | collapse, solo, restore stack across five regions; no pilot |
+| Service | `Tests/Subscriptions/test_watchlist_bundle_service.py` | CRUD, membership, case-insensitive name collision + auto-suffix, folder migration idempotency |
+| DB | `Tests/DB/test_subscriptions_db_watchlists.py` | migration re-runnability, conditional `batch_id` ALTER on fresh vs existing DB, FTS triggers + chunked backfill, cascade on delete |
+| DB | `Tests/Subscriptions/test_item_persist.py` | unified persist writes the **full** column set — the regression that allowed two divergent inserts |
+| UI | `Tests/Watchlists/test_watchlists_tree.py` | roots, scoping, tag filters, orphan reachability after watchlist delete |
+| UI | `Tests/Watchlists/test_watchlists_read_tab.py` | drill-down, both content renderers (article and change), auto-mark-read |
+| UI | `Tests/Watchlists/test_watchlists_inspector.py` | breadcrumb stack targeting, cadence overlap warning, Restore only on server |
+| Security | `Tests/Watchlists/test_watchlists_escaping.py` | a feed title containing `[bold]…[/]` renders literally |
+| Perf | `Tests/Watchlists/test_watchlists_counts.py` | tree counts issue exactly one query (N+1 guard) |
+| Integration | `Tests/UI/test_watchlists_destination_shell.py` (extend) | backend switch, capability banners, Console handoff, route stability |
+
+## Migration and cleanup
+
+- Replace `sources_pane.py`, `items_pane.py`, `runs_pane.py`, `rules_pane.py`, `inspector_pane.py`.
+- Extract Console handoff from the shell into `watchlists_console_handoff.py`.
+- Retire the placeholder column labels ("Column 1: Watchlist List", etc.).
+- Update `Tests/Watchlists/` and `Tests/UI/test_watchlists_*` to the new panes.
+- Amend ADR-018's section IA and pane set; record the new IA and entity model in a new ADR.
+- Note in ADR-018 that its "groups/tags read-only" statement is stale — group CRUD exists at
+  `client.py:6775-6819`.
+
+## Open follow-ups
+
+| Item | Owner |
+|---|---|
+| Server membership endpoint (`group_ids` on source update, or group member endpoints) | follow-up task |
+| Briefing / podcast generation, template authoring, 2-speaker script + audio | spec #2 |
+| Recurring delivery scheduling for artifacts | spec #2, Schedules screen |
+| Fate of the ~4,600 unimported LOC in `Subscriptions/` (briefing, aggregation, distribution, export, RSS generation, recursive summarization) | spec #2 |
+| Local undo-delete parity with the server's restore window | follow-up task |
+| Nested watchlists, if flat proves insufficient | deferred |
+
+## Decisions resolved during design
+
+1. **Watchlist is the bundle** — not folders/tags, not the server's Group+Job split.
+2. **Flat, not nested** — tags carry cross-cutting grouping.
+3. **Artifacts live on the Artifacts screen** — Watchlists links out.
+4. **Cadence edits here, delivery in Schedules.**
+5. **Two renderers, one Content pane** — sites show diffs, feeds show articles.
+6. **FTS5 over items**, not LIKE, not filters-only.
+7. **Rewrite the UI on the existing service seam** — no parallel v2 file.

--- a/Docs/superpowers/specs/2026-07-25-watchlists-console-rebuild-design.md
+++ b/Docs/superpowers/specs/2026-07-25-watchlists-console-rebuild-design.md
@@ -12,6 +12,31 @@ A **watchlist** becomes a first-class entity: a named bundle of sources (RSS fee
 sites) that is the unit of organization, checking, and — in a later slice — briefing and podcast
 generation.
 
+## Starting point — corrected 2026-07-26
+
+An earlier revision of this spec described the existing screen as placeholder scaffolding, citing
+literal `Column 1: Watchlist List` labels. **That was wrong.** Those strings appear only in
+`Docs/static/watchlists-screenshots/`, captured during Slice 1A (`90d4da5b2`); the real panes
+landed the same day in `33fcf3f66`, and the screenshot was stale within hours. It was read in
+preference to the code, and the error propagated into the implementation plans.
+
+What actually ships today: `OverviewPane`, `SourcesPane`, `RunsPane`, `ItemsPane`, `RulesPane`,
+`NotificationsPane`, a section navigator, a backend selector, and an inspector — with 16 tests
+covering run deep-linking across raw/canonical/server backends, the notifications inbox, and
+selection survival across recompose. **This is working, tested product. The rebuild must re-host
+it, never replace it with stubs.**
+
+The case for the redesign is unchanged, but it rests on density rather than absence. Captured live
+at 235×52 on a fresh profile, the shipped screen spends:
+
+- ~55 of 235 columns (23% of width) on a left rail displaying six words
+- a full-width, three-row `Select` on a single Local/Server value
+- an Overview dashboard rendering **seven empty bordered cards** — boxes drawn around nothing
+- three fixed ~52-column panes with heavy internal padding
+
+Structural waste, not empty-state waste: the rail, the selector, and the card grid consume that
+space whether or not any sources exist. The goal is to reclaim it, not to rebuild what works.
+
 The screen's centre becomes a three-level drill-down (feeds → items → content) with every region
 independently collapsible. The service layer beneath the UI does not move.
 
@@ -224,14 +249,14 @@ The shell stays thin. `chat_screen.py` is 13,082 lines and is the failure mode t
 | `UI/Watchlists_Modules/watchlists_workbench.py` | Rails + vertically-stacked collapsible centre container | new |
 | `UI/Watchlists_Modules/watchlist_tree.py` | Left rail: roots, watchlists, sources, tag + status filters | new |
 | `UI/Watchlists_Modules/feeds_pane.py` | Centre pane 1 — feeds table scoped by tree selection | new |
-| `UI/Watchlists_Modules/items_pane.py` | Centre pane 2 — items table | replaces placeholder |
+| `UI/Watchlists_Modules/items_pane.py` | Centre pane 2 — items table | **evolve existing** |
 | `UI/Watchlists_Modules/content_pane.py` | Centre pane 3 — article and change renderers | new |
 | `UI/Watchlists_Modules/content_render.py` | HTML→text, diff formatting, markup escaping | new |
 | `UI/Watchlists_Modules/region_layout.py` | Five-region collapse/solo/restore state; pure, no Textual | new |
 | `UI/Watchlists_Modules/inspector_pane.py` | Right rail — breadcrumb stack + actions | rewrite |
-| `UI/Watchlists_Modules/sources_tab.py` | Source CRUD, OPML, health | replaces `sources_pane` |
-| `UI/Watchlists_Modules/runs_tab.py` | Run history, batches, logs | replaces `runs_pane` |
-| `UI/Watchlists_Modules/rules_tab.py` | Filters + alert rules | replaces `rules_pane` |
+| `UI/Watchlists_Modules/sources_tab.py` | Source CRUD, OPML, health | **evolve existing** `sources_pane` |
+| `UI/Watchlists_Modules/runs_tab.py` | Run history, batches, logs | **evolve existing** `runs_pane` |
+| `UI/Watchlists_Modules/rules_tab.py` | Filters + alert rules | **evolve existing** `rules_pane` |
 | `UI/Watchlists_Modules/artifacts_tab.py` | Artifacts produced by this watchlist → Artifacts screen | new |
 | `UI/Watchlists_Modules/watchlists_backend_controller.py` | Local/server routing, capability reporting | keep, extended |
 | `UI/Watchlists_Modules/overview_pane.py` | Root-node dashboard | keep, re-scoped |
@@ -508,7 +533,8 @@ Feed titles, authors, and bodies are attacker-controllable. Two requirements:
 
 - Replace `sources_pane.py`, `items_pane.py`, `runs_pane.py`, `rules_pane.py`, `inspector_pane.py`.
 - Extract Console handoff from the shell into `watchlists_console_handoff.py`.
-- Retire the placeholder column labels ("Column 1: Watchlist List", etc.).
+- Re-host the existing panes inside the new workbench. They are working, tested product — the
+  earlier "replace the placeholders" framing was based on a stale screenshot and is withdrawn.
 - Update `Tests/Watchlists/` and `Tests/UI/test_watchlists_*` to the new panes.
 - Amend ADR-018's section IA and pane set; record the new IA and entity model in a new ADR.
 - Note in ADR-018 that its "groups/tags read-only" statement is stale — group CRUD exists at

--- a/Tests/DB/test_subscriptions_db.py
+++ b/Tests/DB/test_subscriptions_db.py
@@ -101,6 +101,43 @@ def test_record_check_result_persists_full_column_set_via_unified_path(db):
     assert rows[0]["content"] == "retrieval quality rubric"
 
 
+def test_record_check_result_collapses_canonical_url_variants_to_one_row(db):
+    """Regression for fix round 2 (unpinned ruled behaviour).
+
+    The human ruling's stated reason for keeping the canonical-URL dedupe
+    guard in ``_add_subscription_item`` separate from
+    ``persist_subscription_item``'s own raw-url ``ON CONFLICT`` rule was
+    that URLs differing only by case or a trailing slash must still
+    collapse to a single row. Nothing pinned that until now.
+    """
+    source_id = db.add_subscription(
+        name="ArXiv", type="rss", source="https://a.example/feed"
+    )
+
+    db.record_check_result(
+        subscription_id=source_id,
+        items=[
+            {
+                "url": "HTTPS://A.Example/1",
+                "title": "First variant",
+                "content_hash": "hash-1",
+            },
+            {
+                "url": "https://a.example/1/",
+                "title": "Second variant",
+                "content_hash": "hash-1",
+            },
+        ],
+    )
+
+    rows = db.conn.execute(
+        "SELECT id, url, canonical_url FROM subscription_items WHERE subscription_id = ?",
+        (source_id,),
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["canonical_url"] == "https://a.example/1"
+
+
 def test_deleting_subscription_cascades_to_its_items(db):
     source_id = db.add_subscription(
         name="ArXiv", type="rss", source="https://a.example/feed"

--- a/Tests/DB/test_subscriptions_db.py
+++ b/Tests/DB/test_subscriptions_db.py
@@ -53,3 +53,100 @@ def test_deleting_subscription_cascades_to_its_items(db):
 
     orphans = db.conn.execute("SELECT COUNT(*) FROM subscription_items").fetchone()[0]
     assert orphans == 0
+
+
+def test_legacy_orphaned_filter_survives_action_check_widening(tmp_path):
+    """Regression for Task 1a fix round 1.
+
+    Enabling FK enforcement made the pre-existing subscription_filters
+    CHECK-widening rebuild (CREATE TABLE ..._new -> INSERT ... SELECT ->
+    DROP/RENAME) raise IntegrityError on any real database that (a) predates
+    the 'include'/'exclude'/'flag' widening, so the rebuild still runs, and
+    (b) already contains a subscription_filters row whose subscription_id no
+    longer exists. The rebuild copies that orphan into a table that declares
+    the FK; with enforcement on, the copy failed and the app could not even
+    open the database. Already-orphaned rows must not be deleted -- cleanup
+    is out of scope -- so the rebuild must tolerate them instead.
+    """
+    import sqlite3
+
+    path = tmp_path / "legacy_filters.db"
+    legacy_conn = sqlite3.connect(path)
+    legacy_conn.executescript("""
+        -- Full shape, matching SubscriptionsDB._initialize_schema, so the
+        -- later CREATE INDEX IF NOT EXISTS statements (which reference
+        -- priority/is_paused) succeed against this pre-existing table.
+        CREATE TABLE subscriptions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            type TEXT NOT NULL CHECK(type IN ('rss', 'atom', 'json_feed', 'url', 'url_list', 'podcast', 'sitemap', 'api')),
+            source TEXT NOT NULL,
+            description TEXT,
+            tags TEXT,
+            priority INTEGER DEFAULT 3 CHECK(priority BETWEEN 1 AND 5),
+            folder TEXT,
+            check_frequency INTEGER DEFAULT 3600,
+            last_checked DATETIME,
+            last_successful_check DATETIME,
+            last_error TEXT,
+            error_count INTEGER DEFAULT 0,
+            consecutive_failures INTEGER DEFAULT 0,
+            is_active BOOLEAN DEFAULT 1,
+            is_paused BOOLEAN DEFAULT 0,
+            auto_pause_threshold INTEGER DEFAULT 10,
+            auth_config TEXT,
+            custom_headers TEXT,
+            rate_limit_config TEXT,
+            extraction_method TEXT DEFAULT 'auto',
+            extraction_rules TEXT,
+            processing_options TEXT,
+            auto_ingest BOOLEAN DEFAULT 0,
+            notification_config TEXT,
+            change_threshold FLOAT DEFAULT 0.1,
+            ignore_selectors TEXT,
+            etag TEXT,
+            last_modified TEXT,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE subscription_filters (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            subscription_id INTEGER,
+            name TEXT NOT NULL,
+            is_active BOOLEAN DEFAULT 1,
+            conditions TEXT NOT NULL,
+            action TEXT NOT NULL CHECK(action IN ('auto_ingest', 'auto_ignore', 'tag', 'priority', 'notify')),
+            action_params TEXT,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (subscription_id) REFERENCES subscriptions(id) ON DELETE CASCADE
+        );
+    """)
+    legacy_conn.execute(
+        "INSERT INTO subscriptions (id, name, type, source) VALUES (1, 'ArXiv', 'rss', 'https://a.example/feed')"
+    )
+    legacy_conn.execute(
+        "INSERT INTO subscription_filters (subscription_id, name, conditions, action) "
+        "VALUES (1, 'include ai', '{}', 'auto_ingest')"
+    )
+    # Enforcement defaults to OFF on a bare sqlite3 connection, so this
+    # orphans the filter row exactly as a pre-Task-1a SubscriptionsDB would
+    # have silently allowed.
+    legacy_conn.execute("DELETE FROM subscriptions WHERE id = 1")
+    legacy_conn.commit()
+    legacy_conn.close()
+
+    # Must not raise: this migration runs on every open via _initialize_schema.
+    migrated = SubscriptionsDB(str(path), client_id="test")
+
+    row = migrated.conn.execute(
+        "SELECT subscription_id, action FROM subscription_filters"
+    ).fetchone()
+    # The orphan survives the migration -- cleanup is explicitly out of scope.
+    assert row[0] == 1
+    assert row[1] == "auto_ingest"
+
+    check_sql = migrated.conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='subscription_filters'"
+    ).fetchone()[0]
+    assert "'include'" in check_sql

--- a/Tests/DB/test_subscriptions_db.py
+++ b/Tests/DB/test_subscriptions_db.py
@@ -38,6 +38,69 @@ def test_foreign_keys_enforced_on_runtime_connection(db):
     assert db.conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
 
 
+def test_record_check_result_persists_full_column_set_via_unified_path(db):
+    """Regression for fix round 1, Finding 1.
+
+    ``_add_subscription_item`` (reached via ``record_check_result``, the
+    scheduled-check path used by ``WatchlistCheckHandler``) was the other
+    half of the disjoint-column bug Task 4 exists to fix: it wrote the
+    change/dedup fields but dropped body text, content_kind/content_format,
+    run_id, and alert_matches entirely. It must now route through
+    ``persist_subscription_item`` too, while its own canonical-URL dedupe
+    guard stays exactly as it was -- a second call with the same URL/hash
+    must still collapse to one row rather than adopting
+    persist_subscription_item's separate (raw-url-based) dedupe rule.
+    """
+    source_id = db.add_subscription(
+        name="ArXiv", type="rss", source="https://a.example/feed"
+    )
+
+    db.record_check_result(
+        subscription_id=source_id,
+        items=[
+            {
+                "url": "https://a.example/1",
+                "title": "RAG Evaluation",
+                "content": "retrieval quality rubric",
+                "content_kind": "article",
+                "content_format": "text",
+                "content_hash": "hash-1",
+            }
+        ],
+    )
+
+    row = db.conn.execute(
+        "SELECT content, content_kind, content_format, canonical_url "
+        "FROM subscription_items WHERE subscription_id = ?",
+        (source_id,),
+    ).fetchone()
+    assert row["content"] == "retrieval quality rubric"
+    assert row["content_kind"] == "article"
+    assert row["content_format"] == "text"
+    assert row["canonical_url"] == "https://a.example/1"
+
+    # Same URL/hash again: the canonical-URL guard in _add_subscription_item
+    # must still catch this as a duplicate and skip it entirely (no update),
+    # exactly as before this fix -- the two dedupe rules are not unified.
+    db.record_check_result(
+        subscription_id=source_id,
+        items=[
+            {
+                "url": "https://a.example/1",
+                "title": "RAG Evaluation (updated)",
+                "content": "should not overwrite",
+                "content_hash": "hash-1",
+            }
+        ],
+    )
+    rows = db.conn.execute(
+        "SELECT id, content FROM subscription_items WHERE subscription_id = ?",
+        (source_id,),
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["content"] == "retrieval quality rubric"
+
+
 def test_deleting_subscription_cascades_to_its_items(db):
     source_id = db.add_subscription(
         name="ArXiv", type="rss", source="https://a.example/feed"

--- a/Tests/DB/test_subscriptions_db.py
+++ b/Tests/DB/test_subscriptions_db.py
@@ -20,9 +20,36 @@ def test_watchlists_columns_exist(db):
 
 
 def test_subscription_filters_action_constraint_allows_include(db):
+    source_id = db.add_subscription(
+        name="ArXiv", type="rss", source="https://a.example/feed"
+    )
     cursor = db.conn.cursor()
     cursor.execute(
         "INSERT INTO subscription_filters (subscription_id, name, conditions, action) VALUES (?, ?, ?, ?)",
-        (1, "include ai", "{}", "include"),
+        (source_id, "include ai", "{}", "include"),
     )
     db.conn.commit()
+
+
+def test_foreign_keys_enforced_on_runtime_connection(db):
+    # PRAGMA foreign_keys is per-connection and defaults to OFF. The pragma in
+    # _initialize_schema runs on a connection that is closed immediately after,
+    # so it does not cover the thread-local connection everything else uses.
+    assert db.conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+
+
+def test_deleting_subscription_cascades_to_its_items(db):
+    source_id = db.add_subscription(
+        name="ArXiv", type="rss", source="https://a.example/feed"
+    )
+    with db.transaction() as conn:
+        conn.execute(
+            "INSERT INTO subscription_items (subscription_id, url, title) VALUES (?, ?, ?)",
+            (source_id, "https://a.example/1", "An item"),
+        )
+
+    with db.transaction() as conn:
+        conn.execute("DELETE FROM subscriptions WHERE id = ?", (source_id,))
+
+    orphans = db.conn.execute("SELECT COUNT(*) FROM subscription_items").fetchone()[0]
+    assert orphans == 0

--- a/Tests/DB/test_subscriptions_db.py
+++ b/Tests/DB/test_subscriptions_db.py
@@ -250,3 +250,107 @@ def test_legacy_orphaned_filter_survives_action_check_widening(tmp_path):
         "SELECT sql FROM sqlite_master WHERE type='table' AND name='subscription_filters'"
     ).fetchone()[0]
     assert "'include'" in check_sql
+
+
+def test_rebuild_recovers_from_stray_subscription_filters_new_table(tmp_path):
+    """Regression for Finding 2 (final review).
+
+    Python's sqlite3 module only opens an implicit transaction for DML --
+    CREATE TABLE runs in autocommit. So the ``conn.rollback()`` in the
+    subscription_filters rebuild's ``except`` branch cannot remove
+    ``subscription_filters_new`` if anything after the CREATE fails; that
+    table survives on disk. On the next open, the unguarded
+    ``CREATE TABLE subscription_filters_new`` in ``_ensure_watchlists_schema``
+    then raises ``OperationalError: table subscription_filters_new already
+    exists`` -- and ``SubscriptionsDB`` can never be constructed again.
+    """
+    import sqlite3
+
+    path = tmp_path / "stray_new_table.db"
+    legacy_conn = sqlite3.connect(path)
+    legacy_conn.executescript("""
+        CREATE TABLE subscriptions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            type TEXT NOT NULL CHECK(type IN ('rss', 'atom', 'json_feed', 'url', 'url_list', 'podcast', 'sitemap', 'api')),
+            source TEXT NOT NULL,
+            description TEXT,
+            tags TEXT,
+            priority INTEGER DEFAULT 3 CHECK(priority BETWEEN 1 AND 5),
+            folder TEXT,
+            check_frequency INTEGER DEFAULT 3600,
+            last_checked DATETIME,
+            last_successful_check DATETIME,
+            last_error TEXT,
+            error_count INTEGER DEFAULT 0,
+            consecutive_failures INTEGER DEFAULT 0,
+            is_active BOOLEAN DEFAULT 1,
+            is_paused BOOLEAN DEFAULT 0,
+            auto_pause_threshold INTEGER DEFAULT 10,
+            auth_config TEXT,
+            custom_headers TEXT,
+            rate_limit_config TEXT,
+            extraction_method TEXT DEFAULT 'auto',
+            extraction_rules TEXT,
+            processing_options TEXT,
+            auto_ingest BOOLEAN DEFAULT 0,
+            notification_config TEXT,
+            change_threshold FLOAT DEFAULT 0.1,
+            ignore_selectors TEXT,
+            etag TEXT,
+            last_modified TEXT,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE subscription_filters (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            subscription_id INTEGER,
+            name TEXT NOT NULL,
+            is_active BOOLEAN DEFAULT 1,
+            conditions TEXT NOT NULL,
+            action TEXT NOT NULL CHECK(action IN ('auto_ingest', 'auto_ignore', 'tag', 'priority', 'notify')),
+            action_params TEXT,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (subscription_id) REFERENCES subscriptions(id) ON DELETE CASCADE
+        );
+        -- Left behind by an earlier rebuild attempt that died after the
+        -- CREATE TABLE but before the rename -- autocommit DDL means this
+        -- table is exactly what a crash (or the pre-fix except handler)
+        -- leaves on disk.
+        CREATE TABLE subscription_filters_new (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            subscription_id INTEGER,
+            name TEXT NOT NULL
+        );
+    """)
+    legacy_conn.execute(
+        "INSERT INTO subscriptions (id, name, type, source) VALUES (1, 'ArXiv', 'rss', 'https://a.example/feed')"
+    )
+    legacy_conn.execute(
+        "INSERT INTO subscription_filters (subscription_id, name, conditions, action) "
+        "VALUES (1, 'include ai', '{}', 'auto_ingest')"
+    )
+    legacy_conn.commit()
+    legacy_conn.close()
+
+    # Must not raise "table subscription_filters_new already exists".
+    migrated = SubscriptionsDB(str(path), client_id="test")
+
+    check_sql = migrated.conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='subscription_filters'"
+    ).fetchone()[0]
+    assert "'include'" in check_sql
+
+    row = migrated.conn.execute(
+        "SELECT subscription_id, name FROM subscription_filters"
+    ).fetchone()
+    assert row[0] == 1
+    assert row[1] == "include ai"
+
+    # The stray table is consumed by the rebuild, not left behind again.
+    tables = {
+        r[0]
+        for r in migrated.conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+    assert "subscription_filters_new" not in tables

--- a/Tests/DB/test_subscriptions_db_watchlists.py
+++ b/Tests/DB/test_subscriptions_db_watchlists.py
@@ -114,3 +114,88 @@ def test_lazy_run_schema_helper_is_gone():
     from tldw_chatbook.Subscriptions.local_watchlists_service import LocalWatchlistsService
 
     assert not hasattr(LocalWatchlistsService, "_ensure_run_schema")
+
+
+def _insert_item(db, subscription_id, url, title, content):
+    with db.transaction() as conn:
+        conn.execute(
+            "INSERT INTO subscription_items "
+            "(subscription_id, url, title, content, content_kind, content_format) "
+            "VALUES (?, ?, ?, ?, 'article', 'text')",
+            (subscription_id, url, title, content),
+        )
+
+
+def test_fts_table_created(db):
+    assert "subscription_items_fts" in _tables(db)
+
+
+def test_fts_indexes_inserted_items(db):
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+    _insert_item(db, source_id, "https://a.example/1", "RAG Evaluation", "retrieval quality rubric")
+
+    rows = db.conn.execute(
+        "SELECT rowid FROM subscription_items_fts WHERE subscription_items_fts MATCH ?",
+        ("rubric",),
+    ).fetchall()
+    assert len(rows) == 1
+
+
+def test_fts_follows_updates_and_deletes(db):
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+    _insert_item(db, source_id, "https://a.example/1", "First", "alpha content")
+
+    with db.transaction() as conn:
+        conn.execute("UPDATE subscription_items SET content = 'beta content' WHERE url = ?",
+                     ("https://a.example/1",))
+
+    assert db.conn.execute(
+        "SELECT COUNT(*) FROM subscription_items_fts WHERE subscription_items_fts MATCH ?",
+        ("alpha",),
+    ).fetchone()[0] == 0
+    assert db.conn.execute(
+        "SELECT COUNT(*) FROM subscription_items_fts WHERE subscription_items_fts MATCH ?",
+        ("beta",),
+    ).fetchone()[0] == 1
+
+    with db.transaction() as conn:
+        conn.execute("DELETE FROM subscription_items WHERE url = ?", ("https://a.example/1",))
+
+    assert db.conn.execute(
+        "SELECT COUNT(*) FROM subscription_items_fts WHERE subscription_items_fts MATCH ?",
+        ("beta",),
+    ).fetchone()[0] == 0
+
+
+def test_backfill_is_chunked_and_resumable(db):
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+    with db.transaction() as conn:
+        conn.execute("DROP TRIGGER subscription_items_fts_ai")
+        for index in range(7):
+            conn.execute(
+                "INSERT INTO subscription_items (subscription_id, url, title, content) "
+                "VALUES (?, ?, ?, ?)",
+                (source_id, f"https://a.example/{index}", f"Item {index}", "searchable body"),
+            )
+
+    # A bare (non-MATCH) query against an external-content FTS5 table is
+    # satisfied straight from the content table's rowids, not the FTS index --
+    # so it would read 7 here regardless of indexing state. `_docsize` is the
+    # SQLite-documented shadow table populated only by real writes into the
+    # fts5 table, so it is what actually reflects "nothing indexed yet".
+    assert db.conn.execute("SELECT COUNT(*) FROM subscription_items_fts_docsize").fetchone()[0] == 0
+
+    first = db.backfill_items_fts(chunk_size=3)
+    assert first == 3
+    total = first
+    while True:
+        indexed = db.backfill_items_fts(chunk_size=3)
+        if indexed == 0:
+            break
+        total += indexed
+    assert total == 7
+
+    assert db.conn.execute(
+        "SELECT COUNT(*) FROM subscription_items_fts WHERE subscription_items_fts MATCH ?",
+        ("searchable",),
+    ).fetchone()[0] == 7

--- a/Tests/DB/test_subscriptions_db_watchlists.py
+++ b/Tests/DB/test_subscriptions_db_watchlists.py
@@ -74,3 +74,43 @@ def test_schema_migration_is_idempotent(db):
     db._ensure_watchlists_schema()
     db._ensure_watchlists_schema()
     assert "watchlists" in _tables(db)
+
+
+def test_run_table_owned_by_db_with_batch_id(db):
+    # No service call needed — SubscriptionsDB owns this table now.
+    assert "local_watchlist_runs" in _tables(db)
+    assert "batch_id" in _columns(db, "local_watchlist_runs")
+
+
+def test_batch_id_added_to_preexisting_run_table(tmp_path):
+    import sqlite3
+
+    # A database created before batch_id existed, with the old table shape.
+    path = tmp_path / "legacy.db"
+    legacy_conn = sqlite3.connect(path)
+    legacy_conn.executescript("""
+        CREATE TABLE local_watchlist_runs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            source_id INTEGER NOT NULL,
+            job_id INTEGER,
+            status TEXT NOT NULL,
+            started_at TEXT,
+            finished_at TEXT,
+            stats_json TEXT,
+            error_msg TEXT,
+            log_text TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+    """)
+    legacy_conn.commit()
+    legacy_conn.close()
+
+    migrated = SubscriptionsDB(str(path), client_id="test")
+    assert "batch_id" in _columns(migrated, "local_watchlist_runs")
+
+
+def test_lazy_run_schema_helper_is_gone():
+    from tldw_chatbook.Subscriptions.local_watchlists_service import LocalWatchlistsService
+
+    assert not hasattr(LocalWatchlistsService, "_ensure_run_schema")

--- a/Tests/DB/test_subscriptions_db_watchlists.py
+++ b/Tests/DB/test_subscriptions_db_watchlists.py
@@ -199,3 +199,60 @@ def test_backfill_is_chunked_and_resumable(db):
         "SELECT COUNT(*) FROM subscription_items_fts WHERE subscription_items_fts MATCH ?",
         ("searchable",),
     ).fetchone()[0] == 7
+
+
+class _CountingConnection:
+    """Wraps a connection to count execute() calls."""
+
+    def __init__(self, inner):
+        self._inner = inner
+        self.execute_count = 0
+
+    def execute(self, *args, **kwargs):
+        self.execute_count += 1
+        return self._inner.execute(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
+def test_counts_bucket_by_watchlist_unassigned_and_all(db):
+    from tldw_chatbook.Subscriptions.watchlist_bundle_service import WatchlistBundleService
+
+    service = WatchlistBundleService(db)
+    morning = service.create("Morning")
+    security = service.create("Security")
+
+    shared = db.add_subscription(name="HN", type="rss", source="https://b.example/f")
+    lonely = db.add_subscription(name="Orphan", type="rss", source="https://c.example/f")
+
+    service.add_source(morning["id"], shared)
+    service.add_source(security["id"], shared)
+
+    _insert_item(db, shared, "https://b.example/1", "Shared unread", "body")
+    _insert_item(db, lonely, "https://c.example/1", "Orphan unread", "body")
+    with db.transaction() as conn:
+        conn.execute("UPDATE subscription_items SET status = 'reviewed' WHERE url = ?",
+                     ("https://c.example/1",))
+
+    counts = db.get_watchlist_item_counts()
+
+    assert counts[morning["id"]] == {"total": 1, "unread": 1}
+    assert counts[security["id"]] == {"total": 1, "unread": 1}
+    assert counts[-1] == {"total": 1, "unread": 0}   # Unassigned
+    assert counts[-2] == {"total": 2, "unread": 1}   # All sources
+
+
+def test_counts_use_a_single_query_regardless_of_watchlist_count(db, monkeypatch):
+    from tldw_chatbook.Subscriptions.watchlist_bundle_service import WatchlistBundleService
+
+    service = WatchlistBundleService(db)
+    for index in range(12):
+        service.create(f"List {index}")
+
+    counting = _CountingConnection(db.conn)
+    monkeypatch.setattr(type(db), "conn", property(lambda self: counting))
+
+    db.get_watchlist_item_counts()
+
+    assert counting.execute_count == 1

--- a/Tests/DB/test_subscriptions_db_watchlists.py
+++ b/Tests/DB/test_subscriptions_db_watchlists.py
@@ -201,6 +201,212 @@ def test_backfill_is_chunked_and_resumable(db):
     ).fetchone()[0] == 7
 
 
+def _drop_ai_trigger(db):
+    """Simulate a pre-existing (legacy) row: with no `_ai` trigger, a row
+    inserted afterwards is never written into the FTS index, exactly like a
+    row that already existed in `subscription_items` before this migration
+    ever ran on a real upgraded database."""
+    db.conn.execute("DROP TRIGGER subscription_items_fts_ai")
+    db.conn.commit()
+
+
+def test_update_of_unindexed_legacy_item_succeeds(db):
+    """Regression for Finding 1 (final review). Before the guard, `_au`'s
+    delete leg unconditionally fired 'delete' against `old.id` even when
+    that rowid was never in the FTS index -- illegal for an external-content
+    FTS5 table, so FTS5 rejected the whole UPDATE statement."""
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+    _drop_ai_trigger(db)
+    _insert_item(db, source_id, "https://a.example/1", "Legacy", "alpha content")
+
+    # Confirm the row really is unindexed first, or this test would pass
+    # vacuously.
+    assert db.conn.execute("SELECT COUNT(*) FROM subscription_items_fts_docsize").fetchone()[0] == 0
+
+    with db.transaction() as conn:
+        conn.execute(
+            "UPDATE subscription_items SET content = 'beta content' WHERE url = ?",
+            ("https://a.example/1",),
+        )
+
+    row = db.conn.execute(
+        "SELECT content FROM subscription_items WHERE url = ?", ("https://a.example/1",)
+    ).fetchone()
+    assert row["content"] == "beta content"
+    # The insert leg of `_au` stays unconditional, so the row is indexed now.
+    assert db.conn.execute(
+        "SELECT COUNT(*) FROM subscription_items_fts WHERE subscription_items_fts MATCH ?",
+        ("beta",),
+    ).fetchone()[0] == 1
+    # Raises DatabaseError if the FTS index is actually corrupt.
+    db.conn.execute("INSERT INTO subscription_items_fts(subscription_items_fts) VALUES ('integrity-check')")
+
+
+def test_delete_of_unindexed_legacy_item_succeeds(db):
+    """Regression for Finding 1 (final review). Same illegal-'delete' bug as
+    the UPDATE case, via `_ad` this time."""
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+    _drop_ai_trigger(db)
+    _insert_item(db, source_id, "https://a.example/1", "Legacy", "alpha content")
+
+    assert db.conn.execute("SELECT COUNT(*) FROM subscription_items_fts_docsize").fetchone()[0] == 0
+
+    with db.transaction() as conn:
+        conn.execute("DELETE FROM subscription_items WHERE url = ?", ("https://a.example/1",))
+
+    assert db.conn.execute("SELECT COUNT(*) FROM subscription_items").fetchone()[0] == 0
+    # Raises DatabaseError if the FTS index is actually corrupt.
+    db.conn.execute("INSERT INTO subscription_items_fts(subscription_items_fts) VALUES ('integrity-check')")
+
+
+def test_cascade_delete_of_parent_with_unindexed_items_succeeds(db):
+    """Regression for Finding 1 (final review). Deleting a source cascades
+    to its items via FK ON DELETE CASCADE, which fires `_ad` once per item --
+    all of them unindexed here, exercising the same guard at cascade scale."""
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+    _drop_ai_trigger(db)
+    _insert_item(db, source_id, "https://a.example/1", "Legacy 1", "alpha content")
+    _insert_item(db, source_id, "https://a.example/2", "Legacy 2", "beta content")
+
+    assert db.conn.execute("SELECT COUNT(*) FROM subscription_items_fts_docsize").fetchone()[0] == 0
+
+    with db.transaction() as conn:
+        conn.execute("DELETE FROM subscriptions WHERE id = ?", (source_id,))
+
+    assert db.conn.execute("SELECT COUNT(*) FROM subscription_items").fetchone()[0] == 0
+    # Raises DatabaseError if the FTS index is actually corrupt.
+    db.conn.execute("INSERT INTO subscription_items_fts(subscription_items_fts) VALUES ('integrity-check')")
+
+
+def test_fts_index_passes_integrity_check_after_mixed_mutations(db):
+    """The guard must only skip 'delete' for rows that were never indexed --
+    it must not corrupt the index for rows that legitimately are indexed and
+    are mutated in the same batch as an unindexed row being removed. fts5's
+    'integrity-check' command raises if the index and the external content
+    table disagree.
+
+    Note: unlike the three tests above, this scenario does not reproduce
+    Finding 1 against the pre-fix triggers -- FTS5 only rejects a 'delete'
+    command when the index has never been written to at all (fully virgin
+    docsize/segment state). Here the first `_insert_item` call (with `_ai`
+    still active) writes a real row first, so the index is no longer virgin
+    by the time the second, unindexed row is deleted, and even the unguarded
+    trigger treats that delete as a harmless no-op. This test exists as
+    belt-and-suspenders coverage for the guarded triggers, not as a
+    regression reproduction.
+    """
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+    _insert_item(db, source_id, "https://a.example/indexed", "Indexed", "alpha content")
+
+    _drop_ai_trigger(db)
+    _insert_item(db, source_id, "https://a.example/legacy", "Legacy", "beta content")
+
+    with db.transaction() as conn:
+        conn.execute(
+            "UPDATE subscription_items SET content = 'alpha updated' WHERE url = ?",
+            ("https://a.example/indexed",),
+        )
+        conn.execute("DELETE FROM subscription_items WHERE url = ?", ("https://a.example/legacy",))
+
+    # Raises DatabaseError if the FTS index is actually corrupt.
+    db.conn.execute("INSERT INTO subscription_items_fts(subscription_items_fts) VALUES ('integrity-check')")
+
+
+def test_backfill_converges_after_guarded_delete_skips_legacy_row(db):
+    """Regression for Finding 1 (final review). A guarded, skipped delete
+    must not disturb `_docsize` bookkeeping for the rows that remain -- a
+    later `backfill_items_fts` call must still index them and converge."""
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+    _drop_ai_trigger(db)
+    _insert_item(db, source_id, "https://a.example/keep", "Keep", "alpha content")
+    _insert_item(db, source_id, "https://a.example/gone", "Gone", "beta content")
+
+    with db.transaction() as conn:
+        conn.execute("DELETE FROM subscription_items WHERE url = ?", ("https://a.example/gone",))
+
+    assert db.conn.execute("SELECT COUNT(*) FROM subscription_items_fts_docsize").fetchone()[0] == 0
+
+    indexed = db.backfill_items_fts(chunk_size=10)
+    assert indexed == 1
+    assert db.backfill_items_fts(chunk_size=10) == 0
+    assert db.conn.execute(
+        "SELECT COUNT(*) FROM subscription_items_fts WHERE subscription_items_fts MATCH ?",
+        ("alpha",),
+    ).fetchone()[0] == 1
+
+
+def test_backfill_rejects_non_positive_chunk_size(db):
+    """Regression for Finding 3 (final review). `LIMIT 0` silently returns
+    zero rows, so a non-positive chunk_size would make this method report
+    "0 remaining" (complete) while a real backlog remains."""
+    with pytest.raises(ValueError):
+        db.backfill_items_fts(chunk_size=0)
+    with pytest.raises(ValueError):
+        db.backfill_items_fts(chunk_size=-5)
+
+
+def test_guarded_triggers_replace_old_unguarded_ones_in_place(tmp_path):
+    """Regression for Finding 1's migration concern (final review).
+
+    Both `_ad` and `_au` were created with `CREATE TRIGGER IF NOT EXISTS` on
+    an earlier version of this branch, without the index-membership guard.
+    A database that already opened under that code has those old, unguarded
+    trigger bodies on disk. `IF NOT EXISTS` would silently keep them in
+    place forever -- the fix must `DROP TRIGGER IF EXISTS` first so the next
+    open actually replaces them, not just skip because a same-named trigger
+    already exists.
+
+    Rather than hand-authoring an entire legacy schema, build a real,
+    fully-migrated database with the current code, then downgrade just the
+    two FTS triggers back to their old, unguarded bodies -- reproducing
+    exactly the state Finding 1 describes: a database on which this branch's
+    migration has already run once, before this fix existed.
+    """
+    path = tmp_path / "already_ran_unguarded_triggers.db"
+    db = SubscriptionsDB(str(path), client_id="setup")
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+
+    _drop_ai_trigger(db)
+    _insert_item(db, source_id, "https://a.example/1", "Legacy", "alpha content")
+
+    db.conn.executescript("""
+        DROP TRIGGER subscription_items_fts_ad;
+        DROP TRIGGER subscription_items_fts_au;
+        -- The old, unguarded trigger bodies -- exactly what shipped before
+        -- this fix.
+        CREATE TRIGGER subscription_items_fts_ad
+        AFTER DELETE ON subscription_items BEGIN
+            INSERT INTO subscription_items_fts(subscription_items_fts, rowid, title, content, author)
+            VALUES ('delete', old.id, old.title, old.content, old.author);
+        END;
+        CREATE TRIGGER subscription_items_fts_au
+        AFTER UPDATE ON subscription_items BEGIN
+            INSERT INTO subscription_items_fts(subscription_items_fts, rowid, title, content, author)
+            VALUES ('delete', old.id, old.title, old.content, old.author);
+            INSERT INTO subscription_items_fts(rowid, title, content, author)
+            VALUES (new.id, new.title, new.content, new.author);
+        END;
+    """)
+    db.conn.commit()
+
+    # Reopen: this is the "next open" the finding describes.
+    migrated = SubscriptionsDB(str(path), client_id="test")
+
+    # If DROP TRIGGER IF EXISTS were missing, this open would have kept the
+    # old bodies (CREATE TRIGGER IF NOT EXISTS is a no-op when the name
+    # already exists), and this UPDATE would raise
+    # sqlite3.DatabaseError: database disk image is malformed.
+    with migrated.transaction() as conn:
+        conn.execute(
+            "UPDATE subscription_items SET content = 'beta content' WHERE url = ?",
+            ("https://a.example/1",),
+        )
+
+    assert migrated.conn.execute(
+        "SELECT content FROM subscription_items WHERE url = ?", ("https://a.example/1",)
+    ).fetchone()[0] == "beta content"
+
+
 class _CountingConnection:
     """Wraps a connection to count execute() calls."""
 

--- a/Tests/DB/test_subscriptions_db_watchlists.py
+++ b/Tests/DB/test_subscriptions_db_watchlists.py
@@ -84,27 +84,30 @@ def test_run_table_owned_by_db_with_batch_id(db):
 
 def test_batch_id_added_to_preexisting_run_table(tmp_path):
     import sqlite3
+    from contextlib import closing
 
     # A database created before batch_id existed, with the old table shape.
+    # `sqlite3.connect(...)` used as a context manager only wraps a
+    # transaction, not the connection's lifetime -- `closing()` is what
+    # actually guarantees `.close()` runs.
     path = tmp_path / "legacy.db"
-    legacy_conn = sqlite3.connect(path)
-    legacy_conn.executescript("""
-        CREATE TABLE local_watchlist_runs (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            source_id INTEGER NOT NULL,
-            job_id INTEGER,
-            status TEXT NOT NULL,
-            started_at TEXT,
-            finished_at TEXT,
-            stats_json TEXT,
-            error_msg TEXT,
-            log_text TEXT,
-            created_at TEXT NOT NULL,
-            updated_at TEXT NOT NULL
-        );
-    """)
-    legacy_conn.commit()
-    legacy_conn.close()
+    with closing(sqlite3.connect(path)) as legacy_conn:
+        legacy_conn.executescript("""
+            CREATE TABLE local_watchlist_runs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                source_id INTEGER NOT NULL,
+                job_id INTEGER,
+                status TEXT NOT NULL,
+                started_at TEXT,
+                finished_at TEXT,
+                stats_json TEXT,
+                error_msg TEXT,
+                log_text TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+        """)
+        legacy_conn.commit()
 
     migrated = SubscriptionsDB(str(path), client_id="test")
     assert "batch_id" in _columns(migrated, "local_watchlist_runs")

--- a/Tests/DB/test_subscriptions_db_watchlists.py
+++ b/Tests/DB/test_subscriptions_db_watchlists.py
@@ -243,6 +243,34 @@ def test_counts_bucket_by_watchlist_unassigned_and_all(db):
     assert counts[-2] == {"total": 2, "unread": 1}   # All sources
 
 
+def test_counts_include_watchlist_with_no_sources(db):
+    """A freshly created watchlist has no sources at all yet, but must still
+    appear in the tree (as all zeros) rather than being absent."""
+    from tldw_chatbook.Subscriptions.watchlist_bundle_service import WatchlistBundleService
+
+    service = WatchlistBundleService(db)
+    empty = service.create("Empty")
+
+    counts = db.get_watchlist_item_counts()
+
+    assert counts[empty["id"]] == {"total": 0, "unread": 0}
+
+
+def test_counts_include_watchlist_with_sources_but_no_items(db):
+    """A watchlist can have a source attached before that source has ever
+    produced any items -- it must still report zeros, not be missing."""
+    from tldw_chatbook.Subscriptions.watchlist_bundle_service import WatchlistBundleService
+
+    service = WatchlistBundleService(db)
+    quiet = service.create("Quiet")
+    source = db.add_subscription(name="Quiet Feed", type="rss", source="https://d.example/f")
+    service.add_source(quiet["id"], source)
+
+    counts = db.get_watchlist_item_counts()
+
+    assert counts[quiet["id"]] == {"total": 0, "unread": 0}
+
+
 def test_counts_use_a_single_query_regardless_of_watchlist_count(db, monkeypatch):
     from tldw_chatbook.Subscriptions.watchlist_bundle_service import WatchlistBundleService
 

--- a/Tests/DB/test_subscriptions_db_watchlists.py
+++ b/Tests/DB/test_subscriptions_db_watchlists.py
@@ -1,0 +1,76 @@
+import pytest
+
+from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SubscriptionsDB(str(tmp_path / "subs.db"), client_id="test")
+
+
+def _columns(db, table):
+    cursor = db.conn.cursor()
+    return {row[1] for row in cursor.execute(f"PRAGMA table_info({table})")}
+
+
+def _tables(db):
+    cursor = db.conn.cursor()
+    return {
+        row[0]
+        for row in cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+
+
+def test_watchlist_tables_created(db):
+    tables = _tables(db)
+    assert "watchlists" in tables
+    assert "watchlist_sources" in tables
+    assert "watchlist_migration_state" in tables
+
+
+def test_item_content_columns_created(db):
+    cols = _columns(db, "subscription_items")
+    assert "content" in cols
+    assert "content_format" in cols
+    assert "content_kind" in cols
+    assert "is_flagged" in cols
+
+
+def test_membership_cascades_on_source_delete(db):
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+    with db.transaction() as conn:
+        conn.execute("INSERT INTO watchlists (name) VALUES ('Morning')")
+        watchlist_id = conn.execute("SELECT id FROM watchlists").fetchone()[0]
+        conn.execute(
+            "INSERT INTO watchlist_sources (watchlist_id, subscription_id) VALUES (?, ?)",
+            (watchlist_id, source_id),
+        )
+
+    with db.transaction() as conn:
+        conn.execute("DELETE FROM subscriptions WHERE id = ?", (source_id,))
+
+    remaining = db.conn.execute("SELECT COUNT(*) FROM watchlist_sources").fetchone()[0]
+    assert remaining == 0
+
+
+def test_membership_cascades_on_watchlist_delete(db):
+    source_id = db.add_subscription(name="HN", type="rss", source="https://b.example/f")
+    with db.transaction() as conn:
+        conn.execute("INSERT INTO watchlists (name) VALUES ('Security')")
+        watchlist_id = conn.execute("SELECT id FROM watchlists").fetchone()[0]
+        conn.execute(
+            "INSERT INTO watchlist_sources (watchlist_id, subscription_id) VALUES (?, ?)",
+            (watchlist_id, source_id),
+        )
+        conn.execute("DELETE FROM watchlists WHERE id = ?", (watchlist_id,))
+
+    remaining = db.conn.execute("SELECT COUNT(*) FROM watchlist_sources").fetchone()[0]
+    assert remaining == 0
+    # The source itself survives — only membership is removed.
+    assert db.conn.execute("SELECT COUNT(*) FROM subscriptions").fetchone()[0] == 1
+
+
+def test_schema_migration_is_idempotent(db):
+    db._ensure_watchlists_schema()
+    db._ensure_watchlists_schema()
+    assert "watchlists" in _tables(db)

--- a/Tests/Subscriptions/test_item_persist.py
+++ b/Tests/Subscriptions/test_item_persist.py
@@ -51,6 +51,40 @@ def test_persists_full_column_set(db, source_id):
     assert row[9] == "content"
 
 
+def test_returns_the_real_row_id_on_upsert_not_lastrowid(db, source_id):
+    """Regression for fix round 2.
+
+    ``cursor.lastrowid`` reflects the last genuine INSERT on the
+    *connection*, not the row an ``ON CONFLICT ... DO UPDATE`` actually
+    touched. Insert A, then insert B (B is now the connection's
+    lastrowid), then re-upsert A: the returned id must be A's, not B's.
+    This is reachable in production because ``_upsert_subscription_items``
+    never sets ``canonical_url``, so when the same item later round-trips
+    through ``_add_subscription_item`` (whose guard compares against
+    ``canonical_url``), the guard's NULL comparison never matches, falls
+    through, and the upsert resolves as an UPDATE on a row that is not the
+    most recently inserted one on that connection.
+    """
+    item_a = {"url": "https://a.example/1", "title": "A", "content_hash": "h1", "content": "a"}
+    item_b = {"url": "https://a.example/2", "title": "B", "content_hash": "h2", "content": "b"}
+    with db.transaction() as conn:
+        id_a = persist_subscription_item(conn, source_id, item_a, run_id=1, now="2026-07-25T00:00:00Z")
+        id_b = persist_subscription_item(conn, source_id, item_b, run_id=1, now="2026-07-25T00:00:00Z")
+        assert id_b != id_a  # sanity: two distinct rows exist
+
+        reupsert_id = persist_subscription_item(
+            conn, source_id, item_a, run_id=2, now="2026-07-25T01:00:00Z"
+        )
+
+    assert reupsert_id == id_a
+    assert reupsert_id != id_b
+
+    row = db.conn.execute(
+        "SELECT id FROM subscription_items WHERE url = ?", ("https://a.example/1",)
+    ).fetchone()
+    assert row[0] == id_a
+
+
 @pytest.mark.parametrize("preserved_status", ["reviewed", "ignored", "ingested"])
 def test_upsert_preserves_status_from_user_action(db, source_id, preserved_status):
     """Regression for fix round 1, Finding 2.

--- a/Tests/Subscriptions/test_item_persist.py
+++ b/Tests/Subscriptions/test_item_persist.py
@@ -51,18 +51,48 @@ def test_persists_full_column_set(db, source_id):
     assert row[9] == "content"
 
 
-def test_upsert_preserves_reviewed_status(db, source_id):
+@pytest.mark.parametrize("preserved_status", ["reviewed", "ignored", "ingested"])
+def test_upsert_preserves_status_from_user_action(db, source_id, preserved_status):
+    """Regression for fix round 1, Finding 2.
+
+    ``reviewed``, ``ignored``, and ``ingested`` are all set by a deliberate
+    user action on the item (see Event_Handlers/subscription_events.py for
+    the accept/ignore/review actions). Because execute_run re-upserts every
+    kept item on every poll, an unchanged item must not silently flip back
+    to ``new`` and resurface as unread just because a scheduled re-fetch
+    happened to touch the row.
+    """
     item = {"url": "https://a.example/1", "title": "T", "content_hash": "h", "content": "body"}
     with db.transaction() as conn:
         persist_subscription_item(conn, source_id, item, run_id=1, now="2026-07-25T00:00:00Z")
-        conn.execute("UPDATE subscription_items SET status = 'reviewed' WHERE url = ?",
-                     ("https://a.example/1",))
+        conn.execute(
+            "UPDATE subscription_items SET status = ? WHERE url = ?",
+            (preserved_status, "https://a.example/1"),
+        )
         persist_subscription_item(conn, source_id, item, run_id=2, now="2026-07-25T01:00:00Z")
 
     row = db.conn.execute(
         "SELECT status, run_id FROM subscription_items WHERE url = ?", ("https://a.example/1",)
     ).fetchone()
-    assert row[0] == "reviewed"
+    assert row[0] == preserved_status
+    assert row[1] == 2
+
+
+def test_upsert_resets_error_status_to_new(db, source_id):
+    """``error`` is not a user action -- a successful re-fetch should clear it."""
+    item = {"url": "https://a.example/1", "title": "T", "content_hash": "h", "content": "body"}
+    with db.transaction() as conn:
+        persist_subscription_item(conn, source_id, item, run_id=1, now="2026-07-25T00:00:00Z")
+        conn.execute(
+            "UPDATE subscription_items SET status = 'error' WHERE url = ?",
+            ("https://a.example/1",),
+        )
+        persist_subscription_item(conn, source_id, item, run_id=2, now="2026-07-25T01:00:00Z")
+
+    row = db.conn.execute(
+        "SELECT status, run_id FROM subscription_items WHERE url = ?", ("https://a.example/1",)
+    ).fetchone()
+    assert row[0] == "new"
     assert row[1] == 2
 
 

--- a/Tests/Subscriptions/test_item_persist.py
+++ b/Tests/Subscriptions/test_item_persist.py
@@ -51,6 +51,56 @@ def test_persists_full_column_set(db, source_id):
     assert row[9] == "content"
 
 
+def test_empty_containers_persist_as_null_not_empty_json(db, source_id):
+    """Regression for the unification finding (fix round 3).
+
+    The old DB-side path used truthiness (``if item.get("categories")``),
+    so an empty list stored ``NULL``. The old service-side path used
+    ``is not None``, so an empty list stored the string ``"[]"``. The
+    unified helper must keep the conservative (DB-side) behavior --
+    storing ``"[]"`` would make ``AggregationEngine._parse_categories``
+    (which treats any string as comma-separated) manufacture a phantom
+    ``["[]"]`` category.
+    """
+    item = {
+        "url": "https://a.example/1",
+        "title": "T",
+        "content_hash": "h",
+        "content": "body",
+        "categories": [],
+        "enclosures": [],
+    }
+    with db.transaction() as conn:
+        persist_subscription_item(conn, source_id, item, run_id=1, now="2026-07-25T00:00:00Z")
+
+    row = db.conn.execute(
+        "SELECT categories, enclosures FROM subscription_items WHERE url = ?",
+        ("https://a.example/1",),
+    ).fetchone()
+    assert row[0] is None
+    assert row[1] is None
+
+
+def test_non_empty_containers_still_round_trip_as_json(db, source_id):
+    item = {
+        "url": "https://a.example/1",
+        "title": "T",
+        "content_hash": "h",
+        "content": "body",
+        "categories": ["ai", "rag"],
+        "enclosures": [{"url": "https://a.example/audio.mp3"}],
+    }
+    with db.transaction() as conn:
+        persist_subscription_item(conn, source_id, item, run_id=1, now="2026-07-25T00:00:00Z")
+
+    row = db.conn.execute(
+        "SELECT categories, enclosures FROM subscription_items WHERE url = ?",
+        ("https://a.example/1",),
+    ).fetchone()
+    assert row[0] == '["ai", "rag"]'
+    assert row[1] == '[{"url": "https://a.example/audio.mp3"}]'
+
+
 def test_returns_the_real_row_id_on_upsert_not_lastrowid(db, source_id):
     """Regression for fix round 2.
 

--- a/Tests/Subscriptions/test_item_persist.py
+++ b/Tests/Subscriptions/test_item_persist.py
@@ -1,0 +1,79 @@
+import pytest
+
+from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
+from tldw_chatbook.Subscriptions.item_persist import persist_subscription_item
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SubscriptionsDB(str(tmp_path / "subs.db"), client_id="test")
+
+
+@pytest.fixture
+def source_id(db):
+    return db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+
+
+def test_persists_full_column_set(db, source_id):
+    item = {
+        "url": "https://a.example/1",
+        "title": "RAG Evaluation",
+        "content": "retrieval quality rubric",
+        "content_kind": "article",
+        "content_format": "text",
+        "content_hash": "hash-1",
+        "author": "A. Author",
+        "canonical_url": "https://a.example/1",
+        "change_percentage": 12.5,
+        "diff_summary": "+2 -1",
+        "change_type": "content",
+        "alert_matches": [7],
+    }
+    with db.transaction() as conn:
+        persist_subscription_item(conn, source_id, item, run_id=42, now="2026-07-25T00:00:00Z")
+
+    row = db.conn.execute(
+        "SELECT content, content_kind, content_format, status, run_id, alert_matches, "
+        "canonical_url, change_percentage, diff_summary, change_type "
+        "FROM subscription_items WHERE url = ?",
+        ("https://a.example/1",),
+    ).fetchone()
+
+    assert row[0] == "retrieval quality rubric"
+    assert row[1] == "article"
+    assert row[2] == "text"
+    assert row[3] == "new"
+    assert row[4] == 42
+    assert row[5] == "[7]"
+    assert row[6] == "https://a.example/1"
+    assert row[7] == 12.5
+    assert row[8] == "+2 -1"
+    assert row[9] == "content"
+
+
+def test_upsert_preserves_reviewed_status(db, source_id):
+    item = {"url": "https://a.example/1", "title": "T", "content_hash": "h", "content": "body"}
+    with db.transaction() as conn:
+        persist_subscription_item(conn, source_id, item, run_id=1, now="2026-07-25T00:00:00Z")
+        conn.execute("UPDATE subscription_items SET status = 'reviewed' WHERE url = ?",
+                     ("https://a.example/1",))
+        persist_subscription_item(conn, source_id, item, run_id=2, now="2026-07-25T01:00:00Z")
+
+    row = db.conn.execute(
+        "SELECT status, run_id FROM subscription_items WHERE url = ?", ("https://a.example/1",)
+    ).fetchone()
+    assert row[0] == "reviewed"
+    assert row[1] == 2
+
+
+def test_rejects_invalid_kind_format_pairing(db, source_id):
+    item = {
+        "url": "https://a.example/1",
+        "title": "T",
+        "content_hash": "h",
+        "content_kind": "change",
+        "content_format": "markdown",
+    }
+    with pytest.raises(ValueError, match="content_kind"):
+        with db.transaction() as conn:
+            persist_subscription_item(conn, source_id, item, run_id=1, now="2026-07-25T00:00:00Z")

--- a/Tests/Subscriptions/test_watchlist_bundle_service.py
+++ b/Tests/Subscriptions/test_watchlist_bundle_service.py
@@ -79,6 +79,20 @@ def test_delete_removes_membership_but_not_sources(service, db):
     ).fetchone()[0] == 0
 
 
+def test_list_watchlists_limit_actually_limits(service):
+    for index in range(5):
+        service.create(f"List {index}")
+
+    limited = service.list_watchlists(limit=2)
+    assert len(limited) == 2
+
+    all_of_them = service.list_watchlists()
+    assert len(all_of_them) == 5
+
+    offset_page = service.list_watchlists(limit=2, offset=2)
+    assert [row["name"] for row in offset_page] == [row["name"] for row in all_of_them[2:4]]
+
+
 def test_create_rejects_blank_name(service):
     with pytest.raises(ValueError, match="cannot be empty or whitespace-only"):
         service.create("   ")

--- a/Tests/Subscriptions/test_watchlist_bundle_service.py
+++ b/Tests/Subscriptions/test_watchlist_bundle_service.py
@@ -71,3 +71,38 @@ def test_delete_removes_membership_but_not_sources(service, db):
 
     assert service.list_watchlists() == []
     assert db.conn.execute("SELECT COUNT(*) FROM subscriptions").fetchone()[0] == 1
+    # Verify cascade delete: membership row should be gone
+    assert service.list_sources(watchlist["id"]) == []
+    assert db.conn.execute(
+        "SELECT COUNT(*) FROM watchlist_sources WHERE watchlist_id = ?",
+        (watchlist["id"],)
+    ).fetchone()[0] == 0
+
+
+def test_create_rejects_blank_name(service):
+    with pytest.raises(ValueError, match="cannot be empty or whitespace-only"):
+        service.create("   ")
+
+    with pytest.raises(ValueError, match="cannot be empty or whitespace-only"):
+        service.create("")
+
+
+def test_rename_rejects_blank_name(service):
+    watchlist = service.create("Security")
+    with pytest.raises(ValueError, match="cannot be empty or whitespace-only"):
+        service.rename(watchlist["id"], "   ")
+
+    with pytest.raises(ValueError, match="cannot be empty or whitespace-only"):
+        service.rename(watchlist["id"], "")
+
+
+def test_rename_to_own_exact_name_has_no_suffix(service):
+    watchlist = service.create("Security")
+    renamed = service.rename(watchlist["id"], "Security")
+    assert renamed["name"] == "Security"
+
+
+def test_rename_to_own_case_variant_has_no_suffix(service):
+    watchlist = service.create("Security")
+    renamed = service.rename(watchlist["id"], "security")
+    assert renamed["name"] == "security"

--- a/Tests/Subscriptions/test_watchlist_bundle_service.py
+++ b/Tests/Subscriptions/test_watchlist_bundle_service.py
@@ -106,3 +106,52 @@ def test_rename_to_own_case_variant_has_no_suffix(service):
     watchlist = service.create("Security")
     renamed = service.rename(watchlist["id"], "security")
     assert renamed["name"] == "security"
+
+
+MIGRATION_KEY = "folders_to_watchlists"
+
+
+def test_migrate_folders_groups_by_folder(service, db):
+    first = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f",
+                                folder="Research")
+    second = db.add_subscription(name="HN", type="rss", source="https://b.example/f",
+                                 folder="Research")
+    third = db.add_subscription(name="Krebs", type="rss", source="https://c.example/f",
+                                folder="Security")
+
+    assert service.migrate_folders() is True
+
+    names = {row["name"] for row in service.list_watchlists()}
+    assert names == {"Research", "Security"}
+
+    by_name = {row["name"]: row["id"] for row in service.list_watchlists()}
+    assert sorted(service.list_sources(by_name["Research"])) == sorted([first, second])
+    assert service.list_sources(by_name["Security"]) == [third]
+
+
+def test_migrate_folders_puts_folderless_sources_in_unsorted(service, db):
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+
+    service.migrate_folders()
+
+    by_name = {row["name"]: row["id"] for row in service.list_watchlists()}
+    assert "Unsorted" in by_name
+    assert service.list_sources(by_name["Unsorted"]) == [source_id]
+
+
+def test_migrate_folders_runs_once(service, db):
+    db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f", folder="Research")
+
+    assert service.migrate_folders() is True
+    assert service.migrate_folders() is False
+    assert len(service.list_watchlists()) == 1
+
+    marker = db.conn.execute(
+        "SELECT COUNT(*) FROM watchlist_migration_state WHERE key = ?", (MIGRATION_KEY,)
+    ).fetchone()[0]
+    assert marker == 1
+
+
+def test_migrate_folders_is_noop_with_no_sources(service):
+    assert service.migrate_folders() is True
+    assert service.list_watchlists() == []

--- a/Tests/Subscriptions/test_watchlist_bundle_service.py
+++ b/Tests/Subscriptions/test_watchlist_bundle_service.py
@@ -1,0 +1,73 @@
+import pytest
+
+from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
+from tldw_chatbook.Subscriptions.watchlist_bundle_service import WatchlistBundleService
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SubscriptionsDB(str(tmp_path / "subs.db"), client_id="test")
+
+
+@pytest.fixture
+def service(db):
+    return WatchlistBundleService(db)
+
+
+def test_create_and_list(service):
+    created = service.create("Morning AI Brief", tags=["ai", "daily"])
+    assert created["name"] == "Morning AI Brief"
+    assert created["tags"] == ["ai", "daily"]
+
+    listed = service.list_watchlists()
+    assert [row["name"] for row in listed] == ["Morning AI Brief"]
+
+
+def test_name_collision_is_case_insensitive_and_suffixes(service):
+    service.create("Unsorted")
+    second = service.create("unsorted")
+    third = service.create("UNSORTED")
+    assert second["name"] == "unsorted (2)"
+    assert third["name"] == "UNSORTED (3)"
+
+
+def test_rename_also_avoids_collision(service):
+    service.create("Security")
+    other = service.create("Papers")
+    renamed = service.rename(other["id"], "security")
+    assert renamed["name"] == "security (2)"
+
+
+def test_membership_add_remove_and_idempotent_add(service, db):
+    watchlist = service.create("Morning")
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+
+    service.add_source(watchlist["id"], source_id)
+    service.add_source(watchlist["id"], source_id)  # idempotent
+    assert service.list_sources(watchlist["id"]) == [source_id]
+
+    service.remove_source(watchlist["id"], source_id)
+    assert service.list_sources(watchlist["id"]) == []
+
+
+def test_source_can_belong_to_multiple_watchlists(service, db):
+    first = service.create("Morning")
+    second = service.create("Security")
+    source_id = db.add_subscription(name="HN", type="rss", source="https://b.example/f")
+
+    service.add_source(first["id"], source_id)
+    service.add_source(second["id"], source_id)
+
+    assert service.list_sources(first["id"]) == [source_id]
+    assert service.list_sources(second["id"]) == [source_id]
+
+
+def test_delete_removes_membership_but_not_sources(service, db):
+    watchlist = service.create("Morning")
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+    service.add_source(watchlist["id"], source_id)
+
+    service.delete(watchlist["id"])
+
+    assert service.list_watchlists() == []
+    assert db.conn.execute("SELECT COUNT(*) FROM subscriptions").fetchone()[0] == 1

--- a/backlog/tasks/task-688 - Wire-backfill_items_fts-so-pre-existing-items-become-searchable.md
+++ b/backlog/tasks/task-688 - Wire-backfill_items_fts-so-pre-existing-items-become-searchable.md
@@ -1,0 +1,36 @@
+---
+id: TASK-688
+title: >-
+  Wire backfill_items_fts so pre-existing items become searchable
+status: To Do
+assignee: []
+created_date: '2026-07-25 22:05'
+labels:
+  - watchlists
+  - followup
+  - blocks-phase-b
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Phase A (PR #917) added an FTS5 index over subscription_items plus SubscriptionsDB.backfill_items_fts(chunk_size), a chunked and resumable backfill that returns the number of rows indexed and 0 when complete. Nothing calls it — verified: the only reference in tldw_chatbook/ is its own definition.
+
+The index is created empty over a table that may already hold rows, and only the insert/update triggers populate it going forward. So every item a user scraped before upgrading is absent from the index permanently, and Phase C's search returns nothing for their entire back catalogue while appearing to work.
+
+Wiring was deliberately deferred at the final Phase A review so that phase could stay data-layer only (no app.py or UI changes). This is the task that closes it, and it blocks Phase B from claiming search works.
+
+Related: the same missing-index condition was also behind the Phase A Critical where FTS delete triggers rejected mutations of un-indexed rows. That is fixed independently (the delete legs are membership-guarded), so un-indexed rows are now merely unsearchable rather than fatal — but they stay unsearchable until this runs.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Items that existed before the FTS index was created become searchable without any user action
+- [ ] #2 The backfill runs off the UI thread and never blocks app startup or screen mount, on a database with a large subscription_items table
+- [ ] #3 An interrupted backfill resumes where it left off rather than restarting
+- [ ] #4 The backfill is idempotent — running it again after completion indexes nothing and does not corrupt the index (FTS integrity-check stays clean)
+- [ ] #5 Progress is observable to the user, or at minimum logged, rather than being silently in-flight
+- [ ] #6 A test covers the upgrade path end to end: a database with pre-existing un-indexed items becomes fully searchable after the wired path runs
+<!-- AC:END -->

--- a/backlog/tasks/task-689 - SubscriptionsDB-in-memory-is-non-functional-breaking-source-Preview.md
+++ b/backlog/tasks/task-689 - SubscriptionsDB-in-memory-is-non-functional-breaking-source-Preview.md
@@ -1,0 +1,40 @@
+---
+id: TASK-689
+title: >-
+  SubscriptionsDB(":memory:") is non-functional, breaking source Preview
+status: To Do
+assignee: []
+created_date: '2026-07-25 22:05'
+labels:
+  - watchlists
+  - bug
+  - followup
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+SubscriptionsDB(":memory:") returns an object whose connection has no tables at all. _initialize_schema builds the schema inside `with closing(self._get_connection()) as conn:` — a connection that is closed immediately afterwards — while the thread-local `.conn` property later opens a *separate* :memory: connection, which in SQLite is an entirely different, empty database.
+
+Verified directly:
+
+    tables visible on .conn: []
+    add_subscription: OperationalError: no such table: subscriptions
+
+WatchlistPreviewService.preview() (watchlist_preview_service.py:32) deliberately constructs one — "Use a throw-away in-memory DB so URL snapshots are not persisted" — and the execute path it drives calls db.record_check_result / record_check_error, both of which write to tables. So source Preview / dry-run is very likely broken in production. Its single existing test passes only because it never reaches those calls.
+
+Found while implementing Phase A (PR #917); pre-existing and orthogonal to that work, so it was left out of scope there. It matters for the rebuild because the Phase C Inspector has a Preview action that depends on this path working.
+
+Second, compounding issue for whoever fixes this: Phase A enabled foreign-key enforcement on every SubscriptionsDB connection. watchlist_preview_service.py:57 uses a synthetic subscription id of -1, so once the schema actually exists, any preview write referencing that id will raise IntegrityError. The fix must seed a real parent row or keep preview writes out of FK-bearing tables.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 SubscriptionsDB(":memory:") returns a usable database — the schema is visible on the connection callers actually use
+- [ ] #2 A regression test asserts the tables exist and a basic write succeeds against an in-memory instance
+- [ ] #3 WatchlistPreviewService.preview() completes successfully against a real source config, end to end, without raising
+- [ ] #4 The synthetic subscription id used by preview no longer violates foreign-key enforcement
+- [ ] #5 Preview still persists nothing to the user's real database — the isolation the in-memory DB was chosen for is preserved
+<!-- AC:END -->

--- a/backlog/tasks/task-690 - Relocate-local_watchlist_alert_rules-out-of-lazy-service-creation.md
+++ b/backlog/tasks/task-690 - Relocate-local_watchlist_alert_rules-out-of-lazy-service-creation.md
@@ -1,0 +1,35 @@
+---
+id: TASK-690
+title: >-
+  Relocate local_watchlist_alert_rules out of lazy service-side creation
+status: To Do
+assignee: []
+created_date: '2026-07-25 22:05'
+labels:
+  - watchlists
+  - followup
+  - tech-debt
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+local_watchlist_alert_rules is still created lazily by LocalWatchlistsService._ensure_alert_rule_schema (local_watchlists_service.py:958-976), called from six places. It declares a foreign key to subscriptions.
+
+Phase A (PR #917) established the constraint that all schema lives in SubscriptionsDB — table creation in _initialize_schema, additive migration in _ensure_watchlists_schema — and no table is created lazily from a service. Task 2 of that plan relocated local_watchlist_runs for exactly this reason: a lazily-created table cannot be safely ALTERed by a migration, because on a fresh database the migration runs before the table exists.
+
+local_watchlist_alert_rules was deliberately left out of scope to keep that task bounded. This is the same treatment, applied to the last remaining lazily-created table in this module.
+
+Do it before anything needs to add a column to that table, not after — that ordering is what forced the workaround-then-refactor sequence the first time.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 local_watchlist_alert_rules is created by SubscriptionsDB._initialize_schema, not by a service
+- [ ] #2 LocalWatchlistsService._ensure_alert_rule_schema and all six of its call sites are removed
+- [ ] #3 A migration adds the table to databases that predate the relocation, and is idempotent across fresh, already-migrated, and legacy databases
+- [ ] #4 Existing alert-rule behaviour is unchanged — the Subscriptions and Watchlists suites pass with no new failures
+- [ ] #5 No table in tldw_chatbook/Subscriptions/ is created lazily from a service any more
+<!-- AC:END -->

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -374,6 +374,67 @@ class SubscriptionsDB(BaseDB):
         # Indexes
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_subscription_items_run_id ON subscription_items(run_id)")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_subscription_items_queued ON subscription_items(queued_for_briefing, status)")
+
+        # Reader/body columns. `content` holds the renderable body: article text
+        # for feed items, diff text for site changes. `url_snapshots` remains the
+        # authority for full-page and previous-snapshot views.
+        if "content" not in items_cols:
+            cursor.execute("ALTER TABLE subscription_items ADD COLUMN content TEXT")
+        if "content_format" not in items_cols:
+            cursor.execute("ALTER TABLE subscription_items ADD COLUMN content_format TEXT")
+        if "content_kind" not in items_cols:
+            cursor.execute("ALTER TABLE subscription_items ADD COLUMN content_kind TEXT")
+        # Flag is a separate boolean, not a status: the status CHECK has no
+        # 'flagged' value, and an item can be flagged *and* reviewed at once.
+        if "is_flagged" not in items_cols:
+            cursor.execute("ALTER TABLE subscription_items ADD COLUMN is_flagged BOOLEAN DEFAULT 0")
+
+        # Watchlist bundle entity. `name` is intentionally not UNIQUE — uniqueness
+        # is enforced case-insensitively in WatchlistBundleService with
+        # auto-suffixing, because a SQL constraint would raise mid-migration.
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS watchlists (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                description TEXT,
+                tags TEXT,
+                is_active BOOLEAN DEFAULT 1,
+                sort_order INTEGER DEFAULT 0,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS watchlist_sources (
+                watchlist_id    INTEGER NOT NULL REFERENCES watchlists(id)     ON DELETE CASCADE,
+                subscription_id INTEGER NOT NULL REFERENCES subscriptions(id)  ON DELETE CASCADE,
+                added_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (watchlist_id, subscription_id)
+            )
+        """)
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_watchlist_sources_subscription "
+            "ON watchlist_sources(subscription_id)"
+        )
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_subscription_items_flagged "
+            "ON subscription_items(is_flagged, status)"
+        )
+        cursor.execute("""
+            CREATE TRIGGER IF NOT EXISTS update_watchlists_timestamp
+            AFTER UPDATE ON watchlists
+            BEGIN
+                UPDATE watchlists SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
+            END
+        """)
+        # Per-migration markers. schema_version cannot be reused: it is a single
+        # INTEGER PRIMARY KEY column with no room for keys.
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS watchlist_migration_state (
+                key TEXT PRIMARY KEY,
+                applied_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
         conn.commit()
 
     @property

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -600,6 +600,16 @@ class SubscriptionsDB(BaseDB):
         round-trips. ``SUM(CASE …)`` is used rather than ``COUNT(*) FILTER``
         to avoid depending on a newer SQLite than the bundled one.
 
+        The per-watchlist leg is anchored on ``watchlists`` with LEFT JOINs
+        (not an INNER JOIN from ``watchlist_sources``), so a watchlist with
+        no sources yet -- or sources with no items yet -- still appears with
+        ``{"total": 0, "unread": 0}`` instead of being missing from the
+        result entirely. With a LEFT JOIN, ``COUNT(si.id)`` would still be
+        correct (``COUNT`` ignores NULLs), but ``COUNT(*)`` would wrongly
+        count the null-padded row for a sourceless watchlist -- the
+        ``SUM(CASE WHEN si.id IS NOT NULL ...)`` form is used to make that
+        unambiguous rather than relying on a NULL-counting subtlety.
+
         Returns:
             Mapping of bucket id to ``{"total": int, "unread": int}``. Bucket
             ``-1`` is Unassigned (sources in no watchlist) and ``-2`` is All
@@ -607,12 +617,13 @@ class SubscriptionsDB(BaseDB):
         """
         rows = self.conn.execute(
             """
-            SELECT ws.watchlist_id AS bucket,
-                   COUNT(si.id) AS total,
+            SELECT w.id AS bucket,
+                   SUM(CASE WHEN si.id IS NOT NULL THEN 1 ELSE 0 END) AS total,
                    SUM(CASE WHEN si.status = 'new' THEN 1 ELSE 0 END) AS unread
-            FROM watchlist_sources ws
-            JOIN subscription_items si ON si.subscription_id = ws.subscription_id
-            GROUP BY ws.watchlist_id
+            FROM watchlists w
+            LEFT JOIN watchlist_sources ws  ON ws.watchlist_id = w.id
+            LEFT JOIN subscription_items si ON si.subscription_id = ws.subscription_id
+            GROUP BY w.id
 
             UNION ALL
 
@@ -633,10 +644,12 @@ class SubscriptionsDB(BaseDB):
             (self.UNASSIGNED_BUCKET, self.ALL_SOURCES_BUCKET),
         ).fetchall()
 
+        # No `if row[0] is not None` filter here: watchlists.id and
+        # watchlist_sources.watchlist_id are NOT NULL, and both sentinels
+        # bind non-null literals, so every row's bucket id is always non-null.
         return {
             row[0]: {"total": row[1] or 0, "unread": row[2] or 0}
             for row in rows
-            if row[0] is not None
         }
 
     @property

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -1545,36 +1545,28 @@ class SubscriptionsDB(BaseDB):
         if existing:
             return existing["id"]
 
-        # Insert new item
-        cursor.execute(
-            """
-            INSERT INTO subscription_items
-            (subscription_id, url, title, content_hash, published_date,
-             author, categories, enclosures, extracted_data, canonical_url,
-             previous_hash, change_percentage, diff_summary, change_type)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        """,
-            (
-                subscription_id,
-                item["url"],
-                item.get("title"),
-                item.get("content_hash"),
-                item.get("published_date"),
-                item.get("author"),
-                json.dumps(item.get("categories")) if item.get("categories") else None,
-                json.dumps(item.get("enclosures")) if item.get("enclosures") else None,
-                json.dumps(item.get("extracted_data"))
-                if item.get("extracted_data")
-                else None,
-                canonical_url,
-                item.get("previous_hash"),
-                item.get("change_percentage"),
-                item.get("diff_summary"),
-                item.get("change_type"),
-            ),
-        )
+        # Insert new item via the shared persistence path so the full
+        # column set (content, content_kind, content_format, run_id,
+        # alert_matches, ...) is written, not just the change/dedup fields
+        # this path used to carry alone. The canonical-URL dedupe guard
+        # above is kept unchanged; persist_subscription_item's own
+        # ON CONFLICT target (subscription_id, url, content_hash) is a
+        # narrower, independent dedupe rule that still applies underneath
+        # it — the two dedupe rules are deliberately not unified.
+        #
+        # Imported locally: Subscriptions/__init__.py imports
+        # LocalWatchlistsService, which imports this module, so a
+        # module-level import here would be circular.
+        from ..Subscriptions.item_persist import persist_subscription_item
 
-        return cursor.lastrowid
+        now = datetime.now(timezone.utc).isoformat()
+        return persist_subscription_item(
+            cursor.connection,
+            subscription_id,
+            {**item, "canonical_url": canonical_url},
+            run_id=None,
+            now=now,
+        )
 
     def _update_subscription_stats(
         self, subscription_id: int, stats: Dict[str, Any], had_error: bool

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -22,6 +22,7 @@
 #########################################
 
 import json
+import sqlite3
 import threading
 import time
 from contextlib import closing, contextmanager
@@ -73,6 +74,20 @@ class SubscriptionsDB(BaseDB):
         """
         self._local = threading.local()
         super().__init__(db_path, client_id)
+
+    def _get_connection(self) -> sqlite3.Connection:
+        """Return a connection with foreign-key enforcement enabled.
+
+        ``PRAGMA foreign_keys`` is per-connection and defaults to OFF, and
+        ``BaseDB._get_connection`` sets only ``row_factory``. Without this
+        override every ``ON DELETE CASCADE`` in this schema is inert, which
+        silently orphaned ``subscription_items`` whenever a subscription was
+        deleted. Matches ``ChaChaNotes_DB`` and ``Client_Media_DB_v2``, which
+        each enable it per connection.
+        """
+        conn = super()._get_connection()
+        conn.execute("PRAGMA foreign_keys = ON;")
+        return conn
 
     def _initialize_schema(self):
         """Initialize the database schema."""

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -339,37 +339,77 @@ class SubscriptionsDB(BaseDB):
         for row in cursor.execute("SELECT sql FROM sqlite_master WHERE type='table' AND name='subscription_filters'"):
             existing_check = row[0]
         if existing_check and "'include'" not in existing_check:
-            cursor.execute("""
-                CREATE TABLE subscription_filters_new (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    subscription_id INTEGER,
-                    name TEXT NOT NULL,
-                    is_active BOOLEAN DEFAULT 1,
-                    conditions TEXT NOT NULL,
-                    action TEXT NOT NULL CHECK(action IN ('auto_ingest','auto_ignore','tag','priority','notify','include','exclude','flag')),
-                    action_params TEXT,
-                    priority INTEGER DEFAULT 0,
-                    is_include_required BOOLEAN DEFAULT 0,
-                    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                    FOREIGN KEY (subscription_id) REFERENCES subscriptions(id) ON DELETE CASCADE
+            # This rebuild predates FK enforcement (Task 1a) and may run
+            # against a real database that already has a subscription_filters
+            # row whose subscription_id no longer exists -- the orphan
+            # condition Task 1a exists to stop *creating*, not to clean up
+            # retroactively (cleanup is out of scope; already-orphaned rows
+            # must survive). Copying such a row into subscription_filters_new,
+            # which declares the FK, would raise IntegrityError now that
+            # enforcement is on. Disable enforcement for this rebuild only,
+            # then restore it -- this is the documented SQLite procedure for
+            # a table rebuild that must tolerate pre-existing violations.
+            #
+            # PRAGMA foreign_keys is a no-op while a transaction is pending,
+            # so commit immediately before toggling it off, and again after
+            # the rebuild before toggling it back on. Read the pragma back
+            # rather than assuming the toggle took effect.
+            conn.commit()
+            cursor.execute("PRAGMA foreign_keys = OFF;")
+            if cursor.execute("PRAGMA foreign_keys").fetchone()[0] != 0:
+                raise RuntimeError(
+                    "Could not disable foreign_keys enforcement for the "
+                    "subscription_filters rebuild; refusing to risk a "
+                    "silent partial migration."
                 )
-            """)
-            cursor.execute("""
-                INSERT INTO subscription_filters_new
-                    (id, subscription_id, name, is_active, conditions, action, action_params, priority, is_include_required, created_at, updated_at)
-                SELECT id, subscription_id, name, is_active, conditions, action, action_params, priority, is_include_required, created_at, updated_at
-                FROM subscription_filters
-            """)
-            cursor.execute("DROP TABLE subscription_filters")
-            cursor.execute("ALTER TABLE subscription_filters_new RENAME TO subscription_filters")
-            cursor.execute("""
-                CREATE TRIGGER IF NOT EXISTS update_subscription_filters_timestamp
-                AFTER UPDATE ON subscription_filters
-                BEGIN
-                    UPDATE subscription_filters SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
-                END
-            """)
+            try:
+                cursor.execute("""
+                    CREATE TABLE subscription_filters_new (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        subscription_id INTEGER,
+                        name TEXT NOT NULL,
+                        is_active BOOLEAN DEFAULT 1,
+                        conditions TEXT NOT NULL,
+                        action TEXT NOT NULL CHECK(action IN ('auto_ingest','auto_ignore','tag','priority','notify','include','exclude','flag')),
+                        action_params TEXT,
+                        priority INTEGER DEFAULT 0,
+                        is_include_required BOOLEAN DEFAULT 0,
+                        created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        FOREIGN KEY (subscription_id) REFERENCES subscriptions(id) ON DELETE CASCADE
+                    )
+                """)
+                cursor.execute("""
+                    INSERT INTO subscription_filters_new
+                        (id, subscription_id, name, is_active, conditions, action, action_params, priority, is_include_required, created_at, updated_at)
+                    SELECT id, subscription_id, name, is_active, conditions, action, action_params, priority, is_include_required, created_at, updated_at
+                    FROM subscription_filters
+                """)
+                cursor.execute("DROP TABLE subscription_filters")
+                cursor.execute("ALTER TABLE subscription_filters_new RENAME TO subscription_filters")
+                cursor.execute("""
+                    CREATE TRIGGER IF NOT EXISTS update_subscription_filters_timestamp
+                    AFTER UPDATE ON subscription_filters
+                    BEGIN
+                        UPDATE subscription_filters SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
+                    END
+                """)
+                conn.commit()
+            except Exception:
+                # Roll back any partial rebuild so no pending transaction
+                # remains -- otherwise the PRAGMA restore below would be a
+                # silent no-op and leave enforcement off for the rest of
+                # this connection's life, reintroducing the bug Task 1a
+                # fixed.
+                conn.rollback()
+                raise
+            finally:
+                cursor.execute("PRAGMA foreign_keys = ON;")
+                if cursor.execute("PRAGMA foreign_keys").fetchone()[0] != 1:
+                    logger.error(
+                        "Failed to re-enable foreign_keys enforcement after "
+                        "the subscription_filters rebuild."
+                    )
 
         # Indexes
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_subscription_items_run_id ON subscription_items(run_id)")

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -506,7 +506,88 @@ class SubscriptionsDB(BaseDB):
             "CREATE INDEX IF NOT EXISTS idx_local_watchlist_runs_batch "
             "ON local_watchlist_runs(batch_id)"
         )
+
+        # External-content FTS over items, matching the pattern used by
+        # character_cards_fts / conversations_fts / media_fts. Triggers rather
+        # than explicit index writes, so every INSERT path stays indexed.
+        cursor.execute("""
+            CREATE VIRTUAL TABLE IF NOT EXISTS subscription_items_fts USING fts5(
+                title,
+                content,
+                author,
+                content='subscription_items',
+                content_rowid='id'
+            )
+        """)
+        cursor.execute("""
+            CREATE TRIGGER IF NOT EXISTS subscription_items_fts_ai
+            AFTER INSERT ON subscription_items BEGIN
+                INSERT INTO subscription_items_fts(rowid, title, content, author)
+                VALUES (new.id, new.title, new.content, new.author);
+            END
+        """)
+        cursor.execute("""
+            CREATE TRIGGER IF NOT EXISTS subscription_items_fts_ad
+            AFTER DELETE ON subscription_items BEGIN
+                INSERT INTO subscription_items_fts(subscription_items_fts, rowid, title, content, author)
+                VALUES ('delete', old.id, old.title, old.content, old.author);
+            END
+        """)
+        cursor.execute("""
+            CREATE TRIGGER IF NOT EXISTS subscription_items_fts_au
+            AFTER UPDATE ON subscription_items BEGIN
+                INSERT INTO subscription_items_fts(subscription_items_fts, rowid, title, content, author)
+                VALUES ('delete', old.id, old.title, old.content, old.author);
+                INSERT INTO subscription_items_fts(rowid, title, content, author)
+                VALUES (new.id, new.title, new.content, new.author);
+            END
+        """)
+
         conn.commit()
+
+    def backfill_items_fts(self, chunk_size: int = 500) -> int:
+        """Index one chunk of items that are missing from the FTS table.
+
+        Runs in a background worker, never inline in migration — a synchronous
+        backfill of a large subscription_items table would block app boot.
+        Resumes by rowid, so an interrupted backfill continues rather than
+        restarting.
+
+        The "not yet indexed" check reads ``subscription_items_fts_docsize``
+        rather than ``subscription_items_fts`` itself. For an external-content
+        FTS5 table (``content='subscription_items'``), an unfiltered/no-MATCH
+        query against the fts5 table is satisfied straight from the external
+        content table's rowids -- it does not reflect the actual state of the
+        FTS index. ``%_docsize`` is the shadow table SQLite documents for this
+        purpose: it is populated only by real writes into the fts5 table (the
+        insert/update triggers, or this method), so it is the only place that
+        truthfully answers "has this rowid been indexed yet".
+
+        Args:
+            chunk_size: Maximum rows to index in this call.
+
+        Returns:
+            Number of rows indexed. ``0`` means the backfill is complete.
+        """
+        with self.transaction() as conn:
+            rows = conn.execute(
+                """
+                SELECT id, title, content, author
+                FROM subscription_items
+                WHERE id NOT IN (SELECT rowid FROM subscription_items_fts_docsize)
+                ORDER BY id
+                LIMIT ?
+                """,
+                (chunk_size,),
+            ).fetchall()
+            if not rows:
+                return 0
+            conn.executemany(
+                "INSERT INTO subscription_items_fts(rowid, title, content, author) "
+                "VALUES (?, ?, ?, ?)",
+                [(row[0], row[1], row[2], row[3]) for row in rows],
+            )
+            return len(rows)
 
     @property
     def conn(self):

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -382,6 +382,16 @@ class SubscriptionsDB(BaseDB):
                     "silent partial migration."
                 )
             try:
+                # CREATE TABLE runs in autocommit in Python's sqlite3 module
+                # (only DML gets an implicit transaction), so the
+                # conn.rollback() in the except below cannot undo it. If a
+                # previous run of this rebuild died after creating this table
+                # but before the rename below, `_new` survives indefinitely
+                # and every later open hits "table subscription_filters_new
+                # already exists" here -- permanently. Drop it first so a
+                # stray table from an earlier failed attempt never blocks a
+                # fresh one.
+                cursor.execute("DROP TABLE IF EXISTS subscription_filters_new")
                 cursor.execute("""
                     CREATE TABLE subscription_filters_new (
                         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -421,6 +431,12 @@ class SubscriptionsDB(BaseDB):
                 # this connection's life, reintroducing the bug Task 1a
                 # fixed.
                 conn.rollback()
+                # conn.rollback() does not remove subscription_filters_new
+                # itself (CREATE TABLE is autocommit -- see the comment
+                # above), so this attempt's own partially-built table would
+                # otherwise become the exact stray table the DROP above
+                # exists to guard against, for the next open.
+                cursor.execute("DROP TABLE IF EXISTS subscription_filters_new")
                 raise
             finally:
                 cursor.execute("PRAGMA foreign_keys = ON;")
@@ -510,6 +526,11 @@ class SubscriptionsDB(BaseDB):
         # External-content FTS over items, matching the pattern used by
         # character_cards_fts / conversations_fts / media_fts. Triggers rather
         # than explicit index writes, so every INSERT path stays indexed.
+        #
+        # Do NOT add `columnsize=0` to the fts5 options below: that option
+        # removes the `_docsize` shadow table, which both the guarded delete
+        # legs below and `backfill_items_fts()` depend on to answer "has this
+        # rowid actually been written into the FTS index yet".
         cursor.execute("""
             CREATE VIRTUAL TABLE IF NOT EXISTS subscription_items_fts USING fts5(
                 title,
@@ -526,18 +547,48 @@ class SubscriptionsDB(BaseDB):
                 VALUES (new.id, new.title, new.content, new.author);
             END
         """)
+        # subscription_items_fts is an external-content FTS5 table: its
+        # 'delete' command is only legal for a rowid that is actually present
+        # in the index (has a row in the `_docsize` shadow table). This
+        # migration creates the index over a `subscription_items` table that
+        # may already hold rows from before this branch existed, so without a
+        # guard the very first UPDATE/DELETE of a pre-existing, never-indexed
+        # item would fire 'delete' against a rowid FTS5 has never seen --
+        # FTS5 rejects the whole statement, and it surfaces to the caller as
+        # "database disk image is malformed" even though nothing is actually
+        # corrupt. Guard the delete legs on index membership so an unindexed
+        # row is skipped instead of fatal. `_au`'s insert leg stays
+        # unconditional, so a skipped/unindexed row simply becomes indexed on
+        # its next update.
+        #
+        # These two triggers are dropped and recreated unconditionally
+        # (rather than `CREATE ... IF NOT EXISTS`) so that a database that
+        # already ran the previous, unguarded versions of these triggers on
+        # this branch picks up the fix too -- `IF NOT EXISTS` would otherwise
+        # silently keep the old, unguarded trigger bodies in place. This is
+        # idempotent: re-running it just drops-and-recreates the same guarded
+        # triggers again.
+        #
+        # Do not split `_au` into two separate triggers (one delete, one
+        # insert): SQLite does not guarantee firing order between multiple
+        # triggers on the same event, and an insert-then-guarded-delete
+        # ordering would corrupt the index.
+        cursor.execute("DROP TRIGGER IF EXISTS subscription_items_fts_ad")
         cursor.execute("""
-            CREATE TRIGGER IF NOT EXISTS subscription_items_fts_ad
+            CREATE TRIGGER subscription_items_fts_ad
             AFTER DELETE ON subscription_items BEGIN
                 INSERT INTO subscription_items_fts(subscription_items_fts, rowid, title, content, author)
-                VALUES ('delete', old.id, old.title, old.content, old.author);
+                SELECT 'delete', old.id, old.title, old.content, old.author
+                WHERE EXISTS (SELECT 1 FROM subscription_items_fts_docsize WHERE id = old.id);
             END
         """)
+        cursor.execute("DROP TRIGGER IF EXISTS subscription_items_fts_au")
         cursor.execute("""
-            CREATE TRIGGER IF NOT EXISTS subscription_items_fts_au
+            CREATE TRIGGER subscription_items_fts_au
             AFTER UPDATE ON subscription_items BEGIN
                 INSERT INTO subscription_items_fts(subscription_items_fts, rowid, title, content, author)
-                VALUES ('delete', old.id, old.title, old.content, old.author);
+                SELECT 'delete', old.id, old.title, old.content, old.author
+                WHERE EXISTS (SELECT 1 FROM subscription_items_fts_docsize WHERE id = old.id);
                 INSERT INTO subscription_items_fts(rowid, title, content, author)
                 VALUES (new.id, new.title, new.content, new.author);
             END
@@ -564,11 +615,21 @@ class SubscriptionsDB(BaseDB):
         truthfully answers "has this rowid been indexed yet".
 
         Args:
-            chunk_size: Maximum rows to index in this call.
+            chunk_size: Maximum rows to index in this call. Must be >= 1.
 
         Returns:
             Number of rows indexed. ``0`` means the backfill is complete.
+
+        Raises:
+            ValueError: If ``chunk_size`` is less than 1. A non-positive
+                value would make ``LIMIT ?`` return zero rows regardless of
+                how large the real backlog is, and this method would then
+                report ``0`` ("complete") while unindexed rows remain --
+                silently stranding them once this becomes the repair path
+                for legacy rows the guarded FTS triggers skip.
         """
+        if chunk_size < 1:
+            raise ValueError(f"chunk_size must be >= 1, got {chunk_size!r}")
         with self.transaction() as conn:
             rows = conn.execute(
                 """

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -267,7 +267,26 @@ class SubscriptionsDB(BaseDB):
                 created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
             );
-            
+
+            -- Local watchlist run history. Owned here rather than created
+            -- lazily by LocalWatchlistsService, so one place owns schema and
+            -- additive migrations can ALTER it unconditionally.
+            CREATE TABLE IF NOT EXISTS local_watchlist_runs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                source_id INTEGER NOT NULL,
+                job_id INTEGER,
+                batch_id TEXT,
+                status TEXT NOT NULL,
+                started_at TEXT,
+                finished_at TEXT,
+                stats_json TEXT,
+                error_msg TEXT,
+                log_text TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                FOREIGN KEY (source_id) REFERENCES subscriptions(id) ON DELETE CASCADE
+            );
+
             -- Create indices
             CREATE INDEX IF NOT EXISTS idx_subscriptions_priority_active ON subscriptions(priority DESC, is_active, is_paused);
             CREATE INDEX IF NOT EXISTS idx_subscriptions_tags ON subscriptions(tags);
@@ -475,6 +494,18 @@ class SubscriptionsDB(BaseDB):
                 applied_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
             )
         """)
+
+        # local_watchlist_runs is guaranteed to exist: BaseDB.__init__ runs
+        # _initialize_schema (base_db.py:76), which creates it and then calls
+        # this method. Only the column needs checking, for databases created
+        # before batch_id existed.
+        run_cols = {row[1] for row in cursor.execute("PRAGMA table_info(local_watchlist_runs)")}
+        if "batch_id" not in run_cols:
+            cursor.execute("ALTER TABLE local_watchlist_runs ADD COLUMN batch_id TEXT")
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_local_watchlist_runs_batch "
+            "ON local_watchlist_runs(batch_id)"
+        )
         conn.commit()
 
     @property

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -589,6 +589,56 @@ class SubscriptionsDB(BaseDB):
             )
             return len(rows)
 
+    # Sentinel bucket ids for the watchlists tree roots.
+    UNASSIGNED_BUCKET = -1
+    ALL_SOURCES_BUCKET = -2
+
+    def get_watchlist_item_counts(self) -> Dict[int, Dict[str, int]]:
+        """Item totals and unread counts for every watchlists tree node.
+
+        Returned in a single query so that adding watchlists never adds
+        round-trips. ``SUM(CASE …)`` is used rather than ``COUNT(*) FILTER``
+        to avoid depending on a newer SQLite than the bundled one.
+
+        Returns:
+            Mapping of bucket id to ``{"total": int, "unread": int}``. Bucket
+            ``-1`` is Unassigned (sources in no watchlist) and ``-2`` is All
+            sources. Real watchlist ids are positive.
+        """
+        rows = self.conn.execute(
+            """
+            SELECT ws.watchlist_id AS bucket,
+                   COUNT(si.id) AS total,
+                   SUM(CASE WHEN si.status = 'new' THEN 1 ELSE 0 END) AS unread
+            FROM watchlist_sources ws
+            JOIN subscription_items si ON si.subscription_id = ws.subscription_id
+            GROUP BY ws.watchlist_id
+
+            UNION ALL
+
+            SELECT ?, COUNT(si.id),
+                   SUM(CASE WHEN si.status = 'new' THEN 1 ELSE 0 END)
+            FROM subscription_items si
+            WHERE NOT EXISTS (
+                SELECT 1 FROM watchlist_sources ws
+                WHERE ws.subscription_id = si.subscription_id
+            )
+
+            UNION ALL
+
+            SELECT ?, COUNT(si.id),
+                   SUM(CASE WHEN si.status = 'new' THEN 1 ELSE 0 END)
+            FROM subscription_items si
+            """,
+            (self.UNASSIGNED_BUCKET, self.ALL_SOURCES_BUCKET),
+        ).fetchall()
+
+        return {
+            row[0]: {"total": row[1] or 0, "unread": row[2] or 0}
+            for row in rows
+            if row[0] is not None
+        }
+
     @property
     def conn(self):
         """Thread-local database connection."""

--- a/tldw_chatbook/Subscriptions/item_persist.py
+++ b/tldw_chatbook/Subscriptions/item_persist.py
@@ -101,6 +101,7 @@ def persist_subscription_item(
                 ELSE 'new'
             END,
             updated_at = excluded.updated_at
+        RETURNING id
         """,
         (
             subscription_id,
@@ -127,4 +128,4 @@ def persist_subscription_item(
             now,
         ),
     )
-    return cursor.lastrowid
+    return cursor.fetchone()[0]

--- a/tldw_chatbook/Subscriptions/item_persist.py
+++ b/tldw_chatbook/Subscriptions/item_persist.py
@@ -1,0 +1,122 @@
+"""Single persistence path for scraped subscription items.
+
+Replaces two divergent INSERT statements that wrote disjoint column sets:
+``Subscriptions_DB`` wrote the change/dedup fields but dropped run linkage and
+status, while ``LocalWatchlistsService`` did the reverse. Neither wrote body
+text. Every caller now routes through :func:`persist_subscription_item`.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+
+_VALID_PAIRINGS = {
+    ("article", "text"),
+    ("article", "markdown"),
+    ("change", "diff"),
+}
+
+
+def _json_or_none(value: Any) -> str | None:
+    return json.dumps(value) if value is not None else None
+
+
+def _validate_content_pairing(kind: Any, fmt: Any) -> None:
+    """Reject impossible kind/format combinations at the persist boundary."""
+    if kind is None and fmt is None:
+        return
+    if (kind, fmt) not in _VALID_PAIRINGS:
+        raise ValueError(
+            f"invalid content_kind/content_format pairing: {kind!r}/{fmt!r}. "
+            f"Valid pairings: {sorted(_VALID_PAIRINGS)}"
+        )
+
+
+def persist_subscription_item(
+    conn: Any,
+    subscription_id: int,
+    item: Mapping[str, Any],
+    run_id: int | None,
+    now: str,
+) -> None:
+    """Insert or update one item, writing the full column set.
+
+    Existing ``reviewed`` and ``ignored`` statuses are preserved across
+    re-fetches; anything else resets to ``new``.
+
+    Args:
+        conn: An open connection inside a transaction.
+        subscription_id: Owning source id.
+        item: Normalized item mapping.
+        run_id: Run that produced this item, if any.
+        now: ISO-8601 timestamp for created_at/updated_at.
+
+    Raises:
+        ValueError: If content_kind and content_format are an invalid pairing.
+    """
+    content_kind = item.get("content_kind")
+    content_format = item.get("content_format")
+    _validate_content_pairing(content_kind, content_format)
+
+    conn.execute(
+        """
+        INSERT INTO subscription_items (
+            subscription_id, url, title, content, content_kind, content_format,
+            content_hash, published_date, author, categories, enclosures,
+            extracted_data, status, run_id, alert_matches, canonical_url,
+            previous_hash, change_percentage, diff_summary, change_type,
+            created_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(subscription_id, url, content_hash) DO UPDATE SET
+            title = excluded.title,
+            content = excluded.content,
+            content_kind = excluded.content_kind,
+            content_format = excluded.content_format,
+            published_date = excluded.published_date,
+            author = excluded.author,
+            categories = excluded.categories,
+            enclosures = excluded.enclosures,
+            extracted_data = excluded.extracted_data,
+            run_id = excluded.run_id,
+            alert_matches = excluded.alert_matches,
+            canonical_url = excluded.canonical_url,
+            previous_hash = excluded.previous_hash,
+            change_percentage = excluded.change_percentage,
+            diff_summary = excluded.diff_summary,
+            change_type = excluded.change_type,
+            status = CASE
+                WHEN subscription_items.status IN ('reviewed', 'ignored')
+                THEN subscription_items.status
+                ELSE 'new'
+            END,
+            updated_at = excluded.updated_at
+        """,
+        (
+            subscription_id,
+            item.get("url"),
+            item.get("title"),
+            item.get("content"),
+            content_kind,
+            content_format,
+            item.get("content_hash"),
+            item.get("published_date"),
+            item.get("author"),
+            _json_or_none(item.get("categories")),
+            _json_or_none(item.get("enclosures")),
+            _json_or_none(item.get("extracted_data")),
+            "new",
+            run_id,
+            _json_or_none(item.get("alert_matches")),
+            item.get("canonical_url"),
+            item.get("previous_hash"),
+            item.get("change_percentage"),
+            item.get("diff_summary"),
+            item.get("change_type"),
+            now,
+            now,
+        ),
+    )

--- a/tldw_chatbook/Subscriptions/item_persist.py
+++ b/tldw_chatbook/Subscriptions/item_persist.py
@@ -23,7 +23,25 @@ _VALID_PAIRINGS = {
 
 
 def _json_or_none(value: Any) -> str | None:
-    return json.dumps(value) if value is not None else None
+    """Serialize a value to JSON, collapsing an empty container to ``None``.
+
+    ``categories``, ``enclosures``, ``extracted_data``, and ``alert_matches``
+    are always either ``None``, a list, or a dict -- never a plausible
+    falsy scalar like ``0`` or ``False``. So rather than a general
+    truthiness check (which would also collapse those scalars), this keys
+    specifically on container emptiness: an empty list or dict serializes
+    to ``None`` just like a missing value, matching the old DB-side
+    write path's behavior. Storing the literal string ``"[]"`` instead
+    would make it indistinguishable from a real, non-empty payload to
+    readers that treat "any string" as meaningful, e.g.
+    ``AggregationEngine._parse_categories``, which splits every string on
+    commas and would otherwise manufacture a phantom ``["[]"]`` category.
+    """
+    if value is None:
+        return None
+    if hasattr(value, "__len__") and len(value) == 0:
+        return None
+    return json.dumps(value)
 
 
 def _validate_content_pairing(kind: Any, fmt: Any) -> None:

--- a/tldw_chatbook/Subscriptions/item_persist.py
+++ b/tldw_chatbook/Subscriptions/item_persist.py
@@ -3,7 +3,9 @@
 Replaces two divergent INSERT statements that wrote disjoint column sets:
 ``Subscriptions_DB`` wrote the change/dedup fields but dropped run linkage and
 status, while ``LocalWatchlistsService`` did the reverse. Neither wrote body
-text. Every caller now routes through :func:`persist_subscription_item`.
+text. Both callers (``Subscriptions_DB._add_subscription_item`` and
+``LocalWatchlistsService._upsert_subscription_items``) now route through
+:func:`persist_subscription_item`.
 """
 
 from __future__ import annotations
@@ -41,11 +43,13 @@ def persist_subscription_item(
     item: Mapping[str, Any],
     run_id: int | None,
     now: str,
-) -> None:
+) -> int:
     """Insert or update one item, writing the full column set.
 
-    Existing ``reviewed`` and ``ignored`` statuses are preserved across
-    re-fetches; anything else resets to ``new``.
+    Existing ``reviewed``, ``ignored``, and ``ingested`` statuses are
+    preserved across re-fetches, since each reflects a deliberate user
+    action on that item. Anything else (including ``error``) resets to
+    ``new`` — a successful re-fetch should clear a prior error.
 
     Args:
         conn: An open connection inside a transaction.
@@ -54,6 +58,9 @@ def persist_subscription_item(
         run_id: Run that produced this item, if any.
         now: ISO-8601 timestamp for created_at/updated_at.
 
+    Returns:
+        The id of the inserted or updated row.
+
     Raises:
         ValueError: If content_kind and content_format are an invalid pairing.
     """
@@ -61,7 +68,7 @@ def persist_subscription_item(
     content_format = item.get("content_format")
     _validate_content_pairing(content_kind, content_format)
 
-    conn.execute(
+    cursor = conn.execute(
         """
         INSERT INTO subscription_items (
             subscription_id, url, title, content, content_kind, content_format,
@@ -89,7 +96,7 @@ def persist_subscription_item(
             diff_summary = excluded.diff_summary,
             change_type = excluded.change_type,
             status = CASE
-                WHEN subscription_items.status IN ('reviewed', 'ignored')
+                WHEN subscription_items.status IN ('reviewed', 'ignored', 'ingested')
                 THEN subscription_items.status
                 ELSE 'new'
             END,
@@ -120,3 +127,4 @@ def persist_subscription_item(
             now,
         ),
     )
+    return cursor.lastrowid

--- a/tldw_chatbook/Subscriptions/local_watchlists_service.py
+++ b/tldw_chatbook/Subscriptions/local_watchlists_service.py
@@ -16,6 +16,7 @@ from ..Utils.egress import (
     guarded_fetch_httpx_async,
     origin_set,
 )
+from .item_persist import persist_subscription_item
 from .watchlist_content_alert_service import WatchlistContentAlertService
 from .watchlist_filter_service import WatchlistFilterService
 from .watchlist_normalizers import (
@@ -1272,53 +1273,19 @@ class LocalWatchlistsService:
             return
         now = LocalWatchlistsService._utc_now()
         with db.transaction() as conn:
-            cursor = conn.cursor()
             for item in items:
                 url = str(item.get("url") or "")
                 content_hash = str(item.get("content_hash") or "")
                 if not url or not content_hash:
                     continue
-                title = item.get("title")
-                published_date = item.get("published_date")
-                author = item.get("author")
-                categories = item.get("categories")
-                enclosures = item.get("enclosures")
-                extracted_data = item.get("extracted_data")
                 alert_matches = item.get("alert_matches")
-                cursor.execute(
-                    """
-                    INSERT INTO subscription_items (
-                        subscription_id, url, title, content_hash, published_date,
-                        author, categories, enclosures, extracted_data, status,
-                        run_id, alert_matches, created_at, updated_at
-                    )
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    ON CONFLICT(subscription_id, url, content_hash) DO UPDATE SET
-                        title = excluded.title,
-                        published_date = excluded.published_date,
-                        author = excluded.author,
-                        categories = excluded.categories,
-                        enclosures = excluded.enclosures,
-                        extracted_data = excluded.extracted_data,
-                        status = excluded.status,
-                        run_id = excluded.run_id,
-                        alert_matches = excluded.alert_matches,
-                        updated_at = excluded.updated_at
-                    """,
-                    (
-                        source_id,
-                        url,
-                        title,
-                        content_hash,
-                        published_date,
-                        author,
-                        json.dumps(categories) if categories is not None else None,
-                        json.dumps(enclosures) if enclosures is not None else None,
-                        json.dumps(extracted_data) if extracted_data is not None else None,
-                        "new",
-                        run_id,
-                        json.dumps(alert_matches) if alert_matches is not None else None,
-                        now,
-                        now,
-                    ),
+                persist_subscription_item(
+                    conn,
+                    source_id,
+                    {
+                        **item,
+                        "alert_matches": alert_matches,
+                    },
+                    run_id=run_id,
+                    now=now,
                 )

--- a/tldw_chatbook/Subscriptions/local_watchlists_service.py
+++ b/tldw_chatbook/Subscriptions/local_watchlists_service.py
@@ -179,7 +179,6 @@ class LocalWatchlistsService:
         db = self._db()
         if db.get_subscription(resolved_source_id) is None:
             raise KeyError(f"Subscription not found: {resolved_source_id}")
-        self._ensure_run_schema(db)
         now = self._utc_now()
         with db.transaction() as conn:
             cursor = conn.cursor()
@@ -205,7 +204,6 @@ class LocalWatchlistsService:
     async def execute_run(self, run_id: Any) -> dict[str, Any]:
         """Execute a queued local watchlist run and persist its observed result."""
         db = self._db()
-        self._ensure_run_schema(db)
         current = await self.get_run(run_id)
         source_id = int(current.get("source_id") or current.get("job_id"))
         subscription = db.get_subscription(source_id)
@@ -264,7 +262,6 @@ class LocalWatchlistsService:
         **_: Any,
     ) -> list[dict[str, Any]]:
         db = self._db()
-        self._ensure_run_schema(db)
         filters: list[str] = []
         values: list[Any] = []
         resolved_source_id = source_id if source_id is not None else job_id
@@ -291,7 +288,6 @@ class LocalWatchlistsService:
     def list_home_run_snapshot(self, *, limit: int = 20) -> list[dict[str, Any]]:
         """Return recent local watchlist runs from a synchronous Home-safe path."""
         db = self._db()
-        self._ensure_run_schema(db)
         cursor = db.conn.cursor()
         cursor.execute(
             """
@@ -307,7 +303,6 @@ class LocalWatchlistsService:
 
     async def get_run(self, run_id: Any) -> dict[str, Any]:
         db = self._db()
-        self._ensure_run_schema(db)
         cursor = db.conn.cursor()
         cursor.execute(
             "SELECT * FROM local_watchlist_runs WHERE id = ?", (int(run_id),)
@@ -322,7 +317,6 @@ class LocalWatchlistsService:
 
     async def cancel_run(self, run_id: Any) -> dict[str, Any]:
         db = self._db()
-        self._ensure_run_schema(db)
         now = self._utc_now()
         with db.transaction() as conn:
             cursor = conn.cursor()
@@ -350,7 +344,6 @@ class LocalWatchlistsService:
     ) -> dict[str, Any]:
         """Persist a completed local run and emit notifications for matching alert rules."""
         db = self._db()
-        self._ensure_run_schema(db)
         current = await self.get_run(run_id)
         now = self._utc_now()
         stats_payload = dict(stats or {})
@@ -960,28 +953,6 @@ class LocalWatchlistsService:
         if isinstance(value, list):
             return [str(item).strip() for item in value if str(item).strip()]
         return []
-
-    @staticmethod
-    def _ensure_run_schema(db: SubscriptionsDB) -> None:
-        with db.transaction() as conn:
-            conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS local_watchlist_runs (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    source_id INTEGER NOT NULL,
-                    job_id INTEGER,
-                    status TEXT NOT NULL,
-                    started_at TEXT,
-                    finished_at TEXT,
-                    stats_json TEXT,
-                    error_msg TEXT,
-                    log_text TEXT,
-                    created_at TEXT NOT NULL,
-                    updated_at TEXT NOT NULL,
-                    FOREIGN KEY (source_id) REFERENCES subscriptions(id) ON DELETE CASCADE
-                )
-                """
-            )
 
     @staticmethod
     def _ensure_alert_rule_schema(db: SubscriptionsDB) -> None:

--- a/tldw_chatbook/Subscriptions/watchlist_bundle_service.py
+++ b/tldw_chatbook/Subscriptions/watchlist_bundle_service.py
@@ -35,6 +35,9 @@ class WatchlistBundleService:
 
     @staticmethod
     def _join_tags(tags: Sequence[str] | None) -> str | None:
+        """Join tags as comma-separated string. Note: tags containing commas will be
+        split on round-trip due to this convention (inherited from subscriptions.tags).
+        This is a known, deliberate limitation of the shared comma-joined format."""
         if not tags:
             return None
         cleaned = [str(tag).strip() for tag in tags if str(tag).strip()]
@@ -92,6 +95,8 @@ class WatchlistBundleService:
         tags: Sequence[str] | None = None,
     ) -> dict[str, Any]:
         """Create a watchlist, auto-suffixing the name on collision."""
+        if not name.strip():
+            raise ValueError("watchlist name cannot be empty or whitespace-only")
         with self._db.transaction() as conn:
             resolved = self._unique_name(conn, name)
             cursor = conn.execute(
@@ -102,6 +107,8 @@ class WatchlistBundleService:
 
     def rename(self, watchlist_id: int, name: str) -> dict[str, Any]:
         """Rename a watchlist, auto-suffixing on collision with another row."""
+        if not name.strip():
+            raise ValueError("watchlist name cannot be empty or whitespace-only")
         with self._db.transaction() as conn:
             resolved = self._unique_name(conn, name, exclude_id=watchlist_id)
             conn.execute(

--- a/tldw_chatbook/Subscriptions/watchlist_bundle_service.py
+++ b/tldw_chatbook/Subscriptions/watchlist_bundle_service.py
@@ -1,0 +1,152 @@
+"""Watchlist bundle CRUD and source membership.
+
+A watchlist is a named bundle of sources — the unit of organization and
+checking, and (in a later slice) of briefing generation. Membership is
+many-to-many: a source may belong to any number of watchlists.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from loguru import logger
+
+from ..DB.Subscriptions_DB import SubscriptionsDB
+
+
+logger = logger.bind(module="WatchlistBundleService")
+
+
+class WatchlistBundleService:
+    """Local watchlist bundles backed by ``SubscriptionsDB``."""
+
+    def __init__(self, db: SubscriptionsDB) -> None:
+        self._db = db
+
+    # --- Helpers ---
+
+    @staticmethod
+    def _split_tags(raw: Any) -> list[str]:
+        """Parse the comma-joined tags column used by subscriptions.tags."""
+        if not raw:
+            return []
+        return [part.strip() for part in str(raw).split(",") if part.strip()]
+
+    @staticmethod
+    def _join_tags(tags: Sequence[str] | None) -> str | None:
+        if not tags:
+            return None
+        cleaned = [str(tag).strip() for tag in tags if str(tag).strip()]
+        return ",".join(cleaned) if cleaned else None
+
+    @staticmethod
+    def _row_to_dict(row: Any) -> dict[str, Any]:
+        return {
+            "id": row[0],
+            "name": row[1],
+            "description": row[2],
+            "tags": WatchlistBundleService._split_tags(row[3]),
+            "is_active": bool(row[4]),
+            "sort_order": row[5],
+        }
+
+    def _unique_name(self, conn: Any, name: str, exclude_id: int | None = None) -> str:
+        """Return ``name``, suffixed if it collides case-insensitively.
+
+        Uniqueness lives here rather than in a SQL UNIQUE constraint because a
+        constraint would raise mid-migration on case-variant folder values or
+        OPML re-imports.
+        """
+        base = name.strip()
+        params: list[Any] = []
+        query = "SELECT LOWER(name) FROM watchlists"
+        if exclude_id is not None:
+            query += " WHERE id != ?"
+            params.append(exclude_id)
+        taken = {row[0] for row in conn.execute(query, params)}
+
+        if base.lower() not in taken:
+            return base
+        suffix = 2
+        while f"{base.lower()} ({suffix})" in taken:
+            suffix += 1
+        return f"{base} ({suffix})"
+
+    def _get(self, conn: Any, watchlist_id: int) -> dict[str, Any]:
+        row = conn.execute(
+            "SELECT id, name, description, tags, is_active, sort_order "
+            "FROM watchlists WHERE id = ?",
+            (watchlist_id,),
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"no watchlist with id {watchlist_id}")
+        return self._row_to_dict(row)
+
+    # --- CRUD ---
+
+    def create(
+        self,
+        name: str,
+        description: str | None = None,
+        tags: Sequence[str] | None = None,
+    ) -> dict[str, Any]:
+        """Create a watchlist, auto-suffixing the name on collision."""
+        with self._db.transaction() as conn:
+            resolved = self._unique_name(conn, name)
+            cursor = conn.execute(
+                "INSERT INTO watchlists (name, description, tags) VALUES (?, ?, ?)",
+                (resolved, description, self._join_tags(tags)),
+            )
+            return self._get(conn, cursor.lastrowid)
+
+    def rename(self, watchlist_id: int, name: str) -> dict[str, Any]:
+        """Rename a watchlist, auto-suffixing on collision with another row."""
+        with self._db.transaction() as conn:
+            resolved = self._unique_name(conn, name, exclude_id=watchlist_id)
+            conn.execute(
+                "UPDATE watchlists SET name = ? WHERE id = ?", (resolved, watchlist_id)
+            )
+            return self._get(conn, watchlist_id)
+
+    def delete(self, watchlist_id: int) -> None:
+        """Delete a watchlist. Membership cascades; sources are untouched."""
+        with self._db.transaction() as conn:
+            conn.execute("DELETE FROM watchlists WHERE id = ?", (watchlist_id,))
+
+    def list_watchlists(self) -> list[dict[str, Any]]:
+        """All watchlists in display order."""
+        rows = self._db.conn.execute(
+            "SELECT id, name, description, tags, is_active, sort_order "
+            "FROM watchlists ORDER BY sort_order, LOWER(name)"
+        ).fetchall()
+        return [self._row_to_dict(row) for row in rows]
+
+    # --- Membership ---
+
+    def add_source(self, watchlist_id: int, subscription_id: int) -> None:
+        """Add a source to a watchlist. Idempotent."""
+        with self._db.transaction() as conn:
+            conn.execute(
+                "INSERT OR IGNORE INTO watchlist_sources (watchlist_id, subscription_id) "
+                "VALUES (?, ?)",
+                (watchlist_id, subscription_id),
+            )
+
+    def remove_source(self, watchlist_id: int, subscription_id: int) -> None:
+        """Remove a source from a watchlist. The source itself survives."""
+        with self._db.transaction() as conn:
+            conn.execute(
+                "DELETE FROM watchlist_sources "
+                "WHERE watchlist_id = ? AND subscription_id = ?",
+                (watchlist_id, subscription_id),
+            )
+
+    def list_sources(self, watchlist_id: int) -> list[int]:
+        """Subscription ids belonging to a watchlist."""
+        rows = self._db.conn.execute(
+            "SELECT subscription_id FROM watchlist_sources "
+            "WHERE watchlist_id = ? ORDER BY added_at, subscription_id",
+            (watchlist_id,),
+        ).fetchall()
+        return [row[0] for row in rows]

--- a/tldw_chatbook/Subscriptions/watchlist_bundle_service.py
+++ b/tldw_chatbook/Subscriptions/watchlist_bundle_service.py
@@ -157,3 +157,58 @@ class WatchlistBundleService:
             (watchlist_id,),
         ).fetchall()
         return [row[0] for row in rows]
+
+    # --- Migration ---
+
+    MIGRATION_KEY = "folders_to_watchlists"
+
+    def migrate_folders(self) -> bool:
+        """Turn distinct ``subscriptions.folder`` values into watchlists.
+
+        Sources with no folder join a single ``Unsorted`` watchlist. The
+        ``folder`` column is left in place and untouched, so this is reversible.
+
+        In practice this migrates almost nothing: no live code path writes
+        ``folder``. It exists for hand-seeded databases.
+
+        Returns:
+            ``True`` if the migration ran, ``False`` if it had already been
+            applied.
+        """
+        with self._db.transaction() as conn:
+            already = conn.execute(
+                "SELECT 1 FROM watchlist_migration_state WHERE key = ?",
+                (self.MIGRATION_KEY,),
+            ).fetchone()
+            if already:
+                return False
+
+            rows = conn.execute(
+                "SELECT id, folder FROM subscriptions ORDER BY id"
+            ).fetchall()
+
+            buckets: dict[str, list[int]] = {}
+            for subscription_id, folder in rows:
+                label = (folder or "").strip() or "Unsorted"
+                buckets.setdefault(label, []).append(subscription_id)
+
+            for label, source_ids in buckets.items():
+                resolved = self._unique_name(conn, label)
+                cursor = conn.execute(
+                    "INSERT INTO watchlists (name) VALUES (?)", (resolved,)
+                )
+                watchlist_id = cursor.lastrowid
+                conn.executemany(
+                    "INSERT OR IGNORE INTO watchlist_sources "
+                    "(watchlist_id, subscription_id) VALUES (?, ?)",
+                    [(watchlist_id, source_id) for source_id in source_ids],
+                )
+
+            conn.execute(
+                "INSERT INTO watchlist_migration_state (key) VALUES (?)",
+                (self.MIGRATION_KEY,),
+            )
+            logger.info(
+                "Migrated {} folder group(s) into watchlists.", len(buckets)
+            )
+            return True

--- a/tldw_chatbook/Subscriptions/watchlist_bundle_service.py
+++ b/tldw_chatbook/Subscriptions/watchlist_bundle_service.py
@@ -94,7 +94,26 @@ class WatchlistBundleService:
         description: str | None = None,
         tags: Sequence[str] | None = None,
     ) -> dict[str, Any]:
-        """Create a watchlist, auto-suffixing the name on collision."""
+        """Create a watchlist, auto-suffixing the name on collision.
+
+        Args:
+            name: Display name for the watchlist. Leading/trailing
+                whitespace is stripped before storing. If a watchlist with
+                the same name already exists (case-insensitively), a
+                numeric suffix such as ``" (2)"`` is appended until the
+                resolved name is unique.
+            description: Optional free-text description.
+            tags: Optional tags. Stored as a comma-joined string and split
+                back into a list of stripped, non-empty strings on read.
+
+        Returns:
+            The newly created watchlist as a dict with keys ``id``,
+            ``name``, ``description``, ``tags``, ``is_active``, and
+            ``sort_order``.
+
+        Raises:
+            ValueError: If ``name`` is empty or whitespace-only.
+        """
         if not name.strip():
             raise ValueError("watchlist name cannot be empty or whitespace-only")
         with self._db.transaction() as conn:
@@ -106,7 +125,26 @@ class WatchlistBundleService:
             return self._get(conn, cursor.lastrowid)
 
     def rename(self, watchlist_id: int, name: str) -> dict[str, Any]:
-        """Rename a watchlist, auto-suffixing on collision with another row."""
+        """Rename a watchlist, auto-suffixing on collision with another row.
+
+        Args:
+            watchlist_id: id of the watchlist to rename.
+            name: New display name. Leading/trailing whitespace is
+                stripped before storing. If another watchlist already has
+                this name (case-insensitively), a numeric suffix such as
+                ``" (2)"`` is appended until the resolved name is unique.
+                The watchlist being renamed is excluded from that check,
+                so renaming to its own current name (in any case) is a
+                no-op, not a collision.
+
+        Returns:
+            The updated watchlist as a dict (see :meth:`create` for the
+            shape).
+
+        Raises:
+            ValueError: If ``name`` is empty or whitespace-only.
+            KeyError: If no watchlist with ``watchlist_id`` exists.
+        """
         if not name.strip():
             raise ValueError("watchlist name cannot be empty or whitespace-only")
         with self._db.transaction() as conn:
@@ -117,22 +155,54 @@ class WatchlistBundleService:
             return self._get(conn, watchlist_id)
 
     def delete(self, watchlist_id: int) -> None:
-        """Delete a watchlist. Membership cascades; sources are untouched."""
+        """Delete a watchlist. Membership cascades; sources are untouched.
+
+        Args:
+            watchlist_id: id of the watchlist to delete. Deleting an id
+                that does not exist is a no-op.
+
+        Returns:
+            None.
+        """
         with self._db.transaction() as conn:
             conn.execute("DELETE FROM watchlists WHERE id = ?", (watchlist_id,))
 
-    def list_watchlists(self) -> list[dict[str, Any]]:
-        """All watchlists in display order."""
+    def list_watchlists(self, limit: int = 100, offset: int = 0) -> list[dict[str, Any]]:
+        """All watchlists in display order.
+
+        Args:
+            limit: Maximum number of watchlists to return.
+            offset: Number of leading watchlists (in display order) to skip.
+
+        Returns:
+            Watchlist dicts ordered by ``sort_order`` then case-insensitive
+            name.
+        """
         rows = self._db.conn.execute(
             "SELECT id, name, description, tags, is_active, sort_order "
-            "FROM watchlists ORDER BY sort_order, LOWER(name)"
+            "FROM watchlists ORDER BY sort_order, LOWER(name) "
+            "LIMIT ? OFFSET ?",
+            (limit, offset),
         ).fetchall()
         return [self._row_to_dict(row) for row in rows]
 
     # --- Membership ---
 
     def add_source(self, watchlist_id: int, subscription_id: int) -> None:
-        """Add a source to a watchlist. Idempotent."""
+        """Add a source to a watchlist. Idempotent.
+
+        Args:
+            watchlist_id: id of the watchlist to add the source to.
+            subscription_id: id of the subscription to add.
+
+        Returns:
+            None.
+
+        Raises:
+            sqlite3.IntegrityError: If ``watchlist_id`` or
+                ``subscription_id`` does not reference an existing row
+                (both columns carry a ``FOREIGN KEY`` constraint).
+        """
         with self._db.transaction() as conn:
             conn.execute(
                 "INSERT OR IGNORE INTO watchlist_sources (watchlist_id, subscription_id) "
@@ -141,7 +211,16 @@ class WatchlistBundleService:
             )
 
     def remove_source(self, watchlist_id: int, subscription_id: int) -> None:
-        """Remove a source from a watchlist. The source itself survives."""
+        """Remove a source from a watchlist. The source itself survives.
+
+        Args:
+            watchlist_id: id of the watchlist to remove the source from.
+            subscription_id: id of the subscription to remove. Removing a
+                membership that does not exist is a no-op.
+
+        Returns:
+            None.
+        """
         with self._db.transaction() as conn:
             conn.execute(
                 "DELETE FROM watchlist_sources "
@@ -150,7 +229,17 @@ class WatchlistBundleService:
             )
 
     def list_sources(self, watchlist_id: int) -> list[int]:
-        """Subscription ids belonging to a watchlist."""
+        """Subscription ids belonging to a watchlist.
+
+        Args:
+            watchlist_id: id of the watchlist to list sources for. An id
+                that does not exist, or one with no sources, both yield an
+                empty list -- the two cases are not distinguished.
+
+        Returns:
+            Subscription ids ordered by when they were added to the
+            watchlist, then by id.
+        """
         rows = self._db.conn.execute(
             "SELECT subscription_id FROM watchlist_sources "
             "WHERE watchlist_id = ? ORDER BY added_at, subscription_id",


### PR DESCRIPTION
Phase A of the Watchlists screen rebuild. **Data layer only — no UI file is touched anywhere in this branch.** Spec and plan are included as documents.

Design: `Docs/superpowers/specs/2026-07-25-watchlists-console-rebuild-design.md`
Plan: `Docs/superpowers/plans/2026-07-25-watchlists-rebuild-phase-a-data-foundation.md`

## What this adds

- `watchlists` + `watchlist_sources` tables — a watchlist is a named bundle of sources, many-to-many, the unit of organisation and checking.
- `WatchlistBundleService` — CRUD, membership, case-insensitive name collision with auto-suffixing, and a one-shot `folder` → watchlist migration.
- Durable body text on items (`content`, `content_kind`, `content_format`) plus `is_flagged`, and an FTS5 index over title/content/author with a chunked, resumable backfill.
- `persist_subscription_item` — one persistence path replacing two divergent INSERTs.
- `get_watchlist_item_counts` — per-watchlist plus Unassigned/All-sources counts in a single query.
- `local_watchlist_runs` relocated into `SubscriptionsDB` with a `batch_id` column.

## Pre-existing bugs found and fixed along the way

Design and review turned up several defects that predate this work:

- **Foreign keys were never enforced.** The `PRAGMA foreign_keys = ON` ran on a connection closed immediately afterwards, and `BaseDB._get_connection` sets only `row_factory`. Every `ON DELETE CASCADE` in this schema was inert — deleting a subscription silently orphaned its items. Fixed in its own commit.
- **Two item-INSERT paths wrote disjoint column sets**, and neither wrote body text, so what the reader could display depended on which code path fetched the item.
- **`cursor.lastrowid` returned the wrong row** on the upsert's conflict branch.
- **A failed `subscription_filters` rebuild could brick the database** — `CREATE TABLE` runs in autocommit, so the rollback left the table behind and the next open died inside `_initialize_schema`.
- **The FTS delete triggers rejected mutations of pre-existing rows.** External-content FTS5 only accepts `'delete'` for indexed rowids; the index is created empty over existing data, so update/delete of any legacy item — and cascade-delete of its source — failed with `database disk image is malformed`. The delete legs are now membership-guarded.

## Testing

`Tests/DB Tests/Subscriptions Tests/Watchlists Tests/Scheduling Tests/Home` → **671 passed, 1 failed**.

The single failure is `Tests/Watchlists/test_watchlists_navigator.py::test_navigator_has_all_section_buttons`, which fails on this branch before any of these commits — a pre-existing UI-test failure, out of scope for a data-layer change.

## Known follow-ups (not in this PR)

- **Blocks Phase B:** `backfill_items_fts` has no production caller, so pre-existing items are never indexed. Wiring was deliberately deferred so Phase A stays data-layer only.
- `SubscriptionsDB(":memory:")` is non-functional — schema is built on a throwaway connection while `.conn` opens a different, empty database. `WatchlistPreviewService.preview()` uses `:memory:`, so source Preview/dry-run is very likely broken today. Pre-existing, orthogonal to this work.
- `local_watchlist_alert_rules` is still created lazily from a service, contrary to the plan's "no lazily-created tables" constraint. Same treatment as `local_watchlist_runs`, next phase.
- Server watchlist membership has no wire path (`SourceUpdateRequest` has no `group_ids`; group requests are `extra="forbid"`), so watchlist creation is disabled on the server backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds the data foundation for the Watchlists rebuild: new watchlist storage/services, item content + FTS search, and a single, reliable item-persist path; also adds and corrects the Watchlists design/specs and includes the Phase B workbench/shell plan. No UI changes.

- **New Features**
  - Add `watchlists` and `watchlist_sources` (many-to-many) and a `WatchlistBundleService` (CRUD, membership, case-insensitive naming with auto-suffix, folder→watchlist migration, paginated `list_watchlists`).
  - Store durable item body via `content`, `content_kind`, `content_format`, plus `is_flagged`; add FTS5 over title/content/author with chunked, resumable backfill.
  - Introduce `persist_subscription_item` to replace divergent INSERTs; preserves `reviewed`/`ignored`/`ingested` and returns the correct row id.
  - Provide `get_watchlist_item_counts` for per-watchlist + Unassigned/All-sources in one query.
  - Move `local_watchlist_runs` into `SubscriptionsDB` and add `batch_id`.

- **Bug Fixes**
  - Enable foreign-key enforcement on `SubscriptionsDB` runtime connections; guard the `subscription_filters` rebuild (FK OFF/ON with DROP IF EXISTS) to avoid data loss and startup lockups.
  - Fix upsert id reporting with RETURNING; previous `cursor.lastrowid` could return a wrong row.
  - Guard FTS5 delete triggers to tolerate legacy, unindexed rows and recreate triggers to upgrade in place.
  - Item persistence: route scheduled-checks through `persist_subscription_item`; collapse empty JSON fields to NULL to prevent phantom values.
  - Anchor counts on `watchlists` so empty watchlists and sources with no items report zero.

<sup>Written for commit 803bd0ccec3d7e9598402f2c2cb6b2ca7e9272db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

