### PR TITLE
fix(tests): wait for the conflict buttons, not just the conflict state (task 699 root cause)

### DIFF
--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -6403,8 +6403,16 @@ async def test_library_shell_note_conflict_shows_overwrite_reload_and_keeps_user
             message="The version conflict was never reached.",
         )
 
-        assert screen.query("#library-note-conflict-overwrite")
-        assert screen.query("#library-note-conflict-reload")
+        # Wait for the WIDGET, not just the state. ``_wait_for_condition`` above
+        # returns as soon as ``_library_note_autosave_state`` flips to
+        # "conflict", but the buttons only exist after the screen recomposes --
+        # so asserting on the DOM immediately is a race, and it is the one that
+        # made this test fail intermittently in full-file runs while passing in
+        # isolation (task-699). Captured assertion:
+        #   assert screen.query("#library-note-conflict-overwrite")
+        #   AssertionError: assert <DOMQuery ...>   (an empty query is falsy)
+        await _wait_for_selector(screen, pilot, "#library-note-conflict-overwrite")
+        await _wait_for_selector(screen, pilot, "#library-note-conflict-reload")
         meta = str(screen.query_one("#library-note-meta").renderable)
         assert "changed elsewhere" in meta
         assert screen.query_one("#library-note-body", TextArea).text == (


### PR DESCRIPTION
Root cause of task **699**'s intermittent failures, found and fixed.

## The evidence I never had

Five earlier attempts to capture a traceback all passed. Looping the full file until one failed produced it:

```
Tests/UI/test_library_shell.py:6406:
    assert screen.query("#library-note-conflict-overwrite")
AssertionError: assert <DOMQuery query='#library-note-conflict-overwrite'>
```

An empty `DOMQuery` is falsy — the buttons were not in the DOM.

**What did *not* fail is the informative part.** The `_wait_for_condition` above it returned successfully, so `_library_note_autosave_state` really was `"conflict"`. The state had flipped; the screen had not yet recomposed to render the buttons that state implies.

## The race

The test waits for **state**, then asserts on **DOM**. Whether it passes depends on whether a recompose happens to land inside the same tick.

That explains everything the evidence showed, including the parts that contradicted my earlier theories:

- passes in isolation ✓
- passes alongside all 81 notes tests ✓
- fails only sometimes in a full-file run ✓
- **no correlation with machine load** ✓ — a run failed at 289s where an earlier one passed at 520s
- every failure in the tail was in the note-conflict family — they share this shape ✓

Fixed by awaiting the widgets with `_wait_for_selector`, which polls the DOM rather than assuming it. I grepped the file for the same state-then-DOM pattern; this test is the only instance.

## Supersedes my earlier hypothesis

I proposed load-sensitive wait helpers as the cause in #942. The evidence had already contradicted that, and there is now a positive explanation instead. The wall-clock change from #942 stands on its own merits — and is what makes this fix robust — but it was not the cause, and I would rather say so plainly than let the earlier framing stand.

## Verification

`Tests/UI/test_library_shell.py`: **259 passed, 0 failed.**

For context, this file failed **9 tests on clean dev** at the start of this work. Three were stable failures misfiled as flakiness (fixed in #933 as tasks 687/698), and this was the remaining intermittent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes intermittent failures in the note-conflict UI test by waiting for the conflict buttons to render, not just for the conflict state (Task 699). Improves reliability in `Tests/UI/test_library_shell.py`.

- **Bug Fixes**
  - Replace direct DOM asserts with `await _wait_for_selector` for `#library-note-conflict-overwrite` and `#library-note-conflict-reload`.
  - Removes the race between state flip and screen recomposition; test stability confirmed (259 passed).

<sup>Written for commit 20263907bfe79808f6a3cffa1e265c6f004b8d8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

