### PR TITLE
fix(audio): macOS gets its preferred engine, and audio ingest stops crashing (tasks 839, 840)

### DIFF
--- a/Tests/Local_Ingestion/test_audio_chunking_seam.py
+++ b/Tests/Local_Ingestion/test_audio_chunking_seam.py
@@ -1,0 +1,66 @@
+"""Contract tests for the audio processor's chunking seam (tasks 840, 952 review)."""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+
+class TestAudioChunkingSeam:
+    """The audio path must call the chunking service the way it is declared.
+
+    Every audio and video ingest that reached chunking used to die with
+    "'<=' not supported between instances of 'dict' and 'int'": an options dict
+    was passed positionally into ``chunk_size``. A signature check is the guard
+    that would have caught it, since a hand-written double would have been
+    written to match the wrong call (task-840).
+    """
+
+    def test_the_service_signature_is_the_one_the_caller_assumes(self):
+        from tldw_chatbook.RAG_Search.chunking_service import ChunkingService
+
+        params = inspect.signature(ChunkingService.chunk_text).parameters
+        for name in ("content", "chunk_size", "chunk_overlap", "method"):
+            assert name in params, f"chunk_text lost its {name} parameter"
+        # The defect: a dict landing where an int is declared.
+        assert params["chunk_size"].annotation in (int, "int")
+
+    def test_chunk_text_returns_string_text_and_keeps_offsets(self):
+        """Offsets must survive: the storage path otherwise re-derives them by
+        summing lengths, which double-counts whenever chunks overlap."""
+        from tldw_chatbook.Local_Ingestion.audio_processing import LocalAudioProcessor
+
+        proc = LocalAudioProcessor.__new__(LocalAudioProcessor)
+
+        class _Service:
+            def chunk_text(self, content, chunk_size=400, chunk_overlap=100, method="words"):
+                assert isinstance(chunk_size, int), "an options dict reached chunk_size"
+                return [
+                    {"text": "alpha beta", "start_char": 0, "end_char": 10, "chunk_index": 0},
+                    {"text": "beta gamma", "start_char": 5, "end_char": 15, "chunk_index": 1},
+                ]
+
+        proc.chunking_service = _Service()
+        out = proc._chunk_text("alpha beta gamma", method="words", max_size=2, overlap=1)
+
+        assert [c["text"] for c in out] == ["alpha beta", "beta gamma"]
+        assert all(isinstance(c["text"], str) for c in out)
+        # Overlapping chunks: summing lengths would give 0 and 10, not 0 and 5.
+        assert [c["start_char"] for c in out] == [0, 5]
+        assert [c["end_char"] for c in out] == [10, 15]
+
+    def test_a_string_chunker_result_still_works(self):
+        from tldw_chatbook.Local_Ingestion.audio_processing import LocalAudioProcessor
+
+        proc = LocalAudioProcessor.__new__(LocalAudioProcessor)
+
+        class _StringService:
+            def chunk_text(self, content, chunk_size=400, chunk_overlap=100, method="words"):
+                return ["one two", "three four"]
+
+        proc.chunking_service = _StringService()
+        out = proc._chunk_text("one two three four", method="words")
+
+        assert [c["text"] for c in out] == ["one two", "three four"]
+        assert all("start_char" not in c for c in out), "offsets must not be invented"

