### PR TITLE
fix(runtime-policy): isolate the state file per config profile (task 701)

### DIFF
--- a/Docs/Development/server-client-provider-migration-audit.md
+++ b/Docs/Development/server-client-provider-migration-audit.md
@@ -96,7 +96,7 @@ These are direct helper call sites rather than service classes. They should be r
 
 | Module | Audit lines | Notes |
 | --- | ---: | --- |
-| `tldw_chatbook/Event_Handlers/tldw_api_events.py` | 572 | Explicit UI/event helper holdout. Direct endpoint/auth form flow is not safely replaceable by the current app provider without a broader event/UI state refactor. Semantic match: `api_client = build_runtime_api_client(`. |
+| _(none)_ | — | The sole holdout, `tldw_chatbook/Event_Handlers/tldw_api_events.py`, was deleted with the standalone ingestion window it served (task-684.4). Its direct endpoint/auth form flow -- the reason it could not be migrated to the app provider without a broader event/UI refactor -- went with it, so the holdout resolved by retirement rather than migration. |
 
 ### Intentional Current Provider And Bootstrap Usage
 

--- a/Tests/RuntimePolicy/test_runtime_policy_bootstrap.py
+++ b/Tests/RuntimePolicy/test_runtime_policy_bootstrap.py
@@ -801,3 +801,45 @@ class TestRuntimePolicyPathIsolation:
         assert (scratch.parent / "runtime_policy.json").exists(), (
             "the profile's own policy file was never written"
         )
+
+    def test_a_rejected_override_falls_back_loudly(self, monkeypatch, caplog):
+        """A bad path may not stop the app booting, but must not be silent.
+
+        Falling back means this profile's local/server mode is read from and
+        written to the DEFAULT profile -- the very cross-profile leak this
+        function exists to prevent -- so it is logged at warning, not debug.
+        """
+        from tldw_chatbook.runtime_policy import bootstrap
+
+        def rejecting(*args, **kwargs):
+            raise ValueError("rejected path")
+
+        monkeypatch.setattr(
+            "tldw_chatbook.config._get_effective_config_path", rejecting
+        )
+
+        assert bootstrap.default_runtime_policy_path() == (
+            bootstrap.DEFAULT_RUNTIME_POLICY_PATH
+        )
+
+    def test_an_unexpected_failure_is_not_swallowed(self, monkeypatch):
+        """Only a bad path is absorbed; a defect must surface.
+
+        Catching everything would route runtime-policy state to the wrong
+        profile whenever some unrelated bug appeared in path resolution, and the
+        symptom -- a scratch profile quietly editing the real user's mode -- is
+        precisely what this change set out to stop.
+        """
+        import pytest as _pytest
+
+        from tldw_chatbook.runtime_policy import bootstrap
+
+        def exploding(*args, **kwargs):
+            raise RuntimeError("something unrelated broke")
+
+        monkeypatch.setattr(
+            "tldw_chatbook.config._get_effective_config_path", exploding
+        )
+
+        with _pytest.raises(RuntimeError):
+            bootstrap.default_runtime_policy_path()

--- a/Tests/RuntimePolicy/test_runtime_policy_bootstrap.py
+++ b/Tests/RuntimePolicy/test_runtime_policy_bootstrap.py
@@ -718,3 +718,86 @@ async def test_handle_runtime_backend_changed_forwards_resolved_authoritative_ba
 
     assert app_like.runtime_policy.state.active_source == "local"
     assert forwarded == ["local"]
