### PR TITLE
docs: project-level lessons-learned files + a DoD hook to keep them fed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -435,7 +435,7 @@ A task is **Done** only when **ALL** of the following are complete:
    just the rule**: a lesson without the evidence that produced it decays into folklore
    and gets ignored. Most tasks produce nothing here, and that is fine; do not invent
    one to fill the slot.
-9. **ADR hygiene**: ADR check completed; any new or superseded ADRs are linked from the task Implementation Plan and Implementation Notes.
+10. **ADR hygiene**: ADR check completed; any new or superseded ADRs are linked from the task Implementation Plan and Implementation Notes.
 
 ⚠️ **IMPORTANT**: Never mark a task as Done without completing ALL items above.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,6 +237,13 @@ Critical files for common tasks:
 - Every implementation decision starts with reading the corresponding Markdown task file.
 - Project documentation is in **`backlog/docs/`**.
 - Project decisions are in **`backlog/decisions/`**.
+- Hard-won working knowledge is in **`backlog/docs/lessons-*.md`** -- traps that have
+  actually cost time in this repo, each recorded with the incident that produced it.
+  **Read the one covering your area before starting**; they are short, and they exist
+  because these mistakes recur:
+  - `lessons-testing-evidence.md` -- what actually counts as evidence a change works
+  - `lessons-live-verification.md` -- running the app and talking to a real server
+  - `lessons-backlog-hygiene.md` -- task IDs, CLI quirks, git plumbing
 - Canonical Architecture Decision Records (ADRs) live in **`backlog/decisions/`**. Historical ADR-like material elsewhere is reference-only unless a canonical ADR imports or supersedes it.
 - Before implementation planning, read relevant ADRs and decide whether the task requires a new ADR.
 
@@ -422,6 +429,12 @@ A task is **Done** only when **ALL** of the following are complete:
 6. **Review**: self review code.
 7. **Task hygiene**: status set to **Done** via CLI (`backlog task edit <id> -s Done`).
 8. **No regressions**: performance, security and licence checks green.
+9. **Lessons learned**: if the task surfaced knowledge that generalises beyond it — a
+   trap, a wrong assumption that cost time, a verification that only worked one way —
+   add or update an entry in `backlog/docs/lessons-*.md`. **State the incident, not
+   just the rule**: a lesson without the evidence that produced it decays into folklore
+   and gets ignored. Most tasks produce nothing here, and that is fine; do not invent
+   one to fill the slot.
 9. **ADR hygiene**: ADR check completed; any new or superseded ADRs are linked from the task Implementation Plan and Implementation Notes.
 
 ⚠️ **IMPORTANT**: Never mark a task as Done without completing ALL items above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,13 @@ Critical files for common tasks:
 - Every implementation decision starts with reading the corresponding Markdown task file.
 - Project documentation is in **`backlog/docs/`**.
 - Project decisions are in **`backlog/decisions/`**.
+- Hard-won working knowledge is in **`backlog/docs/lessons-*.md`** -- traps that have
+  actually cost time in this repo, each recorded with the incident that produced it.
+  **Read the one covering your area before starting**; they are short, and they exist
+  because these mistakes recur:
+  - `lessons-testing-evidence.md` -- what actually counts as evidence a change works
+  - `lessons-live-verification.md` -- running the app and talking to a real server
+  - `lessons-backlog-hygiene.md` -- task IDs, CLI quirks, git plumbing
 
 ## 2. Defining Tasks
 
@@ -401,6 +408,12 @@ A task is **Done** only when **ALL** of the following are complete:
 6. **Review**: self review code.
 7. **Task hygiene**: status set to **Done** via CLI (`backlog task edit <id> -s Done`).
 8. **No regressions**: performance, security and licence checks green.
+9. **Lessons learned**: if the task surfaced knowledge that generalises beyond it — a
+   trap, a wrong assumption that cost time, a verification that only worked one way —
+   add or update an entry in `backlog/docs/lessons-*.md`. **State the incident, not
+   just the rule**: a lesson without the evidence that produced it decays into folklore
+   and gets ignored. Most tasks produce nothing here, and that is fine; do not invent
+   one to fill the slot.
 
 ⚠️ **IMPORTANT**: Never mark a task as Done without completing ALL items above.
 

