### PR TITLE
fix(evals): calculate_semantic_similarity returned None whenever it worked

### DIFF
--- a/Tests/Evals/test_evaluation_metrics.py
+++ b/Tests/Evals/test_evaluation_metrics.py
@@ -6,8 +6,29 @@ Tests instruction_adherence, format_compliance, coherence_score, and dialogue_qu
 import pytest
 from unittest.mock import Mock
 
-from tldw_chatbook.Evals.eval_runner import BaseEvalRunner, EvalSample, EvalSampleResult
+from tldw_chatbook.Evals.eval_runner import (
+    BaseEvalRunner,
+    EvalSample,
+    EvalSampleResult,
+    MetricsCalculator,
+)
 from tldw_chatbook.Evals.task_loader import TaskConfig
+
+
+class _StubEmbeddingModel:
+    """Deterministic stand-in for a SentenceTransformer.
+
+    Lets tests exercise the "embedding model IS present" success path of
+    ``calculate_semantic_similarity`` without downloading or loading a real
+    model. Maps each input string to a fixed vector via ``encode()``, the
+    same method name/signature real SentenceTransformer models expose.
+    """
+
+    def __init__(self, vectors: dict):
+        self._vectors = vectors
+
+    def encode(self, texts):
+        return [self._vectors[text] for text in texts]
 
 
 class TestRunner(BaseEvalRunner):
@@ -311,3 +332,84 @@ class TestEvaluationMetrics:
         metrics = runner.calculate_metrics(dialogue, "expected", sample)
         assert "dialogue_quality" in metrics
         assert metrics["dialogue_quality"] > 0.5
+
+
+class TestSemanticSimilarityWithEmbeddingModel:
+    """Exercise the embedding-model success path of calculate_semantic_similarity.
+
+    Regression coverage for TASK-862: when an embedding model is available
+    (real SentenceTransformer or, here, a stub passed via the
+    ``embedding_model`` parameter), the function used to fall off the end
+    without returning anything, silently yielding None on every call. The
+    existing suite only ever exercised the "embeddings unavailable" fallback
+    path, so it never caught this. These tests supply a fake embedding model
+    so they are fast, deterministic, and require no network access or model
+    download.
+    """
+
+    def test_returns_float_not_none_when_embedding_model_present(self):
+        """A real float must come back, not None, when embeddings succeed."""
+        model = _StubEmbeddingModel(
+            {
+                "the cat sat": [1.0, 0.0, 0.0],
+                "the cat sat on the mat": [0.9, 0.1, 0.0],
+            }
+        )
+
+        score = MetricsCalculator.calculate_semantic_similarity(
+            "the cat sat", "the cat sat on the mat", embedding_model=model
+        )
+
+        assert score is not None
+        assert isinstance(score, float)
+        assert 0.0 < score < 1.0
+
+    def test_identical_embeddings_yield_similarity_one(self):
+        """Identical vectors -> cosine similarity 1.0 (clamped upper bound)."""
+        model = _StubEmbeddingModel({"same": [1.0, 2.0, 3.0]})
+
+        score = MetricsCalculator.calculate_semantic_similarity(
+            "same", "same", embedding_model=model
+        )
+
+        assert score == pytest.approx(1.0)
+
+    def test_opposite_embeddings_are_clamped_to_zero(self):
+        """Cosine similarity is [-1, 1], but callers expect a [0, 1] score.
+
+        Opposite vectors give raw cosine similarity -1.0; the function must
+        clamp that into range rather than returning a negative score.
+        """
+        model = _StubEmbeddingModel(
+            {
+                "positive": [1.0, 0.0],
+                "negative": [-1.0, 0.0],
+            }
+        )
+
+        score = MetricsCalculator.calculate_semantic_similarity(
+            "positive", "negative", embedding_model=model
+        )
+
+        assert score is not None
+        assert score == pytest.approx(0.0)
+        assert 0.0 <= score <= 1.0
+
+    def test_zero_norm_embedding_returns_zero_not_exception_fallback(self):
+        """A zero vector must yield 0.0, not divide-by-zero / lexical fallback.
+
+        Uses identical predicted/expected text so the lexical-overlap
+        fallback (used when embeddings error out) would score this 1.0
+        (exact string match). Zero-magnitude embedding vectors previously
+        raised ZeroDivisionError in the pure-Python branch, which the broad
+        `except Exception` silently converted into that 1.0 lexical
+        fallback score. Asserting 0.0 here fails loudly if that regression
+        returns, instead of coincidentally matching either path's output.
+        """
+        model = _StubEmbeddingModel({"identical text": [0.0, 0.0, 0.0]})
+
+        score = MetricsCalculator.calculate_semantic_similarity(
+            "identical text", "identical text", embedding_model=model
+        )
+
+        assert score == 0.0