+
+
+class TestRuntimePolicyPathIsolation:
+    """The runtime-policy state file must follow the active config profile.
+
+    The file records whether the app is running local or server. Its path was
+    derived from a hardcoded home directory rather than from the config path in
+    effect, so a profile launched with ``TLDW_CONFIG_PATH`` shared the real
+    user's local/server mode: switching a scratch profile to server mode left
+    the default profile in server mode afterwards (task-701).
+
+    That is not merely untidy. It made local/server behaviour untestable without
+    mutating real state, which is why verifying the server-ingest path in
+    task-684.1 had to stop short of putting a test profile into server mode.
+    """
+
+    def test_an_isolated_profile_gets_its_own_policy_file(self, tmp_path, monkeypatch):
+        from tldw_chatbook.runtime_policy import bootstrap
+
+        scratch = tmp_path / "profile" / "config.toml"
+        scratch.parent.mkdir(parents=True)
+        scratch.write_text("[general]\n", encoding="utf-8")
+        monkeypatch.setenv("TLDW_CONFIG_PATH", str(scratch))
+
+        resolved = bootstrap.default_runtime_policy_path()
+
+        assert resolved.parent == scratch.parent.resolve(), (
+            f"policy file landed at {resolved}, outside the active profile"
+        )
+        assert resolved.name == "runtime_policy.json"
+
+    def test_two_profiles_do_not_share_a_policy_file(self, tmp_path, monkeypatch):
+        from tldw_chatbook.runtime_policy import bootstrap
+
+        first = tmp_path / "one" / "config.toml"
+        second = tmp_path / "two" / "config.toml"
+        for path in (first, second):
+            path.parent.mkdir(parents=True)
+            path.write_text("[general]\n", encoding="utf-8")
+
+        monkeypatch.setenv("TLDW_CONFIG_PATH", str(first))
+        first_path = bootstrap.default_runtime_policy_path()
+        monkeypatch.setenv("TLDW_CONFIG_PATH", str(second))
+        second_path = bootstrap.default_runtime_policy_path()
+
+        assert first_path != second_path, (
+            "both profiles resolved to the same runtime-policy file, so one "
+            "profile's local/server mode overwrites the other's"
+        )
+
+    def test_the_default_location_is_unchanged_without_an_override(
+        self, monkeypatch
+    ):
+        """No override must mean exactly the historical path, or existing
+        installs silently lose the mode they had persisted."""
+        from tldw_chatbook.config import DEFAULT_CONFIG_PATH
+        from tldw_chatbook.runtime_policy import bootstrap
+
+        monkeypatch.delenv("TLDW_CONFIG_PATH", raising=False)
+
+        assert bootstrap.default_runtime_policy_path() == (
+            DEFAULT_CONFIG_PATH.parent / "runtime_policy.json"
+        )
+
+    def test_the_loader_uses_the_active_profile(self, tmp_path, monkeypatch):
+        """The seam that matters: loading for an app must write to the profile's
+        own file, not merely expose a helper that computes the right path."""
+        from types import SimpleNamespace
+
+        from tldw_chatbook.runtime_policy import bootstrap
+
+        scratch = tmp_path / "profile" / "config.toml"
+        scratch.parent.mkdir(parents=True)
+        scratch.write_text("[general]\n", encoding="utf-8")
+        monkeypatch.setenv("TLDW_CONFIG_PATH", str(scratch))
+
+        app = SimpleNamespace(app_config={})
+        context = bootstrap.load_runtime_policy_for_app(app)
+        context.persist()
+
+        assert (scratch.parent / "runtime_policy.json").exists(), (
+            "the profile's own policy file was never written"
+        )

--- a/backlog/tasks/task-701 - TLDW_CONFIG_PATH-does-not-isolate-the-runtime-policy-state-file.md
+++ b/backlog/tasks/task-701 - TLDW_CONFIG_PATH-does-not-isolate-the-runtime-policy-state-file.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-701
 title: TLDW_CONFIG_PATH does not isolate the runtime-policy state file
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-26 13:59'
+updated_date: '2026-07-26 18:30'
 labels:
   - config
   - testing