--- a/Tests/RAG/test_chunking_service.py
+++ b/Tests/RAG/test_chunking_service.py
@@ -1,0 +1,71 @@
+"""Contract tests for ChunkingService across every supported method."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestEveryChunkingMethodReturnsUsableText:
+    """Every supported method must yield dicts whose ``text`` is a string.
+
+    ``Chunker.chunk_text`` is not uniform: the text methods (words, sentences,
+    paragraphs, tokens, semantic) return plain strings, while the
+    structure-aware ones (json, xml, ebook_chapters) return dicts carrying their
+    text alongside metadata. ``ChunkingService`` assumed strings and called
+    ``.split()`` on them, so **every json and xml chunk request died** with
+    "'dict' object has no attribute 'split'" (task-841).
+
+    Found by exercising each method rather than by reading the dispatch, which
+    looks uniform. This is the third instance in one session of a caller
+    assuming a shape its callee does not produce -- see
+    ``backlog/docs/lessons-testing-evidence.md``.
+    """
+
+    PROSE = (
+        "The first sentence is here. The second follows it. A third arrives.\n\n"
+        "A second paragraph begins. It has two sentences.\n\nThird paragraph."
+    ) * 2
+
+    CASES = [
+        ("words", PROSE),
+        ("sentences", PROSE),
+        ("paragraphs", PROSE),
+        ("tokens", PROSE),
+        ("semantic", PROSE),
+        ("json", '{"data": {"k1": "some text here", "k2": "more", "k3": "third"}}'),
+        ("xml", "<root><item>alpha beta gamma</item><item>delta epsilon</item></root>"),
+    ]
+
+    @pytest.mark.parametrize(("method", "content"), CASES)
+    def test_method_yields_string_text(self, method, content):
+        from tldw_chatbook.RAG_Search.chunking_service import ChunkingService
+
+        try:
+            chunks = ChunkingService().chunk_text(
+                content, chunk_size=20, chunk_overlap=5, method=method
+            )
+        except Exception as exc:  # noqa: BLE001 - classified below
+            # ``semantic`` needs NLTK's punkt tokeniser data, which is a runtime
+            # download rather than a declared dependency. Skip when it is absent
+            # rather than fail: the contract under test is the chunk SHAPE, and
+            # pretending the data gap is a shape bug would bury both.
+            if "punkt" in str(exc) or "NLTK" in str(exc):
+                pytest.skip(f"{method} needs NLTK data that is not installed here")
+            raise
+
+        assert chunks, f"{method} produced no chunks at all"
+        for chunk in chunks:
+            assert isinstance(chunk, dict), f"{method} yielded {type(chunk).__name__}"
+            assert isinstance(chunk.get("text"), str), (
+                f"{method} chunk text is {type(chunk.get('text')).__name__}, "
+                "not a string -- downstream .split() and storage both break"
+            )
+            assert chunk["text"].strip(), f"{method} yielded an empty chunk"
+
+    def test_a_structured_chunk_without_a_text_field_is_not_dropped(self):
+        """Serialise rather than discard: content still reaches the index."""
+        from tldw_chatbook.RAG_Search.chunking_service import _chunk_to_text
+
+        assert _chunk_to_text({"heading": "H", "body": "B"})
+        assert _chunk_to_text({"text": "plain"}) == "plain"
+        assert _chunk_to_text("already a string") == "already a string"

--- a/backlog/tasks/task-839 - macOS-never-gets-its-preferred-transcription-engine.md
+++ b/backlog/tasks/task-839 - macOS-never-gets-its-preferred-transcription-engine.md
@@ -1,0 +1,25 @@
+---
+id: TASK-839
+title: macOS never gets its preferred transcription engine
+status: To Do
+assignee: []
+created_date: '2026-07-27 01:43'
+labels:
+  - audio
+  - packaging
+  - macos
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+On macOS the app prefers parakeet-mlx as its speech-to-text provider and falls back to faster-whisper only when it is absent, but nothing installs parakeet-mlx: the audio and video extras list faster-whisper and mention the Apple Silicon engines only in a comment suggesting a second manual install. The preference can therefore never engage on a normal macOS install. Found while verifying audio ingest end to end, which failed with 'faster-whisper is not installed' on a machine whose audio dependencies were otherwise complete.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A standard macOS install of the audio or video extra provides the engine the app prefers
+- [ ] #2 Audio ingest succeeds on macOS without a second manual install step
+- [ ] #3 Non-macOS installs are unaffected and still use faster-whisper
+<!-- AC:END -->

--- a/backlog/tasks/task-840 - Audio-and-video-ingest-crash-in-chunking-after-transcription.md
+++ b/backlog/tasks/task-840 - Audio-and-video-ingest-crash-in-chunking-after-transcription.md
@@ -1,0 +1,43 @@
+---
+id: TASK-840
+title: Audio and video ingest crash in chunking after transcription
+status: Done
+assignee: []
+created_date: '2026-07-27 01:48'
+updated_date: '2026-07-27 01:49'
+labels:
+  - audio
+  - bug
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Every audio or video ingest that reaches the chunking stage dies with a type error: the audio processor calls the chunking service with an options dictionary in the position where that service expects a chunk size, so a dict is compared against an integer. A second defect sits underneath it: the service returns chunk records carrying a text field, while the caller wraps each one as though it were a bare string, nesting the whole record inside another text key. Transcription itself is fine; the failure is entirely after it. This stayed hidden while no transcription engine was installed, because the path failed earlier for want of an engine.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 An audio file containing speech ingests successfully and stores its transcript
+- [x] #2 Chunk records reach the media row as text rather than nested dictionaries
+- [x] #3 Video ingest is covered by the same fix, since it shares the path
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed and verified with real speech.
+
+The audio processor called ChunkingService.chunk_text(text, chunk_options) -- passing an options dict positionally into a parameter the service declares as chunk_size: int. Its signature is flat keyword arguments (content, chunk_size, chunk_overlap, method), so the dict landed in an integer comparison and every audio or video ingest that got as far as chunking died with "'<=' not supported between instances of 'dict' and 'int'".
+
+A second defect sat underneath: chunk_text returns records like {'text': ..., 'start_char': ..., 'word_count': ...}, but the caller wrapped each as {'text': chunk}, nesting the whole record under another text key. Fixing only the call would have written dictionaries into the media content.
+
+Verified end to end rather than by absence of an exception: macOS 'say' synthesised a Gettysburg line, afconvert made it 16 kHz mono, and after the fix the pipeline returned media_id 1 with 82 characters reading '4-Score and 7 years ago our fathers brought forth on this continent to new nation.' Recognisably the input, so transcription, chunking and persistence all work.
+
+Two notes on how this stayed hidden. It was masked by the missing engine: without faster-whisper or parakeet-mlx the path failed earlier, at transcription, so nothing reached chunking -- fixing packaging in task-839 is what made the crash reachable. And an earlier probe with a 440 Hz sine tone failed with 'No text could be extracted', which is task-677's empty-extraction guard behaving correctly on audio that contains no speech; that fixture could not distinguish a working transcriber from a broken one.
+
+Same shape as the pagination defect in task-684.2: a caller assuming a signature the callee does not have. See backlog/docs/lessons-testing-evidence.md.
+
+Files: Local_Ingestion/audio_processing.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-841 - JSON-and-XML-chunking-crash-on-the-shape-their-own-chunkers-return.md
+++ b/backlog/tasks/task-841 - JSON-and-XML-chunking-crash-on-the-shape-their-own-chunkers-return.md
@@ -1,0 +1,44 @@
+---
+id: TASK-841
+title: JSON and XML chunking crash on the shape their own chunkers return
+status: Done
+assignee: []
+created_date: '2026-07-27 02:02'
+updated_date: '2026-07-27 02:02'
+labels:
+  - chunking
+  - bug
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Every request to chunk content by the JSON or XML method fails with a type error. The chunking service post-processes results assuming each chunk is a plain string, but the structure-aware chunkers return records carrying their text alongside metadata, so a string operation is attempted on a record. The text-oriented methods are unaffected because they do return strings. Found by exercising each supported method in turn rather than by reading the dispatch, which looks uniform.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Chunking by JSON returns usable text chunks
+- [x] #2 Chunking by XML returns usable text chunks
+- [x] #3 A structured chunk carrying no text field is preserved rather than dropped
+- [x] #4 The text-oriented methods are unchanged
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed. Every supported chunking method now returns records whose text is a string.
+
+Chunker.chunk_text is not uniform: words, sentences, paragraphs, tokens and semantic return plain strings, while json, xml and ebook_chapters return records carrying their text alongside metadata. ChunkingService post-processed results assuming strings and called .split() on them, so every json and xml request died with "'dict' object has no attribute 'split'".
+
+A _chunk_to_text normaliser now handles both shapes. A structured record with no text field is serialised rather than dropped, so its content still reaches the index.
+
+Nearly misdiagnosed as two separate issues. JSON first failed with 'Chunkable key data not found', which reads as a deliberate constraint. Retesting with a data key produced the same .split() error as XML, showing one bug rather than two -- the first message was the JSON chunker's own input validation firing before the real defect could.
+
+Third instance in one session of a caller assuming a shape its callee does not produce, after the remote-ingest pagination defect and the audio chunking call in task-840. All three are the same lesson, now recorded in backlog/docs/lessons-testing-evidence.md.
+
+Verified by exercising all seven methods through the real service; regression test parametrises over every one. Tests/RAG + Tests/Local_Ingestion: 792 passed, 9 skipped.
+
+Files: RAG_Search/chunking_service.py, Tests/RAG/test_chunking_service.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-842 - Semantic-chunking-depends-on-an-undeclared-NLTK-download.md
+++ b/backlog/tasks/task-842 - Semantic-chunking-depends-on-an-undeclared-NLTK-download.md
@@ -1,0 +1,24 @@
+---
+id: TASK-842
+title: Semantic chunking depends on an undeclared NLTK download
+status: To Do
+assignee: []
+created_date: '2026-07-27 02:02'
+labels:
+  - chunking
+  - packaging
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The semantic chunking method needs NLTK tokeniser data that is fetched at runtime rather than declared as a dependency. Where that data is absent the method raises a lookup error naming an NLTK resource, which reads as an internal fault rather than a missing optional asset. Observed while exercising every chunking method: the same call succeeded in one environment and failed in another purely because of the cached download.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Semantic chunking either has its data available or explains what to install
+- [ ] #2 The failure is not presented as an internal error
+- [ ] #3 Other chunking methods are unaffected when the data is absent
+<!-- AC:END -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,20 +145,30 @@ audio = [
     "yt-dlp",
     "numpy",
     "pydub",
-    "faster-whisper",  # Default transcription provider
-    # Note: For Apple Silicon optimized transcription, also install:
-    # pip install -e ".[audio,transcription_lightning_whisper]" or
-    # pip install -e ".[audio,transcription_parakeet]"
+    # macOS prefers parakeet-mlx at runtime (see config.py's darwin branch), so
+    # ship it there rather than leaving the preferred engine uninstalled: the
+    # preference could never engage on a normal macOS install, and audio ingest
+    # failed with "faster-whisper is not installed" instead (task-839).
+    "parakeet-mlx; sys_platform == 'darwin'",
+    # Fallback everywhere, and the default off darwin.
+    "faster-whisper",
+    # For the other Apple Silicon engine:
+    # pip install -e ".[audio,transcription_lightning_whisper]"
 ]
 video = [
     "soundfile",
     "scipy",
     "yt-dlp",
     "numpy",
-    "faster-whisper",  # Default transcription provider
-    # Note: For Apple Silicon optimized transcription, also install:
-    # pip install -e ".[video,transcription_lightning_whisper]" or
-    # pip install -e ".[video,transcription_parakeet]"
+    # macOS prefers parakeet-mlx at runtime (see config.py's darwin branch), so
+    # ship it there rather than leaving the preferred engine uninstalled: the
+    # preference could never engage on a normal macOS install, and audio ingest
+    # failed with "faster-whisper is not installed" instead (task-839).
+    "parakeet-mlx; sys_platform == 'darwin'",
+    # Fallback everywhere, and the default off darwin.
+    "faster-whisper",
+    # For the other Apple Silicon engine:
+    # pip install -e ".[video,transcription_lightning_whisper]"
 ]
 media_processing = [
     "soundfile",

--- a/tldw_chatbook/Local_Ingestion/audio_processing.py
+++ b/tldw_chatbook/Local_Ingestion/audio_processing.py
@@ -700,15 +700,26 @@ class LocalAudioProcessor:
         language: str = "en",
     ) -> List[Dict[str, Any]]:
         """Chunk text using the chunking service."""
-        chunk_options = {
-            "method": method,
-            "max_size": max_size,
-            "overlap": overlap,
-            "language": language,
-        }
-
-        chunks = self.chunking_service.chunk_text(text, chunk_options)
-        return [{"text": chunk, "metadata": {"method": method}} for chunk in chunks]
+        # ChunkingService.chunk_text takes flat keyword arguments
+        # (content, chunk_size, chunk_overlap, method) -- NOT an options dict.
+        # Passing one positionally put a dict where chunk_size is expected and
+        # every audio/video ingest died in chunking with
+        # "'<=' not supported between instances of 'dict' and 'int'" (task-840).
+        chunks = self.chunking_service.chunk_text(
+            text,
+            chunk_size=max_size,
+            chunk_overlap=overlap,
+            method=method,
+        )
+        # It returns dicts carrying 'text' plus offsets, not bare strings; the
+        # previous wrapping nested the whole dict under another "text" key.
+        return [
+            {
+                "text": chunk["text"] if isinstance(chunk, dict) else str(chunk),
+                "metadata": {"method": method, "language": language},
+            }
+            for chunk in chunks
+        ]
 
     def _analyze_content(
         self,

--- a/tldw_chatbook/Local_Ingestion/audio_processing.py
+++ b/tldw_chatbook/Local_Ingestion/audio_processing.py
@@ -711,15 +711,32 @@ class LocalAudioProcessor:
             chunk_overlap=overlap,
             method=method,
         )
-        # It returns dicts carrying 'text' plus offsets, not bare strings; the
-        # previous wrapping nested the whole dict under another "text" key.
-        return [
-            {
-                "text": chunk["text"] if isinstance(chunk, dict) else str(chunk),
+        # It returns dicts carrying 'text' plus real character offsets, not bare
+        # strings; the previous wrapping nested the whole dict under another
+        # "text" key. Carry the offsets through rather than dropping them: the
+        # storage path otherwise re-derives them by summing chunk lengths, which
+        # double-counts whenever chunks overlap and drifts whenever chunk text is
+        # trimmed -- and overlap is on by default here.
+        normalised = []
+        for index, chunk in enumerate(chunks):
+            if isinstance(chunk, dict):
+                text = chunk.get("text", "")
+                start_char = chunk.get("start_char")
+                end_char = chunk.get("end_char")
+                chunk_index = chunk.get("chunk_index", index)
+            else:
+                text, start_char, end_char, chunk_index = str(chunk), None, None, index
+            entry = {
+                "text": text,
                 "metadata": {"method": method, "language": language},
+                "chunk_index": chunk_index,
             }
-            for chunk in chunks
-        ]
+            if start_char is not None:
+                entry["start_char"] = start_char
+            if end_char is not None:
+                entry["end_char"] = end_char
+            normalised.append(entry)
+        return normalised
 
     def _analyze_content(
         self,
@@ -810,13 +827,16 @@ class LocalAudioProcessor:
                 chunks_to_add = []
                 for i, chunk in enumerate(result["chunks"]):
                     chunk_text = chunk.get("text", "")
-                    # Calculate start and end indices based on chunk position
-                    # This is approximate since we don't have exact character positions
-                    text_length = len(chunk_text)
-                    start_index = sum(
-                        len(c.get("text", "")) for c in result["chunks"][:i]
-                    )
-                    end_index = start_index + text_length
+                    # Prefer the chunker's real character offsets. Summing prior
+                    # chunk lengths only happens to be right when chunks neither
+                    # overlap nor get trimmed; with overlap on it double-counts.
+                    start_index = chunk.get("start_char")
+                    end_index = chunk.get("end_char")
+                    if start_index is None or end_index is None:
+                        start_index = sum(
+                            len(c.get("text", "")) for c in result["chunks"][:i]
+                        )
+                        end_index = start_index + len(chunk_text)
 
                     chunks_to_add.append(
                         {

--- a/tldw_chatbook/RAG_Search/chunking_service.py
+++ b/tldw_chatbook/RAG_Search/chunking_service.py
@@ -5,6 +5,7 @@ This provides a minimal interface to the existing chunking functionality
 to satisfy the import requirements of the simplified RAG service.
 """
 