--- a/Tests/Evals/test_evaluation_metrics.py
+++ b/Tests/Evals/test_evaluation_metrics.py
@@ -31,6 +31,48 @@ class _StubEmbeddingModel:
         return [self._vectors[text] for text in texts]
 
 
+class _ConstantEmbeddingModel:
+    """Stub embedding model that returns the same fixed vector for every
+    input string, ignoring the text entirely.
+
+    Used to test the exact-match short-circuit in
+    ``calculate_semantic_similarity``: since every string maps to the same
+    vector here, if that short-circuit were removed,
+    ``calculate_semantic_similarity(s, s)`` would fall through to computing
+    cosine self-similarity on this vector instead of returning 1.0
+    immediately. Pairing this with a vector whose self-similarity is
+    demonstrably NOT exactly 1.0 at float64 (see
+    ``_PRECISION_LOSING_VECTOR`` below) makes that fallthrough detectable.
+    """
+
+    def __init__(self, vector):
+        self._vector = vector
+
+    def encode(self, texts):
+        return [self._vector for _ in texts]
+
+
+# An 8-dim vector (arbitrary values from a random search, not float32
+# truncated) whose cosine self-similarity - computed exactly the way
+# calculate_semantic_similarity computes it, dot(v, v) / (norm(v) * norm(v))
+# at float64 - lands at 0.9999999999999999, a couple of ULPs short of exact
+# 1.0. sqrt-then-square rounding does not always cancel out even at double
+# precision. Verified directly:
+#   >>> v = np.asarray(_PRECISION_LOSING_VECTOR, dtype=np.float64)
+#   >>> float(np.dot(v, v) / (np.linalg.norm(v) * np.linalg.norm(v)))
+#   0.9999999999999999
+_PRECISION_LOSING_VECTOR = [
+    0.3610581159591675,
+    -1.952863097190857,
+    2.347409725189209,
+    0.9684969186782837,
+    -0.759387195110321,
+    0.9021982550621033,
+    -0.46695318818092346,
+    -0.060689520090818405,
+]
+
+
 class TestRunner(BaseEvalRunner):
     """Concrete implementation of BaseEvalRunner for testing."""
 
@@ -365,11 +407,25 @@ class TestSemanticSimilarityWithEmbeddingModel:
         assert 0.0 < score < 1.0
 
     def test_identical_embeddings_yield_similarity_one(self):
-        """Identical vectors -> cosine similarity 1.0 (clamped upper bound)."""
-        model = _StubEmbeddingModel({"same": [1.0, 2.0, 3.0]})
+        """Identical vectors -> cosine similarity 1.0 (clamped upper bound).
+
+        Uses two DIFFERENT input strings that happen to map to the same
+        vector, not two identical strings. calculate_semantic_similarity
+        now short-circuits on exact string equality before ever calling
+        the embedding model, so using identical strings here would no
+        longer exercise the embedding math this test is named for - it
+        would just exercise the short-circuit added for a different reason
+        (see TestSemanticSimilarityExactMatchShortCircuit below).
+        """
+        model = _StubEmbeddingModel(
+            {
+                "a cat sentence": [1.0, 2.0, 3.0],
+                "a kitty sentence": [1.0, 2.0, 3.0],
+            }
+        )
 
         score = MetricsCalculator.calculate_semantic_similarity(
-            "same", "same", embedding_model=model
+            "a cat sentence", "a kitty sentence", embedding_model=model
         )
 
         assert score == pytest.approx(1.0)