@@ -18,5 +20,7 @@ The runtime-policy state file (which records whether the app is running local or
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A profile launched with TLDW_CONFIG_PATH reads and writes its own runtime-policy state,Switching modes in an isolated profile leaves the default profile's mode untouched,The default location is unchanged when no override is set
+- [x] #1 A profile launched with TLDW_CONFIG_PATH reads and writes its own runtime-policy state
+- [x] #2 Switching modes in an isolated profile leaves the default profile's mode untouched
+- [x] #3 The default location is unchanged when no override is set
 <!-- AC:END -->

--- a/tldw_chatbook/runtime_policy/bootstrap.py
+++ b/tldw_chatbook/runtime_policy/bootstrap.py
@@ -43,12 +43,22 @@ def default_runtime_policy_path() -> Path:
 
     try:
         return _get_effective_config_path().parent / "runtime_policy.json"
-    except Exception:
-        # An unreadable or rejected override must not stop the app booting;
-        # falling back to the default keeps behaviour identical to before.
-        logger.opt(exception=True).debug(
-            "Could not resolve the active config path for the runtime-policy "
-            "file; using the default location."
+    except (ValueError, OSError):
+        # A rejected or unreadable override must not stop the app booting, but
+        # falling back means this profile's local/server mode is read from and
+        # written to the DEFAULT profile -- exactly the cross-profile leak this
+        # function exists to prevent. So it is a warning, not a debug line: the
+        # earlier version logged at debug and would have hidden the misrouting
+        # in a normal run.
+        #
+        # Only the two failure modes the resolver actually raises are caught.
+        # Anything else is a defect rather than a bad path, and swallowing it
+        # here would silently route state to the wrong profile; letting it
+        # surface is the safer direction.
+        logger.opt(exception=True).warning(
+            f"Could not resolve the active config path; runtime-policy state "
+            f"will use the default profile at {DEFAULT_RUNTIME_POLICY_PATH}. "
+            "A local/server mode change made now will affect that profile."
         )
         return DEFAULT_RUNTIME_POLICY_PATH
 

--- a/tldw_chatbook/runtime_policy/bootstrap.py
+++ b/tldw_chatbook/runtime_policy/bootstrap.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping
 from urllib.parse import urlsplit, urlunsplit
 
+from loguru import logger
+
 from tldw_chatbook.config import DEFAULT_CONFIG_PATH, resolve_tldw_api_config
 
 from .source_state import RuntimeSourceStateStore
@@ -13,8 +15,42 @@ from .types import RuntimeSourceState
 if TYPE_CHECKING:
     from tldw_chatbook.tldw_api import TLDWAPIClient
 
+#: Where the runtime-policy state lands when no config override is set. Kept as
+#: a module constant for callers that reference it, but prefer
+#: :func:`default_runtime_policy_path`, which follows the *active* profile.
 DEFAULT_RUNTIME_POLICY_PATH = DEFAULT_CONFIG_PATH.parent / "runtime_policy.json"
 _VALID_RUNTIME_SOURCES = {"local", "server"}
+
+
+def default_runtime_policy_path() -> Path:
+    """Return the runtime-policy state file for the config profile in effect.
+
+    This file records whether the app runs local or server. It used to be
+    derived from ``DEFAULT_CONFIG_PATH`` -- a hardcoded home directory -- so a
+    profile launched with ``TLDW_CONFIG_PATH`` still read and wrote the real
+    user's file: putting a scratch profile into server mode left the default
+    profile in server mode afterwards (task-701).
+
+    Resolved on each call rather than captured at import, because the override
+    is an environment variable that a test or a launcher can set after this
+    module is first imported; a module-level constant would freeze whichever
+    value happened to be present at import time.
+
+    Returns:
+        The path to ``runtime_policy.json`` beside the active config file.
+    """
+    from tldw_chatbook.config import _get_effective_config_path
+
+    try:
+        return _get_effective_config_path().parent / "runtime_policy.json"
+    except Exception:
+        # An unreadable or rejected override must not stop the app booting;
+        # falling back to the default keeps behaviour identical to before.
+        logger.opt(exception=True).debug(
+            "Could not resolve the active config path for the runtime-policy "
+            "file; using the default location."
+        )
+        return DEFAULT_RUNTIME_POLICY_PATH
 
 
 @dataclass(slots=True)
@@ -140,7 +176,7 @@ def load_runtime_policy_for_app(
     path: str | Path | None = None,
 ) -> RuntimePolicyContext:
     runtime_store = store or RuntimeSourceStateStore(
-        path or DEFAULT_RUNTIME_POLICY_PATH
+        path or default_runtime_policy_path()
     )
     loaded_state = runtime_store.load()
     synchronized_state = synchronize_runtime_source_state_with_app_config(


### PR DESCRIPTION
The runtime-policy state file records whether the app runs **local or server**. Its path came from `DEFAULT_CONFIG_PATH` — a hardcoded home directory — even though the config path itself already had a resolver honouring `TLDW_CONFIG_PATH`.

So a scratch profile read and wrote the **real user's file**: putting a test profile into server mode left the default profile in server mode afterwards.

That is not merely untidy. It is what stopped task-684.1's server-ingest path being verified live — flipping a scratch profile would have flipped the user's own app, and their config has a server bound, so the self-healing demote would not have fired either.

## The fix

`default_runtime_policy_path()` resolves from the config path in effect, **per call** rather than captured at import. The override is an environment variable a launcher or a test can set *after* this module is first imported; a module-level constant freezes whichever value happened to be present then.

`DEFAULT_RUNTIME_POLICY_PATH` stays as the no-override answer and as the fallback when an override cannot be resolved, so an unreadable path cannot stop the app booting.

## Verification

**Live, end to end** — a scratch profile switched to server mode wrote `"server"` into its *own* `runtime_policy.json`, while the real profile stayed `"local"` and byte-identical to a backup taken beforehand.

**Mutation-checked** — reverting to the hardcoded path fails three of the four tests. The fourth deliberately guards the *unchanged* default, so existing installs cannot silently lose the mode they had persisted.

`Tests/RuntimePolicy`: **252 passed**.

## Also: a regression I shipped in #930

Deleting `tldw_api_events.py` with the ingestion window left it listed as the sole holdout in `Docs/Development/server-client-provider-migration-audit.md`, and that document is enforced by a test in `Tests/RuntimePolicy`, which reported inventory drift.

My verification for #930 was full-tree `--collect-only` plus the touched suites. Neither could catch this: collect-only only sees import errors, and `Tests/RuntimePolicy` was not among the suites I ran. The holdout is now recorded as **resolved by retirement** rather than by migration, which is what actually happened.

Worth noting as a method correction — a deletion needs the suites that assert *about* the codebase (inventories, audits, contracts), not only those that import it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates the runtime-policy state file per config profile so profiles no longer overwrite each other’s local/server mode (TASK-701). Fallback now catches only bad path errors and warns; unexpected failures surface.

- **Bug Fixes**
  - Added `default_runtime_policy_path()` to resolve beside the active `TLDW_CONFIG_PATH` profile on each call; falls back to `DEFAULT_RUNTIME_POLICY_PATH` only on `ValueError`/`OSError` and logs at warning.
  - Updated `load_runtime_policy_for_app()` to use the new resolver so each profile persists its own `runtime_policy.json`.
  - Tests cover: per-profile isolation, unchanged default without override, loader writing to the profile path, warned fallback on a rejected override, and propagation of unrelated errors.
  - Updated the migration audit to mark `tldw_chatbook/Event_Handlers/tldw_api_events.py` as retired.

<sup>Written for commit 58154962eaf33cbedad65c56a07469fdcc172461. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

