### PR TITLE
feat(library): open a server-ingested item from the ingest queue (task 700)

### DIFF
--- a/Tests/Library/test_library_ingest_state.py
+++ b/Tests/Library/test_library_ingest_state.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 from tldw_chatbook.Library.ingest_types import PreflightResult
 from tldw_chatbook.Library.library_ingest_jobs import IngestJobState, LibraryIngestJob
 from tldw_chatbook.Library.library_ingest_state import (
@@ -1230,3 +1232,109 @@ def test_a_page_source_offers_its_scope_settings_in_the_canvas_state():
     # cannot answer for raises rather than rendering (task-673).
     fields = {f.name for f in get_capabilities("web").fields}
     assert {"scrape_method", "max_pages", "max_depth"} <= fields
+
+
+class TestOpenAServerIngestedItem:
+    """A finished server job must offer a route to what it produced.
+
+    Its content lives in the server's library, so "Open in Library" -- which
+    resolves a local media row -- stays withheld. The server does report the id
+    of the row it created, so the item is addressable; it just needs its own
+    affordance (task-700).
+    """
+
+    def _server_job(self, **kwargs):
+        from tldw_chatbook.Library.library_ingest_jobs import (
+            IngestJobState,
+            LibraryIngestJob,
+        )
+
+        defaults = dict(
+            job_id="ingest-job-1",
+            source_path="/tmp/paper.pdf",
+            state=IngestJobState.DONE,
+            origin="server",
+            remote_media_id="1125",
+            started_at=1.0,
+            finished_at=2.0,
+        )
+        defaults.update(kwargs)
+        return LibraryIngestJob(**defaults)
+
+    def test_a_finished_server_job_offers_the_server_view(self):
+        from tldw_chatbook.Library.library_ingest_state import (
+            _build_queue_row as build_ingest_queue_row,
+        )
+
+        row = build_ingest_queue_row(self._server_job(), now=3.0)
+
+        assert row.can_open_on_server is True
+        assert row.remote_media_id == "1125"
+        # The local action stays withheld: there is no local row to open.
+        assert row.can_open is False
+
+    def test_a_server_job_without_an_id_offers_nothing(self):
+        """AC#3. The server does not always report an id, and an action that
+        cannot resolve anything is worse than no action."""
+        from tldw_chatbook.Library.library_ingest_state import (
+            _build_queue_row as build_ingest_queue_row,
+        )
+
+        row = build_ingest_queue_row(self._server_job(remote_media_id=None), now=3.0)
+
+        assert row.can_open_on_server is False
+
+    def test_a_local_job_never_offers_the_server_view(self):
+        """Even holding an id, a local job's content is local."""
+        from tldw_chatbook.Library.library_ingest_state import (
+            _build_queue_row as build_ingest_queue_row,
+        )
+
+        row = build_ingest_queue_row(
+            self._server_job(origin="local", media_id=7, remote_media_id="1125"),
+            now=3.0,
+        )
+
+        assert row.can_open_on_server is False
+        assert row.can_open is True
+
+    def test_an_unfinished_server_job_offers_nothing_yet(self):
+        from tldw_chatbook.Library.library_ingest_jobs import IngestJobState
+        from tldw_chatbook.Library.library_ingest_state import (
+            _build_queue_row as build_ingest_queue_row,
+        )
+
+        row = build_ingest_queue_row(
+            self._server_job(state=IngestJobState.PARSING), now=3.0
+        )
+
+        assert row.can_open_on_server is False
+
+
+def test_the_view_on_server_action_cannot_be_caught_by_the_local_open_handler():
+    """The two row actions must not collide on id prefix or class.
+
+    "Open in Library" matches ``.library-ingest-open`` and recovers a job id by
+    stripping the prefix ``library-ingest-open-``. An id like
+    ``library-ingest-open-server-<job>`` would therefore be caught by that
+    handler and parsed into the bogus job id ``server-<job>`` -- opening
+    nothing, from the wrong handler. Both the id prefix and the class are
+    deliberately distinct (task-700).
+    """
+    import inspect
+
+    from tldw_chatbook.Widgets.Library import library_ingest_canvas
+
+    source = inspect.getsource(library_ingest_canvas)
+    assert 'id=f"library-ingest-view-server-{row.job_id}"' in source
+    # Check the id CONSTRUCTIONS, not the raw source: the comment above that
+    # button deliberately names the colliding form to explain why it is avoided.
+    ids = re.findall(r'id=f"([a-z-]+)\{row\.job_id\}"', source)
+    assert not [i for i in ids if i.startswith("library-ingest-open-") and i != "library-ingest-open-"], (
+        f"an action id shadows the local open prefix: {ids}"
+    )
+    # The class the local handler selects on must not be on the server button.
+    server_button = source[source.index('"View on server"'):]
+    server_button = server_button[: server_button.index("compact=True")]
+    assert "library-ingest-view-server" in server_button
+    assert "library-ingest-open " not in server_button

--- a/Tests/Library/test_server_ingest_reconcile.py
+++ b/Tests/Library/test_server_ingest_reconcile.py
@@ -347,3 +347,53 @@ def test_progress_still_lands_while_a_job_stays_running():
     job = registry.jobs()[0]
     assert job.state is IngestJobState.PARSING
     assert job.progress, "progress from a still-running job must be recorded"
+
+
+def test_a_finished_job_records_the_servers_media_id_not_a_local_one():
+    """The server's row id is captured, and kept out of ``media_id``.
+
+    A completed job's ``result`` carries the id of the row the SERVER made
+    (confirmed live). It addresses the server's library, so storing it in
+    ``media_id`` -- which means a row in *this* machine's DB -- would point
+    "Open in Library" at a wrong or absent local row. Both must therefore hold
+    at once: the id is recorded, and the local field stays empty (task-700).
+    """
+    registry = LibraryIngestJobRegistry()
+    _server_job(registry, remote_job_id="281")
+
+    status = _status(281, "completed")
+    status.result = {
+        "status": "Success",
+        "media_id": 1125,
+        "media_uuid": "bee6d9a0-931f-4c11-a87a-07ddebc66443",
+    }
+
+    assert reconcile_remote_ingest_jobs(registry, [status]) == 1
+
+    job = registry.jobs()[0]
+    assert job.state is IngestJobState.DONE
+    assert job.remote_media_id == "1125"
+    assert not job.media_id, "a server id must never land in the local media_id"
+
+
+def test_a_finished_job_without_a_media_id_records_none():
+    """Not every result carries one; absence must not become a bogus id."""
+    registry = LibraryIngestJobRegistry()
+    _server_job(registry, remote_job_id="282")
+
+    status = _status(282, "completed")
+    status.result = {"status": "Success", "error": None}
+
+    reconcile_remote_ingest_jobs(registry, [status])
+
+    assert registry.jobs()[0].remote_media_id is None
+
+
+def test_a_result_that_is_absent_entirely_is_tolerated():
+    registry = LibraryIngestJobRegistry()
+    _server_job(registry, remote_job_id="283")
+
+    reconcile_remote_ingest_jobs(registry, [_status(283, "completed")])
+
+    assert registry.jobs()[0].state is IngestJobState.DONE
+    assert registry.jobs()[0].remote_media_id is None

--- a/backlog/tasks/task-700 - Open-a-server-ingested-item-from-the-ingest-queue.md
+++ b/backlog/tasks/task-700 - Open-a-server-ingested-item-from-the-ingest-queue.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-700
 title: Open a server-ingested item from the ingest queue
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-07-26 13:58'
-updated_date: '2026-07-26 18:13'
+updated_date: '2026-07-26 19:11'
 labels:
   - library
   - ingest
@@ -19,7 +20,29 @@ A server ingest finishes with its content in the server's library, not this mach
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A finished server-origin job offers a way to view the item it created
-- [ ] #2 The action opens the item in a server-scoped view rather than looking for a local row
-- [ ] #3 A job whose server result carries no usable id offers no such action
+- [x] #1 A finished server-origin job offers a way to view the item it created
+- [x] #2 The action opens the item in a server-scoped view rather than looking for a local row
+- [x] #3 A job whose server result carries no usable id offers no such action
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+A finished server ingest now offers 'View on server', and the item it created is reachable.
+
+The server reports the id of the row it made; that id was being discarded. It is now captured as remote_media_id -- deliberately not media_id, which means a row in this machine's DB. The two id spaces are unrelated, so a server id stored there would point 'Open in Library' at a wrong or absent local row.
+
+Schema v4 adds the column by plain ALTER TABLE rather than a rebuild: nothing changes an existing CHECK constraint.
+
+The row gate requires origin=='server' AND a present id, so a job the server reported no id for offers nothing rather than dead bait. 'Open in Library' stays withheld for server jobs; the two actions are never both offered. The handler flips the viewer's detail fetch to server mode, and every local route into the viewer clears that flag so one server view cannot make the next local item resolve remotely.
+
+A collision this nearly shipped with: the button first reused the class .library-ingest-open and an id starting with 'library-ingest-open-'. The existing handler selects on that class and strips that prefix to recover a job id, so it would have caught this button and parsed the bogus id 'server-ingest-job-3' -- opening nothing, from the wrong handler. Both are now distinct, guarded by a test that inspects the id constructions rather than raw source.
+
+VERIFIED LIVE, end to end against a running server: a real submit produced a real completed job whose result carried media_id 1125; the real reconciler folded that into a real registry, leaving remote_media_id='1125' with the local media_id still None; the real state builder then produced can_open=False, can_open_on_server=True. Fetching that id through the server-mode path returns MediaDetailResponse(media_id=1125) -- the exact row the ingest created, so the action resolves what it claims to.
+
+Separately verified through real persistence: two finished server jobs written to a v4 database, read back through the hydration path, gave True and False respectively.
+
+Both clauses of the gate are mutation-checked.
+
+Files: DB/Library_Ingest_Jobs_DB.py (v4), Library/library_ingest_jobs.py, Library/server_ingest_reconcile.py, Library/library_ingest_state.py, Widgets/Library/library_ingest_canvas.py, UI/Screens/library_screen.py.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/DB/Library_Ingest_Jobs_DB.py
+++ b/tldw_chatbook/DB/Library_Ingest_Jobs_DB.py
@@ -19,7 +19,7 @@ from .base_db import BaseDB
 
 
 class LibraryIngestJobsDB(BaseDB):
-    _CURRENT_SCHEMA_VERSION = 3
+    _CURRENT_SCHEMA_VERSION = 4
 
     def __init__(self, db_path: Union[str, Path], client_id: str = "default") -> None:
         self._conn: sqlite3.Connection | None = None
@@ -178,7 +178,8 @@ class LibraryIngestJobsDB(BaseDB):
                 content_hash TEXT DEFAULT NULL,
                 origin TEXT NOT NULL DEFAULT 'local' CHECK (origin IN ('local','server')),
                 remote_job_id TEXT DEFAULT NULL,
-                batch_id TEXT DEFAULT NULL
+                batch_id TEXT DEFAULT NULL,
+                remote_media_id TEXT DEFAULT NULL
             );
             """
         )
@@ -191,6 +192,33 @@ class LibraryIngestJobsDB(BaseDB):
             current_version = 2
         if current_version < 3:
             self._migrate_v2_to_v3()
+            current_version = 3
+        if current_version < 4:
+            self._migrate_v3_to_v4()
+
+
+    def _migrate_v3_to_v4(self) -> None:
+        """Record the id of the media row the SERVER created.
+
+        A finished server job's ``result`` carries a ``media_id``, but it
+        addresses a row in the server's library, not this machine's, so it
+        cannot go in ``media_id`` -- that column means a local row, and pointing
+        "Open in Library" at a server id would open a wrong or absent one
+        (task-700). A separate column keeps both meanings intact.
+
+        A plain ``ALTER TABLE`` here, unlike the v2->v3 rebuild: nothing changes
+        an existing CHECK constraint, so SQLite can add the column in place.
+        """
+        with self.transaction() as conn:
+            try:
+                conn.execute(
+                    "ALTER TABLE ingest_jobs ADD COLUMN remote_media_id TEXT DEFAULT NULL"
+                )
+            except sqlite3.OperationalError as e:
+                if "duplicate column name" not in str(e).lower():
+                    raise
+            conn.execute("DELETE FROM schema_version")
+            conn.execute("INSERT INTO schema_version (version) VALUES (4)")
 
     @staticmethod
     def _seq_of(job_id: str) -> int:
@@ -206,8 +234,8 @@ class LibraryIngestJobsDB(BaseDB):
                chunk_enabled, chunk_size, state, retry_count, detected_type, error,
                finished_at_wall, media_id, superseded, dismissed, permanent,
                ingest_options, error_detail, progress, content_hash,
-               origin, remote_job_id, batch_id)
-            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+               origin, remote_job_id, batch_id, remote_media_id)
+            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
             ON CONFLICT(job_id) DO UPDATE SET
               source_path=excluded.source_path, title=excluded.title, author=excluded.author,
               keywords=excluded.keywords, perform_analysis=excluded.perform_analysis,
@@ -219,7 +247,7 @@ class LibraryIngestJobsDB(BaseDB):
               ingest_options=excluded.ingest_options, error_detail=excluded.error_detail,
               progress=excluded.progress, content_hash=excluded.content_hash,
               origin=excluded.origin, remote_job_id=excluded.remote_job_id,
-              batch_id=excluded.batch_id
+              batch_id=excluded.batch_id, remote_media_id=excluded.remote_media_id
             """,
             (
                 self._seq_of(job.job_id),
@@ -247,6 +275,7 @@ class LibraryIngestJobsDB(BaseDB):
                 job.origin,
                 job.remote_job_id,
                 job.batch_id,
+                job.remote_media_id,
             ),
         )
         conn.commit()

