### PR TITLE
fix(tests): repair Library shell precedence and reset assertions (tasks 687, 698)

### DIFF
--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -9,7 +9,11 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+import dataclasses
+
 import pytest
+
+from tldw_chatbook.Library.ingest_capabilities import get_capabilities
 from textual.app import App, ComposeResult
 from textual.screen import Screen
 from textual.widgets import Button, Collapsible, Input, Markdown, Static, TextArea
@@ -855,13 +859,15 @@ async def test_library_shell_search_history_prefers_app_config_over_cli_config(
     app.app_config["library"] = {"search": {"history": ["from-app-config"]}}
     _seed_conversations(app, _two_conversations())
 
-    def raising_get_cli_setting(*args, **kwargs):
-        raise AssertionError(
-            "get_cli_setting should not be called when app_config already has history"
-        )
+    real_get_cli_setting = library_screen_module.get_cli_setting
+    cli_reads: list[tuple] = []
+
+    def recording_get_cli_setting(*args, **kwargs):
+        cli_reads.append(tuple(args[:2]))
+        return real_get_cli_setting(*args, **kwargs)
 
     monkeypatch.setattr(
-        library_screen_module, "get_cli_setting", raising_get_cli_setting
+        library_screen_module, "get_cli_setting", recording_get_cli_setting
     )
 
     host = LibraryHarness(app)
@@ -870,6 +876,16 @@ async def test_library_shell_search_history_prefers_app_config_over_cli_config(
         await _wait_for_library_shell(screen, pilot)
 
         assert screen._library_search_history == ("from-app-config",)
+
+    # Recorded rather than raised. Two reasons: the screen legitimately reads
+    # OTHER settings during load (rail state, which this test does not seed, and
+    # the ingest canvas's persisted per-type options), so raising on every call
+    # reports a precedence bug that is not there; and the fallbacks sit inside
+    # `except Exception:` blocks, which swallow an AssertionError raised from
+    # the patch and leave the test unable to fail at all (task-687).
+    assert not [read for read in cli_reads if str(read[0]).startswith("library.search")], (
+        f"search history fell back to the CLI config despite app_config: {cli_reads}"
+    )
 
 
 @pytest.mark.asyncio
@@ -922,13 +938,15 @@ async def test_library_shell_rail_preferences_prefers_app_config_over_cli_config
     app.app_config["library"] = {"rail_state": {"sections": {"details_open": True}}}
     _seed_conversations(app, _two_conversations())
 
-    def raising_get_cli_setting(*args, **kwargs):
-        raise AssertionError(
-            "get_cli_setting should not be called when app_config already has rail state"
-        )
+    real_get_cli_setting = library_screen_module.get_cli_setting
+    cli_reads: list[tuple] = []
+
+    def recording_get_cli_setting(*args, **kwargs):
+        cli_reads.append(tuple(args[:2]))
+        return real_get_cli_setting(*args, **kwargs)
 
     monkeypatch.setattr(
-        library_screen_module, "get_cli_setting", raising_get_cli_setting
+        library_screen_module, "get_cli_setting", recording_get_cli_setting
     )
 
     host = LibraryHarness(app)
@@ -937,6 +955,11 @@ async def test_library_shell_rail_preferences_prefers_app_config_over_cli_config
         await _wait_for_library_shell(screen, pilot)
 
         assert screen._library_rail_preferences().details_open is True
+
+    # Recorded, not raised -- see the sibling search-history test for why.
+    assert not [read for read in cli_reads if str(read[0]).startswith("library.rail_state")], (
+        f"rail preferences fell back to the CLI config despite app_config: {cli_reads}"
+    )
 
 
 @pytest.mark.asyncio
@@ -4352,6 +4375,10 @@ async def test_library_shell_ingest_nav_context_deeplink_reentry_resets_stale_fo
             title="Stale title",
             author="Stale author",
             keywords="stale, keywords",
+            # Options the user deliberately moved off their defaults. Without
+            # these the test only proves typed text is cleared, which is the
+            # weaker half of "no state from the previous visit".
+            type_options={"generic": {"chunk_size": "500", "chunk": False}},
         )
 
         # Home's "Open details" control re-enters via this same navigation
@@ -4361,7 +4388,35 @@ async def test_library_shell_ingest_nav_context_deeplink_reentry_resets_stale_fo
         await _wait_for_selector(screen, pilot, "#library-ingest-path")
 
         assert screen._library_selected_row_id == LIBRARY_ROW_INGEST_MEDIA
-        assert screen._library_ingest_form == LibraryIngestFormState()
+
+        # Everything the user could have typed is gone.
+        form = screen._library_ingest_form
+        fresh = LibraryIngestFormState()
+        assert dataclasses.replace(form, type_options={}) == fresh
+
+        # ``type_options`` is compared separately because a *mounted* canvas can
+        # never equal a never-mounted form: each option widget reports the value
+        # it rendered, so the per-type defaults land in the form as soon as the
+        # canvas composes. Asserting equality with a bare LibraryIngestFormState
+        # therefore tested the mount, not the reset, and failed on a screen that
+        # was resetting perfectly well (task-698).
+        #
+        # What matters is that only DEFAULTS are there -- no value carried over
+        # from the previous visit. Verified by pre-filling a changed chunk_size
+        # and chunk above: both come back at their schema defaults, so the reset
+        # really does discard user overrides rather than merely clearing text.
+        generic = form.type_options.get("generic", {})
+        expected_defaults = {
+            field.name: field.default
+            for field in get_capabilities("generic").fields
+        }
+        for name, value in generic.items():
+            # Number inputs round-trip through display text, so compare as text.
+            assert str(value) == str(expected_defaults[name]), (
+                f"{name} came back as {value!r}, not its default "
+                f"{expected_defaults[name]!r} -- a previous visit leaked through"
+            )
+
         path_input = screen.query_one("#library-ingest-path", Input)
         assert path_input.value == ""
 

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -1,6 +1,7 @@
 """Library shell (L1) rail + conversations canvas pilot contracts."""
 
 import asyncio
+import dataclasses
 import json
 import re
 import threading
@@ -9,11 +10,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock
 
-import dataclasses
-
 import pytest
-
-from tldw_chatbook.Library.ingest_capabilities import get_capabilities
 from textual.app import App, ComposeResult
 from textual.screen import Screen
 from textual.widgets import Button, Collapsible, Input, Markdown, Static, TextArea
@@ -28,6 +25,7 @@ from tldw_chatbook.Constants import (
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
 from tldw_chatbook.DB.Prompts_DB import PromptsDatabase
+from tldw_chatbook.Library.ingest_capabilities import get_capabilities
 from tldw_chatbook.Library.ingest_types import PreflightResult
 from tldw_chatbook.Library.library_ingest_jobs import (
     IngestJobState,
@@ -200,6 +198,36 @@ def _seed_conversations(app, conversations, *, notes=None, media=None, highlight
     app.chat_conversation_scope_service = StaticLibraryConversationScopeService(
         conversations
     )
+
+
+
+def _normalised_cli_lookup(*args, **kwargs) -> tuple[str, str]:
+    """Reduce any ``get_cli_setting`` call shape to a ``(section, key)`` pair.
+
+    That helper accepts both ``get_cli_setting("library", "search", default)``
+    and the dotted ``get_cli_setting("library.search")``. Matching on the raw
+    first argument therefore only catches whichever shape the code happens to
+    use today: a switch to the two-argument form would make a precedence test
+    silently stop detecting the fallback it exists to detect. Keyword calls are
+    read too, so a caller moving to keywords cannot make this raise IndexError
+    instead of failing usefully.
+
+    Returns:
+        ``(section, key)`` lowercased, with a dotted section split on its first
+        dot. An unparseable call yields ``("", "")``, which matches nothing.
+    """
+    section = kwargs.get("section")
+    key = kwargs.get("key")
+    positional = list(args)
+    if section is None and positional:
+        section = positional.pop(0)
+    if key is None and positional:
+        key = positional.pop(0)
+    section = str(section or "")
+    if "." in section:
+        # Dotted shape: the second slot carries the default, not a key.
+        section, _, key = section.partition(".")
+    return section.strip().lower(), str(key or "").strip().lower()
 
 
 async def _wait_for_library_shell(screen, pilot, *, attempts=120):
@@ -860,10 +888,10 @@ async def test_library_shell_search_history_prefers_app_config_over_cli_config(
     _seed_conversations(app, _two_conversations())
 
     real_get_cli_setting = library_screen_module.get_cli_setting
-    cli_reads: list[tuple] = []
+    cli_reads: list[tuple[str, str]] = []
 
     def recording_get_cli_setting(*args, **kwargs):
-        cli_reads.append(tuple(args[:2]))
+        cli_reads.append(_normalised_cli_lookup(*args, **kwargs))
         return real_get_cli_setting(*args, **kwargs)
 
     monkeypatch.setattr(
@@ -883,7 +911,7 @@ async def test_library_shell_search_history_prefers_app_config_over_cli_config(
     # reports a precedence bug that is not there; and the fallbacks sit inside
     # `except Exception:` blocks, which swallow an AssertionError raised from
     # the patch and leave the test unable to fail at all (task-687).
-    assert not [read for read in cli_reads if str(read[0]).startswith("library.search")], (
+    assert ("library", "search") not in cli_reads, (
         f"search history fell back to the CLI config despite app_config: {cli_reads}"
     )
 
@@ -939,10 +967,10 @@ async def test_library_shell_rail_preferences_prefers_app_config_over_cli_config
     _seed_conversations(app, _two_conversations())
 
     real_get_cli_setting = library_screen_module.get_cli_setting
-    cli_reads: list[tuple] = []
+    cli_reads: list[tuple[str, str]] = []
 
     def recording_get_cli_setting(*args, **kwargs):
-        cli_reads.append(tuple(args[:2]))
+        cli_reads.append(_normalised_cli_lookup(*args, **kwargs))
         return real_get_cli_setting(*args, **kwargs)
 
     monkeypatch.setattr(
@@ -957,7 +985,7 @@ async def test_library_shell_rail_preferences_prefers_app_config_over_cli_config
         assert screen._library_rail_preferences().details_open is True
 
     # Recorded, not raised -- see the sibling search-history test for why.
-    assert not [read for read in cli_reads if str(read[0]).startswith("library.rail_state")], (
+    assert ("library", "rail_state") not in cli_reads, (
         f"rail preferences fell back to the CLI config despite app_config: {cli_reads}"
     )
 

--- a/backlog/tasks/task-687 - Library-shell-reads-CLI-config-when-app_config-already-answered.md
+++ b/backlog/tasks/task-687 - Library-shell-reads-CLI-config-when-app_config-already-answered.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-687
 title: Library shell reads CLI config when app_config already answered
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-26 05:36'
+updated_date: '2026-07-26 18:06'
 labels:
   - library
   - bug
@@ -18,7 +19,21 @@ Two Library shell tests assert that get_cli_setting is not consulted once app_co
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Search history and rail preferences come from app_config when it has them
-- [ ] #2 get_cli_setting is consulted only as a fallback
-- [ ] #3 Both existing precedence tests pass
+- [x] #1 Search history and rail preferences come from app_config when it has them
+- [x] #2 get_cli_setting is consulted only as a fallback
+- [x] #3 Both existing precedence tests pass
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Not a product bug either. Precedence works; both tests were over-broad.
+
+Probed by recording every get_cli_setting call during a shell load instead of raising on it. The result is symmetric: in the search-history test the history comes back as ('from-app-config',) and library.search is NEVER read; in the rail test details_open is True and library.rail_state is NEVER read. In each case what tripped the blanket raise was the OTHER setting -- the one that test did not seed, so its CLI fallback is correct -- plus twenty library.ingest_options.* reads from the ingest canvas loading its persisted per-type options.
+
+Then a second, worse problem surfaced. Narrowing each trap to raise only on its own key looked right and was VACUOUS: the rail fallback sits inside an except-Exception block, which swallows an AssertionError raised from the patch, so the test could not fail at all. Mutation testing caught it -- breaking precedence outright still passed. That also explains the original symptom: the tests failed with 'Library shell never loaded' rather than the assertion message, because the raise that actually escaped came from a call site without a try/except and killed the load worker.
+
+Both tests now RECORD the calls and assert afterwards, outside the screen's exception handling. Mutation-checked: removing the app_config branch from _library_rail_preferences fails the test with 'rail preferences fell back to the CLI config despite app_config'.
+
+Files: Tests/UI/test_library_shell.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-698 - Ingest-form-does-not-reset-to-defaults-on-Library-re-entry.md
+++ b/backlog/tasks/task-698 - Ingest-form-does-not-reset-to-defaults-on-Library-re-entry.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-698
 title: Ingest form does not reset to defaults on Library re-entry
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-26 05:36'
+updated_date: '2026-07-26 18:06'
 labels:
   - ingest
   - bug
@@ -13,12 +15,28 @@ dependencies: []
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Re-entering the Library ingest canvas via a nav deep-link is supposed to clear any stale form state, but the form no longer equals a fresh one, so something from the previous visit survives. A user returning to the screen can find it carrying values they thought they had left behind. Pre-existing on dev, found while regression-testing the 684.2 registry work: Tests/UI/test_library_shell.py::test_library_shell_ingest_nav_context_deeplink_reentry_resets_stale_form fails identically at 05ebe2ab7, before the ingest UAT batch merged.
+Re-entering the Library ingest canvas via a nav deep-link is asserted to leave the form equal to a freshly constructed one, and it does not. Investigation shows the screen resets correctly and the assertion is wrong: a mounted canvas can never equal a never-mounted form, because each option widget reports the value it rendered, so the per-type defaults land in the form as soon as the canvas composes. The test therefore measured the mount rather than the reset, and failed on a screen that was behaving. The reset itself discards everything from the previous visit, including options the user moved off their defaults.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Re-entering the ingest canvas leaves no state from the previous visit
-- [ ] #2 The existing deep-link re-entry test passes
-- [ ] #3 Whichever field was surviving is identified, and it is clear whether keeping it was intended
+- [x] #1 Re-entering the ingest canvas leaves no state from the previous visit
+- [x] #2 The existing deep-link re-entry test passes
+- [x] #3 Whichever field was surviving is identified, and it is clear whether keeping it was intended
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Not a product bug. The reset works; the test was measuring the wrong thing.
+
+What survived re-entry was type_options, holding {'analyze': False, 'chunk': True, 'chunk_size': '1000'} -- the capability schema's own defaults, with chunk_size as the string '1000' because number inputs round-trip through display text. The test's pre-fill never set type_options at all, so those values could not have come from the previous visit: they are generated when the canvas composes and its widgets report what they rendered.
+
+Proved by probing the stronger question the original test never asked. Pre-filling options the user had deliberately changed (chunk_size='500', chunk=False) and re-entering returns them at their defaults ('1000', True), alongside a cleared path. So nothing from the prior visit survives -- not merely the typed text, but user overrides too.
+
+Fixed the test rather than the screen: it now asserts every other field equals a fresh form, and separately that type_options contains only schema defaults. The pre-fill was strengthened to include those changed options, so the test exercises the invariant its own docstring claims ('no stale half-filled form') instead of the weaker text-only version.
+
+Mutation-checked: disabling the reset in the deep-link branch fails the test on path/title/author/keywords. Worth noting type_options is NOT among the differing attributes under that mutation -- the mount re-seeds defaults whether or not the reset ran, which is further evidence it was never reset-driven state. The type_options assertion therefore guards a different regression (a future change that let user values persist through a mount), not the reset.
+
+Files: Tests/UI/test_library_shell.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-699 - Library-shell-tests-fail-nondeterministically-hiding-real-regressions.md
+++ b/backlog/tasks/task-699 - Library-shell-tests-fail-nondeterministically-hiding-real-regressions.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-699
 title: 'Library shell tests fail nondeterministically, hiding real regressions'
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-07-26 15:02'
+updated_date: '2026-07-26 18:02'
 labels:
   - testing
   - library

--- a/backlog/tasks/task-699 - Library-shell-tests-fail-nondeterministically-hiding-real-regressions.md
+++ b/backlog/tasks/task-699 - Library-shell-tests-fail-nondeterministically-hiding-real-regressions.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@claude'
 created_date: '2026-07-26 15:02'
-updated_date: '2026-07-26 18:02'
+updated_date: '2026-07-26 18:18'
 labels:
   - testing
   - library
@@ -22,3 +22,30 @@ The Library shell test file fails around six tests on every run, but not the sam
 <!-- AC:BEGIN -->
 - [ ] #1 The Library shell test file produces the same result on repeated runs of the same code,A test that passes alone does not fail as part of the file,The three consistently failing tests are either fixed or explicitly recorded as known failures with reasons
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reduced this file from 9 failures on dev to 0-1, by fixing what turned out not to be flakiness at all.
+
+Three of the failures were STABLE across every run and were misfiled as nondeterminism. They were two over-broad precedence traps (task-687) and one assertion that compared a mounted form against a never-mounted one (task-698). Both are fixed; the screen was correct in all three cases. Full-file runs after those fixes: 1 failed / 256 passed, then 0 failed / 257 passed.
+
+What remains is a genuinely order-dependent tail, currently one test:
+test_library_shell_note_conflict_shows_overwrite_reload_and_keeps_user_text. It
+passes alone, passes alongside its siblings, and fails only in a full-file run --
+and not on every full-file run. Its wait carries a 15-second timeout, so simple
+slowness does not explain it; the cause is accumulated state across 257 Textual
+app instances rather than a slow machine.
+
+Measurement conditions matter for anyone picking this up: this machine was
+running fourteen concurrent pytest processes from other agents at load ~12
+throughout. That is enough to change which tests lose a race, so compare failure
+SETS from identical commands in parallel worktrees, never counts between
+different invocations -- a 3-vs-4 count difference across two different commands
+briefly looked like a regression during the 684 work and was not one.
+
+Remaining scope for this task: the note-conflict tail, plus the pool observed
+earlier under load (note_save_result_after_switch_is_discarded,
+export_registry_failure_*, ingest_canvas_different_canvas_isolation), all of
+which pass in isolation.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-700 - Open-a-server-ingested-item-from-the-ingest-queue.md
+++ b/backlog/tasks/task-700 - Open-a-server-ingested-item-from-the-ingest-queue.md
@@ -4,6 +4,7 @@ title: Open a server-ingested item from the ingest queue
 status: To Do
 assignee: []
 created_date: '2026-07-26 13:58'
+updated_date: '2026-07-26 18:13'
 labels:
   - library
   - ingest
@@ -18,5 +19,7 @@ A server ingest finishes with its content in the server's library, not this mach
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A finished server-origin job offers a way to view the item it created,The action opens the item in a server-scoped view rather than looking for a local row,A job whose server result carries no usable id offers no such action
+- [ ] #1 A finished server-origin job offers a way to view the item it created
+- [ ] #2 The action opens the item in a server-scoped view rather than looking for a local row
+- [ ] #3 A job whose server result carries no usable id offers no such action
 <!-- AC:END -->


### PR DESCRIPTION
Fixes the two Library shell config-precedence tests (**687**) and the ingest deep-link reset test (**698**), and closes out most of **699**.

Both tasks were filed as product bugs, from tests that were failing on `dev`. **Neither is a product bug.** The screen behaves correctly in all three cases; the tests were measuring the wrong thing. Established by probing, not by reading the assertions.

`Tests/UI/test_library_shell.py` goes from **9 failures on clean dev** to **0–1**.

## 687 — the precedence tests

Each seeds one setting into `app_config`, then patches `get_cli_setting` to raise on **any** call. Recording the calls instead of raising gives a symmetric answer:

| Test | Value from app_config | Its CLI key read? | What tripped the raise |
|---|---|---|---|
| search history | `('from-app-config',)` ✓ | `library.search` **never** ✓ | `library.rail_state` — not seeded here, so its fallback is correct |
| rail preferences | `details_open=True` ✓ | `library.rail_state` **never** ✓ | `library.search`, plus 20 `library.ingest_options.*` reads |

So precedence holds in both. What tripped each trap was the *other* setting — the one that test doesn't seed — plus the ingest canvas loading its persisted per-type options.

**My first fix was vacuous, and mutation testing caught it.** Narrowing each trap to raise only on its own key looked right, but the rail fallback sits inside an `except Exception:` block that swallows an `AssertionError` raised from the patch — so the test could not fail at all. Deleting the entire `app_config` branch still passed.

That also explains the original symptom: these failed with *"Library shell never loaded"* rather than an assertion message, because the raise that actually escaped came from a call site with no `try`/`except` and killed the load worker.

Both tests now **record** the calls and assert afterwards, outside the screen's exception handling.

## 698 — the deep-link reset

`type_options` survived re-entry holding `{'analyze': False, 'chunk': True, 'chunk_size': '1000'}` — the schema defaults, with `chunk_size` a string because number inputs round-trip through display text. The test's pre-fill never set `type_options`, so those values cannot be "from the previous visit": a mounted canvas reports what its widgets rendered, and so can never equal a never-mounted `LibraryIngestFormState`. The assertion was testing the mount, not the reset.

Probed the stronger question it never asked — pre-fill options the user actually *changed* (`chunk_size='500'`, `chunk=False`) — and they come back at their defaults. The reset discards user overrides, not merely typed text.

The test now asserts every other field equals a fresh form, and separately that `type_options` holds only defaults, with the pre-fill strengthened to include those changed options so it exercises the invariant its own docstring claims.

## 699 — reduced, not closed

Three of the nine failures were **stable across every run** and were misfiled by me as nondeterminism; they are the 687 and 698 cases above. Full-file runs since: **1 failed / 256 passed, then 257 passed, then 257 passed.**

A real order-dependent tail remains — `note_conflict_shows_overwrite_reload_and_keeps_user_text` passes alone, passes with its siblings, and fails only in some full-file runs. Its wait carries a 15-second timeout, so slowness does not explain it; the cause is accumulated state across 257 Textual app instances. **699 stays open** for that.

## Verification

- Mutation-checked, both directions: disabling the deep-link reset fails on `path`/`title`/`author`/`keywords`; removing the `app_config` branch from `_library_rail_preferences` fails with *"rail preferences fell back to the CLI config despite app_config"*
- Three full-file runs after the fixes: 256/257, 257/257, 257/257
- Rebased onto current dev with zero overlapping files

Measurement note: this machine ran 14 concurrent pytest processes at load ~12 throughout, which changes which tests lose a race. Compare failure **sets** from identical commands, never counts across different invocations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three failing Library shell tests by correcting assertions and recording CLI lookups with normalized keys so tests reflect real behavior. Addresses Linear 687 and 698; trims the remaining failure pool in 699.

- **Bug Fixes**
  - Config precedence (687): replaced raising `get_cli_setting` patch with call recording that normalizes to `(section, key)`; assert no reads of `library.search`/`library.rail_state` when `app_config` provides them; covers dotted, multi-arg, and keyword calls.
  - Deep-link reset (698): verify text fields match a fresh `LibraryIngestFormState`; compare `type_options` against capability defaults and pre-fill user-changed options to ensure they reset.
  - Stability (699)/hygiene: full-file runs drop from 9 failures to 0–1; fixed import groups; the remaining order-dependent test stays tracked in 699.

<sup>Written for commit b6c04fe834fb9f987b7259a3ebd969cf34d0a9dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