--- a/backlog/docs/lessons-backlog-hygiene.md
+++ b/backlog/docs/lessons-backlog-hygiene.md
@@ -25,8 +25,15 @@ re-check at merge time — dev moves under you. Never trust the CLI's auto-assig
 ```bash
 git for-each-ref --format='%(refname)' refs/remotes/ | while read -r b; do
   git ls-tree -r -z --name-only "$b" backlog/ | tr '\0' '\n'
-done | grep -oE 'task-[0-9]+' | sort -u | tail -5
+done | grep -oE 'task-[0-9]+' | cut -d- -f2 | sort -n -u | tail -5
 ```
+
+Note `sort -n`, not `sort -u` alone. Lexicographic order puts `task-100` before
+`task-99`, so a plain sort reports the wrong maximum. This is not theoretical: run
+against this repo, the lexicographic version reports **99** as the highest task ID
+while the numeric version reports **838** -- it would have collided on essentially
+every filing. That mistake was in the first draft of this very file, which is a fair
+illustration of why these entries carry their evidence.
 
 ---
 

--- a/backlog/docs/lessons-backlog-hygiene.md
+++ b/backlog/docs/lessons-backlog-hygiene.md
@@ -1,0 +1,108 @@
+# Lessons: backlog, git and tooling traps
+
+Mechanical traps in the task board and the plumbing around it. Cheap to avoid once
+known, expensive to rediscover. Every entry states the incident that produced it.
+
+---
+
+## Task IDs collide constantly — sweep every remote, not just dev
+
+**What happened.** This has recurred **ten-plus times**. Most recently, in one session:
+
+- IDs verified free against `origin/dev` and the local worktree still collided with
+  `feat/watchlists-phase-a-data-foundation`. True max across all 101 remote refs was
+  **699**, while dev's view said 686.
+- The backlog CLI auto-assigned **703** — already taken **on dev itself**.
+- An earlier ID collided with dev's own task of the same number, filed by another agent
+  mid-session.
+
+Checking `origin/dev` *feels* like diligence. It is not: parallel agents hold IDs on
+unmerged branches.
+
+**What to do.** Before filing, sweep **every remote ref** plus every worktree, and
+re-check at merge time — dev moves under you. Never trust the CLI's auto-assignment.
+
+```bash
+git for-each-ref --format='%(refname)' refs/remotes/ | while read -r b; do
+  git ls-tree -r -z --name-only "$b" backlog/ | tr '\0' '\n'
+done | grep -oE 'task-[0-9]+' | sort -u | tail -5
+```
+
+---
+
+## `git ls-tree` octal-escapes non-ASCII filenames
+
+**What happened.** Several task titles contain an em-dash. `git ls-tree` emits those
+paths as `"…\342\200\224…"`, so comparing its output to real filenames reported
+**phantom collisions** for four unrelated tasks — twice in one session.
+
+**What to do.** Use `git ls-tree -r -z --name-only` and split on NUL. That emits raw
+UTF-8 paths.
+
+---
+
+## The backlog CLI collapses multiple `--ac` values into one criterion
+
+**What happened.** Passing three acceptance criteria produced a single criterion with
+the three joined by commas — on two separate tasks, unnoticed until later.
+
+**What to do.** After filing, re-read the `AC:BEGIN` block. If it collapsed, rewrite the
+block directly in the file. Also note the CLI strips some free-form sections, and
+backticks in `--notes` are interpreted by the shell — a phrase in backticks vanished
+from a task note this way.
+
+---
+
+## Never `git add -A` while resolving a rebase conflict
+
+**What happened.** `git add -A` during conflict resolution swept **dev's own renames**
+back to their pre-rename names, silently reverting another agent's work. Caught only by
+auditing `git ls-files` against `git ls-tree origin/dev` afterwards.
+
+**What to do.** Stage conflicts **file by file**. After any rebase touching `backlog/`,
+diff your tree's task filenames against dev's.
+
+---
+
+## Regenerate the CSS bundle; never hand-merge it
+
+**What happened.** `tldw_cli_modular.tcss` is generated and conflicts on essentially
+every rebase, and running the app rewrites its timestamp.
+
+**What to do.** On conflict, take either side, then re-run `python
+tldw_chatbook/css/build_css.py` and stage the result. Verify by diffing the bundle's
+top-level selectors before and after — that shows what actually changed, past the
+timestamp noise.
+
+---
+
+## Scripted `.replace()` matches the *first* occurrence
+
+**What happened.** Twice in one session, a scripted edit landed in the wrong place:
+
+- `import dataclasses` stranded in its own block, breaking import grouping.
+- A screen attribute initialised inside `_reset_library_ingest_transient_state()`
+  instead of `__init__`, because the anchor string appears in both. Restored sessions
+  never run that reset, so **the media viewer stopped mounting** — shipped and caught
+  two commits later.
+
+**What to do.** Anchor on a string unique to the target, or verify where the edit landed
+before moving on. For state that must exist on every path, prefer a **class-level
+attribute** over an assignment in one method.
+
+---
+
+## Audit the board; do not trust your own summary
+
+**What happened.** Two tasks had shipped and been verified live, but their status was
+never moved off `To Do`. Found only by auditing every task in the programme at the end.
+
+**What to do.** Before declaring a programme complete, list every task's status **from
+`origin/dev`**. "I fixed it in that PR" is not the same as the board saying so.
+
+---
+
+## Related
+
+- `lessons-testing-evidence.md`
+- `backlog/decisions/001-adopt-backlog-decisions-as-canonical-adrs.md`

