### PR TITLE
task-686: fal/Gemini backend follow-ups + chat-side x-goog-api-key redirect refusal

### DIFF
--- a/Tests/Chat/test_google_native_tools.py
+++ b/Tests/Chat/test_google_native_tools.py
@@ -15,6 +15,9 @@ and inspect the JSON payload actually sent.
 import json
 from unittest.mock import Mock, patch
 
+import pytest
+
+from tldw_chatbook.Chat.Chat_Deps import ChatProviderError
 from tldw_chatbook.Chat.Chat_Functions import chat_api_call
 
 
@@ -889,3 +892,91 @@ def test_unpairable_tool_result_is_skipped_not_empty_named(mock_post):
     result_turn = sent["contents"][2]
     names = [p["functionResponse"]["name"] for p in result_turn["parts"]]
     assert names == ["calculator"]  # the orphan (position 1 > 0 calls) dropped
+
+
+# ---------------------------------------------------------------------------
+# task-686 AC #3: the `x-goog-api-key` header must never survive a redirect.
+# `requests` follows 3xx responses by default and re-sends custom headers
+# (it only strips `Authorization` on a cross-host hop) -- `chat_with_google`
+# must pass `allow_redirects=False` and refuse loudly on any 3xx instead of
+# silently forwarding the credential to wherever `Location` points.
+# ---------------------------------------------------------------------------
+
+
+def _redirect_response(status_code=302, location="https://evil.example/collect"):
+    mock_response = Mock()
+    mock_response.status_code = status_code
+    mock_response.headers = {"Location": location}
+    mock_response.close = Mock()
+    # If the code under test mistakenly called raise_for_status() on a 3xx,
+    # a real `requests.Response` would NOT raise (raise_for_status only
+    # raises for 4xx/5xx) -- keep this a no-op Mock so a regression that
+    # relies on raise_for_status to catch the redirect fails the "refuses"
+    # assertion below instead of silently passing.
+    mock_response.raise_for_status = Mock()
+    mock_response.json.return_value = {}
+    return mock_response
+
+
+@patch("requests.Session.post")
+def test_post_always_passes_allow_redirects_false(mock_post):
+    """Pin the transport-level guard itself: `requests` cannot silently
+    follow a redirect and re-send the x-goog-api-key header if
+    allow_redirects=False was passed on the request that carries it."""
+    _call_google(mock_post, [{"role": "user", "content": "hi"}])
+    assert mock_post.call_args[1]["allow_redirects"] is False
+    assert mock_post.call_args[1]["headers"]["x-goog-api-key"] == "test-key"
+
+
+@pytest.mark.parametrize("status_code", [301, 302, 303, 307, 308])
+@patch("requests.Session.post")
+def test_non_streaming_redirect_refused_not_followed(mock_post, status_code):
+    mock_post.return_value = _redirect_response(status_code=status_code)
+
+    with pytest.raises(ChatProviderError) as excinfo:
+        chat_api_call(
+            "google",
+            messages_payload=[{"role": "user", "content": "hi"}],
+            api_key="test-key",
+            model="gemini-1.5-flash-latest",
+            streaming=False,
+        )
+
+    assert "redirect" in str(excinfo.value).lower()
+    assert excinfo.value.provider == "google"
+    assert excinfo.value.status_code == status_code
+    # Exactly one request was ever issued -- nothing re-sent the credential
+    # to the Location target.
+    assert mock_post.call_count == 1
+    mock_post.return_value.raise_for_status.assert_not_called()
+    mock_post.return_value.close.assert_called_once()
+
+
+@patch("requests.Session.post")
+def test_streaming_redirect_refused_not_followed(mock_post):
+    """The streaming call shape (`stream=True`) must get the same refusal
+    -- `requests` still honors allow_redirects when streaming."""
+    mock_post.return_value = _redirect_response(status_code=302)
+
+    with pytest.raises(ChatProviderError) as excinfo:
+        chat_api_call(
+            "google",
+            messages_payload=[{"role": "user", "content": "hi"}],
+            api_key="test-key",
+            model="gemini-1.5-flash-latest",
+            streaming=True,
+        )
+
+    assert "redirect" in str(excinfo.value).lower()
+    assert mock_post.call_count == 1
+    mock_post.return_value.close.assert_called_once()
+
+
+@patch("requests.Session.post")
+def test_normal_200_response_unaffected_by_redirect_guard(mock_post):
+    """Normal happy path: allow_redirects=False changes nothing about a
+    non-redirect response -- the existing success path stays intact."""
+    sent = _call_google(mock_post, [{"role": "user", "content": "2+2?"}])
+    assert mock_post.call_args[1]["allow_redirects"] is False
+    assert sent["contents"][0]["parts"][0]["text"] == "2+2?"
+    mock_post.return_value.raise_for_status.assert_called_once()

--- a/Tests/Image_Generation/test_config_loader.py
+++ b/Tests/Image_Generation/test_config_loader.py
@@ -435,3 +435,27 @@ def test_gemini_env_fallback_to_google_api_key(monkeypatch):
     cfg = _load_config_with_section(monkeypatch, {})
     assert cfg.gemini_image_api_key == "fake-google-key"
     assert cfg.key_sources["gemini"] == "env:GOOGLE_API_KEY"
+
+
+# --- task-686: per-backend keyring-source tests (fal/gemini) ---------------
+# The generic keyring path is already covered for novita
+# (test_key_sources_keyring above); fal and gemini share the same
+# _resolve_secret/_keyring_get machinery but had no dedicated coverage.
+
+
+def test_fal_key_sources_keyring(monkeypatch):
+    """keyring-origin secret is recorded as "keyring" (not the raw value)
+    and lands on the flat field, same as the generic-backend case."""
+    _delenv_new_backend_vars(monkeypatch)
+    cfg = _load_config_with_section(monkeypatch, {}, keyring={"fal": "kr-fal-secret"})
+    assert cfg.key_sources["fal"] == "keyring"
+    assert cfg.fal_image_api_key == "kr-fal-secret"
+
+
+def test_gemini_key_sources_keyring(monkeypatch):
+    """keyring-origin secret is recorded as "keyring" (not the raw value)
+    and lands on the flat field, same as the generic-backend case."""
+    _delenv_new_backend_vars(monkeypatch)
+    cfg = _load_config_with_section(monkeypatch, {}, keyring={"gemini": "kr-gemini-secret"})
+    assert cfg.key_sources["gemini"] == "keyring"
+    assert cfg.gemini_image_api_key == "kr-gemini-secret"