--- a/tldw_chatbook/Library/library_ingest_jobs.py
+++ b/tldw_chatbook/Library/library_ingest_jobs.py
@@ -227,6 +227,13 @@ class LibraryIngestJob:
     origin: str = "local"
     remote_job_id: str | None = None
     batch_id: str | None = None
+    #: The id of the media row the SERVER created, read from a finished job's
+    #: ``result``. Deliberately not ``media_id``: that means a row in *this*
+    #: machine's media DB, and the two id spaces are unrelated, so storing a
+    #: server id there would point "Open in Library" at a wrong or absent local
+    #: row. Kept separate so a server-origin job can offer its own affordance
+    #: (task-700) without weakening what ``media_id`` means.
+    remote_media_id: str | None = None
 
 
 class IngestJobStore(Protocol):
@@ -698,7 +705,9 @@ class LibraryIngestJobRegistry:
         self._persist(updated)
         return replace(updated)
 
-    def mark_remote_done(self, job_id: str) -> LibraryIngestJob | None:
+    def mark_remote_done(
+        self, job_id: str, *, remote_media_id: str | None = None
+    ) -> LibraryIngestJob | None:
         """Finish a ``server``-origin job that has no local media row.
 
         ``mark_done`` requires a ``media_id`` because a *local* completion that
@@ -746,6 +755,13 @@ class LibraryIngestJobRegistry:
             state=IngestJobState.DONE,
             finished_at=time.monotonic(),
             finished_at_wall=datetime.now(timezone.utc).isoformat(),
+            # The server's own row id, when it reported one. Not media_id: see
+            # the field's own note on why the two id spaces stay separate.
+            remote_media_id=(
+                str(remote_media_id)
+                if remote_media_id is not None
+                else current.remote_media_id
+            ),
         )
         self._jobs[index] = updated
         self._notify_listeners()
@@ -1118,6 +1134,7 @@ def _job_from_row(row: dict) -> "LibraryIngestJob":
         origin=row.get("origin") or "local",
         remote_job_id=row.get("remote_job_id"),
         batch_id=row.get("batch_id"),
+        remote_media_id=row.get("remote_media_id"),
         # monotonic fields are not round-trippable -- leave defaults.
         submitted_at=0.0,
         started_at=None,

--- a/tldw_chatbook/Library/library_ingest_state.py
+++ b/tldw_chatbook/Library/library_ingest_state.py
@@ -361,6 +361,16 @@ class IngestQueueRow:
     #: and the local pipeline has no cancel seam at all, so offering it
     #: anywhere else would be dead bait.
     can_cancel: bool = False
+    #: Whether this row offers "View on server". Server-only and done-only, and
+    #: additionally requires an id: the server does not always report one, and
+    #: an action that cannot resolve anything is worse than no action.
+    #: Distinct from ``can_open``, which resolves a LOCAL media row -- a server
+    #: ingest has none, so the two are never both true (task-700).
+    can_open_on_server: bool = False
+    #: The id of the media row the SERVER created, mirrored from the job. Kept
+    #: apart from ``media_id`` for the same reason it is on the job: the two id
+    #: spaces are unrelated.
+    remote_media_id: str | None = None
     source_path: str = ""
     progress: dict[str, Any] | None = None
     error_detail: dict[str, Any] | None = None
@@ -580,6 +590,13 @@ def _build_queue_row_for_state(job: LibraryIngestJob, *, now: float) -> IngestQu
             line=f"{_GLYPH_DONE} done · {basename} · {elapsed}",
             can_open=job.media_id is not None,
             can_retry=False,
+            # A server ingest wrote to the server's library, so there is no
+            # local row to open; its own action stands in, when the server told
+            # us which row it made.
+            can_open_on_server=(
+                job.origin == "server" and bool(job.remote_media_id)
+            ),
+            remote_media_id=job.remote_media_id,
             media_id=job.media_id,
             state=job.state,
             source_path=job.source_path,

--- a/tldw_chatbook/Library/server_ingest_reconcile.py
+++ b/tldw_chatbook/Library/server_ingest_reconcile.py
@@ -70,6 +70,32 @@ def _field(status: Any, name: str) -> Any:
     return getattr(status, name, None)
 
 
+
+def _remote_media_id(status: Any) -> str | None:
+    """Read the id of the media row the server created, if it reported one.
+
+    A finished job's ``result`` carries it (confirmed live:
+    ``{"status": "Success", "media_id": 1125, ...}``). It addresses a row in the
+    SERVER's library, so it is kept apart from the local ``media_id`` -- see
+    ``LibraryIngestJob.remote_media_id`` (task-700).
+
+    Args:
+        status: A ``MediaIngestJobStatus``-shaped model or dict.
+
+    Returns:
+        The id as a string, or ``None`` when the result carries none. Returned
+        as a string because the id only ever travels back to the server, and a
+        stringly id cannot be mistaken for a local integer row id.
+    """
+    result = _field(status, "result")
+    if result is None:
+        return None
+    media_id = _field(result, "media_id")
+    if media_id is None or media_id == "":
+        return None
+    return str(media_id)
+
+
 def _progress_payload(status: Any) -> dict[str, Any] | None:
     """Build a progress payload from whatever the server reported, or ``None``."""
     percent = _field(status, "progress_percent")
@@ -134,7 +160,9 @@ def reconcile_remote_ingest_jobs(
         progress = _progress_payload(status)
 
         if target is IngestJobState.DONE:
-            updated = registry.mark_remote_done(job.job_id)
+            updated = registry.mark_remote_done(
+                job.job_id, remote_media_id=_remote_media_id(status)
+            )
         elif target is IngestJobState.FAILED:
             updated = registry.mark_failed(
                 job.job_id,

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -831,6 +831,16 @@ class LibraryScreen(BaseAppScreen):
         ("escape", "library_skill_back", "Back to skills list"),
     ]
 
+    #: Whether the media item open in the viewer lives on the SERVER. Set only
+    #: by the ingest queue's "View on server" action (task-700); every other
+    #: route into the viewer opens a local row and clears it.
+    #:
+    #: Declared on the class, not in a method, because a restored session
+    #: reaches the viewer without running the constructors that set instance
+    #: state -- an attribute defined only there is missing exactly when the
+    #: viewer is rebuilt on mount, and the detail fetch that reads it fails.
+    _library_media_detail_is_remote: bool = False
+
     #: Footer hint set — mirrors the show=True bindings the retired Textual
     #: Footer used to render (task-264 review: per-screen AppFooterStatus
     #: renders registered contexts, not bindings).
@@ -4408,10 +4418,6 @@ class LibraryScreen(BaseAppScreen):
                 pass
             self._library_ingest_preflight_worker = None
         self._library_ingest_form = LibraryIngestFormState()
-        #: Whether the media currently open in the viewer lives on the server.
-        #: Set only by the ingest queue's "View on server" action; every other
-        #: route into the viewer opens a local row and clears it.
-        self._library_media_detail_is_remote = False
 
     # ----- Export canvas -------------------------------------------------
 

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -4126,7 +4126,10 @@ class LibraryScreen(BaseAppScreen):
         try:
             detail = await self._run_library_service_call(
                 get_media_item,
-                mode="local",
+                # A media item opened from a finished SERVER ingest lives in the
+                # server's library, so resolving it locally would find nothing
+                # (task-700). Every other route into this viewer is local.
+                mode="server" if self._library_media_detail_is_remote else "local",
                 media_id=media_id,
                 include_content=True,
                 include_versions=True,
@@ -4405,6 +4408,10 @@ class LibraryScreen(BaseAppScreen):
                 pass
             self._library_ingest_preflight_worker = None
         self._library_ingest_form = LibraryIngestFormState()
+        #: Whether the media currently open in the viewer lives on the server.
+        #: Set only by the ingest queue's "View on server" action; every other
+        #: route into the viewer opens a local row and clears it.
+        self._library_media_detail_is_remote = False
 
     # ----- Export canvas -------------------------------------------------
 
@@ -12202,6 +12209,35 @@ class LibraryScreen(BaseAppScreen):
             return
         self._open_job_in_library(job)
 
+
+    @on(Button.Pressed, ".library-ingest-view-server")
+    def handle_library_ingest_view_on_server(self, event: Button.Pressed) -> None:
+        """Open the item a finished SERVER ingest created, in the server view.
+
+        Distinct from "Open in Library": that resolves a row in this machine's
+        media DB, and a server ingest never wrote one. The server reports the id
+        of the row it made, so the item is addressable -- against the server
+        (task-700).
+
+        Args:
+            event: Button press event emitted by a "View on server" row action.
+        """
+        event.stop()
+        job_id = self._ingest_job_id_from_button(
+            event.button.id, "library-ingest-view-server-"
+        )
+        if job_id is None:
+            return
+        job = self._library_ingest_job_by_id(job_id)
+        remote_media_id = getattr(job, "remote_media_id", None) if job else None
+        if not remote_media_id:
+            # The row only offers this action when the id is present, so this is
+            # a stale-press guard rather than an expected path.
+            self.notify("The server did not report which item it created.")
+            return
+        self._library_media_detail_is_remote = True
+        self.run_worker(self._open_library_item_by_id("media", str(remote_media_id)))
+
     @on(Button.Pressed, ".library-ingest-retry")
     def handle_library_ingest_retry(self, event: Button.Pressed) -> None:
         """Requeue a failed ingest job.
