### PR TITLE
chore(backlog): mark tasks 684.1-684.3 Done

### DIFF
--- a/backlog/tasks/task-684.1 - Bring-server-backed-ingestion-into-the-Library-ingest-canvas.md
+++ b/backlog/tasks/task-684.1 - Bring-server-backed-ingestion-into-the-Library-ingest-canvas.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-684.1
 title: Bring server-backed ingestion into the Library ingest canvas
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-26 04:33'
-updated_date: '2026-07-26 14:00'
+updated_date: '2026-07-26 15:35'
 labels:
   - ingest
   - consolidation

--- a/backlog/tasks/task-684.2 - Show-remote-ingest-jobs-in-the-Library-ingest-queue.md
+++ b/backlog/tasks/task-684.2 - Show-remote-ingest-jobs-in-the-Library-ingest-queue.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-684.2
 title: Show remote ingest jobs in the Library ingest queue
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-26 04:33'
-updated_date: '2026-07-26 14:01'
+updated_date: '2026-07-26 15:35'
 labels:
   - ingest
   - consolidation

--- a/backlog/tasks/task-684.3 - Bring-web-clipping-into-the-Library-ingest-canvas.md
+++ b/backlog/tasks/task-684.3 - Bring-web-clipping-into-the-Library-ingest-canvas.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-684.3
 title: Bring web clipping into the Library ingest canvas
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-07-26 04:33'
-updated_date: '2026-07-26 14:45'
+updated_date: '2026-07-26 15:35'
 labels:
   - ingest
   - consolidation


### PR DESCRIPTION
Status-only follow-up to #923 (merged as `864a2e6b0`). The implementation notes and ticked acceptance criteria shipped with that PR; this just moves the three tasks to `Done`, which the CLI writes as a frontmatter change.

**684.4 stays open**: its AC#1 (Import sources opening the canvas in place) landed in #923, but the window deletion did not — that is a separate ~2,538 LOC removal.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark backlog tasks 684.1–684.3 as Done by updating task frontmatter to reflect shipped work. 684.4 remains open pending window deletion; no code changes.

<sup>Written for commit 4698ce6824778ff8449b205779e3b2079cd86092. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