--- a/Tests/Image_Generation/test_fal_adapter.py
+++ b/Tests/Image_Generation/test_fal_adapter.py
@@ -259,6 +259,42 @@ def test_app_id_rejects_single_segment(monkeypatch):
         m._app_id("onlyone")
 
 
+# --- task-686: fal APP_NAMESPACES grammar (workflows/, comfy/ prefixes) ----
+# Verified 2026-07-25 against fal_client's AppId.from_endpoint_id -- see the
+# module docstring for the exact source lines. A namespaced path keeps
+# THREE segments (namespace/owner/alias), not two.
+
+
+def test_app_id_namespaced_workflows_three_segments_kept_whole(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    assert m._app_id("workflows/fal-ai/some-flow") == "workflows/fal-ai/some-flow"
+
+
+def test_app_id_namespaced_comfy_three_segments_kept_whole(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    assert m._app_id("comfy/fal-ai/some-flow") == "comfy/fal-ai/some-flow"
+
+
+def test_app_id_namespaced_drops_fourth_segment(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    assert m._app_id("workflows/owner/app/variant") == "workflows/owner/app"
+
+
+def test_app_id_namespaced_rejects_too_few_segments(monkeypatch):
+    m = _reset_and_import(monkeypatch)
+    from tldw_chatbook.Image_Generation.exceptions import ImageBackendUnavailableError
+
+    with pytest.raises(ImageBackendUnavailableError):
+        m._app_id("workflows/owner")
+
+
+def test_app_id_plain_path_unchanged_by_namespace_handling(monkeypatch):
+    # Cross-check: plain (non-namespaced) paths must keep the pre-existing
+    # two-segment rule -- the namespace handling must not regress this shape.
+    m = _reset_and_import(monkeypatch)
+    assert m._app_id("fal-ai/flux/schnell") == "fal-ai/flux"
+
+
 def test_fal_polls_two_segment_app_id_url_for_three_segment_model(monkeypatch):
     m = _reset_and_import(monkeypatch)
     _patch_no_op_sleep(monkeypatch, m)
@@ -281,6 +317,35 @@ def test_fal_polls_two_segment_app_id_url_for_three_segment_model(monkeypatch):
         assert url == "https://queue.fal.run/fal-ai/flux/requests/req-xyz/status"
     result_calls = [c for c in calls if c["method"].upper() == "GET" and not c["url"].endswith("/status")]
     assert result_calls[0]["url"] == "https://queue.fal.run/fal-ai/flux/requests/req-xyz"
+
+
+def test_fal_polls_namespaced_three_segment_app_id_for_four_segment_model(monkeypatch):
+    # task-686: a namespaced model path with a trailing variant segment
+    # (workflows/owner/app/variant) must poll using the 3-segment app id
+    # (workflows/owner/app), dropping only the variant -- mirrors
+    # test_fal_polls_two_segment_app_id_url_for_three_segment_model above
+    # for the plain (non-namespaced) shape.
+    m = _reset_and_import(monkeypatch)
+    _patch_no_op_sleep(monkeypatch, m)
+
+    calls = []
+    fake = _make_fake_fetch_json(
+        calls,
+        submit_response=_submit_response(request_id="req-xyz"),
+        statuses=("COMPLETED",),
+    )
+    monkeypatch.setattr(m, "fetch_json", fake)
+    monkeypatch.setattr(m, "fetch_image_bytes", lambda *a, **kw: (_image_bytes_png(), "image/png"))
+
+    req = _req(model="workflows/owner/app/variant")
+    m.FalImageAdapter().generate(req)
+
+    poll_urls = [c["url"] for c in calls if c["url"].endswith("/status")]
+    assert poll_urls
+    for url in poll_urls:
+        assert url == "https://queue.fal.run/workflows/owner/app/requests/req-xyz/status"
+    result_calls = [c for c in calls if c["method"].upper() == "GET" and not c["url"].endswith("/status")]
+    assert result_calls[0]["url"] == "https://queue.fal.run/workflows/owner/app/requests/req-xyz"
 
 
 def test_fal_single_segment_model_refused_before_network(monkeypatch):
@@ -315,6 +380,29 @@ def test_fal_matching_status_url_polls_fine(monkeypatch):
     monkeypatch.setattr(m, "fetch_image_bytes", lambda *a, **kw: (_image_bytes_png(), "image/png"))
 
     req = _req(model="fal-ai/flux/schnell")
+    res = m.FalImageAdapter().generate(req)
+    assert res.bytes_len > 0
+    poll_calls = [c for c in calls if c["url"].endswith("/status")]
+    assert len(poll_calls) == 1
+    assert poll_calls[0]["url"] == expected_status_url
+
+
+def test_fal_namespaced_matching_status_url_polls_fine(monkeypatch):
+    # task-686: the cross-check property must keep working for the
+    # namespaced app-id shape too, not just the plain owner/app shape.
+    m = _reset_and_import(monkeypatch)
+    _patch_no_op_sleep(monkeypatch, m)
+
+    expected_status_url = "https://queue.fal.run/workflows/fal-ai/some-flow/requests/req-1/status"
+    calls = []
+    fake = _make_fake_fetch_json(
+        calls,
+        submit_response=_submit_response(request_id="req-1", status_url=expected_status_url),
+    )
+    monkeypatch.setattr(m, "fetch_json", fake)
+    monkeypatch.setattr(m, "fetch_image_bytes", lambda *a, **kw: (_image_bytes_png(), "image/png"))
+
+    req = _req(model="workflows/fal-ai/some-flow")
     res = m.FalImageAdapter().generate(req)
     assert res.bytes_len > 0
     poll_calls = [c for c in calls if c["url"].endswith("/status")]
@@ -618,6 +706,32 @@ def test_fal_404_names_model_path_and_config_key(monkeypatch):
     assert "fal-ai/nonexistent/model" in message
     assert "[image_generation.fal] default_model" in message
     assert "404" in message
+
+
+def test_fal_403_names_balance_message(monkeypatch):
+    # task-686: a 403 must be enriched with a CATEGORY-level message
+    # (locked/out-of-balance) -- never the raw response body.
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+    m = _reset_and_import(monkeypatch)
+
+    def _raise_403(method, url, **kw):
+        request = httpx.Request(method, url)
+        response = httpx.Response(
+            403, request=request, text="Forbidden: account internal-balance-detail-99 locked"
+        )
+        raise httpx.HTTPStatusError(
+            "Client error '403 Forbidden' for url '{}'".format(url), request=request, response=response
+        )
+
+    monkeypatch.setattr(m, "fetch_json", _raise_403)
+    req = _req(model="fal-ai/flux/schnell")
+    with pytest.raises(ImageGenerationError) as exc_info:
+        m.FalImageAdapter().generate(req)
+    message = str(exc_info.value)
+    assert "fal account locked or out of balance" in message
+    assert "fal.ai/dashboard/billing" in message
+    assert "internal-balance-detail-99" not in message
 
 
 def test_fal_non_404_status_keeps_generic_message(monkeypatch):

--- a/Tests/Image_Generation/test_gemini_adapter.py
+++ b/Tests/Image_Generation/test_gemini_adapter.py
@@ -645,6 +645,32 @@ def test_gemini_400_names_model_and_config_path(monkeypatch):
     assert "400" in message
 
 
+def test_gemini_429_names_model_and_quota_message(monkeypatch):
+    # task-686: a 429 must be enriched with a CATEGORY-level message naming
+    # the model id -- never the raw response body.
+    from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
+
+    m = _reset_and_import(monkeypatch)
+
+    def _raise_429(method, url, **kw):
+        request = httpx.Request(method, url)
+        response = httpx.Response(
+            429, request=request, text="quota exceeded: internal-detail-marker-42"
+        )
+        raise httpx.HTTPStatusError(
+            "Client error '429 Too Many Requests' for url '{}'".format(url), request=request, response=response
+        )
+
+    monkeypatch.setattr(m, "fetch_json", _raise_429)
+    req = _req(model="gemini-2.5-flash-image")
+    with pytest.raises(ImageGenerationError) as exc_info:
+        m.GeminiImageAdapter().generate(req)
+    message = str(exc_info.value)
+    assert "gemini-2.5-flash-image" in message
+    assert "rate limited or image quota exhausted (free-tier caps apply)" in message
+    assert "internal-detail-marker-42" not in message
+
+
 def test_gemini_non_404_400_status_keeps_generic_message(monkeypatch):
     from tldw_chatbook.Image_Generation.exceptions import ImageGenerationError
 

--- a/Tests/Image_Generation/test_request_validation.py
+++ b/Tests/Image_Generation/test_request_validation.py
@@ -92,22 +92,41 @@ def test_reference_image_gif_refused(rv):
 
 
 def test_reference_image_oversize_refused(rv):
+    # Real oversized content, with bytes_len reported honestly -- the size
+    # cap must fire based on the actual content, not merely a claimed field.
+    big_content = b"x" * (rv.IMAGE_GEN_REFERENCE_MAX_BYTES + 1)
     bad = {
         "backend": "fal",
         "prompt": "cat",
         "extra_params": {},
-        "reference_image": _ref(bytes_len=rv.IMAGE_GEN_REFERENCE_MAX_BYTES + 1),
+        "reference_image": _ref(content=big_content, bytes_len=len(big_content)),
+    }
+    issues = rv.validate_image_generation_request(bad)
+    assert "reference image exceeds the 10MB limit" in _messages(issues)
+
+
+def test_reference_image_oversized_content_with_lying_bytes_len_refused(rv):
+    # task-686 choke-point hardening: a constructor that reports a tiny
+    # bytes_len while content is actually oversized must NOT bypass the cap
+    # -- the cap validates len(content), never the caller-supplied bytes_len.
+    big_content = b"x" * (rv.IMAGE_GEN_REFERENCE_MAX_BYTES + 1)
+    bad = {
+        "backend": "fal",
+        "prompt": "cat",
+        "extra_params": {},
+        "reference_image": _ref(content=big_content, bytes_len=4),
     }
     issues = rv.validate_image_generation_request(bad)
     assert "reference image exceeds the 10MB limit" in _messages(issues)
 
 
 def test_reference_image_at_exact_cap_not_refused(rv):
+    ok_content = b"x" * rv.IMAGE_GEN_REFERENCE_MAX_BYTES
     ok = {
         "backend": "fal",
         "prompt": "cat",
         "extra_params": {},
-        "reference_image": _ref(bytes_len=rv.IMAGE_GEN_REFERENCE_MAX_BYTES),
+        "reference_image": _ref(content=ok_content, bytes_len=len(ok_content)),
     }
     assert rv.validate_image_generation_request(ok) == []
 
@@ -123,16 +142,31 @@ def test_reference_image_no_content_refused(rv):
     assert "reference image has no content bytes" in _messages(issues)
 
 
-def test_reference_image_multiple_problems_all_reported(rv):
-    # Unsupported backend + bad mime + oversize + no content, all at once --
-    # the checks must not short-circuit each other.
+def test_reference_image_empty_content_refused(rv):
+    # task-686 choke-point hardening: content == b"" is refused with the
+    # same issue string as content is None, not treated as a (tiny) valid
+    # payload.
+    bad = {
+        "backend": "fal",
+        "prompt": "cat",
+        "extra_params": {},
+        "reference_image": _ref(content=b"", bytes_len=0),
+    }
+    issues = rv.validate_image_generation_request(bad)
+    assert "reference image has no content bytes" in _messages(issues)
+
+
+def test_reference_image_multiple_problems_all_reported_no_content_variant(rv):
+    # Unsupported backend + bad mime + no content, all at once -- the checks
+    # must not short-circuit each other. (Oversize and no-content are now
+    # mutually exclusive states of the same `content` field -- see the
+    # oversize variant below for the sibling case.)
     bad = {
         "backend": "swarmui",
         "prompt": "cat",
         "extra_params": {},
         "reference_image": _ref(
             mime_type="image/gif",
-            bytes_len=rv.IMAGE_GEN_REFERENCE_MAX_BYTES + 1,
             content=None,
             temp_path="/tmp/ref.gif",
         ),
@@ -141,6 +175,27 @@ def test_reference_image_multiple_problems_all_reported(rv):
     messages = _messages(issues)
     assert "backend 'swarmui' does not support reference images" in messages
     assert "reference image mime 'image/gif' is not supported (png/jpeg/webp)" in messages
-    assert "reference image exceeds the 10MB limit" in messages
     assert "reference image has no content bytes" in messages
-    assert len(issues) == 4
+    assert len(issues) == 3
+
+
+def test_reference_image_multiple_problems_all_reported_oversize_variant(rv):
+    # Sibling of the above: unsupported backend + bad mime + oversize
+    # content, all at once.
+    big_content = b"x" * (rv.IMAGE_GEN_REFERENCE_MAX_BYTES + 1)
+    bad = {
+        "backend": "swarmui",
+        "prompt": "cat",
+        "extra_params": {},
+        "reference_image": _ref(
+            mime_type="image/gif",
+            content=big_content,
+            bytes_len=len(big_content),
+        ),
+    }
+    issues = rv.validate_image_generation_request(bad)
+    messages = _messages(issues)
+    assert "backend 'swarmui' does not support reference images" in messages
+    assert "reference image mime 'image/gif' is not supported (png/jpeg/webp)" in messages
+    assert "reference image exceeds the 10MB limit" in messages
+    assert len(issues) == 3

--- a/backlog/tasks/task-686 - fal-Gemini-image-backends-follow-ups.md
+++ b/backlog/tasks/task-686 - fal-Gemini-image-backends-follow-ups.md
@@ -2,7 +2,7 @@
 id: TASK-686
 title: >-
   fal/Gemini image backends follow-ups
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-26 03:30'
 updated_date: '2026-07-26 03:30'
@@ -33,6 +33,9 @@ Non-blocking follow-ups from the fal.ai + Gemini image-backend program's final w
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
+1. Engine cluster (one unit): choke-point hardening (len(content) + empty-content refusal), fal APP_NAMESPACES app-id grammar, per-backend keyring tests, fetch_bytes_via_post docstring, gemini-429/fal-403 enriched messages.
+2. Chat-side x-goog-api-key redirect gap (LLM_API_Calls.py Google path) as its own unit — guarded transport or redirect-strip.
+Each unit: TDD, per-unit review; PR + merge per the standing procedure.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-686 - fal-Gemini-image-backends-follow-ups.md
+++ b/backlog/tasks/task-686 - fal-Gemini-image-backends-follow-ups.md
@@ -1,11 +1,10 @@
 ---
 id: TASK-686
-title: >-
-  fal/Gemini image backends follow-ups
+title: fal/Gemini image backends follow-ups
 status: In Progress
 assignee: []
 created_date: '2026-07-26 03:30'
-updated_date: '2026-07-26 03:30'
+updated_date: '2026-07-26 05:54'
 labels:
   - image-generation
   - followup
@@ -20,14 +19,13 @@ Non-blocking follow-ups from the fal.ai + Gemini image-backend program's final w
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
-- [ ] Reference-image size cap validates `len(content)` rather than trusting the caller-supplied `bytes_len` field, and empty `content=b""` is refused at the choke point (harden BEFORE the Console attach-UX program opens a real production constructor; today both adapters fail loudly anyway).
-- [ ] fal `_app_id` handles fal's `APP_NAMESPACES` endpoint grammar (`workflows/...`, `comfy/...` prefixes shift the owner/app segments by one) — today a namespaced model would misdiagnose as "fal queue URL shape changed" (loud, but wrong diagnosis).
-- [ ] Pre-existing (out of this program's diff): the chat-side Google path (`LLM_Calls/LLM_API_Calls.py` ~:2906) sends `x-goog-api-key` through a redirect-following `requests.Session` — outside the guarded-helper credential-strip net that now protects the image path. Route it through guarded transport or strip on redirect.
-- [ ] Per-backend keyring-source loader tests for `fal`/`gemini` (generic keyring path is covered; sibling backends share the same gap).
-- [ ] `fetch_bytes_via_post`'s docstring cites Fireworks (dropped) as its example consumer — reword to a generic bytes-returning-POST description. Note the helper currently has NO production consumer (kept: tested, guarded, and the class of API it serves recurs).
-- [ ] Gemini 429 (quota) and fal 403 (locked/exhausted-balance) surface generic httpx text — add friendlier enriched messages ("rate limited / image quota exhausted — free-tier caps apply"; "fal account locked or out of balance — top up at fal.ai") alongside the 404 enrichment pattern (live-UAT observations; both raw bodies carry actionable detail our sanitization rightly drops — the enrichment can name the CATEGORY without echoing bodies).
+- [x] #1 Reference-image size cap validates `len(content)` rather than trusting the caller-supplied `bytes_len` field, and empty `content=b""` is refused at the choke point (harden BEFORE the Console attach-UX program opens a real production constructor; today both adapters fail loudly anyway).
+- [x] #2 fal `_app_id` handles fal's `APP_NAMESPACES` endpoint grammar (`workflows/...`, `comfy/...` prefixes shift the owner/app segments by one) — today a namespaced model would misdiagnose as "fal queue URL shape changed" (loud, but wrong diagnosis).
+- [ ] #3 Pre-existing (out of this program's diff): the chat-side Google path (`LLM_Calls/LLM_API_Calls.py` ~:2906) sends `x-goog-api-key` through a redirect-following `requests.Session` — outside the guarded-helper credential-strip net that now protects the image path. Route it through guarded transport or strip on redirect.
+- [x] #4 Per-backend keyring-source loader tests for `fal`/`gemini` (generic keyring path is covered; sibling backends share the same gap).
+- [x] #5 `fetch_bytes_via_post`'s docstring cites Fireworks (dropped) as its example consumer — reword to a generic bytes-returning-POST description. Note the helper currently has NO production consumer (kept: tested, guarded, and the class of API it serves recurs).
+- [x] #6 Gemini 429 (quota) and fal 403 (locked/exhausted-balance) surface generic httpx text — add friendlier enriched messages ("rate limited / image quota exhausted — free-tier caps apply"; "fal account locked or out of balance — top up at fal.ai") alongside the 404 enrichment pattern (live-UAT observations; both raw bodies carry actionable detail our sanitization rightly drops — the enrichment can name the CATEGORY without echoing bodies).
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -41,4 +39,77 @@ Each unit: TDD, per-unit review; PR + merge per the standing procedure.
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
+### Unit 1 (engine cluster) -- 2026-07-25
+
+Implemented the 5 engine-side follow-ups (AC #1, #2, #4, #5, #6). AC #3
+(chat-side `x-goog-api-key` redirect gap in `LLM_Calls/LLM_API_Calls.py`) is
+unit 2, tracked separately -- status stays In Progress until that lands.
+
+- **Choke-point hardening** (`request_validation.py::_validate_reference_image`):
+  the size cap now validates `len(content)`, never the caller-supplied
+  `bytes_len` field (a mismatched constructor could previously bypass the
+  cap by lying about `bytes_len` while `content` was actually oversized).
+  `content is None` and `content == b""` are now refused identically
+  ("reference image has no content bytes"); since both states derive from
+  the same `content` field they're mutually exclusive with the oversize
+  check (`elif`, not independent `if`s like the backend/mime checks).
+  Rewrote the two existing size-boundary tests to use real content bytes
+  instead of a bare `bytes_len` claim, split the old combined
+  "multiple problems" test into a no-content variant and an oversize
+  variant (they can no longer both fire at once), and added a dedicated
+  red test for the lying-`bytes_len` bypass plus an empty-bytes test.
+
+- **fal `APP_NAMESPACES` grammar** (`fal_image_adapter.py::_app_id`):
+  re-verified live against fal_client's own SDK source
+  (https://github.com/fal-ai/fal/blob/main/projects/fal_client/src/fal_client/client.py,
+  `APP_NAMESPACES = ["workflows", "comfy"]` at line 718,
+  `AppId.from_endpoint_id` at lines 743-761, queue-URL builder at lines
+  1439-1440) -- confirms the Task-6 report's finding. A namespaced path
+  (`workflows/...`, `comfy/...`) keeps its first THREE segments
+  (`namespace/owner/alias`) instead of two; anything after that is dropped
+  the same way a variant segment is dropped for plain paths. Implemented
+  exactly this in `_app_id` (namespace check first, 3-segment floor +
+  slice when namespaced, unchanged 2-segment behavior otherwise). Added
+  unit tests for both namespace prefixes, the 4-segment-drops-to-3 case,
+  the too-few-segments error, an explicit "plain path unchanged" pin, an
+  end-to-end poll-URL test through `generate()`, and a namespaced variant
+  of the vendor `status_url` cross-check test (the cross-check property
+  itself needed no code change -- it just needed proof it still holds for
+  the new shape).
+
+- **Per-backend keyring tests** (`test_config_loader.py`): added
+  `test_fal_key_sources_keyring` / `test_gemini_key_sources_keyring`
+  following the existing `test_key_sources_keyring` (novita) pattern --
+  pure coverage, no production code change (the shared
+  `_resolve_secret`/`_keyring_get` machinery already handled both
+  backends correctly).
+
+- **`fetch_bytes_via_post` docstring** (`http_client.py`): reworded the
+  Fireworks-specific example-consumer mention to a generic
+  bytes-returning-POST description, and noted explicitly that no adapter
+  in this codebase currently calls the helper (kept: guarded, tested, and
+  the class of API it serves recurs across vendors).
+
+- **Enriched vendor-wall messages**: added a 429 `elif` branch in
+  `gemini_image_adapter.py` (before the generic wrapper, same shape as the
+  existing 400/404 enrichment) naming the model id and
+  "rate limited or image quota exhausted (free-tier caps apply)"; added a
+  403 `elif` branch in `fal_image_adapter.py::_submit` (before the generic
+  wrapper, same shape as the existing 404 enrichment) with
+  "fal account locked or out of balance -- top up at
+  fal.ai/dashboard/billing". Both are CATEGORY-level only -- never echo
+  the response body; red tests assert the enrichment text is present and
+  an injected body-detail marker is absent, and the existing 500/other
+  generic-message tests stay green unmodified.
+
+Verification: `Tests/Image_Generation/` full suite (251 passed, 9 skipped),
+`ruff check` on all touched files (clean), `python -c "import
+tldw_chatbook.app"` (imports cleanly). Files touched: `request_validation.py`,
+`adapters/fal_image_adapter.py`, `adapters/gemini_image_adapter.py`,
+`http_client.py`, `Tests/Image_Generation/test_request_validation.py`,
+`test_fal_adapter.py`, `test_gemini_adapter.py`, `test_config_loader.py`.
+<!-- SECTION:NOTES:END -->
+
+<!-- SECTION:NOTES:END -->
+
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-686 - fal-Gemini-image-backends-follow-ups.md
+++ b/backlog/tasks/task-686 - fal-Gemini-image-backends-follow-ups.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-686
 title: fal/Gemini image backends follow-ups
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-26 03:30'
-updated_date: '2026-07-26 05:54'
+updated_date: '2026-07-26 06:03'
 labels:
   - image-generation
   - followup
@@ -22,7 +22,7 @@ Non-blocking follow-ups from the fal.ai + Gemini image-backend program's final w
 <!-- AC:BEGIN -->
 - [x] #1 Reference-image size cap validates `len(content)` rather than trusting the caller-supplied `bytes_len` field, and empty `content=b""` is refused at the choke point (harden BEFORE the Console attach-UX program opens a real production constructor; today both adapters fail loudly anyway).
 - [x] #2 fal `_app_id` handles fal's `APP_NAMESPACES` endpoint grammar (`workflows/...`, `comfy/...` prefixes shift the owner/app segments by one) — today a namespaced model would misdiagnose as "fal queue URL shape changed" (loud, but wrong diagnosis).
-- [ ] #3 Pre-existing (out of this program's diff): the chat-side Google path (`LLM_Calls/LLM_API_Calls.py` ~:2906) sends `x-goog-api-key` through a redirect-following `requests.Session` — outside the guarded-helper credential-strip net that now protects the image path. Route it through guarded transport or strip on redirect.
+- [x] #3 Pre-existing (out of this program's diff): the chat-side Google path (`LLM_Calls/LLM_API_Calls.py` ~:2906) sends `x-goog-api-key` through a redirect-following `requests.Session` — outside the guarded-helper credential-strip net that now protects the image path. Route it through guarded transport or strip on redirect.
 - [x] #4 Per-backend keyring-source loader tests for `fal`/`gemini` (generic keyring path is covered; sibling backends share the same gap).
 - [x] #5 `fetch_bytes_via_post`'s docstring cites Fireworks (dropped) as its example consumer — reword to a generic bytes-returning-POST description. Note the helper currently has NO production consumer (kept: tested, guarded, and the class of API it serves recurs).
 - [x] #6 Gemini 429 (quota) and fal 403 (locked/exhausted-balance) surface generic httpx text — add friendlier enriched messages ("rate limited / image quota exhausted — free-tier caps apply"; "fal account locked or out of balance — top up at fal.ai") alongside the 404 enrichment pattern (live-UAT observations; both raw bodies carry actionable detail our sanitization rightly drops — the enrichment can name the CATEGORY without echoing bodies).
@@ -108,6 +108,39 @@ tldw_chatbook.app"` (imports cleanly). Files touched: `request_validation.py`,
 `adapters/fal_image_adapter.py`, `adapters/gemini_image_adapter.py`,
 `http_client.py`, `Tests/Image_Generation/test_request_validation.py`,
 `test_fal_adapter.py`, `test_gemini_adapter.py`, `test_config_loader.py`.
+
+### Unit 2 (chat-side x-goog-api-key redirect gap, AC #3) -- 2026-07-26
+
+`grep -rn "x-goog-api-key" tldw_chatbook/LLM_Calls/` confirmed exactly one
+occurrence -- `chat_with_google` in `LLM_API_Calls.py`, one call site shared
+by both the streaming and non-streaming branches. The `Retry`'s
+`status_forcelist` is `[429, 500, 503]` (never 3xx), and the target URL is a
+hardcoded literal, so no legitimate redirect was ever expected. Chose option
+(a) from the plan: added `allow_redirects=False` to the `session.post(...)`
+call, and an explicit check right after (`raise_for_status()` does NOT raise
+on 3xx, so this can't ride on that) that closes the response and raises
+`ChatProviderError(provider="google", status_code=<3xx>, message="Google
+endpoint redirected unexpectedly -- refusing to follow with credentials.")`
+for any `300 <= status_code < 400`. `ChatProviderError` is a `ChatAPIError`
+subclass, so the function's existing outer exception handler re-raises it
+verbatim instead of wrapping it as a generic error. Verified the streaming
+call shape (`stream=True`) honors `allow_redirects=False` identically to
+non-streaming.
+
+Added 8 tests to the existing `Tests/Chat/test_google_native_tools.py`
+(mocks `requests.Session.post`, drives `chat_api_call`): pin that
+`allow_redirects=False` is always passed; a parametrized 3xx test
+(301/302/303/307/308) for both non-streaming and streaming asserting the
+refusal error, exactly one request issued (nothing re-sent the credential),
+`raise_for_status()` never called, and the response closed; and a pin that
+the normal 200 path is unaffected.
+
+Verification: `Tests/Chat/test_google_native_tools.py` (28 passed, including
+the 8 new), `Tests/Image_Generation/` full suite (251 passed, 9 skipped,
+collateral -- unaffected), `ruff check` on both touched files (clean),
+`python -c "import tldw_chatbook.app"` (imports cleanly). Files touched:
+`LLM_Calls/LLM_API_Calls.py`, `Tests/Chat/test_google_native_tools.py`. Full
+report: `.superpowers/sdd/2026-07-26-imagegen-fal-gemini-fireworks/task-686-unit2-report.md`.
 <!-- SECTION:NOTES:END -->
 
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Image_Generation/adapters/fal_image_adapter.py
+++ b/tldw_chatbook/Image_Generation/adapters/fal_image_adapter.py
@@ -25,6 +25,22 @@ sources):
   which splits an endpoint id into ``owner``/``alias``/``path`` and uses
   only ``owner/alias`` to build the queue status/result base URL --
   exactly the two-segment rule this adapter's ``_app_id`` implements.
+- fal's endpoint grammar also has two "app namespace" prefixes --
+  ``workflows/`` and ``comfy/`` -- that shift the owner/app segments one
+  position to the right. Re-verified 2026-07-25 against the same SDK file
+  (https://github.com/fal-ai/fal/blob/main/projects/fal_client/src/fal_client/client.py):
+  ``APP_NAMESPACES = ["workflows", "comfy"]`` (line 718);
+  ``AppId.from_endpoint_id`` (lines 743-761) special-cases
+  ``parts[0] in APP_NAMESPACES`` to parse ``owner=parts[1]``,
+  ``alias=parts[2]``, ``path="/".join(parts[3:])``, ``namespace=parts[0]``;
+  and the queue URL builders (e.g. lines 1439-1440) prepend
+  ``f"{namespace}/"`` before ``owner/alias`` when a namespace is present.
+  So for a namespaced path the kept prefix is THREE segments
+  (``namespace/owner/alias``), not two -- ``_app_id`` below implements this
+  exactly: ``workflows/fal-ai/some-flow`` (3 segments) is kept whole,
+  ``workflows/owner/app/variant`` (4 segments) drops only the trailing
+  ``variant``, and a plain (non-namespaced) path keeps the original
+  two-segment rule unchanged.
 
 Because the polling/result URLs are self-built from validated inputs
 (never taken from the API response), a submit response's own
@@ -74,6 +90,11 @@ _MODEL_PATH_CHARSET_RE = re.compile(r"^[A-Za-z0-9._\-/]+$")
 # path above.
 _REQUEST_ID_RE = re.compile(r"^[A-Za-z0-9-]+$")
 
+# fal's "app namespace" prefixes (see module docstring for the verified
+# source): a path starting with one of these shifts owner/alias one segment
+# to the right, so `_app_id` must keep three segments instead of two.
+_APP_NAMESPACES = frozenset({"workflows", "comfy"})
+
 
 def _validate_model_path(path: str) -> str:
     """Validate a fal model path's charset and segment shape, returning it stripped.
@@ -110,24 +131,39 @@ def _validate_model_path(path: str) -> str:
 
 
 def _app_id(model_path: str) -> str:
-    """Derive fal's queue "app id" (owner/app) from an already-validated model path.
+    """Derive fal's queue "app id" from an already-validated model path.
 
-    Only the first two ``/``-segments are used -- any further segments (a
-    model variant, e.g. ``schnell`` in ``fal-ai/flux/schnell``) are dropped.
-    See the module docstring for how this was verified against fal's own
-    client SDK.
+    For a plain path, only the first two ``/``-segments are used -- any
+    further segments (a model variant, e.g. ``schnell`` in
+    ``fal-ai/flux/schnell``) are dropped. When the path starts with one of
+    fal's namespace prefixes (``workflows/``, ``comfy/`` -- see
+    ``_APP_NAMESPACES`` and the module docstring for how this was verified
+    against fal's own client SDK), the owner/alias segments are shifted one
+    position to the right, so the first THREE segments are kept instead
+    (``namespace/owner/alias``); any segments after that are dropped the
+    same way.
 
     Args:
         model_path: An already ``_validate_model_path``-validated path.
 
     Returns:
-        The first two segments joined by ``/`` (e.g. ``"fal-ai/flux"``).
+        The first two segments joined by ``/`` (e.g. ``"fal-ai/flux"``), or
+        the first three when ``model_path`` starts with an app-namespace
+        prefix (e.g. ``"workflows/owner/app"``).
 
     Raises:
         ImageBackendUnavailableError: If ``model_path`` has fewer than two
-            ``/``-segments.
+            ``/``-segments (fewer than three when namespaced).
     """
     segments = model_path.split("/")
+    if segments[0] in _APP_NAMESPACES:
+        if len(segments) < 3:
+            raise ImageBackendUnavailableError(
+                f"invalid fal model path {model_path!r} -- a {segments[0]!r}-namespaced "
+                "path needs at least three path segments (e.g. "
+                f"'{segments[0]}/owner/app') -- check [image_generation.fal] default_model"
+            )
+        return "/".join(segments[:3])
     if len(segments) < 2:
         raise ImageBackendUnavailableError(
             f"invalid fal model path {model_path!r} -- expected at least two "
@@ -291,6 +327,16 @@ class FalImageAdapter:
                 raise ImageGenerationError(
                     f"model {model_path!r} was rejected by fal (404) -- check "
                     "[image_generation.fal] default_model"
+                ) from exc
+            # task-686 (live-UAT observation): a bare httpx 403 doesn't say
+            # *why* -- name the CATEGORY (locked / out-of-balance account)
+            # and where to fix it, never the raw response body (it may
+            # carry account-identifying detail our sanitization rightly
+            # drops).
+            if exc.response is not None and exc.response.status_code == 403:
+                raise ImageGenerationError(
+                    "fal account locked or out of balance -- top up at "
+                    "fal.ai/dashboard/billing (403)"
                 ) from exc
             raise ImageGenerationError(f"fal submit request failed: {exc}") from exc
         except ImageGenerationError:

--- a/tldw_chatbook/Image_Generation/adapters/gemini_image_adapter.py
+++ b/tldw_chatbook/Image_Generation/adapters/gemini_image_adapter.py
@@ -146,6 +146,15 @@ class GeminiImageAdapter:
                     f"model {model!r} was rejected by Gemini ({status}) — check "
                     "[image_generation.gemini] default_model"
                 ) from exc
+            # task-686 (live-UAT observation): a bare httpx 429 doesn't say
+            # *why* -- name the CATEGORY (rate limited / quota exhausted)
+            # and the model id, never the raw response body (it may carry
+            # account-identifying detail our sanitization rightly drops).
+            if exc.response is not None and exc.response.status_code == 429:
+                raise ImageGenerationError(
+                    f"Gemini rate limited or image quota exhausted (free-tier caps apply) "
+                    f"for model {model!r} (429)"
+                ) from exc
             raise ImageGenerationError(f"Gemini request failed: {exc}") from exc
         except ImageGenerationError:
             raise

--- a/tldw_chatbook/Image_Generation/http_client.py
+++ b/tldw_chatbook/Image_Generation/http_client.py
@@ -272,10 +272,15 @@ def fetch_bytes_via_post(
 ) -> tuple[bytes, str]:
     """Issue a POST request and return the raw response body, not parsed JSON.
 
-    For backends that return image bytes directly from a POST (e.g. Fireworks'
-    image-generation endpoint) rather than a JSON envelope carrying a URL or
-    base64 payload. Mirrors ``fetch_json``'s manual, per-hop-validated
-    redirect loop: egress is re-validated on every hop,
+    For backends whose generation endpoint returns the response bytes (e.g.
+    raw image data) directly from a POST, rather than a JSON envelope
+    carrying a URL or a base64 payload. No adapter in this codebase calls
+    this helper today -- it is kept because this class of API (a POST that
+    streams the payload straight back instead of wrapping it in JSON)
+    recurs across image-generation vendors, and it stays guarded and tested
+    (see ``test_http_client.py``) so it's ready the next time one shows up.
+    Mirrors ``fetch_json``'s manual, per-hop-validated redirect loop: egress
+    is re-validated on every hop,
     ``Authorization``/``Cookie``/``Proxy-Authorization`` are stripped on any
     hop whose origin differs from the original request's (see ``fetch_json``'s
     docstring for the full same-origin rationale), and redirects are never

--- a/tldw_chatbook/Image_Generation/request_validation.py
+++ b/tldw_chatbook/Image_Generation/request_validation.py
@@ -222,10 +222,16 @@ def _validate_reference_image(
             )
         )
 
-    bytes_len = getattr(reference_image, "bytes_len", None)
-    if isinstance(bytes_len, int) and not isinstance(bytes_len, bool) and bytes_len > IMAGE_GEN_REFERENCE_MAX_BYTES:
-        issues.append(_issue("reference image exceeds the 10MB limit", "reference_image"))
-
+    # task-686 hardening: the size cap validates the ACTUAL content bytes,
+    # never the caller-supplied `bytes_len` field -- a constructor that
+    # mismatches the two (e.g. reports a small bytes_len while content is
+    # genuinely oversized) must not bypass the cap. `content == b""` is
+    # refused the same way as `content is None`: both mean "no usable
+    # content bytes", and can't simultaneously be "oversized", so these are
+    # mutually exclusive states of one field (unlike the backend/mime checks
+    # above, which remain independent of each other and of this one).
     content = getattr(reference_image, "content", None)
-    if content is None:
+    if content is None or content == b"":
         issues.append(_issue("reference image has no content bytes", "reference_image"))
+    elif len(content) > IMAGE_GEN_REFERENCE_MAX_BYTES:
+        issues.append(_issue("reference image exceeds the 10MB limit", "reference_image"))

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -2929,6 +2929,29 @@ def chat_with_google(
                 json=payload,
                 stream=current_streaming,
                 timeout=180,
+                # task-686 AC #3: the API key travels in the custom
+                # `x-goog-api-key` header. `requests` strips `Authorization`
+                # across a redirect host change but NOT custom headers, so a
+                # 3xx from this endpoint would re-send the key wherever
+                # `Location` points. Refuse to follow rather than silently
+                # forward credentials -- see the explicit 3xx check below.
+                allow_redirects=False,
+            )
+        if 300 <= response.status_code < 400:
+            location = response.headers.get("Location", "<no Location header>")
+            logger.error(
+                f"Google Gemini: API endpoint returned a redirect "
+                f"({response.status_code} -> {location}); refusing to follow "
+                f"with the x-goog-api-key credential."
+            )
+            response.close()
+            raise ChatProviderError(
+                provider="google",
+                message=(
+                    "Google endpoint redirected unexpectedly -- refusing to "
+                    "follow with credentials."
+                ),
+                status_code=response.status_code,
             )
         response.raise_for_status()
 


### PR DESCRIPTION
## Summary

Closes **task-686** — the follow-up list from the fal/Gemini backends program (#915), both units SDD-reviewed and approved with zero findings.

### Engine follow-ups (`578749581`)
- **Choke-point hardening**: the reference-image size cap now validates `len(content)` (a constructor with a lying `bytes_len` could previously bypass it) and `content=b""` is refused — closing the two edges the #915 final review triaged here, ahead of the Console attach-UX program.
- **fal APP_NAMESPACES grammar**: `_app_id` now handles fal's namespaced endpoint ids (`workflows/...`, `comfy/...` keep namespace/owner/alias — verified live against fal_client's `AppId.from_endpoint_id` source); the self-built-poll-URL security property is test-proven for both shapes.
- **Friendlier vendor-wall errors** (from live UAT): Gemini 429 → "rate limited or image quota exhausted (free-tier caps apply)" naming the model; fal 403 → "account locked or out of balance — top up at fal.ai/dashboard/billing". Category-level only; response bodies still never echoed (pinned).
- Per-backend keyring-source loader tests for fal/gemini; `fetch_bytes_via_post` docstring reworded (no more dropped-Fireworks reference; honest no-current-consumer note).

### Chat-side credential fix (`9f8341870`)
- Pre-existing gap (found by the #915 final review, outside that PR's diff): `chat_with_google` sent `x-goog-api-key` through a redirect-following `requests.Session` — requests strips `Authorization` on host changes but NOT custom headers. The call now sets `allow_redirects=False` and refuses any 3xx with a clear error ("refusing to follow with credentials"): the URL is a hardcoded Google literal, so no redirect is ever legitimate — refusal beats stripping. Proven by call-recording fakes (single request, both streaming and non-streaming shapes); 200-path behavior unchanged; reviewer traced requests' adapter internals to confirm no code path can re-send after a 3xx.

## Testing
`Tests/Image_Generation/` 251 passed / 9 skipped; `Tests/Chat/test_google_native_tools.py` 28 passed (8 new); ruff clean; app import clean. Reviewers independently re-verified the fal SDK grammar claim and the requests redirect internals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens fal/Gemini image backends and blocks Google chat redirects that could leak the `x-goog-api-key`. Completes task-686 with stricter reference-image validation, correct fal namespaced app IDs, and clearer quota/billing errors.

- **Bug Fixes**
  - Google chat: set `allow_redirects=False` on `requests.Session.post`; refuse any 3xx with a clear error to prevent forwarding `x-goog-api-key` (streaming and non-streaming).
  - Reference images: size cap uses `len(content)` and rejects `content=b""`; a lying `bytes_len` can’t bypass the limit.
  - fal app IDs: support `workflows/...` and `comfy/...` by keeping the first three segments; poll URLs validated for namespaced and plain paths.
  - Errors: enrich Gemini 429 with “rate limited or image quota exhausted” (names model), and fal 403 with “account locked or out of balance — top up at fal.ai/dashboard/billing”; never echo response bodies.

- **Refactors**
  - `fetch_bytes_via_post` docstring generalized and notes no current consumer.
  - Added per-backend keyring-source tests for `fal` and `gemini`.

<sup>Written for commit c60201507a7b4ce317b782149954a1ab76a3c965. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

