### PR TITLE
chore(backlog): mark tasks 697 and 702 Done

### DIFF
--- a/backlog/tasks/task-697 - Ingest-pre-flight-turns-its-own-403-into-an-unreachable-URL-error.md
+++ b/backlog/tasks/task-697 - Ingest-pre-flight-turns-its-own-403-into-an-unreachable-URL-error.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-697
 title: Ingest pre-flight turns its own 403 into an unreachable-URL error
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-26 14:12'
-updated_date: '2026-07-26 14:31'
+updated_date: '2026-07-26 23:45'
 labels:
   - library
   - ingest
@@ -22,3 +22,17 @@ The ingest pre-flight probes a URL with a HEAD request and turns any failure int
 - [ ] #1 A URL that answers 403 to the probe is not reported as unreachable,A page the server can fetch is not blocked by the local pre-flight,A genuinely unreachable URL is still reported as such
 - [ ] #2 A URL the probe cannot verify is not reported as unreachable,A page the configured backend can fetch is not blocked by the local pre-flight,A genuinely unresolvable URL is still surfaced to the user,A fetch that fails during ingest is reported as a failed job rather than silently succeeding
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed in PR #923 as a prerequisite for bringing web clipping into the canvas.
+
+The pre-flight's HEAD probe turned any failure into 'URL unreachable' and dropped the source entirely -- not merely warned: the URL never reached type_groups, so total_files stayed 0. But any HTTP status proves the host resolved and answered, and sites routinely refuse HEAD (405) or unrecognised clients (403) while serving the page fine to whoever actually fetches it. Confirmed on a Wikipedia article that answers 403 to our client even with a browser User-Agent -- so the User-Agent is not the cause -- and that a tldw server clipped at 200, because its browser-based stack succeeds where ours is refused. The local pre-flight was blocking content the configured backend could retrieve.
+
+A probe may now report doubt but not refuse: an uninterpretable status becomes a 'Could not check the link' warning. 404/410 still refuse, since there the host is stating the resource is not there.
+
+Verified live: the Wikipedia article now reaches the canvas as the web group with that warning, while a real 404 is still refused.
+
+The status was never updated when it shipped; the code has been on dev since #923.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-702 - Library-ingest-reports-a-YouTube-URL-as-an-unsupported-file.md
+++ b/backlog/tasks/task-702 - Library-ingest-reports-a-YouTube-URL-as-an-unsupported-file.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-702
 title: Library ingest reports a YouTube URL as an unsupported file
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-26 14:12'
+updated_date: '2026-07-26 23:45'
 labels:
   - library
   - ingest
@@ -20,3 +21,15 @@ Pasting a video URL into the Library ingest canvas reports it as an unsupported 
 <!-- AC:BEGIN -->
 - [ ] #1 A video-hosting URL is recognised as audio/video by the ingest canvas,A URL without a file extension is not reported as an unsupported file when the pipeline can ingest it,The canvas's classification of a source agrees with what the ingest pipeline will actually do
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed in PR #923 as a prerequisite for bringing web clipping into the canvas.
+
+get_type_group decided by file extension alone via detect_file_type, so any extension-less URL fell to the unsupported bucket -- a YouTube link pre-flighted as an unsupported FILE while the pipeline's own classify_ingest_source called the same URL video and would have ingested it. URLs now defer to classify_ingest_source rather than re-deriving the rules, with a test comparing the two classifiers directly so a future divergence fails in CI rather than on a user's screen. An extension still wins where there is one, so a link to a .pdf or .epub is parsed as that rather than scraped as HTML.
+
+Verified live: youtube.com/watch -> audio_video, 1 file, no errors.
+
+The status was never updated when it shipped; the code has been on dev since #923.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
Status-only. Both shipped in #923 as prerequisites for web clipping, verified live at the time, but their status was never moved off `To Do`.

Confirmed the code is on dev before changing it: `_url_type_group` and the `web` type group for **702**; `UrlProbe` and `_ABSENT_STATUSES` for **697**.

Caught while auditing final task states rather than assuming the programme was closed — "I fixed it in that PR" is not the same as the board saying so.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark backlog tasks 697 and 702 as Done to sync the board with work already shipped in #923. Verified on dev: ingest pre-flight no longer flags 403s as unreachable, and YouTube/web URLs are correctly classified; no code changes.

<sup>Written for commit 2fe873df839b359312786cab655610ff78124efc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