@@ -398,18 +454,87 @@ class TestSemanticSimilarityWithEmbeddingModel:
     def test_zero_norm_embedding_returns_zero_not_exception_fallback(self):
         """A zero vector must yield 0.0, not divide-by-zero / lexical fallback.
 
-        Uses identical predicted/expected text so the lexical-overlap
-        fallback (used when embeddings error out) would score this 1.0
-        (exact string match). Zero-magnitude embedding vectors previously
-        raised ZeroDivisionError in the pure-Python branch, which the broad
-        `except Exception` silently converted into that 1.0 lexical
-        fallback score. Asserting 0.0 here fails loudly if that regression
+        Uses two DIFFERENT (not exactly equal, so the string-equality
+        short-circuit does not fire) but lexically overlapping predicted/
+        expected strings, both mapped to a zero-magnitude embedding vector.
+        The lexical-overlap fallback (used when embeddings error out) scores
+        this pair at ~0.857 (verified via
+        MetricsCalculator._calculate_lexical_semantic_fallback), not 0.0 and
+        not 1.0. Zero-magnitude embedding vectors previously raised
+        ZeroDivisionError in the pure-Python branch, which the broad
+        `except Exception` silently converted into that lexical fallback
+        score. Asserting exactly 0.0 here fails loudly if that regression
         returns, instead of coincidentally matching either path's output.
         """
-        model = _StubEmbeddingModel({"identical text": [0.0, 0.0, 0.0]})
+        model = _StubEmbeddingModel(
+            {
+                "the cat sat down": [0.0, 0.0, 0.0],
+                "the cat sat": [0.0, 0.0, 0.0],
+            }
+        )
 
         score = MetricsCalculator.calculate_semantic_similarity(
-            "identical text", "identical text", embedding_model=model
+            "the cat sat down", "the cat sat", embedding_model=model
         )
 
         assert score == 0.0
+
+
+class TestSemanticSimilarityExactMatchShortCircuit:
+    """calculate_semantic_similarity(s, s) must return exactly 1.0.
+
+    Follow-up regression coverage: the initial TASK-862 fix upcast
+    embeddings to float64 before the cosine-similarity division, which
+    reduces but does NOT eliminate floating point precision loss -
+    sqrt-then-square rounding still leaves a real fraction of embeddings a
+    few ULPs short of exact 1.0 even at float64 (measured empirically:
+    ~30% of random float32 vectors; concretely,
+    ``calculate_semantic_similarity("the cat sat on the mat", "the cat sat
+    on the mat")`` returned 0.9999999999999998 through the real cached
+    MiniLM model on this machine). Cosine similarity of a vector with
+    itself is 1.0 by construction, so exact string equality must
+    short-circuit before the embedding model is ever consulted, rather than
+    depending on floating point arithmetic to land exactly on 1.0.
+    """
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "4",
+            "hello",
+            "the cat sat on the mat",
+            "a much longer sentence with several different words in it",
+        ],
+    )
+    def test_exact_match_returns_one_despite_lossy_embedding(self, text):
+        # Every input string maps to the SAME deliberately precision-losing
+        # vector (see _PRECISION_LOSING_VECTOR), regardless of its content.
+        # If the short-circuit were removed, this would compute cosine
+        # self-similarity on that vector - 0.9999999999999999, not 1.0 -
+        # instead of returning the exact 1.0 guaranteed by construction.
+        model = _ConstantEmbeddingModel(_PRECISION_LOSING_VECTOR)
+
+        score = MetricsCalculator.calculate_semantic_similarity(
+            text, text, embedding_model=model
+        )
+
+        assert score == 1.0
+
+    def test_non_identical_strings_still_use_the_embedding_path(self):
+        """Only LITERAL equality short-circuits; near-misses must not.
+
+        "4" and "4 " are different strings (trailing space), so they must
+        still go through the embedding model rather than short-circuiting.
+        Both map to the same precision-losing vector here, so the result
+        should be extremely close to 1.0 but demonstrably NOT the exact
+        1.0 the short-circuit would produce - proving this pair took the
+        embedding path, not the short-circuit.
+        """
+        model = _ConstantEmbeddingModel(_PRECISION_LOSING_VECTOR)
+
+        score = MetricsCalculator.calculate_semantic_similarity(
+            "4", "4 ", embedding_model=model
+        )
+
+        assert score != 1.0
+        assert score == pytest.approx(1.0)