--- a/backlog/docs/lessons-live-verification.md
+++ b/backlog/docs/lessons-live-verification.md
@@ -48,9 +48,22 @@ offered, the user could select it, and every submission failed with
 button rendered *above* its own status line, so the screen read as a contradiction
 top-to-bottom — no unit test would ever say so.
 
-**What to do.** For anything user-facing, run the app (see the `verify` skill's tmux
-recipe). Ask: does the screen read correctly top-to-bottom, and does the affordance
-actually lead somewhere?
+**What to do.** For anything user-facing, run the app and look at it. Ask: does the
+screen read correctly top-to-bottom, and does the affordance actually lead somewhere?
+
+Headless recipe (no repo tooling required):
+
+```bash
+tmux -L verify new-session -d -x 235 -y 52 '.venv/bin/python -m tldw_chatbook.app'
+sleep 12                                    # cold start is ~10s, import-dominated
+tmux -L verify capture-pane -p | head -8    # pane as text
+tmux -L verify send-keys C-p                # command palette
+tmux -L verify kill-server                  # done
+```
+
+Use `TLDW_CONFIG_PATH=<scratch>/config.toml` so the run cannot touch real state (see
+the profile-isolation entry below). Ctrl+digit hotkeys cannot be sent through tmux --
+verify those bindings by reading `BINDINGS` in the code instead.
 
 ---
 
@@ -92,4 +105,3 @@ confirm `git diff | grep -c "<key-fragment>"` is `0`. Advise rotation afterwards
 ## Related
 
 - `lessons-testing-evidence.md` — why the green suite was not evidence
-- `.claude/skills/verify/` — the tmux recipe for driving the real TUI