@@ -14591,6 +14627,7 @@ class LibraryScreen(BaseAppScreen):
             # Mirrors handle_library_media_row's full state-set EXACTLY so
             # the recomposed canvas lands on a clean viewer, never a stale
             # one carried over from a previously opened item.
+            self._library_media_detail_is_remote = False
             self._selected_media_id = record_id
             self._library_selected_row_id = LIBRARY_ROW_BROWSE_MEDIA
             self._library_media_view = "viewer"

--- a/tldw_chatbook/Widgets/Library/library_ingest_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_ingest_canvas.py
@@ -382,6 +382,7 @@ class LibraryIngestCanvas(VerticalScroll):
             row_classes = "library-ingest-row"
             has_actions = (
                 row.can_open
+                or row.can_open_on_server
                 or row.can_retry
                 or row.can_dismiss
                 or row.can_cancel
@@ -439,6 +440,28 @@ class LibraryIngestCanvas(VerticalScroll):
                             id=f"library-ingest-open-{row.job_id}",
                             classes=(
                                 "library-canvas-action library-ingest-open "
+                                "library-ingest-row-action"
+                            ),
+                            compact=True,
+                        )
+                    if row.can_open_on_server:
+                        # Its own action rather than a reworded "Open in
+                        # Library": that one resolves a LOCAL media row, and a
+                        # server ingest has none. The label says where the
+                        # content actually is.
+                        yield Button(
+                            "View on server",
+                            # Neither the id prefix nor the class may collide
+                            # with "Open in Library": that handler matches
+                            # ``.library-ingest-open`` and strips the prefix
+                            # ``library-ingest-open-`` to recover a job id, so
+                            # an id of ``library-ingest-open-server-<job>``
+                            # would be caught by it and parsed into the bogus
+                            # job id ``server-<job>``.
+                            id=f"library-ingest-view-server-{row.job_id}",
+                            classes=(
+                                "library-canvas-action "
+                                "library-ingest-view-server "
                                 "library-ingest-row-action"
                             ),
                             compact=True,


### PR DESCRIPTION
A finished **server** ingest now offers a route to the item it produced. Completes **task 700**, the last feature follow-up from the Library ingest UAT.

Before this, a server ingest finished and dead-ended: its content is in the server's library, so the queue row's "Open in Library" stays withheld, and the id the server reported for the row it created was being discarded.

## What changed

**Schema v4** adds `remote_media_id` by plain `ALTER TABLE` — nothing changes an existing CHECK constraint, so no table rebuild (unlike v2→v3).

Deliberately **not** stored in `media_id`. That column means a row in *this* machine's media DB; the two id spaces are unrelated, so putting a server id there would point "Open in Library" at a wrong or absent local row. Keeping them apart is what lets a server job grow its own affordance without weakening what `media_id` means — the same distinction that made `mark_remote_done` a separate terminal path in 684.2.

**The row action** is gated on `origin == "server"` **and** a present id, so a job the server reported no id for offers nothing rather than dead bait (AC#3). The handler flips the viewer's detail fetch from `mode="local"` to `mode="server"` (AC#2); every local route into the viewer clears that flag, or one server view would make the next local item resolve remotely.

## A collision this nearly shipped with

The button first reused the class `.library-ingest-open` and an id starting with `library-ingest-open-`. The existing handler selects on that class and recovers a job id by **stripping that exact prefix** — so it would have caught this button and parsed the bogus job id `server-ingest-job-3`, opening nothing, from the wrong handler.

Both are now distinct, guarded by a test that inspects the id *constructions* rather than raw source. (Its first version failed against its own explanatory comment, which names the colliding form.)

## Verified live, end to end

Against a running server, every step real:

```
BATCH 698f0315-…          STATUS completed
RESULT {"status": "Success", "media_id": 1125, …}

LIVE remote_media_id     = '1125'
LIVE media_id (local)    = None
LIVE can_open            = False
LIVE can_open_on_server  = True
```

Then the check that actually matters: fetching `1125` through the **server-mode path** returns `MediaDetailResponse(media_id=1125)` — the exact row the ingest created. Everything before that proved the id was captured and the button appears; only this proves the button leads somewhere.

Also verified through real persistence: two finished server jobs written to a v4 database, read back through the hydration path, gave `can_open_on_server` True and False respectively.

Both clauses of the gate are mutation-checked: dropping either fails a distinct test.

## A regression I introduced and caught mid-branch

Worth flagging rather than hiding in the log. The remote flag's initialiser landed inside `_reset_library_ingest_transient_state()` instead of `__init__` — a scripted edit matched the *first* occurrence of a line that appears in that reset. A restored session never runs it, so the attribute was missing exactly when the viewer rebuilds on mount, the detail fetch raised `AttributeError`, and **the media viewer never mounted**.

Now declared on the class, so it exists regardless of which constructors a route runs.

Three earlier checks passed and said nothing about it: `Tests/Library` doesn't exercise the media viewer, the affordance tests call `_build_queue_row` directly and never touch the screen, and the live verification covered reconcile → state, not the restore path. **Passing the suites a change touches is not passing the suites it can reach** — the same gap that let #930 break the provider-migration audit.

## Test result

`Tests/Library` + `Tests/UI/test_library_shell.py`: **1,117 passed, 0 failed**, on the final commit.

The run before the regression fix showed two notes-test failures; both are green here and both pass in isolation, which places them in the order-dependent tail tracked as **task-699** rather than anything in this change.

Rebased onto current dev — zero overlapping files, and dev's ingest-jobs schema was still at v3, so the v4 migration does not collide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “View on server” action for finished server ingests by capturing the server’s `remote_media_id` and opening the item in a server-scoped viewer. Completes task-700 and meets its ACs.

- **New Features**
  - DB schema v4 adds `remote_media_id` (via ALTER TABLE). Kept separate from local `media_id`.
  - Reconcile stores the server’s result `media_id` into `remote_media_id` (string).
  - Ingest queue shows “View on server” only for `origin=="server"` and when an id is present; “Open in Library” stays hidden for server jobs.
  - Viewer loads details with `mode="server"` for this action; all local routes clear the flag to avoid leaking server mode.
  - New button uses distinct id/class to avoid colliding with the local open handler.

- **Bug Fixes**
  - Fixed a crash on session restore by declaring `_library_media_detail_is_remote` on the class so the viewer always has the flag.

<sup>Written for commit 7c0113c724c8516918e17e9552f73690bd2da675. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

