### PR TITLE
feat(rag): persist terminal local citation traces

### DIFF
--- a/Docs/superpowers/plans/2026-07-25-local-rag-retrieval-prompt-evidence-capture.md
+++ b/Docs/superpowers/plans/2026-07-25-local-rag-retrieval-prompt-evidence-capture.md
@@ -1,0 +1,781 @@
+# Local RAG Retrieval and Prompt-Evidence Capture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Capture each local RAG retrieval execution and the exact marked evidence text submitted to the provider in a request-scoped canonical citation builder.
+
+**Architecture:** Add a pure mutable `CitationTraceBuilder` beside the frozen citation contracts, but stop before answer-attempt capture or sealing. The existing citation repository remains the trusted composition boundary for local identity and keyed fingerprints. Local RAG keeps its legacy string behavior when canonical writes are unavailable; when enabled, the final ranked results are normalized, scope-checked again, formatted once with stable `[S#]` markers, recorded as governed snapshots, and passed through the existing post-chat-dictionary RAG payload seam so those snapshot bytes reach the provider unchanged.
+
+**Tech Stack:** Python 3.11+, Pydantic v2 citation contracts, Textual chat event handlers, SQLite-backed citation repository composition, pytest, Ruff.
+
+---
+
+## Scope and file structure
+
+**Create**
+
+- `tldw_chatbook/Chat/citation_trace_builder.py` — request-scoped local capture state and mutations only; no persistence or sealing.
+- `tldw_chatbook/RAG_Search/local_citation_capture.py` — normalize final local `SearchResult` dictionaries, re-check scope, and format exact canonical prompt blocks.
+- `Tests/Chat/test_citation_trace_builder.py` — pure builder RED/GREEN coverage.
+- `Tests/RAG/test_local_citation_capture.py` — prompt formatting, scope, truncation, and chat-boundary integration coverage.
+
+**Modify**
+
+- `tldw_chatbook/Chat/citation_trace_repository.py` — safe factory/fingerprint seam using the repository’s existing identity and secret.
+- `tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py` — opt-in capture-aware result API while preserving `get_rag_context_for_chat()`.
+- `tldw_chatbook/Event_Handlers/Chat_Events/chat_events.py` — use the capture-aware API and carry the builder into the request worker.
+- `tldw_chatbook/Event_Handlers/worker_events.py` — keep the builder request-scoped and remove it before provider dispatch; answer capture is explicitly deferred.
+- `tldw_chatbook/Chat/Chat_Functions.py` — sanitize provider-bound logging; canonical evidence uses its existing post-dictionary `media_content` seam.
+- `tldw_chatbook/RAG_Search/pipeline_functions_simple.py` — correct semantic result source identity normalization needed by canonical capture.
+- `Tests/Chat/test_citation_trace_repository.py` — repository factory readiness and fail-closed tests.
+- `Tests/Chat/test_chat_function_local_citation_boundary.py` — real provider-payload and sensitive-log regression coverage.
+- Existing RAG/chat event tests only where the production call seam changes.
+- `Docs/superpowers/specs/2026-07-23-rag-citation-provenance-design.md` — link the concrete child task/plan without changing ADR semantics.
+- `backlog/tasks/task-553.13 - Capture-local-RAG-retrieval-runs-and-exact-prompt-evidence-sets.md` — final AC checks and concise implementation notes.
+
+## Non-goals
+
+- No `AnswerAttempt`, citation occurrence parsing, visible repair, trace seal, or message persistence.
+- No current-source resolution, native/external source opening, export, import, artifacts, or Sync v2.
+- No server `grounding_trace/v1` production or adaptation.
+- No dual-write to the legacy JSON sidecar.
+- No global or app-owned mutable builder registry.
+
+## ADR check
+
+ADR required: yes  
+ADR path: `backlog/decisions/024-rag-citation-provenance-and-source-resolution.md`  
+Reason: This plan implements ADR-024’s local retrieval-run and exact prompt-boundary evidence capture contracts. It does not introduce a new architectural choice.
+
+---
+
+### Task 1: Build the request-scoped local citation accumulator
+
+**Files:**
+
+- Create: `Tests/Chat/test_citation_trace_builder.py`
+- Create: `tldw_chatbook/Chat/citation_trace_builder.py`
+
+- [ ] **Step 1: Write failing constructor and privacy tests**
+
+Add tests that construct the builder with a fixed `LocalCitationIdentityContext`,
+`CitationFingerprintCodec`, `request_id`, and `generation_id`. Assert:
+
+```python
+builder = CitationTraceBuilder.local(
+    request_id="request-1",
+    generation_id="generation-1",
+    identity_context=identity,
+    fingerprint_codec=codec,
+    created_at=NOW,
+)
+
+assert builder.request_id == "request-1"
+assert builder.generation_id == "generation-1"
+assert builder.evidence_runs == ()
+assert builder.prompt_evidence_sets == ()
+assert builder.is_sealed is False
+assert "secret query" not in repr(builder)
+```
+
+Also assert frozen identity inputs are validated and the builder cannot be
+constructed without a local authority/profile binding.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest Tests/Chat/test_citation_trace_builder.py -q
+```
+
+Expected: collection/import failure because `citation_trace_builder.py` does
+not exist.
+
+- [ ] **Step 3: Implement the minimal builder constructor**
+
+Create a mutable class whose public collection properties return tuples. Keep
+secret material private and redact it from `repr`:
+
+```python
+class CitationTraceBuilder:
+    @classmethod
+    def local(
+        cls,
+        *,
+        request_id: str,
+        generation_id: str,
+        identity_context: LocalCitationIdentityContext,
+        fingerprint_codec: CitationFingerprintCodec,
+        created_at: datetime | None = None,
+    ) -> "CitationTraceBuilder":
+        ...
+
+    @property
+    def evidence_runs(self) -> tuple[EvidenceRun, ...]:
+        return tuple(self._evidence_runs)
+```
+
+The builder must not expose a generic `seal()` in this task.
+
+- [ ] **Step 4: Write failing retrieval-run tests**
+
+Define narrow typed inputs such as `LocalRetrievalCandidateCapture` and
+`LocalRetrievalRunMetadata`; do not import `SearchResult` into the Chat layer
+and do not accept a free-form metadata dictionary. Test ordered candidates,
+typed score semantics, bounded allowlisted metadata, HMAC query identity, and
+absence of candidate content:
+
+```python
+run_id = builder.record_retrieval_run(
+    stage="hybrid",
+    raw_query="secret query",
+    candidates=(candidate_one, candidate_two),
+    retrieval_metadata=LocalRetrievalRunMetadata(
+        search_mode="hybrid",
+        requested_top_k=5,
+        max_context_characters=10_000,
+        rerank_enabled=True,
+        source_kinds=(CanonicalSourceKind.MEDIA_DB,),
+        scope_state="unscoped",
+    ),
+    started_at=NOW,
+    ended_at=NOW,
+)
+
+assert builder.evidence_runs[0].run_id == run_id
+assert builder.evidence_run_payloads[0].raw_query is None
+assert builder.evidence_run_payloads[0].query_fingerprint.startswith(
+    "hmac-sha256-v1:"
+)
+assert [item.rank for item in builder.evidence_run_payloads[0].candidates] == [1, 2]
+assert "content" not in builder.evidence_run_payloads[0].model_dump()
+```
+
+Reject duplicate/unknown run references, non-finite scores, excess candidates,
+unknown metadata fields, path/URL-shaped metadata values, and payloads beyond
+existing model caps.
+
+- [ ] **Step 5: Run and verify RED, then implement retrieval capture**
+
+Run the focused test, confirm failures are caused by the missing method, then
+implement only enough to create `EvidenceRun` and `EvidenceRunPayload` using:
+
+- `CitationFingerprintDomain.RAW_QUERY`
+- `new_opaque_id("evidence-run")`
+- `new_opaque_id("run-payload")`
+- typed `RetrievalScoreKind` and `RetrievalScoreScale`
+
+Serialize only the typed metadata model into
+`EvidenceRunPayload.retrieval_metadata`. Never log query, title, source
+identity, locator, lineage, or fingerprints.
+
+- [ ] **Step 6: Write failing prompt-set tests**
+
+Test exact bytes, stable ordinals, transformations, and run linkage:
+
+```python
+prompt_set_id = builder.record_prompt_evidence_set(
+    run_id=run_id,
+    evidence=(
+        LocalPromptEvidenceCapture(
+            candidate_rank=1,
+            snapshot_text="[S1] MEDIA — Alpha\nExact transformed text",
+            transformations=("heading_injected",),
+        ),
+    ),
+    created_at=NOW,
+)
+
+entry = builder.prompt_evidence_sets[0].entries[0]
+snapshot = builder.evidence_snapshot_payloads[0]
+assert entry.marker_ordinal == 1
+assert entry.evidence_ordinal == 1
+assert entry.run_id == run_id
+assert snapshot.snapshot_text == "[S1] MEDIA — Alpha\nExact transformed text"
+assert snapshot.storage_mode is EvidenceStorageMode.EMBEDDED
+```
+
+Assert no prompt set is created for zero evidence, ordinals are unique,
+snapshots use keyed exact/comparison fingerprints, and no partial state is
+appended when validation fails.
+
+- [ ] **Step 7: Run and verify RED, implement prompt capture, then run GREEN**
+
+Build all Pydantic objects before mutating builder lists so a failure is atomic.
+Use `MarkerNamespace.CHATBOOK_S_V1`. The builder remains unsealed and
+non-persistable.
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest Tests/Chat/test_citation_trace_builder.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Tests/Chat/test_citation_trace_builder.py \
+  tldw_chatbook/Chat/citation_trace_builder.py
+git commit -m "feat(rag): add request-scoped citation trace builder"
+```
+
+---
+
+### Task 2: Normalize and format exact local prompt evidence
+
+**Files:**
+
+- Create: `Tests/RAG/test_local_citation_capture.py`
+- Modify: `Tests/RAG/test_scope_pipeline_enforcement.py`
+- Create: `tldw_chatbook/RAG_Search/local_citation_capture.py`
+- Modify: `tldw_chatbook/RAG_Search/pipeline_functions_simple.py`
+- Modify: `tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py`
+
+- [ ] **Step 1: Write failing source-normalization tests**
+
+Cover the three allowed local families and common aliases:
+
+```python
+assert normalize_local_result(media_result).source_kind is CanonicalSourceKind.MEDIA_DB
+assert normalize_local_result(note_result).source_kind is CanonicalSourceKind.NOTES
+assert normalize_local_result(conversation_result).source_kind is CanonicalSourceKind.CHAT_HISTORY
+```
+
+Normalize semantic media results from their governed metadata when their
+top-level source is currently `"unknown"`. Reject empty IDs, unknown source
+kinds, non-string title/content, control-bearing titles, unsafe metadata, and
+non-finite scores with a non-content reason code.
+
+Use an explicit final-score mapping driven by producer metadata, never by the
+bare float alone:
+
+- `_final_score_kind=reranker` written by a successful `rerank_results()` call
+  -> `RERANKER` / `UNBOUNDED`
+- RRF fusion metadata, only when no later final-score marker exists -> `RRF` /
+  `NON_NEGATIVE`
+- semantic similarity metadata, only when no later final-score marker exists
+  -> `VECTOR_SIMILARITY` / `UNBOUNDED`
+- all custom, FTS placeholder, or otherwise opaque scores -> `LEGACY` /
+  `UNBOUNDED`
+
+Update `rerank_results()` test-first so successful FlashRank output writes the
+explicit final-score marker when it overwrites `SearchResult.score`. Import,
+initialization, and execution fallback must not write that marker; the retained
+prior score is then classified from reliable prior metadata or as `LEGACY`.
+Never infer BM25 or normalized similarity semantics from a bare float.
+
+- [ ] **Step 2: Run RED, then implement a strict allowlisted normalizer**
+
+The normalizer may retain only:
+
+- canonical source kind and opaque item ID
+- bounded title
+- exact content for the live formatter
+- typed score kind/scale/value
+- allowlisted non-executable lineage keys
+
+Do not copy arbitrary metadata, URLs, paths, or citation dictionaries into
+source identity or locator fields. Resolver-family tasks will add typed native
+locators later.
+
+- [ ] **Step 3: Write failing canonical formatter tests**
+
+Test that one formatting function produces both the provider context and the
+exact per-entry blocks:
+
+```python
+formatted = format_local_evidence_context(
+    normalized_results,
+    max_length=90,
+)
+
+assert formatted.context == "\n---\n".join(
+    entry.snapshot_text for entry in formatted.entries
+)
+assert formatted.entries[0].snapshot_text.startswith("[S1] ")
+assert len(formatted.context) <= 90
+assert formatted.omitted_candidate_ranks == (3,)
+```
+
+Include:
+
+- exact-fit and one-character-short budgets
+- UTF-8/Unicode input while the configured budget remains the existing
+  character budget
+- ellipsis included inside the captured snapshot
+- stable contiguous marker ordinals after invalid/unauthorized candidates are
+  excluded
+- no snapshots for omitted candidates
+
+- [ ] **Step 4: Run RED, implement the formatter, then run GREEN**
+
+Build each block as:
+
+```text
+[S1] MEDIA — Title
+exact submitted content
+```
+
+Use a single calculation for returned context and snapshot text. Never parse
+the aggregate context afterward to reconstruct entries.
+
+- [ ] **Step 5: Write failing prompt-boundary authority tests**
+
+Test a fresh, uncached post-retrieval check:
+
+- a media/note/conversation result is retrieved, then its backing row is
+  deleted or soft-deleted before prompt assembly; it is excluded
+- a conversation or workspace scope is narrowed after retrieval without
+  reusing the old `ScopeCache` entry; newly unauthorized evidence is excluded
+- conversations remain excluded under an active local RAG scope
+- an `empty` or failed authority/existence read rejects every entry
+
+- [ ] **Step 6: Implement the fresh authority/existence seam and run GREEN**
+
+Add an explicit uncached mode to the existing scope-resolution seam and a
+batched current-existence query for all three local source families. Prompt
+assembly must re-read the conversation/workspace scope and current backing rows
+after retrieval, off the event loop where appropriate. Do not consult the
+pre-retrieval `EffectiveScope` or `ScopeCache` for this decision. Query/read
+errors fail closed. The check consumes canonical item IDs, not display titles
+or raw metadata, and runs before marker ordinals are assigned.
+
+- [ ] **Step 7: Correct semantic source propagation test-first**
+
+Add focused regressions proving:
+
+- `search_semantic()` uses the result metadata’s allowlisted source when no
+  top-level source attribute exists
+- successful reranking marks the overwritten score as
+  `RERANKER`/`UNBOUNDED`
+- reranker import/execution fallback retains honest prior RRF/semantic metadata
+  or degrades an opaque score to `LEGACY`
+
+Preserve the existing return shape and citation metadata behavior.
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/RAG/test_local_citation_capture.py \
+  Tests/RAG/test_scope_pipeline_enforcement.py \
+  Tests/RAG/test_semantic_honest_states.py \
+  Tests/RAG/test_fusion.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Tests/RAG/test_local_citation_capture.py \
+  Tests/RAG/test_scope_pipeline_enforcement.py \
+  tldw_chatbook/RAG_Search/local_citation_capture.py \
+  tldw_chatbook/RAG_Search/pipeline_functions_simple.py \
+  tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
+git commit -m "feat(rag): format exact canonical prompt evidence"
+```
+
+---
+
+### Task 3: Compose builders through the existing citation repository
+
+**Files:**
+
+- Modify: `Tests/Chat/test_citation_trace_repository.py`
+- Modify: `tldw_chatbook/Chat/citation_trace_repository.py`
+
+- [ ] **Step 1: Write failing readiness/factory tests**
+
+Test:
+
+```python
+assert disabled_repository.create_local_trace_builder(
+    request_id="request-1",
+    generation_id="generation-1",
+) is None
+
+builder = enabled_repository.create_local_trace_builder(
+    request_id="request-1",
+    generation_id="generation-1",
+)
+assert builder is not None
+```
+
+Also cover missing identity, missing fingerprint key, and persisted identity
+mismatch. None of these states may break ordinary RAG generation.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/Chat/test_citation_trace_repository.py \
+  -k "local_trace_builder or canonical_capture" -q
+```
+
+Expected: failures because the factory does not exist.
+
+- [ ] **Step 3: Implement the minimal safe factory**
+
+The repository owns access to `_fingerprint_codec`; do not add a public secret
+or codec property. Re-read the persisted identity before issuing a builder, as
+the persistence path already does:
+
+```python
+def create_local_trace_builder(
+    self,
+    *,
+    request_id: str,
+    generation_id: str,
+) -> CitationTraceBuilder | None:
+    if not self.canonical_writes_enabled:
+        return None
+    ...
+```
+
+Return `None` for unavailable prerequisites and use only non-content diagnostic
+codes if logging is necessary.
+
+- [ ] **Step 4: Run GREEN and broader repository tests**
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/Chat/test_citation_trace_repository.py \
+  Tests/Chat/test_citation_trace_identity.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Tests/Chat/test_citation_trace_repository.py \
+  tldw_chatbook/Chat/citation_trace_repository.py
+git commit -m "feat(rag): compose local citation capture securely"
+```
+
+---
+
+### Task 4: Wire capture through every local Chat RAG mode
+
+**Files:**
+
+- Modify: `Tests/RAG/test_local_citation_capture.py`
+- Modify: `Tests/RAG/test_rag_ui_integration.py`
+- Modify: `Tests/RAG/test_scope_pipeline_enforcement.py`
+- Modify: `tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py`
+
+- [ ] **Step 1: Write failing capture-aware API tests**
+
+Add a frozen result wrapper:
+
+```python
+@dataclass(frozen=True)
+class LocalRagContextResult:
+    context: str | None
+    citation_builder: CitationTraceBuilder | None
+```
+
+Test a new `get_rag_context_capture_for_chat()` while retaining the old API:
+
+```python
+captured = await get_rag_context_capture_for_chat(app, "query")
+assert captured.context.startswith("[S1] ")
+assert len(captured.citation_builder.evidence_runs) == 1
+assert len(captured.citation_builder.prompt_evidence_sets) == 1
+
+legacy = await get_rag_context_for_chat(app, "query")
+assert isinstance(legacy, str)
+```
+
+- [ ] **Step 2: Run RED**
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/RAG/test_local_citation_capture.py \
+  Tests/RAG/test_rag_ui_integration.py -q
+```
+
+- [ ] **Step 3: Implement opt-in capture without changing pipeline tuples**
+
+At request start:
+
+1. Allocate opaque request/generation IDs.
+2. Ask `app.citation_trace_repository` for a builder.
+3. Capture the active conversation/workspace/session identity and retrieval
+   start time.
+4. Execute the existing selected pipeline unchanged.
+5. When no builder exists, return the pipeline’s existing context byte for
+   byte.
+6. When a builder exists, normalize the final ordered results, re-read the
+   original request’s conversation/workspace scope without `ScopeCache`
+   (never whichever session happens to be active after retrieval), batch-check
+   current backing-row existence for media, notes, and conversations, exclude
+   anything no longer authorized/available, record the full retrieval run,
+   format the exact marked prompt evidence, record the prompt set, and return
+   that exact context.
+7. Exclude individual malformed or unauthorized results before assigning
+   markers. If the canonical capture operation itself cannot complete
+   atomically, return no RAG context and no builder so ordinary chat remains
+   available without submitting uncaptured evidence or retaining partial
+   provenance.
+
+Sanitize the modified RAG path’s existing query/error logs as part of the same
+RED/GREEN change. Log only mode, counts, timing, and fixed non-content reason
+codes; never log the user query, formatted context, title, identity, locator,
+lineage, snapshot, fingerprint, or `str(ValidationError)`.
+
+- [ ] **Step 4: Test all pipeline selection branches**
+
+Parameterize `plain`, `semantic`, `hybrid`, and a custom pipeline. The tests
+may monkeypatch their `perform_*` functions to return the same ranked results;
+assert each branch produces one equivalent run/prompt capture.
+
+Cover:
+
+- empty results/context
+- pipeline exception
+- malformed result exclusion
+- scope exclusion
+- backing-row deletion between retrieval and prompt assembly
+- scope narrowing between retrieval and prompt assembly despite a populated
+  pre-retrieval cache
+- canonical writes disabled
+- repository absent
+- key/identity unavailable
+
+Add log-capture assertions using unique sentinel query/title/content strings.
+Neither successful capture, malformed-result rejection, nor validation failure
+may place the sentinels into log messages.
+
+- [ ] **Step 5: Run focused GREEN and compatibility suites**
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/RAG/test_local_citation_capture.py \
+  Tests/RAG/test_rag_ui_integration.py \
+  Tests/RAG/test_scope_pipeline_enforcement.py \
+  Tests/RAG/test_semantic_honest_states.py \
+  Tests/RAG/test_fusion.py -q
+```
+
+Expected: all tests pass and the old string-return assertions remain valid.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Tests/RAG/test_local_citation_capture.py \
+  Tests/RAG/test_rag_ui_integration.py \
+  Tests/RAG/test_scope_pipeline_enforcement.py \
+  tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
+git commit -m "feat(rag): capture local retrieval and prompt evidence"
+```
+
+---
+
+### Task 5: Keep the builder alive across the current request worker
+
+**Files:**
+
+- Modify: `Tests/Event_Handlers/Chat_Events/test_chat_events.py`
+- Create: `Tests/Event_Handlers/test_worker_local_citation_capture.py`
+- Create: `Tests/Chat/test_chat_function_local_citation_boundary.py`
+- Modify: `tldw_chatbook/Event_Handlers/Chat_Events/chat_events.py`
+- Modify: `tldw_chatbook/Event_Handlers/worker_events.py`
+- Modify: `tldw_chatbook/Chat/Chat_Functions.py`
+
+- [ ] **Step 1: Write a failing chat-send seam test**
+
+Assert the send handler uses `get_rag_context_capture_for_chat()` and forwards
+the same builder object as an internal-only worker keyword. Canonical context
+must use the existing `media_content`/`selected_parts` seam instead of being
+concatenated into `message`, because `Chat_Functions.chat()` applies chat
+dictionary transformations to `message` before provider dispatch:
+
+```python
+assert captured_chat_wrapper_kwargs["citation_trace_builder"] is builder
+assert captured_chat_wrapper_kwargs["message"] == original_user_message
+assert captured_chat_wrapper_kwargs["media_content"] == {
+    "evidence": captured.context,
+}
+assert captured_chat_wrapper_kwargs["selected_parts"] == ["evidence"]
+```
+
+- [ ] **Step 2: Write failing worker and real provider-boundary tests**
+
+Assert `chat_wrapper_function()` removes `citation_trace_builder` before
+calling `core_chat_function`, so it cannot reach provider adapters or generic
+payload parameter routing. It must leave canonical `media_content` and
+`selected_parts` intact. The wrapper keeps the object in a local variable for
+the lifetime of generation, then drops it because answer-attempt capture is the
+next task.
+
+In `Tests/Chat/test_chat_function_local_citation_boundary.py`, call the real
+`Chat_Functions.chat()` with:
+
+- canonical evidence containing unique title/body sentinels
+- an evidence block with intentional leading/trailing whitespace
+- a chat-dictionary entry that would mutate those sentinels if it saw them
+- `media_content={"evidence": canonical_context}`
+- `selected_parts=["evidence"]`
+- a patched `chat_api_call` that captures `messages_payload`
+
+Assert every `EvidenceSnapshotPayload.snapshot_text` remains an exact substring
+of the provider-bound user text after `process_user_input()` runs, while the
+ordinary user prompt still receives its configured dictionary transformation.
+The whitespace-bearing snapshot must also match byte for byte despite
+`Chat_Functions.chat()` assembling the overall message with `.strip()`. This is
+the terminal prompt-boundary proof for this task.
+
+- [ ] **Step 3: Run RED, implement the minimal threading seam, then run GREEN**
+
+When `citation_builder is None`, keep the current legacy behavior byte for byte:
+prepend the old RAG context to `message` and pass empty `media_content` /
+`selected_parts`. When a builder exists, keep `message` free of canonical
+evidence and pass the canonical context through the dedicated RAG seam above.
+Do not store the builder on `app`, a module global, a sidecar, or SQLite. Do not
+log or serialize it.
+
+Sanitize existing logs on this modified path:
+
+- `chat_rag_events.py`: log mode/count/timing only, never raw query or
+  validation exception text
+- `chat_events.py`: log message length/history count, never message previews
+- `Chat_Functions.py`: log content types and lengths only, never input text,
+  prompt previews, provider-payload text previews, custom-prompt text, answer
+  previews, or post-generation replacement previews
+
+Tests must attach capture handlers with unique query, prompt, title, snapshot,
+and answer sentinels and assert none appear in emitted records. Validation
+failures log a fixed reason code, not `str(ValidationError)`. Exercise both the
+real local pipeline functions and streaming/non-streaming worker paths so
+downstream query and answer logging is covered.
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/Event_Handlers/Chat_Events/test_chat_events.py \
+  Tests/Event_Handlers/test_worker_local_citation_capture.py \
+  Tests/Chat/test_chat_function_local_citation_boundary.py \
+  Tests/RAG/test_local_citation_capture.py \
+  Tests/Chat/test_citation_trace_builder.py -q
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tldw_chatbook/Event_Handlers/Chat_Events/chat_events.py \
+  tldw_chatbook/Event_Handlers/worker_events.py \
+  tldw_chatbook/Chat/Chat_Functions.py \
+  Tests/Event_Handlers/Chat_Events/test_chat_events.py \
+  Tests/Event_Handlers/test_worker_local_citation_capture.py \
+  Tests/Chat/test_chat_function_local_citation_boundary.py
+git commit -m "feat(rag): carry citation builder through generation request"
+```
+
+---
+
+### Task 6: Documentation, self-review, and verification
+
+**Files:**
+
+- Modify: `Docs/superpowers/specs/2026-07-23-rag-citation-provenance-design.md`
+- Modify: `backlog/tasks/task-553.13 - Capture-local-RAG-retrieval-runs-and-exact-prompt-evidence-sets.md`
+
+- [ ] **Step 1: Update implementation links and boundary notes**
+
+Record that workstreams 10 is implemented while workstreams 11–30 remain
+follow-ons. Do not mark the epic complete.
+
+- [ ] **Step 2: Run formatting/static checks**
+
+```bash
+../../.venv/bin/python -m ruff check \
+  tldw_chatbook/Chat/citation_trace_builder.py \
+  tldw_chatbook/Chat/citation_trace_repository.py \
+  tldw_chatbook/RAG_Search/local_citation_capture.py \
+  tldw_chatbook/RAG_Search/pipeline_functions_simple.py \
+  tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py \
+  tldw_chatbook/Event_Handlers/Chat_Events/chat_events.py \
+  tldw_chatbook/Event_Handlers/worker_events.py \
+  tldw_chatbook/Chat/Chat_Functions.py \
+  Tests/Chat/test_citation_trace_builder.py \
+  Tests/Chat/test_chat_function_local_citation_boundary.py \
+  Tests/RAG/test_local_citation_capture.py \
+  Tests/Event_Handlers/test_worker_local_citation_capture.py
+```
+
+Expected: no findings in changed files.
+
+- [ ] **Step 3: Run the complete focused regression set**
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/Chat/test_citation_trace_builder.py \
+  Tests/Chat/test_citation_trace_models.py \
+  Tests/Chat/test_citation_trace_identity.py \
+  Tests/Chat/test_citation_trace_repository.py \
+  Tests/Chat/test_chat_persistence_service.py \
+  Tests/Chat/test_chat_function_local_citation_boundary.py \
+  Tests/Event_Handlers/Chat_Events/test_chat_events.py \
+  Tests/Event_Handlers/test_worker_local_citation_capture.py \
+  Tests/RAG/test_local_citation_capture.py \
+  Tests/RAG/test_rag_ui_integration.py \
+  Tests/RAG/test_scope_pipeline_enforcement.py \
+  Tests/RAG/test_semantic_honest_states.py \
+  Tests/RAG/test_fusion.py -q
+```
+
+Expected: zero failures.
+
+- [ ] **Step 4: Run repository-wide verification without concurrent pytest**
+
+First verify no other pytest process is active, then run:
+
+```bash
+../../.venv/bin/python -m pytest
+```
+
+Expected: zero failures. If unrelated baseline failures exist, record exact
+node IDs and compare them against a fresh `origin/dev` worktree before making
+any completion claim.
+
+- [ ] **Step 5: Review the diff and task acceptance criteria**
+
+```bash
+git diff --check
+git status --short
+git diff --stat origin/dev...
+git diff origin/dev... -- \
+  tldw_chatbook Tests Docs backlog/tasks
+```
+
+Confirm:
+
+- no sensitive content logging
+- no arbitrary metadata copied into locator/source fields
+- no partial builder persistence
+- disabled mode preserves existing prompt bytes
+- exact captured snapshot blocks compose the provider context
+- no answer-attempt, marker-occurrence, repair, UI, resolver, server, or sync
+  scope leaked into this task
+
+- [ ] **Step 6: Complete Backlog hygiene**
+
+Check all six acceptance criteria, add concise implementation notes with test
+evidence and the ADR-024 link, and set TASK-553.13 to Done only after every DoD
+gate passes.
+
+- [ ] **Step 7: Commit documentation/task closeout**
+
+```bash
+git add \
+  Docs/superpowers/specs/2026-07-23-rag-citation-provenance-design.md \
+  Docs/superpowers/plans/2026-07-25-local-rag-retrieval-prompt-evidence-capture.md \
+  'backlog/tasks/task-553.13 - Capture-local-RAG-retrieval-runs-and-exact-prompt-evidence-sets.md'
+git commit -m "docs(rag): record local citation capture delivery"
+```

--- a/Docs/superpowers/plans/2026-07-25-local-rag-retrieval-prompt-evidence-capture.md
+++ b/Docs/superpowers/plans/2026-07-25-local-rag-retrieval-prompt-evidence-capture.md
@@ -43,8 +43,8 @@
 
 ## ADR check
 
-ADR required: yes  
-ADR path: `backlog/decisions/024-rag-citation-provenance-and-source-resolution.md`  
+ADR required: yes
+ADR path: `backlog/decisions/024-rag-citation-provenance-and-source-resolution.md`
 Reason: This plan implements ADR-024’s local retrieval-run and exact prompt-boundary evidence capture contracts. It does not introduce a new architectural choice.
 
 ---
@@ -56,7 +56,7 @@ Reason: This plan implements ADR-024’s local retrieval-run and exact prompt-bo
 - Create: `Tests/Chat/test_citation_trace_builder.py`
 - Create: `tldw_chatbook/Chat/citation_trace_builder.py`
 
-- [ ] **Step 1: Write failing constructor and privacy tests**
+- [x] **Step 1: Write failing constructor and privacy tests**
 
 Add tests that construct the builder with a fixed `LocalCitationIdentityContext`,
 `CitationFingerprintCodec`, `request_id`, and `generation_id`. Assert:
@@ -81,7 +81,7 @@ assert "secret query" not in repr(builder)
 Also assert frozen identity inputs are validated and the builder cannot be
 constructed without a local authority/profile binding.
 
-- [ ] **Step 2: Run the focused tests and verify RED**
+- [x] **Step 2: Run the focused tests and verify RED**
 
 Run:
 
@@ -92,7 +92,7 @@ Run:
 Expected: collection/import failure because `citation_trace_builder.py` does
 not exist.
 
-- [ ] **Step 3: Implement the minimal builder constructor**
+- [x] **Step 3: Implement the minimal builder constructor**
 
 Create a mutable class whose public collection properties return tuples. Keep
 secret material private and redact it from `repr`:
@@ -118,7 +118,7 @@ class CitationTraceBuilder:
 
 The builder must not expose a generic `seal()` in this task.
 
-- [ ] **Step 4: Write failing retrieval-run tests**
+- [x] **Step 4: Write failing retrieval-run tests**
 
 Define narrow typed inputs such as `LocalRetrievalCandidateCapture` and
 `LocalRetrievalRunMetadata`; do not import `SearchResult` into the Chat layer
@@ -156,7 +156,7 @@ Reject duplicate/unknown run references, non-finite scores, excess candidates,
 unknown metadata fields, path/URL-shaped metadata values, and payloads beyond
 existing model caps.
 
-- [ ] **Step 5: Run and verify RED, then implement retrieval capture**
+- [x] **Step 5: Run and verify RED, then implement retrieval capture**
 
 Run the focused test, confirm failures are caused by the missing method, then
 implement only enough to create `EvidenceRun` and `EvidenceRunPayload` using:
@@ -170,7 +170,7 @@ Serialize only the typed metadata model into
 `EvidenceRunPayload.retrieval_metadata`. Never log query, title, source
 identity, locator, lineage, or fingerprints.
 
-- [ ] **Step 6: Write failing prompt-set tests**
+- [x] **Step 6: Write failing prompt-set tests**
 
 Test exact bytes, stable ordinals, transformations, and run linkage:
 
@@ -200,7 +200,7 @@ Assert no prompt set is created for zero evidence, ordinals are unique,
 snapshots use keyed exact/comparison fingerprints, and no partial state is
 appended when validation fails.
 
-- [ ] **Step 7: Run and verify RED, implement prompt capture, then run GREEN**
+- [x] **Step 7: Run and verify RED, implement prompt capture, then run GREEN**
 
 Build all Pydantic objects before mutating builder lists so a failure is atomic.
 Use `MarkerNamespace.CHATBOOK_S_V1`. The builder remains unsealed and
@@ -214,7 +214,7 @@ Run:
 
 Expected: all tests pass.
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 git add Tests/Chat/test_citation_trace_builder.py \
@@ -234,7 +234,7 @@ git commit -m "feat(rag): add request-scoped citation trace builder"
 - Modify: `tldw_chatbook/RAG_Search/pipeline_functions_simple.py`
 - Modify: `tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py`
 
-- [ ] **Step 1: Write failing source-normalization tests**
+- [x] **Step 1: Write failing source-normalization tests**
 
 Cover the three allowed local families and common aliases:
 
@@ -267,7 +267,7 @@ initialization, and execution fallback must not write that marker; the retained
 prior score is then classified from reliable prior metadata or as `LEGACY`.
 Never infer BM25 or normalized similarity semantics from a bare float.
 
-- [ ] **Step 2: Run RED, then implement a strict allowlisted normalizer**
+- [x] **Step 2: Run RED, then implement a strict allowlisted normalizer**
 
 The normalizer may retain only:
 
@@ -281,7 +281,7 @@ Do not copy arbitrary metadata, URLs, paths, or citation dictionaries into
 source identity or locator fields. Resolver-family tasks will add typed native
 locators later.
 
-- [ ] **Step 3: Write failing canonical formatter tests**
+- [x] **Step 3: Write failing canonical formatter tests**
 
 Test that one formatting function produces both the provider context and the
 exact per-entry blocks:
@@ -310,7 +310,7 @@ Include:
   excluded
 - no snapshots for omitted candidates
 
-- [ ] **Step 4: Run RED, implement the formatter, then run GREEN**
+- [x] **Step 4: Run RED, implement the formatter, then run GREEN**
 
 Build each block as:
 
@@ -322,7 +322,7 @@ exact submitted content
 Use a single calculation for returned context and snapshot text. Never parse
 the aggregate context afterward to reconstruct entries.
 
-- [ ] **Step 5: Write failing prompt-boundary authority tests**
+- [x] **Step 5: Write failing prompt-boundary authority tests**
 
 Test a fresh, uncached post-retrieval check:
 
@@ -333,7 +333,7 @@ Test a fresh, uncached post-retrieval check:
 - conversations remain excluded under an active local RAG scope
 - an `empty` or failed authority/existence read rejects every entry
 
-- [ ] **Step 6: Implement the fresh authority/existence seam and run GREEN**
+- [x] **Step 6: Implement the fresh authority/existence seam and run GREEN**
 
 Add an explicit uncached mode to the existing scope-resolution seam and a
 batched current-existence query for all three local source families. Prompt
@@ -343,7 +343,7 @@ pre-retrieval `EffectiveScope` or `ScopeCache` for this decision. Query/read
 errors fail closed. The check consumes canonical item IDs, not display titles
 or raw metadata, and runs before marker ordinals are assigned.
 
-- [ ] **Step 7: Correct semantic source propagation test-first**
+- [x] **Step 7: Correct semantic source propagation test-first**
 
 Add focused regressions proving:
 
@@ -368,7 +368,7 @@ Run:
 
 Expected: all tests pass.
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 git add Tests/RAG/test_local_citation_capture.py \
@@ -388,7 +388,7 @@ git commit -m "feat(rag): format exact canonical prompt evidence"
 - Modify: `Tests/Chat/test_citation_trace_repository.py`
 - Modify: `tldw_chatbook/Chat/citation_trace_repository.py`
 
-- [ ] **Step 1: Write failing readiness/factory tests**
+- [x] **Step 1: Write failing readiness/factory tests**
 
 Test:
 
@@ -408,7 +408,7 @@ assert builder is not None
 Also cover missing identity, missing fingerprint key, and persisted identity
 mismatch. None of these states may break ordinary RAG generation.
 
-- [ ] **Step 2: Run RED**
+- [x] **Step 2: Run RED**
 
 ```bash
 ../../.venv/bin/python -m pytest \
@@ -418,7 +418,7 @@ mismatch. None of these states may break ordinary RAG generation.
 
 Expected: failures because the factory does not exist.
 
-- [ ] **Step 3: Implement the minimal safe factory**
+- [x] **Step 3: Implement the minimal safe factory**
 
 The repository owns access to `_fingerprint_codec`; do not add a public secret
 or codec property. Re-read the persisted identity before issuing a builder, as
@@ -439,7 +439,7 @@ def create_local_trace_builder(
 Return `None` for unavailable prerequisites and use only non-content diagnostic
 codes if logging is necessary.
 
-- [ ] **Step 4: Run GREEN and broader repository tests**
+- [x] **Step 4: Run GREEN and broader repository tests**
 
 ```bash
 ../../.venv/bin/python -m pytest \
@@ -449,7 +449,7 @@ codes if logging is necessary.
 
 Expected: all tests pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add Tests/Chat/test_citation_trace_repository.py \
@@ -468,7 +468,7 @@ git commit -m "feat(rag): compose local citation capture securely"
 - Modify: `Tests/RAG/test_scope_pipeline_enforcement.py`
 - Modify: `tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py`
 
-- [ ] **Step 1: Write failing capture-aware API tests**
+- [x] **Step 1: Write failing capture-aware API tests**
 
 Add a frozen result wrapper:
 
@@ -491,7 +491,7 @@ legacy = await get_rag_context_for_chat(app, "query")
 assert isinstance(legacy, str)
 ```
 
-- [ ] **Step 2: Run RED**
+- [x] **Step 2: Run RED**
 
 ```bash
 ../../.venv/bin/python -m pytest \
@@ -499,7 +499,7 @@ assert isinstance(legacy, str)
   Tests/RAG/test_rag_ui_integration.py -q
 ```
 
-- [ ] **Step 3: Implement opt-in capture without changing pipeline tuples**
+- [x] **Step 3: Implement opt-in capture without changing pipeline tuples**
 
 At request start:
 
@@ -528,7 +528,7 @@ RED/GREEN change. Log only mode, counts, timing, and fixed non-content reason
 codes; never log the user query, formatted context, title, identity, locator,
 lineage, snapshot, fingerprint, or `str(ValidationError)`.
 
-- [ ] **Step 4: Test all pipeline selection branches**
+- [x] **Step 4: Test all pipeline selection branches**
 
 Parameterize `plain`, `semantic`, `hybrid`, and a custom pipeline. The tests
 may monkeypatch their `perform_*` functions to return the same ranked results;
@@ -551,7 +551,7 @@ Add log-capture assertions using unique sentinel query/title/content strings.
 Neither successful capture, malformed-result rejection, nor validation failure
 may place the sentinels into log messages.
 
-- [ ] **Step 5: Run focused GREEN and compatibility suites**
+- [x] **Step 5: Run focused GREEN and compatibility suites**
 
 ```bash
 ../../.venv/bin/python -m pytest \
@@ -564,7 +564,7 @@ may place the sentinels into log messages.
 
 Expected: all tests pass and the old string-return assertions remain valid.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add Tests/RAG/test_local_citation_capture.py \
@@ -576,106 +576,62 @@ git commit -m "feat(rag): capture local retrieval and prompt evidence"
 
 ---
 
-### Task 5: Keep the builder alive across the current request worker
+### Task 5: Keep the builder alive across the current Console generation request
 
 **Files:**
 
-- Modify: `Tests/Event_Handlers/Chat_Events/test_chat_events.py`
-- Create: `Tests/Event_Handlers/test_worker_local_citation_capture.py`
-- Create: `Tests/Chat/test_chat_function_local_citation_boundary.py`
-- Modify: `tldw_chatbook/Event_Handlers/Chat_Events/chat_events.py`
-- Modify: `tldw_chatbook/Event_Handlers/worker_events.py`
-- Modify: `tldw_chatbook/Chat/Chat_Functions.py`
+- Create: `Tests/Chat/test_console_local_citation_boundary.py`
+- Create: `Tests/UI/test_console_local_citation_capture.py`
+- Modify: `Tests/RAG/test_local_citation_capture.py`
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py`
+- Modify: `tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
 
-- [ ] **Step 1: Write a failing chat-send seam test**
+- [x] **Step 1: Rebase the boundary plan onto the native Console architecture**
 
-Assert the send handler uses `get_rag_context_capture_for_chat()` and forwards
-the same builder object as an internal-only worker keyword. Canonical context
-must use the existing `media_content`/`selected_parts` seam instead of being
-concatenated into `message`, because `Chat_Functions.chat()` applies chat
-dictionary transformations to `message` before provider dispatch:
+Latest `dev` retired the legacy `chat_events.py` send path planned originally.
+The live boundary is now `ChatScreen` → `ConsoleChatController.submit_draft()`
+→ direct provider or agent dispatch. Keep the retired entrypoints absent and
+port the same request-local ownership and exact prompt-boundary guarantees to
+the native Console path.
 
-```python
-assert captured_chat_wrapper_kwargs["citation_trace_builder"] is builder
-assert captured_chat_wrapper_kwargs["message"] == original_user_message
-assert captured_chat_wrapper_kwargs["media_content"] == {
-    "evidence": captured.context,
-}
-assert captured_chat_wrapper_kwargs["selected_parts"] == ["evidence"]
-```
+- [x] **Step 2: Write failing Console prompt-boundary tests**
 
-- [ ] **Step 2: Write failing worker and real provider-boundary tests**
-
-Assert `chat_wrapper_function()` removes `citation_trace_builder` before
-calling `core_chat_function`, so it cannot reach provider adapters or generic
-payload parameter routing. It must leave canonical `media_content` and
-`selected_parts` intact. The wrapper keeps the object in a local variable for
-the lifetime of generation, then drops it because answer-attempt capture is the
-next task.
-
-In `Tests/Chat/test_chat_function_local_citation_boundary.py`, call the real
-`Chat_Functions.chat()` with:
+Cover:
 
 - canonical evidence containing unique title/body sentinels
 - an evidence block with intentional leading/trailing whitespace
 - a chat-dictionary entry that would mutate those sentinels if it saw them
-- `media_content={"evidence": canonical_context}`
-- `selected_parts=["evidence"]`
-- a patched `chat_api_call` that captures `messages_payload`
+- stored/visible user text remains the original draft
+- the ordinary prompt still receives dictionary/world-info transformations
+- canonical evidence is added only after those transforms
+- exact snapshots reach both direct-provider and agent payloads byte for byte
+- multimodal image parts remain unchanged
+- the request-local builder remains alive through generation and is then
+  released
+- capture failures log fixed structural diagnostics without sentinels
 
-Assert every `EvidenceSnapshotPayload.snapshot_text` remains an exact substring
-of the provider-bound user text after `process_user_input()` runs, while the
-ordinary user prompt still receives its configured dictionary transformation.
-The whitespace-bearing snapshot must also match byte for byte despite
-`Chat_Functions.chat()` assembling the overall message with `.strip()`. This is
-the terminal prompt-boundary proof for this task.
+- [x] **Step 3: Stage and reauthorize the complete Console evidence bundle**
 
-- [ ] **Step 3: Run RED, implement the minimal threading seam, then run GREEN**
+Stage every retrieved Library-RAG result, not only the first display result.
+At send time, validate the serialized `EvidenceBundle`, reject non-local or
+unavailable references, re-read source existence and active scope without the
+cache, format the canonical markers once, and record the run plus exact prompt
+evidence set. If no repository/builder is available, preserve the compatible
+context-only behavior.
 
-When `citation_builder is None`, keep the current legacy behavior byte for byte:
-prepend the old RAG context to `message` and pass empty `media_content` /
-`selected_parts`. When a builder exists, keep `message` free of canonical
-evidence and pass the canonical context through the dedicated RAG seam above.
-Do not store the builder on `app`, a module global, a sidecar, or SQLite. Do not
-log or serialize it.
+- [x] **Step 4: Thread request-local capture through native generation**
 
-Sanitize existing logs on this modified path:
+Inject a request-local capture provider into `ConsoleChatController`. Keep the
+builder in a local variable across the awaited direct-provider or agent
+generation; never store, log, serialize, or persist it. Canonical evidence is
+prefixed after ordinary prompt transforms, while the no-builder compatibility
+path preserves its prior ordering.
 
-- `chat_rag_events.py`: log mode/count/timing only, never raw query or
-  validation exception text
-- `chat_events.py`: log message length/history count, never message previews
-- `Chat_Functions.py`: log content types and lengths only, never input text,
-  prompt previews, provider-payload text previews, custom-prompt text, answer
-  previews, or post-generation replacement previews
+- [x] **Step 5: Verify and commit the native Console port**
 
-Tests must attach capture handlers with unique query, prompt, title, snapshot,
-and answer sentinels and assert none appear in emitted records. Validation
-failures log a fixed reason code, not `str(ValidationError)`. Exercise both the
-real local pipeline functions and streaming/non-streaming worker paths so
-downstream query and answer logging is covered.
-
-Run:
-
-```bash
-../../.venv/bin/python -m pytest \
-  Tests/Event_Handlers/Chat_Events/test_chat_events.py \
-  Tests/Event_Handlers/test_worker_local_citation_capture.py \
-  Tests/Chat/test_chat_function_local_citation_boundary.py \
-  Tests/RAG/test_local_citation_capture.py \
-  Tests/Chat/test_citation_trace_builder.py -q
-```
-
-- [ ] **Step 4: Commit**
-
-```bash
-git add tldw_chatbook/Event_Handlers/Chat_Events/chat_events.py \
-  tldw_chatbook/Event_Handlers/worker_events.py \
-  tldw_chatbook/Chat/Chat_Functions.py \
-  Tests/Event_Handlers/Chat_Events/test_chat_events.py \
-  Tests/Event_Handlers/test_worker_local_citation_capture.py \
-  Tests/Chat/test_chat_function_local_citation_boundary.py
-git commit -m "feat(rag): carry citation builder through generation request"
-```
+The final touched-code gate is recorded in Task 6. Commit the Console port with
+the task closeout after the rebased diff is reviewed.
 
 ---
 
@@ -686,65 +642,56 @@ git commit -m "feat(rag): carry citation builder through generation request"
 - Modify: `Docs/superpowers/specs/2026-07-23-rag-citation-provenance-design.md`
 - Modify: `backlog/tasks/task-553.13 - Capture-local-RAG-retrieval-runs-and-exact-prompt-evidence-sets.md`
 
-- [ ] **Step 1: Update implementation links and boundary notes**
+- [x] **Step 1: Update implementation links and boundary notes**
 
 Record that workstreams 10 is implemented while workstreams 11–30 remain
 follow-ons. Do not mark the epic complete.
 
-- [ ] **Step 2: Run formatting/static checks**
+- [x] **Step 2: Run formatting/static checks**
 
 ```bash
-../../.venv/bin/python -m ruff check \
-  tldw_chatbook/Chat/citation_trace_builder.py \
-  tldw_chatbook/Chat/citation_trace_repository.py \
-  tldw_chatbook/RAG_Search/local_citation_capture.py \
-  tldw_chatbook/RAG_Search/pipeline_functions_simple.py \
+../../.venv/bin/ruff check \
+  tldw_chatbook/Chat/console_chat_controller.py \
   tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py \
-  tldw_chatbook/Event_Handlers/Chat_Events/chat_events.py \
-  tldw_chatbook/Event_Handlers/worker_events.py \
-  tldw_chatbook/Chat/Chat_Functions.py \
-  Tests/Chat/test_citation_trace_builder.py \
-  Tests/Chat/test_chat_function_local_citation_boundary.py \
-  Tests/RAG/test_local_citation_capture.py \
-  Tests/Event_Handlers/test_worker_local_citation_capture.py
+  tldw_chatbook/UI/Screens/chat_screen.py \
+  Tests/Chat/test_console_local_citation_boundary.py \
+  Tests/UI/test_console_local_citation_capture.py \
+  Tests/RAG/test_local_citation_capture.py
 ```
 
 Expected: no findings in changed files.
 
-- [ ] **Step 3: Run the complete focused regression set**
+Result: `ruff check` passed for the six citation/Console-RAG code and test
+files. `ruff format --check` passed for the three touched test files. The large
+native Console modules retain the current `dev` formatting baseline to avoid
+unrelated mechanical churn.
 
-```bash
-../../.venv/bin/python -m pytest \
-  Tests/Chat/test_citation_trace_builder.py \
-  Tests/Chat/test_citation_trace_models.py \
-  Tests/Chat/test_citation_trace_identity.py \
-  Tests/Chat/test_citation_trace_repository.py \
-  Tests/Chat/test_chat_persistence_service.py \
-  Tests/Chat/test_chat_function_local_citation_boundary.py \
-  Tests/Event_Handlers/Chat_Events/test_chat_events.py \
-  Tests/Event_Handlers/test_worker_local_citation_capture.py \
-  Tests/RAG/test_local_citation_capture.py \
-  Tests/RAG/test_rag_ui_integration.py \
-  Tests/RAG/test_scope_pipeline_enforcement.py \
-  Tests/RAG/test_semantic_honest_states.py \
-  Tests/RAG/test_fusion.py -q
-```
+- [x] **Step 3: Run the complete focused regression set**
+
+Run the three direct citation files plus only the existing Console seams changed
+by the native port: provider dictionary/world-info ordering, Library-RAG
+staging/authority display, query validation, and retired-entrypoint guards.
 
 Expected: zero failures.
 
-- [ ] **Step 4: Run repository-wide verification without concurrent pytest**
+Result: `110 passed, 1 dependency-version warning in 25.74s`.
 
-First verify no other pytest process is active, then run:
+- [x] **Step 4: Record the repository-wide verification deviation**
 
-```bash
-../../.venv/bin/python -m pytest
-```
+The repository-wide run was stopped at the user's direction after several
+hours, and all lingering broad `tldw_chatbook` UI/RAG pytest processes were
+terminated. Verification is intentionally limited to touched code for this
+task.
 
-Expected: zero failures. If unrelated baseline failures exist, record exact
-node IDs and compare them against a fresh `origin/dev` worktree before making
-any completion claim.
+Two failures encountered while narrowing the gate reproduce on pristine
+`origin/dev` (`af2aee6cd`) and are tracked separately:
 
-- [ ] **Step 5: Review the diff and task acceptance criteria**
+- TASK-761:
+  `Tests/UI/test_console_dictionary_send_integration.py::test_native_send_applies_conversation_dictionary_agent_branch`
+- TASK-762:
+  `Tests/UI/test_console_internals_decomposition.py::test_console_rag_action_without_service_stages_recoverable_blocker`
+
+- [x] **Step 5: Review the diff and task acceptance criteria**
 
 ```bash
 git diff --check
@@ -761,16 +708,16 @@ Confirm:
 - no partial builder persistence
 - disabled mode preserves existing prompt bytes
 - exact captured snapshot blocks compose the provider context
-- no answer-attempt, marker-occurrence, repair, UI, resolver, server, or sync
-  scope leaked into this task
+- no answer-attempt, marker-occurrence, repair, citation-presentation/source-open
+  UI, resolver, server, or sync scope leaked into this task
 
-- [ ] **Step 6: Complete Backlog hygiene**
+- [x] **Step 6: Complete Backlog hygiene**
 
 Check all six acceptance criteria, add concise implementation notes with test
 evidence and the ADR-024 link, and set TASK-553.13 to Done only after every DoD
 gate passes.
 
-- [ ] **Step 7: Commit documentation/task closeout**
+- [x] **Step 7: Commit documentation/task closeout**
 
 ```bash
 git add \

--- a/Docs/superpowers/plans/2026-07-26-local-answer-attempt-terminal-sealing.md
+++ b/Docs/superpowers/plans/2026-07-26-local-answer-attempt-terminal-sealing.md
@@ -1,0 +1,1065 @@
+# Local Answer-Attempt and Terminal Citation Sealing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist one eligible marker-free local RAG answer and its complete prompt provenance atomically from the exact terminal Console body.
+
+**Architecture:** Extend the request-scoped citation builder with governed answer attempts and one-shot sealing, then carry an explicit prompt-set ID and a transient finalizer into the native Console assistant placeholder. The store owns exact-body materialization, terminal deferral, stable message identity, and bounded retry/fallback behavior; the existing persistence service and citation repository continue to own the single SQLite transaction. Production composition passes the same repository instance to both capture and persistence, while unsupported adapters remain on the ordinary message path.
+
+**Tech Stack:** Python 3.11+, Pydantic v2, Textual Console store/controller, SQLite/FTS-backed `CharactersRAGDB`, pytest, Loguru.
+
+---
+
+## Planning constraints
+
+- Required implementation discipline: `@superpowers:test-driven-development`.
+- Completion verification: `@superpowers:verification-before-completion`.
+- ADR required: yes.
+- ADR path: `backlog/decisions/024-rag-citation-provenance-and-source-resolution.md`.
+- Reason: this task directly implements ADR-024's existing request-scoped builder, terminal seal, governed answer-body, message ownership, and atomic persistence decisions. It does not make a new architectural decision.
+- Base dependency: TASK-553.13 / commit `22e9e6b9b`.
+- Work only in `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/rag-answer-attempt-sealing`.
+- Do not add occurrence mappings, citation repair, Sources UI, source opening, retry/regenerate provenance, server traces, or Sync v2 trace transport.
+- Do not weaken `SealedCitationWrite`'s exact occurrence/body validation.
+- Run only the focused tests named in this plan. Repository-wide baseline repair remains separate.
+- Never log answer bodies, queries, titles, snapshots, source identities, locators, fingerprints, or exception text on the finalization path.
+
+## File responsibility map
+
+| File | Responsibility in this task |
+| --- | --- |
+| `tldw_chatbook/Chat/citation_trace_builder.py` | Validate and retain the initial governed answer attempt, enforce marker-free eligibility and chronology, and seal one immutable write. |
+| `tldw_chatbook/Chat/citation_trace_repository.py` | Own the fixed local seal policy and supply it through the builder factory. |
+| `tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py` | Return the exact prompt-evidence-set ID alongside context and builder. |
+| `tldw_chatbook/Chat/chat_persistence_service.py` | Advertise fail-closed canonical-write readiness from the real repository/database binding. |
+| `tldw_chatbook/Chat/console_chat_store.py` | Atomically register transient finalization state, defer early persistence, invoke the exact-body finalizer, and implement stable retry/fallback behavior. |
+| `tldw_chatbook/Chat/console_chat_controller.py` | Create the request-local finalizer, install it only for initial sends, and clear it on every exit. |
+| `tldw_chatbook/UI/Screens/chat_screen.py` | Pass the app's exact citation repository into the Console persistence service. |
+| `Tests/Chat/test_citation_trace_builder.py` | Builder mutation, privacy, chronology, completeness, and one-shot seal tests. |
+| `Tests/Chat/test_citation_trace_repository.py` | Repository-owned seal-policy factory tests. |
+| `Tests/RAG/test_local_citation_capture.py` | Prompt-evidence-set ID handoff tests for local capture paths. |
+| `Tests/RAG/test_scope_pipeline_enforcement.py` | Existing direct-builder fixture compatibility after policy injection becomes required. |
+| `Tests/Chat/test_chat_function_local_citation_boundary.py` | Existing direct-builder boundary fixture plus prompt-set ID handoff coverage. |
+| `Tests/Chat/test_console_chat_store.py` | Existing non-citation persistence timing regressions. |
+| `Tests/Chat/test_console_terminal_citation_persistence.py` | New focused store retry/fallback, cleanup, exact-body, and real atomic persistence tests. |
+| `Tests/Chat/test_console_local_citation_boundary.py` | Direct-provider and agent request lifecycle integration tests. |
+| `Tests/UI/test_console_native_chat_flow.py` | Production repository-composition test. |
+| `backlog/tasks/task-553.14 - Capture-answer-attempts-and-seal-terminal-local-citation-traces.md` | Implementation plan, checked acceptance criteria, verification evidence, and implementation notes. |
+
+### Task 1: Add repository-owned local policy and one-shot builder sealing
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/citation_trace_repository.py:488-517`
+- Modify: `tldw_chatbook/Chat/citation_trace_builder.py:21-605`
+- Modify: `Tests/Chat/test_citation_trace_builder.py`
+- Modify: `Tests/Chat/test_citation_trace_repository.py`
+- Modify: `Tests/RAG/test_local_citation_capture.py`
+- Modify: `Tests/RAG/test_scope_pipeline_enforcement.py`
+- Modify: `Tests/Chat/test_chat_function_local_citation_boundary.py`
+
+- [ ] **Step 1: Add failing builder tests for the initial answer attempt**
+
+Add tests that construct one run and prompt set, then call the proposed terminal APIs:
+
+```python
+def _record_prompt(builder: CitationTraceBuilder) -> str:
+    run_id = _record_run(builder)
+    return builder.record_prompt_evidence_set(
+        run_id=run_id,
+        evidence=(
+            LocalPromptEvidenceCapture(
+                candidate_rank=1,
+                snapshot_text="[S1] MEDIA — Alpha\nexact evidence",
+            ),
+        ),
+        created_at=NOW + timedelta(seconds=1),
+    )
+
+
+def test_local_builder_records_exact_governed_initial_answer() -> None:
+    builder = _builder()
+    prompt_id = _record_prompt(builder)
+
+    attempt_id = builder.record_initial_answer_attempt(
+        prompt_evidence_set_id=prompt_id,
+        answer_body="marker-free exact answer",
+        completed_at=NOW + timedelta(seconds=2),
+    )
+
+    assert builder.answer_attempts[0].attempt_id == attempt_id
+    assert builder.answer_attempts[0].kind is AnswerAttemptKind.INITIAL
+    assert builder.answer_attempt_payloads[0].answer_body == "marker-free exact answer"
+    assert builder.answer_attempt_payloads[0].body_integrity_hmac
+    assert "marker-free exact answer" not in builder.answer_attempts[0].model_dump_json()
+```
+
+Also add tests for:
+
+- single and multiple eligible `[S#]` markers both raising the same safe `occurrence_mapping_unavailable` reason
+- markers inside Markdown code or escaped literals remaining eligible for marker-free sealing
+- answer-body byte cap and aggregate governed-payload cap
+- unknown prompt-set ID
+- attempt completion before prompt creation
+- rejected recording leaving both attempt collections unchanged
+
+- [ ] **Step 2: Run the new answer-attempt tests and confirm they fail**
+
+Run:
+
+```bash
+../../.venv/bin/pytest -q \
+  Tests/Chat/test_citation_trace_builder.py \
+  -k 'initial_answer or marker_free or answer_body or attempt_completion'
+```
+
+Expected: failures because `record_initial_answer_attempt`, `answer_attempts`, and `answer_attempt_payloads` do not exist.
+
+- [ ] **Step 3: Add failing seal and policy tests**
+
+Cover:
+
+```python
+def test_local_builder_seals_once_with_repository_policy() -> None:
+    builder = _builder()
+    prompt_id = _record_prompt(builder)
+    attempt_id = builder.record_initial_answer_attempt(
+        prompt_evidence_set_id=prompt_id,
+        answer_body="final answer",
+        completed_at=NOW + timedelta(seconds=2),
+    )
+
+    write = builder.seal(
+        selected_attempt_id=attempt_id,
+        sealed_at=NOW + timedelta(seconds=3),
+    )
+
+    assert write.trace.origin is TraceOrigin.LOCAL
+    assert write.trace.lifecycle is TraceLifecycle.SEALED
+    assert write.trace.policy_version == "local-prompt-provenance-v1"
+    assert write.trace.policy_capabilities == (
+        PolicyCapability.VIEW_SNAPSHOT,
+        PolicyCapability.VIEW_SOURCE_IDENTITY,
+    )
+    assert write.trace.completeness_at_seal is CitationCompleteness.COMPLETE
+    assert write.trace.answer_attempts[0].occurrences == ()
+    assert builder.is_sealed is True
+    with pytest.raises(ValueError, match="sealed"):
+        builder.seal(selected_attempt_id=attempt_id, sealed_at=NOW + timedelta(seconds=4))
+```
+
+Add the remaining privacy assertions:
+
+```python
+assert write.trace.answer_attempts[0].occurrences == ()
+assert "final answer" not in write.trace.model_dump_json()
+assert write.answer_attempt_payloads[0].answer_body == "final answer"
+```
+
+Also test:
+
+- every run requires non-null `ended_at`
+- each prompt entry's `run.ended_at <= prompt.created_at`
+- each attempt's `prompt.created_at <= attempt.created_at`
+- every run, prompt, and attempt boundary is `<= sealed_at`
+- failed sealing does not set `is_sealed`
+- every mutation method rejects after a successful seal
+- a second initial-attempt recording is rejected without partial mutation
+- the returned `SealedCitationWrite` object can be reused unchanged
+- repository factory builders receive the fixed version and only the two approved capabilities
+- disabled or identity/key-unready repositories still return no builder
+
+- [ ] **Step 4: Run the seal/policy tests and confirm they fail**
+
+Run:
+
+```bash
+../../.venv/bin/pytest -q \
+  Tests/Chat/test_citation_trace_builder.py \
+  Tests/Chat/test_citation_trace_repository.py \
+  -k 'seal or policy or closed_retrieval or lifecycle_order'
+```
+
+Expected: failures because the builder cannot seal and the repository factory does not supply policy metadata.
+
+- [ ] **Step 5: Implement the minimal repository-owned policy**
+
+In `citation_trace_repository.py`, keep the values private and non-configurable:
+
+```python
+_LOCAL_TRACE_POLICY_VERSION = "local-prompt-provenance-v1"
+_LOCAL_TRACE_POLICY_CAPABILITIES = (
+    PolicyCapability.VIEW_SNAPSHOT,
+    PolicyCapability.VIEW_SOURCE_IDENTITY,
+)
+```
+
+Pass both values from `create_local_trace_builder()` into `CitationTraceBuilder.local()`. Do not add them to `CitationProvenanceRuntimePolicy`.
+
+Make `policy_version` and `policy_capabilities` required builder-construction
+arguments, so a seal-capable builder cannot silently invent or default policy
+metadata. Update every existing direct test builder listed in this task with
+explicit test policy values; production continues to construct builders only
+through the repository factory.
+
+- [ ] **Step 6: Implement bounded answer-attempt state**
+
+In `citation_trace_builder.py`:
+
+- import the existing attempt, trace, lifecycle, policy, reducer, and marker helper models
+- add answer-attempt and answer-payload collections, stable trace ID, policy metadata, and sealed-write state to `__slots__`
+- add deep-copy tuple properties for governed payloads
+- extend `_ensure_governed_payload_capacity()` and `_canonical_payload_bytes()` to include `AnswerAttemptPayload`
+- add `_ensure_unsealed()` and invoke it before every mutation
+- make `is_sealed` reflect the sealed-write state
+- reject a second initial attempt in TASK-553.14; do not add repair or rerun mutation APIs
+- compute `body_integrity_hmac` with the existing `MESSAGE_BODY` fingerprint domain
+
+Use a safe typed denial:
+
+```python
+class CitationTraceBuildUnavailable(ValueError):
+    def __init__(self, reason_code: str) -> None:
+        self.reason_code = reason_code
+        super().__init__(reason_code)
+```
+
+Export this exception from the builder module for the Console boundary.
+
+Implement the marker guard without changing the shared helper:
+
+```python
+try:
+    spans = eligible_citation_marker_spans(
+        answer_body,
+        prompt_set.marker_namespace,
+        max_count=1,
+    )
+except ValueError:
+    raise CitationTraceBuildUnavailable(
+        "occurrence_mapping_unavailable"
+    ) from None
+if spans:
+    raise CitationTraceBuildUnavailable(
+        "occurrence_mapping_unavailable"
+    )
+```
+
+Construct all prospective `AnswerAttemptPayload` and `AnswerAttempt` objects, validate aggregate capacity, and only then append them.
+
+- [ ] **Step 7: Implement one-shot sealing**
+
+Implement:
+
+```python
+def seal(
+    self,
+    *,
+    selected_attempt_id: str,
+    sealed_at: datetime | None = None,
+) -> SealedCitationWrite:
+    ...
+```
+
+The method must:
+
+1. reject an already sealed builder
+2. require runs, prompt sets, attempts, and a known selected attempt
+3. require every local run to have `ended_at`
+4. validate the complete temporal chain
+5. build a provisional `CitationTrace` only to call `reduce_selected_attempt_completeness()`
+6. rebuild the validated trace with the reduced completeness
+7. build a complete `SealedCitationWrite`
+8. assign `_sealed_write` only after all validation succeeds
+9. return the same immutable write on the persistence path without exposing the codec
+
+Do not parse or create occurrences.
+
+- [ ] **Step 8: Run focused builder and factory tests**
+
+Run:
+
+```bash
+../../.venv/bin/pytest -q \
+  Tests/Chat/test_citation_trace_builder.py \
+  Tests/Chat/test_citation_trace_repository.py \
+  -k 'local_builder or create_local_trace_builder'
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 9: Run direct-builder fixture compatibility tests**
+
+Run the existing tests whose fakes construct builders directly:
+
+```bash
+../../.venv/bin/pytest -q \
+  Tests/Chat/test_chat_function_local_citation_boundary.py \
+  Tests/RAG/test_local_citation_capture.py \
+  Tests/RAG/test_scope_pipeline_enforcement.py \
+  -k 'canonical_evidence_at_provider_boundary or capture_api_records or console_staged_local_evidence or empty_retrieval or pipeline_exception or malformed_result or off_selection_source or validation_failure or fresh_scoped_existence_failure or backing_row_deleted or original_session_fresh_scope or original_unpersisted_holder'
+```
+
+Expected: all selected tests pass without builder-construction errors.
+
+- [ ] **Step 10: Commit the builder boundary**
+
+```bash
+git add \
+  tldw_chatbook/Chat/citation_trace_builder.py \
+  tldw_chatbook/Chat/citation_trace_repository.py \
+  Tests/Chat/test_citation_trace_builder.py \
+  Tests/Chat/test_citation_trace_repository.py \
+  Tests/RAG/test_local_citation_capture.py \
+  Tests/RAG/test_scope_pipeline_enforcement.py \
+  Tests/Chat/test_chat_function_local_citation_boundary.py
+git commit -m "feat(rag): seal local citation answer attempts"
+```
+
+### Task 2: Carry the exact prompt-set identity through local capture
+
+**Files:**
+- Modify: `tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py:67-73,1415-1515,1570-1705`
+- Modify: `Tests/RAG/test_local_citation_capture.py`
+- Modify: `Tests/Chat/test_chat_function_local_citation_boundary.py`
+
+- [ ] **Step 1: Write failing prompt-ID handoff tests**
+
+Extend the successful pipeline and Console evidence capture tests:
+
+```python
+result = await prepare_local_rag_context(...)
+
+assert result.citation_builder is builder
+assert result.prompt_evidence_set_id == builder.prompt_evidence_sets[-1].prompt_set_id
+```
+
+Assert `prompt_evidence_set_id is None` for:
+
+- no builder
+- empty formatted evidence
+- authority/capture failure
+- a builder run that cannot record a prompt set
+
+- [ ] **Step 2: Run the handoff tests and confirm they fail**
+
+Run:
+
+```bash
+../../.venv/bin/pytest -q \
+  Tests/RAG/test_local_citation_capture.py \
+  Tests/Chat/test_chat_function_local_citation_boundary.py \
+  -k 'prompt_evidence_set_id or canonical_capture or local_citation'
+```
+
+Expected: failure because `LocalRagContextResult` has no prompt-set ID.
+
+- [ ] **Step 3: Implement the explicit handoff**
+
+Add a backward-compatible default:
+
+```python
+@dataclass(frozen=True)
+class LocalRagContextResult:
+    context: str | None
+    citation_builder: CitationTraceBuilder | None
+    prompt_evidence_set_id: str | None = None
+```
+
+Capture the exact returned ID rather than rediscovering the last prompt set:
+
+```python
+prompt_evidence_set_id = None
+if formatted.entries:
+    prompt_evidence_set_id = builder.record_prompt_evidence_set(...)
+return LocalRagContextResult(
+    context,
+    builder,
+    prompt_evidence_set_id,
+)
+```
+
+Apply the same rule to every local capture path. A builder without a recorded non-empty prompt set must not carry an ID.
+
+- [ ] **Step 4: Run focused capture tests**
+
+Run:
+
+```bash
+../../.venv/bin/pytest -q \
+  Tests/RAG/test_local_citation_capture.py \
+  Tests/Chat/test_chat_function_local_citation_boundary.py \
+  -k 'prompt or canonical or builder'
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 5: Commit the capture handoff**
+
+```bash
+git add \
+  tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py \
+  Tests/RAG/test_local_citation_capture.py \
+  Tests/Chat/test_chat_function_local_citation_boundary.py
+git commit -m "feat(rag): return captured prompt evidence identity"
+```
+
+### Task 3: Advertise persistence readiness and wire the production repository
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/citation_trace_repository.py:488-578`
+- Modify: `tldw_chatbook/Chat/chat_persistence_service.py:18-28`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py:2959-2977`
+- Modify: `Tests/Chat/test_citation_trace_repository.py`
+- Modify: `Tests/Chat/test_chat_persistence_service.py`
+- Modify: `Tests/UI/test_console_native_chat_flow.py`
+
+- [ ] **Step 1: Write failing readiness tests**
+
+Add focused service tests:
+
+```python
+def test_canonical_citation_writes_ready_requires_matching_enabled_repository(
+    db_instance,
+) -> None:
+    repository = citation_repository(db_instance)
+    service = ChatPersistenceService(
+        db_instance,
+        citation_repository=repository,
+    )
+    assert service.canonical_citation_writes_ready is True
+
+
+def test_canonical_citation_writes_ready_is_false_without_repository(
+    db_instance,
+) -> None:
+    assert ChatPersistenceService(
+        db_instance
+    ).canonical_citation_writes_ready is False
+```
+
+Cover disabled, identity/key-unready, and database-mismatched repositories as false.
+
+Add repository tests for a dedicated public
+`local_citation_writes_ready` property. It must match the builder factory's
+actual prerequisites, including equality with the persisted singleton
+identity, rather than reusing the migration-named readiness property.
+
+- [ ] **Step 2: Write the failing ChatScreen composition test**
+
+Build a bare `ChatScreen` using the existing native Console harness pattern. Put a sentinel repository on `app_instance`, call `_ensure_console_chat_store()`, and assert:
+
+```python
+assert store.persistence is not None
+assert store.persistence.citation_repository is repository
+assert store.persistence.db is repository.db
+```
+
+Also assert a mismatched repository is not passed into the service.
+
+- [ ] **Step 3: Run the readiness/composition tests and confirm they fail**
+
+Run:
+
+```bash
+../../.venv/bin/pytest -q \
+  Tests/Chat/test_citation_trace_repository.py \
+  Tests/Chat/test_chat_persistence_service.py::TestChatPersistenceService::test_canonical_citation_writes_ready_requires_matching_enabled_repository \
+  Tests/Chat/test_chat_persistence_service.py::TestChatPersistenceService::test_canonical_citation_writes_ready_is_false_without_repository \
+  Tests/UI/test_console_native_chat_flow.py::test_console_store_uses_app_citation_repository \
+  -k 'local_citation_writes_ready or canonical_citation_writes_ready or console_store_uses_app_citation_repository'
+```
+
+Expected: failures because readiness is not exposed and `ChatScreen` omits the repository.
+
+- [ ] **Step 4: Implement fail-closed service readiness**
+
+Add a read-only property:
+
+```python
+@property
+def canonical_citation_writes_ready(self) -> bool:
+    repository = self.citation_repository
+    return bool(
+        repository is not None
+        and repository.db is self.db
+        and repository.local_citation_writes_ready
+    )
+```
+
+Add `CitationTraceRepository.local_citation_writes_ready` as a content-free,
+read-only check for the same canonical-write switch, identity, codec, and
+persisted-identity equality required by `create_local_trace_builder()`. Reuse
+that property inside the factory to prevent readiness drift. It may read the
+persisted singleton but must not load keys, mutate configuration, or log
+governed values. A failed persisted-identity read returns false.
+
+- [ ] **Step 5: Wire the exact app repository**
+
+In `ChatScreen._ensure_console_chat_store()`:
+
+```python
+repository = getattr(
+    self.app_instance,
+    "citation_trace_repository",
+    None,
+)
+if repository is not None and getattr(repository, "db", None) is not db:
+    repository = None
+persistence = ChatPersistenceService(
+    db,
+    workspace_registry=...,
+    citation_repository=repository,
+)
+```
+
+Keep `persistence=None` when the app has no ChaChaNotes DB.
+
+- [ ] **Step 6: Run the focused readiness/composition tests**
+
+Run the three node IDs from Step 3 plus the disabled/mismatch parameterized node IDs.
+
+Expected: all pass.
+
+- [ ] **Step 7: Commit production composition**
+
+```bash
+git add \
+  tldw_chatbook/Chat/citation_trace_repository.py \
+  tldw_chatbook/Chat/chat_persistence_service.py \
+  tldw_chatbook/UI/Screens/chat_screen.py \
+  Tests/Chat/test_citation_trace_repository.py \
+  Tests/Chat/test_chat_persistence_service.py \
+  Tests/UI/test_console_native_chat_flow.py
+git commit -m "fix(console): wire canonical citation persistence"
+```
+
+### Task 4: Add transient terminal finalization to `ConsoleChatStore`
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_store.py:1-105,228-320,543-578,810-858,1232-1268,1478-1555,1980-2190,2793-2823`
+- Create: `Tests/Chat/test_console_terminal_citation_persistence.py`
+- Modify: `Tests/Chat/test_console_chat_store.py`
+
+- [ ] **Step 1: Write failing capability and early-persistence tests**
+
+Create focused fakes:
+
+```python
+class _CitationPersistenceFake:
+    db = None
+    canonical_citation_writes_ready = True
+
+    def __init__(self) -> None:
+        self.create_calls: list[dict[str, object]] = []
+
+    def create_message(self, **kwargs) -> str:
+        self.create_calls.append(kwargs)
+        return str(kwargs["message_id"])
+```
+
+Test that:
+
+- a ready adapter accepting `citation_write` atomically arms the placeholder
+- an adapter without `citation_write`, readiness, or persistence does not arm it
+- `get_message()` and `messages_for_session()` materialize streamed text without calling persistence while terminal deferral is active
+- ordinary assistant messages retain current first-content persistence
+
+- [ ] **Step 2: Run the new store tests and confirm they fail**
+
+Run:
+
+```bash
+../../.venv/bin/pytest -q \
+  Tests/Chat/test_console_terminal_citation_persistence.py \
+  -k 'capability or deferred or ordinary'
+```
+
+Expected: failures because `append_message()` cannot accept a finalizer and the store has no terminal deferral.
+
+- [ ] **Step 3: Add the optional protocol and transient state**
+
+Update `ConsoleChatPersistence.create_message()` with optional `citation_write`, and document that narrow fakes may omit it.
+
+Add:
+
+```python
+TerminalCitationFinalizer = Callable[
+    [str],
+    SealedCitationWrite | None,
+]
+```
+
+Store only transient state:
+
+```python
+self._terminal_citation_finalizers: dict[
+    str, TerminalCitationFinalizer
+] = {}
+self._terminal_persistence_deferred_ids: set[str] = set()
+```
+
+Add `_citation_persistence_ready()` requiring:
+
+- persistence exists
+- `create_message` accepts `citation_write`
+- `canonical_citation_writes_ready is True`
+
+Any readiness property/signature inspection failure returns false without
+logging exception text. Existing fakes that omit readiness remain fail-closed
+and ordinary.
+
+- [ ] **Step 4: Install finalizer and deferral atomically**
+
+Extend `append_message()` with:
+
+```python
+terminal_citation_finalizer: TerminalCitationFinalizer | None = None
+```
+
+Before mutating the tree, reject callback placement on a non-assistant or
+non-empty/attachment-bearing message, evaluating attachments after the
+existing scalar-image-to-tuple normalization. A valid callback arms only when:
+
+- role is assistant
+- content and attachments are empty/pending
+- `persist is True`
+- persistence readiness passes
+
+An unavailable persistence capability is fail-closed ordinary behavior, not a
+caller error. After registering the new assistant tree node and before any
+persistence call, install both transient entries together. If the subsequent
+session-persistence/defer setup raises before `append_message()` can return,
+clear both transient entries before re-raising. Never leave only one entry
+installed.
+
+- [ ] **Step 5: Block UI polling from flushing deferred messages**
+
+Add the terminal-deferral membership check to `_persist_pending_message_if_ready()`. Do not change `_materialize_stream_buffer()`; it must still update visible in-memory content.
+
+Add one idempotent cleanup method:
+
+```python
+def clear_terminal_citation_state(self, message_id: str) -> None:
+    self._terminal_citation_finalizers.pop(message_id, None)
+    self._terminal_persistence_deferred_ids.discard(message_id)
+```
+
+Call the same cleanup from session close, subtree deletion, store clear/shutdown, and every non-success terminal transition.
+
+- [ ] **Step 6: Run capability/deferral tests**
+
+Run the command from Step 2.
+
+Expected: all selected tests pass.
+
+- [ ] **Step 7: Write failing exact-body and stable-ID tests**
+
+Test that successful completion:
+
+- materializes the exact buffered body first
+- calls the finalizer exactly once with that body
+- supplies the same native message UUID as `message_id`
+- passes the returned `SealedCitationWrite` by object identity
+- clears finalizer and deferral after completion
+- does not call the finalizer again on later reads
+- an exception during append-time session persistence leaves neither transient entry behind
+
+Use a marker-free sealed-write fixture whose selected answer body exactly matches the test message.
+
+- [ ] **Step 8: Write failing fallback and ambiguous-retry tests**
+
+Use behavior-controlled fakes to cover:
+
+1. finalizer returns `None` → one ordinary stable-ID create
+2. first citation call raises `CitationPersistenceUnavailable` → one ordinary stable-ID create
+3. first citation call raises an ambiguous exception → one retry with the same ID and same sealed-write object
+4. both ambiguous calls fail → no ordinary insert, message remains complete in memory
+5. the ambiguous retry raises `CitationPersistenceUnavailable` → still no ordinary insert
+6. deterministic ordinary fallback also fails → no new ID and no later polling-triggered create
+
+After terminal abandonment, call both `get_message()` and `messages_for_session()` and assert the fake's call count does not increase. The store must remove the ID from ordinary pending persistence when it intentionally abandons a conflicting durable write.
+
+- [ ] **Step 9: Run exact-body/retry tests and confirm they fail**
+
+Run:
+
+```bash
+../../.venv/bin/pytest -q \
+  Tests/Chat/test_console_terminal_citation_persistence.py \
+  -k 'exact_body or stable_id or fallback or ambiguous or abandoned'
+```
+
+Expected: failures because terminal citation persistence is not implemented.
+
+- [ ] **Step 10: Implement the citation-aware create call**
+
+Refactor `_persist_new_message()` just enough to build `create_kwargs` once and accept:
+
+```python
+citation_write: SealedCitationWrite | None = None
+force_stable_message_id: bool = False
+```
+
+Use `message.id` when either `generation_metadata` or `force_stable_message_id` is true. Keep attachment, metadata, parent, feedback, active-leaf, and Sync v2 behavior unchanged.
+
+Isolate retry around only:
+
+```python
+self.persistence.create_message(**create_kwargs)
+```
+
+Apply this fixed first-failure disposition:
+
+```text
+CitationPersistenceUnavailable first
+  -> remove citation_write
+  -> one ordinary same-ID attempt
+
+any other exception first
+  -> one same-ID, same-write retry
+  -> never ordinary fallback after that branch
+```
+
+Catch persistence failures inside the provenance-aware terminal path so a completed provider/agent run remains complete. Log only fixed reason codes.
+
+If the final durable attempt fails, discard the message ID from ordinary pending persistence so later UI polling cannot insert a conflicting row.
+
+Once `create_message()` succeeds, assign/discard the durable identity before
+active-leaf and Sync v2 bookkeeping. A later bookkeeping failure is logged with
+a fixed diagnostic and never replays the atomic create call.
+
+- [ ] **Step 11: Implement exact-body terminal completion**
+
+On `mark_message_complete()`:
+
+1. materialize the stream buffer
+2. atomically pop the finalizer while retaining a local stable-ID flag
+3. invoke it once with `message.content`
+4. mark the message complete
+5. persist through the citation-aware create helper
+6. clear terminal state in `finally`
+
+Defensively translate a finalizer exception to a fixed `terminal_finalizer_unavailable` diagnostic and ordinary stable-ID persistence. Never log `str(exception)`.
+
+On stopped, failed, canceled, and empty paths, clear terminal state before using existing ordinary persistence behavior.
+
+- [ ] **Step 12: Run focused store tests**
+
+Run:
+
+```bash
+../../.venv/bin/pytest -q \
+  Tests/Chat/test_console_terminal_citation_persistence.py \
+  Tests/Chat/test_console_chat_store.py \
+  -k 'citation or persist or stream or complete or stopped or failed'
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 13: Commit the store lifecycle**
+
+```bash
+git add \
+  tldw_chatbook/Chat/console_chat_store.py \
+  Tests/Chat/test_console_terminal_citation_persistence.py \
+  Tests/Chat/test_console_chat_store.py
+git commit -m "feat(console): finalize citation traces at terminal persistence"
+```
+
+### Task 5: Integrate initial direct and agent Console generations
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py:667-855,3351-3370,3485-3710,3962-4170`
+- Modify: `Tests/Chat/test_console_local_citation_boundary.py`
+- Modify: `Tests/Chat/test_console_terminal_citation_persistence.py`
+
+- [ ] **Step 1: Write failing direct-provider integration tests**
+
+Use a real `CitationTraceBuilder` and a ready citation persistence fake. Have the capture provider return:
+
+```python
+SimpleNamespace(
+    context=context,
+    citation_builder=builder,
+    prompt_evidence_set_id=prompt_id,
+)
+```
+
+Cover:
+
+- marker-free direct success seals the exact visible output
+- successful prefill plus streamed output seals the concatenated visible body
+- marker-bearing output persists ordinarily with no citation write
+- an empty provider stream does not seal
+- provider failure and user stop do not seal
+- no builder/finalizer remains reachable from store transient state after any exit
+
+- [ ] **Step 2: Write failing agent integration tests**
+
+The fake agent bridge must stream into the actual placeholder before returning `RUN_DONE`:
+
+```python
+def run_reply(**kwargs):
+    store.append_stream_chunk(
+        kwargs["assistant_message_id"],
+        "agent answer",
+    )
+    return "run-test", RunOutcome(
+        status=RUN_DONE,
+        steps=[],
+        final_text="agent answer",
+    )
+```
+
+Cover:
+
+- agent success seals its exact materialized body
+- `RUN_DONE` with empty `final_text` clears terminal citation state before adding `"No response was generated."`
+- canceled, stopped, and failed agent outcomes do not seal
+- a missing/replaced placeholder never transfers the finalizer to another assistant row
+- after an initial RAG send exits, `retry_message()` and
+  `regenerate_message()` run without a terminal callback, do not add citation
+  persistence calls, and do not mutate or inherit the original builder
+
+- [ ] **Step 3: Run direct/agent tests and confirm they fail**
+
+Run:
+
+```bash
+../../.venv/bin/pytest -q \
+  Tests/Chat/test_console_local_citation_boundary.py \
+  -k 'terminal or seal or marker_bearing or empty or stopped or agent or retry or regenerate'
+```
+
+Expected: failures because the controller drops the builder without installing a finalizer.
+
+- [ ] **Step 4: Return the full capture triple**
+
+Change `_capture_rag_context()` to return:
+
+```python
+tuple[str | None, CitationTraceBuilder | None, str | None]
+```
+
+Validate all three values independently. Context-only compatibility remains available, but no terminal finalizer is built unless context, builder, and explicit prompt ID are all present.
+
+- [ ] **Step 5: Build a content-safe request-local finalizer**
+
+Add a narrow helper returning `TerminalCitationFinalizer | None`. Its closure:
+
+```python
+def finalize(exact_body: str) -> SealedCitationWrite | None:
+    try:
+        terminal_at = datetime.now(UTC)
+        attempt_id = builder.record_initial_answer_attempt(
+            prompt_evidence_set_id=prompt_evidence_set_id,
+            answer_body=exact_body,
+            completed_at=terminal_at,
+        )
+        return builder.seal(
+            selected_attempt_id=attempt_id,
+            sealed_at=terminal_at,
+        )
+    except CitationTraceBuildUnavailable as exc:
+        logger.warning(
+            "Console citation finalization unavailable; reason={}",
+            exc.reason_code,
+        )
+    except Exception:
+        logger.warning(
+            "Console citation finalization unavailable; "
+            "reason=attempt_or_seal_failure"
+        )
+    return None
+```
+
+Do not include the exception object, body, builder representation, or governed values in any log call.
+
+- [ ] **Step 6: Install and clear the finalizer across the whole send**
+
+In `submit_draft()`:
+
+1. receive context, builder, and prompt ID
+2. create the finalizer before appending the assistant
+3. pass it into the same `append_message()` call that creates the empty placeholder
+4. keep the existing user-message persistence ordering
+5. in the outer `finally`, call `store.clear_terminal_citation_state(assistant.id)` and delete the local builder reference
+
+Do not pass a finalizer from retry, regenerate, edit/resend, or continuation entry points.
+
+- [ ] **Step 7: Disarm the empty-agent fallback**
+
+Before `_complete_agent_message()` appends `"No response was generated."` for an empty final result, call the idempotent terminal-state cleanup. Successful non-empty agent output keeps the finalizer until `mark_message_complete()`.
+
+- [ ] **Step 8: Add content-free diagnostic tests**
+
+Use sentinels in:
+
+- answer body
+- marker-bearing body
+- a forged finalizer exception
+- query/title/snapshot fields
+
+Capture Loguru output and assert none of those sentinels occur. Assert only fixed reason codes are present.
+
+- [ ] **Step 9: Run focused controller integration tests**
+
+Run:
+
+```bash
+../../.venv/bin/pytest -q \
+  Tests/Chat/test_console_local_citation_boundary.py \
+  Tests/Chat/test_console_terminal_citation_persistence.py \
+  -k 'direct or agent or terminal or marker or empty or stop or retry or regenerate or diagnostic'
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 10: Commit the Console integration**
+
+```bash
+git add \
+  tldw_chatbook/Chat/console_chat_controller.py \
+  Tests/Chat/test_console_local_citation_boundary.py \
+  Tests/Chat/test_console_terminal_citation_persistence.py
+git commit -m "feat(console): seal initial local RAG answers"
+```
+
+### Task 6: Prove real atomic persistence and close TASK-553.14
+
+**Files:**
+- Modify: `Tests/Chat/test_console_terminal_citation_persistence.py`
+- Modify: `backlog/tasks/task-553.14 - Capture-answer-attempts-and-seal-terminal-local-citation-traces.md`
+
+- [ ] **Step 1: Add the real database integration fixture**
+
+Use `CharactersRAGDB`, the persisted local identity, the test fingerprint codec, enabled `CitationProvenanceRuntimePolicy`, `CitationTraceRepository`, and `ChatPersistenceService` to build a real `ConsoleChatStore`.
+
+The repository instance passed to `ChatPersistenceService` must be the same instance used to create the builder.
+
+- [ ] **Step 2: Add the failing end-to-end atomic persistence test**
+
+Drive a marker-free direct-provider answer through `ConsoleChatController.submit_draft()`, then assert:
+
+```python
+assistant = next(
+    message
+    for message in store.messages_for_session(session.id)
+    if message.role is ConsoleMessageRole.ASSISTANT
+)
+assert assistant.persisted_message_id == assistant.id
+assert db.get_message_by_id(assistant.id)["content"] == "exact final answer"
+```
+
+Query the citation tables or use the existing repository hydration/owner APIs to assert:
+
+- one trace exists
+- its selected attempt body equals the persisted message body
+- run, prompt snapshot, attempt payload, reference, and owner rows exist
+- the immutable trace JSON contains neither answer body nor integrity HMAC
+- `occurrences == ()`
+- restart/reload can find the active owner
+
+- [ ] **Step 3: Add the failing rollback/fallback integration test**
+
+Use a test-only repository subclass that overrides the existing row-family
+failure seam to raise
+`CitationPersistenceUnavailable("forced_deterministic_unavailable")` after a
+chosen row family. Do not use the stock `failure_after_row_family` behavior
+here: it raises `RuntimeError`, which is intentionally ambiguous and must not
+fall back to an ordinary insert. Assert:
+
+- no partial trace/run/snapshot/attempt/reference/owner rows remain
+- the ordinary assistant message is still persisted under its native ID when the failure is deterministic
+- it has no active trace owner
+- the answer remains complete in memory
+
+Do not duplicate repository transaction matrix tests already covered in `test_citation_trace_repository.py`; this test proves only the Console-to-service integration seam.
+
+- [ ] **Step 4: Run the new real integration tests**
+
+Run:
+
+```bash
+../../.venv/bin/pytest -q \
+  Tests/Chat/test_console_terminal_citation_persistence.py \
+  -k 'real_atomic or real_rollback'
+```
+
+Expected: both pass.
+
+- [ ] **Step 5: Run the final scoped verification**
+
+Run only touched-code coverage:
+
+```bash
+../../.venv/bin/pytest -q \
+  Tests/Chat/test_citation_trace_builder.py \
+  Tests/Chat/test_citation_trace_repository.py \
+  Tests/RAG/test_local_citation_capture.py \
+  Tests/RAG/test_scope_pipeline_enforcement.py \
+  Tests/Chat/test_chat_function_local_citation_boundary.py \
+  Tests/Chat/test_chat_persistence_service.py \
+  Tests/Chat/test_console_chat_store.py \
+  Tests/Chat/test_console_local_citation_boundary.py \
+  Tests/Chat/test_console_terminal_citation_persistence.py \
+  Tests/UI/test_console_native_chat_flow.py \
+  -k 'initial_answer or marker_free or answer_body or seal or local_builder or create_local_trace_builder or prompt_evidence_set_id or local_citation or canonical_capture or canonical_evidence_at_provider_boundary or capture_api_records or console_staged_local_evidence or empty_retrieval or pipeline_exception or malformed_result or off_selection_source or validation_failure or fresh_scoped_existence_failure or backing_row_deleted or original_session_fresh_scope or original_unpersisted_holder or canonical_citation or citation_repository or terminal_citation or console_citation or marker_bearing or exact_body or deferred or fallback or ambiguous or abandoned or retry or regenerate or diagnostic or real_atomic or real_rollback'
+```
+
+Expected: all selected tests pass with no collection errors.
+
+Then run:
+
+```bash
+git diff --check
+```
+
+Expected: no output and exit code 0.
+
+- [ ] **Step 6: Self-review the exact diff**
+
+Check:
+
+- no occurrence parsing or UI presentation entered the diff
+- no raw governed value or exception text appears in logs
+- every transient map/set is swept on completion, failure, cancellation, deletion, close, and clear
+- the first ambiguous failure alone determines retry disposition
+- an abandoned write cannot later fall through ordinary pending persistence
+- production `ChatPersistenceService` owns the same repository instance as capture
+- only initial sends receive finalizers
+
+- [ ] **Step 7: Update Backlog implementation notes and acceptance criteria**
+
+Use Backlog CLI to:
+
+1. check all six acceptance criteria only after their tests pass
+2. add concise implementation notes listing the builder, capture handoff, store lifecycle, controller integration, production wiring, and scoped verification
+3. retain the ADR check:
+
+```text
+ADR required: yes
+ADR path: backlog/decisions/024-rag-citation-provenance-and-source-resolution.md
+Reason: Direct implementation of the accepted terminal seal and atomic ownership contract; no new decision.
+```
+
+4. set TASK-553.14 to Done only after every Definition-of-Done item is satisfied
+
+- [ ] **Step 8: Commit closeout metadata**
+
+```bash
+git add \
+  Tests/Chat/test_console_terminal_citation_persistence.py \
+  'backlog/tasks/task-553.14 - Capture-answer-attempts-and-seal-terminal-local-citation-traces.md'
+git commit -m "test(rag): verify terminal citation persistence"
+```
+
+- [ ] **Step 9: Verify TASK-553.14 closeout**
+
+Run:
+
+```bash
+backlog task 553.14 --plain
+```
+
+Expected: status `Done`, all acceptance criteria checked, implementation plan and implementation notes present, and ADR linkage retained.

--- a/Docs/superpowers/specs/2026-07-23-rag-citation-provenance-design.md
+++ b/Docs/superpowers/specs/2026-07-23-rag-citation-provenance-design.md
@@ -1186,6 +1186,12 @@ criteria cannot be completed in one PR:
 30. Publish the fixed RAG evaluation dataset, human labels, commands, and
     deterministic retrieval/generation gates.
 
+Workstream 10 is delivered by
+[TASK-553.13](../../../backlog/tasks/task-553.13%20-%20Capture-local-RAG-retrieval-runs-and-exact-prompt-evidence-sets.md)
+under the
+[local RAG retrieval and prompt-evidence capture plan](../plans/2026-07-25-local-rag-retrieval-prompt-evidence-capture.md).
+Workstreams 11–30 remain follow-on work, and parent epic TASK-553 remains open.
+
 Do not combine export, import, artifact ownership, and sync into one task. Do not
 combine all resolver families into one task. Do not combine a server producer
 change with a Chatbook consumer change. Security, performance, and RAG quality

--- a/Docs/superpowers/specs/2026-07-26-local-answer-attempt-terminal-sealing-design.md
+++ b/Docs/superpowers/specs/2026-07-26-local-answer-attempt-terminal-sealing-design.md
@@ -116,6 +116,11 @@ local seal policy. The policy contains:
 - `VIEW_SNAPSHOT`
 - `VIEW_SOURCE_IDENTITY`
 
+The seal policy is one repository-module constant or private frozen value. It
+is deliberately separate from `CitationProvenanceRuntimePolicy`, whose only
+authority remains enabling or disabling canonical writes. Configuration cannot
+choose a policy version or widen capabilities.
+
 It does not advertise `RESOLVE_CURRENT_SOURCE`; current native locators and
 resolver navigation are not implemented yet. The controller never chooses or
 widens capabilities.
@@ -150,14 +155,14 @@ The initial attempt records:
 The exact body and its integrity fingerprint remain governed payload fields and
 must not appear in immutable trace JSON, logs, exceptions, or diagnostics.
 
-Before constructing the attempt, the builder uses the existing bounded,
-Markdown-aware marker-span helper only as an eligibility guard. If the exact
-body contains any eligible marker under the selected prompt set's namespace,
-recording fails atomically with a fixed reason code. TASK-553.14 does not
-construct occurrence records, infer evidence mappings, or weaken the model
-invariant that a retained body's eligible markers must be represented exactly.
-Workstream 13 removes this temporary restriction by adding canonical occurrence
-parsing.
+Before constructing the attempt, the builder uses the existing Markdown-aware
+marker-span helper with `max_count=1` only as a bounded eligibility guard. If
+the exact body contains any eligible marker under the selected prompt set's
+namespace, recording fails atomically with a fixed reason code. TASK-553.14
+does not construct occurrence records, infer evidence mappings, or weaken the
+model invariant that a retained body's eligible markers must be represented
+exactly. Workstream 13 removes this temporary restriction by adding canonical
+occurrence parsing.
 
 The answer payload participates in both its per-payload byte cap and the
 aggregate governed-payload cap. Validation constructs all prospective objects
@@ -203,8 +208,12 @@ Today an empty assistant placeholder is queued for persistence, and any UI
 poll that materializes the first stream chunk can persist it immediately.
 That behavior would make a later message-plus-trace transaction impossible.
 
-Provenance-eligible initial assistant placeholders therefore opt into
-terminal-deferred persistence:
+The controller constructs the request-local finalizer before appending the
+assistant placeholder. One store operation then creates the placeholder,
+registers the finalizer, and enables terminal-deferred persistence atomically;
+the placeholder is never observable with only half of that state installed.
+
+Provenance-eligible initial assistant placeholders therefore:
 
 - stream chunks and UI polling may materialize visible content in memory
 - pending/streaming states cannot flush the assistant row
@@ -219,6 +228,12 @@ Non-citation messages keep the current first-content persistence behavior.
 Callbacks live only in a bounded transient store map keyed by native message ID;
 they are not serialized into message or session models and cannot transfer to a
 replacement, retry, regenerated variant, or runtime-written assistant row.
+
+The controller also clears any still-registered finalizer in an outer
+`finally` around the complete dispatch lifecycle. This cleanup covers
+`CancelledError`, session closure, and failures before provider or agent
+terminal handling begins. Clearing an already consumed or session-removed
+entry is a no-op.
 
 ### Exact-body callback
 
@@ -248,9 +263,11 @@ When a sealed write exists, `ConsoleChatStore` passes it through the optional
 `citation_write` parameter already supported by the real
 `ChatPersistenceService.create_message()` implementation.
 
-The store also supplies the native Console message UUID as the explicit
-database message ID. This is required even for ordinary text assistants when a
-citation write is attached:
+The store supplies the native Console message UUID as the explicit database
+message ID for every provenance-eligible terminal persistence attempt. The
+same ID is retained when marker eligibility rejects sealing, canonical
+persistence is deterministically unavailable, or an ambiguous write is
+retried. Non-provenance messages retain their existing database-ID behavior:
 
 - message retry targets the same row
 - the trace retains the same stable identity
@@ -302,6 +319,12 @@ For a non-policy exception whose commit outcome may be uncertain:
    record a fixed content-free diagnostic, and do not attempt a potentially
    conflicting ordinary insert
 
+The disposition is fixed by the first failure. If the retry raises
+`CitationPersistenceUnavailable`, it remains the second failure of an
+ambiguous attempt and does not enter the ordinary-fallback branch. Retry logic
+wraps only the atomic message-plus-trace `create_message()` call; later active
+leaf or Sync v2 bookkeeping cannot cause that transaction to be replayed.
+
 The failed persistence state must not cause the controller to reclassify a
 successful generation as a provider or agent failure.
 
@@ -350,11 +373,17 @@ without overstating structural or semantic trust.
 ### Store and persistence tests
 
 - UI materialization does not persist a terminal-deferred assistant early
+- placeholder creation installs finalizer and deferral atomically
+- outer dispatch cleanup clears unconsumed finalizers on cancellation and
+  pre-terminal failure
 - exact materialized body reaches the callback once
-- stable native message ID reaches `create_message`
+- stable native message ID reaches sealed, marker-rejected, fallback, and retry
+  `create_message` calls
 - message and trace commit atomically
 - deterministic denial falls back to an ordinary ungrounded message
 - ambiguous failure retries once with the same IDs and sealed write
+- a differently typed retry failure does not change the first-failure
+  disposition
 - second ambiguous failure leaves the answer visible without a conflicting
   ordinary insert
 - non-citation messages preserve current persistence timing

--- a/Docs/superpowers/specs/2026-07-26-local-answer-attempt-terminal-sealing-design.md
+++ b/Docs/superpowers/specs/2026-07-26-local-answer-attempt-terminal-sealing-design.md
@@ -157,12 +157,14 @@ must not appear in immutable trace JSON, logs, exceptions, or diagnostics.
 
 Before constructing the attempt, the builder uses the existing Markdown-aware
 marker-span helper with `max_count=1` only as a bounded eligibility guard. If
-the exact body contains any eligible marker under the selected prompt set's
-namespace, recording fails atomically with a fixed reason code. TASK-553.14
-does not construct occurrence records, infer evidence mappings, or weaken the
-model invariant that a retained body's eligible markers must be represented
-exactly. Workstream 13 removes this temporary restriction by adding canonical
-occurrence parsing.
+the helper returns a non-empty result, recording fails atomically with a fixed
+reason code. The existing helper raises `ValueError` when it encounters a
+second eligible marker beyond `max_count=1`; that overflow is caught and
+translated to the same fixed `occurrence_mapping_unavailable` denial. This task
+does not change the shared helper's semantics. TASK-553.14 does not construct
+occurrence records, infer evidence mappings, or weaken the model invariant that
+a retained body's eligible markers must be represented exactly. Workstream 13
+removes this temporary restriction by adding canonical occurrence parsing.
 
 The answer payload participates in both its per-payload byte cap and the
 aggregate governed-payload cap. Validation constructs all prospective objects
@@ -229,10 +231,12 @@ Callbacks live only in a bounded transient store map keyed by native message ID;
 they are not serialized into message or session models and cannot transfer to a
 replacement, retry, regenerated variant, or runtime-written assistant row.
 
-The controller also clears any still-registered finalizer in an outer
-`finally` around the complete dispatch lifecycle. This cleanup covers
-`CancelledError`, session closure, and failures before provider or agent
-terminal handling begins. Clearing an already consumed or session-removed
+The controller also invokes one idempotent store cleanup operation in an outer
+`finally` around the complete dispatch lifecycle. That operation clears both
+the still-registered finalizer and its paired terminal-deferral flag; it does
+not discard the store's ordinary pending-persistence bookkeeping. This cleanup
+covers `CancelledError`, session closure, and failures before provider or agent
+terminal handling begins. Cleaning an already consumed or session-removed
 entry is a no-op.
 
 ### Exact-body callback
@@ -374,8 +378,8 @@ without overstating structural or semantic trust.
 
 - UI materialization does not persist a terminal-deferred assistant early
 - placeholder creation installs finalizer and deferral atomically
-- outer dispatch cleanup clears unconsumed finalizers on cancellation and
-  pre-terminal failure
+- outer dispatch cleanup clears unconsumed finalizers and terminal deferrals on
+  cancellation and pre-terminal failure
 - exact materialized body reaches the callback once
 - stable native message ID reaches sealed, marker-rejected, fallback, and retry
   `create_message` calls

--- a/Docs/superpowers/specs/2026-07-26-local-answer-attempt-terminal-sealing-design.md
+++ b/Docs/superpowers/specs/2026-07-26-local-answer-attempt-terminal-sealing-design.md
@@ -1,0 +1,380 @@
+# Local Answer-Attempt and Terminal Citation Sealing Design
+
+**Status:** Approved design for TASK-553.14
+**Date:** 2026-07-26
+**Parent:** TASK-553
+**Depends on:** TASK-553.13
+
+## Purpose
+
+Complete one eligible marker-free local RAG generation by binding the exact
+final assistant body to the request-scoped citation builder, sealing a
+canonical `CitationTrace`, and persisting the assistant message and provenance
+in one idempotent transaction.
+
+TASK-553.13 already captures ordered local retrieval runs and exact prompt
+evidence sets. This task adds the next lifecycle boundary:
+
+```text
+EvidenceRun
+  -> PromptEvidenceSet
+  -> initial AnswerAttempt
+  -> terminal CitationTrace seal
+  -> atomic assistant-message plus provenance persistence
+```
+
+The trace remains internal. It must not yet be presented as having cited
+sources because canonical occurrence parsing and visible citation trust are
+separate workstreams.
+
+## ADR check
+
+ADR required: yes
+ADR path: `backlog/decisions/024-rag-citation-provenance-and-source-resolution.md`
+Reason: This task directly implements ADR-024's accepted request-scoped
+builder, terminal seal, governed answer body, message ownership, and atomic
+persistence contracts. It does not introduce or change an architectural
+decision, so no new ADR is required.
+
+## Scope
+
+### In scope
+
+- record a bounded governed initial answer-attempt payload
+- bind the attempt to the exact final materialized assistant body with the
+  existing secret-scoped message-body fingerprint codec
+- seal only answers with no eligible marker syntax under the selected prompt
+  namespace; marker-bearing answers remain ordinary ungrounded messages until
+  canonical occurrence parsing is implemented
+- seal the request-scoped builder exactly once
+- derive selected-attempt completeness using the canonical reducer
+- carry repository-owned policy version and capabilities into the trace
+- defer citation-bearing assistant persistence until terminal completion
+- atomically persist the final message, trace, governed payloads, references,
+  and owner association
+- use stable message and trace identities for one same-identity retry after an
+  ambiguous transaction failure
+- preserve ordinary ungrounded answers when canonical writes are
+  deterministically unavailable
+- cover both direct-provider and agent success paths
+
+### Out of scope
+
+- citation occurrence parsing or legacy numeric marker mapping
+- semantic support verification
+- citation repair or provisional repair presentation
+- retrieval/generation reruns, retry, regenerate, edit/resend, or cache reuse
+- Sources footer, inspector, source opening, or resolver capabilities
+- saved-artifact ownership, export, import, server traces, or Sync v2
+- changing the canonical payload schema or database schema
+
+## Approaches considered
+
+### Selected: builder-owned sealing plus a terminal persistence callback
+
+`CitationTraceBuilder` records the answer attempt and seals its own immutable
+graph. The Console store receives a narrow callback that accepts the exact
+materialized final body and returns a `SealedCitationWrite`. The store invokes
+the callback after stream-buffer materialization but before the first durable
+assistant write.
+
+This preserves three existing boundaries:
+
+- the builder owns construction and secret fingerprint use
+- the store owns exact visible-body materialization and terminal state
+- `ChatPersistenceService` and `CitationTraceRepository` own the atomic
+  transaction
+
+### Rejected: controller-side chunk reconstruction
+
+Rebuilding the final body from provider chunks in the controller can diverge
+from the visible store body because of prefill text, empty-answer fallback,
+agent output normalization, resets, and stream-buffer materialization. A trace
+must bind to the body actually persisted, not an approximation.
+
+### Rejected: repository seals mutable builders
+
+Passing the mutable builder into the repository mixes construction and
+persistence authority, expands the repository's secret-bearing surface, and
+makes it harder to prove that the exact visible body was selected before the
+transaction.
+
+### Rejected: a separate finalization coordinator
+
+A coordinator could wrap builder, store, and repository calls, but it would
+duplicate lifecycle ownership already present in those components. A typed
+terminal callback is sufficient and has a smaller compatibility surface.
+
+## Builder contract
+
+### Repository-owned seal policy
+
+The repository factory supplies each local builder with a frozen, versioned
+local seal policy. The policy contains:
+
+- a bounded policy version identifier
+- `VIEW_SNAPSHOT`
+- `VIEW_SOURCE_IDENTITY`
+
+It does not advertise `RESOLVE_CURRENT_SOURCE`; current native locators and
+resolver navigation are not implemented yet. The controller never chooses or
+widens capabilities.
+
+### Request-scoped state
+
+The builder adds:
+
+- one opaque trace ID allocated once and retained through persistence retry
+- bounded `AnswerAttempt` metadata
+- bounded governed `AnswerAttemptPayload` values
+- the repository-owned seal policy
+- a sealed-state guard and the resulting immutable `SealedCitationWrite`
+
+All mutation methods reject calls after sealing.
+
+### Answer-attempt recording
+
+The initial attempt records:
+
+- a new opaque attempt ID and ordinal
+- `AnswerAttemptKind.INITIAL`
+- the explicit prompt-evidence-set ID returned by prompt capture
+- a governed answer payload reference
+- the exact final assistant body
+- a `MESSAGE_BODY` domain fingerprint in `body_integrity_hmac`
+- no occurrence mappings yet
+- structural and semantic summaries derived by the existing model contracts
+- an aware completion timestamp
+
+The exact body and its integrity fingerprint remain governed payload fields and
+must not appear in immutable trace JSON, logs, exceptions, or diagnostics.
+
+Before constructing the attempt, the builder uses the existing bounded,
+Markdown-aware marker-span helper only as an eligibility guard. If the exact
+body contains any eligible marker under the selected prompt set's namespace,
+recording fails atomically with a fixed reason code. TASK-553.14 does not
+construct occurrence records, infer evidence mappings, or weaken the model
+invariant that a retained body's eligible markers must be represented exactly.
+Workstream 13 removes this temporary restriction by adding canonical occurrence
+parsing.
+
+The answer payload participates in both its per-payload byte cap and the
+aggregate governed-payload cap. Validation constructs all prospective objects
+before mutating builder collections, so a rejected body leaves no partial
+attempt.
+
+### One-shot seal
+
+`seal()` requires:
+
+- at least one evidence run
+- the selected prompt set
+- the selected answer attempt
+- a terminal timestamp not preceding request, retrieval, prompt, or attempt
+  boundaries
+
+It constructs a local, sealed `CitationTrace`, computes
+`completeness_at_seal` with `reduce_selected_attempt_completeness()`, and then
+constructs a full `SealedCitationWrite`. Validation completes before the
+builder changes to sealed state.
+
+A second seal call is rejected. Persistence retry reuses the same returned
+sealed write and stable IDs; it never calls `seal()` again.
+
+## Prompt-capture handoff
+
+`LocalRagContextResult` gains an optional prompt-evidence-set ID. Capture paths
+set it only when the builder successfully records a non-empty prompt evidence
+set. The Console request keeps the tuple of:
+
+- canonical context
+- request-local builder
+- explicit prompt-evidence-set ID
+
+If any element required for terminal provenance is missing, generation remains
+compatible but no terminal citation callback is installed.
+
+## Console completion contract
+
+### Deferred first durable write
+
+Today an empty assistant placeholder is queued for persistence, and any UI
+poll that materializes the first stream chunk can persist it immediately.
+That behavior would make a later message-plus-trace transaction impossible.
+
+Citation-bearing initial assistant placeholders therefore opt into
+terminal-deferred persistence:
+
+- stream chunks and UI polling may materialize visible content in memory
+- pending/streaming states cannot flush the assistant row
+- successful completion releases the deferral only through the citation-aware
+  terminal path
+- stopped, canceled, failed, or empty terminal paths release the deferral and
+  retain existing ordinary persistence behavior without a trace
+- each terminal path consumes or clears its callback exactly once
+- closing or removing a session clears both callback and deferral bookkeeping
+
+Non-citation messages keep the current first-content persistence behavior.
+Callbacks live only in a bounded transient store map keyed by native message ID;
+they are not serialized into message or session models and cannot transfer to a
+replacement, retry, regenerated variant, or runtime-written assistant row.
+
+### Exact-body callback
+
+Initial send installs a request-local callback with the shape:
+
+```text
+exact materialized assistant body -> SealedCitationWrite or no write
+```
+
+On successful direct-provider or agent completion, the store:
+
+1. materializes the final stream buffer
+2. applies existing successful-response prefill behavior
+3. gives the resulting exact body to the callback once
+4. marks the message complete
+5. persists the message with the returned sealed write, or ordinarily without
+   provenance when the callback rejects marker-bearing content
+
+Retry, regenerate, edit/resend, continuation, stopped, canceled, failed, and
+empty-generation paths do not receive this callback in TASK-553.14. An agent
+success outcome with no generated final text may retain its current visible
+fallback copy, but that fallback is not an answer attempt and is not sealed.
+
+## Atomic persistence and identity
+
+When a sealed write exists, `ConsoleChatStore` passes it through the optional
+`citation_write` parameter already supported by the real
+`ChatPersistenceService.create_message()` implementation.
+
+The store also supplies the native Console message UUID as the explicit
+database message ID. This is required even for ordinary text assistants when a
+citation write is attached:
+
+- message retry targets the same row
+- the trace retains the same stable identity
+- an uncertain commit cannot create a duplicate assistant message
+- `ChatPersistenceService` can verify an existing row and idempotently finish
+  or return the committed aggregate
+
+The existing persistence service preflights the sealed write, then commits the
+message, trace, governed payloads, references, tombstone checks, and owner
+association in its existing single SQLite transaction. No partial builder or
+retrieval rows are written before terminal completion.
+
+## Failure handling
+
+### Builder or seal unavailable
+
+If answer-attempt validation or sealing fails:
+
+- log only a fixed reason code and structural counts
+- do not include answer, query, title, snapshot, source identity, fingerprint,
+  locator, or exception text
+- complete and persist the assistant normally without a citation write
+- do not retain a partial attempt or sealed trace
+
+Eligible marker syntax is one such deterministic validation denial for this
+task. It is recorded only as a fixed `occurrence_mapping_unavailable` reason;
+the marker text and answer body are not logged. The answer is preserved as an
+ordinary ungrounded message until workstream 13 supplies exact occurrence
+mappings.
+
+### Deterministic canonical persistence denial
+
+If persistence raises `CitationPersistenceUnavailable`, the transaction has
+not produced a usable canonical trace. Attempt to persist the same assistant
+answer normally, without provenance, under its stable message ID. If that
+stable-ID insert also fails, retain the completed answer in memory and do not
+overwrite, update, or allocate a different durable row. The answer remains
+visible and is not labeled grounded.
+
+### Ambiguous persistence failure
+
+For a non-policy exception whose commit outcome may be uncertain:
+
+1. retry exactly once with the same explicit message ID and the same
+   `SealedCitationWrite`
+2. rely on existing message/trace idempotency verification if the first
+   transaction committed
+3. if the retry also fails, keep the completed answer visible in memory,
+   record a fixed content-free diagnostic, and do not attempt a potentially
+   conflicting ordinary insert
+
+The failed persistence state must not cause the controller to reclassify a
+successful generation as a provider or agent failure.
+
+## Trust semantics
+
+This task establishes complete or reduced prompt-provenance storage, not a
+claim that the answer cited or was supported by the evidence.
+
+- `occurrences` remains empty
+- only marker-free answers can produce a trace in this task
+- semantic status remains not checked
+- no Sources footer or interactive marker is enabled
+- no source-resolution capability is advertised
+- later occurrence parsing and UI workstreams decide cited-vs-submitted
+  presentation
+
+The stored trace can therefore survive restart and be inspected internally
+without overstating structural or semantic trust.
+
+## Security and privacy
+
+- no raw answer, query, title, snapshot, identity, locator, or fingerprint in
+  immutable trace JSON or logs
+- no logging of `str(exception)` on the citation finalization path
+- no builder, callback, or sealed write stored on the app, module globals, or
+  serialized/long-lived Console session models; the store holds only bounded
+  request-local transient state cleared on every terminal or removal path
+- policy metadata comes only from the repository-owned factory
+- selected-answer body integrity uses the existing keyed fingerprint codec
+- disabled canonical writes cannot create partial canonical rows
+
+## Testing strategy
+
+### Builder tests
+
+- answer attempt exact-body payload and immutable-trace privacy
+- marker-bearing body rejection with no partial mutation
+- answer-body and aggregate byte bounds
+- explicit prompt-set linkage and timestamp ordering
+- atomic rejection with no partial mutation
+- repository-owned policy metadata and bounded capabilities
+- deterministic completeness
+- one-shot seal and post-seal mutation rejection
+- stable sealed write reuse for persistence retry
+
+### Store and persistence tests
+
+- UI materialization does not persist a terminal-deferred assistant early
+- exact materialized body reaches the callback once
+- stable native message ID reaches `create_message`
+- message and trace commit atomically
+- deterministic denial falls back to an ordinary ungrounded message
+- ambiguous failure retries once with the same IDs and sealed write
+- second ambiguous failure leaves the answer visible without a conflicting
+  ordinary insert
+- non-citation messages preserve current persistence timing
+
+### Console integration tests
+
+- direct-provider success seals and persists exact output
+- agent success seals and persists exact output
+- successful prefill generation binds the exact visible body
+- empty provider and empty agent generation do not seal
+- marker-bearing answers persist ordinarily without provenance
+- capture/seal diagnostics contain no sentinel content
+- stopped, canceled, failed, empty, retry, and regenerate paths do not seal
+
+Verification remains scoped to touched builder, Console controller/store,
+persistence, and citation tests. Repository-wide baseline repair remains
+separate.
+
+## Rollout and rollback
+
+Canonical writes remain behind the existing runtime recovery switch. Disabling
+the switch stops new terminal traces while preserving ordinary messages and
+readability of already stored provenance. No down-migration or schema rollback
+is required.

--- a/Docs/superpowers/specs/2026-07-26-local-answer-attempt-terminal-sealing-design.md
+++ b/Docs/superpowers/specs/2026-07-26-local-answer-attempt-terminal-sealing-design.md
@@ -144,7 +144,8 @@ The initial attempt records:
 - a `MESSAGE_BODY` domain fingerprint in `body_integrity_hmac`
 - no occurrence mappings yet
 - structural and semantic summaries derived by the existing model contracts
-- an aware completion timestamp
+- an aware completion timestamp that is not earlier than the selected prompt
+  evidence set's `created_at`
 
 The exact body and its integrity fingerprint remain governed payload fields and
 must not appear in immutable trace JSON, logs, exceptions, or diagnostics.
@@ -202,7 +203,7 @@ Today an empty assistant placeholder is queued for persistence, and any UI
 poll that materializes the first stream chunk can persist it immediately.
 That behavior would make a later message-plus-trace transaction impossible.
 
-Citation-bearing initial assistant placeholders therefore opt into
+Provenance-eligible initial assistant placeholders therefore opt into
 terminal-deferred persistence:
 
 - stream chunks and UI polling may materialize visible content in memory

--- a/Docs/superpowers/specs/2026-07-26-local-answer-attempt-terminal-sealing-design.md
+++ b/Docs/superpowers/specs/2026-07-26-local-answer-attempt-terminal-sealing-design.md
@@ -49,7 +49,9 @@ decision, so no new ADR is required.
 - seal the request-scoped builder exactly once
 - derive selected-attempt completeness using the canonical reducer
 - carry repository-owned policy version and capabilities into the trace
-- defer citation-bearing assistant persistence until terminal completion
+- wire the Console persistence service to the same repository instance that
+  created the request-local builder
+- defer provenance-eligible assistant persistence until terminal completion
 - atomically persist the final message, trace, governed payloads, references,
   and owner association
 - use stable message and trace identities for one same-identity retry after an
@@ -176,10 +178,13 @@ attempt.
 `seal()` requires:
 
 - at least one evidence run
+- every local evidence run has a non-null `ended_at`
 - the selected prompt set
 - the selected answer attempt
-- a terminal timestamp not preceding request, retrieval, prompt, or attempt
-  boundaries
+- strict lifecycle ordering from each retrieval end through its prompt set,
+  selected answer attempt, and terminal seal
+- a terminal timestamp not preceding any request, retrieval, prompt, or
+  attempt boundary
 
 It constructs a local, sealed `CitationTrace`, computes
 `completeness_at_seal` with `reduce_selected_attempt_completeness()`, and then
@@ -200,7 +205,10 @@ set. The Console request keeps the tuple of:
 - explicit prompt-evidence-set ID
 
 If any element required for terminal provenance is missing, generation remains
-compatible but no terminal citation callback is installed.
+compatible but no terminal citation callback is installed. Required elements
+include a persistence adapter that accepts `citation_write` and, for the real
+Console service, the exact repository instance used by the app's capture
+factory bound to the same database.
 
 ## Console completion contract
 
@@ -266,6 +274,23 @@ fallback copy, but that fallback is not an answer attempt and is not sealed.
 When a sealed write exists, `ConsoleChatStore` passes it through the optional
 `citation_write` parameter already supported by the real
 `ChatPersistenceService.create_message()` implementation.
+
+### Production composition and compatibility
+
+`ChatScreen._ensure_console_chat_store()` must construct
+`ChatPersistenceService` with both the ChaChaNotes database and the exact
+`app_instance.citation_trace_repository` used by local RAG capture. The
+repository must be bound to that same database. Without this composition, the
+existing service deterministically raises `citation_repository_unavailable`
+and no trace can reach storage.
+
+The Console persistence protocol declares `citation_write` as an optional
+creation capability. Existing narrow test fakes may continue to omit it, using
+the store's existing signature-probing compatibility pattern. A nonpersistent
+store, an adapter without that capability, a missing repository, or a
+repository/database mismatch does not arm a terminal finalizer and keeps
+ordinary message behavior. It must not build and seal a trace that cannot be
+stored.
 
 The store supplies the native Console message UUID as the explicit database
 message ID for every provenance-eligible terminal persistence attempt. The
@@ -368,6 +393,7 @@ without overstating structural or semantic trust.
 - marker-bearing body rejection with no partial mutation
 - answer-body and aggregate byte bounds
 - explicit prompt-set linkage and timestamp ordering
+- incomplete local retrieval runs and out-of-order lifecycle rejection
 - atomic rejection with no partial mutation
 - repository-owned policy metadata and bounded capabilities
 - deterministic completeness
@@ -376,6 +402,9 @@ without overstating structural or semantic trust.
 
 ### Store and persistence tests
 
+- real Console composition passes the app's exact citation repository instance
+  into `ChatPersistenceService`
+- nonpersistent and citation-incapable adapters never arm a finalizer
 - UI materialization does not persist a terminal-deferred assistant early
 - placeholder creation installs finalizer and deferral atomically
 - outer dispatch cleanup clears unconsumed finalizers and terminal deferrals on

--- a/Tests/Chat/test_chat_function_local_citation_boundary.py
+++ b/Tests/Chat/test_chat_function_local_citation_boundary.py
@@ -20,6 +20,7 @@ from tldw_chatbook.Chat.citation_trace_identity import (
     LocalCitationIdentityContext,
 )
 from tldw_chatbook.Chat.citation_trace_models import (
+    PolicyCapability,
     RetrievalScoreKind,
     RetrievalScoreScale,
 )
@@ -70,6 +71,11 @@ def _canonical_capture():
             fingerprint_key_id="fingerprint-key-1",
         ),
         fingerprint_codec=CitationFingerprintCodec(SECRET),
+        policy_version="test-local-policy-v1",
+        policy_capabilities=(
+            PolicyCapability.VIEW_SNAPSHOT,
+            PolicyCapability.VIEW_SOURCE_IDENTITY,
+        ),
         created_at=NOW,
     )
     candidates = tuple(

--- a/Tests/Chat/test_chat_function_local_citation_boundary.py
+++ b/Tests/Chat/test_chat_function_local_citation_boundary.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+import pytest
+from loguru import logger as loguru_logger
+from pydantic import ValidationError
+
+import tldw_chatbook.Chat.Chat_Functions as chat_functions
+from tldw_chatbook.Chat.Chat_Functions import ChatDictionary
+from tldw_chatbook.Chat.citation_source_locators import CanonicalSourceKind
+from tldw_chatbook.Chat.citation_trace_builder import (
+    CitationTraceBuilder,
+    LocalRetrievalCandidateCapture,
+    LocalRetrievalRunMetadata,
+)
+from tldw_chatbook.Chat.citation_trace_identity import (
+    CitationFingerprintCodec,
+    LocalCitationIdentityContext,
+)
+from tldw_chatbook.Chat.citation_trace_models import (
+    RetrievalScoreKind,
+    RetrievalScoreScale,
+)
+from tldw_chatbook.RAG_Search.local_citation_capture import (
+    format_local_evidence_context,
+    normalize_local_result,
+)
+
+
+NOW = datetime(2026, 7, 25, 12, 0, tzinfo=UTC)
+SECRET = b"0123456789abcdef0123456789abcdef"
+
+
+def _canonical_capture():
+    title_one = "EVIDENCE_TITLE_ONE_SENTINEL_TASK_553_13"
+    title_two = "EVIDENCE_TITLE_TWO_SENTINEL_TASK_553_13"
+    body_one = "EVIDENCE_BODY_ONE_SENTINEL_TASK_553_13"
+    body_two = "  EVIDENCE_BODY_TWO_SENTINEL_TASK_553_13  \n\t"
+    raw_results = (
+        {
+            "id": "media-1",
+            "source": "media",
+            "title": title_one,
+            "content": body_one,
+            "score": 0.9,
+            "metadata": {"source_type": "media", "source_id": "media-1"},
+        },
+        {
+            "id": "media-2",
+            "source": "media",
+            "title": title_two,
+            "content": body_two,
+            "score": 0.8,
+            "metadata": {"source_type": "media", "source_id": "media-2"},
+        },
+    )
+    normalized = tuple(
+        normalize_local_result(result, candidate_rank=rank)
+        for rank, result in enumerate(raw_results, start=1)
+    )
+    formatted = format_local_evidence_context(normalized, max_length=10_000)
+    builder = CitationTraceBuilder.local(
+        request_id="request-boundary",
+        generation_id="generation-boundary",
+        identity_context=LocalCitationIdentityContext(
+            profile_id="profile-1",
+            local_authority_id="authority-1",
+            fingerprint_key_id="fingerprint-key-1",
+        ),
+        fingerprint_codec=CitationFingerprintCodec(SECRET),
+        created_at=NOW,
+    )
+    candidates = tuple(
+        LocalRetrievalCandidateCapture(
+            candidate_rank=result.candidate_rank,
+            source_kind=CanonicalSourceKind.MEDIA_DB,
+            source_id=result.source_id,
+            title=result.title,
+            score_kind=RetrievalScoreKind.VECTOR_SIMILARITY,
+            score_scale=RetrievalScoreScale.ZERO_TO_ONE,
+            score=result.score,
+        )
+        for result in normalized
+    )
+    run_id = builder.record_retrieval_run(
+        stage="plain",
+        raw_query="BOUNDARY_QUERY_SENTINEL_TASK_553_13",
+        candidates=candidates,
+        retrieval_metadata=LocalRetrievalRunMetadata(
+            search_mode="plain",
+            requested_top_k=2,
+            max_context_characters=10_000,
+            rerank_enabled=False,
+            source_kinds=(CanonicalSourceKind.MEDIA_DB,),
+            scope_state="unscoped",
+        ),
+        started_at=NOW,
+        ended_at=NOW,
+    )
+    builder.record_prompt_evidence_set(
+        run_id=run_id,
+        evidence=formatted.entries,
+        created_at=NOW,
+    )
+    return formatted.context, builder
+
+
+def _provider_user_text(messages_payload):
+    current_user = messages_payload[-1]
+    content = current_user["content"]
+    if isinstance(content, str):
+        return content
+    return next(part["text"] for part in content if part.get("type") == "text")
+
+
+@pytest.mark.parametrize("api_endpoint", ["openai", "deepseek"])
+def test_chat_dictionary_never_mutates_canonical_evidence_at_provider_boundary(
+    api_endpoint,
+    monkeypatch,
+    caplog,
+):
+    ordinary_prompt = "ORDINARY_PROMPT_SENTINEL_TASK_553_13"
+    transformed_prompt = "ORDINARY_PROMPT_TRANSFORMED_TASK_553_13"
+    custom_prompt = "CUSTOM_PROMPT_SENTINEL_TASK_553_13"
+    answer = "NONSTREAM_ANSWER_SENTINEL_TASK_553_13"
+    canonical_context, builder = _canonical_capture()
+    captured_call = {}
+
+    def fake_chat_api_call(**kwargs):
+        captured_call.update(kwargs)
+        return answer
+
+    monkeypatch.setattr(chat_functions, "chat_api_call", fake_chat_api_call)
+    monkeypatch.setattr(chat_functions, "load_settings", lambda: {})
+    chatdict_entries = [
+        ChatDictionary(key=ordinary_prompt, content=transformed_prompt),
+        ChatDictionary(
+            key="EVIDENCE_TITLE_ONE_SENTINEL_TASK_553_13",
+            content="MUTATED_EVIDENCE_TITLE_TASK_553_13",
+        ),
+        ChatDictionary(
+            key="EVIDENCE_BODY_TWO_SENTINEL_TASK_553_13",
+            content="MUTATED_EVIDENCE_BODY_TASK_553_13",
+        ),
+    ]
+    captured_logs = []
+    sink_id = loguru_logger.add(
+        captured_logs.append,
+        level="DEBUG",
+        format="{message}",
+    )
+
+    try:
+        with caplog.at_level(logging.DEBUG):
+            response = chat_functions.chat(
+                message=ordinary_prompt,
+                history=[
+                    {
+                        "role": "user",
+                        "content": "HISTORY_TEXT_SENTINEL_TASK_553_13",
+                    }
+                ],
+                media_content={"evidence": canonical_context},
+                selected_parts=["evidence"],
+                api_endpoint=api_endpoint,
+                api_key="test-key",
+                custom_prompt=custom_prompt,
+                temperature=0.7,
+                streaming=False,
+                model="test-model",
+                chatdict_entries=chatdict_entries,
+            )
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert response == answer
+    provider_user_text = _provider_user_text(captured_call["messages_payload"])
+    assert transformed_prompt in provider_user_text
+    assert ordinary_prompt not in provider_user_text
+    assert custom_prompt in provider_user_text
+    assert "MUTATED_EVIDENCE_TITLE_TASK_553_13" not in provider_user_text
+    assert "MUTATED_EVIDENCE_BODY_TASK_553_13" not in provider_user_text
+    for payload in builder.evidence_snapshot_payloads:
+        assert payload.snapshot_text is not None
+        assert payload.snapshot_text in provider_user_text
+    whitespace_snapshot = builder.evidence_snapshot_payloads[-1].snapshot_text
+    assert whitespace_snapshot is not None
+    assert whitespace_snapshot.endswith("  \n\t")
+    assert whitespace_snapshot.encode("utf-8") in provider_user_text.encode("utf-8")
+
+    rendered_logs = "".join(
+        record.getMessage()
+        for record in caplog.records
+        if record.pathname.endswith("Chat_Functions.py")
+    ) + "".join(str(message) for message in captured_logs)
+    for sentinel in (
+        ordinary_prompt,
+        "HISTORY_TEXT_SENTINEL_TASK_553_13",
+        custom_prompt,
+        "EVIDENCE_TITLE_ONE_SENTINEL_TASK_553_13",
+        "EVIDENCE_TITLE_TWO_SENTINEL_TASK_553_13",
+        "EVIDENCE_BODY_ONE_SENTINEL_TASK_553_13",
+        "EVIDENCE_BODY_TWO_SENTINEL_TASK_553_13",
+        answer,
+    ):
+        assert sentinel not in rendered_logs
+
+
+def test_chat_validation_failure_log_does_not_render_sensitive_input(
+    monkeypatch,
+    caplog,
+):
+    validation_sentinel = "CHAT_VALIDATION_FAILURE_SENTINEL_TASK_553_13"
+    validation_error = ValidationError.from_exception_data(
+        "SensitiveInput",
+        [
+            {
+                "type": "value_error",
+                "loc": ("message",),
+                "input": validation_sentinel,
+                "ctx": {"error": ValueError("invalid")},
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        chat_functions,
+        "process_user_input",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(validation_error),
+    )
+    captured_logs = []
+    sink_id = loguru_logger.add(
+        captured_logs.append,
+        level="DEBUG",
+        format="{message}",
+    )
+
+    try:
+        with caplog.at_level(logging.DEBUG):
+            chat_functions.chat(
+                message="trigger",
+                history=[],
+                media_content={},
+                selected_parts=[],
+                api_endpoint="openai",
+                api_key="test-key",
+                custom_prompt=None,
+                temperature=0.7,
+                chatdict_entries=[ChatDictionary(key="trigger", content="replacement")],
+            )
+    finally:
+        loguru_logger.remove(sink_id)
+
+    rendered_logs = "".join(
+        record.getMessage()
+        for record in caplog.records
+        if record.pathname.endswith("Chat_Functions.py")
+    ) + "".join(str(message) for message in captured_logs)
+    assert validation_sentinel not in rendered_logs

--- a/Tests/Chat/test_chat_persistence_service.py
+++ b/Tests/Chat/test_chat_persistence_service.py
@@ -3,6 +3,7 @@ import inspect
 import pytest
 
 from Tests.Chat.test_citation_trace_repository import (
+    _TrackingKeyProvider,
     _exact_governed_payload_write,
     _identity as citation_identity,
     _repository as citation_repository,
@@ -65,6 +66,124 @@ class TestChatPersistenceService:
         )
         conversation = db_instance.get_conversation_by_id(conversation_id)
         assert conversation["assistant_id"] == "char.local.alice"
+
+    def test_canonical_citation_writes_ready_requires_matching_ready_repository(
+        self,
+        db_instance: CharactersRAGDB,
+    ):
+        repository = citation_repository(db_instance)
+        service = ChatPersistenceService(
+            db_instance,
+            citation_repository=repository,
+        )
+
+        assert service.canonical_citation_writes_ready is True
+        assert service.citation_repository is repository
+        assert service.db is repository.db
+
+    def test_canonical_citation_writes_ready_is_false_without_repository(
+        self,
+        db_instance: CharactersRAGDB,
+    ):
+        service = ChatPersistenceService(db_instance)
+
+        assert service.canonical_citation_writes_ready is False
+
+    def test_canonical_citation_writes_ready_rejects_repository_database_mismatch(
+        self,
+        db_instance: CharactersRAGDB,
+        tmp_path,
+    ):
+        other_db = CharactersRAGDB(
+            tmp_path / "readiness-other.sqlite",
+            client_id="readiness-other",
+        )
+        try:
+            service = ChatPersistenceService(
+                db_instance,
+                citation_repository=citation_repository(other_db),
+            )
+
+            assert service.canonical_citation_writes_ready is False
+        finally:
+            other_db.close_connection()
+
+    @pytest.mark.parametrize(
+        "unready_reason",
+        (
+            "disabled",
+            "missing_identity",
+            "missing_codec",
+            "missing_persisted_identity",
+            "mismatched_identity",
+        ),
+    )
+    def test_canonical_citation_writes_ready_fails_closed_for_unready_repository(
+        self,
+        db_instance: CharactersRAGDB,
+        unready_reason: str,
+    ):
+        identity = citation_identity(db_instance)
+        repository = CitationTraceRepository(
+            db_instance,
+            policy=CitationProvenanceRuntimePolicy(
+                canonical_writes_enabled=unready_reason != "disabled",
+            ),
+            identity_context=(
+                None
+                if unready_reason == "missing_identity"
+                else identity.model_copy(
+                    update={"local_authority_id": "mismatched-local-authority"}
+                )
+                if unready_reason == "mismatched_identity"
+                else identity
+            ),
+            fingerprint_codec=(
+                None
+                if unready_reason == "missing_codec"
+                else CitationFingerprintCodec(b"k" * 32)
+            ),
+        )
+        if unready_reason == "missing_persisted_identity":
+            with db_instance.transaction() as cursor:
+                cursor.execute(
+                    "DELETE FROM rag_identity_context WHERE context_name = 'default'"
+                )
+
+        service = ChatPersistenceService(
+            db_instance,
+            citation_repository=repository,
+        )
+
+        assert service.canonical_citation_writes_ready is False
+
+    def test_canonical_citation_writes_ready_is_read_only_and_side_effect_free(
+        self,
+        db_instance: CharactersRAGDB,
+    ):
+        identity = citation_identity(db_instance)
+        provider = _TrackingKeyProvider(b"k" * 32)
+        repository = CitationTraceRepository.from_key_provider(
+            db_instance,
+            policy=CitationProvenanceRuntimePolicy(canonical_writes_enabled=True),
+            identity_context=identity,
+            key_provider=provider,
+        )
+        service = ChatPersistenceService(
+            db_instance,
+            citation_repository=repository,
+        )
+        expected_key_calls = [identity.fingerprint_key_id]
+        original_policy = repository.policy.model_dump()
+
+        readiness = service.canonical_citation_writes_ready
+
+        assert type(readiness) is bool
+        assert readiness is True
+        assert provider.calls == expected_key_calls
+        assert repository.policy.model_dump() == original_policy
+        with pytest.raises(AttributeError):
+            service.canonical_citation_writes_ready = False  # type: ignore[misc]
 
     def test_citation_write_requires_an_explicit_available_repository_before_transaction(
         self,

--- a/Tests/Chat/test_citation_trace_builder.py
+++ b/Tests/Chat/test_citation_trace_builder.py
@@ -21,19 +21,31 @@ from tldw_chatbook.Chat.citation_trace_identity import (
     LocalCitationIdentityContext,
 )
 from tldw_chatbook.Chat.citation_trace_models import (
+    ANSWER_ATTEMPT_BODY_UTF8_BYTES_MAX,
     EVIDENCE_ENTRIES_PER_PROMPT_MAX,
     PROMPT_EVIDENCE_SETS_MAX,
     RETRIEVAL_CANDIDATES_PER_RUN_MAX,
     SNAPSHOT_TEXT_UTF8_BYTES_MAX,
+    AnswerAttemptKind,
+    CitationCompleteness,
     EvidenceStorageMode,
     MarkerNamespace,
+    PolicyCapability,
     RetrievalScoreKind,
     RetrievalScoreScale,
+    TraceLifecycle,
+    TraceOrigin,
+    reduce_selected_attempt_completeness,
 )
 
 
 NOW = datetime(2026, 7, 25, 12, 0, tzinfo=UTC)
 SECRET = b"0123456789abcdef0123456789abcdef"
+TEST_POLICY_VERSION = "test-local-policy-v1"
+TEST_POLICY_CAPABILITIES = (
+    PolicyCapability.VIEW_SNAPSHOT,
+    PolicyCapability.VIEW_SOURCE_IDENTITY,
+)
 
 
 def _identity() -> LocalCitationIdentityContext:
@@ -50,6 +62,8 @@ def _builder() -> CitationTraceBuilder:
         generation_id="generation-1",
         identity_context=_identity(),
         fingerprint_codec=CitationFingerprintCodec(SECRET),
+        policy_version=TEST_POLICY_VERSION,
+        policy_capabilities=TEST_POLICY_CAPABILITIES,
         created_at=NOW,
     )
 
@@ -100,6 +114,40 @@ def _record_run(builder: CitationTraceBuilder) -> str:
     )
 
 
+def _record_prompt_set(
+    builder: CitationTraceBuilder,
+    *,
+    run_id: str | None = None,
+    created_at: datetime = NOW,
+) -> str:
+    linked_run_id = run_id if run_id is not None else _record_run(builder)
+    return builder.record_prompt_evidence_set(
+        run_id=linked_run_id,
+        evidence=(
+            LocalPromptEvidenceCapture(
+                candidate_rank=1,
+                snapshot_text="[S1] MEDIA — Alpha\nExact",
+            ),
+        ),
+        created_at=created_at,
+    )
+
+
+def _builder_with_initial_answer(
+    *,
+    answer_body: str = "Marker-free exact answer.",
+    completed_at: datetime = NOW,
+) -> tuple[CitationTraceBuilder, str]:
+    builder = _builder()
+    prompt_set_id = _record_prompt_set(builder)
+    attempt_id = builder.record_initial_answer_attempt(
+        prompt_evidence_set_id=prompt_set_id,
+        answer_body=answer_body,
+        completed_at=completed_at,
+    )
+    return builder, attempt_id
+
+
 def _compact_model_json_bytes(model: BaseModel) -> int:
     return len(
         json.dumps(
@@ -121,8 +169,10 @@ def test_local_builder_starts_empty_unsealed_and_redacts_private_context() -> No
     assert builder.evidence_run_payloads == ()
     assert builder.prompt_evidence_sets == ()
     assert builder.evidence_snapshot_payloads == ()
+    assert builder.answer_attempts == ()
+    assert builder.answer_attempt_payloads == ()
     assert builder.is_sealed is False
-    assert not hasattr(builder, "seal")
+    assert hasattr(builder, "seal")
     assert not hasattr(builder, "persist")
     assert not hasattr(builder, "prepare_write")
     assert SECRET.decode() not in repr(builder)
@@ -146,6 +196,8 @@ def test_local_builder_requires_a_valid_frozen_local_identity_binding() -> None:
             generation_id="generation-1",
             identity_context=missing_profile,
             fingerprint_codec=CitationFingerprintCodec(SECRET),
+            policy_version=TEST_POLICY_VERSION,
+            policy_capabilities=TEST_POLICY_CAPABILITIES,
             created_at=NOW,
         )
     with pytest.raises(TypeError, match="identity_context"):
@@ -153,6 +205,19 @@ def test_local_builder_requires_a_valid_frozen_local_identity_binding() -> None:
             request_id="request-1",
             generation_id="generation-1",
             identity_context=None,  # type: ignore[arg-type]
+            fingerprint_codec=CitationFingerprintCodec(SECRET),
+            policy_version=TEST_POLICY_VERSION,
+            policy_capabilities=TEST_POLICY_CAPABILITIES,
+            created_at=NOW,
+        )
+
+
+def test_local_builder_requires_explicit_policy_metadata() -> None:
+    with pytest.raises(TypeError):
+        CitationTraceBuilder.local(
+            request_id="request-1",
+            generation_id="generation-1",
+            identity_context=_identity(),
             fingerprint_codec=CitationFingerprintCodec(SECRET),
             created_at=NOW,
         )
@@ -177,6 +242,8 @@ def test_local_builder_rejects_invalid_request_identity_or_timestamp(
             generation_id=generation_id,
             identity_context=_identity(),
             fingerprint_codec=CitationFingerprintCodec(SECRET),
+            policy_version=TEST_POLICY_VERSION,
+            policy_capabilities=TEST_POLICY_CAPABILITIES,
             created_at=created_at,
         )
 
@@ -188,6 +255,8 @@ def test_local_builder_rejects_falsy_non_datetime_created_at() -> None:
             generation_id="generation-1",
             identity_context=_identity(),
             fingerprint_codec=CitationFingerprintCodec(SECRET),
+            policy_version=TEST_POLICY_VERSION,
+            policy_capabilities=TEST_POLICY_CAPABILITIES,
             created_at=0,  # type: ignore[arg-type]
         )
 
@@ -232,6 +301,8 @@ def test_strict_revalidation_never_leaks_sensitive_values_to_warnings_or_stderr(
                 generation_id="generation-1",
                 identity_context=forged_identity,
                 fingerprint_codec=CitationFingerprintCodec(SECRET),
+                policy_version=TEST_POLICY_VERSION,
+                policy_capabilities=TEST_POLICY_CAPABILITIES,
                 created_at=NOW,
             )
         with pytest.raises(ValidationError):
@@ -971,3 +1042,378 @@ def test_cumulative_snapshot_batch_overflow_is_atomic(
 
     assert builder.prompt_evidence_sets == ()
     assert builder.evidence_snapshot_payloads == ()
+
+
+def test_record_initial_answer_attempt_retains_governed_body_and_metadata() -> None:
+    answer_body = "Marker-free exact answer 🧪."
+    builder, attempt_id = _builder_with_initial_answer(answer_body=answer_body)
+
+    assert len(builder.answer_attempts) == 1
+    attempt = builder.answer_attempts[0]
+    payload = builder.answer_attempt_payloads[0]
+    assert attempt.attempt_id == attempt_id
+    assert attempt.attempt_ordinal == 1
+    assert attempt.kind is AnswerAttemptKind.INITIAL
+    assert attempt.prompt_evidence_set_id == builder.prompt_evidence_sets[0].prompt_set_id
+    assert attempt.answer_payload_ref == payload.payload_id
+    assert attempt.occurrences == ()
+    assert attempt.created_at == NOW
+    assert payload.attempt_id == attempt_id
+    assert payload.answer_body == answer_body
+    assert payload.body_integrity_hmac == CitationFingerprintCodec(SECRET).fingerprint(
+        CitationFingerprintDomain.MESSAGE_BODY,
+        answer_body,
+    )
+    immutable_json = json.dumps(attempt.model_dump(mode="json"), sort_keys=True)
+    assert answer_body not in immutable_json
+    assert payload.body_integrity_hmac not in immutable_json
+
+
+def test_initial_answer_governed_payload_view_is_deep_detached() -> None:
+    builder, _attempt_id = _builder_with_initial_answer()
+
+    returned = builder.answer_attempt_payloads[0]
+    object.__setattr__(returned, "answer_body", "tampered")
+
+    assert builder.answer_attempt_payloads[0].answer_body == "Marker-free exact answer."
+
+
+@pytest.mark.parametrize(
+    "answer_body",
+    (
+        "Eligible [S1] marker.",
+        "Eligible [S1] and [S2] markers.",
+    ),
+)
+def test_initial_answer_with_eligible_markers_is_unavailable_and_atomic(
+    answer_body: str,
+) -> None:
+    builder = _builder()
+    prompt_set_id = _record_prompt_set(builder)
+
+    with pytest.raises(ValueError) as captured:
+        builder.record_initial_answer_attempt(
+            prompt_evidence_set_id=prompt_set_id,
+            answer_body=answer_body,
+            completed_at=NOW,
+        )
+
+    assert isinstance(
+        captured.value,
+        builder_module.CitationTraceBuildUnavailable,
+    )
+    assert captured.value.reason_code == "occurrence_mapping_unavailable"
+    assert builder.answer_attempts == ()
+    assert builder.answer_attempt_payloads == ()
+
+
+@pytest.mark.parametrize(
+    "answer_body",
+    (
+        r"Escaped marker \[S1] is literal.",
+        "Inline code `[S1]` is literal.",
+        "```text\n[S1]\n```\nCode fence only.",
+    ),
+)
+def test_marker_free_eligibility_ignores_markdown_code_and_escaped_literals(
+    answer_body: str,
+) -> None:
+    builder, attempt_id = _builder_with_initial_answer(answer_body=answer_body)
+
+    assert builder.answer_attempts[0].attempt_id == attempt_id
+    assert builder.answer_attempts[0].occurrences == ()
+
+
+def test_answer_body_byte_cap_rejects_initial_attempt_atomically() -> None:
+    builder = _builder()
+    prompt_set_id = _record_prompt_set(builder)
+    sentinel = "ANSWER_BODY_SECRET_SENTINEL"
+    oversized = sentinel * (
+        (ANSWER_ATTEMPT_BODY_UTF8_BYTES_MAX // len(sentinel)) + 1
+    )
+
+    with pytest.raises(ValueError, match="answer_body exceeds") as captured:
+        builder.record_initial_answer_attempt(
+            prompt_evidence_set_id=prompt_set_id,
+            answer_body=oversized,
+            completed_at=NOW,
+        )
+
+    assert "ANSWER_BODY_" not in str(captured.value)
+    assert builder.answer_attempts == ()
+    assert builder.answer_attempt_payloads == ()
+
+
+def test_answer_body_aggregate_governed_payload_overflow_is_atomic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    measuring_builder, _attempt_id = _builder_with_initial_answer()
+    governed_bytes = sum(
+        _compact_model_json_bytes(payload)
+        for payload in (
+            *measuring_builder.evidence_run_payloads,
+            *measuring_builder.evidence_snapshot_payloads,
+            *measuring_builder.answer_attempt_payloads,
+        )
+    )
+    builder = _builder()
+    prompt_set_id = _record_prompt_set(builder)
+    monkeypatch.setattr(
+        builder_module,
+        "GOVERNED_PAYLOAD_UTF8_BYTES_MAX",
+        governed_bytes - 1,
+        raising=False,
+    )
+
+    with pytest.raises(ValueError, match="governed payload exceeds"):
+        builder.record_initial_answer_attempt(
+            prompt_evidence_set_id=prompt_set_id,
+            answer_body="Marker-free exact answer.",
+            completed_at=NOW,
+        )
+
+    assert builder.answer_attempts == ()
+    assert builder.answer_attempt_payloads == ()
+
+
+def test_initial_answer_rejects_unknown_prompt_set_atomically() -> None:
+    builder = _builder()
+
+    with pytest.raises(ValueError, match="unknown prompt evidence set"):
+        builder.record_initial_answer_attempt(
+            prompt_evidence_set_id="missing-prompt",
+            answer_body="Marker-free exact answer.",
+            completed_at=NOW,
+        )
+
+    assert builder.answer_attempts == ()
+    assert builder.answer_attempt_payloads == ()
+
+
+def test_attempt_completion_cannot_precede_prompt_creation_and_is_atomic() -> None:
+    builder = _builder()
+    prompt_set_id = _record_prompt_set(builder, created_at=NOW + timedelta(seconds=1))
+
+    with pytest.raises(ValueError, match="prompt evidence set"):
+        builder.record_initial_answer_attempt(
+            prompt_evidence_set_id=prompt_set_id,
+            answer_body="Marker-free exact answer.",
+            completed_at=NOW,
+        )
+
+    assert builder.answer_attempts == ()
+    assert builder.answer_attempt_payloads == ()
+
+
+def test_second_initial_answer_attempt_is_rejected_without_repair_or_rerun_api() -> None:
+    builder, first_attempt_id = _builder_with_initial_answer()
+
+    with pytest.raises(ValueError, match="initial answer attempt"):
+        builder.record_initial_answer_attempt(
+            prompt_evidence_set_id=builder.prompt_evidence_sets[0].prompt_set_id,
+            answer_body="Another marker-free answer.",
+            completed_at=NOW,
+        )
+
+    assert [attempt.attempt_id for attempt in builder.answer_attempts] == [
+        first_attempt_id
+    ]
+    assert len(builder.answer_attempt_payloads) == 1
+    assert not hasattr(builder, "record_repair_answer_attempt")
+    assert not hasattr(builder, "record_pipeline_rerun")
+
+
+def test_seal_returns_one_shot_local_immutable_write_with_fixed_linkage() -> None:
+    answer_body = "Marker-free exact answer."
+    builder, attempt_id = _builder_with_initial_answer(answer_body=answer_body)
+
+    sealed_write = builder.seal(
+        selected_attempt_id=attempt_id,
+        sealed_at=NOW + timedelta(seconds=1),
+    )
+
+    trace = sealed_write.trace
+    assert builder.is_sealed is True
+    assert trace.origin is TraceOrigin.LOCAL
+    assert trace.lifecycle is TraceLifecycle.SEALED
+    assert trace.completeness_at_seal is CitationCompleteness.COMPLETE
+    assert trace.completeness_at_seal is reduce_selected_attempt_completeness(
+        trace,
+        {
+            payload.payload_id: payload
+            for payload in sealed_write.evidence_snapshot_payloads
+        },
+    )
+    assert trace.selected_attempt_id == attempt_id
+    assert trace.answer_attempts[0].occurrences == ()
+    assert trace.policy_version == TEST_POLICY_VERSION
+    assert trace.policy_capabilities == TEST_POLICY_CAPABILITIES
+    assert sealed_write.evidence_run_payloads == builder.evidence_run_payloads
+    assert (
+        sealed_write.evidence_snapshot_payloads
+        == builder.evidence_snapshot_payloads
+    )
+    assert sealed_write.answer_attempt_payloads == builder.answer_attempt_payloads
+    trace_json = json.dumps(trace.model_dump(mode="json"), sort_keys=True)
+    assert answer_body not in trace_json
+    assert sealed_write.answer_attempt_payloads[0].body_integrity_hmac not in trace_json
+    assert sealed_write.answer_attempt_payloads[0].answer_body == answer_body
+    assert (
+        sealed_write.answer_attempt_payloads[0].body_integrity_hmac
+        == CitationFingerprintCodec(SECRET).fingerprint(
+            CitationFingerprintDomain.MESSAGE_BODY,
+            answer_body,
+        )
+    )
+    persistence_retry = sealed_write
+    assert persistence_retry is sealed_write
+
+
+def test_seal_requires_complete_graph_and_known_selected_attempt() -> None:
+    empty = _builder()
+    with pytest.raises(ValueError, match="evidence run"):
+        empty.seal(selected_attempt_id="missing", sealed_at=NOW)
+    assert empty.is_sealed is False
+
+    run_only = _builder()
+    _record_run(run_only)
+    with pytest.raises(ValueError, match="prompt evidence set"):
+        run_only.seal(selected_attempt_id="missing", sealed_at=NOW)
+    assert run_only.is_sealed is False
+
+    prompt_only = _builder()
+    _record_prompt_set(prompt_only)
+    with pytest.raises(ValueError, match="answer attempt"):
+        prompt_only.seal(selected_attempt_id="missing", sealed_at=NOW)
+    assert prompt_only.is_sealed is False
+
+    complete, _attempt_id = _builder_with_initial_answer()
+    with pytest.raises(ValueError, match="selected answer attempt"):
+        complete.seal(selected_attempt_id="missing", sealed_at=NOW)
+    assert complete.is_sealed is False
+
+
+def test_seal_requires_every_retrieval_run_to_have_ended() -> None:
+    builder = _builder()
+    run_id = builder.record_retrieval_run(
+        stage="hybrid",
+        raw_query="secret query",
+        candidates=(_candidate(),),
+        retrieval_metadata=_metadata(),
+        started_at=NOW,
+        ended_at=None,
+    )
+    prompt_set_id = _record_prompt_set(builder, run_id=run_id)
+    attempt_id = builder.record_initial_answer_attempt(
+        prompt_evidence_set_id=prompt_set_id,
+        answer_body="Marker-free exact answer.",
+        completed_at=NOW,
+    )
+
+    with pytest.raises(ValueError, match="ended_at"):
+        builder.seal(selected_attempt_id=attempt_id, sealed_at=NOW)
+
+    assert builder.is_sealed is False
+
+
+def test_seal_revalidates_run_prompt_and_attempt_lifecycle_order() -> None:
+    builder, attempt_id = _builder_with_initial_answer()
+    prompt = builder.prompt_evidence_sets[0]
+    builder._evidence_runs[0] = builder.evidence_runs[0].model_copy(  # type: ignore[attr-defined]
+        update={"ended_at": prompt.created_at + timedelta(seconds=1)}
+    )
+
+    with pytest.raises(ValueError, match="prompt"):
+        builder.seal(
+            selected_attempt_id=attempt_id,
+            sealed_at=NOW + timedelta(seconds=2),
+        )
+    assert builder.is_sealed is False
+
+    builder._evidence_runs[0] = builder.evidence_runs[0].model_copy(  # type: ignore[attr-defined]
+        update={"ended_at": NOW}
+    )
+    builder._answer_attempts[0] = builder.answer_attempts[0].model_copy(  # type: ignore[attr-defined]
+        update={"created_at": prompt.created_at - timedelta(seconds=1)}
+    )
+    with pytest.raises(ValueError, match="attempt"):
+        builder.seal(
+            selected_attempt_id=attempt_id,
+            sealed_at=NOW + timedelta(seconds=2),
+        )
+    assert builder.is_sealed is False
+
+
+@pytest.mark.parametrize(
+    "sealed_at",
+    (
+        NOW - timedelta(seconds=1),
+        NOW + timedelta(milliseconds=500),
+        NOW + timedelta(seconds=2, milliseconds=500),
+        NOW + timedelta(seconds=3, milliseconds=500),
+    ),
+)
+def test_seal_rejects_sealed_at_before_any_lifecycle_order_boundary(
+    sealed_at: datetime,
+) -> None:
+    builder = _builder()
+    run_id = builder.record_retrieval_run(
+        stage="hybrid",
+        raw_query="secret query",
+        candidates=(_candidate(),),
+        retrieval_metadata=_metadata(),
+        started_at=NOW + timedelta(seconds=1),
+        ended_at=NOW + timedelta(seconds=2),
+    )
+    prompt_set_id = _record_prompt_set(
+        builder,
+        run_id=run_id,
+        created_at=NOW + timedelta(seconds=3),
+    )
+    attempt_id = builder.record_initial_answer_attempt(
+        prompt_evidence_set_id=prompt_set_id,
+        answer_body="Marker-free exact answer.",
+        completed_at=NOW + timedelta(seconds=4),
+    )
+
+    with pytest.raises((ValueError, ValidationError), match="sealed_at"):
+        builder.seal(selected_attempt_id=attempt_id, sealed_at=sealed_at)
+
+    assert builder.is_sealed is False
+
+
+def test_every_mutation_and_second_seal_reject_after_successful_seal() -> None:
+    builder, attempt_id = _builder_with_initial_answer()
+    builder.seal(selected_attempt_id=attempt_id, sealed_at=NOW)
+    run_id = builder.evidence_runs[0].run_id
+    prompt_set_id = builder.prompt_evidence_sets[0].prompt_set_id
+
+    mutations = (
+        lambda: builder.record_retrieval_run(
+            stage="hybrid",
+            raw_query="secret query",
+            candidates=(_candidate(),),
+            retrieval_metadata=_metadata(),
+            started_at=NOW,
+            ended_at=NOW,
+        ),
+        lambda: builder.record_prompt_evidence_set(
+            run_id=run_id,
+            evidence=(
+                LocalPromptEvidenceCapture(
+                    candidate_rank=1,
+                    snapshot_text="[S1] MEDIA — Alpha\nExact",
+                ),
+            ),
+            created_at=NOW,
+        ),
+        lambda: builder.record_initial_answer_attempt(
+            prompt_evidence_set_id=prompt_set_id,
+            answer_body="Marker-free answer.",
+            completed_at=NOW,
+        ),
+        lambda: builder.seal(selected_attempt_id=attempt_id, sealed_at=NOW),
+    )
+    for mutation in mutations:
+        with pytest.raises(ValueError, match="sealed"):
+            mutation()

--- a/Tests/Chat/test_citation_trace_builder.py
+++ b/Tests/Chat/test_citation_trace_builder.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
+import json
+import warnings
 
 import pytest
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
+import tldw_chatbook.Chat.citation_trace_builder as builder_module
 from tldw_chatbook.Chat.citation_source_locators import CanonicalSourceKind
 from tldw_chatbook.Chat.citation_trace_builder import (
     CitationTraceBuilder,
@@ -97,6 +100,17 @@ def _record_run(builder: CitationTraceBuilder) -> str:
     )
 
 
+def _compact_model_json_bytes(model: BaseModel) -> int:
+    return len(
+        json.dumps(
+            model.model_dump(mode="json"),
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    )
+
+
 def test_local_builder_starts_empty_unsealed_and_redacts_private_context() -> None:
     builder = _builder()
 
@@ -176,6 +190,88 @@ def test_local_builder_rejects_falsy_non_datetime_created_at() -> None:
             fingerprint_codec=CitationFingerprintCodec(SECRET),
             created_at=0,  # type: ignore[arg-type]
         )
+
+
+def test_strict_revalidation_never_leaks_sensitive_values_to_warnings_or_stderr(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    identity_sentinel = "identity-secret-warning-sentinel"
+    metadata_sentinel = "metadata-secret-warning-sentinel"
+    candidate_sentinel = "candidate-secret-warning-sentinel"
+    snapshot_sentinel = "snapshot-secret-warning-sentinel"
+    forged_identity = LocalCitationIdentityContext.model_construct(
+        profile_id=[identity_sentinel],
+        local_authority_id="local-authority-1",
+        fingerprint_key_id="fingerprint-key-1",
+    )
+    forged_metadata = LocalRetrievalRunMetadata.model_construct(
+        search_mode=[metadata_sentinel],
+        requested_top_k=5,
+        max_context_characters=10_000,
+        rerank_enabled=True,
+        source_kinds=(CanonicalSourceKind.MEDIA_DB,),
+        scope_state="unscoped",
+    )
+    forged_candidate = LocalRetrievalCandidateCapture.model_construct(
+        **{
+            **_candidate().model_dump(mode="python"),
+            "source_id": [candidate_sentinel],
+        }
+    )
+    forged_snapshot = LocalPromptEvidenceCapture.model_construct(
+        candidate_rank=1,
+        snapshot_text=[snapshot_sentinel],
+        transformations=(),
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with pytest.raises(ValidationError):
+            CitationTraceBuilder.local(
+                request_id="request-1",
+                generation_id="generation-1",
+                identity_context=forged_identity,
+                fingerprint_codec=CitationFingerprintCodec(SECRET),
+                created_at=NOW,
+            )
+        with pytest.raises(ValidationError):
+            _builder().record_retrieval_run(
+                stage="hybrid",
+                raw_query="secret query",
+                candidates=(_candidate(),),
+                retrieval_metadata=forged_metadata,
+                started_at=NOW,
+                ended_at=NOW,
+            )
+        with pytest.raises(ValidationError):
+            _builder().record_retrieval_run(
+                stage="hybrid",
+                raw_query="secret query",
+                candidates=(forged_candidate,),
+                retrieval_metadata=_metadata(),
+                started_at=NOW,
+                ended_at=NOW,
+            )
+        prompt_builder = _builder()
+        run_id = _record_run(prompt_builder)
+        with pytest.raises(ValidationError):
+            prompt_builder.record_prompt_evidence_set(
+                run_id=run_id,
+                evidence=(forged_snapshot,),
+                created_at=NOW,
+            )
+
+    captured = capsys.readouterr()
+    leak_text = "\n".join(
+        [*(str(item.message) for item in caught), captured.out, captured.err]
+    )
+    for sentinel in (
+        identity_sentinel,
+        metadata_sentinel,
+        candidate_sentinel,
+        snapshot_sentinel,
+    ):
+        assert sentinel not in leak_text
 
 
 def test_local_capture_types_reject_non_local_source_families() -> None:
@@ -266,6 +362,41 @@ def test_record_retrieval_run_preserves_order_and_governs_sensitive_data(
     assert "secret query" not in caplog.text
     assert "Sensitive Alpha" not in caplog.text
     assert payload.query_fingerprint not in caplog.text
+
+
+def test_governed_payload_views_are_deep_detached_from_builder_state() -> None:
+    builder = _builder()
+    run_id = _record_run(builder)
+    returned_run_payload = builder.evidence_run_payloads[0]
+    returned_candidate = returned_run_payload.candidates[0]
+
+    returned_run_payload.retrieval_metadata["search_mode"] = "tampered"
+    returned_candidate.source_identity["source_id"] = "tampered-source"
+    returned_candidate.lineage["chunk_index"] = 999
+    builder.record_prompt_evidence_set(
+        run_id=run_id,
+        evidence=(
+            LocalPromptEvidenceCapture(
+                candidate_rank=1,
+                snapshot_text="[S1] MEDIA — Alpha\nExact",
+            ),
+        ),
+        created_at=NOW,
+    )
+
+    internal_run_payload = builder.evidence_run_payloads[0]
+    internal_snapshot = builder.evidence_snapshot_payloads[0]
+    assert internal_run_payload.retrieval_metadata["search_mode"] == "hybrid"
+    assert internal_run_payload.candidates[0].source_identity["source_id"] == "media-1"
+    assert internal_run_payload.candidates[0].lineage["chunk_index"] == 3
+    assert internal_snapshot.source_identity["source_id"] == "media-1"
+    assert internal_snapshot.lineage["chunk_index"] == 3
+
+    internal_snapshot.source_identity["source_id"] = "tampered-snapshot"
+    internal_snapshot.lineage["chunk_index"] = 777
+    fresh_snapshot = builder.evidence_snapshot_payloads[0]
+    assert fresh_snapshot.source_identity["source_id"] == "media-1"
+    assert fresh_snapshot.lineage["chunk_index"] == 3
 
 
 def test_retrieval_inputs_forbid_free_form_or_executable_metadata() -> None:
@@ -386,6 +517,23 @@ def test_invalid_retrieval_run_data_does_not_partially_mutate_state(
     assert builder.evidence_run_payloads == ()
 
 
+def test_retrieval_run_cannot_start_before_builder_creation_and_is_atomic() -> None:
+    builder = _builder()
+
+    with pytest.raises(ValueError, match="builder created_at"):
+        builder.record_retrieval_run(
+            stage="hybrid",
+            raw_query="secret query",
+            candidates=(_candidate(),),
+            retrieval_metadata=_metadata(),
+            started_at=NOW - timedelta(seconds=1),
+            ended_at=NOW,
+        )
+
+    assert builder.evidence_runs == ()
+    assert builder.evidence_run_payloads == ()
+
+
 def test_duplicate_candidate_ranks_fail_without_a_partial_run_or_payload() -> None:
     builder = _builder()
 
@@ -402,6 +550,87 @@ def test_duplicate_candidate_ranks_fail_without_a_partial_run_or_payload() -> No
             ended_at=NOW,
         )
 
+    assert builder.evidence_runs == ()
+    assert builder.evidence_run_payloads == ()
+
+
+def test_candidate_rank_cannot_exceed_requested_top_k_before_id_allocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    builder = _builder()
+    allocated_prefixes: list[str] = []
+    monkeypatch.setattr(
+        builder_module,
+        "new_opaque_id",
+        lambda prefix: allocated_prefixes.append(prefix) or f"{prefix}_unused",
+    )
+
+    with pytest.raises(ValueError, match="requested_top_k"):
+        builder.record_retrieval_run(
+            stage="hybrid",
+            raw_query="secret query",
+            candidates=(_candidate(rank=2),),
+            retrieval_metadata=_metadata().model_copy(update={"requested_top_k": 1}),
+            started_at=NOW,
+            ended_at=NOW,
+        )
+
+    assert allocated_prefixes == []
+    assert builder.evidence_runs == ()
+    assert builder.evidence_run_payloads == ()
+
+
+def test_candidate_source_kind_must_be_declared_before_id_allocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    builder = _builder()
+    allocated_prefixes: list[str] = []
+    monkeypatch.setattr(
+        builder_module,
+        "new_opaque_id",
+        lambda prefix: allocated_prefixes.append(prefix) or f"{prefix}_unused",
+    )
+    note_candidate = _candidate().model_copy(
+        update={"source_kind": CanonicalSourceKind.NOTES}
+    )
+
+    with pytest.raises(ValueError, match="metadata source_kinds"):
+        builder.record_retrieval_run(
+            stage="hybrid",
+            raw_query="secret query",
+            candidates=(note_candidate,),
+            retrieval_metadata=_metadata(),
+            started_at=NOW,
+            ended_at=NOW,
+        )
+
+    assert allocated_prefixes == []
+    assert builder.evidence_runs == ()
+    assert builder.evidence_run_payloads == ()
+
+
+def test_empty_scope_rejects_candidates_before_id_allocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    builder = _builder()
+    allocated_prefixes: list[str] = []
+    monkeypatch.setattr(
+        builder_module,
+        "new_opaque_id",
+        lambda prefix: allocated_prefixes.append(prefix) or f"{prefix}_unused",
+    )
+
+    with pytest.raises(ValueError, match="empty scope"):
+        builder.record_retrieval_run(
+            stage="hybrid",
+            raw_query="secret query",
+            candidates=(_candidate(),),
+            retrieval_metadata=_metadata().model_copy(update={"scope_state": "empty"}),
+            started_at=NOW,
+            ended_at=NOW,
+        )
+
+    assert allocated_prefixes == []
     assert builder.evidence_runs == ()
     assert builder.evidence_run_payloads == ()
 
@@ -525,6 +754,55 @@ def test_prompt_evidence_rejects_unknown_runs_zero_entries_and_duplicate_ranks()
 
 
 @pytest.mark.parametrize(
+    ("started_at", "ended_at", "prompt_created_at"),
+    [
+        (
+            NOW,
+            NOW + timedelta(seconds=2),
+            NOW + timedelta(seconds=1),
+        ),
+        (
+            NOW + timedelta(seconds=2),
+            None,
+            NOW + timedelta(seconds=1),
+        ),
+    ],
+    ids=("ended-at-boundary", "started-at-boundary"),
+)
+def test_prompt_set_cannot_precede_linked_run_terminal_boundary_and_is_atomic(
+    started_at: datetime,
+    ended_at: datetime | None,
+    prompt_created_at: datetime,
+) -> None:
+    builder = _builder()
+    run_id = builder.record_retrieval_run(
+        stage="hybrid",
+        raw_query="secret query",
+        candidates=(_candidate(),),
+        retrieval_metadata=_metadata(),
+        started_at=started_at,
+        ended_at=ended_at,
+    )
+
+    with pytest.raises(ValueError, match="run terminal boundary"):
+        builder.record_prompt_evidence_set(
+            run_id=run_id,
+            evidence=(
+                LocalPromptEvidenceCapture(
+                    candidate_rank=1,
+                    snapshot_text="[S1] MEDIA — Alpha\nExact",
+                ),
+            ),
+            created_at=prompt_created_at,
+        )
+
+    assert len(builder.evidence_runs) == 1
+    assert len(builder.evidence_run_payloads) == 1
+    assert builder.prompt_evidence_sets == ()
+    assert builder.evidence_snapshot_payloads == ()
+
+
+@pytest.mark.parametrize(
     ("evidence", "created_at", "message"),
     [
         (
@@ -621,3 +899,75 @@ def test_prompt_evidence_set_enforces_snapshot_entry_and_set_caps_atomically() -
 
     assert len(builder.prompt_evidence_sets) == PROMPT_EVIDENCE_SETS_MAX
     assert len(builder.evidence_snapshot_payloads) == snapshot_count
+
+
+def test_cumulative_run_payload_budget_accepts_exact_limit_then_rejects_overflow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    builder = _builder()
+    _record_run(builder)
+    one_run_bytes = _compact_model_json_bytes(builder.evidence_run_payloads[0])
+    monkeypatch.setattr(
+        builder_module,
+        "GOVERNED_PAYLOAD_UTF8_BYTES_MAX",
+        one_run_bytes * 2,
+        raising=False,
+    )
+
+    _record_run(builder)
+    assert len(builder.evidence_runs) == 2
+    assert len(builder.evidence_run_payloads) == 2
+
+    with pytest.raises(ValueError, match="governed payload exceeds"):
+        _record_run(builder)
+
+    assert len(builder.evidence_runs) == 2
+    assert len(builder.evidence_run_payloads) == 2
+
+
+def test_cumulative_snapshot_batch_overflow_is_atomic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    evidence = (
+        LocalPromptEvidenceCapture(
+            candidate_rank=1,
+            snapshot_text="[S1] MEDIA — Alpha\nExact first block",
+        ),
+        LocalPromptEvidenceCapture(
+            candidate_rank=2,
+            snapshot_text="[S2] MEDIA — Beta\nExact second block",
+        ),
+    )
+    measuring_builder = _builder()
+    measuring_run_id = _record_run(measuring_builder)
+    measuring_builder.record_prompt_evidence_set(
+        run_id=measuring_run_id,
+        evidence=evidence,
+        created_at=NOW,
+    )
+    snapshot_batch_bytes = sum(
+        _compact_model_json_bytes(payload)
+        for payload in measuring_builder.evidence_snapshot_payloads
+    )
+
+    builder = _builder()
+    run_id = _record_run(builder)
+    existing_run_bytes = sum(
+        _compact_model_json_bytes(payload) for payload in builder.evidence_run_payloads
+    )
+    monkeypatch.setattr(
+        builder_module,
+        "GOVERNED_PAYLOAD_UTF8_BYTES_MAX",
+        existing_run_bytes + snapshot_batch_bytes - 1,
+        raising=False,
+    )
+
+    with pytest.raises(ValueError, match="governed payload exceeds"):
+        builder.record_prompt_evidence_set(
+            run_id=run_id,
+            evidence=evidence,
+            created_at=NOW,
+        )
+
+    assert builder.prompt_evidence_sets == ()
+    assert builder.evidence_snapshot_payloads == ()

--- a/Tests/Chat/test_citation_trace_builder.py
+++ b/Tests/Chat/test_citation_trace_builder.py
@@ -1190,6 +1190,42 @@ def test_initial_answer_rejects_unknown_prompt_set_atomically() -> None:
     assert builder.answer_attempt_payloads == ()
 
 
+def test_initial_answer_rejects_non_datetime_completion_explicitly_and_atomically() -> (
+    None
+):
+    builder = _builder()
+    prompt_set_id = _record_prompt_set(builder)
+    body_sentinel = "ANSWER_COMPLETION_BODY_SENTINEL"
+
+    with pytest.raises(TypeError, match="completed_at must be a datetime") as captured:
+        builder.record_initial_answer_attempt(
+            prompt_evidence_set_id=prompt_set_id,
+            answer_body=body_sentinel,
+            completed_at="not-a-datetime",  # type: ignore[arg-type]
+        )
+
+    assert body_sentinel not in str(captured.value)
+    assert builder.answer_attempts == ()
+    assert builder.answer_attempt_payloads == ()
+
+
+def test_initial_answer_rejects_naive_completion_explicitly_and_atomically() -> None:
+    builder = _builder()
+    prompt_set_id = _record_prompt_set(builder)
+    body_sentinel = "ANSWER_COMPLETION_BODY_SENTINEL"
+
+    with pytest.raises(ValueError, match="completed_at must be timezone-aware") as captured:
+        builder.record_initial_answer_attempt(
+            prompt_evidence_set_id=prompt_set_id,
+            answer_body=body_sentinel,
+            completed_at=NOW.replace(tzinfo=None),
+        )
+
+    assert body_sentinel not in str(captured.value)
+    assert builder.answer_attempts == ()
+    assert builder.answer_attempt_payloads == ()
+
+
 def test_attempt_completion_cannot_precede_prompt_creation_and_is_atomic() -> None:
     builder = _builder()
     prompt_set_id = _record_prompt_set(builder, created_at=NOW + timedelta(seconds=1))

--- a/Tests/Chat/test_citation_trace_builder.py
+++ b/Tests/Chat/test_citation_trace_builder.py
@@ -1054,7 +1054,9 @@ def test_record_initial_answer_attempt_retains_governed_body_and_metadata() -> N
     assert attempt.attempt_id == attempt_id
     assert attempt.attempt_ordinal == 1
     assert attempt.kind is AnswerAttemptKind.INITIAL
-    assert attempt.prompt_evidence_set_id == builder.prompt_evidence_sets[0].prompt_set_id
+    assert (
+        attempt.prompt_evidence_set_id == builder.prompt_evidence_sets[0].prompt_set_id
+    )
     assert attempt.answer_payload_ref == payload.payload_id
     assert attempt.occurrences == ()
     assert attempt.created_at == NOW
@@ -1128,9 +1130,7 @@ def test_answer_body_byte_cap_rejects_initial_attempt_atomically() -> None:
     builder = _builder()
     prompt_set_id = _record_prompt_set(builder)
     sentinel = "ANSWER_BODY_SECRET_SENTINEL"
-    oversized = sentinel * (
-        (ANSWER_ATTEMPT_BODY_UTF8_BYTES_MAX // len(sentinel)) + 1
-    )
+    oversized = sentinel * ((ANSWER_ATTEMPT_BODY_UTF8_BYTES_MAX // len(sentinel)) + 1)
 
     with pytest.raises(ValueError, match="answer_body exceeds") as captured:
         builder.record_initial_answer_attempt(
@@ -1214,7 +1214,9 @@ def test_initial_answer_rejects_naive_completion_explicitly_and_atomically() -> 
     prompt_set_id = _record_prompt_set(builder)
     body_sentinel = "ANSWER_COMPLETION_BODY_SENTINEL"
 
-    with pytest.raises(ValueError, match="completed_at must be timezone-aware") as captured:
+    with pytest.raises(
+        ValueError, match="completed_at must be timezone-aware"
+    ) as captured:
         builder.record_initial_answer_attempt(
             prompt_evidence_set_id=prompt_set_id,
             answer_body=body_sentinel,
@@ -1241,7 +1243,9 @@ def test_attempt_completion_cannot_precede_prompt_creation_and_is_atomic() -> No
     assert builder.answer_attempt_payloads == ()
 
 
-def test_second_initial_answer_attempt_is_rejected_without_repair_or_rerun_api() -> None:
+def test_second_initial_answer_attempt_is_rejected_without_repair_or_rerun_api() -> (
+    None
+):
     builder, first_attempt_id = _builder_with_initial_answer()
 
     with pytest.raises(ValueError, match="initial answer attempt"):
@@ -1285,21 +1289,17 @@ def test_seal_returns_one_shot_local_immutable_write_with_fixed_linkage() -> Non
     assert trace.policy_version == TEST_POLICY_VERSION
     assert trace.policy_capabilities == TEST_POLICY_CAPABILITIES
     assert sealed_write.evidence_run_payloads == builder.evidence_run_payloads
-    assert (
-        sealed_write.evidence_snapshot_payloads
-        == builder.evidence_snapshot_payloads
-    )
+    assert sealed_write.evidence_snapshot_payloads == builder.evidence_snapshot_payloads
     assert sealed_write.answer_attempt_payloads == builder.answer_attempt_payloads
     trace_json = json.dumps(trace.model_dump(mode="json"), sort_keys=True)
     assert answer_body not in trace_json
     assert sealed_write.answer_attempt_payloads[0].body_integrity_hmac not in trace_json
     assert sealed_write.answer_attempt_payloads[0].answer_body == answer_body
-    assert (
-        sealed_write.answer_attempt_payloads[0].body_integrity_hmac
-        == CitationFingerprintCodec(SECRET).fingerprint(
-            CitationFingerprintDomain.MESSAGE_BODY,
-            answer_body,
-        )
+    assert sealed_write.answer_attempt_payloads[
+        0
+    ].body_integrity_hmac == CitationFingerprintCodec(SECRET).fingerprint(
+        CitationFingerprintDomain.MESSAGE_BODY,
+        answer_body,
     )
     persistence_retry = sealed_write
     assert persistence_retry is sealed_write

--- a/Tests/Chat/test_citation_trace_builder.py
+++ b/Tests/Chat/test_citation_trace_builder.py
@@ -167,6 +167,17 @@ def test_local_builder_rejects_invalid_request_identity_or_timestamp(
         )
 
 
+def test_local_builder_rejects_falsy_non_datetime_created_at() -> None:
+    with pytest.raises(ValidationError):
+        CitationTraceBuilder.local(
+            request_id="request-1",
+            generation_id="generation-1",
+            identity_context=_identity(),
+            fingerprint_codec=CitationFingerprintCodec(SECRET),
+            created_at=0,  # type: ignore[arg-type]
+        )
+
+
 def test_local_capture_types_reject_non_local_source_families() -> None:
     with pytest.raises(ValidationError, match="local source"):
         LocalRetrievalCandidateCapture(

--- a/Tests/Chat/test_citation_trace_builder.py
+++ b/Tests/Chat/test_citation_trace_builder.py
@@ -1,0 +1,612 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from tldw_chatbook.Chat.citation_source_locators import CanonicalSourceKind
+from tldw_chatbook.Chat.citation_trace_builder import (
+    CitationTraceBuilder,
+    LocalPromptEvidenceCapture,
+    LocalRetrievalCandidateCapture,
+    LocalRetrievalRunMetadata,
+)
+from tldw_chatbook.Chat.citation_trace_identity import (
+    CitationFingerprintCodec,
+    CitationFingerprintDomain,
+    LocalCitationIdentityContext,
+)
+from tldw_chatbook.Chat.citation_trace_models import (
+    EVIDENCE_ENTRIES_PER_PROMPT_MAX,
+    PROMPT_EVIDENCE_SETS_MAX,
+    RETRIEVAL_CANDIDATES_PER_RUN_MAX,
+    SNAPSHOT_TEXT_UTF8_BYTES_MAX,
+    EvidenceStorageMode,
+    MarkerNamespace,
+    RetrievalScoreKind,
+    RetrievalScoreScale,
+)
+
+
+NOW = datetime(2026, 7, 25, 12, 0, tzinfo=UTC)
+SECRET = b"0123456789abcdef0123456789abcdef"
+
+
+def _identity() -> LocalCitationIdentityContext:
+    return LocalCitationIdentityContext(
+        profile_id="profile-1",
+        local_authority_id="local-authority-1",
+        fingerprint_key_id="fingerprint-key-1",
+    )
+
+
+def _builder() -> CitationTraceBuilder:
+    return CitationTraceBuilder.local(
+        request_id="request-1",
+        generation_id="generation-1",
+        identity_context=_identity(),
+        fingerprint_codec=CitationFingerprintCodec(SECRET),
+        created_at=NOW,
+    )
+
+
+def _candidate(
+    *,
+    rank: int = 1,
+    source_id: str = "media-1",
+    title: str = "Alpha",
+    score: float = 0.9,
+) -> LocalRetrievalCandidateCapture:
+    return LocalRetrievalCandidateCapture(
+        candidate_rank=rank,
+        source_kind=CanonicalSourceKind.MEDIA_DB,
+        source_id=source_id,
+        title=title,
+        score_kind=RetrievalScoreKind.VECTOR_SIMILARITY,
+        score_scale=RetrievalScoreScale.ZERO_TO_ONE,
+        score=score,
+        chunk_index=3,
+        start_char=10,
+        end_char=20,
+    )
+
+
+def _metadata() -> LocalRetrievalRunMetadata:
+    return LocalRetrievalRunMetadata(
+        search_mode="hybrid",
+        requested_top_k=5,
+        max_context_characters=10_000,
+        rerank_enabled=True,
+        source_kinds=(CanonicalSourceKind.MEDIA_DB,),
+        scope_state="unscoped",
+    )
+
+
+def _record_run(builder: CitationTraceBuilder) -> str:
+    return builder.record_retrieval_run(
+        stage="hybrid",
+        raw_query="secret query",
+        candidates=(
+            _candidate(rank=1, source_id="media-1", title="Alpha"),
+            _candidate(rank=2, source_id="media-2", title="Beta"),
+        ),
+        retrieval_metadata=_metadata(),
+        started_at=NOW,
+        ended_at=NOW,
+    )
+
+
+def test_local_builder_starts_empty_unsealed_and_redacts_private_context() -> None:
+    builder = _builder()
+
+    assert builder.request_id == "request-1"
+    assert builder.generation_id == "generation-1"
+    assert builder.created_at == NOW
+    assert builder.evidence_runs == ()
+    assert builder.evidence_run_payloads == ()
+    assert builder.prompt_evidence_sets == ()
+    assert builder.evidence_snapshot_payloads == ()
+    assert builder.is_sealed is False
+    assert not hasattr(builder, "seal")
+    assert not hasattr(builder, "persist")
+    assert not hasattr(builder, "prepare_write")
+    assert SECRET.decode() not in repr(builder)
+    assert "fingerprint-key-1" not in repr(builder)
+
+
+def test_local_builder_requires_a_valid_frozen_local_identity_binding() -> None:
+    identity = _identity()
+
+    with pytest.raises(ValidationError, match="frozen"):
+        identity.profile_id = "changed"  # type: ignore[misc]
+
+    missing_profile = LocalCitationIdentityContext.model_construct(
+        profile_id="",
+        local_authority_id="local-authority-1",
+        fingerprint_key_id="fingerprint-key-1",
+    )
+    with pytest.raises((TypeError, ValueError, ValidationError), match="identifier"):
+        CitationTraceBuilder.local(
+            request_id="request-1",
+            generation_id="generation-1",
+            identity_context=missing_profile,
+            fingerprint_codec=CitationFingerprintCodec(SECRET),
+            created_at=NOW,
+        )
+    with pytest.raises(TypeError, match="identity_context"):
+        CitationTraceBuilder.local(
+            request_id="request-1",
+            generation_id="generation-1",
+            identity_context=None,  # type: ignore[arg-type]
+            fingerprint_codec=CitationFingerprintCodec(SECRET),
+            created_at=NOW,
+        )
+
+
+@pytest.mark.parametrize(
+    ("request_id", "generation_id", "created_at"),
+    [
+        ("", "generation-1", NOW),
+        ("request-1", "", NOW),
+        ("request-1", "generation-1", NOW.replace(tzinfo=None)),
+    ],
+)
+def test_local_builder_rejects_invalid_request_identity_or_timestamp(
+    request_id: str,
+    generation_id: str,
+    created_at: datetime,
+) -> None:
+    with pytest.raises((ValueError, ValidationError)):
+        CitationTraceBuilder.local(
+            request_id=request_id,
+            generation_id=generation_id,
+            identity_context=_identity(),
+            fingerprint_codec=CitationFingerprintCodec(SECRET),
+            created_at=created_at,
+        )
+
+
+def test_local_capture_types_reject_non_local_source_families() -> None:
+    with pytest.raises(ValidationError, match="local source"):
+        LocalRetrievalCandidateCapture(
+            candidate_rank=1,
+            source_kind=CanonicalSourceKind.WEB_CONTENT,
+            source_id="web-1",
+            title="Remote result",
+        )
+    with pytest.raises(ValidationError, match="local source"):
+        LocalRetrievalRunMetadata(
+            search_mode="hybrid",
+            requested_top_k=5,
+            max_context_characters=10_000,
+            rerank_enabled=False,
+            source_kinds=(CanonicalSourceKind.WEB_CONTENT,),
+            scope_state="unscoped",
+        )
+
+
+def test_record_retrieval_run_preserves_order_and_governs_sensitive_data(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    builder = _builder()
+    codec = CitationFingerprintCodec(SECRET)
+    candidates = (
+        _candidate(rank=2, source_id="media-2", title="Sensitive Beta"),
+        _candidate(rank=1, source_id="media-1", title="Sensitive Alpha"),
+    )
+
+    run_id = builder.record_retrieval_run(
+        stage="hybrid",
+        raw_query="secret query",
+        candidates=candidates,
+        retrieval_metadata=_metadata(),
+        started_at=NOW,
+        ended_at=NOW,
+    )
+
+    run = builder.evidence_runs[0]
+    payload = builder.evidence_run_payloads[0]
+    assert run.run_id == run_id
+    assert run.request_id == "request-1"
+    assert run.run_ordinal == 1
+    assert run.stage == "hybrid"
+    assert run.payload_ref == payload.payload_id
+    assert run.started_at == NOW
+    assert run.ended_at == NOW
+    assert payload.run_id == run_id
+    assert payload.raw_query is None
+    assert payload.query_fingerprint == codec.fingerprint(
+        CitationFingerprintDomain.RAW_QUERY,
+        "secret query",
+    )
+    assert payload.authority_id == "local-authority-1"
+    assert payload.retrieval_metadata == {
+        "search_mode": "hybrid",
+        "requested_top_k": 5,
+        "max_context_characters": 10_000,
+        "rerank_enabled": True,
+        "source_kinds": ["media_db"],
+        "scope_state": "unscoped",
+    }
+    assert [candidate.rank for candidate in payload.candidates] == [2, 1]
+    assert [candidate.title for candidate in payload.candidates] == [
+        "Sensitive Beta",
+        "Sensitive Alpha",
+    ]
+    assert payload.candidates[0].source_identity == {
+        "source_kind": "media_db",
+        "source_id": "media-2",
+    }
+    assert payload.candidates[0].locator == {}
+    assert payload.candidates[0].lineage == {
+        "chunk_index": 3,
+        "start_char": 10,
+        "end_char": 20,
+    }
+    assert payload.candidates[0].score_kind is RetrievalScoreKind.VECTOR_SIMILARITY
+    assert payload.candidates[0].score_scale is RetrievalScoreScale.ZERO_TO_ONE
+    dumped = payload.model_dump(mode="json")
+    assert "content" not in repr(dumped)
+    assert "secret query" not in repr(builder)
+    assert "Sensitive Alpha" not in repr(builder)
+    assert "media-1" not in repr(builder)
+    assert payload.query_fingerprint not in repr(builder)
+    assert "secret query" not in caplog.text
+    assert "Sensitive Alpha" not in caplog.text
+    assert payload.query_fingerprint not in caplog.text
+
+
+def test_retrieval_inputs_forbid_free_form_or_executable_metadata() -> None:
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        LocalRetrievalRunMetadata.model_validate(
+            {
+                **_metadata().model_dump(mode="python"),
+                "workspace_path": "/private/workspace",
+            }
+        )
+    with pytest.raises(ValidationError):
+        LocalRetrievalRunMetadata.model_validate(
+            {
+                **_metadata().model_dump(mode="python"),
+                "search_mode": "https://example.invalid/search",
+            }
+        )
+    with pytest.raises(ValidationError):
+        LocalRetrievalRunMetadata.model_validate(
+            {
+                **_metadata().model_dump(mode="python"),
+                "scope_state": "/private/workspace",
+            }
+        )
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        LocalRetrievalCandidateCapture.model_validate(
+            {
+                **_candidate().model_dump(mode="python"),
+                "content": "candidate content must not cross this boundary",
+            }
+        )
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        LocalRetrievalCandidateCapture.model_validate(
+            {
+                **_candidate().model_dump(mode="python"),
+                "metadata": {"url": "https://example.invalid"},
+            }
+        )
+    for field, value in (
+        ("source_id", "https://example.invalid/item"),
+        ("source_id", "/private/source"),
+        ("chunk_id", "../other/chunk"),
+    ):
+        with pytest.raises(ValidationError, match="executable path or URL"):
+            LocalRetrievalCandidateCapture.model_validate(
+                {
+                    **_candidate().model_dump(mode="python"),
+                    field: value,
+                }
+            )
+
+
+def test_retrieval_run_rejects_non_finite_scores_and_candidate_overflow_atomically() -> (
+    None
+):
+    builder = _builder()
+    non_finite = LocalRetrievalCandidateCapture.model_construct(
+        **{**_candidate().model_dump(mode="python"), "score": float("nan")}
+    )
+
+    with pytest.raises(ValidationError, match="finite"):
+        builder.record_retrieval_run(
+            stage="semantic",
+            raw_query="secret query",
+            candidates=(non_finite,),
+            retrieval_metadata=_metadata(),
+            started_at=NOW,
+            ended_at=NOW,
+        )
+    assert builder.evidence_runs == ()
+    assert builder.evidence_run_payloads == ()
+
+    with pytest.raises(ValueError, match="candidates"):
+        builder.record_retrieval_run(
+            stage="semantic",
+            raw_query="secret query",
+            candidates=(_candidate(),) * (RETRIEVAL_CANDIDATES_PER_RUN_MAX + 1),
+            retrieval_metadata=_metadata(),
+            started_at=NOW,
+            ended_at=NOW,
+        )
+    assert builder.evidence_runs == ()
+    assert builder.evidence_run_payloads == ()
+
+
+@pytest.mark.parametrize(
+    ("stage", "started_at", "ended_at", "message"),
+    [
+        ("", NOW, NOW, "at least 1 character"),
+        ("hybrid", NOW, NOW.replace(tzinfo=None), "timezone-aware"),
+        (
+            "hybrid",
+            NOW,
+            datetime(2026, 7, 25, 11, 59, tzinfo=UTC),
+            "must not precede",
+        ),
+    ],
+)
+def test_invalid_retrieval_run_data_does_not_partially_mutate_state(
+    stage: str,
+    started_at: datetime,
+    ended_at: datetime,
+    message: str,
+) -> None:
+    builder = _builder()
+
+    with pytest.raises(ValidationError, match=message):
+        builder.record_retrieval_run(
+            stage=stage,
+            raw_query="secret query",
+            candidates=(_candidate(),),
+            retrieval_metadata=_metadata(),
+            started_at=started_at,
+            ended_at=ended_at,
+        )
+
+    assert builder.evidence_runs == ()
+    assert builder.evidence_run_payloads == ()
+
+
+def test_duplicate_candidate_ranks_fail_without_a_partial_run_or_payload() -> None:
+    builder = _builder()
+
+    with pytest.raises(ValidationError, match="candidate rank"):
+        builder.record_retrieval_run(
+            stage="hybrid",
+            raw_query="secret query",
+            candidates=(
+                _candidate(rank=1, source_id="media-1"),
+                _candidate(rank=1, source_id="media-2"),
+            ),
+            retrieval_metadata=_metadata(),
+            started_at=NOW,
+            ended_at=NOW,
+        )
+
+    assert builder.evidence_runs == ()
+    assert builder.evidence_run_payloads == ()
+
+
+def test_record_prompt_evidence_set_preserves_exact_snapshot_bytes_and_linkage() -> (
+    None
+):
+    builder = _builder()
+    codec = CitationFingerprintCodec(SECRET)
+    run_id = _record_run(builder)
+    first_snapshot = "[S1] MEDIA — Alpha\r\nExact transformed 🧪 e\u0301"
+    second_snapshot = "[S2] MEDIA — Beta\nSecond exact block"
+
+    prompt_set_id = builder.record_prompt_evidence_set(
+        run_id=run_id,
+        evidence=(
+            LocalPromptEvidenceCapture(
+                candidate_rank=1,
+                snapshot_text=first_snapshot,
+                transformations=("heading_injected", "marker_injected"),
+            ),
+            LocalPromptEvidenceCapture(
+                candidate_rank=2,
+                snapshot_text=second_snapshot,
+                transformations=("heading_injected", "marker_injected"),
+            ),
+        ),
+        created_at=NOW,
+    )
+
+    prompt_set = builder.prompt_evidence_sets[0]
+    assert prompt_set.prompt_set_id == prompt_set_id
+    assert prompt_set.prompt_set_ordinal == 1
+    assert prompt_set.marker_namespace is MarkerNamespace.CHATBOOK_S_V1
+    assert prompt_set.created_at == NOW
+    assert [entry.evidence_ordinal for entry in prompt_set.entries] == [1, 2]
+    assert [entry.marker_ordinal for entry in prompt_set.entries] == [1, 2]
+    assert [entry.run_id for entry in prompt_set.entries] == [run_id, run_id]
+    assert all(
+        entry.storage_mode is EvidenceStorageMode.EMBEDDED
+        for entry in prompt_set.entries
+    )
+
+    first_payload, second_payload = builder.evidence_snapshot_payloads
+    assert prompt_set.entries[0].snapshot_payload_ref == first_payload.payload_id
+    assert prompt_set.entries[1].snapshot_payload_ref == second_payload.payload_id
+    assert first_payload.snapshot_text == first_snapshot
+    assert first_payload.snapshot_text.encode("utf-8") == first_snapshot.encode("utf-8")
+    assert first_payload.storage_mode is EvidenceStorageMode.EMBEDDED
+    assert first_payload.title == "Alpha"
+    assert first_payload.source_identity == {
+        "source_kind": "media_db",
+        "source_id": "media-1",
+    }
+    assert first_payload.locator == {}
+    assert first_payload.lineage == {
+        "chunk_index": 3,
+        "start_char": 10,
+        "end_char": 20,
+    }
+    assert first_payload.transformations == (
+        "heading_injected",
+        "marker_injected",
+    )
+    assert first_payload.content_hash == codec.fingerprint(
+        CitationFingerprintDomain.EXACT_PAYLOAD,
+        "exact-snapshot-v1",
+        first_snapshot.encode("utf-8"),
+    )
+    assert first_payload.comparison_hash == codec.fingerprint(
+        CitationFingerprintDomain.EXACT_PAYLOAD,
+        "comparison-nfc-lf-v1",
+        "[S1] MEDIA — Alpha\nExact transformed 🧪 é".encode("utf-8"),
+    )
+    assert second_payload.snapshot_text == second_snapshot
+    assert first_snapshot not in repr(builder)
+    assert first_payload.content_hash not in repr(builder)
+
+
+def test_prompt_evidence_rejects_unknown_runs_zero_entries_and_duplicate_ranks() -> (
+    None
+):
+    builder = _builder()
+    run_id = _record_run(builder)
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        builder.record_prompt_evidence_set(
+            run_id=run_id,
+            evidence=(),
+            created_at=NOW,
+        )
+    with pytest.raises(ValueError, match="unknown evidence run"):
+        builder.record_prompt_evidence_set(
+            run_id="missing-run",
+            evidence=(
+                LocalPromptEvidenceCapture(
+                    candidate_rank=1,
+                    snapshot_text="[S1] MEDIA — Alpha\nExact",
+                ),
+            ),
+            created_at=NOW,
+        )
+    with pytest.raises(ValueError, match="candidate_rank"):
+        builder.record_prompt_evidence_set(
+            run_id=run_id,
+            evidence=(
+                LocalPromptEvidenceCapture(
+                    candidate_rank=1,
+                    snapshot_text="[S1] MEDIA — Alpha\nExact",
+                ),
+                LocalPromptEvidenceCapture(
+                    candidate_rank=1,
+                    snapshot_text="[S2] MEDIA — Alpha\nDuplicate rank",
+                ),
+            ),
+            created_at=NOW,
+        )
+
+    assert builder.prompt_evidence_sets == ()
+    assert builder.evidence_snapshot_payloads == ()
+
+
+@pytest.mark.parametrize(
+    ("evidence", "created_at", "message"),
+    [
+        (
+            (
+                LocalPromptEvidenceCapture(
+                    candidate_rank=1,
+                    snapshot_text="[S9] MEDIA — Alpha\nWrong marker",
+                ),
+            ),
+            NOW,
+            "marker ordinal",
+        ),
+        (
+            (
+                LocalPromptEvidenceCapture(
+                    candidate_rank=1,
+                    snapshot_text="[S1] MEDIA — Alpha\nExact",
+                ),
+            ),
+            NOW.replace(tzinfo=None),
+            "timezone-aware",
+        ),
+    ],
+)
+def test_invalid_prompt_evidence_set_is_atomic(
+    evidence: tuple[LocalPromptEvidenceCapture, ...],
+    created_at: datetime,
+    message: str,
+) -> None:
+    builder = _builder()
+    run_id = _record_run(builder)
+
+    with pytest.raises((ValueError, ValidationError), match=message):
+        builder.record_prompt_evidence_set(
+            run_id=run_id,
+            evidence=evidence,
+            created_at=created_at,
+        )
+
+    assert builder.prompt_evidence_sets == ()
+    assert builder.evidence_snapshot_payloads == ()
+
+
+def test_prompt_evidence_set_enforces_snapshot_entry_and_set_caps_atomically() -> None:
+    builder = _builder()
+    run_id = _record_run(builder)
+    oversized = LocalPromptEvidenceCapture.model_construct(
+        candidate_rank=1,
+        snapshot_text="[S1] " + ("é" * SNAPSHOT_TEXT_UTF8_BYTES_MAX),
+        transformations=(),
+    )
+
+    with pytest.raises(ValidationError, match="snapshot_text exceeds"):
+        builder.record_prompt_evidence_set(
+            run_id=run_id,
+            evidence=(oversized,),
+            created_at=NOW,
+        )
+    with pytest.raises(ValueError, match="evidence entries"):
+        builder.record_prompt_evidence_set(
+            run_id=run_id,
+            evidence=tuple(
+                LocalPromptEvidenceCapture(
+                    candidate_rank=1,
+                    snapshot_text=f"[S{ordinal}] MEDIA — Alpha\nExact",
+                )
+                for ordinal in range(1, EVIDENCE_ENTRIES_PER_PROMPT_MAX + 2)
+            ),
+            created_at=NOW,
+        )
+    assert builder.prompt_evidence_sets == ()
+    assert builder.evidence_snapshot_payloads == ()
+
+    single = (
+        LocalPromptEvidenceCapture(
+            candidate_rank=1,
+            snapshot_text="[S1] MEDIA — Alpha\nExact",
+        ),
+    )
+    for _ in range(PROMPT_EVIDENCE_SETS_MAX):
+        builder.record_prompt_evidence_set(
+            run_id=run_id,
+            evidence=single,
+            created_at=NOW,
+        )
+    snapshot_count = len(builder.evidence_snapshot_payloads)
+
+    with pytest.raises(ValueError, match="prompt evidence sets"):
+        builder.record_prompt_evidence_set(
+            run_id=run_id,
+            evidence=single,
+            created_at=NOW,
+        )
+
+    assert len(builder.prompt_evidence_sets) == PROMPT_EVIDENCE_SETS_MAX
+    assert len(builder.evidence_snapshot_payloads) == snapshot_count

--- a/Tests/Chat/test_citation_trace_repository.py
+++ b/Tests/Chat/test_citation_trace_repository.py
@@ -407,6 +407,54 @@ def test_local_trace_builder_canonical_capture_returns_request_scoped_builder(
     assert builder.prompt_evidence_sets == ()
 
 
+def test_repository_factory_owns_fixed_closed_retrieval_policy(
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = _repository(db)
+    sentinel = object()
+    captured: dict[str, object] = {}
+
+    def capture_local_builder(
+        cls: type[CitationTraceBuilder],
+        **kwargs: object,
+    ) -> object:
+        del cls
+        captured.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(
+        CitationTraceBuilder,
+        "local",
+        classmethod(capture_local_builder),
+    )
+
+    result = repository.create_local_trace_builder(
+        request_id="request-policy",
+        generation_id="generation-policy",
+    )
+
+    assert result is sentinel
+    assert captured["policy_version"] == "local-prompt-provenance-v1"
+    assert captured["policy_capabilities"] == (
+        PolicyCapability.VIEW_SNAPSHOT,
+        PolicyCapability.VIEW_SOURCE_IDENTITY,
+    )
+    assert PolicyCapability.RESOLVE_CURRENT_SOURCE not in captured[
+        "policy_capabilities"
+    ]
+    assert PolicyCapability.OPEN_NATIVE not in captured["policy_capabilities"]
+    assert PolicyCapability.OPEN_EXTERNAL not in captured["policy_capabilities"]
+    assert set(captured) == {
+        "request_id",
+        "generation_id",
+        "identity_context",
+        "fingerprint_codec",
+        "policy_version",
+        "policy_capabilities",
+    }
+
+
 def test_local_trace_builder_canonical_capture_without_injected_identity_returns_none(
     db: CharactersRAGDB,
 ) -> None:

--- a/Tests/Chat/test_citation_trace_repository.py
+++ b/Tests/Chat/test_citation_trace_repository.py
@@ -27,6 +27,7 @@ from tldw_chatbook.Chat.citation_trace_identity import (
     LocalCitationIdentityContext,
     local_trace_namespace,
 )
+from tldw_chatbook.Chat.citation_trace_builder import CitationTraceBuilder
 from tldw_chatbook.Chat.citation_trace_models import (
     AnswerAttempt,
     AnswerAttemptKind,
@@ -358,6 +359,149 @@ def test_repository_composition_never_loads_a_key_while_writes_are_disabled(
     ):
         repository.prepare_write(_sealed_write())
     assert provider.calls == []
+
+
+def test_local_trace_builder_disabled_returns_before_identity_read(
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = _repository(db, enabled=False)
+    identity_reads = 0
+
+    def fail_on_identity_read(_db: CharactersRAGDB) -> None:
+        nonlocal identity_reads
+        identity_reads += 1
+        raise AssertionError("disabled capture must not read identity")
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Chat.citation_trace_repository."
+        "load_local_citation_identity_context",
+        fail_on_identity_read,
+    )
+
+    assert (
+        repository.create_local_trace_builder(
+            request_id="request-disabled",
+            generation_id="generation-disabled",
+        )
+        is None
+    )
+    assert identity_reads == 0
+
+
+def test_local_trace_builder_canonical_capture_returns_request_scoped_builder(
+    db: CharactersRAGDB,
+) -> None:
+    repository = _repository(db)
+
+    builder = repository.create_local_trace_builder(
+        request_id="request-capture",
+        generation_id="generation-capture",
+    )
+
+    assert isinstance(builder, CitationTraceBuilder)
+    assert builder.request_id == "request-capture"
+    assert builder.generation_id == "generation-capture"
+    assert builder.is_sealed is False
+    assert builder.evidence_runs == ()
+    assert builder.prompt_evidence_sets == ()
+
+
+def test_local_trace_builder_canonical_capture_without_injected_identity_returns_none(
+    db: CharactersRAGDB,
+) -> None:
+    repository = CitationTraceRepository(
+        db,
+        policy=CitationProvenanceRuntimePolicy(canonical_writes_enabled=True),
+        identity_context=None,
+        fingerprint_codec=TEST_FINGERPRINT_CODEC,
+    )
+
+    assert (
+        repository.create_local_trace_builder(
+            request_id="request-no-identity",
+            generation_id="generation-no-identity",
+        )
+        is None
+    )
+
+
+def test_local_trace_builder_canonical_capture_without_codec_returns_none(
+    db: CharactersRAGDB,
+) -> None:
+    repository = CitationTraceRepository(
+        db,
+        policy=CitationProvenanceRuntimePolicy(canonical_writes_enabled=True),
+        identity_context=_identity(db),
+        fingerprint_codec=None,
+    )
+
+    assert (
+        repository.create_local_trace_builder(
+            request_id="request-no-codec",
+            generation_id="generation-no-codec",
+        )
+        is None
+    )
+
+
+def test_local_trace_builder_canonical_capture_without_persisted_identity_returns_none(
+    db: CharactersRAGDB,
+) -> None:
+    repository = _repository(db)
+    with db.transaction() as cursor:
+        cursor.execute(
+            "DELETE FROM rag_identity_context WHERE context_name = 'default'"
+        )
+
+    assert (
+        repository.create_local_trace_builder(
+            request_id="request-no-persisted-identity",
+            generation_id="generation-no-persisted-identity",
+        )
+        is None
+    )
+
+
+def test_local_trace_builder_canonical_capture_identity_mismatch_returns_none(
+    db: CharactersRAGDB,
+) -> None:
+    mismatched = _identity(db).model_copy(
+        update={"local_authority_id": "replacement-authority"}
+    )
+    repository = _repository(db, identity=mismatched)
+
+    assert (
+        repository.create_local_trace_builder(
+            request_id="request-identity-mismatch",
+            generation_id="generation-identity-mismatch",
+        )
+        is None
+    )
+
+
+def test_local_trace_builder_canonical_capture_identity_read_failure_returns_none(
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = _repository(db)
+
+    def fail_identity_read(_db: CharactersRAGDB) -> None:
+        raise sqlite3.DatabaseError("identity table unreadable")
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Chat.citation_trace_repository."
+        "load_local_citation_identity_context",
+        fail_identity_read,
+    )
+
+    assert (
+        repository.create_local_trace_builder(
+            request_id="request-identity-read-failure",
+            generation_id="generation-identity-read-failure",
+        )
+        is None
+    )
 
 
 def test_missing_existing_key_is_not_silently_provisioned_or_replaced(

--- a/Tests/Chat/test_citation_trace_repository.py
+++ b/Tests/Chat/test_citation_trace_repository.py
@@ -546,9 +546,9 @@ def test_repository_factory_owns_fixed_closed_retrieval_policy(
         PolicyCapability.VIEW_SNAPSHOT,
         PolicyCapability.VIEW_SOURCE_IDENTITY,
     )
-    assert PolicyCapability.RESOLVE_CURRENT_SOURCE not in captured[
-        "policy_capabilities"
-    ]
+    assert (
+        PolicyCapability.RESOLVE_CURRENT_SOURCE not in captured["policy_capabilities"]
+    )
     assert PolicyCapability.OPEN_NATIVE not in captured["policy_capabilities"]
     assert PolicyCapability.OPEN_EXTERNAL not in captured["policy_capabilities"]
     assert set(captured) == {

--- a/Tests/Chat/test_citation_trace_repository.py
+++ b/Tests/Chat/test_citation_trace_repository.py
@@ -361,6 +361,112 @@ def test_repository_composition_never_loads_a_key_while_writes_are_disabled(
     assert provider.calls == []
 
 
+def test_local_citation_writes_ready_requires_matching_persisted_identity(
+    db: CharactersRAGDB,
+) -> None:
+    repository = _repository(db)
+
+    assert repository.local_citation_writes_ready is True
+    with pytest.raises(AttributeError):
+        repository.local_citation_writes_ready = False  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    "unready_reason",
+    (
+        "disabled",
+        "missing_identity",
+        "missing_codec",
+        "missing_persisted_identity",
+        "mismatched_identity",
+    ),
+)
+def test_local_citation_writes_ready_fails_closed_for_unready_composition(
+    db: CharactersRAGDB,
+    unready_reason: str,
+) -> None:
+    identity = _identity(db)
+    enabled = unready_reason != "disabled"
+    injected_identity = (
+        None
+        if unready_reason == "missing_identity"
+        else identity.model_copy(
+            update={"local_authority_id": "mismatched-local-authority"}
+        )
+        if unready_reason == "mismatched_identity"
+        else identity
+    )
+    codec = None if unready_reason == "missing_codec" else TEST_FINGERPRINT_CODEC
+    repository = CitationTraceRepository(
+        db,
+        policy=CitationProvenanceRuntimePolicy(
+            canonical_writes_enabled=enabled,
+        ),
+        identity_context=injected_identity,
+        fingerprint_codec=codec,
+    )
+    if unready_reason == "missing_persisted_identity":
+        with db.transaction() as cursor:
+            cursor.execute(
+                "DELETE FROM rag_identity_context WHERE context_name = 'default'"
+            )
+
+    assert repository.local_citation_writes_ready is False
+
+
+def test_local_citation_writes_ready_identity_read_failure_is_content_free(
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repository = _repository(db)
+    governed_identity = "governed-authority-do-not-log"
+    exception_text = "identity-read-exception-do-not-log"
+
+    def fail_identity_read(_db: CharactersRAGDB) -> None:
+        raise sqlite3.DatabaseError(f"{exception_text}: {governed_identity}")
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Chat.citation_trace_repository."
+        "load_local_citation_identity_context",
+        fail_identity_read,
+    )
+
+    assert repository.local_citation_writes_ready is False
+    captured = capsys.readouterr()
+    output = f"{captured.out}\n{captured.err}"
+    assert governed_identity not in output
+    assert exception_text not in output
+
+
+def test_create_local_trace_builder_uses_local_citation_writes_ready_contract(
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = _repository(db)
+    readiness_reads = 0
+
+    def unready(_repository: CitationTraceRepository) -> bool:
+        nonlocal readiness_reads
+        readiness_reads += 1
+        return False
+
+    monkeypatch.setattr(
+        CitationTraceRepository,
+        "local_citation_writes_ready",
+        property(unready),
+    )
+
+    assert (
+        repository.create_local_trace_builder(
+            request_id="request-shared-readiness",
+            generation_id="generation-shared-readiness",
+        )
+        is None
+    )
+    assert readiness_reads == 1
+
+
 def test_local_trace_builder_disabled_returns_before_identity_read(
     db: CharactersRAGDB,
     monkeypatch: pytest.MonkeyPatch,

--- a/Tests/Chat/test_console_local_citation_boundary.py
+++ b/Tests/Chat/test_console_local_citation_boundary.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import gc
+import weakref
+from types import SimpleNamespace
+
+import pytest
+from loguru import logger as loguru_logger
+
+from tldw_chatbook.Agents.agent_models import RUN_DONE, RunOutcome
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+
+
+class _RequestBuilder:
+    pass
+
+
+class _RecordingGateway:
+    def __init__(self, builder_ref=None):
+        self.builder_ref = builder_ref
+        self.messages_seen = None
+
+    async def resolve_for_send(self, _selection):
+        return SimpleNamespace(
+            ready=True,
+            visible_copy="",
+            provider="llama_cpp",
+            model="test-model",
+            max_tokens=128,
+        )
+
+    async def stream_chat(self, _resolution, messages):
+        if self.builder_ref is not None:
+            assert self.builder_ref() is not None
+        self.messages_seen = messages
+        yield "answer"
+
+
+def _persisted_store() -> ConsoleChatStore:
+    store = ConsoleChatStore()
+    session = store.ensure_session()
+    session.persisted_conversation_id = "conversation-1"
+    return store
+
+
+def _final_user_content(messages) -> str:
+    return next(
+        message["content"]
+        for message in reversed(messages)
+        if message["role"] == ConsoleMessageRole.USER.value
+    )
+
+
+@pytest.mark.asyncio
+async def test_console_canonical_evidence_is_added_after_prompt_transforms_and_builder_is_local():
+    ordinary_prompt = "ORDINARY_PROMPT_SENTINEL_TASK_553_13"
+    transformed_prompt = "TRANSFORMED_PROMPT_SENTINEL_TASK_553_13"
+    evidence_title = "EVIDENCE_TITLE_SENTINEL_TASK_553_13"
+    evidence_body = "  EVIDENCE_BODY_SENTINEL_TASK_553_13  \n\t"
+    canonical_context = f"[S1] MEDIA — {evidence_title}\n{evidence_body}"
+    builder_holder = [_RequestBuilder()]
+    builder_ref = weakref.ref(builder_holder[0])
+
+    async def capture(_draft):
+        return SimpleNamespace(
+            context=canonical_context,
+            citation_builder=builder_holder.pop(),
+        )
+
+    def apply_dictionary(_conversation_id, text):
+        return (
+            text.replace(ordinary_prompt, transformed_prompt)
+            .replace(evidence_title, "MUTATED_EVIDENCE_TITLE")
+            .replace(evidence_body, "MUTATED_EVIDENCE_BODY")
+        )
+
+    store = _persisted_store()
+    gateway = _RecordingGateway(builder_ref)
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        chat_dictionary_applier=apply_dictionary,
+        rag_capture_provider=capture,
+        agent_runtime_enabled=False,
+    )
+
+    result = await controller.submit_draft(ordinary_prompt)
+
+    assert result.accepted is True
+    stored_user = next(
+        message
+        for message in store.messages_for_session(store.active_session_id)
+        if message.role is ConsoleMessageRole.USER
+    )
+    assert stored_user.content == ordinary_prompt
+    provider_user = _final_user_content(gateway.messages_seen)
+    assert provider_user == (
+        f"Evidence: {canonical_context}\n\n---\n\n{transformed_prompt}"
+    )
+    assert "MUTATED_EVIDENCE_TITLE" not in provider_user
+    assert "MUTATED_EVIDENCE_BODY" not in provider_user
+    assert evidence_body.encode("utf-8") in provider_user.encode("utf-8")
+
+    gc.collect()
+    assert builder_ref() is None
+
+
+@pytest.mark.asyncio
+async def test_console_without_builder_keeps_compatibility_transform_order():
+    context = "[S1] MEDIA — LEGACY_EVIDENCE_TITLE\nlegacy evidence body"
+
+    async def capture(_draft):
+        return SimpleNamespace(context=context, citation_builder=None)
+
+    def apply_dictionary(_conversation_id, text):
+        return text.replace("legacy evidence body", "transformed evidence body")
+
+    store = _persisted_store()
+    gateway = _RecordingGateway()
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        chat_dictionary_applier=apply_dictionary,
+        rag_capture_provider=capture,
+        agent_runtime_enabled=False,
+    )
+
+    result = await controller.submit_draft("question")
+
+    assert result.accepted is True
+    assert _final_user_content(gateway.messages_seen) == (
+        "Evidence: [S1] MEDIA — LEGACY_EVIDENCE_TITLE\n"
+        "transformed evidence body\n\n---\n\nquestion"
+    )
+
+
+@pytest.mark.asyncio
+async def test_console_canonical_evidence_reaches_agent_and_keeps_builder_alive():
+    context = "[S1] MEDIA — Agent source\nexact agent evidence"
+    builder_holder = [_RequestBuilder()]
+    builder_ref = weakref.ref(builder_holder[0])
+
+    async def capture(_draft):
+        return SimpleNamespace(
+            context=context,
+            citation_builder=builder_holder.pop(),
+        )
+
+    bridge_calls = []
+
+    def run_reply(**kwargs):
+        assert builder_ref() is not None
+        bridge_calls.append(kwargs)
+        return "run-test", RunOutcome(
+            status=RUN_DONE,
+            steps=[],
+            final_text="agent answer",
+        )
+
+    store = _persisted_store()
+    gateway = _RecordingGateway()
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        rag_capture_provider=capture,
+        agent_runtime_enabled=True,
+    )
+    controller._agent_bridge = SimpleNamespace(run_reply=run_reply)
+
+    result = await controller.submit_draft("question")
+
+    assert result.accepted is True
+    assert len(bridge_calls) == 1
+    assert _final_user_content(bridge_calls[0]["agent_messages"]) == (
+        f"Evidence: {context}\n\n---\n\nquestion"
+    )
+    assert gateway.messages_seen is None
+    gc.collect()
+    assert builder_ref() is None
+
+
+def test_prepend_evidence_context_preserves_multimodal_parts_and_input():
+    original = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "question"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,abc"},
+                },
+            ],
+        }
+    ]
+
+    updated = ConsoleChatController._prepend_evidence_context(
+        original,
+        "[S1] MEDIA — Image source\nimage evidence",
+    )
+
+    assert updated[0]["content"][0]["text"] == (
+        "Evidence: [S1] MEDIA — Image source\nimage evidence\n\n---\n\nquestion"
+    )
+    assert updated[0]["content"][1] == original[0]["content"][1]
+    assert original[0]["content"][0]["text"] == "question"
+
+
+@pytest.mark.asyncio
+async def test_console_capture_failure_logs_no_sensitive_text_and_sends_without_evidence():
+    failure_sentinel = "CAPTURE_FAILURE_SENTINEL_TASK_553_13"
+
+    async def capture(_draft):
+        raise ValueError(failure_sentinel)
+
+    captured_logs = []
+    sink_id = loguru_logger.add(
+        captured_logs.append,
+        level="DEBUG",
+        format="{message}",
+    )
+    try:
+        store = _persisted_store()
+        gateway = _RecordingGateway()
+        controller = ConsoleChatController(
+            store=store,
+            provider_gateway=gateway,
+            rag_capture_provider=capture,
+            agent_runtime_enabled=False,
+        )
+
+        result = await controller.submit_draft("question")
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert result.accepted is True
+    assert _final_user_content(gateway.messages_seen) == "question"
+    assert failure_sentinel not in "".join(str(message) for message in captured_logs)

--- a/Tests/Chat/test_console_local_citation_boundary.py
+++ b/Tests/Chat/test_console_local_citation_boundary.py
@@ -249,6 +249,36 @@ def _final_user_content(messages) -> str:
 
 
 @pytest.mark.asyncio
+async def test_capture_provider_failure_logs_only_structural_context():
+    async def capture(_draft):
+        raise RuntimeError(_PRIVATE_EXCEPTION)
+
+    controller = ConsoleChatController(
+        store=_persisted_store(),
+        provider_gateway=_RecordingGateway(),
+        rag_capture_provider=capture,
+        agent_runtime_enabled=False,
+    )
+    captured_logs = []
+    sink_id = loguru_logger.add(
+        captured_logs.append,
+        level="DEBUG",
+        format="{message}",
+    )
+    try:
+        captured = await controller._capture_rag_context(_PRIVATE_QUERY)
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert captured == (None, None, None)
+    rendered_logs = "".join(str(message) for message in captured_logs)
+    assert "reason=capture_provider_failure" in rendered_logs
+    assert f"draft_length={len(_PRIVATE_QUERY)}" in rendered_logs
+    assert _PRIVATE_QUERY not in rendered_logs
+    assert _PRIVATE_EXCEPTION not in rendered_logs
+
+
+@pytest.mark.asyncio
 async def test_console_canonical_evidence_is_added_after_prompt_transforms_and_builder_is_local():
     ordinary_prompt = "ORDINARY_PROMPT_SENTINEL_TASK_553_13"
     transformed_prompt = "TRANSFORMED_PROMPT_SENTINEL_TASK_553_13"

--- a/Tests/Chat/test_console_local_citation_boundary.py
+++ b/Tests/Chat/test_console_local_citation_boundary.py
@@ -1,15 +1,43 @@
 from __future__ import annotations
 
 import gc
+import asyncio
+import threading
+import time
 import weakref
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from loguru import logger as loguru_logger
 
-from tldw_chatbook.Agents.agent_models import RUN_DONE, RunOutcome
+from tldw_chatbook.Agents.agent_models import (
+    RUN_CANCELLED,
+    RUN_DONE,
+    RUN_ERROR,
+    RunOutcome,
+)
+from tldw_chatbook.Chat.citation_source_locators import CanonicalSourceKind
+from tldw_chatbook.Chat.citation_trace_builder import (
+    CitationTraceBuilder,
+    LocalPromptEvidenceCapture,
+    LocalRetrievalCandidateCapture,
+    LocalRetrievalRunMetadata,
+)
+from tldw_chatbook.Chat.citation_trace_identity import (
+    CitationFingerprintCodec,
+    LocalCitationIdentityContext,
+)
+from tldw_chatbook.Chat.citation_trace_models import (
+    PolicyCapability,
+    RetrievalScoreKind,
+    RetrievalScoreScale,
+    SealedCitationWrite,
+)
 from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
 from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
 
 
@@ -17,9 +45,133 @@ class _RequestBuilder:
     pass
 
 
+class _WeakCitationBuilder(CitationTraceBuilder):
+    """Real citation builder that remains weak-referenceable for lifecycle tests."""
+
+    __slots__ = ("__weakref__",)
+
+
+_PRIVATE_QUERY = "PRIVATE_QUERY_SENTINEL_TASK_553_14"
+_PRIVATE_TITLE = "PRIVATE_TITLE_SENTINEL_TASK_553_14"
+_PRIVATE_SNAPSHOT = "PRIVATE_SNAPSHOT_SENTINEL_TASK_553_14"
+_PRIVATE_EXCEPTION = "PRIVATE_EXCEPTION_SENTINEL_TASK_553_14"
+_MISSING = object()
+
+
+def _citation_builder(
+    *,
+    weak_referenceable: bool = False,
+) -> tuple[CitationTraceBuilder, str]:
+    now = datetime.now(UTC) - timedelta(seconds=2)
+    builder_type = _WeakCitationBuilder if weak_referenceable else CitationTraceBuilder
+    builder = builder_type.local(
+        request_id="request-console-terminal",
+        generation_id="generation-console-terminal",
+        identity_context=LocalCitationIdentityContext(
+            profile_id="profile-console-terminal",
+            local_authority_id="authority-console-terminal",
+            fingerprint_key_id="fingerprint-console-terminal",
+        ),
+        fingerprint_codec=CitationFingerprintCodec(b"0123456789abcdef0123456789abcdef"),
+        policy_version="console-terminal-policy-v1",
+        policy_capabilities=(
+            PolicyCapability.VIEW_SNAPSHOT,
+            PolicyCapability.VIEW_SOURCE_IDENTITY,
+        ),
+        created_at=now,
+    )
+    run_id = builder.record_retrieval_run(
+        stage="hybrid",
+        raw_query=_PRIVATE_QUERY,
+        candidates=(
+            LocalRetrievalCandidateCapture(
+                candidate_rank=1,
+                source_kind=CanonicalSourceKind.MEDIA_DB,
+                source_id="media-console-terminal",
+                title=_PRIVATE_TITLE,
+                score_kind=RetrievalScoreKind.VECTOR_SIMILARITY,
+                score_scale=RetrievalScoreScale.ZERO_TO_ONE,
+                score=0.9,
+                chunk_id="chunk-console-terminal",
+            ),
+        ),
+        retrieval_metadata=LocalRetrievalRunMetadata(
+            search_mode="hybrid",
+            requested_top_k=1,
+            max_context_characters=1_000,
+            rerank_enabled=False,
+            source_kinds=(CanonicalSourceKind.MEDIA_DB,),
+            scope_state="unscoped",
+        ),
+        started_at=now,
+        ended_at=now,
+    )
+    prompt_id = builder.record_prompt_evidence_set(
+        run_id=run_id,
+        evidence=(
+            LocalPromptEvidenceCapture(
+                candidate_rank=1,
+                snapshot_text=f"[S1] {_PRIVATE_SNAPSHOT}",
+            ),
+        ),
+        created_at=now,
+    )
+    return builder, prompt_id
+
+
+class _ReadyCitationPersistence:
+    canonical_citation_writes_ready = True
+    db = None
+
+    def __init__(self) -> None:
+        self.create_calls: list[dict[str, Any]] = []
+
+    def create_conversation(self, **_kwargs: Any) -> str:
+        return "conversation-1"
+
+    def create_message(
+        self,
+        *,
+        conversation_id: str,
+        sender: str,
+        content: str,
+        image_data: bytes | None,
+        image_mime_type: str | None,
+        message_id: str | None = None,
+        parent_message_id: str | None = None,
+        feedback: str | None = None,
+        citation_write: SealedCitationWrite | None | object = _MISSING,
+    ) -> str:
+        call = {
+            "conversation_id": conversation_id,
+            "sender": sender,
+            "content": content,
+            "image_data": image_data,
+            "image_mime_type": image_mime_type,
+            "message_id": message_id,
+            "parent_message_id": parent_message_id,
+            "feedback": feedback,
+        }
+        if citation_write is not _MISSING:
+            call["citation_write"] = citation_write
+        self.create_calls.append(call)
+        return message_id or f"persisted-{len(self.create_calls)}"
+
+    def update_message_content(self, **_kwargs: Any) -> bool:
+        return True
+
+
 class _RecordingGateway:
-    def __init__(self, builder_ref=None):
+    def __init__(
+        self,
+        builder_ref=None,
+        *,
+        chunks: tuple[str, ...] = ("answer",),
+        error: BaseException | None = None,
+    ):
         self.builder_ref = builder_ref
+        self.chunks = chunks
+        self.error = error
         self.messages_seen = None
 
     async def resolve_for_send(self, _selection):
@@ -35,14 +187,57 @@ class _RecordingGateway:
         if self.builder_ref is not None:
             assert self.builder_ref() is not None
         self.messages_seen = messages
-        yield "answer"
+        for chunk in self.chunks:
+            yield chunk
+        if self.error is not None:
+            raise self.error
 
 
-def _persisted_store() -> ConsoleChatStore:
-    store = ConsoleChatStore()
-    session = store.ensure_session()
+def _persisted_store(
+    persistence: _ReadyCitationPersistence | None = None,
+) -> ConsoleChatStore:
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.ensure_session(
+        settings=ConsoleSessionSettings(provider="llama_cpp")
+    )
     session.persisted_conversation_id = "conversation-1"
     return store
+
+
+def _capture_result(
+    builder: CitationTraceBuilder,
+    prompt_id: str,
+    *,
+    context: Any = "[S1] MEDIA — Source\nExact evidence",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        context=context,
+        citation_builder=builder,
+        prompt_evidence_set_id=prompt_id,
+    )
+
+
+def _assistant(store: ConsoleChatStore):
+    return next(
+        message
+        for message in store.messages_for_session(store.active_session_id)
+        if message.role is ConsoleMessageRole.ASSISTANT
+    )
+
+
+def _citation_calls(
+    persistence: _ReadyCitationPersistence,
+) -> list[dict[str, Any]]:
+    return [
+        call
+        for call in persistence.create_calls
+        if call.get("citation_write") is not None
+    ]
+
+
+def _assert_no_terminal_state(store: ConsoleChatStore) -> None:
+    assert store._terminal_citation_finalizers == {}
+    assert store._terminal_persistence_deferred_ids == set()
 
 
 def _final_user_content(messages) -> str:
@@ -60,13 +255,16 @@ async def test_console_canonical_evidence_is_added_after_prompt_transforms_and_b
     evidence_title = "EVIDENCE_TITLE_SENTINEL_TASK_553_13"
     evidence_body = "  EVIDENCE_BODY_SENTINEL_TASK_553_13  \n\t"
     canonical_context = f"[S1] MEDIA — {evidence_title}\n{evidence_body}"
-    builder_holder = [_RequestBuilder()]
+    builder, prompt_id = _citation_builder(weak_referenceable=True)
+    builder_holder = [builder]
     builder_ref = weakref.ref(builder_holder[0])
+    del builder
 
     async def capture(_draft):
         return SimpleNamespace(
             context=canonical_context,
             citation_builder=builder_holder.pop(),
+            prompt_evidence_set_id=prompt_id,
         )
 
     def apply_dictionary(_conversation_id, text):
@@ -139,13 +337,16 @@ async def test_console_without_builder_keeps_compatibility_transform_order():
 @pytest.mark.asyncio
 async def test_console_canonical_evidence_reaches_agent_and_keeps_builder_alive():
     context = "[S1] MEDIA — Agent source\nexact agent evidence"
-    builder_holder = [_RequestBuilder()]
+    builder, prompt_id = _citation_builder(weak_referenceable=True)
+    builder_holder = [builder]
     builder_ref = weakref.ref(builder_holder[0])
+    del builder
 
     async def capture(_draft):
         return SimpleNamespace(
             context=context,
             citation_builder=builder_holder.pop(),
+            prompt_evidence_set_id=prompt_id,
         )
 
     bridge_calls = []
@@ -153,6 +354,7 @@ async def test_console_canonical_evidence_reaches_agent_and_keeps_builder_alive(
     def run_reply(**kwargs):
         assert builder_ref() is not None
         bridge_calls.append(kwargs)
+        store.append_stream_chunk(kwargs["assistant_message_id"], "agent answer")
         return "run-test", RunOutcome(
             status=RUN_DONE,
             steps=[],
@@ -237,3 +439,631 @@ async def test_console_capture_failure_logs_no_sensitive_text_and_sends_without_
     assert result.accepted is True
     assert _final_user_content(gateway.messages_seen) == "question"
     assert failure_sentinel not in "".join(str(message) for message in captured_logs)
+
+
+@pytest.mark.asyncio
+async def test_direct_initial_rag_success_seals_exact_materialized_body_once():
+    body = "Exact direct answer 🧪\nacross chunk boundaries."
+    builder, prompt_id = _citation_builder()
+    persistence = _ReadyCitationPersistence()
+    store = _persisted_store(persistence)
+    gateway = _RecordingGateway(
+        chunks=("Exact direct ", "answer 🧪\n", "across chunk boundaries.")
+    )
+
+    async def capture(_draft):
+        return _capture_result(builder, prompt_id)
+
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        rag_capture_provider=capture,
+        agent_runtime_enabled=False,
+    )
+
+    result = await controller.submit_draft("question")
+
+    assistant = _assistant(store)
+    citation_calls = _citation_calls(persistence)
+    assert result.accepted is True
+    assert assistant.content == body
+    assert assistant.persisted_message_id == assistant.id
+    assert len(citation_calls) == 1
+    assert citation_calls[0]["content"] == assistant.content
+    assert citation_calls[0]["message_id"] == assistant.id
+    write = citation_calls[0]["citation_write"]
+    assert isinstance(write, SealedCitationWrite)
+    assert write.answer_attempt_payloads[0].answer_body == assistant.content
+    assert write.trace.answer_attempts[0].prompt_evidence_set_id == prompt_id
+    assert builder.is_sealed is True
+    assert len(builder.answer_attempts) == 1
+    _assert_no_terminal_state(store)
+
+
+@pytest.mark.asyncio
+async def test_direct_initial_rag_prefill_seals_exact_prefill_plus_stream_body():
+    builder, prompt_id = _citation_builder()
+    persistence = _ReadyCitationPersistence()
+    store = _persisted_store(persistence)
+    store.set_session_pinned_prefill(store.active_session_id, "Prefill: ")
+    gateway = _RecordingGateway(chunks=("streamed ", "answer"))
+
+    async def capture(_draft):
+        return _capture_result(builder, prompt_id)
+
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        rag_capture_provider=capture,
+        agent_runtime_enabled=False,
+    )
+
+    await controller.submit_draft("question")
+
+    assistant = _assistant(store)
+    citation_calls = _citation_calls(persistence)
+    assert assistant.content == "Prefill: streamed answer"
+    assert len(citation_calls) == 1
+    assert citation_calls[0]["content"] == assistant.content
+    assert (
+        citation_calls[0]["citation_write"].answer_attempt_payloads[0].answer_body
+        == assistant.content
+    )
+    _assert_no_terminal_state(store)
+
+
+@pytest.mark.parametrize(
+    "body",
+    (
+        "Native marker [S1] remains ordinary.",
+        "Native markers [S1] and [S2] remain ordinary.",
+    ),
+)
+@pytest.mark.asyncio
+async def test_direct_marker_answer_uses_ordinary_stable_persistence_and_fixed_diagnostic(
+    body: str,
+):
+    builder, prompt_id = _citation_builder()
+    persistence = _ReadyCitationPersistence()
+    store = _persisted_store(persistence)
+
+    async def capture(_draft):
+        return _capture_result(builder, prompt_id)
+
+    captured_logs: list[Any] = []
+    sink_id = loguru_logger.add(captured_logs.append, format="{message}", level="DEBUG")
+    try:
+        controller = ConsoleChatController(
+            store=store,
+            provider_gateway=_RecordingGateway(chunks=(body,)),
+            rag_capture_provider=capture,
+            agent_runtime_enabled=False,
+        )
+        await controller.submit_draft("question")
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assistant = _assistant(store)
+    assistant_calls = [
+        call
+        for call in persistence.create_calls
+        if call["sender"] == ConsoleMessageRole.ASSISTANT.value
+    ]
+    output = "".join(str(message) for message in captured_logs)
+    assert assistant.content == body
+    assert assistant.persisted_message_id == assistant.id
+    assert len(assistant_calls) == 1
+    assert assistant_calls[0]["message_id"] == assistant.id
+    assert "citation_write" not in assistant_calls[0]
+    assert builder.is_sealed is False
+    assert builder.answer_attempts == ()
+    assert builder.answer_attempt_payloads == ()
+    assert "occurrence_mapping_unavailable" in output
+    for sentinel in (
+        body,
+        _PRIVATE_QUERY,
+        _PRIVATE_TITLE,
+        _PRIVATE_SNAPSHOT,
+    ):
+        assert sentinel not in output
+    _assert_no_terminal_state(store)
+
+
+@pytest.mark.parametrize(
+    "body",
+    (
+        r"Escaped literal \[S1] remains eligible.",
+        "Inline code `[S1]` remains eligible.",
+        "```text\n[S1]\n```\nCode fence remains eligible.",
+    ),
+)
+@pytest.mark.asyncio
+async def test_direct_markers_in_markdown_literals_still_seal(body: str):
+    builder, prompt_id = _citation_builder()
+    persistence = _ReadyCitationPersistence()
+    store = _persisted_store(persistence)
+
+    async def capture(_draft):
+        return _capture_result(builder, prompt_id)
+
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=_RecordingGateway(chunks=(body,)),
+        rag_capture_provider=capture,
+        agent_runtime_enabled=False,
+    )
+    await controller.submit_draft("question")
+
+    citation_calls = _citation_calls(persistence)
+    assert len(citation_calls) == 1
+    assert (
+        citation_calls[0]["citation_write"].answer_attempt_payloads[0].answer_body
+        == _assistant(store).content
+    )
+    assert builder.is_sealed is True
+    _assert_no_terminal_state(store)
+
+
+@pytest.mark.parametrize(
+    ("chunks", "error", "raises"),
+    (
+        ((), None, False),
+        (("partial",), RuntimeError("provider failed"), False),
+        (("partial",), asyncio.CancelledError(), True),
+    ),
+    ids=("empty", "provider-error", "cancelled-error"),
+)
+@pytest.mark.asyncio
+async def test_direct_non_success_does_not_seal_and_clears_terminal_state(
+    chunks: tuple[str, ...],
+    error: BaseException | None,
+    raises: bool,
+):
+    builder, prompt_id = _citation_builder()
+    persistence = _ReadyCitationPersistence()
+    store = _persisted_store(persistence)
+
+    async def capture(_draft):
+        return _capture_result(builder, prompt_id)
+
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=_RecordingGateway(chunks=chunks, error=error),
+        rag_capture_provider=capture,
+        agent_runtime_enabled=False,
+    )
+
+    if raises:
+        with pytest.raises(asyncio.CancelledError):
+            await controller.submit_draft("question")
+    else:
+        await controller.submit_draft("question")
+
+    assert _citation_calls(persistence) == []
+    assert builder.is_sealed is False
+    assert builder.answer_attempts == ()
+    _assert_no_terminal_state(store)
+
+
+@pytest.mark.asyncio
+async def test_direct_user_stop_does_not_seal_and_clears_terminal_state():
+    builder, prompt_id = _citation_builder()
+    persistence = _ReadyCitationPersistence()
+    store = _persisted_store(persistence)
+    stream_parked = asyncio.Event()
+
+    class _ParkedGateway(_RecordingGateway):
+        async def stream_chat(self, _resolution, messages):
+            self.messages_seen = messages
+            yield "partial"
+            stream_parked.set()
+            await asyncio.Event().wait()
+
+    async def capture(_draft):
+        return _capture_result(builder, prompt_id)
+
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=_ParkedGateway(),
+        rag_capture_provider=capture,
+        agent_runtime_enabled=False,
+    )
+    task = asyncio.create_task(controller.submit_draft("question"))
+    await stream_parked.wait()
+
+    assert controller.stop_active_run() is True
+    await task
+
+    assert _assistant(store).status == "stopped"
+    assert _citation_calls(persistence) == []
+    assert builder.is_sealed is False
+    assert builder.answer_attempts == ()
+    _assert_no_terminal_state(store)
+
+
+@pytest.mark.parametrize(
+    ("context", "builder_kind", "prompt_id_kind", "expects_context"),
+    (
+        (None, "valid", "valid", False),
+        (123, "valid", "valid", False),
+        ("legacy context", "invalid", "valid", True),
+        ("canonical context", "valid", "missing", True),
+        ("canonical context", "valid", "blank", True),
+        ("canonical context", "valid", "invalid", True),
+    ),
+    ids=(
+        "missing-context",
+        "invalid-context",
+        "invalid-builder",
+        "missing-prompt-id",
+        "blank-prompt-id",
+        "invalid-prompt-id",
+    ),
+)
+@pytest.mark.asyncio
+async def test_invalid_capture_parts_preserve_context_compatibility_without_finalizer(
+    context: Any,
+    builder_kind: str,
+    prompt_id_kind: str,
+    expects_context: bool,
+):
+    builder, prompt_id = _citation_builder()
+    captured_builder: Any = builder if builder_kind == "valid" else _RequestBuilder()
+    captured_prompt_id: Any = {
+        "valid": prompt_id,
+        "missing": None,
+        "blank": "  ",
+        "invalid": 17,
+    }[prompt_id_kind]
+    persistence = _ReadyCitationPersistence()
+    store = _persisted_store(persistence)
+    gateway = _RecordingGateway()
+
+    async def capture(_draft):
+        return SimpleNamespace(
+            context=context,
+            citation_builder=captured_builder,
+            prompt_evidence_set_id=captured_prompt_id,
+        )
+
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        rag_capture_provider=capture,
+        agent_runtime_enabled=False,
+    )
+    await controller.submit_draft("question")
+
+    final_user = _final_user_content(gateway.messages_seen)
+    assert ("Evidence:" in final_user) is expects_context
+    assert _citation_calls(persistence) == []
+    assert builder.is_sealed is False
+    assert builder.answer_attempts == ()
+    _assert_no_terminal_state(store)
+
+
+@pytest.mark.asyncio
+async def test_finalizer_exception_logs_only_fixed_content_safe_diagnostic(monkeypatch):
+    body = "PRIVATE_ANSWER_SENTINEL_TASK_553_14"
+    builder, prompt_id = _citation_builder()
+    persistence = _ReadyCitationPersistence()
+    store = _persisted_store(persistence)
+
+    def fail_attempt(_self, **_kwargs):
+        raise RuntimeError(_PRIVATE_EXCEPTION)
+
+    monkeypatch.setattr(
+        CitationTraceBuilder,
+        "record_initial_answer_attempt",
+        fail_attempt,
+    )
+
+    async def capture(_draft):
+        return _capture_result(builder, prompt_id)
+
+    captured_logs: list[Any] = []
+    sink_id = loguru_logger.add(captured_logs.append, format="{message}", level="DEBUG")
+    try:
+        controller = ConsoleChatController(
+            store=store,
+            provider_gateway=_RecordingGateway(chunks=(body,)),
+            rag_capture_provider=capture,
+            agent_runtime_enabled=False,
+        )
+        await controller.submit_draft("question")
+    finally:
+        loguru_logger.remove(sink_id)
+
+    output = "".join(str(message) for message in captured_logs)
+    assistant_calls = [
+        call
+        for call in persistence.create_calls
+        if call["sender"] == ConsoleMessageRole.ASSISTANT.value
+    ]
+    assert len(assistant_calls) == 1
+    assert "citation_write" not in assistant_calls[0]
+    assert "attempt_or_seal_failure" in output
+    for sentinel in (
+        body,
+        _PRIVATE_QUERY,
+        _PRIVATE_TITLE,
+        _PRIVATE_SNAPSHOT,
+        _PRIVATE_EXCEPTION,
+    ):
+        assert sentinel not in output
+    assert builder.is_sealed is False
+    assert builder.answer_attempts == ()
+    _assert_no_terminal_state(store)
+
+
+class _AgentBridge:
+    def __init__(
+        self,
+        store: ConsoleChatStore,
+        *,
+        status: str = RUN_DONE,
+        text: str = "agent answer",
+        append_text: bool = True,
+    ) -> None:
+        self.store = store
+        self.status = status
+        self.text = text
+        self.append_text = append_text
+        self.calls: list[dict[str, Any]] = []
+
+    def run_reply(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.append_text and self.text:
+            self.store.append_stream_chunk(
+                kwargs["assistant_message_id"],
+                self.text,
+            )
+        return "run-console-terminal", RunOutcome(
+            status=self.status,
+            steps=[],
+            final_text=self.text,
+        )
+
+    def record_run_assistant_message(self, _run_id, _message_id):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_agent_initial_rag_success_seals_exact_runtime_materialized_body_once():
+    builder, prompt_id = _citation_builder()
+    persistence = _ReadyCitationPersistence()
+    store = _persisted_store(persistence)
+    bridge = _AgentBridge(store, text="agent answer")
+
+    async def capture(_draft):
+        return _capture_result(builder, prompt_id)
+
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=_RecordingGateway(),
+        rag_capture_provider=capture,
+        agent_bridge=bridge,
+        agent_runtime_enabled=True,
+    )
+
+    await controller.submit_draft("question")
+
+    assistant = _assistant(store)
+    citation_calls = _citation_calls(persistence)
+    assert assistant.content == "agent answer"
+    assert len(bridge.calls) == 1
+    assert len(citation_calls) == 1
+    assert citation_calls[0]["content"] == assistant.content
+    assert citation_calls[0]["message_id"] == assistant.id
+    assert (
+        citation_calls[0]["citation_write"].answer_attempt_payloads[0].answer_body
+        == assistant.content
+    )
+    assert builder.is_sealed is True
+    assert len(builder.answer_attempts) == 1
+    _assert_no_terminal_state(store)
+
+
+@pytest.mark.asyncio
+async def test_agent_empty_done_disarms_before_ordinary_fallback():
+    builder, prompt_id = _citation_builder()
+    persistence = _ReadyCitationPersistence()
+    store = _persisted_store(persistence)
+    bridge = _AgentBridge(store, text="", append_text=False)
+
+    async def capture(_draft):
+        return _capture_result(builder, prompt_id)
+
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=_RecordingGateway(),
+        rag_capture_provider=capture,
+        agent_bridge=bridge,
+        agent_runtime_enabled=True,
+    )
+    await controller.submit_draft("question")
+
+    assistant = _assistant(store)
+    assistant_calls = [
+        call
+        for call in persistence.create_calls
+        if call["sender"] == ConsoleMessageRole.ASSISTANT.value
+    ]
+    assert assistant.content == "No response was generated."
+    assert len(assistant_calls) == 1
+    assert "citation_write" not in assistant_calls[0]
+    assert builder.is_sealed is False
+    assert builder.answer_attempts == ()
+    _assert_no_terminal_state(store)
+
+
+@pytest.mark.parametrize("status", (RUN_CANCELLED, RUN_ERROR))
+@pytest.mark.asyncio
+async def test_agent_non_success_does_not_seal(status: str):
+    builder, prompt_id = _citation_builder()
+    persistence = _ReadyCitationPersistence()
+    store = _persisted_store(persistence)
+    bridge = _AgentBridge(store, status=status, text="agent partial")
+
+    async def capture(_draft):
+        return _capture_result(builder, prompt_id)
+
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=_RecordingGateway(),
+        rag_capture_provider=capture,
+        agent_bridge=bridge,
+        agent_runtime_enabled=True,
+    )
+    await controller.submit_draft("question")
+
+    assert _citation_calls(persistence) == []
+    assert builder.is_sealed is False
+    assert builder.answer_attempts == ()
+    _assert_no_terminal_state(store)
+
+
+@pytest.mark.asyncio
+async def test_agent_user_stop_does_not_seal():
+    builder, prompt_id = _citation_builder()
+    persistence = _ReadyCitationPersistence()
+    store = _persisted_store(persistence)
+    started = threading.Event()
+
+    class _StoppedAgentBridge(_AgentBridge):
+        def run_reply(self, **kwargs):
+            started.set()
+            while not kwargs["should_cancel"]():
+                time.sleep(0.001)
+            return "run-console-terminal", RunOutcome(
+                status=RUN_CANCELLED,
+                steps=[],
+                final_text="",
+            )
+
+    async def capture(_draft):
+        return _capture_result(builder, prompt_id)
+
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=_RecordingGateway(),
+        rag_capture_provider=capture,
+        agent_bridge=_StoppedAgentBridge(store),
+        agent_runtime_enabled=True,
+    )
+    task = asyncio.create_task(controller.submit_draft("question"))
+    await asyncio.to_thread(started.wait)
+
+    assert controller.stop_active_run() is True
+    await task
+
+    assert _citation_calls(persistence) == []
+    assert builder.is_sealed is False
+    assert builder.answer_attempts == ()
+    _assert_no_terminal_state(store)
+
+
+@pytest.mark.asyncio
+async def test_agent_replaced_placeholder_does_not_transfer_finalizer():
+    builder, prompt_id = _citation_builder()
+    persistence = _ReadyCitationPersistence()
+    store = _persisted_store(persistence)
+
+    class _ReplacingAgentBridge(_AgentBridge):
+        def run_reply(self, **kwargs):
+            original_id = kwargs["assistant_message_id"]
+            session_id = self.store.session_id_for_message(original_id)
+            session = next(
+                session for session in self.store.sessions() if session.id == session_id
+            )
+            retained = [
+                message
+                for message in self.store.messages_for_session(session_id)
+                if message.id != original_id
+            ]
+            self.store.restore_state(
+                sessions=[session],
+                messages_by_session={session_id: retained},
+                active_session_id=session_id,
+            )
+            replacement = self.store.append_message(
+                session_id,
+                role=ConsoleMessageRole.ASSISTANT,
+                content="",
+                persist=True,
+            )
+            self.store.append_stream_chunk(replacement.id, "replacement answer")
+            return "run-console-terminal", RunOutcome(
+                status=RUN_DONE,
+                steps=[],
+                final_text="replacement answer",
+            )
+
+    async def capture(_draft):
+        return _capture_result(builder, prompt_id)
+
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=_RecordingGateway(),
+        rag_capture_provider=capture,
+        agent_bridge=_ReplacingAgentBridge(store),
+        agent_runtime_enabled=True,
+    )
+    await controller.submit_draft("question")
+
+    assistant = _assistant(store)
+    assistant_calls = [
+        call
+        for call in persistence.create_calls
+        if call["sender"] == ConsoleMessageRole.ASSISTANT.value
+    ]
+    assert assistant.content == "replacement answer"
+    assert len(assistant_calls) == 1
+    assert "citation_write" not in assistant_calls[0]
+    assert builder.is_sealed is False
+    assert builder.answer_attempts == ()
+    _assert_no_terminal_state(store)
+
+
+@pytest.mark.asyncio
+async def test_retry_and_regenerate_never_inherit_initial_rag_finalizer():
+    builder, prompt_id = _citation_builder()
+    persistence = _ReadyCitationPersistence()
+    store = _persisted_store(persistence)
+    gateway = _RecordingGateway(
+        chunks=("initial partial",),
+        error=RuntimeError("initial failure"),
+    )
+
+    async def capture(_draft):
+        return _capture_result(builder, prompt_id)
+
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        rag_capture_provider=capture,
+        agent_runtime_enabled=False,
+    )
+    await controller.submit_draft("question")
+    failed = _assistant(store)
+    assert failed.status == "failed"
+    assert builder.answer_attempts == ()
+
+    gateway.chunks = ("retry answer",)
+    gateway.error = None
+    await controller.retry_message(failed.id)
+    retried = store.get_message(failed.id)
+    assert retried.status == "complete"
+    assert retried.content == "retry answer"
+
+    gateway.chunks = ("regenerated answer",)
+    await controller.regenerate_message(failed.id)
+    regenerated = store.get_message(store.active_leaf(store.active_session_id))
+    assert regenerated.id != failed.id
+    assert regenerated.content == "regenerated answer"
+
+    assert _citation_calls(persistence) == []
+    assert builder.is_sealed is False
+    assert builder.answer_attempts == ()
+    assert builder.answer_attempt_payloads == ()
+    _assert_no_terminal_state(store)

--- a/Tests/Chat/test_console_terminal_citation_persistence.py
+++ b/Tests/Chat/test_console_terminal_citation_persistence.py
@@ -1,0 +1,825 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from io import StringIO
+from typing import Any
+
+import pytest
+from loguru import logger
+
+import tldw_chatbook.Chat.console_chat_store as console_chat_store_module
+from tldw_chatbook.Chat.citation_source_locators import CanonicalSourceKind
+from tldw_chatbook.Chat.citation_trace_builder import (
+    CitationTraceBuilder,
+    LocalPromptEvidenceCapture,
+    LocalRetrievalCandidateCapture,
+    LocalRetrievalRunMetadata,
+)
+from tldw_chatbook.Chat.citation_trace_identity import (
+    CitationFingerprintCodec,
+    LocalCitationIdentityContext,
+)
+from tldw_chatbook.Chat.citation_trace_models import (
+    PolicyCapability,
+    RetrievalScoreKind,
+    RetrievalScoreScale,
+    SealedCitationWrite,
+)
+from tldw_chatbook.Chat.citation_trace_repository import (
+    CitationPersistenceUnavailable,
+)
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleMessageRole,
+    MessageAttachment,
+)
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+
+
+_MISSING = object()
+_NOW = datetime(2026, 7, 26, 12, 0, tzinfo=UTC)
+_BODY_SENTINEL = "Exact terminal body 🧪\nwith arbitrary boundaries."
+_QUERY_SENTINEL = "PRIVATE_QUERY_SENTINEL"
+_TITLE_SENTINEL = "PRIVATE_TITLE_SENTINEL"
+_SNAPSHOT_SENTINEL = "PRIVATE_SNAPSHOT_SENTINEL"
+_SOURCE_SENTINEL = "PRIVATE_SOURCE_SENTINEL"
+_LOCATOR_SENTINEL = "PRIVATE_LOCATOR_SENTINEL"
+_EXCEPTION_SENTINEL = "PRIVATE_EXCEPTION_SENTINEL"
+
+
+class _PersistenceBase:
+    db = None
+
+    def __init__(self, outcomes: list[object] | None = None) -> None:
+        self.create_calls: list[dict[str, Any]] = []
+        self.update_calls: list[dict[str, Any]] = []
+        self.outcomes = list(outcomes or [])
+
+    def create_conversation(self, **kwargs: Any) -> str:
+        return "conv-1"
+
+    def update_message_content(self, **kwargs: Any) -> bool:
+        self.update_calls.append(kwargs)
+        return True
+
+
+class _ReadyCitationPersistence(_PersistenceBase):
+    canonical_citation_writes_ready = True
+
+    def create_message(
+        self,
+        *,
+        conversation_id: str,
+        sender: str,
+        content: str,
+        image_data: bytes | None,
+        image_mime_type: str | None,
+        message_id: str | None = None,
+        parent_message_id: str | None = None,
+        feedback: str | None = None,
+        citation_write: SealedCitationWrite | None | object = _MISSING,
+    ) -> str:
+        call = {
+            "conversation_id": conversation_id,
+            "sender": sender,
+            "content": content,
+            "image_data": image_data,
+            "image_mime_type": image_mime_type,
+            "message_id": message_id,
+            "parent_message_id": parent_message_id,
+            "feedback": feedback,
+        }
+        if citation_write is not _MISSING:
+            call["citation_write"] = citation_write
+        self.create_calls.append(call)
+        if self.outcomes:
+            outcome = self.outcomes.pop(0)
+            if isinstance(outcome, BaseException):
+                raise outcome
+            if outcome is not None:
+                return str(outcome)
+        return message_id or f"msg-{len(self.create_calls)}"
+
+
+class _NoCitationKwargPersistence(_PersistenceBase):
+    canonical_citation_writes_ready = True
+
+    def create_message(
+        self,
+        *,
+        conversation_id: str,
+        sender: str,
+        content: str,
+        image_data: bytes | None,
+        image_mime_type: str | None,
+        message_id: str | None = None,
+        parent_message_id: str | None = None,
+        feedback: str | None = None,
+    ) -> str:
+        call = {
+            "conversation_id": conversation_id,
+            "sender": sender,
+            "content": content,
+            "image_data": image_data,
+            "image_mime_type": image_mime_type,
+            "message_id": message_id,
+            "parent_message_id": parent_message_id,
+            "feedback": feedback,
+        }
+        self.create_calls.append(call)
+        return message_id or f"msg-{len(self.create_calls)}"
+
+
+class _MissingReadinessPersistence(_PersistenceBase):
+    create_message = _ReadyCitationPersistence.create_message
+
+
+class _FalseReadinessPersistence(_ReadyCitationPersistence):
+    canonical_citation_writes_ready = False
+
+
+class _RaisingReadinessPersistence(_ReadyCitationPersistence):
+    @property
+    def canonical_citation_writes_ready(self) -> bool:
+        raise RuntimeError("readiness-sentinel")
+
+
+class _FailingConversationPersistence(_ReadyCitationPersistence):
+    def create_conversation(self, **kwargs: Any) -> str:
+        raise RuntimeError("append-setup-sentinel")
+
+
+class _RaisingLeafDb:
+    def set_conversation_active_leaf(
+        self, conversation_id: str, message_id: str | None
+    ) -> None:
+        raise RuntimeError(_EXCEPTION_SENTINEL)
+
+
+class _BookkeepingFailurePersistence(_ReadyCitationPersistence):
+    def __init__(self) -> None:
+        super().__init__()
+        self.db = _RaisingLeafDb()
+
+
+class _RaisingSyncProducer:
+    def enqueue_chat_message(self, **kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError(_EXCEPTION_SENTINEL)
+
+
+def _assert_terminal_state_paired(store: ConsoleChatStore) -> None:
+    assert set(store._terminal_citation_finalizers) == set(
+        store._terminal_persistence_deferred_ids
+    )
+
+
+def _append_eligible(
+    store: ConsoleChatStore,
+    finalizer: Callable[[str], object | None] = lambda body: None,
+    *,
+    persist: bool = True,
+) -> tuple[str, str]:
+    session = store.ensure_session()
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="",
+        persist=persist,
+        terminal_citation_finalizer=finalizer,
+    )
+    return session.id, message.id
+
+
+def _sealed_write_for_body(body: str) -> SealedCitationWrite:
+    builder = CitationTraceBuilder.local(
+        request_id="request-terminal-store",
+        generation_id="generation-terminal-store",
+        identity_context=LocalCitationIdentityContext(
+            profile_id="profile-terminal-store",
+            local_authority_id="authority-terminal-store",
+            fingerprint_key_id="fingerprint-terminal-store",
+        ),
+        fingerprint_codec=CitationFingerprintCodec(b"0123456789abcdef0123456789abcdef"),
+        policy_version="terminal-store-policy-v1",
+        policy_capabilities=(
+            PolicyCapability.VIEW_SNAPSHOT,
+            PolicyCapability.VIEW_SOURCE_IDENTITY,
+        ),
+        created_at=_NOW,
+    )
+    run_id = builder.record_retrieval_run(
+        stage="hybrid",
+        raw_query=_QUERY_SENTINEL,
+        candidates=(
+            LocalRetrievalCandidateCapture(
+                candidate_rank=1,
+                source_kind=CanonicalSourceKind.MEDIA_DB,
+                source_id=_SOURCE_SENTINEL,
+                title=_TITLE_SENTINEL,
+                score_kind=RetrievalScoreKind.VECTOR_SIMILARITY,
+                score_scale=RetrievalScoreScale.ZERO_TO_ONE,
+                score=0.9,
+                chunk_id=_LOCATOR_SENTINEL,
+            ),
+        ),
+        retrieval_metadata=LocalRetrievalRunMetadata(
+            search_mode="hybrid",
+            requested_top_k=1,
+            max_context_characters=1_000,
+            rerank_enabled=False,
+            source_kinds=(CanonicalSourceKind.MEDIA_DB,),
+            scope_state="unscoped",
+        ),
+        started_at=_NOW,
+        ended_at=_NOW,
+    )
+    prompt_set_id = builder.record_prompt_evidence_set(
+        run_id=run_id,
+        evidence=(
+            LocalPromptEvidenceCapture(
+                candidate_rank=1,
+                snapshot_text=f"[S1] {_SNAPSHOT_SENTINEL}",
+            ),
+        ),
+        created_at=_NOW,
+    )
+    attempt_id = builder.record_initial_answer_attempt(
+        prompt_evidence_set_id=prompt_set_id,
+        answer_body=body,
+        completed_at=_NOW,
+    )
+    return builder.seal(
+        selected_attempt_id=attempt_id,
+        sealed_at=_NOW + timedelta(seconds=1),
+    )
+
+
+def _capture_logs() -> tuple[StringIO, int]:
+    stream = StringIO()
+    handler_id = logger.add(stream, format="{message}", level="DEBUG")
+    return stream, handler_id
+
+
+def _assert_content_free_diagnostics(
+    log_output: str,
+    *,
+    sealed_write: SealedCitationWrite | None = None,
+) -> None:
+    for sentinel in (
+        _BODY_SENTINEL,
+        _QUERY_SENTINEL,
+        _TITLE_SENTINEL,
+        _SNAPSHOT_SENTINEL,
+        _SOURCE_SENTINEL,
+        _LOCATOR_SENTINEL,
+        _EXCEPTION_SENTINEL,
+    ):
+        assert sentinel not in log_output
+    if sealed_write is not None:
+        assert (
+            sealed_write.answer_attempt_payloads[0].body_integrity_hmac
+            not in log_output
+        )
+
+
+def test_capability_ready_adapter_arms_callback_and_deferral_in_append() -> None:
+    persistence = _ReadyCitationPersistence()
+    store = ConsoleChatStore(persistence=persistence)
+
+    def finalizer(body: str) -> None:
+        return None
+
+    _, message_id = _append_eligible(store, finalizer)
+
+    assert store._terminal_citation_finalizers[message_id] is finalizer
+    assert message_id in store._terminal_persistence_deferred_ids
+    assert message_id in store._pending_persistence_message_ids
+    assert persistence.create_calls == []
+    _assert_terminal_state_paired(store)
+
+
+@pytest.mark.parametrize(
+    ("persistence", "persist"),
+    [
+        (None, True),
+        (_ReadyCitationPersistence(), False),
+        (_NoCitationKwargPersistence(), True),
+        (_MissingReadinessPersistence(), True),
+        (_FalseReadinessPersistence(), True),
+        (_RaisingReadinessPersistence(), True),
+    ],
+    ids=[
+        "no-persistence",
+        "persist-false",
+        "citation-kwarg-missing",
+        "readiness-missing",
+        "readiness-false",
+        "readiness-raises",
+    ],
+)
+def test_capability_ineligible_adapters_do_not_arm_and_keep_ordinary_behavior(
+    persistence: _PersistenceBase | None,
+    persist: bool,
+) -> None:
+    store = ConsoleChatStore(persistence=persistence)
+    session_id, message_id = _append_eligible(store, persist=persist)
+
+    assert message_id not in store._terminal_citation_finalizers
+    assert message_id not in store._terminal_persistence_deferred_ids
+    _assert_terminal_state_paired(store)
+
+    store.append_stream_chunk(message_id, "first")
+    assert store.get_message(message_id).content == "first"
+    if persistence is not None and persist:
+        assert len(persistence.create_calls) == 1
+        assert persistence.create_calls[0]["content"] == "first"
+    else:
+        assert persistence is None or persistence.create_calls == []
+    assert store.messages_for_session(session_id)[-1].content == "first"
+
+
+def test_capability_signature_inspection_exception_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    persistence = _ReadyCitationPersistence()
+    store = ConsoleChatStore(persistence=persistence)
+
+    def raise_signature_error(value: object) -> object:
+        raise RuntimeError("signature-sentinel")
+
+    monkeypatch.setattr(
+        console_chat_store_module.inspect, "signature", raise_signature_error
+    )
+
+    _, message_id = _append_eligible(store)
+
+    assert message_id not in store._terminal_citation_finalizers
+    assert message_id not in store._terminal_persistence_deferred_ids
+    _assert_terminal_state_paired(store)
+
+
+@pytest.mark.parametrize(
+    "append_kwargs",
+    [
+        {"terminal_citation_finalizer": object()},
+        {
+            "role": ConsoleMessageRole.USER,
+            "terminal_citation_finalizer": lambda body: None,
+        },
+        {
+            "content": "already present",
+            "terminal_citation_finalizer": lambda body: None,
+        },
+        {
+            "attachments": (
+                MessageAttachment(
+                    data=b"image",
+                    mime_type="image/png",
+                    display_name="image.png",
+                    position=0,
+                ),
+            ),
+            "terminal_citation_finalizer": lambda body: None,
+        },
+        {
+            "image_data": b"scalar-image",
+            "image_mime_type": "image/png",
+            "terminal_citation_finalizer": lambda body: None,
+        },
+    ],
+    ids=[
+        "non-callable",
+        "non-assistant",
+        "non-empty",
+        "attachments",
+        "scalar-image",
+    ],
+)
+def test_placement_invalid_callback_rejected_before_tree_or_session_mutation(
+    append_kwargs: dict[str, Any],
+) -> None:
+    persistence = _ReadyCitationPersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.ensure_session()
+    original_updated_at = session.updated_at
+    kwargs: dict[str, Any] = {
+        "role": ConsoleMessageRole.ASSISTANT,
+        "content": "",
+        "persist": True,
+    }
+    kwargs.update(append_kwargs)
+
+    with pytest.raises(ValueError):
+        store.append_message(session.id, **kwargs)
+
+    assert store.messages_for_session(session.id) == []
+    assert store.active_leaf(session.id) is None
+    assert session.updated_at == original_updated_at
+    assert persistence.create_calls == []
+    _assert_terminal_state_paired(store)
+
+
+def test_deferred_reads_materialize_chunks_without_early_create() -> None:
+    persistence = _ReadyCitationPersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    session_id, message_id = _append_eligible(store)
+
+    store.append_stream_chunk(message_id, "α")
+    assert store.get_message(message_id).content == "α"
+    store.append_stream_chunk(message_id, "β")
+    assert store.messages_for_session(session_id)[-1].content == "αβ"
+
+    assert persistence.create_calls == []
+    assert message_id in store._pending_persistence_message_ids
+    _assert_terminal_state_paired(store)
+
+
+def test_ordinary_empty_assistant_keeps_first_content_persistence_timing() -> None:
+    persistence = _ReadyCitationPersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.ensure_session()
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="",
+        persist=True,
+    )
+
+    store.append_stream_chunk(message.id, "first")
+    assert persistence.create_calls == []
+    assert store.get_message(message.id).content == "first"
+
+    assert len(persistence.create_calls) == 1
+    assert persistence.create_calls[0]["content"] == "first"
+    assert message.id not in store._pending_persistence_message_ids
+
+
+def test_append_failure_clears_callback_and_deferral_before_reraising() -> None:
+    store = ConsoleChatStore(persistence=_FailingConversationPersistence())
+    session = store.ensure_session()
+
+    with pytest.raises(RuntimeError, match="append-setup-sentinel"):
+        store.append_message(
+            session.id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="",
+            persist=True,
+            terminal_citation_finalizer=lambda body: None,
+        )
+
+    registered_ids = set(store._nodes_by_session[session.id])
+    assert len(registered_ids) == 1
+    message_id = registered_ids.pop()
+    assert message_id not in store._terminal_citation_finalizers
+    assert message_id not in store._terminal_persistence_deferred_ids
+    _assert_terminal_state_paired(store)
+
+
+def test_cleanup_clear_is_idempotent_and_preserves_ordinary_pending() -> None:
+    store = ConsoleChatStore(persistence=_ReadyCitationPersistence())
+    _, message_id = _append_eligible(store)
+
+    store.clear_terminal_citation_state(message_id)
+    store.clear_terminal_citation_state(message_id)
+
+    assert message_id in store._pending_persistence_message_ids
+    assert message_id not in store._terminal_citation_finalizers
+    assert message_id not in store._terminal_persistence_deferred_ids
+    _assert_terminal_state_paired(store)
+
+
+def test_cleanup_close_session_sweeps_terminal_state() -> None:
+    store = ConsoleChatStore(persistence=_ReadyCitationPersistence())
+    session_id, message_id = _append_eligible(store)
+
+    store.close_session(session_id)
+
+    assert message_id not in store._terminal_citation_finalizers
+    assert message_id not in store._terminal_persistence_deferred_ids
+    _assert_terminal_state_paired(store)
+
+
+def test_cleanup_subtree_deletion_sweeps_terminal_state() -> None:
+    store = ConsoleChatStore(persistence=_ReadyCitationPersistence())
+    session = store.ensure_session()
+    parent = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="complete parent",
+    )
+    _, child_id = _append_eligible(store)
+
+    store.delete_message(parent.id)
+
+    with pytest.raises(KeyError):
+        store.get_message(child_id)
+    assert child_id not in store._terminal_citation_finalizers
+    assert child_id not in store._terminal_persistence_deferred_ids
+    _assert_terminal_state_paired(store)
+
+
+def test_cleanup_restore_state_sweeps_terminal_state() -> None:
+    store = ConsoleChatStore(persistence=_ReadyCitationPersistence())
+    _append_eligible(store)
+
+    store.restore_state(sessions=[])
+
+    assert store._terminal_citation_finalizers == {}
+    assert store._terminal_persistence_deferred_ids == set()
+    _assert_terminal_state_paired(store)
+
+
+@pytest.mark.parametrize(
+    ("terminal_method_name", "expected_status"),
+    [("mark_message_stopped", "stopped"), ("mark_message_failed", "failed")],
+)
+def test_cleanup_non_success_terminal_clears_deferral_before_ordinary_persistence(
+    terminal_method_name: str,
+    expected_status: str,
+) -> None:
+    persistence = _ReadyCitationPersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    finalizer_calls: list[str] = []
+    _, message_id = _append_eligible(
+        store, lambda body: finalizer_calls.append(body) or None
+    )
+    store.append_stream_chunk(message_id, "partial")
+
+    terminal_method = getattr(store, terminal_method_name)
+    result = terminal_method(message_id)
+
+    assert result.status == expected_status
+    assert result.content == "partial"
+    assert finalizer_calls == []
+    assert len(persistence.create_calls) == 1
+    assert persistence.create_calls[0]["content"] == "partial"
+    assert persistence.create_calls[0].get("citation_write") is None
+    assert message_id not in store._terminal_citation_finalizers
+    assert message_id not in store._terminal_persistence_deferred_ids
+    _assert_terminal_state_paired(store)
+
+
+def test_exact_body_completion_uses_stable_id_and_same_sealed_write_identity() -> None:
+    persistence = _ReadyCitationPersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    sealed_write = _sealed_write_for_body(_BODY_SENTINEL)
+    finalized_bodies: list[str] = []
+
+    def finalize(body: str) -> SealedCitationWrite:
+        finalized_bodies.append(body)
+        return sealed_write
+
+    session_id, message_id = _append_eligible(store, finalize)
+    store.append_stream_chunk(message_id, "Exact terminal ")
+    assert store.get_message(message_id).content == "Exact terminal "
+    store.append_stream_chunk(message_id, "body 🧪")
+    store.append_stream_chunk(message_id, "\nwith arbitrary")
+    store.append_stream_chunk(message_id, " boundaries.")
+
+    completed = store.mark_message_complete(message_id)
+
+    assert completed.content == _BODY_SENTINEL
+    assert completed.status == "complete"
+    assert completed.persisted_message_id == message_id
+    assert finalized_bodies == [_BODY_SENTINEL]
+    assert len(persistence.create_calls) == 1
+    assert persistence.create_calls[0]["content"] == _BODY_SENTINEL
+    assert persistence.create_calls[0]["message_id"] == message_id
+    assert persistence.create_calls[0]["citation_write"] is sealed_write
+    assert message_id not in store._terminal_citation_finalizers
+    assert message_id not in store._terminal_persistence_deferred_ids
+    _assert_terminal_state_paired(store)
+
+    assert store.get_message(message_id).content == _BODY_SENTINEL
+    assert store.messages_for_session(session_id)[-1].content == _BODY_SENTINEL
+    assert finalized_bodies == [_BODY_SENTINEL]
+    assert len(persistence.create_calls) == 1
+
+
+def test_finalizer_none_uses_one_ordinary_stable_id_create() -> None:
+    persistence = _ReadyCitationPersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    _, message_id = _append_eligible(store, lambda body: None)
+    store.append_stream_chunk(message_id, _BODY_SENTINEL)
+
+    completed = store.mark_message_complete(message_id)
+
+    assert completed.status == "complete"
+    assert completed.persisted_message_id == message_id
+    assert len(persistence.create_calls) == 1
+    assert persistence.create_calls[0]["message_id"] == message_id
+    assert "citation_write" not in persistence.create_calls[0]
+
+
+def test_finalizer_exception_logs_fixed_diagnostic_and_uses_ordinary_stable_id() -> (
+    None
+):
+    persistence = _ReadyCitationPersistence()
+    store = ConsoleChatStore(persistence=persistence)
+
+    def unavailable_finalizer(body: str) -> SealedCitationWrite:
+        raise RuntimeError(f"{_EXCEPTION_SENTINEL}:{body}")
+
+    _, message_id = _append_eligible(store, unavailable_finalizer)
+    store.append_stream_chunk(message_id, _BODY_SENTINEL)
+    log_stream, handler_id = _capture_logs()
+    try:
+        completed = store.mark_message_complete(message_id)
+    finally:
+        logger.remove(handler_id)
+
+    output = log_stream.getvalue()
+    assert completed.status == "complete"
+    assert completed.persisted_message_id == message_id
+    assert len(persistence.create_calls) == 1
+    assert persistence.create_calls[0]["message_id"] == message_id
+    assert "citation_write" not in persistence.create_calls[0]
+    assert "terminal_finalizer_unavailable" in output
+    _assert_content_free_diagnostics(output)
+
+
+def test_fallback_first_unavailable_uses_one_ordinary_same_id_create() -> None:
+    persistence = _ReadyCitationPersistence(
+        outcomes=[CitationPersistenceUnavailable("deterministic"), None]
+    )
+    store = ConsoleChatStore(persistence=persistence)
+    sealed_write = _sealed_write_for_body(_BODY_SENTINEL)
+    _, message_id = _append_eligible(store, lambda body: sealed_write)
+    store.append_stream_chunk(message_id, _BODY_SENTINEL)
+
+    completed = store.mark_message_complete(message_id)
+
+    assert completed.status == "complete"
+    assert completed.persisted_message_id == message_id
+    assert len(persistence.create_calls) == 2
+    assert [call["message_id"] for call in persistence.create_calls] == [
+        message_id,
+        message_id,
+    ]
+    assert persistence.create_calls[0]["citation_write"] is sealed_write
+    assert "citation_write" not in persistence.create_calls[1]
+
+
+def test_ambiguous_first_failure_retries_same_id_and_same_write_once() -> None:
+    persistence = _ReadyCitationPersistence(
+        outcomes=[RuntimeError(_EXCEPTION_SENTINEL), None]
+    )
+    store = ConsoleChatStore(persistence=persistence)
+    sealed_write = _sealed_write_for_body(_BODY_SENTINEL)
+    _, message_id = _append_eligible(store, lambda body: sealed_write)
+    store.append_stream_chunk(message_id, _BODY_SENTINEL)
+
+    completed = store.mark_message_complete(message_id)
+
+    assert completed.status == "complete"
+    assert completed.persisted_message_id == message_id
+    assert len(persistence.create_calls) == 2
+    assert [call["message_id"] for call in persistence.create_calls] == [
+        message_id,
+        message_id,
+    ]
+    assert all(
+        call["citation_write"] is sealed_write for call in persistence.create_calls
+    )
+
+
+@pytest.mark.parametrize(
+    "second_failure",
+    [
+        RuntimeError(f"second:{_EXCEPTION_SENTINEL}"),
+        CitationPersistenceUnavailable("second-deterministic"),
+    ],
+    ids=["ambiguous", "citation-unavailable"],
+)
+def test_ambiguous_retry_failure_is_abandoned_without_ordinary_insert(
+    second_failure: BaseException,
+) -> None:
+    persistence = _ReadyCitationPersistence(
+        outcomes=[RuntimeError(f"first:{_EXCEPTION_SENTINEL}"), second_failure]
+    )
+    store = ConsoleChatStore(persistence=persistence)
+    sealed_write = _sealed_write_for_body(_BODY_SENTINEL)
+    session_id, message_id = _append_eligible(store, lambda body: sealed_write)
+    store.append_stream_chunk(message_id, _BODY_SENTINEL)
+    log_stream, handler_id = _capture_logs()
+    try:
+        completed = store.mark_message_complete(message_id)
+    finally:
+        logger.remove(handler_id)
+
+    output = log_stream.getvalue()
+    assert completed.status == "complete"
+    assert completed.content == _BODY_SENTINEL
+    assert completed.persisted_message_id is None
+    assert len(persistence.create_calls) == 2
+    assert all(
+        call["message_id"] == message_id and call["citation_write"] is sealed_write
+        for call in persistence.create_calls
+    )
+    assert message_id not in store._pending_persistence_message_ids
+    assert "terminal_citation_persistence_abandoned" in output
+    _assert_content_free_diagnostics(output, sealed_write=sealed_write)
+
+    store.get_message(message_id)
+    store.messages_for_session(session_id)
+    assert len(persistence.create_calls) == 2
+
+
+def test_fallback_failure_is_abandoned_without_later_polling_create() -> None:
+    persistence = _ReadyCitationPersistence(
+        outcomes=[
+            CitationPersistenceUnavailable("deterministic"),
+            RuntimeError(_EXCEPTION_SENTINEL),
+        ]
+    )
+    store = ConsoleChatStore(persistence=persistence)
+    sealed_write = _sealed_write_for_body(_BODY_SENTINEL)
+    session_id, message_id = _append_eligible(store, lambda body: sealed_write)
+    store.append_stream_chunk(message_id, _BODY_SENTINEL)
+
+    completed = store.mark_message_complete(message_id)
+
+    assert completed.status == "complete"
+    assert completed.persisted_message_id is None
+    assert len(persistence.create_calls) == 2
+    assert persistence.create_calls[0]["citation_write"] is sealed_write
+    assert "citation_write" not in persistence.create_calls[1]
+    assert {call["message_id"] for call in persistence.create_calls} == {message_id}
+    assert message_id not in store._pending_persistence_message_ids
+    store.get_message(message_id)
+    store.messages_for_session(session_id)
+    assert len(persistence.create_calls) == 2
+
+
+def test_finalizer_none_ordinary_failure_is_abandoned_without_later_create() -> None:
+    persistence = _ReadyCitationPersistence(
+        outcomes=[RuntimeError(_EXCEPTION_SENTINEL)]
+    )
+    store = ConsoleChatStore(persistence=persistence)
+    session_id, message_id = _append_eligible(store, lambda body: None)
+    store.append_stream_chunk(message_id, _BODY_SENTINEL)
+
+    completed = store.mark_message_complete(message_id)
+
+    assert completed.status == "complete"
+    assert completed.persisted_message_id is None
+    assert len(persistence.create_calls) == 1
+    assert persistence.create_calls[0]["message_id"] == message_id
+    assert "citation_write" not in persistence.create_calls[0]
+    assert message_id not in store._pending_persistence_message_ids
+    store.get_message(message_id)
+    store.messages_for_session(session_id)
+    assert len(persistence.create_calls) == 1
+
+
+def test_empty_terminal_completion_skips_finalizer_and_keeps_ordinary_pending() -> None:
+    persistence = _ReadyCitationPersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    finalizer_calls: list[str] = []
+    _, message_id = _append_eligible(
+        store, lambda body: finalizer_calls.append(body) or None
+    )
+
+    completed = store.mark_message_complete(message_id)
+
+    assert completed.status == "complete"
+    assert completed.content == ""
+    assert completed.persisted_message_id is None
+    assert finalizer_calls == []
+    assert persistence.create_calls == []
+    assert message_id in store._pending_persistence_message_ids
+    assert message_id not in store._terminal_citation_finalizers
+    assert message_id not in store._terminal_persistence_deferred_ids
+
+
+@pytest.mark.parametrize("failure_kind", ["active-leaf", "sync"])
+def test_bookkeeping_failure_after_create_never_replays_terminal_create(
+    failure_kind: str,
+) -> None:
+    persistence: _ReadyCitationPersistence
+    store_kwargs: dict[str, Any] = {}
+    if failure_kind == "active-leaf":
+        persistence = _BookkeepingFailurePersistence()
+    else:
+        persistence = _ReadyCitationPersistence()
+        store_kwargs = {
+            "sync_v2_chat_producer": _RaisingSyncProducer(),
+            "sync_v2_server_profile_id": "server-terminal-store",
+        }
+    store = ConsoleChatStore(persistence=persistence, **store_kwargs)
+    sealed_write = _sealed_write_for_body(_BODY_SENTINEL)
+    _, message_id = _append_eligible(store, lambda body: sealed_write)
+    store.append_stream_chunk(message_id, _BODY_SENTINEL)
+    log_stream, handler_id = _capture_logs()
+    try:
+        completed = store.mark_message_complete(message_id)
+    finally:
+        logger.remove(handler_id)
+
+    output = log_stream.getvalue()
+    assert completed.status == "complete"
+    assert completed.persisted_message_id == message_id
+    assert message_id not in store._pending_persistence_message_ids
+    assert len(persistence.create_calls) == 1
+    assert "terminal_persistence_bookkeeping_unavailable" in output
+    _assert_content_free_diagnostics(output, sealed_write=sealed_write)

--- a/Tests/Chat/test_console_terminal_citation_persistence.py
+++ b/Tests/Chat/test_console_terminal_citation_persistence.py
@@ -441,14 +441,26 @@ def _real_assistant(store: ConsoleChatStore):
 def _citation_row_counts(db: CharactersRAGDB) -> dict[str, int]:
     connection = db.get_connection()
     return {
-        table: connection.execute(f"SELECT count(*) FROM {table}").fetchone()[0]
-        for table in (
-            "rag_citation_traces",
-            "rag_evidence_runs",
-            "rag_evidence_snapshots",
-            "rag_answer_attempt_payloads",
-            "rag_trace_evidence_refs",
-            "rag_message_trace_owners",
+        table: connection.execute(query).fetchone()[0]
+        for table, query in (
+            ("rag_citation_traces", "SELECT count(*) FROM rag_citation_traces"),
+            ("rag_evidence_runs", "SELECT count(*) FROM rag_evidence_runs"),
+            (
+                "rag_evidence_snapshots",
+                "SELECT count(*) FROM rag_evidence_snapshots",
+            ),
+            (
+                "rag_answer_attempt_payloads",
+                "SELECT count(*) FROM rag_answer_attempt_payloads",
+            ),
+            (
+                "rag_trace_evidence_refs",
+                "SELECT count(*) FROM rag_trace_evidence_refs",
+            ),
+            (
+                "rag_message_trace_owners",
+                "SELECT count(*) FROM rag_message_trace_owners",
+            ),
         )
     }
 

--- a/Tests/Chat/test_console_terminal_citation_persistence.py
+++ b/Tests/Chat/test_console_terminal_citation_persistence.py
@@ -1,14 +1,22 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from io import StringIO
+import json
+from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 from loguru import logger
 
 import tldw_chatbook.Chat.console_chat_store as console_chat_store_module
+from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
+from tldw_chatbook.Chat.citation_provenance_runtime import (
+    CitationProvenanceRuntimePolicy,
+)
 from tldw_chatbook.Chat.citation_source_locators import CanonicalSourceKind
 from tldw_chatbook.Chat.citation_trace_builder import (
     CitationTraceBuilder,
@@ -27,13 +35,19 @@ from tldw_chatbook.Chat.citation_trace_models import (
     SealedCitationWrite,
 )
 from tldw_chatbook.Chat.citation_trace_repository import (
+    ActiveCitationTraceState,
     CitationPersistenceUnavailable,
+    CitationTraceRepository,
+    load_local_citation_identity_context,
 )
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
 from tldw_chatbook.Chat.console_chat_models import (
     ConsoleMessageRole,
     MessageAttachment,
 )
+from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 
 
 _MISSING = object()
@@ -167,6 +181,98 @@ class _RaisingSyncProducer:
         raise RuntimeError(_EXCEPTION_SENTINEL)
 
 
+class _DeterministicallyUnavailableRepository(CitationTraceRepository):
+    def _fail_after(self, row_family: str) -> None:
+        if row_family == "owner":
+            raise CitationPersistenceUnavailable("forced_deterministic_unavailable")
+
+
+class _RealDirectGateway:
+    def __init__(self, chunks: tuple[str, ...]) -> None:
+        self.chunks = chunks
+
+    async def resolve_for_send(self, _selection: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            ready=True,
+            visible_copy="",
+            provider="llama_cpp",
+            model="test-model",
+            max_tokens=128,
+        )
+
+    async def stream_chat(
+        self,
+        _resolution: object,
+        _messages: object,
+    ):
+        for chunk in self.chunks:
+            yield chunk
+
+
+@dataclass(slots=True)
+class _RealCitationStack:
+    db_path: Path
+    client_id: str
+    db: CharactersRAGDB
+    codec: CitationFingerprintCodec
+    repository: CitationTraceRepository
+    store: ConsoleChatStore
+    closed: bool = False
+
+    def close(self) -> None:
+        if not self.closed:
+            self.db.close_connection()
+            self.closed = True
+
+
+@pytest.fixture
+def real_citation_stack_factory(tmp_path: Path):
+    stacks: list[_RealCitationStack] = []
+
+    def create(
+        name: str,
+        repository_type: type[CitationTraceRepository] = CitationTraceRepository,
+    ) -> _RealCitationStack:
+        client_id = f"{name}-client"
+        db_path = tmp_path / f"{name}.sqlite"
+        db = CharactersRAGDB(db_path, client_id=client_id)
+        identity = load_local_citation_identity_context(db)
+        assert identity is not None
+        codec = CitationFingerprintCodec(b"task-553.14-real-integration-key")
+        repository = repository_type(
+            db,
+            policy=CitationProvenanceRuntimePolicy(canonical_writes_enabled=True),
+            identity_context=identity,
+            fingerprint_codec=codec,
+        )
+        persistence = ChatPersistenceService(
+            db,
+            citation_repository=repository,
+        )
+        store = ConsoleChatStore(persistence=persistence)
+        session = store.ensure_session(
+            settings=ConsoleSessionSettings(provider="llama_cpp")
+        )
+        session.persisted_conversation_id = persistence.create_conversation(
+            runtime_backend="local"
+        )
+        stack = _RealCitationStack(
+            db_path=db_path,
+            client_id=client_id,
+            db=db,
+            codec=codec,
+            repository=repository,
+            store=store,
+        )
+        stacks.append(stack)
+        return stack
+
+    yield create
+
+    for stack in stacks:
+        stack.close()
+
+
 def _assert_terminal_state_paired(store: ConsoleChatStore) -> None:
     assert set(store._terminal_citation_finalizers) == set(
         store._terminal_persistence_deferred_ids
@@ -252,6 +358,99 @@ def _sealed_write_for_body(body: str) -> SealedCitationWrite:
         selected_attempt_id=attempt_id,
         sealed_at=_NOW + timedelta(seconds=1),
     )
+
+
+def _real_captured_builder(
+    repository: CitationTraceRepository,
+) -> tuple[CitationTraceBuilder, str]:
+    builder = repository.create_local_trace_builder(
+        request_id="request-real-terminal",
+        generation_id="generation-real-terminal",
+    )
+    assert builder is not None
+    captured_at = datetime.now(UTC)
+    run_id = builder.record_retrieval_run(
+        stage="hybrid",
+        raw_query=_QUERY_SENTINEL,
+        candidates=(
+            LocalRetrievalCandidateCapture(
+                candidate_rank=1,
+                source_kind=CanonicalSourceKind.MEDIA_DB,
+                source_id=_SOURCE_SENTINEL,
+                title=_TITLE_SENTINEL,
+                score_kind=RetrievalScoreKind.VECTOR_SIMILARITY,
+                score_scale=RetrievalScoreScale.ZERO_TO_ONE,
+                score=0.9,
+                chunk_id=_LOCATOR_SENTINEL,
+            ),
+        ),
+        retrieval_metadata=LocalRetrievalRunMetadata(
+            search_mode="hybrid",
+            requested_top_k=1,
+            max_context_characters=1_000,
+            rerank_enabled=False,
+            source_kinds=(CanonicalSourceKind.MEDIA_DB,),
+            scope_state="unscoped",
+        ),
+        started_at=captured_at,
+        ended_at=captured_at,
+    )
+    prompt_id = builder.record_prompt_evidence_set(
+        run_id=run_id,
+        evidence=(
+            LocalPromptEvidenceCapture(
+                candidate_rank=1,
+                snapshot_text=f"[S1] {_SNAPSHOT_SENTINEL}",
+            ),
+        ),
+        created_at=captured_at,
+    )
+    return builder, prompt_id
+
+
+def _real_controller(
+    stack: _RealCitationStack,
+    builder: CitationTraceBuilder,
+    prompt_id: str,
+) -> ConsoleChatController:
+    async def capture(_draft: str) -> SimpleNamespace:
+        return SimpleNamespace(
+            context=f"[S1] MEDIA — {_TITLE_SENTINEL}\n{_SNAPSHOT_SENTINEL}",
+            citation_builder=builder,
+            prompt_evidence_set_id=prompt_id,
+        )
+
+    return ConsoleChatController(
+        store=stack.store,
+        provider_gateway=_RealDirectGateway(
+            ("Exact terminal body 🧪\n", "with arbitrary boundaries.")
+        ),
+        rag_capture_provider=capture,
+        agent_runtime_enabled=False,
+    )
+
+
+def _real_assistant(store: ConsoleChatStore):
+    return next(
+        message
+        for message in store.messages_for_session(store.active_session_id)
+        if message.role is ConsoleMessageRole.ASSISTANT
+    )
+
+
+def _citation_row_counts(db: CharactersRAGDB) -> dict[str, int]:
+    connection = db.get_connection()
+    return {
+        table: connection.execute(f"SELECT count(*) FROM {table}").fetchone()[0]
+        for table in (
+            "rag_citation_traces",
+            "rag_evidence_runs",
+            "rag_evidence_snapshots",
+            "rag_answer_attempt_payloads",
+            "rag_trace_evidence_refs",
+            "rag_message_trace_owners",
+        )
+    }
 
 
 def _capture_logs() -> tuple[StringIO, int]:
@@ -848,3 +1047,147 @@ def test_bookkeeping_failure_after_create_never_replays_terminal_create(
     assert len(persistence.create_calls) == 1
     assert "terminal_persistence_bookkeeping_unavailable" in output
     _assert_content_free_diagnostics(output, sealed_write=sealed_write)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_real_atomic_direct_controller_persists_exact_body_and_trace_on_restart(
+    real_citation_stack_factory,
+) -> None:
+    stack = real_citation_stack_factory("real-atomic")
+    builder, prompt_id = _real_captured_builder(stack.repository)
+    controller = _real_controller(stack, builder, prompt_id)
+    log_stream, handler_id = _capture_logs()
+    try:
+        result = await controller.submit_draft("question")
+    finally:
+        logger.remove(handler_id)
+
+    assistant = _real_assistant(stack.store)
+    persisted = stack.db.get_message_by_id(assistant.id)
+    assert result.accepted is True
+    assert assistant.status == "complete"
+    assert assistant.content == _BODY_SENTINEL
+    assert assistant.persisted_message_id == assistant.id
+    assert persisted is not None
+    assert persisted["id"] == assistant.id
+    assert persisted["content"] == assistant.content
+    assert _citation_row_counts(stack.db) == {
+        "rag_citation_traces": 1,
+        "rag_evidence_runs": 1,
+        "rag_evidence_snapshots": 1,
+        "rag_answer_attempt_payloads": 1,
+        "rag_trace_evidence_refs": 1,
+        "rag_message_trace_owners": 1,
+    }
+
+    connection = stack.db.get_connection()
+    trace_row = connection.execute(
+        "SELECT trace_id, aggregate_json FROM rag_citation_traces"
+    ).fetchone()
+    attempt_row = connection.execute(
+        """
+        SELECT attempt_id, answer_body, body_integrity_hmac
+        FROM rag_answer_attempt_payloads
+        """
+    ).fetchone()
+    owner_row = connection.execute(
+        """
+        SELECT message_id, message_revision, trace_id, state
+        FROM rag_message_trace_owners
+        """
+    ).fetchone()
+    aggregate = json.loads(trace_row["aggregate_json"])
+
+    assert attempt_row["attempt_id"] == aggregate["selected_attempt_id"]
+    assert attempt_row["answer_body"] == persisted["content"]
+    assert aggregate["answer_attempts"][0]["occurrences"] == []
+    assert len(aggregate["evidence_runs"]) == 1
+    assert len(aggregate["prompt_evidence_sets"]) == 1
+    assert _BODY_SENTINEL not in trace_row["aggregate_json"]
+    assert attempt_row["body_integrity_hmac"] not in trace_row["aggregate_json"]
+    assert "body_integrity_hmac" not in trace_row["aggregate_json"]
+    assert owner_row["message_id"] == assistant.id
+    assert owner_row["message_revision"] == persisted["version"]
+    assert owner_row["trace_id"] == trace_row["trace_id"]
+    assert owner_row["state"] == "active"
+
+    log_output = log_stream.getvalue()
+    _assert_content_free_diagnostics(log_output)
+    assert attempt_row["body_integrity_hmac"] not in log_output
+
+    persisted_version = persisted["version"]
+    trace_id = trace_row["trace_id"]
+    stack.close()
+    reopened = CharactersRAGDB(stack.db_path, client_id=stack.client_id)
+    try:
+        reopened_identity = load_local_citation_identity_context(reopened)
+        assert reopened_identity is not None
+        restarted_repository = CitationTraceRepository(
+            reopened,
+            policy=CitationProvenanceRuntimePolicy(canonical_writes_enabled=True),
+            identity_context=reopened_identity,
+            fingerprint_codec=stack.codec,
+        )
+
+        active = restarted_repository.get_active_trace_for_message(
+            assistant.id,
+            persisted_version,
+            assistant.content,
+            stack.codec,
+        )
+
+        assert active.state is ActiveCitationTraceState.ACTIVE
+        assert active.summary is not None
+        assert active.summary.trace.trace_id == trace_id
+        assert restarted_repository.verify_active_trace_result(active) is True
+    finally:
+        reopened.close_connection()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_real_rollback_deterministic_unavailable_falls_back_without_trace_rows(
+    real_citation_stack_factory,
+) -> None:
+    stack = real_citation_stack_factory(
+        "real-rollback",
+        _DeterministicallyUnavailableRepository,
+    )
+    builder, prompt_id = _real_captured_builder(stack.repository)
+    controller = _real_controller(stack, builder, prompt_id)
+    log_stream, handler_id = _capture_logs()
+    try:
+        result = await controller.submit_draft("question")
+    finally:
+        logger.remove(handler_id)
+
+    assistant = _real_assistant(stack.store)
+    persisted = stack.db.get_message_by_id(assistant.id)
+    assert result.accepted is True
+    assert assistant.status == "complete"
+    assert assistant.content == _BODY_SENTINEL
+    assert assistant.persisted_message_id == assistant.id
+    assert persisted is not None
+    assert persisted["id"] == assistant.id
+    assert persisted["content"] == assistant.content
+    assert _citation_row_counts(stack.db) == {
+        "rag_citation_traces": 0,
+        "rag_evidence_runs": 0,
+        "rag_evidence_snapshots": 0,
+        "rag_answer_attempt_payloads": 0,
+        "rag_trace_evidence_refs": 0,
+        "rag_message_trace_owners": 0,
+    }
+
+    active = stack.repository.get_active_trace_for_message(
+        assistant.id,
+        persisted["version"],
+        persisted["content"],
+        stack.codec,
+    )
+    assert active.state is ActiveCitationTraceState.NOT_FOUND
+
+    log_output = log_stream.getvalue()
+    _assert_content_free_diagnostics(log_output)
+    assert builder.answer_attempt_payloads[0].body_integrity_hmac not in log_output

--- a/Tests/Chat/test_console_terminal_citation_persistence.py
+++ b/Tests/Chat/test_console_terminal_citation_persistence.py
@@ -1190,4 +1190,5 @@ async def test_real_rollback_deterministic_unavailable_falls_back_without_trace_
 
     log_output = log_stream.getvalue()
     _assert_content_free_diagnostics(log_output)
+    assert "forced_deterministic_unavailable" not in log_output
     assert builder.answer_attempt_payloads[0].body_integrity_hmac not in log_output

--- a/Tests/Chat/test_console_terminal_citation_persistence.py
+++ b/Tests/Chat/test_console_terminal_citation_persistence.py
@@ -434,6 +434,31 @@ def test_deferred_reads_materialize_chunks_without_early_create() -> None:
     _assert_terminal_state_paired(store)
 
 
+def test_explicit_persist_keeps_terminal_message_deferred_until_completion() -> None:
+    persistence = _ReadyCitationPersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    sealed_write = _sealed_write_for_body(_BODY_SENTINEL)
+    session_id, message_id = _append_eligible(store, lambda body: sealed_write)
+    store.append_stream_chunk(message_id, _BODY_SENTINEL)
+
+    assert store.get_message(message_id).content == _BODY_SENTINEL
+    assert store.messages_for_session(session_id)[-1].content == _BODY_SENTINEL
+    explicitly_persisted = store.persist_message_if_needed(message_id)
+
+    assert explicitly_persisted.persisted_message_id is None
+    assert persistence.create_calls == []
+    assert message_id in store._pending_persistence_message_ids
+    assert message_id in store._terminal_persistence_deferred_ids
+    _assert_terminal_state_paired(store)
+
+    completed = store.mark_message_complete(message_id)
+
+    assert completed.persisted_message_id == message_id
+    assert len(persistence.create_calls) == 1
+    assert persistence.create_calls[0]["message_id"] == message_id
+    assert persistence.create_calls[0]["citation_write"] is sealed_write
+
+
 def test_ordinary_empty_assistant_keeps_first_content_persistence_timing() -> None:
     persistence = _ReadyCitationPersistence()
     store = ConsoleChatStore(persistence=persistence)

--- a/Tests/DB/test_sql_debug_logging.py
+++ b/Tests/DB/test_sql_debug_logging.py
@@ -12,6 +12,7 @@ These tests prove:
   * it is *still* never stringified in full even with a DEBUG sink attached
     (lazy logging only defers the *decision*; once made, the preview helper
     must summarize bytes rather than repr() them);
+  * message INSERT parameters are replaced by one fixed redaction marker;
   * the shared ``preview_params`` helper produces the documented shapes.
 """
 
@@ -111,6 +112,54 @@ class TestNoStringifyAtDefaultLevel:
             logger.remove(sink_id)
         captured = capsys.readouterr()
         assert "Executing SQL" in captured.err
+
+
+def test_add_message_debug_log_redacts_sensitive_insert_params(db):
+    conversation_id = db.add_conversation(
+        {
+            "title": "SQL logging privacy",
+            "character_id": None,
+        }
+    )
+    body_sentinel = "PRIVATE_MESSAGE_BODY_SENTINEL"
+    message_id_sentinel = "private-message-id-sentinel"
+    sender_sentinel = "private-sender-identity-sentinel"
+    client_id_sentinel = "private-client-identity-sentinel"
+    captured_messages = []
+    sink_id = logger.add(
+        captured_messages.append,
+        level="DEBUG",
+        format="{message}",
+        filter=lambda record: record["level"].name == "DEBUG",
+    )
+    try:
+        db.add_message(
+            {
+                "id": message_id_sentinel,
+                "conversation_id": conversation_id,
+                "sender": sender_sentinel,
+                "content": body_sentinel,
+                "client_id": client_id_sentinel,
+            }
+        )
+    finally:
+        logger.remove(sink_id)
+
+    insert_logs = [
+        str(message)
+        for message in captured_messages
+        if "INSERT INTO messages" in str(message)
+    ]
+    assert len(insert_logs) == 1
+    insert_log = insert_logs[0]
+    assert "Params: <redacted>" in insert_log
+    for sentinel in (
+        body_sentinel,
+        message_id_sentinel,
+        sender_sentinel,
+        client_id_sentinel,
+    ):
+        assert sentinel not in insert_log
 
 
 class TestPreviewParamsHelperShapes:

--- a/Tests/Event_Handlers/test_worker_local_citation_capture.py
+++ b/Tests/Event_Handlers/test_worker_local_citation_capture.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import gc
+import json
+import weakref
+from unittest.mock import MagicMock
+
+from loguru import logger as loguru_logger
+
+import tldw_chatbook.Event_Handlers.worker_events as worker_events
+
+
+class _RequestBuilder:
+    pass
+
+
+def _app() -> MagicMock:
+    app = MagicMock()
+    app.loguru_logger = loguru_logger
+    app.current_chat_worker = None
+    app.app_config = {"chat_defaults": {"strip_thinking_tags": True}}
+    app.post_message = MagicMock()
+    return app
+
+
+def _request_kwargs(builder: object, *, streaming: bool) -> dict:
+    return {
+        "message": "WORKER_QUERY_SENTINEL_TASK_553_13",
+        "history": [],
+        "media_content": {"evidence": "WORKER_EVIDENCE_SNAPSHOT_SENTINEL_TASK_553_13"},
+        "selected_parts": ["evidence"],
+        "citation_trace_builder": builder,
+        "api_endpoint": "openai",
+        "api_key": "test-key",
+        "custom_prompt": "WORKER_CUSTOM_PROMPT_SENTINEL_TASK_553_13",
+        "temperature": 0.7,
+        "streaming": streaming,
+        "model": "test-model",
+        "llm_logprobs": True,
+        "llm_top_logprobs": 2,
+    }
+
+
+def test_streaming_worker_keeps_builder_local_and_logs_no_request_or_answer_content(
+    monkeypatch,
+):
+    app = _app()
+    builder = _RequestBuilder()
+    builder_ref = weakref.ref(builder)
+    media_content = {"evidence": "WORKER_EVIDENCE_SNAPSHOT_SENTINEL_TASK_553_13"}
+    selected_parts = ["evidence"]
+    answer = "STREAMING_ANSWER_SENTINEL_TASK_553_13"
+    reasoning = "STREAMING_REASONING_SENTINEL_TASK_553_13"
+    observed = {}
+
+    def fake_core_chat_function(**kwargs):
+        observed.update(kwargs)
+        assert "citation_trace_builder" not in kwargs
+        assert kwargs["media_content"] is media_content
+        assert kwargs["selected_parts"] is selected_parts
+
+        def stream():
+            assert builder_ref() is not None
+            yield "data: " + json.dumps(
+                {
+                    "choices": [
+                        {
+                            "delta": {
+                                "content": answer,
+                                "reasoning_content": reasoning,
+                            },
+                            "logprobs": {
+                                "content": [{"token": answer, "logprob": -0.1}]
+                            },
+                        }
+                    ]
+                }
+            )
+            assert builder_ref() is not None
+            yield "data: [DONE]"
+
+        return stream()
+
+    monkeypatch.setattr(worker_events, "core_chat_function", fake_core_chat_function)
+    captured_logs = []
+    sink_id = loguru_logger.add(
+        captured_logs.append,
+        level="DEBUG",
+        format="{message}",
+    )
+    kwargs = _request_kwargs(builder, streaming=True)
+    kwargs["media_content"] = media_content
+    kwargs["selected_parts"] = selected_parts
+    del builder
+
+    try:
+        result = worker_events.chat_wrapper_function(app, **kwargs)
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert result == "STREAMING_HANDLED_BY_EVENTS"
+    assert "citation_trace_builder" not in observed
+    del kwargs
+    gc.collect()
+    assert builder_ref() is None
+    rendered_logs = "".join(str(message) for message in captured_logs)
+    for sentinel in (
+        "WORKER_QUERY_SENTINEL_TASK_553_13",
+        "WORKER_EVIDENCE_SNAPSHOT_SENTINEL_TASK_553_13",
+        "WORKER_CUSTOM_PROMPT_SENTINEL_TASK_553_13",
+        answer,
+        reasoning,
+    ):
+        assert sentinel not in rendered_logs
+
+
+def test_non_streaming_worker_removes_builder_without_changing_rag_seam(
+    monkeypatch,
+):
+    app = _app()
+    builder = _RequestBuilder()
+    media_content = {"evidence": "NONSTREAM_EVIDENCE_SENTINEL_TASK_553_13"}
+    selected_parts = ["evidence"]
+    answer = "NONSTREAM_ANSWER_SENTINEL_TASK_553_13"
+    observed = {}
+
+    def fake_core_chat_function(**kwargs):
+        observed.update(kwargs)
+        return answer
+
+    monkeypatch.setattr(worker_events, "core_chat_function", fake_core_chat_function)
+    captured_logs = []
+    sink_id = loguru_logger.add(
+        captured_logs.append,
+        level="DEBUG",
+        format="{message}",
+    )
+    kwargs = _request_kwargs(builder, streaming=False)
+    kwargs["media_content"] = media_content
+    kwargs["selected_parts"] = selected_parts
+
+    try:
+        result = worker_events.chat_wrapper_function(app, **kwargs)
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert result == answer
+    assert "citation_trace_builder" not in observed
+    assert observed["media_content"] is media_content
+    assert observed["selected_parts"] is selected_parts
+    rendered_logs = "".join(str(message) for message in captured_logs)
+    for sentinel in (
+        "WORKER_QUERY_SENTINEL_TASK_553_13",
+        "NONSTREAM_EVIDENCE_SENTINEL_TASK_553_13",
+        "WORKER_CUSTOM_PROMPT_SENTINEL_TASK_553_13",
+        answer,
+    ):
+        assert sentinel not in rendered_logs
+
+
+def test_worker_exception_log_uses_structural_reason_only(monkeypatch):
+    app = _app()
+    failure_sentinel = "WORKER_VALIDATION_FAILURE_SENTINEL_TASK_553_13"
+
+    def fake_core_chat_function(**_kwargs):
+        raise ValueError(failure_sentinel)
+
+    monkeypatch.setattr(worker_events, "core_chat_function", fake_core_chat_function)
+    captured_logs = []
+    sink_id = loguru_logger.add(
+        captured_logs.append,
+        level="DEBUG",
+        format="{message}",
+    )
+
+    try:
+        result = worker_events.chat_wrapper_function(
+            app,
+            **_request_kwargs(_RequestBuilder(), streaming=False),
+        )
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert result == "STREAMING_HANDLED_BY_EVENTS"
+    assert failure_sentinel not in "".join(str(message) for message in captured_logs)

--- a/Tests/Event_Handlers/test_worker_local_citation_capture.py
+++ b/Tests/Event_Handlers/test_worker_local_citation_capture.py
@@ -46,12 +46,12 @@ def test_streaming_worker_keeps_builder_local_and_logs_no_request_or_answer_cont
 ):
     app = _app()
     builder = _RequestBuilder()
-    builder_ref = weakref.ref(builder)
     media_content = {"evidence": "WORKER_EVIDENCE_SNAPSHOT_SENTINEL_TASK_553_13"}
     selected_parts = ["evidence"]
     answer = "STREAMING_ANSWER_SENTINEL_TASK_553_13"
     reasoning = "STREAMING_REASONING_SENTINEL_TASK_553_13"
     observed = {}
+    builder_alive_during_stream = []
 
     def fake_core_chat_function(**kwargs):
         observed.update(kwargs)
@@ -60,7 +60,8 @@ def test_streaming_worker_keeps_builder_local_and_logs_no_request_or_answer_cont
         assert kwargs["selected_parts"] is selected_parts
 
         def stream():
-            assert builder_ref() is not None
+            builder_alive_during_stream.append(builder_ref() is not None)
+            assert builder_alive_during_stream[-1]
             yield "data: " + json.dumps(
                 {
                     "choices": [
@@ -76,7 +77,8 @@ def test_streaming_worker_keeps_builder_local_and_logs_no_request_or_answer_cont
                     ]
                 }
             )
-            assert builder_ref() is not None
+            builder_alive_during_stream.append(builder_ref() is not None)
+            assert builder_alive_during_stream[-1]
             yield "data: [DONE]"
 
         return stream()
@@ -91,16 +93,24 @@ def test_streaming_worker_keeps_builder_local_and_logs_no_request_or_answer_cont
     kwargs = _request_kwargs(builder, streaming=True)
     kwargs["media_content"] = media_content
     kwargs["selected_parts"] = selected_parts
+    builder_box = [kwargs.pop("citation_trace_builder")]
+    assert "citation_trace_builder" not in kwargs
+    builder_ref = weakref.ref(builder_box[0])
     del builder
 
     try:
-        result = worker_events.chat_wrapper_function(app, **kwargs)
+        result = worker_events.chat_wrapper_function(
+            app,
+            citation_trace_builder=builder_box.pop(),
+            **kwargs,
+        )
     finally:
         loguru_logger.remove(sink_id)
 
+    assert builder_alive_during_stream == [True, True]
     assert result == "STREAMING_HANDLED_BY_EVENTS"
+    assert builder_box == []
     assert "citation_trace_builder" not in observed
-    del kwargs
     gc.collect()
     assert builder_ref() is None
     rendered_logs = "".join(str(message) for message in captured_logs)
@@ -114,18 +124,25 @@ def test_streaming_worker_keeps_builder_local_and_logs_no_request_or_answer_cont
         assert sentinel not in rendered_logs
 
 
-def test_non_streaming_worker_removes_builder_without_changing_rag_seam(
+def test_non_streaming_worker_keeps_builder_local_without_changing_rag_seam(
     monkeypatch,
 ):
     app = _app()
     builder = _RequestBuilder()
+    builder_ref = weakref.ref(builder)
     media_content = {"evidence": "NONSTREAM_EVIDENCE_SENTINEL_TASK_553_13"}
     selected_parts = ["evidence"]
     answer = "NONSTREAM_ANSWER_SENTINEL_TASK_553_13"
     observed = {}
+    builder_alive_in_core = []
 
     def fake_core_chat_function(**kwargs):
+        builder_alive_in_core.append(builder_ref() is not None)
+        assert builder_alive_in_core[-1]
         observed.update(kwargs)
+        assert "citation_trace_builder" not in kwargs
+        assert kwargs["media_content"] is media_content
+        assert kwargs["selected_parts"] is selected_parts
         return answer
 
     monkeypatch.setattr(worker_events, "core_chat_function", fake_core_chat_function)
@@ -138,16 +155,27 @@ def test_non_streaming_worker_removes_builder_without_changing_rag_seam(
     kwargs = _request_kwargs(builder, streaming=False)
     kwargs["media_content"] = media_content
     kwargs["selected_parts"] = selected_parts
+    builder_box = [kwargs.pop("citation_trace_builder")]
+    assert "citation_trace_builder" not in kwargs
+    del builder
 
     try:
-        result = worker_events.chat_wrapper_function(app, **kwargs)
+        result = worker_events.chat_wrapper_function(
+            app,
+            citation_trace_builder=builder_box.pop(),
+            **kwargs,
+        )
     finally:
         loguru_logger.remove(sink_id)
 
+    assert builder_alive_in_core == [True]
     assert result == answer
+    assert builder_box == []
     assert "citation_trace_builder" not in observed
     assert observed["media_content"] is media_content
     assert observed["selected_parts"] is selected_parts
+    gc.collect()
+    assert builder_ref() is None
     rendered_logs = "".join(str(message) for message in captured_logs)
     for sentinel in (
         "WORKER_QUERY_SENTINEL_TASK_553_13",

--- a/Tests/Event_Handlers/test_worker_local_citation_capture.py
+++ b/Tests/Event_Handlers/test_worker_local_citation_capture.py
@@ -124,6 +124,69 @@ def test_streaming_worker_keeps_builder_local_and_logs_no_request_or_answer_cont
         assert sentinel not in rendered_logs
 
 
+def test_streaming_first_chunk_structure_is_logged_once_per_request(monkeypatch):
+    answers = [
+        "FIRST_REQUEST_ANSWER_SENTINEL_TASK_553_13",
+        "SECOND_REQUEST_ANSWER_SENTINEL_TASK_553_13",
+    ]
+
+    def fake_core_chat_function(**_kwargs):
+        answer = answers.pop(0)
+
+        def stream():
+            for suffix in ("one", "two"):
+                yield "data: " + json.dumps(
+                    {
+                        "choices": [
+                            {
+                                "delta": {"content": f"{answer}-{suffix}"},
+                                "logprobs": {
+                                    "content": [
+                                        {
+                                            "token": f"{answer}-{suffix}",
+                                            "logprob": -0.1,
+                                        }
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                )
+            yield "data: [DONE]"
+
+        return stream()
+
+    monkeypatch.setattr(worker_events, "core_chat_function", fake_core_chat_function)
+    diagnostic = (
+        "First streaming chunk received with logprobs enabled; "
+        "provider=openai; choice_count=1"
+    )
+    per_request_logs = []
+
+    for answer in tuple(answers):
+        captured_logs = []
+        sink_id = loguru_logger.add(
+            captured_logs.append,
+            level="DEBUG",
+            format="{message}",
+        )
+        try:
+            result = worker_events.chat_wrapper_function(
+                _app(),
+                **_request_kwargs(_RequestBuilder(), streaming=True),
+            )
+        finally:
+            loguru_logger.remove(sink_id)
+
+        assert result == "STREAMING_HANDLED_BY_EVENTS"
+        rendered_logs = "".join(str(message) for message in captured_logs)
+        assert answer not in rendered_logs
+        per_request_logs.append(rendered_logs)
+
+    assert not hasattr(worker_events.chat_wrapper_function, "_logged_structure")
+    assert [logs.count(diagnostic) for logs in per_request_logs] == [1, 1]
+
+
 def test_non_streaming_worker_keeps_builder_local_without_changing_rag_seam(
     monkeypatch,
 ):

--- a/Tests/RAG/test_local_citation_capture.py
+++ b/Tests/RAG/test_local_citation_capture.py
@@ -36,6 +36,7 @@ from tldw_chatbook.Chat.citation_trace_repository import (
     load_local_citation_identity_context,
 )
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
 from tldw_chatbook.RAG_Search.local_citation_capture import (
     FINAL_SCORE_KIND_KEY,
     FINAL_SCORE_KIND_RERANKER,
@@ -986,11 +987,39 @@ async def test_capture_api_records_one_equivalent_run_and_prompt_for_every_mode(
     expected_context = f"[S1] MEDIA — {title}\n{content}"
     repository = _CaptureRepository()
     app = _CaptureApp(search_mode=search_mode, repository=repository)
-    _patch_pipeline(
-        monkeypatch,
-        [_ranked_result(title=title, content=content)],
-        "legacy pipeline bytes",
+    pipeline_function_names = (
+        "perform_plain_rag_search",
+        "perform_full_rag_pipeline",
+        "perform_hybrid_rag_search",
+        "perform_search_with_pipeline",
     )
+    expected_function_name = {
+        "plain": "perform_plain_rag_search",
+        "semantic": "perform_full_rag_pipeline",
+        "hybrid": "perform_hybrid_rag_search",
+        "custom-pipeline": "perform_search_with_pipeline",
+    }[search_mode]
+    calls = []
+
+    def _refuse_wrong_branch(function_name):
+        async def _refuse(*_args, **_kwargs):
+            raise AssertionError(f"unexpected pipeline branch: {function_name}")
+
+        return _refuse
+
+    for function_name in pipeline_function_names:
+        monkeypatch.setattr(cre, function_name, _refuse_wrong_branch(function_name))
+
+    async def _expected_branch(*args, **kwargs):
+        calls.append((args, kwargs))
+        return [_ranked_result(title=title, content=content)], "legacy pipeline bytes"
+
+    monkeypatch.setattr(cre, expected_function_name, _expected_branch)
+
+    async def _semantic_service(*_args, **_kwargs):
+        return object(), None
+
+    monkeypatch.setattr(cre, "resolve_semantic_rag_service", _semantic_service)
     captured_logs = []
     sink_id = loguru_logger.add(
         captured_logs.append,
@@ -1020,6 +1049,9 @@ async def test_capture_api_records_one_equivalent_run_and_prompt_for_every_mode(
     assert re.fullmatch(r"request_[0-9a-f]{32}", repository.request_ids[0])
     assert re.fullmatch(r"generation_[0-9a-f]{32}", repository.generation_ids[0])
     assert repository.request_ids[0] != repository.generation_ids[0]
+    assert len(calls) == 1
+    if search_mode == "custom-pipeline":
+        assert calls[0][0][3] == "custom-pipeline"
 
     rendered_logs = "".join(str(message) for message in captured_logs)
     for sentinel in (query, title, content):
@@ -1185,6 +1217,55 @@ async def test_malformed_result_is_excluded_before_markers_and_logs_are_sanitize
 
 
 @pytest.mark.asyncio
+async def test_off_selection_source_is_excluded_before_authorization_and_capture(
+    monkeypatch,
+):
+    sentinel = "PRIVATE-OFF-SELECTION-NOTE-SENTINEL"
+    repository = _CaptureRepository()
+    app = _CaptureApp(repository=repository, media_ids=("m1",))
+    note_result = {
+        "source": "note",
+        "id": "n1",
+        "title": sentinel,
+        "content": sentinel,
+        "score": 0.9,
+        "metadata": {},
+    }
+    media_result = _ranked_result(
+        result_id="m1",
+        title="Selected",
+        content="selected body",
+    )
+    _patch_pipeline(
+        monkeypatch,
+        [note_result, media_result],
+        "legacy context must not survive canonical capture",
+    )
+    captured_logs = []
+    sink_id = loguru_logger.add(
+        captured_logs.append,
+        level="DEBUG",
+        format="{message}",
+    )
+    try:
+        captured = await cre.get_rag_context_capture_for_chat(app, "query")
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert captured.context == "[S1] MEDIA — Selected\nselected body"
+    assert captured.citation_builder is repository.builders[0]
+    run_payload = captured.citation_builder.evidence_run_payloads[0]
+    assert [candidate.rank for candidate in run_payload.candidates] == [2]
+    assert [
+        candidate.source_identity["source_kind"] for candidate in run_payload.candidates
+    ] == [CanonicalSourceKind.MEDIA_DB.value]
+    prompt = captured.citation_builder.prompt_evidence_sets[0]
+    assert [entry.marker_ordinal for entry in prompt.entries] == [1]
+    rendered_logs = "".join(str(message) for message in captured_logs)
+    assert sentinel not in rendered_logs
+
+
+@pytest.mark.asyncio
 async def test_validation_failure_discards_context_and_partial_builder_without_logging(
     monkeypatch, tmp_path
 ):
@@ -1237,3 +1318,103 @@ async def test_validation_failure_discards_context_and_partial_builder_without_l
         assert "reason=canonical_capture_failure" in rendered_logs
     finally:
         db.close_connection()
+
+
+def test_sensitive_real_database_reads_do_not_log_source_identities(tmp_path):
+    media_sentinel = "987654321"
+    note_sentinel = "PRIVATE-NOTE-IDENTITY-SENTINEL"
+    conversation_sentinel = "PRIVATE-CONVERSATION-IDENTITY-SENTINEL"
+    media_db = MediaDatabase(tmp_path / "sensitive-media.sqlite", "sensitive-media")
+    chacha_db = CharactersRAGDB(
+        tmp_path / "sensitive-chacha.sqlite",
+        client_id="sensitive-chacha",
+    )
+    app = SimpleNamespace(media_db=media_db, chachanotes_db=chacha_db)
+    captured_logs = []
+    sink_id = loguru_logger.add(
+        captured_logs.append,
+        level="DEBUG",
+        format="{message}",
+    )
+    try:
+        assert (
+            cre._existing_ids_sync(
+                app,
+                cre.SOURCE_TYPE_MEDIA,
+                frozenset({media_sentinel}),
+            )
+            == frozenset()
+        )
+        assert (
+            cre._existing_ids_sync(
+                app,
+                cre.SOURCE_TYPE_NOTE,
+                frozenset({note_sentinel}),
+            )
+            == frozenset()
+        )
+        assert (
+            cre._current_media_evidence_ids_sync(
+                media_db,
+                frozenset({media_sentinel}),
+            )
+            == frozenset()
+        )
+        assert (
+            cre._current_chacha_evidence_ids_sync(
+                chacha_db,
+                frozenset({note_sentinel}),
+                frozenset({conversation_sentinel}),
+            )
+            == frozenset()
+        )
+    finally:
+        loguru_logger.remove(sink_id)
+        media_db.close_connection()
+        chacha_db.close_connection()
+
+    rendered_logs = "".join(str(message) for message in captured_logs)
+    for sentinel in (media_sentinel, note_sentinel, conversation_sentinel):
+        assert sentinel not in rendered_logs
+
+
+@pytest.mark.asyncio
+async def test_fresh_persisted_scope_read_does_not_log_conversation_identity(
+    tmp_path,
+):
+    conversation_sentinel = "PRIVATE-FRESH-CONVERSATION-IDENTITY-SENTINEL"
+    chacha_db = CharactersRAGDB(
+        tmp_path / "fresh-scope-chacha.sqlite",
+        client_id="fresh-scope-chacha",
+    )
+    chacha_db.add_conversation(
+        {
+            "id": conversation_sentinel,
+            "title": "Private identity log regression",
+        }
+    )
+    app = SimpleNamespace(chachanotes_db=chacha_db, media_db=None)
+    session = SimpleNamespace(
+        id="session-log-regression",
+        persisted_conversation_id=conversation_sentinel,
+        workspace_id=None,
+    )
+    captured_logs = []
+    sink_id = loguru_logger.add(
+        captured_logs.append,
+        level="DEBUG",
+        format="{message}",
+    )
+    try:
+        resolution = await cre.resolve_scope_for_session(
+            app,
+            session,
+            use_cache=False,
+        )
+    finally:
+        loguru_logger.remove(sink_id)
+        chacha_db.close_connection()
+
+    assert resolution.effective.state == "unscoped"
+    rendered_logs = "".join(str(message) for message in captured_logs)
+    assert conversation_sentinel not in rendered_logs

--- a/Tests/RAG/test_local_citation_capture.py
+++ b/Tests/RAG/test_local_citation_capture.py
@@ -16,6 +16,11 @@ from pydantic import ValidationError
 from tldw_chatbook.Chat.citation_provenance_runtime import (
     CitationProvenanceRuntimePolicy,
 )
+from tldw_chatbook.Chat.citation_evidence_models import (
+    EvidenceBundle,
+    EvidenceReference,
+)
+from tldw_chatbook.Chat.console_live_work import ConsoleLiveWorkLaunch
 from tldw_chatbook.Chat.citation_source_locators import CanonicalSourceKind
 from tldw_chatbook.Chat.citation_trace_builder import (
     CitationTraceBuilder,
@@ -1139,6 +1144,103 @@ def test_local_rag_context_result_is_frozen():
 
     with pytest.raises(FrozenInstanceError):
         result.context = "changed"
+
+
+@pytest.mark.asyncio
+async def test_console_staged_local_evidence_records_exact_prompt_capture():
+    query = "CONSOLE_PRIVATE_QUERY_SENTINEL_TASK_553_13"
+    title = "CONSOLE_PRIVATE_TITLE_SENTINEL_TASK_553_13"
+    snippet = "  CONSOLE_PRIVATE_BODY_SENTINEL_TASK_553_13  \n\t"
+    repository = _CaptureRepository()
+    app = _CaptureApp(repository=repository)
+    launch = ConsoleLiveWorkLaunch.from_values(
+        source="Library Search/RAG",
+        title=title,
+        payload={
+            "requested_top_k": 5,
+            "search_mode": "rag",
+            "evidence_bundle": EvidenceBundle(
+                bundle_id="bundle-1",
+                query=query,
+                references=(
+                    EvidenceReference(
+                        evidence_id="S1",
+                        source_id="m1",
+                        source_type="media",
+                        title=title,
+                        snippet=snippet,
+                        authority_label="local",
+                        source_owner="local",
+                        score=0.75,
+                    ),
+                ),
+            ).to_payload(),
+        },
+        status="staged",
+    )
+
+    captured = await cre.capture_console_staged_evidence_for_chat(
+        app,
+        launch,
+        user_message="ordinary prompt",
+    )
+
+    assert captured.context == f"[S1] MEDIA — {title}\n{snippet}"
+    assert captured.citation_builder is repository.builders[0]
+    run_payload = captured.citation_builder.evidence_run_payloads[0]
+    assert run_payload.raw_query is None
+    assert run_payload.query_fingerprint is not None
+    assert run_payload.retrieval_metadata == {
+        "max_context_characters": len(captured.context),
+        "requested_top_k": 5,
+        "rerank_enabled": False,
+        "scope_state": "unscoped",
+        "search_mode": "console_rag",
+        "source_kinds": ["media_db"],
+    }
+    assert [candidate.rank for candidate in run_payload.candidates] == [1]
+    snapshot = captured.citation_builder.evidence_snapshot_payloads[0]
+    assert snapshot.snapshot_text == captured.context
+    assert snapshot.snapshot_text.encode("utf-8").endswith(snippet.encode("utf-8"))
+
+
+@pytest.mark.asyncio
+async def test_console_staged_local_evidence_without_repository_keeps_context():
+    title = "Legacy staged source"
+    launch = ConsoleLiveWorkLaunch.from_values(
+        source="Library Search/RAG",
+        title=title,
+        payload={
+            "evidence_bundle": EvidenceBundle(
+                bundle_id="bundle-legacy",
+                query="legacy query",
+                references=(
+                    EvidenceReference(
+                        evidence_id="S1",
+                        source_id="m1",
+                        source_type="media",
+                        title=title,
+                        snippet="legacy body",
+                        authority_label="local",
+                        source_owner="local",
+                        score=0.5,
+                    ),
+                ),
+            ).to_payload(),
+        },
+        status="staged",
+    )
+
+    captured = await cre.capture_console_staged_evidence_for_chat(
+        _CaptureApp(),
+        launch,
+        user_message="ordinary prompt",
+    )
+
+    assert captured == cre.LocalRagContextResult(
+        context="[S1] MEDIA — Legacy staged source\nlegacy body",
+        citation_builder=None,
+    )
 
 
 @pytest.mark.asyncio

--- a/Tests/RAG/test_local_citation_capture.py
+++ b/Tests/RAG/test_local_citation_capture.py
@@ -7,6 +7,7 @@ import sys
 from types import SimpleNamespace
 
 import pytest
+from loguru import logger as loguru_logger
 
 from tldw_chatbook.Chat.citation_source_locators import CanonicalSourceKind
 from tldw_chatbook.Chat.citation_trace_models import (
@@ -353,6 +354,14 @@ class _SemanticService:
         return [self.result]
 
 
+class _Citation:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def to_dict(self):
+        return dict(self.payload)
+
+
 @pytest.mark.asyncio
 async def test_search_semantic_propagates_allowlisted_metadata_source_and_score_marker():
     app = SimpleNamespace(
@@ -405,6 +414,39 @@ async def test_search_semantic_replaces_untrusted_internal_score_metadata():
         normalize_local_result(result).score_kind
         is RetrievalScoreKind.VECTOR_SIMILARITY
     )
+
+
+@pytest.mark.asyncio
+async def test_citation_semantic_result_keeps_shape_and_governed_source():
+    producer = _SemanticResult(
+        source="unknown",
+        metadata={
+            "source_type": "note",
+            "source_id": "note-7",
+            "safe_lineage": "kept",
+        },
+    )
+    producer.id = "note_note-7_chunk_0"
+    producer.citations = [_Citation({"document_id": "note-7", "text": "quote"})]
+    app = SimpleNamespace(_rag_service=_SemanticService(producer))
+
+    result = (await pfs.search_semantic(app, "query", {"notes": True}))[0]
+
+    assert isinstance(result, SearchResult)
+    assert result.source == "note"
+    assert result.id == "note_note-7_chunk_0"
+    assert result.title == "Semantic"
+    assert result.content == "semantic body"
+    assert result.score == 0.73
+    assert result.metadata["source_id"] == "note-7"
+    assert result.metadata["safe_lineage"] == "kept"
+    assert result.metadata["_has_citations"] is True
+    assert result.metadata["_citations"] == [{"document_id": "note-7", "text": "quote"}]
+    assert (
+        result.metadata[SEMANTIC_SCORE_KIND_KEY]
+        == SEMANTIC_SCORE_KIND_VECTOR_SIMILARITY
+    )
+    assert FINAL_SCORE_KIND_KEY not in result.metadata
 
 
 def _install_flashrank(monkeypatch, *, ranked=None, init_error=None, run_error=None):
@@ -468,9 +510,40 @@ def test_invalid_flashrank_score_falls_back_without_marker(monkeypatch):
     )
 
 
+def _prior_score_result(prior_kind):
+    if prior_kind is RetrievalScoreKind.RRF:
+        return _result(
+            score=0.3 / 61,
+            metadata={
+                "hybrid_fusion": {
+                    "fts_rank": 1,
+                    "vector_rank": None,
+                    "fts_rrf": 1 / 61,
+                    "vector_rrf": 0.0,
+                    "alpha": 0.7,
+                    "rrf_k": 60,
+                }
+            },
+        )
+    if prior_kind is RetrievalScoreKind.VECTOR_SIMILARITY:
+        return _result(
+            score=0.73,
+            metadata={SEMANTIC_SCORE_KIND_KEY: SEMANTIC_SCORE_KIND_VECTOR_SIMILARITY},
+        )
+    return _result(score=-4.2, metadata={"producer": "opaque"})
+
+
 @pytest.mark.parametrize("failure_stage", ["import", "initialization", "execution"])
+@pytest.mark.parametrize(
+    "prior_kind",
+    [
+        RetrievalScoreKind.RRF,
+        RetrievalScoreKind.VECTOR_SIMILARITY,
+        RetrievalScoreKind.LEGACY,
+    ],
+)
 def test_flashrank_fallback_never_claims_reranker_and_keeps_prior_semantics(
-    monkeypatch, failure_stage
+    monkeypatch, failure_stage, prior_kind
 ):
     if failure_stage == "import":
         monkeypatch.setitem(sys.modules, "flashrank", None)
@@ -478,26 +551,35 @@ def test_flashrank_fallback_never_claims_reranker_and_keeps_prior_semantics(
         _install_flashrank(monkeypatch, init_error=RuntimeError("init failed"))
     else:
         _install_flashrank(monkeypatch, run_error=RuntimeError("run failed"))
-    score = 0.3 / 61
-    result = _result(
-        score=score,
-        metadata={
-            "hybrid_fusion": {
-                "fts_rank": 1,
-                "vector_rank": None,
-                "fts_rrf": 1 / 61,
-                "vector_rrf": 0.0,
-                "alpha": 0.7,
-                "rrf_k": 60,
-            }
-        },
-    )
+    result = _prior_score_result(prior_kind)
 
     fallback = pfs.rerank_results([result], "query", top_k=1)
 
     assert fallback == [result]
     assert FINAL_SCORE_KIND_KEY not in fallback[0].metadata
-    assert normalize_local_result(fallback[0]).score_kind is RetrievalScoreKind.RRF
+    assert normalize_local_result(fallback[0]).score_kind is prior_kind
+
+
+def test_flashrank_execution_failure_log_omits_exception_and_content(monkeypatch):
+    sentinel = "PRIVATE-RAG-CONTENT-SENTINEL"
+    _install_flashrank(monkeypatch, run_error=RuntimeError(sentinel))
+    result = _result(title=sentinel, content=sentinel)
+    captured = []
+    sink_id = loguru_logger.add(
+        captured.append,
+        level="WARNING",
+        format="{message}",
+    )
+    try:
+        fallback = pfs.rerank_results([result], sentinel, top_k=1)
+    finally:
+        loguru_logger.remove(sink_id)
+
+    rendered = "".join(str(message) for message in captured)
+    assert fallback == [result]
+    assert sentinel not in rendered
+    assert "status=fallback" in rendered
+    assert "reason=execution_failure" in rendered
 
 
 def test_weighted_score_overwrite_removes_prior_semantic_classification():

--- a/Tests/RAG/test_local_citation_capture.py
+++ b/Tests/RAG/test_local_citation_capture.py
@@ -2,14 +2,26 @@
 
 from __future__ import annotations
 
+import json
 import math
+import re
 import sys
+from dataclasses import FrozenInstanceError
 from types import SimpleNamespace
 
 import pytest
 from loguru import logger as loguru_logger
+from pydantic import ValidationError
 
 from tldw_chatbook.Chat.citation_source_locators import CanonicalSourceKind
+from tldw_chatbook.Chat.citation_trace_builder import (
+    CitationTraceBuilder,
+    LocalRetrievalRunMetadata,
+)
+from tldw_chatbook.Chat.citation_trace_identity import (
+    CitationFingerprintCodec,
+    LocalCitationIdentityContext,
+)
 from tldw_chatbook.Chat.citation_trace_models import (
     EVIDENCE_ENTRIES_PER_PROMPT_MAX,
     RetrievalScoreKind,
@@ -26,6 +38,7 @@ from tldw_chatbook.RAG_Search.local_citation_capture import (
     format_local_evidence_context,
     normalize_local_result,
 )
+from tldw_chatbook.Event_Handlers.Chat_Events import chat_rag_events as cre
 from tldw_chatbook.RAG_Search import pipeline_functions_simple as pfs
 from tldw_chatbook.RAG_Search.pipeline_types import SearchResult
 
@@ -813,3 +826,344 @@ def test_weighted_score_overwrite_removes_prior_semantic_classification():
 
     assert SEMANTIC_SCORE_KIND_KEY not in merged[0].metadata
     assert normalize_local_result(merged[0]).score_kind is RetrievalScoreKind.LEGACY
+
+
+class _CaptureWidget:
+    def __init__(self, value):
+        self.value = value
+
+
+class _Rows:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def fetchall(self):
+        return self._rows
+
+
+class _ExistingMediaDB:
+    is_memory_db = True
+
+    def __init__(self, *existing_ids: str):
+        self.existing_ids = set(existing_ids)
+
+    def execute_query(self, _query, params):
+        requested = set(json.loads(params[0]))
+        return _Rows(
+            [(source_id,) for source_id in sorted(requested & self.existing_ids)]
+        )
+
+
+class _CaptureRepository:
+    def __init__(self):
+        self.builders = []
+        self.request_ids = []
+        self.generation_ids = []
+
+    def create_local_trace_builder(self, *, request_id, generation_id):
+        self.request_ids.append(request_id)
+        self.generation_ids.append(generation_id)
+        builder = CitationTraceBuilder.local(
+            request_id=request_id,
+            generation_id=generation_id,
+            identity_context=LocalCitationIdentityContext(
+                profile_id="profile-1",
+                local_authority_id="authority-1",
+                fingerprint_key_id="key-1",
+            ),
+            fingerprint_codec=CitationFingerprintCodec(b"k" * 32),
+        )
+        self.builders.append(builder)
+        return builder
+
+
+class _UnavailableCaptureRepository:
+    def create_local_trace_builder(self, *, request_id, generation_id):
+        del request_id, generation_id
+        return None
+
+
+class _CaptureApp:
+    def __init__(self, *, search_mode="plain", repository=None, media_ids=("m1",)):
+        self._widgets = {
+            "#chat-rag-enable-checkbox": _CaptureWidget(True),
+            "#chat-rag-plain-enable-checkbox": _CaptureWidget(search_mode == "plain"),
+            "#chat-rag-search-mode": _CaptureWidget(search_mode),
+            "#chat-rag-search-media-checkbox": _CaptureWidget(True),
+            "#chat-rag-search-conversations-checkbox": _CaptureWidget(False),
+            "#chat-rag-search-notes-checkbox": _CaptureWidget(False),
+            "#chat-rag-keyword-filter": _CaptureWidget(""),
+            "#chat-rag-top-k": _CaptureWidget("5"),
+            "#chat-rag-max-context-length": _CaptureWidget("500"),
+            "#chat-rag-rerank-enable-checkbox": _CaptureWidget(False),
+            "#chat-rag-reranker-model": _CaptureWidget("flashrank"),
+            "#chat-rag-chunk-size": _CaptureWidget("400"),
+            "#chat-rag-chunk-overlap": _CaptureWidget("100"),
+            "#chat-rag-chunk-type": _CaptureWidget("words"),
+            "#chat-rag-include-metadata-checkbox": _CaptureWidget(False),
+        }
+        self.media_db = _ExistingMediaDB(*media_ids)
+        self.notifications = []
+        if repository is not None:
+            self.citation_trace_repository = repository
+
+    def query_one(self, selector):
+        return self._widgets[selector]
+
+    def notify(self, message, severity="information", **_kwargs):
+        self.notifications.append((message, severity))
+
+
+def _ranked_result(
+    *,
+    result_id="m1",
+    title="Title",
+    content="body",
+    metadata=None,
+):
+    return {
+        "source": "media",
+        "id": result_id,
+        "title": title,
+        "content": content,
+        "score": 0.75,
+        "metadata": {} if metadata is None else metadata,
+    }
+
+
+def _patch_pipeline(monkeypatch, results, context):
+    async def _search(*_args, **_kwargs):
+        return results, context
+
+    for function_name in (
+        "perform_plain_rag_search",
+        "perform_full_rag_pipeline",
+        "perform_hybrid_rag_search",
+        "perform_search_with_pipeline",
+    ):
+        monkeypatch.setattr(cre, function_name, _search)
+
+    async def _semantic_service(*_args, **_kwargs):
+        return object(), None
+
+    monkeypatch.setattr(cre, "resolve_semantic_rag_service", _semantic_service)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "search_mode",
+    ["plain", "semantic", "hybrid", "custom-pipeline"],
+)
+async def test_capture_api_records_one_equivalent_run_and_prompt_for_every_mode(
+    monkeypatch, search_mode
+):
+    query = "PRIVATE-QUERY-CAPTURE-SENTINEL"
+    title = "PRIVATE-TITLE-CAPTURE-SENTINEL"
+    content = "PRIVATE-CONTENT-CAPTURE-SENTINEL"
+    expected_context = f"[S1] MEDIA — {title}\n{content}"
+    repository = _CaptureRepository()
+    app = _CaptureApp(search_mode=search_mode, repository=repository)
+    _patch_pipeline(
+        monkeypatch,
+        [_ranked_result(title=title, content=content)],
+        "legacy pipeline bytes",
+    )
+    captured_logs = []
+    sink_id = loguru_logger.add(
+        captured_logs.append,
+        level="DEBUG",
+        format="{message}",
+    )
+    try:
+        captured = await cre.get_rag_context_capture_for_chat(app, query)
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert isinstance(captured, cre.LocalRagContextResult)
+    assert captured.context == expected_context
+    assert captured.citation_builder is repository.builders[0]
+    assert len(captured.citation_builder.evidence_runs) == 1
+    assert len(captured.citation_builder.prompt_evidence_sets) == 1
+    assert len(captured.citation_builder.evidence_run_payloads) == 1
+    assert len(captured.citation_builder.evidence_snapshot_payloads) == 1
+    run_payload = captured.citation_builder.evidence_run_payloads[0]
+    assert run_payload.raw_query is None
+    assert run_payload.query_fingerprint is not None
+    assert run_payload.retrieval_metadata["search_mode"] == search_mode
+    assert [candidate.rank for candidate in run_payload.candidates] == [1]
+    snapshot = captured.citation_builder.evidence_snapshot_payloads[0]
+    assert snapshot.snapshot_text == expected_context
+    assert captured.citation_builder.evidence_runs[0].ended_at is not None
+    assert re.fullmatch(r"request_[0-9a-f]{32}", repository.request_ids[0])
+    assert re.fullmatch(r"generation_[0-9a-f]{32}", repository.generation_ids[0])
+    assert repository.request_ids[0] != repository.generation_ids[0]
+
+    rendered_logs = "".join(str(message) for message in captured_logs)
+    for sentinel in (query, title, content):
+        assert sentinel not in rendered_logs
+
+
+def test_local_rag_context_result_is_frozen():
+    result = cre.LocalRagContextResult(context=None, citation_builder=None)
+
+    with pytest.raises(FrozenInstanceError):
+        result.context = "changed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "availability",
+    ["repository-absent", "writes-disabled", "key-unavailable", "identity-unavailable"],
+)
+async def test_unavailable_canonical_capture_preserves_legacy_pipeline_bytes(
+    monkeypatch, availability
+):
+    repository = (
+        None if availability == "repository-absent" else _UnavailableCaptureRepository()
+    )
+    app = _CaptureApp(repository=repository)
+    raw_context = "LEGACY\x00PIPELINE\nBYTES"
+    _patch_pipeline(monkeypatch, [_ranked_result()], raw_context)
+
+    captured = await cre.get_rag_context_capture_for_chat(app, "query")
+    legacy = await cre.get_rag_context_for_chat(app, "query")
+
+    assert captured == cre.LocalRagContextResult(
+        context=raw_context,
+        citation_builder=None,
+    )
+    assert isinstance(legacy, str)
+    assert legacy == raw_context
+
+
+@pytest.mark.asyncio
+async def test_empty_retrieval_records_only_the_empty_run(monkeypatch):
+    repository = _CaptureRepository()
+    app = _CaptureApp(repository=repository)
+    _patch_pipeline(monkeypatch, [], "")
+
+    captured = await cre.get_rag_context_capture_for_chat(app, "query")
+
+    assert captured.context is None
+    assert captured.citation_builder is repository.builders[0]
+    assert len(captured.citation_builder.evidence_runs) == 1
+    assert captured.citation_builder.evidence_run_payloads[0].candidates == ()
+    assert captured.citation_builder.prompt_evidence_sets == ()
+
+
+@pytest.mark.asyncio
+async def test_pipeline_exception_returns_no_context_or_builder_and_sanitizes_log(
+    monkeypatch,
+):
+    query = "PRIVATE-PIPELINE-QUERY-SENTINEL"
+    failure = "PRIVATE-PIPELINE-FAILURE-SENTINEL"
+    repository = _CaptureRepository()
+    app = _CaptureApp(repository=repository)
+
+    async def _raise(*_args, **_kwargs):
+        raise RuntimeError(failure)
+
+    monkeypatch.setattr(cre, "perform_plain_rag_search", _raise)
+    captured_logs = []
+    sink_id = loguru_logger.add(
+        captured_logs.append,
+        level="DEBUG",
+        format="{message}",
+    )
+    try:
+        captured = await cre.get_rag_context_capture_for_chat(app, query)
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert captured == cre.LocalRagContextResult(
+        context=None,
+        citation_builder=None,
+    )
+    rendered_logs = "".join(str(message) for message in captured_logs)
+    assert query not in rendered_logs
+    assert failure not in rendered_logs
+    assert "reason=pipeline_failure" in rendered_logs
+
+
+@pytest.mark.asyncio
+async def test_malformed_result_is_excluded_before_markers_and_logs_are_sanitized(
+    monkeypatch,
+):
+    sentinel = "PRIVATE-MALFORMED-RESULT-SENTINEL"
+    repository = _CaptureRepository()
+    app = _CaptureApp(repository=repository, media_ids=("m2",))
+    malformed = _ranked_result(
+        result_id="m1",
+        title=f"{sentinel}\ninvalid",
+        content=sentinel,
+    )
+    valid = _ranked_result(result_id="m2", title="Valid", content="safe")
+    _patch_pipeline(monkeypatch, [malformed, valid], sentinel)
+    captured_logs = []
+    sink_id = loguru_logger.add(
+        captured_logs.append,
+        level="DEBUG",
+        format="{message}",
+    )
+    try:
+        captured = await cre.get_rag_context_capture_for_chat(app, sentinel)
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert captured.context == "[S1] MEDIA — Valid\nsafe"
+    assert captured.citation_builder is not None
+    candidates = captured.citation_builder.evidence_run_payloads[0].candidates
+    assert [candidate.rank for candidate in candidates] == [2]
+    assert (
+        captured.citation_builder.prompt_evidence_sets[0].entries[0].marker_ordinal == 1
+    )
+    rendered_logs = "".join(str(message) for message in captured_logs)
+    assert sentinel not in rendered_logs
+    assert "reason=invalid_local_result" in rendered_logs
+
+
+@pytest.mark.asyncio
+async def test_validation_failure_discards_context_and_partial_builder_without_logging(
+    monkeypatch,
+):
+    sentinel = "PRIVATE-VALIDATION-FAILURE-SENTINEL"
+    repository = _CaptureRepository()
+    app = _CaptureApp(repository=repository)
+    _patch_pipeline(monkeypatch, [_ranked_result()], "legacy")
+    with pytest.raises(ValidationError) as exc_info:
+        LocalRetrievalRunMetadata(
+            search_mode=f"{sentinel}/invalid",
+            requested_top_k=1,
+            max_context_characters=100,
+            rerank_enabled=False,
+            source_kinds=(CanonicalSourceKind.MEDIA_DB,),
+            scope_state="unscoped",
+        )
+    validation_error = exc_info.value
+
+    def _reject_prompt(*_args, **_kwargs):
+        raise validation_error
+
+    monkeypatch.setattr(
+        CitationTraceBuilder,
+        "record_prompt_evidence_set",
+        _reject_prompt,
+    )
+    captured_logs = []
+    sink_id = loguru_logger.add(
+        captured_logs.append,
+        level="DEBUG",
+        format="{message}",
+    )
+    try:
+        captured = await cre.get_rag_context_capture_for_chat(app, "query")
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert captured == cre.LocalRagContextResult(
+        context=None,
+        citation_builder=None,
+    )
+    rendered_logs = "".join(str(message) for message in captured_logs)
+    assert sentinel not in rendered_logs
+    assert "reason=canonical_capture_failure" in rendered_logs

--- a/Tests/RAG/test_local_citation_capture.py
+++ b/Tests/RAG/test_local_citation_capture.py
@@ -73,6 +73,82 @@ def _result(
     )
 
 
+@pytest.mark.asyncio
+async def test_lower_level_retrieval_logs_omit_query_without_changing_search_input():
+    query = "PRIVATE-LOWER-RETRIEVAL-QUERY-SENTINEL"
+
+    class MediaSearchDouble:
+        def __init__(self):
+            self.queries = []
+
+        def search_media_db(self, **kwargs):
+            self.queries.append(kwargs["search_query"])
+            return []
+
+    class ChaChaSearchDouble:
+        def __init__(self):
+            self.conversation_queries = []
+            self.note_queries = []
+
+        def search_conversations_by_content(self, *, search_query, limit):
+            self.conversation_queries.append(search_query)
+            return []
+
+        def get_messages_for_conversations_batch(self, **kwargs):
+            return {}
+
+        def search_notes(self, *, search_term, limit, id_allowlist):
+            self.note_queries.append(search_term)
+            return []
+
+    class SemanticSearchDouble:
+        def __init__(self):
+            self.queries = []
+
+        async def search(self, **kwargs):
+            self.queries.append(kwargs["query"])
+            return [
+                SimpleNamespace(
+                    id="semantic-1",
+                    source="media",
+                    title="Semantic result",
+                    document="Semantic body",
+                    content="Semantic body",
+                    score=0.5,
+                    metadata={},
+                    citations=[],
+                )
+            ]
+
+    media_db = MediaSearchDouble()
+    chacha_db = ChaChaSearchDouble()
+    semantic_service = SemanticSearchDouble()
+    app = SimpleNamespace(
+        media_db=media_db,
+        chachanotes_db=chacha_db,
+        _rag_service=semantic_service,
+    )
+    captured_logs = []
+    sink_id = loguru_logger.add(
+        captured_logs.append,
+        level="DEBUG",
+        format="{message}",
+    )
+    try:
+        await pfs.search_media_fts5(app, query)
+        await pfs.search_conversations_fts5(app, query)
+        await pfs.search_notes_fts5(app, query)
+        await pfs.search_semantic(app, query, {"media": True})
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert media_db.queries == [query]
+    assert chacha_db.conversation_queries == [query]
+    assert chacha_db.note_queries == [query]
+    assert semantic_service.queries == [query]
+    assert query not in "".join(str(message) for message in captured_logs)
+
+
 @pytest.mark.parametrize(
     ("source", "expected"),
     [

--- a/Tests/RAG/test_local_citation_capture.py
+++ b/Tests/RAG/test_local_citation_capture.py
@@ -1061,6 +1061,38 @@ def _real_capture_repository(tmp_path, availability):
 
 
 @pytest.mark.asyncio
+async def test_missing_custom_pipeline_log_includes_safe_context(monkeypatch):
+    from tldw_chatbook.RAG_Search import pipeline_builder_simple
+
+    monkeypatch.setattr(
+        pipeline_builder_simple, "get_pipeline", lambda _pipeline_id: None
+    )
+    captured_logs = []
+    sink_id = loguru_logger.add(
+        captured_logs.append,
+        level="DEBUG",
+        format="{message}",
+    )
+    try:
+        results, error = await cre.perform_search_with_pipeline(
+            app=None,
+            query="PRIVATE-MISSING-PIPELINE-QUERY",
+            sources={"media": True, "conversations": False, "notes": True},
+            pipeline_id="custom-local-pipeline",
+        )
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert results == []
+    assert error == "Pipeline 'custom-local-pipeline' not found"
+    rendered_logs = "".join(str(message) for message in captured_logs)
+    assert "reason=pipeline_not_found" in rendered_logs
+    assert "pipeline_id=custom-local-pipeline" in rendered_logs
+    assert "selected_source_count=2" in rendered_logs
+    assert "PRIVATE-MISSING-PIPELINE-QUERY" not in rendered_logs
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "search_mode",
     ["plain", "semantic", "hybrid", "custom-pipeline"],
@@ -1362,6 +1394,8 @@ async def test_console_prompt_evidence_recording_failure_returns_no_capture(
     assert captured.prompt_evidence_set_id is None
     rendered_logs = "".join(str(message) for message in captured_logs)
     assert "reason=canonical_capture_failure" in rendered_logs
+    assert "normalized_candidates=1" in rendered_logs
+    assert "authorized_candidates=1" in rendered_logs
     for sentinel in (query, title, content, failure):
         assert sentinel not in rendered_logs
 
@@ -1699,13 +1733,17 @@ async def test_prompt_evidence_set_recording_failure_discards_context_and_builde
         )
         assert captured.prompt_evidence_set_id is None
         connection = db.get_connection()
-        for table in ("rag_evidence_runs", "rag_evidence_snapshots"):
-            assert (
-                connection.execute(f"SELECT count(*) FROM {table}").fetchone()[0] == 0
-            )
+        for query in (
+            "SELECT count(*) FROM rag_evidence_runs",
+            "SELECT count(*) FROM rag_evidence_snapshots",
+        ):
+            assert connection.execute(query).fetchone()[0] == 0
         rendered_logs = "".join(str(message) for message in captured_logs)
         assert sentinel not in rendered_logs
         assert "reason=canonical_capture_failure" in rendered_logs
+        assert "mode=plain" in rendered_logs
+        assert "requested_top_k=5" in rendered_logs
+        assert "scope_state=unscoped" in rendered_logs
     finally:
         db.close_connection()
 

--- a/Tests/RAG/test_local_citation_capture.py
+++ b/Tests/RAG/test_local_citation_capture.py
@@ -1418,3 +1418,108 @@ async def test_fresh_persisted_scope_read_does_not_log_conversation_identity(
     assert resolution.effective.state == "unscoped"
     rendered_logs = "".join(str(message) for message in captured_logs)
     assert conversation_sentinel not in rendered_logs
+
+
+@pytest.mark.asyncio
+async def test_request_start_cached_scope_read_does_not_log_conversation_identity(
+    tmp_path,
+    monkeypatch,
+):
+    conversation_sentinel = "PRIVATE-CACHED-CONVERSATION-IDENTITY-SENTINEL"
+    chacha_db = CharactersRAGDB(
+        tmp_path / "cached-scope-chacha.sqlite",
+        client_id="cached-scope-chacha",
+    )
+    chacha_db.add_conversation(
+        {
+            "id": conversation_sentinel,
+            "title": "Cached request-start identity regression",
+        }
+    )
+    app = _CaptureApp()
+    app.chachanotes_db = chacha_db
+    session = SimpleNamespace(
+        id="cached-request-session",
+        persisted_conversation_id=conversation_sentinel,
+        workspace_id=None,
+    )
+    monkeypatch.setattr(cre, "_active_console_session", lambda _app: session)
+    raw_context = "CACHED REQUEST-START PIPELINE CONTEXT"
+    _patch_pipeline(monkeypatch, [_ranked_result()], raw_context)
+    captured_logs = []
+    sink_id = loguru_logger.add(
+        captured_logs.append,
+        level="DEBUG",
+        format="{message}",
+    )
+    try:
+        captured = await cre.get_rag_context_capture_for_chat(app, "query")
+    finally:
+        loguru_logger.remove(sink_id)
+        chacha_db.close_connection()
+
+    assert captured == cre.LocalRagContextResult(raw_context, None)
+    rendered_logs = "".join(str(message) for message in captured_logs)
+    assert conversation_sentinel not in rendered_logs
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "raw_metadata",
+    [
+        "{malformed-json",
+        "[]",
+        json.dumps(
+            {
+                "rag_scope": {
+                    "version": 1,
+                    "items": "malformed-items",
+                    "updated_at": "t1",
+                }
+            }
+        ),
+        json.dumps(
+            {
+                "rag_scope": {
+                    "version": 1,
+                    "items": [],
+                    "updated_at": "t1",
+                }
+            }
+        ),
+    ],
+    ids=["malformed-json", "non-object", "malformed-scope", "empty-scope"],
+)
+async def test_cached_scope_read_preserves_guarded_unscoped_semantics(
+    tmp_path,
+    raw_metadata,
+):
+    conversation_id = "cached-guarded-semantics"
+    chacha_db = CharactersRAGDB(
+        tmp_path / "cached-guarded-chacha.sqlite",
+        client_id="cached-guarded-chacha",
+    )
+    chacha_db.add_conversation({"id": conversation_id, "title": "Guarded"})
+    connection = chacha_db.get_connection()
+    connection.execute(
+        "UPDATE conversations SET metadata = ? WHERE id = ?",
+        (raw_metadata, conversation_id),
+    )
+    connection.commit()
+    app = SimpleNamespace(chachanotes_db=chacha_db, media_db=None)
+    session = SimpleNamespace(
+        id="cached-guarded-session",
+        persisted_conversation_id=conversation_id,
+        workspace_id=None,
+    )
+    try:
+        resolution = await cre.resolve_scope_for_session(
+            app,
+            session,
+            use_cache=True,
+        )
+    finally:
+        chacha_db.close_connection()
+
+    assert resolution.conv_scope is None
+    assert resolution.effective.state == "unscoped"

--- a/Tests/RAG/test_local_citation_capture.py
+++ b/Tests/RAG/test_local_citation_capture.py
@@ -1,0 +1,512 @@
+"""Exact local-RAG prompt evidence normalization and formatting."""
+
+from __future__ import annotations
+
+import math
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.Chat.citation_source_locators import CanonicalSourceKind
+from tldw_chatbook.Chat.citation_trace_models import (
+    RetrievalScoreKind,
+    RetrievalScoreScale,
+)
+from tldw_chatbook.RAG_Search.local_citation_capture import (
+    FINAL_SCORE_KIND_KEY,
+    FINAL_SCORE_KIND_RERANKER,
+    LocalResultNormalizationError,
+    LocalResultRejectionCode,
+    SEMANTIC_SCORE_KIND_KEY,
+    SEMANTIC_SCORE_KIND_VECTOR_SIMILARITY,
+    format_local_evidence_context,
+    normalize_local_result,
+)
+from tldw_chatbook.RAG_Search import pipeline_functions_simple as pfs
+from tldw_chatbook.RAG_Search.pipeline_types import SearchResult
+
+pytestmark = pytest.mark.unit
+
+
+def _result(
+    *,
+    source: str = "media",
+    result_id: str = "m1",
+    title: object = "Title",
+    content: object = "body",
+    score: float = 1.0,
+    metadata: object = None,
+) -> SearchResult:
+    return SearchResult(
+        source=source,
+        id=result_id,
+        title=title,  # type: ignore[arg-type]
+        content=content,  # type: ignore[arg-type]
+        score=score,
+        metadata={} if metadata is None else metadata,  # type: ignore[arg-type]
+    )
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("media", CanonicalSourceKind.MEDIA_DB),
+        ("media_db", CanonicalSourceKind.MEDIA_DB),
+        ("note", CanonicalSourceKind.NOTES),
+        ("notes", CanonicalSourceKind.NOTES),
+        ("conversation", CanonicalSourceKind.CHAT_HISTORY),
+        ("chat_history", CanonicalSourceKind.CHAT_HISTORY),
+    ],
+)
+def test_normalize_local_result_maps_common_source_aliases(source, expected):
+    assert normalize_local_result(_result(source=source)).source_kind is expected
+
+
+def test_unknown_semantic_top_level_source_uses_allowlisted_metadata_source():
+    normalized = normalize_local_result(
+        _result(
+            source="unknown",
+            result_id="note_n1_chunk_0",
+            metadata={
+                "source_type": "note",
+                "source_id": "n1",
+                "_semantic_score_kind": "vector_similarity",
+            },
+            score=0.81,
+        )
+    )
+
+    assert normalized.source_kind is CanonicalSourceKind.NOTES
+    assert normalized.source_id == "n1"
+    assert normalized.score_kind is RetrievalScoreKind.VECTOR_SIMILARITY
+    assert normalized.score_scale is RetrievalScoreScale.UNBOUNDED
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        _result(result_id=""),
+        _result(source="web"),
+        _result(title=123),
+        _result(content=123),
+        _result(title="bad\nheader"),
+        _result(score=math.inf),
+        _result(score=math.nan),
+        _result(metadata=[]),
+        _result(metadata={"chunk_id": "file:///tmp/secret"}),
+        _result(metadata={"source_id": 123}),
+    ],
+)
+def test_invalid_result_rejected_with_non_content_reason_code(result):
+    with pytest.raises(LocalResultNormalizationError) as exc_info:
+        normalize_local_result(result)
+
+    assert exc_info.value.reason_code is LocalResultRejectionCode.INVALID_RESULT
+    assert "body" not in str(exc_info.value)
+
+
+def test_invalid_candidate_rank_is_rejected_not_silently_rewritten():
+    with pytest.raises(LocalResultNormalizationError):
+        normalize_local_result(_result(), candidate_rank=0)
+
+
+def test_normalizer_retains_only_allowlisted_non_executable_lineage():
+    normalized = normalize_local_result(
+        _result(
+            metadata={
+                "chunk_id": "chunk-7",
+                "chunk_index": 2,
+                "start_char": 4,
+                "end_char": 12,
+                "url": "https://example.test/private",
+                "path": "/tmp/private",
+                "_citations": [{"url": "https://example.test"}],
+                "arbitrary": {"call": "tool"},
+            }
+        )
+    )
+
+    assert normalized.chunk_id == "chunk-7"
+    assert normalized.chunk_index == 2
+    assert normalized.start_char == 4
+    assert normalized.end_char == 12
+    assert not hasattr(normalized, "url")
+    assert not hasattr(normalized, "path")
+    assert not hasattr(normalized, "citations")
+    assert normalized.to_candidate_capture(candidate_rank=1).model_dump() == {
+        "candidate_rank": 1,
+        "source_kind": CanonicalSourceKind.MEDIA_DB,
+        "source_id": "m1",
+        "title": "Title",
+        "score_kind": RetrievalScoreKind.LEGACY,
+        "score_scale": RetrievalScoreScale.UNBOUNDED,
+        "score": 1.0,
+        "chunk_id": "chunk-7",
+        "chunk_index": 2,
+        "start_char": 4,
+        "end_char": 12,
+    }
+
+
+def test_reliable_rrf_metadata_classifies_score_without_using_float_range():
+    score = 0.3 / 61 + 0.7 / 62
+    normalized = normalize_local_result(
+        _result(
+            score=score,
+            metadata={
+                "hybrid_fusion": {
+                    "fts_rank": 1,
+                    "vector_rank": 2,
+                    "fts_rrf": 1 / 61,
+                    "vector_rrf": 1 / 62,
+                    "alpha": 0.7,
+                    "rrf_k": 60,
+                }
+            },
+        )
+    )
+
+    assert normalized.score_kind is RetrievalScoreKind.RRF
+    assert normalized.score_scale is RetrievalScoreScale.NON_NEGATIVE
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {},
+        {"score_kind": "bm25"},
+        {"hybrid_fusion": {"fts_rank": 1}},
+        {"_semantic_score_kind": "custom"},
+    ],
+)
+def test_ambiguous_or_bare_scores_are_legacy(metadata):
+    normalized = normalize_local_result(_result(score=0.4, metadata=metadata))
+
+    assert normalized.score_kind is RetrievalScoreKind.LEGACY
+    assert normalized.score_scale is RetrievalScoreScale.UNBOUNDED
+
+
+def test_explicit_successful_reranker_marker_wins_over_prior_rrf_metadata():
+    normalized = normalize_local_result(
+        _result(
+            score=-2.3,
+            metadata={
+                "_final_score_kind": "reranker",
+                "hybrid_fusion": {
+                    "fts_rank": 1,
+                    "vector_rank": None,
+                    "fts_rrf": 1 / 61,
+                    "vector_rrf": 0.0,
+                    "alpha": 0.0,
+                    "rrf_k": 60,
+                },
+            },
+        )
+    )
+
+    assert normalized.score_kind is RetrievalScoreKind.RERANKER
+    assert normalized.score_scale is RetrievalScoreScale.UNBOUNDED
+
+
+def test_unreliable_rrf_or_unknown_later_marker_degrades_to_legacy():
+    semantic_marker = {
+        SEMANTIC_SCORE_KIND_KEY: SEMANTIC_SCORE_KIND_VECTOR_SIMILARITY,
+        "hybrid_fusion": {"fts_rank": 1},
+    }
+    unknown_final_marker = {
+        FINAL_SCORE_KIND_KEY: "custom",
+        "hybrid_fusion": {
+            "fts_rank": 1,
+            "vector_rank": None,
+            "fts_rrf": 1 / 61,
+            "vector_rrf": 0.0,
+            "alpha": 0.0,
+            "rrf_k": 60,
+        },
+    }
+
+    assert (
+        normalize_local_result(_result(score=0.4, metadata=semantic_marker)).score_kind
+        is RetrievalScoreKind.LEGACY
+    )
+    assert (
+        normalize_local_result(
+            _result(score=1 / 61, metadata=unknown_final_marker)
+        ).score_kind
+        is RetrievalScoreKind.LEGACY
+    )
+
+
+def test_formatter_exact_fit_uses_exact_content_and_captured_block_once():
+    normalized = normalize_local_result(
+        _result(content="exact submitted content"), candidate_rank=3
+    )
+    expected = "[S1] MEDIA — Title\nexact submitted content"
+
+    formatted = format_local_evidence_context([normalized], max_length=len(expected))
+
+    assert formatted.context == expected
+    assert formatted.entries[0].snapshot_text == expected
+    assert formatted.entries[0].candidate_rank == 3
+    assert formatted.entries[0].transformations == ()
+    assert formatted.context == "\n---\n".join(
+        entry.snapshot_text for entry in formatted.entries
+    )
+    assert formatted.omitted_candidate_ranks == ()
+
+
+def test_formatter_one_character_short_uses_ellipsis_inside_snapshot():
+    normalized = normalize_local_result(_result(content="abcd"), candidate_rank=7)
+    full = "[S1] MEDIA — Title\nabcd"
+
+    formatted = format_local_evidence_context([normalized], max_length=len(full) - 1)
+
+    assert formatted.context == "[S1] MEDIA — Title\nab…"
+    assert formatted.entries[0].snapshot_text == formatted.context
+    assert formatted.entries[0].transformations == ("content_truncated",)
+    assert len(formatted.context) == len(full) - 1
+
+
+def test_formatter_uses_unicode_codepoint_budget_not_utf8_bytes():
+    normalized = normalize_local_result(
+        _result(title="題", content="🙂🙂🙂"), candidate_rank=1
+    )
+    expected = "[S1] MEDIA — 題\n🙂🙂🙂"
+
+    formatted = format_local_evidence_context([normalized], max_length=len(expected))
+
+    assert formatted.context == expected
+    assert len(formatted.context) == len(expected)
+    assert len(formatted.context.encode("utf-8")) > len(formatted.context)
+
+
+def test_formatter_assigns_contiguous_markers_and_canonical_labels_after_filtering():
+    note = normalize_local_result(
+        _result(source="note", result_id="n1", title="N", content="note"),
+        candidate_rank=2,
+    )
+    chat = normalize_local_result(
+        _result(
+            source="conversation",
+            result_id="c1",
+            title="C",
+            content="chat",
+        ),
+        candidate_rank=5,
+    )
+
+    formatted = format_local_evidence_context([note, chat], max_length=200)
+
+    assert formatted.context == (
+        "[S1] NOTES — N\nnote\n---\n[S2] CHAT HISTORY — C\nchat"
+    )
+    assert [entry.candidate_rank for entry in formatted.entries] == [2, 5]
+
+
+def test_formatter_reports_omitted_rank_without_creating_snapshot():
+    too_long_header = normalize_local_result(
+        _result(result_id="m1", title="A very long title", content="body"),
+        candidate_rank=4,
+    )
+    short = normalize_local_result(
+        _result(source="note", result_id="n1", title="N", content="x"),
+        candidate_rank=9,
+    )
+
+    formatted = format_local_evidence_context(
+        [too_long_header, short],
+        max_length=len("[S1] NOTES — N\nx"),
+    )
+
+    assert formatted.context == "[S1] NOTES — N\nx"
+    assert tuple(entry.candidate_rank for entry in formatted.entries) == (9,)
+    assert formatted.omitted_candidate_ranks == (4,)
+    assert all("long title" not in entry.snapshot_text for entry in formatted.entries)
+
+
+def test_formatter_never_exceeds_budget_when_no_candidate_header_fits():
+    normalized = normalize_local_result(_result(), candidate_rank=11)
+
+    formatted = format_local_evidence_context([normalized], max_length=3)
+
+    assert formatted.context == ""
+    assert formatted.entries == ()
+    assert formatted.omitted_candidate_ranks == (11,)
+
+
+class _SemanticResult:
+    def __init__(self, *, source: str = "unknown", metadata=None):
+        self.source = source
+        self.id = "m-semantic"
+        self.title = "Semantic"
+        self.document = "semantic body"
+        self.score = 0.73
+        self.metadata = {} if metadata is None else metadata
+
+
+class _SemanticService:
+    def __init__(self, result):
+        self.result = result
+
+    async def search(self, **_kwargs):
+        return [self.result]
+
+
+@pytest.mark.asyncio
+async def test_search_semantic_propagates_allowlisted_metadata_source_and_score_marker():
+    app = SimpleNamespace(
+        _rag_service=_SemanticService(
+            _SemanticResult(metadata={"source_type": "media"})
+        )
+    )
+
+    results = await pfs.search_semantic(app, "query", {"media": True})
+
+    assert results[0].source == "media"
+    assert (
+        results[0].metadata[SEMANTIC_SCORE_KIND_KEY]
+        == SEMANTIC_SCORE_KIND_VECTOR_SIMILARITY
+    )
+    assert FINAL_SCORE_KIND_KEY not in results[0].metadata
+
+
+@pytest.mark.asyncio
+async def test_search_semantic_replaces_untrusted_internal_score_metadata():
+    app = SimpleNamespace(
+        _rag_service=_SemanticService(
+            _SemanticResult(
+                metadata={
+                    "source_type": "media",
+                    FINAL_SCORE_KIND_KEY: FINAL_SCORE_KIND_RERANKER,
+                    SEMANTIC_SCORE_KIND_KEY: "custom",
+                    "hybrid_fusion": {
+                        "fts_rank": 1,
+                        "vector_rank": None,
+                        "fts_rrf": 1 / 61,
+                        "vector_rrf": 0.0,
+                        "alpha": 0.0,
+                        "rrf_k": 60,
+                    },
+                }
+            )
+        )
+    )
+
+    result = (await pfs.search_semantic(app, "query", {"media": True}))[0]
+
+    assert FINAL_SCORE_KIND_KEY not in result.metadata
+    assert "hybrid_fusion" not in result.metadata
+    assert (
+        result.metadata[SEMANTIC_SCORE_KIND_KEY]
+        == SEMANTIC_SCORE_KIND_VECTOR_SIMILARITY
+    )
+    assert (
+        normalize_local_result(result).score_kind
+        is RetrievalScoreKind.VECTOR_SIMILARITY
+    )
+
+
+def _install_flashrank(monkeypatch, *, ranked=None, init_error=None, run_error=None):
+    class _Ranker:
+        def __init__(self, **_kwargs):
+            if init_error is not None:
+                raise init_error
+
+        def rerank(self, _request):
+            if run_error is not None:
+                raise run_error
+            return ranked or []
+
+    class _Request:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    monkeypatch.setitem(
+        sys.modules,
+        "flashrank",
+        SimpleNamespace(RankRequest=_Request, RerankRequest=_Request, Ranker=_Ranker),
+    )
+
+
+def test_successful_flashrank_overwrite_writes_final_score_marker(monkeypatch):
+    _install_flashrank(
+        monkeypatch,
+        ranked=[SimpleNamespace(index=0, score=-1.25)],
+    )
+    result = _result(
+        score=0.5,
+        metadata={SEMANTIC_SCORE_KIND_KEY: SEMANTIC_SCORE_KIND_VECTOR_SIMILARITY},
+    )
+
+    reranked = pfs.rerank_results([result], "query", top_k=1)
+
+    assert reranked[0].score == -1.25
+    assert reranked[0].metadata[FINAL_SCORE_KIND_KEY] == FINAL_SCORE_KIND_RERANKER
+    normalized = normalize_local_result(reranked[0])
+    assert normalized.score_kind is RetrievalScoreKind.RERANKER
+
+
+def test_invalid_flashrank_score_falls_back_without_marker(monkeypatch):
+    _install_flashrank(
+        monkeypatch,
+        ranked=[SimpleNamespace(index=0, score=math.nan)],
+    )
+    result = _result(
+        score=0.5,
+        metadata={SEMANTIC_SCORE_KIND_KEY: SEMANTIC_SCORE_KIND_VECTOR_SIMILARITY},
+    )
+
+    fallback = pfs.rerank_results([result], "query", top_k=1)
+
+    assert fallback == [result]
+    assert fallback[0].score == 0.5
+    assert FINAL_SCORE_KIND_KEY not in fallback[0].metadata
+    assert (
+        normalize_local_result(fallback[0]).score_kind
+        is RetrievalScoreKind.VECTOR_SIMILARITY
+    )
+
+
+@pytest.mark.parametrize("failure_stage", ["import", "initialization", "execution"])
+def test_flashrank_fallback_never_claims_reranker_and_keeps_prior_semantics(
+    monkeypatch, failure_stage
+):
+    if failure_stage == "import":
+        monkeypatch.setitem(sys.modules, "flashrank", None)
+    elif failure_stage == "initialization":
+        _install_flashrank(monkeypatch, init_error=RuntimeError("init failed"))
+    else:
+        _install_flashrank(monkeypatch, run_error=RuntimeError("run failed"))
+    score = 0.3 / 61
+    result = _result(
+        score=score,
+        metadata={
+            "hybrid_fusion": {
+                "fts_rank": 1,
+                "vector_rank": None,
+                "fts_rrf": 1 / 61,
+                "vector_rrf": 0.0,
+                "alpha": 0.7,
+                "rrf_k": 60,
+            }
+        },
+    )
+
+    fallback = pfs.rerank_results([result], "query", top_k=1)
+
+    assert fallback == [result]
+    assert FINAL_SCORE_KIND_KEY not in fallback[0].metadata
+    assert normalize_local_result(fallback[0]).score_kind is RetrievalScoreKind.RRF
+
+
+def test_weighted_score_overwrite_removes_prior_semantic_classification():
+    semantic = _result(
+        score=0.8,
+        metadata={SEMANTIC_SCORE_KIND_KEY: SEMANTIC_SCORE_KIND_VECTOR_SIMILARITY},
+    )
+
+    merged = pfs.weighted_merge([[semantic]], [0.5])
+
+    assert SEMANTIC_SCORE_KIND_KEY not in merged[0].metadata
+    assert normalize_local_result(merged[0]).score_kind is RetrievalScoreKind.LEGACY

--- a/Tests/RAG/test_local_citation_capture.py
+++ b/Tests/RAG/test_local_citation_capture.py
@@ -1065,7 +1065,7 @@ def _real_capture_repository(tmp_path, availability):
     "search_mode",
     ["plain", "semantic", "hybrid", "custom-pipeline"],
 )
-async def test_capture_api_records_one_equivalent_run_and_prompt_for_every_mode(
+async def test_capture_api_returns_prompt_evidence_set_id_for_every_mode(
     monkeypatch, search_mode
 ):
     query = "PRIVATE-QUERY-CAPTURE-SENTINEL"
@@ -1123,6 +1123,10 @@ async def test_capture_api_records_one_equivalent_run_and_prompt_for_every_mode(
     assert captured.citation_builder is repository.builders[0]
     assert len(captured.citation_builder.evidence_runs) == 1
     assert len(captured.citation_builder.prompt_evidence_sets) == 1
+    assert (
+        captured.prompt_evidence_set_id
+        == captured.citation_builder.prompt_evidence_sets[-1].prompt_set_id
+    )
     assert len(captured.citation_builder.evidence_run_payloads) == 1
     assert len(captured.citation_builder.evidence_snapshot_payloads) == 1
     run_payload = captured.citation_builder.evidence_run_payloads[0]
@@ -1145,11 +1149,43 @@ async def test_capture_api_records_one_equivalent_run_and_prompt_for_every_mode(
         assert sentinel not in rendered_logs
 
 
-def test_local_rag_context_result_is_frozen():
-    result = cre.LocalRagContextResult(context=None, citation_builder=None)
+@pytest.mark.asyncio
+async def test_pipeline_prompt_evidence_set_id_uses_record_method_return(
+    monkeypatch,
+):
+    authoritative_prompt_set_id = "prompt-set-authoritative-pipeline-return"
+    original_record = CitationTraceBuilder.record_prompt_evidence_set
 
+    def _record_with_authoritative_return(self, **kwargs):
+        original_record(self, **kwargs)
+        return authoritative_prompt_set_id
+
+    monkeypatch.setattr(
+        CitationTraceBuilder,
+        "record_prompt_evidence_set",
+        _record_with_authoritative_return,
+    )
+    repository = _CaptureRepository()
+    app = _CaptureApp(repository=repository)
+    _patch_pipeline(monkeypatch, [_ranked_result()], "legacy")
+
+    captured = await cre.get_rag_context_capture_for_chat(app, "query")
+
+    assert captured.prompt_evidence_set_id == authoritative_prompt_set_id
+    assert (
+        captured.citation_builder.prompt_evidence_sets[-1].prompt_set_id
+        != authoritative_prompt_set_id
+    )
+
+
+def test_local_rag_context_result_prompt_evidence_set_id_defaults_none_and_is_frozen():
+    result = cre.LocalRagContextResult(None, None)
+
+    assert result.prompt_evidence_set_id is None
     with pytest.raises(FrozenInstanceError):
         result.context = "changed"
+    with pytest.raises(FrozenInstanceError):
+        result.prompt_evidence_set_id = "prompt-set-changed"
 
 
 @pytest.mark.asyncio
@@ -1193,6 +1229,10 @@ async def test_console_staged_local_evidence_records_exact_prompt_capture():
 
     assert captured.context == f"[S1] MEDIA — {title}\n{snippet}"
     assert captured.citation_builder is repository.builders[0]
+    assert (
+        captured.prompt_evidence_set_id
+        == captured.citation_builder.prompt_evidence_sets[-1].prompt_set_id
+    )
     run_payload = captured.citation_builder.evidence_run_payloads[0]
     assert run_payload.raw_query is None
     assert run_payload.query_fingerprint is not None
@@ -1211,7 +1251,123 @@ async def test_console_staged_local_evidence_records_exact_prompt_capture():
 
 
 @pytest.mark.asyncio
-async def test_console_staged_local_evidence_without_repository_keeps_context():
+async def test_console_prompt_evidence_set_id_uses_record_method_return(monkeypatch):
+    authoritative_prompt_set_id = "prompt-set-authoritative-console-return"
+    original_record = CitationTraceBuilder.record_prompt_evidence_set
+
+    def _record_with_authoritative_return(self, **kwargs):
+        original_record(self, **kwargs)
+        return authoritative_prompt_set_id
+
+    monkeypatch.setattr(
+        CitationTraceBuilder,
+        "record_prompt_evidence_set",
+        _record_with_authoritative_return,
+    )
+    title = "Console staged source"
+    launch = ConsoleLiveWorkLaunch.from_values(
+        source="Library Search/RAG",
+        title=title,
+        payload={
+            "evidence_bundle": EvidenceBundle(
+                bundle_id="bundle-direct-return",
+                query="query",
+                references=(
+                    EvidenceReference(
+                        evidence_id="S1",
+                        source_id="m1",
+                        source_type="media",
+                        title=title,
+                        snippet="body",
+                        authority_label="local",
+                        source_owner="local",
+                        score=0.5,
+                    ),
+                ),
+            ).to_payload(),
+        },
+        status="staged",
+    )
+    repository = _CaptureRepository()
+
+    captured = await cre.capture_console_staged_evidence_for_chat(
+        _CaptureApp(repository=repository),
+        launch,
+        user_message="ordinary prompt",
+    )
+
+    assert captured.prompt_evidence_set_id == authoritative_prompt_set_id
+    assert (
+        captured.citation_builder.prompt_evidence_sets[-1].prompt_set_id
+        != authoritative_prompt_set_id
+    )
+
+
+@pytest.mark.asyncio
+async def test_console_prompt_evidence_recording_failure_returns_no_capture(
+    monkeypatch,
+):
+    query = "CONSOLE_PRIVATE_PROMPT_FAILURE_QUERY_SENTINEL"
+    title = "CONSOLE_PRIVATE_PROMPT_FAILURE_TITLE_SENTINEL"
+    content = "CONSOLE_PRIVATE_PROMPT_FAILURE_CONTENT_SENTINEL"
+    failure = "CONSOLE_PRIVATE_PROMPT_FAILURE_EXCEPTION_SENTINEL"
+    launch = ConsoleLiveWorkLaunch.from_values(
+        source="Library Search/RAG",
+        title=title,
+        payload={
+            "evidence_bundle": EvidenceBundle(
+                bundle_id="bundle-record-failure",
+                query=query,
+                references=(
+                    EvidenceReference(
+                        evidence_id="S1",
+                        source_id="m1",
+                        source_type="media",
+                        title=title,
+                        snippet=content,
+                        authority_label="local",
+                        source_owner="local",
+                        score=0.5,
+                    ),
+                ),
+            ).to_payload(),
+        },
+        status="staged",
+    )
+
+    def _raise_recording_failure(*_args, **_kwargs):
+        raise RuntimeError(failure)
+
+    monkeypatch.setattr(
+        CitationTraceBuilder,
+        "record_prompt_evidence_set",
+        _raise_recording_failure,
+    )
+    captured_logs = []
+    sink_id = loguru_logger.add(
+        captured_logs.append,
+        level="DEBUG",
+        format="{message}",
+    )
+    try:
+        captured = await cre.capture_console_staged_evidence_for_chat(
+            _CaptureApp(repository=_CaptureRepository()),
+            launch,
+            user_message="ordinary prompt",
+        )
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert captured == cre.LocalRagContextResult(None, None)
+    assert captured.prompt_evidence_set_id is None
+    rendered_logs = "".join(str(message) for message in captured_logs)
+    assert "reason=canonical_capture_failure" in rendered_logs
+    for sentinel in (query, title, content, failure):
+        assert sentinel not in rendered_logs
+
+
+@pytest.mark.asyncio
+async def test_console_without_repository_returns_no_prompt_id_and_keeps_context():
     title = "Legacy staged source"
     launch = ConsoleLiveWorkLaunch.from_values(
         source="Library Search/RAG",
@@ -1247,10 +1403,13 @@ async def test_console_staged_local_evidence_without_repository_keeps_context():
         context="[S1] MEDIA — Legacy staged source\nlegacy body",
         citation_builder=None,
     )
+    assert captured.prompt_evidence_set_id is None
 
 
 @pytest.mark.asyncio
-async def test_absent_repository_preserves_legacy_pipeline_bytes(monkeypatch):
+async def test_absent_repository_returns_no_prompt_id_and_preserves_pipeline_bytes(
+    monkeypatch,
+):
     app = _CaptureApp()
     raw_context = "LEGACY\x00PIPELINE\nBYTES"
     _patch_pipeline(monkeypatch, [_ranked_result()], raw_context)
@@ -1262,6 +1421,7 @@ async def test_absent_repository_preserves_legacy_pipeline_bytes(monkeypatch):
         context=raw_context,
         citation_builder=None,
     )
+    assert captured.prompt_evidence_set_id is None
     assert isinstance(legacy, str)
     assert legacy == raw_context
 
@@ -1308,6 +1468,7 @@ async def test_real_repository_prerequisite_states_preserve_legacy_pipeline_byte
             context=raw_context,
             citation_builder=None,
         )
+        assert captured.prompt_evidence_set_id is None
         assert isinstance(legacy, str)
         assert legacy == raw_context
     finally:
@@ -1315,7 +1476,7 @@ async def test_real_repository_prerequisite_states_preserve_legacy_pipeline_byte
 
 
 @pytest.mark.asyncio
-async def test_empty_retrieval_records_only_the_empty_run(monkeypatch):
+async def test_empty_retrieval_records_run_but_returns_no_prompt_id(monkeypatch):
     repository = _CaptureRepository()
     app = _CaptureApp(repository=repository)
     _patch_pipeline(monkeypatch, [], "")
@@ -1324,9 +1485,52 @@ async def test_empty_retrieval_records_only_the_empty_run(monkeypatch):
 
     assert captured.context is None
     assert captured.citation_builder is repository.builders[0]
+    assert captured.prompt_evidence_set_id is None
     assert len(captured.citation_builder.evidence_runs) == 1
     assert captured.citation_builder.evidence_run_payloads[0].candidates == ()
     assert captured.citation_builder.prompt_evidence_sets == ()
+
+
+@pytest.mark.asyncio
+async def test_prompt_authority_failure_returns_no_context_builder_or_prompt_id(
+    monkeypatch,
+):
+    query = "PRIVATE-PROMPT-AUTHORITY-QUERY-SENTINEL"
+    title = "PRIVATE-PROMPT-AUTHORITY-TITLE-SENTINEL"
+    content = "PRIVATE-PROMPT-AUTHORITY-CONTENT-SENTINEL"
+    repository = _CaptureRepository()
+    app = _CaptureApp(repository=repository)
+    _patch_pipeline(
+        monkeypatch,
+        [_ranked_result(title=title, content=content)],
+        "legacy",
+    )
+
+    async def _fail_authority(*_args, **_kwargs):
+        return cre._PromptAuthorizationResult((), False)
+
+    monkeypatch.setattr(
+        cre,
+        "_authorize_local_results_for_prompt",
+        _fail_authority,
+    )
+    captured_logs = []
+    sink_id = loguru_logger.add(
+        captured_logs.append,
+        level="DEBUG",
+        format="{message}",
+    )
+    try:
+        captured = await cre.get_rag_context_capture_for_chat(app, query)
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert captured == cre.LocalRagContextResult(None, None)
+    assert captured.prompt_evidence_set_id is None
+    rendered_logs = "".join(str(message) for message in captured_logs)
+    assert "reason=prompt_authority_failure" in rendered_logs
+    for sentinel in (query, title, content):
+        assert sentinel not in rendered_logs
 
 
 @pytest.mark.asyncio
@@ -1357,6 +1561,7 @@ async def test_pipeline_exception_returns_no_context_or_builder_and_sanitizes_lo
         context=None,
         citation_builder=None,
     )
+    assert captured.prompt_evidence_set_id is None
     rendered_logs = "".join(str(message) for message in captured_logs)
     assert query not in rendered_logs
     assert failure not in rendered_logs
@@ -1450,7 +1655,7 @@ async def test_off_selection_source_is_excluded_before_authorization_and_capture
 
 
 @pytest.mark.asyncio
-async def test_validation_failure_discards_context_and_partial_builder_without_logging(
+async def test_prompt_evidence_set_recording_failure_discards_context_and_builder(
     monkeypatch, tmp_path
 ):
     sentinel = "PRIVATE-VALIDATION-FAILURE-SENTINEL"
@@ -1492,6 +1697,7 @@ async def test_validation_failure_discards_context_and_partial_builder_without_l
             context=None,
             citation_builder=None,
         )
+        assert captured.prompt_evidence_set_id is None
         connection = db.get_connection()
         for table in ("rag_evidence_runs", "rag_evidence_snapshots"):
             assert (

--- a/Tests/RAG/test_local_citation_capture.py
+++ b/Tests/RAG/test_local_citation_capture.py
@@ -13,6 +13,9 @@ import pytest
 from loguru import logger as loguru_logger
 from pydantic import ValidationError
 
+from tldw_chatbook.Chat.citation_provenance_runtime import (
+    CitationProvenanceRuntimePolicy,
+)
 from tldw_chatbook.Chat.citation_source_locators import CanonicalSourceKind
 from tldw_chatbook.Chat.citation_trace_builder import (
     CitationTraceBuilder,
@@ -28,6 +31,11 @@ from tldw_chatbook.Chat.citation_trace_models import (
     RetrievalScoreScale,
     SNAPSHOT_TEXT_UTF8_BYTES_MAX,
 )
+from tldw_chatbook.Chat.citation_trace_repository import (
+    CitationTraceRepository,
+    load_local_citation_identity_context,
+)
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 from tldw_chatbook.RAG_Search.local_citation_capture import (
     FINAL_SCORE_KIND_KEY,
     FINAL_SCORE_KIND_RERANKER,
@@ -877,12 +885,6 @@ class _CaptureRepository:
         return builder
 
 
-class _UnavailableCaptureRepository:
-    def create_local_trace_builder(self, *, request_id, generation_id):
-        del request_id, generation_id
-        return None
-
-
 class _CaptureApp:
     def __init__(self, *, search_mode="plain", repository=None, media_ids=("m1",)):
         self._widgets = {
@@ -949,6 +951,27 @@ def _patch_pipeline(monkeypatch, results, context):
     monkeypatch.setattr(cre, "resolve_semantic_rag_service", _semantic_service)
 
 
+def _real_capture_repository(tmp_path, availability):
+    db = CharactersRAGDB(
+        tmp_path / f"capture-{availability}.sqlite",
+        client_id=f"capture-{availability}",
+    )
+    identity = load_local_citation_identity_context(db)
+    assert identity is not None
+    enabled = availability != "writes-disabled"
+    repository = CitationTraceRepository(
+        db,
+        policy=CitationProvenanceRuntimePolicy(canonical_writes_enabled=enabled),
+        identity_context=None if availability == "identity-unavailable" else identity,
+        fingerprint_codec=(
+            None
+            if availability == "key-unavailable"
+            else CitationFingerprintCodec(b"k" * 32)
+        ),
+    )
+    return db, repository
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "search_mode",
@@ -1011,17 +1034,8 @@ def test_local_rag_context_result_is_frozen():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "availability",
-    ["repository-absent", "writes-disabled", "key-unavailable", "identity-unavailable"],
-)
-async def test_unavailable_canonical_capture_preserves_legacy_pipeline_bytes(
-    monkeypatch, availability
-):
-    repository = (
-        None if availability == "repository-absent" else _UnavailableCaptureRepository()
-    )
-    app = _CaptureApp(repository=repository)
+async def test_absent_repository_preserves_legacy_pipeline_bytes(monkeypatch):
+    app = _CaptureApp()
     raw_context = "LEGACY\x00PIPELINE\nBYTES"
     _patch_pipeline(monkeypatch, [_ranked_result()], raw_context)
 
@@ -1034,6 +1048,54 @@ async def test_unavailable_canonical_capture_preserves_legacy_pipeline_bytes(
     )
     assert isinstance(legacy, str)
     assert legacy == raw_context
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("availability", "writes_enabled", "has_identity", "has_codec"),
+    [
+        ("writes-disabled", False, True, True),
+        ("key-unavailable", True, True, False),
+        ("identity-unavailable", True, False, True),
+    ],
+)
+async def test_real_repository_prerequisite_states_preserve_legacy_pipeline_bytes(
+    monkeypatch,
+    tmp_path,
+    availability,
+    writes_enabled,
+    has_identity,
+    has_codec,
+):
+    db, repository = _real_capture_repository(tmp_path, availability)
+    try:
+        assert repository.canonical_writes_enabled is writes_enabled
+        assert (repository.identity_context is not None) is has_identity
+        assert repository.artifact_binding_verification_available is (
+            has_identity and has_codec
+        )
+        assert (
+            repository.create_local_trace_builder(
+                request_id=f"request-{availability}",
+                generation_id=f"generation-{availability}",
+            )
+            is None
+        )
+        app = _CaptureApp(repository=repository)
+        raw_context = f"LEGACY\x00{availability}\nBYTES"
+        _patch_pipeline(monkeypatch, [_ranked_result()], raw_context)
+
+        captured = await cre.get_rag_context_capture_for_chat(app, "query")
+        legacy = await cre.get_rag_context_for_chat(app, "query")
+
+        assert captured == cre.LocalRagContextResult(
+            context=raw_context,
+            citation_builder=None,
+        )
+        assert isinstance(legacy, str)
+        assert legacy == raw_context
+    finally:
+        db.close_connection()
 
 
 @pytest.mark.asyncio
@@ -1124,46 +1186,54 @@ async def test_malformed_result_is_excluded_before_markers_and_logs_are_sanitize
 
 @pytest.mark.asyncio
 async def test_validation_failure_discards_context_and_partial_builder_without_logging(
-    monkeypatch,
+    monkeypatch, tmp_path
 ):
     sentinel = "PRIVATE-VALIDATION-FAILURE-SENTINEL"
-    repository = _CaptureRepository()
-    app = _CaptureApp(repository=repository)
-    _patch_pipeline(monkeypatch, [_ranked_result()], "legacy")
-    with pytest.raises(ValidationError) as exc_info:
-        LocalRetrievalRunMetadata(
-            search_mode=f"{sentinel}/invalid",
-            requested_top_k=1,
-            max_context_characters=100,
-            rerank_enabled=False,
-            source_kinds=(CanonicalSourceKind.MEDIA_DB,),
-            scope_state="unscoped",
-        )
-    validation_error = exc_info.value
-
-    def _reject_prompt(*_args, **_kwargs):
-        raise validation_error
-
-    monkeypatch.setattr(
-        CitationTraceBuilder,
-        "record_prompt_evidence_set",
-        _reject_prompt,
-    )
-    captured_logs = []
-    sink_id = loguru_logger.add(
-        captured_logs.append,
-        level="DEBUG",
-        format="{message}",
-    )
+    db, repository = _real_capture_repository(tmp_path, "enabled")
     try:
-        captured = await cre.get_rag_context_capture_for_chat(app, "query")
-    finally:
-        loguru_logger.remove(sink_id)
+        app = _CaptureApp(repository=repository)
+        _patch_pipeline(monkeypatch, [_ranked_result()], "legacy")
+        with pytest.raises(ValidationError) as exc_info:
+            LocalRetrievalRunMetadata(
+                search_mode=f"{sentinel}/invalid",
+                requested_top_k=1,
+                max_context_characters=100,
+                rerank_enabled=False,
+                source_kinds=(CanonicalSourceKind.MEDIA_DB,),
+                scope_state="unscoped",
+            )
+        validation_error = exc_info.value
 
-    assert captured == cre.LocalRagContextResult(
-        context=None,
-        citation_builder=None,
-    )
-    rendered_logs = "".join(str(message) for message in captured_logs)
-    assert sentinel not in rendered_logs
-    assert "reason=canonical_capture_failure" in rendered_logs
+        def _reject_prompt(*_args, **_kwargs):
+            raise validation_error
+
+        monkeypatch.setattr(
+            CitationTraceBuilder,
+            "record_prompt_evidence_set",
+            _reject_prompt,
+        )
+        captured_logs = []
+        sink_id = loguru_logger.add(
+            captured_logs.append,
+            level="DEBUG",
+            format="{message}",
+        )
+        try:
+            captured = await cre.get_rag_context_capture_for_chat(app, "query")
+        finally:
+            loguru_logger.remove(sink_id)
+
+        assert captured == cre.LocalRagContextResult(
+            context=None,
+            citation_builder=None,
+        )
+        connection = db.get_connection()
+        for table in ("rag_evidence_runs", "rag_evidence_snapshots"):
+            assert (
+                connection.execute(f"SELECT count(*) FROM {table}").fetchone()[0] == 0
+            )
+        rendered_logs = "".join(str(message) for message in captured_logs)
+        assert sentinel not in rendered_logs
+        assert "reason=canonical_capture_failure" in rendered_logs
+    finally:
+        db.close_connection()

--- a/Tests/RAG/test_local_citation_capture.py
+++ b/Tests/RAG/test_local_citation_capture.py
@@ -11,8 +11,10 @@ from loguru import logger as loguru_logger
 
 from tldw_chatbook.Chat.citation_source_locators import CanonicalSourceKind
 from tldw_chatbook.Chat.citation_trace_models import (
+    EVIDENCE_ENTRIES_PER_PROMPT_MAX,
     RetrievalScoreKind,
     RetrievalScoreScale,
+    SNAPSHOT_TEXT_UTF8_BYTES_MAX,
 )
 from tldw_chatbook.RAG_Search.local_citation_capture import (
     FINAL_SCORE_KIND_KEY,
@@ -85,6 +87,61 @@ def test_unknown_semantic_top_level_source_uses_allowlisted_metadata_source():
 
 
 @pytest.mark.parametrize(
+    ("source", "metadata"),
+    [
+        ("media", {"source_type": "note"}),
+        ("media", {"source_kind": "conversation"}),
+        ("unknown", {"source_type": "media", "source_kind": "note"}),
+    ],
+    ids=[
+        "top-level-vs-source-type",
+        "top-level-vs-source-kind",
+        "source-type-vs-source-kind",
+    ],
+)
+def test_conflicting_source_identity_indicators_are_rejected(source, metadata):
+    with pytest.raises(LocalResultNormalizationError) as exc_info:
+        normalize_local_result(_result(source=source, metadata=metadata))
+
+    assert exc_info.value.reason_code is LocalResultRejectionCode.INVALID_RESULT
+
+
+@pytest.mark.parametrize(
+    ("source", "metadata"),
+    [
+        ("media", {"source_type": "web"}),
+        ("unknown", {"source_type": "media", "source_kind": 123}),
+    ],
+)
+def test_invalid_present_source_identity_indicator_is_rejected(source, metadata):
+    with pytest.raises(LocalResultNormalizationError) as exc_info:
+        normalize_local_result(_result(source=source, metadata=metadata))
+
+    assert exc_info.value.reason_code is LocalResultRejectionCode.INVALID_RESULT
+
+
+@pytest.mark.parametrize(
+    ("source", "metadata", "expected"),
+    [
+        (
+            "media",
+            {"source_type": "media_db", "source_kind": "media-db"},
+            CanonicalSourceKind.MEDIA_DB,
+        ),
+        (
+            "unknown",
+            {"source_type": "note", "source_kind": "notes"},
+            CanonicalSourceKind.NOTES,
+        ),
+    ],
+)
+def test_equivalent_source_aliases_resolve_consistently(source, metadata, expected):
+    normalized = normalize_local_result(_result(source=source, metadata=metadata))
+
+    assert normalized.source_kind is expected
+
+
+@pytest.mark.parametrize(
     "result",
     [
         _result(result_id=""),
@@ -148,6 +205,52 @@ def test_normalizer_retains_only_allowlisted_non_executable_lineage():
         "start_char": 4,
         "end_char": 12,
     }
+
+
+def test_normalizer_maps_real_semantic_chunk_offsets():
+    normalized = normalize_local_result(
+        _result(
+            metadata={
+                "chunk_id": "chunk-7",
+                "chunk_start": 4,
+                "chunk_end": 12,
+            }
+        )
+    )
+
+    assert normalized.start_char == 4
+    assert normalized.end_char == 12
+    assert (
+        normalized.to_candidate_capture(candidate_rank=1).model_dump()["start_char"]
+        == 4
+    )
+    assert (
+        normalized.to_candidate_capture(candidate_rank=1).model_dump()["end_char"] == 12
+    )
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {
+            "start_char": 4,
+            "end_char": 12,
+            "chunk_start": 5,
+            "chunk_end": 12,
+        },
+        {
+            "start_char": 4,
+            "end_char": 12,
+            "chunk_start": 4,
+            "chunk_end": 13,
+        },
+    ],
+)
+def test_conflicting_canonical_and_semantic_offsets_are_rejected(metadata):
+    with pytest.raises(LocalResultNormalizationError) as exc_info:
+        normalize_local_result(_result(metadata=metadata))
+
+    assert exc_info.value.reason_code is LocalResultRejectionCode.INVALID_RESULT
 
 
 def test_reliable_rrf_metadata_classifies_score_without_using_float_range():
@@ -336,6 +439,81 @@ def test_formatter_never_exceeds_budget_when_no_candidate_header_fits():
     assert formatted.omitted_candidate_ranks == (11,)
 
 
+def _multibyte_content_for_snapshot_bytes(header: str, total_bytes: int) -> str:
+    remaining = total_bytes - len(header.encode("utf-8"))
+    assert remaining >= 0
+    return ("é" * (remaining // 2)) + ("x" if remaining % 2 else "")
+
+
+def test_formatter_accepts_snapshot_at_exact_utf8_byte_cap():
+    header = "[S1] MEDIA — Title\n"
+    content = _multibyte_content_for_snapshot_bytes(
+        header, SNAPSHOT_TEXT_UTF8_BYTES_MAX
+    )
+    normalized = normalize_local_result(_result(content=content), candidate_rank=1)
+
+    formatted = format_local_evidence_context(
+        [normalized], max_length=len(header) + len(content)
+    )
+
+    assert len(formatted.entries) == 1
+    assert (
+        len(formatted.entries[0].snapshot_text.encode("utf-8"))
+        == SNAPSHOT_TEXT_UTF8_BYTES_MAX
+    )
+    assert formatted.entries[0].transformations == ()
+    assert formatted.omitted_candidate_ranks == ()
+
+
+def test_formatter_truncates_multibyte_snapshot_inside_utf8_and_character_budgets():
+    header = "[S1] MEDIA — Title\n"
+    at_cap = _multibyte_content_for_snapshot_bytes(header, SNAPSHOT_TEXT_UTF8_BYTES_MAX)
+    content = at_cap + "é"
+    max_length = len(header) + len(content)
+    normalized = normalize_local_result(_result(content=content), candidate_rank=7)
+
+    formatted = format_local_evidence_context([normalized], max_length=max_length)
+
+    snapshot = formatted.entries[0].snapshot_text
+    assert snapshot.endswith("…")
+    assert len(snapshot) <= max_length
+    assert len(snapshot.encode("utf-8")) <= SNAPSHOT_TEXT_UTF8_BYTES_MAX
+    assert formatted.entries[0].transformations == ("content_truncated",)
+    assert formatted.omitted_candidate_ranks == ()
+
+
+@pytest.mark.parametrize(
+    ("result_count", "expected_entries", "expected_omitted"),
+    [
+        (EVIDENCE_ENTRIES_PER_PROMPT_MAX, EVIDENCE_ENTRIES_PER_PROMPT_MAX, ()),
+        (
+            EVIDENCE_ENTRIES_PER_PROMPT_MAX + 1,
+            EVIDENCE_ENTRIES_PER_PROMPT_MAX,
+            (EVIDENCE_ENTRIES_PER_PROMPT_MAX + 1,),
+        ),
+    ],
+)
+def test_formatter_enforces_canonical_entry_limit(
+    result_count, expected_entries, expected_omitted
+):
+    normalized = [
+        normalize_local_result(
+            _result(result_id=f"m{rank}", title=f"T{rank}", content="x"),
+            candidate_rank=rank,
+        )
+        for rank in range(1, result_count + 1)
+    ]
+
+    formatted = format_local_evidence_context(normalized, max_length=100_000)
+
+    assert len(formatted.entries) == expected_entries
+    assert formatted.omitted_candidate_ranks == expected_omitted
+    assert all(
+        len(entry.snapshot_text.encode("utf-8")) <= SNAPSHOT_TEXT_UTF8_BYTES_MAX
+        for entry in formatted.entries
+    )
+
+
 class _SemanticResult:
     def __init__(self, *, source: str = "unknown", metadata=None):
         self.source = source
@@ -508,6 +686,49 @@ def test_invalid_flashrank_score_falls_back_without_marker(monkeypatch):
         normalize_local_result(fallback[0]).score_kind
         is RetrievalScoreKind.VECTOR_SIMILARITY
     )
+
+
+def test_flashrank_metadata_validation_is_atomic_across_all_results(monkeypatch):
+    _install_flashrank(
+        monkeypatch,
+        ranked=[
+            SimpleNamespace(index=0, score=0.9),
+            SimpleNamespace(index=1, score=0.8),
+        ],
+    )
+    first = _result(result_id="m1", score=0.5, metadata={"producer": "first"})
+    invalid_metadata = ["PRIVATE-RERANK-METADATA-SENTINEL"]
+    second = _result(result_id="m2", score=0.4, metadata=invalid_metadata)
+
+    fallback = pfs.rerank_results([first, second], "query", top_k=2)
+
+    assert fallback == [first, second]
+    assert first.score == 0.5
+    assert first.metadata == {"producer": "first"}
+    assert second.score == 0.4
+    assert second.metadata is invalid_metadata
+    assert FINAL_SCORE_KIND_KEY not in first.metadata
+
+
+def test_flashrank_duplicate_indexes_fallback_without_mutation(monkeypatch):
+    _install_flashrank(
+        monkeypatch,
+        ranked=[
+            SimpleNamespace(index=0, score=0.9),
+            SimpleNamespace(index=0, score=0.8),
+        ],
+    )
+    first = _result(result_id="m1", score=0.5, metadata={"producer": "first"})
+    second = _result(result_id="m2", score=0.4, metadata={"producer": "second"})
+
+    fallback = pfs.rerank_results([first, second], "query", top_k=2)
+
+    assert fallback == [first, second]
+    assert first.score == 0.5
+    assert first.metadata == {"producer": "first"}
+    assert second.score == 0.4
+    assert second.metadata == {"producer": "second"}
+    assert all(FINAL_SCORE_KIND_KEY not in result.metadata for result in fallback)
 
 
 def _prior_score_result(prior_kind):

--- a/Tests/RAG/test_local_citation_capture.py
+++ b/Tests/RAG/test_local_citation_capture.py
@@ -32,6 +32,7 @@ from tldw_chatbook.Chat.citation_trace_identity import (
 )
 from tldw_chatbook.Chat.citation_trace_models import (
     EVIDENCE_ENTRIES_PER_PROMPT_MAX,
+    PolicyCapability,
     RetrievalScoreKind,
     RetrievalScoreScale,
     SNAPSHOT_TEXT_UTF8_BYTES_MAX,
@@ -962,6 +963,11 @@ class _CaptureRepository:
                 fingerprint_key_id="key-1",
             ),
             fingerprint_codec=CitationFingerprintCodec(b"k" * 32),
+            policy_version="test-local-policy-v1",
+            policy_capabilities=(
+                PolicyCapability.VIEW_SNAPSHOT,
+                PolicyCapability.VIEW_SOURCE_IDENTITY,
+            ),
         )
         self.builders.append(builder)
         return builder

--- a/Tests/RAG/test_rag_ui_integration.py
+++ b/Tests/RAG/test_rag_ui_integration.py
@@ -77,6 +77,9 @@ class MockApp:
             "#chat-rag-plain-enable-checkbox": MockCheckbox(
                 rag_settings.get("enable_plain_rag", True)
             ),
+            "#chat-rag-search-mode": MockSelect(
+                rag_settings.get("search_mode", "plain")
+            ),
             "#chat-rag-search-media-checkbox": MockCheckbox(
                 rag_settings.get("search_media", True)
             ),
@@ -90,6 +93,7 @@ class MockApp:
             "#chat-rag-max-context-length": MockInput(
                 str(rag_settings.get("max_context_length", 10000))
             ),
+            "#chat-rag-keyword-filter": MockInput(""),
             "#chat-rag-rerank-enable-checkbox": MockCheckbox(
                 rag_settings.get("enable_rerank", False)
             ),
@@ -100,6 +104,7 @@ class MockApp:
             "#chat-rag-chunk-overlap": MockInput(
                 str(rag_settings.get("chunk_overlap", 100))
             ),
+            "#chat-rag-chunk-type": MockSelect(rag_settings.get("chunk_type", "words")),
             "#chat-rag-include-metadata-checkbox": MockCheckbox(
                 rag_settings.get("include_metadata", False)
             ),
@@ -413,6 +418,47 @@ async def test_context_formatting():
 
             if augmented_message.endswith(user_message):
                 logger.success("✅ Context properly formatted for message augmentation")
+
+
+@pytest.mark.asyncio
+async def test_capture_unavailable_keeps_ui_pipeline_context_and_legacy_string(
+    monkeypatch,
+):
+    """The UI-facing legacy API remains byte-compatible without a repository."""
+    from tldw_chatbook.Event_Handlers.Chat_Events import chat_rag_events as cre
+
+    app = MockApp(
+        {
+            "enable_plain_rag": True,
+            "search_mode": "plain",
+            "search_media": True,
+            "search_conversations": False,
+            "search_notes": False,
+        }
+    )
+    raw_context = "UI PIPELINE CONTEXT\nunchanged"
+
+    async def _plain_search(*_args, **_kwargs):
+        return [
+            {
+                "source": "media",
+                "id": "not-assembled-without-capture",
+                "title": "Pipeline title",
+                "content": "Pipeline content",
+                "score": 1.0,
+                "metadata": {},
+            }
+        ], raw_context
+
+    monkeypatch.setattr(cre, "perform_plain_rag_search", _plain_search)
+
+    captured = await cre.get_rag_context_capture_for_chat(app, "query")
+    legacy = await cre.get_rag_context_for_chat(app, "query")
+
+    assert captured.context == raw_context
+    assert captured.citation_builder is None
+    assert isinstance(legacy, str)
+    assert legacy == raw_context
 
 
 async def main():

--- a/Tests/RAG/test_rag_ui_integration.py
+++ b/Tests/RAG/test_rag_ui_integration.py
@@ -122,6 +122,36 @@ class MockApp:
         logger.info(f"[{severity.upper()}] {message}")
 
 
+class CaptureUnavailableApp:
+    """DB-free app double for capture compatibility at the UI boundary."""
+
+    def __init__(self):
+        self.ui_elements = {
+            "#chat-rag-enable-checkbox": MockCheckbox(False),
+            "#chat-rag-plain-enable-checkbox": MockCheckbox(True),
+            "#chat-rag-search-mode": MockSelect("plain"),
+            "#chat-rag-search-media-checkbox": MockCheckbox(True),
+            "#chat-rag-search-conversations-checkbox": MockCheckbox(False),
+            "#chat-rag-search-notes-checkbox": MockCheckbox(False),
+            "#chat-rag-top-k": MockInput("5"),
+            "#chat-rag-max-context-length": MockInput("10000"),
+            "#chat-rag-keyword-filter": MockInput(""),
+            "#chat-rag-rerank-enable-checkbox": MockCheckbox(False),
+            "#chat-rag-reranker-model": MockSelect("flashrank"),
+            "#chat-rag-chunk-size": MockInput("400"),
+            "#chat-rag-chunk-overlap": MockInput("100"),
+            "#chat-rag-chunk-type": MockSelect("words"),
+            "#chat-rag-include-metadata-checkbox": MockCheckbox(False),
+        }
+        self.notifications = []
+
+    def query_one(self, selector: str):
+        return self.ui_elements[selector]
+
+    def notify(self, message: str, severity: str = "info"):
+        self.notifications.append((message, severity))
+
+
 @pytest.mark.requires_rag_deps
 @pytest.mark.asyncio
 async def test_get_rag_context_basic():
@@ -427,15 +457,10 @@ async def test_capture_unavailable_keeps_ui_pipeline_context_and_legacy_string(
     """The UI-facing legacy API remains byte-compatible without a repository."""
     from tldw_chatbook.Event_Handlers.Chat_Events import chat_rag_events as cre
 
-    app = MockApp(
-        {
-            "enable_plain_rag": True,
-            "search_mode": "plain",
-            "search_media": True,
-            "search_conversations": False,
-            "search_notes": False,
-        }
-    )
+    app = CaptureUnavailableApp()
+    assert not hasattr(app, "media_db")
+    assert not hasattr(app, "chachanotes_db")
+    assert not hasattr(app, "rag_db")
     raw_context = "UI PIPELINE CONTEXT\nunchanged"
 
     async def _plain_search(*_args, **_kwargs):

--- a/Tests/RAG/test_scope_pipeline_enforcement.py
+++ b/Tests/RAG/test_scope_pipeline_enforcement.py
@@ -23,6 +23,7 @@ mirroring ``Tests/RAG_Search/test_pipeline_notes_search.py`` and
 """
 
 import asyncio
+import json
 import threading
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
@@ -1934,8 +1935,9 @@ class TestFreshPromptBoundaryAuthority:
             "{PRIVATE-WORKSPACE-SCOPE-SENTINEL",
             '{"version": 1, "items": "PRIVATE-WORKSPACE-SCOPE-SENTINEL", '
             '"updated_at": "t1"}',
+            '{"version": true, "items": [], "updated_at": "t1"}',
         ],
-        ids=["malformed-json", "decoded-invalid-scope"],
+        ids=["malformed-json", "decoded-invalid-scope", "bool-version"],
     )
     @pytest.mark.asyncio
     async def test_fresh_malformed_workspace_scope_fails_closed(
@@ -1993,6 +1995,135 @@ class TestFreshPromptBoundaryAuthority:
 
         assert effective.state == "unscoped"
         assert authorized == (candidate,)
+
+    @pytest.mark.asyncio
+    async def test_fresh_missing_linked_workspace_fails_closed(
+        self, media_db, tmp_path, monkeypatch
+    ):
+        media_id = _seed_media(media_db, n=1)[0]
+        registry = LocalWorkspaceRegistryService(
+            WorkspaceDB(tmp_path / "workspaces.sqlite", client_id="task2-missing")
+        )
+        session = SimpleNamespace(
+            persisted_conversation_id=None,
+            workspace_id="workspace-does-not-exist",
+        )
+        monkeypatch.setattr(cre, "_active_console_session", lambda _app: session)
+        app = _App(media_db=media_db)
+        app.workspace_registry_service = registry
+        candidate = self._normalized("media", media_id, "Media", rank=1)
+
+        effective = await cre.resolve_effective_scope_for_chat(app, use_cache=False)
+        authorized = await cre.authorize_local_results_for_prompt(app, (candidate,))
+
+        assert effective.state == "empty"
+        assert effective.cause == "workspace-scope-unavailable"
+        assert authorized == ()
+
+    @pytest.mark.asyncio
+    async def test_fresh_workspace_version_rejection_does_not_log_raw_value(
+        self, media_db, tmp_path, monkeypatch
+    ):
+        sentinel = "PRIVATE-VERSION-SENTINEL"
+        media_id = _seed_media(media_db, n=1)[0]
+        registry = LocalWorkspaceRegistryService(
+            WorkspaceDB(tmp_path / "workspaces.sqlite", client_id="task2-version")
+        )
+        registry.create_workspace(workspace_id="ws-version", name="Version")
+        payload = json.dumps(
+            {
+                "version": sentinel,
+                "items": [{"source_type": SOURCE_TYPE_MEDIA, "source_id": media_id}],
+                "updated_at": "t1",
+            }
+        )
+        with registry.db.transaction() as conn:
+            conn.execute(
+                """
+                INSERT INTO workspace_rag_scopes (workspace_id, payload, updated_at)
+                VALUES (?, ?, ?)
+                """,
+                ("ws-version", payload, "t1"),
+            )
+        session = SimpleNamespace(
+            persisted_conversation_id=None,
+            workspace_id="ws-version",
+        )
+        monkeypatch.setattr(cre, "_active_console_session", lambda _app: session)
+        app = _App(media_db=media_db)
+        app.workspace_registry_service = registry
+        candidate = self._normalized("media", media_id, "Media", rank=1)
+        captured = []
+        sink_id = loguru_logger.add(
+            captured.append,
+            level="WARNING",
+            format="{message}",
+        )
+        try:
+            effective = await cre.resolve_effective_scope_for_chat(app, use_cache=False)
+            authorized = await cre.authorize_local_results_for_prompt(app, (candidate,))
+        finally:
+            loguru_logger.remove(sink_id)
+
+        rendered = "".join(str(message) for message in captured)
+        assert effective.state == "empty"
+        assert effective.cause == "workspace-scope-unavailable"
+        assert authorized == ()
+        assert sentinel not in rendered
+
+    @pytest.mark.asyncio
+    async def test_fresh_conversation_version_rejection_does_not_log_raw_value(
+        self, media_db, cha_db, monkeypatch
+    ):
+        sentinel = "PRIVATE-VERSION-SENTINEL"
+        media_id = _seed_media(media_db, n=1)[0]
+        conversation_id = cha_db.add_conversation({"title": "Version"})
+        record = cha_db.get_conversation_by_id(conversation_id)
+        assert record is not None
+        cha_db.update_conversation(
+            conversation_id,
+            {
+                "metadata": json.dumps(
+                    {
+                        "rag_scope": {
+                            "version": sentinel,
+                            "items": [
+                                {
+                                    "source_type": SOURCE_TYPE_MEDIA,
+                                    "source_id": media_id,
+                                }
+                            ],
+                            "updated_at": "t1",
+                        }
+                    }
+                )
+            },
+            expected_version=record["version"],
+        )
+        session = SimpleNamespace(
+            persisted_conversation_id=conversation_id,
+            workspace_id=None,
+        )
+        monkeypatch.setattr(cre, "_active_console_session", lambda _app: session)
+        app = _App(media_db=media_db, chachanotes_db=cha_db)
+        candidate = self._normalized("media", media_id, "Media", rank=1)
+        captured = []
+        sink_id = loguru_logger.add(
+            captured.append,
+            level="WARNING",
+            format="{message}",
+        )
+        try:
+            effective = await cre.resolve_effective_scope_for_chat(app, use_cache=False)
+            authorized = await cre.authorize_local_results_for_prompt(app, (candidate,))
+        finally:
+            loguru_logger.remove(sink_id)
+
+        rendered = "".join(str(message) for message in captured)
+        assert effective.state == "empty"
+        assert effective.cause == "conversation-scope-unavailable"
+        assert authorized == ()
+        assert sentinel not in rendered
 
     @pytest.mark.asyncio
     async def test_prompt_authority_failure_log_omits_sensitive_values(

--- a/Tests/RAG/test_scope_pipeline_enforcement.py
+++ b/Tests/RAG/test_scope_pipeline_enforcement.py
@@ -46,6 +46,11 @@ from tldw_chatbook.Chat.rag_scope import (
     note_id_params,
     write_conversation_scope,
 )
+from tldw_chatbook.Chat.citation_trace_builder import CitationTraceBuilder
+from tldw_chatbook.Chat.citation_trace_identity import (
+    CitationFingerprintCodec,
+    LocalCitationIdentityContext,
+)
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
 from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
@@ -822,6 +827,7 @@ class _ChatMockApp:
         media_db: Any = None,
         chachanotes_db: Any = None,
         rag_service: Any = None,
+        citation_trace_repository: Any = None,
     ):
         self._widgets = {
             "#chat-rag-enable-checkbox": _MockWidget(True),
@@ -844,6 +850,8 @@ class _ChatMockApp:
         self.chachanotes_db = chachanotes_db
         if rag_service is not None:
             self._rag_service = rag_service
+        if citation_trace_repository is not None:
+            self.citation_trace_repository = citation_trace_repository
         self.notifications: List[tuple] = []
 
     def query_one(self, selector):
@@ -851,6 +859,25 @@ class _ChatMockApp:
 
     def notify(self, message, severity="information", **kwargs):
         self.notifications.append((message, severity))
+
+
+class _BuilderRepository:
+    def __init__(self):
+        self.builders = []
+
+    def create_local_trace_builder(self, *, request_id, generation_id):
+        builder = CitationTraceBuilder.local(
+            request_id=request_id,
+            generation_id=generation_id,
+            identity_context=LocalCitationIdentityContext(
+                profile_id="scope-profile",
+                local_authority_id="scope-authority",
+                fingerprint_key_id="scope-key",
+            ),
+            fingerprint_codec=CitationFingerprintCodec(b"s" * 32),
+        )
+        self.builders.append(builder)
+        return builder
 
 
 class TestChatEntryPointScopedE2E:
@@ -2430,6 +2457,134 @@ class TestFreshPromptBoundaryAuthority:
         assert captured.entries[0].candidate_rank == 3
         assert "Invalid" not in captured.entries[0].snapshot_text
         assert "Unauthorized" not in captured.entries[0].snapshot_text
+
+
+class TestCapturePromptBoundaryFreshAuthority:
+    """Capture rechecks the original request identity after retrieval."""
+
+    @pytest.mark.asyncio
+    async def test_backing_row_deleted_during_retrieval_is_not_submitted(
+        self, media_db, cha_db, monkeypatch
+    ):
+        media_id = _seed_media(media_db, n=1)[0]
+        repository = _BuilderRepository()
+        app = _ChatMockApp(
+            search_mode="plain",
+            media_db=media_db,
+            chachanotes_db=cha_db,
+            citation_trace_repository=repository,
+        )
+        monkeypatch.setattr(cre, "_active_console_session", lambda _app: None)
+
+        async def _delete_then_return(*_args, **_kwargs):
+            media_db.soft_delete_media(int(media_id))
+            return [
+                {
+                    "source": "media",
+                    "id": media_id,
+                    "title": "Deleted",
+                    "content": "must not reach the prompt",
+                    "score": 1.0,
+                    "metadata": {},
+                }
+            ], "legacy context must not survive canonical capture"
+
+        monkeypatch.setattr(cre, "perform_plain_rag_search", _delete_then_return)
+
+        captured = await cre.get_rag_context_capture_for_chat(app, "query")
+
+        assert captured.context is None
+        assert captured.citation_builder is repository.builders[0]
+        assert len(captured.citation_builder.evidence_runs) == 1
+        assert captured.citation_builder.evidence_run_payloads[0].candidates == ()
+        assert captured.citation_builder.prompt_evidence_sets == ()
+
+    @pytest.mark.asyncio
+    async def test_original_session_fresh_scope_beats_stale_cache_and_later_session(
+        self, media_db, cha_db, tmp_path, monkeypatch
+    ):
+        media_ids = _seed_media(media_db, n=2)
+        registry = LocalWorkspaceRegistryService(
+            WorkspaceDB(tmp_path / "workspaces.sqlite", client_id="task4-original")
+        )
+        registry.create_workspace(workspace_id="ws-original", name="Original")
+        registry.create_workspace(workspace_id="ws-later", name="Later")
+        registry.set_workspace_scope(
+            "ws-original",
+            RagScope(
+                items=(ScopeItem(SOURCE_TYPE_MEDIA, media_ids[0]),),
+                updated_at="unchanged-stamp",
+            ),
+        )
+        registry.set_workspace_scope(
+            "ws-later",
+            RagScope(
+                items=(ScopeItem(SOURCE_TYPE_MEDIA, media_ids[0]),),
+                updated_at="later-stamp",
+            ),
+        )
+        original_session = SimpleNamespace(
+            id="session-original",
+            persisted_conversation_id=None,
+            workspace_id="ws-original",
+        )
+        later_session = SimpleNamespace(
+            id="session-later",
+            persisted_conversation_id=None,
+            workspace_id="ws-later",
+        )
+        active = {"session": original_session}
+        monkeypatch.setattr(
+            cre,
+            "_active_console_session",
+            lambda _app: active["session"],
+        )
+        repository = _BuilderRepository()
+        app = _ChatMockApp(
+            search_mode="plain",
+            media_db=media_db,
+            chachanotes_db=cha_db,
+            citation_trace_repository=repository,
+        )
+        app.workspace_registry_service = registry
+        cached = await cre.resolve_effective_scope_for_chat(app)
+        assert cached.allowlist == {SOURCE_TYPE_MEDIA: frozenset({media_ids[0]})}
+
+        async def _narrow_original_then_switch_session(*_args, scope=None, **_kwargs):
+            assert scope is not None
+            assert scope.allowlist == {SOURCE_TYPE_MEDIA: frozenset({media_ids[0]})}
+            registry.set_workspace_scope(
+                "ws-original",
+                RagScope(
+                    items=(ScopeItem(SOURCE_TYPE_MEDIA, media_ids[1]),),
+                    updated_at="unchanged-stamp",
+                ),
+            )
+            active["session"] = later_session
+            return [
+                {
+                    "source": "media",
+                    "id": source_id,
+                    "title": title,
+                    "content": f"{title} body",
+                    "score": 1.0,
+                    "metadata": {},
+                }
+                for source_id, title in zip(media_ids, ("Stale", "Current"))
+            ], "legacy context"
+
+        monkeypatch.setattr(
+            cre,
+            "perform_plain_rag_search",
+            _narrow_original_then_switch_session,
+        )
+
+        captured = await cre.get_rag_context_capture_for_chat(app, "query")
+
+        assert captured.context == "[S1] MEDIA — Current\nCurrent body"
+        assert captured.citation_builder is repository.builders[0]
+        candidates = captured.citation_builder.evidence_run_payloads[0].candidates
+        assert [candidate.rank for candidate in candidates] == [2]
 
 
 class TestActiveConsoleSessionRealGlue:

--- a/Tests/RAG/test_scope_pipeline_enforcement.py
+++ b/Tests/RAG/test_scope_pipeline_enforcement.py
@@ -28,6 +28,7 @@ from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 
 import pytest
+from loguru import logger as loguru_logger
 
 from tldw_chatbook.Chat.rag_scope import (
     EffectiveScope,
@@ -1884,7 +1885,7 @@ class TestFreshPromptBoundaryAuthority:
 
     @pytest.mark.asyncio
     async def test_same_stamp_scope_narrowing_ignores_pre_retrieval_cache(
-        self, media_db, monkeypatch
+        self, media_db, tmp_path, monkeypatch
     ):
         media_ids = _seed_media(media_db, n=2)
         session = SimpleNamespace(
@@ -1893,27 +1894,28 @@ class TestFreshPromptBoundaryAuthority:
             workspace_id="ws-1",
         )
         monkeypatch.setattr(cre, "_active_console_session", lambda _app: session)
-
-        class _Registry:
-            db = SimpleNamespace(is_memory_db=True)
-
-            def __init__(self):
-                self.scope = RagScope(
-                    items=(ScopeItem(SOURCE_TYPE_MEDIA, media_ids[0]),),
-                    updated_at="unchanged-stamp",
-                )
-
-            def get_workspace_scope(self, _workspace_id):
-                return self.scope
-
+        registry = LocalWorkspaceRegistryService(
+            WorkspaceDB(tmp_path / "workspaces.sqlite", client_id="task2-fresh")
+        )
+        registry.create_workspace(workspace_id="ws-1", name="Fresh authority")
+        registry.set_workspace_scope(
+            "ws-1",
+            RagScope(
+                items=(ScopeItem(SOURCE_TYPE_MEDIA, media_ids[0]),),
+                updated_at="unchanged-stamp",
+            ),
+        )
         app = _App(media_db=media_db)
-        app.workspace_registry_service = _Registry()
+        app.workspace_registry_service = registry
         cached = await cre.resolve_effective_scope_for_chat(app)
         assert cached.allowlist == {SOURCE_TYPE_MEDIA: frozenset({media_ids[0]})}
 
-        app.workspace_registry_service.scope = RagScope(
-            items=(ScopeItem(SOURCE_TYPE_MEDIA, media_ids[1]),),
-            updated_at="unchanged-stamp",
+        registry.set_workspace_scope(
+            "ws-1",
+            RagScope(
+                items=(ScopeItem(SOURCE_TYPE_MEDIA, media_ids[1]),),
+                updated_at="unchanged-stamp",
+            ),
         )
         candidates = (
             self._normalized("media", media_ids[0], "Old", rank=1),
@@ -1925,6 +1927,105 @@ class TestFreshPromptBoundaryAuthority:
         assert [(item.source_id, item.candidate_rank) for item in authorized] == [
             (media_ids[1], 2)
         ]
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            "{PRIVATE-WORKSPACE-SCOPE-SENTINEL",
+            '{"version": 1, "items": "PRIVATE-WORKSPACE-SCOPE-SENTINEL", '
+            '"updated_at": "t1"}',
+        ],
+        ids=["malformed-json", "decoded-invalid-scope"],
+    )
+    @pytest.mark.asyncio
+    async def test_fresh_malformed_workspace_scope_fails_closed(
+        self, media_db, tmp_path, monkeypatch, payload
+    ):
+        media_id = _seed_media(media_db, n=1)[0]
+        registry = LocalWorkspaceRegistryService(
+            WorkspaceDB(tmp_path / "workspaces.sqlite", client_id="task2-strict")
+        )
+        registry.create_workspace(workspace_id="ws-malformed", name="Malformed")
+        with registry.db.transaction() as conn:
+            conn.execute(
+                """
+                INSERT INTO workspace_rag_scopes (workspace_id, payload, updated_at)
+                VALUES (?, ?, ?)
+                """,
+                ("ws-malformed", payload, "t1"),
+            )
+        session = SimpleNamespace(
+            persisted_conversation_id=None,
+            workspace_id="ws-malformed",
+        )
+        monkeypatch.setattr(cre, "_active_console_session", lambda _app: session)
+        app = _App(media_db=media_db)
+        app.workspace_registry_service = registry
+        candidate = self._normalized("media", media_id, "Media", rank=1)
+
+        effective = await cre.resolve_effective_scope_for_chat(app, use_cache=False)
+        authorized = await cre.authorize_local_results_for_prompt(app, (candidate,))
+
+        assert effective.state == "empty"
+        assert effective.cause == "workspace-scope-unavailable"
+        assert authorized == ()
+
+    @pytest.mark.asyncio
+    async def test_fresh_workspace_with_no_scope_row_remains_unscoped(
+        self, media_db, tmp_path, monkeypatch
+    ):
+        media_id = _seed_media(media_db, n=1)[0]
+        registry = LocalWorkspaceRegistryService(
+            WorkspaceDB(tmp_path / "workspaces.sqlite", client_id="task2-unset")
+        )
+        registry.create_workspace(workspace_id="ws-unset", name="Unset")
+        session = SimpleNamespace(
+            persisted_conversation_id=None,
+            workspace_id="ws-unset",
+        )
+        monkeypatch.setattr(cre, "_active_console_session", lambda _app: session)
+        app = _App(media_db=media_db)
+        app.workspace_registry_service = registry
+        candidate = self._normalized("media", media_id, "Media", rank=1)
+
+        effective = await cre.resolve_effective_scope_for_chat(app, use_cache=False)
+        authorized = await cre.authorize_local_results_for_prompt(app, (candidate,))
+
+        assert effective.state == "unscoped"
+        assert authorized == (candidate,)
+
+    @pytest.mark.asyncio
+    async def test_prompt_authority_failure_log_omits_sensitive_values(
+        self, monkeypatch
+    ):
+        sentinel = "PRIVATE-PROMPT-AUTHORITY-SENTINEL"
+
+        class _SensitiveFailureMediaDB:
+            is_memory_db = True
+
+            def execute_query(self, *_args, **_kwargs):
+                raise RuntimeError(sentinel)
+
+        monkeypatch.setattr(cre, "_active_console_session", lambda _app: None)
+        candidate = self._normalized("media", sentinel, sentinel, rank=1)
+        captured = []
+        sink_id = loguru_logger.add(
+            captured.append,
+            level="WARNING",
+            format="{message}",
+        )
+        try:
+            authorized = await cre.authorize_local_results_for_prompt(
+                _App(media_db=_SensitiveFailureMediaDB()), (candidate,)
+            )
+        finally:
+            loguru_logger.remove(sink_id)
+
+        rendered = "".join(str(message) for message in captured)
+        assert authorized == ()
+        assert sentinel not in rendered
+        assert "status=unavailable" in rendered
+        assert "reason=media_existence_read_failure" in rendered
 
     @pytest.mark.asyncio
     async def test_failed_authority_or_existence_read_rejects_every_candidate(

--- a/Tests/RAG/test_scope_pipeline_enforcement.py
+++ b/Tests/RAG/test_scope_pipeline_enforcement.py
@@ -1367,13 +1367,13 @@ class TestScopeCacheWiring:
         app = _App(media_db=media_db, chachanotes_db=cha_db)
 
         calls: list[int] = []
-        real_resolve = cre.resolve_effective_scope
+        real_resolve = cre._resolve_scope_with_current_ids
 
-        def _spy_resolve(*args, **kwargs):
+        async def _spy_resolve(*args, **kwargs):
             calls.append(1)
-            return real_resolve(*args, **kwargs)
+            return await real_resolve(*args, **kwargs)
 
-        monkeypatch.setattr(cre, "resolve_effective_scope", _spy_resolve)
+        monkeypatch.setattr(cre, "_resolve_scope_with_current_ids", _spy_resolve)
 
         first = await cre.resolve_effective_scope_for_chat(app)
         second = await cre.resolve_effective_scope_for_chat(app)
@@ -1401,13 +1401,13 @@ class TestScopeCacheWiring:
         app = _App(media_db=media_db, chachanotes_db=cha_db)
 
         calls: list[int] = []
-        real_resolve = cre.resolve_effective_scope
+        real_resolve = cre._resolve_scope_with_current_ids
 
-        def _spy_resolve(*args, **kwargs):
+        async def _spy_resolve(*args, **kwargs):
             calls.append(1)
-            return real_resolve(*args, **kwargs)
+            return await real_resolve(*args, **kwargs)
 
-        monkeypatch.setattr(cre, "resolve_effective_scope", _spy_resolve)
+        monkeypatch.setattr(cre, "_resolve_scope_with_current_ids", _spy_resolve)
 
         await cre.resolve_effective_scope_for_chat(app)
         await cre.resolve_effective_scope_for_chat(app)
@@ -1436,13 +1436,13 @@ class TestScopeCacheWiring:
         app = _App(media_db=media_db, chachanotes_db=cha_db)
 
         calls: list[int] = []
-        real_resolve = cre.resolve_effective_scope
+        real_resolve = cre._resolve_scope_with_current_ids
 
-        def _spy_resolve(*args, **kwargs):
+        async def _spy_resolve(*args, **kwargs):
             calls.append(1)
-            return real_resolve(*args, **kwargs)
+            return await real_resolve(*args, **kwargs)
 
-        monkeypatch.setattr(cre, "resolve_effective_scope", _spy_resolve)
+        monkeypatch.setattr(cre, "_resolve_scope_with_current_ids", _spy_resolve)
 
         first = await cre.resolve_effective_scope_for_chat(app)
         assert first.allowlist == {SOURCE_TYPE_MEDIA: frozenset({media_ids[0]})}
@@ -1497,13 +1497,13 @@ class TestScopeCacheWiring:
         app.workspace_registry_service = registry
 
         calls: list[int] = []
-        real_resolve = cre.resolve_effective_scope
+        real_resolve = cre._resolve_scope_with_current_ids
 
-        def _spy_resolve(*args, **kwargs):
+        async def _spy_resolve(*args, **kwargs):
             calls.append(1)
-            return real_resolve(*args, **kwargs)
+            return await real_resolve(*args, **kwargs)
 
-        monkeypatch.setattr(cre, "resolve_effective_scope", _spy_resolve)
+        monkeypatch.setattr(cre, "_resolve_scope_with_current_ids", _spy_resolve)
 
         first = await cre.resolve_effective_scope_for_chat(app)
         assert first.allowlist == {SOURCE_TYPE_MEDIA: frozenset({media_ids[0]})}
@@ -1562,13 +1562,13 @@ class TestScopeCacheWiring:
         app.workspace_registry_service = registry
 
         calls: list[int] = []
-        real_resolve = cre.resolve_effective_scope
+        real_resolve = cre._resolve_scope_with_current_ids
 
-        def _spy_resolve(*args, **kwargs):
+        async def _spy_resolve(*args, **kwargs):
             calls.append(1)
-            return real_resolve(*args, **kwargs)
+            return await real_resolve(*args, **kwargs)
 
-        monkeypatch.setattr(cre, "resolve_effective_scope", _spy_resolve)
+        monkeypatch.setattr(cre, "_resolve_scope_with_current_ids", _spy_resolve)
 
         first = await cre.resolve_effective_scope_for_chat(app)
         assert first.allowlist == {SOURCE_TYPE_MEDIA: frozenset({media_ids[0]})}
@@ -1819,6 +1819,63 @@ class TestResolveEffectiveScopeMemoryDbGuard:
             assert resolution.effective.state == "unscoped"
             assert len(call_threads) == 1
             assert call_threads[0] is not main_thread
+        finally:
+            memory_media.close_connection()
+
+    @pytest.mark.asyncio
+    async def test_mixed_store_scope_existence_reads_use_each_store_thread(
+        self, cha_db, monkeypatch
+    ):
+        memory_media = MediaDatabase(":memory:", client_id="task4-mixed-existence")
+        try:
+            media_id = _seed_media(memory_media, n=1)[0]
+            note_id = _seed_notes(cha_db, n=1)[0]
+            conversation_id = cha_db.add_conversation({"title": "Mixed scope"})
+            write_conversation_scope(
+                cha_db,
+                conversation_id,
+                RagScope(
+                    items=(
+                        ScopeItem(SOURCE_TYPE_MEDIA, media_id),
+                        ScopeItem(SOURCE_TYPE_NOTE, note_id),
+                    ),
+                    updated_at="t1",
+                ),
+            )
+            session = SimpleNamespace(
+                persisted_conversation_id=conversation_id,
+                workspace_id=None,
+            )
+            main_thread = threading.current_thread()
+            call_threads = {"media": [], "note": []}
+            real_sensitive_fetchall = cre._sensitive_fetchall
+
+            def _record_existence_thread(db, query, params):
+                if query.startswith("SELECT id FROM Media"):
+                    call_threads["media"].append(threading.current_thread())
+                elif query.startswith("SELECT id FROM notes"):
+                    call_threads["note"].append(threading.current_thread())
+                return real_sensitive_fetchall(db, query, params)
+
+            monkeypatch.setattr(
+                cre,
+                "_sensitive_fetchall",
+                _record_existence_thread,
+            )
+
+            resolution = await cre.resolve_scope_for_session(
+                _App(media_db=memory_media, chachanotes_db=cha_db),
+                session,
+                use_cache=False,
+            )
+
+            assert resolution.effective.allowlist == {
+                SOURCE_TYPE_MEDIA: frozenset({media_id}),
+                SOURCE_TYPE_NOTE: frozenset({note_id}),
+            }
+            assert call_threads["media"] == [main_thread]
+            assert len(call_threads["note"]) == 1
+            assert call_threads["note"][0] is not main_thread
         finally:
             memory_media.close_connection()
 

--- a/Tests/RAG/test_scope_pipeline_enforcement.py
+++ b/Tests/RAG/test_scope_pipeline_enforcement.py
@@ -49,7 +49,9 @@ from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
 from tldw_chatbook.Event_Handlers.Chat_Events import chat_rag_events as cre
 from tldw_chatbook.RAG_Search import pipeline_builder_simple as pbs
 from tldw_chatbook.RAG_Search import pipeline_functions_simple as pfs
+from tldw_chatbook.RAG_Search.local_citation_capture import normalize_local_result
 from tldw_chatbook.RAG_Search.pipeline_functions_simple import SCOPE_DIAGNOSTICS_KEY
+from tldw_chatbook.RAG_Search.pipeline_types import SearchResult
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 from tldw_chatbook.Workspaces import LocalWorkspaceRegistryService
 
@@ -146,9 +148,7 @@ class _RefusingConversationsDB:
         raise AssertionError("search_conversations_by_content must not be called")
 
     def get_messages_for_conversations_batch(self, *args, **kwargs):
-        raise AssertionError(
-            "get_messages_for_conversations_batch must not be called"
-        )
+        raise AssertionError("get_messages_for_conversations_batch must not be called")
 
 
 class _RefusingRagService:
@@ -249,9 +249,7 @@ class TestMediaLegScopeEnforcement:
         app = _App(media_db=media_db)
         eff = _scoped(media={ids[1]})
 
-        results = await pfs.search_media_fts5(
-            app, "zanzibarite", limit=10, scope=eff
-        )
+        results = await pfs.search_media_fts5(app, "zanzibarite", limit=10, scope=eff)
 
         assert [r.id for r in results] == [ids[1]]
 
@@ -262,9 +260,7 @@ class TestMediaLegScopeEnforcement:
         app = _App(media_db=_RefusingMediaDB())
         eff = _scoped(note={"n1"})  # media type absent
 
-        results = await pfs.search_media_fts5(
-            app, "zanzibarite", limit=10, scope=eff
-        )
+        results = await pfs.search_media_fts5(app, "zanzibarite", limit=10, scope=eff)
 
         assert results == []
 
@@ -296,9 +292,7 @@ class TestNotesLegScopeEnforcement:
         app = _App(chachanotes_db=cha_db)
         eff = _scoped(note={ids[2]})
 
-        results = await pfs.search_notes_fts5(
-            app, "zanzibarite", limit=10, scope=eff
-        )
+        results = await pfs.search_notes_fts5(app, "zanzibarite", limit=10, scope=eff)
 
         assert [r.id for r in results] == [ids[2]]
 
@@ -308,9 +302,7 @@ class TestNotesLegScopeEnforcement:
         app = _App(chachanotes_db=_RefusingChaChaDB())
         eff = _scoped(media={"1"})  # note type absent
 
-        results = await pfs.search_notes_fts5(
-            app, "zanzibarite", limit=10, scope=eff
-        )
+        results = await pfs.search_notes_fts5(app, "zanzibarite", limit=10, scope=eff)
 
         assert results == []
 
@@ -1069,6 +1061,7 @@ class TestWorkspaceScopeIntersectionE2E:
             "perform_hybrid_rag_search",
             "perform_search_with_pipeline",
         ):
+
             def _refuse(*args, __name=fn_name, **kwargs):
                 raise AssertionError(f"{__name} must not be called on EMPTY scope")
 
@@ -1132,6 +1125,7 @@ class TestWorkspaceScopeReadFailureFailsClosed:
             "perform_hybrid_rag_search",
             "perform_search_with_pipeline",
         ):
+
             def _refuse(*args, __name=fn_name, **kwargs):
                 raise AssertionError(f"{__name} must not be called on EMPTY scope")
 
@@ -1180,6 +1174,7 @@ class TestWorkspaceScopeReadFailureFailsClosed:
             "perform_hybrid_rag_search",
             "perform_search_with_pipeline",
         ):
+
             def _refuse(*args, __name=fn_name, **kwargs):
                 raise AssertionError(f"{__name} must not be called on EMPTY scope")
 
@@ -1200,9 +1195,7 @@ class TestWorkspaceScopeReadFailureFailsClosed:
         ), app.notifications
 
     @pytest.mark.asyncio
-    async def test_resolve_scope_for_session_reports_distinct_cause(
-        self, cha_db
-    ):
+    async def test_resolve_scope_for_session_reports_distinct_cause(self, cha_db):
         """Unit-level check directly against ``resolve_scope_for_session``:
         the returned ``ScopeResolution`` carries ``ws_scope=None`` (the read
         never produced a usable value -- distinct from "cleanly unset") and
@@ -1239,9 +1232,7 @@ class TestWorkspaceScopeMemoryDbGuard:
     """
 
     @pytest.mark.asyncio
-    async def test_memory_backed_registry_reads_inline(
-        self, media_db, monkeypatch
-    ):
+    async def test_memory_backed_registry_reads_inline(self, media_db, monkeypatch):
         """Checks the WORKSPACE-scope read's own thread, not a blanket
         ``asyncio.to_thread`` spy: the overall ``resolve_effective_scope``
         call is offloaded independently based on ``chachanotes_db``/
@@ -1282,9 +1273,7 @@ class TestWorkspaceScopeMemoryDbGuard:
         )
 
     @pytest.mark.asyncio
-    async def test_file_backed_registry_still_offloaded(
-        self, media_db, monkeypatch
-    ):
+    async def test_file_backed_registry_still_offloaded(self, media_db, monkeypatch):
         import threading
 
         media_ids = _seed_media(media_db, n=1)
@@ -1361,6 +1350,40 @@ class TestScopeCacheWiring:
         assert first == second
         assert first.state == "scoped"
         assert len(calls) == 1, "the second call must be served from ScopeCache"
+
+    @pytest.mark.asyncio
+    async def test_explicit_uncached_mode_bypasses_populated_scope_cache(
+        self, media_db, cha_db, monkeypatch
+    ):
+        media_ids = _seed_media(media_db, n=1)
+        conv_id = cha_db.add_conversation({"title": "Fresh boundary"})
+        write_conversation_scope(
+            cha_db,
+            conv_id,
+            RagScope(
+                items=(ScopeItem(SOURCE_TYPE_MEDIA, media_ids[0]),),
+                updated_at="same-stamp",
+            ),
+        )
+        session = SimpleNamespace(persisted_conversation_id=conv_id)
+        monkeypatch.setattr(cre, "_active_console_session", lambda app: session)
+        app = _App(media_db=media_db, chachanotes_db=cha_db)
+
+        calls: list[int] = []
+        real_resolve = cre.resolve_effective_scope
+
+        def _spy_resolve(*args, **kwargs):
+            calls.append(1)
+            return real_resolve(*args, **kwargs)
+
+        monkeypatch.setattr(cre, "resolve_effective_scope", _spy_resolve)
+
+        await cre.resolve_effective_scope_for_chat(app)
+        await cre.resolve_effective_scope_for_chat(app)
+        fresh = await cre.resolve_effective_scope_for_chat(app, use_cache=False)
+
+        assert fresh.allowlist == {SOURCE_TYPE_MEDIA: frozenset({media_ids[0]})}
+        assert len(calls) == 2
 
     @pytest.mark.asyncio
     async def test_cache_miss_on_conversation_scope_stamp_change(
@@ -1560,6 +1583,7 @@ class TestChatEntryPointEmptyScopeShortCircuit:
             "perform_hybrid_rag_search",
             "perform_search_with_pipeline",
         ):
+
             def _refuse(*args, __name=fn_name, **kwargs):
                 raise AssertionError(f"{__name} must not be called on EMPTY scope")
 
@@ -1723,7 +1747,9 @@ class TestResolveEffectiveScopeMemoryDbGuard:
 
             assert effective.state == "scoped"
             assert effective.allowlist == {SOURCE_TYPE_NOTE: frozenset({note_id})}
-            assert calls, "file-backed DB reads must still be offloaded via asyncio.to_thread"
+            assert calls, (
+                "file-backed DB reads must still be offloaded via asyncio.to_thread"
+            )
         finally:
             cha_db.close_connection()
 
@@ -1778,6 +1804,281 @@ class TestChatEntryPointUnscopedZeroDrift:
         assert context == "some context"
         assert "scope" in captured
         assert captured["scope"] is None
+
+
+class TestFreshPromptBoundaryAuthority:
+    """Prompt evidence gets a fresh, fail-closed scope/existence decision."""
+
+    @staticmethod
+    def _normalized(source: str, source_id: str, title: str, *, rank: int):
+        return normalize_local_result(
+            SearchResult(
+                source=source,
+                id=source_id,
+                title=title,
+                content=f"{title} body",
+            ),
+            candidate_rank=rank,
+        )
+
+    @pytest.mark.asyncio
+    async def test_soft_deleted_media_note_and_conversation_are_all_excluded(
+        self, media_db, cha_db, monkeypatch
+    ):
+        media_id = _seed_media(media_db, n=1)[0]
+        note_id = _seed_notes(cha_db, n=1)[0]
+        conv_id = cha_db.add_conversation({"title": "Candidate conversation"})
+        monkeypatch.setattr(cre, "_active_console_session", lambda _app: None)
+        candidates = (
+            self._normalized("media", media_id, "Media", rank=1),
+            self._normalized("note", note_id, "Note", rank=2),
+            self._normalized("conversation", conv_id, "Conversation", rank=3),
+        )
+
+        media_db.soft_delete_media(int(media_id))
+        note = cha_db.get_note_by_id(note_id)
+        conversation = cha_db.get_conversation_by_id(conv_id)
+        assert note is not None and conversation is not None
+        cha_db.soft_delete_note(note_id, expected_version=note["version"])
+        cha_db.soft_delete_conversation(
+            conv_id, expected_version=conversation["version"]
+        )
+
+        authorized = await cre.authorize_local_results_for_prompt(
+            _App(media_db=media_db, chachanotes_db=cha_db), candidates
+        )
+
+        assert authorized == ()
+
+    @pytest.mark.asyncio
+    async def test_active_scope_excludes_conversations_and_non_allowlisted_ids(
+        self, media_db, cha_db, monkeypatch
+    ):
+        media_ids = _seed_media(media_db, n=2)
+        candidate_conv_id = cha_db.add_conversation({"title": "Candidate"})
+        session_conv_id = cha_db.add_conversation({"title": "Active"})
+        write_conversation_scope(
+            cha_db,
+            session_conv_id,
+            RagScope(
+                items=(ScopeItem(SOURCE_TYPE_MEDIA, media_ids[1]),),
+                updated_at="t1",
+            ),
+        )
+        session = SimpleNamespace(persisted_conversation_id=session_conv_id)
+        monkeypatch.setattr(cre, "_active_console_session", lambda _app: session)
+        candidates = (
+            self._normalized("media", media_ids[0], "Denied", rank=1),
+            self._normalized("conversation", candidate_conv_id, "Chat", rank=2),
+            self._normalized("media", media_ids[1], "Allowed", rank=3),
+        )
+
+        authorized = await cre.authorize_local_results_for_prompt(
+            _App(media_db=media_db, chachanotes_db=cha_db), candidates
+        )
+
+        assert [(item.source_id, item.candidate_rank) for item in authorized] == [
+            (media_ids[1], 3)
+        ]
+
+    @pytest.mark.asyncio
+    async def test_same_stamp_scope_narrowing_ignores_pre_retrieval_cache(
+        self, media_db, monkeypatch
+    ):
+        media_ids = _seed_media(media_db, n=2)
+        session = SimpleNamespace(
+            id="session-1",
+            persisted_conversation_id=None,
+            workspace_id="ws-1",
+        )
+        monkeypatch.setattr(cre, "_active_console_session", lambda _app: session)
+
+        class _Registry:
+            db = SimpleNamespace(is_memory_db=True)
+
+            def __init__(self):
+                self.scope = RagScope(
+                    items=(ScopeItem(SOURCE_TYPE_MEDIA, media_ids[0]),),
+                    updated_at="unchanged-stamp",
+                )
+
+            def get_workspace_scope(self, _workspace_id):
+                return self.scope
+
+        app = _App(media_db=media_db)
+        app.workspace_registry_service = _Registry()
+        cached = await cre.resolve_effective_scope_for_chat(app)
+        assert cached.allowlist == {SOURCE_TYPE_MEDIA: frozenset({media_ids[0]})}
+
+        app.workspace_registry_service.scope = RagScope(
+            items=(ScopeItem(SOURCE_TYPE_MEDIA, media_ids[1]),),
+            updated_at="unchanged-stamp",
+        )
+        candidates = (
+            self._normalized("media", media_ids[0], "Old", rank=1),
+            self._normalized("media", media_ids[1], "Current", rank=2),
+        )
+
+        authorized = await cre.authorize_local_results_for_prompt(app, candidates)
+
+        assert [(item.source_id, item.candidate_rank) for item in authorized] == [
+            (media_ids[1], 2)
+        ]
+
+    @pytest.mark.asyncio
+    async def test_failed_authority_or_existence_read_rejects_every_candidate(
+        self, monkeypatch
+    ):
+        candidate = self._normalized("media", "m1", "Media", rank=1)
+        app = _App(media_db=_RefusingMediaDB())
+        monkeypatch.setattr(cre, "_active_console_session", lambda _app: None)
+
+        assert await cre.authorize_local_results_for_prompt(app, (candidate,)) == ()
+
+        async def _raise_authority(*_args, **_kwargs):
+            raise RuntimeError("authority unavailable")
+
+        monkeypatch.setattr(cre, "resolve_effective_scope_for_chat", _raise_authority)
+        assert await cre.authorize_local_results_for_prompt(app, (candidate,)) == ()
+
+    @pytest.mark.asyncio
+    async def test_missing_or_failed_active_scope_authority_rejects_all(
+        self, media_db, monkeypatch
+    ):
+        media_id = _seed_media(media_db, n=1)[0]
+        candidate = self._normalized("media", media_id, "Media", rank=1)
+
+        session = SimpleNamespace(persisted_conversation_id="active-conv")
+        monkeypatch.setattr(cre, "_active_console_session", lambda _app: session)
+        assert (
+            await cre.authorize_local_results_for_prompt(
+                _App(media_db=media_db), (candidate,)
+            )
+            == ()
+        )
+
+        class _BrokenScopeDB:
+            is_memory_db = True
+
+            def get_conversation_by_id(self, _conversation_id):
+                raise RuntimeError("scope read failed")
+
+        assert (
+            await cre.authorize_local_results_for_prompt(
+                _App(media_db=media_db, chachanotes_db=_BrokenScopeDB()),
+                (candidate,),
+            )
+            == ()
+        )
+
+        session.persisted_conversation_id = None
+        session.workspace_id = "linked-workspace"
+        assert (
+            await cre.authorize_local_results_for_prompt(
+                _App(media_db=media_db), (candidate,)
+            )
+            == ()
+        )
+
+    @pytest.mark.asyncio
+    async def test_current_existence_reads_are_batched_by_backing_store(
+        self, media_db, cha_db, monkeypatch
+    ):
+        media_ids = _seed_media(media_db, n=2)
+        note_ids = _seed_notes(cha_db, n=2)
+        conv_ids = [cha_db.add_conversation({"title": f"C{i}"}) for i in range(2)]
+        monkeypatch.setattr(cre, "_active_console_session", lambda _app: None)
+        candidates = tuple(
+            [
+                self._normalized("media", source_id, "M", rank=index + 1)
+                for index, source_id in enumerate(media_ids)
+            ]
+            + [
+                self._normalized("note", source_id, "N", rank=index + 3)
+                for index, source_id in enumerate(note_ids)
+            ]
+            + [
+                self._normalized("conversation", source_id, "C", rank=index + 5)
+                for index, source_id in enumerate(conv_ids)
+            ]
+        )
+        calls = {"media": 0, "chacha": 0}
+        real_media_execute = media_db.execute_query
+        real_chacha_execute = cha_db.execute_query
+
+        def _media_execute(*args, **kwargs):
+            calls["media"] += 1
+            return real_media_execute(*args, **kwargs)
+
+        def _chacha_execute(*args, **kwargs):
+            calls["chacha"] += 1
+            return real_chacha_execute(*args, **kwargs)
+
+        monkeypatch.setattr(media_db, "execute_query", _media_execute)
+        monkeypatch.setattr(cha_db, "execute_query", _chacha_execute)
+
+        authorized = await cre.authorize_local_results_for_prompt(
+            _App(media_db=media_db, chachanotes_db=cha_db), candidates
+        )
+
+        assert len(authorized) == 6
+        assert calls == {"media": 1, "chacha": 1}
+
+    @pytest.mark.asyncio
+    async def test_opt_in_assembly_filters_before_assigning_markers(
+        self, media_db, cha_db, monkeypatch
+    ):
+        media_id = _seed_media(media_db, n=1)[0]
+        note_id = _seed_notes(cha_db, n=1)[0]
+        session_conv_id = cha_db.add_conversation({"title": "Active"})
+        write_conversation_scope(
+            cha_db,
+            session_conv_id,
+            RagScope(
+                items=(ScopeItem(SOURCE_TYPE_NOTE, note_id),),
+                updated_at="t1",
+            ),
+        )
+        session = SimpleNamespace(persisted_conversation_id=session_conv_id)
+        monkeypatch.setattr(cre, "_active_console_session", lambda _app: session)
+        raw_results = [
+            {
+                "source": "unknown",
+                "id": "unsafe",
+                "title": "Invalid",
+                "content": "invalid",
+                "score": 1.0,
+                "metadata": {},
+            },
+            {
+                "source": "media",
+                "id": media_id,
+                "title": "Unauthorized",
+                "content": "media body",
+                "score": 1.0,
+                "metadata": {},
+            },
+            {
+                "source": "note",
+                "id": note_id,
+                "title": "Authorized",
+                "content": "exact note body",
+                "score": 1.0,
+                "metadata": {},
+            },
+        ]
+
+        captured = await cre.assemble_local_evidence_for_prompt(
+            _App(media_db=media_db, chachanotes_db=cha_db),
+            raw_results,
+            max_length=200,
+        )
+
+        assert captured.context == ("[S1] NOTES — Authorized\nexact note body")
+        assert len(captured.entries) == 1
+        assert captured.entries[0].candidate_rank == 3
+        assert "Invalid" not in captured.entries[0].snapshot_text
+        assert "Unauthorized" not in captured.entries[0].snapshot_text
 
 
 class TestActiveConsoleSessionRealGlue:

--- a/Tests/RAG/test_scope_pipeline_enforcement.py
+++ b/Tests/RAG/test_scope_pipeline_enforcement.py
@@ -38,6 +38,7 @@ from tldw_chatbook.Chat.rag_scope import (
     SCOPE_REASON_EMPTY,
     SCOPE_STATUS_EMPTY,
     SCOPE_STATUS_EXCLUDED,
+    SessionScopeHolder,
     ScopeItem,
     SOURCE_TYPE_MEDIA,
     SOURCE_TYPE_NOTE,
@@ -2559,6 +2560,86 @@ class TestCapturePromptBoundaryFreshAuthority:
                     items=(ScopeItem(SOURCE_TYPE_MEDIA, media_ids[1]),),
                     updated_at="unchanged-stamp",
                 ),
+            )
+            active["session"] = later_session
+            return [
+                {
+                    "source": "media",
+                    "id": source_id,
+                    "title": title,
+                    "content": f"{title} body",
+                    "score": 1.0,
+                    "metadata": {},
+                }
+                for source_id, title in zip(media_ids, ("Stale", "Current"))
+            ], "legacy context"
+
+        monkeypatch.setattr(
+            cre,
+            "perform_plain_rag_search",
+            _narrow_original_then_switch_session,
+        )
+
+        captured = await cre.get_rag_context_capture_for_chat(app, "query")
+
+        assert captured.context == "[S1] MEDIA — Current\nCurrent body"
+        assert captured.citation_builder is repository.builders[0]
+        candidates = captured.citation_builder.evidence_run_payloads[0].candidates
+        assert [candidate.rank for candidate in candidates] == [2]
+
+    @pytest.mark.asyncio
+    async def test_original_unpersisted_holder_uses_current_scope_after_retrieval(
+        self, media_db, cha_db, monkeypatch
+    ):
+        media_ids = _seed_media(media_db, n=2)
+        original_holder = SessionScopeHolder()
+        original_holder.set(
+            RagScope(
+                items=(ScopeItem(SOURCE_TYPE_MEDIA, media_ids[0]),),
+                updated_at="before-retrieval",
+            )
+        )
+        original_session = SimpleNamespace(
+            id="session-original",
+            persisted_conversation_id=None,
+            workspace_id=None,
+            rag_scope_holder=original_holder,
+        )
+        later_holder = SessionScopeHolder()
+        later_holder.set(
+            RagScope(
+                items=(ScopeItem(SOURCE_TYPE_MEDIA, media_ids[0]),),
+                updated_at="later-session",
+            )
+        )
+        later_session = SimpleNamespace(
+            id="session-later",
+            persisted_conversation_id=None,
+            workspace_id=None,
+            rag_scope_holder=later_holder,
+        )
+        active = {"session": original_session}
+        monkeypatch.setattr(
+            cre,
+            "_active_console_session",
+            lambda _app: active["session"],
+        )
+        repository = _BuilderRepository()
+        app = _ChatMockApp(
+            search_mode="plain",
+            media_db=media_db,
+            chachanotes_db=cha_db,
+            citation_trace_repository=repository,
+        )
+
+        async def _narrow_original_then_switch_session(*_args, scope=None, **_kwargs):
+            assert scope is not None
+            assert scope.allowlist == {SOURCE_TYPE_MEDIA: frozenset({media_ids[0]})}
+            original_holder.set(
+                RagScope(
+                    items=(ScopeItem(SOURCE_TYPE_MEDIA, media_ids[1]),),
+                    updated_at="after-retrieval",
+                )
             )
             active["session"] = later_session
             return [

--- a/Tests/RAG/test_scope_pipeline_enforcement.py
+++ b/Tests/RAG/test_scope_pipeline_enforcement.py
@@ -23,6 +23,7 @@ mirroring ``Tests/RAG_Search/test_pipeline_notes_search.py`` and
 """
 
 import asyncio
+import threading
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 
@@ -2023,6 +2024,52 @@ class TestFreshPromptBoundaryAuthority:
 
         assert len(authorized) == 6
         assert calls == {"media": 1, "chacha": 1}
+
+    @pytest.mark.asyncio
+    async def test_mixed_stores_dispatch_each_read_on_its_required_thread(
+        self, monkeypatch
+    ):
+        main_thread = threading.current_thread()
+        calls = {"media": [], "chacha": []}
+
+        class _Cursor:
+            def __init__(self, rows):
+                self._rows = rows
+
+            def fetchall(self):
+                return self._rows
+
+        class _MemoryMediaDB:
+            is_memory_db = True
+
+            def execute_query(self, *_args, **_kwargs):
+                calls["media"].append(threading.current_thread())
+                return _Cursor([("m1",)])
+
+        class _FileChachaDB:
+            is_memory_db = False
+
+            def execute_query(self, *_args, **_kwargs):
+                calls["chacha"].append(threading.current_thread())
+                return _Cursor([("notes", "n1"), ("chat_history", "c1")])
+
+        monkeypatch.setattr(cre, "_active_console_session", lambda _app: None)
+        candidates = (
+            self._normalized("media", "m1", "Media", rank=1),
+            self._normalized("note", "n1", "Note", rank=2),
+            self._normalized("conversation", "c1", "Conversation", rank=3),
+        )
+
+        authorized = await cre.authorize_local_results_for_prompt(
+            _App(media_db=_MemoryMediaDB(), chachanotes_db=_FileChachaDB()),
+            candidates,
+        )
+
+        assert len(authorized) == 3
+        assert len(calls["media"]) == 1
+        assert len(calls["chacha"]) == 1
+        assert calls["media"][0] is main_thread
+        assert calls["chacha"][0] is not main_thread
 
     @pytest.mark.asyncio
     async def test_opt_in_assembly_filters_before_assigning_markers(

--- a/Tests/RAG/test_scope_pipeline_enforcement.py
+++ b/Tests/RAG/test_scope_pipeline_enforcement.py
@@ -1997,6 +1997,42 @@ class TestFreshPromptBoundaryAuthority:
         assert authorized == (candidate,)
 
     @pytest.mark.asyncio
+    async def test_fresh_workspace_with_valid_zero_item_scope_remains_unscoped(
+        self, media_db, tmp_path, monkeypatch
+    ):
+        media_id = _seed_media(media_db, n=1)[0]
+        registry = LocalWorkspaceRegistryService(
+            WorkspaceDB(tmp_path / "workspaces.sqlite", client_id="task2-empty")
+        )
+        registry.create_workspace(workspace_id="ws-empty", name="Empty")
+        with registry.db.transaction() as conn:
+            conn.execute(
+                """
+                INSERT INTO workspace_rag_scopes (workspace_id, payload, updated_at)
+                VALUES (?, ?, ?)
+                """,
+                (
+                    "ws-empty",
+                    json.dumps({"version": 1, "items": [], "updated_at": "t1"}),
+                    "t1",
+                ),
+            )
+        session = SimpleNamespace(
+            persisted_conversation_id=None,
+            workspace_id="ws-empty",
+        )
+        monkeypatch.setattr(cre, "_active_console_session", lambda _app: session)
+        app = _App(media_db=media_db)
+        app.workspace_registry_service = registry
+        candidate = self._normalized("media", media_id, "Media", rank=1)
+
+        effective = await cre.resolve_effective_scope_for_chat(app, use_cache=False)
+        authorized = await cre.authorize_local_results_for_prompt(app, (candidate,))
+
+        assert effective.state == "unscoped"
+        assert authorized == (candidate,)
+
+    @pytest.mark.asyncio
     async def test_fresh_missing_linked_workspace_fails_closed(
         self, media_db, tmp_path, monkeypatch
     ):

--- a/Tests/RAG/test_scope_pipeline_enforcement.py
+++ b/Tests/RAG/test_scope_pipeline_enforcement.py
@@ -1799,14 +1799,16 @@ class TestResolveEffectiveScopeMemoryDbGuard:
             )
             main_thread = threading.current_thread()
             call_threads = []
-            real_get_conversation = cha_db.get_conversation_by_id
+            real_read_metadata = cre._read_fresh_conversation_metadata_sync
 
-            def _recording_get_conversation(*args, **kwargs):
+            def _recording_read_metadata(*args, **kwargs):
                 call_threads.append(threading.current_thread())
-                return real_get_conversation(*args, **kwargs)
+                return real_read_metadata(*args, **kwargs)
 
             monkeypatch.setattr(
-                cha_db, "get_conversation_by_id", _recording_get_conversation
+                cre,
+                "_read_fresh_conversation_metadata_sync",
+                _recording_read_metadata,
             )
             app = _App(media_db=memory_media, chachanotes_db=cha_db)
 
@@ -2336,19 +2338,20 @@ class TestFreshPromptBoundaryAuthority:
             ]
         )
         calls = {"media": 0, "chacha": 0}
-        real_media_execute = media_db.execute_query
-        real_chacha_execute = cha_db.execute_query
+        real_sensitive_fetchall = cre._sensitive_fetchall
 
-        def _media_execute(*args, **kwargs):
-            calls["media"] += 1
-            return real_media_execute(*args, **kwargs)
+        def _recording_sensitive_fetchall(db, *args, **kwargs):
+            if db is media_db:
+                calls["media"] += 1
+            elif db is cha_db:
+                calls["chacha"] += 1
+            return real_sensitive_fetchall(db, *args, **kwargs)
 
-        def _chacha_execute(*args, **kwargs):
-            calls["chacha"] += 1
-            return real_chacha_execute(*args, **kwargs)
-
-        monkeypatch.setattr(media_db, "execute_query", _media_execute)
-        monkeypatch.setattr(cha_db, "execute_query", _chacha_execute)
+        monkeypatch.setattr(
+            cre,
+            "_sensitive_fetchall",
+            _recording_sensitive_fetchall,
+        )
 
         authorized = await cre.authorize_local_results_for_prompt(
             _App(media_db=media_db, chachanotes_db=cha_db), candidates
@@ -2462,6 +2465,79 @@ class TestFreshPromptBoundaryAuthority:
 
 class TestCapturePromptBoundaryFreshAuthority:
     """Capture rechecks the original request identity after retrieval."""
+
+    @pytest.mark.asyncio
+    async def test_fresh_scoped_existence_failure_discards_context_and_builder(
+        self, media_db, cha_db, monkeypatch
+    ):
+        failure_sentinel = "PRIVATE-SCOPE-EXISTENCE-FAILURE-SENTINEL"
+        media_id = _seed_media(media_db, n=1)[0]
+        conversation_id = cha_db.add_conversation({"title": "Scoped"})
+        write_conversation_scope(
+            cha_db,
+            conversation_id,
+            RagScope(
+                items=(ScopeItem(SOURCE_TYPE_MEDIA, media_id),),
+                updated_at="t1",
+            ),
+        )
+        session = SimpleNamespace(
+            id="request-session",
+            persisted_conversation_id=conversation_id,
+            workspace_id=None,
+        )
+        repository = _BuilderRepository()
+        app = _ChatMockApp(
+            search_mode="plain",
+            media_db=media_db,
+            chachanotes_db=cha_db,
+            citation_trace_repository=repository,
+        )
+        monkeypatch.setattr(cre, "_active_console_session", lambda _app: session)
+
+        async def _return_candidate(*_args, **_kwargs):
+            return [
+                {
+                    "source": "media",
+                    "id": media_id,
+                    "title": "Fresh authority",
+                    "content": "must not reach the prompt",
+                    "score": 1.0,
+                    "metadata": {},
+                }
+            ], "legacy context must not survive canonical capture"
+
+        monkeypatch.setattr(cre, "perform_plain_rag_search", _return_candidate)
+        real_sensitive_fetchall = cre._sensitive_fetchall
+        scope_existence_reads = 0
+
+        def _fail_fresh_scope_existence(db, query, params):
+            nonlocal scope_existence_reads
+            if db is media_db and query.startswith("SELECT id FROM Media"):
+                scope_existence_reads += 1
+                if scope_existence_reads == 2:
+                    raise RuntimeError(failure_sentinel)
+            return real_sensitive_fetchall(db, query, params)
+
+        monkeypatch.setattr(cre, "_sensitive_fetchall", _fail_fresh_scope_existence)
+        captured_logs = []
+        sink_id = loguru_logger.add(
+            captured_logs.append,
+            level="DEBUG",
+            format="{message}",
+        )
+        try:
+            captured = await cre.get_rag_context_capture_for_chat(app, "query")
+        finally:
+            loguru_logger.remove(sink_id)
+
+        assert scope_existence_reads == 2
+        assert captured == cre.LocalRagContextResult(None, None)
+        assert repository.builders[0].evidence_runs == ()
+        rendered_logs = "".join(str(message) for message in captured_logs)
+        assert failure_sentinel not in rendered_logs
+        assert "reason=scope_existing_ids_read_failure" in rendered_logs
+        assert "reason=prompt_authority_failure" in rendered_logs
 
     @pytest.mark.asyncio
     async def test_backing_row_deleted_during_retrieval_is_not_submitted(

--- a/Tests/RAG/test_scope_pipeline_enforcement.py
+++ b/Tests/RAG/test_scope_pipeline_enforcement.py
@@ -1756,6 +1756,42 @@ class TestResolveEffectiveScopeMemoryDbGuard:
         finally:
             cha_db.close_connection()
 
+    @pytest.mark.asyncio
+    async def test_memory_media_does_not_force_file_chacha_authority_inline(
+        self, cha_db, monkeypatch
+    ):
+        memory_media = MediaDatabase(":memory:", client_id="task2-mixed-routing")
+        try:
+            assert memory_media.is_memory_db is True
+            assert cha_db.is_memory_db is False
+            conversation_id = cha_db.add_conversation({"title": "Mixed stores"})
+            session = SimpleNamespace(
+                persisted_conversation_id=conversation_id,
+                workspace_id=None,
+            )
+            main_thread = threading.current_thread()
+            call_threads = []
+            real_get_conversation = cha_db.get_conversation_by_id
+
+            def _recording_get_conversation(*args, **kwargs):
+                call_threads.append(threading.current_thread())
+                return real_get_conversation(*args, **kwargs)
+
+            monkeypatch.setattr(
+                cha_db, "get_conversation_by_id", _recording_get_conversation
+            )
+            app = _App(media_db=memory_media, chachanotes_db=cha_db)
+
+            resolution = await cre.resolve_scope_for_session(
+                app, session, use_cache=False
+            )
+
+            assert resolution.effective.state == "unscoped"
+            assert len(call_threads) == 1
+            assert call_threads[0] is not main_thread
+        finally:
+            memory_media.close_connection()
+
 
 class TestChatEntryPointUnscopedZeroDrift:
     """No active native-Console session (today's real default) must resolve

--- a/Tests/RAG/test_scope_pipeline_enforcement.py
+++ b/Tests/RAG/test_scope_pipeline_enforcement.py
@@ -52,6 +52,7 @@ from tldw_chatbook.Chat.citation_trace_identity import (
     CitationFingerprintCodec,
     LocalCitationIdentityContext,
 )
+from tldw_chatbook.Chat.citation_trace_models import PolicyCapability
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
 from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
@@ -876,6 +877,11 @@ class _BuilderRepository:
                 fingerprint_key_id="scope-key",
             ),
             fingerprint_codec=CitationFingerprintCodec(b"s" * 32),
+            policy_version="test-local-policy-v1",
+            policy_capabilities=(
+                PolicyCapability.VIEW_SNAPSHOT,
+                PolicyCapability.VIEW_SOURCE_IDENTITY,
+            ),
         )
         self.builders.append(builder)
         return builder

--- a/Tests/UI/test_console_local_citation_capture.py
+++ b/Tests/UI/test_console_local_citation_capture.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from Tests.UI.test_console_dictionary_send_integration import (
+    _CapturingGateway,
+    _final_user_content,
+)
+from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from tldw_chatbook.Chat.citation_evidence_models import EvidenceBundle
+from tldw_chatbook.Chat.console_live_work import ConsoleLiveWorkLaunch
+from tldw_chatbook.Event_Handlers.Chat_Events.chat_rag_events import (
+    LocalRagContextResult,
+)
+from tldw_chatbook.Library.library_rag_service import LibraryRagSearchRequest
+from tldw_chatbook.Library.library_rag_state import LibraryRagResultRow
+from tldw_chatbook.UI.Screens import chat_screen as chat_screen_module
+
+
+@pytest.mark.asyncio
+async def test_console_controller_wires_current_staged_rag_capture(monkeypatch):
+    app = _build_test_app()
+    launch = ConsoleLiveWorkLaunch.from_values(
+        source="Library Search/RAG",
+        title="Source",
+        payload={"evidence_bundle": {"bundle_id": "unused"}},
+        status="staged",
+    )
+    capture = AsyncMock(
+        return_value=LocalRagContextResult(
+            context="[S1] MEDIA — Source\nexact body",
+            citation_builder=object(),
+        )
+    )
+    monkeypatch.setattr(
+        chat_screen_module,
+        "capture_console_staged_evidence_for_chat",
+        capture,
+    )
+
+    async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
+        screen = pilot.app.screen_stack[-1]
+        await _wait_for_selector(screen, pilot, "#console-native-composer")
+        screen._pending_console_launch_context = launch
+        controller = screen._ensure_console_chat_controller()
+        gateway = _CapturingGateway()
+        controller.provider_gateway = gateway
+        controller._agent_runtime_enabled = False
+
+        result = await controller.submit_draft("question")
+
+    assert result.accepted is True
+    capture.assert_awaited_once_with(
+        app,
+        launch,
+        user_message="question",
+    )
+    assert _final_user_content(gateway.captured) == (
+        "Evidence: [S1] MEDIA — Source\nexact body\n\n---\n\nquestion"
+    )
+
+
+@pytest.mark.asyncio
+async def test_console_library_rag_stages_all_retrieved_evidence():
+    rows = tuple(
+        LibraryRagResultRow.from_result(
+            {
+                "source_id": f"media-{index}",
+                "chunk_id": f"chunk-{index}",
+                "title": f"Source {index}",
+                "content": f"Body {index}",
+                "score": 1.0 - index / 10,
+                "runtime_backend": "local",
+                "source_type": "media",
+            }
+        )
+        for index in (1, 2)
+    )
+    staged = []
+    screen = SimpleNamespace(
+        is_mounted=True,
+        _stage_console_library_rag_launch=staged.append,
+    )
+    request = LibraryRagSearchRequest(
+        query="question",
+        source_types=("media",),
+        mode="rag",
+        top_k=5,
+    )
+    outcome = SimpleNamespace(results=rows)
+
+    await chat_screen_module.ChatScreen._apply_console_library_rag_search_outcome(
+        screen,
+        request,
+        outcome,
+    )
+
+    assert len(staged) == 1
+    payload = staged[0].payload
+    bundle = EvidenceBundle.from_payload(payload["evidence_bundle"])
+    assert [reference.source_id for reference in bundle.references] == [
+        "media-1",
+        "media-2",
+    ]
+    assert payload["requested_top_k"] == 5
+    assert payload["search_mode"] == "rag"

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -79,6 +79,47 @@ def _configure_native_ready_console(app, model: str = "local-model") -> None:
     app.chat_api_model_value = model
 
 
+def test_console_store_uses_app_citation_repository_for_matching_database():
+    app = _build_test_app()
+    db = Mock(name="chachanotes-db")
+    repository = SimpleNamespace(db=db)
+    app.chachanotes_db = db
+    app.citation_trace_repository = repository
+    screen = ChatScreen(app)
+
+    store = screen._ensure_console_chat_store()
+
+    assert store.persistence is not None
+    assert store.persistence.citation_repository is repository
+    assert store.persistence.db is repository.db
+
+
+def test_console_store_rejects_mismatched_citation_repository():
+    app = _build_test_app()
+    db = Mock(name="chachanotes-db")
+    repository = SimpleNamespace(db=Mock(name="other-chachanotes-db"))
+    app.chachanotes_db = db
+    app.citation_trace_repository = repository
+    screen = ChatScreen(app)
+
+    store = screen._ensure_console_chat_store()
+
+    assert store.persistence is not None
+    assert store.persistence.db is db
+    assert store.persistence.citation_repository is None
+
+
+def test_console_store_uses_app_citation_repository_only_with_database():
+    app = _build_test_app()
+    app.chachanotes_db = None
+    app.citation_trace_repository = SimpleNamespace(db=Mock(name="unused-db"))
+    screen = ChatScreen(app)
+
+    store = screen._ensure_console_chat_store()
+
+    assert store.persistence is None
+
+
 def test_console_workspace_conversation_titles_wrap_instead_of_truncating():
     """Long workspace conversation titles wrap at the rail budget."""
     from tldw_chatbook.Widgets.Console.console_workspace_context import (

--- a/backlog/tasks/task-553 - Canonical-RAG-citation-provenance-epic.md
+++ b/backlog/tasks/task-553 - Canonical-RAG-citation-provenance-epic.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-553
 title: Canonical RAG citation provenance epic
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-24 00:42'
+updated_date: '2026-07-26 18:18'
 labels:
   - rag
   - citations

--- a/backlog/tasks/task-553.13 - Capture-local-RAG-retrieval-runs-and-exact-prompt-evidence-sets.md
+++ b/backlog/tasks/task-553.13 - Capture-local-RAG-retrieval-runs-and-exact-prompt-evidence-sets.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-553.13
 title: Capture local RAG retrieval runs and exact prompt evidence sets
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-25 13:52'
-updated_date: '2026-07-25 13:56'
+updated_date: '2026-07-26 17:59'
 labels:
   - rag
   - citations
@@ -17,7 +17,8 @@ dependencies:
 references:
   - Docs/superpowers/specs/2026-07-23-rag-citation-provenance-design.md
   - Docs/superpowers/plans/2026-07-23-rag-citation-provenance-foundation.md
-  - Docs/superpowers/plans/2026-07-25-local-rag-retrieval-prompt-evidence-capture.md
+  - >-
+    Docs/superpowers/plans/2026-07-25-local-rag-retrieval-prompt-evidence-capture.md
   - backlog/decisions/024-rag-citation-provenance-and-source-resolution.md
 parent_task_id: TASK-553
 priority: high
@@ -31,12 +32,12 @@ Carry one local RAG request’s ordered retrieval results and the exact transfor
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Canonical local RAG capture records an ordered evidence run and governed candidate metadata for the retrieval execution without putting sensitive payload fields in immutable trace data or logs.
-- [ ] #2 The prompt evidence set preserves the exact post-formatting and post-truncation text submitted for every included source, with stable chatbook_s_v1 marker ordinals and governed embedded snapshot payloads.
-- [ ] #3 Retrieved candidates omitted by the prompt character budget retain bounded explanatory metadata but no snapshot text, and unauthorized or invalid evidence fails closed before prompt submission.
-- [ ] #4 Canonical capture remains request-scoped and unsealed; this task does not persist partial builders or implement answer attempts, occurrence parsing, repair, source opening, export, or sync.
-- [ ] #5 When canonical writes are disabled or capture prerequisites are unavailable, existing local RAG return values and provider prompt text remain backwards compatible and no partial provenance is retained.
-- [ ] #6 Focused unit and integration tests cover enabled capture, truncation and exclusion, disabled compatibility, empty results, malformed result metadata, and the plain/semantic/hybrid/custom pipeline boundary.
+- [x] #1 Canonical local RAG capture records an ordered evidence run and governed candidate metadata for the retrieval execution without putting sensitive payload fields in immutable trace data or logs.
+- [x] #2 The prompt evidence set preserves the exact post-formatting and post-truncation text submitted for every included source, with stable chatbook_s_v1 marker ordinals and governed embedded snapshot payloads.
+- [x] #3 Retrieved candidates omitted by the prompt character budget retain bounded explanatory metadata but no snapshot text, and unauthorized or invalid evidence fails closed before prompt submission.
+- [x] #4 Canonical capture remains request-scoped and unsealed; this task does not persist partial builders or implement answer attempts, occurrence parsing, repair, source opening, export, or sync.
+- [x] #5 When canonical writes are disabled or capture prerequisites are unavailable, existing local RAG return values and provider prompt text remain backwards compatible and no partial provenance is retained.
+- [x] #6 Focused unit and integration tests cover enabled capture, truncation and exclusion, disabled compatibility, empty results, malformed result metadata, and the plain/semantic/hybrid/custom pipeline boundary.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -52,3 +53,15 @@ ADR required: yes
 ADR path: backlog/decisions/024-rag-citation-provenance-and-source-resolution.md
 Reason: Implements ADR-024’s local retrieval-run and exact prompt-boundary evidence capture contract without changing the accepted architecture.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented ADR-024 local retrieval-run and exact prompt-evidence capture with a request-scoped, unsealed CitationTraceBuilder; strict local result normalization; fresh prompt-boundary authority checks; bounded governed snapshots; and repository-owned builder creation. Rebased the final send boundary onto the native Console architecture: all staged Library-RAG results now travel as an EvidenceBundle, are reauthorized at send time, and exact canonical evidence reaches both direct-provider and agent payloads after ordinary prompt transforms while visible/persisted user text remains unchanged. Builders remain local to one awaited generation and are never serialized or partially persisted.
+
+ADR required: yes. ADR path: backlog/decisions/024-rag-citation-provenance-and-source-resolution.md. No new ADR was needed because this task directly implements the accepted boundary.
+
+Verification: touched-code pytest gate 110 passed with 1 dependency-version warning in 25.74s; targeted direct/agent/multimodal boundary tests 5 passed; Ruff check passed on six touched code/test files; Ruff format check passed on the three touched test files; git diff --check passed. The user stopped repository-wide testing after several hours and directed touched-code-only verification. Two failures reproduced on pristine origin/dev af2aee6cd and are tracked separately as TASK-761 and TASK-762.
+
+Primary changes: citation trace builder/repository contracts, local capture normalization and formatting, RAG authority/capture integration, native Console controller/screen staging and generation threading, focused tests, the implementation plan, and the citation provenance workstream status.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-553.13 - Capture-local-RAG-retrieval-runs-and-exact-prompt-evidence-sets.md
+++ b/backlog/tasks/task-553.13 - Capture-local-RAG-retrieval-runs-and-exact-prompt-evidence-sets.md
@@ -1,0 +1,54 @@
+---
+id: TASK-553.13
+title: Capture local RAG retrieval runs and exact prompt evidence sets
+status: In Progress
+assignee: []
+created_date: '2026-07-25 13:52'
+updated_date: '2026-07-25 13:56'
+labels:
+  - rag
+  - citations
+  - provenance
+  - local-pipeline
+dependencies:
+  - TASK-553.2
+  - TASK-553.3
+  - TASK-553.4
+references:
+  - Docs/superpowers/specs/2026-07-23-rag-citation-provenance-design.md
+  - Docs/superpowers/plans/2026-07-23-rag-citation-provenance-foundation.md
+  - Docs/superpowers/plans/2026-07-25-local-rag-retrieval-prompt-evidence-capture.md
+  - backlog/decisions/024-rag-citation-provenance-and-source-resolution.md
+parent_task_id: TASK-553
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Carry one local RAG request’s ordered retrieval results and the exact transformed evidence submitted to the provider into a request-scoped canonical citation builder, so later answer-attempt and sealing work has trustworthy prompt-boundary provenance.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Canonical local RAG capture records an ordered evidence run and governed candidate metadata for the retrieval execution without putting sensitive payload fields in immutable trace data or logs.
+- [ ] #2 The prompt evidence set preserves the exact post-formatting and post-truncation text submitted for every included source, with stable chatbook_s_v1 marker ordinals and governed embedded snapshot payloads.
+- [ ] #3 Retrieved candidates omitted by the prompt character budget retain bounded explanatory metadata but no snapshot text, and unauthorized or invalid evidence fails closed before prompt submission.
+- [ ] #4 Canonical capture remains request-scoped and unsealed; this task does not persist partial builders or implement answer attempts, occurrence parsing, repair, source opening, export, or sync.
+- [ ] #5 When canonical writes are disabled or capture prerequisites are unavailable, existing local RAG return values and provider prompt text remain backwards compatible and no partial provenance is retained.
+- [ ] #6 Focused unit and integration tests cover enabled capture, truncation and exclusion, disabled compatibility, empty results, malformed result metadata, and the plain/semantic/hybrid/custom pipeline boundary.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a pure request-scoped CitationTraceBuilder that can record bounded local EvidenceRun metadata and exact PromptEvidenceSet payloads without sealing or persistence.
+2. Add a repository-owned factory that supplies the builder with the existing local identity and keyed fingerprint context only when canonical capture is ready.
+3. Extend RAG context formatting with an opt-in structured capture result so the exact marked, transformed, and truncated evidence text is the same text prepended to the provider request.
+4. Wire the local Chat RAG boundary to retain the request-scoped capture while preserving the current string API and byte-for-byte behavior when canonical writes are disabled or prerequisites are unavailable.
+5. Add RED/GREEN unit and integration coverage for ordering, bounds, truncation/exclusion, malformed evidence, all pipeline modes, and disabled compatibility; update citation pipeline documentation and run focused plus repository verification.
+
+ADR required: yes
+ADR path: backlog/decisions/024-rag-citation-provenance-and-source-resolution.md
+Reason: Implements ADR-024’s local retrieval-run and exact prompt-boundary evidence capture contract without changing the accepted architecture.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-553.14 - Capture-answer-attempts-and-seal-terminal-local-citation-traces.md
+++ b/backlog/tasks/task-553.14 - Capture-answer-attempts-and-seal-terminal-local-citation-traces.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-553.14
 title: Capture answer attempts and seal terminal local citation traces
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-26 18:18'
-updated_date: '2026-07-26 18:26'
+updated_date: '2026-07-26 19:03'
 labels:
   - rag
   - citations
@@ -37,3 +37,20 @@ Complete one eligible marker-free local RAG generation by binding its exact fina
 - [ ] #5 Failed, stopped, canceled, empty, retry, and regenerate paths do not seal or inherit unfinished builders.
 - [ ] #6 Focused tests cover builder atomicity, production repository wiring, persistence-capability gating, direct and agent completion, exact-body fidelity, transient-finalizer cleanup, atomic persistence, fallback, idempotent retry, and content-free diagnostics.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: yes
+ADR path: backlog/decisions/024-rag-citation-provenance-and-source-resolution.md
+Reason: Direct implementation of ADR-024’s accepted request-scoped builder, terminal seal, governed answer body, message ownership, and atomic persistence contracts; no new architectural decision.
+
+Detailed plan: Docs/superpowers/plans/2026-07-26-local-answer-attempt-terminal-sealing.md
+
+1. Add repository-owned local seal policy, bounded initial answer attempts, closed-run chronology, and one-shot builder sealing.
+2. Return the exact prompt-evidence-set identity from every successful local capture path.
+3. Expose fail-closed canonical-write readiness and wire the app’s exact citation repository into Console persistence.
+4. Add transient terminal finalization, early-write deferral, stable identity, deterministic fallback, and one ambiguous same-write retry to ConsoleChatStore.
+5. Install finalizers only for initial direct-provider and agent sends; clear them on every non-success, empty, retry, regenerate, replacement, and outer-exit path.
+6. Prove exact-body atomic persistence and rollback with real SQLite integration tests, then run only the touched-code verification listed in the detailed plan.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-553.14 - Capture-answer-attempts-and-seal-terminal-local-citation-traces.md
+++ b/backlog/tasks/task-553.14 - Capture-answer-attempts-and-seal-terminal-local-citation-traces.md
@@ -4,7 +4,7 @@ title: Capture answer attempts and seal terminal local citation traces
 status: Done
 assignee: []
 created_date: '2026-07-26 18:18'
-updated_date: '2026-07-26 20:46'
+updated_date: '2026-07-26 20:56'
 labels:
   - rag
   - citations
@@ -64,6 +64,6 @@ Detailed plan: Docs/superpowers/plans/2026-07-26-local-answer-attempt-terminal-s
 - Added real CharactersRAGDB controller integration proving atomic message/trace graph ownership, marker-free empty occurrences, governed-body privacy, restart discovery, and deterministic owner-stage rollback with no partial provenance.
 - Plan deviation/privacy fix: the real RED test exposed message bodies in CharactersRAGDB SQL DEBUG parameter previews. Added an explicit redact_params keyword to execute_query and enabled it only for add_message's sensitive INSERT; default SQL preview and execution/error semantics remain unchanged. Added focused SQL-log regression coverage.
 - ADR required: yes. ADR path: backlog/decisions/024-rag-citation-provenance-and-source-resolution.md. Reason: Direct implementation of the accepted terminal seal and atomic ownership contract; no new decision.
-- Scoped verification: SQL-log RED 1 failed/13 deselected, then GREEN 1 passed/13 deselected; complete SQL-log file 14 passed; real integration RED 2 failed/35 deselected solely on privacy, then GREEN 2 passed/35 deselected; final plan gate 254 passed/506 deselected with one existing dependency warning. Ruff lint passed on touched Python files; Ruff format check passed on the changed test files. Whole-file Ruff format for ChaChaNotes_DB.py retains identical pre-existing baseline drift before and after this task, while the changed execute_query and add_message hunks are formatter-stable. git diff --check passed.
+- Scoped verification: SQL-log RED 1 failed/13 deselected, then GREEN 1 passed/13 deselected; complete SQL-log file 14 passed; real integration RED 2 failed/35 deselected solely on privacy, then GREEN 2 passed/35 deselected; final plan gate 254 passed/506 deselected with one existing dependency warning. Ruff lint passed on touched Python files. All task-introduced test formatter drift was corrected: Tests/Chat/test_citation_trace_builder.py, Tests/Chat/test_citation_trace_repository.py, Tests/Chat/test_console_terminal_citation_persistence.py, and Tests/DB/test_sql_debug_logging.py pass Ruff format check. Whole-file Ruff format for ChaChaNotes_DB.py retains identical pre-existing baseline drift before and after this task, while the changed execute_query and add_message hunks are formatter-stable. git diff --check passed.
 - Task-6 files: Tests/Chat/test_console_terminal_citation_persistence.py, Tests/DB/test_sql_debug_logging.py, tldw_chatbook/DB/ChaChaNotes_DB.py, and this Backlog task file.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-553.14 - Capture-answer-attempts-and-seal-terminal-local-citation-traces.md
+++ b/backlog/tasks/task-553.14 - Capture-answer-attempts-and-seal-terminal-local-citation-traces.md
@@ -4,7 +4,7 @@ title: Capture answer attempts and seal terminal local citation traces
 status: Done
 assignee: []
 created_date: '2026-07-26 18:18'
-updated_date: '2026-07-26 20:36'
+updated_date: '2026-07-26 20:46'
 labels:
   - rag
   - citations
@@ -64,6 +64,6 @@ Detailed plan: Docs/superpowers/plans/2026-07-26-local-answer-attempt-terminal-s
 - Added real CharactersRAGDB controller integration proving atomic message/trace graph ownership, marker-free empty occurrences, governed-body privacy, restart discovery, and deterministic owner-stage rollback with no partial provenance.
 - Plan deviation/privacy fix: the real RED test exposed message bodies in CharactersRAGDB SQL DEBUG parameter previews. Added an explicit redact_params keyword to execute_query and enabled it only for add_message's sensitive INSERT; default SQL preview and execution/error semantics remain unchanged. Added focused SQL-log regression coverage.
 - ADR required: yes. ADR path: backlog/decisions/024-rag-citation-provenance-and-source-resolution.md. Reason: Direct implementation of the accepted terminal seal and atomic ownership contract; no new decision.
-- Scoped verification: SQL-log RED 1 failed/13 deselected, then GREEN 1 passed/13 deselected; complete SQL-log file 14 passed; real integration RED 2 failed/35 deselected solely on privacy, then GREEN 2 passed/35 deselected; final plan gate 254 passed/506 deselected with one existing dependency warning; targeted Ruff lint/format and git diff --check passed.
+- Scoped verification: SQL-log RED 1 failed/13 deselected, then GREEN 1 passed/13 deselected; complete SQL-log file 14 passed; real integration RED 2 failed/35 deselected solely on privacy, then GREEN 2 passed/35 deselected; final plan gate 254 passed/506 deselected with one existing dependency warning. Ruff lint passed on touched Python files; Ruff format check passed on the changed test files. Whole-file Ruff format for ChaChaNotes_DB.py retains identical pre-existing baseline drift before and after this task, while the changed execute_query and add_message hunks are formatter-stable. git diff --check passed.
 - Task-6 files: Tests/Chat/test_console_terminal_citation_persistence.py, Tests/DB/test_sql_debug_logging.py, tldw_chatbook/DB/ChaChaNotes_DB.py, and this Backlog task file.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-553.14 - Capture-answer-attempts-and-seal-terminal-local-citation-traces.md
+++ b/backlog/tasks/task-553.14 - Capture-answer-attempts-and-seal-terminal-local-citation-traces.md
@@ -35,5 +35,5 @@ Complete one eligible marker-free local RAG generation by binding its exact fina
 - [ ] #3 Eligible marker-free initial Console direct-provider and agent generations seal from the exact materialized visible body and atomically persist the message plus trace under stable idempotent identities.
 - [ ] #4 Disabled, marker-mapping-ineligible, or deterministically unavailable canonical persistence preserves the ordinary answer as ungrounded, while ambiguous transaction failure receives at most one same-identity retry and never leaves partial provenance.
 - [ ] #5 Failed, stopped, canceled, empty, retry, and regenerate paths do not seal or inherit unfinished builders.
-- [ ] #6 Focused tests cover builder atomicity, direct and agent completion, exact-body fidelity, atomic persistence, fallback, idempotent retry, and content-free diagnostics.
+- [ ] #6 Focused tests cover builder atomicity, direct and agent completion, exact-body fidelity, transient-finalizer cleanup, atomic persistence, fallback, idempotent retry, and content-free diagnostics.
 <!-- AC:END -->

--- a/backlog/tasks/task-553.14 - Capture-answer-attempts-and-seal-terminal-local-citation-traces.md
+++ b/backlog/tasks/task-553.14 - Capture-answer-attempts-and-seal-terminal-local-citation-traces.md
@@ -31,9 +31,9 @@ Complete one eligible marker-free local RAG generation by binding its exact fina
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [ ] #1 The local builder records a bounded governed initial answer attempt whose exact body and secret-scoped integrity fingerprint never enter immutable trace JSON or logs.
-- [ ] #2 Sealing is one-shot and produces a validated local SealedCitationWrite with repository-owned policy metadata, selected-attempt linkage, and deterministic completeness.
-- [ ] #3 Eligible marker-free initial Console direct-provider and agent generations seal from the exact materialized visible body and atomically persist the message plus trace under stable idempotent identities.
+- [ ] #2 Sealing requires closed, chronologically ordered local retrieval and produces a one-shot validated SealedCitationWrite with repository-owned policy metadata, selected-attempt linkage, and deterministic completeness.
+- [ ] #3 Eligible marker-free initial Console direct-provider and agent generations use the same repository for capture and persistence, seal from the exact materialized visible body, and atomically persist the message plus trace under stable idempotent identities.
 - [ ] #4 Disabled, marker-mapping-ineligible, or deterministically unavailable canonical persistence preserves the ordinary answer as ungrounded, while ambiguous transaction failure receives at most one same-identity retry and never leaves partial provenance.
 - [ ] #5 Failed, stopped, canceled, empty, retry, and regenerate paths do not seal or inherit unfinished builders.
-- [ ] #6 Focused tests cover builder atomicity, direct and agent completion, exact-body fidelity, transient-finalizer cleanup, atomic persistence, fallback, idempotent retry, and content-free diagnostics.
+- [ ] #6 Focused tests cover builder atomicity, production repository wiring, persistence-capability gating, direct and agent completion, exact-body fidelity, transient-finalizer cleanup, atomic persistence, fallback, idempotent retry, and content-free diagnostics.
 <!-- AC:END -->

--- a/backlog/tasks/task-553.14 - Capture-answer-attempts-and-seal-terminal-local-citation-traces.md
+++ b/backlog/tasks/task-553.14 - Capture-answer-attempts-and-seal-terminal-local-citation-traces.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-553.14
 title: Capture answer attempts and seal terminal local citation traces
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-26 18:18'
-updated_date: '2026-07-26 19:03'
+updated_date: '2026-07-26 20:36'
 labels:
   - rag
   - citations
@@ -30,12 +30,12 @@ Complete one eligible marker-free local RAG generation by binding its exact fina
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The local builder records a bounded governed initial answer attempt whose exact body and secret-scoped integrity fingerprint never enter immutable trace JSON or logs.
-- [ ] #2 Sealing requires closed, chronologically ordered local retrieval and produces a one-shot validated SealedCitationWrite with repository-owned policy metadata, selected-attempt linkage, and deterministic completeness.
-- [ ] #3 Eligible marker-free initial Console direct-provider and agent generations use the same repository for capture and persistence, seal from the exact materialized visible body, and atomically persist the message plus trace under stable idempotent identities.
-- [ ] #4 Disabled, marker-mapping-ineligible, or deterministically unavailable canonical persistence preserves the ordinary answer as ungrounded, while ambiguous transaction failure receives at most one same-identity retry and never leaves partial provenance.
-- [ ] #5 Failed, stopped, canceled, empty, retry, and regenerate paths do not seal or inherit unfinished builders.
-- [ ] #6 Focused tests cover builder atomicity, production repository wiring, persistence-capability gating, direct and agent completion, exact-body fidelity, transient-finalizer cleanup, atomic persistence, fallback, idempotent retry, and content-free diagnostics.
+- [x] #1 The local builder records a bounded governed initial answer attempt whose exact body and secret-scoped integrity fingerprint never enter immutable trace JSON or logs.
+- [x] #2 Sealing requires closed, chronologically ordered local retrieval and produces a one-shot validated SealedCitationWrite with repository-owned policy metadata, selected-attempt linkage, and deterministic completeness.
+- [x] #3 Eligible marker-free initial Console direct-provider and agent generations use the same repository for capture and persistence, seal from the exact materialized visible body, and atomically persist the message plus trace under stable idempotent identities.
+- [x] #4 Disabled, marker-mapping-ineligible, or deterministically unavailable canonical persistence preserves the ordinary answer as ungrounded, while ambiguous transaction failure receives at most one same-identity retry and never leaves partial provenance.
+- [x] #5 Failed, stopped, canceled, empty, retry, and regenerate paths do not seal or inherit unfinished builders.
+- [x] #6 Focused tests cover builder atomicity, production repository wiring, persistence-capability gating, direct and agent completion, exact-body fidelity, transient-finalizer cleanup, atomic persistence, fallback, idempotent retry, and content-free diagnostics.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -54,3 +54,16 @@ Detailed plan: Docs/superpowers/plans/2026-07-26-local-answer-attempt-terminal-s
 5. Install finalizers only for initial direct-provider and agent sends; clear them on every non-success, empty, retry, regenerate, replacement, and outer-exit path.
 6. Prove exact-body atomic persistence and rollback with real SQLite integration tests, then run only the touched-code verification listed in the detailed plan.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Implemented ADR-024's request-scoped local answer-attempt lifecycle: repository-owned seal policy, governed body binding, closed-run chronology, one-shot sealing, and deterministic completeness.
+- Carried the exact prompt-evidence-set identity through local capture, gated persistence on the same ready repository/database binding, and wired production Console persistence to that repository.
+- Added terminal deferral/finalization with native stable message IDs, exact materialized-body sealing, deterministic ordinary fallback, one bounded ambiguous retry, and cleanup across non-success, retry, and regenerate paths for direct and agent generations.
+- Added real CharactersRAGDB controller integration proving atomic message/trace graph ownership, marker-free empty occurrences, governed-body privacy, restart discovery, and deterministic owner-stage rollback with no partial provenance.
+- Plan deviation/privacy fix: the real RED test exposed message bodies in CharactersRAGDB SQL DEBUG parameter previews. Added an explicit redact_params keyword to execute_query and enabled it only for add_message's sensitive INSERT; default SQL preview and execution/error semantics remain unchanged. Added focused SQL-log regression coverage.
+- ADR required: yes. ADR path: backlog/decisions/024-rag-citation-provenance-and-source-resolution.md. Reason: Direct implementation of the accepted terminal seal and atomic ownership contract; no new decision.
+- Scoped verification: SQL-log RED 1 failed/13 deselected, then GREEN 1 passed/13 deselected; complete SQL-log file 14 passed; real integration RED 2 failed/35 deselected solely on privacy, then GREEN 2 passed/35 deselected; final plan gate 254 passed/506 deselected with one existing dependency warning; targeted Ruff lint/format and git diff --check passed.
+- Task-6 files: Tests/Chat/test_console_terminal_citation_persistence.py, Tests/DB/test_sql_debug_logging.py, tldw_chatbook/DB/ChaChaNotes_DB.py, and this Backlog task file.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-553.14 - Capture-answer-attempts-and-seal-terminal-local-citation-traces.md
+++ b/backlog/tasks/task-553.14 - Capture-answer-attempts-and-seal-terminal-local-citation-traces.md
@@ -1,0 +1,39 @@
+---
+id: TASK-553.14
+title: Capture answer attempts and seal terminal local citation traces
+status: To Do
+assignee: []
+created_date: '2026-07-26 18:18'
+updated_date: '2026-07-26 18:26'
+labels:
+  - rag
+  - citations
+  - provenance
+  - local-pipeline
+dependencies:
+  - TASK-553.13
+references:
+  - Docs/superpowers/specs/2026-07-23-rag-citation-provenance-design.md
+  - >-
+    Docs/superpowers/specs/2026-07-26-local-answer-attempt-terminal-sealing-design.md
+  - backlog/decisions/024-rag-citation-provenance-and-source-resolution.md
+  - TASK-553.13
+parent_task_id: TASK-553
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Complete one eligible marker-free local RAG generation by binding its exact final assistant body to a governed answer attempt, sealing the request-scoped citation builder, and atomically persisting the message and canonical trace so retrieval provenance survives restart without overstating citation trust.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The local builder records a bounded governed initial answer attempt whose exact body and secret-scoped integrity fingerprint never enter immutable trace JSON or logs.
+- [ ] #2 Sealing is one-shot and produces a validated local SealedCitationWrite with repository-owned policy metadata, selected-attempt linkage, and deterministic completeness.
+- [ ] #3 Eligible marker-free initial Console direct-provider and agent generations seal from the exact materialized visible body and atomically persist the message plus trace under stable idempotent identities.
+- [ ] #4 Disabled, marker-mapping-ineligible, or deterministically unavailable canonical persistence preserves the ordinary answer as ungrounded, while ambiguous transaction failure receives at most one same-identity retry and never leaves partial provenance.
+- [ ] #5 Failed, stopped, canceled, empty, retry, and regenerate paths do not seal or inherit unfinished builders.
+- [ ] #6 Focused tests cover builder atomicity, direct and agent completion, exact-body fidelity, atomic persistence, fallback, idempotent retry, and content-free diagnostics.
+<!-- AC:END -->

--- a/backlog/tasks/task-761 - Restore-Console-agent-dictionary-send-integration-baseline.md
+++ b/backlog/tasks/task-761 - Restore-Console-agent-dictionary-send-integration-baseline.md
@@ -1,0 +1,24 @@
+---
+id: TASK-761
+title: Restore Console agent dictionary send integration baseline
+status: To Do
+assignee: []
+created_date: '2026-07-26 17:57'
+labels:
+  - console
+  - chat-dictionaries
+  - baseline
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Restore the Console agent send integration contract so a conversation dictionary is applied before the agent bridge receives provider messages, eliminating the deterministic failure inherited from dev.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Agent-path Console sends apply the active conversation dictionary before agent dispatch,Provider-path dictionary behavior remains unchanged,The exact agent dictionary integration regression passes offline,Focused Console controller and dictionary tests pass
+<!-- AC:END -->

--- a/backlog/tasks/task-762 - Make-Console-RAG-no-service-recovery-deterministic-offline.md
+++ b/backlog/tasks/task-762 - Make-Console-RAG-no-service-recovery-deterministic-offline.md
@@ -1,0 +1,25 @@
+---
+id: TASK-762
+title: Make Console RAG no-service recovery deterministic offline
+status: To Do
+assignee: []
+created_date: '2026-07-26 17:57'
+labels:
+  - console
+  - rag
+  - baseline
+  - offline
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make the Console Library RAG no-service path stage its recoverable blocked state without attempting embedding-model initialization or network access, eliminating the deterministic offline baseline failure inherited from dev.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 No-service Console RAG action stages a blocked recoverable result,The no-service path performs no embedding download or network access,Existing configured-service RAG staging remains unchanged,The exact no-service regression and focused Console RAG tests pass offline
+<!-- AC:END -->

--- a/tldw_chatbook/Chat/Chat_Functions.py
+++ b/tldw_chatbook/Chat/Chat_Functions.py
@@ -30,7 +30,7 @@ from typing import List, Dict, Any, Tuple, Optional, Union, Literal
 # 3rd-party Libraries
 from loguru import logger
 import requests
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 # Configure logger with context
 logger = logger.bind(module="Chat_Functions")
@@ -865,7 +865,7 @@ def chat_api_call(
 
         if isinstance(response, str):
             logger.debug(
-                f"Debug - Chat API Call - Response (first 500 chars): {response[:500]}..."
+                f"Debug - Chat API Call - Response type=str; length={len(response)}"
             )
         elif hasattr(response, "__iter__") and not isinstance(
             response, (str, bytes, dict)
@@ -879,15 +879,11 @@ def chat_api_call(
     except requests.exceptions.HTTPError as e:
         status_code = getattr(e.response, "status_code", 500)
         error_text = getattr(e.response, "text", str(e))
-        log_message_base = f"{endpoint_lower} API call failed with status {status_code}"
-
-        # Log safely first
-        try:
-            logger.error("{}. Details: {}", log_message_base, error_text[:500])
-        except Exception as log_e:
-            logger.error(f"Error during logging HTTPError details: {log_e}")
-
-        detail_message = f"API call to {endpoint_lower} failed with status {status_code}. Response: {error_text[:200]}"
+        logger.error(
+            "{} API call failed; status={}; reason=http_error",
+            endpoint_lower,
+            status_code,
+        )
         if status_code == 401:
             raise ChatAuthenticationError(
                 provider=endpoint_lower,
@@ -916,7 +912,11 @@ def chat_api_call(
                 status_code=status_code,
             )
     except requests.exceptions.RequestException as e:
-        logger.error(f"Network error connecting to {endpoint_lower}: {e}")
+        logger.error(
+            "Network error connecting to {}; error_type={}",
+            endpoint_lower,
+            type(e).__name__,
+        )
         raise ChatProviderError(
             provider=endpoint_lower, message=f"Network error: {e}", status_code=504
         )
@@ -932,16 +932,19 @@ def chat_api_call(
         # (e.g. non-HTTP error, or it decided to raise a specific Chat*Error type)
         # and raises one of our custom exceptions.
         status_code = getattr(e_chat_direct, "status_code", 0)
-        logger.opt(exception=isinstance(status_code, int) and status_code >= 500).error(
-            "Handler for {} directly raised: {} - {}",
+        logger.error(
+            "Handler for {} directly raised; error_type={}; status={}",
             endpoint_lower,
             type(e_chat_direct).__name__,
-            e_chat_direct.message,
+            status_code,
         )
         raise e_chat_direct  # Re-raise the specific error
     except (ValueError, TypeError, KeyError) as e:
-        logger.opt(exception=True).error(
-            f"Value/Type/Key error during chat API call setup for {endpoint_lower}: {e}"
+        logger.error(
+            "Chat API call setup failed for {}; error_type={}; "
+            "reason=invalid_parameter",
+            endpoint_lower,
+            type(e).__name__,
         )
         error_type = "Configuration/Parameter Error"
         if "Unsupported API endpoint" in str(e):
@@ -955,8 +958,10 @@ def chat_api_call(
                 message=f"{error_type} for {endpoint_lower}: {e}",
             )
     except Exception as e:
-        logger.exception(
-            f"Unexpected internal error in chat_api_call for {endpoint_lower}: {e}"
+        logger.error(
+            "Unexpected internal error in chat_api_call for {}; error_type={}",
+            endpoint_lower,
+            type(e).__name__,
         )
         raise ChatAPIError(
             provider=endpoint_lower,
@@ -1077,30 +1082,52 @@ def chat(
 
     try:
         logging.info(
-            f"Debug - Chat Function - Input Text: '{message}', Image provided: {'Yes' if current_image_input else 'No'}"
+            "Debug - Chat Function - Input type=%s; length=%d; image_provided=%s",
+            type(message).__name__,
+            len(message),
+            bool(current_image_input),
         )
         if current_image_input:
             logging.info(
-                f"DEBUG: current_image_input contents: {current_image_input.keys() if isinstance(current_image_input, dict) else type(current_image_input)}"
+                "DEBUG: current_image_input type=%s; key_count=%d",
+                type(current_image_input).__name__,
+                len(current_image_input)
+                if isinstance(current_image_input, dict)
+                else 0,
             )
             if isinstance(current_image_input, dict):
                 logging.info(
-                    f"DEBUG: has base64_data={bool(current_image_input.get('base64_data'))}, mime_type={current_image_input.get('mime_type')}"
+                    "DEBUG: image has_base64_data=%s; has_mime_type=%s",
+                    bool(current_image_input.get("base64_data")),
+                    bool(current_image_input.get("mime_type")),
                 )
         logging.info(
             f"Debug - Chat Function - History length: {len(history)}, Image History Mode: {image_history_mode}"
         )
         logging.info(
-            f"Debug - Chat Function - LLM Max Tokens: {llm_max_tokens}, LLM Seed: {llm_seed}, LLM Stop: {llm_stop}, LLM N: {llm_n}"
+            "Debug - Chat Function - LLM options: max_tokens=%s; seed_set=%s; "
+            "stop_type=%s; n=%s; user_identifier_set=%s; logprobs=%s; "
+            "top_logprobs=%s",
+            llm_max_tokens,
+            llm_seed is not None,
+            type(llm_stop).__name__ if llm_stop is not None else "none",
+            llm_n,
+            llm_user_identifier is not None,
+            llm_logprobs,
+            llm_top_logprobs,
         )
         logging.info(
-            f"Debug - Chat Function - LLM User Identifier: {llm_user_identifier}, LLM Logprobs: {llm_logprobs}, LLM Top Logprobs: {llm_top_logprobs}"
-        )
-        logging.info(
-            f"Debug - Chat Function - LLM Logit Bias: {llm_logit_bias}, LLM Presence Penalty: {llm_presence_penalty}, LLM Frequency Penalty: {llm_frequency_penalty}"
-        )
-        logging.info(
-            f"Debug - Chat Function - LLM Tools: {llm_tools}, LLM Tool Choice: {llm_tool_choice}, LLM Response Format (dict): {llm_response_format}"
+            "Debug - Chat Function - Structured options: logit_bias_count=%d; "
+            "presence_penalty=%s; frequency_penalty=%s; tools_count=%d; "
+            "tool_choice_type=%s; response_format_type=%s",
+            len(llm_logit_bias or {}),
+            llm_presence_penalty,
+            llm_frequency_penalty,
+            len(llm_tools or []),
+            type(llm_tool_choice).__name__ if llm_tool_choice is not None else "none",
+            type(llm_response_format).__name__
+            if llm_response_format is not None
+            else "none",
         )
 
         # Ensure selected_parts is a list
@@ -1190,9 +1217,10 @@ def chat(
                                     mime_type_part = image_url_data.split(";base64,")[
                                         0
                                     ].split("/")[-1]
-                                except (IndexError, ValueError) as e:
+                                except (IndexError, ValueError):
                                     logger.debug(
-                                        f"Failed to parse image MIME type from data URL: {e}"
+                                        "Failed to parse image MIME type from data URL; "
+                                        "reason=invalid_data_url"
                                     )
                                     # mime_type_part remains "image"
                             processed_hist_content_parts.append(
@@ -1245,7 +1273,8 @@ def chat(
                 not appended_to_last
             ):  # No user message in history, or image already there
                 logging.debug(
-                    f"Could not append last_user_image_from_history, no suitable prior user message or already present. Image: {last_user_image_url_from_history[:60]}..."
+                    "Could not append last user image from history; "
+                    "reason=no_suitable_user_message"
                 )
 
         # Log history processing metrics
@@ -1271,13 +1300,13 @@ def chat(
         if media_content and selected_parts:
             rag_start_time = time.time()
             rag_text_prefix = "\n\n".join(
-                [
-                    f"{part.capitalize()}: {media_content.get(part, '')}"
-                    for part in selected_parts
-                    if media_content.get(part)
-                ]
-            ).strip()
-            if rag_text_prefix:
+                f"{part.capitalize()}: {media_content.get(part, '')}"
+                for part in selected_parts
+                if media_content.get(part)
+            )
+            if "evidence" not in selected_parts:
+                rag_text_prefix = rag_text_prefix.strip()
+            if rag_text_prefix.strip():
                 rag_text_prefix += "\n\n---\n\n"
                 rag_duration = time.time() - rag_start_time
                 log_histogram(
@@ -1354,28 +1383,38 @@ def chat(
         try:
             temperature_float = float(temperature) if temperature is not None else 0.7
         except ValueError:
-            logging.warning(f"Invalid temperature '{temperature}', using 0.7.")
+            logging.warning(
+                "Invalid temperature; reason=value_error; using_default=0.7"
+            )
 
-        logging.debug(
-            "Debug - Chat Function - Final LLM Payload (structure, image data truncated):"
-        )
+        logging.debug("Debug - Chat Function - Final LLM payload structure:")
         for i, msg_p in enumerate(llm_messages_payload):
             content_log = []
             if isinstance(msg_p.get("content"), list):
-                for part_idx, part_c in enumerate(msg_p["content"]):
+                for part_c in msg_p["content"]:
                     if part_c.get("type") == "text":
-                        content_log.append(f"text: '{part_c['text'][:30]}...'")
-                    elif part_c.get("type") == "image_url":
                         content_log.append(
-                            f"image: '{part_c['image_url']['url'][:40]}...'"
+                            f"text(length={len(part_c.get('text', ''))})"
                         )
+                    elif part_c.get("type") == "image_url":
+                        image_url_value = part_c.get("image_url", {}).get("url", "")
+                        content_log.append(f"image_url(length={len(image_url_value)})")
             logging.debug(
-                f"  Msg {i}: Role: {msg_p['role']}, Content: [{', '.join(content_log)}]"
+                "  Msg %d: content_type=%s; parts=[%s]",
+                i,
+                type(msg_p.get("content")).__name__,
+                ", ".join(content_log),
             )
 
-        logging.debug(f"Debug - Chat Function - Temperature: {temperature}")
+        logging.debug(
+            "Debug - Chat Function - Temperature configured: %s",
+            temperature_float,
+        )
         logging.debug("Debug - Chat Function - API key provided: %s", bool(api_key))
-        logging.debug(f"Debug - Chat Function - Prompt: {custom_prompt}")
+        logging.debug(
+            "Debug - Chat Function - Custom prompt length: %d",
+            len(custom_prompt) if custom_prompt else 0,
+        )
 
         #####################################################################
         # --- Adapt payload for specific provider requirements ---
@@ -1389,7 +1428,7 @@ def chat(
                 "Adapting message payload for DeepSeek (text-only string content)."
             )
             adapted_payload_for_deepseek = []
-            for msg_obj in llm_messages_payload:
+            for message_index, msg_obj in enumerate(llm_messages_payload):
                 role = msg_obj.get("role")
                 content_input = msg_obj.get("content")
 
@@ -1405,7 +1444,8 @@ def chat(
                             # You already log warnings about image handling during payload construction if current_image_input is present.
                             # This is an additional safeguard if history contains images.
                             logging.warning(
-                                f"DeepSeek (API: {api_endpoint}) does not support images. Image part in role '{role}' will be ignored."
+                                "DeepSeek does not support images; "
+                                f"message_index={message_index}; image_ignored=true"
                             )
                 elif isinstance(
                     content_input, str
@@ -1413,7 +1453,9 @@ def chat(
                     text_parts.append(content_input)
                 else:
                     logging.warning(
-                        f"Unexpected content type for role '{role}' in payload for DeepSeek: {type(content_input)}. Attempting to coerce to string."
+                        "Unexpected DeepSeek content type; "
+                        f"message_index={message_index}; "
+                        f"content_type={type(content_input).__name__}"
                     )
                     text_parts.append(str(content_input))
 
@@ -1424,7 +1466,8 @@ def chat(
                 # For now, we'll pass the potentially empty string.
                 if image_detected_and_ignored and not final_text_content:
                     logging.debug(
-                        f"Message for role '{role}' contained only an image (ignored for DeepSeek), resulting in empty text content."
+                        "DeepSeek message contained only an ignored image; "
+                        f"message_index={message_index}"
                     )
 
                 adapted_payload_for_deepseek.append(
@@ -1433,15 +1476,13 @@ def chat(
 
             final_api_payload_for_provider = adapted_payload_for_deepseek
 
-            # Optional: Re-log the adapted payload for DeepSeek to confirm its structure
             logging.debug("Debug - Chat Function - Adapted LLM Payload for DeepSeek:")
             for i, msg_p in enumerate(final_api_payload_for_provider):
-                # Ensure content is logged even if it's long by truncating
-                content_preview = str(msg_p.get("content", ""))[:100] + (
-                    "..." if len(str(msg_p.get("content", ""))) > 100 else ""
-                )
                 logging.debug(
-                    f"  Msg {i}: Role: {msg_p['role']}, Content: '{content_preview}'"
+                    "  Msg %d: content_type=%s; content_length=%d",
+                    i,
+                    type(msg_p.get("content")).__name__,
+                    len(str(msg_p.get("content", ""))),
                 )
 
         # --- Call the LLM via the updated chat_api_call ---
@@ -1488,7 +1529,9 @@ def chat(
                 "chat_success_multimodal", labels={"api_endpoint": api_endpoint}
             )
             logging.debug(
-                f"Chat Function - Response (first 500 chars): {str(response)[:500]}"
+                "Chat Function - Response type=%s; length=%d",
+                type(response).__name__,
+                len(response) if isinstance(response, (str, bytes)) else 0,
             )
 
             loaded_config_data = load_settings()
@@ -1515,9 +1558,9 @@ def chat(
                                 response = process_user_input(
                                     response, post_gen_chat_dict_objects
                                 )
-                                # The original warning log can be removed or changed to a debug log if successfully applied.
                                 logging.debug(
-                                    f"Response after post-gen replacement (first 500 chars): {str(response)[:500]}"
+                                    "Post-generation replacement complete; "
+                                    f"response_length={len(response)}"
                                 )
                             else:
                                 logging.debug(
@@ -1525,16 +1568,19 @@ def chat(
                                 )
                         else:
                             logging.debug(
-                                f"Post-gen replacement dictionary at {post_gen_replacement_dict_path} was empty or failed to parse."
+                                "Post-generation replacement dictionary empty "
+                                "or unavailable"
                             )
 
                         logging.debug(
-                            f"Response after post-gen replacement (first 500 chars): {str(response)[:500]}"
+                            "Post-generation processing complete; "
+                            f"response_length={len(response)}"
                         )
                     except Exception as e_post_gen:
                         logging.error(
-                            f"Error during post-generation replacement: {e_post_gen}",
-                            exc_info=True,
+                            "Error during post-generation replacement; "
+                            "reason=processing_failure; error_type=%s",
+                            type(e_post_gen).__name__,
                         )
                 else:
                     logging.warning(
@@ -1570,7 +1616,8 @@ def chat(
                     text_parts.append(response[last_kept_block_end:])
                     response = "".join(text_parts)
                     logging.debug(
-                        f"Response after stripping all but last think block: {response[:200]}..."
+                        "Response thinking-tag stripping complete; "
+                        f"response_length={len(response)}"
                     )
                 elif think_blocks:  # Only one block, or stripping not needed / done
                     logging.info(
@@ -1588,11 +1635,20 @@ def chat(
             return response
 
     except Exception as e:
+        error_reason = (
+            "validation_failure"
+            if isinstance(e, ValidationError)
+            else "unexpected_error"
+        )
         log_counter(
             "chat_error_multimodal",
-            labels={"api_endpoint": api_endpoint, "error": str(e)},
+            labels={"api_endpoint": api_endpoint, "reason": error_reason},
         )
-        logging.error(f"Error in multimodal chat function: {str(e)}", exc_info=True)
+        logging.error(
+            "Error in multimodal chat function; reason=%s; error_type=%s",
+            error_reason,
+            type(e).__name__,
+        )
         # Consider if the error format should change from just a string
         return f"An error occurred in the chat function: {str(e)}"
 

--- a/tldw_chatbook/Chat/chat_persistence_service.py
+++ b/tldw_chatbook/Chat/chat_persistence_service.py
@@ -26,6 +26,17 @@ class ChatPersistenceService:
         self.workspace_registry = workspace_registry
         self.citation_repository = citation_repository
 
+    @property
+    def canonical_citation_writes_ready(self) -> bool:
+        """Return whether this service can persist canonical local citations."""
+
+        repository = self.citation_repository
+        return bool(
+            repository is not None
+            and repository.db is self.db
+            and repository.local_citation_writes_ready
+        )
+
     @staticmethod
     def derive_conversation_title(
         *,

--- a/tldw_chatbook/Chat/chat_persistence_service.py
+++ b/tldw_chatbook/Chat/chat_persistence_service.py
@@ -28,7 +28,12 @@ class ChatPersistenceService:
 
     @property
     def canonical_citation_writes_ready(self) -> bool:
-        """Return whether this service can persist canonical local citations."""
+        """Return whether this service can persist canonical local citations.
+
+        Returns:
+            True when the configured citation repository shares this service's
+            database and is ready for local canonical writes.
+        """
 
         repository = self.citation_repository
         return bool(

--- a/tldw_chatbook/Chat/citation_trace_builder.py
+++ b/tldw_chatbook/Chat/citation_trace_builder.py
@@ -644,6 +644,10 @@ class CitationTraceBuilder:
                 "answer_body exceeds "
                 f"{ANSWER_ATTEMPT_BODY_UTF8_BYTES_MAX} UTF-8 bytes"
             )
+        if not isinstance(completed_at, datetime):
+            raise TypeError("completed_at must be a datetime")
+        if completed_at.tzinfo is None or completed_at.utcoffset() is None:
+            raise ValueError("completed_at must be timezone-aware")
         matching_prompt_sets = [
             prompt_set
             for prompt_set in self._prompt_evidence_sets

--- a/tldw_chatbook/Chat/citation_trace_builder.py
+++ b/tldw_chatbook/Chat/citation_trace_builder.py
@@ -19,22 +19,35 @@ from .citation_trace_identity import (
     new_opaque_id,
 )
 from .citation_trace_models import (
+    ANSWER_ATTEMPT_BODY_UTF8_BYTES_MAX,
+    ANSWER_ATTEMPTS_MAX,
     EVIDENCE_ENTRIES_PER_PROMPT_MAX,
     GOVERNED_PAYLOAD_UTF8_BYTES_MAX,
     PROMPT_EVIDENCE_SETS_MAX,
     RETRIEVAL_CANDIDATES_PER_RUN_MAX,
     SNAPSHOT_TEXT_UTF8_BYTES_MAX,
+    AnswerAttempt,
+    AnswerAttemptKind,
+    AnswerAttemptPayload,
+    CitationCompleteness,
+    CitationTrace,
     EvidenceRun,
     EvidenceRunPayload,
     EvidenceSnapshotPayload,
     EvidenceStorageMode,
     MarkerNamespace,
+    PolicyCapability,
     PromptEvidenceEntry,
     PromptEvidenceSet,
     RetrievalCandidatePayload,
     RetrievalScoreKind,
     RetrievalScoreScale,
+    SealedCitationWrite,
     ShortCode,
+    TraceLifecycle,
+    TraceOrigin,
+    eligible_citation_marker_spans,
+    reduce_selected_attempt_completeness,
 )
 
 _SAFE_PIPELINE_CODE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,63}\Z")
@@ -65,7 +78,19 @@ class _StrictFrozenCapture(BaseModel):
 class _LocalBuilderHeader(_StrictFrozenCapture):
     request_id: BoundedIdentifier
     generation_id: BoundedIdentifier
+    policy_version: BoundedIdentifier
+    policy_capabilities: tuple[PolicyCapability, ...] = Field(min_length=1)
     created_at: datetime
+
+    @field_validator("policy_capabilities")
+    @classmethod
+    def _validate_policy_capabilities(
+        cls,
+        value: tuple[PolicyCapability, ...],
+    ) -> tuple[PolicyCapability, ...]:
+        if len(set(value)) != len(value):
+            raise ValueError("policy_capabilities must be unique")
+        return value
 
     @field_validator("created_at")
     @classmethod
@@ -191,14 +216,24 @@ class LocalPromptEvidenceCapture(_StrictFrozenCapture):
         return self
 
 
+class CitationTraceBuildUnavailable(ValueError):
+    """Fail-closed local trace construction denial."""
+
+    reason_code = "occurrence_mapping_unavailable"
+
+    def __init__(self) -> None:
+        super().__init__(self.reason_code)
+
+
 class CitationTraceBuilder:
     """Mutable, request-scoped local citation capture.
 
-    The builder intentionally has no persistence or sealing API. Secret
-    fingerprint material remains private and is never represented.
+    Secret fingerprint material remains private and is never represented.
     """
 
     __slots__ = (
+        "_answer_attempt_payloads",
+        "_answer_attempts",
         "_created_at",
         "_evidence_run_payloads",
         "_evidence_runs",
@@ -206,8 +241,12 @@ class CitationTraceBuilder:
         "_fingerprint_codec",
         "_generation_id",
         "_identity_context",
+        "_policy_capabilities",
+        "_policy_version",
         "_prompt_evidence_sets",
         "_request_id",
+        "_sealed_write",
+        "_trace_id",
     )
 
     def __init__(
@@ -217,6 +256,8 @@ class CitationTraceBuilder:
         generation_id: str,
         identity_context: LocalCitationIdentityContext,
         fingerprint_codec: CitationFingerprintCodec,
+        policy_version: str,
+        policy_capabilities: tuple[PolicyCapability, ...],
         created_at: datetime,
     ) -> None:
         if not isinstance(identity_context, LocalCitationIdentityContext):
@@ -232,17 +273,25 @@ class CitationTraceBuilder:
         header = _LocalBuilderHeader(
             request_id=request_id,
             generation_id=generation_id,
+            policy_version=policy_version,
+            policy_capabilities=policy_capabilities,
             created_at=created_at,
         )
         self._request_id = header.request_id
         self._generation_id = header.generation_id
+        self._trace_id = new_opaque_id("citation-trace")
         self._identity_context = validated_identity
         self._fingerprint_codec = fingerprint_codec
+        self._policy_version = header.policy_version
+        self._policy_capabilities = header.policy_capabilities
         self._created_at = header.created_at
         self._evidence_runs: list[EvidenceRun] = []
         self._evidence_run_payloads: list[EvidenceRunPayload] = []
         self._prompt_evidence_sets: list[PromptEvidenceSet] = []
         self._evidence_snapshot_payloads: list[EvidenceSnapshotPayload] = []
+        self._answer_attempts: list[AnswerAttempt] = []
+        self._answer_attempt_payloads: list[AnswerAttemptPayload] = []
+        self._sealed_write: SealedCitationWrite | None = None
 
     @classmethod
     def local(
@@ -252,6 +301,8 @@ class CitationTraceBuilder:
         generation_id: str,
         identity_context: LocalCitationIdentityContext,
         fingerprint_codec: CitationFingerprintCodec,
+        policy_version: str,
+        policy_capabilities: tuple[PolicyCapability, ...],
         created_at: datetime | None = None,
     ) -> CitationTraceBuilder:
         """Create a builder bound to one validated local authority profile."""
@@ -261,6 +312,8 @@ class CitationTraceBuilder:
             generation_id=generation_id,
             identity_context=identity_context,
             fingerprint_codec=fingerprint_codec,
+            policy_version=policy_version,
+            policy_capabilities=policy_capabilities,
             created_at=created_at if created_at is not None else datetime.now(UTC),
         )
 
@@ -311,6 +364,20 @@ class CitationTraceBuilder:
             for payload in self._evidence_snapshot_payloads
         )
 
+    @property
+    def answer_attempts(self) -> tuple[AnswerAttempt, ...]:
+        """Return immutable generation-attempt relationships."""
+
+        return tuple(self._answer_attempts)
+
+    @property
+    def answer_attempt_payloads(self) -> tuple[AnswerAttemptPayload, ...]:
+        """Return governed exact answer payloads recorded so far."""
+
+        return tuple(
+            payload.model_copy(deep=True) for payload in self._answer_attempt_payloads
+        )
+
     def record_retrieval_run(
         self,
         *,
@@ -323,6 +390,7 @@ class CitationTraceBuilder:
     ) -> str:
         """Record one validated local retrieval execution atomically."""
 
+        self._ensure_unsealed()
         if not isinstance(stage, str):
             raise TypeError("stage must be a string")
         if stage and _SAFE_PIPELINE_CODE.fullmatch(stage) is None:
@@ -441,6 +509,7 @@ class CitationTraceBuilder:
     ) -> str:
         """Record one exact local prompt-evidence set atomically."""
 
+        self._ensure_unsealed()
         if not isinstance(run_id, str):
             raise TypeError("run_id must be a string")
         if len(self._prompt_evidence_sets) >= PROMPT_EVIDENCE_SETS_MAX:
@@ -550,6 +619,82 @@ class CitationTraceBuilder:
         self._prompt_evidence_sets.append(prompt_set)
         return prompt_set_id
 
+    def record_initial_answer_attempt(
+        self,
+        *,
+        prompt_evidence_set_id: str,
+        answer_body: str,
+        completed_at: datetime,
+    ) -> str:
+        """Record the single marker-free initial answer atomically."""
+
+        self._ensure_unsealed()
+        if self._answer_attempts:
+            raise ValueError("initial answer attempt is already recorded")
+        if len(self._answer_attempts) >= ANSWER_ATTEMPTS_MAX:
+            raise ValueError(
+                f"answer attempts exceeds {ANSWER_ATTEMPTS_MAX} entries"
+            )
+        if not isinstance(prompt_evidence_set_id, str):
+            raise TypeError("prompt_evidence_set_id must be a string")
+        if not isinstance(answer_body, str):
+            raise TypeError("answer_body must be a string")
+        if len(answer_body.encode("utf-8")) > ANSWER_ATTEMPT_BODY_UTF8_BYTES_MAX:
+            raise ValueError(
+                "answer_body exceeds "
+                f"{ANSWER_ATTEMPT_BODY_UTF8_BYTES_MAX} UTF-8 bytes"
+            )
+        matching_prompt_sets = [
+            prompt_set
+            for prompt_set in self._prompt_evidence_sets
+            if prompt_set.prompt_set_id == prompt_evidence_set_id
+        ]
+        if not matching_prompt_sets:
+            raise ValueError("unknown prompt evidence set")
+        if len(matching_prompt_sets) != 1:
+            raise ValueError("duplicate prompt evidence set reference")
+        prompt_set = matching_prompt_sets[0]
+        if completed_at < prompt_set.created_at:
+            raise ValueError(
+                "answer attempt cannot precede its prompt evidence set"
+            )
+        try:
+            marker_spans = eligible_citation_marker_spans(
+                answer_body,
+                prompt_set.marker_namespace,
+                max_count=1,
+            )
+        except ValueError:
+            raise CitationTraceBuildUnavailable() from None
+        if marker_spans:
+            raise CitationTraceBuildUnavailable()
+
+        attempt_id = new_opaque_id("answer-attempt")
+        payload_id = new_opaque_id("answer-payload")
+        payload = AnswerAttemptPayload(
+            payload_id=payload_id,
+            attempt_id=attempt_id,
+            answer_body=answer_body,
+            body_integrity_hmac=self._fingerprint_codec.fingerprint(
+                CitationFingerprintDomain.MESSAGE_BODY,
+                answer_body,
+            ),
+        )
+        attempt = AnswerAttempt(
+            attempt_id=attempt_id,
+            attempt_ordinal=1,
+            kind=AnswerAttemptKind.INITIAL,
+            prompt_evidence_set_id=prompt_set.prompt_set_id,
+            answer_payload_ref=payload.payload_id,
+            occurrences=(),
+            created_at=completed_at,
+        )
+        self._ensure_governed_payload_capacity((payload,))
+
+        self._answer_attempt_payloads.append(payload)
+        self._answer_attempts.append(attempt)
+        return attempt_id
+
     @staticmethod
     def _comparison_snapshot_bytes(snapshot_text: str) -> bytes:
         normalized_newlines = snapshot_text.replace("\r\n", "\n").replace("\r", "\n")
@@ -557,11 +702,15 @@ class CitationTraceBuilder:
 
     def _ensure_governed_payload_capacity(
         self,
-        proposed: tuple[EvidenceRunPayload | EvidenceSnapshotPayload, ...],
+        proposed: tuple[
+            EvidenceRunPayload | EvidenceSnapshotPayload | AnswerAttemptPayload,
+            ...,
+        ],
     ) -> None:
         payloads = (
             *self._evidence_run_payloads,
             *self._evidence_snapshot_payloads,
+            *self._answer_attempt_payloads,
             *proposed,
         )
         byte_count = sum(self._canonical_payload_bytes(payload) for payload in payloads)
@@ -573,7 +722,9 @@ class CitationTraceBuilder:
 
     @staticmethod
     def _canonical_payload_bytes(
-        payload: EvidenceRunPayload | EvidenceSnapshotPayload,
+        payload: EvidenceRunPayload
+        | EvidenceSnapshotPayload
+        | AnswerAttemptPayload,
     ) -> int:
         return len(
             json.dumps(
@@ -584,11 +735,137 @@ class CitationTraceBuilder:
             ).encode("utf-8")
         )
 
+    def seal(
+        self,
+        *,
+        selected_attempt_id: str,
+        sealed_at: datetime | None = None,
+    ) -> SealedCitationWrite:
+        """Seal the complete local trace exactly once."""
+
+        self._ensure_unsealed()
+        if not self._evidence_runs:
+            raise ValueError("citation trace requires at least one evidence run")
+        if not self._prompt_evidence_sets:
+            raise ValueError(
+                "citation trace requires at least one prompt evidence set"
+            )
+        if not self._answer_attempts:
+            raise ValueError("citation trace requires at least one answer attempt")
+        selected_attempts = [
+            attempt
+            for attempt in self._answer_attempts
+            if attempt.attempt_id == selected_attempt_id
+        ]
+        if not selected_attempts:
+            raise ValueError("selected answer attempt is unknown")
+        if len(selected_attempts) != 1:
+            raise ValueError("selected answer attempt is duplicated")
+
+        runs_by_id = {run.run_id: run for run in self._evidence_runs}
+        if len(runs_by_id) != len(self._evidence_runs):
+            raise ValueError("evidence run identity is duplicated")
+        for run in self._evidence_runs:
+            if run.ended_at is None:
+                raise ValueError("every evidence run requires ended_at before seal")
+        prompts_by_id = {
+            prompt_set.prompt_set_id: prompt_set
+            for prompt_set in self._prompt_evidence_sets
+        }
+        if len(prompts_by_id) != len(self._prompt_evidence_sets):
+            raise ValueError("prompt evidence set identity is duplicated")
+        for prompt_set in self._prompt_evidence_sets:
+            for entry in prompt_set.entries:
+                run = runs_by_id.get(entry.run_id)
+                if run is None:
+                    raise ValueError("prompt entry references an unknown evidence run")
+                if run.ended_at is None:
+                    raise ValueError(
+                        "every evidence run requires ended_at before seal"
+                    )
+                if run.ended_at > prompt_set.created_at:
+                    raise ValueError(
+                        "prompt evidence set cannot precede its evidence run end"
+                    )
+        for attempt in self._answer_attempts:
+            prompt_set = prompts_by_id.get(attempt.prompt_evidence_set_id)
+            if prompt_set is None:
+                raise ValueError(
+                    "answer attempt references an unknown prompt evidence set"
+                )
+            if prompt_set.created_at > attempt.created_at:
+                raise ValueError(
+                    "answer attempt cannot precede its prompt evidence set"
+                )
+
+        seal_time = sealed_at if sealed_at is not None else datetime.now(UTC)
+        if not isinstance(seal_time, datetime):
+            raise TypeError("sealed_at must be a datetime")
+        if seal_time.tzinfo is None or seal_time.utcoffset() is None:
+            raise ValueError("sealed_at must be timezone-aware")
+        lifecycle_boundaries = [
+            self._created_at,
+            *(run.started_at for run in self._evidence_runs),
+            *(
+                run.ended_at
+                for run in self._evidence_runs
+                if run.ended_at is not None
+            ),
+            *(prompt.created_at for prompt in self._prompt_evidence_sets),
+            *(attempt.created_at for attempt in self._answer_attempts),
+        ]
+        if any(boundary > seal_time for boundary in lifecycle_boundaries):
+            raise ValueError("sealed_at must not precede any lifecycle boundary")
+
+        trace_data = {
+            "trace_id": self._trace_id,
+            "request_id": self._request_id,
+            "generation_id": self._generation_id,
+            "origin": TraceOrigin.LOCAL,
+            "lifecycle": TraceLifecycle.SEALED,
+            "evidence_runs": tuple(self._evidence_runs),
+            "prompt_evidence_sets": tuple(self._prompt_evidence_sets),
+            "answer_attempts": tuple(self._answer_attempts),
+            "selected_attempt_id": selected_attempt_id,
+            "policy_capabilities": self._policy_capabilities,
+            "policy_version": self._policy_version,
+            "created_at": self._created_at,
+            "sealed_at": seal_time,
+        }
+        provisional_trace = CitationTrace(
+            **trace_data,
+            completeness_at_seal=CitationCompleteness.UNAVAILABLE,
+        )
+        snapshot_payload_index = {
+            payload.payload_id: payload
+            for payload in self._evidence_snapshot_payloads
+        }
+        completeness = reduce_selected_attempt_completeness(
+            provisional_trace,
+            snapshot_payload_index,
+        )
+        trace = CitationTrace(
+            **trace_data,
+            completeness_at_seal=completeness,
+        )
+        sealed_write = SealedCitationWrite(
+            trace=trace,
+            evidence_run_payloads=tuple(self._evidence_run_payloads),
+            evidence_snapshot_payloads=tuple(self._evidence_snapshot_payloads),
+            answer_attempt_payloads=tuple(self._answer_attempt_payloads),
+        )
+        self._sealed_write = sealed_write
+        return sealed_write
+
+    def _ensure_unsealed(self) -> None:
+        if self._sealed_write is not None:
+            raise ValueError("citation trace builder is already sealed")
+
     @property
     def is_sealed(self) -> bool:
-        """Report the intentionally unsealed state of this request builder."""
+        """Return whether a complete immutable write was built successfully."""
 
-        return False
+        return self._sealed_write is not None
 
     def __repr__(self) -> str:
         return (
@@ -597,11 +874,14 @@ class CitationTraceBuilder:
             f"generation_id={self._generation_id!r}, "
             f"evidence_runs={len(self._evidence_runs)}, "
             f"prompt_evidence_sets={len(self._prompt_evidence_sets)}, "
+            f"answer_attempts={len(self._answer_attempts)}, "
+            f"is_sealed={self.is_sealed}, "
             "fingerprint_codec=<redacted>)"
         )
 
 
 __all__ = [
+    "CitationTraceBuildUnavailable",
     "CitationTraceBuilder",
     "LocalPromptEvidenceCapture",
     "LocalRetrievalCandidateCapture",

--- a/tldw_chatbook/Chat/citation_trace_builder.py
+++ b/tldw_chatbook/Chat/citation_trace_builder.py
@@ -1,0 +1,552 @@
+"""Request-scoped construction of local citation provenance."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import re
+from typing import Literal
+import unicodedata
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from .citation_source_locators import CanonicalSourceKind
+from .citation_trace_identity import (
+    BoundedIdentifier,
+    CitationFingerprintCodec,
+    CitationFingerprintDomain,
+    LocalCitationIdentityContext,
+    new_opaque_id,
+)
+from .citation_trace_models import (
+    EVIDENCE_ENTRIES_PER_PROMPT_MAX,
+    PROMPT_EVIDENCE_SETS_MAX,
+    RETRIEVAL_CANDIDATES_PER_RUN_MAX,
+    SNAPSHOT_TEXT_UTF8_BYTES_MAX,
+    EvidenceRun,
+    EvidenceRunPayload,
+    EvidenceSnapshotPayload,
+    EvidenceStorageMode,
+    MarkerNamespace,
+    PromptEvidenceEntry,
+    PromptEvidenceSet,
+    RetrievalCandidatePayload,
+    RetrievalScoreKind,
+    RetrievalScoreScale,
+    ShortCode,
+)
+
+_SAFE_PIPELINE_CODE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,63}\Z")
+_RAW_QUERY_UTF8_BYTES_MAX = 64 * 1024
+_TITLE_UTF8_BYTES_MAX = 4 * 1024
+_MAX_CONTEXT_CHARACTERS = 4 * 1024 * 1024
+_MAX_LINEAGE_OFFSET = (2**63) - 1
+_LOCAL_SOURCE_KINDS = frozenset(
+    {
+        CanonicalSourceKind.MEDIA_DB,
+        CanonicalSourceKind.NOTES,
+        CanonicalSourceKind.CHAT_HISTORY,
+    }
+)
+_URI_SCHEME = re.compile(r"[A-Za-z][A-Za-z0-9+.-]*:")
+
+
+class _StrictFrozenCapture(BaseModel):
+    model_config = ConfigDict(
+        allow_inf_nan=False,
+        extra="forbid",
+        frozen=True,
+        revalidate_instances="always",
+        strict=True,
+    )
+
+
+class _LocalBuilderHeader(_StrictFrozenCapture):
+    request_id: BoundedIdentifier
+    generation_id: BoundedIdentifier
+    created_at: datetime
+
+    @field_validator("created_at")
+    @classmethod
+    def _validate_created_at(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("created_at must be timezone-aware")
+        return value
+
+
+class LocalRetrievalCandidateCapture(_StrictFrozenCapture):
+    """Bounded local candidate data accepted by the Chat provenance layer."""
+
+    candidate_rank: int = Field(ge=1, le=RETRIEVAL_CANDIDATES_PER_RUN_MAX)
+    source_kind: CanonicalSourceKind
+    source_id: BoundedIdentifier
+    title: str = Field(min_length=1)
+    score_kind: RetrievalScoreKind | None = None
+    score_scale: RetrievalScoreScale | None = None
+    score: float | None = None
+    chunk_id: BoundedIdentifier | None = None
+    chunk_index: int | None = Field(default=None, ge=0, le=_MAX_LINEAGE_OFFSET)
+    start_char: int | None = Field(default=None, ge=0, le=_MAX_LINEAGE_OFFSET)
+    end_char: int | None = Field(default=None, ge=0, le=_MAX_LINEAGE_OFFSET)
+
+    @field_validator("source_id", "chunk_id")
+    @classmethod
+    def _validate_opaque_source_identifier(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if (
+            _URI_SCHEME.match(value) is not None
+            or "/" in value
+            or "\\" in value
+            or value.startswith("~")
+        ):
+            raise ValueError(
+                "source identifiers cannot contain an executable path or URL"
+            )
+        return value
+
+    @field_validator("title")
+    @classmethod
+    def _validate_title(cls, value: str) -> str:
+        byte_count = len(value.encode("utf-8"))
+        if byte_count > _TITLE_UTF8_BYTES_MAX:
+            raise ValueError(f"title exceeds {_TITLE_UTF8_BYTES_MAX} UTF-8 bytes")
+        if any(ord(character) < 32 and character not in "\t" for character in value):
+            raise ValueError("title must not contain control characters")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_score_and_lineage(self) -> LocalRetrievalCandidateCapture:
+        if self.source_kind not in _LOCAL_SOURCE_KINDS:
+            raise ValueError("source_kind must identify a local source family")
+        score_parts = (self.score_kind, self.score_scale, self.score)
+        if any(part is not None for part in score_parts) and any(
+            part is None for part in score_parts
+        ):
+            raise ValueError("score requires kind, scale, and value together")
+        if (self.start_char is None) != (self.end_char is None):
+            raise ValueError("start_char and end_char must be supplied together")
+        if (
+            self.start_char is not None
+            and self.end_char is not None
+            and self.end_char < self.start_char
+        ):
+            raise ValueError("end_char must not precede start_char")
+        return self
+
+
+class LocalRetrievalRunMetadata(_StrictFrozenCapture):
+    """Allowlisted, non-executable metadata for one local retrieval run."""
+
+    search_mode: str
+    requested_top_k: int = Field(ge=1, le=RETRIEVAL_CANDIDATES_PER_RUN_MAX)
+    max_context_characters: int = Field(ge=0, le=_MAX_CONTEXT_CHARACTERS)
+    rerank_enabled: bool
+    source_kinds: tuple[CanonicalSourceKind, ...] = Field(
+        min_length=1,
+        max_length=len(CanonicalSourceKind),
+    )
+    scope_state: Literal["unscoped", "scoped", "empty"]
+
+    @field_validator("search_mode")
+    @classmethod
+    def _validate_search_mode(cls, value: str) -> str:
+        if _SAFE_PIPELINE_CODE.fullmatch(value) is None:
+            raise ValueError("search_mode must be a safe pipeline identifier")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_source_kinds(self) -> LocalRetrievalRunMetadata:
+        if len(set(self.source_kinds)) != len(self.source_kinds):
+            raise ValueError("source_kinds must be unique")
+        if any(
+            source_kind not in _LOCAL_SOURCE_KINDS for source_kind in self.source_kinds
+        ):
+            raise ValueError("source_kinds must identify local source families")
+        return self
+
+
+class LocalPromptEvidenceCapture(_StrictFrozenCapture):
+    """One exact marked evidence block submitted at the prompt boundary."""
+
+    candidate_rank: int = Field(ge=1, le=RETRIEVAL_CANDIDATES_PER_RUN_MAX)
+    snapshot_text: str = Field(min_length=1)
+    transformations: tuple[ShortCode, ...] = Field(default=(), max_length=32)
+
+    @field_validator("snapshot_text")
+    @classmethod
+    def _validate_snapshot_text(cls, value: str) -> str:
+        byte_count = len(value.encode("utf-8"))
+        if byte_count > SNAPSHOT_TEXT_UTF8_BYTES_MAX:
+            raise ValueError(
+                f"snapshot_text exceeds {SNAPSHOT_TEXT_UTF8_BYTES_MAX} UTF-8 bytes"
+            )
+        return value
+
+    @model_validator(mode="after")
+    def _validate_transformations(self) -> LocalPromptEvidenceCapture:
+        if len(set(self.transformations)) != len(self.transformations):
+            raise ValueError("transformations must be unique")
+        return self
+
+
+class CitationTraceBuilder:
+    """Mutable, request-scoped local citation capture.
+
+    The builder intentionally has no persistence or sealing API. Secret
+    fingerprint material remains private and is never represented.
+    """
+
+    __slots__ = (
+        "_created_at",
+        "_evidence_run_payloads",
+        "_evidence_runs",
+        "_evidence_snapshot_payloads",
+        "_fingerprint_codec",
+        "_generation_id",
+        "_identity_context",
+        "_prompt_evidence_sets",
+        "_request_id",
+    )
+
+    def __init__(
+        self,
+        *,
+        request_id: str,
+        generation_id: str,
+        identity_context: LocalCitationIdentityContext,
+        fingerprint_codec: CitationFingerprintCodec,
+        created_at: datetime,
+    ) -> None:
+        if not isinstance(identity_context, LocalCitationIdentityContext):
+            raise TypeError("identity_context must be a LocalCitationIdentityContext")
+        if not isinstance(fingerprint_codec, CitationFingerprintCodec):
+            raise TypeError("fingerprint_codec must be a CitationFingerprintCodec")
+        validated_identity = LocalCitationIdentityContext.model_validate(
+            identity_context.model_dump(mode="python")
+        )
+        header = _LocalBuilderHeader(
+            request_id=request_id,
+            generation_id=generation_id,
+            created_at=created_at,
+        )
+        self._request_id = header.request_id
+        self._generation_id = header.generation_id
+        self._identity_context = validated_identity
+        self._fingerprint_codec = fingerprint_codec
+        self._created_at = header.created_at
+        self._evidence_runs: list[EvidenceRun] = []
+        self._evidence_run_payloads: list[EvidenceRunPayload] = []
+        self._prompt_evidence_sets: list[PromptEvidenceSet] = []
+        self._evidence_snapshot_payloads: list[EvidenceSnapshotPayload] = []
+
+    @classmethod
+    def local(
+        cls,
+        *,
+        request_id: str,
+        generation_id: str,
+        identity_context: LocalCitationIdentityContext,
+        fingerprint_codec: CitationFingerprintCodec,
+        created_at: datetime | None = None,
+    ) -> CitationTraceBuilder:
+        """Create a builder bound to one validated local authority profile."""
+
+        return cls(
+            request_id=request_id,
+            generation_id=generation_id,
+            identity_context=identity_context,
+            fingerprint_codec=fingerprint_codec,
+            created_at=created_at or datetime.now(UTC),
+        )
+
+    @property
+    def request_id(self) -> str:
+        """Return the provider-request identity."""
+
+        return self._request_id
+
+    @property
+    def generation_id(self) -> str:
+        """Return the generation identity."""
+
+        return self._generation_id
+
+    @property
+    def created_at(self) -> datetime:
+        """Return the builder creation timestamp."""
+
+        return self._created_at
+
+    @property
+    def evidence_runs(self) -> tuple[EvidenceRun, ...]:
+        """Return the recorded immutable run relationships."""
+
+        return tuple(self._evidence_runs)
+
+    @property
+    def evidence_run_payloads(self) -> tuple[EvidenceRunPayload, ...]:
+        """Return the governed retrieval payloads recorded so far."""
+
+        return tuple(self._evidence_run_payloads)
+
+    @property
+    def prompt_evidence_sets(self) -> tuple[PromptEvidenceSet, ...]:
+        """Return exact prompt-boundary evidence relationships."""
+
+        return tuple(self._prompt_evidence_sets)
+
+    @property
+    def evidence_snapshot_payloads(self) -> tuple[EvidenceSnapshotPayload, ...]:
+        """Return governed exact prompt evidence payloads."""
+
+        return tuple(self._evidence_snapshot_payloads)
+
+    def record_retrieval_run(
+        self,
+        *,
+        stage: str,
+        raw_query: str,
+        candidates: tuple[LocalRetrievalCandidateCapture, ...],
+        retrieval_metadata: LocalRetrievalRunMetadata,
+        started_at: datetime,
+        ended_at: datetime | None,
+    ) -> str:
+        """Record one validated local retrieval execution atomically."""
+
+        if not isinstance(stage, str):
+            raise TypeError("stage must be a string")
+        if stage and _SAFE_PIPELINE_CODE.fullmatch(stage) is None:
+            raise ValueError("stage must be a safe non-empty pipeline identifier")
+        if not isinstance(raw_query, str):
+            raise TypeError("raw_query must be a string")
+        if not raw_query:
+            raise ValueError("raw_query must not be empty")
+        if len(raw_query.encode("utf-8")) > _RAW_QUERY_UTF8_BYTES_MAX:
+            raise ValueError(
+                f"raw_query exceeds {_RAW_QUERY_UTF8_BYTES_MAX} UTF-8 bytes"
+            )
+        if not isinstance(candidates, tuple):
+            raise TypeError("candidates must be a tuple")
+        if len(candidates) > RETRIEVAL_CANDIDATES_PER_RUN_MAX:
+            raise ValueError(
+                f"candidates exceeds {RETRIEVAL_CANDIDATES_PER_RUN_MAX} entries"
+            )
+        if not isinstance(retrieval_metadata, LocalRetrievalRunMetadata):
+            raise TypeError("retrieval_metadata must be LocalRetrievalRunMetadata")
+
+        metadata = LocalRetrievalRunMetadata.model_validate(
+            retrieval_metadata.model_dump(mode="python")
+        )
+        validated_candidates: list[LocalRetrievalCandidateCapture] = []
+        for candidate in candidates:
+            if not isinstance(candidate, LocalRetrievalCandidateCapture):
+                raise TypeError(
+                    "candidates must contain LocalRetrievalCandidateCapture values"
+                )
+            validated_candidates.append(
+                LocalRetrievalCandidateCapture.model_validate(
+                    candidate.model_dump(mode="python")
+                )
+            )
+
+        run_id = new_opaque_id("evidence-run")
+        payload_id = new_opaque_id("run-payload")
+        candidate_payloads = tuple(
+            self._candidate_payload(candidate) for candidate in validated_candidates
+        )
+        run_payload = EvidenceRunPayload(
+            payload_id=payload_id,
+            run_id=run_id,
+            raw_query=None,
+            query_fingerprint=self._fingerprint_codec.fingerprint(
+                CitationFingerprintDomain.RAW_QUERY,
+                raw_query,
+            ),
+            authority_id=self._identity_context.local_authority_id,
+            retrieval_metadata=metadata.model_dump(mode="json"),
+            candidates=candidate_payloads,
+        )
+        run = EvidenceRun(
+            run_id=run_id,
+            request_id=self._request_id,
+            run_ordinal=len(self._evidence_runs) + 1,
+            stage=stage,
+            payload_ref=payload_id,
+            started_at=started_at,
+            ended_at=ended_at,
+        )
+
+        self._evidence_runs.append(run)
+        self._evidence_run_payloads.append(run_payload)
+        return run_id
+
+    @staticmethod
+    def _candidate_payload(
+        candidate: LocalRetrievalCandidateCapture,
+    ) -> RetrievalCandidatePayload:
+        lineage = {
+            key: value
+            for key, value in (
+                ("chunk_id", candidate.chunk_id),
+                ("chunk_index", candidate.chunk_index),
+                ("start_char", candidate.start_char),
+                ("end_char", candidate.end_char),
+            )
+            if value is not None
+        }
+        return RetrievalCandidatePayload(
+            candidate_id=new_opaque_id("retrieval-candidate"),
+            rank=candidate.candidate_rank,
+            source_identity={
+                "source_kind": candidate.source_kind.value,
+                "source_id": candidate.source_id,
+            },
+            title=candidate.title,
+            locator={},
+            lineage=lineage,
+            score_kind=candidate.score_kind,
+            score_scale=candidate.score_scale,
+            score=candidate.score,
+        )
+
+    def record_prompt_evidence_set(
+        self,
+        *,
+        run_id: str,
+        evidence: tuple[LocalPromptEvidenceCapture, ...],
+        created_at: datetime,
+    ) -> str:
+        """Record one exact local prompt-evidence set atomically."""
+
+        if not isinstance(run_id, str):
+            raise TypeError("run_id must be a string")
+        if len(self._prompt_evidence_sets) >= PROMPT_EVIDENCE_SETS_MAX:
+            raise ValueError(
+                f"prompt evidence sets exceeds {PROMPT_EVIDENCE_SETS_MAX} entries"
+            )
+        if not isinstance(evidence, tuple):
+            raise TypeError("evidence must be a tuple")
+        if not evidence:
+            raise ValueError("evidence must not be empty")
+        if len(evidence) > EVIDENCE_ENTRIES_PER_PROMPT_MAX:
+            raise ValueError(
+                f"evidence entries exceeds {EVIDENCE_ENTRIES_PER_PROMPT_MAX} entries"
+            )
+
+        matching_runs = [run for run in self._evidence_runs if run.run_id == run_id]
+        matching_payloads = [
+            payload
+            for payload in self._evidence_run_payloads
+            if payload.run_id == run_id
+        ]
+        if not matching_runs or not matching_payloads:
+            raise ValueError("unknown evidence run")
+        if len(matching_runs) != 1 or len(matching_payloads) != 1:
+            raise ValueError("duplicate evidence run reference")
+        run_payload = matching_payloads[0]
+        candidates_by_rank = {
+            candidate.rank: candidate for candidate in run_payload.candidates
+        }
+
+        validated_evidence: list[LocalPromptEvidenceCapture] = []
+        for capture in evidence:
+            if not isinstance(capture, LocalPromptEvidenceCapture):
+                raise TypeError(
+                    "evidence must contain LocalPromptEvidenceCapture values"
+                )
+            validated_evidence.append(
+                LocalPromptEvidenceCapture.model_validate(
+                    capture.model_dump(mode="python")
+                )
+            )
+        candidate_ranks = [capture.candidate_rank for capture in validated_evidence]
+        if len(set(candidate_ranks)) != len(candidate_ranks):
+            raise ValueError("candidate_rank must be unique within a prompt set")
+
+        snapshots: list[EvidenceSnapshotPayload] = []
+        entries: list[PromptEvidenceEntry] = []
+        for ordinal, capture in enumerate(validated_evidence, start=1):
+            marker_match = re.match(
+                r"\[S([1-9][0-9]*)\](?:\s|$)", capture.snapshot_text
+            )
+            if marker_match is None or int(marker_match.group(1)) != ordinal:
+                raise ValueError(
+                    "snapshot marker ordinal must match its prompt evidence ordinal"
+                )
+            candidate = candidates_by_rank.get(capture.candidate_rank)
+            if candidate is None:
+                raise ValueError("prompt evidence references unknown candidate_rank")
+            snapshot_id = new_opaque_id("snapshot-payload")
+            exact_bytes = capture.snapshot_text.encode("utf-8")
+            comparison_bytes = self._comparison_snapshot_bytes(capture.snapshot_text)
+            snapshot = EvidenceSnapshotPayload(
+                payload_id=snapshot_id,
+                storage_mode=EvidenceStorageMode.EMBEDDED,
+                snapshot_text=capture.snapshot_text,
+                title=candidate.title,
+                source_identity=candidate.source_identity,
+                locator=candidate.locator,
+                lineage=candidate.lineage,
+                transformations=capture.transformations,
+                content_hash=self._fingerprint_codec.fingerprint(
+                    CitationFingerprintDomain.EXACT_PAYLOAD,
+                    "exact-snapshot-v1",
+                    exact_bytes,
+                ),
+                comparison_hash=self._fingerprint_codec.fingerprint(
+                    CitationFingerprintDomain.EXACT_PAYLOAD,
+                    "comparison-nfc-lf-v1",
+                    comparison_bytes,
+                ),
+            )
+            entry = PromptEvidenceEntry(
+                evidence_ordinal=ordinal,
+                marker_ordinal=ordinal,
+                run_id=run_id,
+                snapshot_payload_ref=snapshot_id,
+                storage_mode=EvidenceStorageMode.EMBEDDED,
+            )
+            snapshots.append(snapshot)
+            entries.append(entry)
+
+        prompt_set_id = new_opaque_id("prompt-set")
+        prompt_set = PromptEvidenceSet(
+            prompt_set_id=prompt_set_id,
+            prompt_set_ordinal=len(self._prompt_evidence_sets) + 1,
+            marker_namespace=MarkerNamespace.CHATBOOK_S_V1,
+            entries=tuple(entries),
+            created_at=created_at,
+        )
+
+        self._evidence_snapshot_payloads.extend(snapshots)
+        self._prompt_evidence_sets.append(prompt_set)
+        return prompt_set_id
+
+    @staticmethod
+    def _comparison_snapshot_bytes(snapshot_text: str) -> bytes:
+        normalized_newlines = snapshot_text.replace("\r\n", "\n").replace("\r", "\n")
+        return unicodedata.normalize("NFC", normalized_newlines).encode("utf-8")
+
+    @property
+    def is_sealed(self) -> bool:
+        """Report the intentionally unsealed state of this request builder."""
+
+        return False
+
+    def __repr__(self) -> str:
+        return (
+            "CitationTraceBuilder("
+            f"request_id={self._request_id!r}, "
+            f"generation_id={self._generation_id!r}, "
+            f"evidence_runs={len(self._evidence_runs)}, "
+            f"prompt_evidence_sets={len(self._prompt_evidence_sets)}, "
+            "fingerprint_codec=<redacted>)"
+        )
+
+
+__all__ = [
+    "CitationTraceBuilder",
+    "LocalPromptEvidenceCapture",
+    "LocalRetrievalCandidateCapture",
+    "LocalRetrievalRunMetadata",
+]

--- a/tldw_chatbook/Chat/citation_trace_builder.py
+++ b/tldw_chatbook/Chat/citation_trace_builder.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+import json
 import re
 from typing import Literal
 import unicodedata
@@ -19,6 +20,7 @@ from .citation_trace_identity import (
 )
 from .citation_trace_models import (
     EVIDENCE_ENTRIES_PER_PROMPT_MAX,
+    GOVERNED_PAYLOAD_UTF8_BYTES_MAX,
     PROMPT_EVIDENCE_SETS_MAX,
     RETRIEVAL_CANDIDATES_PER_RUN_MAX,
     SNAPSHOT_TEXT_UTF8_BYTES_MAX,
@@ -221,8 +223,11 @@ class CitationTraceBuilder:
             raise TypeError("identity_context must be a LocalCitationIdentityContext")
         if not isinstance(fingerprint_codec, CitationFingerprintCodec):
             raise TypeError("fingerprint_codec must be a CitationFingerprintCodec")
-        validated_identity = LocalCitationIdentityContext.model_validate(
-            identity_context.model_dump(mode="python")
+        validated_identity = LocalCitationIdentityContext(
+            schema_version=identity_context.schema_version,
+            profile_id=identity_context.profile_id,
+            local_authority_id=identity_context.local_authority_id,
+            fingerprint_key_id=identity_context.fingerprint_key_id,
         )
         header = _LocalBuilderHeader(
             request_id=request_id,
@@ -287,7 +292,9 @@ class CitationTraceBuilder:
     def evidence_run_payloads(self) -> tuple[EvidenceRunPayload, ...]:
         """Return the governed retrieval payloads recorded so far."""
 
-        return tuple(self._evidence_run_payloads)
+        return tuple(
+            payload.model_copy(deep=True) for payload in self._evidence_run_payloads
+        )
 
     @property
     def prompt_evidence_sets(self) -> tuple[PromptEvidenceSet, ...]:
@@ -299,7 +306,10 @@ class CitationTraceBuilder:
     def evidence_snapshot_payloads(self) -> tuple[EvidenceSnapshotPayload, ...]:
         """Return governed exact prompt evidence payloads."""
 
-        return tuple(self._evidence_snapshot_payloads)
+        return tuple(
+            payload.model_copy(deep=True)
+            for payload in self._evidence_snapshot_payloads
+        )
 
     def record_retrieval_run(
         self,
@@ -334,9 +344,7 @@ class CitationTraceBuilder:
         if not isinstance(retrieval_metadata, LocalRetrievalRunMetadata):
             raise TypeError("retrieval_metadata must be LocalRetrievalRunMetadata")
 
-        metadata = LocalRetrievalRunMetadata.model_validate(
-            retrieval_metadata.model_dump(mode="python")
-        )
+        metadata = LocalRetrievalRunMetadata.model_validate(retrieval_metadata)
         validated_candidates: list[LocalRetrievalCandidateCapture] = []
         for candidate in candidates:
             if not isinstance(candidate, LocalRetrievalCandidateCapture):
@@ -344,9 +352,21 @@ class CitationTraceBuilder:
                     "candidates must contain LocalRetrievalCandidateCapture values"
                 )
             validated_candidates.append(
-                LocalRetrievalCandidateCapture.model_validate(
-                    candidate.model_dump(mode="python")
-                )
+                LocalRetrievalCandidateCapture.model_validate(candidate)
+            )
+        if metadata.scope_state == "empty" and validated_candidates:
+            raise ValueError("empty scope cannot retain retrieval candidates")
+        if any(
+            candidate.candidate_rank > metadata.requested_top_k
+            for candidate in validated_candidates
+        ):
+            raise ValueError("candidate rank cannot exceed requested_top_k")
+        if any(
+            candidate.source_kind not in metadata.source_kinds
+            for candidate in validated_candidates
+        ):
+            raise ValueError(
+                "candidate source_kind must appear in metadata source_kinds"
             )
 
         run_id = new_opaque_id("evidence-run")
@@ -375,6 +395,9 @@ class CitationTraceBuilder:
             started_at=started_at,
             ended_at=ended_at,
         )
+        if run.started_at < self._created_at:
+            raise ValueError("retrieval run cannot start before builder created_at")
+        self._ensure_governed_payload_capacity((run_payload,))
 
         self._evidence_runs.append(run)
         self._evidence_run_payloads.append(run_payload)
@@ -455,9 +478,7 @@ class CitationTraceBuilder:
                     "evidence must contain LocalPromptEvidenceCapture values"
                 )
             validated_evidence.append(
-                LocalPromptEvidenceCapture.model_validate(
-                    capture.model_dump(mode="python")
-                )
+                LocalPromptEvidenceCapture.model_validate(capture)
             )
         candidate_ranks = [capture.candidate_rank for capture in validated_evidence]
         if len(set(candidate_ranks)) != len(candidate_ranks):
@@ -517,6 +538,13 @@ class CitationTraceBuilder:
             entries=tuple(entries),
             created_at=created_at,
         )
+        run = matching_runs[0]
+        run_terminal_boundary = run.ended_at or run.started_at
+        if prompt_set.created_at < run_terminal_boundary:
+            raise ValueError(
+                "prompt evidence set cannot precede its run terminal boundary"
+            )
+        self._ensure_governed_payload_capacity(tuple(snapshots))
 
         self._evidence_snapshot_payloads.extend(snapshots)
         self._prompt_evidence_sets.append(prompt_set)
@@ -526,6 +554,35 @@ class CitationTraceBuilder:
     def _comparison_snapshot_bytes(snapshot_text: str) -> bytes:
         normalized_newlines = snapshot_text.replace("\r\n", "\n").replace("\r", "\n")
         return unicodedata.normalize("NFC", normalized_newlines).encode("utf-8")
+
+    def _ensure_governed_payload_capacity(
+        self,
+        proposed: tuple[EvidenceRunPayload | EvidenceSnapshotPayload, ...],
+    ) -> None:
+        payloads = (
+            *self._evidence_run_payloads,
+            *self._evidence_snapshot_payloads,
+            *proposed,
+        )
+        byte_count = sum(self._canonical_payload_bytes(payload) for payload in payloads)
+        if byte_count > GOVERNED_PAYLOAD_UTF8_BYTES_MAX:
+            raise ValueError(
+                "governed payload exceeds "
+                f"{GOVERNED_PAYLOAD_UTF8_BYTES_MAX} UTF-8 bytes"
+            )
+
+    @staticmethod
+    def _canonical_payload_bytes(
+        payload: EvidenceRunPayload | EvidenceSnapshotPayload,
+    ) -> int:
+        return len(
+            json.dumps(
+                payload.model_dump(mode="json"),
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ).encode("utf-8")
+        )
 
     @property
     def is_sealed(self) -> bool:

--- a/tldw_chatbook/Chat/citation_trace_builder.py
+++ b/tldw_chatbook/Chat/citation_trace_builder.py
@@ -256,7 +256,7 @@ class CitationTraceBuilder:
             generation_id=generation_id,
             identity_context=identity_context,
             fingerprint_codec=fingerprint_codec,
-            created_at=created_at or datetime.now(UTC),
+            created_at=created_at if created_at is not None else datetime.now(UTC),
         )
 
     @property

--- a/tldw_chatbook/Chat/citation_trace_repository.py
+++ b/tldw_chatbook/Chat/citation_trace_repository.py
@@ -490,6 +490,21 @@ class CitationTraceRepository:
 
         return self._fingerprint_codec is not None and self.identity_context is not None
 
+    @property
+    def local_citation_writes_ready(self) -> bool:
+        """Return whether local canonical writes have an exact persisted identity."""
+
+        if not self.policy.canonical_writes_enabled:
+            return False
+        identity = self.identity_context
+        if identity is None or self._fingerprint_codec is None:
+            return False
+        try:
+            persisted = load_local_citation_identity_context(self.db)
+        except Exception:
+            return False
+        return persisted == identity
+
     def create_local_trace_builder(
         self,
         *,
@@ -498,21 +513,11 @@ class CitationTraceRepository:
     ) -> CitationTraceBuilder | None:
         """Create request-scoped local capture when canonical writes are enabled."""
 
-        if not self.policy.canonical_writes_enabled:
+        if not self.local_citation_writes_ready:
             return None
         identity = self.identity_context
-        if identity is None:
-            return None
         codec = self._fingerprint_codec
-        if codec is None:
-            return None
-        try:
-            persisted = load_local_citation_identity_context(self.db)
-        except Exception:
-            return None
-        if persisted is None:
-            return None
-        if persisted != identity:
+        if identity is None or codec is None:
             return None
         return CitationTraceBuilder.local(
             request_id=request_id,

--- a/tldw_chatbook/Chat/citation_trace_repository.py
+++ b/tldw_chatbook/Chat/citation_trace_repository.py
@@ -31,6 +31,7 @@ from tldw_chatbook.Chat.citation_source_locators import (
     SOURCE_INVENTORY_BY_SCOPE_V1,
     SourceCapability,
 )
+from tldw_chatbook.Chat.citation_trace_builder import CitationTraceBuilder
 from tldw_chatbook.Chat.citation_trace_identity import (
     CitationFingerprintCodec,
     CitationFingerprintDomain,
@@ -483,6 +484,37 @@ class CitationTraceRepository:
         """Return whether signed artifact bindings can currently be verified."""
 
         return self._fingerprint_codec is not None and self.identity_context is not None
+
+    def create_local_trace_builder(
+        self,
+        *,
+        request_id: str,
+        generation_id: str,
+    ) -> CitationTraceBuilder | None:
+        """Create request-scoped local capture when canonical writes are enabled."""
+
+        if not self.policy.canonical_writes_enabled:
+            return None
+        identity = self.identity_context
+        if identity is None:
+            return None
+        codec = self._fingerprint_codec
+        if codec is None:
+            return None
+        try:
+            persisted = load_local_citation_identity_context(self.db)
+        except Exception:
+            return None
+        if persisted is None:
+            return None
+        if persisted != identity:
+            return None
+        return CitationTraceBuilder.local(
+            request_id=request_id,
+            generation_id=generation_id,
+            identity_context=identity,
+            fingerprint_codec=codec,
+        )
 
     @classmethod
     def from_key_provider(

--- a/tldw_chatbook/Chat/citation_trace_repository.py
+++ b/tldw_chatbook/Chat/citation_trace_repository.py
@@ -492,7 +492,12 @@ class CitationTraceRepository:
 
     @property
     def local_citation_writes_ready(self) -> bool:
-        """Return whether local canonical writes have an exact persisted identity."""
+        """Return whether local canonical writes have an exact persisted identity.
+
+        Returns:
+            True when canonical writes are enabled and the active identity
+            exactly matches the identity persisted in the repository.
+        """
 
         if not self.policy.canonical_writes_enabled:
             return False
@@ -511,7 +516,16 @@ class CitationTraceRepository:
         request_id: str,
         generation_id: str,
     ) -> CitationTraceBuilder | None:
-        """Create request-scoped local capture when canonical writes are enabled."""
+        """Create request-scoped local capture when canonical writes are enabled.
+
+        Args:
+            request_id: Opaque identifier for the generation request.
+            generation_id: Opaque identifier for the generation attempt.
+
+        Returns:
+            A request-scoped citation builder, or ``None`` when canonical local
+            writes are not ready.
+        """
 
         if not self.local_citation_writes_ready:
             return None

--- a/tldw_chatbook/Chat/citation_trace_repository.py
+++ b/tldw_chatbook/Chat/citation_trace_repository.py
@@ -68,6 +68,11 @@ if TYPE_CHECKING:
 
 
 _ROW_FAMILIES = frozenset({"trace", "runs", "snapshots", "attempts", "refs", "owner"})
+_LOCAL_TRACE_POLICY_VERSION = "local-prompt-provenance-v1"
+_LOCAL_TRACE_POLICY_CAPABILITIES = (
+    PolicyCapability.VIEW_SNAPSHOT,
+    PolicyCapability.VIEW_SOURCE_IDENTITY,
+)
 
 
 class CitationPersistenceUnavailable(RuntimeError):
@@ -514,6 +519,8 @@ class CitationTraceRepository:
             generation_id=generation_id,
             identity_context=identity,
             fingerprint_codec=codec,
+            policy_version=_LOCAL_TRACE_POLICY_VERSION,
+            policy_capabilities=_LOCAL_TRACE_POLICY_CAPABILITIES,
         )
 
     @classmethod

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -9,7 +9,7 @@ import threading
 import time
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Protocol
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Protocol
 from uuid import uuid4
 
 from tldw_chatbook.Chat.attachment_core import (
@@ -553,6 +553,7 @@ class ConsoleChatController:
         skill_substitution_enabled: bool = True,
         chat_dictionary_applier: "Callable[[str | None, str], str] | None" = None,
         world_info_applier: "Callable[[str | None, str, list], str] | None" = None,
+        rag_capture_provider: "Callable[[str], Awaitable[Any]] | None" = None,
     ) -> None:
         self.store = store
         self.provider_gateway = provider_gateway
@@ -581,6 +582,7 @@ class ConsoleChatController:
         self._skill_substitution_enabled = skill_substitution_enabled
         self._chat_dictionary_applier = chat_dictionary_applier
         self._world_info_applier = world_info_applier
+        self._rag_capture_provider = rag_capture_provider
         self.run_state = ConsoleRunState()
         self.run_state_history: list[ConsoleRunStatus] = [self.run_state.status]
         #: Optional owner hook invoked once a submit is accepted (user message
@@ -766,6 +768,7 @@ class ConsoleChatController:
 
         if pendings:
             self.store.clear_pending_attachments(session.id)
+        citation_trace_builder = None
         try:
             provider_messages = self._provider_messages_for_session(
                 session.id, annotate_ids=True
@@ -789,12 +792,25 @@ class ConsoleChatController:
                 self.store.append_message(
                     session.id, role=ConsoleMessageRole.SYSTEM, content=note
                 )
+            citation_context, citation_trace_builder = await self._capture_rag_context(
+                clean_draft
+            )
+            if citation_context and citation_trace_builder is None:
+                provider_messages = self._prepend_evidence_context(
+                    provider_messages,
+                    citation_context,
+                )
             provider_messages = await self._apply_chat_dictionaries(
                 provider_messages, session.id
             )
             provider_messages = await self._apply_world_info(
                 provider_messages, session.id
             )
+            if citation_context and citation_trace_builder is not None:
+                provider_messages = self._prepend_evidence_context(
+                    provider_messages,
+                    citation_context,
+                )
             prefill, prefill_from_one_shot = self._resolve_submit_prefill(session.id)
         except BaseException:
             # Any failure between the optimistic echo and the confirmed turn
@@ -824,15 +840,18 @@ class ConsoleChatController:
             content="",
             persist=self.store.persistence is not None,
         )
-        return await self._stream_assistant_response(
-            resolution=resolution,
-            provider_messages=provider_messages,
-            assistant_message_id=assistant.id,
-            prefill=prefill,
-            prefill_from_one_shot=prefill_from_one_shot,
-            skill_bindings=skill_bindings,
-            skill_bundle_block=skill_bundle_block,
-        )
+        try:
+            return await self._stream_assistant_response(
+                resolution=resolution,
+                provider_messages=provider_messages,
+                assistant_message_id=assistant.id,
+                prefill=prefill,
+                prefill_from_one_shot=prefill_from_one_shot,
+                skill_bindings=skill_bindings,
+                skill_bundle_block=skill_bundle_block,
+            )
+        finally:
+            del citation_trace_builder
 
     def new_session(
         self,
@@ -3328,6 +3347,76 @@ class ConsoleChatController:
             should_clear_draft=False,
             visible_copy=visible_copy,
         )
+
+    async def _capture_rag_context(self, draft: str) -> tuple[str | None, Any | None]:
+        """Resolve optional staged RAG context without exposing request state."""
+
+        provider = self._rag_capture_provider
+        if provider is None:
+            return None, None
+        try:
+            captured = await provider(draft)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.error(
+                "Console RAG capture unavailable; reason=capture_provider_failure"
+            )
+            return None, None
+        context = getattr(captured, "context", None)
+        builder = getattr(captured, "citation_builder", None)
+        if not isinstance(context, str) or not context.strip():
+            return None, builder
+        return context, builder
+
+    @staticmethod
+    def _prepend_evidence_context(
+        provider_messages: list[dict[str, Any]],
+        context: str,
+    ) -> list[dict[str, Any]]:
+        """Prefix exact evidence to the final provider-only user message."""
+
+        final_index = next(
+            (
+                index
+                for index in range(len(provider_messages) - 1, -1, -1)
+                if provider_messages[index].get("role")
+                == ConsoleMessageRole.USER.value
+            ),
+            None,
+        )
+        if final_index is None:
+            return provider_messages
+        prefix = f"Evidence: {context}\n\n---\n\n"
+        message = provider_messages[final_index]
+        content = message.get("content")
+        if isinstance(content, str):
+            new_content: Any = prefix + content
+        elif isinstance(content, list):
+            new_content = list(content)
+            text_index = next(
+                (
+                    index
+                    for index, part in enumerate(new_content)
+                    if isinstance(part, dict)
+                    and part.get("type") == "text"
+                    and isinstance(part.get("text"), str)
+                ),
+                None,
+            )
+            if text_index is None:
+                new_content.insert(0, {"type": "text", "text": prefix})
+            else:
+                text_part = new_content[text_index]
+                new_content[text_index] = {
+                    **text_part,
+                    "text": prefix + text_part["text"],
+                }
+        else:
+            return provider_messages
+        updated = list(provider_messages)
+        updated[final_index] = {**message, "content": new_content}
+        return updated
 
     def _notify_submission_accepted(self) -> None:
         """Invoke the owner accepted-hook without letting UI errors kill the run."""

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -437,7 +437,9 @@ def build_tool_review_hook(
         decisions = request_approvals(all_pending)
         if mcp_provider is not None:
             mcp_decisions = {
-                name: decisions[name] for name in mcp_claimed_names if name in decisions
+                name: decisions[name]
+                for name in mcp_claimed_names
+                if name in decisions
             }
             mcp_provider.apply_batch_decisions(mcp_decisions)
         for row in builtin_pending:
@@ -901,9 +903,7 @@ class ConsoleChatController:
             return
         derived = derive_console_session_title(draft)
         if derived:
-            self.store.rename_session(
-                session.id, derived
-            )  # (session, persisted) — auto-title best-effort
+            self.store.rename_session(session.id, derived)  # (session, persisted) — auto-title best-effort
 
     def update_provider_selection(self, selection: ConsoleProviderSelection) -> None:
         """Sync controller provider settings from a Console selection."""
@@ -1756,7 +1756,9 @@ class ConsoleChatController:
         provider_messages = await self._apply_chat_dictionaries(
             provider_messages, session_id
         )
-        provider_messages = await self._apply_world_info(provider_messages, session_id)
+        provider_messages = await self._apply_world_info(
+            provider_messages, session_id
+        )
         prefill = self._pinned_prefill_for_session(session_id)
         return await self._stream_assistant_response(
             resolution=resolution,
@@ -1824,7 +1826,9 @@ class ConsoleChatController:
         provider_messages = await self._apply_chat_dictionaries(
             provider_messages, session_id
         )
-        provider_messages = await self._apply_world_info(provider_messages, session_id)
+        provider_messages = await self._apply_world_info(
+            provider_messages, session_id
+        )
         assistant = self.store.append_message(
             session_id,
             role=ConsoleMessageRole.ASSISTANT,
@@ -1927,7 +1931,9 @@ class ConsoleChatController:
         provider_messages = await self._apply_chat_dictionaries(
             provider_messages, session_id
         )
-        provider_messages = await self._apply_world_info(provider_messages, session_id)
+        provider_messages = await self._apply_world_info(
+            provider_messages, session_id
+        )
         prefill = self._pinned_prefill_for_session(session_id)
         new_message = self.store.create_sibling(
             message_id,
@@ -2108,20 +2114,14 @@ class ConsoleChatController:
             ]
             transcript_text = "\n".join(lines)
             if prior_summary:
-                return (
-                    f"[Previous summary]\n{prior_summary}\n\n{transcript_text}".rstrip()
-                )
+                return f"[Previous summary]\n{prior_summary}\n\n{transcript_text}".rstrip()
             return transcript_text
 
         rows = list(span)
         body = assemble(rows)
-        while (
-            len(rows) > 1
-            and count_console_messages_tokens(
-                [{"role": "user", "content": body}], model
-            )
-            > self._SUMMARY_SPAN_TOKEN_BUDGET
-        ):
+        while len(rows) > 1 and count_console_messages_tokens(
+            [{"role": "user", "content": body}], model
+        ) > self._SUMMARY_SPAN_TOKEN_BUDGET:
             rows = rows[1:]
             body = assemble(rows)
         return body
@@ -2310,7 +2310,9 @@ class ConsoleChatController:
         provider_messages = await self._apply_chat_dictionaries(
             provider_messages, session_id
         )
-        provider_messages = await self._apply_world_info(provider_messages, session_id)
+        provider_messages = await self._apply_world_info(
+            provider_messages, session_id
+        )
         prefill = self._pinned_prefill_for_session(session_id)
 
         # Every transform succeeded: now (and only now) fork the edited USER
@@ -2404,9 +2406,7 @@ class ConsoleChatController:
             )
 
             # Chat dictionaries are safe to apply (string replacements only).
-            provider_messages = await self._apply_chat_dictionaries(
-                provider_messages, session_id
-            )
+            provider_messages = await self._apply_chat_dictionaries(provider_messages, session_id)
 
             # task-548: mirror the dispatch choke point's boundary-summary
             # compaction so the preview matches what is actually sent when a
@@ -2441,9 +2441,7 @@ class ConsoleChatController:
                 ]
 
             # Replace image data with placeholders for the preview, including historical images.
-            provider_messages = self._replace_image_data_with_placeholders(
-                provider_messages
-            )
+            provider_messages = self._replace_image_data_with_placeholders(provider_messages)
 
             # Gather native tool schemas and MCP note.
             tools_info = self._build_tools_info_for_snapshot()
@@ -2531,9 +2529,7 @@ class ConsoleChatController:
             )
 
     @staticmethod
-    def _replace_image_data_with_placeholders(
-        messages: list[dict[str, Any]],
-    ) -> list[dict[str, Any]]:
+    def _replace_image_data_with_placeholders(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         result = copy.deepcopy(messages)
 
         def _is_data_url(value: Any) -> bool:
@@ -2565,9 +2561,7 @@ class ConsoleChatController:
                     if not isinstance(part, dict):
                         continue
                     if part.get("type") == "image_url":
-                        part["image_url"] = _redact_image_url_value(
-                            part.get("image_url")
-                        )
+                        part["image_url"] = _redact_image_url_value(part.get("image_url"))
                     if part.get("type") == "image":
                         # Anthropic-style image parts use a ``source`` dict with
                         # base64 data; preserve the surrounding structure.
@@ -2637,7 +2631,9 @@ class ConsoleChatController:
             tools = self._agent_bridge.native_tool_schemas()
         mcp_note: str | None = None
         if self._mcp_provider:
-            mcp_note = "MCP tools are configured but live catalog composition is not shown in this preview."
+            mcp_note = (
+                "MCP tools are configured but live catalog composition is not shown in this preview."
+            )
         if tools:
             preview_note = (
                 "This preview shows only builtin native tools. "
@@ -2651,20 +2647,15 @@ class ConsoleChatController:
             "preview_note": preview_note,
         }
 
-    _SECRET_REDACTION_KEYS = {
-        "api_key",
-        "apikey",
-        "token",
-        "password",
-        "secret",
-        "bearer",
-    }
+    _SECRET_REDACTION_KEYS = {"api_key", "apikey", "token", "password", "secret", "bearer"}
     _SECRET_REDACTION_KEYS_NORMALIZED = {
         k.replace("-", "").replace("_", "") for k in _SECRET_REDACTION_KEYS
     }
     _SECRET_REDACTION_PATTERN = re.compile(
         r"(?P<open_quote>[\"']?)"
-        r"(?P<key>" + "|".join(re.escape(k) for k in _SECRET_REDACTION_KEYS) + r")"
+        r"(?P<key>"
+        + "|".join(re.escape(k) for k in _SECRET_REDACTION_KEYS)
+        + r")"
         r"(?P=open_quote)"
         r"(?P<sep>\s*[:=]\s*)"
         r"(?P<value>"
@@ -2699,9 +2690,7 @@ class ConsoleChatController:
                 sep = match.group("sep")
                 return f"{open_quote}{key}{open_quote}{sep}{redacted_value}"
 
-            return ConsoleChatController._SECRET_REDACTION_PATTERN.sub(
-                _replace_value, value
-            )
+            return ConsoleChatController._SECRET_REDACTION_PATTERN.sub(_replace_value, value)
 
         def _matches_secret_key(key: str) -> bool:
             """Return True when ``key`` matches or ends with a secret word.
@@ -2837,7 +2826,9 @@ class ConsoleChatController:
 
     async def _apply_skill_substitution(
         self, provider_messages: list[dict[str, Any]]
-    ) -> tuple[list[dict[str, Any]], str | None, tuple[str, ...], tuple[str, ...], str]:
+    ) -> tuple[
+        list[dict[str, Any]], str | None, tuple[str, ...], tuple[str, ...], str
+    ]:
         """Render-fresh the triggering turn's skill mention(s) at payload build time.
 
         Spec: "Invocation semantics" §5 (the substitution rule) -- one rule
@@ -3068,7 +3059,9 @@ class ConsoleChatController:
                 result.get("execution_mode") if isinstance(result, Mapping) else None
             )
             rendered = (
-                result.get("rendered_prompt", "") if isinstance(result, Mapping) else ""
+                result.get("rendered_prompt", "")
+                if isinstance(result, Mapping)
+                else ""
             )
             # Fork (or anything non-inline) cannot splice in place: leave
             # the mention literal, no note (this is not a trust failure).
@@ -3473,7 +3466,8 @@ class ConsoleChatController:
             (
                 index
                 for index in range(len(provider_messages) - 1, -1, -1)
-                if provider_messages[index].get("role") == ConsoleMessageRole.USER.value
+                if provider_messages[index].get("role")
+                == ConsoleMessageRole.USER.value
             ),
             None,
         )
@@ -3591,7 +3585,9 @@ class ConsoleChatController:
             owner_id = self.store.session_id_for_message(assistant_message_id)
         except KeyError:
             return self._session_closed_result()
-        owner = next((s for s in self.store.sessions() if s.id == owner_id), None)
+        owner = next(
+            (s for s in self.store.sessions() if s.id == owner_id), None
+        )
         # task-427: a character session always takes the plain-provider
         # path, even with the global agent runtime enabled and a bridge
         # present. Keyed on the message's OWNING session (looked up here,
@@ -3694,7 +3690,9 @@ class ConsoleChatController:
                         )
                     except KeyError:
                         return self._session_closed_result()
-                    self._consume_one_shot_prefill(assistant_message_id, one_shot_used)
+                    self._consume_one_shot_prefill(
+                        assistant_message_id, one_shot_used
+                    )
                     return ConsoleSubmitResult(True, True, stopped.content)
                 if prepare_retry and not retry_prepared:
                     self.store.prepare_message_retry(assistant_message_id)
@@ -3722,7 +3720,9 @@ class ConsoleChatController:
                     )
                 except KeyError:
                     return self._session_closed_result()
-                self._consume_one_shot_prefill(assistant_message_id, one_shot_used)
+                self._consume_one_shot_prefill(
+                    assistant_message_id, one_shot_used
+                )
                 return ConsoleSubmitResult(True, True, stopped.content)
             if not emitted_content:
                 try:
@@ -3764,7 +3764,9 @@ class ConsoleChatController:
                     )
                 except KeyError:
                     return self._session_closed_result()
-                self._consume_one_shot_prefill(assistant_message_id, one_shot_used)
+                self._consume_one_shot_prefill(
+                    assistant_message_id, one_shot_used
+                )
                 return ConsoleSubmitResult(True, True, stopped.content)
             raise
         except Exception as exc:
@@ -3992,9 +3994,11 @@ class ConsoleChatController:
             # preserves whatever partial content already streamed
             # otherwise).
             visible_copy = f"Agent run failed: {describe_stream_failure(exc)}"
-            if getattr(
-                getattr(exc, "response", None), "status_code", None
-            ) is not None and self._session_history_carries_images(session_id):
+            if (
+                getattr(getattr(exc, "response", None), "status_code", None)
+                is not None
+                and self._session_history_carries_images(session_id)
+            ):
                 visible_copy += self._IMAGE_REJECTION_RECOVERY_HINT
             try:
                 self.store.mark_message_failed(assistant_message_id)
@@ -4076,8 +4080,9 @@ class ConsoleChatController:
         # prior status for a regenerate, "stopped" for a plain send) and
         # the variant base (already popped), so this is a benign no-op
         # read-back, never an error, in either case.
-        stopped_now = (current is not None and current.status == "stopped") or (
-            cancel_event is not None and cancel_event.is_set()
+        stopped_now = (
+            (current is not None and current.status == "stopped")
+            or (cancel_event is not None and cancel_event.is_set())
         )
         if stopped_now:
             # The stopped message was already persisted by
@@ -4092,39 +4097,24 @@ class ConsoleChatController:
             self._set_run_state(
                 ConsoleRunState(ConsoleRunStatus.STOPPED, "Response stopped.")
             )
-            return ConsoleSubmitResult(
-                True, True, current.content if current is not None else ""
-            )
+            return ConsoleSubmitResult(True, True, current.content if current is not None else "")
 
         if outcome.status == RUN_CANCELLED:
             return self._finalize_agent_cancelled(
-                assistant_message_id,
-                session_id,
-                variant_mode=variant_mode,
-                run_id=run_id,
-            )
+                assistant_message_id, session_id, variant_mode=variant_mode,
+                run_id=run_id)
 
         if outcome.status != RUN_DONE:
             return self._finalize_agent_failure(
-                assistant_message_id,
-                session_id,
-                outcome,
-                variant_mode=variant_mode,
-                run_id=run_id,
-            )
+                assistant_message_id, session_id, outcome, variant_mode=variant_mode,
+                run_id=run_id)
 
         return self._finalize_agent_success(
-            assistant_message_id,
-            session_id,
-            outcome,
-            variant_mode=variant_mode,
-            run_id=run_id,
-        )
+            assistant_message_id, session_id, outcome,
+            variant_mode=variant_mode, run_id=run_id)
 
     def _ensure_assistant_placeholder(
-        self,
-        assistant_message_id: str,
-        session_id: str,
+        self, assistant_message_id: str, session_id: str,
     ) -> ConsoleChatMessage | None:
         """Return the assistant placeholder message if it still exists.
 
@@ -4138,8 +4128,7 @@ class ConsoleChatController:
             return None
 
     def _find_runtime_written_assistant(
-        self,
-        session_id: str,
+        self, session_id: str,
     ) -> ConsoleChatMessage | None:
         """Return the most recent assistant message in ``session_id``, if any."""
         try:
@@ -4152,10 +4141,7 @@ class ConsoleChatController:
         return None
 
     def _complete_agent_message(
-        self,
-        assistant_message_id: str,
-        variant_mode: bool,
-        outcome: Any,
+        self, assistant_message_id: str, variant_mode: bool, outcome: Any,
     ) -> ConsoleChatMessage:
         """Finalize a placeholder, applying the empty-final-text fallback.
 
@@ -4173,11 +4159,7 @@ class ConsoleChatController:
         return self.store.mark_message_complete(assistant_message_id)
 
     def _finalize_agent_cancelled(
-        self,
-        assistant_message_id: str,
-        session_id: str,
-        *,
-        variant_mode: bool,
+        self, assistant_message_id: str, session_id: str, *, variant_mode: bool,
         run_id: str | None = None,
     ) -> ConsoleSubmitResult:
         """Handle a ``RUN_CANCELLED`` outcome: the placeholder becomes ``failed``.
@@ -4191,9 +4173,7 @@ class ConsoleChatController:
         ordinal fallback -- see ``_record_run_assistant_message``).
         """
         visible_copy = "Response stopped/cancelled."
-        placeholder = self._ensure_assistant_placeholder(
-            assistant_message_id, session_id
-        )
+        placeholder = self._ensure_assistant_placeholder(assistant_message_id, session_id)
         if placeholder is not None:
             failed = self.store.mark_message_failed(assistant_message_id)
         else:
@@ -4203,13 +4183,8 @@ class ConsoleChatController:
         return ConsoleSubmitResult(True, True, failed.content)
 
     def _finalize_agent_failure(
-        self,
-        assistant_message_id: str,
-        session_id: str,
-        outcome: Any,
-        *,
-        variant_mode: bool,
-        run_id: str | None = None,
+        self, assistant_message_id: str, session_id: str, outcome: Any,
+        *, variant_mode: bool, run_id: str | None = None,
     ) -> ConsoleSubmitResult:
         """Handle ``RUN_ERROR``, ``RUN_STUCK``, or any unknown non-done outcome.
 
@@ -4230,9 +4205,7 @@ class ConsoleChatController:
             self._session_history_carries_images(session_id)
         ):
             visible_copy += self._IMAGE_REJECTION_RECOVERY_HINT
-        placeholder = self._ensure_assistant_placeholder(
-            assistant_message_id, session_id
-        )
+        placeholder = self._ensure_assistant_placeholder(assistant_message_id, session_id)
         if placeholder is not None:
             failed = self.store.mark_message_failed(assistant_message_id)
             self._record_run_assistant_message(run_id, failed)
@@ -4241,10 +4214,7 @@ class ConsoleChatController:
             return ConsoleSubmitResult(True, True, failed.content)
 
         runtime_written = self._find_runtime_written_assistant(session_id)
-        if runtime_written is not None and runtime_written.status in {
-            "pending",
-            "streaming",
-        }:
+        if runtime_written is not None and runtime_written.status in {"pending", "streaming"}:
             self.store.append_stream_chunk(runtime_written.id, f"\n\n{visible_copy}")
             failed = self.store.mark_message_failed(runtime_written.id)
         else:
@@ -4254,13 +4224,8 @@ class ConsoleChatController:
         return ConsoleSubmitResult(True, True, failed.content)
 
     def _finalize_agent_success(
-        self,
-        assistant_message_id: str,
-        session_id: str,
-        outcome: Any,
-        *,
-        variant_mode: bool,
-        run_id: str | None = None,
+        self, assistant_message_id: str, session_id: str, outcome: Any,
+        *, variant_mode: bool, run_id: str | None = None,
     ) -> ConsoleSubmitResult:
         """Handle ``RUN_DONE``: complete the placeholder (or a runtime-written one).
 
@@ -4274,47 +4239,29 @@ class ConsoleChatController:
         ``_record_run_assistant_message`` -- the load-bearing correction of
         the native id ``create_run`` recorded, which resume anchors markers by.
         """
-        placeholder = self._ensure_assistant_placeholder(
-            assistant_message_id, session_id
-        )
+        placeholder = self._ensure_assistant_placeholder(assistant_message_id, session_id)
         if placeholder is not None:
-            completed = self._complete_agent_message(
-                assistant_message_id, variant_mode, outcome
-            )
+            completed = self._complete_agent_message(assistant_message_id, variant_mode, outcome)
             self._record_run_assistant_message(run_id, completed)
-            self._set_run_state(
-                ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete.")
-            )
+            self._set_run_state(ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete."))
             return ConsoleSubmitResult(True, True, completed.content)
 
         runtime_written = self._find_runtime_written_assistant(session_id)
-        if runtime_written is not None and runtime_written.status in {
-            "pending",
-            "streaming",
-        }:
-            completed = self._complete_agent_message(
-                runtime_written.id, variant_mode=False, outcome=outcome
-            )
+        if runtime_written is not None and runtime_written.status in {"pending", "streaming"}:
+            completed = self._complete_agent_message(runtime_written.id, variant_mode=False, outcome=outcome)
             self._record_run_assistant_message(run_id, completed)
-            self._set_run_state(
-                ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete.")
-            )
+            self._set_run_state(ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete."))
             return ConsoleSubmitResult(True, True, completed.content)
 
         final_text = getattr(outcome, "final_text", "") or "No response was generated."
         completed = self.store.append_message(
-            session_id, role=ConsoleMessageRole.ASSISTANT, content=final_text
-        )
+            session_id, role=ConsoleMessageRole.ASSISTANT, content=final_text)
         self._record_run_assistant_message(run_id, completed)
-        self._set_run_state(
-            ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete.")
-        )
+        self._set_run_state(ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete."))
         return ConsoleSubmitResult(True, True, completed.content)
 
     def _record_run_assistant_message(
-        self,
-        run_id: str | None,
-        completed: ConsoleChatMessage,
+        self, run_id: str | None, completed: ConsoleChatMessage,
     ) -> None:
         """Write the completed reply's PERSISTED id onto the agent run.
 
@@ -4356,7 +4303,9 @@ class ConsoleChatController:
         if self._agent_bridge is None:
             return None
         try:
-            return self._agent_bridge.latest_unanchored_primary_run_id(conversation_id)
+            return self._agent_bridge.latest_unanchored_primary_run_id(
+                conversation_id
+            )
         except Exception:  # noqa: BLE001 -- bookkeeping must never fail the stop
             logger.opt(exception=True).warning(
                 "failed to look up unanchored primary run for stop recording",
@@ -4365,9 +4314,7 @@ class ConsoleChatController:
             return None
 
     def _append_failed_assistant(
-        self,
-        session_id: str,
-        visible_copy: str,
+        self, session_id: str, visible_copy: str,
     ) -> ConsoleChatMessage:
         """Append a failed assistant message carrying ``visible_copy``.
 
@@ -4376,8 +4323,7 @@ class ConsoleChatController:
         streamed in, and then it is marked failed.
         """
         message = self.store.append_message(
-            session_id, role=ConsoleMessageRole.ASSISTANT, content=""
-        )
+            session_id, role=ConsoleMessageRole.ASSISTANT, content="")
         self.store.append_stream_chunk(message.id, visible_copy)
         return self.store.mark_message_failed(message.id)
 
@@ -4536,9 +4482,7 @@ class ConsoleChatController:
             if message.id == message_id:
                 break
         return self._leading_system_message() + self._provider_message_payloads(
-            collected,
-            skip_failed=False,
-            use_variant_content=True,
+            collected, skip_failed=False, use_variant_content=True,
             annotate_ids=annotate_ids,
         )
 

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -3388,7 +3388,8 @@ class ConsoleChatController:
             raise
         except Exception:
             logger.error(
-                "Console RAG capture unavailable; reason=capture_provider_failure"
+                "Console RAG capture unavailable; "
+                f"reason=capture_provider_failure; draft_length={len(draft)}"
             )
             return None, None, None
         captured_context = getattr(captured, "context", None)

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -9,6 +9,7 @@ import threading
 import time
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Protocol
 from uuid import uuid4
 
@@ -29,7 +30,16 @@ from tldw_chatbook.Chat.console_chat_models import (
     derive_console_session_title,
     is_default_console_session_title,
 )
-from tldw_chatbook.Chat.console_chat_store import ConsoleChatSession, ConsoleChatStore
+from tldw_chatbook.Chat.citation_trace_builder import (
+    CitationTraceBuilder,
+    CitationTraceBuildUnavailable,
+)
+from tldw_chatbook.Chat.citation_trace_models import SealedCitationWrite
+from tldw_chatbook.Chat.console_chat_store import (
+    ConsoleChatSession,
+    ConsoleChatStore,
+    TerminalCitationFinalizer,
+)
 from tldw_chatbook.Chat.console_command_grammar import COMMAND_PREFIX
 from tldw_chatbook.Chat.console_history_budget import (
     DEFAULT_RESPONSE_RESERVATION,
@@ -427,9 +437,7 @@ def build_tool_review_hook(
         decisions = request_approvals(all_pending)
         if mcp_provider is not None:
             mcp_decisions = {
-                name: decisions[name]
-                for name in mcp_claimed_names
-                if name in decisions
+                name: decisions[name] for name in mcp_claimed_names if name in decisions
             }
             mcp_provider.apply_batch_decisions(mcp_decisions)
         for row in builtin_pending:
@@ -768,7 +776,10 @@ class ConsoleChatController:
 
         if pendings:
             self.store.clear_pending_attachments(session.id)
-        citation_trace_builder = None
+        citation_context: str | None = None
+        citation_trace_builder: CitationTraceBuilder | None = None
+        prompt_evidence_set_id: str | None = None
+        terminal_citation_finalizer: TerminalCitationFinalizer | None = None
         try:
             provider_messages = self._provider_messages_for_session(
                 session.id, annotate_ids=True
@@ -792,9 +803,11 @@ class ConsoleChatController:
                 self.store.append_message(
                     session.id, role=ConsoleMessageRole.SYSTEM, content=note
                 )
-            citation_context, citation_trace_builder = await self._capture_rag_context(
-                clean_draft
-            )
+            (
+                citation_context,
+                citation_trace_builder,
+                prompt_evidence_set_id,
+            ) = await self._capture_rag_context(clean_draft)
             if citation_context and citation_trace_builder is None:
                 provider_messages = self._prepend_evidence_context(
                     provider_messages,
@@ -812,6 +825,11 @@ class ConsoleChatController:
                     citation_context,
                 )
             prefill, prefill_from_one_shot = self._resolve_submit_prefill(session.id)
+            terminal_citation_finalizer = self._build_terminal_citation_finalizer(
+                context=citation_context,
+                builder=citation_trace_builder,
+                prompt_evidence_set_id=prompt_evidence_set_id,
+            )
         except BaseException:
             # Any failure between the optimistic echo and the confirmed turn
             # (dictionary/world-info application, prefill resolution) must also
@@ -834,13 +852,15 @@ class ConsoleChatController:
         # echo to durable storage now (creating the conversation), BEFORE the
         # assistant row, so a reload shows the user's prompt ahead of its reply.
         self.store.persist_message_if_needed(echoed_user.id)
-        assistant = self.store.append_message(
-            session.id,
-            role=ConsoleMessageRole.ASSISTANT,
-            content="",
-            persist=self.store.persistence is not None,
-        )
+        assistant: ConsoleChatMessage | None = None
         try:
+            assistant = self.store.append_message(
+                session.id,
+                role=ConsoleMessageRole.ASSISTANT,
+                content="",
+                persist=self.store.persistence is not None,
+                terminal_citation_finalizer=terminal_citation_finalizer,
+            )
             return await self._stream_assistant_response(
                 resolution=resolution,
                 provider_messages=provider_messages,
@@ -851,6 +871,9 @@ class ConsoleChatController:
                 skill_bundle_block=skill_bundle_block,
             )
         finally:
+            if assistant is not None:
+                self.store.clear_terminal_citation_state(assistant.id)
+            del terminal_citation_finalizer
             del citation_trace_builder
 
     def new_session(
@@ -878,7 +901,9 @@ class ConsoleChatController:
             return
         derived = derive_console_session_title(draft)
         if derived:
-            self.store.rename_session(session.id, derived)  # (session, persisted) — auto-title best-effort
+            self.store.rename_session(
+                session.id, derived
+            )  # (session, persisted) — auto-title best-effort
 
     def update_provider_selection(self, selection: ConsoleProviderSelection) -> None:
         """Sync controller provider settings from a Console selection."""
@@ -1731,9 +1756,7 @@ class ConsoleChatController:
         provider_messages = await self._apply_chat_dictionaries(
             provider_messages, session_id
         )
-        provider_messages = await self._apply_world_info(
-            provider_messages, session_id
-        )
+        provider_messages = await self._apply_world_info(provider_messages, session_id)
         prefill = self._pinned_prefill_for_session(session_id)
         return await self._stream_assistant_response(
             resolution=resolution,
@@ -1801,9 +1824,7 @@ class ConsoleChatController:
         provider_messages = await self._apply_chat_dictionaries(
             provider_messages, session_id
         )
-        provider_messages = await self._apply_world_info(
-            provider_messages, session_id
-        )
+        provider_messages = await self._apply_world_info(provider_messages, session_id)
         assistant = self.store.append_message(
             session_id,
             role=ConsoleMessageRole.ASSISTANT,
@@ -1906,9 +1927,7 @@ class ConsoleChatController:
         provider_messages = await self._apply_chat_dictionaries(
             provider_messages, session_id
         )
-        provider_messages = await self._apply_world_info(
-            provider_messages, session_id
-        )
+        provider_messages = await self._apply_world_info(provider_messages, session_id)
         prefill = self._pinned_prefill_for_session(session_id)
         new_message = self.store.create_sibling(
             message_id,
@@ -2089,14 +2108,20 @@ class ConsoleChatController:
             ]
             transcript_text = "\n".join(lines)
             if prior_summary:
-                return f"[Previous summary]\n{prior_summary}\n\n{transcript_text}".rstrip()
+                return (
+                    f"[Previous summary]\n{prior_summary}\n\n{transcript_text}".rstrip()
+                )
             return transcript_text
 
         rows = list(span)
         body = assemble(rows)
-        while len(rows) > 1 and count_console_messages_tokens(
-            [{"role": "user", "content": body}], model
-        ) > self._SUMMARY_SPAN_TOKEN_BUDGET:
+        while (
+            len(rows) > 1
+            and count_console_messages_tokens(
+                [{"role": "user", "content": body}], model
+            )
+            > self._SUMMARY_SPAN_TOKEN_BUDGET
+        ):
             rows = rows[1:]
             body = assemble(rows)
         return body
@@ -2285,9 +2310,7 @@ class ConsoleChatController:
         provider_messages = await self._apply_chat_dictionaries(
             provider_messages, session_id
         )
-        provider_messages = await self._apply_world_info(
-            provider_messages, session_id
-        )
+        provider_messages = await self._apply_world_info(provider_messages, session_id)
         prefill = self._pinned_prefill_for_session(session_id)
 
         # Every transform succeeded: now (and only now) fork the edited USER
@@ -2381,7 +2404,9 @@ class ConsoleChatController:
             )
 
             # Chat dictionaries are safe to apply (string replacements only).
-            provider_messages = await self._apply_chat_dictionaries(provider_messages, session_id)
+            provider_messages = await self._apply_chat_dictionaries(
+                provider_messages, session_id
+            )
 
             # task-548: mirror the dispatch choke point's boundary-summary
             # compaction so the preview matches what is actually sent when a
@@ -2416,7 +2441,9 @@ class ConsoleChatController:
                 ]
 
             # Replace image data with placeholders for the preview, including historical images.
-            provider_messages = self._replace_image_data_with_placeholders(provider_messages)
+            provider_messages = self._replace_image_data_with_placeholders(
+                provider_messages
+            )
 
             # Gather native tool schemas and MCP note.
             tools_info = self._build_tools_info_for_snapshot()
@@ -2504,7 +2531,9 @@ class ConsoleChatController:
             )
 
     @staticmethod
-    def _replace_image_data_with_placeholders(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def _replace_image_data_with_placeholders(
+        messages: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
         result = copy.deepcopy(messages)
 
         def _is_data_url(value: Any) -> bool:
@@ -2536,7 +2565,9 @@ class ConsoleChatController:
                     if not isinstance(part, dict):
                         continue
                     if part.get("type") == "image_url":
-                        part["image_url"] = _redact_image_url_value(part.get("image_url"))
+                        part["image_url"] = _redact_image_url_value(
+                            part.get("image_url")
+                        )
                     if part.get("type") == "image":
                         # Anthropic-style image parts use a ``source`` dict with
                         # base64 data; preserve the surrounding structure.
@@ -2606,9 +2637,7 @@ class ConsoleChatController:
             tools = self._agent_bridge.native_tool_schemas()
         mcp_note: str | None = None
         if self._mcp_provider:
-            mcp_note = (
-                "MCP tools are configured but live catalog composition is not shown in this preview."
-            )
+            mcp_note = "MCP tools are configured but live catalog composition is not shown in this preview."
         if tools:
             preview_note = (
                 "This preview shows only builtin native tools. "
@@ -2622,15 +2651,20 @@ class ConsoleChatController:
             "preview_note": preview_note,
         }
 
-    _SECRET_REDACTION_KEYS = {"api_key", "apikey", "token", "password", "secret", "bearer"}
+    _SECRET_REDACTION_KEYS = {
+        "api_key",
+        "apikey",
+        "token",
+        "password",
+        "secret",
+        "bearer",
+    }
     _SECRET_REDACTION_KEYS_NORMALIZED = {
         k.replace("-", "").replace("_", "") for k in _SECRET_REDACTION_KEYS
     }
     _SECRET_REDACTION_PATTERN = re.compile(
         r"(?P<open_quote>[\"']?)"
-        r"(?P<key>"
-        + "|".join(re.escape(k) for k in _SECRET_REDACTION_KEYS)
-        + r")"
+        r"(?P<key>" + "|".join(re.escape(k) for k in _SECRET_REDACTION_KEYS) + r")"
         r"(?P=open_quote)"
         r"(?P<sep>\s*[:=]\s*)"
         r"(?P<value>"
@@ -2665,7 +2699,9 @@ class ConsoleChatController:
                 sep = match.group("sep")
                 return f"{open_quote}{key}{open_quote}{sep}{redacted_value}"
 
-            return ConsoleChatController._SECRET_REDACTION_PATTERN.sub(_replace_value, value)
+            return ConsoleChatController._SECRET_REDACTION_PATTERN.sub(
+                _replace_value, value
+            )
 
         def _matches_secret_key(key: str) -> bool:
             """Return True when ``key`` matches or ends with a secret word.
@@ -2801,9 +2837,7 @@ class ConsoleChatController:
 
     async def _apply_skill_substitution(
         self, provider_messages: list[dict[str, Any]]
-    ) -> tuple[
-        list[dict[str, Any]], str | None, tuple[str, ...], tuple[str, ...], str
-    ]:
+    ) -> tuple[list[dict[str, Any]], str | None, tuple[str, ...], tuple[str, ...], str]:
         """Render-fresh the triggering turn's skill mention(s) at payload build time.
 
         Spec: "Invocation semantics" §5 (the substitution rule) -- one rule
@@ -3034,9 +3068,7 @@ class ConsoleChatController:
                 result.get("execution_mode") if isinstance(result, Mapping) else None
             )
             rendered = (
-                result.get("rendered_prompt", "")
-                if isinstance(result, Mapping)
-                else ""
+                result.get("rendered_prompt", "") if isinstance(result, Mapping) else ""
             )
             # Fork (or anything non-inline) cannot splice in place: leave
             # the mention literal, no note (this is not a trust failure).
@@ -3348,12 +3380,15 @@ class ConsoleChatController:
             visible_copy=visible_copy,
         )
 
-    async def _capture_rag_context(self, draft: str) -> tuple[str | None, Any | None]:
+    async def _capture_rag_context(
+        self,
+        draft: str,
+    ) -> tuple[str | None, CitationTraceBuilder | None, str | None]:
         """Resolve optional staged RAG context without exposing request state."""
 
         provider = self._rag_capture_provider
         if provider is None:
-            return None, None
+            return None, None, None
         try:
             captured = await provider(draft)
         except asyncio.CancelledError:
@@ -3362,12 +3397,70 @@ class ConsoleChatController:
             logger.error(
                 "Console RAG capture unavailable; reason=capture_provider_failure"
             )
-            return None, None
-        context = getattr(captured, "context", None)
-        builder = getattr(captured, "citation_builder", None)
-        if not isinstance(context, str) or not context.strip():
-            return None, builder
-        return context, builder
+            return None, None, None
+        captured_context = getattr(captured, "context", None)
+        context = (
+            captured_context
+            if isinstance(captured_context, str) and captured_context.strip()
+            else None
+        )
+        captured_builder = getattr(captured, "citation_builder", None)
+        builder = (
+            captured_builder
+            if isinstance(captured_builder, CitationTraceBuilder)
+            else None
+        )
+        captured_prompt_id = getattr(captured, "prompt_evidence_set_id", None)
+        prompt_evidence_set_id = (
+            captured_prompt_id
+            if isinstance(captured_prompt_id, str) and captured_prompt_id.strip()
+            else None
+        )
+        return context, builder, prompt_evidence_set_id
+
+    @staticmethod
+    def _build_terminal_citation_finalizer(
+        *,
+        context: str | None,
+        builder: CitationTraceBuilder | None,
+        prompt_evidence_set_id: str | None,
+    ) -> TerminalCitationFinalizer | None:
+        """Build exact-body citation finalization for one eligible initial send."""
+
+        if (
+            not isinstance(context, str)
+            or not context.strip()
+            or not isinstance(builder, CitationTraceBuilder)
+            or not isinstance(prompt_evidence_set_id, str)
+            or not prompt_evidence_set_id.strip()
+        ):
+            return None
+
+        def finalize(answer_body: str) -> SealedCitationWrite | None:
+            terminal_at = datetime.now(UTC)
+            try:
+                attempt_id = builder.record_initial_answer_attempt(
+                    prompt_evidence_set_id=prompt_evidence_set_id,
+                    answer_body=answer_body,
+                    completed_at=terminal_at,
+                )
+                return builder.seal(
+                    selected_attempt_id=attempt_id,
+                    sealed_at=terminal_at,
+                )
+            except CitationTraceBuildUnavailable:
+                logger.warning(
+                    "Console citation finalization unavailable; "
+                    "reason=occurrence_mapping_unavailable"
+                )
+            except Exception:
+                logger.warning(
+                    "Console citation finalization unavailable; "
+                    "reason=attempt_or_seal_failure"
+                )
+            return None
+
+        return finalize
 
     @staticmethod
     def _prepend_evidence_context(
@@ -3380,8 +3473,7 @@ class ConsoleChatController:
             (
                 index
                 for index in range(len(provider_messages) - 1, -1, -1)
-                if provider_messages[index].get("role")
-                == ConsoleMessageRole.USER.value
+                if provider_messages[index].get("role") == ConsoleMessageRole.USER.value
             ),
             None,
         )
@@ -3499,9 +3591,7 @@ class ConsoleChatController:
             owner_id = self.store.session_id_for_message(assistant_message_id)
         except KeyError:
             return self._session_closed_result()
-        owner = next(
-            (s for s in self.store.sessions() if s.id == owner_id), None
-        )
+        owner = next((s for s in self.store.sessions() if s.id == owner_id), None)
         # task-427: a character session always takes the plain-provider
         # path, even with the global agent runtime enabled and a bridge
         # present. Keyed on the message's OWNING session (looked up here,
@@ -3604,9 +3694,7 @@ class ConsoleChatController:
                         )
                     except KeyError:
                         return self._session_closed_result()
-                    self._consume_one_shot_prefill(
-                        assistant_message_id, one_shot_used
-                    )
+                    self._consume_one_shot_prefill(assistant_message_id, one_shot_used)
                     return ConsoleSubmitResult(True, True, stopped.content)
                 if prepare_retry and not retry_prepared:
                     self.store.prepare_message_retry(assistant_message_id)
@@ -3634,9 +3722,7 @@ class ConsoleChatController:
                     )
                 except KeyError:
                     return self._session_closed_result()
-                self._consume_one_shot_prefill(
-                    assistant_message_id, one_shot_used
-                )
+                self._consume_one_shot_prefill(assistant_message_id, one_shot_used)
                 return ConsoleSubmitResult(True, True, stopped.content)
             if not emitted_content:
                 try:
@@ -3678,9 +3764,7 @@ class ConsoleChatController:
                     )
                 except KeyError:
                     return self._session_closed_result()
-                self._consume_one_shot_prefill(
-                    assistant_message_id, one_shot_used
-                )
+                self._consume_one_shot_prefill(assistant_message_id, one_shot_used)
                 return ConsoleSubmitResult(True, True, stopped.content)
             raise
         except Exception as exc:
@@ -3908,11 +3992,9 @@ class ConsoleChatController:
             # preserves whatever partial content already streamed
             # otherwise).
             visible_copy = f"Agent run failed: {describe_stream_failure(exc)}"
-            if (
-                getattr(getattr(exc, "response", None), "status_code", None)
-                is not None
-                and self._session_history_carries_images(session_id)
-            ):
+            if getattr(
+                getattr(exc, "response", None), "status_code", None
+            ) is not None and self._session_history_carries_images(session_id):
                 visible_copy += self._IMAGE_REJECTION_RECOVERY_HINT
             try:
                 self.store.mark_message_failed(assistant_message_id)
@@ -3994,9 +4076,8 @@ class ConsoleChatController:
         # prior status for a regenerate, "stopped" for a plain send) and
         # the variant base (already popped), so this is a benign no-op
         # read-back, never an error, in either case.
-        stopped_now = (
-            (current is not None and current.status == "stopped")
-            or (cancel_event is not None and cancel_event.is_set())
+        stopped_now = (current is not None and current.status == "stopped") or (
+            cancel_event is not None and cancel_event.is_set()
         )
         if stopped_now:
             # The stopped message was already persisted by
@@ -4011,24 +4092,39 @@ class ConsoleChatController:
             self._set_run_state(
                 ConsoleRunState(ConsoleRunStatus.STOPPED, "Response stopped.")
             )
-            return ConsoleSubmitResult(True, True, current.content if current is not None else "")
+            return ConsoleSubmitResult(
+                True, True, current.content if current is not None else ""
+            )
 
         if outcome.status == RUN_CANCELLED:
             return self._finalize_agent_cancelled(
-                assistant_message_id, session_id, variant_mode=variant_mode,
-                run_id=run_id)
+                assistant_message_id,
+                session_id,
+                variant_mode=variant_mode,
+                run_id=run_id,
+            )
 
         if outcome.status != RUN_DONE:
             return self._finalize_agent_failure(
-                assistant_message_id, session_id, outcome, variant_mode=variant_mode,
-                run_id=run_id)
+                assistant_message_id,
+                session_id,
+                outcome,
+                variant_mode=variant_mode,
+                run_id=run_id,
+            )
 
         return self._finalize_agent_success(
-            assistant_message_id, session_id, outcome,
-            variant_mode=variant_mode, run_id=run_id)
+            assistant_message_id,
+            session_id,
+            outcome,
+            variant_mode=variant_mode,
+            run_id=run_id,
+        )
 
     def _ensure_assistant_placeholder(
-        self, assistant_message_id: str, session_id: str,
+        self,
+        assistant_message_id: str,
+        session_id: str,
     ) -> ConsoleChatMessage | None:
         """Return the assistant placeholder message if it still exists.
 
@@ -4042,7 +4138,8 @@ class ConsoleChatController:
             return None
 
     def _find_runtime_written_assistant(
-        self, session_id: str,
+        self,
+        session_id: str,
     ) -> ConsoleChatMessage | None:
         """Return the most recent assistant message in ``session_id``, if any."""
         try:
@@ -4055,7 +4152,10 @@ class ConsoleChatController:
         return None
 
     def _complete_agent_message(
-        self, assistant_message_id: str, variant_mode: bool, outcome: Any,
+        self,
+        assistant_message_id: str,
+        variant_mode: bool,
+        outcome: Any,
     ) -> ConsoleChatMessage:
         """Finalize a placeholder, applying the empty-final-text fallback.
 
@@ -4063,13 +4163,21 @@ class ConsoleChatController:
         existing persistence/validation paths stay unchanged.
         """
         if not getattr(outcome, "final_text", ""):
-            self.store.append_stream_chunk(assistant_message_id, "No response was generated.")
+            self.store.clear_terminal_citation_state(assistant_message_id)
+            self.store.append_stream_chunk(
+                assistant_message_id,
+                "No response was generated.",
+            )
         if variant_mode:
             return self.store.finalize_variant_stream(assistant_message_id)
         return self.store.mark_message_complete(assistant_message_id)
 
     def _finalize_agent_cancelled(
-        self, assistant_message_id: str, session_id: str, *, variant_mode: bool,
+        self,
+        assistant_message_id: str,
+        session_id: str,
+        *,
+        variant_mode: bool,
         run_id: str | None = None,
     ) -> ConsoleSubmitResult:
         """Handle a ``RUN_CANCELLED`` outcome: the placeholder becomes ``failed``.
@@ -4083,7 +4191,9 @@ class ConsoleChatController:
         ordinal fallback -- see ``_record_run_assistant_message``).
         """
         visible_copy = "Response stopped/cancelled."
-        placeholder = self._ensure_assistant_placeholder(assistant_message_id, session_id)
+        placeholder = self._ensure_assistant_placeholder(
+            assistant_message_id, session_id
+        )
         if placeholder is not None:
             failed = self.store.mark_message_failed(assistant_message_id)
         else:
@@ -4093,8 +4203,13 @@ class ConsoleChatController:
         return ConsoleSubmitResult(True, True, failed.content)
 
     def _finalize_agent_failure(
-        self, assistant_message_id: str, session_id: str, outcome: Any,
-        *, variant_mode: bool, run_id: str | None = None,
+        self,
+        assistant_message_id: str,
+        session_id: str,
+        outcome: Any,
+        *,
+        variant_mode: bool,
+        run_id: str | None = None,
     ) -> ConsoleSubmitResult:
         """Handle ``RUN_ERROR``, ``RUN_STUCK``, or any unknown non-done outcome.
 
@@ -4115,7 +4230,9 @@ class ConsoleChatController:
             self._session_history_carries_images(session_id)
         ):
             visible_copy += self._IMAGE_REJECTION_RECOVERY_HINT
-        placeholder = self._ensure_assistant_placeholder(assistant_message_id, session_id)
+        placeholder = self._ensure_assistant_placeholder(
+            assistant_message_id, session_id
+        )
         if placeholder is not None:
             failed = self.store.mark_message_failed(assistant_message_id)
             self._record_run_assistant_message(run_id, failed)
@@ -4124,7 +4241,10 @@ class ConsoleChatController:
             return ConsoleSubmitResult(True, True, failed.content)
 
         runtime_written = self._find_runtime_written_assistant(session_id)
-        if runtime_written is not None and runtime_written.status in {"pending", "streaming"}:
+        if runtime_written is not None and runtime_written.status in {
+            "pending",
+            "streaming",
+        }:
             self.store.append_stream_chunk(runtime_written.id, f"\n\n{visible_copy}")
             failed = self.store.mark_message_failed(runtime_written.id)
         else:
@@ -4134,8 +4254,13 @@ class ConsoleChatController:
         return ConsoleSubmitResult(True, True, failed.content)
 
     def _finalize_agent_success(
-        self, assistant_message_id: str, session_id: str, outcome: Any,
-        *, variant_mode: bool, run_id: str | None = None,
+        self,
+        assistant_message_id: str,
+        session_id: str,
+        outcome: Any,
+        *,
+        variant_mode: bool,
+        run_id: str | None = None,
     ) -> ConsoleSubmitResult:
         """Handle ``RUN_DONE``: complete the placeholder (or a runtime-written one).
 
@@ -4149,29 +4274,47 @@ class ConsoleChatController:
         ``_record_run_assistant_message`` -- the load-bearing correction of
         the native id ``create_run`` recorded, which resume anchors markers by.
         """
-        placeholder = self._ensure_assistant_placeholder(assistant_message_id, session_id)
+        placeholder = self._ensure_assistant_placeholder(
+            assistant_message_id, session_id
+        )
         if placeholder is not None:
-            completed = self._complete_agent_message(assistant_message_id, variant_mode, outcome)
+            completed = self._complete_agent_message(
+                assistant_message_id, variant_mode, outcome
+            )
             self._record_run_assistant_message(run_id, completed)
-            self._set_run_state(ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete."))
+            self._set_run_state(
+                ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete.")
+            )
             return ConsoleSubmitResult(True, True, completed.content)
 
         runtime_written = self._find_runtime_written_assistant(session_id)
-        if runtime_written is not None and runtime_written.status in {"pending", "streaming"}:
-            completed = self._complete_agent_message(runtime_written.id, variant_mode=False, outcome=outcome)
+        if runtime_written is not None and runtime_written.status in {
+            "pending",
+            "streaming",
+        }:
+            completed = self._complete_agent_message(
+                runtime_written.id, variant_mode=False, outcome=outcome
+            )
             self._record_run_assistant_message(run_id, completed)
-            self._set_run_state(ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete."))
+            self._set_run_state(
+                ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete.")
+            )
             return ConsoleSubmitResult(True, True, completed.content)
 
         final_text = getattr(outcome, "final_text", "") or "No response was generated."
         completed = self.store.append_message(
-            session_id, role=ConsoleMessageRole.ASSISTANT, content=final_text)
+            session_id, role=ConsoleMessageRole.ASSISTANT, content=final_text
+        )
         self._record_run_assistant_message(run_id, completed)
-        self._set_run_state(ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete."))
+        self._set_run_state(
+            ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete.")
+        )
         return ConsoleSubmitResult(True, True, completed.content)
 
     def _record_run_assistant_message(
-        self, run_id: str | None, completed: ConsoleChatMessage,
+        self,
+        run_id: str | None,
+        completed: ConsoleChatMessage,
     ) -> None:
         """Write the completed reply's PERSISTED id onto the agent run.
 
@@ -4213,9 +4356,7 @@ class ConsoleChatController:
         if self._agent_bridge is None:
             return None
         try:
-            return self._agent_bridge.latest_unanchored_primary_run_id(
-                conversation_id
-            )
+            return self._agent_bridge.latest_unanchored_primary_run_id(conversation_id)
         except Exception:  # noqa: BLE001 -- bookkeeping must never fail the stop
             logger.opt(exception=True).warning(
                 "failed to look up unanchored primary run for stop recording",
@@ -4224,7 +4365,9 @@ class ConsoleChatController:
             return None
 
     def _append_failed_assistant(
-        self, session_id: str, visible_copy: str,
+        self,
+        session_id: str,
+        visible_copy: str,
     ) -> ConsoleChatMessage:
         """Append a failed assistant message carrying ``visible_copy``.
 
@@ -4233,7 +4376,8 @@ class ConsoleChatController:
         streamed in, and then it is marked failed.
         """
         message = self.store.append_message(
-            session_id, role=ConsoleMessageRole.ASSISTANT, content="")
+            session_id, role=ConsoleMessageRole.ASSISTANT, content=""
+        )
         self.store.append_stream_chunk(message.id, visible_copy)
         return self.store.mark_message_failed(message.id)
 
@@ -4392,7 +4536,9 @@ class ConsoleChatController:
             if message.id == message_id:
                 break
         return self._leading_system_message() + self._provider_message_payloads(
-            collected, skip_failed=False, use_variant_content=True,
+            collected,
+            skip_failed=False,
+            use_variant_content=True,
             annotate_ids=annotate_ids,
         )
 

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -884,6 +884,7 @@ class ConsoleChatStore:
         self._active_leaf_by_session[session_id] = message.id
         self._recompute_active_path(session_id)
         if arm_terminal_citation:
+            assert terminal_citation_finalizer is not None
             self._terminal_citation_finalizers[message.id] = terminal_citation_finalizer
             self._terminal_persistence_deferred_ids.add(message.id)
         try:
@@ -2054,6 +2055,10 @@ class ConsoleChatStore:
     ) -> None:
         if self.persistence is None:
             return
+        if message.id in self._terminal_persistence_deferred_ids:
+            self._pending_persistence_message_ids.add(message.id)
+            self.persist_session_if_needed(session_id)
+            return
         if not message.content and not message.attachments:
             self._pending_persistence_message_ids.add(message.id)
             self.persist_session_if_needed(session_id)
@@ -2073,7 +2078,12 @@ class ConsoleChatStore:
             )
             return (
                 accepts_citation_write
-                and persistence.canonical_citation_writes_ready is True
+                and getattr(
+                    persistence,
+                    "canonical_citation_writes_ready",
+                    False,
+                )
+                is True
             )
         except Exception:
             return False

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -11,6 +11,10 @@ from uuid import uuid4
 from loguru import logger
 
 from tldw_chatbook.Chat.attachment_core import PendingAttachment
+from tldw_chatbook.Chat.citation_trace_models import SealedCitationWrite
+from tldw_chatbook.Chat.citation_trace_repository import (
+    CitationPersistenceUnavailable,
+)
 from tldw_chatbook.Chat.console_chat_models import (
     CONSOLE_GLOBAL_WORKSPACE_ID,
     DEFAULT_CONSOLE_SESSION_TITLE,
@@ -29,6 +33,8 @@ from tldw_chatbook.Chat.rag_scope import RagScope, SessionScopeHolder
 
 #: Maximum number of attachments a Console session may stage before send.
 MAX_PENDING_ATTACHMENTS = 5
+
+TerminalCitationFinalizer = Callable[[str], SealedCitationWrite | None]
 
 
 @dataclass(frozen=True)
@@ -74,6 +80,7 @@ class ConsoleChatPersistence(Protocol):
         parent_message_id: str | None = None,
         feedback: str | None = None,
         attachments: Sequence[Mapping[str, Any]] | None = None,
+        citation_write: SealedCitationWrite | None = None,
     ) -> str:
         """Create a persisted message and return its ID.
 
@@ -81,6 +88,10 @@ class ConsoleChatPersistence(Protocol):
         authoritative over the scalar ``image_data``/``image_mime_type``
         kwargs; ``None`` leaves the pre-split legacy behavior unchanged.
         Optional: fakes used in tests may omit this parameter entirely.
+
+        ``citation_write``, when present, is committed atomically with the
+        message by citation-aware adapters. Narrow test fakes may omit this
+        optional parameter entirely.
         """
 
     def update_message_content(
@@ -298,6 +309,8 @@ class ConsoleChatStore:
         #: None)`` = no summary. Write-through is ``_persist_context_summary``.
         self._context_summary_by_session: dict[str, tuple[str | None, str | None]] = {}
         self._pending_persistence_message_ids: set[str] = set()
+        self._terminal_citation_finalizers: dict[str, TerminalCitationFinalizer] = {}
+        self._terminal_persistence_deferred_ids: set[str] = set()
         self._stream_chunks_by_message: dict[str, list[str]] = {}
         self._stream_materialized_counts: dict[str, int] = {}
         self._sync_v2_message_versions: dict[str, str] = {}
@@ -563,6 +576,7 @@ class ConsoleChatStore:
             if owner == session_id
         ]
         for message_id in owned_message_ids:
+            self.clear_terminal_citation_state(message_id)
             self._message_session_index.pop(message_id, None)
             self._stream_chunks_by_message.pop(message_id, None)
             self._stream_materialized_counts.pop(message_id, None)
@@ -755,6 +769,8 @@ class ConsoleChatStore:
         self._messages_by_session.clear()
         self._message_session_index.clear()
         self._pending_persistence_message_ids.clear()
+        self._terminal_citation_finalizers.clear()
+        self._terminal_persistence_deferred_ids.clear()
         self._stream_chunks_by_message.clear()
         self._stream_materialized_counts.clear()
         self._sync_v2_message_versions.clear()
@@ -818,6 +834,7 @@ class ConsoleChatStore:
         image_data: bytes | None = None,
         image_mime_type: str | None = None,
         attachment_label: str | None = None,
+        terminal_citation_finalizer: TerminalCitationFinalizer | None = None,
     ) -> ConsoleChatMessage:
         """Append a message; scalar image kwargs become a one-item tuple."""
         self._session_or_raise(session_id)
@@ -831,6 +848,19 @@ class ConsoleChatStore:
                     position=0,
                 ),
             )
+        if terminal_citation_finalizer is not None:
+            if not callable(terminal_citation_finalizer):
+                raise ValueError("terminal_citation_finalizer must be callable")
+            if role is not ConsoleMessageRole.ASSISTANT or content != "" or effective:
+                raise ValueError(
+                    "terminal_citation_finalizer requires an empty, "
+                    "attachment-free assistant placeholder"
+                )
+        arm_terminal_citation = (
+            terminal_citation_finalizer is not None
+            and persist
+            and self._citation_persistence_ready()
+        )
         message = ConsoleChatMessage(
             role=role,
             content=content,
@@ -853,8 +883,18 @@ class ConsoleChatStore:
         self._register_tree_node(session_id, message, parent_native_id=old_leaf)
         self._active_leaf_by_session[session_id] = message.id
         self._recompute_active_path(session_id)
-        if persist:
-            self._persist_new_message_or_defer(session_id=session_id, message=message)
+        if arm_terminal_citation:
+            self._terminal_citation_finalizers[message.id] = terminal_citation_finalizer
+            self._terminal_persistence_deferred_ids.add(message.id)
+        try:
+            if persist:
+                self._persist_new_message_or_defer(
+                    session_id=session_id, message=message
+                )
+        except Exception:
+            if arm_terminal_citation:
+                self.clear_terminal_citation_state(message.id)
+            raise
         return self._snapshot(message)
 
     def create_sibling(
@@ -1252,6 +1292,7 @@ class ConsoleChatStore:
         # Purge the deleted node AND its whole subtree from every structure --
         # deleting a mid-conversation node drops the branch beneath it.
         for node_id in subtree_ids:
+            self.clear_terminal_citation_state(node_id)
             nodes.pop(node_id, None)
             children_map.pop(node_id, None)
             self._native_parent_by_message.pop(node_id, None)
@@ -1307,9 +1348,7 @@ class ConsoleChatStore:
         self._recompute_active_path(session_id)
         self._persist_active_leaf(session_id, message_id)
 
-    def session_context_summary(
-        self, session_id: str
-    ) -> tuple[str | None, str | None]:
+    def session_context_summary(self, session_id: str) -> tuple[str | None, str | None]:
         """Return the session's in-memory ``(summary, boundary_native_id)`` pair.
 
         Console `/rewind` "summarize up to here" (SP2). ``(None, None)`` when
@@ -1380,9 +1419,7 @@ class ConsoleChatStore:
         ids.reverse()
         return ids
 
-    def siblings_at(
-        self, message_id: str
-    ) -> tuple[list[ConsoleChatMessage], int, int]:
+    def siblings_at(self, message_id: str) -> tuple[list[ConsoleChatMessage], int, int]:
         """Return ``(ordered sibling snapshots, index of message_id, count)``.
 
         Siblings are the children of ``message_id``'s native parent, in creation
@@ -1480,9 +1517,45 @@ class ConsoleChatStore:
         message = self._message_or_raise(message_id)
         self._validate_can_mark_terminal(message)
         self._materialize_stream_buffer(message)
-        message.status = "complete"
-        self._persist_existing_message(message)
-        return self._snapshot(message)
+        finalizer = self._terminal_citation_finalizers.pop(message.id, None)
+        terminal_persistence = (
+            finalizer is not None
+            or message.id in self._terminal_persistence_deferred_ids
+        )
+        self._terminal_persistence_deferred_ids.discard(message.id)
+        if not terminal_persistence:
+            message.status = "complete"
+            self._persist_existing_message(message)
+            return self._snapshot(message)
+
+        try:
+            if not message.content:
+                message.status = "complete"
+                self._persist_existing_message(message)
+                return self._snapshot(message)
+
+            citation_write = None
+            if finalizer is not None:
+                try:
+                    citation_write = finalizer(message.content)
+                except Exception:
+                    logger.warning("terminal_finalizer_unavailable")
+            message.status = "complete"
+            session_id = self._message_session_index[message.id]
+            try:
+                self._persist_new_message(
+                    session_id=session_id,
+                    message=message,
+                    citation_write=citation_write,
+                    force_stable_message_id=True,
+                    terminal_persistence=True,
+                )
+            except Exception:
+                self._pending_persistence_message_ids.discard(message.id)
+                logger.warning("terminal_citation_persistence_abandoned")
+            return self._snapshot(message)
+        finally:
+            self.clear_terminal_citation_state(message.id)
 
     def mark_message_stopped(self, message_id: str) -> ConsoleChatMessage:
         """Mark a message stopped and flush final visible content to persistence.
@@ -1506,6 +1579,7 @@ class ConsoleChatStore:
         """
         message = self._message_or_raise(message_id)
         self._validate_can_mark_terminal(message)
+        self.clear_terminal_citation_state(message.id)
         self._materialize_stream_buffer(message)
         base = self._variant_stream_bases.pop(message.id, None)
         if base is not None:
@@ -1536,6 +1610,7 @@ class ConsoleChatStore:
         """
         message = self._message_or_raise(message_id)
         self._validate_can_mark_terminal(message)
+        self.clear_terminal_citation_state(message.id)
         self._materialize_stream_buffer(message)
         base = self._variant_stream_bases.pop(message.id, None)
         if base is not None:
@@ -1985,6 +2060,29 @@ class ConsoleChatStore:
             return
         self._persist_new_message(session_id=session_id, message=message)
 
+    def _citation_persistence_ready(self) -> bool:
+        """Return whether terminal citation writes can be accepted safely."""
+        persistence = self.persistence
+        if persistence is None:
+            return False
+        try:
+            parameters = inspect.signature(persistence.create_message).parameters
+            accepts_citation_write = "citation_write" in parameters or any(
+                parameter.kind is inspect.Parameter.VAR_KEYWORD
+                for parameter in parameters.values()
+            )
+            return (
+                accepts_citation_write
+                and persistence.canonical_citation_writes_ready is True
+            )
+        except Exception:
+            return False
+
+    def clear_terminal_citation_state(self, message_id: str) -> None:
+        """Clear transient terminal citation state without changing persistence."""
+        self._terminal_citation_finalizers.pop(message_id, None)
+        self._terminal_persistence_deferred_ids.discard(message_id)
+
     @staticmethod
     def _persistence_accepts_kwarg(func: Any, name: str) -> bool:
         """Return True when ``func`` can be called with keyword ``name``.
@@ -2043,7 +2141,13 @@ class ConsoleChatStore:
         return None
 
     def _persist_new_message(
-        self, *, session_id: str, message: ConsoleChatMessage
+        self,
+        *,
+        session_id: str,
+        message: ConsoleChatMessage,
+        citation_write: SealedCitationWrite | None = None,
+        force_stable_message_id: bool = False,
+        terminal_persistence: bool = False,
     ) -> None:
         if self.persistence is None:
             return
@@ -2071,7 +2175,9 @@ class ConsoleChatStore:
             # ``message.persisted_message_id`` straight through with no
             # separate id-translation bookkeeping. Every other message kind
             # keeps letting the DB assign its own id (unchanged).
-            message_id=message.id if message.generation_metadata else None,
+            message_id=message.id
+            if message.generation_metadata or force_stable_message_id
+            else None,
             parent_message_id=parent_persisted_id,
             feedback=message.feedback,
         )
@@ -2129,7 +2235,19 @@ class ConsoleChatStore:
                     message.attachments, message.generation_metadata
                 )
             ]
-        message.persisted_message_id = self.persistence.create_message(**create_kwargs)
+        if citation_write is not None:
+            create_kwargs["citation_write"] = citation_write
+        if terminal_persistence:
+            persisted_message_id = self._create_terminal_message(
+                create_kwargs=create_kwargs,
+                citation_write=citation_write,
+            )
+            if persisted_message_id is None:
+                self._pending_persistence_message_ids.discard(message.id)
+                return
+        else:
+            persisted_message_id = self.persistence.create_message(**create_kwargs)
+        message.persisted_message_id = persisted_message_id
         self._pending_persistence_message_ids.discard(message.id)
         # Carried-forward (Task 8): when this newly persisted message IS the
         # session's active leaf, write the durable active-leaf pointer through
@@ -2140,9 +2258,58 @@ class ConsoleChatStore:
         # later resume walks the wrong branch and drops the continuation. Also
         # covers the deferred path (``_persist_pending_message_if_ready`` ->
         # here) where the id only exists once streamed content arrives.
-        if message.id == self._active_leaf_by_session.get(session_id):
-            self._persist_active_leaf(session_id, message.id)
-        self._enqueue_sync_v2_message_if_ready(message)
+        if terminal_persistence:
+            try:
+                if message.id == self._active_leaf_by_session.get(session_id):
+                    self._persist_active_leaf(
+                        session_id,
+                        message.id,
+                        content_safe_diagnostic=True,
+                    )
+                self._enqueue_sync_v2_message_if_ready(
+                    message,
+                    content_safe_diagnostic=True,
+                )
+            except Exception:
+                logger.warning("terminal_persistence_bookkeeping_unavailable")
+        else:
+            if message.id == self._active_leaf_by_session.get(session_id):
+                self._persist_active_leaf(session_id, message.id)
+            self._enqueue_sync_v2_message_if_ready(message)
+
+    def _create_terminal_message(
+        self,
+        *,
+        create_kwargs: dict[str, Any],
+        citation_write: SealedCitationWrite | None,
+    ) -> str | None:
+        """Perform the bounded terminal create/fallback disposition."""
+        if self.persistence is None:
+            return None
+        if citation_write is None:
+            try:
+                return self.persistence.create_message(**create_kwargs)
+            except Exception:
+                logger.warning("terminal_ordinary_persistence_abandoned")
+                return None
+
+        try:
+            return self.persistence.create_message(**create_kwargs)
+        except CitationPersistenceUnavailable:
+            logger.warning("terminal_citation_persistence_fallback")
+            create_kwargs.pop("citation_write", None)
+            try:
+                return self.persistence.create_message(**create_kwargs)
+            except Exception:
+                logger.warning("terminal_citation_persistence_abandoned")
+                return None
+        except Exception:
+            logger.warning("terminal_citation_persistence_ambiguous_retry")
+            try:
+                return self.persistence.create_message(**create_kwargs)
+            except Exception:
+                logger.warning("terminal_citation_persistence_abandoned")
+                return None
 
     def _persist_existing_message(
         self,
@@ -2181,13 +2348,19 @@ class ConsoleChatStore:
         if (
             self.persistence is None
             or message.id not in self._pending_persistence_message_ids
+            or message.id in self._terminal_persistence_deferred_ids
             or not message.content
         ):
             return
         session_id = self._message_session_index[message.id]
         self._persist_new_message(session_id=session_id, message=message)
 
-    def _enqueue_sync_v2_message_if_ready(self, message: ConsoleChatMessage) -> None:
+    def _enqueue_sync_v2_message_if_ready(
+        self,
+        message: ConsoleChatMessage,
+        *,
+        content_safe_diagnostic: bool = False,
+    ) -> None:
         if (
             self.sync_v2_chat_producer is None
             or self.sync_v2_server_profile_id is None
@@ -2227,6 +2400,9 @@ class ConsoleChatStore:
             )
             self._record_sync_v2_message_version(stable_key, result)
         except Exception:
+            if content_safe_diagnostic:
+                logger.warning("terminal_persistence_bookkeeping_unavailable")
+                return
             logger.bind(
                 server_profile_id=self.sync_v2_server_profile_id,
                 authenticated_principal_id=self.sync_v2_authenticated_principal_id,
@@ -2642,7 +2818,11 @@ class ConsoleChatStore:
             current = children[-1]
 
     def _persist_active_leaf(
-        self, session_id: str, message_id: str | None
+        self,
+        session_id: str,
+        message_id: str | None,
+        *,
+        content_safe_diagnostic: bool = False,
     ) -> None:
         """Write-through the local-only active-leaf pointer for a persisted conv.
 
@@ -2670,6 +2850,9 @@ class ConsoleChatStore:
                 conversation_id, leaf_persisted_id
             )
         except Exception:
+            if content_safe_diagnostic:
+                logger.warning("terminal_persistence_bookkeeping_unavailable")
+                return
             logger.bind(
                 session_id=session_id,
                 conversation_id=conversation_id,

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -2883,6 +2883,7 @@ UPDATE db_schema_version
         *,
         commit: bool = False,
         script: bool = False,
+        redact_params: bool = False,
     ) -> sqlite3.Cursor:
         """
         Executes a single SQL query or an entire SQL script.
@@ -2896,6 +2897,9 @@ UPDATE db_schema_version
                     Defaults to False.
             script: If True, executes the query string as an SQL script using `executescript`.
                     `params` are ignored if `script` is True. Defaults to False.
+            redact_params: If True, replaces the debug parameter preview with a
+                    fixed redaction marker. Query execution still receives the
+                    original parameters. Defaults to False.
 
         Returns:
             The sqlite3.Cursor object after execution.
@@ -2918,7 +2922,10 @@ UPDATE db_schema_version
             logger.opt(lazy=True).debug(
                 "Executing SQL (script={}): {}",
                 lambda: script,
-                lambda: f"{query[:300]}... Params: {preview_params(params)}",
+                lambda: (
+                    f"{query[:300]}... Params: "
+                    f"{'<redacted>' if redact_params else preview_params(params)}"
+                ),
             )
 
             if script:
@@ -7398,7 +7405,9 @@ UPDATE db_schema_version
                         f"Cannot add message: Conversation ID '{msg_data['conversation_id']}' not found or deleted."
                     )
                 self.execute_query(
-                    query, params
+                    query,
+                    params,
+                    redact_params=True,
                 )  # commit handled by transaction context
             logger.info(
                 f"Added message ID: {msg_id} to conversation {msg_data['conversation_id']} (Image: {'Yes' if msg_data.get('image_data') else 'No'})."

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
@@ -898,11 +898,62 @@ async def resolve_effective_scope_for_chat(
 _resolve_effective_scope_for_chat = resolve_effective_scope_for_chat
 
 
-def _current_local_evidence_ids_sync(
+def _current_media_evidence_ids_sync(
+    media_db: Any,
+    media_ids: frozenset[str],
+) -> Optional[frozenset[tuple[CanonicalSourceKind, str]]]:
+    """Return current media identities with one batched database read."""
+
+    try:
+        rows = media_db.execute_query(
+            "SELECT id FROM Media "
+            "WHERE id IN (SELECT value FROM json_each(?)) AND deleted = 0",
+            (json.dumps(sorted(media_ids)),),
+        ).fetchall()
+    except Exception:
+        logger.opt(exception=True).warning(
+            "Prompt-boundary media existence read failed"
+        )
+        return None
+    return frozenset((CanonicalSourceKind.MEDIA_DB, str(row[0])) for row in rows)
+
+
+def _current_chacha_evidence_ids_sync(
+    db: Any,
+    note_ids: frozenset[str],
+    conversation_ids: frozenset[str],
+) -> Optional[frozenset[tuple[CanonicalSourceKind, str]]]:
+    """Return current note/conversation identities with one batched DB read."""
+
+    try:
+        rows = db.execute_query(
+            "SELECT 'notes' AS source_kind, id FROM notes "
+            "WHERE id IN (SELECT value FROM json_each(?)) AND deleted = 0 "
+            "UNION ALL "
+            "SELECT 'chat_history' AS source_kind, id FROM conversations "
+            "WHERE id IN (SELECT value FROM json_each(?)) AND deleted = 0",
+            (
+                json.dumps(sorted(note_ids)),
+                json.dumps(sorted(conversation_ids)),
+            ),
+        ).fetchall()
+    except Exception:
+        logger.opt(exception=True).warning(
+            "Prompt-boundary notes/conversations existence read failed"
+        )
+        return None
+    source_kinds = {
+        "notes": CanonicalSourceKind.NOTES,
+        "chat_history": CanonicalSourceKind.CHAT_HISTORY,
+    }
+    return frozenset((source_kinds[str(row[0])], str(row[1])) for row in rows)
+
+
+async def _current_local_evidence_ids(
     app: "TldwCli",
     ids_by_source: Dict[CanonicalSourceKind, frozenset[str]],
 ) -> Optional[frozenset[tuple[CanonicalSourceKind, str]]]:
-    """Return current non-deleted local identities using batched DB reads."""
+    """Read each backing store on the thread required by that store."""
 
     found: set[tuple[CanonicalSourceKind, str]] = set()
     media_ids = ids_by_source.get(CanonicalSourceKind.MEDIA_DB, frozenset())
@@ -910,18 +961,15 @@ def _current_local_evidence_ids_sync(
         media_db = getattr(app, "media_db", None)
         if media_db is None:
             return None
-        try:
-            rows = media_db.execute_query(
-                "SELECT id FROM Media "
-                "WHERE id IN (SELECT value FROM json_each(?)) AND deleted = 0",
-                (json.dumps(sorted(media_ids)),),
-            ).fetchall()
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Prompt-boundary media existence read failed"
+        if bool(getattr(media_db, "is_memory_db", False)):
+            media_found = _current_media_evidence_ids_sync(media_db, media_ids)
+        else:
+            media_found = await asyncio.to_thread(
+                _current_media_evidence_ids_sync, media_db, media_ids
             )
+        if media_found is None:
             return None
-        found.update((CanonicalSourceKind.MEDIA_DB, str(row[0])) for row in rows)
+        found.update(media_found)
 
     note_ids = ids_by_source.get(CanonicalSourceKind.NOTES, frozenset())
     conversation_ids = ids_by_source.get(CanonicalSourceKind.CHAT_HISTORY, frozenset())
@@ -929,28 +977,20 @@ def _current_local_evidence_ids_sync(
         db = getattr(app, "chachanotes_db", None)
         if db is None:
             return None
-        try:
-            rows = db.execute_query(
-                "SELECT 'notes' AS source_kind, id FROM notes "
-                "WHERE id IN (SELECT value FROM json_each(?)) AND deleted = 0 "
-                "UNION ALL "
-                "SELECT 'chat_history' AS source_kind, id FROM conversations "
-                "WHERE id IN (SELECT value FROM json_each(?)) AND deleted = 0",
-                (
-                    json.dumps(sorted(note_ids)),
-                    json.dumps(sorted(conversation_ids)),
-                ),
-            ).fetchall()
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Prompt-boundary notes/conversations existence read failed"
+        if bool(getattr(db, "is_memory_db", False)):
+            chacha_found = _current_chacha_evidence_ids_sync(
+                db, note_ids, conversation_ids
             )
+        else:
+            chacha_found = await asyncio.to_thread(
+                _current_chacha_evidence_ids_sync,
+                db,
+                note_ids,
+                conversation_ids,
+            )
+        if chacha_found is None:
             return None
-        source_kinds = {
-            "notes": CanonicalSourceKind.NOTES,
-            "chat_history": CanonicalSourceKind.CHAT_HISTORY,
-        }
-        found.update((source_kinds[str(row[0])], str(row[1])) for row in rows)
+        found.update(chacha_found)
 
     return frozenset(found)
 
@@ -991,19 +1031,7 @@ async def authorize_local_results_for_prompt(
         source_kind: frozenset(source_ids)
         for source_kind, source_ids in ids_by_source.items()
     }
-    dbs = (
-        getattr(app, "media_db", None),
-        getattr(app, "chachanotes_db", None),
-    )
-    run_inline = any(
-        bool(getattr(db, "is_memory_db", False)) for db in dbs if db is not None
-    )
-    if run_inline:
-        existing = _current_local_evidence_ids_sync(app, frozen_ids)
-    else:
-        existing = await asyncio.to_thread(
-            _current_local_evidence_ids_sync, app, frozen_ids
-        )
+    existing = await _current_local_evidence_ids(app, frozen_ids)
     if existing is None:
         return ()
 

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
@@ -630,6 +630,38 @@ def _scope_cache_for(app: "TldwCli") -> ScopeCache:
     return cache
 
 
+def _read_fresh_workspace_scope_sync(
+    registry_service: Any, workspace_id: str
+) -> Optional[RagScope]:
+    """Read a workspace scope without collapsing malformed rows into unset."""
+
+    if not isinstance(workspace_id, str) or not workspace_id:
+        raise ValueError("workspace authority identifier is invalid")
+    registry_db = getattr(registry_service, "db", None)
+    if registry_db is None:
+        raise RuntimeError("workspace authority database is unavailable")
+    with registry_db.connection() as conn:
+        row = conn.execute(
+            """
+            SELECT payload
+            FROM workspace_rag_scopes
+            WHERE workspace_id = ?
+            """,
+            (workspace_id,),
+        ).fetchone()
+    if row is None:
+        return None
+    try:
+        payload = row["payload"]
+    except (IndexError, KeyError, TypeError):
+        payload = row[0]
+    raw_scope = json.loads(payload)
+    scope = parse_scope(raw_scope)
+    if scope is None:
+        raise ValueError("workspace scope authority is malformed")
+    return scope
+
+
 async def resolve_scope_for_session(
     app: "TldwCli", session: Optional[Any], *, use_cache: bool = True
 ) -> ScopeResolution:
@@ -653,14 +685,15 @@ async def resolve_scope_for_session(
     ``getattr`` so callers/tests that pass a session double without this
     attribute degrade to "no workspace scope" rather than raising -- task-13
     Phase 3 of the rag-scope-narrowing program). The workspace's stored
-    scope is read via ``app.workspace_registry_service.get_workspace_scope``.
-    A missing service or a missing/empty ``workspace_id`` degrades to
-    ``ws_scope=None`` (no workspace scope to bound with -- the conversation
-    scope alone still applies normally). A storage READ FAILURE is handled
-    differently (PR#757 review, comment 5): it does NOT degrade to
-    ``ws_scope=None``, because that would silently drop the workspace bound
-    and widen a hard-filter feature on error. Instead this function returns
-    early with an EMPTY ``EffectiveScope`` (``cause="workspace-scope-
+    scope is normally read through ``workspace_registry_service``'s
+    ``get_workspace_scope`` method. Fresh prompt authorization instead reads
+    the registry row directly so a genuinely missing row remains unscoped
+    while a malformed stored row is distinguishable and fails closed. A
+    missing service or a missing/empty ``workspace_id`` degrades to
+    ``ws_scope=None`` only outside fresh authorization. A storage READ FAILURE
+    does NOT degrade to ``ws_scope=None``, because that would silently drop the
+    workspace bound and widen a hard-filter feature on error. Instead this
+    function returns early with an EMPTY ``EffectiveScope`` (``cause="workspace-scope-
     unavailable"``), regardless of whether the conversation itself has a
     scope, since conv-scope-alone is always wider than the (conv ∩
     workspace) intersection that can no longer be computed.
@@ -743,8 +776,9 @@ async def resolve_scope_for_session(
                 if conv_scope is not None and not conv_scope.items:
                     conv_scope = None
             except Exception:
-                logger.opt(exception=True).warning(
-                    "Fresh prompt-boundary conversation scope read failed"
+                logger.warning(
+                    "Prompt-boundary authority unavailable; status=unavailable; "
+                    "reason=conversation_scope_read_failure"
                 )
                 return ScopeResolution(
                     None,
@@ -789,37 +823,29 @@ async def resolve_scope_for_session(
         registry_db = getattr(registry_service, "db", None)
         registry_is_memory = bool(getattr(registry_db, "is_memory_db", False))
         try:
-            if registry_is_memory:
+            if not use_cache and registry_is_memory:
+                ws_scope = _read_fresh_workspace_scope_sync(
+                    registry_service, workspace_id
+                )
+            elif not use_cache:
+                ws_scope = await asyncio.to_thread(
+                    _read_fresh_workspace_scope_sync,
+                    registry_service,
+                    workspace_id,
+                )
+            elif registry_is_memory:
                 ws_scope = registry_service.get_workspace_scope(workspace_id)
             else:
                 ws_scope = await asyncio.to_thread(
                     registry_service.get_workspace_scope, workspace_id
                 )
         except Exception:
-            # PR#757 review (comment 5): a workspace-scope READ FAILURE is
-            # NOT the same thing as "no workspace scope set". Forcing
-            # ws_scope=None here (the old behavior) silently drops the
-            # workspace bound and lets resolution fall through to
-            # conv-scope-alone -- or fully UNSCOPED when the conversation
-            # also has no scope of its own -- widening a hard-filter
-            # feature precisely when its own read fails. Fail CLOSED
-            # instead: the (conv ∩ workspace) intersection can't be
-            # computed without the workspace scope, and conv-scope-alone
-            # is always WIDER than that intersection, so an EMPTY
-            # effective scope is returned unconditionally here (in both
-            # the conversation-scoped and conversation-unscoped
-            # sub-cases) -- this short-circuits retrieval via the same
-            # EMPTY pathway ``get_rag_context_for_chat`` already uses for
-            # a configured-but-nothing-left scope, with an honest,
-            # distinct cause instead of a generic one.
-            #
-            # This deliberately does NOT touch the conversation-scope
-            # read a few lines above, which keeps its pre-existing
-            # fail-open-to-None pattern -- see the backlog follow-up task
-            # filed against this comment for reconsidering that
-            # separately.
-            logger.opt(exception=True).warning(
-                f"workspace rag_scope read failed for {workspace_id}"
+            # A malformed or unreadable stored scope is not equivalent to no
+            # stored row. Dropping that workspace bound would widen retrieval,
+            # so authority failures always resolve EMPTY.
+            logger.warning(
+                "Prompt-boundary authority unavailable; status=unavailable; "
+                "reason=workspace_scope_read_failure"
             )
             return ScopeResolution(
                 conv_scope,
@@ -911,8 +937,9 @@ def _current_media_evidence_ids_sync(
             (json.dumps(sorted(media_ids)),),
         ).fetchall()
     except Exception:
-        logger.opt(exception=True).warning(
-            "Prompt-boundary media existence read failed"
+        logger.warning(
+            "Prompt-boundary authority unavailable; status=unavailable; "
+            "reason=media_existence_read_failure"
         )
         return None
     return frozenset((CanonicalSourceKind.MEDIA_DB, str(row[0])) for row in rows)
@@ -938,8 +965,9 @@ def _current_chacha_evidence_ids_sync(
             ),
         ).fetchall()
     except Exception:
-        logger.opt(exception=True).warning(
-            "Prompt-boundary notes/conversations existence read failed"
+        logger.warning(
+            "Prompt-boundary authority unavailable; status=unavailable; "
+            "reason=chacha_existence_read_failure"
         )
         return None
     source_kinds = {
@@ -1015,8 +1043,9 @@ async def authorize_local_results_for_prompt(
     try:
         effective_scope = await resolve_effective_scope_for_chat(app, use_cache=False)
     except Exception:
-        logger.opt(exception=True).warning(
-            "Prompt-boundary scope authority read failed"
+        logger.warning(
+            "Prompt-boundary authority unavailable; status=unavailable; "
+            "reason=scope_resolution_failure"
         )
         return ()
     if effective_scope.state == "empty":

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
@@ -6,12 +6,19 @@ import asyncio
 import copy
 import json
 from dataclasses import dataclass
+from datetime import UTC, datetime
+from time import perf_counter
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple
 
 from loguru import logger
 
 # Local Imports
 from ...Chat.citation_source_locators import CanonicalSourceKind
+from ...Chat.citation_trace_builder import (
+    CitationTraceBuilder,
+    LocalRetrievalRunMetadata,
+)
+from ...Chat.citation_trace_identity import new_opaque_id
 from ...Chat.rag_scope import (
     CONVERSATION_METADATA_SCOPE_KEY,
     EffectiveScope,
@@ -54,6 +61,36 @@ if TYPE_CHECKING:
 # Configure logger with context
 logger = logger.bind(module="chat_rag_events_simplified")
 
+
+@dataclass(frozen=True)
+class LocalRagContextResult:
+    """RAG context plus an optional request-scoped canonical capture."""
+
+    context: str | None
+    citation_builder: CitationTraceBuilder | None
+
+
+@dataclass(frozen=True)
+class _RequestScopeSession:
+    """Immutable request-start identity used for both scope reads."""
+
+    id: Any
+    persisted_conversation_id: Any
+    workspace_id: Any
+    rag_scope_holder: SessionScopeHolder | None
+
+
+@dataclass(frozen=True)
+class _PromptAuthorizationResult:
+    """Authorized candidates plus whether every authority read completed."""
+
+    candidates: Tuple[NormalizedLocalResult, ...]
+    completed: bool
+
+
+_CURRENT_ACTIVE_SESSION = object()
+
+
 # Check if RAG dependencies are available
 try:
     from ...RAG_Search.simplified import (
@@ -87,7 +124,7 @@ async def perform_plain_rag_search(
             task-5). Forwarded to ``execute_pipeline`` so every leg
             self-enforces it; ``None`` performs today's unrestricted search.
     """
-    logger.info(f"Performing plain RAG search for query: '{query}'")
+    logger.info("RAG pipeline starting; mode=plain")
 
     # Build pipeline configuration
     config = BUILTIN_PIPELINES["plain"].copy()
@@ -139,7 +176,7 @@ async def perform_full_rag_pipeline(
             task-5). Forwarded to ``execute_pipeline`` so every leg
             self-enforces it; ``None`` performs today's unrestricted search.
     """
-    logger.info(f"Performing semantic RAG search for query: '{query}'")
+    logger.info("RAG pipeline starting; mode=semantic")
 
     # Build pipeline configuration
     config = BUILTIN_PIPELINES["semantic"].copy()
@@ -224,7 +261,7 @@ async def perform_hybrid_rag_search(
         Tuple of (result dicts sorted by fused score, formatted context
         string for the LLM).
     """
-    logger.info(f"Performing hybrid RAG search for query: '{query}'")
+    logger.info("RAG pipeline starting; mode=hybrid")
 
     # Map legacy weight parameters onto alpha for backwards compatibility
     if hybrid_alpha is None and (bm25_weight is not None or vector_weight is not None):
@@ -290,7 +327,7 @@ async def perform_search_with_pipeline(
             self-enforces it, including custom TOML pipeline shapes;
             ``None`` performs today's unrestricted search.
     """
-    logger.info(f"Performing search with pipeline '{pipeline_id}' for query: '{query}'")
+    logger.info("RAG pipeline starting; mode=custom")
 
     # Get pipeline configuration (from built-ins or TOML)
     from ...RAG_Search.pipeline_builder_simple import get_pipeline
@@ -298,7 +335,7 @@ async def perform_search_with_pipeline(
     config = get_pipeline(pipeline_id)
 
     if not config:
-        logger.error(f"Pipeline '{pipeline_id}' not found")
+        logger.error("RAG pipeline unavailable; reason=pipeline_not_found")
         return [], f"Pipeline '{pipeline_id}' not found"
 
     # Make a copy to avoid modifying the original
@@ -368,8 +405,10 @@ async def get_or_initialize_rag_service(app: "TldwCli") -> Optional[Any]:
             rag_config = app.config.get("rag", {})
             service_config = rag_config.get("service", {})
             profile_name = service_config.get("profile")
-    except Exception as e:
-        logger.debug(f"Could not read RAG profile preference from app config: {e}")
+    except Exception:
+        logger.debug(
+            "RAG profile preference unavailable; reason=profile_config_read_failure"
+        )
 
     service, _reason = await resolve_semantic_rag_service(app, profile_name)
     return service
@@ -421,11 +460,13 @@ def _notify_semantic_leg_state(
     if scope_state.get("status") == SCOPE_STATUS_EMPTY:
         cause = scope_state.get("cause") or "unknown"
         notification = SCOPE_EMPTY_NOTICE_TEMPLATE.format(cause=cause)
-        logger.warning(notification)
+        logger.warning("RAG scope empty; reason=scope_empty")
         try:
             app.notify(notification, severity="warning")
-        except Exception as e:
-            logger.debug(f"Could not notify scope-empty state: {e}")
+        except Exception:
+            logger.debug(
+                "RAG notification unavailable; reason=scope_notification_failure"
+            )
         return
 
     semantic_state = diagnostics.get(SEMANTIC_DIAGNOSTICS_KEY) or {}
@@ -443,11 +484,13 @@ def _notify_semantic_leg_state(
         notification = f"RAG context is keyword-only (FTS): {message}"
     else:
         notification = f"Semantic retrieval returned no context: {message}"
-    logger.warning(notification)
+    logger.warning("RAG semantic state unavailable; reason=semantic_leg_unavailable")
     try:
         app.notify(notification, severity="warning")
-    except Exception as e:
-        logger.debug(f"Could not notify semantic-leg state: {e}")
+    except Exception:
+        logger.debug(
+            "RAG notification unavailable; reason=semantic_notification_failure"
+        )
 
 
 def _record_scope_empty(diagnostics: Dict[str, Any], cause: Optional[str]) -> None:
@@ -508,8 +551,10 @@ def _active_console_session(app: "TldwCli") -> Optional[Any]:
         return None
     try:
         screen = getattr(app, "screen", None)
-    except Exception as e:
-        logger.debug(f"Could not access the active screen: {e}")
+    except Exception:
+        logger.debug(
+            "RAG session lookup unavailable; reason=active_screen_read_failure"
+        )
         return None
     if not isinstance(screen, ChatScreen):
         return None
@@ -523,9 +568,38 @@ def _active_console_session(app: "TldwCli") -> Optional[Any]:
         for session in store.sessions():
             if session.id == session_id:
                 return session
-    except Exception as e:
-        logger.debug(f"Could not resolve the active Console session: {e}")
+    except Exception:
+        logger.debug(
+            "RAG session lookup unavailable; reason=active_session_read_failure"
+        )
     return None
+
+
+def _capture_request_scope_session(app: "TldwCli") -> _RequestScopeSession | None:
+    """Copy the active session identity before retrieval can change it."""
+
+    session = _active_console_session(app)
+    if session is None:
+        return None
+    try:
+        holder = getattr(session, "rag_scope_holder", None)
+        captured_holder = None
+        if isinstance(holder, SessionScopeHolder):
+            captured_holder = SessionScopeHolder()
+            captured_holder.set(holder.scope)
+        return _RequestScopeSession(
+            id=getattr(session, "id", None),
+            persisted_conversation_id=getattr(
+                session, "persisted_conversation_id", None
+            ),
+            workspace_id=getattr(session, "workspace_id", None),
+            rag_scope_holder=captured_holder,
+        )
+    except Exception:
+        logger.warning(
+            "RAG session identity unavailable; reason=session_identity_read_failure"
+        )
+        return None
 
 
 def _existing_ids_sync(
@@ -572,8 +646,10 @@ def _existing_ids_sync(
             (json.dumps(sorted(ids)),),
         ).fetchall()
         return frozenset(str(row[0]) for row in rows)
-    except Exception as e:
-        logger.warning(f"rag_scope existing-ids check failed for {source_type}: {e}")
+    except Exception:
+        logger.warning(
+            "RAG scope existence unavailable; reason=scope_existing_ids_read_failure"
+        )
         return frozenset()
 
 
@@ -1048,38 +1124,45 @@ async def _current_local_evidence_ids(
     return frozenset(found)
 
 
-async def authorize_local_results_for_prompt(
+async def _authorize_local_results_for_prompt(
     app: "TldwCli",
     normalized_results: Sequence[NormalizedLocalResult],
-) -> Tuple[NormalizedLocalResult, ...]:
-    """Re-read current authority and backing rows before assigning markers.
-
-    Args:
-        app: Running app with current session and local DB authorities.
-        normalized_results: Strict canonical candidates in retrieval order.
-
-    Returns:
-        Current, authorized candidates in their original order. Any authority
-        or existence read failure returns an empty tuple.
-    """
+    *,
+    request_session: _RequestScopeSession | None | object = _CURRENT_ACTIVE_SESSION,
+) -> _PromptAuthorizationResult:
+    """Re-read one request's authority and backing rows before markers."""
 
     if not normalized_results:
-        return ()
+        return _PromptAuthorizationResult((), True)
     try:
-        effective_scope = await resolve_effective_scope_for_chat(app, use_cache=False)
+        if request_session is _CURRENT_ACTIVE_SESSION:
+            effective_scope = await resolve_effective_scope_for_chat(
+                app, use_cache=False
+            )
+        else:
+            resolution = await resolve_scope_for_session(
+                app,
+                request_session,
+                use_cache=False,
+            )
+            effective_scope = resolution.effective
     except Exception:
         logger.warning(
             "Prompt-boundary authority unavailable; status=unavailable; "
             "reason=scope_resolution_failure"
         )
-        return ()
+        return _PromptAuthorizationResult((), False)
     if effective_scope.state == "empty":
-        return ()
+        authority_failed = effective_scope.cause in {
+            "conversation-scope-unavailable",
+            "workspace-scope-unavailable",
+        }
+        return _PromptAuthorizationResult((), not authority_failed)
 
     ids_by_source: Dict[CanonicalSourceKind, set[str]] = {}
     for result in normalized_results:
         if not isinstance(result, NormalizedLocalResult):
-            return ()
+            return _PromptAuthorizationResult((), False)
         ids_by_source.setdefault(result.source_kind, set()).add(result.source_id)
     frozen_ids = {
         source_kind: frozenset(source_ids)
@@ -1087,7 +1170,7 @@ async def authorize_local_results_for_prompt(
     }
     existing = await _current_local_evidence_ids(app, frozen_ids)
     if existing is None:
-        return ()
+        return _PromptAuthorizationResult((), False)
 
     scope_source_types = {
         CanonicalSourceKind.MEDIA_DB: SOURCE_TYPE_MEDIA,
@@ -1107,7 +1190,29 @@ async def authorize_local_results_for_prompt(
             ):
                 continue
         authorized.append(result)
-    return tuple(authorized)
+    return _PromptAuthorizationResult(tuple(authorized), True)
+
+
+async def authorize_local_results_for_prompt(
+    app: "TldwCli",
+    normalized_results: Sequence[NormalizedLocalResult],
+) -> Tuple[NormalizedLocalResult, ...]:
+    """Re-read current authority and backing rows before assigning markers.
+
+    Args:
+        app: Running app with current session and local DB authorities.
+        normalized_results: Strict canonical candidates in retrieval order.
+
+    Returns:
+        Current, authorized candidates in their original order. Any authority
+        or existence read failure returns an empty tuple.
+    """
+
+    authorization = await _authorize_local_results_for_prompt(
+        app,
+        normalized_results,
+    )
+    return authorization.candidates
 
 
 async def assemble_local_evidence_for_prompt(
@@ -1139,21 +1244,149 @@ async def assemble_local_evidence_for_prompt(
     return format_local_evidence_context(authorized, max_length=max_length)
 
 
-async def get_rag_context_for_chat(app: "TldwCli", user_message: str) -> Optional[str]:
-    """
-    Get RAG context for a chat message based on current settings.
+def _create_local_capture_builder(app: "TldwCli") -> CitationTraceBuilder | None:
+    """Ask the configured repository for one opaque request-scoped builder."""
 
-    Resolves the effective RAG retrieval scope (rag-scope narrowing, task-5)
-    before running any pipeline: unscoped (the default -- no active native
-    Console session, or no scope configured) performs today's unrestricted
-    search; a scoped conversation restricts every pipeline leg to its
-    allowlist; an EMPTY resolution (a configured scope with nothing left to
-    search, e.g. its items were deleted) short-circuits before any
-    pipeline/leg call and returns ``None`` with a notification instead.
+    request_id = new_opaque_id("request")
+    generation_id = new_opaque_id("generation")
+    repository = getattr(app, "citation_trace_repository", None)
+    factory = getattr(repository, "create_local_trace_builder", None)
+    if not callable(factory):
+        return None
+    try:
+        builder = factory(
+            request_id=request_id,
+            generation_id=generation_id,
+        )
+    except Exception:
+        logger.warning(
+            "Canonical RAG capture unavailable; reason=builder_factory_failure"
+        )
+        return None
+    return builder if isinstance(builder, CitationTraceBuilder) else None
 
-    Returns the context string to be prepended to the user message, or None if RAG is disabled.
+
+def _selected_source_kinds(
+    sources: Dict[str, bool],
+) -> Tuple[CanonicalSourceKind, ...]:
+    """Map selected UI source families to the canonical local allowlist."""
+
+    mappings = (
+        ("media", CanonicalSourceKind.MEDIA_DB),
+        ("notes", CanonicalSourceKind.NOTES),
+        ("conversations", CanonicalSourceKind.CHAT_HISTORY),
+    )
+    return tuple(source_kind for key, source_kind in mappings if sources.get(key))
+
+
+async def _capture_local_pipeline_results(
+    app: "TldwCli",
+    *,
+    builder: CitationTraceBuilder,
+    request_session: _RequestScopeSession | None,
+    user_message: str,
+    search_mode: str,
+    sources: Dict[str, bool],
+    top_k: int,
+    max_context_length: int,
+    enable_rerank: bool,
+    effective_scope: EffectiveScope,
+    results: List[Any],
+    retrieval_started_at: datetime,
+    retrieval_ended_at: datetime,
+    retrieval_elapsed_ms: int,
+) -> LocalRagContextResult:
+    """Atomically assemble and record canonical local prompt evidence."""
+
+    try:
+        normalized: list[NormalizedLocalResult] = []
+        rejected_count = 0
+        for candidate_rank, result in enumerate(results, start=1):
+            try:
+                normalized.append(
+                    normalize_local_result(result, candidate_rank=candidate_rank)
+                )
+            except LocalResultNormalizationError:
+                rejected_count += 1
+        if rejected_count:
+            logger.warning(
+                "RAG candidates rejected; "
+                f"count={rejected_count}; reason=invalid_local_result"
+            )
+
+        authorization = await _authorize_local_results_for_prompt(
+            app,
+            tuple(normalized),
+            request_session=request_session,
+        )
+        if not authorization.completed:
+            logger.warning(
+                "Canonical RAG capture unavailable; reason=prompt_authority_failure"
+            )
+            return LocalRagContextResult(None, None)
+        excluded_count = len(normalized) - len(authorization.candidates)
+        if excluded_count:
+            logger.info(
+                "RAG candidates excluded; "
+                f"count={excluded_count}; reason=not_currently_authorized"
+            )
+
+        formatted = format_local_evidence_context(
+            authorization.candidates,
+            max_length=max_context_length,
+        )
+        retrieval_metadata = LocalRetrievalRunMetadata(
+            search_mode=search_mode,
+            requested_top_k=top_k,
+            max_context_characters=max_context_length,
+            rerank_enabled=bool(enable_rerank),
+            source_kinds=_selected_source_kinds(sources),
+            scope_state=effective_scope.state,
+        )
+        candidates = tuple(
+            result.to_candidate_capture() for result in authorization.candidates
+        )
+        run_id = builder.record_retrieval_run(
+            stage=search_mode,
+            raw_query=user_message,
+            candidates=candidates,
+            retrieval_metadata=retrieval_metadata,
+            started_at=retrieval_started_at,
+            ended_at=retrieval_ended_at,
+        )
+        if formatted.entries:
+            builder.record_prompt_evidence_set(
+                run_id=run_id,
+                evidence=formatted.entries,
+                created_at=datetime.now(UTC),
+            )
+        logger.info(
+            "Canonical RAG capture completed; "
+            f"mode={search_mode}; candidates={len(candidates)}; "
+            f"prompt_entries={len(formatted.entries)}; "
+            f"duration_ms={retrieval_elapsed_ms}"
+        )
+        context = formatted.context if formatted.context.strip() else None
+        return LocalRagContextResult(context, builder)
+    except Exception:
+        logger.error("Canonical RAG capture failed; reason=canonical_capture_failure")
+        return LocalRagContextResult(None, None)
+
+
+async def get_rag_context_capture_for_chat(
+    app: "TldwCli", user_message: str
+) -> LocalRagContextResult:
+    """Get local RAG context with optional request-scoped citation capture.
+
+    Pipelines retain their legacy ``(results, context)`` tuple. When the
+    repository cannot issue a canonical builder, the returned context is the
+    pipeline context byte-for-byte. When a builder exists, only freshly
+    authorized normalized candidates are formatted, recorded, and returned.
     """
     from textual.css.query import NoMatches
+
+    builder = _create_local_capture_builder(app)
+    request_session = _capture_request_scope_session(app)
 
     # Check if RAG is enabled
     try:
@@ -1161,14 +1394,14 @@ async def get_rag_context_for_chat(app: "TldwCli", user_message: str) -> Optiona
         plain_rag_enabled = app.query_one("#chat-rag-plain-enable-checkbox").value
     except NoMatches:
         logger.debug("RAG checkboxes not found, RAG disabled")
-        return None
-    except Exception as e:
-        logger.error(f"Error reading RAG enable state: {e}")
-        return None
+        return LocalRagContextResult(None, None)
+    except Exception:
+        logger.error("RAG configuration unavailable; reason=enable_state_read_failure")
+        return LocalRagContextResult(None, None)
 
     if not rag_enabled and not plain_rag_enabled:
         logger.debug("RAG is disabled")
-        return None
+        return LocalRagContextResult(None, None)
 
     # Get search mode from the new dropdown (if it exists)
     search_mode = None
@@ -1181,7 +1414,7 @@ async def get_rag_context_for_chat(app: "TldwCli", user_message: str) -> Optiona
         if search_mode == "none":
             # Manual configuration mode - use existing logic
             search_mode = "plain" if plain_rag_enabled else "semantic"
-            logger.info(f"Manual config mode: using {search_mode} based on checkboxes")
+            logger.info(f"RAG search mode resolved; mode={search_mode}")
     except NoMatches:
         # Fallback to checkbox-based detection for backward compatibility
         logger.debug("Search mode dropdown not found, using checkbox-based detection")
@@ -1206,7 +1439,7 @@ async def get_rag_context_for_chat(app: "TldwCli", user_message: str) -> Optiona
         )
 
         if keyword_filter_list:
-            logger.info(f"Applying keyword filter: {keyword_filter_list}")
+            logger.info(f"RAG keyword filter active; count={len(keyword_filter_list)}")
 
         top_k = int(app.query_one("#chat-rag-top-k").value or "5")
         max_context_length = int(
@@ -1221,15 +1454,15 @@ async def get_rag_context_for_chat(app: "TldwCli", user_message: str) -> Optiona
         chunk_type = app.query_one("#chat-rag-chunk-type").value or "words"
         include_metadata = app.query_one("#chat-rag-include-metadata-checkbox").value
 
-    except Exception as e:
-        logger.error(f"Error reading RAG settings: {e}")
-        return None
+    except Exception:
+        logger.error("RAG configuration unavailable; reason=settings_read_failure")
+        return LocalRagContextResult(None, None)
 
     # Check if any sources are selected
     if not any(sources.values()):
         logger.warning("No RAG sources selected")
         app.notify("Please select at least one RAG source", severity="warning")
-        return None
+        return LocalRagContextResult(None, None)
 
     # Semantic-leg availability states, and the resolved-scope state, ride
     # out of the pipeline (or the EMPTY short-circuit below) here.
@@ -1242,12 +1475,18 @@ async def get_rag_context_for_chat(app: "TldwCli", user_message: str) -> Optiona
     # short-circuits entirely -- task-4's legs deliberately treat an EMPTY
     # scope the same as unscoped (they would search everything), so this
     # caller must never let one reach a leg call.
-    effective_scope = await resolve_effective_scope_for_chat(app)
+    try:
+        effective_scope = (
+            await resolve_scope_for_session(app, request_session)
+        ).effective
+    except Exception:
+        logger.error("RAG scope unavailable; reason=scope_resolution_failure")
+        return LocalRagContextResult(None, None)
 
     if effective_scope.state == "empty":
         _record_scope_empty(diagnostics, effective_scope.cause)
         _notify_semantic_leg_state(app, diagnostics, results=None)
-        return None
+        return LocalRagContextResult(None, None)
 
     scope_for_pipeline: Optional[EffectiveScope] = (
         effective_scope if effective_scope.state == "scoped" else None
@@ -1264,8 +1503,8 @@ async def get_rag_context_for_chat(app: "TldwCli", user_message: str) -> Optiona
                 SEMANTIC_UNAVAILABLE_MESSAGES[SEMANTIC_REASON_INIT_FAILED],
             )
             logger.warning(
-                f"RAG service not available ({unavailable_reason}), "
-                "falling back to plain search"
+                "RAG semantic service unavailable; "
+                f"reason={unavailable_reason}; fallback=plain"
             )
             app.notify(
                 f"{message} Using keyword (FTS) search instead.",
@@ -1274,8 +1513,10 @@ async def get_rag_context_for_chat(app: "TldwCli", user_message: str) -> Optiona
             search_mode = "plain"
 
     # Perform the search
+    retrieval_started_at = datetime.now(UTC)
+    retrieval_started_clock = perf_counter()
     try:
-        logger.info(f"Performing {search_mode} RAG search for: '{user_message}'")
+        logger.info(f"RAG search starting; mode={search_mode}")
 
         if search_mode == "plain":
             results, context = await perform_plain_rag_search(
@@ -1342,16 +1583,42 @@ async def get_rag_context_for_chat(app: "TldwCli", user_message: str) -> Optiona
                 scope=scope_for_pipeline,
             )
 
+        retrieval_ended_at = datetime.now(UTC)
+        retrieval_elapsed_ms = int((perf_counter() - retrieval_started_clock) * 1000)
         _notify_semantic_leg_state(app, diagnostics, results)
+
+        if builder is not None:
+            return await _capture_local_pipeline_results(
+                app,
+                builder=builder,
+                request_session=request_session,
+                user_message=user_message,
+                search_mode=search_mode,
+                sources=sources,
+                top_k=top_k,
+                max_context_length=max_context_length,
+                enable_rerank=enable_rerank,
+                effective_scope=effective_scope,
+                results=results,
+                retrieval_started_at=retrieval_started_at,
+                retrieval_ended_at=retrieval_ended_at,
+                retrieval_elapsed_ms=retrieval_elapsed_ms,
+            )
 
         if context and context.strip():
             logger.info(f"RAG context generated: {len(context)} characters")
-            return context
-        else:
-            logger.warning("No relevant RAG context found")
-            return None
+            return LocalRagContextResult(context, None)
+        logger.warning("No relevant RAG context found")
+        return LocalRagContextResult(None, None)
 
-    except Exception as e:
-        logger.error(f"RAG search failed: {e}")
-        app.notify(f"RAG search failed: {str(e)}", severity="error")
-        return None
+    except Exception:
+        logger.error("RAG search failed; reason=pipeline_failure")
+        app.notify("RAG search failed", severity="error")
+        return LocalRagContextResult(None, None)
+
+
+async def get_rag_context_for_chat(app: "TldwCli", user_message: str) -> Optional[str]:
+    """Return only the legacy RAG context string for existing callers."""
+
+    captured = await get_rag_context_capture_for_chat(app, user_message)
+    return captured.context

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
@@ -32,7 +32,6 @@ from ...Chat.rag_scope import (
     ScopeCache,
     SessionScopeHolder,
     parse_scope,
-    read_conversation_scope,
     resolve_effective_scope,
 )
 from ...RAG_Search.fusion import resolve_hybrid_alpha
@@ -648,6 +647,35 @@ def _read_fresh_conversation_metadata_sync(db: Any, conversation_id: str) -> Any
         return row[0]
 
 
+def _read_cached_conversation_scope_sync(
+    db: Any,
+    conversation_id: str,
+) -> Optional[RagScope]:
+    """Read cached-path scope with legacy guarded parsing and silent identity."""
+
+    try:
+        raw_metadata = _read_fresh_conversation_metadata_sync(db, conversation_id)
+    except Exception:
+        logger.warning(
+            "RAG cached conversation scope unavailable; "
+            "reason=conversation_scope_read_failure"
+        )
+        return None
+    if raw_metadata in (None, ""):
+        metadata: Any = {}
+    else:
+        try:
+            metadata = json.loads(raw_metadata)
+        except (TypeError, ValueError):
+            return None
+    if not isinstance(metadata, dict):
+        return None
+    scope = parse_scope(metadata.get(CONVERSATION_METADATA_SCOPE_KEY))
+    if scope is not None and not scope.items:
+        return None
+    return scope
+
+
 def _existing_ids_sync(
     app: "TldwCli", source_type: str, ids: "frozenset[str]"
 ) -> "frozenset[str]":
@@ -700,6 +728,46 @@ def _existing_ids_sync(
             "RAG scope existence unavailable; reason=scope_existing_ids_read_failure"
         )
         raise _ScopeExistenceReadError from None
+
+
+async def _resolve_scope_with_current_ids(
+    app: "TldwCli",
+    conv_scope: Optional[RagScope],
+    ws_scope: Optional[RagScope],
+) -> EffectiveScope:
+    """Resolve scope while routing each existence read for its own store."""
+
+    candidate_scope = resolve_effective_scope(
+        conv_scope,
+        ws_scope,
+        lambda _source_type, ids: ids,
+    )
+    if candidate_scope.state != "scoped":
+        return candidate_scope
+
+    survivors: dict[str, frozenset[str]] = {}
+    for source_type, ids in candidate_scope.allowlist.items():
+        if source_type == SOURCE_TYPE_MEDIA:
+            db = getattr(app, "media_db", None)
+        elif source_type == SOURCE_TYPE_NOTE:
+            db = getattr(app, "chachanotes_db", None)
+        else:
+            continue
+        if bool(getattr(db, "is_memory_db", False)):
+            survivors[source_type] = _existing_ids_sync(app, source_type, ids)
+        else:
+            survivors[source_type] = await asyncio.to_thread(
+                _existing_ids_sync,
+                app,
+                source_type,
+                ids,
+            )
+
+    return resolve_effective_scope(
+        conv_scope,
+        ws_scope,
+        lambda source_type, _ids: survivors.get(source_type, frozenset()),
+    )
 
 
 @dataclass(frozen=True)
@@ -824,9 +892,11 @@ async def resolve_scope_for_session(
 
     Conversation identity comes from ``session.persisted_conversation_id``.
     When the conversation is persisted, its scope is read from storage
-    (``read_conversation_scope``). When the session has not been persisted
-    yet, an in-session ``SessionScopeHolder`` attached to the session object
-    (``session.rag_scope_holder``, duck-typed) is consulted instead (task-9).
+    through a local non-logging raw-connection read with the same guarded
+    parsing semantics as ``read_conversation_scope``. When the session has
+    not been persisted yet, an in-session ``SessionScopeHolder`` attached to
+    the session object (``session.rag_scope_holder``, duck-typed) is consulted
+    instead (task-9).
 
     Workspace identity comes from ``session.workspace_id`` (the Console
     session's linked local-workspace-registry id, duck-typed via
@@ -887,20 +957,20 @@ async def resolve_scope_for_session(
     )
 
     db = getattr(app, "chachanotes_db", None)
-    media_db = getattr(app, "media_db", None)
     conversation_is_memory_db = bool(getattr(db, "is_memory_db", False))
-    scope_resolution_requires_inline = conversation_is_memory_db or bool(
-        getattr(media_db, "is_memory_db", False)
-    )
 
     conv_scope: Optional[RagScope] = None
     if conversation_id and db is not None:
         if use_cache:
             if conversation_is_memory_db:
-                conv_scope = read_conversation_scope(db, conversation_id)
+                conv_scope = _read_cached_conversation_scope_sync(
+                    db, str(conversation_id)
+                )
             else:
                 conv_scope = await asyncio.to_thread(
-                    read_conversation_scope, db, conversation_id
+                    _read_cached_conversation_scope_sync,
+                    db,
+                    str(conversation_id),
                 )
         else:
             try:
@@ -1026,16 +1096,12 @@ async def resolve_scope_for_session(
         if cached is not None:
             return ScopeResolution(conv_scope, ws_scope, cached)
 
-    def _existing_ids(source_type: str, ids: "frozenset[str]") -> "frozenset[str]":
-        return _existing_ids_sync(app, source_type, ids)
-
     try:
-        if scope_resolution_requires_inline:
-            effective = resolve_effective_scope(conv_scope, ws_scope, _existing_ids)
-        else:
-            effective = await asyncio.to_thread(
-                resolve_effective_scope, conv_scope, ws_scope, _existing_ids
-            )
+        effective = await _resolve_scope_with_current_ids(
+            app,
+            conv_scope,
+            ws_scope,
+        )
     except _ScopeExistenceReadError:
         return ScopeResolution(
             conv_scope,

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
@@ -5,6 +5,7 @@
 import asyncio
 import copy
 import json
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from time import perf_counter
@@ -13,12 +14,14 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple
 from loguru import logger
 
 # Local Imports
+from ...Chat.citation_evidence_models import EvidenceBundle
 from ...Chat.citation_source_locators import CanonicalSourceKind
 from ...Chat.citation_trace_builder import (
     CitationTraceBuilder,
     LocalRetrievalRunMetadata,
 )
 from ...Chat.citation_trace_identity import new_opaque_id
+from ...Chat.citation_trace_models import RETRIEVAL_CANDIDATES_PER_RUN_MAX
 from ...Chat.rag_scope import (
     CONVERSATION_METADATA_SCOPE_KEY,
     EffectiveScope,
@@ -1514,6 +1517,175 @@ async def _capture_local_pipeline_results(
     except Exception:
         logger.error("Canonical RAG capture failed; reason=canonical_capture_failure")
         return LocalRagContextResult(None, None)
+
+
+async def capture_console_staged_evidence_for_chat(
+    app: "TldwCli",
+    launch: Any,
+    *,
+    user_message: str,
+) -> LocalRagContextResult:
+    """Capture Console-staged local evidence at the provider prompt boundary.
+
+    Console Library-RAG retrieval is staged separately from the eventual
+    generation request. This adapter re-validates the serialized evidence
+    bundle, re-reads local source authority, formats the exact prompt blocks,
+    and creates a generation-scoped builder only when canonical capture is
+    available.
+
+    Args:
+        app: Running app with local source databases and citation repository.
+        launch: Current ``ConsoleLiveWorkLaunch``-like staged context.
+        user_message: Current Console draft, used only when the staged bundle
+            has no retrieval query.
+
+    Returns:
+        Exact provider context plus an optional request-local citation builder.
+    """
+
+    payload = getattr(launch, "payload", None)
+    if not isinstance(payload, Mapping):
+        return LocalRagContextResult(None, None)
+    bundle_payload = payload.get("evidence_bundle")
+    if not isinstance(bundle_payload, Mapping):
+        return LocalRagContextResult(None, None)
+    try:
+        bundle = EvidenceBundle.from_payload(bundle_payload)
+    except Exception:
+        logger.warning(
+            "Console RAG evidence unavailable; reason=invalid_evidence_bundle"
+        )
+        return LocalRagContextResult(None, None)
+
+    normalized: list[NormalizedLocalResult] = []
+    rejected_count = 0
+    for reference in bundle.available_references():
+        if reference.source_owner.strip().lower() != "local":
+            rejected_count += 1
+            continue
+        metadata: Dict[str, Any] = {
+            "source_type": reference.source_type,
+            "source_id": reference.source_id,
+        }
+        chunk_id = reference.metadata.get("chunk_id")
+        if isinstance(chunk_id, str) and chunk_id:
+            metadata["chunk_id"] = chunk_id
+        result_id = (
+            chunk_id if isinstance(chunk_id, str) and chunk_id else reference.source_id
+        )
+        try:
+            normalized.append(
+                normalize_local_result(
+                    {
+                        "source": reference.source_type,
+                        "id": result_id,
+                        "title": reference.title,
+                        "content": reference.snippet,
+                        "score": (
+                            reference.score if reference.score is not None else 0.0
+                        ),
+                        "metadata": metadata,
+                    },
+                    candidate_rank=len(normalized) + 1,
+                )
+            )
+        except LocalResultNormalizationError:
+            rejected_count += 1
+    if rejected_count:
+        logger.info(
+            "Console RAG evidence excluded; "
+            f"count={rejected_count}; reason=not_canonical_local_evidence"
+        )
+    if not normalized:
+        return LocalRagContextResult(None, None)
+
+    request_session = _capture_request_scope_session(app)
+    authorization = await _authorize_local_results_for_prompt(
+        app,
+        tuple(normalized),
+        request_session=request_session,
+    )
+    if not authorization.completed:
+        logger.warning(
+            "Console RAG evidence unavailable; reason=prompt_authority_failure"
+        )
+        return LocalRagContextResult(None, None)
+    formatted = format_local_evidence_context(
+        authorization.candidates,
+        max_length=sum(
+            len(candidate.title) + len(candidate.content) + 32
+            for candidate in authorization.candidates
+        ),
+    )
+    context = formatted.context if formatted.context.strip() else None
+    if context is None:
+        return LocalRagContextResult(None, None)
+
+    builder = _create_local_capture_builder(app)
+    if builder is None:
+        return LocalRagContextResult(context, None)
+
+    try:
+        scope_resolution = await resolve_scope_for_session(
+            app,
+            request_session,
+            use_cache=False,
+        )
+        source_kinds = tuple(
+            dict.fromkeys(
+                candidate.source_kind for candidate in authorization.candidates
+            )
+        )
+        requested_top_k = payload.get("requested_top_k", len(normalized))
+        if isinstance(requested_top_k, bool):
+            requested_top_k = len(normalized)
+        try:
+            requested_top_k = int(requested_top_k)
+        except (TypeError, ValueError):
+            requested_top_k = len(normalized)
+        requested_top_k = max(
+            1,
+            min(requested_top_k, RETRIEVAL_CANDIDATES_PER_RUN_MAX),
+        )
+        captured_at = datetime.now(UTC)
+        run_id = builder.record_retrieval_run(
+            stage="console_rag",
+            raw_query=bundle.query or user_message,
+            candidates=tuple(
+                candidate.to_candidate_capture(candidate_rank=rank)
+                for rank, candidate in enumerate(
+                    authorization.candidates,
+                    start=1,
+                )
+            ),
+            retrieval_metadata=LocalRetrievalRunMetadata(
+                search_mode="console_rag",
+                requested_top_k=requested_top_k,
+                max_context_characters=len(context),
+                rerank_enabled=False,
+                source_kinds=source_kinds,
+                scope_state=scope_resolution.effective.state,
+            ),
+            started_at=captured_at,
+            ended_at=captured_at,
+        )
+        builder.record_prompt_evidence_set(
+            run_id=run_id,
+            evidence=formatted.entries,
+            created_at=captured_at,
+        )
+    except Exception:
+        logger.error(
+            "Console canonical RAG capture failed; reason=canonical_capture_failure"
+        )
+        return LocalRagContextResult(None, None)
+
+    logger.info(
+        "Console canonical RAG capture completed; "
+        f"candidates={len(authorization.candidates)}; "
+        f"prompt_entries={len(formatted.entries)}"
+    )
+    return LocalRagContextResult(context, builder)
 
 
 async def get_rag_context_capture_for_chat(

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
@@ -664,6 +664,8 @@ def _read_fresh_workspace_scope_sync(
     scope = _parse_fresh_scope(raw_scope)
     if scope is None:
         raise ValueError("workspace scope authority is malformed")
+    if not scope.items:
+        return None
     return scope
 
 

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
@@ -16,6 +16,7 @@ from ...Chat.rag_scope import (
     CONVERSATION_METADATA_SCOPE_KEY,
     EffectiveScope,
     RagScope,
+    SCOPE_VERSION,
     SCOPE_EMPTY_NOTICE_TEMPLATE,
     SCOPE_REASON_EMPTY,
     SCOPE_STATUS_EMPTY,
@@ -643,22 +644,42 @@ def _read_fresh_workspace_scope_sync(
     with registry_db.connection() as conn:
         row = conn.execute(
             """
-            SELECT payload
-            FROM workspace_rag_scopes
-            WHERE workspace_id = ?
+            SELECT records.workspace_id, scopes.payload
+            FROM workspace_records AS records
+            LEFT JOIN workspace_rag_scopes AS scopes
+                ON scopes.workspace_id = records.workspace_id
+            WHERE records.workspace_id = ?
             """,
             (workspace_id,),
         ).fetchone()
     if row is None:
-        return None
+        raise LookupError("linked workspace authority is unavailable")
     try:
         payload = row["payload"]
     except (IndexError, KeyError, TypeError):
-        payload = row[0]
+        payload = row[1]
+    if payload is None:
+        return None
     raw_scope = json.loads(payload)
-    scope = parse_scope(raw_scope)
+    scope = _parse_fresh_scope(raw_scope)
     if scope is None:
         raise ValueError("workspace scope authority is malformed")
+    return scope
+
+
+def _parse_fresh_scope(raw_scope: Any) -> Optional[RagScope]:
+    """Parse fresh authority without exposing an untrusted version in logs."""
+
+    if raw_scope is None:
+        return None
+    if not isinstance(raw_scope, dict):
+        raise ValueError("fresh scope authority is malformed")
+    version = raw_scope.get("version")
+    if type(version) is not int or version != SCOPE_VERSION:
+        raise ValueError("fresh scope authority version is invalid")
+    scope = parse_scope(raw_scope)
+    if scope is None:
+        raise ValueError("fresh scope authority is malformed")
     return scope
 
 
@@ -687,13 +708,14 @@ async def resolve_scope_for_session(
     Phase 3 of the rag-scope-narrowing program). The workspace's stored
     scope is normally read through ``workspace_registry_service``'s
     ``get_workspace_scope`` method. Fresh prompt authorization instead reads
-    the registry row directly so a genuinely missing row remains unscoped
-    while a malformed stored row is distinguishable and fails closed. A
-    missing service or a missing/empty ``workspace_id`` degrades to
-    ``ws_scope=None`` only outside fresh authorization. A storage READ FAILURE
-    does NOT degrade to ``ws_scope=None``, because that would silently drop the
-    workspace bound and widen a hard-filter feature on error. Instead this
-    function returns early with an EMPTY ``EffectiveScope`` (``cause="workspace-scope-
+    workspace record and optional scope row together so an existing workspace
+    with no scope remains unscoped while a missing workspace or malformed
+    stored scope fails closed. A missing service or a missing/empty
+    ``workspace_id`` degrades to ``ws_scope=None`` only outside fresh
+    authorization. A storage READ FAILURE does NOT degrade to ``ws_scope=None``,
+    because that would silently drop the workspace bound and widen a hard-filter
+    feature on error. Instead this function returns early with an EMPTY
+    ``EffectiveScope`` (``cause="workspace-scope-
     unavailable"``), regardless of whether the conversation itself has a
     scope, since conv-scope-alone is always wider than the (conv ∩
     workspace) intersection that can no longer be computed.
@@ -770,7 +792,7 @@ async def resolve_scope_for_session(
                     if not isinstance(metadata, dict):
                         raise ValueError("conversation metadata is not an object")
                 raw_scope = metadata.get(CONVERSATION_METADATA_SCOPE_KEY)
-                conv_scope = parse_scope(raw_scope)
+                conv_scope = _parse_fresh_scope(raw_scope)
                 if raw_scope is not None and conv_scope is None:
                     raise ValueError("conversation scope is malformed")
                 if conv_scope is not None and not conv_scope.items:

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
@@ -88,6 +88,10 @@ class _PromptAuthorizationResult:
     completed: bool
 
 
+class _ScopeExistenceReadError(RuntimeError):
+    """A scoped dangling-id authority read did not complete."""
+
+
 _CURRENT_ACTIVE_SESSION = object()
 
 
@@ -598,6 +602,52 @@ def _capture_request_scope_session(app: "TldwCli") -> _RequestScopeSession | Non
         return None
 
 
+def _sensitive_fetchall(
+    db: Any,
+    query: str,
+    params: tuple[Any, ...],
+) -> list[Any]:
+    """Run an identity-bearing read without the public query logger.
+
+    Production database classes expose ``get_connection``; their public
+    ``execute_query`` helpers DEBUG-log parameters and therefore must not be
+    used for prompt-boundary identity reads. The fallback exists only for
+    deliberately small test doubles in test modules.
+    """
+
+    get_connection = getattr(db, "get_connection", None)
+    if callable(get_connection):
+        return list(get_connection().execute(query, params).fetchall())
+
+    module_name = type(db).__module__
+    is_test_double = (
+        module_name.startswith("Tests.")
+        or module_name.startswith("test_")
+        or ".test_" in module_name
+    )
+    execute_query = getattr(db, "execute_query", None)
+    if is_test_double and callable(execute_query):
+        return list(execute_query(query, params).fetchall())
+    raise RuntimeError("sensitive database read is unavailable")
+
+
+def _read_fresh_conversation_metadata_sync(db: Any, conversation_id: str) -> Any:
+    """Read prompt-boundary conversation metadata without logging its id."""
+
+    rows = _sensitive_fetchall(
+        db,
+        "SELECT metadata FROM conversations WHERE id = ? AND deleted = 0",
+        (conversation_id,),
+    )
+    if not rows:
+        raise LookupError("active conversation unavailable")
+    row = rows[0]
+    try:
+        return row["metadata"]
+    except (IndexError, KeyError, TypeError):
+        return row[0]
+
+
 def _existing_ids_sync(
     app: "TldwCli", source_type: str, ids: "frozenset[str]"
 ) -> "frozenset[str]":
@@ -610,10 +660,9 @@ def _existing_ids_sync(
     ``asyncio.to_thread`` around the whole ``resolve_effective_scope`` call,
     matching this file's existing threading discipline for DB work).
 
-    Missing DB handles or query errors degrade to "nothing survives" (an
-    empty ``frozenset``) rather than raising or assuming existence: a broken
-    existence check must never let scope enforcement silently widen to
-    "search everything".
+    Missing DB handles or query errors raise ``_ScopeExistenceReadError`` so
+    callers can distinguish unavailable authority from a successful read in
+    which no rows survive.
 
     Args:
         app: App-like object exposing ``media_db``/``chachanotes_db``.
@@ -634,19 +683,23 @@ def _existing_ids_sync(
     else:
         return frozenset()
     if db is None:
-        return frozenset()
+        logger.warning(
+            "RAG scope existence unavailable; reason=scope_existing_ids_read_failure"
+        )
+        raise _ScopeExistenceReadError from None
     try:
-        rows = db.execute_query(
+        rows = _sensitive_fetchall(
+            db,
             f"SELECT id FROM {table} "
             "WHERE id IN (SELECT value FROM json_each(?)) AND deleted = 0",
             (json.dumps(sorted(ids)),),
-        ).fetchall()
+        )
         return frozenset(str(row[0]) for row in rows)
     except Exception:
         logger.warning(
             "RAG scope existence unavailable; reason=scope_existing_ids_read_failure"
         )
-        return frozenset()
+        raise _ScopeExistenceReadError from None
 
 
 @dataclass(frozen=True)
@@ -852,14 +905,15 @@ async def resolve_scope_for_session(
         else:
             try:
                 if conversation_is_memory_db:
-                    record = db.get_conversation_by_id(str(conversation_id))
-                else:
-                    record = await asyncio.to_thread(
-                        db.get_conversation_by_id, str(conversation_id)
+                    raw_metadata = _read_fresh_conversation_metadata_sync(
+                        db, str(conversation_id)
                     )
-                if record is None:
-                    raise LookupError("active conversation unavailable")
-                raw_metadata = record.get("metadata")
+                else:
+                    raw_metadata = await asyncio.to_thread(
+                        _read_fresh_conversation_metadata_sync,
+                        db,
+                        str(conversation_id),
+                    )
                 if raw_metadata in (None, ""):
                     metadata = {}
                 else:
@@ -975,11 +1029,22 @@ async def resolve_scope_for_session(
     def _existing_ids(source_type: str, ids: "frozenset[str]") -> "frozenset[str]":
         return _existing_ids_sync(app, source_type, ids)
 
-    if scope_resolution_requires_inline:
-        effective = resolve_effective_scope(conv_scope, ws_scope, _existing_ids)
-    else:
-        effective = await asyncio.to_thread(
-            resolve_effective_scope, conv_scope, ws_scope, _existing_ids
+    try:
+        if scope_resolution_requires_inline:
+            effective = resolve_effective_scope(conv_scope, ws_scope, _existing_ids)
+        else:
+            effective = await asyncio.to_thread(
+                resolve_effective_scope, conv_scope, ws_scope, _existing_ids
+            )
+    except _ScopeExistenceReadError:
+        return ScopeResolution(
+            conv_scope,
+            ws_scope,
+            EffectiveScope(
+                state="empty",
+                allowlist={},
+                cause="scope-existence-unavailable",
+            ),
         )
     if use_cache:
         cache.put(cache_key_id, workspace_id, conv_stamp, ws_stamp, effective)
@@ -1028,11 +1093,12 @@ def _current_media_evidence_ids_sync(
     """Return current media identities with one batched database read."""
 
     try:
-        rows = media_db.execute_query(
+        rows = _sensitive_fetchall(
+            media_db,
             "SELECT id FROM Media "
             "WHERE id IN (SELECT value FROM json_each(?)) AND deleted = 0",
             (json.dumps(sorted(media_ids)),),
-        ).fetchall()
+        )
     except Exception:
         logger.warning(
             "Prompt-boundary authority unavailable; status=unavailable; "
@@ -1050,7 +1116,8 @@ def _current_chacha_evidence_ids_sync(
     """Return current note/conversation identities with one batched DB read."""
 
     try:
-        rows = db.execute_query(
+        rows = _sensitive_fetchall(
+            db,
             "SELECT 'notes' AS source_kind, id FROM notes "
             "WHERE id IN (SELECT value FROM json_each(?)) AND deleted = 0 "
             "UNION ALL "
@@ -1060,7 +1127,7 @@ def _current_chacha_evidence_ids_sync(
                 json.dumps(sorted(note_ids)),
                 json.dumps(sorted(conversation_ids)),
             ),
-        ).fetchall()
+        )
     except Exception:
         logger.warning(
             "Prompt-boundary authority unavailable; status=unavailable; "
@@ -1151,6 +1218,7 @@ async def _authorize_local_results_for_prompt(
     if effective_scope.state == "empty":
         authority_failed = effective_scope.cause in {
             "conversation-scope-unavailable",
+            "scope-existence-unavailable",
             "workspace-scope-unavailable",
         }
         return _PromptAuthorizationResult((), not authority_failed)
@@ -1295,19 +1363,32 @@ async def _capture_local_pipeline_results(
     """Atomically assemble and record canonical local prompt evidence."""
 
     try:
+        selected_source_kinds = _selected_source_kinds(sources)
+        selected_source_kind_set = frozenset(selected_source_kinds)
         normalized: list[NormalizedLocalResult] = []
         rejected_count = 0
+        off_selection_count = 0
         for candidate_rank, result in enumerate(results, start=1):
             try:
-                normalized.append(
-                    normalize_local_result(result, candidate_rank=candidate_rank)
+                candidate = normalize_local_result(
+                    result,
+                    candidate_rank=candidate_rank,
                 )
+                if candidate.source_kind not in selected_source_kind_set:
+                    off_selection_count += 1
+                    continue
+                normalized.append(candidate)
             except LocalResultNormalizationError:
                 rejected_count += 1
         if rejected_count:
             logger.warning(
                 "RAG candidates rejected; "
                 f"count={rejected_count}; reason=invalid_local_result"
+            )
+        if off_selection_count:
+            logger.info(
+                "RAG candidates excluded; "
+                f"count={off_selection_count}; reason=source_not_selected"
             )
 
         authorization = await _authorize_local_results_for_prompt(
@@ -1336,7 +1417,7 @@ async def _capture_local_pipeline_results(
             requested_top_k=top_k,
             max_context_characters=max_context_length,
             rerank_enabled=bool(enable_rerank),
-            source_kinds=_selected_source_kinds(sources),
+            source_kinds=selected_source_kinds,
             scope_state=effective_scope.state,
         )
         candidates = tuple(

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
@@ -6,12 +6,14 @@ import asyncio
 import copy
 import json
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple
 
 from loguru import logger
 
 # Local Imports
+from ...Chat.citation_source_locators import CanonicalSourceKind
 from ...Chat.rag_scope import (
+    CONVERSATION_METADATA_SCOPE_KEY,
     EffectiveScope,
     RagScope,
     SCOPE_EMPTY_NOTICE_TEMPLATE,
@@ -21,10 +23,18 @@ from ...Chat.rag_scope import (
     SOURCE_TYPE_NOTE,
     ScopeCache,
     SessionScopeHolder,
+    parse_scope,
     read_conversation_scope,
     resolve_effective_scope,
 )
 from ...RAG_Search.fusion import resolve_hybrid_alpha
+from ...RAG_Search.local_citation_capture import (
+    LocalEvidenceContext,
+    LocalResultNormalizationError,
+    NormalizedLocalResult,
+    format_local_evidence_context,
+    normalize_local_result,
+)
 from ...RAG_Search.pipeline_builder_simple import BUILTIN_PIPELINES, execute_pipeline
 from ...RAG_Search.pipeline_functions_simple import SCOPE_DIAGNOSTICS_KEY
 from ...RAG_Search.semantic_availability import (
@@ -299,7 +309,13 @@ async def perform_search_with_pipeline(
 
     # Execute pipeline with merged parameters
     return await execute_pipeline(
-        config, app, query, sources, diagnostics=diagnostics, scope=scope, **merged_params
+        config,
+        app,
+        query,
+        sources,
+        diagnostics=diagnostics,
+        scope=scope,
+        **merged_params,
     )
 
 
@@ -556,9 +572,7 @@ def _existing_ids_sync(
         ).fetchall()
         return frozenset(str(row[0]) for row in rows)
     except Exception as e:
-        logger.warning(
-            f"rag_scope existing-ids check failed for {source_type}: {e}"
-        )
+        logger.warning(f"rag_scope existing-ids check failed for {source_type}: {e}")
         return frozenset()
 
 
@@ -617,7 +631,7 @@ def _scope_cache_for(app: "TldwCli") -> ScopeCache:
 
 
 async def resolve_scope_for_session(
-    app: "TldwCli", session: Optional[Any]
+    app: "TldwCli", session: Optional[Any], *, use_cache: bool = True
 ) -> ScopeResolution:
     """Resolve conversation + workspace RAG retrieval scope for ``session``.
 
@@ -676,6 +690,9 @@ async def resolve_scope_for_session(
         app: The running app instance.
         session: The Console session to resolve scope for, or ``None`` (no
             active session -- resolves fully unscoped with zero DB work).
+        use_cache: Whether to consult and populate the per-app scope cache.
+            Prompt-boundary evidence authorization passes ``False`` so
+            retrieval-time scope state cannot authorize stale evidence.
 
     Returns:
         A ``ScopeResolution`` carrying the raw conversation scope, the raw
@@ -695,12 +712,59 @@ async def resolve_scope_for_session(
 
     conv_scope: Optional[RagScope] = None
     if conversation_id and db is not None:
-        if is_memory_db:
-            conv_scope = read_conversation_scope(db, conversation_id)
+        if use_cache:
+            if is_memory_db:
+                conv_scope = read_conversation_scope(db, conversation_id)
+            else:
+                conv_scope = await asyncio.to_thread(
+                    read_conversation_scope, db, conversation_id
+                )
         else:
-            conv_scope = await asyncio.to_thread(
-                read_conversation_scope, db, conversation_id
-            )
+            try:
+                if is_memory_db:
+                    record = db.get_conversation_by_id(str(conversation_id))
+                else:
+                    record = await asyncio.to_thread(
+                        db.get_conversation_by_id, str(conversation_id)
+                    )
+                if record is None:
+                    raise LookupError("active conversation unavailable")
+                raw_metadata = record.get("metadata")
+                if raw_metadata in (None, ""):
+                    metadata = {}
+                else:
+                    metadata = json.loads(raw_metadata)
+                    if not isinstance(metadata, dict):
+                        raise ValueError("conversation metadata is not an object")
+                raw_scope = metadata.get(CONVERSATION_METADATA_SCOPE_KEY)
+                conv_scope = parse_scope(raw_scope)
+                if raw_scope is not None and conv_scope is None:
+                    raise ValueError("conversation scope is malformed")
+                if conv_scope is not None and not conv_scope.items:
+                    conv_scope = None
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Fresh prompt-boundary conversation scope read failed"
+                )
+                return ScopeResolution(
+                    None,
+                    None,
+                    EffectiveScope(
+                        state="empty",
+                        allowlist={},
+                        cause="conversation-scope-unavailable",
+                    ),
+                )
+    elif conversation_id and not use_cache:
+        return ScopeResolution(
+            None,
+            None,
+            EffectiveScope(
+                state="empty",
+                allowlist={},
+                cause="conversation-scope-unavailable",
+            ),
+        )
     elif session is not None:
         holder = getattr(session, "rag_scope_holder", None)
         if isinstance(holder, SessionScopeHolder):
@@ -711,6 +775,16 @@ async def resolve_scope_for_session(
     )
     ws_scope: Optional[RagScope] = None
     registry_service = getattr(app, "workspace_registry_service", None)
+    if workspace_id and registry_service is None and not use_cache:
+        return ScopeResolution(
+            conv_scope,
+            None,
+            EffectiveScope(
+                state="empty",
+                allowlist={},
+                cause="workspace-scope-unavailable",
+            ),
+        )
     if workspace_id and registry_service is not None:
         registry_db = getattr(registry_service, "db", None)
         registry_is_memory = bool(getattr(registry_db, "is_memory_db", False))
@@ -770,9 +844,10 @@ async def resolve_scope_for_session(
     conv_stamp = conv_scope.updated_at if conv_scope is not None else None
     ws_stamp = ws_scope.updated_at if ws_scope is not None else None
     cache = _scope_cache_for(app)
-    cached = cache.get(cache_key_id, workspace_id, conv_stamp, ws_stamp)
-    if cached is not None:
-        return ScopeResolution(conv_scope, ws_scope, cached)
+    if use_cache:
+        cached = cache.get(cache_key_id, workspace_id, conv_stamp, ws_stamp)
+        if cached is not None:
+            return ScopeResolution(conv_scope, ws_scope, cached)
 
     def _existing_ids(source_type: str, ids: "frozenset[str]") -> "frozenset[str]":
         return _existing_ids_sync(app, source_type, ids)
@@ -783,11 +858,14 @@ async def resolve_scope_for_session(
         effective = await asyncio.to_thread(
             resolve_effective_scope, conv_scope, ws_scope, _existing_ids
         )
-    cache.put(cache_key_id, workspace_id, conv_stamp, ws_stamp, effective)
+    if use_cache:
+        cache.put(cache_key_id, workspace_id, conv_stamp, ws_stamp, effective)
     return ScopeResolution(conv_scope, ws_scope, effective)
 
 
-async def resolve_effective_scope_for_chat(app: "TldwCli") -> EffectiveScope:
+async def resolve_effective_scope_for_chat(
+    app: "TldwCli", *, use_cache: bool = True
+) -> EffectiveScope:
     """Resolve the RAG retrieval scope for the message about to be sent.
 
     Conversation identity comes from the active native-Console session's
@@ -799,6 +877,8 @@ async def resolve_effective_scope_for_chat(app: "TldwCli") -> EffectiveScope:
 
     Args:
         app: The running app instance.
+        use_cache: Whether to use the retrieval/display scope cache. Pass
+            ``False`` at a provider prompt boundary.
 
     Returns:
         The resolved ``EffectiveScope`` -- ``state == "unscoped"`` (with no
@@ -807,7 +887,7 @@ async def resolve_effective_scope_for_chat(app: "TldwCli") -> EffectiveScope:
         ``resolve_effective_scope``'s own both-``None`` contract.
     """
     session = _active_console_session(app)
-    resolution = await resolve_scope_for_session(app, session)
+    resolution = await resolve_scope_for_session(app, session, use_cache=use_cache)
     return resolution.effective
 
 
@@ -816,6 +896,165 @@ async def resolve_effective_scope_for_chat(app: "TldwCli") -> EffectiveScope:
 # `chat_rag_events._resolve_effective_scope_for_chat`) keeps working. New
 # code should import `resolve_effective_scope_for_chat` directly.
 _resolve_effective_scope_for_chat = resolve_effective_scope_for_chat
+
+
+def _current_local_evidence_ids_sync(
+    app: "TldwCli",
+    ids_by_source: Dict[CanonicalSourceKind, frozenset[str]],
+) -> Optional[frozenset[tuple[CanonicalSourceKind, str]]]:
+    """Return current non-deleted local identities using batched DB reads."""
+
+    found: set[tuple[CanonicalSourceKind, str]] = set()
+    media_ids = ids_by_source.get(CanonicalSourceKind.MEDIA_DB, frozenset())
+    if media_ids:
+        media_db = getattr(app, "media_db", None)
+        if media_db is None:
+            return None
+        try:
+            rows = media_db.execute_query(
+                "SELECT id FROM Media "
+                "WHERE id IN (SELECT value FROM json_each(?)) AND deleted = 0",
+                (json.dumps(sorted(media_ids)),),
+            ).fetchall()
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Prompt-boundary media existence read failed"
+            )
+            return None
+        found.update((CanonicalSourceKind.MEDIA_DB, str(row[0])) for row in rows)
+
+    note_ids = ids_by_source.get(CanonicalSourceKind.NOTES, frozenset())
+    conversation_ids = ids_by_source.get(CanonicalSourceKind.CHAT_HISTORY, frozenset())
+    if note_ids or conversation_ids:
+        db = getattr(app, "chachanotes_db", None)
+        if db is None:
+            return None
+        try:
+            rows = db.execute_query(
+                "SELECT 'notes' AS source_kind, id FROM notes "
+                "WHERE id IN (SELECT value FROM json_each(?)) AND deleted = 0 "
+                "UNION ALL "
+                "SELECT 'chat_history' AS source_kind, id FROM conversations "
+                "WHERE id IN (SELECT value FROM json_each(?)) AND deleted = 0",
+                (
+                    json.dumps(sorted(note_ids)),
+                    json.dumps(sorted(conversation_ids)),
+                ),
+            ).fetchall()
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Prompt-boundary notes/conversations existence read failed"
+            )
+            return None
+        source_kinds = {
+            "notes": CanonicalSourceKind.NOTES,
+            "chat_history": CanonicalSourceKind.CHAT_HISTORY,
+        }
+        found.update((source_kinds[str(row[0])], str(row[1])) for row in rows)
+
+    return frozenset(found)
+
+
+async def authorize_local_results_for_prompt(
+    app: "TldwCli",
+    normalized_results: Sequence[NormalizedLocalResult],
+) -> Tuple[NormalizedLocalResult, ...]:
+    """Re-read current authority and backing rows before assigning markers.
+
+    Args:
+        app: Running app with current session and local DB authorities.
+        normalized_results: Strict canonical candidates in retrieval order.
+
+    Returns:
+        Current, authorized candidates in their original order. Any authority
+        or existence read failure returns an empty tuple.
+    """
+
+    if not normalized_results:
+        return ()
+    try:
+        effective_scope = await resolve_effective_scope_for_chat(app, use_cache=False)
+    except Exception:
+        logger.opt(exception=True).warning(
+            "Prompt-boundary scope authority read failed"
+        )
+        return ()
+    if effective_scope.state == "empty":
+        return ()
+
+    ids_by_source: Dict[CanonicalSourceKind, set[str]] = {}
+    for result in normalized_results:
+        if not isinstance(result, NormalizedLocalResult):
+            return ()
+        ids_by_source.setdefault(result.source_kind, set()).add(result.source_id)
+    frozen_ids = {
+        source_kind: frozenset(source_ids)
+        for source_kind, source_ids in ids_by_source.items()
+    }
+    dbs = (
+        getattr(app, "media_db", None),
+        getattr(app, "chachanotes_db", None),
+    )
+    run_inline = any(
+        bool(getattr(db, "is_memory_db", False)) for db in dbs if db is not None
+    )
+    if run_inline:
+        existing = _current_local_evidence_ids_sync(app, frozen_ids)
+    else:
+        existing = await asyncio.to_thread(
+            _current_local_evidence_ids_sync, app, frozen_ids
+        )
+    if existing is None:
+        return ()
+
+    scope_source_types = {
+        CanonicalSourceKind.MEDIA_DB: SOURCE_TYPE_MEDIA,
+        CanonicalSourceKind.NOTES: SOURCE_TYPE_NOTE,
+    }
+    authorized: list[NormalizedLocalResult] = []
+    for result in normalized_results:
+        identity = (result.source_kind, result.source_id)
+        if identity not in existing:
+            continue
+        if effective_scope.state == "scoped":
+            source_type = scope_source_types.get(result.source_kind)
+            if source_type is None:
+                continue
+            if result.source_id not in effective_scope.allowlist.get(
+                source_type, frozenset()
+            ):
+                continue
+        authorized.append(result)
+    return tuple(authorized)
+
+
+async def assemble_local_evidence_for_prompt(
+    app: "TldwCli",
+    results: List[Any],
+    *,
+    max_length: int = 90,
+) -> LocalEvidenceContext:
+    """Opt in to strict normalization, fresh authorization, and formatting.
+
+    Args:
+        app: Running app with current session and local DB authorities.
+        results: Legacy pipeline result mappings or objects.
+        max_length: Maximum Unicode codepoints in the formatted context.
+
+    Returns:
+        Exact prompt context and canonical per-entry snapshot captures.
+    """
+
+    normalized: list[NormalizedLocalResult] = []
+    for candidate_rank, result in enumerate(results, start=1):
+        try:
+            normalized.append(
+                normalize_local_result(result, candidate_rank=candidate_rank)
+            )
+        except LocalResultNormalizationError:
+            continue
+    authorized = await authorize_local_results_for_prompt(app, tuple(normalized))
+    return format_local_evidence_context(authorized, max_length=max_length)
 
 
 async def get_rag_context_for_chat(app: "TldwCli", user_message: str) -> Optional[str]:

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
@@ -66,7 +66,10 @@ logger = logger.bind(module="chat_rag_events_simplified")
 
 @dataclass(frozen=True)
 class LocalRagContextResult:
-    """RAG context plus an optional request-scoped canonical capture."""
+    """RAG context with optional request-scoped builder and prompt-set identity.
+
+    The optional ID is the authoritative prompt-evidence-set identity.
+    """
 
     context: str | None
     citation_builder: CitationTraceBuilder | None
@@ -1542,7 +1545,10 @@ async def capture_console_staged_evidence_for_chat(
             has no retrieval query.
 
     Returns:
-        Exact provider context plus an optional request-local citation builder.
+        Exact provider context, an optional request-local citation builder,
+        and its authoritative prompt-evidence-set ID. The ID is present only
+        after a non-empty prompt evidence set is recorded successfully;
+        otherwise it is ``None``.
     """
 
     payload = getattr(launch, "payload", None)

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
@@ -345,7 +345,11 @@ async def perform_search_with_pipeline(
     config = get_pipeline(pipeline_id)
 
     if not config:
-        logger.error("RAG pipeline unavailable; reason=pipeline_not_found")
+        logger.error(
+            "RAG pipeline unavailable; reason=pipeline_not_found; "
+            f"pipeline_id={pipeline_id}; "
+            f"selected_source_count={sum(bool(value) for value in sources.values())}"
+        )
         return [], f"Pipeline '{pipeline_id}' not found"
 
     # Make a copy to avoid modifying the original
@@ -1520,7 +1524,11 @@ async def _capture_local_pipeline_results(
         context = formatted.context if formatted.context.strip() else None
         return LocalRagContextResult(context, builder, prompt_evidence_set_id)
     except Exception:
-        logger.error("Canonical RAG capture failed; reason=canonical_capture_failure")
+        logger.error(
+            "Canonical RAG capture failed; reason=canonical_capture_failure; "
+            f"mode={search_mode}; requested_top_k={top_k}; "
+            f"scope_state={effective_scope.state}"
+        )
         return LocalRagContextResult(None, None)
 
 
@@ -1684,7 +1692,10 @@ async def capture_console_staged_evidence_for_chat(
         )
     except Exception:
         logger.error(
-            "Console canonical RAG capture failed; reason=canonical_capture_failure"
+            "Console canonical RAG capture failed; "
+            "reason=canonical_capture_failure; "
+            f"normalized_candidates={len(normalized)}; "
+            f"authorized_candidates={len(authorization.candidates)}"
         )
         return LocalRagContextResult(None, None)
 

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
@@ -763,14 +763,15 @@ async def resolve_scope_for_session(
 
     db = getattr(app, "chachanotes_db", None)
     media_db = getattr(app, "media_db", None)
-    is_memory_db = bool(getattr(db, "is_memory_db", False)) or bool(
+    conversation_is_memory_db = bool(getattr(db, "is_memory_db", False))
+    scope_resolution_requires_inline = conversation_is_memory_db or bool(
         getattr(media_db, "is_memory_db", False)
     )
 
     conv_scope: Optional[RagScope] = None
     if conversation_id and db is not None:
         if use_cache:
-            if is_memory_db:
+            if conversation_is_memory_db:
                 conv_scope = read_conversation_scope(db, conversation_id)
             else:
                 conv_scope = await asyncio.to_thread(
@@ -778,7 +779,7 @@ async def resolve_scope_for_session(
                 )
         else:
             try:
-                if is_memory_db:
+                if conversation_is_memory_db:
                     record = db.get_conversation_by_id(str(conversation_id))
                 else:
                     record = await asyncio.to_thread(
@@ -902,7 +903,7 @@ async def resolve_scope_for_session(
     def _existing_ids(source_type: str, ids: "frozenset[str]") -> "frozenset[str]":
         return _existing_ids_sync(app, source_type, ids)
 
-    if is_memory_db:
+    if scope_resolution_requires_inline:
         effective = resolve_effective_scope(conv_scope, ws_scope, _existing_ids)
     else:
         effective = await asyncio.to_thread(

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
@@ -70,6 +70,7 @@ class LocalRagContextResult:
 
     context: str | None
     citation_builder: CitationTraceBuilder | None
+    prompt_evidence_set_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -1500,8 +1501,9 @@ async def _capture_local_pipeline_results(
             started_at=retrieval_started_at,
             ended_at=retrieval_ended_at,
         )
+        prompt_evidence_set_id = None
         if formatted.entries:
-            builder.record_prompt_evidence_set(
+            prompt_evidence_set_id = builder.record_prompt_evidence_set(
                 run_id=run_id,
                 evidence=formatted.entries,
                 created_at=datetime.now(UTC),
@@ -1513,7 +1515,7 @@ async def _capture_local_pipeline_results(
             f"duration_ms={retrieval_elapsed_ms}"
         )
         context = formatted.context if formatted.context.strip() else None
-        return LocalRagContextResult(context, builder)
+        return LocalRagContextResult(context, builder, prompt_evidence_set_id)
     except Exception:
         logger.error("Canonical RAG capture failed; reason=canonical_capture_failure")
         return LocalRagContextResult(None, None)
@@ -1669,7 +1671,7 @@ async def capture_console_staged_evidence_for_chat(
             started_at=captured_at,
             ended_at=captured_at,
         )
-        builder.record_prompt_evidence_set(
+        prompt_evidence_set_id = builder.record_prompt_evidence_set(
             run_id=run_id,
             evidence=formatted.entries,
             created_at=captured_at,
@@ -1685,7 +1687,7 @@ async def capture_console_staged_evidence_for_chat(
         f"candidates={len(authorization.candidates)}; "
         f"prompt_entries={len(formatted.entries)}"
     )
-    return LocalRagContextResult(context, builder)
+    return LocalRagContextResult(context, builder, prompt_evidence_set_id)
 
 
 async def get_rag_context_capture_for_chat(

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
@@ -583,17 +583,13 @@ def _capture_request_scope_session(app: "TldwCli") -> _RequestScopeSession | Non
         return None
     try:
         holder = getattr(session, "rag_scope_holder", None)
-        captured_holder = None
-        if isinstance(holder, SessionScopeHolder):
-            captured_holder = SessionScopeHolder()
-            captured_holder.set(holder.scope)
         return _RequestScopeSession(
             id=getattr(session, "id", None),
             persisted_conversation_id=getattr(
                 session, "persisted_conversation_id", None
             ),
             workspace_id=getattr(session, "workspace_id", None),
-            rag_scope_holder=captured_holder,
+            rag_scope_holder=holder if isinstance(holder, SessionScopeHolder) else None,
         )
     except Exception:
         logger.warning(

--- a/tldw_chatbook/Event_Handlers/worker_events.py
+++ b/tldw_chatbook/Event_Handlers/worker_events.py
@@ -72,6 +72,7 @@ def chat_wrapper_function(
     posts StreamingChunk and StreamDone messages, and returns a specific string value.
     If core_chat_function returns a direct result (non-streaming), this function returns it as is.
     """
+    citation_trace_builder = kwargs.pop("citation_trace_builder", None)
     logger = getattr(app_instance, "loguru_logger", _loguru_fallback_logger)
     start_time = time.time()
 
@@ -428,6 +429,8 @@ def chat_wrapper_function(
         # task-634: non-streaming callers consume the return value directly -- a swallowed
         # exception rendered the sentinel as the response. Propagate instead.
         raise
+    finally:
+        del citation_trace_builder
 
 
 #

--- a/tldw_chatbook/Event_Handlers/worker_events.py
+++ b/tldw_chatbook/Event_Handlers/worker_events.py
@@ -111,6 +111,7 @@ def chat_wrapper_function(
             error_message_if_any = None
             chunk_count = 0
             stream_start_time = time.time()
+            logged_first_chunk_structure = False
 
             log_counter(
                 "chat_worker_streaming_started",
@@ -173,14 +174,11 @@ def chat_wrapper_function(
                                 "vllm",
                             ]:
                                 if "choices" in json_data and json_data.get("choices"):
-                                    # Only log if we haven't logged the structure yet
-                                    if not hasattr(
-                                        chat_wrapper_function, "_logged_structure"
-                                    ):
+                                    if not logged_first_chunk_structure:
                                         logger.info(
                                             f"First streaming chunk structure for {api_endpoint} with logprobs enabled: {json.dumps(json_data, indent=2)[:1000]}..."
                                         )
-                                        chat_wrapper_function._logged_structure = True
+                                        logged_first_chunk_structure = True
 
                             choices = json_data.get("choices")
                             if (

--- a/tldw_chatbook/RAG_Search/local_citation_capture.py
+++ b/tldw_chatbook/RAG_Search/local_citation_capture.py
@@ -14,7 +14,12 @@ from ..Chat.citation_trace_builder import (
     LocalPromptEvidenceCapture,
     LocalRetrievalCandidateCapture,
 )
-from ..Chat.citation_trace_models import RetrievalScoreKind, RetrievalScoreScale
+from ..Chat.citation_trace_models import (
+    EVIDENCE_ENTRIES_PER_PROMPT_MAX,
+    RetrievalScoreKind,
+    RetrievalScoreScale,
+    SNAPSHOT_TEXT_UTF8_BYTES_MAX,
+)
 
 FINAL_SCORE_KIND_KEY = "_final_score_kind"
 FINAL_SCORE_KIND_RERANKER = "reranker"
@@ -34,7 +39,11 @@ _SOURCE_ALIASES = {
     "chat-history": CanonicalSourceKind.CHAT_HISTORY,
 }
 _METADATA_SOURCE_KEYS = ("source_type", "source_kind")
-_LINEAGE_KEYS = ("chunk_id", "chunk_index", "start_char", "end_char")
+_DIRECT_LINEAGE_KEYS = ("chunk_id", "chunk_index")
+_OFFSET_ALIASES = {
+    "start_char": "chunk_start",
+    "end_char": "chunk_end",
+}
 _TITLE_UTF8_BYTES_MAX = 4 * 1024
 _SEPARATOR = "\n---\n"
 _SOURCE_LABELS = {
@@ -132,19 +141,46 @@ def _result_value(result: Any, field: str) -> Any:
 
 def _resolve_source(result: Any, metadata: Mapping[str, Any]) -> CanonicalSourceKind:
     source = _result_value(result, "source")
+    if not isinstance(source, str):
+        _reject()
+    resolved: list[CanonicalSourceKind] = []
     canonical = _canonical_source(source)
     if canonical is not None:
-        return canonical
-    if not isinstance(source, str) or source.strip().lower() not in {"", "unknown"}:
+        resolved.append(canonical)
+    elif source.strip().lower() not in {"", "unknown"}:
         _reject()
     for key in _METADATA_SOURCE_KEYS:
         if key not in metadata:
             continue
         canonical = _canonical_source(metadata[key])
-        if canonical is not None:
-            return canonical
+        if canonical is None:
+            _reject()
+        resolved.append(canonical)
+    if not resolved or any(value is not resolved[0] for value in resolved[1:]):
         _reject()
-    _reject()
+    return resolved[0]
+
+
+def _resolve_lineage(metadata: Mapping[str, Any]) -> dict[str, Any]:
+    """Resolve allowlisted lineage and strict semantic offset aliases."""
+
+    lineage = {key: metadata.get(key) for key in _DIRECT_LINEAGE_KEYS}
+    for canonical_key, producer_key in _OFFSET_ALIASES.items():
+        canonical_present = canonical_key in metadata
+        producer_present = producer_key in metadata
+        if (
+            canonical_present
+            and producer_present
+            and metadata[canonical_key] != metadata[producer_key]
+        ):
+            _reject()
+        if canonical_present:
+            lineage[canonical_key] = metadata[canonical_key]
+        elif producer_present:
+            lineage[canonical_key] = metadata[producer_key]
+        else:
+            lineage[canonical_key] = None
+    return lineage
 
 
 def _reliable_rrf(metadata: Mapping[str, Any], score: float) -> bool:
@@ -264,7 +300,7 @@ def normalize_local_result(
     ):
         _reject()
 
-    lineage = {key: metadata.get(key) for key in _LINEAGE_KEYS}
+    lineage = _resolve_lineage(metadata)
     if (
         "source_id" in metadata
         and lineage["chunk_id"] is None
@@ -302,6 +338,24 @@ def normalize_local_result(
     )
 
 
+def _content_prefix_within_budgets(
+    content: str, *, character_budget: int, utf8_byte_budget: int
+) -> str:
+    """Return the longest whole-codepoint prefix within both budgets."""
+
+    prefix: list[str] = []
+    byte_count = 0
+    for character in content:
+        if len(prefix) >= character_budget:
+            break
+        character_bytes = len(character.encode("utf-8"))
+        if byte_count + character_bytes > utf8_byte_budget:
+            break
+        prefix.append(character)
+        byte_count += character_bytes
+    return "".join(prefix)
+
+
 def format_local_evidence_context(
     normalized_results: Sequence[NormalizedLocalResult], max_length: int = 90
 ) -> LocalEvidenceContext:
@@ -327,22 +381,41 @@ def format_local_evidence_context(
         if not isinstance(result, NormalizedLocalResult):
             raise TypeError("normalized_results must contain NormalizedLocalResult")
         candidate_rank = result.candidate_rank or position
+        if len(entries) >= EVIDENCE_ENTRIES_PER_PROMPT_MAX:
+            omitted.append(candidate_rank)
+            continue
         ordinal = len(entries) + 1
         label = _SOURCE_LABELS[result.source_kind]
         header = f"[S{ordinal}] {label} — {result.title}\n"
         separator_size = len(_SEPARATOR) if blocks else 0
-        available = max_length - context_length - separator_size
+        available_characters = max_length - context_length - separator_size
         full_block = f"{header}{result.content}"
         transformations: tuple[str, ...] = ()
-        if len(full_block) <= available:
+        if (
+            len(full_block) <= available_characters
+            and len(full_block.encode("utf-8")) <= SNAPSHOT_TEXT_UTF8_BYTES_MAX
+        ):
             block = full_block
-        elif available >= len(header) + 1:
-            content_budget = available - len(header) - 1
-            block = f"{header}{result.content[:content_budget]}…"
-            transformations = ("content_truncated",)
         else:
-            omitted.append(candidate_rank)
-            continue
+            ellipsis = "…"
+            content_character_budget = (
+                available_characters - len(header) - len(ellipsis)
+            )
+            content_byte_budget = (
+                SNAPSHOT_TEXT_UTF8_BYTES_MAX
+                - len(header.encode("utf-8"))
+                - len(ellipsis.encode("utf-8"))
+            )
+            if content_character_budget < 0 or content_byte_budget < 0:
+                omitted.append(candidate_rank)
+                continue
+            content = _content_prefix_within_budgets(
+                result.content,
+                character_budget=content_character_budget,
+                utf8_byte_budget=content_byte_budget,
+            )
+            block = f"{header}{content}{ellipsis}"
+            transformations = ("content_truncated",)
         blocks.append(block)
         context_length += separator_size + len(block)
         entries.append(

--- a/tldw_chatbook/RAG_Search/local_citation_capture.py
+++ b/tldw_chatbook/RAG_Search/local_citation_capture.py
@@ -1,0 +1,375 @@
+"""Strict normalization and exact formatting for local RAG prompt evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import math
+from collections.abc import Mapping, Sequence
+from typing import Any
+import unicodedata
+
+from ..Chat.citation_source_locators import CanonicalSourceKind
+from ..Chat.citation_trace_builder import (
+    LocalPromptEvidenceCapture,
+    LocalRetrievalCandidateCapture,
+)
+from ..Chat.citation_trace_models import RetrievalScoreKind, RetrievalScoreScale
+
+FINAL_SCORE_KIND_KEY = "_final_score_kind"
+FINAL_SCORE_KIND_RERANKER = "reranker"
+SEMANTIC_SCORE_KIND_KEY = "_semantic_score_kind"
+SEMANTIC_SCORE_KIND_VECTOR_SIMILARITY = "vector_similarity"
+
+_SOURCE_ALIASES = {
+    "media": CanonicalSourceKind.MEDIA_DB,
+    "media_db": CanonicalSourceKind.MEDIA_DB,
+    "media-db": CanonicalSourceKind.MEDIA_DB,
+    "note": CanonicalSourceKind.NOTES,
+    "notes": CanonicalSourceKind.NOTES,
+    "conversation": CanonicalSourceKind.CHAT_HISTORY,
+    "conversations": CanonicalSourceKind.CHAT_HISTORY,
+    "chat": CanonicalSourceKind.CHAT_HISTORY,
+    "chat_history": CanonicalSourceKind.CHAT_HISTORY,
+    "chat-history": CanonicalSourceKind.CHAT_HISTORY,
+}
+_METADATA_SOURCE_KEYS = ("source_type", "source_kind")
+_LINEAGE_KEYS = ("chunk_id", "chunk_index", "start_char", "end_char")
+_TITLE_UTF8_BYTES_MAX = 4 * 1024
+_SEPARATOR = "\n---\n"
+_SOURCE_LABELS = {
+    CanonicalSourceKind.MEDIA_DB: "MEDIA",
+    CanonicalSourceKind.NOTES: "NOTES",
+    CanonicalSourceKind.CHAT_HISTORY: "CHAT HISTORY",
+}
+
+
+class LocalResultRejectionCode(str, Enum):
+    """Stable non-content reason codes for rejected local candidates."""
+
+    INVALID_RESULT = "invalid_local_result"
+
+
+class LocalResultNormalizationError(ValueError):
+    """A local candidate was unsafe or incompatible with canonical capture."""
+
+    def __init__(self, reason_code: LocalResultRejectionCode) -> None:
+        self.reason_code = reason_code
+        super().__init__(reason_code.value)
+
+
+@dataclass(frozen=True)
+class NormalizedLocalResult:
+    """Allowlisted local result ready for canonical builder capture."""
+
+    source_kind: CanonicalSourceKind
+    source_id: str
+    title: str
+    content: str
+    score_kind: RetrievalScoreKind
+    score_scale: RetrievalScoreScale
+    score: float
+    chunk_id: str | None = None
+    chunk_index: int | None = None
+    start_char: int | None = None
+    end_char: int | None = None
+    candidate_rank: int | None = None
+
+    def to_candidate_capture(
+        self, *, candidate_rank: int | None = None
+    ) -> LocalRetrievalCandidateCapture:
+        """Convert to the canonical retrieval-candidate builder contract.
+
+        Args:
+            candidate_rank: Optional 1-based rank override.
+
+        Returns:
+            The canonical builder candidate capture.
+        """
+
+        rank = candidate_rank if candidate_rank is not None else self.candidate_rank
+        if rank is None:
+            raise ValueError("candidate_rank is required")
+        return LocalRetrievalCandidateCapture(
+            candidate_rank=rank,
+            source_kind=self.source_kind,
+            source_id=self.source_id,
+            title=self.title,
+            score_kind=self.score_kind,
+            score_scale=self.score_scale,
+            score=self.score,
+            chunk_id=self.chunk_id,
+            chunk_index=self.chunk_index,
+            start_char=self.start_char,
+            end_char=self.end_char,
+        )
+
+
+@dataclass(frozen=True)
+class LocalEvidenceContext:
+    """Exact context and canonical per-entry prompt capture blocks."""
+
+    context: str
+    entries: tuple[LocalPromptEvidenceCapture, ...]
+    omitted_candidate_ranks: tuple[int, ...]
+
+
+def _reject() -> None:
+    raise LocalResultNormalizationError(LocalResultRejectionCode.INVALID_RESULT)
+
+
+def _canonical_source(value: Any) -> CanonicalSourceKind | None:
+    if not isinstance(value, str):
+        return None
+    return _SOURCE_ALIASES.get(value.strip().lower())
+
+
+def _result_value(result: Any, field: str) -> Any:
+    if isinstance(result, Mapping):
+        return result.get(field)
+    return getattr(result, field, None)
+
+
+def _resolve_source(result: Any, metadata: Mapping[str, Any]) -> CanonicalSourceKind:
+    source = _result_value(result, "source")
+    canonical = _canonical_source(source)
+    if canonical is not None:
+        return canonical
+    if not isinstance(source, str) or source.strip().lower() not in {"", "unknown"}:
+        _reject()
+    for key in _METADATA_SOURCE_KEYS:
+        if key not in metadata:
+            continue
+        canonical = _canonical_source(metadata[key])
+        if canonical is not None:
+            return canonical
+        _reject()
+    _reject()
+
+
+def _reliable_rrf(metadata: Mapping[str, Any], score: float) -> bool:
+    fusion = metadata.get("hybrid_fusion")
+    if not isinstance(fusion, Mapping):
+        return False
+    required = {
+        "fts_rank",
+        "vector_rank",
+        "fts_rrf",
+        "vector_rrf",
+        "alpha",
+        "rrf_k",
+    }
+    if set(fusion) != required:
+        return False
+    alpha = fusion["alpha"]
+    rrf_k = fusion["rrf_k"]
+    if (
+        isinstance(alpha, bool)
+        or not isinstance(alpha, (int, float))
+        or not math.isfinite(float(alpha))
+        or not 0 <= float(alpha) <= 1
+        or isinstance(rrf_k, bool)
+        or not isinstance(rrf_k, int)
+        or rrf_k < 0
+    ):
+        return False
+
+    expected_contributions: list[float] = []
+    for rank_key, contribution_key in (
+        ("fts_rank", "fts_rrf"),
+        ("vector_rank", "vector_rrf"),
+    ):
+        rank = fusion[rank_key]
+        contribution = fusion[contribution_key]
+        if (
+            isinstance(contribution, bool)
+            or not isinstance(contribution, (int, float))
+            or not math.isfinite(float(contribution))
+        ):
+            return False
+        if rank is None:
+            expected = 0.0
+        elif isinstance(rank, int) and not isinstance(rank, bool) and rank >= 1:
+            expected = 1.0 / (rrf_k + rank)
+        else:
+            return False
+        if not math.isclose(
+            float(contribution), expected, rel_tol=1e-12, abs_tol=1e-15
+        ):
+            return False
+        expected_contributions.append(expected)
+    if not any(fusion[key] is not None for key in ("fts_rank", "vector_rank")):
+        return False
+    expected_score = (1 - float(alpha)) * expected_contributions[0] + float(
+        alpha
+    ) * expected_contributions[1]
+    return math.isclose(score, expected_score, rel_tol=1e-12, abs_tol=1e-15)
+
+
+def _score_semantics(
+    metadata: Mapping[str, Any], score: float
+) -> tuple[RetrievalScoreKind, RetrievalScoreScale]:
+    if FINAL_SCORE_KIND_KEY in metadata:
+        if metadata[FINAL_SCORE_KIND_KEY] == FINAL_SCORE_KIND_RERANKER:
+            return RetrievalScoreKind.RERANKER, RetrievalScoreScale.UNBOUNDED
+        return RetrievalScoreKind.LEGACY, RetrievalScoreScale.UNBOUNDED
+    if "hybrid_fusion" in metadata:
+        if _reliable_rrf(metadata, score):
+            return RetrievalScoreKind.RRF, RetrievalScoreScale.NON_NEGATIVE
+        return RetrievalScoreKind.LEGACY, RetrievalScoreScale.UNBOUNDED
+    if metadata.get(SEMANTIC_SCORE_KIND_KEY) == SEMANTIC_SCORE_KIND_VECTOR_SIMILARITY:
+        return RetrievalScoreKind.VECTOR_SIMILARITY, RetrievalScoreScale.UNBOUNDED
+    return RetrievalScoreKind.LEGACY, RetrievalScoreScale.UNBOUNDED
+
+
+def normalize_local_result(
+    result: Any, *, candidate_rank: int | None = None
+) -> NormalizedLocalResult:
+    """Normalize one producer result into the strict local citation allowlist.
+
+    Args:
+        result: Search-result object or mapping from a local retrieval producer.
+        candidate_rank: Optional 1-based rank in the retrieval run.
+
+    Returns:
+        Strict canonical identity, exact content, score semantics, and lineage.
+
+    Raises:
+        LocalResultNormalizationError: If any governed field is invalid.
+    """
+
+    metadata = _result_value(result, "metadata")
+    if not isinstance(metadata, Mapping):
+        _reject()
+    source_kind = _resolve_source(result, metadata)
+
+    producer_result_id = _result_value(result, "id")
+    source_id = metadata.get("source_id", producer_result_id)
+    title = _result_value(result, "title")
+    content = _result_value(result, "content")
+    score = _result_value(result, "score")
+    if (
+        not isinstance(producer_result_id, str)
+        or not producer_result_id
+        or not isinstance(source_id, str)
+        or not source_id
+        or not isinstance(title, str)
+        or not title
+        or not isinstance(content, str)
+        or isinstance(score, bool)
+        or not isinstance(score, (int, float))
+        or not math.isfinite(float(score))
+        or len(title.encode("utf-8")) > _TITLE_UTF8_BYTES_MAX
+        or any(unicodedata.category(character).startswith("C") for character in title)
+    ):
+        _reject()
+
+    lineage = {key: metadata.get(key) for key in _LINEAGE_KEYS}
+    if (
+        "source_id" in metadata
+        and lineage["chunk_id"] is None
+        and producer_result_id != source_id
+    ):
+        lineage["chunk_id"] = producer_result_id
+    score_kind, score_scale = _score_semantics(metadata, float(score))
+    try:
+        candidate = LocalRetrievalCandidateCapture(
+            candidate_rank=candidate_rank if candidate_rank is not None else 1,
+            source_kind=source_kind,
+            source_id=source_id,
+            title=title,
+            score_kind=score_kind,
+            score_scale=score_scale,
+            score=float(score),
+            **lineage,
+        )
+    except (TypeError, ValueError):
+        _reject()
+
+    return NormalizedLocalResult(
+        source_kind=candidate.source_kind,
+        source_id=candidate.source_id,
+        title=candidate.title,
+        content=content,
+        score_kind=candidate.score_kind or RetrievalScoreKind.LEGACY,
+        score_scale=candidate.score_scale or RetrievalScoreScale.UNBOUNDED,
+        score=candidate.score if candidate.score is not None else float(score),
+        chunk_id=candidate.chunk_id,
+        chunk_index=candidate.chunk_index,
+        start_char=candidate.start_char,
+        end_char=candidate.end_char,
+        candidate_rank=candidate_rank,
+    )
+
+
+def format_local_evidence_context(
+    normalized_results: Sequence[NormalizedLocalResult], max_length: int = 90
+) -> LocalEvidenceContext:
+    """Format canonical marked evidence without reparsing aggregate context.
+
+    Args:
+        normalized_results: Authorized normalized results in retrieval order.
+        max_length: Maximum Unicode codepoints in the aggregate context.
+
+    Returns:
+        Exact aggregate context, per-entry builder captures, and omitted ranks.
+    """
+    if isinstance(max_length, bool) or not isinstance(max_length, int):
+        raise TypeError("max_length must be an integer")
+    if max_length < 0:
+        raise ValueError("max_length must be non-negative")
+
+    blocks: list[str] = []
+    entries: list[LocalPromptEvidenceCapture] = []
+    omitted: list[int] = []
+    context_length = 0
+    for position, result in enumerate(normalized_results, start=1):
+        if not isinstance(result, NormalizedLocalResult):
+            raise TypeError("normalized_results must contain NormalizedLocalResult")
+        candidate_rank = result.candidate_rank or position
+        ordinal = len(entries) + 1
+        label = _SOURCE_LABELS[result.source_kind]
+        header = f"[S{ordinal}] {label} — {result.title}\n"
+        separator_size = len(_SEPARATOR) if blocks else 0
+        available = max_length - context_length - separator_size
+        full_block = f"{header}{result.content}"
+        transformations: tuple[str, ...] = ()
+        if len(full_block) <= available:
+            block = full_block
+        elif available >= len(header) + 1:
+            content_budget = available - len(header) - 1
+            block = f"{header}{result.content[:content_budget]}…"
+            transformations = ("content_truncated",)
+        else:
+            omitted.append(candidate_rank)
+            continue
+        blocks.append(block)
+        context_length += separator_size + len(block)
+        entries.append(
+            LocalPromptEvidenceCapture(
+                candidate_rank=candidate_rank,
+                snapshot_text=block,
+                transformations=transformations,
+            )
+        )
+
+    context = _SEPARATOR.join(blocks)
+    return LocalEvidenceContext(
+        context=context,
+        entries=tuple(entries),
+        omitted_candidate_ranks=tuple(omitted),
+    )
+
+
+__all__ = [
+    "FINAL_SCORE_KIND_KEY",
+    "FINAL_SCORE_KIND_RERANKER",
+    "LocalEvidenceContext",
+    "LocalResultNormalizationError",
+    "LocalResultRejectionCode",
+    "NormalizedLocalResult",
+    "SEMANTIC_SCORE_KIND_KEY",
+    "SEMANTIC_SCORE_KIND_VECTOR_SIMILARITY",
+    "format_local_evidence_context",
+    "normalize_local_result",
+]

--- a/tldw_chatbook/RAG_Search/pipeline_functions_simple.py
+++ b/tldw_chatbook/RAG_Search/pipeline_functions_simple.py
@@ -671,8 +671,9 @@ def rerank_results(
             logger.warning("FlashRank not available, returning original order")
             return results[:top_k]
         except Exception:
-            logger.opt(exception=True).warning(
-                "FlashRank reranking failed; returning original order"
+            logger.warning(
+                "FlashRank reranking unavailable; status=fallback; "
+                "reason=execution_failure; returning original order"
             )
             return results[:top_k]
 

--- a/tldw_chatbook/RAG_Search/pipeline_functions_simple.py
+++ b/tldw_chatbook/RAG_Search/pipeline_functions_simple.py
@@ -6,6 +6,7 @@ No complex error handling - just let exceptions propagate.
 """
 
 import asyncio
+from collections.abc import Mapping
 import math
 from typing import Any, Dict, List, Optional
 
@@ -645,25 +646,36 @@ def rerank_results(
             # producer score or provenance marker. A partial/raising fallback
             # must leave prior RRF/semantic score semantics honest.
             planned_updates = []
+            seen_indexes: set[int] = set()
             for ranked in ranked_results[:top_k]:
                 idx = ranked.index
-                score = float(ranked.score)
                 if (
                     isinstance(idx, bool)
                     or not isinstance(idx, int)
                     or not 0 <= idx < len(results)
-                    or not math.isfinite(score)
+                    or idx in seen_indexes
                 ):
                     raise ValueError("invalid FlashRank result")
-                planned_updates.append((results[idx], score))
-
-            reranked = []
-            for result, score in planned_updates:
-                result.score = score
-                result.metadata = {
-                    **(result.metadata or {}),
+                raw_score = ranked.score
+                if isinstance(raw_score, bool):
+                    raise ValueError("invalid FlashRank result")
+                score = float(raw_score)
+                if not math.isfinite(score):
+                    raise ValueError("invalid FlashRank result")
+                result = results[idx]
+                if not isinstance(result.metadata, Mapping):
+                    raise ValueError("invalid FlashRank result metadata")
+                replacement_metadata = {
+                    **dict(result.metadata),
                     FINAL_SCORE_KIND_KEY: FINAL_SCORE_KIND_RERANKER,
                 }
+                seen_indexes.add(idx)
+                planned_updates.append((result, score, replacement_metadata))
+
+            reranked = []
+            for result, score, replacement_metadata in planned_updates:
+                result.score = score
+                result.metadata = replacement_metadata
                 reranked.append(result)
             return reranked
 

--- a/tldw_chatbook/RAG_Search/pipeline_functions_simple.py
+++ b/tldw_chatbook/RAG_Search/pipeline_functions_simple.py
@@ -175,7 +175,7 @@ async def search_media_fts5(
     if not app.media_db:
         return []
 
-    logger.debug(f"Searching media for: {query}")
+    logger.debug("RAG retrieval starting; source=media; search=fts5")
 
     search_kwargs: Dict[str, Any] = dict(
         search_query=query,
@@ -313,7 +313,7 @@ async def search_conversations_fts5(
     if db is None:
         return []
 
-    logger.debug(f"Searching conversations for: {query}")
+    logger.debug("RAG retrieval starting; source=conversations; search=fts5")
     conv_results = await asyncio.to_thread(
         db.search_conversations_by_content, search_query=query, limit=limit * 2
     )
@@ -406,7 +406,7 @@ async def search_notes_fts5(
     if db is None:
         return []
 
-    logger.debug(f"Searching notes for: {query}")
+    logger.debug("RAG retrieval starting; source=notes; search=fts5")
 
     note_results = await asyncio.to_thread(
         db.search_notes, search_term=query, limit=limit, id_allowlist=id_allowlist
@@ -494,7 +494,7 @@ async def search_semantic(
         record_semantic_unavailable(diagnostics, unavailable_reason)
         return []
 
-    logger.debug(f"Performing semantic search for: {query}")
+    logger.debug("RAG retrieval starting; source=selected; search=semantic")
 
     allowlists = build_semantic_allowlists(scope) if scope is not None else None
 

--- a/tldw_chatbook/RAG_Search/pipeline_functions_simple.py
+++ b/tldw_chatbook/RAG_Search/pipeline_functions_simple.py
@@ -6,6 +6,7 @@ No complex error handling - just let exceptions propagate.
 """
 
 import asyncio
+import math
 from typing import Any, Dict, List, Optional
 
 from loguru import logger
@@ -21,6 +22,12 @@ from ..Chat.rag_scope import (
     note_id_params,
 )
 from .pipeline_types import SearchResult
+from .local_citation_capture import (
+    FINAL_SCORE_KIND_KEY,
+    FINAL_SCORE_KIND_RERANKER,
+    SEMANTIC_SCORE_KIND_KEY,
+    SEMANTIC_SCORE_KIND_VECTOR_SIMILARITY,
+)
 from .semantic_availability import (
     SEMANTIC_REASON_SEARCH_ERROR,
     SEMANTIC_UNAVAILABLE_MESSAGES,
@@ -34,6 +41,18 @@ from .semantic_availability import (
 #: Key under which pipeline diagnostics record scope-enforcement state
 #: (mirrors semantic_availability.SEMANTIC_DIAGNOSTICS_KEY's pattern).
 SCOPE_DIAGNOSTICS_KEY = "scope"
+_SEMANTIC_SOURCE_ALIASES = {
+    "media": "media",
+    "media_db": "media",
+    "media-db": "media",
+    "note": "note",
+    "notes": "note",
+    "conversation": "conversation",
+    "conversations": "conversation",
+    "chat": "conversation",
+    "chat_history": "conversation",
+    "chat-history": "conversation",
+}
 
 
 def _record_scope_conversations_excluded(diagnostics: Optional[Dict[str, Any]]) -> None:
@@ -520,16 +539,35 @@ async def search_semantic(
     # Convert to our SearchResult format
     results = []
     for result in rag_results:
+        metadata = result.metadata.copy() if result.metadata else {}
+        metadata.pop(FINAL_SCORE_KIND_KEY, None)
+        metadata.pop(SEMANTIC_SCORE_KIND_KEY, None)
+        metadata.pop("hybrid_fusion", None)
+        metadata[SEMANTIC_SCORE_KIND_KEY] = SEMANTIC_SCORE_KIND_VECTOR_SIMILARITY
+        raw_source = getattr(result, "source", None)
+        source = (
+            raw_source
+            if isinstance(raw_source, str)
+            and raw_source.strip().lower() not in {"", "unknown"}
+            else next(
+                (
+                    _SEMANTIC_SOURCE_ALIASES[value.strip().lower()]
+                    for key in ("source_type", "source_kind")
+                    if isinstance((value := metadata.get(key)), str)
+                    and value.strip().lower() in _SEMANTIC_SOURCE_ALIASES
+                ),
+                "unknown",
+            )
+        )
         # Check if this result has citations
         if hasattr(result, "citations") and result.citations:
             # Include citations in metadata
-            metadata = result.metadata.copy() if result.metadata else {}
             metadata["_has_citations"] = True
             metadata["_citations"] = [c.to_dict() for c in result.citations]
 
             results.append(
                 SearchResult(
-                    source=getattr(result, "source", "unknown"),
+                    source=source,
                     id=result.id,
                     title=getattr(result, "title", result.document[:50]),
                     content=result.document,
@@ -541,12 +579,12 @@ async def search_semantic(
             # Basic result without citations
             results.append(
                 SearchResult(
-                    source=getattr(result, "source", "unknown"),
+                    source=source,
                     id=result.id,
                     title=getattr(result, "title", result.document[:50]),
                     content=getattr(result, "content", result.document),
                     score=result.score,
-                    metadata=result.metadata if hasattr(result, "metadata") else {},
+                    metadata=metadata,
                 )
             )
 
@@ -603,19 +641,39 @@ def rerank_results(
             rerank_req = RerankRequest(query=query, passages=passages)
             ranked_results = ranker.rerank(rerank_req)
 
-            # Reorder results
-            reranked = []
+            # Validate the complete reranker response before mutating any
+            # producer score or provenance marker. A partial/raising fallback
+            # must leave prior RRF/semantic score semantics honest.
+            planned_updates = []
             for ranked in ranked_results[:top_k]:
                 idx = ranked.index
-                if idx < len(results):
-                    result = results[idx]
-                    result.score = float(ranked.score)
-                    reranked.append(result)
+                score = float(ranked.score)
+                if (
+                    isinstance(idx, bool)
+                    or not isinstance(idx, int)
+                    or not 0 <= idx < len(results)
+                    or not math.isfinite(score)
+                ):
+                    raise ValueError("invalid FlashRank result")
+                planned_updates.append((results[idx], score))
 
+            reranked = []
+            for result, score in planned_updates:
+                result.score = score
+                result.metadata = {
+                    **(result.metadata or {}),
+                    FINAL_SCORE_KIND_KEY: FINAL_SCORE_KIND_RERANKER,
+                }
+                reranked.append(result)
             return reranked
 
         except ImportError:
             logger.warning("FlashRank not available, returning original order")
+            return results[:top_k]
+        except Exception:
+            logger.opt(exception=True).warning(
+                "FlashRank reranking failed; returning original order"
+            )
             return results[:top_k]
 
     # Default: just sort by score and limit
@@ -802,6 +860,10 @@ def weighted_merge(
                 # New result with weighted score
                 result.score = result.score * weight
                 merged[key] = result
+            result.metadata = dict(result.metadata or {})
+            result.metadata.pop(FINAL_SCORE_KIND_KEY, None)
+            result.metadata.pop(SEMANTIC_SCORE_KIND_KEY, None)
+            result.metadata.pop("hybrid_fusion", None)
 
     # Sort by final score
     final_results = list(merged.values())

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -51,6 +51,7 @@ from ...Event_Handlers.Chat_Events.chat_events_console_dictionaries import (
 # identity via `persisted_conversation_id`, `SessionScopeHolder` for
 # unpersisted sessions, `EffectiveScope` state.
 from ...Event_Handlers.Chat_Events.chat_rag_events import (
+    capture_console_staged_evidence_for_chat,
     resolve_effective_scope_for_chat,
     resolve_scope_for_session,
 )
@@ -360,7 +361,10 @@ from ...Workspaces import (
 )
 from ...Widgets.compact_model_bar import CompactModelBar
 from ...Widgets.Persona_Widgets.dictionary_picker import DictionaryPicker
-from ..Views.RAGSearch.search_handoff import build_library_rag_console_live_work_payload
+from ..Views.RAGSearch.search_handoff import (
+    build_library_rag_console_live_work_payload,
+    build_library_rag_evidence_bundle,
+)
 
 if TYPE_CHECKING:
     from tldw_chatbook.app import TldwCli
@@ -3402,6 +3406,7 @@ class ChatScreen(BaseAppScreen):
                 skills_service=getattr(self.app_instance, "skills_scope_service", None),
                 chat_dictionary_applier=self._console_chat_dictionary_applier,
                 world_info_applier=self._console_world_info_applier,
+                rag_capture_provider=self._capture_console_staged_rag,
             )
         self._console_chat_controller.on_submission_accepted = (
             self._on_console_submission_accepted
@@ -3424,6 +3429,15 @@ class ChatScreen(BaseAppScreen):
         )
         self._sync_console_chat_core_state()
         return self._console_chat_controller
+
+    async def _capture_console_staged_rag(self, draft: str):
+        """Resolve the current staged Library-RAG bundle for one Console send."""
+
+        return await capture_console_staged_evidence_for_chat(
+            self.app_instance,
+            self._consume_pending_console_launch(),
+            user_message=draft,
+        )
 
     def _sync_console_chat_core_state(self) -> ConsoleProviderSelection:
         """Push current workspace/provider selection into native Console services."""
@@ -9015,14 +9029,21 @@ class ChatScreen(BaseAppScreen):
             return
         if outcome.results:
             result = outcome.results[0]
+            launch_payload = build_library_rag_console_live_work_payload(
+                result,
+                query=request.query,
+            )
+            launch_payload["evidence_bundle"] = build_library_rag_evidence_bundle(
+                outcome.results,
+                query=request.query,
+            ).to_payload()
+            launch_payload["requested_top_k"] = request.top_k
+            launch_payload["search_mode"] = request.mode
             self._stage_console_library_rag_launch(
                 ConsoleLiveWorkLaunch.from_values(
                     source="Library Search/RAG",
                     title=result.title,
-                    payload=build_library_rag_console_live_work_payload(
-                        result,
-                        query=request.query,
-                    ),
+                    payload=launch_payload,
                     status="staged",
                     recovery=CONSOLE_LIBRARY_RAG_RECOVERY_COPY,
                     action_label="Review evidence in Console",

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -3127,6 +3127,16 @@ class ChatScreen(BaseAppScreen):
             persistence = None
             db = getattr(self.app_instance, "chachanotes_db", None)
             if db is not None:
+                citation_repository = getattr(
+                    self.app_instance,
+                    "citation_trace_repository",
+                    None,
+                )
+                if (
+                    citation_repository is not None
+                    and getattr(citation_repository, "db", None) is not db
+                ):
+                    citation_repository = None
                 persistence = ChatPersistenceService(
                     db,
                     workspace_registry=getattr(
@@ -3134,6 +3144,7 @@ class ChatScreen(BaseAppScreen):
                         "workspace_registry_service",
                         None,
                     ),
+                    citation_repository=citation_repository,
                 )
             self._console_chat_store = ConsoleChatStore(
                 persistence=persistence,


### PR DESCRIPTION
## Summary

- carry canonical local retrieval and prompt evidence through the RAG pipeline with explicit prompt-evidence identity
- record and seal marker-free initial answer attempts, then persist message ownership and citation provenance atomically under the native message ID
- cover direct and agent terminal lifecycles, deterministic fallback versus ambiguous retry, restart discovery, privacy-safe diagnostics, and sensitive SQL parameter redaction
- complete TASK-553.13 and TASK-553.14 under ADR-024

## Verification

- 254 passed, 506 deselected in the approved touched-code citation/controller/persistence suite
- 14 passed in the SQL debug-logging privacy suite
- Ruff lint passed on all touched Python files
- Ruff format passed on task-owned changed test files; unchanged whole-file DB formatting drift is documented in TASK-553.14
- cumulative git diff --check passed

## Notes

- This is a cumulative PR because the TASK-553.13 parent branch is not present in dev and has no remote PR.
- The scoped test run emits one existing RequestsDependencyWarning; no task-specific warnings or failures remain.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persists terminal local RAG citation traces by capturing normalized prompt evidence and sealing the first marker‑free answer, then atomically writing the assistant message and provenance under the native message ID. Completes TASK-553.13 and TASK-553.14.

- **New Features**
  - Added request‑scoped `CitationTraceBuilder` to record ordered retrieval runs and normalized prompt evidence with stable IDs; tightened invariants and timestamp validation; returns prompt‑evidence identity.
  - Normalized evidence and formatted once with stable `[S#]` markers; enforced caps/lengths; isolated and revalidated scope authority at the store boundary.
  - Console wiring: carries the builder through UI and worker generation, defers assistant persistence, and finalizes via a `TerminalCitationFinalizer` that seals the governed answer using the exact final body; persists the message and `SealedCitationWrite` atomically.
  - Persistence gates: repository `local_citation_writes_ready` requires a matching persisted identity and approved local policy; service `canonical_citation_writes_ready` additionally requires the same DB instance; the Console store enables canonical writes only when the repository DB matches.
  - Privacy and logs: SQL debug logging redacts message INSERT parameters; raw retrieval queries are no longer logged.

- **Migration**
  - Pass a `citation_trace_repository` bound to the same DB used by chat persistence to enable canonical writes; otherwise citation writes stay disabled.
  - No citation UX changes; traces remain internal‑only for now.

<sup>Written for commit 512007d38b051183451e36de09a8fe462cd63dad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

