### PR TITLE
feat(settings): Workspaces management category (PR2 of 2)

### DIFF
--- a/Docs/superpowers/plans/2026-07-26-settings-workspaces-folder-roots.md
+++ b/Docs/superpowers/plans/2026-07-26-settings-workspaces-folder-roots.md
@@ -1,0 +1,1734 @@
+# Settings ▸ Workspaces + Folder Access Roots Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the two-PR train from
+`Docs/superpowers/specs/2026-07-26-settings-workspaces-category-design.md`:
+PR1 makes workspace folder bindings real (service + file-tool enforcement),
+PR2 adds the Settings ▸ Workspaces management category.
+
+**Architecture:** PR1 extends `LocalWorkspaceRegistryService` with lifecycle +
+folder-binding methods, adds a multi-root path validator, and routes the
+agent file tools through a run-bound allowed-roots seam (ContextVar set by
+`BuiltinToolProvider.invoke`, workspace id threaded through
+`_compose_run_registry_and_allowed`). PR2 registers a new immediate-apply
+Settings category rendering a list+detail management pane on top of the PR1
+service. Zero bindings ⇒ byte-identical behavior to today.
+
+**Tech Stack:** Python 3.11+, Textual, sqlite (WorkspaceDB), pytest
+(venv-only: run everything with `.venv/bin/python -m pytest` from the repo
+root).
+
+## Global Constraints
+
+- Branches: PR1 `feat/workspace-folder-bindings`, PR2
+  `feat/settings-workspaces-category` stacked on PR1; both off `origin/dev`;
+  merged as one train.
+- Folder access default is read-only: `metadata={"access": "ro"}`; write is
+  per-folder opt-in (`"rw"`).
+- Deny binding the filesystem root and `Path.home()` itself.
+- Stored binding status is display-only; enforcement re-checks
+  `Path.is_dir()` at call time.
+- Reads are confined to sandbox+roots as well as writes (deliberate Codex
+  divergence — ADR-028 §c; do not widen reads).
+- Existing tool gates (`[tools] read_file_enabled` etc.) are untouched.
+- The Default workspace can never hold bindings
+  (`save_runtime_binding` already enforces this — keep that error path).
+- Never hand-edit `tldw_chatbook/css/tldw_cli_modular.tcss`; if a component
+  sheet changes, regenerate via `cd tldw_chatbook/css && python build_css.py`.
+- Blocked/invalid states must explain themselves inline, never
+  tooltip-only, and never via a disabled Button that is expected to emit
+  Pressed (disabled Textual Buttons never emit Pressed).
+- All copy strings in this plan are exact — use them verbatim.
+
+---
+
+## PR1 — service + enforcement
+
+### Task 1: `unarchive_workspace` + duplicate-name guard
+
+**Files:**
+- Modify: `tldw_chatbook/Workspaces/registry_service.py` (near
+  `archive_workspace`, added by TASK-714)
+- Test: `Tests/Workspaces/test_workspace_registry_service.py` (append)
+
+**Interfaces:**
+- Consumes: existing `archive_workspace`, `get_workspace`,
+  `list_workspaces(include_archived=...)`, `WorkspaceNotFound`,
+  `WorkspaceRegistryServiceError`, `_normalize_required_text`,
+  `self._now_factory()`, `self.db.transaction()`.
+- Produces: `unarchive_workspace(workspace_id: str) -> WorkspaceRecord`;
+  case-insensitive duplicate-name rejection inside `rename_workspace` and
+  `create_workspace` raising
+  `WorkspaceRegistryServiceError(f"A workspace named {name} already exists.")`.
+
+- [ ] **Step 1: Write the failing tests** (append to the test file; it
+  already imports `WorkspaceNotFound`, `WorkspaceRegistryServiceError`,
+  `build_test_registry`, `DEFAULT_WORKSPACE_ID`)
+
+```python
+def test_unarchive_workspace_restores_listing_without_activating(tmp_path: Path) -> None:
+    service = build_test_registry(tmp_path)
+    service.ensure_default_workspace()
+    service.create_workspace(workspace_id="ws-a", name="Workspace 1")
+    service.set_active_workspace("ws-a")
+    service.archive_workspace("ws-a")
+
+    restored = service.unarchive_workspace("ws-a")
+
+    assert restored.archived is False
+    assert restored.active is False  # never auto-activates
+    listed = {record.workspace_id for record in service.list_workspaces()}
+    assert "ws-a" in listed
+    active = service.get_active_workspace()
+    assert active is not None and active.workspace_id == DEFAULT_WORKSPACE_ID
+
+
+def test_unarchive_workspace_rejects_unknown_and_unarchived(tmp_path: Path) -> None:
+    service = build_test_registry(tmp_path)
+    service.create_workspace(workspace_id="ws-a", name="Workspace 1")
+
+    with pytest.raises(WorkspaceNotFound):
+        service.unarchive_workspace("ws-missing")
+    with pytest.raises(WorkspaceNotFound):
+        service.unarchive_workspace("ws-a")  # not archived
+
+
+def test_duplicate_names_rejected_case_insensitively(tmp_path: Path) -> None:
+    service = build_test_registry(tmp_path)
+    service.create_workspace(workspace_id="ws-a", name="Client A")
+    service.create_workspace(workspace_id="ws-b", name="Workspace 2")
+
+    with pytest.raises(WorkspaceRegistryServiceError):
+        service.rename_workspace("ws-b", "client a")
+    with pytest.raises(WorkspaceRegistryServiceError):
+        service.create_workspace(workspace_id="ws-c", name="CLIENT A")
+    # Renaming to its own current name (case-changed) is allowed.
+    renamed = service.rename_workspace("ws-a", "client A")
+    assert renamed.name == "client A"
+
+
+def test_archived_names_do_not_block_reuse(tmp_path: Path) -> None:
+    service = build_test_registry(tmp_path)
+    service.create_workspace(workspace_id="ws-a", name="Client A")
+    service.archive_workspace("ws-a")
+
+    created = service.create_workspace(workspace_id="ws-b", name="Client A")
+    assert created.name == "Client A"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/python -m pytest "Tests/Workspaces/test_workspace_registry_service.py" -q -k "unarchive or duplicate_names or archived_names"`
+Expected: FAIL — `AttributeError: ... has no attribute 'unarchive_workspace'` and missing duplicate-name errors.
+
+- [ ] **Step 3: Implement.** In `registry_service.py`, add below
+  `archive_workspace`:
+
+```python
+    def unarchive_workspace(self, workspace_id: str) -> WorkspaceRecord:
+        """Restore an archived workspace to listings (spec §2).
+
+        Never auto-activates: the user chooses when to switch.
+
+        Raises:
+            WorkspaceNotFound: Unknown or not-archived workspace.
+            WorkspaceRegistryServiceError: Storage failure.
+        """
+        safe_workspace_id = _normalize_required_text(workspace_id, "workspace_id")
+        record = self.get_workspace(safe_workspace_id)
+        if record is None or not record.archived:
+            raise WorkspaceNotFound(safe_workspace_id)
+        now = self._now_factory()
+        try:
+            with self.db.transaction() as conn:
+                conn.execute(
+                    """
+                    UPDATE workspace_records
+                    SET archived = 0, updated_at = ?
+                    WHERE workspace_id = ?
+                    """,
+                    (now, safe_workspace_id),
+                )
+        except sqlite3.Error as exc:
+            raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
+        restored = self.get_workspace(safe_workspace_id)
+        if restored is None:
+            raise WorkspaceRegistryServiceError("Workspace unarchive failed.")
+        return restored
+
+    def _reject_duplicate_name(
+        self, name: str, *, exclude_workspace_id: str | None = None
+    ) -> None:
+        """Raise when a non-archived workspace already uses ``name``.
+
+        Case-insensitive; archived workspaces do not block reuse (spec §2).
+        """
+        needle = name.strip().casefold()
+        for record in self.list_workspaces():
+            if exclude_workspace_id and record.workspace_id == exclude_workspace_id:
+                continue
+            if str(record.name or "").strip().casefold() == needle:
+                raise WorkspaceRegistryServiceError(
+                    f"A workspace named {name} already exists."
+                )
+```
+
+  Then wire the guard in: in `create_workspace`, immediately after the
+  `record = WorkspaceRecord(...)` construction line, insert
+  `self._reject_duplicate_name(record.name)`. In `rename_workspace`
+  (TASK-714), after the existing `safe_name` blank-check, insert
+  `self._reject_duplicate_name(safe_name, exclude_workspace_id=safe_workspace_id)`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/python -m pytest "Tests/Workspaces/test_workspace_registry_service.py" -q`
+Expected: PASS (all — including the pre-existing 27+ cases; `ensure_default_workspace` and `next_local_workspace_identity` generate unique names so nothing else trips the guard).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Workspaces/registry_service.py Tests/Workspaces/test_workspace_registry_service.py
+git commit -m "feat(workspaces): unarchive + case-insensitive duplicate-name guard"
+```
+
+### Task 2: folder-binding service methods
+
+**Files:**
+- Modify: `tldw_chatbook/Workspaces/registry_service.py`
+- Modify: `tldw_chatbook/Workspaces/__init__.py` (export `BindingNotFound`)
+- Test: `Tests/Workspaces/test_workspace_folder_bindings.py` (new file)
+
+**Interfaces:**
+- Consumes: existing `save_runtime_binding(binding) -> WorkspaceRuntimeBinding`
+  (already rejects Default + unknown workspaces),
+  `list_runtime_bindings(workspace_id, binding_kind=None)`,
+  `WorkspaceRuntimeBinding(workspace_id, binding_id, binding_kind, label,
+  locator, status, metadata, ...)`, `RuntimeBindingKind.LOCAL_FILESYSTEM`,
+  `RuntimeBindingStatus.READY / .MISSING`.
+- Produces (used by Tasks 3-6 and PR2):
+  - `class BindingNotFound(WorkspaceRegistryServiceError)` with
+    `binding_id` attribute.
+  - `add_folder_binding(workspace_id: str, path: str | Path, *,
+    allow_write: bool = False) -> WorkspaceRuntimeBinding`
+  - `remove_runtime_binding(binding_id: str) -> None`
+  - `list_folder_bindings(workspace_id: str) -> tuple[WorkspaceRuntimeBinding, ...]`
+    (status recomputed from the filesystem; metadata carries
+    `{"access": "ro"|"rw"}`).
+  - `set_folder_binding_access(binding_id: str, *, allow_write: bool) ->
+    WorkspaceRuntimeBinding` (PR2's rw toggle).
+
+- [ ] **Step 1: Write the failing tests** (new file)
+
+```python
+"""Folder-binding service methods (spec 2026-07-26 settings-workspaces §2)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+from tldw_chatbook.Workspaces import DEFAULT_WORKSPACE_ID, LocalWorkspaceRegistryService
+from tldw_chatbook.Workspaces.registry_service import (
+    BindingNotFound,
+    WorkspaceNotFound,
+    WorkspaceRegistryServiceError,
+)
+
+
+def build_registry(tmp_path: Path) -> LocalWorkspaceRegistryService:
+    return LocalWorkspaceRegistryService(
+        WorkspaceDB(tmp_path / "workspaces.sqlite", client_id="folder-tests")
+    )
+
+
+@pytest.fixture()
+def service(tmp_path: Path) -> LocalWorkspaceRegistryService:
+    registry = build_registry(tmp_path)
+    registry.ensure_default_workspace()
+    registry.create_workspace(workspace_id="ws-a", name="Client A")
+    return registry
+
+
+def test_add_folder_binding_stores_canonical_ro_binding(
+    service: LocalWorkspaceRegistryService, tmp_path: Path
+) -> None:
+    folder = tmp_path / "project"
+    folder.mkdir()
+
+    binding = service.add_folder_binding("ws-a", folder)
+
+    assert binding.locator == str(folder.resolve())
+    assert binding.label == "project"
+    assert str(binding.binding_kind) in ("local-filesystem", "RuntimeBindingKind.LOCAL_FILESYSTEM")
+    assert binding.metadata["access"] == "ro"
+    assert str(binding.status) in ("ready", "RuntimeBindingStatus.READY")
+
+
+def test_add_folder_binding_allow_write(
+    service: LocalWorkspaceRegistryService, tmp_path: Path
+) -> None:
+    folder = tmp_path / "writable"
+    folder.mkdir()
+    binding = service.add_folder_binding("ws-a", folder, allow_write=True)
+    assert binding.metadata["access"] == "rw"
+
+
+def test_add_folder_binding_validation_matrix(
+    service: LocalWorkspaceRegistryService, tmp_path: Path
+) -> None:
+    missing = tmp_path / "nope"
+    a_file = tmp_path / "file.txt"
+    a_file.write_text("x")
+    with pytest.raises(WorkspaceRegistryServiceError):
+        service.add_folder_binding("ws-a", missing)
+    with pytest.raises(WorkspaceRegistryServiceError):
+        service.add_folder_binding("ws-a", a_file)
+    with pytest.raises(WorkspaceRegistryServiceError):
+        service.add_folder_binding("ws-a", Path("/"))
+    with pytest.raises(WorkspaceRegistryServiceError):
+        service.add_folder_binding("ws-a", Path.home())
+    with pytest.raises(WorkspaceNotFound):
+        service.add_folder_binding("ws-missing", tmp_path)
+
+
+def test_add_folder_binding_rejects_default_workspace(
+    service: LocalWorkspaceRegistryService, tmp_path: Path
+) -> None:
+    folder = tmp_path / "any"
+    folder.mkdir()
+    with pytest.raises(WorkspaceRegistryServiceError):
+        service.add_folder_binding(DEFAULT_WORKSPACE_ID, folder)
+
+
+def test_add_folder_binding_rejects_duplicates_and_nesting(
+    service: LocalWorkspaceRegistryService, tmp_path: Path
+) -> None:
+    parent = tmp_path / "parent"
+    child = parent / "child"
+    child.mkdir(parents=True)
+    service.add_folder_binding("ws-a", parent)
+
+    with pytest.raises(WorkspaceRegistryServiceError):
+        service.add_folder_binding("ws-a", parent)  # duplicate
+    with pytest.raises(WorkspaceRegistryServiceError):
+        service.add_folder_binding("ws-a", child)  # nested under existing
+
+    # And the reverse direction: existing child blocks a new parent root.
+    other = build_registry(tmp_path / "second-db")
+    other.create_workspace(workspace_id="ws-b", name="Client B")
+    other.add_folder_binding("ws-b", child)
+    with pytest.raises(WorkspaceRegistryServiceError):
+        other.add_folder_binding("ws-b", parent)
+
+
+def test_list_folder_bindings_recomputes_status(
+    service: LocalWorkspaceRegistryService, tmp_path: Path
+) -> None:
+    folder = tmp_path / "ephemeral"
+    folder.mkdir()
+    service.add_folder_binding("ws-a", folder)
+    folder.rmdir()
+
+    bindings = service.list_folder_bindings("ws-a")
+    assert len(bindings) == 1
+    assert str(bindings[0].status) in ("missing", "RuntimeBindingStatus.MISSING")
+
+
+def test_remove_and_toggle_access(
+    service: LocalWorkspaceRegistryService, tmp_path: Path
+) -> None:
+    folder = tmp_path / "toggled"
+    folder.mkdir()
+    binding = service.add_folder_binding("ws-a", folder)
+
+    updated = service.set_folder_binding_access(binding.binding_id, allow_write=True)
+    assert updated.metadata["access"] == "rw"
+
+    service.remove_runtime_binding(binding.binding_id)
+    assert service.list_folder_bindings("ws-a") == ()
+    with pytest.raises(BindingNotFound):
+        service.remove_runtime_binding(binding.binding_id)
+    with pytest.raises(BindingNotFound):
+        service.set_folder_binding_access(binding.binding_id, allow_write=False)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/python -m pytest "Tests/Workspaces/test_workspace_folder_bindings.py" -q`
+Expected: FAIL — `ImportError: cannot import name 'BindingNotFound'`.
+
+- [ ] **Step 3: Implement.** In `registry_service.py`:
+
+```python
+class BindingNotFound(WorkspaceRegistryServiceError):
+    """Raised when a runtime binding id does not exist."""
+
+    def __init__(self, binding_id: str) -> None:
+        super().__init__(f"Runtime binding not found: {binding_id}")
+        self.binding_id = binding_id
+```
+
+  Methods on `LocalWorkspaceRegistryService` (place after
+  `save_runtime_binding`; `uuid4` from the module's existing imports or add
+  `from uuid import uuid4`):
+
+```python
+    def add_folder_binding(
+        self,
+        workspace_id: str,
+        path: str | Path,
+        *,
+        allow_write: bool = False,
+    ) -> WorkspaceRuntimeBinding:
+        """Bind a folder as a file-tool access root (spec §2).
+
+        Read-only by default; canonical (resolved) locator; denies the
+        filesystem root, the home directory itself, non-directories, and
+        duplicate/nested roots within the same workspace. Default-workspace
+        and unknown-workspace rejection is delegated to
+        ``save_runtime_binding``.
+        """
+        candidate = Path(path).expanduser()
+        try:
+            resolved = candidate.resolve()
+        except OSError as exc:
+            raise WorkspaceRegistryServiceError(
+                f"Folder path could not be resolved: {candidate}"
+            ) from exc
+        if not resolved.is_dir():
+            raise WorkspaceRegistryServiceError(
+                f"Folder does not exist or is not a directory: {resolved}"
+            )
+        if resolved == Path(resolved.anchor):
+            raise WorkspaceRegistryServiceError(
+                "The filesystem root cannot be bound to a workspace."
+            )
+        if resolved == Path.home().resolve():
+            raise WorkspaceRegistryServiceError(
+                "Your home directory itself cannot be bound; choose a "
+                "project folder inside it."
+            )
+        for existing in self.list_folder_bindings(workspace_id):
+            existing_path = Path(existing.locator)
+            if resolved == existing_path:
+                raise WorkspaceRegistryServiceError(
+                    f"{resolved} is already bound to this workspace."
+                )
+            if existing_path in resolved.parents:
+                raise WorkspaceRegistryServiceError(
+                    f"{resolved} is inside the already-bound folder "
+                    f"{existing_path}."
+                )
+            if resolved in existing_path.parents:
+                raise WorkspaceRegistryServiceError(
+                    f"The already-bound folder {existing_path} is inside "
+                    f"{resolved}; remove it first."
+                )
+        binding = WorkspaceRuntimeBinding(
+            workspace_id=workspace_id,
+            binding_id=f"folder-{uuid4().hex[:12]}",
+            binding_kind=RuntimeBindingKind.LOCAL_FILESYSTEM,
+            label=resolved.name or str(resolved),
+            locator=str(resolved),
+            status=RuntimeBindingStatus.READY,
+            metadata={"access": "rw" if allow_write else "ro"},
+        )
+        return self.save_runtime_binding(binding)
+
+    def list_folder_bindings(
+        self, workspace_id: str
+    ) -> tuple[WorkspaceRuntimeBinding, ...]:
+        """Local-filesystem bindings with status recomputed from disk."""
+        bindings = self.list_runtime_bindings(
+            workspace_id, binding_kind=RuntimeBindingKind.LOCAL_FILESYSTEM
+        )
+        refreshed: list[WorkspaceRuntimeBinding] = []
+        for binding in bindings:
+            actual = (
+                RuntimeBindingStatus.READY
+                if Path(binding.locator).is_dir()
+                else RuntimeBindingStatus.MISSING
+            )
+            refreshed.append(
+                WorkspaceRuntimeBinding(
+                    workspace_id=binding.workspace_id,
+                    binding_id=binding.binding_id,
+                    binding_kind=binding.binding_kind,
+                    label=binding.label,
+                    locator=binding.locator,
+                    status=actual,
+                    metadata=binding.metadata,
+                    created_at=binding.created_at,
+                    updated_at=binding.updated_at,
+                )
+            )
+        return tuple(refreshed)
+
+    def remove_runtime_binding(self, binding_id: str) -> None:
+        """Delete a runtime binding row (spec §2)."""
+        safe_binding_id = _normalize_required_text(binding_id, "binding_id")
+        try:
+            with self.db.transaction() as conn:
+                cursor = conn.execute(
+                    "DELETE FROM workspace_runtime_bindings WHERE binding_id = ?",
+                    (safe_binding_id,),
+                )
+        except sqlite3.Error as exc:
+            raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
+        if cursor.rowcount == 0:
+            raise BindingNotFound(safe_binding_id)
+
+    def set_folder_binding_access(
+        self, binding_id: str, *, allow_write: bool
+    ) -> WorkspaceRuntimeBinding:
+        """Flip a folder binding's ro/rw access flag (spec §4 toggle)."""
+        existing = self.get_runtime_binding(binding_id)
+        if existing is None:
+            raise BindingNotFound(binding_id)
+        metadata = dict(existing.metadata)
+        metadata["access"] = "rw" if allow_write else "ro"
+        return self.save_runtime_binding(
+            WorkspaceRuntimeBinding(
+                workspace_id=existing.workspace_id,
+                binding_id=existing.binding_id,
+                binding_kind=existing.binding_kind,
+                label=existing.label,
+                locator=existing.locator,
+                status=existing.status,
+                metadata=metadata,
+                created_at=existing.created_at,
+            )
+        )
+```
+
+  Check `list_runtime_bindings`'s actual signature first (it exists at
+  `registry_service.py` ~line 584): if it does not accept a
+  `binding_kind=` filter, filter in `list_folder_bindings` instead:
+  `[b for b in self.list_runtime_bindings(workspace_id) if
+  str(b.binding_kind) in ("local-filesystem",
+  str(RuntimeBindingKind.LOCAL_FILESYSTEM))]`.
+  Export `BindingNotFound` from `tldw_chatbook/Workspaces/__init__.py`
+  alongside the existing service exports.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/python -m pytest "Tests/Workspaces/" -q`
+Expected: PASS (new file + all pre-existing Workspaces suites).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Workspaces/registry_service.py tldw_chatbook/Workspaces/__init__.py Tests/Workspaces/test_workspace_folder_bindings.py
+git commit -m "feat(workspaces): folder-binding service methods (add/list/remove/access)"
+```
+
+### Task 3: `validate_path_multi`
+
+**Files:**
+- Modify: `tldw_chatbook/Utils/path_validation.py`
+- Test: `Tests/Utils/test_path_validation_multi.py` (new; if
+  `Tests/Utils/` lacks an `__init__.py` convention check a sibling test
+  file — `ls Tests/Utils/` — and mirror it)
+
+**Interfaces:**
+- Consumes: existing `validate_path(user_path, base_directory) -> Path`
+  (raises `ValueError` on escape; relative paths resolve against base).
+- Produces: `validate_path_multi(user_path: Union[str, Path], roots:
+  Sequence[Union[str, Path]]) -> Path` — tries roots in order; relative
+  paths resolve against `roots[0]`; raises `ValueError` whose message names
+  every consulted root when none matches.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Multi-root path validation (spec 2026-07-26 settings-workspaces §3)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Utils.path_validation import validate_path_multi
+
+
+def test_accepts_path_inside_any_root(tmp_path: Path) -> None:
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+    (root_b / "sub").mkdir(parents=True)
+    root_a.mkdir()
+    target = root_b / "sub" / "file.txt"
+    target.write_text("x")
+
+    assert validate_path_multi(target, [root_a, root_b]) == target.resolve()
+
+
+def test_relative_paths_resolve_against_first_root(tmp_path: Path) -> None:
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    (sandbox / "note.txt").write_text("x")
+
+    resolved = validate_path_multi("note.txt", [sandbox, tmp_path / "other"])
+    assert resolved == (sandbox / "note.txt").resolve()
+
+
+def test_rejection_names_all_roots(tmp_path: Path) -> None:
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+    root_a.mkdir()
+    root_b.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("x")
+
+    with pytest.raises(ValueError) as excinfo:
+        validate_path_multi(outside, [root_a, root_b])
+    message = str(excinfo.value)
+    assert str(root_a) in message and str(root_b) in message
+
+
+def test_empty_roots_rejected() -> None:
+    with pytest.raises(ValueError):
+        validate_path_multi("anything", [])
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/python -m pytest "Tests/Utils/test_path_validation_multi.py" -q`
+Expected: FAIL — `ImportError: cannot import name 'validate_path_multi'`.
+
+- [ ] **Step 3: Implement** (append to `path_validation.py`, reusing
+  `validate_path` so every per-root security check — traversal, hidden-file
+  rules — stays identical):
+
+```python
+def validate_path_multi(
+    user_path: Union[str, Path], roots: Sequence[Union[str, Path]]
+) -> Path:
+    """Validate ``user_path`` against several allowed roots (first match wins).
+
+    Relative paths resolve against ``roots[0]`` (the primary root — callers
+    pass the tool sandbox first so legacy relative-path behavior is
+    unchanged). The rejection message names every consulted root so a
+    denial is actionable.
+
+    Args:
+        user_path: The path provided by the user or model.
+        roots: Allowed base directories, in priority order.
+
+    Returns:
+        The validated absolute path.
+
+    Raises:
+        ValueError: No roots given, or the path escapes all of them.
+    """
+    root_list = [Path(root) for root in roots]
+    if not root_list:
+        raise ValueError("No allowed roots configured for path validation.")
+    candidate = Path(user_path)
+    for index, root in enumerate(root_list):
+        if index > 0 and not candidate.is_absolute():
+            continue  # relative paths anchor to the primary root only
+        try:
+            return validate_path(user_path, root)
+        except ValueError:
+            continue
+    consulted = ", ".join(str(root.resolve()) for root in root_list)
+    raise ValueError(
+        f"Path '{user_path}' is outside every allowed root ({consulted})."
+    )
+```
+
+  Add `Sequence` to the module's `typing` import if absent.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/python -m pytest "Tests/Utils/test_path_validation_multi.py" -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Utils/path_validation.py Tests/Utils/test_path_validation_multi.py
+git commit -m "feat(utils): validate_path_multi for multi-root file-tool validation"
+```
+
+### Task 4: run-bound allowed-roots seam
+
+**Files:**
+- Create: `tldw_chatbook/Tools/workspace_file_roots.py`
+- Test: `Tests/Tools/test_workspace_file_roots.py` (new; mirror
+  `Tests/Tools/` conventions — `ls Tests/Tools/` first)
+
+**Interfaces:**
+- Consumes: Task 2's `list_folder_bindings`;
+  `tldw_chatbook.config.get_workspaces_db_path`;
+  `LocalWorkspaceRegistryService`, `WorkspaceDB`.
+- Produces (used by Tasks 5-6):
+  - `run_workspace(workspace_id: str | None)` — context manager binding the
+    current run's workspace id (ContextVar-backed, safe across
+    `asyncio.run` inside worker threads).
+  - `current_run_workspace_id() -> str | None`.
+  - `allowed_file_roots(*, write: bool, sandbox_root: Path) ->
+    tuple[Path, ...]` — `(sandbox_root, *existing folder roots)` for the
+    run's workspace (fallback: active workspace); `write=True` keeps only
+    `metadata["access"] == "rw"` folders; folders that are not directories
+    at call time are dropped.
+  - `_registry_factory` module attribute (callable returning a registry) —
+    the test seam.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Run-bound allowed file roots (spec 2026-07-26 settings-workspaces §3)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+from tldw_chatbook.Workspaces import LocalWorkspaceRegistryService
+from tldw_chatbook.Tools import workspace_file_roots as wfr
+
+
+def _registry(tmp_path: Path) -> LocalWorkspaceRegistryService:
+    registry = LocalWorkspaceRegistryService(
+        WorkspaceDB(tmp_path / "ws.sqlite", client_id="roots-tests")
+    )
+    registry.ensure_default_workspace()
+    registry.create_workspace(workspace_id="ws-a", name="Client A")
+    registry.create_workspace(workspace_id="ws-b", name="Client B")
+    return registry
+
+
+def test_roots_follow_run_workspace_not_active(tmp_path, monkeypatch) -> None:
+    registry = _registry(tmp_path)
+    folder_a = tmp_path / "a"
+    folder_a.mkdir()
+    folder_b = tmp_path / "b"
+    folder_b.mkdir()
+    registry.add_folder_binding("ws-a", folder_a)
+    registry.add_folder_binding("ws-b", folder_b)
+    registry.set_active_workspace("ws-b")
+    monkeypatch.setattr(wfr, "_registry_factory", lambda: registry)
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+
+    with wfr.run_workspace("ws-a"):
+        roots = wfr.allowed_file_roots(write=False, sandbox_root=sandbox)
+    assert roots == (sandbox, folder_a.resolve())
+
+    # Outside a run: falls back to the ACTIVE workspace (ws-b).
+    roots = wfr.allowed_file_roots(write=False, sandbox_root=sandbox)
+    assert roots == (sandbox, folder_b.resolve())
+
+
+def test_write_roots_require_rw_and_existing_dirs(tmp_path, monkeypatch) -> None:
+    registry = _registry(tmp_path)
+    ro_folder = tmp_path / "ro"
+    ro_folder.mkdir()
+    rw_folder = tmp_path / "rw"
+    rw_folder.mkdir()
+    gone = tmp_path / "gone"
+    gone.mkdir()
+    registry.add_folder_binding("ws-a", ro_folder)
+    registry.add_folder_binding("ws-a", rw_folder, allow_write=True)
+    registry.add_folder_binding("ws-a", gone, allow_write=True)
+    gone.rmdir()  # deleted after binding: must drop out at call time
+    monkeypatch.setattr(wfr, "_registry_factory", lambda: registry)
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+
+    with wfr.run_workspace("ws-a"):
+        read_roots = wfr.allowed_file_roots(write=False, sandbox_root=sandbox)
+        write_roots = wfr.allowed_file_roots(write=True, sandbox_root=sandbox)
+
+    assert ro_folder.resolve() in read_roots
+    assert write_roots == (sandbox, rw_folder.resolve())
+
+
+def test_registry_failure_degrades_to_sandbox_only(tmp_path, monkeypatch) -> None:
+    def _boom():
+        raise RuntimeError("registry down")
+
+    monkeypatch.setattr(wfr, "_registry_factory", _boom)
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    with wfr.run_workspace("ws-a"):
+        assert wfr.allowed_file_roots(write=True, sandbox_root=sandbox) == (sandbox,)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/python -m pytest "Tests/Tools/test_workspace_file_roots.py" -q`
+Expected: FAIL — `ModuleNotFoundError: ... workspace_file_roots`.
+
+- [ ] **Step 3: Implement** (new module):
+
+```python
+"""Run-bound workspace folder roots for the agent file tools.
+
+Spec: Docs/superpowers/specs/2026-07-26-settings-workspaces-category-design.md §3.
+The provider (`BuiltinToolProvider.invoke`) binds the run's workspace via
+``run_workspace``; the file tools ask ``allowed_file_roots`` at call time.
+Reads and writes are both confined to sandbox+roots (deliberate Codex
+divergence, ADR-028) and stored binding status is never trusted — existence
+is re-checked here on every call.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from pathlib import Path
+from typing import Iterator
+
+from loguru import logger
+
+_RUN_WORKSPACE_ID: ContextVar[str | None] = ContextVar(
+    "tldw_run_workspace_id", default=None
+)
+
+
+def _default_registry_factory():
+    from tldw_chatbook.config import get_workspaces_db_path
+    from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+    from tldw_chatbook.Workspaces import LocalWorkspaceRegistryService
+
+    return LocalWorkspaceRegistryService(
+        WorkspaceDB(get_workspaces_db_path(), client_id="file-tools")
+    )
+
+
+#: Test seam: monkeypatch with a factory returning a prepared registry.
+_registry_factory = _default_registry_factory
+
+
+@contextmanager
+def run_workspace(workspace_id: str | None) -> Iterator[None]:
+    """Bind the current run's workspace for the duration of a tool call."""
+    token = _RUN_WORKSPACE_ID.set(workspace_id)
+    try:
+        yield
+    finally:
+        _RUN_WORKSPACE_ID.reset(token)
+
+
+def current_run_workspace_id() -> str | None:
+    return _RUN_WORKSPACE_ID.get()
+
+
+def allowed_file_roots(*, write: bool, sandbox_root: Path) -> tuple[Path, ...]:
+    """Sandbox root plus the run's workspace folder roots, existing-only.
+
+    Fail-safe: any registry failure degrades to sandbox-only rather than
+    widening access.
+    """
+    roots: list[Path] = [sandbox_root]
+    try:
+        registry = _registry_factory()
+        workspace_id = current_run_workspace_id()
+        if workspace_id is None:
+            active = registry.get_active_workspace()
+            workspace_id = active.workspace_id if active is not None else None
+        if workspace_id is None:
+            return tuple(roots)
+        for binding in registry.list_folder_bindings(workspace_id):
+            if write and str(binding.metadata.get("access", "ro")) != "rw":
+                continue
+            folder = Path(binding.locator)
+            if folder.is_dir():
+                roots.append(folder)
+    except Exception:
+        logger.opt(exception=True).warning(
+            "Workspace folder roots unavailable; file tools confined to sandbox"
+        )
+        return (sandbox_root,)
+    return tuple(roots)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/python -m pytest "Tests/Tools/test_workspace_file_roots.py" -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Tools/workspace_file_roots.py Tests/Tools/test_workspace_file_roots.py
+git commit -m "feat(tools): run-bound workspace file-roots seam (sandbox-plus-folders)"
+```
+
+### Task 5: route file tools through multi-root validation
+
+**Files:**
+- Modify: `tldw_chatbook/Tools/file_operation_tools.py` (three `execute`
+  methods; `validate_path` call sites at ~line 106 (`ReadFileTool`), ~216
+  (`ListDirectoryTool`), and inside `WriteFileTool.execute` ~line 368+)
+- Test: `Tests/Tools/test_file_tools_workspace_roots.py` (new)
+
+**Interfaces:**
+- Consumes: Task 3 `validate_path_multi`, Task 4 `allowed_file_roots` /
+  `run_workspace`; existing `_tool_sandbox_root()`.
+- Produces: unchanged tool APIs; new behavior — reads/lists validate
+  against `allowed_file_roots(write=False, sandbox_root=_tool_sandbox_root())`,
+  writes against `write=True`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""File tools honor workspace folder roots (spec §3)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+from tldw_chatbook.Workspaces import LocalWorkspaceRegistryService
+from tldw_chatbook.Tools import file_operation_tools as fot
+from tldw_chatbook.Tools import workspace_file_roots as wfr
+from tldw_chatbook.Tools.file_operation_tools import (
+    ListDirectoryTool,
+    ReadFileTool,
+    WriteFileTool,
+)
+
+
+@pytest.fixture()
+def bound_workspace(tmp_path, monkeypatch):
+    registry = LocalWorkspaceRegistryService(
+        WorkspaceDB(tmp_path / "ws.sqlite", client_id="tool-tests")
+    )
+    registry.ensure_default_workspace()
+    registry.create_workspace(workspace_id="ws-a", name="Client A")
+    ro_folder = tmp_path / "ro-project"
+    rw_folder = tmp_path / "rw-project"
+    ro_folder.mkdir()
+    rw_folder.mkdir()
+    registry.add_folder_binding("ws-a", ro_folder)
+    registry.add_folder_binding("ws-a", rw_folder, allow_write=True)
+    monkeypatch.setattr(wfr, "_registry_factory", lambda: registry)
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    monkeypatch.setattr(fot, "_resolve_sandbox_config", lambda: str(sandbox))
+    return {"ro": ro_folder, "rw": rw_folder, "sandbox": sandbox}
+
+
+@pytest.mark.asyncio
+async def test_read_allowed_in_bound_folder(bound_workspace) -> None:
+    target = bound_workspace["ro"] / "notes.md"
+    target.write_text("hello")
+    with wfr.run_workspace("ws-a"):
+        result = await ReadFileTool().execute(file_path=str(target))
+    assert result.get("error") is None
+    assert result["content"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_write_denied_in_ro_folder_allowed_in_rw(bound_workspace) -> None:
+    ro_target = bound_workspace["ro"] / "out.txt"
+    rw_target = bound_workspace["rw"] / "out.txt"
+    with wfr.run_workspace("ws-a"):
+        denied = await WriteFileTool().execute(
+            file_path=str(ro_target), content="x"
+        )
+        allowed = await WriteFileTool().execute(
+            file_path=str(rw_target), content="x"
+        )
+    assert denied.get("error")
+    assert allowed.get("error") is None
+    assert rw_target.read_text() == "x"
+
+
+@pytest.mark.asyncio
+async def test_denial_names_roots_and_other_workspace_is_denied(
+    bound_workspace, tmp_path
+) -> None:
+    outside = tmp_path / "elsewhere.txt"
+    outside.write_text("x")
+    with wfr.run_workspace("ws-a"):
+        result = await ReadFileTool().execute(file_path=str(outside))
+    assert result.get("error")
+    assert str(bound_workspace["sandbox"]) in result["error"]
+
+    with wfr.run_workspace("workspace-default"):
+        default_denied = await ReadFileTool().execute(
+            file_path=str(bound_workspace["ro"] / "notes.md")
+        )
+    assert default_denied.get("error")
+
+
+@pytest.mark.asyncio
+async def test_zero_bindings_parity_with_sandbox(bound_workspace) -> None:
+    inside = bound_workspace["sandbox"] / "kept.txt"
+    inside.write_text("sandboxed")
+    with wfr.run_workspace("workspace-default"):
+        listed = await ListDirectoryTool().execute(
+            directory_path=str(bound_workspace["sandbox"])
+        )
+        read = await ReadFileTool().execute(file_path=str(inside))
+    assert listed.get("error") is None
+    assert read.get("error") is None
+```
+
+  Check `ListDirectoryTool.parameters` for its actual argument name
+  (`directory_path` assumed — read the class; if it is `path`, adjust the
+  test, not the tool).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/python -m pytest "Tests/Tools/test_file_tools_workspace_roots.py" -q`
+Expected: FAIL — reads/writes in bound folders rejected ("outside the allowed directory").
+
+- [ ] **Step 3: Implement.** In `file_operation_tools.py` add imports:
+
+```python
+from tldw_chatbook.Utils.path_validation import validate_path, validate_path_multi
+from tldw_chatbook.Tools.workspace_file_roots import allowed_file_roots
+```
+
+  and replace each per-tool validation call:
+
+```python
+# ReadFileTool.execute and ListDirectoryTool.execute:
+validated_path = validate_path_multi(
+    file_path,
+    allowed_file_roots(write=False, sandbox_root=_tool_sandbox_root()),
+)
+# WriteFileTool.execute:
+validated_path = validate_path_multi(
+    file_path,
+    allowed_file_roots(write=True, sandbox_root=_tool_sandbox_root()),
+)
+```
+
+  (`ListDirectoryTool` validates its directory argument the same way; keep
+  every surrounding error-dict shape untouched — the `ValueError` message
+  from `validate_path_multi` flows into the existing `{"error": ...}`
+  handling.)
+
+- [ ] **Step 4: Run to verify pass + regression pin**
+
+Run: `.venv/bin/python -m pytest "Tests/Tools/" -q`
+Expected: PASS — new file AND every pre-existing file-tool test (those are
+the zero-binding parity pin: they run without any workspace bindings and
+must behave exactly as before).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Tools/file_operation_tools.py Tests/Tools/test_file_tools_workspace_roots.py
+git commit -m "feat(tools): file tools honor workspace folder roots (ro/rw, call-time)"
+```
+
+### Task 6: bind the run's workspace through the provider
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/tool_catalog.py`
+  (`BuiltinToolProvider.__init__` ~line 273, `invoke` ~line 360)
+- Modify: `tldw_chatbook/Chat/console_agent_bridge.py`
+  (`_compose_run_registry_and_allowed` ~line 778 and its call site(s) —
+  find with `grep -n "_compose_run_registry_and_allowed(" tldw_chatbook/Chat/console_agent_bridge.py`)
+- Test: `Tests/Agents/test_builtin_provider_workspace_binding.py` (new;
+  mirror `Tests/Agents/` conventions)
+
+**Interfaces:**
+- Consumes: Task 4 `run_workspace`.
+- Produces: `BuiltinToolProvider(gate=None, workspace_id: str | None = None)`;
+  `_compose_run_registry_and_allowed(..., workspace_id: str | None = None)`
+  threading it; the bridge's caller passes the running session's
+  `workspace_id` (the Console session object's `workspace_id` attribute —
+  the caller that invokes `_compose_run_registry_and_allowed` has the
+  session/store in scope; trace it at implementation time and pass
+  `session.workspace_id`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""BuiltinToolProvider binds the run's workspace around tool execution."""
+
+from __future__ import annotations
+
+from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider
+from tldw_chatbook.Tools import workspace_file_roots as wfr
+
+
+class _ProbeTool:
+    name = "probe_workspace"
+    description = "records the bound run workspace"
+    parameters = {"type": "object", "properties": {}}
+
+    async def execute(self, **kwargs):
+        return {"workspace": wfr.current_run_workspace_id()}
+
+
+class _OpenGate:
+    def check(self, tool):
+        return None
+
+
+def test_invoke_binds_and_clears_run_workspace() -> None:
+    provider = BuiltinToolProvider(gate=_OpenGate(), workspace_id="ws-a")
+    provider._tools["probe_workspace"] = _ProbeTool()
+
+    result = provider.invoke("builtin:probe_workspace", {})
+
+    assert result.ok, result.error
+    assert '"workspace": "ws-a"' in result.content
+    assert wfr.current_run_workspace_id() is None  # cleared after invoke
+
+
+def test_invoke_without_workspace_leaves_context_unset() -> None:
+    provider = BuiltinToolProvider(gate=_OpenGate())
+    provider._tools["probe_workspace"] = _ProbeTool()
+
+    result = provider.invoke("builtin:probe_workspace", {})
+
+    assert result.ok, result.error
+    assert '"workspace": null' in result.content
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/python -m pytest "Tests/Agents/test_builtin_provider_workspace_binding.py" -q`
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'workspace_id'`.
+
+- [ ] **Step 3: Implement.** In `tool_catalog.py`:
+
+```python
+    def __init__(
+        self, gate: Any | None = None, workspace_id: str | None = None
+    ) -> None:
+        # spec §3: the run's workspace, bound around every tool execution so
+        # file tools resolve THIS run's folder roots — not whatever
+        # workspace the user is looking at when the tool fires.
+        self._workspace_id = workspace_id
+        ...  # existing body unchanged
+```
+
+  and in `invoke`, wrap the execution line:
+
+```python
+        from tldw_chatbook.Tools.workspace_file_roots import run_workspace
+
+        try:
+            with run_workspace(self._workspace_id):
+                raw = asyncio.run(tool.execute(**args))
+```
+
+  (When `self._workspace_id` is `None`, `run_workspace(None)` keeps the
+  ContextVar at `None`, so `allowed_file_roots` falls back to the active
+  workspace — the spec's documented fallback.)
+  In `console_agent_bridge.py`, add `workspace_id: str | None = None` to
+  `_compose_run_registry_and_allowed`'s keyword parameters, pass it into
+  `BuiltinToolProvider(gate=builtin_gate, workspace_id=workspace_id)`, and
+  thread the session's `workspace_id` from the call site (grep as noted in
+  **Files**; the surrounding function has the active run's session in
+  scope).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/python -m pytest "Tests/Agents/" -q`
+Expected: PASS (new + existing agent suites — the added keyword defaults to
+`None` everywhere it is not passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Agents/tool_catalog.py tldw_chatbook/Chat/console_agent_bridge.py Tests/Agents/test_builtin_provider_workspace_binding.py
+git commit -m "feat(agents): bind run workspace through BuiltinToolProvider for file roots"
+```
+
+### Task 7: ADR-028 + PR1 assembly
+
+**Files:**
+- Create: `backlog/decisions/028-settings-workspaces-category-and-folder-roots.md`
+- Test: none (docs) — full-suite verification instead.
+
+**Interfaces:** none produced; records spec §8 items (a)-(d) verbatim.
+
+- [ ] **Step 1: Write the ADR.** Content: title
+  `# 028 - Settings owns workspace management; folders are file-tool access roots`;
+  Date/Status/Relates-to header (relates to spec
+  `2026-07-26-settings-workspaces-category-design.md`, supersedes the
+  Stage-5 read-only boundary in
+  `Docs/superpowers/plans/2026-05-29-settings-configuration-hub.md`); then
+  four decision sections copied from spec §8: (a) ownership supersession
+  with Console/Library quick actions retained, (b) folder semantics
+  (access roots, `ro` default, call-time existence validation, run-bound
+  resolution, Default stays tool-less), (c) the deliberate Codex
+  divergence — reads confined too, "do not 'fix' this to match Codex", (d)
+  canonical locators as the `runtimeWorkspaceRoots`-shaped export surface
+  for external runtimes.
+
+- [ ] **Step 2: Full PR1 verification**
+
+Run: `.venv/bin/python -m pytest "Tests/Workspaces/" "Tests/Tools/" "Tests/Agents/" "Tests/Utils/test_path_validation_multi.py" "Tests/UI/test_console_workspace_lifecycle.py" "Tests/UI/test_console_workspace_keyboard.py" -q`
+Expected: PASS. Then the two big pins:
+`.venv/bin/python -m pytest "Tests/UI/test_console_native_chat_flow.py" -q`
+Expected: 201 passed (known-flaky exceptions documented in the workspace
+program memory do not include this file).
+
+- [ ] **Step 3: Commit + push + PR**
+
+```bash
+git add backlog/decisions/028-settings-workspaces-category-and-folder-roots.md
+git commit -m "docs: ADR-028 Settings-owned workspace management + folder access roots"
+git push -u origin feat/workspace-folder-bindings
+gh pr create --base dev --title "feat(workspaces): folder access roots — service + file-tool enforcement (PR1 of 2)" --body "Implements spec 2026-07-26-settings-workspaces-category-design.md §§2-3,5,8. Zero bindings = behavior identical to today. PR2 (Settings category) stacks on this."
+```
+
+---
+
+## PR2 — Settings ▸ Workspaces category
+*(branch `feat/settings-workspaces-category` off PR1's branch)*
+
+### Task 8: register the category
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/settings_config_models.py`
+  (`SettingsCategoryId` enum)
+- Modify: `tldw_chatbook/UI/Screens/settings_screen.py` —
+  `_category_summaries` (~line 926), `_category_groups` (~line 1044), the
+  Save/Revert suppression sites (comment at ~415 explains the pattern;
+  actual suppression membership at ~1870-1876 where THEME and
+  SPLASH_SCREEN are listed — add WORKSPACES beside them at BOTH sites
+  found by `grep -n "SettingsCategoryId.THEME" tldw_chatbook/UI/Screens/settings_screen.py`),
+  ownership records (~974-988 region), and `_render_detail_pane` dispatch
+  (~line 7034) routing to a stub `_render_workspaces_detail`.
+- Test: `Tests/UI/test_settings_workspaces_category.py` (new; harness
+  pattern from `Tests/UI/test_settings_configuration_hub.py`:
+  `DestinationHarness(app, "settings")`, `_open_settings_category(pilot,
+  "#settings-category-workspaces")`, `_visible_text`)
+
+**Interfaces:**
+- Produces: `SettingsCategoryId.WORKSPACES = "workspaces"`; category button
+  id `settings-category-workspaces`; stub pane rendering a Static
+  `"Workspace management"` that Task 9 replaces.
+- Category summary copy (verbatim):
+  title `"Workspaces"`, description
+  `"Create, rename, archive, and bind folders for agent file tools."`,
+  status `"Immediate actions"`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Settings ▸ Workspaces category registration (spec §4)."""
+
+from __future__ import annotations
+
+import pytest
+
+from Tests.UI.test_settings_configuration_hub import (
+    DestinationHarness,
+    _active_destination_screen,
+    _build_test_app,
+    _open_settings_category,
+    _visible_text,
+)
+
+
+@pytest.mark.asyncio
+async def test_workspaces_category_registered_and_immediate() -> None:
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _open_settings_category(pilot, "#settings-category-workspaces")
+        text = _visible_text(screen)
+
+        assert "Workspace management" in text
+        # Immediate-apply category: the guided Save/Revert buttons are
+        # suppressed exactly like Theme/Splash.
+        assert not screen.query("#settings-save-category")
+```
+
+  (Before writing, check the actual Save button id used by the suppression
+  assertion in existing Theme tests — `grep -n "settings-save-category\|save.*suppress" Tests/UI/test_settings_configuration_hub.py`
+  — and mirror whatever those tests assert. If the helpers above are named
+  differently in that file, import the real names.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/python -m pytest "Tests/UI/test_settings_workspaces_category.py" -q`
+Expected: FAIL — no `#settings-category-workspaces` button.
+
+- [ ] **Step 3: Implement.** Enum:
+  `WORKSPACES = "workspaces"` (place after STORAGE). Summary entry in
+  `_category_summaries` with the verbatim copy above; group it in
+  `_category_groups` under the `"Data & Privacy"` tuple after Storage;
+  add `SettingsCategoryId.WORKSPACES` to BOTH Save/Revert suppression
+  sites beside THEME/SPLASH_SCREEN; ownership record mirroring the
+  THEME record's shape (~974) with
+  `owns_config_sections=()`,
+  `runtime_owner="Workspace registry (immediate actions)"`,
+  `boundary_copy="Lifecycle and folder bindings apply immediately; no draft state."`,
+  `recovery_copy="Quick actions: switch/rename/archive in Console (Alt+W); create in Library."`;
+  dispatch branch in `_render_detail_pane`:
+
+```python
+        if category is SettingsCategoryId.WORKSPACES:
+            yield from self._render_workspaces_detail()
+            return
+```
+
+  stub:
+
+```python
+    def _render_workspaces_detail(self) -> ComposeResult:
+        yield Static("Workspace management", classes="destination-section")
+```
+
+  (Match the surrounding dispatch style — if `_render_detail_pane` uses
+  `return self._render_x()` lists instead of `yield from`, mirror it.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/python -m pytest "Tests/UI/test_settings_workspaces_category.py" "Tests/UI/test_settings_configuration_hub.py" -q`
+Expected: PASS (hub suite guards the category list/grouping invariants).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/settings_config_models.py tldw_chatbook/UI/Screens/settings_screen.py Tests/UI/test_settings_workspaces_category.py
+git commit -m "feat(settings): register Workspaces category (immediate-apply, stub pane)"
+```
+
+### Task 9: workspace list + create + lifecycle card
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/settings_screen.py`
+  (`_render_workspaces_detail` + handlers)
+- Test: `Tests/UI/test_settings_workspaces_category.py` (append)
+
+**Interfaces:**
+- Consumes: `app_instance.workspace_registry_service` (
+  `list_workspaces(include_archived=...)`, `get_active_workspace`,
+  `create_workspace`, `rename_workspace`, `set_active_workspace`,
+  `archive_workspace`, `unarchive_workspace`,
+  `next_local_workspace_identity` for generated ids),
+  `ConfirmationDialog` (`tldw_chatbook.Widgets.confirmation_dialog`;
+  its confirm callback MUST be a coroutine function).
+- Produces (ids Task 10/11 and tests rely on):
+  `#settings-workspaces-list` (Vertical of row Buttons
+  `#settings-workspace-row-{workspace_id}`),
+  `#settings-workspaces-show-archived` (Checkbox),
+  `#settings-workspace-create-name` (Input) +
+  `#settings-workspace-create` (Button),
+  detail card `#settings-workspace-card` with
+  `#settings-workspace-rename-input`, `#settings-workspace-rename-apply`,
+  `#settings-workspace-set-active`, `#settings-workspace-archive`,
+  `#settings-workspace-unarchive`,
+  result line `#settings-workspaces-result` (inline errors/confirmations —
+  never tooltip-only). Selection state:
+  `self._settings_selected_workspace_id: str | None`.
+- Copy (verbatim): archive confirm message
+  `f"Archive {name}? Its conversations stay saved and remain visible in Library; the workspace disappears from the switcher and the Console browser."`;
+  Default card explanation
+  `"The built-in Default workspace keeps its identity and stays tool-less; create a workspace to bind folders."`.
+
+- [ ] **Step 1: Write the failing tests** (append)
+
+```python
+@pytest.mark.asyncio
+async def test_create_rename_archive_unarchive_flow() -> None:
+    from textual.widgets import Button, Checkbox, Input
+
+    app = _build_test_app()
+    registry = app.workspace_registry_service
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _open_settings_category(pilot, "#settings-category-workspaces")
+
+        # Create with a free-form name.
+        screen.query_one("#settings-workspace-create-name", Input).value = "Client X"
+        screen.query_one("#settings-workspace-create", Button).press()
+        await pilot.pause(0.3)
+        created = [w for w in registry.list_workspaces() if w.name == "Client X"]
+        assert len(created) == 1
+        workspace_id = created[0].workspace_id
+
+        # Select, rename.
+        screen.query_one(f"#settings-workspace-row-{workspace_id}", Button).press()
+        await pilot.pause(0.2)
+        screen.query_one("#settings-workspace-rename-input", Input).value = "Client Y"
+        screen.query_one("#settings-workspace-rename-apply", Button).press()
+        await pilot.pause(0.3)
+        assert registry.get_workspace(workspace_id).name == "Client Y"
+
+        # Duplicate rename surfaces inline, not as a crash.
+        screen.query_one("#settings-workspace-rename-input", Input).value = "Default"
+        screen.query_one("#settings-workspace-rename-apply", Button).press()
+        await pilot.pause(0.3)
+        assert "already exists" in _visible_text(screen)
+
+        # Set active.
+        screen.query_one("#settings-workspace-set-active", Button).press()
+        await pilot.pause(0.3)
+        assert registry.get_active_workspace().workspace_id == workspace_id
+
+        # Archive (confirm dialog), falls back to Default.
+        screen.query_one("#settings-workspace-archive", Button).press()
+        await pilot.pause(0.3)
+        confirm = host.screen_stack[-1]
+        confirm.query_one("#confirm-button", Button).press()
+        await pilot.pause(0.4)
+        assert registry.get_workspace(workspace_id).archived is True
+        assert registry.get_active_workspace().workspace_id == "workspace-default"
+
+        # Hidden until Show archived; then unarchive (no auto-activate).
+        assert not screen.query(f"#settings-workspace-row-{workspace_id}")
+        screen.query_one("#settings-workspaces-show-archived", Checkbox).value = True
+        await pilot.pause(0.3)
+        screen.query_one(f"#settings-workspace-row-{workspace_id}", Button).press()
+        await pilot.pause(0.2)
+        screen.query_one("#settings-workspace-unarchive", Button).press()
+        await pilot.pause(0.3)
+        record = registry.get_workspace(workspace_id)
+        assert record.archived is False and record.active is False
+
+
+@pytest.mark.asyncio
+async def test_default_workspace_card_is_protected() -> None:
+    from textual.widgets import Button
+
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _open_settings_category(pilot, "#settings-category-workspaces")
+        screen.query_one("#settings-workspace-row-workspace-default", Button).press()
+        await pilot.pause(0.2)
+
+        assert not screen.query("#settings-workspace-rename-apply")
+        assert not screen.query("#settings-workspace-archive")
+        assert "stays tool-less" in _visible_text(screen)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/python -m pytest "Tests/UI/test_settings_workspaces_category.py" -q`
+Expected: FAIL — stub pane has none of the queried ids.
+
+- [ ] **Step 3: Implement `_render_workspaces_detail` + handlers.**
+  Rendering (shape; follow the settings screen's existing
+  `settings-input-row` / `destination-section` classes):
+
+```python
+    def _render_workspaces_detail(self) -> ComposeResult:
+        registry = getattr(self.app_instance, "workspace_registry_service", None)
+        yield Static("Workspace management", classes="destination-section")
+        if registry is None:
+            yield Static(
+                "Workspace service is not ready. Restart Chatbook and retry.",
+                id="settings-workspaces-result",
+                classes="settings-status-row",
+            )
+            return
+        show_archived = bool(getattr(self, "_settings_show_archived_workspaces", False))
+        active = registry.get_active_workspace()
+        active_id = active.workspace_id if active is not None else None
+        with Horizontal(classes="settings-input-row"):
+            yield Input(
+                placeholder="New workspace name",
+                id="settings-workspace-create-name",
+                classes="settings-compact-input",
+            )
+            yield Button("Create", id="settings-workspace-create", compact=True)
+        yield Checkbox(
+            "Show archived", show_archived, id="settings-workspaces-show-archived"
+        )
+        with Vertical(id="settings-workspaces-list"):
+            for record in registry.list_workspaces(include_archived=show_archived):
+                marker = " (active)" if record.workspace_id == active_id else ""
+                archived = " [archived]" if record.archived else ""
+                folders = len(registry.list_folder_bindings(record.workspace_id)) if record.workspace_id != "workspace-default" else 0
+                row = Button(
+                    f"{record.name}{marker}{archived} - {folders} folders",
+                    id=f"settings-workspace-row-{record.workspace_id}",
+                    classes="settings-workspace-row",
+                    compact=True,
+                )
+                yield row
+        yield Static("", id="settings-workspaces-result", classes="settings-status-row")
+        yield from self._render_workspace_card(registry, active_id)
+```
+
+  `_render_workspace_card` renders nothing when no selection; for the
+  Default workspace it renders ONLY the protection Static (verbatim copy
+  above); otherwise rename input+apply, Set active (omit when already
+  active and render Static `"This workspace is active."` instead — never a
+  disabled Button expected to explain itself), Archive OR Unarchive per
+  `record.archived`, and (Task 10) the folder section. Handlers use
+  `@on(Button.Pressed, "#settings-workspace-create")` etc.; every mutation
+  is wrapped:
+
+```python
+        try:
+            ...registry call...
+        except WorkspaceRegistryServiceError as exc:
+            self._set_settings_workspaces_result(str(exc))
+            return
+        self._refresh_settings_workspaces_pane()
+```
+
+  where `_set_settings_workspaces_result(text)` updates
+  `#settings-workspaces-result` in place and
+  `_refresh_settings_workspaces_pane()` triggers the category re-render via
+  the screen's existing recompose path (mirror how Theme applies changes —
+  find with `grep -n "def _render_theme" -A4 tldw_chatbook/UI/Screens/settings_screen.py`
+  and follow whatever refresh idiom its action handlers use). Row press
+  sets `self._settings_selected_workspace_id` then refreshes. Archive goes
+  through `ConfirmationDialog` with an **async** confirm callback (it is
+  awaited). Import `WorkspaceRegistryServiceError` at the settings module's
+  workspace-import site.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/python -m pytest "Tests/UI/test_settings_workspaces_category.py" -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/settings_screen.py Tests/UI/test_settings_workspaces_category.py
+git commit -m "feat(settings): workspace list, create, rename, active, archive/unarchive"
+```
+
+### Task 10: folder-bindings editor
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/settings_screen.py`
+  (extend `_render_workspace_card` + handlers)
+- Test: `Tests/UI/test_settings_workspaces_category.py` (append)
+
+**Interfaces:**
+- Consumes: Task 2 service methods; Task 9 card scaffolding + result line.
+- Produces ids: folder rows `#settings-workspace-folder-{binding_id}`
+  (Static: `f"{locator} [{access}] {status}"`), per-row
+  `#settings-workspace-folder-toggle-{binding_id}` (Button, label
+  `"Allow write"` when ro / `"Read-only"` when rw) and
+  `#settings-workspace-folder-remove-{binding_id}` (Button `"Remove"`);
+  add row `#settings-workspace-folder-path` (Input, placeholder
+  `"~/path/to/folder"`) + `#settings-workspace-folder-add` (Button `"Add folder"`).
+
+- [ ] **Step 1: Write the failing test** (append)
+
+```python
+@pytest.mark.asyncio
+async def test_folder_bindings_add_toggle_remove_and_inline_errors(tmp_path) -> None:
+    from textual.widgets import Button, Input
+
+    app = _build_test_app()
+    registry = app.workspace_registry_service
+    registry.create_workspace(workspace_id="ws-folders", name="Folder WS")
+    project = tmp_path / "project"
+    project.mkdir()
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _open_settings_category(pilot, "#settings-category-workspaces")
+        screen.query_one("#settings-workspace-row-ws-folders", Button).press()
+        await pilot.pause(0.2)
+
+        # Add (defaults to read-only).
+        screen.query_one("#settings-workspace-folder-path", Input).value = str(project)
+        screen.query_one("#settings-workspace-folder-add", Button).press()
+        await pilot.pause(0.3)
+        bindings = registry.list_folder_bindings("ws-folders")
+        assert len(bindings) == 1
+        binding = bindings[0]
+        assert binding.metadata["access"] == "ro"
+        assert "[ro]" in _visible_text(screen)
+
+        # Toggle to rw.
+        screen.query_one(
+            f"#settings-workspace-folder-toggle-{binding.binding_id}", Button
+        ).press()
+        await pilot.pause(0.3)
+        assert registry.list_folder_bindings("ws-folders")[0].metadata["access"] == "rw"
+
+        # Invalid add explains inline.
+        screen.query_one("#settings-workspace-folder-path", Input).value = str(
+            tmp_path / "missing"
+        )
+        screen.query_one("#settings-workspace-folder-add", Button).press()
+        await pilot.pause(0.3)
+        assert "not a directory" in _visible_text(screen)
+
+        # Remove.
+        screen.query_one(
+            f"#settings-workspace-folder-remove-{binding.binding_id}", Button
+        ).press()
+        await pilot.pause(0.3)
+        assert registry.list_folder_bindings("ws-folders") == ()
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/python -m pytest "Tests/UI/test_settings_workspaces_category.py" -q -k folder`
+Expected: FAIL — folder ids absent from the card.
+
+- [ ] **Step 3: Implement.** Extend `_render_workspace_card` (non-Default
+  branch) with a `"Folders (agent file-tool access)"` section Static, one
+  row per `registry.list_folder_bindings(workspace_id)` (Static text
+  `f"{binding.locator} [{binding.metadata.get('access', 'ro')}] {'ready' if str(binding.status).endswith('ready') else 'missing'}"`
+  — compute from the recomputed status), the toggle/remove Buttons with the
+  ids above, then the add row. Handlers:
+
+```python
+    @on(Button.Pressed, "#settings-workspace-folder-add")
+    def _settings_workspace_add_folder(self, event: Button.Pressed) -> None:
+        event.stop()
+        registry = self.app_instance.workspace_registry_service
+        raw = self.query_one("#settings-workspace-folder-path", Input).value
+        try:
+            registry.add_folder_binding(
+                self._settings_selected_workspace_id, raw
+            )
+        except WorkspaceRegistryServiceError as exc:
+            self._set_settings_workspaces_result(str(exc))
+            return
+        self._set_settings_workspaces_result("Folder added (read-only).")
+        self._refresh_settings_workspaces_pane()
+```
+
+  Toggle and Remove handlers use `@on(Button.Pressed,
+  ".settings-workspace-folder-toggle")` / `".settings-workspace-folder-remove"`
+  class selectors with the binding id parsed from `event.button.id`
+  (`event.button.id.rsplit("-", 1)` will split uuids — instead stash
+  `event.button.binding_id = binding.binding_id` at compose time, exactly
+  like the conversation browser stashes `conversation_id` on row buttons,
+  and read `getattr(event.button, "binding_id")` in the handler). Toggle
+  computes `allow_write = binding.metadata.get("access") != "rw"` from a
+  fresh `list_folder_bindings` read, then
+  `set_folder_binding_access(binding_id, allow_write=allow_write)`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/python -m pytest "Tests/UI/test_settings_workspaces_category.py" -q`
+Expected: PASS (all category tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/settings_screen.py Tests/UI/test_settings_workspaces_category.py
+git commit -m "feat(settings): folder-bindings editor (add ro/rw toggle, remove, inline errors)"
+```
+
+### Task 11: freshness + cross-surface copy + PR2 assembly
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/settings_screen.py` (refresh-on-resume;
+  Overview recovery copy)
+- Modify: `tldw_chatbook/Workspaces/display_state.py` +
+  `tldw_chatbook/UI/Screens/chat_screen.py` (repoint the TASK-719 copy)
+- Test: `Tests/UI/test_settings_workspaces_category.py` +
+  `Tests/UI/test_settings_configuration_hub.py` (adjust pinned copy)
+
+**Interfaces:**
+- Consumes: everything prior.
+- Produces: final copy strings (verbatim):
+  - Overview recovery copy becomes:
+    `"Sync status here is read-only - manage workspaces in Settings > Workspaces; switch in Console (Alt+W); run sync from the owning sync surfaces."`
+  - `display_state.py` single-workspace recovery (currently
+    `"Create one with the rail's New button or in Library > Details > Workspace."`)
+    becomes:
+    `"Create one with the rail's New button or in Settings > Workspaces."`
+  - `chat_screen.py` zero-workspace toast gets the same new string.
+
+- [ ] **Step 1: Write the failing tests.** Append to the category test
+  file:
+
+```python
+@pytest.mark.asyncio
+async def test_pane_refreshes_after_external_registry_change() -> None:
+    from textual.widgets import Button
+
+    app = _build_test_app()
+    registry = app.workspace_registry_service
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _open_settings_category(pilot, "#settings-category-workspaces")
+        assert not screen.query("#settings-workspace-row-ws-late")
+
+        registry.create_workspace(workspace_id="ws-late", name="Late Arrival")
+        screen._refresh_settings_workspaces_pane()
+        await pilot.pause(0.3)
+        assert screen.query_one("#settings-workspace-row-ws-late", Button)
+```
+
+  In the hub test file, update the assertions pinned by TASK-719 (find with
+  `grep -n "Library > Details > Workspace" Tests/UI/test_settings_configuration_hub.py`)
+  to the new Overview copy above.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/python -m pytest "Tests/UI/test_settings_workspaces_category.py" -q -k refresh`
+Expected: FAIL until the refresh helper is public-stable and the copy sites
+are updated (hub tests fail on old copy).
+
+- [ ] **Step 3: Implement.** (1) Call
+  `self._refresh_settings_workspaces_pane()` from the screen's
+  resume/refresh hook when the active category is WORKSPACES — find the
+  hook with `grep -n "on_screen_resume\|def on_resume" tldw_chatbook/UI/Screens/settings_screen.py`
+  and mirror how sync rows refresh there. (2) Apply the three verbatim copy
+  replacements listed in **Interfaces** (grep each old string; they are
+  unique). (3) Update the hub-test pins.
+
+- [ ] **Step 4: Full PR2 verification**
+
+Run: `.venv/bin/python -m pytest "Tests/UI/test_settings_workspaces_category.py" "Tests/UI/test_settings_configuration_hub.py" "Tests/Workspaces/" "Tests/UI/test_console_workspace_lifecycle.py" "Tests/UI/test_console_workspace_context_rail.py" -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit + push + PR**
+
+```bash
+git add -A tldw_chatbook/UI/Screens/settings_screen.py tldw_chatbook/Workspaces/display_state.py tldw_chatbook/UI/Screens/chat_screen.py Tests/UI/
+git commit -m "feat(settings): workspaces pane freshness + management-home copy repoint"
+git push -u origin feat/settings-workspaces-category
+gh pr create --base dev --title "feat(settings): Workspaces management category (PR2 of 2)" --body "Implements spec 2026-07-26-settings-workspaces-category-design.md §4. Stacked on PR1 (folder roots); merge PR1 first, then this — one train."
+```
+
+### Task 12: live smoke (non-negotiable before merge)
+
+**Files:** none (verification only).
+
+- [ ] **Step 1:** Launch per `.claude/skills/verify/SKILL.md` on a scratch
+  profile (`TLDW_CONFIG_PATH`, fresh `users_name`), from the PR2 worktree.
+- [ ] **Step 2:** Drive: Settings ▸ Workspaces → create "Smoke WS" → bind a
+  real temp folder → toggle rw → confirm the Console Details tray shows
+  "File tools: 1 ready" for that workspace after switching to it (Alt+W).
+- [ ] **Step 3:** With `[tools] read_file_enabled = true` in the scratch
+  config and the local llama server, run an agent turn that reads a file
+  inside the bound folder (allowed) and one outside (denied, error names
+  the roots). Capture both transcripts into the session scratchpad.
+- [ ] **Step 4:** Kill tmux server, delete the scratch profile dir.
+
+## Self-review notes (already applied)
+
+- Spec §2/§3/§4/§5/§8 each map to Tasks 1-2 / 3-6 / 8-11 / (5+2) / 7;
+  §7 phasing = the PR boundaries; §6's suites appear in Tasks 4-6, 9-11
+  steps; live proof = Task 12.
+- Names used across tasks are consistent: `add_folder_binding`,
+  `list_folder_bindings`, `remove_runtime_binding`,
+  `set_folder_binding_access`, `BindingNotFound`, `validate_path_multi`,
+  `allowed_file_roots`, `run_workspace`, `current_run_workspace_id`,
+  `_registry_factory`, `BuiltinToolProvider(workspace_id=...)`,
+  `_refresh_settings_workspaces_pane`, `_set_settings_workspaces_result`,
+  `_settings_selected_workspace_id`.
+- Known verify-at-implementation points are explicit: `list_runtime_bindings`
+  filter signature (Task 2), `ListDirectoryTool` argument name (Task 5),
+  the bridge call-site trace (Task 6), hub-test helper names (Task 8),
+  Theme refresh idiom (Task 9), resume hook name (Task 11).

--- a/Docs/superpowers/specs/2026-07-26-settings-workspaces-category-design.md
+++ b/Docs/superpowers/specs/2026-07-26-settings-workspaces-category-design.md
@@ -24,6 +24,17 @@ lets users modify existing workspaces by **adding/removing folders**.
 - **Two stacked PRs, merged as one train** (§7): PR1 = service + enforcement,
   PR2 = the Settings page. Never ship management UI for behavior that does
   not exist yet (the aspirational-UI failure the UX review condemned).
+- **Companion package (separate spec, same program): parallel agents across
+  workspaces.** The user's end goal is agents working in parallel in
+  different workspaces, swapped between from the Console sidebar. Console
+  runs are globally serialized today (single exclusive `console-run` worker
+  group + an "already running" send gate), so that requires a Console
+  concurrency change — per-session run state/workers, sidebar run
+  indicators, background-run streaming/approval UX — specced separately.
+  This spec deliberately builds the enabling primitive: run-bound folder
+  roots (§3) mean concurrent runs each enforce their own workspace's
+  folders with no cross-talk, so the companion work needs no enforcement
+  changes.
 
 ## 2. Service layer (PR1)
 
@@ -204,7 +215,9 @@ roots model.
 
 ## 9. Out of scope
 
-Non-filesystem binding kinds (git-worktree, container, VM, remote, ACP);
+Parallel/concurrent agent runs and sidebar run indicators (companion spec,
+see §1); non-filesystem binding kinds (git-worktree, container, VM, remote,
+ACP);
 per-folder permissions beyond ro/rw; folder pickers (text input only);
 watching/ingesting folder contents (that is Library/watchlists territory);
 server sync of bindings.

--- a/Docs/superpowers/specs/2026-07-26-settings-workspaces-category-design.md
+++ b/Docs/superpowers/specs/2026-07-26-settings-workspaces-category-design.md
@@ -1,0 +1,201 @@
+# Settings ▸ Workspaces — management category with folder access roots
+
+Date: 2026-07-26
+Status: approved design, pending implementation
+Supersedes: the Stage-5 "sync & workspace status in Settings is read-only"
+boundary (`Docs/superpowers/plans/2026-05-29-settings-configuration-hub.md`);
+a new ADR (see §8) records the supersession.
+Builds on: workspace UX review + fix campaign (PRs #928/#932, tasks 712-723,
+ADR-027).
+
+## 1. Goal and decisions (locked with the user)
+
+A dedicated **Settings ▸ Workspaces** category that hosts workspace
+management outright — create, rename, archive/unarchive, set active — and
+lets users modify existing workspaces by **adding/removing folders**.
+
+- **Folders are file-tool access roots.** A folder bound to a workspace
+  defines where that workspace's agent file tools (`read_file`,
+  `list_directory`, `write_file`) may operate, activating the dormant
+  `workspace_runtime_bindings` machinery (`kind=local-filesystem`). The
+  Details tray's "File tools: N ready, M missing" copy becomes true.
+- **Coexistence:** Settings is the management home; the Alt+W switcher keeps
+  switch/rename/archive and Library keeps create as in-context quick actions.
+- **Two stacked PRs, merged as one train** (§7): PR1 = service + enforcement,
+  PR2 = the Settings page. Never ship management UI for behavior that does
+  not exist yet (the aspirational-UI failure the UX review condemned).
+
+## 2. Service layer (PR1)
+
+`LocalWorkspaceRegistryService` (`tldw_chatbook/Workspaces/registry_service.py`)
+gains:
+
+- `unarchive_workspace(workspace_id)` — clears `archived`; does **not**
+  auto-activate. `WorkspaceNotFound` for unknown/not-archived; Default is
+  never archived so needs no special case.
+- `add_folder_binding(workspace_id, path, *, allow_write=False)` — thin
+  wrapper over the existing `save_runtime_binding`:
+  - Path normalization: `expanduser()` + `resolve()` (canonical locator; a
+    symlinked root is stored as its target).
+  - Validation: must exist and be a directory; **deny** the filesystem root
+    and the user's home directory itself (`WorkspaceRegistryServiceError`
+    with explicit copy); deny duplicates and roots nested inside an existing
+    binding of the same workspace (and vice versa — an existing child root
+    is reported so the user can remove it first).
+  - Default workspace: rejected (`"The Default workspace cannot have folder
+    bindings."`) — preserves the existing design where
+    `_delete_default_runtime_bindings` keeps Default tool-less.
+  - Stored fields: `binding_kind=LOCAL_FILESYSTEM`, `locator=<resolved
+    path>`, `label=<basename>`, `status=ready|missing` (display-only, see
+    §3), `metadata={"access": "rw"|"ro"}` — **`ro` is the default**; write
+    access is per-folder opt-in.
+- `remove_runtime_binding(binding_id)` — deletes the row; raises a new
+  `BindingNotFound(WorkspaceRegistryServiceError)` for unknown ids.
+- `list_folder_bindings(workspace_id)` — `list_runtime_bindings` filtered to
+  `LOCAL_FILESYSTEM`, with status recomputed from the filesystem at read
+  time (a stored `ready` is never trusted for display either).
+- `rename_workspace` / `create_workspace` (Settings path): add a
+  case-insensitive duplicate-name check across non-archived workspaces
+  (`WorkspaceRegistryServiceError: "A workspace named X already exists."`).
+  The switcher's disambiguation depends on distinct names. (Applies to the
+  service so Alt+W rename gets it too.)
+
+## 3. Enforcement (PR1) — folders become real
+
+`tldw_chatbook/Tools/file_operation_tools.py` currently confines every
+operation to one global sandbox root (`[tools] file_sandbox_root`, default
+`<user data dir>/tool_sandbox`), resolved **at call time** inside each
+tool's `execute()`. Changes:
+
+- New module-level seam `_allowed_roots(write: bool) -> tuple[Path, ...]`:
+  the global sandbox root **plus** the bound folders of the *resolved
+  workspace* (see below). For `write=True`, only folders with
+  `metadata.access == "rw"`. Each folder is included only if the directory
+  **exists at call time** — stored status is never trusted; a deleted folder
+  drops out of the allowed set immediately.
+- New `validate_path_multi(path, roots)` beside the existing
+  `validate_path`: succeeds if the resolved path is within any root; its
+  error copy names the roots that were consulted (so a denial is
+  actionable). Existing single-root callers are untouched.
+- `ReadFileTool`/`ListDirectoryTool` use `_allowed_roots(write=False)`;
+  `WriteFileTool` uses `_allowed_roots(write=True)`.
+- **Workspace resolution — the run, not the mouse.** The tool catalog
+  (`Agents/tool_catalog.py`) is where tool instances are constructed for a
+  run; it injects a roots-provider closure bound to the run's workspace id
+  (from the run/session context the agent engine already carries). Only
+  when a run has no workspace context does the provider fall back to a
+  call-time `get_active_workspace()` read. This prevents a mid-run Alt+W
+  switch from silently retargeting where a running agent may write.
+  `WorkspaceDB` opens a fresh connection per call, so worker-thread reads
+  are safe. If inspection during implementation shows the engine truly has
+  no per-run workspace seam, the fallback becomes the behavior and the spec
+  note is updated — do not invent a parallel context channel for this.
+- **Gates unchanged:** the existing built-in tool gates (Allow/Ask/Off,
+  `read_file_enabled` etc.) still decide *whether* a tool runs; folders
+  only widen *where*. Default workspace: no bindings can exist, so tools
+  keep today's sandbox-only behavior there — as designed.
+- Net effect with zero bindings: byte-for-byte today's behavior. Safe to
+  merge PR1 alone.
+
+## 4. Settings category (PR2)
+
+**Integration touchpoints** (all in `UI/Screens/`): add `WORKSPACES` to
+`SettingsCategoryId` (`settings_config_models.py`); category summary +
+"Data & Privacy" group (`_category_summaries`, `_category_groups`); detail
+dispatch (`_render_detail_pane` → new `_render_workspaces_detail`); add to
+the Save/Revert **suppression** set alongside Theme/Splash (management
+actions are immediate, not draft-based; the Scope Inspector shows an
+explanatory guided-action message instead); ownership record (owns workspace
+lifecycle + folder bindings; names Console/Library quick actions);
+deep-link navigation target. Do **not** add it to
+`GUIDED_SETTINGS_MUTATION_CATEGORIES`.
+
+**Page layout** (single detail pane, list-then-detail):
+
+- Workspace list: name, id, `(active)` marker, folder count, archived badge;
+  a "Show archived" checkbox (off by default). Selection is in-pane state.
+- Detail card for the selected workspace:
+  - Rename: Input + Apply (duplicate names rejected with the service copy).
+  - Set active button (disabled-with-inline-reason when already active).
+  - Archive / Unarchive (ConfirmationDialog for archive, same copy contract
+    as the switcher: conversations stay saved and visible in Library;
+    archiving the active workspace falls back to Default; unarchive never
+    auto-activates).
+  - **Folders**: one row per binding — locator, ro/rw tag, live
+    ready/missing status; a per-row write-access toggle; per-row Remove.
+    Below: Add-folder Input (`~` expansion) + Add button; service
+    validation errors surface inline next to the input, not tooltip-only
+    (TASK-716 lesson: a disabled control with a tooltip explanation is
+    unreachable — blocked states explain themselves inline).
+  - Default workspace: rename/archive/folder controls replaced by a static
+    inline explanation ("The built-in Default workspace keeps its identity
+    and stays tool-less; create a workspace to bind folders.").
+- Create: name Input + Create button at the top of the list pane (id stays
+  generated `workspace-local-N`; the name is free-form — first surface
+  without forced "Workspace N" names).
+- **Freshness:** the list re-reads the registry on screen resume and after
+  every action (Console/Library mutate the registry concurrently). Follow
+  the existing settings recompose-hygiene patterns (coalesced refresh +
+  focus restoration, task-290; no watcher-built content that a deferred
+  recompose can wipe).
+
+**Cross-surface copy (PR2):** Overview's workspace rows and recovery copy
+name Settings ▸ Workspaces as the management home (replacing the
+"Library > Details > Workspace" pointer shipped in TASK-719); the Details
+tray's file-tools row stays as-is (it now reports real state); Console/
+Library quick-action copy unchanged.
+
+## 5. Security model (summary)
+
+- Read-only by default; write is per-folder opt-in (`metadata.access`).
+- Deny `/` and `$HOME` as roots; locators stored canonical (resolved).
+- Symlinks inside a bound root that escape it are already denied by the
+  existing resolve-then-compare check (`_is_within`); `validate_path_multi`
+  keeps that property per root.
+- Existence re-checked at call time; gates still control tool availability;
+  Default workspace remains tool-less.
+
+## 6. Testing
+
+- **Service (PR1):** unarchive (incl. not-auto-activating), folder add
+  (validation matrix: missing path, file-not-dir, `/`, `$HOME`, duplicate,
+  nested-either-direction, Default rejection, ro default), remove, status
+  recompute, duplicate-name rename/create.
+- **Enforcement (PR1):** read allowed inside a bound folder of the run's
+  workspace; write denied for `ro` folder and allowed after `rw` toggle;
+  denied outside all roots with error copy naming roots; deleted-folder
+  drop-out; sandbox-only fallback with zero bindings byte-identical to
+  today (regression pin); other-workspace folders not consulted.
+- **UI (PR2):** mounted Settings tests for CRUD flows, Default protections,
+  archived filtering, inline validation errors, refresh-on-action; a
+  Save/Revert-suppression assertion; cross-surface copy test for the
+  Overview pointer.
+- Suites to keep green: settings hub, Workspaces, workspace lifecycle/
+  keyboard, agent tool-gate tests, native-chat-flow.
+
+## 7. PR phasing
+
+- **PR1 `feat/workspace-folder-bindings-enforcement`**: §2 service + §3
+  enforcement + §5 + their tests + the ADR (§8). Zero-binding behavior
+  identical to today.
+- **PR2 `feat/settings-workspaces-category`** (stacked on PR1): §4 UI +
+  cross-surface copy + UI tests.
+- Merge as one train (PR1 then PR2, same session) so no released state has
+  management UI without enforcement or enforcement without a management
+  surface.
+
+## 8. ADR
+
+`backlog/decisions/028-settings-workspaces-category-and-folder-roots.md`:
+records (a) superseding the Stage-5 read-only boundary — Settings now owns
+workspace lifecycle + folder bindings, with Console/Library keeping quick
+actions; (b) folder semantics: file-tool access roots, read-only default,
+call-time existence validation, run-bound workspace resolution, Default
+stays tool-less.
+
+## 9. Out of scope
+
+Non-filesystem binding kinds (git-worktree, container, VM, remote, ACP);
+per-folder permissions beyond ro/rw; folder pickers (text input only);
+watching/ingesting folder contents (that is Library/watchlists territory);
+server sync of bindings.

--- a/Docs/superpowers/specs/2026-07-26-settings-workspaces-category-design.md
+++ b/Docs/superpowers/specs/2026-07-26-settings-workspaces-category-design.md
@@ -191,7 +191,16 @@ records (a) superseding the Stage-5 read-only boundary — Settings now owns
 workspace lifecycle + folder bindings, with Console/Library keeping quick
 actions; (b) folder semantics: file-tool access roots, read-only default,
 call-time existence validation, run-bound workspace resolution, Default
-stays tool-less.
+stays tool-less; (c) **deliberate divergence from Codex prior art**: OpenAI
+Codex's `workspace-write` sandbox allows reads anywhere and confines only
+writes (workspace + `sandbox_workspace_write.writable_roots`) — tldw
+confines *reads* to the sandbox + bound folders as well, because the
+existing sandbox already does and the app is privacy-first; do not "fix"
+this to match Codex; (d) **external-runtime export surface**: canonical
+folder locators are the roots handed to external agent runtimes (the shape
+Codex's app-server takes as `runtimeWorkspaceRoots` at thread/turn start),
+so the future ACP/app-server handoff consumes bindings as-is — no separate
+roots model.
 
 ## 9. Out of scope
 

--- a/Tests/Agents/test_builtin_provider_workspace_binding.py
+++ b/Tests/Agents/test_builtin_provider_workspace_binding.py
@@ -1,0 +1,41 @@
+"""BuiltinToolProvider binds the run's workspace around tool execution."""
+
+from __future__ import annotations
+
+from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider
+from tldw_chatbook.Tools import workspace_file_roots as wfr
+
+
+class _ProbeTool:
+    name = "probe_workspace"
+    description = "records the bound run workspace"
+    parameters = {"type": "object", "properties": {}}
+
+    async def execute(self, **kwargs):
+        return {"workspace": wfr.current_run_workspace_id()}
+
+
+class _OpenGate:
+    def check(self, tool):
+        return None
+
+
+def test_invoke_binds_and_clears_run_workspace() -> None:
+    provider = BuiltinToolProvider(gate=_OpenGate(), workspace_id="ws-a")
+    provider._tools["probe_workspace"] = _ProbeTool()
+
+    result = provider.invoke("builtin:probe_workspace", {})
+
+    assert result.ok, result.error
+    assert '"workspace": "ws-a"' in result.content
+    assert wfr.current_run_workspace_id() is None  # cleared after invoke
+
+
+def test_invoke_without_workspace_leaves_context_unset() -> None:
+    provider = BuiltinToolProvider(gate=_OpenGate())
+    provider._tools["probe_workspace"] = _ProbeTool()
+
+    result = provider.invoke("builtin:probe_workspace", {})
+
+    assert result.ok, result.error
+    assert '"workspace": null' in result.content

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -243,6 +243,56 @@ def test_run_reply_threads_builtin_gate_end_to_end(tmp_path):
     assert store.get_message(aid).content == "it was refused."
 
 
+def test_run_reply_threads_session_workspace_id_end_to_end(tmp_path, monkeypatch):
+    """task-6 (settings-workspaces-folder-roots spec Sec3): the RUNNING
+    session's own ``workspace_id`` must reach the run's
+    ``BuiltinToolProvider``, so a builtin tool observes it (via
+    ``workspace_file_roots.run_workspace``) while it executes -- not
+    whatever workspace happens to be active in the UI by the time the
+    call actually fires. Verified by monkeypatching ``CalculatorTool.
+    execute`` (the real built-in tool the scripted fence calls) to record
+    the ContextVar it sees, since the bridge builds its own
+    ``BuiltinToolProvider`` internally with no seam for a test double."""
+    from tldw_chatbook.Tools import workspace_file_roots as wfr
+    from tldw_chatbook.Tools.tool_executor import CalculatorTool
+
+    observed: list[str | None] = []
+    real_execute = CalculatorTool.execute
+
+    async def _recording_execute(self, expression):
+        observed.append(wfr.current_run_workspace_id())
+        return await real_execute(self, expression)
+
+    monkeypatch.setattr(CalculatorTool, "execute", _recording_execute)
+
+    scripts = [
+        [_fence("calculator", {"expression": "6*7"})],
+        ["It is 42."],
+    ]
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    store = ConsoleChatStore()
+    session = store.create_session(workspace_id="ws-session-42")
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="hi")
+    assistant = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content=""
+    )
+    bridge = ConsoleAgentBridge(
+        agent_runs_db=db, store=store, provider_gateway=_ChunkGateway(scripts)
+    )
+    # Any non-None `builtin_gate` forces the fresh-build branch that
+    # actually looks up and threads the session's workspace_id (see
+    # `run_reply`'s own docstring) -- the shared/no-gate fast path's
+    # provider is built once at bridge-construction time, before any
+    # session exists, so it is out of scope for a per-session binding.
+    outcome = _run(
+        bridge, store, session, assistant.id,
+        builtin_gate=_FakeBuiltinGateForRegistry(refuse=False),
+    )
+    assert outcome.status == "done"
+    assert observed == ["ws-session-42"]
+    assert wfr.current_run_workspace_id() is None  # cleared after the run
+
+
 def test_leaked_prose_before_disobedient_fence_is_reset_not_garbled(tmp_path):
     # Finding A repro: a disobedient turn streams prose live, THEN a tool
     # fence, in the same response. The gate has already forwarded the prose
@@ -1629,6 +1679,50 @@ def test_compose_run_registry_and_allowed_no_builtin_gate_is_unchanged():
     assert allowed_tools == ("calculator", "get_current_datetime", SPAWN_TOOL_NAME)
     result = registry.invoke_by_name("calculator", {"expression": "6*7"})
     assert result.ok is True
+
+
+class _WorkspaceProbeTool:
+    """A minimal Tool double that reports the run workspace bound around it."""
+
+    name = "probe_workspace"
+    description = "records the bound run workspace"
+    parameters = {"type": "object", "properties": {}}
+
+    async def execute(self, **kwargs):
+        from tldw_chatbook.Tools import workspace_file_roots as wfr
+
+        return {"workspace": wfr.current_run_workspace_id()}
+
+
+def test_compose_run_registry_and_allowed_threads_workspace_id_into_the_provider():
+    """task-6 (settings-workspaces-folder-roots spec Sec3): `workspace_id=`
+    must reach the freshly-built `BuiltinToolProvider` so its `invoke()`
+    binds the run's workspace around every tool call."""
+    registry, _allowed_tools, _builtin_names = _compose_run_registry_and_allowed(
+        {},
+        builtin_gate=_FakeBuiltinGateForRegistry(refuse=False),
+        workspace_id="ws-compose",
+    )
+    # registry._providers[0] is the BuiltinToolProvider this call just built
+    # (see _compose_run_registry_and_allowed's own body) -- poke a probe
+    # tool onto it exactly as the constructor-level test does, since the
+    # real calculator/datetime tools have no way to report the ContextVar.
+    registry._providers[0]._tools["probe_workspace"] = _WorkspaceProbeTool()
+    result = registry.invoke_by_name("probe_workspace", {})
+    assert result.ok, result.error
+    assert '"workspace": "ws-compose"' in result.content
+
+
+def test_compose_run_registry_and_allowed_no_workspace_id_is_unchanged():
+    """`workspace_id=None` (the default) must not alter the pre-task-6
+    behavior -- the provider leaves the run workspace unbound."""
+    registry, _allowed_tools, _builtin_names = _compose_run_registry_and_allowed(
+        {}, builtin_gate=_FakeBuiltinGateForRegistry(refuse=False)
+    )
+    registry._providers[0]._tools["probe_workspace"] = _WorkspaceProbeTool()
+    result = registry.invoke_by_name("probe_workspace", {})
+    assert result.ok, result.error
+    assert '"workspace": null' in result.content
 
 
 def test_compose_run_registry_and_allowed_excludes_mcp_name_colliding_with_builtin():

--- a/Tests/Tools/test_file_tools_workspace_roots.py
+++ b/Tests/Tools/test_file_tools_workspace_roots.py
@@ -1,0 +1,94 @@
+"""File tools honor workspace folder roots (spec §3)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+from tldw_chatbook.Workspaces import LocalWorkspaceRegistryService
+from tldw_chatbook.Tools import file_operation_tools as fot
+from tldw_chatbook.Tools import workspace_file_roots as wfr
+from tldw_chatbook.Tools.file_operation_tools import (
+    ListDirectoryTool,
+    ReadFileTool,
+    WriteFileTool,
+)
+
+
+@pytest.fixture()
+def bound_workspace(tmp_path, monkeypatch):
+    registry = LocalWorkspaceRegistryService(
+        WorkspaceDB(tmp_path / "ws.sqlite", client_id="tool-tests")
+    )
+    registry.ensure_default_workspace()
+    registry.create_workspace(workspace_id="ws-a", name="Client A")
+    ro_folder = tmp_path / "ro-project"
+    rw_folder = tmp_path / "rw-project"
+    ro_folder.mkdir()
+    rw_folder.mkdir()
+    registry.add_folder_binding("ws-a", ro_folder)
+    registry.add_folder_binding("ws-a", rw_folder, allow_write=True)
+    monkeypatch.setattr(wfr, "_registry_factory", lambda: registry)
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    monkeypatch.setattr(fot, "_resolve_sandbox_config", lambda: str(sandbox))
+    return {"ro": ro_folder, "rw": rw_folder, "sandbox": sandbox}
+
+
+@pytest.mark.asyncio
+async def test_read_allowed_in_bound_folder(bound_workspace) -> None:
+    target = bound_workspace["ro"] / "notes.md"
+    target.write_text("hello")
+    with wfr.run_workspace("ws-a"):
+        result = await ReadFileTool().execute(file_path=str(target))
+    assert result.get("error") is None
+    assert result["content"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_write_denied_in_ro_folder_allowed_in_rw(bound_workspace) -> None:
+    ro_target = bound_workspace["ro"] / "out.txt"
+    rw_target = bound_workspace["rw"] / "out.txt"
+    with wfr.run_workspace("ws-a"):
+        denied = await WriteFileTool().execute(
+            file_path=str(ro_target), content="x"
+        )
+        allowed = await WriteFileTool().execute(
+            file_path=str(rw_target), content="x"
+        )
+    assert denied.get("error")
+    assert allowed.get("error") is None
+    assert rw_target.read_text() == "x"
+
+
+@pytest.mark.asyncio
+async def test_denial_names_roots_and_other_workspace_is_denied(
+    bound_workspace, tmp_path
+) -> None:
+    outside = tmp_path / "elsewhere.txt"
+    outside.write_text("x")
+    with wfr.run_workspace("ws-a"):
+        result = await ReadFileTool().execute(file_path=str(outside))
+    assert result.get("error")
+    assert str(bound_workspace["sandbox"]) in result["error"]
+
+    with wfr.run_workspace("workspace-default"):
+        default_denied = await ReadFileTool().execute(
+            file_path=str(bound_workspace["ro"] / "notes.md")
+        )
+    assert default_denied.get("error")
+
+
+@pytest.mark.asyncio
+async def test_zero_bindings_parity_with_sandbox(bound_workspace) -> None:
+    inside = bound_workspace["sandbox"] / "kept.txt"
+    inside.write_text("sandboxed")
+    with wfr.run_workspace("workspace-default"):
+        listed = await ListDirectoryTool().execute(
+            directory_path=str(bound_workspace["sandbox"])
+        )
+        read = await ReadFileTool().execute(file_path=str(inside))
+    assert listed.get("error") is None
+    assert read.get("error") is None

--- a/Tests/Tools/test_file_tools_workspace_roots.py
+++ b/Tests/Tools/test_file_tools_workspace_roots.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -92,3 +93,69 @@ async def test_zero_bindings_parity_with_sandbox(bound_workspace) -> None:
         read = await ReadFileTool().execute(file_path=str(inside))
     assert listed.get("error") is None
     assert read.get("error") is None
+
+
+@pytest.mark.asyncio
+async def test_recursive_listing_descends_into_bound_folder(bound_workspace) -> None:
+    """Pins the containment_root fix: recursion must not cap at depth 0 for
+    a directory that resolves into a bound workspace folder rather than the
+    sandbox (pre-fix, `_is_within(item, sandbox_root)` was hardcoded and
+    every child of a workspace folder failed it, silently stopping descent).
+    """
+    ro_folder = bound_workspace["ro"]
+    deep_dir = ro_folder / "sub" / "deeper"
+    deep_dir.mkdir(parents=True)
+    deep_file = deep_dir / "file.txt"
+    deep_file.write_text("nested")
+
+    with wfr.run_workspace("ws-a"):
+        result = await ListDirectoryTool().execute(
+            directory_path=str(ro_folder), recursive=True, max_depth=5
+        )
+
+    assert result.get("error") is None
+    deep_entries = [e for e in result["entries"] if e["name"] == "file.txt"]
+    assert deep_entries, f"expected file.txt to be listed, got: {result['entries']}"
+    assert deep_entries[0]["depth"] >= 2
+
+
+@pytest.mark.asyncio
+async def test_symlink_inside_bound_folder_cannot_escape(
+    bound_workspace, tmp_path
+) -> None:
+    """A symlink planted inside a bound folder must not let a recursive
+    listing (or a direct listing of the link itself) reach outside every
+    allowed root.
+    """
+    ro_folder = bound_workspace["ro"]
+    legit_file = ro_folder / "other.txt"
+    legit_file.write_text("legit")
+
+    target_dir = tmp_path / "loot"
+    target_dir.mkdir()
+    marker = target_dir / "secret.txt"
+    marker.write_text("marker")
+
+    link = ro_folder / "link"
+    os.symlink(target_dir, link)
+
+    with wfr.run_workspace("ws-a"):
+        result = await ListDirectoryTool().execute(
+            directory_path=str(ro_folder), recursive=True, max_depth=5
+        )
+        direct_link_result = await ListDirectoryTool().execute(
+            directory_path=str(link)
+        )
+
+    # (a) Nothing from inside the symlink target leaks into the recursive
+    # listing, but legitimate sibling content is still present.
+    assert result.get("error") is None
+    names = {e["name"] for e in result["entries"]}
+    paths = {e["path"] for e in result["entries"]}
+    assert "secret.txt" not in names
+    assert not any("loot" in p for p in paths)
+    assert "other.txt" in names
+
+    # (b) Listing the symlink directly is denied outright — the resolved
+    # target sits outside every allowed root.
+    assert direct_link_result.get("error")

--- a/Tests/Tools/test_workspace_file_roots.py
+++ b/Tests/Tools/test_workspace_file_roots.py
@@ -3,10 +3,21 @@
 from __future__ import annotations
 
 from pathlib import Path
+import shutil
+
+import pytest
 
 from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
 from tldw_chatbook.Workspaces import LocalWorkspaceRegistryService
 from tldw_chatbook.Tools import workspace_file_roots as wfr
+
+
+@pytest.fixture(autouse=True)
+def _reset_default_registry_cache():
+    """Item E's default-factory memoization must not leak across tests."""
+    wfr._default_registry_instance = None
+    yield
+    wfr._default_registry_instance = None
 
 
 def _registry(tmp_path: Path) -> LocalWorkspaceRegistryService:
@@ -74,3 +85,44 @@ def test_registry_failure_degrades_to_sandbox_only(tmp_path, monkeypatch) -> Non
     sandbox.mkdir()
     with wfr.run_workspace("ws-a"):
         assert wfr.allowed_file_roots(write=True, sandbox_root=sandbox) == (sandbox,)
+
+
+def test_default_registry_factory_is_cached(tmp_path, monkeypatch) -> None:
+    """Item E: the default factory must not rebuild WorkspaceDB on every call."""
+    monkeypatch.setattr(
+        "tldw_chatbook.config.get_workspaces_db_path",
+        lambda: tmp_path / "cached.sqlite",
+    )
+
+    first = wfr._default_registry_factory()
+    second = wfr._default_registry_factory()
+
+    assert first is second
+    assert isinstance(first, LocalWorkspaceRegistryService)
+
+
+def test_symlink_replaced_root_excluded_from_allowed_roots(
+    tmp_path, monkeypatch
+) -> None:
+    """Item F: a bound folder later swapped for a symlink must not widen roots."""
+    registry = _registry(tmp_path)
+    bound = tmp_path / "bound-root"
+    bound.mkdir()
+    registry.add_folder_binding("ws-a", bound)
+
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    (elsewhere / "secret.txt").write_text("nope")
+
+    # Replace the bound directory in place with a symlink to another folder.
+    shutil.rmtree(bound)
+    bound.symlink_to(elsewhere)
+
+    monkeypatch.setattr(wfr, "_registry_factory", lambda: registry)
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+
+    with wfr.run_workspace("ws-a"):
+        roots = wfr.allowed_file_roots(write=False, sandbox_root=sandbox)
+
+    assert roots == (sandbox,)

--- a/Tests/Tools/test_workspace_file_roots.py
+++ b/Tests/Tools/test_workspace_file_roots.py
@@ -1,0 +1,76 @@
+"""Run-bound allowed file roots (spec 2026-07-26 settings-workspaces §3)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+from tldw_chatbook.Workspaces import LocalWorkspaceRegistryService
+from tldw_chatbook.Tools import workspace_file_roots as wfr
+
+
+def _registry(tmp_path: Path) -> LocalWorkspaceRegistryService:
+    registry = LocalWorkspaceRegistryService(
+        WorkspaceDB(tmp_path / "ws.sqlite", client_id="roots-tests")
+    )
+    registry.ensure_default_workspace()
+    registry.create_workspace(workspace_id="ws-a", name="Client A")
+    registry.create_workspace(workspace_id="ws-b", name="Client B")
+    return registry
+
+
+def test_roots_follow_run_workspace_not_active(tmp_path, monkeypatch) -> None:
+    registry = _registry(tmp_path)
+    folder_a = tmp_path / "a"
+    folder_a.mkdir()
+    folder_b = tmp_path / "b"
+    folder_b.mkdir()
+    registry.add_folder_binding("ws-a", folder_a)
+    registry.add_folder_binding("ws-b", folder_b)
+    registry.set_active_workspace("ws-b")
+    monkeypatch.setattr(wfr, "_registry_factory", lambda: registry)
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+
+    with wfr.run_workspace("ws-a"):
+        roots = wfr.allowed_file_roots(write=False, sandbox_root=sandbox)
+    assert roots == (sandbox, folder_a.resolve())
+
+    # Outside a run: falls back to the ACTIVE workspace (ws-b).
+    roots = wfr.allowed_file_roots(write=False, sandbox_root=sandbox)
+    assert roots == (sandbox, folder_b.resolve())
+
+
+def test_write_roots_require_rw_and_existing_dirs(tmp_path, monkeypatch) -> None:
+    registry = _registry(tmp_path)
+    ro_folder = tmp_path / "ro"
+    ro_folder.mkdir()
+    rw_folder = tmp_path / "rw"
+    rw_folder.mkdir()
+    gone = tmp_path / "gone"
+    gone.mkdir()
+    registry.add_folder_binding("ws-a", ro_folder)
+    registry.add_folder_binding("ws-a", rw_folder, allow_write=True)
+    registry.add_folder_binding("ws-a", gone, allow_write=True)
+    gone.rmdir()  # deleted after binding: must drop out at call time
+    monkeypatch.setattr(wfr, "_registry_factory", lambda: registry)
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+
+    with wfr.run_workspace("ws-a"):
+        read_roots = wfr.allowed_file_roots(write=False, sandbox_root=sandbox)
+        write_roots = wfr.allowed_file_roots(write=True, sandbox_root=sandbox)
+
+    assert ro_folder.resolve() in read_roots
+    assert write_roots == (sandbox, rw_folder.resolve())
+
+
+def test_registry_failure_degrades_to_sandbox_only(tmp_path, monkeypatch) -> None:
+    def _boom():
+        raise RuntimeError("registry down")
+
+    monkeypatch.setattr(wfr, "_registry_factory", _boom)
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    with wfr.run_workspace("ws-a"):
+        assert wfr.allowed_file_roots(write=True, sandbox_root=sandbox) == (sandbox,)

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -151,13 +151,15 @@ def test_settings_category_summaries_cover_every_category_id_exactly_once():
     """Guards the total sidebar category count.
 
     Adding Internal Prompts brought the total from 19 to 20; adding Image Gen
-    (Settings > Image Gen task 4) brought it to 21. This pins the literal
-    count so the next addition must touch this assertion deliberately, and
-    cross-checks that summaries neither miss nor duplicate an enum member.
+    (Settings > Image Gen task 4) brought it to 21; adding Workspaces
+    (settings-workspaces-folder-roots task 8) brought it to 22. This pins
+    the literal count so the next addition must touch this assertion
+    deliberately, and cross-checks that summaries neither miss nor duplicate
+    an enum member.
     """
     screen = SettingsScreen(_build_test_app())
     summaries = screen._category_summaries()
-    assert len(summaries) == len(list(SettingsCategoryId)) == 21
+    assert len(summaries) == len(list(SettingsCategoryId)) == 22
     assert {s.category for s in summaries} == set(SettingsCategoryId)
 
 
@@ -6156,7 +6158,12 @@ async def test_settings_storage_privacy_diagnostics_label_unsupported_mutations_
             ),
             ("#settings-category-diagnostics", "Diagnostics writes: unavailable/WIP"),
         ):
-            await pilot.click(button_id)
+            # Scroll the target into view before clicking: the category
+            # rail is taller than the fixed pilot viewport, and Settings >
+            # Workspaces (task 8) pushed Privacy & Security further down
+            # the "Data & Privacy" group, so a raw pilot.click() can land
+            # outside the visible screen region.
+            await _open_settings_category(pilot, button_id)
             screen = _active_destination_screen(host)
             text = _visible_text(screen)
 

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -1786,7 +1786,7 @@ def test_settings_server_sync_workspace_rows_fallback_to_read_only_wip_copy():
     assert "Collections: dry-run only" in rows["Sync safety"]
     assert "Workspaces: dry-run only" in rows["Sync safety"]
     assert rows["Workspace default"] == (
-        "Local Default; switch in Console (Alt+W), manage in Library > Details > Workspace"
+        "Local Default; switch in Console (Alt+W), manage in Settings > Workspaces"
     )
     assert rows["Library visibility"] == LIBRARY_WORKSPACE_VISIBILITY_COPY
     assert rows["ACP handoff readiness"] == (

--- a/Tests/UI/test_settings_workspaces_category.py
+++ b/Tests/UI/test_settings_workspaces_category.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from tldw_chatbook.UI.Screens.settings_screen import SettingsScreen
 from Tests.UI.test_settings_configuration_hub import (
     DestinationHarness,
     _active_destination_screen,
@@ -155,3 +156,50 @@ async def test_folder_bindings_add_toggle_remove_and_inline_errors(tmp_path) -> 
         ).press()
         await pilot.pause(0.3)
         assert registry.list_folder_bindings("ws-folders") == ()
+
+
+@pytest.mark.asyncio
+async def test_pane_refreshes_after_external_registry_change() -> None:
+    from textual.widgets import Button
+
+    app = _build_test_app()
+    registry = app.workspace_registry_service
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _open_settings_category(pilot, "#settings-category-workspaces")
+        assert not screen.query("#settings-workspace-row-ws-late")
+
+        registry.create_workspace(workspace_id="ws-late", name="Late Arrival")
+        screen._refresh_settings_workspaces_pane()
+        await pilot.pause(0.3)
+        assert screen.query_one("#settings-workspace-row-ws-late", Button)
+
+
+@pytest.mark.asyncio
+async def test_resume_refreshes_workspaces_pane_only_when_active(monkeypatch) -> None:
+    refresh_calls = 0
+
+    def fake_refresh(self):
+        nonlocal refresh_calls
+        refresh_calls += 1
+
+    monkeypatch.setattr(SettingsScreen, "_refresh_settings_workspaces_pane", fake_refresh)
+
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+
+        # Still on Overview (the default category) -- resuming must not
+        # touch the Workspaces pane.
+        screen.on_screen_resume()
+        await pilot.pause(0.2)
+        assert refresh_calls == 0
+
+        await _open_settings_category(pilot, "#settings-category-workspaces")
+        screen.on_screen_resume()
+        await pilot.pause(0.2)
+        assert refresh_calls == 1

--- a/Tests/UI/test_settings_workspaces_category.py
+++ b/Tests/UI/test_settings_workspaces_category.py
@@ -105,3 +105,53 @@ async def test_default_workspace_card_is_protected() -> None:
         assert not screen.query("#settings-workspace-rename-apply")
         assert not screen.query("#settings-workspace-archive")
         assert "stays tool-less" in _visible_text(screen)
+
+
+@pytest.mark.asyncio
+async def test_folder_bindings_add_toggle_remove_and_inline_errors(tmp_path) -> None:
+    from textual.widgets import Button, Input
+
+    app = _build_test_app()
+    registry = app.workspace_registry_service
+    registry.create_workspace(workspace_id="ws-folders", name="Folder WS")
+    project = tmp_path / "project"
+    project.mkdir()
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _open_settings_category(pilot, "#settings-category-workspaces")
+        screen.query_one("#settings-workspace-row-ws-folders", Button).press()
+        await pilot.pause(0.2)
+
+        # Add (defaults to read-only).
+        screen.query_one("#settings-workspace-folder-path", Input).value = str(project)
+        screen.query_one("#settings-workspace-folder-add", Button).press()
+        await pilot.pause(0.3)
+        bindings = registry.list_folder_bindings("ws-folders")
+        assert len(bindings) == 1
+        binding = bindings[0]
+        assert binding.metadata["access"] == "ro"
+        assert "[ro]" in _visible_text(screen)
+
+        # Toggle to rw.
+        screen.query_one(
+            f"#settings-workspace-folder-toggle-{binding.binding_id}", Button
+        ).press()
+        await pilot.pause(0.3)
+        assert registry.list_folder_bindings("ws-folders")[0].metadata["access"] == "rw"
+
+        # Invalid add explains inline.
+        screen.query_one("#settings-workspace-folder-path", Input).value = str(
+            tmp_path / "missing"
+        )
+        screen.query_one("#settings-workspace-folder-add", Button).press()
+        await pilot.pause(0.3)
+        assert "not a directory" in _visible_text(screen)
+
+        # Remove.
+        screen.query_one(
+            f"#settings-workspace-folder-remove-{binding.binding_id}", Button
+        ).press()
+        await pilot.pause(0.3)
+        assert registry.list_folder_bindings("ws-folders") == ()

--- a/Tests/UI/test_settings_workspaces_category.py
+++ b/Tests/UI/test_settings_workspaces_category.py
@@ -10,6 +10,7 @@ from Tests.UI.test_settings_configuration_hub import (
     _active_destination_screen,
     _build_test_app,
     _open_settings_category,
+    _settle_settings_mount_storm,
     _visible_text,
 )
 
@@ -109,6 +110,43 @@ async def test_default_workspace_card_is_protected() -> None:
 
 
 @pytest.mark.asyncio
+async def test_archived_workspace_card_offers_only_unarchive() -> None:
+    """Finding 3: an archived workspace's card must not offer controls that
+
+    fail with a bare-id error against an archived (currently invisible)
+    workspace -- rename/set-active/archive/folder-add all require the
+    record to be reachable outside the Show-archived view.
+    """
+    from textual.widgets import Button, Checkbox
+
+    app = _build_test_app()
+    registry = app.workspace_registry_service
+    registry.create_workspace(workspace_id="ws-archived", name="Archived WS")
+    registry.archive_workspace("ws-archived")
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _open_settings_category(pilot, "#settings-category-workspaces")
+
+        screen.query_one("#settings-workspaces-show-archived", Checkbox).value = True
+        await pilot.pause(0.3)
+        screen.query_one("#settings-workspace-row-ws-archived", Button).press()
+        await pilot.pause(0.2)
+
+        assert not screen.query("#settings-workspace-rename-input")
+        assert not screen.query("#settings-workspace-rename-apply")
+        assert not screen.query("#settings-workspace-set-active")
+        assert not screen.query("#settings-workspace-archive")
+        assert not screen.query("#settings-workspace-folder-add")
+        assert screen.query_one("#settings-workspace-unarchive", Button)
+        assert (
+            "Archived workspace. Unarchive it to rename, activate, "
+            "or edit folders." in _visible_text(screen)
+        )
+
+
+@pytest.mark.asyncio
 async def test_folder_bindings_add_toggle_remove_and_inline_errors(tmp_path) -> None:
     from textual.widgets import Button, Input
 
@@ -203,3 +241,50 @@ async def test_resume_refreshes_workspaces_pane_only_when_active(monkeypatch) ->
         screen.on_screen_resume()
         await pilot.pause(0.2)
         assert refresh_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_scope_inspector_shows_immediate_actions_not_read_only() -> None:
+    """Finding 1: Workspaces is an immediate-apply category, not read-only.
+
+    The Scope Inspector impact pane (and the ``s`` Save-shortcut toast, both
+    driven by ``_guided_action_message``) must not fall through to the
+    generic "Guided edits: read-only." default -- Workspaces has its own
+    message, mirroring how THEME/SPLASH_SCREEN get theirs.
+    """
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _open_settings_category(pilot, "#settings-category-workspaces")
+        text = _visible_text(screen)
+
+        assert "read-only" not in text
+        assert (
+            "Immediate actions: workspace changes apply as you make them; "
+            "there is no draft to save or revert." in text
+        )
+
+
+@pytest.mark.asyncio
+async def test_overview_pins_workspaces_recovery_copy() -> None:
+    """Finding 2 (spec §6): Overview must point users at Settings > Workspaces.
+
+    Cross-surface copy pin -- Settings Overview's "Where changes happen"
+    recovery row is the guidance a user sees before ever opening the
+    Workspaces category, so it must name the real owning surfaces.
+    """
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _settle_settings_mount_storm(pilot)
+        screen = _active_destination_screen(host)
+        text = _visible_text(screen)
+
+        assert (
+            "Sync status here is read-only - manage workspaces in "
+            "Settings > Workspaces; switch in Console (Alt+W); run "
+            "sync from the owning sync surfaces." in text
+        )

--- a/Tests/UI/test_settings_workspaces_category.py
+++ b/Tests/UI/test_settings_workspaces_category.py
@@ -27,3 +27,81 @@ async def test_workspaces_category_registered_and_immediate() -> None:
         # Immediate-apply category: the guided Save/Revert buttons are
         # suppressed exactly like Theme/Splash.
         assert not screen.query("#settings-save-category")
+
+
+@pytest.mark.asyncio
+async def test_create_rename_archive_unarchive_flow() -> None:
+    from textual.widgets import Button, Checkbox, Input
+
+    app = _build_test_app()
+    registry = app.workspace_registry_service
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _open_settings_category(pilot, "#settings-category-workspaces")
+
+        # Create with a free-form name.
+        screen.query_one("#settings-workspace-create-name", Input).value = "Client X"
+        screen.query_one("#settings-workspace-create", Button).press()
+        await pilot.pause(0.3)
+        created = [w for w in registry.list_workspaces() if w.name == "Client X"]
+        assert len(created) == 1
+        workspace_id = created[0].workspace_id
+
+        # Select, rename.
+        screen.query_one(f"#settings-workspace-row-{workspace_id}", Button).press()
+        await pilot.pause(0.2)
+        screen.query_one("#settings-workspace-rename-input", Input).value = "Client Y"
+        screen.query_one("#settings-workspace-rename-apply", Button).press()
+        await pilot.pause(0.3)
+        assert registry.get_workspace(workspace_id).name == "Client Y"
+
+        # Duplicate rename surfaces inline, not as a crash.
+        screen.query_one("#settings-workspace-rename-input", Input).value = "Default"
+        screen.query_one("#settings-workspace-rename-apply", Button).press()
+        await pilot.pause(0.3)
+        assert "already exists" in _visible_text(screen)
+
+        # Set active.
+        screen.query_one("#settings-workspace-set-active", Button).press()
+        await pilot.pause(0.3)
+        assert registry.get_active_workspace().workspace_id == workspace_id
+
+        # Archive (confirm dialog), falls back to Default.
+        screen.query_one("#settings-workspace-archive", Button).press()
+        await pilot.pause(0.3)
+        confirm = host.screen_stack[-1]
+        confirm.query_one("#confirm-button", Button).press()
+        await pilot.pause(0.4)
+        assert registry.get_workspace(workspace_id).archived is True
+        assert registry.get_active_workspace().workspace_id == "workspace-default"
+
+        # Hidden until Show archived; then unarchive (no auto-activate).
+        assert not screen.query(f"#settings-workspace-row-{workspace_id}")
+        screen.query_one("#settings-workspaces-show-archived", Checkbox).value = True
+        await pilot.pause(0.3)
+        screen.query_one(f"#settings-workspace-row-{workspace_id}", Button).press()
+        await pilot.pause(0.2)
+        screen.query_one("#settings-workspace-unarchive", Button).press()
+        await pilot.pause(0.3)
+        record = registry.get_workspace(workspace_id)
+        assert record.archived is False and record.active is False
+
+
+@pytest.mark.asyncio
+async def test_default_workspace_card_is_protected() -> None:
+    from textual.widgets import Button
+
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _open_settings_category(pilot, "#settings-category-workspaces")
+        screen.query_one("#settings-workspace-row-workspace-default", Button).press()
+        await pilot.pause(0.2)
+
+        assert not screen.query("#settings-workspace-rename-apply")
+        assert not screen.query("#settings-workspace-archive")
+        assert "stays tool-less" in _visible_text(screen)

--- a/Tests/UI/test_settings_workspaces_category.py
+++ b/Tests/UI/test_settings_workspaces_category.py
@@ -1,0 +1,29 @@
+"""Settings ▸ Workspaces category registration (spec §4)."""
+
+from __future__ import annotations
+
+import pytest
+
+from Tests.UI.test_settings_configuration_hub import (
+    DestinationHarness,
+    _active_destination_screen,
+    _build_test_app,
+    _open_settings_category,
+    _visible_text,
+)
+
+
+@pytest.mark.asyncio
+async def test_workspaces_category_registered_and_immediate() -> None:
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _open_settings_category(pilot, "#settings-category-workspaces")
+        text = _visible_text(screen)
+
+        assert "Workspace management" in text
+        # Immediate-apply category: the guided Save/Revert buttons are
+        # suppressed exactly like Theme/Splash.
+        assert not screen.query("#settings-save-category")

--- a/Tests/Utils/test_path_validation_multi.py
+++ b/Tests/Utils/test_path_validation_multi.py
@@ -1,0 +1,48 @@
+"""Multi-root path validation (spec 2026-07-26 settings-workspaces §3)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Utils.path_validation import validate_path_multi
+
+
+def test_accepts_path_inside_any_root(tmp_path: Path) -> None:
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+    (root_b / "sub").mkdir(parents=True)
+    root_a.mkdir()
+    target = root_b / "sub" / "file.txt"
+    target.write_text("x")
+
+    assert validate_path_multi(target, [root_a, root_b]) == target.resolve()
+
+
+def test_relative_paths_resolve_against_first_root(tmp_path: Path) -> None:
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    (sandbox / "note.txt").write_text("x")
+
+    resolved = validate_path_multi("note.txt", [sandbox, tmp_path / "other"])
+    assert resolved == (sandbox / "note.txt").resolve()
+
+
+def test_rejection_names_all_roots(tmp_path: Path) -> None:
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+    root_a.mkdir()
+    root_b.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("x")
+
+    with pytest.raises(ValueError) as excinfo:
+        validate_path_multi(outside, [root_a, root_b])
+    message = str(excinfo.value)
+    assert str(root_a) in message and str(root_b) in message
+
+
+def test_empty_roots_rejected() -> None:
+    with pytest.raises(ValueError):
+        validate_path_multi("anything", [])

--- a/Tests/Workspaces/test_workspace_display_state.py
+++ b/Tests/Workspaces/test_workspace_display_state.py
@@ -152,6 +152,40 @@ def test_console_workspace_state_reports_active_workspace_and_runtime(
     assert state.new_conversation_recovery == ""
 
 
+def test_console_workspace_state_recomputes_stale_filesystem_binding_status(
+    tmp_path: Path,
+) -> None:
+    """Finding 4 (final review): the Console tray's runtime label must not
+    trust a local-filesystem binding's STORED status forever.
+
+    `list_runtime_bindings` returns whatever status was last persisted
+    (READY at bind time); it never checks disk again. The moment the bound
+    folder is deleted out from under the binding, the tray must still
+    report it as missing -- mirrors `list_folder_bindings`' own
+    disk-recompute semantics instead of trusting the stale row.
+    """
+    service = _registry(tmp_path)
+    service.create_workspace(workspace_id="ws-a", name="Research Sprint")
+    service.set_active_workspace("ws-a")
+    folder = tmp_path / "project"
+    folder.mkdir()
+    service.add_folder_binding("ws-a", folder)
+
+    state = build_console_workspace_state(
+        registry_service=service,
+        current_conversation=None,
+    )
+    assert state.runtime_label == "Runtime: 1 binding, 1 ready"
+
+    folder.rmdir()
+
+    state = build_console_workspace_state(
+        registry_service=service,
+        current_conversation=None,
+    )
+    assert state.runtime_label == "Runtime: 1 binding, 0 ready, 1 missing"
+
+
 def test_console_workspace_state_enables_switching_with_multiple_workspaces(
     tmp_path: Path,
 ) -> None:

--- a/Tests/Workspaces/test_workspace_folder_bindings.py
+++ b/Tests/Workspaces/test_workspace_folder_bindings.py
@@ -1,0 +1,132 @@
+"""Folder-binding service methods (spec 2026-07-26 settings-workspaces §2)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+from tldw_chatbook.Workspaces import DEFAULT_WORKSPACE_ID, LocalWorkspaceRegistryService
+from tldw_chatbook.Workspaces.registry_service import (
+    BindingNotFound,
+    WorkspaceNotFound,
+    WorkspaceRegistryServiceError,
+)
+
+
+def build_registry(tmp_path: Path) -> LocalWorkspaceRegistryService:
+    return LocalWorkspaceRegistryService(
+        WorkspaceDB(tmp_path / "workspaces.sqlite", client_id="folder-tests")
+    )
+
+
+@pytest.fixture()
+def service(tmp_path: Path) -> LocalWorkspaceRegistryService:
+    registry = build_registry(tmp_path)
+    registry.ensure_default_workspace()
+    registry.create_workspace(workspace_id="ws-a", name="Client A")
+    return registry
+
+
+def test_add_folder_binding_stores_canonical_ro_binding(
+    service: LocalWorkspaceRegistryService, tmp_path: Path
+) -> None:
+    folder = tmp_path / "project"
+    folder.mkdir()
+
+    binding = service.add_folder_binding("ws-a", folder)
+
+    assert binding.locator == str(folder.resolve())
+    assert binding.label == "project"
+    assert str(binding.binding_kind) in ("local-filesystem", "RuntimeBindingKind.LOCAL_FILESYSTEM")
+    assert binding.metadata["access"] == "ro"
+    assert str(binding.status) in ("ready", "RuntimeBindingStatus.READY")
+
+
+def test_add_folder_binding_allow_write(
+    service: LocalWorkspaceRegistryService, tmp_path: Path
+) -> None:
+    folder = tmp_path / "writable"
+    folder.mkdir()
+    binding = service.add_folder_binding("ws-a", folder, allow_write=True)
+    assert binding.metadata["access"] == "rw"
+
+
+def test_add_folder_binding_validation_matrix(
+    service: LocalWorkspaceRegistryService, tmp_path: Path
+) -> None:
+    missing = tmp_path / "nope"
+    a_file = tmp_path / "file.txt"
+    a_file.write_text("x")
+    with pytest.raises(WorkspaceRegistryServiceError):
+        service.add_folder_binding("ws-a", missing)
+    with pytest.raises(WorkspaceRegistryServiceError):
+        service.add_folder_binding("ws-a", a_file)
+    with pytest.raises(WorkspaceRegistryServiceError):
+        service.add_folder_binding("ws-a", Path("/"))
+    with pytest.raises(WorkspaceRegistryServiceError):
+        service.add_folder_binding("ws-a", Path.home())
+    with pytest.raises(WorkspaceNotFound):
+        service.add_folder_binding("ws-missing", tmp_path)
+
+
+def test_add_folder_binding_rejects_default_workspace(
+    service: LocalWorkspaceRegistryService, tmp_path: Path
+) -> None:
+    folder = tmp_path / "any"
+    folder.mkdir()
+    with pytest.raises(WorkspaceRegistryServiceError):
+        service.add_folder_binding(DEFAULT_WORKSPACE_ID, folder)
+
+
+def test_add_folder_binding_rejects_duplicates_and_nesting(
+    service: LocalWorkspaceRegistryService, tmp_path: Path
+) -> None:
+    parent = tmp_path / "parent"
+    child = parent / "child"
+    child.mkdir(parents=True)
+    service.add_folder_binding("ws-a", parent)
+
+    with pytest.raises(WorkspaceRegistryServiceError):
+        service.add_folder_binding("ws-a", parent)  # duplicate
+    with pytest.raises(WorkspaceRegistryServiceError):
+        service.add_folder_binding("ws-a", child)  # nested under existing
+
+    # And the reverse direction: existing child blocks a new parent root.
+    other = build_registry(tmp_path / "second-db")
+    other.create_workspace(workspace_id="ws-b", name="Client B")
+    other.add_folder_binding("ws-b", child)
+    with pytest.raises(WorkspaceRegistryServiceError):
+        other.add_folder_binding("ws-b", parent)
+
+
+def test_list_folder_bindings_recomputes_status(
+    service: LocalWorkspaceRegistryService, tmp_path: Path
+) -> None:
+    folder = tmp_path / "ephemeral"
+    folder.mkdir()
+    service.add_folder_binding("ws-a", folder)
+    folder.rmdir()
+
+    bindings = service.list_folder_bindings("ws-a")
+    assert len(bindings) == 1
+    assert str(bindings[0].status) in ("missing", "RuntimeBindingStatus.MISSING")
+
+
+def test_remove_and_toggle_access(
+    service: LocalWorkspaceRegistryService, tmp_path: Path
+) -> None:
+    folder = tmp_path / "toggled"
+    folder.mkdir()
+    binding = service.add_folder_binding("ws-a", folder)
+
+    updated = service.set_folder_binding_access(binding.binding_id, allow_write=True)
+    assert updated.metadata["access"] == "rw"
+
+    service.remove_runtime_binding(binding.binding_id)
+    assert service.list_folder_bindings("ws-a") == ()
+    with pytest.raises(BindingNotFound):
+        service.remove_runtime_binding(binding.binding_id)
+    with pytest.raises(BindingNotFound):
+        service.set_folder_binding_access(binding.binding_id, allow_write=False)

--- a/Tests/Workspaces/test_workspace_folder_bindings.py
+++ b/Tests/Workspaces/test_workspace_folder_bindings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import shutil
 
 import pytest
 
@@ -108,6 +109,26 @@ def test_list_folder_bindings_recomputes_status(
     folder.mkdir()
     service.add_folder_binding("ws-a", folder)
     folder.rmdir()
+
+    bindings = service.list_folder_bindings("ws-a")
+    assert len(bindings) == 1
+    assert str(bindings[0].status) in ("missing", "RuntimeBindingStatus.MISSING")
+
+
+def test_list_folder_bindings_reports_symlink_swap_as_missing(
+    service: LocalWorkspaceRegistryService, tmp_path: Path
+) -> None:
+    """Item F: a bound folder later replaced by a symlink must report MISSING,
+    since trusting it would silently widen the root at enforcement time."""
+    real_root = tmp_path / "real-root"
+    real_root.mkdir()
+    service.add_folder_binding("ws-a", real_root)
+
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+
+    shutil.rmtree(real_root)
+    real_root.symlink_to(elsewhere)
 
     bindings = service.list_folder_bindings("ws-a")
     assert len(bindings) == 1

--- a/Tests/Workspaces/test_workspace_registry_service.py
+++ b/Tests/Workspaces/test_workspace_registry_service.py
@@ -509,3 +509,56 @@ def test_archive_workspace_protects_default_and_unknown(tmp_path: Path) -> None:
         service.archive_workspace(DEFAULT_WORKSPACE_ID)
     with pytest.raises(WorkspaceNotFound):
         service.archive_workspace("ws-missing")
+
+
+# --- TASK-1: unarchive + duplicate-name guard --------------------------------
+
+
+def test_unarchive_workspace_restores_listing_without_activating(tmp_path: Path) -> None:
+    service = build_test_registry(tmp_path)
+    service.ensure_default_workspace()
+    service.create_workspace(workspace_id="ws-a", name="Workspace 1")
+    service.set_active_workspace("ws-a")
+    service.archive_workspace("ws-a")
+
+    restored = service.unarchive_workspace("ws-a")
+
+    assert restored.archived is False
+    assert restored.active is False  # never auto-activates
+    listed = {record.workspace_id for record in service.list_workspaces()}
+    assert "ws-a" in listed
+    active = service.get_active_workspace()
+    assert active is not None and active.workspace_id == DEFAULT_WORKSPACE_ID
+
+
+def test_unarchive_workspace_rejects_unknown_and_unarchived(tmp_path: Path) -> None:
+    service = build_test_registry(tmp_path)
+    service.create_workspace(workspace_id="ws-a", name="Workspace 1")
+
+    with pytest.raises(WorkspaceNotFound):
+        service.unarchive_workspace("ws-missing")
+    with pytest.raises(WorkspaceNotFound):
+        service.unarchive_workspace("ws-a")  # not archived
+
+
+def test_duplicate_names_rejected_case_insensitively(tmp_path: Path) -> None:
+    service = build_test_registry(tmp_path)
+    service.create_workspace(workspace_id="ws-a", name="Client A")
+    service.create_workspace(workspace_id="ws-b", name="Workspace 2")
+
+    with pytest.raises(WorkspaceRegistryServiceError):
+        service.rename_workspace("ws-b", "client a")
+    with pytest.raises(WorkspaceRegistryServiceError):
+        service.create_workspace(workspace_id="ws-c", name="CLIENT A")
+    # Renaming to its own current name (case-changed) is allowed.
+    renamed = service.rename_workspace("ws-a", "client A")
+    assert renamed.name == "client A"
+
+
+def test_archived_names_do_not_block_reuse(tmp_path: Path) -> None:
+    service = build_test_registry(tmp_path)
+    service.create_workspace(workspace_id="ws-a", name="Client A")
+    service.archive_workspace("ws-a")
+
+    created = service.create_workspace(workspace_id="ws-b", name="Client A")
+    assert created.name == "Client A"

--- a/Tests/Workspaces/test_workspace_registry_service.py
+++ b/Tests/Workspaces/test_workspace_registry_service.py
@@ -470,6 +470,28 @@ def test_rename_workspace_protects_default(tmp_path: Path) -> None:
         service.rename_workspace(DEFAULT_WORKSPACE_ID, "Not Default")
 
 
+def test_rename_default_reports_default_protection_even_with_taken_name(
+    tmp_path: Path,
+) -> None:
+    service = build_test_registry(tmp_path)
+    service.ensure_default_workspace()
+    service.create_workspace(workspace_id="ws-a", name="Client A")
+
+    with pytest.raises(WorkspaceRegistryServiceError) as excinfo:
+        service.rename_workspace(DEFAULT_WORKSPACE_ID, "Client A")
+    assert "Default workspace cannot be renamed" in str(excinfo.value)
+
+
+def test_rename_unknown_id_reports_not_found_even_with_taken_name(
+    tmp_path: Path,
+) -> None:
+    service = build_test_registry(tmp_path)
+    service.create_workspace(workspace_id="ws-a", name="Client A")
+
+    with pytest.raises(WorkspaceNotFound):
+        service.rename_workspace("ws-missing", "Client A")
+
+
 def test_archive_workspace_hides_from_listing(tmp_path: Path) -> None:
     service = build_test_registry(tmp_path)
     service.ensure_default_workspace()
@@ -562,3 +584,50 @@ def test_archived_names_do_not_block_reuse(tmp_path: Path) -> None:
 
     created = service.create_workspace(workspace_id="ws-b", name="Client A")
     assert created.name == "Client A"
+
+
+def test_unarchive_collision_with_live_name_is_explained(tmp_path: Path) -> None:
+    service = build_test_registry(tmp_path)
+    service.create_workspace(workspace_id="ws-a", name="Client A")
+    service.archive_workspace("ws-a")
+    service.create_workspace(workspace_id="ws-b", name="Client A")
+
+    with pytest.raises(WorkspaceRegistryServiceError) as excinfo:
+        service.unarchive_workspace("ws-a")
+    assert "rename it before unarchiving" in str(excinfo.value)
+
+
+def test_v2_migration_dedupes_and_indexes_existing_duplicates(tmp_path: Path) -> None:
+    from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+
+    db = WorkspaceDB(tmp_path / "mig.sqlite", client_id="mig")
+    with db.connection() as conn:
+        conn.execute("DROP INDEX IF EXISTS idx_workspace_records_name_ci")
+        conn.execute("DELETE FROM schema_version WHERE version = 2")
+        for wid, name in (("w1", "Same Name"), ("w2", "same name"), ("w3", "SAME NAME")):
+            conn.execute(
+                """
+                INSERT INTO workspace_records
+                    (workspace_id, name, description, authority, sync_status,
+                     active, archived, created_at, updated_at)
+                VALUES (?, ?, '', 'local-only', 'not-configured', 0, 0, ?, ?)
+                """,
+                (wid, name, f"2026-01-0{wid[-1]}T00:00:00+00:00", "2026-01-01T00:00:00+00:00"),
+            )
+        conn.commit()
+
+    db._initialize_schema()
+
+    with db.connection() as conn:
+        names = [
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM workspace_records WHERE archived = 0 ORDER BY workspace_id"
+            ).fetchall()
+        ]
+        index_row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_workspace_records_name_ci'"
+        ).fetchone()
+
+    assert index_row is not None
+    assert len({n.strip().casefold() for n in names}) == len(names)

--- a/Tests/Workspaces/test_workspace_registry_service.py
+++ b/Tests/Workspaces/test_workspace_registry_service.py
@@ -631,3 +631,82 @@ def test_v2_migration_dedupes_and_indexes_existing_duplicates(tmp_path: Path) ->
 
     assert index_row is not None
     assert len({n.strip().casefold() for n in names}) == len(names)
+
+
+def test_v2_migration_dedupes_across_groups_without_collision(tmp_path: Path) -> None:
+    """A rename generated for one duplicate group must not collide with a
+    name reserved by a different duplicate group's rename (Qodo #943/#944)."""
+    from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+
+    db = WorkspaceDB(tmp_path / "mig-cross-group.sqlite", client_id="mig")
+    with db.connection() as conn:
+        conn.execute("DROP INDEX IF EXISTS idx_workspace_records_name_ci")
+        conn.execute("DELETE FROM schema_version WHERE version = 2")
+        # Group 1: "Foo" / "foo" duplicates. Group 2: a lone pre-existing
+        # "Foo (2)" that is NOT a duplicate of anything by itself, but is
+        # exactly the candidate name group 1's rename would naively produce.
+        for wid, name in (("w1", "Foo"), ("w2", "foo"), ("w3", "Foo (2)")):
+            conn.execute(
+                """
+                INSERT INTO workspace_records
+                    (workspace_id, name, description, authority, sync_status,
+                     active, archived, created_at, updated_at)
+                VALUES (?, ?, '', 'local-only', 'not-configured', 0, 0, ?, ?)
+                """,
+                (wid, name, f"2026-01-0{wid[-1]}T00:00:00+00:00", "2026-01-01T00:00:00+00:00"),
+            )
+        conn.commit()
+
+    db._initialize_schema()
+
+    with db.connection() as conn:
+        names = [
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM workspace_records WHERE archived = 0 ORDER BY workspace_id"
+            ).fetchall()
+        ]
+        index_row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_workspace_records_name_ci'"
+        ).fetchone()
+
+    assert index_row is not None
+    assert len({n.strip().casefold() for n in names}) == len(names)
+
+
+def test_v2_migration_dedupes_against_preexisting_suffixed_name(tmp_path: Path) -> None:
+    """A generated rename must not collide with a real, pre-existing name
+    that already looks like a generated suffix (Qodo #943/#944)."""
+    from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+
+    db = WorkspaceDB(tmp_path / "mig-preexisting-suffix.sqlite", client_id="mig")
+    with db.connection() as conn:
+        conn.execute("DROP INDEX IF EXISTS idx_workspace_records_name_ci")
+        conn.execute("DELETE FROM schema_version WHERE version = 2")
+        for wid, name in (("w1", "Bar"), ("w2", "bar"), ("w3", "Bar (2)")):
+            conn.execute(
+                """
+                INSERT INTO workspace_records
+                    (workspace_id, name, description, authority, sync_status,
+                     active, archived, created_at, updated_at)
+                VALUES (?, ?, '', 'local-only', 'not-configured', 0, 0, ?, ?)
+                """,
+                (wid, name, f"2026-01-0{wid[-1]}T00:00:00+00:00", "2026-01-01T00:00:00+00:00"),
+            )
+        conn.commit()
+
+    db._initialize_schema()
+
+    with db.connection() as conn:
+        names = [
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM workspace_records WHERE archived = 0 ORDER BY workspace_id"
+            ).fetchall()
+        ]
+        index_row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_workspace_records_name_ci'"
+        ).fetchone()
+
+    assert index_row is not None
+    assert len({n.strip().casefold() for n in names}) == len(names)

