### PR TITLE
chore(backlog): mark task 700 Done

### DIFF
--- a/backlog/tasks/task-700 - Open-a-server-ingested-item-from-the-ingest-queue.md
+++ b/backlog/tasks/task-700 - Open-a-server-ingested-item-from-the-ingest-queue.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-700
 title: Open a server-ingested item from the ingest queue
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-07-26 13:58'
-updated_date: '2026-07-26 19:11'
+updated_date: '2026-07-26 22:00'
 labels:
   - library
   - ingest


### PR DESCRIPTION
Status-only follow-up to #938 (merged as `27cebfc1a`). No code changes.

Remaining ingest-UAT follow-ups: **699** (order-dependent test tail) and **745** (bundled ingest stylesheets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks backlog task 700 as Done to reflect completion of “Open a server-ingested item from the ingest queue.”

No code changes; only updates the task status and updated_date in the backlog file.

<sup>Written for commit 418cfec4a2e79a342f055e3e8cd8cc2ee95a2b3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

