### PR TITLE
fix(evals): the Evals DB ignored the configured profile and always wrote to default_user

### DIFF
--- a/Tests/Evals/test_eval_orchestrator_db_path.py
+++ b/Tests/Evals/test_eval_orchestrator_db_path.py
@@ -248,3 +248,100 @@ def test_legacy_notice_uses_the_hardcoded_legacy_location_even_with_custom_data_
     joined = "\n".join(messages)
     assert str(legacy_db) in joined, messages
     assert legacy_db.read_bytes() == b"pretend-legacy-sqlite-bytes"
+
+
+def test_legacy_notice_still_fires_once_routed_through_path_validation(
+    monkeypatch, tmp_path
+):
+    """Qodo (PR #959) flagged that _warn_if_legacy_data_exists() checked
+    .exists() on config/env-derived paths without validating them through
+    path_validation.py, unlike the rest of this file. This confirms both
+    that validate_path_simple() is actually consulted (a spy wraps the
+    real implementation) and that doing so still lets the notice fire for
+    an ordinary, legitimate legacy path -- the validation step must not
+    silently swallow the happy path."""
+    home_dir = tmp_path / "home_validated_happy_path"
+    home_dir.mkdir()
+    legacy_dir = home_dir / ".local" / "share" / "tldw_cli" / "default_user"
+    legacy_dir.mkdir(parents=True)
+    legacy_db = legacy_dir / "evals.db"
+    legacy_db.write_bytes(b"pretend-legacy-sqlite-bytes")
+
+    _isolate_profile(monkeypatch, tmp_path, "zeta_profile", home_dir=home_dir)
+
+    from tldw_chatbook.Utils.path_validation import (
+        validate_path_simple as real_validate_path_simple,
+    )
+
+    validated_paths: list[Path] = []
+
+    def _spy_validate_path_simple(path, require_exists=False):
+        validated_paths.append(Path(path))
+        return real_validate_path_simple(path, require_exists=require_exists)
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Evals.eval_orchestrator.validate_path_simple",
+        _spy_validate_path_simple,
+    )
+
+    messages: list[str] = []
+    sink_id = loguru_logger.add(messages.append, level="WARNING", format="{message}")
+    try:
+        orchestrator = EvaluationOrchestrator(client_id="test_zeta")
+    finally:
+        loguru_logger.remove(sink_id)
+
+    resolved_path = Path(orchestrator.db.db_path)
+    joined = "\n".join(messages)
+    assert str(resolved_path) in joined, messages
+    assert str(legacy_db) in joined, messages
+
+    # The notice's paths must actually have been routed through
+    # validate_path_simple(), not just checked with .exists() directly.
+    assert resolved_path in validated_paths, validated_paths
+    assert legacy_db in validated_paths, validated_paths
+
+
+def test_legacy_notice_does_not_raise_when_path_validation_fails(
+    monkeypatch, tmp_path
+):
+    """validate_path_simple() can over-reject legitimate paths (TASK-838:
+    its raw-string scan for parent-directory patterns runs before
+    normalization and can misfire on legitimate Windows-style paths).
+    _warn_if_legacy_data_exists() only ever emits an informational
+    warning about pre-existing data, so a validation failure must degrade
+    to "skip the warning" -- it must never raise into
+    _initialize_database and break Evals startup."""
+    home_dir = tmp_path / "home_validation_fails"
+    home_dir.mkdir()
+    legacy_dir = home_dir / ".local" / "share" / "tldw_cli" / "default_user"
+    legacy_dir.mkdir(parents=True)
+    (legacy_dir / "evals.db").write_bytes(b"pretend-legacy-sqlite-bytes")
+
+    _isolate_profile(monkeypatch, tmp_path, "eta_profile", home_dir=home_dir)
+
+    def _always_reject(path, require_exists=False):
+        raise ValueError("simulated TASK-838-style over-rejection")
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Evals.eval_orchestrator.validate_path_simple",
+        _always_reject,
+    )
+
+    messages: list[str] = []
+    sink_id = loguru_logger.add(messages.append, level="WARNING", format="{message}")
+    try:
+        # Must not raise even though validate_path_simple() always rejects.
+        orchestrator = EvaluationOrchestrator(client_id="test_eta")
+    finally:
+        loguru_logger.remove(sink_id)
+
+    # The DB itself still initializes normally -- only the legacy-data
+    # notice is affected by validation failing.
+    resolved_path = Path(orchestrator.db.db_path)
+    assert resolved_path.parent.name == "eta_profile"
+    assert resolved_path.exists()
+
+    # No legacy-data warning is emitted when validation can't vouch for the
+    # paths, even though legacy data genuinely exists on disk.
+    assert not any("default_user" in message for message in messages), messages