--- a/backlog/decisions/028-settings-workspaces-category-and-folder-roots.md
+++ b/backlog/decisions/028-settings-workspaces-category-and-folder-roots.md
@@ -1,0 +1,39 @@
+# 028 - Settings owns workspace management; folders are file-tool access roots
+
+Date: 2026-07-26
+Status: accepted
+Relates to: spec `2026-07-26-settings-workspaces-category-design.md`; supersedes the Stage-5 read-only boundary in `Docs/superpowers/plans/2026-05-29-settings-configuration-hub.md`
+
+## Context
+
+The tldw_chatbook workspace architecture requires a management surface and a coherent enforcement model for folder access. Prior to this decision, workspace state was read-only in Settings, and folder bindings existed only as a data model without enforcement or UI.
+
+## Decision
+
+### (a) Ownership supersession with Console/Library quick actions retained
+
+Settings now owns the complete workspace lifecycle — create, rename, archive/unarchive, set active, and add/remove folder bindings. The Console workspace switcher (Alt+W) and Library quick actions retain their convenience surfaces: the switcher keeps switch/rename/archive, and Library keeps create as in-context actions. This coexistence avoids centralizing every operation in Settings while making Settings the authoritative management home.
+
+### (b) Folder semantics: access roots, read-only default, call-time validation, run-bound resolution
+
+Folders bound to a workspace define file-tool access roots — the boundaries where agent file tools (`read_file`, `list_directory`, `write_file`) may operate. Each folder binding specifies:
+- **Access mode:** read-only is the default; write access is per-folder opt-in via an explicit toggle.
+- **Existence validation:** folders are validated at call time, not at binding time. A deleted folder drops out of the allowed set immediately and does not block tool operations.
+- **Workspace resolution:** the tool catalog injects a roots-provider closure bound to each run's workspace id, so the same tool instance cannot silently retarget if the active workspace changes mid-run. Only when a run has no workspace context does the provider fall back to `get_active_workspace()` at call time.
+- **Default workspace:** the built-in Default workspace cannot have folder bindings. It remains tool-less by design, preserving the existing sandbox-only behavior for everyday chats that do not opt into workspace separation.
+
+### (c) Deliberate divergence from Codex prior art — reads are confined too
+
+OpenAI Codex's `workspace-write` sandbox allows reads anywhere and confines only writes (via `workspace + sandbox_workspace_write.writable_roots`). tldw deliberately confines both reads and writes to the sandbox plus bound folders, because the existing sandbox architecture already does so and the app is privacy-first. Do not "fix" this divergence to match Codex's model; the asymmetry is intentional.
+
+### (d) Canonical locators as the external-runtime export surface
+
+Canonical folder locators (resolved paths with symlinks dereferenced) are the roots handed to external agent runtimes — the shape that Codex's app-server takes as `runtimeWorkspaceRoots` at thread/turn start. The future ACP/app-server handoff will consume workspace bindings as-is via this export surface; no separate roots model is needed.
+
+## Consequences
+
+- Settings becomes the single authoritative surface for workspace and folder management, reducing cognitive load and surfacing management actions consistently.
+- File-tool access is scoped to workspace-bound folders (plus the global sandbox), enabling privacy-preserving agent isolation without sacrificing usability.
+- Run-bound workspace resolution prevents mid-run context switches from silently retargeting agent file operations.
+- Folder validation at call time keeps the system robust to filesystem changes without requiring background monitoring.
+- The export surface enables future external runtimes (ACP, app-server) to enforce the same workspace semantics.