+import json
 import re
 from typing import List, Dict, Any
 import logging
@@ -23,6 +24,34 @@ class InvalidChunkingMethodError(ChunkingError):
     """Exception raised when an invalid chunking method is specified."""
 
     pass
+
+
+def _chunk_to_text(chunk: Any) -> str:
+    """Return the text of a chunk, whatever shape the chunker produced.
+
+    ``Chunker.chunk_text`` is not uniform: the text methods yield plain strings,
+    while the structure-aware ones (``json``, ``xml``, ``ebook_chapters``) yield
+    dicts carrying their text alongside metadata. Callers that assumed one shape
+    crashed on the other -- see task-840 for the audio path and task-841 for this
+    one.
+
+    Args:
+        chunk: A chunk as returned by the underlying chunker.
+
+    Returns:
+        The chunk's text, or an empty string when it carries none.
+    """
+    if isinstance(chunk, str):
+        return chunk
+    if isinstance(chunk, dict):
+        for key in ("text", "content", "chunk"):
+            value = chunk.get(key)
+            if isinstance(value, str):
+                return value
+        # A structured payload with no text field: serialise rather than drop it,
+        # so the content still reaches the index.
+        return json.dumps(chunk, ensure_ascii=False, default=str)
+    return str(chunk)
 
 
 class ChunkingService:
@@ -181,7 +210,16 @@ class ChunkingService:
                 total_length = len(content)
                 num_chunks = len([c for c in chunks if c])
 
-                for i, chunk_text in enumerate(chunks):
+                for i, raw_chunk in enumerate(chunks):
+                    if not raw_chunk:
+                        continue
+
+                    # Structure-aware chunkers (json, xml, ebook_chapters) return
+                    # dicts carrying their own text plus metadata, while the text
+                    # methods return plain strings. Assuming a string here called
+                    # .split() on a dict and every json/xml chunk request died with
+                    # "'dict' object has no attribute 'split'" (task-841).
+                    chunk_text = _chunk_to_text(raw_chunk)
                     if not chunk_text:
                         continue
 


### PR DESCRIPTION
Two bugs, the first of which was **hiding** the second. Audio and video ingest could never complete.

## 839 — macOS never gets its preferred engine

`config.py`'s darwin branch prefers `parakeet-mlx`, then `lightning-whisper-mlx`, then `faster-whisper`. That logic is correct. But **nothing installed either Apple Silicon engine**: the `audio` and `video` extras pinned `faster-whisper` and mentioned the others only in a comment suggesting a second manual install.

So the preference could never engage. On a machine with `soundfile`, `scipy` and `numpy` all present, audio ingest failed with:

```
FileIngestionError: Audio processing failed:
faster-whisper is not installed. Install with: pip install faster-whisper
```

…while the app had logged *"No macOS-specific STT providers found, using faster-whisper as default"* at startup — the fallback firing exactly as written, for want of a package no install path provided.

Both extras now carry `parakeet-mlx; sys_platform == 'darwin'`. `faster-whisper` stays for every other platform and as the darwin fallback, so **non-macOS installs are unchanged**. Confirmed after installing: the log flips to *"Detected parakeet-mlx available on macOS, setting as default STT provider."*

## 840 — the crash that gap was hiding

With an engine finally present, transcription succeeded and **chunking died**:

```
Failed to chunk text using method 'words':
'<=' not supported between instances of 'dict' and 'int'
```

`ChunkingService.chunk_text` takes flat keyword arguments `(content, chunk_size, chunk_overlap, method)`. The audio processor passed an options **dict positionally**, so it landed in `chunk_size` and was compared against an integer.

A second defect sat underneath: `chunk_text` returns records like `{'text': ..., 'start_char': ..., 'word_count': ...}`, not bare strings, but the caller wrapped each as `{"text": chunk}` — nesting the whole record under another `text` key. Fixing only the call would have written dictionaries into the media content.

## Verified with a real transcript

Not by absence of an exception. macOS `say` synthesised a Gettysburg line, `afconvert` made it 16 kHz mono, and after the fix the pipeline returns 82 characters:

> `4-Score and 7 years ago our fathers brought forth on this continent to new nation.`

Recognisably the input — so transcription, chunking and persistence all work. `Tests/Local_Ingestion`: **77 passed**.

## Why neither was caught before

The missing engine **masked** the crash: without any transcriber the path failed earlier, so nothing reached chunking. Fixing packaging is what made it reachable.

And my first fixture was a 440 Hz sine tone, which failed with *"No text could be extracted"* — that is task-677's empty-extraction guard behaving **correctly** on audio containing no speech. A tone cannot distinguish a working transcriber from a broken one; only synthesized speech can.

## Pattern

840 is the same shape as the pagination defect in 684.2 — a caller assuming a signature the callee does not have — which is the first entry in `backlog/docs/lessons-testing-evidence.md`, added earlier today. It recurred within the same session, in a different subsystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix macOS audio/video ingest by shipping `parakeet-mlx` on macOS and repairing chunking and storage so transcription completes. Normalize chunk shapes and keep real offsets to stop JSON/XML crashes and overlapping range errors. Addresses Linear 839, 840, and 841.

- **Bug Fixes**
  - Audio/video: call `chunk_text` with named args (`content`, `chunk_size`, `chunk_overlap`, `method`), preserve `start_char`/`end_char`/`chunk_index`, and avoid nesting. Storage uses real offsets with a length-sum fallback only when missing. Added seam tests for signature and offset handling.
  - RAG chunking: add `_chunk_to_text` to handle string and dict chunks; serialize structured chunks missing `text`. Contract tests across methods; skip `semantic` when NLTK data is absent.

- **Dependencies**
  - Add `parakeet-mlx` to `audio` and `video` extras for `sys_platform == 'darwin'`; keep `faster-whisper` as fallback and the non-macOS default. macOS now gets its preferred engine as defined in config.

<sup>Written for commit e3ac7dcd716064c8fd188dadd8756ca9b3c4fb41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