--- a/backlog/docs/lessons-live-verification.md
+++ b/backlog/docs/lessons-live-verification.md
@@ -1,0 +1,95 @@
+# Lessons: verifying against the real thing
+
+Traps found by running the app and talking to a real server, which the test suite
+structurally could not surface. Every entry states the incident that produced it.
+
+---
+
+## The suite cannot see a contract you guessed
+
+**What happened.** The Library ingest UAT (tasks 673–702) found **seven** defects
+through live contact that a green suite never would:
+
+| Defect | Why tests missed it |
+|---|---|
+| Runtime policy refuses `…launch.server` outside server mode | 941 unit tests passed; direct API probes bypass the app's enforcer |
+| Server accepts only `video\|audio\|document\|pdf\|ebook` | The accepted set is **not in its OpenAPI spec** — `media_type` is a bare string with a runtime validator |
+| `result` typed as another domain's model | Only a *completed* job triggers it; cancel-only testing never does |
+| `offset` never sent | The fake declared it |
+| `/ingest-web-content` needs a lowercase `token` header | Not exercised by any test |
+| YouTube URL grouped as an unsupported *file* | Two classifiers disagreed; nothing compared them |
+| Pre-flight vetoed pages the backend could fetch | Its own 403 became the user's error |
+
+**What to do.** Before building on a remote contract, **ask the service**, not the
+spec. Submit one real request. A spec that types a field as `string` may still have a
+runtime validator behind it.
+
+---
+
+## This server reports denials as 429, not 401
+
+**What happened.** `token` alone on `/ingest-web-content` returned
+`429 {"error": "rate_limited"}` with `retry_after: 1`. That reads as throttling, so the
+obvious response is to back off — and backing off never helps, because it is a
+**denial**. ~80 seconds were lost to retries before a control request against a
+route known to accept `X-API-KEY` returned 200 and distinguished the two.
+
+**What to do.** On a 429 from this server, send a **control request** to a route you
+know works. If that succeeds, you are being denied, not throttled. Unauthenticated
+calls to media routes return 429 `policy_id: media.access` — not 401.
+
+---
+
+## Verify at the surface the user touches
+
+**What happened.** A feature was fully unit-tested and unusable: the switch was
+offered, the user could select it, and every submission failed with
+*"requires server mode"*. Only driving the real TUI exposed it. Separately, an action
+button rendered *above* its own status line, so the screen read as a contradiction
+top-to-bottom — no unit test would ever say so.
+
+**What to do.** For anything user-facing, run the app (see the `verify` skill's tmux
+recipe). Ask: does the screen read correctly top-to-bottom, and does the affordance
+actually lead somewhere?
+
+---
+
+## "It resolves" is not "it resolves the right thing"
+
+**What happened.** Verifying an "open the item the server created" action, the fetch
+returned without error but with `title=None`. Accepting that would have been a false
+positive. Inspecting the payload confirmed a real `MediaDetailResponse(media_id=1125)`
+— the exact row the ingest reported.
+
+**What to do.** Assert on **identifying content**, not on the absence of an exception.
+The chain that matters is: real submit → real completion → real reconcile → the
+affordance → *the thing it opens*.
+
+---
+
+## Isolate the profile before touching runtime state
+
+**What happened.** The runtime-policy state file (which records local vs. server mode)
+resolved from a hardcoded home path, ignoring `TLDW_CONFIG_PATH`. Putting a *scratch*
+profile into server mode would have left the **real** profile in server mode — and the
+self-healing demote would not fire, because a server was configured. This blocked
+server-mode verification entirely until fixed (task-701).
+
+**What to do.** Launch with `TLDW_CONFIG_PATH=<scratch>/config.toml`, then **verify the
+isolation actually held**: back up the real file, and diff it afterwards. Never assume
+an env var isolates everything — check which paths derive from it.
+
+---
+
+## Credentials in a live run
+
+A live credential pasted into a session is a real secret. Keep it in an env var for the
+run; never write it to a config file that could be committed; and before committing,
+confirm `git diff | grep -c "<key-fragment>"` is `0`. Advise rotation afterwards.
+
+---
+
+## Related
+
+- `lessons-testing-evidence.md` — why the green suite was not evidence
+- `.claude/skills/verify/` — the tmux recipe for driving the real TUI

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -1,0 +1,128 @@
+# Lessons: what counts as evidence a change works
+
+Working knowledge about testing in this repo. Not decisions (see `backlog/decisions/`)
+and not point-in-time audits — these are traps that have actually cost time here, kept
+so the next person does not rediscover them.
+
+**Every entry states the incident that produced it.** A lesson without its evidence
+decays into folklore, and folklore is ignored. If you add one, bring the incident.
+
+---
+
+## A fake written to match your call site validates the mistake
+
+**The trap.** You write a test double to match how you are calling the real thing. If
+the call is wrong, the double is wrong in the same way, and the test passes forever.
+
+**What happened.** Three times on one branch (task-684 series):
+
+- `cancel_media_ingest_jobs_batch` is keyword-only; it was called positionally. The
+  fake declared a positional parameter, because it was written to match the call.
+- The remote-ingest poller asked for an `offset` the real client did not accept. The
+  fake declared `offset`. **Pagination was dead in production** and 900+ tests were green.
+- `MediaIngestJobStatus.result` was typed as a different domain's model. Every fixture
+  matched the wrong model, so **every completed job was unparseable** and the queue
+  would have shown jobs stuck at "queued" forever.
+
+**What to do.** For anything crossing a seam you do not own, assert against the **real
+signature** and a **verbatim captured payload**, not a hand-written double:
+
+```python
+assert _accepts_keyword(RealService.method, "offset")     # the real signature
+LIVE_RESPONSE = { ... }                                    # pasted from the wire
+```
+
+A fake can agree with a wrong assumption; `inspect.signature` cannot.
+
+---
+
+## Mutation-test every guard you add
+
+**The trap.** A test that cannot fail is worse than no test: it reports safety that
+does not exist.
+
+**What happened.** Three fixes in one session were **vacuous** and only mutation
+testing caught them:
+
+- A precedence trap patched `get_cli_setting` to raise — but the code under test wraps
+  that call in `except Exception:`, which **swallowed the AssertionError**. Deleting the
+  entire precedence branch still passed.
+- A wait helper's timeout was checked in the loop *header*, so a pause overshooting the
+  deadline exited without re-testing the condition — reporting "never mounted" for a
+  widget that had just appeared. The guard for "can the helper still time out?" passed,
+  because it waited on a condition that is never satisfied.
+- A first-run classifier keyed on an in-memory counter that resets each run, so a real
+  failure in the first batch after restart was downgraded. Three tests passed with the
+  bug present; none modelled a restart.
+
+**What to do.** After writing a guard, break the thing it guards and confirm the test
+fails. If it still passes, the guard is decorative. Prefer **recording and asserting
+after the fact** over raising inside code that catches broadly.
+
+---
+
+## Passing the suites a change touches is not passing the suites it can reach
+
+**The trap.** You run the tests near your edit. The breakage is somewhere that merely
+*depends* on it.
+
+**What happened.**
+
+- Deleting a module left a doc-enforced inventory (`Tests/RuntimePolicy`) listing it.
+  Full-tree `--collect-only` passed: that only catches import errors, not stale
+  assertions *about* the codebase.
+- Adding a screen attribute in the wrong method broke the media viewer on **restored
+  sessions**. `Tests/Library` (859 green), the state-level tests, and a live server run
+  all passed and were blind to it.
+
+**What to do.** Ask what your change can *reach*, not what it touches. For deletions,
+that includes **inventories, audits and architecture-contract tests**, which assert
+about the codebase rather than importing it. `--collect-only` over the full tree is
+necessary and not sufficient.
+
+---
+
+## A re-export hides a dependency from a module-name grep
+
+**What happened.** `test_plaintext_ingest_events.py` imported a deleted function *via*
+`ingest_events`, so grepping the deleted module's name never matched it. Worse, a
+per-symbol reachability scan excluded it because the filename
+`test_plaintext_ingest_events.py` *contains* `ingest_events.py` as a substring — the one
+file that disproved the conclusion was skipped as "internal".
+
+**What to do.** Match paths **exactly**, never by substring. Run
+`pytest --collect-only` over the whole tree before deleting anything; it is the only
+check that sees through a re-export.
+
+---
+
+## Compare failure *sets* from identical commands, never counts
+
+**What happened.** A 3-vs-4 failure count between two *different* invocations
+(one file alone vs. that file plus another suite) read as a regression. It was not.
+Later, the same file gave 6, then 4, then 0, then 1, then 0 failures on unchanged code.
+
+**What to do.** Run the **identical command** on your branch and on a clean `origin/dev`
+worktree, and diff the failure **sets**. Counts across differing commands are
+meaningless. Machine load changes which tests lose a race — this repo regularly has
+10+ concurrent pytest processes from parallel agents.
+
+---
+
+## A low-rate intermittent needs a loop, not a rerun
+
+**What happened.** Five single-run attempts to capture a flaky test's traceback all
+passed. Looping the file until one failed produced it on the first loop — and the
+assertion identified the cause immediately (a test waiting on *state* then asserting on
+*DOM*, before the recompose that renders it).
+
+**What to do.** For anything below ~30% failure rate, loop with `-rf` and capture. A
+single run is not a diagnostic. And prefer waiting for the **widget** over waiting for
+the state that implies it.
+
+---
+
+## Related
+
+- `lessons-live-verification.md` — why the suite could not see seven of these defects
+- `lessons-backlog-hygiene.md` — task IDs, CLI quirks, git plumbing traps


