### PR TITLE
fix(rag): tell a fresh install what to set up, not that its ingest failed (task 685)

### DIFF
--- a/Tests/RAG/test_ingestion_indexing.py
+++ b/Tests/RAG/test_ingestion_indexing.py
@@ -1190,3 +1190,73 @@ class TestSharedRagServiceLockDeadlock:
             resolve_may_return.set()
             getter.join(timeout=5)
             ingestion_indexing.reset_shared_rag_service()
+
+
+class TestFirstRunIndexingIsNotReportedAsFailure:
+    """A fresh install must not present its first successful ingest as a failure.
+
+    With the embeddings_rag deps installed but no embedding model downloaded,
+    every chunk fails to embed and the indexer reported "RAG indexing failed" as
+    a warning toast. The import itself succeeded, so the first thing a new user
+    saw after their first working action was a failure they did not cause and
+    could not act on (task-685).
+    """
+
+    def _indexer(self, tmp_path, notes):
+        idx = IngestionIndexer(
+            rag_service=None,
+            indexing_db=RAGIndexingDB(tmp_path / "rag_indexing.db"),
+        )
+        idx.set_failure_notifier(lambda m: notes.append(("failure", m)))
+        idx.set_guidance_notifier(lambda m: notes.append(("guidance", m)))
+        return idx
+
+    def test_embeddings_never_worked_is_guidance_not_a_failure(self, tmp_path):
+        notes: list[tuple[str, str]] = []
+        idx = self._indexer(tmp_path, notes)
+
+        idx._report_index_summary(
+            {
+                "indexed": 0,
+                "skipped": 0,
+                "failed": 2,
+                "errors": ["All chunks failed embedding generation"] * 2,
+            }
+        )
+
+        assert notes, "the user was told nothing at all"
+        kind, message = notes[-1]
+        assert kind == "guidance", f"still reported as a {kind}: {message}"
+        # AC#2: say what indexing gives and how to turn it on.
+        lowered = message.lower()
+        assert "search" in lowered
+        assert "embedding" in lowered
+        assert "failed" not in lowered, "guidance must not read as a failure"
+
+    def test_a_real_failure_on_a_working_install_still_surfaces(self, tmp_path):
+        """AC#3. Embeddings clearly work here -- something indexed -- so a
+        failure on one item is a genuine problem, not a first-run gap."""
+        notes: list[tuple[str, str]] = []
+        idx = self._indexer(tmp_path, notes)
+
+        idx._report_index_summary(
+            {
+                "indexed": 5,
+                "skipped": 0,
+                "failed": 1,
+                "errors": ["All chunks failed embedding generation"],
+            }
+        )
+
+        assert notes and notes[-1][0] == "failure", notes
+
+    def test_an_unrelated_error_always_surfaces(self, tmp_path):
+        """A vector-store or DB error is never a missing-model story."""
+        notes: list[tuple[str, str]] = []
+        idx = self._indexer(tmp_path, notes)
+
+        idx._report_index_summary(
+            {"indexed": 0, "skipped": 0, "failed": 1, "errors": ["disk I/O error"]}
+        )
+
+        assert notes and notes[-1][0] == "failure", notes

--- a/Tests/RAG/test_ingestion_indexing.py
+++ b/Tests/RAG/test_ingestion_indexing.py
@@ -1260,3 +1260,39 @@ class TestFirstRunIndexingIsNotReportedAsFailure:
         )
 
         assert notes and notes[-1][0] == "failure", notes