--- a/Tests/Evals/test_eval_orchestrator_db_path.py
+++ b/Tests/Evals/test_eval_orchestrator_db_path.py
@@ -1,0 +1,250 @@
+# test_eval_orchestrator_db_path.py
+# Description: Regression tests for TASK-860 (Evals DB profile isolation)
+#
+"""
+Regression tests for task-860: EvaluationOrchestrator._initialize_database()
+must honor the configured profile, not always write to "default_user".
+
+Background: the old code resolved the profile via
+``settings.get("user_id", settings.get("username", "default_user"))`` and
+the data root via ``settings.get("user_data_dir", ...)``. ``load_settings()``
+never publishes either key -- the real profile name is published as
+``USERS_NAME`` -- so both lookups silently missed and every profile shared
+one ``default_user/evals.db``. The fix resolves the path through
+``tldw_chatbook.config.get_user_data_dir()``, the same helper every other DB
+in the app uses.
+"""
+
+from pathlib import Path
+
+import pytest
+from loguru import logger as loguru_logger
+
+from tldw_chatbook import config as config_module
+from tldw_chatbook.Evals.eval_orchestrator import EvaluationOrchestrator
+
+
+@pytest.fixture(autouse=True)
+def _clear_settings_cache():
+    """Force load_settings()/get_cli_setting() to re-read the (monkeypatched)
+    active config in every test here, instead of serving a stale cross-test
+    cache (see Tests/test_user_data_dir_isolation.py for the same pattern)."""
+    _reset_config_caches()
+    yield
+    _reset_config_caches()
+
+
+def _reset_config_caches():
+    config_module._SETTINGS_CACHE = None
+    config_module._SETTINGS_CACHE_SOURCE = None
+    config_module._CONFIG_CACHE = None
+    config_module._CONFIG_CACHE_SOURCE = None
+
+
+def _isolate_profile(
+    monkeypatch,
+    tmp_path,
+    profile_name: str,
+    *,
+    home_dir: Path,
+    data_dir: Path | None = None,
+) -> None:
+    """Point HOME at a scratch dir and configure the given profile name.
+
+    No ``[paths] data_dir`` is set unless ``data_dir`` is given, so
+    ``get_user_data_dir()`` normally exercises the real default-fallback
+    branch (``HOME/.local/share/tldw_cli``).
+    """
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+
+    data_dir_line = f'data_dir = "{data_dir}"\n' if data_dir is not None else ""
+    scratch_config = tmp_path / f"config_{profile_name}.toml"
+    scratch_config.write_text(
+        f'[general]\nusers_name = "{profile_name}"\n\n[paths]\n{data_dir_line}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(scratch_config))
+
+
+def test_evals_db_path_changes_with_the_configured_profile(monkeypatch, tmp_path):
+    """Two different profiles under the same HOME must resolve to two
+    different evals.db paths, and neither may be hardcoded to
+    'default_user' when the configured profile says otherwise."""
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+
+    _isolate_profile(monkeypatch, tmp_path, "alpha_profile", home_dir=home_dir)
+    orchestrator_a = EvaluationOrchestrator(client_id="test_a")
+    path_a = Path(orchestrator_a.db.db_path)
+
+    _reset_config_caches()
+
+    _isolate_profile(monkeypatch, tmp_path, "beta_profile", home_dir=home_dir)
+    orchestrator_b = EvaluationOrchestrator(client_id="test_b")
+    path_b = Path(orchestrator_b.db.db_path)
+
+    assert path_a != path_b, (
+        f"Both profiles resolved to the same evals.db path ({path_a}) -- "
+        "the profile is not actually being honored."
+    )
+    assert path_a.name == "evals.db"
+    assert path_b.name == "evals.db"
+    assert path_a.parent.name == "alpha_profile", path_a
+    assert path_b.parent.name == "beta_profile", path_b
+    assert "default_user" not in path_a.parts, path_a
+    assert "default_user" not in path_b.parts, path_b
+    assert str(path_a).startswith(str(home_dir)), path_a
+    assert str(path_b).startswith(str(home_dir)), path_b
+
+
+def test_evals_db_path_still_used_for_the_default_user_profile(monkeypatch, tmp_path):
+    """A profile literally named 'default_user' is still a legitimate
+    profile -- it must resolve normally, not be treated specially."""
+    home_dir = tmp_path / "home_default"
+    home_dir.mkdir()
+    _isolate_profile(monkeypatch, tmp_path, "default_user", home_dir=home_dir)
+
+    orchestrator = EvaluationOrchestrator(client_id="test_default")
+    path = Path(orchestrator.db.db_path)
+
+    assert path.parent.name == "default_user"
+    assert path.name == "evals.db"
+    assert str(path).startswith(str(home_dir))
+
+
+def test_legacy_default_user_data_notice_fires_when_legacy_exists(
+    monkeypatch, tmp_path
+):
+    """If the profile-resolved path has no data yet but the legacy
+    default_user/evals.db does, a clear one-time warning must fire naming
+    both paths -- and the legacy file must be left completely untouched
+    (no silent copy or move)."""
+    home_dir = tmp_path / "home_legacy"
+    home_dir.mkdir()
+    legacy_dir = home_dir / ".local" / "share" / "tldw_cli" / "default_user"
+    legacy_dir.mkdir(parents=True)
+    legacy_db = legacy_dir / "evals.db"
+    legacy_db.write_bytes(b"pretend-legacy-sqlite-bytes")
+    legacy_mtime = legacy_db.stat().st_mtime
+
+    _isolate_profile(monkeypatch, tmp_path, "gamma_profile", home_dir=home_dir)
+
+    messages: list[str] = []
+    sink_id = loguru_logger.add(messages.append, level="WARNING", format="{message}")
+    try:
+        orchestrator = EvaluationOrchestrator(client_id="test_gamma")
+    finally:
+        loguru_logger.remove(sink_id)
+
+    resolved_path = Path(orchestrator.db.db_path)
+    assert resolved_path.parent.name == "gamma_profile"
+
+    joined = "\n".join(messages)
+    assert str(resolved_path) in joined, messages
+    assert str(legacy_db) in joined, messages
+
+    # Nothing was copied or moved: the legacy file is unchanged, and the new
+    # profile got its own fresh (empty-of-legacy-content) database file.
+    assert legacy_db.read_bytes() == b"pretend-legacy-sqlite-bytes"
+    assert legacy_db.stat().st_mtime == legacy_mtime
+    assert resolved_path != legacy_db
+    assert resolved_path.exists()  # EvalsDB creates its own fresh file
+    assert resolved_path.stat().st_size != legacy_db.stat().st_size or (
+        resolved_path.read_bytes() != legacy_db.read_bytes()
+    )
+
+
+def test_no_legacy_notice_when_no_legacy_data_exists(monkeypatch, tmp_path):
+    """A brand-new user with no legacy default_user/evals.db must not be
+    warned about data that was never there."""
+    home_dir = tmp_path / "home_fresh"
+    home_dir.mkdir()
+    _isolate_profile(monkeypatch, tmp_path, "fresh_profile", home_dir=home_dir)
+
+    messages: list[str] = []
+    sink_id = loguru_logger.add(messages.append, level="WARNING", format="{message}")
+    try:
+        EvaluationOrchestrator(client_id="test_fresh")
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert not any("default_user" in message for message in messages), messages
+
+
+def test_no_legacy_notice_when_the_new_profile_already_has_its_own_data(
+    monkeypatch, tmp_path
+):
+    """Once a profile has its own evals.db, the legacy notice must stop --
+    it already has independent data and does not need the old file."""
+    home_dir = tmp_path / "home_has_own_data"
+    home_dir.mkdir()
+    legacy_dir = home_dir / ".local" / "share" / "tldw_cli" / "default_user"
+    legacy_dir.mkdir(parents=True)
+    (legacy_dir / "evals.db").write_bytes(b"legacy-bytes")
+
+    _isolate_profile(monkeypatch, tmp_path, "delta_profile", home_dir=home_dir)
+
+    # First run creates the profile's own evals.db.
+    EvaluationOrchestrator(client_id="test_delta_first")
+
+    _reset_config_caches()
+    _isolate_profile(monkeypatch, tmp_path, "delta_profile", home_dir=home_dir)
+
+    messages: list[str] = []
+    sink_id = loguru_logger.add(messages.append, level="WARNING", format="{message}")
+    try:
+        EvaluationOrchestrator(client_id="test_delta_second")
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert not any("default_user" in message for message in messages), messages
+
+
+def test_legacy_notice_uses_the_hardcoded_legacy_location_even_with_custom_data_dir(
+    monkeypatch, tmp_path
+):
+    """The pre-fix code's `user_data_dir` lookup key never existed in
+    `load_settings()`, so it ALWAYS fell back to the literal
+    "~/.local/share/tldw_cli", even for a user who had configured a custom
+    `[paths] data_dir`. The real legacy Evals data for such a user is
+    therefore under HOME, not under their custom data root -- the notice
+    must look there, or it would miss exactly the users most likely to have
+    lost track of an old file."""
+    home_dir = tmp_path / "home_custom_data_dir"
+    home_dir.mkdir()
+    custom_data_dir = tmp_path / "somewhere_else_entirely"
+    custom_data_dir.mkdir()
+
+    # The TRUE legacy location the old buggy code always wrote to: hardcoded,
+    # under HOME, regardless of the custom data_dir configured below.
+    legacy_dir = home_dir / ".local" / "share" / "tldw_cli" / "default_user"
+    legacy_dir.mkdir(parents=True)
+    legacy_db = legacy_dir / "evals.db"
+    legacy_db.write_bytes(b"pretend-legacy-sqlite-bytes")
+
+    _isolate_profile(
+        monkeypatch,
+        tmp_path,
+        "epsilon_profile",
+        home_dir=home_dir,
+        data_dir=custom_data_dir,
+    )
+
+    messages: list[str] = []
+    sink_id = loguru_logger.add(messages.append, level="WARNING", format="{message}")
+    try:
+        orchestrator = EvaluationOrchestrator(client_id="test_epsilon")
+    finally:
+        loguru_logger.remove(sink_id)
+
+    resolved_path = Path(orchestrator.db.db_path)
+    # Sanity: the profile's own DB really did land under the custom data
+    # root, not under HOME -- confirms the test is exercising the scenario
+    # it claims to.
+    assert str(resolved_path).startswith(str(custom_data_dir)), resolved_path
+    assert resolved_path.parent.name == "epsilon_profile"
+
+    joined = "\n".join(messages)
+    assert str(legacy_db) in joined, messages
+    assert legacy_db.read_bytes() == b"pretend-legacy-sqlite-bytes"

--- a/backlog/tasks/task-860 - Evals-DB-ignores-configured-profile-writes-to-default_user.md
+++ b/backlog/tasks/task-860 - Evals-DB-ignores-configured-profile-writes-to-default_user.md
@@ -2,7 +2,7 @@
 id: TASK-860
 title: >-
   Evals DB ignores the configured profile and always writes to default_user
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-27 02:40'
 labels:
@@ -32,8 +32,29 @@ Note this is pre-existing and unrelated to the word bench engine — `eval_orche
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] The Evals DB path honours the same profile name every other DB uses
-- [ ] Launching with a non-default profile creates `<profile>/evals.db`, not `default_user/evals.db`
-- [ ] The data root honours the configured value rather than silently falling back
-- [ ] A test asserts the resolved path changes when the profile changes
+- [x] The Evals DB path honours the same profile name every other DB uses
+- [x] Launching with a non-default profile creates `<profile>/evals.db`, not `default_user/evals.db`
+- [x] The data root honours the configured value rather than silently falling back
+- [x] A test asserts the resolved path changes when the profile changes
 <!-- AC:END -->
+
+## Implementation Notes
+
+**Approach.** `EvaluationOrchestrator._initialize_database()` (`tldw_chatbook/Evals/eval_orchestrator.py`) no longer re-derives the profile/data-root from `settings.get(...)` with guessed keys. It now calls `tldw_chatbook.config.get_user_data_dir()` directly — the same shared, profile-aware helper every other DB (`get_chachanotes_db_path`, `get_media_db_path`, etc.) already uses. That helper correctly resolves `[general] users_name` (env `USERS_NAME`) and honours `[paths] data_dir` when configured.
+
+**Existing-data handling.** Chose the notice-only option specified in the task rather than any silent copy/move. Added `EvaluationOrchestrator._warn_if_legacy_data_exists()`, called once per orchestrator construction (i.e., effectively once per app launch, since `EvalsDB.__init__` immediately creates the schema file, so the profile's own path exists on every subsequent call and the check short-circuits). It fires a `logger.warning` naming both the new (empty) path and the legacy path when: the resolved path doesn't yet exist, the legacy file does, and the two paths differ. It never touches either file.
+
+One subtlety caught in self-review: the pre-fix code's `user_data_dir` lookup key was **never published** by `load_settings()` at all, so its fallback literal `"~/.local/share/tldw_cli"` always won — even for a user who had configured a custom `[paths] data_dir`. The true legacy location is therefore always the hardcoded `~/.local/share/tldw_cli/default_user/evals.db`, not `<configured_data_root>/default_user/evals.db`. The legacy-notice path is computed as that hardcoded literal (not derived relative to the newly-resolved path), or it would have missed exactly the users most likely to have a custom data root and lost track of an old file. Verified with a dedicated test (`test_legacy_notice_uses_the_hardcoded_legacy_location_even_with_custom_data_dir`) that fails against the naive relative-path version and passes against the shipped one.
+
+**Tests.** New file `Tests/Evals/test_eval_orchestrator_db_path.py`, 6 tests:
+- two different configured profiles resolve to two different `evals.db` paths, neither hardcoded to `default_user`
+- a profile literally named `default_user` still resolves normally (not special-cased away)
+- the legacy notice fires, names both paths, and leaves the legacy file byte-for-byte untouched
+- no notice when there's no legacy file, and no notice once the profile has its own data
+- the custom-`data_dir` edge case described above
+
+Revert-check: reverted `eval_orchestrator.py` to `HEAD` and reran the new test file — 3 of 5 tests failed as expected (the two path-changed-with-profile assertions and the legacy-notice-fires assertion; the other two incidentally still passed for reasons orthogonal to the fix — one because the profile used was literally `default_user`, one because "no notice when nothing to notice about" holds trivially with no warning logic at all). Also reverted just the legacy-path line to the naive (buggy) relative-path form and confirmed the custom-`data_dir` test alone fails against it. Restored the fix afterward and reran clean.
+
+**Test counts.** `pytest Tests/Evals/ -q`: baseline (pre-fix, without the new test file) 405 passed / 13 skipped / 0 failed; after (fix + 6 new tests) 411 passed / 13 skipped / 0 failed. No regressions, no pre-existing failures.
+
+**Files modified:** `tldw_chatbook/Evals/eval_orchestrator.py`. **Files added:** `Tests/Evals/test_eval_orchestrator_db_path.py`. No schema changes; word bench engine and Evals UI untouched.

--- a/tldw_chatbook/Evals/eval_orchestrator.py
+++ b/tldw_chatbook/Evals/eval_orchestrator.py
@@ -81,22 +81,72 @@ class EvaluationOrchestrator:
     def _initialize_database(self, db_path: str, client_id: str) -> EvalsDB:
         """Initialize database connection with proper path."""
         if db_path is None:
-            # Use default path in user data directory
-            from tldw_chatbook.config import load_settings
+            # Resolve the default path through the same shared, profile-aware
+            # mechanism every other DB in the app uses. Do NOT re-derive the
+            # profile / data-root from settings.get(...) with guessed keys --
+            # load_settings() publishes the profile name as "USERS_NAME"
+            # (not "user_id"/"username"), and it does not publish
+            # "user_data_dir" at all, so both lookups used to silently miss.
+            from tldw_chatbook.config import get_user_data_dir
 
-            settings = load_settings()
-            user_data_dir = Path(
-                settings.get("user_data_dir", "~/.local/share/tldw_cli")
-            ).expanduser()
+            user_dir = get_user_data_dir()
+            resolved_path = user_dir / "evals.db"
 
-            # Use user ID from config
-            user_id = settings.get("user_id", settings.get("username", "default_user"))
-            db_path = user_data_dir / user_id / "evals.db"
+            self._warn_if_legacy_data_exists(resolved_path)
+
+            db_path = resolved_path
 
         # Ensure directory exists
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
 
         return EvalsDB(db_path=str(db_path), client_id=client_id)
+
+    @staticmethod
+    def _warn_if_legacy_data_exists(resolved_path: Path) -> None:
+        """Warn once if the profile-resolved evals.db is missing but legacy data exists.
+
+        Before this fix, EVERY profile shared a single Evals database at the
+        literal, hardcoded path "~/.local/share/tldw_cli/default_user/evals.db"
+        -- not "<configured_data_root>/default_user/evals.db". The buggy code
+        read `settings.get("user_data_dir", "~/.local/share/tldw_cli")`, and
+        `load_settings()` never publishes a "user_data_dir" key, so that
+        fallback literal always won even for users with a custom
+        `[paths] data_dir`. The legacy location this function checks must
+        therefore stay hardcoded too, or it would miss exactly the users most
+        likely to be surprised (those who already customized their data root).
+
+        If the newly-resolved, profile-specific path has no data yet but that
+        legacy file does, the user's existing benches/datasets/runs are not
+        lost -- they are simply still sitting at the old, hardcoded path.
+        Surface that clearly instead of silently starting a brand-new, empty
+        database.
+
+        This function never copies, moves, or deletes anything.
+        """
+        legacy_path = (
+            Path("~/.local/share/tldw_cli").expanduser() / "default_user" / "evals.db"
+        )
+
+        if resolved_path == legacy_path:
+            # The configured profile IS "default_user" (with no custom data
+            # root) -- this IS the legacy location, nothing to warn about.
+            return
+
+        if resolved_path.exists():
+            # This profile already has its own data; nothing to warn about.
+            return
+
+        if legacy_path.exists():
+            logger.warning(
+                "No Evals database found for the current profile at {}. "
+                "Older versions of this app ignored the configured profile and "
+                "always wrote Evals data under the 'default_user' profile -- "
+                "your existing benches, datasets and runs are still there: {}. "
+                "Nothing has been moved or copied automatically; if you want "
+                "that data under this profile, copy the file there yourself.",
+                resolved_path,
+                legacy_path,
+            )
 
     @contextmanager
     def _db_operation(self, operation_name: str):

--- a/tldw_chatbook/Evals/eval_orchestrator.py
+++ b/tldw_chatbook/Evals/eval_orchestrator.py
@@ -102,6 +102,33 @@ class EvaluationOrchestrator:
         return EvalsDB(db_path=str(db_path), client_id=client_id)
 
     @staticmethod
+    def _safe_validate_existence_check_path(
+        path: Path, purpose: str
+    ) -> Optional[Path]:
+        """Validate a path through validate_path_simple before an existence check.
+
+        This exists solely to decide whether to emit an informational warning
+        about legacy Evals data -- it must never turn into a startup failure.
+        validate_path_simple can raise on paths it has no business rejecting
+        here (see TASK-838: its raw-string scan for parent-directory patterns
+        runs before normalization and over-rejects some legitimate Windows
+        paths, e.g. drive-relative paths containing "..\\" style segments).
+        If validation raises for any reason, log why at debug level and
+        return None so the caller degrades to "skip the warning" instead of
+        propagating the error into _initialize_database.
+        """
+        try:
+            return validate_path_simple(path)
+        except Exception as e:
+            logger.debug(
+                "Skipping legacy-Evals-data check for {} path {}: {}",
+                purpose,
+                path,
+                e,
+            )
+            return None
+
+    @staticmethod
     def _warn_if_legacy_data_exists(resolved_path: Path) -> None:
         """Warn once if the profile-resolved evals.db is missing but legacy data exists.
 
@@ -126,6 +153,24 @@ class EvaluationOrchestrator:
         legacy_path = (
             Path("~/.local/share/tldw_cli").expanduser() / "default_user" / "evals.db"
         )
+
+        validated_resolved_path = EvaluationOrchestrator._safe_validate_existence_check_path(
+            resolved_path, "resolved Evals database"
+        )
+        if validated_resolved_path is None:
+            # Validation failed (e.g. TASK-838 over-rejection). This function
+            # only ever emits an informational warning, so degrade to
+            # "nothing to warn about" rather than risk breaking Evals
+            # startup over a path we can't safely check.
+            return
+        resolved_path = validated_resolved_path
+
+        validated_legacy_path = EvaluationOrchestrator._safe_validate_existence_check_path(
+            legacy_path, "legacy Evals database"
+        )
+        if validated_legacy_path is None:
+            return
+        legacy_path = validated_legacy_path
 
         if resolved_path == legacy_path:
             # The configured profile IS "default_user" (with no custom data


### PR DESCRIPTION
Every database in this app honours the configured profile and lands under
`~/.local/share/tldw_cli/<profile>/`. The Evals database did not — it always wrote to
`default_user/evals.db`.

`eval_orchestrator._initialize_database` resolved the profile with
`settings.get("user_id", settings.get("username", "default_user"))`, but `load_settings()`
publishes the profile as **`USERS_NAME`**. Both lookups missed, so the hardcoded fallback always
won. `user_data_dir` is likewise never published, so the data root fell back to a literal too.

Two consequences: profiles were not isolated for Evals (all shared one file), and scratch/test
profiles silently wrote into the user's real Evals data. That is how it was found — a verification
run with a throwaway `TLDW_CONFIG_PATH` put every other DB under the scratch profile but created its
bench, dataset and run inside `default_user/evals.db`.

**Fix:** resolve through the shared, profile-aware `get_user_data_dir()` helper the rest of the app
uses, rather than re-deriving from `settings.get(...)` with guessed key names.

**Existing data is not touched.** Users whose profile is not literally `default_user` would otherwise
open an empty database and appear to have lost everything. When the profile-resolved path does not
exist but legacy data does, a warning names both paths. Nothing is copied, moved, or deleted.

One subtlety worth recording: the legacy check must use the *literal* `~/.local/share/tldw_cli/
default_user/evals.db`, not a path derived from the new resolution. The old code's `user_data_dir`
key was never published either, so it hardcoded that root regardless of any custom `[paths] data_dir`
— a first draft that derived the legacy path relative to the new one would have missed exactly the
users it was meant to help.

Tests: `Tests/Evals/` 405 → 411 passed, 0 failed. Closes TASK-860.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Evals DB to honor the configured profile and data root via `tldw_chatbook.config.get_user_data_dir()`, so each profile gets its own `evals.db`. Adds a one-time legacy-data warning and validates paths before existence checks to avoid startup errors; existing data is not moved.

- **Bug Fixes**
  - Resolve DB path via `get_user_data_dir()` to use `USERS_NAME` and optional `[paths] data_dir`.
  - Warn when the profile DB is missing and legacy `~/.local/share/tldw_cli/default_user/evals.db` exists; never auto-migrate.
  - Validate both resolved and legacy paths with `validate_path_simple` before `.exists()` checks; on validation failures, skip the warning to keep startup safe.
  - Added tests for profile isolation, custom `data_dir`, legacy notice behavior, and validation pass/fail. Satisfies TASK-860.

<sup>Written for commit e428ace06342ce2d5703b2c6f44a53d8430daf5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

