### PR TITLE
test: bound the Library shell wait helpers by wall clock (task 699 progress)

### DIFF
--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -244,17 +244,29 @@ async def _wait_for_library_shell(screen, pilot, *, attempts=120, timeout=15.0):
     ``attempts`` is kept as a floor so a caller that deliberately passes a small
     number still gets at least that many polls.
     """
-    deadline = time.monotonic() + timeout
+    # One effective budget, so the reported deadline is the real one. ``attempts``
+    # only raises the floor for a caller that wants more polls than the timeout
+    # would allow; it never extends the wait past its own stated bound, which the
+    # first version did by keeping the loop alive on ``polls < attempts``.
+    budget = max(timeout, attempts * 0.02)
+    deadline = time.monotonic() + budget
     polls = 0
-    while polls < attempts or time.monotonic() < deadline:
+    while True:
+        # Condition FIRST, deadline second -- mirroring ``_wait_for_condition``.
+        # Checking the deadline in the loop header instead means a ``pilot.pause``
+        # that overshoots it exits without re-testing, so a shell that finished
+        # loading *during* that pause is reported as never loaded: a false
+        # timeout, and exactly the class of flake this helper exists to avoid.
         if getattr(screen, "_library_loaded", False) and screen.query("#library-rail"):
             await pilot.pause()
             await pilot.pause()
             return
+        if time.monotonic() >= deadline:
+            break
         await pilot.pause(0.02)
         polls += 1
     raise AssertionError(
-        f"Library shell never loaded within {timeout}s ({polls} polls). "
+        f"Library shell never loaded within {budget:.1f}s ({polls} polls). "
         f"Visible text: {_visible_text(screen)}"
     )
 
@@ -262,17 +274,20 @@ async def _wait_for_library_shell(screen, pilot, *, attempts=120, timeout=15.0):
 async def _wait_for_selector(screen, pilot, selector, *, attempts=120, timeout=15.0):
     """Await ``selector`` mounting. Wall-clock bounded -- see
     ``_wait_for_library_shell`` for why a pause count is not a time budget."""
-    deadline = time.monotonic() + timeout
+    budget = max(timeout, attempts * 0.02)
+    deadline = time.monotonic() + budget
     polls = 0
-    while polls < attempts or time.monotonic() < deadline:
+    while True:
         matches = list(screen.query(selector))
         if matches:
             await pilot.pause()
             return matches[0]
+        if time.monotonic() >= deadline:
+            break
         await pilot.pause(0.02)
         polls += 1
     raise AssertionError(
-        f"{selector} never mounted within {timeout}s ({polls} polls). "
+        f"{selector} never mounted within {budget:.1f}s ({polls} polls). "
         f"Visible text: {_visible_text(screen)}"
     )
 
@@ -11531,3 +11546,32 @@ async def test_the_wait_helpers_still_fail_on_something_that_never_appears():
 
     assert "never mounted within 1.0s" in str(excinfo.value)
     assert elapsed < 10.0, f"took {elapsed:.1f}s -- the budget was not respected"
+
+
+@pytest.mark.asyncio
+async def test_a_condition_met_during_the_last_pause_is_not_a_timeout():
+    """A pause that overshoots the deadline must not cause a false timeout.
+
+    The first version of these helpers tested the deadline in the loop HEADER, so
+    a ``pilot.pause`` running past it exited without re-checking -- reporting
+    "never mounted" for a widget that appeared during that very pause. That is a
+    false timeout, and precisely the class of flake the helpers exist to avoid;
+    ``_wait_for_condition`` already checked its predicate before enforcing its
+    deadline for the same reason.
+
+    Simulated with an already-elapsed budget: the target exists, so the helper
+    must return it rather than raise, because the condition is tested first.
+    """
+    app = _build_test_app()
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+
+        # timeout=0 and attempts=0 leave no budget at all: a header-checked
+        # deadline would raise immediately even though #library-rail is mounted.
+        found = await _wait_for_selector(
+            screen, pilot, "#library-rail", attempts=0, timeout=0.0
+        )
+
+    assert found is not None, "an already-satisfied condition must not time out"

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -230,27 +230,50 @@ def _normalised_cli_lookup(*args, **kwargs) -> tuple[str, str]:
     return section.strip().lower(), str(key or "").strip().lower()
 
 
-async def _wait_for_library_shell(screen, pilot, *, attempts=120):
-    for _ in range(attempts):
+async def _wait_for_library_shell(screen, pilot, *, attempts=120, timeout=15.0):
+    """Await the Library shell being loaded with its rail mounted.
+
+    Bounded by WALL CLOCK, not by a pause count. ``attempts`` alone measured
+    iterations of ``pilot.pause(0.02)``, and a pause takes as long as the event
+    loop needs -- so on a loaded machine the same 120 iterations buy far less
+    real time than they appear to, and the helper reports "never loaded" for a
+    shell that was merely slow. That is how this file's failures moved around
+    with machine load (task-699); ``_wait_for_condition`` below already used a
+    wall-clock budget for the same reason.
+
+    ``attempts`` is kept as a floor so a caller that deliberately passes a small
+    number still gets at least that many polls.
+    """
+    deadline = time.monotonic() + timeout
+    polls = 0
+    while polls < attempts or time.monotonic() < deadline:
         if getattr(screen, "_library_loaded", False) and screen.query("#library-rail"):
             await pilot.pause()
             await pilot.pause()
             return
         await pilot.pause(0.02)
+        polls += 1
     raise AssertionError(
-        f"Library shell never loaded. Visible text: {_visible_text(screen)}"
+        f"Library shell never loaded within {timeout}s ({polls} polls). "
+        f"Visible text: {_visible_text(screen)}"
     )
 
 
-async def _wait_for_selector(screen, pilot, selector, *, attempts=120):
-    for _ in range(attempts):
+async def _wait_for_selector(screen, pilot, selector, *, attempts=120, timeout=15.0):
+    """Await ``selector`` mounting. Wall-clock bounded -- see
+    ``_wait_for_library_shell`` for why a pause count is not a time budget."""
+    deadline = time.monotonic() + timeout
+    polls = 0
+    while polls < attempts or time.monotonic() < deadline:
         matches = list(screen.query(selector))
         if matches:
             await pilot.pause()
             return matches[0]
         await pilot.pause(0.02)
+        polls += 1
     raise AssertionError(
-        f"{selector} never mounted. Visible text: {_visible_text(screen)}"
+        f"{selector} never mounted within {timeout}s ({polls} polls). "
+        f"Visible text: {_visible_text(screen)}"
     )
 
 
@@ -11481,3 +11504,30 @@ async def test_library_shell_export_registry_failure_warns_it_wont_appear_in_art
                 f"(still disabled={screen.query_one('#library-export-submit', Button).disabled})."
             ),
         )
+
+
+@pytest.mark.asyncio
+async def test_the_wait_helpers_still_fail_on_something_that_never_appears():
+    """The wall-clock budget must not make the wait helpers unable to fail.
+
+    ``_wait_for_library_shell``/``_wait_for_selector`` were bounded by a count of
+    ``pilot.pause`` calls, which is not a time budget: a pause takes as long as
+    the loop needs, so under load the same 120 iterations bought far less real
+    time and the helpers reported "never mounted" for a widget that was merely
+    slow (task-699). They are wall-clock bounded now -- but a wait that cannot
+    time out would turn every genuine failure into a hang, which is worse than
+    the flakiness it replaced, so the timeout is asserted here.
+    """
+    app = _build_test_app()
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        started = time.monotonic()
+        with pytest.raises(AssertionError) as excinfo:
+            await _wait_for_selector(
+                screen, pilot, "#definitely-not-a-real-widget", attempts=1, timeout=1.0
+            )
+        elapsed = time.monotonic() - started
+
+    assert "never mounted within 1.0s" in str(excinfo.value)
+    assert elapsed < 10.0, f"took {elapsed:.1f}s -- the budget was not respected"

--- a/backlog/tasks/task-699 - Library-shell-tests-fail-nondeterministically-hiding-real-regressions.md
+++ b/backlog/tasks/task-699 - Library-shell-tests-fail-nondeterministically-hiding-real-regressions.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@claude'
 created_date: '2026-07-26 15:02'
-updated_date: '2026-07-26 18:18'
+updated_date: '2026-07-26 22:20'
 labels:
   - testing
   - library
@@ -26,26 +26,17 @@ The Library shell test file fails around six tests on every run, but not the sam
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Reduced this file from 9 failures on dev to 0-1, by fixing what turned out not to be flakiness at all.
+Reduced this file from 9 failures to a low-rate intermittent, and ruled out two candidate causes. NOT closed.
 
-Three of the failures were STABLE across every run and were misfiled as nondeterminism. They were two over-broad precedence traps (task-687) and one assertion that compared a mounted form against a never-mounted one (task-698). Both are fixed; the screen was correct in all three cases. Full-file runs after those fixes: 1 failed / 256 passed, then 0 failed / 257 passed.
+WHAT WAS FIXED. Three of the original nine were STABLE, not flaky, and were misfiled here as nondeterminism: two over-broad config-precedence traps (task-687) and one assertion comparing a mounted form against a never-mounted one (task-698). Both merged in PR #933. The screen was correct in all three cases.
 
-What remains is a genuinely order-dependent tail, currently one test:
-test_library_shell_note_conflict_shows_overwrite_reload_and_keeps_user_text. It
-passes alone, passes alongside its siblings, and fails only in a full-file run --
-and not on every full-file run. Its wait carries a 15-second timeout, so simple
-slowness does not explain it; the cause is accumulated state across 257 Textual
-app instances rather than a slow machine.
+WHAT WAS RULED OUT. The wait helpers were bounded by a count of pilot.pause(0.02) calls rather than wall clock, which is genuinely wrong -- a pause takes as long as the loop needs, so under contention the budget silently shrinks. Fixed, and worth keeping. But it is NOT the cause of the remaining tail: the very next full-file run still failed, in 289s against an earlier 520s, i.e. under LESS load. Do not re-litigate load sensitivity; it has been tested.
 
-Measurement conditions matter for anyone picking this up: this machine was
-running fourteen concurrent pytest processes from other agents at load ~12
-throughout. That is enough to change which tests lose a race, so compare failure
-SETS from identical commands in parallel worktrees, never counts between
-different invocations -- a 3-vs-4 count difference across two different commands
-briefly looked like a regression during the 684 work and was not one.
+Also ruled out: cross-contamination inside the notes suite. All 81 notes tests pass together, and each failing test passes in isolation. So the polluter, if there is one, is outside that set.
 
-Remaining scope for this task: the note-conflict tail, plus the pool observed
-earlier under load (note_save_result_after_switch_is_discarded,
-export_registry_failure_*, ingest_canvas_different_canvas_isolation), all of
-which pass in isolation.
+OBSERVED RATES, so the next attempt starts from data. Before the helper change: 4 failed, 2, 0, 1, 0. After: 1, 0. Every failure has been in the notes/note-conflict family -- note_conflict_shows_overwrite_reload_and_keeps_user_text, note_conflict_during_preview_reads_live_text, note_conflict_reload_discards_local_edits, note_save_result_after_switch_is_discarded, notes_sync_now_calls_recording_service_with_chosen_enums -- plus export_registry_failure_* and ingest_canvas_different_canvas_isolation seen earlier.
+
+WHAT I NEVER GOT. The assertion text. Every encounter was a bare FAILED line, and the two runs where I set out to capture the traceback both passed. That is the single most useful next step: run the full file repeatedly with -rf until one fails and the message is captured, since the failing tests have several await points where a prior test's pending autosave or a stale preview snapshot could interfere -- a far better fit for 'passes alone, fails in a full file' than timing.
+
+Suggested approach next time: rather than bisecting 257 tests by hand, run the file under pytest-repeat or in a loop capturing -rf output, get one real traceback, and work back from the assertion. A rate this low makes single-run bisection unreliable.
 <!-- SECTION:NOTES:END -->


### PR DESCRIPTION
Makes two Library shell wait helpers robust, and records what task **699** has ruled out. **699 stays open** — this is not a fix for it, and I want to be explicit about that.

## The change

`_wait_for_library_shell` and `_wait_for_selector` were bounded by a **count of `pilot.pause(0.02)` calls**. That reads as "2.4 seconds" and is not a time budget: a pause takes as long as the event loop needs, so under contention the same 120 iterations buy far less real time and the helper reports *"never loaded"* for a shell that was merely slow.

`_wait_for_condition`, in the same file, already used a wall-clock budget — so the file was inconsistent with itself. Both now take a `timeout`, keeping `attempts` as a floor so a caller passing a deliberately small number still gets its polls. Failure messages name the budget and the poll count actually reached.

**Guarded**: a wait that cannot time out converts every genuine "never mounted" into a hang, which is worse than the flakiness it replaces. The added test asserts the helper still fails, with the right message, inside its budget.

## What this does NOT do — a correction

I proposed this as the cause of 699's order-dependent tail. **The evidence does not support that.** The very next full-file run still failed (`note_conflict_during_preview_reads_live_text`) in **289s**, against **520s** for an earlier run — i.e. under *less* load, not more. A following run passed.

So the tail is a low-rate intermittent that is not primarily load-driven. This change stands on its own merits only.

## What 699 has now ruled out, with evidence

| Hypothesis | Verdict |
|---|---|
| Load sensitivity via the wait helpers | **Ruled out** — next run failed under less load |
| Contamination within the notes suite | **Ruled out** — all 81 notes tests pass together; each failure passes alone |

The real reduction (9 failures → this tail) came from #933: three of the original nine were *stable* failures misfiled as flakiness, and the screen was correct in all three cases.

**Observed rates**, recorded in the task for whoever continues: 4 → 2 → 0 → 1 → 0 before this change; 1 → 0 after. Every failure so far is in the notes/note-conflict family.

**Never obtained: an actual assertion message.** Every encounter was a bare `FAILED` line, and both runs where I deliberately set out to capture a traceback passed. That is the most useful next step — loop the file with `-rf` until one fails, then work back from the assertion. The failing tests have several await points where a prior test's pending autosave or a stale preview snapshot could interfere, which fits "passes alone, fails in a full file" far better than timing does. Single-run bisection is unreliable at this rate.

2 files, +70/−29. Rebased onto current dev with zero overlapping files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the Library shell wait helpers by wall clock and fixed a false‑timeout edge case; not a fix for task‑699. Added tests to enforce correct timeout behavior and updated task‑699 notes to record that load sensitivity via these helpers and contamination inside the notes suite are ruled out.

- **Bug Fixes**
  - `_wait_for_library_shell` and `_wait_for_selector` use a wall‑clock `timeout`; `attempts` is a floor with a single budget `max(timeout, attempts*0.02)` that never exceeds the stated bound.
  - Conditions are checked before the deadline to prevent false timeouts when a `pilot.pause` overshoots; a new test covers an already‑satisfied condition.
  - Failure messages include the timeout and poll count; a guard test ensures a never‑mounted selector fails within budget.

<sup>Written for commit dca3c98848d0911ea3b07148656bb3a60d9b2006. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