### PR DESCRIPTION
Working knowledge about this repo has been living in **per-agent memory** — invisible to you, to Codex, and to the next session. This moves it into the repo.

## Three files, split by theme

| File | Covers |
|---|---|
| `lessons-testing-evidence.md` | what actually counts as evidence a change works |
| `lessons-live-verification.md` | running the app, talking to a real server |
| `lessons-backlog-hygiene.md` | task IDs, CLI quirks, git plumbing |

Deliberately **not** ADRs and **not** audits. `backlog/decisions/` records decisions with alternatives weighed; `backlog/docs/` has held point-in-time reports. A lesson is neither — it is a trap that recurs, and it needs to accumulate.

## Three choices worth arguing

**Split by theme, not one `LESSONS.md`.** This repo routinely has several agents committing at once, and a single hot file would conflict constantly — that happened repeatedly during the work these lessons came from.

**Evidence-first entries**: claim → the incident that produced it → the action. A lesson without its incident decays into folklore and stops being trusted.

> "Fakes can validate your own mistake" is arguable.
> "The fake declared `offset` because I wrote it to match my call site, and pagination was dead in production while 900+ tests were green" is not.

**A lifecycle hook, or none of this happens.** DoD gains item 9: if a task surfaced knowledge that generalises, record it — with the incident. It explicitly says most tasks produce nothing and not to invent one, because a file padded with platitudes is worse than no file.