--- a/backlog/decisions/028-settings-workspaces-category-and-folder-roots.md
+++ b/backlog/decisions/028-settings-workspaces-category-and-folder-roots.md
@@ -21,6 +21,7 @@ Folders bound to a workspace define file-tool access roots — the boundaries wh
 - **Existence validation:** folders are validated at call time, not at binding time. A deleted folder drops out of the allowed set immediately and does not block tool operations.
 - **Workspace resolution:** the tool catalog injects a roots-provider closure bound to each run's workspace id, so the same tool instance cannot silently retarget if the active workspace changes mid-run. Only when a run has no workspace context does the provider fall back to `get_active_workspace()` at call time.
 - **Default workspace:** the built-in Default workspace cannot have folder bindings. It remains tool-less by design, preserving the existing sandbox-only behavior for everyday chats that do not opt into workspace separation.
+- **Archiving preserves bindings:** archiving a workspace intentionally preserves its folder bindings — archiving only hides the workspace from normal listings; bindings stay user-removable via the Show-archived card and are only reachable by that workspace's own runs.
 
 ### (c) Deliberate divergence from Codex prior art — reads are confined too
 

--- a/backlog/tasks/task-836 - Harden-Workspace_DB-v2-name-dedupe-against-pre-existing-suffixed-names.md
+++ b/backlog/tasks/task-836 - Harden-Workspace_DB-v2-name-dedupe-against-pre-existing-suffixed-names.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-836
 title: Harden Workspace_DB v2 name-dedupe against pre-existing suffixed names
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-26 16:20'
 labels:
@@ -21,7 +21,13 @@ Source: workspace folder-roots train final review (spec 2026-07-26-settings-work
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Migration succeeds on a DB containing both case-duplicates and pre-existing '(n)' names
-- [ ] #2 A regression test covers the contrived layout
-- [ ] #3 Index creation can no longer abort schema initialization for any dedupe outcome
+- [x] #1 Migration succeeds on a DB containing both case-duplicates and pre-existing '(n)' names
+- [x] #2 A regression test covers the contrived layout
+- [x] #3 Index creation can no longer abort schema initialization for any dedupe outcome
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Absorbed into the PR-review fix wave on feat/workspace-folder-bindings (commit 97dc1ea43): the v2 dedupe now pre-seeds a reserved set with ALL non-archived casefolded names before any rename (covering cross-group collisions AND pre-existing '(n)' names), strips names before suffixing, and the whole migration runs inside the shared transaction() for atomic rollback. Regression tests: cross-group and pre-existing-suffix layouts in test_workspace_registry_service.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-836 - Harden-Workspace_DB-v2-name-dedupe-against-pre-existing-suffixed-names.md
+++ b/backlog/tasks/task-836 - Harden-Workspace_DB-v2-name-dedupe-against-pre-existing-suffixed-names.md
@@ -1,0 +1,27 @@
+---
+id: TASK-836
+title: Harden Workspace_DB v2 name-dedupe against pre-existing suffixed names
+status: To Do
+assignee: []
+created_date: '2026-07-26 16:20'
+labels:
+  - workspaces
+  - db
+  - hardening
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The v2 migration's duplicate-name dedupe only collision-checks names it renames within the same pass, not pre-existing '(n)'-suffixed names already in the table. A contrived legacy DB holding both a real 'Foo (2)' workspace and a foo/Foo duplicate pair can have the migration rename into a still-colliding name, making CREATE UNIQUE INDEX raise and abort _initialize_schema for that DB. Seed the dedupe's seen-set with ALL existing non-archived names (not just renamed ones) and add a regression test for the contrived layout.
+
+Source: workspace folder-roots train final review (spec 2026-07-26-settings-workspaces-category-design.md), deferred-minor triage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Migration succeeds on a DB containing both case-duplicates and pre-existing '(n)' names
+- [ ] #2 A regression test covers the contrived layout
+- [ ] #3 Index creation can no longer abort schema initialization for any dedupe outcome
+<!-- AC:END -->

--- a/backlog/tasks/task-837 - Cache-workspace-folder-root-lookups-off-the-file-tool-hot-path.md
+++ b/backlog/tasks/task-837 - Cache-workspace-folder-root-lookups-off-the-file-tool-hot-path.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-837
 title: Cache workspace folder-root lookups off the file-tool hot path
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-26 16:20'
 labels:
@@ -21,7 +21,13 @@ Source: workspace folder-roots train final review (spec 2026-07-26-settings-work
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 File-tool invocations no longer open a new WorkspaceDB connection per call in steady state
-- [ ] #2 Folder existence is still verified live at call time
-- [ ] #3 Binding add/remove/toggle invalidates or bypasses the cache within one run
+- [x] #1 File-tool invocations no longer open a new WorkspaceDB connection per call in steady state
+- [x] #2 Folder existence is still verified live at call time
+- [x] #3 Binding add/remove/toggle invalidates or bypasses the cache within one run
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Absorbed into the PR-review fix wave (commit 97dc1ea43): the default registry factory now lazily caches a singleton LocalWorkspaceRegistryService behind a lock — no per-tool-call WorkspaceDB construction/schema-init; SQLite connections remain per-call inside the service so thread safety and live folder-existence checks are unchanged; the _registry_factory monkeypatch seam bypasses the cache for tests. Cache-coherence AC is moot: no binding DATA is cached, list_folder_bindings still queries per call.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-837 - Cache-workspace-folder-root-lookups-off-the-file-tool-hot-path.md
+++ b/backlog/tasks/task-837 - Cache-workspace-folder-root-lookups-off-the-file-tool-hot-path.md
@@ -1,0 +1,27 @@
+---
+id: TASK-837
+title: Cache workspace folder-root lookups off the file-tool hot path
+status: To Do
+assignee: []
+created_date: '2026-07-26 16:20'
+labels:
+  - tools
+  - performance
+  - workspaces
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+allowed_file_roots opens a fresh WorkspaceDB connection on every file-tool invocation (read/list/write), including the zero-binding case. Correctness is unaffected (fail-safe design), but tight agent tool loops pay a per-call SQLite open. Add a short-TTL cache or per-run memoization keyed by workspace id, preserving the call-time existence re-check for the folders themselves (existence must stay live; only the binding LIST may be cached).
+
+Source: workspace folder-roots train final review (spec 2026-07-26-settings-workspaces-category-design.md), deferred-minor triage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 File-tool invocations no longer open a new WorkspaceDB connection per call in steady state
+- [ ] #2 Folder existence is still verified live at call time
+- [ ] #3 Binding add/remove/toggle invalidates or bypasses the cache within one run
+<!-- AC:END -->

--- a/tldw_chatbook/Agents/tool_catalog.py
+++ b/tldw_chatbook/Agents/tool_catalog.py
@@ -270,7 +270,18 @@ class BuiltinToolProvider:
 
     SOURCE = "builtin"
 
-    def __init__(self, gate: Any | None = None) -> None:
+    def __init__(
+        self, gate: Any | None = None, workspace_id: str | None = None
+    ) -> None:
+        # settings-workspaces-folder-roots spec §3: the run's workspace,
+        # bound around every tool execution (see `invoke`) so file tools
+        # resolve THIS run's folder roots -- never whatever workspace the
+        # user happens to be looking at when the tool actually fires.
+        # `None` (the default -- every construction site that never cares
+        # about workspace-scoped file roots, e.g. Settings-time enumeration
+        # in `builtin_tool_gate.builtin_permission_rows`) leaves
+        # `allowed_file_roots` to fall back to the active workspace.
+        self._workspace_id = workspace_id
         self._tools = {t.name: t for t in (CalculatorTool(), DateTimeTool())}
         # task-584: surface the app's existing sandbox-rooted file tools to the
         # agent loop. They were registered on the global ToolExecutor but never
@@ -373,11 +384,20 @@ class BuiltinToolProvider:
             return ToolResult(ok=False, error=f"permission check failed: {exc}")
         if refusal is not None:
             return ToolResult(ok=False, error=refusal)
+        from tldw_chatbook.Tools.workspace_file_roots import run_workspace
+
         try:
             # Providers bridge async tools; the loop's interface is sync.
             # Safe here: the service runs in a worker thread with no
-            # running event loop.
-            raw = asyncio.run(tool.execute(**args))
+            # running event loop. `run_workspace` binds this run's
+            # workspace for the DURATION of the call only (context-managed,
+            # reset in its own `finally`) so file tools (`allowed_file_
+            # roots`) resolve THIS run's folder bindings, never a stale or
+            # concurrent run's. `self._workspace_id=None` keeps the
+            # ContextVar at `None`, which is `allowed_file_roots`' own
+            # documented fallback to the active workspace.
+            with run_workspace(self._workspace_id):
+                raw = asyncio.run(tool.execute(**args))
         except Exception as exc:  # noqa: BLE001 — captured, never escapes
             return ToolResult(ok=False, error=str(exc))
         if isinstance(raw, dict) and raw.get("error"):

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -780,6 +780,7 @@ def _compose_run_registry_and_allowed(
     *,
     mcp_provider: Any | None = None,
     builtin_gate: Any | None = None,
+    workspace_id: str | None = None,
 ) -> tuple[ToolCatalogRegistry, tuple[str, ...], tuple[str, ...]]:
     """Build a fresh per-run tool registry + allow-list from a skills snapshot.
 
@@ -809,6 +810,14 @@ def _compose_run_registry_and_allowed(
             own fail-closed default) -- callers that care about the hook
             and ``invoke()`` agreeing on stamps must pass the same object
             to both.
+        workspace_id: task-6 (settings-workspaces-folder-roots spec §3) --
+            the running session's workspace id, threaded into the
+            freshly-constructed ``BuiltinToolProvider`` so its ``invoke()``
+            binds THIS run's workspace (via ``run_workspace``) around every
+            tool call, and file tools resolve that workspace's folder
+            roots. ``None`` (the default) leaves the ContextVar unset for
+            the run, which is ``allowed_file_roots``'s own documented
+            fallback to whatever workspace is currently active.
 
     Returns:
         ``(registry, allowed_tools, builtin_names)`` -- the per-run
@@ -819,7 +828,7 @@ def _compose_run_registry_and_allowed(
         so a skill's sub-agent can never call another skill).
     """
     registry = ToolCatalogRegistry()
-    builtin_provider = BuiltinToolProvider(gate=builtin_gate)
+    builtin_provider = BuiltinToolProvider(gate=builtin_gate, workspace_id=workspace_id)
     registry.register_provider(builtin_provider)
     builtin_names = tuple(entry.name for entry in builtin_provider.list_catalog())
     eligible = _non_colliding_skill_entries(context, builtin_names)
@@ -1017,6 +1026,17 @@ class ConsoleAgentBridge:
         skills/MCP-free run on the shared, construction-time
         ``self._registry``/``self._allowed_tools`` fast path unchanged.
 
+        task-6 (settings-workspaces-folder-roots spec §3): whenever this
+        run takes the fresh-build branch below, ``self._store``'s own
+        record of ``session_id``'s bound workspace is looked up and
+        threaded into ``_compose_run_registry_and_allowed`` as
+        ``workspace_id`` -- so this run's ``BuiltinToolProvider`` binds
+        THIS session's workspace, not whatever workspace is active in the
+        UI by the time a file tool actually fires. A missing store or an
+        already-closed session degrades to ``None`` (the documented
+        active-workspace fallback) rather than failing the run over an
+        ancillary lookup.
+
         Returns:
             A ``(run_id, outcome)`` tuple: the primary run's id (so the
             caller can record the produced reply's persisted id onto the run
@@ -1068,8 +1088,21 @@ class ConsoleAgentBridge:
             context: Mapping[str, Any] = {}
             if self._skills_service is not None:
                 context = asyncio.run(self._skills_service.get_context(mode="local"))
+            # task-6: `self._store` is `None` in some bridge-construction-only
+            # tests, and `session_id` could in principle name an already-
+            # closed session -- either degrades to `None`, never raises,
+            # matching `allowed_file_roots`'s own fail-safe posture.
+            run_workspace_id: str | None = None
+            if self._store is not None:
+                try:
+                    run_workspace_id = self._store.session_workspace_id(session_id)
+                except KeyError:
+                    run_workspace_id = None
             registry, allowed_tools, builtin_names = _compose_run_registry_and_allowed(
-                context, mcp_provider=mcp_provider, builtin_gate=builtin_gate
+                context,
+                mcp_provider=mcp_provider,
+                builtin_gate=builtin_gate,
+                workspace_id=run_workspace_id,
             )
             if self._skills_service is not None:
                 skill_names = frozenset(

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -612,6 +612,17 @@ class ConsoleChatStore:
         """Return in-memory settings for a native Console session."""
         return self._session_or_raise(session_id).settings
 
+    def session_workspace_id(self, session_id: str) -> str:
+        """Return the workspace id a native Console session is bound to.
+
+        Used by ``ConsoleAgentBridge.run_reply`` (task-6, settings-
+        workspaces-folder-roots spec §3) to thread the RUNNING session's
+        own workspace into ``BuiltinToolProvider`` -- never whatever
+        workspace happens to be active in the UI by the time a tool
+        actually fires.
+        """
+        return self._session_or_raise(session_id).workspace_id
+
     def replace_session_settings(
         self,
         session_id: str,

--- a/tldw_chatbook/DB/Workspace_DB.py
+++ b/tldw_chatbook/DB/Workspace_DB.py
@@ -124,11 +124,15 @@ class WorkspaceDB(BaseDB):
             )
             conn.commit()
 
-            # v2 migration: add case-insensitive unique index on non-archived names
+            # v2 migration: add case-insensitive unique index on non-archived names.
+            # Keep this runner SQL aligned with
+            # tldw_chatbook/DB/migrations/workspaces_v1_to_v2_name_unique_index.sql.
             version_row = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()
             version = int(version_row[0] or 0) if version_row is not None else 0
-            if version < 2:
-                # Dedup non-archived duplicate names so the index can build on old DBs
+            needs_v2 = version < 2
+            rows: list[tuple[str, str]] = []
+            if needs_v2:
+                # Reads only here; all v2 writes happen below inside self.transaction().
                 rows = conn.execute(
                     """
                     SELECT workspace_id, name
@@ -137,43 +141,54 @@ class WorkspaceDB(BaseDB):
                     ORDER BY created_at ASC, workspace_id ASC
                     """
                 ).fetchall()
-                seen_names = {}  # maps casefold -> list of (workspace_id, original_name)
-                for workspace_id, name in rows:
-                    needle = name.strip().casefold()
-                    if needle not in seen_names:
-                        seen_names[needle] = []
-                    seen_names[needle].append((workspace_id, name))
 
-                # For groups with >1 row, rename all but the first
-                seen_final = set()
-                for needle, group in seen_names.items():
-                    if len(group) > 1:
-                        for idx, (workspace_id, orig_name) in enumerate(group[1:], start=2):
-                            # Generate unique suffix until we find a free name
-                            new_name = f"{orig_name} ({idx})"
-                            suffix = idx
-                            while new_name.strip().casefold() in seen_final:
-                                suffix += 1
-                                new_name = f"{orig_name} ({suffix})"
-                            seen_final.add(new_name.strip().casefold())
-                            conn.execute(
-                                "UPDATE workspace_records SET name = ? WHERE workspace_id = ?",
-                                (new_name, workspace_id),
-                            )
-                    else:
-                        seen_final.add(needle)
+        if not needs_v2:
+            return
 
-                # Create case-insensitive unique index on non-archived names
-                # SQLite lower() is ASCII-only, so the index is the coarse backstop
-                # while the service-level casefold() check remains the primary, broader guard
-                conn.execute(
-                    """
-                    CREATE UNIQUE INDEX IF NOT EXISTS idx_workspace_records_name_ci
-                    ON workspace_records (lower(name)) WHERE archived = 0
-                    """
+        # Reserve every existing non-archived name up front (stripped, casefolded)
+        # so renames below can never collide with a retained first-of-group row,
+        # nor with a pre-existing unrelated name that already looks like a
+        # generated suffix (e.g. a real "Foo (2)").
+        reserved = {name.strip().casefold() for _, name in rows}
+
+        groups: dict[str, list[tuple[str, str]]] = {}
+        for workspace_id, name in rows:
+            groups.setdefault(name.strip().casefold(), []).append((workspace_id, name))
+
+        # For groups with >1 row, keep the first (earliest-created) row as-is
+        # and rename the rest against the shared `reserved` set.
+        renames: list[tuple[str, str]] = []  # (workspace_id, new_name)
+        for group in groups.values():
+            if len(group) <= 1:
+                continue
+            for idx, (workspace_id, orig_name) in enumerate(group[1:], start=2):
+                base = orig_name.strip()
+                candidate = f"{base} ({idx})"
+                suffix = idx
+                while candidate.casefold() in reserved:
+                    suffix += 1
+                    candidate = f"{base} ({suffix})"
+                reserved.add(candidate.casefold())
+                renames.append((workspace_id, candidate))
+
+        # All v2 writes run inside one transaction so a mid-migration failure
+        # (e.g. the unique index hitting an unresolved collision) rolls back
+        # atomically instead of leaving the database half-migrated.
+        with self.transaction() as write_conn:
+            for workspace_id, candidate in renames:
+                write_conn.execute(
+                    "UPDATE workspace_records SET name = ? WHERE workspace_id = ?",
+                    (candidate, workspace_id),
                 )
-                conn.execute("INSERT OR IGNORE INTO schema_version (version) VALUES (2)")
-                conn.commit()
+            # SQLite lower() is ASCII-only, so the index is the coarse backstop
+            # while the service-level casefold() check remains the primary, broader guard
+            write_conn.execute(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_workspace_records_name_ci
+                ON workspace_records (lower(name)) WHERE archived = 0
+                """
+            )
+            write_conn.execute("INSERT OR IGNORE INTO schema_version (version) VALUES (2)")
 
     def get_schema_version(self) -> int:
         """Return the initialized schema version."""

--- a/tldw_chatbook/DB/Workspace_DB.py
+++ b/tldw_chatbook/DB/Workspace_DB.py
@@ -13,7 +13,7 @@ from .base_db import BaseDB
 class WorkspaceDB(BaseDB):
     """Database wrapper for local workspace registry state."""
 
-    _CURRENT_SCHEMA_VERSION = 1
+    _CURRENT_SCHEMA_VERSION = 2
 
     def __init__(self, db_path: Union[str, Path], client_id: str = "default") -> None:
         super().__init__(db_path, client_id)
@@ -123,6 +123,57 @@ class WorkspaceDB(BaseDB):
                 """
             )
             conn.commit()
+
+            # v2 migration: add case-insensitive unique index on non-archived names
+            version_row = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()
+            version = int(version_row[0] or 0) if version_row is not None else 0
+            if version < 2:
+                # Dedup non-archived duplicate names so the index can build on old DBs
+                rows = conn.execute(
+                    """
+                    SELECT workspace_id, name
+                    FROM workspace_records
+                    WHERE archived = 0
+                    ORDER BY created_at ASC, workspace_id ASC
+                    """
+                ).fetchall()
+                seen_names = {}  # maps casefold -> list of (workspace_id, original_name)
+                for workspace_id, name in rows:
+                    needle = name.strip().casefold()
+                    if needle not in seen_names:
+                        seen_names[needle] = []
+                    seen_names[needle].append((workspace_id, name))
+
+                # For groups with >1 row, rename all but the first
+                seen_final = set()
+                for needle, group in seen_names.items():
+                    if len(group) > 1:
+                        for idx, (workspace_id, orig_name) in enumerate(group[1:], start=2):
+                            # Generate unique suffix until we find a free name
+                            new_name = f"{orig_name} ({idx})"
+                            suffix = idx
+                            while new_name.strip().casefold() in seen_final:
+                                suffix += 1
+                                new_name = f"{orig_name} ({suffix})"
+                            seen_final.add(new_name.strip().casefold())
+                            conn.execute(
+                                "UPDATE workspace_records SET name = ? WHERE workspace_id = ?",
+                                (new_name, workspace_id),
+                            )
+                    else:
+                        seen_final.add(needle)
+
+                # Create case-insensitive unique index on non-archived names
+                # SQLite lower() is ASCII-only, so the index is the coarse backstop
+                # while the service-level casefold() check remains the primary, broader guard
+                conn.execute(
+                    """
+                    CREATE UNIQUE INDEX IF NOT EXISTS idx_workspace_records_name_ci
+                    ON workspace_records (lower(name)) WHERE archived = 0
+                    """
+                )
+                conn.execute("INSERT OR IGNORE INTO schema_version (version) VALUES (2)")
+                conn.commit()
 
     def get_schema_version(self) -> int:
         """Return the initialized schema version."""

--- a/tldw_chatbook/DB/migrations/workspaces_v1_to_v2_name_unique_index.sql
+++ b/tldw_chatbook/DB/migrations/workspaces_v1_to_v2_name_unique_index.sql
@@ -1,0 +1,26 @@
+-- Migration: Workspace registry V1 to V2 case-insensitive unique names
+-- Adds a case-insensitive uniqueness guarantee on non-archived workspace
+-- names so two workspaces can never collide (e.g. "Client A" vs "client a").
+--
+-- Procedural step (not expressible as plain SQL, see the runner in
+-- tldw_chatbook/DB/Workspace_DB.py `_initialize_schema`):
+--   Before the index below can be created, any pre-existing non-archived
+--   duplicate names (case-insensitive) must be deduped. The runner:
+--     1. Reads all non-archived (workspace_id, name) rows, ordered by
+--        created_at ASC, workspace_id ASC.
+--     2. Builds a `reserved` set of every existing name's stripped,
+--        casefolded form up front (covers retained rows AND any
+--        pre-existing "Name (n)"-shaped names).
+--     3. For each duplicate group (by casefolded name), keeps the first
+--        (earliest-created) row untouched and renames the rest to
+--        "<original name> (n)", probing n upward until the candidate's
+--        casefolded form is not in `reserved`, then reserving it.
+--     4. Applies the renames as UPDATE workspace_records SET name = ...
+--        WHERE workspace_id = ... statements.
+--   All of the above renames plus the statements below run inside a single
+--   transaction so a mid-migration failure rolls back atomically.
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_workspace_records_name_ci
+    ON workspace_records (lower(name)) WHERE archived = 0;
+
+INSERT OR IGNORE INTO schema_version (version) VALUES (2);

--- a/tldw_chatbook/Tools/file_operation_tools.py
+++ b/tldw_chatbook/Tools/file_operation_tools.py
@@ -9,7 +9,8 @@ from typing import Dict, Any
 from loguru import logger
 
 from . import Tool
-from ..Utils.path_validation import validate_path
+from ..Utils.path_validation import validate_path_multi
+from .workspace_file_roots import allowed_file_roots
 
 
 def _resolve_sandbox_config() -> str:
@@ -102,8 +103,12 @@ class ReadFileTool(Tool):
         encoding = kwargs.get("encoding", "utf-8")
 
         try:
-            # Validate the path
-            validated_path = validate_path(file_path, _tool_sandbox_root())
+            # Validate the path against the sandbox plus any read-eligible
+            # workspace folder roots bound to the run.
+            validated_path = validate_path_multi(
+                file_path,
+                allowed_file_roots(write=False, sandbox_root=_tool_sandbox_root()),
+            )
             path = Path(validated_path)
 
             # Check if file exists
@@ -212,10 +217,21 @@ class ListDirectoryTool(Tool):
         max_depth = kwargs.get("max_depth", 2)
 
         try:
-            # Validate the path
+            # Validate the path against the sandbox plus any read-eligible
+            # workspace folder roots bound to the run.
             sandbox_root = _tool_sandbox_root()
-            validated_path = validate_path(directory_path, sandbox_root)
+            read_roots = allowed_file_roots(write=False, sandbox_root=sandbox_root)
+            validated_path = validate_path_multi(directory_path, read_roots)
             path = Path(validated_path)
+
+            # The recursive-descent symlink guard below must compare against
+            # whichever allowed root actually contains ``path`` — not always
+            # the sandbox — otherwise a legitimately bound workspace folder
+            # would silently refuse to recurse past its top level.
+            containment_root = next(
+                (root for root in read_roots if _is_within(path, root)),
+                sandbox_root,
+            )
 
             # Check if directory exists
             if not path.exists():
@@ -257,18 +273,18 @@ class ListDirectoryTool(Tool):
                             entries.append(entry)
 
                             # Recursively list subdirectories, but NEVER
-                            # follow a symlink: a link planted inside the
-                            # sandbox would otherwise let the walk enumerate
-                            # files outside file_sandbox_root, breaking the
+                            # follow a symlink: a link planted inside an
+                            # allowed root would otherwise let the walk
+                            # enumerate files outside it, breaking the
                             # containment every other path here relies on.
                             # Belt-and-braces, the resolved child must still
-                            # sit under the sandbox root.
+                            # sit under the root that contains this listing.
                             if (
                                 recursive
                                 and item.is_dir()
                                 and not item.is_symlink()
                                 and current_depth < max_depth
-                                and _is_within(item, sandbox_root)
+                                and _is_within(item, containment_root)
                             ):
                                 list_dir_contents(item, current_depth + 1)
 
@@ -392,8 +408,12 @@ class WriteFileTool(Tool):
         create_directories = kwargs.get("create_directories", False)
 
         try:
-            # Validate the path
-            validated_path = validate_path(file_path, _tool_sandbox_root())
+            # Validate the path against the sandbox plus any write-eligible
+            # (rw) workspace folder roots bound to the run.
+            validated_path = validate_path_multi(
+                file_path,
+                allowed_file_roots(write=True, sandbox_root=_tool_sandbox_root()),
+            )
             path = Path(validated_path)
 
             # Check if we're overwriting an existing file

--- a/tldw_chatbook/Tools/workspace_file_roots.py
+++ b/tldw_chatbook/Tools/workspace_file_roots.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from contextlib import contextmanager
 from contextvars import ContextVar
 from pathlib import Path
+import threading
 from typing import Iterator
 
 from loguru import logger
@@ -21,15 +22,47 @@ _RUN_WORKSPACE_ID: ContextVar[str | None] = ContextVar(
     "tldw_run_workspace_id", default=None
 )
 
+#: Process-wide cache for the default registry service (see
+#: ``_default_registry_factory``). Reset to ``None`` by tests that need a
+#: fresh instance.
+_default_registry_instance = None
+_default_registry_lock = threading.Lock()
+
 
 def _default_registry_factory():
-    from tldw_chatbook.config import get_workspaces_db_path
-    from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
-    from tldw_chatbook.Workspaces import LocalWorkspaceRegistryService
+    """Build, cache, and return the process-wide default workspace registry.
 
-    return LocalWorkspaceRegistryService(
-        WorkspaceDB(get_workspaces_db_path(), client_id="file-tools")
-    )
+    Constructing a ``WorkspaceDB`` runs schema initialization (and logs) on
+    every call, which is wasteful on the hot path of every tool
+    invocation. This factory memoizes that construction at module scope:
+    the first call builds the service and caches it in
+    ``_default_registry_instance``; subsequent calls return the cached
+    instance without touching the database again.
+
+    Thread safety: the cached ``LocalWorkspaceRegistryService`` instance is
+    shared across threads/calls, but ``WorkspaceDB`` opens a fresh
+    ``sqlite3`` connection per operation (see ``WorkspaceDB.connection`` /
+    ``WorkspaceDB.transaction``) rather than holding one open, so sharing
+    the service object does not share any live connection state and is
+    safe under concurrent tool calls.
+
+    Returns:
+        The cached (or newly constructed) ``LocalWorkspaceRegistryService``
+        backed by the default workspaces database.
+    """
+    global _default_registry_instance
+    if _default_registry_instance is not None:
+        return _default_registry_instance
+    with _default_registry_lock:
+        if _default_registry_instance is None:
+            from tldw_chatbook.config import get_workspaces_db_path
+            from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+            from tldw_chatbook.Workspaces import LocalWorkspaceRegistryService
+
+            _default_registry_instance = LocalWorkspaceRegistryService(
+                WorkspaceDB(get_workspaces_db_path(), client_id="file-tools")
+            )
+    return _default_registry_instance
 
 
 #: Test seam: monkeypatch with a factory returning a prepared registry.
@@ -38,7 +71,22 @@ _registry_factory = _default_registry_factory
 
 @contextmanager
 def run_workspace(workspace_id: str | None) -> Iterator[None]:
-    """Bind the current run's workspace for the duration of a tool call."""
+    """Bind the current run's workspace for the duration of a tool call.
+
+    Sets a context-local workspace id that ``allowed_file_roots`` and
+    ``current_run_workspace_id`` read for the lifetime of the ``with``
+    block, then restores whatever was bound before (or unbound), so nested
+    or sequential runs never leak each other's workspace binding.
+
+    Args:
+        workspace_id: Identifier of the workspace to bind for the run, or
+            ``None`` to explicitly bind "no workspace" (``allowed_file_roots``
+            then falls back to the active workspace).
+
+    Yields:
+        None. The wrapped block executes with ``workspace_id`` bound as the
+        current run's workspace.
+    """
     token = _RUN_WORKSPACE_ID.set(workspace_id)
     try:
         yield
@@ -47,6 +95,12 @@ def run_workspace(workspace_id: str | None) -> Iterator[None]:
 
 
 def current_run_workspace_id() -> str | None:
+    """Return the workspace id bound by the current ``run_workspace`` scope.
+
+    Returns:
+        The workspace id most recently bound via ``run_workspace`` for the
+        current run/task, or ``None`` if no run has bound one.
+    """
     return _RUN_WORKSPACE_ID.get()
 
 
@@ -54,7 +108,26 @@ def allowed_file_roots(*, write: bool, sandbox_root: Path) -> tuple[Path, ...]:
     """Sandbox root plus the run's workspace folder roots, existing-only.
 
     Fail-safe: any registry failure degrades to sandbox-only rather than
-    widening access.
+    widening access. Folder bindings are re-checked against the filesystem
+    on every call rather than trusting stored status: a bound folder that
+    has been deleted is dropped, and so is one whose path no longer
+    resolves to itself -- for example because it was replaced by a symlink
+    or the target of a mount after binding, which would otherwise silently
+    widen the sandboxed root at enforcement time (ADR-028).
+
+    Args:
+        write: Whether the caller needs write access. When True, only
+            folder bindings whose access metadata is ``"rw"`` are included;
+            read-only bindings are omitted entirely from the result.
+        sandbox_root: The tool's own sandbox root; always included first,
+            regardless of ``write``.
+
+    Returns:
+        A tuple of existing, non-symlinked directories the current run may
+        operate on: ``sandbox_root`` followed by zero or more bound
+        workspace folders in binding order. Falls back to
+        ``(sandbox_root,)`` alone if the workspace registry is unavailable,
+        raises, or no workspace is bound.
     """
     roots: list[Path] = [sandbox_root]
     try:
@@ -69,8 +142,17 @@ def allowed_file_roots(*, write: bool, sandbox_root: Path) -> tuple[Path, ...]:
             if write and str(binding.metadata.get("access", "ro")) != "rw":
                 continue
             folder = Path(binding.locator)
-            if folder.is_dir():
-                roots.append(folder)
+            if not folder.is_dir():
+                continue
+            if folder.is_symlink() or folder.resolve() != folder:
+                logger.warning(
+                    "Workspace folder root {!r} no longer resolves to its "
+                    "bound path (symlink or mount drift); excluding from "
+                    "allowed roots",
+                    binding.locator,
+                )
+                continue
+            roots.append(folder)
     except Exception:
         logger.opt(exception=True).warning(
             "Workspace folder roots unavailable; file tools confined to sandbox"

--- a/tldw_chatbook/Tools/workspace_file_roots.py
+++ b/tldw_chatbook/Tools/workspace_file_roots.py
@@ -1,0 +1,79 @@
+"""Run-bound workspace folder roots for the agent file tools.
+
+Spec: Docs/superpowers/specs/2026-07-26-settings-workspaces-category-design.md §3.
+The provider (`BuiltinToolProvider.invoke`) binds the run's workspace via
+``run_workspace``; the file tools ask ``allowed_file_roots`` at call time.
+Reads and writes are both confined to sandbox+roots (deliberate Codex
+divergence, ADR-028) and stored binding status is never trusted — existence
+is re-checked here on every call.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from pathlib import Path
+from typing import Iterator
+
+from loguru import logger
+
+_RUN_WORKSPACE_ID: ContextVar[str | None] = ContextVar(
+    "tldw_run_workspace_id", default=None
+)
+
+
+def _default_registry_factory():
+    from tldw_chatbook.config import get_workspaces_db_path
+    from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+    from tldw_chatbook.Workspaces import LocalWorkspaceRegistryService
+
+    return LocalWorkspaceRegistryService(
+        WorkspaceDB(get_workspaces_db_path(), client_id="file-tools")
+    )
+
+
+#: Test seam: monkeypatch with a factory returning a prepared registry.
+_registry_factory = _default_registry_factory
+
+
+@contextmanager
+def run_workspace(workspace_id: str | None) -> Iterator[None]:
+    """Bind the current run's workspace for the duration of a tool call."""
+    token = _RUN_WORKSPACE_ID.set(workspace_id)
+    try:
+        yield
+    finally:
+        _RUN_WORKSPACE_ID.reset(token)
+
+
+def current_run_workspace_id() -> str | None:
+    return _RUN_WORKSPACE_ID.get()
+
+
+def allowed_file_roots(*, write: bool, sandbox_root: Path) -> tuple[Path, ...]:
+    """Sandbox root plus the run's workspace folder roots, existing-only.
+
+    Fail-safe: any registry failure degrades to sandbox-only rather than
+    widening access.
+    """
+    roots: list[Path] = [sandbox_root]
+    try:
+        registry = _registry_factory()
+        workspace_id = current_run_workspace_id()
+        if workspace_id is None:
+            active = registry.get_active_workspace()
+            workspace_id = active.workspace_id if active is not None else None
+        if workspace_id is None:
+            return tuple(roots)
+        for binding in registry.list_folder_bindings(workspace_id):
+            if write and str(binding.metadata.get("access", "ro")) != "rw":
+                continue
+            folder = Path(binding.locator)
+            if folder.is_dir():
+                roots.append(folder)
+    except Exception:
+        logger.opt(exception=True).warning(
+            "Workspace folder roots unavailable; file tools confined to sandbox"
+        )
+        return (sandbox_root,)
+    return tuple(roots)

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -1623,7 +1623,7 @@ class ChatScreen(BaseAppScreen):
             return
         if not workspaces:
             self.app_instance.notify(
-                "Create one with the rail's New button or in Library > Details > Workspace.",
+                "Create one with the rail's New button or in Settings > Workspaces.",
                 severity="warning",
             )
             return

--- a/tldw_chatbook/UI/Screens/settings_config_models.py
+++ b/tldw_chatbook/UI/Screens/settings_config_models.py
@@ -16,6 +16,7 @@ class SettingsCategoryId(StrEnum):
     THEME = "theme"
     SPLASH_SCREEN = "splash_screen"
     STORAGE = "storage"
+    WORKSPACES = "workspaces"
     PRIVACY_SECURITY = "privacy-security"
     CONSOLE_BEHAVIOR = "console-behavior"
     LIBRARY_RAG = "library-rag"

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -56,6 +56,7 @@ from ...Sync_Interop.sync_readiness import (
 )
 from ...Sync_Interop.manual_sync_control import ManualSyncPreview, ManualSyncRunResult
 from ...Workspaces.display_state import LIBRARY_WORKSPACE_VISIBILITY_COPY
+from ...Workspaces.models import RuntimeBindingStatus
 from ...Workspaces.registry_service import (
     DEFAULT_WORKSPACE_ID,
     LocalWorkspaceRegistryService,
@@ -10213,6 +10214,61 @@ class SettingsScreen(BaseAppScreen):
                 yield Button(
                     "Archive", id="settings-workspace-archive", compact=True
                 )
+            yield from self._render_workspace_folder_bindings(registry, record.workspace_id)
+
+    def _render_workspace_folder_bindings(
+        self,
+        registry: LocalWorkspaceRegistryService,
+        workspace_id: str,
+    ) -> ComposeResult:
+        """Render the folder-bindings editor for the selected workspace (task 10).
+
+        One row per bound folder with its access level and freshness
+        (recomputed from disk by `list_folder_bindings`), a per-row
+        ro/rw toggle and remove button, then an add row. Toggle/remove
+        buttons stash `binding_id` as a plain attribute at compose time
+        (mirrors the conversation browser's `conversation_id` stash) so
+        the handler never has to parse a uuid out of the button id.
+        """
+        yield Static(
+            "Folders (agent file-tool access)", classes="destination-section"
+        )
+        for binding in registry.list_folder_bindings(workspace_id):
+            access = binding.metadata.get("access", "ro")
+            freshness = (
+                "ready" if binding.status == RuntimeBindingStatus.READY else "missing"
+            )
+            yield Static(
+                f"{binding.locator} [{access}] {freshness}",
+                id=f"settings-workspace-folder-{binding.binding_id}",
+                classes="settings-detail-row",
+            )
+            with Horizontal(classes="settings-input-row"):
+                toggle_button = Button(
+                    "Allow write" if access != "rw" else "Read-only",
+                    id=f"settings-workspace-folder-toggle-{binding.binding_id}",
+                    classes="settings-workspace-folder-toggle",
+                    compact=True,
+                )
+                toggle_button.binding_id = binding.binding_id
+                yield toggle_button
+                remove_button = Button(
+                    "Remove",
+                    id=f"settings-workspace-folder-remove-{binding.binding_id}",
+                    classes="settings-workspace-folder-remove",
+                    compact=True,
+                )
+                remove_button.binding_id = binding.binding_id
+                yield remove_button
+        with Horizontal(classes="settings-input-row"):
+            yield Input(
+                placeholder="~/path/to/folder",
+                id="settings-workspace-folder-path",
+                classes="settings-compact-input",
+            )
+            yield Button(
+                "Add folder", id="settings-workspace-folder-add", compact=True
+            )
 
     def _set_settings_workspaces_result(self, text: str) -> None:
         self._settings_workspaces_result = text
@@ -11790,6 +11846,80 @@ class SettingsScreen(BaseAppScreen):
             return
         try:
             registry.unarchive_workspace(workspace_id)
+        except WorkspaceRegistryServiceError as exc:
+            self._set_settings_workspaces_result(str(exc))
+            return
+        self._settings_workspaces_result = ""
+        self._refresh_settings_workspaces_pane()
+
+    @on(Button.Pressed, "#settings-workspace-folder-add")
+    def _settings_workspace_add_folder(self, event: Button.Pressed) -> None:
+        """Bind a folder as a read-only file-tool access root (task 10)."""
+        event.stop()
+        workspace_id = self._settings_selected_workspace_id
+        if not workspace_id:
+            return
+        registry = getattr(self.app_instance, "workspace_registry_service", None)
+        if registry is None:
+            return
+        raw = self.query_one("#settings-workspace-folder-path", Input).value
+        try:
+            registry.add_folder_binding(workspace_id, raw)
+        except WorkspaceRegistryServiceError as exc:
+            self._set_settings_workspaces_result(str(exc))
+            return
+        self._set_settings_workspaces_result("Folder added (read-only).")
+        self._refresh_settings_workspaces_pane()
+
+    @on(Button.Pressed, ".settings-workspace-folder-toggle")
+    def _settings_workspace_toggle_folder_access(self, event: Button.Pressed) -> None:
+        """Flip a folder binding between read-only and read-write (task 10).
+
+        The binding id is read from `event.button.binding_id`, stashed at
+        compose time -- never parsed out of the button's dom id, which
+        would split a uuid on its own hyphens.
+        """
+        event.stop()
+        workspace_id = self._settings_selected_workspace_id
+        if not workspace_id:
+            return
+        registry = getattr(self.app_instance, "workspace_registry_service", None)
+        if registry is None:
+            return
+        binding_id = str(getattr(event.button, "binding_id", "") or "")
+        if not binding_id:
+            return
+        current = next(
+            (
+                binding
+                for binding in registry.list_folder_bindings(workspace_id)
+                if binding.binding_id == binding_id
+            ),
+            None,
+        )
+        if current is None:
+            return
+        allow_write = current.metadata.get("access") != "rw"
+        try:
+            registry.set_folder_binding_access(binding_id, allow_write=allow_write)
+        except WorkspaceRegistryServiceError as exc:
+            self._set_settings_workspaces_result(str(exc))
+            return
+        self._settings_workspaces_result = ""
+        self._refresh_settings_workspaces_pane()
+
+    @on(Button.Pressed, ".settings-workspace-folder-remove")
+    def _settings_workspace_remove_folder(self, event: Button.Pressed) -> None:
+        """Unbind a folder from the selected workspace (task 10)."""
+        event.stop()
+        registry = getattr(self.app_instance, "workspace_registry_service", None)
+        if registry is None:
+            return
+        binding_id = str(getattr(event.button, "binding_id", "") or "")
+        if not binding_id:
+            return
+        try:
+            registry.remove_runtime_binding(binding_id)
         except WorkspaceRegistryServiceError as exc:
             self._set_settings_workspaces_result(str(exc))
             return

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -1844,10 +1844,21 @@ class SettingsScreen(BaseAppScreen):
     def on_screen_resume(self) -> None:
         self._queue_sync_rows_refresh()
         self._maybe_refresh_rag_index_status_on_show()
+        self._maybe_refresh_workspaces_pane_on_show()
 
     def _maybe_refresh_rag_index_status_on_show(self) -> None:
         if self._active_category_id() is SettingsCategoryId.LIBRARY_RAG:
             self._refresh_library_rag_index_status()
+
+    def _maybe_refresh_workspaces_pane_on_show(self) -> None:
+        """Task 11: pick up registry changes made while this screen was
+        suspended (e.g. a workspace created/archived from Console) as soon
+        as the user resumes back into the WORKSPACES category -- mirrors
+        `_maybe_refresh_rag_index_status_on_show`'s per-category resume
+        guard above.
+        """
+        if self._active_category_id() is SettingsCategoryId.WORKSPACES:
+            self._refresh_settings_workspaces_pane()
 
     def _queue_sync_rows_refresh(self) -> None:
         if not getattr(self, "is_mounted", False):
@@ -2204,10 +2215,9 @@ class SettingsScreen(BaseAppScreen):
                     value for _, value in SETTINGS_OVERVIEW_BOUNDARY_ROWS
                 ),
                 recovery_copy=(
-                    "Sync and workspace status here is read-only - switch "
-                    "workspaces in Console (Alt+W), manage them in "
-                    "Library > Details > Workspace, and run sync from the "
-                    "owning sync surfaces."
+                    "Sync status here is read-only - manage workspaces in "
+                    "Settings > Workspaces; switch in Console (Alt+W); run "
+                    "sync from the owning sync surfaces."
                 ),
                 read_only_reason="Overview summarizes status and ownership only.",
             ),

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -56,6 +56,12 @@ from ...Sync_Interop.sync_readiness import (
 )
 from ...Sync_Interop.manual_sync_control import ManualSyncPreview, ManualSyncRunResult
 from ...Workspaces.display_state import LIBRARY_WORKSPACE_VISIBILITY_COPY
+from ...Workspaces.registry_service import (
+    DEFAULT_WORKSPACE_ID,
+    LocalWorkspaceRegistryService,
+    WorkspaceRegistryServiceError,
+    next_local_workspace_identity,
+)
 from ...Widgets.confirmation_dialog import ConfirmationDialog
 from ...Widgets.destination_workbench import DestinationModeStrip
 from ...Chat.provider_catalog import (
@@ -1649,6 +1655,18 @@ class SettingsScreen(BaseAppScreen):
             "Appearance defaults have not been saved this session."
         )
         self._storage_result = "Storage defaults have not been saved this session."
+        #: Task 9 (workspace lifecycle card): the workspace row currently
+        #: selected in the list, or None when nothing is selected -- the
+        #: card renders nothing in that case. Reset whenever the user
+        #: navigates away from WORKSPACES (see _select_category) and
+        #: whenever a workspace is archived (its row disappears from the
+        #: default, not-showing-archived list).
+        self._settings_selected_workspace_id: str | None = None
+        #: Task 9: mirrors the "Show archived" checkbox; read directly by
+        #: `_render_workspaces_detail` on every (re)compose rather than
+        #: cached separately, so there is no stale-watcher state to wipe.
+        self._settings_show_archived_workspaces: bool = False
+        self._settings_workspaces_result = ""
         self._advanced_config_result = "Advanced config validation: not run"
         self._advanced_config_validated_text: str | None = None
         self._ownership_by_category_cache = self._build_ownership_by_category()
@@ -10095,10 +10113,128 @@ class SettingsScreen(BaseAppScreen):
             yield self._detail_row("Follow-up", contract.follow_up)
 
     def _render_workspaces_detail(self) -> ComposeResult:
-        # Stub pane (task-8): registers the category and its immediate-apply
-        # boundary (no Save/Revert draft state). Task 9 replaces this with
-        # the real workspace list + lifecycle card.
+        registry = getattr(self.app_instance, "workspace_registry_service", None)
         yield Static("Workspace management", classes="destination-section")
+        if registry is None:
+            yield Static(
+                "Workspace service is not ready. Restart Chatbook and retry.",
+                id="settings-workspaces-result",
+                classes="settings-status-row",
+            )
+            return
+        show_archived = bool(self._settings_show_archived_workspaces)
+        active = registry.get_active_workspace()
+        active_id = active.workspace_id if active is not None else None
+        with Horizontal(classes="settings-input-row"):
+            yield Input(
+                placeholder="New workspace name",
+                id="settings-workspace-create-name",
+                classes="settings-compact-input",
+            )
+            yield Button("Create", id="settings-workspace-create", compact=True)
+        yield Checkbox(
+            "Show archived", show_archived, id="settings-workspaces-show-archived"
+        )
+        with Vertical(id="settings-workspaces-list"):
+            for record in registry.list_workspaces(include_archived=show_archived):
+                marker = " (active)" if record.workspace_id == active_id else ""
+                archived_suffix = " [archived]" if record.archived else ""
+                folders = (
+                    len(registry.list_folder_bindings(record.workspace_id))
+                    if record.workspace_id != DEFAULT_WORKSPACE_ID
+                    else 0
+                )
+                yield Button(
+                    f"{record.name}{marker}{archived_suffix} - {folders} folders",
+                    id=f"settings-workspace-row-{record.workspace_id}",
+                    classes="settings-workspace-row",
+                    compact=True,
+                )
+        yield Static(
+            self._settings_workspaces_result,
+            id="settings-workspaces-result",
+            classes="settings-status-row",
+        )
+        yield from self._render_workspace_card(registry, active_id)
+
+    def _render_workspace_card(
+        self,
+        registry: LocalWorkspaceRegistryService,
+        active_id: str | None,
+    ) -> ComposeResult:
+        """Render the selected workspace's lifecycle card, if any (Task 9).
+
+        Renders nothing when no workspace is selected. The built-in Default
+        workspace gets ONLY the protection notice -- it keeps its identity
+        (no rename/archive) and stays tool-less (no folder bindings, see
+        Task 10). Every other workspace gets rename + set-active (or a
+        Static when it is already active -- never a disabled Button
+        expected to explain itself) + archive/unarchive.
+        """
+        workspace_id = self._settings_selected_workspace_id
+        if not workspace_id:
+            return
+        record = registry.get_workspace(workspace_id)
+        if record is None:
+            # The selection outlived its workspace (e.g. removed by another
+            # session) -- render nothing rather than a card for a ghost id.
+            return
+        yield Static("Selected workspace", classes="destination-section")
+        with Vertical(id="settings-workspace-card", classes="settings-focus-card"):
+            if record.workspace_id == DEFAULT_WORKSPACE_ID:
+                yield Static(
+                    "The built-in Default workspace keeps its identity and "
+                    "stays tool-less; create a workspace to bind folders.",
+                    classes="settings-detail-row",
+                )
+                return
+            with Horizontal(classes="settings-input-row"):
+                yield Input(
+                    value=record.name,
+                    id="settings-workspace-rename-input",
+                    classes="settings-compact-input",
+                )
+                yield Button(
+                    "Rename", id="settings-workspace-rename-apply", compact=True
+                )
+            if record.workspace_id == active_id:
+                yield Static(
+                    "This workspace is active.", classes="settings-detail-row"
+                )
+            else:
+                yield Button(
+                    "Set active", id="settings-workspace-set-active", compact=True
+                )
+            if record.archived:
+                yield Button(
+                    "Unarchive", id="settings-workspace-unarchive", compact=True
+                )
+            else:
+                yield Button(
+                    "Archive", id="settings-workspace-archive", compact=True
+                )
+
+    def _set_settings_workspaces_result(self, text: str) -> None:
+        self._settings_workspaces_result = text
+        self._set_static_text("#settings-workspaces-result", text)
+
+    def _refresh_settings_workspaces_pane(self) -> None:
+        """Re-render the Workspaces category via the screen's existing
+        category-recompose path (task 9).
+
+        `active_category` is a `recompose=True` reactive that already
+        drives every category switch (`_select_category`); forcing it here
+        with `mutate_reactive` reuses that same, already-proven path
+        instead of recomposing a bespoke nested container (Textual only
+        regenerates a widget's children from ITS OWN `compose()` -- a
+        generic `Vertical` yielded inline here has none, so recomposing it
+        directly would just wipe it). `_render_workspaces_detail` reads
+        the registry plus the plain `_settings_selected_workspace_id` /
+        `_settings_show_archived_workspaces` attributes fresh on every
+        call, so there is no separate watcher-populated cache that could
+        go stale or get wiped by the recompose.
+        """
+        self.mutate_reactive(SettingsScreen.active_category)
 
     def _render_detail_pane(self) -> ComposeResult:
         category = SettingsCategoryId(self.active_category)
@@ -11133,6 +11269,12 @@ class SettingsScreen(BaseAppScreen):
         # category -- e.g. the user backs out mid-fetch. Unconditional
         # reset; a no-op for every category but LIBRARY_RAG.
         self._rag_reindex_confirm_in_flight = False
+        if category_value != SettingsCategoryId.WORKSPACES.value:
+            # Task 9: leaving the category recomposes the detail pane from
+            # scratch -- a selection that survived would point the freshly
+            # (re)composed card at a workspace id a later visit's list may
+            # not even show (e.g. after an archive elsewhere).
+            self._settings_selected_workspace_id = None
         self.active_category = category_value
         # Task 6 (541 AC6): keep the footer's a/c/b hint in sync with a
         # live in-session category switch (on_mount's call alone only
@@ -11503,6 +11645,156 @@ class SettingsScreen(BaseAppScreen):
         category_value = self._category_value_from_button(event.button)
         if category_value is not None:
             self._select_category(category_value, restore_focus=event.button.has_focus)
+
+    @on(Button.Pressed, ".settings-workspace-row")
+    def handle_workspace_row_pressed(self, event: Button.Pressed) -> None:
+        """Select a workspace row, then refresh so its card renders (task 9)."""
+        event.stop()
+        button_id = str(getattr(event.button, "id", "") or "")
+        prefix = "settings-workspace-row-"
+        if not button_id.startswith(prefix):
+            return
+        workspace_id = button_id.removeprefix(prefix)
+        if not workspace_id:
+            return
+        self._settings_selected_workspace_id = workspace_id
+        self._settings_workspaces_result = ""
+        self._refresh_settings_workspaces_pane()
+
+    @on(Checkbox.Changed, "#settings-workspaces-show-archived")
+    def handle_workspaces_show_archived_changed(self, event: Checkbox.Changed) -> None:
+        event.stop()
+        self._settings_show_archived_workspaces = event.value
+        self._refresh_settings_workspaces_pane()
+
+    @on(Button.Pressed, "#settings-workspace-create")
+    def handle_workspace_create(self, event: Button.Pressed) -> None:
+        """Create a workspace from the typed name, or a generated one when
+        left blank -- the id always comes from `next_local_workspace_identity`
+        (task 9)."""
+        event.stop()
+        registry = getattr(self.app_instance, "workspace_registry_service", None)
+        if registry is None:
+            return
+        try:
+            name_input = self.query_one("#settings-workspace-create-name", Input)
+        except QueryError:
+            return
+        typed_name = name_input.value.strip()
+        workspace_id, generated_name = next_local_workspace_identity(registry)
+        try:
+            registry.create_workspace(
+                workspace_id=workspace_id, name=typed_name or generated_name
+            )
+        except WorkspaceRegistryServiceError as exc:
+            self._set_settings_workspaces_result(str(exc))
+            return
+        self._settings_workspaces_result = ""
+        self._refresh_settings_workspaces_pane()
+
+    @on(Button.Pressed, "#settings-workspace-rename-apply")
+    def handle_workspace_rename_apply(self, event: Button.Pressed) -> None:
+        event.stop()
+        workspace_id = self._settings_selected_workspace_id
+        if not workspace_id:
+            return
+        registry = getattr(self.app_instance, "workspace_registry_service", None)
+        if registry is None:
+            return
+        try:
+            rename_input = self.query_one("#settings-workspace-rename-input", Input)
+        except QueryError:
+            return
+        try:
+            registry.rename_workspace(workspace_id, rename_input.value)
+        except WorkspaceRegistryServiceError as exc:
+            self._set_settings_workspaces_result(str(exc))
+            return
+        self._settings_workspaces_result = ""
+        self._refresh_settings_workspaces_pane()
+
+    @on(Button.Pressed, "#settings-workspace-set-active")
+    def handle_workspace_set_active(self, event: Button.Pressed) -> None:
+        event.stop()
+        workspace_id = self._settings_selected_workspace_id
+        if not workspace_id:
+            return
+        registry = getattr(self.app_instance, "workspace_registry_service", None)
+        if registry is None:
+            return
+        try:
+            registry.set_active_workspace(workspace_id)
+        except WorkspaceRegistryServiceError as exc:
+            self._set_settings_workspaces_result(str(exc))
+            return
+        self._settings_workspaces_result = ""
+        self._refresh_settings_workspaces_pane()
+
+    @on(Button.Pressed, "#settings-workspace-archive")
+    def handle_workspace_archive(self, event: Button.Pressed) -> None:
+        """Confirm, then archive (task 9).
+
+        Mirrors `ChatScreen._confirm_console_workspace_archive` (Console's
+        own archive flow): the SAME verbatim copy, and the SAME shape --
+        an async closure passed as `confirm_callback`, since
+        `ConfirmationDialog.on_button_pressed` `await`s that callback and a
+        plain sync function would raise there instead of archiving.
+        """
+        event.stop()
+        workspace_id = self._settings_selected_workspace_id
+        if not workspace_id:
+            return
+        registry = getattr(self.app_instance, "workspace_registry_service", None)
+        if registry is None:
+            return
+        record = registry.get_workspace(workspace_id)
+        if record is None:
+            return
+
+        async def _archive() -> None:
+            try:
+                registry.archive_workspace(workspace_id)
+            except WorkspaceRegistryServiceError as exc:
+                self._set_settings_workspaces_result(str(exc))
+                return
+            # The row disappears from the default (not-showing-archived)
+            # list -- a selection surviving would point the card at a
+            # workspace no longer in view.
+            self._settings_selected_workspace_id = None
+            self._settings_workspaces_result = ""
+            self._refresh_settings_workspaces_pane()
+
+        self.app.push_screen(
+            ConfirmationDialog(
+                title="Archive workspace?",
+                message=(
+                    f"Archive {record.name}? Its conversations stay saved and "
+                    "remain visible in Library; the workspace disappears from "
+                    "the switcher and the Console browser."
+                ),
+                confirm_label="Archive",
+                confirm_callback=_archive,
+            )
+        )
+
+    @on(Button.Pressed, "#settings-workspace-unarchive")
+    def handle_workspace_unarchive(self, event: Button.Pressed) -> None:
+        """Restore a workspace to the default listing without activating it
+        (spec: never auto-activate on unarchive, task 9)."""
+        event.stop()
+        workspace_id = self._settings_selected_workspace_id
+        if not workspace_id:
+            return
+        registry = getattr(self.app_instance, "workspace_registry_service", None)
+        if registry is None:
+            return
+        try:
+            registry.unarchive_workspace(workspace_id)
+        except WorkspaceRegistryServiceError as exc:
+            self._set_settings_workspaces_result(str(exc))
+            return
+        self._settings_workspaces_result = ""
+        self._refresh_settings_workspaces_pane()
 
     @on(Input.Changed, "#settings-category-search")
     def handle_category_search_changed(self, event: Input.Changed) -> None:

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -3472,6 +3472,11 @@ class SettingsScreen(BaseAppScreen):
             return "Use the editor's Apply/Save/Reset buttons to manage themes."
         if category == SettingsCategoryId.SPLASH_SCREEN:
             return "Splash defaults are saved automatically."
+        if category == SettingsCategoryId.WORKSPACES:
+            return (
+                "Immediate actions: workspace changes apply as you make them; "
+                "there is no draft to save or revert."
+            )
         if category == SettingsCategoryId.INTERNAL_PROMPTS:
             return "Use each prompt's Save / Reset buttons in the editor to manage overrides."
         if category == SettingsCategoryId.IMAGE_GENERATION:
@@ -4732,7 +4737,7 @@ class SettingsScreen(BaseAppScreen):
         # TASK-719: name the concrete owning surfaces instead of a vague list.
         return (
             "Local Default; switch in Console (Alt+W), "
-            "manage in Library > Details > Workspace"
+            "manage in Settings > Workspaces"
         )
 
     def _acp_runtime_session_state(self) -> ACPRuntimeSessionState:
@@ -10178,9 +10183,12 @@ class SettingsScreen(BaseAppScreen):
         Renders nothing when no workspace is selected. The built-in Default
         workspace gets ONLY the protection notice -- it keeps its identity
         (no rename/archive) and stays tool-less (no folder bindings, see
-        Task 10). Every other workspace gets rename + set-active (or a
-        Static when it is already active -- never a disabled Button
-        expected to explain itself) + archive/unarchive.
+        Task 10). An archived workspace (final review Finding 3) gets ONLY
+        an explanatory note + Unarchive -- rename/set-active/archive/folder
+        controls are withheld since they act on a workspace_id that is
+        currently archived. Every other workspace gets rename + set-active
+        (or a Static when it is already active -- never a disabled Button
+        expected to explain itself) + archive + folder bindings.
         """
         workspace_id = self._settings_selected_workspace_id
         if not workspace_id:
@@ -10197,6 +10205,22 @@ class SettingsScreen(BaseAppScreen):
                     "The built-in Default workspace keeps its identity and "
                     "stays tool-less; create a workspace to bind folders.",
                     classes="settings-detail-row",
+                )
+                return
+            if record.archived:
+                # Finding 3 (final review): rename/set-active/archive/folder
+                # controls all require an ACTIVE workspace_id underneath --
+                # offering them here let a user hit a bare-id error acting
+                # on a workspace that is currently invisible everywhere
+                # else. Unarchive first restores it to normal editing.
+                yield Static(
+                    "Archived workspace. Unarchive it to rename, activate, "
+                    "or edit folders.",
+                    id="settings-workspace-archived-note",
+                    classes="settings-status-row",
+                )
+                yield Button(
+                    "Unarchive", id="settings-workspace-unarchive", compact=True
                 )
                 return
             with Horizontal(classes="settings-input-row"):
@@ -10216,14 +10240,9 @@ class SettingsScreen(BaseAppScreen):
                 yield Button(
                     "Set active", id="settings-workspace-set-active", compact=True
                 )
-            if record.archived:
-                yield Button(
-                    "Unarchive", id="settings-workspace-unarchive", compact=True
-                )
-            else:
-                yield Button(
-                    "Archive", id="settings-workspace-archive", compact=True
-                )
+            yield Button(
+                "Archive", id="settings-workspace-archive", compact=True
+            )
             yield from self._render_workspace_folder_bindings(registry, record.workspace_id)
 
     def _render_workspace_folder_bindings(

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -903,6 +903,20 @@ _INSPECTOR_GUIDANCE: dict[SettingsCategoryId, tuple[tuple[str, str], ...]] = {
             "server handoff does not move local source content unless explicitly requested",
         ),
     ),
+    SettingsCategoryId.WORKSPACES: (
+        (
+            "Affected config",
+            "workspace lifecycle records and their bound folders",
+        ),
+        (
+            "Recovery",
+            "switch/rename/archive in Console (Alt+W); create a workspace in Library",
+        ),
+        (
+            "Boundary",
+            "lifecycle and folder bindings apply immediately; there is no draft state here",
+        ),
+    ),
     SettingsCategoryId.PRIVACY_SECURITY: (
         (
             "Affected config",
@@ -1885,6 +1899,12 @@ class SettingsScreen(BaseAppScreen):
                 "Guided",
             ),
             SettingsCategorySummary(
+                SettingsCategoryId.WORKSPACES,
+                "Workspaces",
+                "Create, rename, archive, and bind folders for agent file tools.",
+                "Immediate actions",
+            ),
+            SettingsCategorySummary(
                 SettingsCategoryId.PRIVACY_SECURITY,
                 "Privacy & Security",
                 "Secrets, encryption, redaction, and local privacy boundaries.",
@@ -2027,6 +2047,7 @@ class SettingsScreen(BaseAppScreen):
                 "Data & Privacy",
                 (
                     SettingsCategoryId.STORAGE,
+                    SettingsCategoryId.WORKSPACES,
                     SettingsCategoryId.PRIVACY_SECURITY,
                 ),
             ),
@@ -2270,6 +2291,19 @@ class SettingsScreen(BaseAppScreen):
                 recovery_copy=(
                     "Validate paths, save the config-only change, then restart Chatbook to "
                     "activate new storage defaults."
+                ),
+            ),
+            SettingsOwnershipRecord(
+                category=SettingsCategoryId.WORKSPACES,
+                owns_config_sections=(),
+                reads_runtime_state_from=("workspace registry",),
+                writes_allowed=True,
+                runtime_owner="Workspace registry (immediate actions)",
+                boundary_copy=(
+                    "Lifecycle and folder bindings apply immediately; no draft state."
+                ),
+                recovery_copy=(
+                    "Quick actions: switch/rename/archive in Console (Alt+W); create in Library."
                 ),
             ),
             SettingsOwnershipRecord(
@@ -10060,6 +10094,12 @@ class SettingsScreen(BaseAppScreen):
                 yield self._detail_row(label, value)
             yield self._detail_row("Follow-up", contract.follow_up)
 
+    def _render_workspaces_detail(self) -> ComposeResult:
+        # Stub pane (task-8): registers the category and its immediate-apply
+        # boundary (no Save/Revert draft state). Task 9 replaces this with
+        # the real workspace list + lifecycle card.
+        yield Static("Workspace management", classes="destination-section")
+
     def _render_detail_pane(self) -> ComposeResult:
         category = SettingsCategoryId(self.active_category)
         if category is SettingsCategoryId.OVERVIEW:
@@ -10315,6 +10355,8 @@ class SettingsScreen(BaseAppScreen):
                     "Handoff boundary",
                     "database and media paths remain local unless a server handoff is explicit",
                 )
+        elif category is SettingsCategoryId.WORKSPACES:
+            yield from self._render_workspaces_detail()
         elif category is SettingsCategoryId.PRIVACY_SECURITY:
             posture = self._settings_privacy_posture()
             yield Static(
@@ -10562,6 +10604,7 @@ class SettingsScreen(BaseAppScreen):
             SettingsCategoryId.SPLASH_SCREEN,
             SettingsCategoryId.INTERNAL_PROMPTS,
             SettingsCategoryId.IMAGE_GENERATION,
+            SettingsCategoryId.WORKSPACES,
         ):
             save_button = Button(
                 "Save",
@@ -13463,6 +13506,7 @@ class SettingsScreen(BaseAppScreen):
             SettingsCategoryId.THEME,
             SettingsCategoryId.SPLASH_SCREEN,
             SettingsCategoryId.INTERNAL_PROMPTS,
+            SettingsCategoryId.WORKSPACES,
         ):
             self.app.notify(
                 "Use the editor's own buttons for this category", severity="information"

--- a/tldw_chatbook/Utils/path_validation.py
+++ b/tldw_chatbook/Utils/path_validation.py
@@ -8,7 +8,7 @@ escape allowed directories.
 import os
 import time
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Sequence, Union
 from loguru import logger
 from ..Metrics.metrics_logger import log_counter, log_histogram
 
@@ -361,3 +361,40 @@ def validate_path_simple(
         if isinstance(e, ValueError):
             raise
         raise ValueError(f"Invalid path: {user_path}")
+
+
+def validate_path_multi(
+    user_path: Union[str, Path], roots: Sequence[Union[str, Path]]
+) -> Path:
+    """Validate ``user_path`` against several allowed roots (first match wins).
+
+    Relative paths resolve against ``roots[0]`` (the primary root — callers
+    pass the tool sandbox first so legacy relative-path behavior is
+    unchanged). The rejection message names every consulted root so a
+    denial is actionable.
+
+    Args:
+        user_path: The path provided by the user or model.
+        roots: Allowed base directories, in priority order.
+
+    Returns:
+        The validated absolute path.
+
+    Raises:
+        ValueError: No roots given, or the path escapes all of them.
+    """
+    root_list = [Path(root) for root in roots]
+    if not root_list:
+        raise ValueError("No allowed roots configured for path validation.")
+    candidate = Path(user_path)
+    for index, root in enumerate(root_list):
+        if index > 0 and not candidate.is_absolute():
+            continue  # relative paths anchor to the primary root only
+        try:
+            return validate_path(user_path, root)
+        except ValueError:
+            continue
+    consulted = ", ".join(str(root.resolve()) for root in root_list)
+    raise ValueError(
+        f"Path '{user_path}' is outside every allowed root ({consulted})."
+    )

--- a/tldw_chatbook/Workspaces/__init__.py
+++ b/tldw_chatbook/Workspaces/__init__.py
@@ -41,12 +41,13 @@ from .models import (
     WorkspaceSyncStatus,
     WorkspaceTransferPolicy,
 )
-from .registry_service import LocalWorkspaceRegistryService
+from .registry_service import BindingNotFound, LocalWorkspaceRegistryService
 
 __all__ = [
     "CONSOLE_CONVERSATION_BROWSER_GROUP_ROW_LIMIT",
     "CONSOLE_CONVERSATION_BROWSER_RESULT_LIMIT",
     "CONSOLE_WORKSPACE_CONVERSATION_RESULT_LIMIT",
+    "BindingNotFound",
     "ConsoleConversationBrowserGroup",
     "ConsoleConversationBrowserInputRow",
     "ConsoleConversationBrowserRow",

--- a/tldw_chatbook/Workspaces/display_state.py
+++ b/tldw_chatbook/Workspaces/display_state.py
@@ -391,7 +391,7 @@ def build_console_workspace_state(
             change_workspace_recovery=(
                 ""
                 if can_switch
-                else "Create one with the rail's New button or in Library > Details > Workspace."
+                else "Create one with the rail's New button or in Settings > Workspaces."
             ),
             new_conversation_enabled=True,
             new_conversation_recovery="",

--- a/tldw_chatbook/Workspaces/display_state.py
+++ b/tldw_chatbook/Workspaces/display_state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable, Mapping
 
 from loguru import logger
@@ -15,6 +16,7 @@ from tldw_chatbook.Sync_Interop.sync_readiness import (
 
 from .models import (
     DEFAULT_WORKSPACE_ID,
+    RuntimeBindingKind,
     RuntimeBindingStatus,
     WorkspaceAuthority,
     WorkspaceMembership,
@@ -620,12 +622,65 @@ def _safe_runtime_bindings(
         )
         if not runtime_bindings:
             return ()
-        return tuple(runtime_bindings)
+        return tuple(
+            _recompute_filesystem_binding_status(binding)
+            for binding in runtime_bindings
+        )
     except Exception:
         logger.opt(exception=True).warning(
             "Failed to read workspace runtime bindings for Console context rail",
         )
         return ()
+
+
+def _recompute_filesystem_binding_status(
+    binding: WorkspaceRuntimeBinding,
+) -> WorkspaceRuntimeBinding:
+    """Recompute a local-filesystem binding's status straight from disk.
+
+    Stored ``status`` is display-only and is never trusted for
+    local-filesystem bindings here: the bound folder may have been
+    deleted, or replaced by a symlink/mount that resolves somewhere else,
+    which would otherwise let the Console context rail keep reporting a
+    widened root as "ready" (ADR-028). Non local-filesystem bindings are
+    returned unchanged.
+
+    Args:
+        binding: The runtime binding to check.
+
+    Returns:
+        ``binding`` unchanged if it is not a local-filesystem binding or
+        its recomputed status matches the stored one; otherwise a copy with
+        ``status`` set to MISSING (folder gone, a symlink, or its resolved
+        path no longer matches its own stored, already-resolved locator)
+        or READY.
+    """
+    if str(binding.binding_kind) not in (
+        "local-filesystem",
+        str(RuntimeBindingKind.LOCAL_FILESYSTEM),
+    ):
+        return binding
+    folder = Path(binding.locator)
+    is_missing = True
+    if folder.is_dir() and not folder.is_symlink():
+        try:
+            is_missing = folder.resolve() != folder
+        except OSError:
+            is_missing = True
+    status = RuntimeBindingStatus.MISSING if is_missing else RuntimeBindingStatus.READY
+    if status == binding.status:
+        return binding
+    return WorkspaceRuntimeBinding(
+        workspace_id=binding.workspace_id,
+        binding_id=binding.binding_id,
+        binding_kind=binding.binding_kind,
+        label=binding.label,
+        locator=binding.locator,
+        status=status,
+        metadata=binding.metadata,
+        created_at=binding.created_at,
+        updated_at=binding.updated_at,
+    )
 
 
 def _safe_workspaces(registry_service: Any) -> tuple[WorkspaceRecord, ...]:

--- a/tldw_chatbook/Workspaces/display_state.py
+++ b/tldw_chatbook/Workspaces/display_state.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable, Mapping
 

--- a/tldw_chatbook/Workspaces/registry_service.py
+++ b/tldw_chatbook/Workspaces/registry_service.py
@@ -78,6 +78,7 @@ class LocalWorkspaceRegistryService:
             created_at=now,
             updated_at=now,
         )
+        self._reject_duplicate_name(record.name)
         try:
             with self.db.transaction() as conn:
                 conn.execute(
@@ -183,6 +184,7 @@ class LocalWorkspaceRegistryService:
         safe_name = str(name or "").strip()
         if not safe_name:
             raise WorkspaceRegistryServiceError("Workspace name cannot be blank.")
+        self._reject_duplicate_name(safe_name, exclude_workspace_id=safe_workspace_id)
         if safe_workspace_id == DEFAULT_WORKSPACE_ID:
             raise WorkspaceRegistryServiceError(
                 "The Default workspace cannot be renamed."
@@ -256,6 +258,53 @@ class LocalWorkspaceRegistryService:
         if archived is None:
             raise WorkspaceRegistryServiceError("Workspace archive failed.")
         return archived
+
+    def unarchive_workspace(self, workspace_id: str) -> WorkspaceRecord:
+        """Restore an archived workspace to listings (spec §2).
+
+        Never auto-activates: the user chooses when to switch.
+
+        Raises:
+            WorkspaceNotFound: Unknown or not-archived workspace.
+            WorkspaceRegistryServiceError: Storage failure.
+        """
+        safe_workspace_id = _normalize_required_text(workspace_id, "workspace_id")
+        record = self.get_workspace(safe_workspace_id)
+        if record is None or not record.archived:
+            raise WorkspaceNotFound(safe_workspace_id)
+        now = self._now_factory()
+        try:
+            with self.db.transaction() as conn:
+                conn.execute(
+                    """
+                    UPDATE workspace_records
+                    SET archived = 0, updated_at = ?
+                    WHERE workspace_id = ?
+                    """,
+                    (now, safe_workspace_id),
+                )
+        except sqlite3.Error as exc:
+            raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
+        restored = self.get_workspace(safe_workspace_id)
+        if restored is None:
+            raise WorkspaceRegistryServiceError("Workspace unarchive failed.")
+        return restored
+
+    def _reject_duplicate_name(
+        self, name: str, *, exclude_workspace_id: str | None = None
+    ) -> None:
+        """Raise when a non-archived workspace already uses ``name``.
+
+        Case-insensitive; archived workspaces do not block reuse (spec §2).
+        """
+        needle = name.strip().casefold()
+        for record in self.list_workspaces():
+            if exclude_workspace_id and record.workspace_id == exclude_workspace_id:
+                continue
+            if str(record.name or "").strip().casefold() == needle:
+                raise WorkspaceRegistryServiceError(
+                    f"A workspace named {name} already exists."
+                )
 
     def set_active_workspace(self, workspace_id: str) -> WorkspaceRecord:
         """Set exactly one active workspace."""

--- a/tldw_chatbook/Workspaces/registry_service.py
+++ b/tldw_chatbook/Workspaces/registry_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 import json
+from pathlib import Path
 import sqlite3
 from uuid import uuid4
 
@@ -41,6 +42,14 @@ class WorkspaceNotFound(WorkspaceRegistryServiceError):
 
 class DuplicateWorkspace(WorkspaceRegistryServiceError):
     """Raised when a workspace id already exists."""
+
+
+class BindingNotFound(WorkspaceRegistryServiceError):
+    """Raised when a runtime binding id does not exist."""
+
+    def __init__(self, binding_id: str) -> None:
+        super().__init__(f"Runtime binding not found: {binding_id}")
+        self.binding_id = binding_id
 
 
 class LocalWorkspaceRegistryService:
@@ -617,6 +626,138 @@ class LocalWorkspaceRegistryService:
         if stored is None:
             raise WorkspaceRegistryServiceError("Runtime binding save failed.")
         return stored
+
+    def add_folder_binding(
+        self,
+        workspace_id: str,
+        path: str | Path,
+        *,
+        allow_write: bool = False,
+    ) -> WorkspaceRuntimeBinding:
+        """Bind a folder as a file-tool access root (spec §2).
+
+        Read-only by default; canonical (resolved) locator; denies the
+        filesystem root, the home directory itself, non-directories, and
+        duplicate/nested roots within the same workspace. Default-workspace
+        and unknown-workspace rejection is delegated to
+        ``save_runtime_binding``.
+        """
+        candidate = Path(path).expanduser()
+        try:
+            resolved = candidate.resolve()
+        except OSError as exc:
+            raise WorkspaceRegistryServiceError(
+                f"Folder path could not be resolved: {candidate}"
+            ) from exc
+        if not resolved.is_dir():
+            raise WorkspaceRegistryServiceError(
+                f"Folder does not exist or is not a directory: {resolved}"
+            )
+        if resolved == Path(resolved.anchor):
+            raise WorkspaceRegistryServiceError(
+                "The filesystem root cannot be bound to a workspace."
+            )
+        if resolved == Path.home().resolve():
+            raise WorkspaceRegistryServiceError(
+                "Your home directory itself cannot be bound; choose a "
+                "project folder inside it."
+            )
+        for existing in self.list_folder_bindings(workspace_id):
+            existing_path = Path(existing.locator)
+            if resolved == existing_path:
+                raise WorkspaceRegistryServiceError(
+                    f"{resolved} is already bound to this workspace."
+                )
+            if existing_path in resolved.parents:
+                raise WorkspaceRegistryServiceError(
+                    f"{resolved} is inside the already-bound folder "
+                    f"{existing_path}."
+                )
+            if resolved in existing_path.parents:
+                raise WorkspaceRegistryServiceError(
+                    f"The already-bound folder {existing_path} is inside "
+                    f"{resolved}; remove it first."
+                )
+        binding = WorkspaceRuntimeBinding(
+            workspace_id=workspace_id,
+            binding_id=f"folder-{uuid4().hex[:12]}",
+            binding_kind=RuntimeBindingKind.LOCAL_FILESYSTEM,
+            label=resolved.name or str(resolved),
+            locator=str(resolved),
+            status=RuntimeBindingStatus.READY,
+            metadata={"access": "rw" if allow_write else "ro"},
+        )
+        return self.save_runtime_binding(binding)
+
+    def list_folder_bindings(
+        self, workspace_id: str
+    ) -> tuple[WorkspaceRuntimeBinding, ...]:
+        """Local-filesystem bindings with status recomputed from disk."""
+        bindings = self.list_runtime_bindings(workspace_id)
+        # Filter to only local-filesystem bindings
+        filtered = [
+            b
+            for b in bindings
+            if str(b.binding_kind)
+            in ("local-filesystem", str(RuntimeBindingKind.LOCAL_FILESYSTEM))
+        ]
+        refreshed: list[WorkspaceRuntimeBinding] = []
+        for binding in filtered:
+            actual = (
+                RuntimeBindingStatus.READY
+                if Path(binding.locator).is_dir()
+                else RuntimeBindingStatus.MISSING
+            )
+            refreshed.append(
+                WorkspaceRuntimeBinding(
+                    workspace_id=binding.workspace_id,
+                    binding_id=binding.binding_id,
+                    binding_kind=binding.binding_kind,
+                    label=binding.label,
+                    locator=binding.locator,
+                    status=actual,
+                    metadata=binding.metadata,
+                    created_at=binding.created_at,
+                    updated_at=binding.updated_at,
+                )
+            )
+        return tuple(refreshed)
+
+    def remove_runtime_binding(self, binding_id: str) -> None:
+        """Delete a runtime binding row (spec §2)."""
+        safe_binding_id = _normalize_required_text(binding_id, "binding_id")
+        try:
+            with self.db.transaction() as conn:
+                cursor = conn.execute(
+                    "DELETE FROM workspace_runtime_bindings WHERE binding_id = ?",
+                    (safe_binding_id,),
+                )
+        except sqlite3.Error as exc:
+            raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
+        if cursor.rowcount == 0:
+            raise BindingNotFound(safe_binding_id)
+
+    def set_folder_binding_access(
+        self, binding_id: str, *, allow_write: bool
+    ) -> WorkspaceRuntimeBinding:
+        """Flip a folder binding's ro/rw access flag (spec §4 toggle)."""
+        existing = self.get_runtime_binding(binding_id)
+        if existing is None:
+            raise BindingNotFound(binding_id)
+        metadata = dict(existing.metadata)
+        metadata["access"] = "rw" if allow_write else "ro"
+        return self.save_runtime_binding(
+            WorkspaceRuntimeBinding(
+                workspace_id=existing.workspace_id,
+                binding_id=existing.binding_id,
+                binding_kind=existing.binding_kind,
+                label=existing.label,
+                locator=existing.locator,
+                status=existing.status,
+                metadata=metadata,
+                created_at=existing.created_at,
+            )
+        )
 
     def get_runtime_binding(self, binding_id: str) -> WorkspaceRuntimeBinding | None:
         """Return one runtime binding if it exists."""

--- a/tldw_chatbook/Workspaces/registry_service.py
+++ b/tldw_chatbook/Workspaces/registry_service.py
@@ -32,6 +32,34 @@ from .models import (
 _STORAGE_FAILURE_MESSAGE = "Workspace registry storage failed."
 
 
+def _filesystem_binding_missing(locator: str) -> bool:
+    """Whether a local-filesystem binding's locator no longer resolves safely.
+
+    A bound folder counts as missing not only once it no longer exists, but
+    also once the path has been replaced by a symlink or its resolved form
+    no longer matches the stored locator. ``add_folder_binding`` always
+    stores an already-resolved path, so any drift here means a symlink or
+    mount trick appeared along the path after binding -- trusting it could
+    silently widen the sandboxed root at enforcement time (ADR-028).
+
+    Args:
+        locator: The binding's stored (already-resolved) folder path.
+
+    Returns:
+        True if the locator no longer points at a real, non-symlinked
+        directory matching its own resolved form; False otherwise.
+    """
+    folder = Path(locator)
+    if folder.is_symlink():
+        return True
+    if not folder.is_dir():
+        return True
+    try:
+        return folder.resolve() != folder
+    except OSError:
+        return True
+
+
 class WorkspaceRegistryServiceError(Exception):
     """Base exception for workspace registry failures."""
 
@@ -704,9 +732,9 @@ class LocalWorkspaceRegistryService:
         refreshed: list[WorkspaceRuntimeBinding] = []
         for binding in filtered:
             actual = (
-                RuntimeBindingStatus.READY
-                if Path(binding.locator).is_dir()
-                else RuntimeBindingStatus.MISSING
+                RuntimeBindingStatus.MISSING
+                if _filesystem_binding_missing(binding.locator)
+                else RuntimeBindingStatus.READY
             )
             refreshed.append(
                 WorkspaceRuntimeBinding(

--- a/tldw_chatbook/Workspaces/registry_service.py
+++ b/tldw_chatbook/Workspaces/registry_service.py
@@ -109,6 +109,10 @@ class LocalWorkspaceRegistryService:
                     ),
                 )
         except sqlite3.IntegrityError as exc:
+            if "idx_workspace_records_name_ci" in str(exc):
+                raise WorkspaceRegistryServiceError(
+                    f"A workspace named {record.name} already exists."
+                ) from exc
             raise DuplicateWorkspace(record.workspace_id) from exc
         except sqlite3.Error as exc:
             raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
@@ -184,7 +188,6 @@ class LocalWorkspaceRegistryService:
         safe_name = str(name or "").strip()
         if not safe_name:
             raise WorkspaceRegistryServiceError("Workspace name cannot be blank.")
-        self._reject_duplicate_name(safe_name, exclude_workspace_id=safe_workspace_id)
         if safe_workspace_id == DEFAULT_WORKSPACE_ID:
             raise WorkspaceRegistryServiceError(
                 "The Default workspace cannot be renamed."
@@ -192,6 +195,7 @@ class LocalWorkspaceRegistryService:
         record = self.get_workspace(safe_workspace_id)
         if record is None or record.archived:
             raise WorkspaceNotFound(safe_workspace_id)
+        self._reject_duplicate_name(safe_name, exclude_workspace_id=safe_workspace_id)
         now = self._now_factory()
         try:
             with self.db.transaction() as conn:
@@ -203,6 +207,10 @@ class LocalWorkspaceRegistryService:
                     """,
                     (safe_name, now, safe_workspace_id),
                 )
+        except sqlite3.IntegrityError as exc:
+            raise WorkspaceRegistryServiceError(
+                f"A workspace named {safe_name} already exists."
+            ) from exc
         except sqlite3.Error as exc:
             raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
         renamed = self.get_workspace(safe_workspace_id)
@@ -283,6 +291,10 @@ class LocalWorkspaceRegistryService:
                     """,
                     (now, safe_workspace_id),
                 )
+        except sqlite3.IntegrityError as exc:
+            raise WorkspaceRegistryServiceError(
+                f"A workspace named {record.name} already exists; rename it before unarchiving."
+            ) from exc
         except sqlite3.Error as exc:
             raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
         restored = self.get_workspace(safe_workspace_id)


### PR DESCRIPTION
## Summary

PR2 of the train (stacked on #943 — merge that first). Implements spec §4: the **Settings ▸ Workspaces** category — immediate-apply (Save/Revert suppressed like Theme), list + lifecycle card (create with free-form names, rename, set-active, archive/unarchive with confirmation, Default protected, archived cards offer only Unarchive with an explanation), and the **folder-bindings editor** (add read-only by default, per-folder write toggle, remove, live ready/missing status, inline errors — never tooltip-only). Cross-surface copy repointed to Settings as the management home; Console Details tray now reports live filesystem-binding status. Files follow-up tasks 836-837 from final-review triage.

## Notes
- Run-bound semantics observed live: a pre-existing tab's runs correctly use the SESSION's workspace while the tray shows the ACTIVE workspace's readiness — per ADR-028; the parallel-agents companion spec (named in the design spec §1) adds per-session visibility.
- Verification: whole-branch review clean after one fix wave; hub suite 249 green post-rebase (category-count pin re-verified against today's dev); live smoke drove every control in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces the Settings ▸ Workspaces category (immediate-apply) to manage workspaces and bind folders as file-tool access roots. File tools now run in the running session’s workspace and are confined to the sandbox plus bound folders; Console recomputes live binding status.

- **New Features**
  - Manage workspaces: list, create, rename, set active, archive/unarchive; Default workspace protected; archived cards only offer Unarchive with an explanation.
  - Folder bindings editor: add folders (read-only by default), toggle write per folder, remove; shows ready/missing status and inline errors; app copy now points to Settings as the management home.
  - Run-bound file access: Console threads the session `workspace_id` into `BuiltinToolProvider`; tools use sandbox+workspace roots with `validate_path_multi`; per-call existence checks; recursive listing and symlink-escape hardened; root lookups cached off the hot path.

- **Migration**
  - Workspace DB schema v2 adds a case-insensitive unique index on non-archived names and dedupes legacy collisions (including pre-existing “(n)” names); guard ordering and friendly errors added for create/rename/unarchive when names collide. No manual steps required.

<sup>Written for commit 9bd2ec633eae08a7c9f02abc8a08484f4141974a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

