### PR TITLE
Watchlists follow-ups: wire the FTS backfill, fix in-memory SubscriptionsDB

### DIFF
--- a/Tests/DB/test_subscriptions_db.py
+++ b/Tests/DB/test_subscriptions_db.py
@@ -354,3 +354,53 @@ def test_rebuild_recovers_from_stray_subscription_filters_new_table(tmp_path):
         for r in migrated.conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
     }
     assert "subscription_filters_new" not in tables
+
+
+def test_in_memory_db_has_usable_schema():
+    """Regression for task-689. Before the fix, ``_initialize_schema`` built
+    the schema on a connection from ``with closing(self._get_connection())``
+    that was closed immediately after, while the ``.conn`` property used by
+    every other method opened a *different* ``:memory:`` connection -- an
+    entirely separate, empty database in SQLite's model. ``.conn`` therefore
+    had zero tables and any write raised ``OperationalError: no such table``.
+    """
+    db = SubscriptionsDB(":memory:", client_id="probe")
+    tables = {
+        row[0]
+        for row in db.conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+    assert "subscriptions" in tables
+    assert "subscription_items" in tables
+    assert "watchlists" in tables
+
+    # A basic write must succeed against the connection callers actually use.
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+    assert db.get_subscription(source_id)["name"] == "ArXiv"
+
+
+def test_in_memory_db_instances_stay_isolated():
+    """Two separate ``:memory:`` instances must not see each other's data --
+    each opens its own private SQLite database, and nothing here shares a
+    cache or file between them."""
+    db_a = SubscriptionsDB(":memory:", client_id="a")
+    db_b = SubscriptionsDB(":memory:", client_id="b")
+
+    db_a.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+
+    assert db_a.conn.execute("SELECT COUNT(*) FROM subscriptions").fetchone()[0] == 1
+    assert db_b.conn.execute("SELECT COUNT(*) FROM subscriptions").fetchone()[0] == 0
+
+
+def test_ensure_watchlists_schema_idempotent_on_in_memory_db():
+    """The ``conn=None`` standalone-call path (used directly by
+    test_schema_migration_is_idempotent's file-backed counterpart) must also
+    stay correct against an in-memory instance rather than silently
+    operating on a throwaway, discarded connection."""
+    db = SubscriptionsDB(":memory:", client_id="probe")
+    db._ensure_watchlists_schema()
+    db._ensure_watchlists_schema()
+    tables = {
+        row[0]
+        for row in db.conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+    assert "watchlists" in tables

--- a/Tests/Subscriptions/test_fts_backfill.py
+++ b/Tests/Subscriptions/test_fts_backfill.py
@@ -15,8 +15,8 @@ def _drop_ai_trigger(db):
     row that already existed in `subscription_items` before the FTS index
     was ever created on a real upgraded database. Matches the established
     pattern in Tests/DB/test_subscriptions_db_watchlists.py."""
-    db.conn.execute("DROP TRIGGER subscription_items_fts_ai")
-    db.conn.commit()
+    with db.transaction() as conn:
+        conn.execute("DROP TRIGGER subscription_items_fts_ai")
 
 
 def _insert_legacy_item(db, subscription_id, url, title, content):

--- a/Tests/Subscriptions/test_fts_backfill.py
+++ b/Tests/Subscriptions/test_fts_backfill.py
@@ -1,0 +1,88 @@
+import pytest
+
+from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
+from tldw_chatbook.Subscriptions.fts_backfill import backfill_subscription_items_fts
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SubscriptionsDB(str(tmp_path / "subs.db"), client_id="test")
+
+
+def _drop_ai_trigger(db):
+    """Simulate pre-existing (legacy) rows: with no `_ai` trigger, a row
+    inserted afterwards is never written into the FTS index, exactly like a
+    row that already existed in `subscription_items` before the FTS index
+    was ever created on a real upgraded database. Matches the established
+    pattern in Tests/DB/test_subscriptions_db_watchlists.py."""
+    db.conn.execute("DROP TRIGGER subscription_items_fts_ai")
+    db.conn.commit()
+
+
+def _insert_legacy_item(db, subscription_id, url, title, content):
+    with db.transaction() as conn:
+        conn.execute(
+            "INSERT INTO subscription_items "
+            "(subscription_id, url, title, content, content_kind, content_format) "
+            "VALUES (?, ?, ?, ?, 'article', 'text')",
+            (subscription_id, url, title, content),
+        )
+
+
+def test_wired_backfill_makes_preexisting_items_searchable(db):
+    """task-688: the upgrade path end to end. A database with items that
+    predate the FTS index becomes fully searchable after the wired
+    (looping-to-completion) path runs, not just after a single chunk."""
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+    _drop_ai_trigger(db)
+    for index in range(12):
+        _insert_legacy_item(
+            db,
+            source_id,
+            f"https://a.example/{index}",
+            f"Item {index}",
+            "retrieval quality rubric",
+        )
+
+    # Confirm the rows really are unindexed first, or this test would pass
+    # vacuously.
+    assert db.conn.execute(
+        "SELECT COUNT(*) FROM subscription_items_fts_docsize"
+    ).fetchone()[0] == 0
+
+    total = backfill_subscription_items_fts(db, chunk_size=5)
+
+    assert total == 12
+    assert db.conn.execute(
+        "SELECT COUNT(*) FROM subscription_items_fts WHERE subscription_items_fts MATCH ?",
+        ("rubric",),
+    ).fetchone()[0] == 12
+
+
+def test_wired_backfill_is_idempotent_once_complete(db):
+    """A second call after completion indexes nothing and does not corrupt
+    the index (fts5 'integrity-check' stays clean)."""
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+    _drop_ai_trigger(db)
+    _insert_legacy_item(db, source_id, "https://a.example/1", "Item", "alpha content")
+
+    first_total = backfill_subscription_items_fts(db)
+    assert first_total == 1
+
+    second_total = backfill_subscription_items_fts(db)
+    assert second_total == 0
+
+    # Raises DatabaseError if the FTS index is actually corrupt.
+    db.conn.execute(
+        "INSERT INTO subscription_items_fts(subscription_items_fts) VALUES ('integrity-check')"
+    )
+
+
+def test_wired_backfill_on_already_fully_indexed_db_is_a_noop(db):
+    """A database with no legacy backlog at all (the common case, since the
+    `_ai` trigger indexes every item going forward) should not error and
+    should report nothing to do."""
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+    _insert_legacy_item(db, source_id, "https://a.example/1", "Item", "alpha content")
+
+    assert backfill_subscription_items_fts(db) == 0

--- a/Tests/Subscriptions/test_subscriptions_smoke.py
+++ b/Tests/Subscriptions/test_subscriptions_smoke.py
@@ -34,9 +34,26 @@ class _TrackedConnection:
 
 
 @pytest.mark.unit
-def test_subscriptions_db_closes_schema_initialization_connection(
+def test_subscriptions_db_schema_initialization_reuses_and_closes_connection(
     tmp_path, monkeypatch
 ):
+    """Updated for task-689.
+
+    Before task-689, ``_initialize_schema`` opened a throwaway connection via
+    ``with closing(self._get_connection()) as conn:`` and closed it
+    immediately -- harmless for a file database (a later connection reaches
+    the same file) but the exact reason a ``:memory:`` database ended up
+    with an empty ``.conn``: the schema landed on a connection nothing else
+    could ever see. This test used to assert that immediate close as the
+    expected behavior; it now asserts the fixed behavior instead.
+
+    ``_initialize_schema`` now runs on ``self.conn``, the thread-local
+    connection every other method reuses, so schema init opens exactly one
+    connection for the whole object, and that connection must still not be
+    leaked -- the original motivation for wrapping schema init in
+    ``closing(...)`` at all (commit ec489c052). It just needs to stay open
+    until ``db.close()``, not close immediately after init.
+    """
     connections = []
     original_connect = base_db_module.sqlite3.connect
 
@@ -49,10 +66,12 @@ def test_subscriptions_db_closes_schema_initialization_connection(
 
     db = SubscriptionsDB(tmp_path / "subscriptions.db")
     try:
-        assert connections
-        assert connections[0].closed is True
+        assert len(connections) == 1
+        assert connections[0].closed is False
     finally:
         db.close()
+
+    assert connections[0].closed is True
 
 
 @pytest.mark.unit

--- a/Tests/Subscriptions/test_watchlist_preview_service.py
+++ b/Tests/Subscriptions/test_watchlist_preview_service.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 import pytest
+from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
 from tldw_chatbook.Subscriptions.watchlist_preview_service import WatchlistPreviewService
 
 
@@ -18,6 +19,54 @@ async def test_preview_uses_run_executor_when_provided():
 
     assert result["items"][0]["url"] == "https://example.com/post"
     assert "Preview completed" in result["log_text"]
+
+
+@pytest.mark.asyncio
+async def test_preview_closes_its_database_on_success(monkeypatch):
+    """Since task-689 made the ``:memory:`` DB a real, functional connection
+    (rather than the inert, schema-less object it used to be), ``preview()``
+    must close it deterministically -- otherwise every preview call leaks a
+    thread-local sqlite3 connection and its in-memory database."""
+    closed = []
+    real_close = SubscriptionsDB.close
+
+    def spy_close(self):
+        closed.append(self)
+        real_close(self)
+
+    monkeypatch.setattr(SubscriptionsDB, "close", spy_close)
+
+    async def fake_executor(subscription):
+        return {"items": []}
+
+    svc = WatchlistPreviewService(run_executor=fake_executor)
+    await svc.preview({"source_type": "rss", "url": "https://example.com/feed"})
+
+    assert len(closed) == 1
+
+
+@pytest.mark.asyncio
+async def test_preview_closes_its_database_even_when_the_work_raises(monkeypatch):
+    """A failed preview is exactly when the resource must come back: the
+    connection must not be leaked on the exception path either."""
+    closed = []
+    real_close = SubscriptionsDB.close
+
+    def spy_close(self):
+        closed.append(self)
+        real_close(self)
+
+    monkeypatch.setattr(SubscriptionsDB, "close", spy_close)
+
+    async def raising_executor(subscription):
+        raise RuntimeError("boom")
+
+    svc = WatchlistPreviewService(run_executor=raising_executor)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await svc.preview({"source_type": "rss", "url": "https://example.com/feed"})
+
+    assert len(closed) == 1
 
 
 @pytest.mark.asyncio

--- a/Tests/Subscriptions/test_watchlist_preview_service.py
+++ b/Tests/Subscriptions/test_watchlist_preview_service.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 from tldw_chatbook.Subscriptions.watchlist_preview_service import WatchlistPreviewService
 
@@ -15,4 +17,43 @@ async def test_preview_uses_run_executor_when_provided():
     result = await svc.preview({"source_type": "rss", "url": "https://example.com/feed"})
 
     assert result["items"][0]["url"] == "https://example.com/post"
+    assert "Preview completed" in result["log_text"]
+
+
+@pytest.mark.asyncio
+async def test_preview_url_source_completes_end_to_end_without_raising(monkeypatch):
+    """Regression for task-689, exercising the real (non-overridden)
+    execution path -- no ``run_executor`` override, so this drives the
+    default executor's ``URLMonitor(db).check_url()`` for real, including
+    its write to ``url_snapshots``.
+
+    Before the fix this raised twice over: first ``OperationalError: no
+    such table: subscriptions`` (the in-memory schema bug), and once that
+    was fixed on its own, ``IntegrityError`` (the ``url_snapshots`` write
+    referencing the synthetic subscription id ``-1``, which has no parent
+    row once foreign_keys=ON actually has a real schema to enforce against).
+    """
+
+    async def fake_guarded(
+        url, *, client, max_bytes, trusted_origins=frozenset(), headers=None, params=None, auth=None
+    ):
+        return SimpleNamespace(
+            status_code=200,
+            headers={"content-type": "text/html"},
+            text="<html><body>hello world</body></html>",
+            final_url=url,
+            raise_for_status=lambda: None,
+        )
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Subscriptions.monitoring_engine.guarded_fetch_httpx_async",
+        fake_guarded,
+    )
+
+    svc = WatchlistPreviewService()
+    result = await svc.preview({"source_type": "url", "url": "https://example.com/page"})
+
+    # First check for a URL source stores a baseline snapshot and reports no
+    # change yet -- the point of this test is that it completes at all.
+    assert result["items"] == []
     assert "Preview completed" in result["log_text"]

--- a/backlog/tasks/task-688 - Wire-backfill_items_fts-so-pre-existing-items-become-searchable.md
+++ b/backlog/tasks/task-688 - Wire-backfill_items_fts-so-pre-existing-items-become-searchable.md
@@ -2,7 +2,7 @@
 id: TASK-688
 title: >-
   Wire backfill_items_fts so pre-existing items become searchable
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-25 22:05'
 labels:
@@ -27,10 +27,27 @@ Related: the same missing-index condition was also behind the Phase A Critical w
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Items that existed before the FTS index was created become searchable without any user action
-- [ ] #2 The backfill runs off the UI thread and never blocks app startup or screen mount, on a database with a large subscription_items table
-- [ ] #3 An interrupted backfill resumes where it left off rather than restarting
-- [ ] #4 The backfill is idempotent — running it again after completion indexes nothing and does not corrupt the index (FTS integrity-check stays clean)
-- [ ] #5 Progress is observable to the user, or at minimum logged, rather than being silently in-flight
-- [ ] #6 A test covers the upgrade path end to end: a database with pre-existing un-indexed items becomes fully searchable after the wired path runs
+- [x] #1 Items that existed before the FTS index was created become searchable without any user action
+- [x] #2 The backfill runs off the UI thread and never blocks app startup or screen mount, on a database with a large subscription_items table
+- [x] #3 An interrupted backfill resumes where it left off rather than restarting
+- [x] #4 The backfill is idempotent — running it again after completion indexes nothing and does not corrupt the index (FTS integrity-check stays clean)
+- [x] #5 Progress is observable to the user, or at minimum logged, rather than being silently in-flight
+- [x] #6 A test covers the upgrade path end to end: a database with pre-existing un-indexed items becomes fully searchable after the wired path runs
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Extract the backfill-to-completion loop into a small, pure, testable helper (`Subscriptions/fts_backfill.py::backfill_subscription_items_fts(db, chunk_size)`) that calls `SubscriptionsDB.backfill_items_fts` in a loop until it returns `0`, logging chunk progress and a completion summary.
+2. Wire a thin `TldwCli._backfill_subscription_items_fts()` worker body in `app.py` that opens its own `SubscriptionsDB` (same path/client id the rest of the app uses), delegates to the helper, and never lets an exception escape (catches, logs, closes the connection).
+3. Start it from `on_mount()` via `self.run_worker(..., thread=True, exclusive=True, group="subscriptions-fts-backfill")`, alongside the existing `scheduler_worker` / `model-catalog-refresh` startup workers, so it never blocks startup or screen mount.
+4. Add a regression test using the established drop-`_ai`-trigger pattern from `Tests/DB/test_subscriptions_db_watchlists.py` to simulate pre-existing un-indexed rows, and verify the wired helper converges to full searchability, is idempotent, and is a no-op when there is nothing to backfill.
+
+## Implementation Notes
+
+Wired via a small dedicated module rather than embedding the loop directly in `app.py`, so the core "drive backfill_items_fts to completion" logic is unit-testable without needing a full Textual `App` harness:
+
+- `tldw_chatbook/Subscriptions/fts_backfill.py` (new): `backfill_subscription_items_fts(db, chunk_size=500)` loops `SubscriptionsDB.backfill_items_fts` to completion, logging per-chunk progress at debug and a completion summary at info (AC #5). Idempotency and resumability (AC #3, #4) fall directly out of `backfill_items_fts`'s own docsize-backed "not yet indexed" check — the loop adds no additional state of its own that could get out of sync.
+- `tldw_chatbook/app.py`: added `TldwCli._backfill_subscription_items_fts()` (constructs its own `SubscriptionsDB(get_subscriptions_db_path(), CLI_APP_CLIENT_ID)`, delegates to the helper, closes the connection, and swallows/logs any exception so a backfill failure never crashes the app) and wired it into `on_mount()` via `self.run_worker(self._backfill_subscription_items_fts, thread=True, exclusive=True, group="subscriptions-fts-backfill")`, placed next to the existing `scheduler_worker` and `model-catalog-refresh` startup workers (AC #2 — `run_worker` only schedules the thread and returns immediately, so `on_mount` itself never blocks).
+- Each worker thread opens its own `SubscriptionsDB` instance rather than sharing one across threads, matching this codebase's thread-local-connection convention (`ChaChaNotes_DB`, `Client_Media_DB_v2`, and this same class all use `threading.local()`).
+- Tests: `Tests/Subscriptions/test_fts_backfill.py` (new) — `test_wired_backfill_makes_preexisting_items_searchable` (12 legacy rows across 3 chunks of 5, all become MATCH-searchable), `test_wired_backfill_is_idempotent_once_complete` (second call indexes 0, FTS `integrity-check` stays clean), `test_wired_backfill_on_already_fully_indexed_db_is_a_noop`. Additionally manually verified the actual `TldwCli._backfill_subscription_items_fts` wrapper end-to-end against a scratch DB path (bypassing the real user data dir) to confirm the app.py wiring itself, not just the helper, works.
+- Modified/added files: `tldw_chatbook/Subscriptions/fts_backfill.py` (new), `tldw_chatbook/app.py`, `Tests/Subscriptions/test_fts_backfill.py` (new).

--- a/backlog/tasks/task-689 - SubscriptionsDB-in-memory-is-non-functional-breaking-source-Preview.md
+++ b/backlog/tasks/task-689 - SubscriptionsDB-in-memory-is-non-functional-breaking-source-Preview.md
@@ -2,7 +2,7 @@
 id: TASK-689
 title: >-
   SubscriptionsDB(":memory:") is non-functional, breaking source Preview
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-25 22:05'
 labels:
@@ -32,9 +32,46 @@ Second, compounding issue for whoever fixes this: Phase A enabled foreign-key en
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 SubscriptionsDB(":memory:") returns a usable database — the schema is visible on the connection callers actually use
-- [ ] #2 A regression test asserts the tables exist and a basic write succeeds against an in-memory instance
-- [ ] #3 WatchlistPreviewService.preview() completes successfully against a real source config, end to end, without raising
-- [ ] #4 The synthetic subscription id used by preview no longer violates foreign-key enforcement
-- [ ] #5 Preview still persists nothing to the user's real database — the isolation the in-memory DB was chosen for is preserved
+- [x] #1 SubscriptionsDB(":memory:") returns a usable database — the schema is visible on the connection callers actually use
+- [x] #2 A regression test asserts the tables exist and a basic write succeeds against an in-memory instance
+- [x] #3 WatchlistPreviewService.preview() completes successfully against a real source config, end to end, without raising
+- [x] #4 The synthetic subscription id used by preview no longer violates foreign-key enforcement
+- [x] #5 Preview still persists nothing to the user's real database — the isolation the in-memory DB was chosen for is preserved
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Reproduce: confirm `SubscriptionsDB(":memory:").conn` has zero tables and `add_subscription` raises `no such table`.
+2. Root-cause and choose a fix for `_initialize_schema`'s throwaway-connection pattern; evaluate shared-cache URI + keepalive vs. reusing the thread-local `self.conn` (the approach `ChaChaNotes_DB` already uses), and pick one with an explicit multi-thread trade-off written down.
+3. Apply the same fix to `_ensure_watchlists_schema`'s `conn=None` standalone-call branch, so it is consistent.
+4. Fix the compounding FK issue in `WatchlistPreviewService.preview()`: seed a real `subscriptions` row in the throwaway in-memory DB instead of using the synthetic id `-1`.
+5. Add regression tests: schema/write on a bare in-memory instance, two-instance isolation, and an end-to-end `preview()` call that exercises the real (non-overridden) execute path, including its `url_snapshots` write.
+6. Update the one pre-existing test that encoded the old (buggy) close-immediately behavior as an expected invariant.
+
+## Implementation Notes
+
+**Root cause confirmed exactly as described.** `_initialize_schema` ran the schema on `with closing(self._get_connection()) as conn:`, closing that connection immediately, while `.conn` (used by every other method) lazily opens a *different* connection via the same `_get_connection()`. For a file database both calls reach the same file, so it was invisible; for `:memory:`, `sqlite3.connect(':memory:')` is a private, anonymous database per call, so the schema landed on a connection nothing else could ever reach.
+
+**Approach chosen: reuse `self.conn` (the thread-local connection) in `_initialize_schema`, rather than a shared-cache `file::memory:?cache=shared` URI + keepalive connection.** Both fix the bug. Reasons for the simpler one:
+- It is the pattern this codebase already uses for the identical problem: `ChaChaNotes_DB._initialize_schema` calls `self.get_connection()` (its own thread-local accessor), not a throwaway one. Matching precedent beats inventing a second mechanism for the same class of bug.
+- The only current `:memory:` caller, `WatchlistPreviewService.preview()`, constructs, uses, and discards its `SubscriptionsDB` instance within a single coroutine on one thread (scheduled via `run_worker(coroutine)`, not `thread=True` — confirmed by reading `watchlists_collections_screen.py`'s `self.run_worker(self._preview_source(entity), exclusive=True)`), so it never crosses a thread boundary.
+- A shared-cache URI adds real failure modes of its own (the shared in-memory database is destroyed the instant its last connection closes, so the keepalive connection's lifecycle becomes another thing that must never be gotten wrong) for a multi-thread need nothing in this codebase currently has.
+
+**Trade-off, made explicit rather than silently accepted:** if a *second* thread later touches `.conn` on the same in-memory `SubscriptionsDB` instance, that thread's own thread-local slot is empty, so it lazily opens yet another private, schema-less `:memory:` connection — the identical limitation `ChaChaNotes_DB` already carries for the same reason. Documented in the `_initialize_schema` docstring; a future caller that needs a genuinely thread-shared in-memory instance would need the shared-cache-URI approach instead.
+
+Applied the same reasoning to `_ensure_watchlists_schema`'s `conn=None` branch (previously also `with closing(self._get_connection()) as conn: ...; return`) so the standalone call path (used directly by an existing file-DB idempotency test) is consistent and in-memory-safe too.
+
+**FK fix:** `WatchlistPreviewService.preview()` now seeds a real `subscriptions` row via `preview_db.add_subscription(...)` and overwrites the synthetic `id: -1` with the real returned id before calling `_execute_subscription`. This is written into the same throwaway in-memory `preview_db`, so isolation from the user's real database is unaffected (AC #5) — confirmed by grep: `FeedMonitor.check_feed` (rss/atom/json_feed/podcast) makes no DB writes at all; only `url`/`url_list`/`sitemap` sources reach `URLMonitor._store_snapshot`'s `INSERT INTO url_snapshots`, which is the write this seed makes possible.
+
+**Pre-existing test updated, not just left broken:** `Tests/Subscriptions/test_subscriptions_smoke.py::test_subscriptions_db_closes_schema_initialization_connection` asserted the old bug's behavior directly ("the schema-init connection gets closed immediately"). Investigated its git history (`ec489c052`): it was added to guard against a real, separate leak (`with self._get_connection() as conn:` alone does not close a sqlite3 connection — only wraps a transaction — so the *original* pre-`closing()` code leaked a connection every construction). Renamed and rewritten as `test_subscriptions_db_schema_initialization_reuses_and_closes_connection`, asserting the corrected invariant: exactly one connection is opened for schema init, it is not closed immediately, and it *is* closed by `db.close()` — preserving the original no-leak guarantee without reintroducing the in-memory bug.
+
+**Tests added:**
+- `Tests/DB/test_subscriptions_db.py`: `test_in_memory_db_has_usable_schema`, `test_in_memory_db_instances_stay_isolated`, `test_ensure_watchlists_schema_idempotent_on_in_memory_db` (AC #1, #2).
+- `Tests/Subscriptions/test_watchlist_preview_service.py`: `test_preview_url_source_completes_end_to_end_without_raising` — no `run_executor` override, so it drives the real default executor's `URLMonitor(db).check_url()`, including the `url_snapshots` write, with only the network fetch (`guarded_fetch_httpx_async`) mocked out (AC #3, #4).
+- `Tests/Subscriptions/test_subscriptions_smoke.py`: updated as described above.
+
+**Verification beyond pytest:** manually confirmed two live `SubscriptionsDB(":memory:")` instances each see 17 tables and stay isolated (one instance's `add_subscription` write is invisible to the other), and confirmed the real config file (`~/.config/tldw_cli/config.toml`) was untouched throughout (mtime checked before/after every command; `TLDW_CONFIG_PATH` pointed at a scratch file for anything that imports `tldw_chatbook.config`/`app.py`).
+
+**Scope boundary respected — but flagging a related risk, per the task's instruction.** Did not touch `Library_Collections_DB`, `Workspace_DB`, or `AgentRuns_DB`. Checked each directly: all three use `with closing(self._get_connection()) as conn: yield conn` as a `connection()` *context manager* used fresh on every single call site, not a cached `.conn`/thread-local property. None has a production `:memory:` caller (grep for `LibraryCollectionsDB(`, `WorkspaceDB(`, `AgentRunsDB(` outside `Tests/` shows only real file paths). So today, nothing is broken. But if any of them were ever pointed at `:memory:`, the failure mode would arguably be *worse* than this task's bug: every single method call opens a brand-new, private, empty `:memory:` connection, so not even `_initialize_schema`'s own schema would survive to the next call, let alone a second thread. Not fixing this speculatively (no caller needs it, and "fix a bug with no reproduction" is exactly the kind of scope creep the task warns against) — filing this observation per the instruction rather than silently expanding scope or silently doing nothing.
+
+**Modified/added files:** `tldw_chatbook/DB/Subscriptions_DB.py`, `tldw_chatbook/Subscriptions/watchlist_preview_service.py`, `Tests/DB/test_subscriptions_db.py`, `Tests/Subscriptions/test_watchlist_preview_service.py`, `Tests/Subscriptions/test_subscriptions_smoke.py`.

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -118,8 +118,8 @@ class SubscriptionsDB(BaseDB):
         fix (e.g. a shared-cache ``file::memory:?cache=shared`` URI plus a
         dedicated keepalive connection).
         """
-        conn = self.conn
-        conn.executescript("""
+        with self.transaction() as conn:
+            conn.executescript("""
             PRAGMA foreign_keys = ON;
             
             -- Schema version tracking
@@ -349,7 +349,6 @@ class SubscriptionsDB(BaseDB):
                 UPDATE subscription_templates SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
             END;
             """)
-        conn.commit()
         self._ensure_watchlists_schema(conn)
 
     def _ensure_watchlists_schema(self, conn=None):

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -25,7 +25,7 @@ import json
 import sqlite3
 import threading
 import time
-from contextlib import closing, contextmanager
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Dict, Any, Optional, Union
@@ -90,9 +90,36 @@ class SubscriptionsDB(BaseDB):
         return conn
 
     def _initialize_schema(self):
-        """Initialize the database schema."""
-        with closing(self._get_connection()) as conn:
-            conn.executescript("""
+        """Initialize the database schema.
+
+        Runs on ``self.conn`` (the thread-local connection everything else on
+        this thread reuses) rather than a throwaway connection that used to
+        get closed immediately afterwards. For a file-backed database both
+        approaches land on the same file, so it made no observable
+        difference. For ``:memory:``, every ``sqlite3.connect(':memory:')``
+        call opens a brand-new, private, empty database -- so the old
+        close-then-reopen sequence built the schema somewhere the rest of
+        the class could never see, leaving ``.conn`` pointed at zero tables.
+        Matches the pattern ``ChaChaNotes_DB._initialize_schema`` already
+        uses (``self.get_connection()``) for the same reason.
+
+        Trade-off carried over from that same precedent: this only makes the
+        constructing thread's connection schema-bearing. If a *second*
+        thread later touches ``.conn`` on this same in-memory instance, its
+        own thread-local slot is empty, so the ``.conn`` property lazily
+        opens yet another private ``:memory:`` connection with no schema --
+        identical to the limitation already accepted in ``ChaChaNotes_DB``.
+        The only current ``:memory:`` caller, ``WatchlistPreviewService.
+        preview()``, constructs, uses, and discards its instance within a
+        single coroutine on one thread (it is scheduled via
+        ``run_worker(coroutine)``, not ``thread=True``), so this does not
+        apply there today; a future caller that hands an in-memory
+        ``SubscriptionsDB`` across a thread boundary would need a different
+        fix (e.g. a shared-cache ``file::memory:?cache=shared`` URI plus a
+        dedicated keepalive connection).
+        """
+        conn = self.conn
+        conn.executescript("""
             PRAGMA foreign_keys = ON;
             
             -- Schema version tracking
@@ -322,15 +349,17 @@ class SubscriptionsDB(BaseDB):
                 UPDATE subscription_templates SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
             END;
             """)
-            conn.commit()
-            self._ensure_watchlists_schema(conn)
+        conn.commit()
+        self._ensure_watchlists_schema(conn)
 
     def _ensure_watchlists_schema(self, conn=None):
         """Idempotent migration for watchlists screen schema additions."""
         if conn is None:
-            with closing(self._get_connection()) as conn:
-                self._ensure_watchlists_schema(conn)
-                return
+            # Same in-memory-safe reasoning as _initialize_schema above: reuse
+            # the thread-local connection rather than opening-and-closing a
+            # throwaway one, so this is also correct when called standalone
+            # (e.g. from a test) against an in-memory instance.
+            conn = self.conn
 
         cursor = conn.cursor()
 

--- a/tldw_chatbook/Subscriptions/fts_backfill.py
+++ b/tldw_chatbook/Subscriptions/fts_backfill.py
@@ -1,0 +1,68 @@
+"""Background FTS backfill for pre-existing subscription_items rows (task-688).
+
+``SubscriptionsDB.backfill_items_fts`` (task-1a / Phase A) is chunked and
+resumable, but nothing called it: the ``subscription_items_fts`` index is
+created empty over a table that may already hold rows scraped before the
+index existed, and only the insert/update triggers populate it going
+forward. Without this wiring, every item scraped before upgrading stays
+permanently unsearchable even though the search UI looks like it works.
+
+:func:`backfill_subscription_items_fts` is the pure, testable core of the
+fix -- it just drives ``backfill_items_fts`` to completion. ``app.py`` wires
+it into a ``run_worker(thread=True)`` call at startup so a large backlog
+never blocks app boot or screen mount; see
+``TldwCli._backfill_subscription_items_fts``.
+"""
+
+from __future__ import annotations
+
+from loguru import logger
+
+from ..DB.Subscriptions_DB import SubscriptionsDB
+
+
+def backfill_subscription_items_fts(db: SubscriptionsDB, chunk_size: int = 500) -> int:
+    """Index every pre-existing ``subscription_items`` row missing from FTS.
+
+    ``SubscriptionsDB.backfill_items_fts`` indexes at most ``chunk_size`` rows
+    per call and returns ``0`` once nothing remains. Looping it to completion
+    here is what makes the *wired* path resumable and idempotent, not just
+    the underlying method in isolation: the "not yet indexed" state lives in
+    the database itself (the ``subscription_items_fts_docsize`` shadow
+    table), not in any counter kept by this function or its caller, so an
+    interrupted run (app killed mid-loop, worker cancelled, ...) simply
+    leaves some rows unindexed for the next call to pick up, and a call made
+    after completion does no writes at all rather than re-indexing or
+    corrupting anything.
+
+    Args:
+        db: The ``SubscriptionsDB`` instance to backfill.
+        chunk_size: Rows to index per underlying ``backfill_items_fts`` call.
+
+    Returns:
+        Total number of rows indexed by this call (``0`` if there was
+        nothing left to index).
+    """
+    total = 0
+    while True:
+        indexed = db.backfill_items_fts(chunk_size=chunk_size)
+        if indexed == 0:
+            break
+        total += indexed
+        logger.debug(
+            "Subscription items FTS backfill: indexed {} row(s) this chunk "
+            "({} total so far).",
+            indexed,
+            total,
+        )
+
+    if total:
+        logger.info(
+            "Subscription items FTS backfill complete: indexed {} "
+            "pre-existing row(s).",
+            total,
+        )
+    else:
+        logger.debug("Subscription items FTS backfill: nothing to index.")
+
+    return total

--- a/tldw_chatbook/Subscriptions/fts_backfill.py
+++ b/tldw_chatbook/Subscriptions/fts_backfill.py
@@ -21,6 +21,24 @@ from loguru import logger
 from ..DB.Subscriptions_DB import SubscriptionsDB
 
 
+class FTSBackfillError(RuntimeError):
+    """Raised when the backfill loop fails partway through a run.
+
+    Carries ``rows_indexed`` -- how many rows this run had already indexed
+    (and committed; each chunk is its own transaction) before the failing
+    chunk -- so a caller's error log can report real progress instead of
+    just "it failed", without needing to duplicate the loop to track that
+    count itself.
+    """
+
+    def __init__(self, rows_indexed: int) -> None:
+        super().__init__(
+            f"Subscription items FTS backfill failed after indexing "
+            f"{rows_indexed} row(s) this run"
+        )
+        self.rows_indexed = rows_indexed
+
+
 def backfill_subscription_items_fts(db: SubscriptionsDB, chunk_size: int = 500) -> int:
     """Index every pre-existing ``subscription_items`` row missing from FTS.
 
@@ -42,10 +60,20 @@ def backfill_subscription_items_fts(db: SubscriptionsDB, chunk_size: int = 500) 
     Returns:
         Total number of rows indexed by this call (``0`` if there was
         nothing left to index).
+
+    Raises:
+        FTSBackfillError: If the underlying ``backfill_items_fts`` call
+            raises partway through the run. Wraps the original exception
+            (via ``raise ... from``) and records how many rows this run had
+            already indexed, so a caller logging the failure can report
+            real progress rather than a bare "it failed".
     """
     total = 0
     while True:
-        indexed = db.backfill_items_fts(chunk_size=chunk_size)
+        try:
+            indexed = db.backfill_items_fts(chunk_size=chunk_size)
+        except Exception as exc:
+            raise FTSBackfillError(total) from exc
         if indexed == 0:
             break
         total += indexed

--- a/tldw_chatbook/Subscriptions/watchlist_preview_service.py
+++ b/tldw_chatbook/Subscriptions/watchlist_preview_service.py
@@ -36,6 +36,20 @@ class WatchlistPreviewService:
         )
 
         subscription = self._build_subscription(source_config)
+        # Foreign-key enforcement is on for every SubscriptionsDB connection
+        # (task-1a), so url_snapshots.subscription_id -- written by the
+        # execute path below for url/url_list/sitemap sources -- must
+        # reference a real row in `subscriptions`, not the synthetic id
+        # placeholder `_build_subscription` fills in. Seed one here, in this
+        # same throwaway in-memory DB, so the write succeeds without ever
+        # touching the caller's real database: preview still persists
+        # nothing outside `preview_db`, which is discarded when this call
+        # returns.
+        subscription["id"] = preview_db.add_subscription(
+            name=subscription["name"],
+            type=subscription["type"],
+            source=subscription["source"],
+        )
         result = await service._execute_subscription(subscription, preview_db)
         items = list(result.get("items") or [])
         return {
@@ -53,6 +67,9 @@ class WatchlistPreviewService:
             or ""
         )
         subscription: dict[str, Any] = {
+            # Placeholder -- preview() overwrites this with a real row id
+            # seeded into the throwaway in-memory DB before executing, so
+            # any FK-bearing write (e.g. url_snapshots) has a valid parent.
             "id": -1,
             "name": str(source_config.get("name") or "Preview"),
             "type": source_type,

--- a/tldw_chatbook/Subscriptions/watchlist_preview_service.py
+++ b/tldw_chatbook/Subscriptions/watchlist_preview_service.py
@@ -29,33 +29,41 @@ class WatchlistPreviewService:
             A dict with ``items`` (list of candidate items) and ``log_text``.
         """
         # Use a throw-away in-memory DB so URL snapshots are not persisted.
+        # Since task-689, this is a real, functional connection (not the
+        # inert schema-less object it used to be), so it must be closed
+        # deterministically -- otherwise every preview call leaks a
+        # thread-local sqlite3 connection and its in-memory database until
+        # GC happens to collect this object.
         preview_db = SubscriptionsDB(":memory:", client_id="preview")
-        service = LocalWatchlistsService(
-            db_factory=lambda: preview_db,
-            run_executor=self.run_executor,
-        )
+        try:
+            service = LocalWatchlistsService(
+                db_factory=lambda: preview_db,
+                run_executor=self.run_executor,
+            )
 
-        subscription = self._build_subscription(source_config)
-        # Foreign-key enforcement is on for every SubscriptionsDB connection
-        # (task-1a), so url_snapshots.subscription_id -- written by the
-        # execute path below for url/url_list/sitemap sources -- must
-        # reference a real row in `subscriptions`, not the synthetic id
-        # placeholder `_build_subscription` fills in. Seed one here, in this
-        # same throwaway in-memory DB, so the write succeeds without ever
-        # touching the caller's real database: preview still persists
-        # nothing outside `preview_db`, which is discarded when this call
-        # returns.
-        subscription["id"] = preview_db.add_subscription(
-            name=subscription["name"],
-            type=subscription["type"],
-            source=subscription["source"],
-        )
-        result = await service._execute_subscription(subscription, preview_db)
-        items = list(result.get("items") or [])
-        return {
-            "items": items,
-            "log_text": f"Preview completed with {len(items)} candidate item(s).",
-        }
+            subscription = self._build_subscription(source_config)
+            # Foreign-key enforcement is on for every SubscriptionsDB connection
+            # (task-1a), so url_snapshots.subscription_id -- written by the
+            # execute path below for url/url_list/sitemap sources -- must
+            # reference a real row in `subscriptions`, not the synthetic id
+            # placeholder `_build_subscription` fills in. Seed one here, in this
+            # same throwaway in-memory DB, so the write succeeds without ever
+            # touching the caller's real database: preview still persists
+            # nothing outside `preview_db`, which is discarded when this call
+            # returns.
+            subscription["id"] = preview_db.add_subscription(
+                name=subscription["name"],
+                type=subscription["type"],
+                source=subscription["source"],
+            )
+            result = await service._execute_subscription(subscription, preview_db)
+            items = list(result.get("items") or [])
+            return {
+                "items": items,
+                "log_text": f"Preview completed with {len(items)} candidate item(s).",
+            }
+        finally:
+            preview_db.close()
 
     @staticmethod
     def _build_subscription(source_config: Mapping[str, Any]) -> dict[str, Any]:

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -474,6 +474,9 @@ from tldw_chatbook.Subscriptions import (  # noqa: E402
     ServerWatchlistsService,
     WatchlistScopeService,
 )
+from tldw_chatbook.Subscriptions.fts_backfill import (  # noqa: E402
+    backfill_subscription_items_fts,
+)
 from tldw_chatbook.Translation_Interop import (  # noqa: E402
     ServerTranslationService,
     TranslationScopeService,
@@ -5475,6 +5478,30 @@ class TldwCli(
         )
         self.local_watchlists_service.notification_app = self
 
+    def _backfill_subscription_items_fts(self) -> None:
+        """Worker body: index subscription_items rows that predate the FTS
+        index (task-688). Started from ``on_mount`` via
+        ``run_worker(thread=True)`` so a large backlog never blocks app
+        startup or screen mount. Builds its own ``SubscriptionsDB`` instance
+        rather than reusing one built on another thread, since SQLite
+        connections in this codebase are thread-local and not shared.
+        """
+        db = None
+        try:
+            db = SubscriptionsDB(get_subscriptions_db_path(), CLI_APP_CLIENT_ID)
+            backfill_subscription_items_fts(db)
+        except Exception:
+            logger.opt(exception=True).error(
+                "Subscription items FTS backfill failed; some pre-existing "
+                "items may remain unsearchable until the app is restarted."
+            )
+        finally:
+            if db is not None:
+                try:
+                    db.close()
+                except Exception:
+                    pass
+
     def _wire_server_parity_state_repositories(self) -> None:
         try:
             self.server_parity_state = build_server_parity_state_repositories(
@@ -7489,6 +7516,18 @@ class TldwCli(
             self._refresh_model_catalogs(),
             exclusive=True,
             group="model-catalog-refresh",
+        )
+
+        # task-688: index subscription_items rows scraped before the FTS5
+        # index existed, so search covers a user's whole back catalogue
+        # without any action on their part. thread=True because this does
+        # blocking sqlite work; never blocks startup or screen mount since
+        # run_worker only schedules it.
+        self.run_worker(
+            self._backfill_subscription_items_fts,
+            thread=True,
+            exclusive=True,
+            group="subscriptions-fts-backfill",
         )
 
     def _init_model_catalog_disk_store(self) -> "ModelCatalogDiskStore | None":

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -475,6 +475,7 @@ from tldw_chatbook.Subscriptions import (  # noqa: E402
     WatchlistScopeService,
 )
 from tldw_chatbook.Subscriptions.fts_backfill import (  # noqa: E402
+    FTSBackfillError,
     backfill_subscription_items_fts,
 )
 from tldw_chatbook.Translation_Interop import (  # noqa: E402
@@ -5487,20 +5488,35 @@ class TldwCli(
         connections in this codebase are thread-local and not shared.
         """
         db = None
+        db_path = get_subscriptions_db_path()
         try:
-            db = SubscriptionsDB(get_subscriptions_db_path(), CLI_APP_CLIENT_ID)
+            db = SubscriptionsDB(db_path, CLI_APP_CLIENT_ID)
             backfill_subscription_items_fts(db)
+        except FTSBackfillError as exc:
+            logger.opt(exception=True).error(
+                "Subscription items FTS backfill failed for database {} "
+                "after indexing {} row(s) this run; some pre-existing "
+                "items may remain unsearchable until the app is restarted.",
+                db_path,
+                exc.rows_indexed,
+            )
         except Exception:
             logger.opt(exception=True).error(
-                "Subscription items FTS backfill failed; some pre-existing "
-                "items may remain unsearchable until the app is restarted."
+                "Subscription items FTS backfill failed for database {}; "
+                "some pre-existing items may remain unsearchable until the "
+                "app is restarted.",
+                db_path,
             )
         finally:
             if db is not None:
                 try:
                     db.close()
                 except Exception:
-                    pass
+                    logger.opt(exception=True).warning(
+                        "Failed to close SubscriptionsDB {} after FTS "
+                        "backfill.",
+                        db_path,
+                    )
 
     def _wire_server_parity_state_repositories(self) -> None:
         try:


### PR DESCRIPTION
The two blocking follow-ups filed from the Watchlists Phase A/B work (#917, #926).

## task-689 — `SubscriptionsDB(":memory:")` was non-functional

Verified before the fix: an in-memory instance had **zero tables** on the connection everything uses, and `add_subscription` raised `no such table: subscriptions`.

`_initialize_schema` built the schema inside `with closing(self._get_connection())` — a connection closed immediately after — while the thread-local `.conn` property opened a *different* one. For a file database both point at the same file, so it worked. For `:memory:`, every connection is a separate private database, so the schema landed somewhere nothing could see.

This mattered in production: `WatchlistPreviewService.preview()` deliberately constructs an in-memory DB so URL snapshots aren't persisted, and its execute path calls `record_check_result`/`record_check_error`, which write to tables. **Source Preview / dry-run was very likely broken.**

Fixed by initialising the schema on the thread-local connection, matching `ChaChaNotes_DB`'s existing pattern. The documented trade-off — a second thread touching the same in-memory instance still gets a schema-less connection — is the same limitation `ChaChaNotes_DB` already accepts, and the only `:memory:` caller never crosses threads.

Also fixed a second failure on that same path: Phase A enabled FK enforcement, and preview used a synthetic `subscription_id` of `-1`, so any FK-bearing write would raise `IntegrityError` once the schema actually existed. Preview now seeds a real parent row and still persists nothing to the user's real database.

Verified after: 17 tables present, writes succeed, and two in-memory instances stay isolated from each other.

## task-688 — `backfill_items_fts` had no caller

The FTS index is created empty over a table that may already hold rows, and only the insert/update triggers populate it going forward — so every item scraped before the upgrade was permanently unsearchable while search appeared to work.

Now driven to completion from `on_mount` via `run_worker(..., thread=True, exclusive=True, group=…)`, so a large backlog never blocks startup or screen mount. The worker builds its own `SubscriptionsDB` because connections here are thread-local, and logs rather than crashing if indexing fails.

## Testing

`Tests/DB Tests/Subscriptions Tests/Watchlists Tests/App` → **434 passed, 1 failed**.

The failure is `Tests/Watchlists/test_watchlists_navigator.py::test_navigator_has_all_section_buttons`, which fails on `dev` itself.

## Noted, not fixed

`Library_Collections_DB`, `Workspace_DB` and `AgentRuns_DB` share the same throwaway-connection pattern in `_initialize_schema`. They have no `.conn` cache and no production `:memory:` caller, so they aren't broken today — but they would fail the same way if ever pointed at `:memory:`. Left alone deliberately rather than fixed blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the broken in-memory `SubscriptionsDB` used by Watchlist Preview and wires a startup FTS backfill so pre-existing `subscription_items` are searchable, with safer resource handling and better logs. Completes task-689 (in-memory DB + preview) and task-688 (FTS backfill).

- **Bug Fixes**
  - Initialize schema on `self.conn` (via `self.transaction()`); `_ensure_watchlists_schema` reuses the same connection. `WatchlistPreviewService.preview()` seeds a real `subscriptions` row to satisfy FKs, persists nothing, and now closes its in-memory DB in a try/finally (also on errors).
  - Backfill worker logs the DB path and rows indexed (via `FTSBackfillError`) and always closes its DB; added tests for in-memory schema/isolation, close-on-success/error, and an end-to-end preview URL path.

- **New Features**
  - Added `tldw_chatbook/Subscriptions/fts_backfill.py::backfill_subscription_items_fts` to loop `db.backfill_items_fts` to completion.
  - Started a background worker in `on_mount` (`thread=True`, `exclusive=True`, `group="subscriptions-fts-backfill"`) that opens its own `SubscriptionsDB`; runs off the UI thread, is idempotent/resumable, and logs progress.

<sup>Written for commit 6b1e97f436dbc837216380bbd062a6fbfb9fc35a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