+
+    def test_a_failure_in_the_first_batch_after_a_restart_still_surfaces(
+        self, tmp_path
+    ):
+        """The in-process counter resets every run; indexing history does not.
+
+        On a configured install the first batch after any restart has
+        ``_stats["indexed"] == 0``, so relying on that alone downgraded a
+        genuine failure to guidance -- and the same error text is produced by
+        embeddings init errors and circuit breakers, not only by a missing
+        model. The indexing DB is the durable record that embeddings have worked
+        here before (task-685 review).
+        """
+        notes: list[tuple[str, str]] = []
+        indexing_db = RAGIndexingDB(tmp_path / "rag_indexing.db")
+        # A previous run indexed something on this install.
+        indexing_db.mark_item_indexed(
+            item_id="1", item_type="media", last_modified=datetime.now(), chunk_count=3
+        )
+
+        idx = IngestionIndexer(rag_service=None, indexing_db=indexing_db)
+        idx.set_failure_notifier(lambda m: notes.append(("failure", m)))
+        idx.set_guidance_notifier(lambda m: notes.append(("guidance", m)))
+
+        idx._report_index_summary(
+            {
+                "indexed": 0,
+                "skipped": 0,
+                "failed": 1,
+                "errors": ["All chunks failed embedding generation"],
+            }
+        )
+
+        assert notes and notes[-1][0] == "failure", (
+            f"a real failure was downgraded on a configured install: {notes}"
+        )

--- a/backlog/tasks/task-685 - Stop-scaring-new-users-with-RAG-indexing-failures-on-every-ingest.md
+++ b/backlog/tasks/task-685 - Stop-scaring-new-users-with-RAG-indexing-failures-on-every-ingest.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-685
 title: Stop scaring new users with RAG indexing failures on every ingest
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-07-26 04:05'
+updated_date: '2026-07-26 23:57'
 labels:
   - ingest
   - ux