## Both guidance files

`CLAUDE.md` and `AGENTS.md` each get the DoD item and a pointer near *Source of Truth*, so Claude and Codex get the same instruction. Edited byte-safe — these two have had CRLF churn before; the diff is 26 added lines with no whitespace noise.

## Where the content came from

The Library ingest UAT (tasks 673–702, 17 PRs). Every entry is an incident from that work: seven defects found only by live contact, three fixes that were vacuous until mutation testing caught them, two regressions that slipped through because the suites run weren't the suites the change could reach, and ten-plus task-ID collisions.

## Note for backlog-md-py

`backlog doc list` renders every entry blank — including the five docs that predate these. The docs carry no frontmatter (they open with an H1), so the lister has no title to read. Not fixed here, but it's a small gap worth closing in your port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three incident-backed lessons-learned docs and a Definition of Done hook to capture new lessons. Also fixes DoD numbering, corrects the task-ID sweep command, and replaces a dead verify link with an inline recipe.

- **New Features**
  - Added `backlog/docs/lessons-testing-evidence.md`, `backlog/docs/lessons-live-verification.md`, and `backlog/docs/lessons-backlog-hygiene.md`.
  - Added DoD item: when a task surfaces reusable knowledge, add/update a `lessons-*.md` entry and include the incident; most tasks won’t add one.
  - Linked from `CLAUDE.md` and `AGENTS.md`; read the relevant lessons file before starting.

- **Bug Fixes**
  - Fixed DoD numbering in `AGENTS.md` (Lessons learned is 9; ADR hygiene is 10).
  - Corrected the task-ID sweep to use numeric sort; added a measured example showing why.
  - Replaced a dead verify link with an inline `tmux` recipe and notes on `TLDW_CONFIG_PATH` isolation and Ctrl+digit limits.

<sup>Written for commit fff98616702c5eafd4c6ac30ffa1b7d612da1ad4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

