### PR TITLE
chore(backlog): resolve 839-842 id collision from concurrent filing

### DIFF
--- a/backlog/tasks/task-847 - Harden-is_sensitive_path-fail-closed-on-unresolvable-paths.md
+++ b/backlog/tasks/task-847 - Harden-is_sensitive_path-fail-closed-on-unresolvable-paths.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-839
+id: TASK-847
 title: Harden is_sensitive_path fail-closed on unresolvable paths
 status: To Do
 assignee: []

--- a/backlog/tasks/task-848 - Extend-agent-file-tool-denylist-beyond-the-active-user-data-folder.md
+++ b/backlog/tasks/task-848 - Extend-agent-file-tool-denylist-beyond-the-active-user-data-folder.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-840
+id: TASK-848
 title: Extend agent file-tool denylist beyond the active user data folder
 status: To Do
 assignee: []

--- a/backlog/tasks/task-849 - Agent-created-directory-can-shadow-a-not-yet-created-state-file.md
+++ b/backlog/tasks/task-849 - Agent-created-directory-can-shadow-a-not-yet-created-state-file.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-841
+id: TASK-849
 title: Agent-created directory can shadow a not-yet-created state file
 status: To Do
 assignee: []

--- a/backlog/tasks/task-850 - Scope-glob_files-and-grep_files-to-workspace-folder-roots.md
+++ b/backlog/tasks/task-850 - Scope-glob_files-and-grep_files-to-workspace-folder-roots.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-842
+id: TASK-850
 title: Scope glob_files and grep_files to workspace folder roots
 status: To Do
 assignee: []


### PR DESCRIPTION
Four ids were filed twice within the same window.

A concurrent session filed 839-842 between the duplicate scan run for #953 and #953 merging. That session's PR #954 landed first and its own title references `task 842`, so those four keep their ids under the usual rule that a referenced task never moves. The four filed alongside #953 move to 847-850:

- 839 → 847 Harden `is_sensitive_path` fail-closed on unresolvable paths
- 840 → 848 Extend agent file-tool denylist beyond the active user data folder
- 841 → 849 Agent-created directory can shadow a not-yet-created state file
- 842 → 850 Scope `glob_files`/`grep_files` to workspace folder roots

No cross-references needed updating. Duplicate scan over `backlog/tasks` is clean.

Worth noting the guard did not catch this: the scan is advisory and ran *before* the concurrent filing landed, so a clean scan at filing time says nothing about the state at merge time. Re-running it immediately before merge would have caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve a concurrent filing collision by reassigning backlog task IDs 839–842 to 847–850. Preserves existing references and keeps the backlog consistent.

- **Bug Fixes**
  - Reassigned IDs 839–842 → 847–850; updated front matter and filenames.
  - Kept references used by PR #954; no cross-references needed changes; duplicate scan is clean.

<sup>Written for commit 5bf7da32cfa45dc38d0c18c616f73c300d0c6655. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