@@ -19,7 +21,27 @@ On a fresh install with no embedding model downloaded, every successful ingest r
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A fresh install with no embedding model does not report an ingest as failing when only indexing was skipped
-- [ ] #2 The user is told what indexing gives them and how to enable it, rather than shown a raw failure
-- [ ] #3 Genuine indexing failures on a configured install are still surfaced
+- [x] #1 A fresh install with no embedding model does not report an ingest as failing when only indexing was skipped
+- [x] #2 The user is told what indexing gives them and how to enable it, rather than shown a raw failure
+- [x] #3 Genuine indexing failures on a configured install are still surfaced
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+A fresh install no longer presents its first successful ingest as a failure.
+
+With the embeddings_rag deps installed but no model downloaded, every chunk fails to embed, and the indexer surfaced 'RAG indexing failed for N item(s): All chunks failed embedding generation' as a warning toast after every otherwise-successful import. The import worked; the first thing a new user saw after their first working action was a failure they did not cause and could not act on.
+
+The discriminator is deliberately NOT the error text alone. A configured install can legitimately fail to embed one bad document, and that is a real failure worth surfacing (AC#3). Guidance is offered only when embeddings have never worked -- nothing indexed in this process OR in the current batch -- and every error in the batch is the embeddings-unavailable one. Anything else reports exactly as before.
+
+Counting the current batch as well as process history matters: if this batch embedded anything, embeddings demonstrably work whatever the history says. That case was what turned my first implementation red.
+
+The message says what indexing gives and how to enable it rather than what broke: 'Saved, but not added to semantic search yet -- no embedding model is set up. Download one in Settings to search this content by meaning as well as by keyword.'
+
+Guidance travels on its own notifier so the app can render it as information rather than a warning; when no guidance notifier is supplied it falls back to the failure channel, so the message is never simply lost.
+
+Mutation-checked: removing the have-embeddings-ever-worked guard downgrades a genuine failure to guidance and fails the AC#3 test.
+
+Files: RAG_Search/ingestion_indexing.py, app.py, Tests/RAG/test_ingestion_indexing.py.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/RAG_Search/ingestion_indexing.py
+++ b/tldw_chatbook/RAG_Search/ingestion_indexing.py
@@ -846,7 +846,13 @@ class IngestionIndexer:
     def set_guidance_notifier(
         self, notifier: Optional[Callable[[str], None]]
     ) -> None:
-        """Set the sink for setup-gap messages, which are not failures."""
+        """Set the sink for setup-gap messages, which are not failures.
+
+        Args:
+            notifier: Callable invoked with a single guidance message, or
+                ``None`` to clear it. When unset, guidance falls back to the
+                failure notifier so the message is not lost.
+        """
         self._guidance_notifier = notifier
 
     def set_failure_notifier(self, notifier: Optional[Callable[[str], None]]) -> None:
@@ -1000,8 +1006,16 @@ class IngestionIndexer:
         with self._state_lock:
             ever_indexed = self._stats["indexed"] > 0
         # This batch counts too: if anything in it embedded successfully then
-        # embeddings work, whatever the process history says.
+        # embeddings work, whatever the history says.
         ever_indexed = ever_indexed or int(summary.get("indexed") or 0) > 0
+        # ...and so does anything indexed in a PREVIOUS run. ``_stats`` is
+        # in-memory and resets to 0 on every start, so relying on it alone would
+        # downgrade a genuine failure in the FIRST batch after any restart --
+        # the same error text is produced by embeddings init errors and circuit
+        # breakers, not only by a missing model. The indexing DB is the durable
+        # record of embeddings having ever worked on this install.
+        if not ever_indexed:
+            ever_indexed = self._any_previously_indexed()
 
         embeddings_never_worked = not ever_indexed and all(
             self._EMBEDDINGS_UNAVAILABLE_ERROR in str(error) for error in errors
@@ -1017,6 +1031,26 @@ class IngestionIndexer:
         self._notify_failure(
             f"RAG indexing failed for {summary['failed']} item(s): {errors[-1]}"
         )
+
+
+    def _any_previously_indexed(self) -> bool:
+        """Report whether anything has ever been indexed on this install.
+
+        Read from the indexing DB rather than in-process counters, because the
+        counters start at zero every run and "first batch of this process" is
+        not the same question as "embeddings have never worked here".
+
+        Returns:
+            ``True`` when the indexing DB records at least one indexed item.
+            A DB that cannot be read returns ``True`` -- the safe direction,
+            since it keeps reporting failures as failures.
+        """
+        try:
+            stats = self._get_indexing_db().get_indexing_stats()
+            return int(stats.get("total_indexed") or 0) > 0
+        except Exception as e:
+            logger.debug(f"Could not read indexing history: {e}")
+            return True
 
     def _notify_guidance(self, message: str) -> None:
         """Surface a setup gap. Falls back to the failure channel only if no

--- a/tldw_chatbook/RAG_Search/ingestion_indexing.py
+++ b/tldw_chatbook/RAG_Search/ingestion_indexing.py
@@ -780,6 +780,7 @@ class IngestionIndexer:
         self._indexing_db_resolved = indexing_db is not None
         self._batch_size = max(1, batch_size)
         self._failure_notifier = failure_notifier
+        self._guidance_notifier: Optional[Callable[[str], None]] = None
         self._thread: Optional[threading.Thread] = None
         self._thread_lock = threading.Lock()
         self._state_lock = threading.Lock()
@@ -841,6 +842,12 @@ class IngestionIndexer:
             snapshot = dict(self._stats)
             snapshot["pending"] = self._pending
             return snapshot
+
+    def set_guidance_notifier(
+        self, notifier: Optional[Callable[[str], None]]
+    ) -> None:
+        """Set the sink for setup-gap messages, which are not failures."""
+        self._guidance_notifier = notifier
 
     def set_failure_notifier(self, notifier: Optional[Callable[[str], None]]) -> None:
         """Install a callback invoked with a short message on indexing failures."""
@@ -959,9 +966,68 @@ class IngestionIndexer:
             if summary["errors"]:
                 self._stats["last_error"] = summary["errors"][-1]
         if summary["errors"]:
-            self._notify_failure(
-                f"RAG indexing failed for {summary['failed']} item(s): {summary['errors'][-1]}"
+            self._report_index_summary(summary)
+
+
+    #: The error every item reports when embedding generation produced nothing.
+    #: On a fresh install that means no model has been downloaded yet, which is
+    #: a setup gap rather than a fault in the import that just succeeded.
+    _EMBEDDINGS_UNAVAILABLE_ERROR = "All chunks failed embedding generation"
+
+    def _report_index_summary(self, summary: Mapping[str, Any]) -> None:
+        """Tell the user what happened, distinguishing a gap from a fault.
+
+        A fresh install with the ``embeddings_rag`` deps present but no model
+        downloaded fails to embed every chunk, and this used to surface as
+        "RAG indexing failed" on every otherwise-successful ingest -- the first
+        thing a new user saw after their first working action was a failure they
+        did not cause and could not act on (task-685).
+
+        The discriminator is whether embeddings have EVER worked in this
+        process, not the error text alone: a configured install can legitimately
+        fail to embed one bad document, and that is a real failure worth
+        surfacing. So guidance is only offered when nothing has ever indexed and
+        every error is the embeddings-unavailable one; anything else is reported
+        as before.
+
+        Args:
+            summary: The counts and errors from :func:`index_entries`.
+        """
+        errors = list(summary.get("errors") or [])
+        if not errors:
+            return
+
+        with self._state_lock:
+            ever_indexed = self._stats["indexed"] > 0
+        # This batch counts too: if anything in it embedded successfully then
+        # embeddings work, whatever the process history says.
+        ever_indexed = ever_indexed or int(summary.get("indexed") or 0) > 0
+
+        embeddings_never_worked = not ever_indexed and all(
+            self._EMBEDDINGS_UNAVAILABLE_ERROR in str(error) for error in errors
+        )
+        if embeddings_never_worked:
+            self._notify_guidance(
+                "Saved, but not added to semantic search yet -- no embedding "
+                "model is set up. Download one in Settings to search this "
+                "content by meaning as well as by keyword."
             )
+            return
+
+        self._notify_failure(
+            f"RAG indexing failed for {summary['failed']} item(s): {errors[-1]}"
+        )
+
+    def _notify_guidance(self, message: str) -> None:
+        """Surface a setup gap. Falls back to the failure channel only if no
+        guidance notifier was supplied, so the message is never simply lost."""
+        notifier = self._guidance_notifier or self._failure_notifier
+        if notifier is None:
+            return
+        try:
+            notifier(message)
+        except Exception as e:
+            logger.debug(f"Indexing guidance notifier raised: {e}")
 
     def _record_batch_failure(self, batch: Sequence[IndexEntry], message: str) -> None:
         logger.error(
@@ -1039,12 +1105,18 @@ def _media_post_ingest_hook(db: Any, media_id: int, media_uuid: Optional[str]) -
 
 def install_media_ingest_hook(
     failure_notifier: Optional[Callable[[str], None]] = None,
+    guidance_notifier: Optional[Callable[[str], None]] = None,
 ) -> None:
     """Install the post-ingest indexing hook on the media DB seam (idempotent).
 
     Args:
         failure_notifier: Optional callable for surfacing indexing failures
             (installed on the process-wide indexer).
+        guidance_notifier: Optional callable for surfacing a setup gap, such as
+            no embedding model being available yet. Kept separate from
+            ``failure_notifier`` so a fresh install is not told its successful
+            import failed (task-685); when omitted, guidance falls back to the
+            failure channel rather than being lost.
     """
     global _hook_installed
     from ..DB.Client_Media_DB_v2 import register_media_post_ingest_callback
@@ -1055,6 +1127,11 @@ def install_media_ingest_hook(
                 get_ingestion_indexer().set_failure_notifier(failure_notifier)
             except Exception as e:
                 logger.debug(f"Could not install indexing failure notifier: {e}")
+        if guidance_notifier is not None:
+            try:
+                get_ingestion_indexer().set_guidance_notifier(guidance_notifier)
+            except Exception as e:
+                logger.debug(f"Could not install indexing guidance notifier: {e}")
         if _hook_installed:
             return
         register_media_post_ingest_callback(_media_post_ingest_hook)

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -5756,7 +5756,8 @@ class TldwCli(
                 from .RAG_Search.ingestion_indexing import install_media_ingest_hook
 
                 install_media_ingest_hook(
-                    failure_notifier=self._notify_rag_indexing_failure
+                    failure_notifier=self._notify_rag_indexing_failure,
+                    guidance_notifier=self._notify_rag_indexing_guidance,
                 )
             except Exception as e:
                 logger.warning(f"Could not install RAG ingestion-indexing hook: {e}")
@@ -5788,6 +5789,22 @@ class TldwCli(
             self.call_from_thread(self.notify, message, severity="warning", timeout=6)
         except Exception as e:
             logger.debug(f"Could not surface RAG indexing failure in UI: {e}")
+
+    def _notify_rag_indexing_guidance(self, message: str) -> None:
+        """Surface a RAG setup gap as information, not a warning.
+
+        A fresh install has no embedding model, so nothing can be indexed for
+        semantic search -- but the import itself succeeded, and presenting that
+        as a warning made a new user's first successful action look like a
+        failure (task-685). Same marshalling as the failure notifier: called
+        from the indexer's worker thread.
+        """
+        try:
+            self.call_from_thread(
+                self.notify, message, severity="information", timeout=8
+            )
+        except Exception as e:
+            logger.debug(f"Could not surface RAG indexing guidance in UI: {e}")
 
     def _init_worker_handlers(self) -> None:
         """Initialize the worker handler registry and register all handlers."""


### PR DESCRIPTION
The last open task from the Library ingest UAT.

On a fresh install the `embeddings_rag` deps are present but no embedding model has been downloaded, so every chunk fails to embed and the indexer surfaced:

> ⚠ RAG indexing failed for 1 item(s): All chunks failed embedding generation

…as a warning after every **successful** import. The import worked. The first thing a new user saw after their first working action was a failure they did not cause and could not act on.

## Why the obvious fix would have been wrong

Suppressing that error string is the one-line change, and it breaks AC#3: a properly configured install can legitimately fail to embed one bad document, and that **is** a real failure worth surfacing.

So the discriminator is behavioural rather than textual — **have embeddings ever worked here?**

Guidance is offered only when nothing has indexed (in this process *or* in the current batch) **and** every error in the batch is the embeddings-unavailable one. Anything else reports exactly as before.

Counting the current batch as well as process history was not in my first implementation, and the AC#3 test caught it: if this batch embedded anything, embeddings demonstrably work whatever the history says.

## What the user sees instead

> Saved, but not added to semantic search yet — no embedding model is set up. Download one in Settings to search this content by meaning as well as by keyword.

It says what indexing *gives* and how to enable it, rather than what broke (AC#2). It travels on its own notifier so the app renders it as **information** rather than a warning; if no guidance notifier is supplied it falls back to the failure channel, because a setup gap should not become silence.

## Verification

- `Tests/RAG`: **707 passed, 8 skipped, 0 failed**
- Three new tests cover the three ACs: first-run gap → guidance; a failure on a working install → still a failure; an unrelated error (disk I/O) → always a failure
- **Mutation-checked**: removing the have-embeddings-ever-worked guard downgrades a genuine failure to guidance and fails the AC#3 test

## Programme

This closes the last of **22 tasks** from the original 14 UAT findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the misleading RAG “indexing failed” toast on first ingest by showing setup guidance when no embedding model is installed. Detection is now durable across restarts via the indexing DB; real indexing failures still surface as failures. Addresses TASK-685 (AC1–AC3).

- New Features
  - Added a guidance notifier channel for RAG indexing; surfaced as information in the UI.
  - Clear message explaining semantic search and how to enable it by downloading an embedding model.

- Bug Fixes
  - Indexer now shows guidance only when embeddings have never worked (no prior indexed items per the indexing DB, nothing indexed in the current batch) and all errors are "All chunks failed embedding generation"; otherwise reports a failure. Unreadable DB defaults to treating failures as failures.
  - Added tests for first-run guidance, real failures on a working install, unrelated errors, and the first batch after a restart (uses durable history to avoid downgrading real failures).

<sup>Written for commit 112afbe37673d098c2a7a7c0bf4b0f49d757cb25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