--- a/Tests/Evals/test_evaluation_metrics.py
+++ b/Tests/Evals/test_evaluation_metrics.py
@@ -3,14 +3,18 @@ Tests for custom evaluation metrics.
 Tests instruction_adherence, format_compliance, coherence_score, and dialogue_quality metrics.
 """
 
-import pytest
 from unittest.mock import Mock
+
+import pytest
 
 from tldw_chatbook.Evals.eval_runner import (
     BaseEvalRunner,
     EvalSample,
     EvalSampleResult,
     MetricsCalculator,
+)
+from tldw_chatbook.Evals.metrics_calculator import (
+    MetricsCalculator as StandaloneMetricsCalculator,
 )
 from tldw_chatbook.Evals.task_loader import TaskConfig
 
@@ -507,6 +511,15 @@ class TestSemanticSimilarityExactMatchShortCircuit:
         ],
     )
     def test_exact_match_returns_one_despite_lossy_embedding(self, text):
+        """An exact string match returns exactly 1.0 despite a lossy embedding round-trip.
+
+        Args:
+            text: Input string used as both the predicted and expected value.
+                Every case maps, via ``_ConstantEmbeddingModel``, to the same
+                deliberately precision-losing vector, so this parametrization
+                confirms the short-circuit holds regardless of the specific
+                text content.
+        """
         # Every input string maps to the SAME deliberately precision-losing
         # vector (see _PRECISION_LOSING_VECTOR), regardless of its content.
         # If the short-circuit were removed, this would compute cosine
@@ -538,3 +551,75 @@ class TestSemanticSimilarityExactMatchShortCircuit:
 
         assert score != 1.0
         assert score == pytest.approx(1.0)
+
+
+class TestStandaloneMetricsCalculatorSemanticSimilarity:
+    """Regression coverage for the second ``MetricsCalculator`` copy.
+
+    ``tldw_chatbook/Evals/metrics_calculator.py`` defines a standalone
+    ``MetricsCalculator`` that duplicates the one in ``eval_runner.py``
+    (see TASK-863). Nothing imports it at runtime, but ``Evals/README.md``
+    and ``DEVELOPER_GUIDE.md`` both instruct users to import it directly, so
+    it needs to uphold the same ``[0, 1]``-score invariants as the
+    ``eval_runner`` copy even though the two have not yet been consolidated
+    into one implementation. These tests exercise
+    ``StandaloneMetricsCalculator`` (imported from ``metrics_calculator``,
+    aliased to avoid colliding with the ``eval_runner`` import used above)
+    directly, independent of the ``eval_runner`` tests.
+    """
+
+    def test_exact_match_returns_one(self):
+        """An exact string match returns exactly 1.0 without calling the embedding model."""
+        model = _ConstantEmbeddingModel(_PRECISION_LOSING_VECTOR)
+
+        score = StandaloneMetricsCalculator.calculate_semantic_similarity(
+            "the cat sat on the mat", "the cat sat on the mat", embedding_model=model
+        )
+
+        assert score == 1.0
+
+    def test_opposite_embeddings_are_clamped_to_zero_not_negative_one(self):
+        """Cosine similarity is [-1, 1], but callers expect a [0, 1] score.
+
+        Opposite vectors give raw cosine similarity -1.0; the standalone
+        copy must clamp that into range rather than returning the negative
+        raw cosine value (the defect TASK-863 flagged: this copy previously
+        returned raw cosine similarity uncapped).
+        """
+        model = _StubEmbeddingModel(
+            {
+                "positive": [1.0, 0.0],
+                "negative": [-1.0, 0.0],
+            }
+        )
+
+        score = StandaloneMetricsCalculator.calculate_semantic_similarity(
+            "positive", "negative", embedding_model=model
+        )
+
+        assert score is not None
+        assert score == pytest.approx(0.0)
+        assert 0.0 <= score <= 1.0
+
+    def test_zero_norm_embedding_returns_zero_without_raising(self):
+        """A zero-magnitude embedding vector must yield 0.0, not raise or return NaN.
+
+        Uses two DIFFERENT (not exactly equal, so the string-equality
+        short-circuit does not fire) strings, both mapped to a
+        zero-magnitude embedding vector. An unguarded division here
+        computes 0/0, which numpy turns into NaN rather than raising -
+        asserting exactly 0.0 (not just "no exception") fails loudly if
+        that NaN leaks out instead of being caught by the zero-guard.
+        """
+        model = _StubEmbeddingModel(
+            {
+                "the cat sat down": [0.0, 0.0, 0.0],
+                "the cat sat": [0.0, 0.0, 0.0],
+            }
+        )
+
+        score = StandaloneMetricsCalculator.calculate_semantic_similarity(
+            "the cat sat down", "the cat sat", embedding_model=model
+        )
+
+        assert score == 0.0

--- a/backlog/tasks/task-863 - Evals-metrics_calculator-is-an-orphan-the-README-tells-users-to-import.md
+++ b/backlog/tasks/task-863 - Evals-metrics_calculator-is-an-orphan-the-README-tells-users-to-import.md
@@ -34,3 +34,7 @@ Decide one of: delete the orphan and repoint the docs at `eval_runner.py`, or ma
 - [ ] The surviving `calculate_semantic_similarity` clamps to `[0, 1]` and cannot return a negative score
 - [ ] A test would fail if the two implementations were reintroduced and drifted
 <!-- AC:END -->
+
+## Notes
+
+- 2026-07-27: PR #957 (TASK-862 follow-up, addressing a Qodo review finding) brought `calculate_semantic_similarity` in both copies into semantic agreement: `metrics_calculator.py`'s copy now also has the exact-string-equality short-circuit (`predicted == expected` -> `1.0`) and clamps its result to `[0, 1]` on both the numpy and pure-Python branches, matching `eval_runner.py`'s copy. Its zero-guard (`else 1.0` denominator swap on the pure-Python branch) was already correct and was left unchanged; a `norm_product > 0` guard was added to the numpy branch, which previously had no zero-guard at all and could return `NaN` for zero-magnitude vectors. New regression tests cover this copy directly in `Tests/Evals/test_evaluation_metrics.py::TestStandaloneMetricsCalculatorSemanticSimilarity`. The two copies are no longer semantically divergent - the remaining work here is consolidating them into a single implementation (this task's actual AC), not fixing further drift.

--- a/backlog/tasks/task-863 - Evals-metrics_calculator-is-an-orphan-the-README-tells-users-to-import.md
+++ b/backlog/tasks/task-863 - Evals-metrics_calculator-is-an-orphan-the-README-tells-users-to-import.md
@@ -1,0 +1,36 @@
+---
+id: TASK-863
+title: >-
+  Evals/metrics_calculator.py is a 506-line orphan the README tells users to import
+status: To Do
+assignee: []
+created_date: '2026-07-27 04:00'
+labels:
+  - evals
+  - dead-code
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found while fixing TASK-862. `tldw_chatbook/Evals/metrics_calculator.py` defines a `MetricsCalculator` class that duplicates the one in `eval_runner.py`. No Python file imports it — the only references anywhere in the tree are documentation.
+
+That duplication is the root cause of TASK-862. The two copies drifted, and `eval_runner.py`'s copy silently lost the `cosine_sim =` assignment and its `return` from `calculate_semantic_similarity`, plus had its zero-guard changed from `else 1.0` to `else 0.0` (turning a correct `0/1.0 = 0.0` into a `ZeroDivisionError`). Nothing detected the drift because nothing compares the copies.
+
+**The good news, established by an AST diff of the two classes:** of the 11 methods they share, 9 are byte-identical, and `calculate_perplexity` differs only cosmetically (`return math.exp(x)` vs assign-then-return). Only `calculate_semantic_similarity` had genuinely drifted. So there is no second latent bug of the same class hiding here — but there is nothing preventing the next one either.
+
+**The live hazard is the documentation.** `Evals/README.md:309` instructs `from tldw_chatbook.Evals.metrics_calculator import MetricsCalculator`, and `DEVELOPER_GUIDE.md` presents `metrics_calculator.py` as "the Metrics System". Anyone following those docs imports the orphan, which — after TASK-862 — is the copy that still returns raw cosine values. Verified: with opposite embedding vectors it returns `-1.0`, where every caller treats the result as a `[0, 1]` score.
+
+Decide one of: delete the orphan and repoint the docs at `eval_runner.py`, or make it the single source and have `eval_runner` import from it. Do not leave two copies.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] Exactly one `MetricsCalculator` implementation remains importable
+- [ ] `Evals/README.md` and `DEVELOPER_GUIDE.md` point at the surviving one
+- [ ] The surviving `calculate_semantic_similarity` clamps to `[0, 1]` and cannot return a negative score
+- [ ] A test would fail if the two implementations were reintroduced and drifted
+<!-- AC:END -->

--- a/tldw_chatbook/Evals/eval_runner.py
+++ b/tldw_chatbook/Evals/eval_runner.py
@@ -768,18 +768,39 @@ class MetricsCalculator:
 
             # Calculate cosine similarity
             try:
-                from numpy import dot
+                from numpy import asarray, dot, float64
                 from numpy.linalg import norm
 
-                dot(pred_embedding, exp_embedding) / (
-                    norm(pred_embedding) * norm(exp_embedding)
+                # Upcast to float64: real embedding models commonly hand back
+                # float32 vectors, and computing the dot product / norms at
+                # float32 precision can make a vector's similarity with
+                # itself land a few ULPs short of 1.0 (e.g. 0.99999988
+                # instead of 1.0). Computing in double precision avoids that
+                # avoidable precision loss.
+                pred_vec = asarray(pred_embedding, dtype=float64)
+                exp_vec = asarray(exp_embedding, dtype=float64)
+                norm_product = norm(pred_vec) * norm(exp_vec)
+                similarity = (
+                    float(dot(pred_vec, exp_vec) / norm_product)
+                    if norm_product > 0
+                    else 0.0
                 )
             except ImportError:
-                # Fallback to pure Python cosine similarity
-                dot_product = sum(a * b for a, b in zip(pred_embedding, exp_embedding))
-                norm1 = sum(a * a for a in pred_embedding) ** 0.5
-                norm2 = sum(b * b for b in exp_embedding) ** 0.5
-                dot_product / ((norm1 * norm2) if norm1 * norm2 > 0 else 0.0)
+                # Fallback to pure Python cosine similarity. Cast each
+                # element to a native Python float (double precision) so
+                # this matches the numpy branch above regardless of the
+                # embedding model's native dtype.
+                dot_product = sum(
+                    float(a) * float(b) for a, b in zip(pred_embedding, exp_embedding)
+                )
+                norm1 = sum(float(a) * float(a) for a in pred_embedding) ** 0.5
+                norm2 = sum(float(b) * float(b) for b in exp_embedding) ** 0.5
+                norm_product = norm1 * norm2
+                similarity = dot_product / norm_product if norm_product > 0 else 0.0
+
+            # Cosine similarity ranges over [-1, 1]; callers/tests expect a
+            # [0, 1] score, so clamp before returning.
+            return max(0.0, min(1.0, similarity))
 
         except ImportError:
             # Fallback to token overlap if embeddings not available

--- a/tldw_chatbook/Evals/eval_runner.py
+++ b/tldw_chatbook/Evals/eval_runner.py
@@ -747,6 +747,18 @@ class MetricsCalculator:
         if not predicted or not expected:
             return 0.0
 
+        # Exact string equality guarantees cosine similarity of 1.0 by
+        # construction (a vector's similarity with itself is always 1),
+        # so short-circuit before touching the embedding model at all.
+        # This is NOT the same guarantee as "the model embeds these two
+        # (possibly different) strings identically" - computing that case
+        # through dot()/norm() at float64 lands short of 1.0 for a real
+        # fraction of embeddings (float32 rounding in the model output
+        # doesn't cancel exactly under sqrt-then-square), so it must not
+        # be special-cased here. Only a literal `==` match qualifies.
+        if predicted == expected:
+            return 1.0
+
         lexical_fallback = MetricsCalculator._calculate_lexical_semantic_fallback(
             predicted, expected
         )
@@ -775,8 +787,13 @@ class MetricsCalculator:
                 # float32 vectors, and computing the dot product / norms at
                 # float32 precision can make a vector's similarity with
                 # itself land a few ULPs short of 1.0 (e.g. 0.99999988
-                # instead of 1.0). Computing in double precision avoids that
-                # avoidable precision loss.
+                # instead of 1.0). Computing in double precision reduces
+                # that avoidable precision loss, but sqrt-then-square
+                # rounding still leaves a real fraction of embeddings a
+                # few ULPs off exact 1.0 even at float64 - this is a
+                # quality improvement, not an exactness guarantee. Exact
+                # equality of the *input strings* is handled separately
+                # above, before the embedding model is ever called.
                 pred_vec = asarray(pred_embedding, dtype=float64)
                 exp_vec = asarray(exp_embedding, dtype=float64)
                 norm_product = norm(pred_vec) * norm(exp_vec)

--- a/tldw_chatbook/Evals/metrics_calculator.py
+++ b/tldw_chatbook/Evals/metrics_calculator.py
@@ -275,6 +275,16 @@ class MetricsCalculator:
         if not predicted or not expected:
             return 0.0
 
+        # Exact string equality guarantees cosine similarity of 1.0 by
+        # construction (a vector's similarity with itself is always 1), so
+        # short-circuit before touching the embedding model at all. Kept in
+        # sync with eval_runner.MetricsCalculator.calculate_semantic_similarity
+        # - see that copy's docstring/comments for the full rationale on why
+        # this must be a literal `==` check rather than relying on the
+        # embedding math to land on exactly 1.0.
+        if predicted == expected:
+            return 1.0
+
         lexical_fallback = MetricsCalculator._calculate_lexical_semantic_fallback(
             predicted, expected
         )
@@ -299,19 +309,33 @@ class MetricsCalculator:
                 from numpy import dot
                 from numpy.linalg import norm
 
-                cosine_sim = dot(pred_embedding, exp_embedding) / (
-                    norm(pred_embedding) * norm(exp_embedding)
+                norm_product = norm(pred_embedding) * norm(exp_embedding)
+                # Guard against zero-magnitude vectors: an unguarded division
+                # here computes 0/0, which numpy silently turns into NaN
+                # rather than raising - and NaN survives an unguarded
+                # min()/max() clamp depending on argument order, so it must
+                # be caught here rather than left to the clamp below.
+                cosine_sim = (
+                    float(dot(pred_embedding, exp_embedding) / norm_product)
+                    if norm_product > 0
+                    else 0.0
                 )
-                return float(cosine_sim)
             except ImportError:
-                # Fallback to pure Python cosine similarity
+                # Fallback to pure Python cosine similarity. The zero-guard
+                # below swaps in a 1.0 denominator (not the final value) when
+                # both vectors are zero-magnitude: the dot product is also 0
+                # in that case, so 0 / 1.0 = 0.0, which is the correct
+                # similarity for two zero vectors.
                 dot_product = sum(a * b for a, b in zip(pred_embedding, exp_embedding))
                 norm1 = sum(a * a for a in pred_embedding) ** 0.5
                 norm2 = sum(b * b for b in exp_embedding) ** 0.5
                 cosine_sim = dot_product / (
                     (norm1 * norm2) if norm1 * norm2 > 0 else 1.0
                 )
-                return cosine_sim
+
+            # Cosine similarity ranges over [-1, 1]; callers/tests expect a
+            # [0, 1] score, so clamp before returning.
+            return max(0.0, min(1.0, cosine_sim))
 
         except ImportError:
             # Fallback to token overlap if embeddings not available


### PR DESCRIPTION
## The bug

`MetricsCalculator.calculate_semantic_similarity` is annotated `-> float` but returned `None`
whenever it actually worked.

It reads as a flake and is not one. With `sentence_transformers` importable the function returns
`None`; with the import unavailable it returns a correct float via the lexical fallback. So it fails
on a developer machine with the model cached and passes on a bare CI box. The only environment where
it worked was the one where it could not do its job.

## Four defects, not one

1. **The result was computed and discarded on both success paths.** The numpy branch evaluated
   `dot(pred, exp) / (norm(pred) * norm(exp))` as a bare expression statement, and the pure-Python
   fallback did the same. Neither was returned or assigned, so control fell off the end to an
   implicit `None`. Only the two `except` handlers returned anything.

2. **The pure-Python zero-guard was inverted.** `dot_product / ((norm1 * norm2) if norm1 * norm2 > 0
   else 0.0)` divides *by* `0.0` when the norms vanish, raising `ZeroDivisionError` that the broad
   `except Exception` then silently converted into the lexical fallback. The intent was plainly to
   *return* `0.0`.

3. **Range mismatch.** Cosine similarity is `[-1, 1]`; callers and tests treat the result as a
   `[0, 1]` score. Unrelated text could score negative.

4. **Precision.** Fixing (1) exposed that float32 embeddings make a vector's similarity with itself
   land a few ULPs short of 1.0. Measured across 2000 random float32 vectors of MiniLM's 384 dims:
   only 802 self-similarities land exactly `1.0`, and 593 land *below* it, where a clamp cannot help.
   The real model returns `0.9999999999999998` for `"the cat sat on the mat"`.

   Upcasting to float64 alone would have made the existing test pass for its one input string
   without guaranteeing anything — the same "works for this input, on this machine" shape as the
   original bug. Fixed by construction instead: an exact-string-equality short-circuit before any
   embedding work, which is correct by definition and skips a pointless model round-trip. The
   lexical fallback already did exactly this. The float64 upcast is kept, because it genuinely
   improves the non-identical cases, but nothing now depends on it for exactness.

## Blast radius

Worse than a null score. In `_calculate_instruction_adherence` the `None` was appended to
`requirement_scores` and then summed, raising
`TypeError: unsupported operand type(s) for +: 'float' and 'NoneType'` — so any sample carrying an
`include`/`avoid` requirement crashed the scorer. A second path returned the `None` directly, which
is the pre-existing failure of `test_instruction_adherence_basic` (`assert None == 1.0`). It passes now.

## Why it survived

Every existing test exercised only the path where the dependency is **missing**. This PR adds tests
that assert a real float comes back when an embedding model **is** present, using stub models so they
stay fast and offline.

## Verified

- self-similarity is exactly `1.0` across multiple strings, including the one that failed
- the embedding path still produces graded scores (0.13-0.89), so the short-circuit did not swallow it
- opposite vectors clamp to `0.0` instead of `-1.0`
- zero-norm vectors return `0.0` instead of raising
- `Tests/Evals/`: 393 passed, 13 skipped, 0 failed

Every added test was checked by reverting the fix and confirming it fails.

## Root cause, filed as TASK-863

`Evals/metrics_calculator.py` is a 506-line orphan defining a second `MetricsCalculator` that nothing
imports. The two copies drifted and this one lost its `return`, with nothing comparing them. An AST
diff shows 9 of their 11 shared methods are byte-identical and `calculate_perplexity` differs only
cosmetically, so there is no second latent bug — but nothing prevents the next one. The live hazard
is that `Evals/README.md:309` instructs importing the orphan, which still returns unclamped cosine
values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `MetricsCalculator.calculate_semantic_similarity` to always return a [0, 1] float (never None/negative) and prevents instruction-adherence crashes. Also aligns the standalone `tldw_chatbook/Evals/metrics_calculator.py` copy with the same behavior and adds targeted tests. Addresses TASK-862 and progresses TASK-863.

- Bug Fixes
  - Return the computed cosine; clamp to [0, 1]; guard zero norms; compute in float64 for stability.
  - Short-circuit exact string equality to 1.0 before any embedding call; keep lexical fallback only when embeddings are unavailable or error.
  - Apply the same semantics to `tldw_chatbook/Evals/metrics_calculator.py` (added exact-match short-circuit, zero-guard, and clamping; fixed prior NaN case); add regression tests for this copy.
  - Add fast stub-embedding tests for the embedding-present path and edge cases (identical/opposite/zero-norm). Logged TASK-863 for consolidation of the duplicate.

<sup>Written for commit ea544a482f411b6442212c921537332c1e85081a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

