### PR TITLE
refactor(evals): clear the deferred results-grid polish findings

### DIFF
--- a/Tests/Evals/word_bench/test_analysis.py
+++ b/Tests/Evals/word_bench/test_analysis.py
@@ -76,14 +76,43 @@ def test_entropy_normalizes_to_a_shared_k_like_divergence_does():
 def test_effective_k_is_the_minimum_k_returned_across_cells():
     """The grid-level K a mixed-K comparison (e.g. an OpenAI legacy target
     capped at K=5 alongside a llama.cpp target requested at K=20) must
-    render entropy at."""
-    a = _cap([("a", 0.5)], k_returned=20)
-    b = _cap([("b", 0.5)], k_returned=5)
+    render entropy at.
+
+    Each cell's ``top_k`` is padded out to its own claimed ``k_returned``
+    (mirroring a real capture, where the two always agree by construction
+    -- see ``capture_client.py``) so this test exercises the min-across-
+    cells rule on its own, not ``effective_k``'s separate defensive
+    ``len(top_k)`` clamp -- see
+    ``test_effective_k_clamps_a_k_returned_that_exceeds_the_actual_top_k_length``
+    for that."""
+    a = _cap([("a", 0.5)] + [(f"a_extra_{i}", 0.001) for i in range(19)], k_returned=20)
+    b = _cap([("b", 0.5)] + [(f"b_extra_{i}", 0.001) for i in range(4)], k_returned=5)
+    assert len(a.top_k) == 20 and len(b.top_k) == 5, "fixture must match its own k_returned"
     assert effective_k([a, b]) == 5
 
 
 def test_effective_k_of_no_cells_is_zero():
     assert effective_k([]) == 0
+
+
+def test_effective_k_clamps_a_k_returned_that_exceeds_the_actual_top_k_length():
+    """TASK-861 item 6 (defensive only, NOT a live-path fix): on every real
+    capture ``k_returned == len(top_k)`` holds by construction --
+    ``capture_client.py`` sets ``k_returned=len(tokens)`` from the very
+    list that becomes ``top_k``. This only guards a ``CellCapture``
+    rebuilt from STORED JSON where the two fields were read independently
+    (``storage.py``) and could disagree if the row were corrupted; there is
+    no ``__post_init__`` on ``CellCapture`` stopping a caller (or a
+    corrupted round-trip) from constructing exactly that shape, which is
+    what this test does directly.
+
+    Without the clamp, ``effective_k`` would report the corrupted cell's
+    inflated ``k_returned`` (99) as usable, when the cell only actually has
+    2 ranked tokens -- mirrors ``divergence()``'s own two-way clamp
+    (``min(a.k_returned, b.k_returned, len(a.top_k), len(b.top_k))``),
+    which ``effective_k`` did not have before this fix."""
+    corrupted = _cap([("a", 0.5), ("b", 0.5)], k_returned=99)
+    assert effective_k([corrupted]) == 2
 
 
 def test_divergence_of_identical_distributions_is_zero():

--- a/Tests/UI/test_evals_results_grid.py
+++ b/Tests/UI/test_evals_results_grid.py
@@ -291,6 +291,14 @@ def k_depth_matched_run_group(evals_db: EvalsDB) -> dict:
     copy of ``clean_run_group``'s own s1 -- already K-depth-matched by the
     original author, per its own comment -- so nothing about the asserted
     entropy/truncation numbers below changes.
+
+    Args:
+        evals_db: The EvalsDB database instance for creating models,
+            datasets, and run groups.
+
+    Returns:
+        A dict with keys "group_id" (str), "base_id" (int), and "poor_id"
+        (int) identifying the test run group and its two target models.
     """
     base_id = evals_db.create_model(name="llama-3-8b", provider="llama_cpp", model_id="m")
     poor_id = evals_db.create_model(name="capped-target", provider="openai", model_id="m2")

--- a/Tests/UI/test_evals_results_grid.py
+++ b/Tests/UI/test_evals_results_grid.py
@@ -266,6 +266,60 @@ def clean_run_group(evals_db: EvalsDB) -> dict:
     return {"group_id": group_id, "base_id": base_id, "poor_id": poor_id}
 
 
+@pytest.fixture
+def k_depth_matched_run_group(evals_db: EvalsDB) -> dict:
+    """A single-snippet K=20-vs-K=5 grid where EVERY cell's ``top_k``
+    length actually matches its claimed ``k_returned`` -- unlike
+    ``clean_run_group``'s s2/s3 rows above, whose ``top_k`` is
+    deliberately abbreviated below their claimed ``k_returned`` (a
+    fixture-writing shorthand used throughout this file: list only the
+    tokens whose probability matters and let the rest live in
+    ``_distribution``'s implicit "other" bucket).
+
+    ``analysis.effective_k`` (TASK-861) now clamps each cell's
+    ``k_returned`` to ``len(top_k)`` before taking the cross-cell minimum
+    -- a defensive guard against corrupted stored JSON, a no-op on a real
+    capture where the two always agree by construction (see
+    ``capture_client.py``). Mixing one of ``clean_run_group``'s
+    abbreviated rows into a grid-wide ``effective_k`` computation would
+    drag the WHOLE grid's effective K down to that row's tiny native
+    length (1 or 2), which is exactly why this fixture exists rather than
+    reusing ``clean_run_group`` for the two tests below: padding s2/s3
+    out to their claimed K would change the divergence figures a dozen
+    OTHER tests in this file hard-code (bang-marker flags, spread
+    ordering, group means), while this fixture's single row is a direct
+    copy of ``clean_run_group``'s own s1 -- already K-depth-matched by the
+    original author, per its own comment -- so nothing about the asserted
+    entropy/truncation numbers below changes.
+    """
+    base_id = evals_db.create_model(name="llama-3-8b", provider="llama_cpp", model_id="m")
+    poor_id = evals_db.create_model(name="capped-target", provider="openai", model_id="m2")
+    dataset_id = evals_db.create_dataset(
+        name="k-depth-set", format="custom", source_path="inline:k-depth-set"
+    )
+    config = BenchConfig(
+        name="k-depth bench", prompt_mode="raw", top_k=20,
+        dataset_id=dataset_id, target_ids=(base_id, poor_id),
+    )
+    task_id = save_bench(evals_db, config)
+    targets = [
+        Target(id=base_id, name="llama-3-8b", provider="llama_cpp", model_id="m"),
+        Target(id=poor_id, name="capped-target", provider="openai", model_id="m2"),
+    ]
+    snippets = [Snippet(id="s1", text="the protestors were", group="neutral")]
+    group_id, run_ids = create_run_group(evals_db, task_id, config, targets, snippets)
+
+    same_dist = [(" a", 0.5), (" the", 0.3), (" an", 0.1), (" some", 0.05), (" one", 0.03)]
+    rich_tail = [(f"_extra_{i}", 0.001) for i in range(15)]  # +15 real low-prob tokens
+    save_cell(
+        evals_db, run_ids[base_id], snippets[0],
+        _cap(same_dist + rich_tail, k_returned=20),
+    )
+    save_cell(evals_db, run_ids[poor_id], snippets[0], _cap(same_dist, k_returned=5))
+
+    return {"group_id": group_id, "base_id": base_id, "poor_id": poor_id}
+
+
 # ---------------------------------------------------------------------------
 # Fixture: a snippet whose text is itself Rich markup syntax -- the exact
 # pattern confirmed (against this project's pinned Textual version) to
@@ -353,6 +407,60 @@ async def _select_run_group(pilot, group_id: str) -> ResultsGrid:
 # ---------------------------------------------------------------------------
 # Pure-function unit tests: no Textual app needed at all.
 # ---------------------------------------------------------------------------
+
+
+def test_ever_observed_helpers_share_one_scan_and_hold_the_right_axis_fixed():
+    """TASK-861 item 1: ``_ever_observed_active_probe`` (one probe, every
+    target) and ``_ever_observed_all_probes`` (one target, every probe)
+    used to each carry their own copy of the identical nested scan (the
+    second's own docstring admitted as much). Folded into a shared
+    module-level ``_probe_observed_in_target(snippets, cells, target_id,
+    probe)``.
+
+    Monkeypatches that shared helper and asserts BOTH methods route
+    through it -- proving neither kept a private copy of the scan -- and
+    asserts the EXACT (target, probe) pairs each one calls it with, which
+    pins that each call site still holds its own axis fixed rather than
+    the fold accidentally making the single-active-probe call site pay for
+    every configured probe (or vice versa)."""
+    from tldw_chatbook.UI.Evals import results_grid as results_grid_module
+
+    grid = ResultsGrid(view_model=None, run_group_id="g")
+    calls: list[tuple[str, str]] = []
+
+    def _fake_observed(snippets, cells, target_id, probe):
+        calls.append((target_id, probe))
+        return target_id == "t1"
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(results_grid_module, "_probe_observed_in_target", _fake_observed)
+    try:
+        targets = [{"id": "t1", "name": "a"}, {"id": "t2", "name": "b"}]
+        snippets = [{"id": "s1", "text": "x"}]
+        cells: dict = {}
+
+        # One probe, every target -- probe held fixed.
+        result = grid._ever_observed_active_probe(targets, snippets, cells, " a")
+        assert result == {"t1": True, "t2": False}
+        assert calls == [("t1", " a"), ("t2", " a")], (
+            "must call the shared scan exactly once per target for the "
+            f"single active probe, not once per (target, probe) pair: {calls!r}"
+        )
+
+        # One target, every probe -- target held fixed.
+        calls.clear()
+        grid._grid = {
+            "snapshot": {"probes": (" a", " b"), "snippets": snippets},
+            "cells": cells,
+        }
+        result2 = grid._ever_observed_all_probes("t1")
+        assert result2 == {" a": True, " b": True}
+        assert calls == [("t1", " a"), ("t1", " b")], (
+            "must call the shared scan exactly once per configured probe "
+            f"for the single fixed target, not once per (target, probe) pair: {calls!r}"
+        )
+    finally:
+        monkeypatch.undo()
 
 
 def test_near_tie_threshold_is_a_named_constant_not_a_magic_number():
@@ -598,15 +706,20 @@ async def test_warned_column_header_carries_the_warning_the_clean_one_does_not(
 
 @pytest.mark.asyncio
 async def test_entropy_lens_states_effective_k_and_uses_it_for_every_cell(
-    evals_app, clean_run_group
+    evals_app, k_depth_matched_run_group
 ):
     """A K=20 cell and a K=5 cell holding the SAME underlying distribution
     (over the first 5 ranks) must read identical entropy once both are
     read at the shared effective K -- otherwise the K=20 column would look
-    "more confident" purely from its setting."""
+    "more confident" purely from its setting.
+
+    Uses ``k_depth_matched_run_group`` rather than ``clean_run_group``: see
+    that fixture's own docstring for why (``clean_run_group``'s s2/s3 rows
+    would drag a clamped ``effective_k`` down to their own tiny native
+    length)."""
     async with evals_app.run_test(size=(160, 45)) as pilot:
         await pilot.pause()
-        grid = await _select_run_group(pilot, clean_run_group["group_id"])
+        grid = await _select_run_group(pilot, k_depth_matched_run_group["group_id"])
         select = grid.query_one("#evals-lens-selector", Select)
         select.value = "entropy"
         await pilot.pause()
@@ -616,8 +729,8 @@ async def test_entropy_lens_states_effective_k_and_uses_it_for_every_cell(
         assert "· K 5 ·" in meta, f"header must state the effective K (5), got {meta!r}"
 
         table = grid.query_one("#evals-grid-table", DataTable)
-        rich_text = str(table.get_cell("s1", clean_run_group["base_id"]))
-        poor_text = str(table.get_cell("s1", clean_run_group["poor_id"]))
+        rich_text = str(table.get_cell("s1", k_depth_matched_run_group["base_id"]))
+        poor_text = str(table.get_cell("s1", k_depth_matched_run_group["poor_id"]))
         assert rich_text == poor_text, (
             f"same distribution at a shared effective K must produce equal "
             f"entropy: rich={rich_text!r} poor={poor_text!r}"
@@ -1111,17 +1224,22 @@ async def test_unexpected_load_grid_failure_renders_error_state_without_crashing
 
 @pytest.mark.asyncio
 async def test_truncation_lens_uses_the_shared_k_the_header_states(
-    evals_app, clean_run_group
+    evals_app, k_depth_matched_run_group
 ):
     """Same misrepresentation the shared-K entropy rule exists to prevent,
     one lens over. s1's two cells hold the SAME distribution over the first
     5 ranks; base additionally has 15 real low-probability tokens beyond
     rank 5 (native K=20) while the capped target stops at 5. Read at each
     cell's own native K they show 1% vs 2% -- a 2x "difference" produced
-    purely by the requested K, under a header that says ``K 5``."""
+    purely by the requested K, under a header that says ``K 5``.
+
+    Uses ``k_depth_matched_run_group`` rather than ``clean_run_group``: see
+    that fixture's own docstring for why (``clean_run_group``'s s2/s3 rows
+    would drag a clamped ``effective_k`` down to their own tiny native
+    length)."""
     async with evals_app.run_test(size=(160, 45)) as pilot:
         await pilot.pause()
-        grid = await _select_run_group(pilot, clean_run_group["group_id"])
+        grid = await _select_run_group(pilot, k_depth_matched_run_group["group_id"])
         grid.query_one("#evals-lens-selector", Select).value = "coverage"
         await pilot.pause()
 
@@ -1129,8 +1247,8 @@ async def test_truncation_lens_uses_the_shared_k_the_header_states(
         assert "· K 5 ·" in meta, meta
 
         table = grid.query_one("#evals-grid-table", DataTable)
-        rich_text = str(table.get_cell("s1", clean_run_group["base_id"]))
-        poor_text = str(table.get_cell("s1", clean_run_group["poor_id"]))
+        rich_text = str(table.get_cell("s1", k_depth_matched_run_group["base_id"]))
+        poor_text = str(table.get_cell("s1", k_depth_matched_run_group["poor_id"]))
         assert rich_text == poor_text, (
             f"same distribution at the shared K {5} must produce equal "
             f"truncation: rich={rich_text!r} poor={poor_text!r}"
@@ -1144,9 +1262,9 @@ async def test_truncation_lens_uses_the_shared_k_the_header_states(
         from tldw_chatbook.Evals.word_bench.storage import load_grid
 
         db = pilot.app.app_instance.evaluation_orchestrator.db
-        cells = load_grid(db, clean_run_group["group_id"])["cells"]
-        native_rich = cells[("s1", clean_run_group["base_id"])].truncated_mass
-        native_poor = cells[("s1", clean_run_group["poor_id"])].truncated_mass
+        cells = load_grid(db, k_depth_matched_run_group["group_id"])["cells"]
+        native_rich = cells[("s1", k_depth_matched_run_group["base_id"])].truncated_mass
+        native_poor = cells[("s1", k_depth_matched_run_group["poor_id"])].truncated_mass
         assert round(native_rich, 4) != round(native_poor, 4)
 
 

--- a/Tests/UI/test_evals_screen.py
+++ b/Tests/UI/test_evals_screen.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from loguru import logger as loguru_logger
 from textual.app import App
 from textual.widget import Widget
 
@@ -382,6 +383,70 @@ async def test_primary_action_is_disabled_with_a_reason_when_nothing_is_selected
         action = evals_app.screen.query_one("#evals-primary-action")
         assert action.disabled is True
         assert action.tooltip, "a disabled primary action must say why"
+
+
+@pytest.mark.asyncio
+async def test_inspector_reports_an_unexpected_load_bench_failure_instead_of_going_blank(
+    evals_app, seeded_bench, monkeypatch
+):
+    """Regression (TASK-861 item 5): ``EvalsInspector.compose`` caught
+    ``load_bench``'s failure with a bare ``except Exception: return`` --
+    since ``compose()`` is a generator, that yielded ZERO widgets, leaving a
+    blank inspector pane with no message and no log line: nothing to
+    diagnose from.
+
+    ``_compose_inspector_pane`` only mounts ``EvalsInspector`` once
+    ``EvalsViewModel.bench_by_id`` has already found the bench (see
+    ``evals_screen.py``), so reaching this branch for real means either a
+    race (deleted between that read and this one) or an unexpected failure
+    below it -- simulated here the same way
+    ``test_unexpected_load_grid_failure_renders_error_state_without_crashing_the_app``
+    (``test_evals_results_grid.py``) simulates the analogous failure for
+    ``ResultsGrid``: monkeypatching ``load_bench`` in the ``inspector``
+    module's own namespace to raise a DB-level fault for an otherwise valid
+    bench id.
+    """
+    import sqlite3
+
+    from tldw_chatbook.UI.Evals import inspector as inspector_module
+
+    def _raise_operational_error(db, task_id):
+        raise sqlite3.OperationalError("no such table: eval_tasks")
+
+    monkeypatch.setattr(inspector_module, "load_bench", _raise_operational_error)
+
+    records: list[dict] = []
+    sink_id = loguru_logger.add(lambda message: records.append(message.record), level="ERROR")
+    try:
+        async with evals_app.run_test(size=(160, 45)) as pilot:
+            await pilot.pause()
+            evals_app.screen.select(kind="bench", id=seeded_bench)
+            await pilot.pause()
+
+            error_state = evals_app.screen.query_one("#evals-inspector-error")
+            message = str(error_state.renderable)
+            assert "unexpected error" in message
+
+            # A failed load must not also render stale/partial readiness
+            # rows -- compose() returned before yielding any of them.
+            # Filtered in Python by id prefix (not the bare
+            # ".ds-status-badge" class, which the shell chrome's own
+            # workbench-header-status Static also carries for an unrelated
+            # purpose, and not a CSS attribute selector -- Textual's own
+            # selector grammar doesn't support "^=" prefix matching).
+            target_badges = [
+                w
+                for w in evals_app.screen.query(Widget)
+                if w.id and w.id.startswith("evals-inspector-target-")
+            ]
+            assert not target_badges, target_badges
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert records, "the failure must be logged, not just rendered"
+    assert any(seeded_bench in r["message"] for r in records), (
+        f"the log line must name which bench failed: {[r['message'] for r in records]}"
+    )
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-861 - Evals-results-grid-polish-dedupe-scans-unused-params-and-two-unconfirmed-robustness-gaps.md
+++ b/backlog/tasks/task-861 - Evals-results-grid-polish-dedupe-scans-unused-params-and-two-unconfirmed-robustness-gaps.md
@@ -1,10 +1,13 @@
 ---
 id: TASK-861
 title: >-
-  Evals results-grid polish: dedupe scans, unused params, and two unconfirmed robustness gaps
-status: To Do
-assignee: []
+  Evals results-grid polish: dedupe scans, unused params, and two unconfirmed
+  robustness gaps
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-27 03:00'
+updated_date: '2026-07-27 05:53'
 labels:
   - evals
   - polish
@@ -63,11 +66,36 @@ Reproduced, with the caveat that not every corruption shape triggers it:
 **Partly unresolved:** the CSV terminator was probed directly rather than reasoned about — on POSIX the bytes on disk are correct RFC-4180 `\r\n` with no doubling. The Windows `\r\r\n` risk follows from documented `io.TextIOWrapper` semantics but was NOT executed, as no Windows host was available. Passing `newline=""` is XS and removes the question either way.
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
-- [ ] The duplicated probe scan and the three `_notify` copies are each single-sourced
-- [ ] `combined_truncation`'s `k` parameter is either used or removed
-- [ ] The two unconfirmed robustness gaps are each verified, then fixed or closed with the evidence
-- [ ] The inspector's bare except either reports a reason or is narrowed
-- [ ] CSV line terminator is a deliberate, documented choice
+- [x] #1 The duplicated probe scan and the three `_notify` copies are each single-sourced
+- [x] #2 `combined_truncation`'s `k` parameter is either used or removed
+- [x] #3 The two unconfirmed robustness gaps are each verified, then fixed or closed with the evidence
+- [x] #4 The inspector's bare except either reports a reason or is narrowed
+- [x] #5 CSV line terminator is a deliberate, documented choice
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Cleared all 8 in-scope items from the investigation (item 2, the compose() broad-catch, was already merged and skipped per instruction).
+
+1. Folded probe scan: `_ever_observed_active_probe`/`_ever_observed_all_probes` now both call a new module-level `_probe_observed_in_target(snippets, cells, target_id, probe)` in results_grid.py, each still holding its own axis fixed (one probe/every target vs. one target/every probe), so neither call site pays for the other's cross-product. Test: `test_ever_observed_helpers_share_one_scan_and_hold_the_right_axis_fixed` monkeypatches the shared helper and asserts exact call counts/args per axis; reverted the fold and confirmed it fails (AssertionError on the dict content), then restored.
+
+2. `_notify` de-duplicated into `tldw_chatbook/UI/Evals/notify_mixin.py::NotifyMixin`, a plain mixin (no `@on` handlers, so no metaclass concerns) mixed into `ResultsGrid`, `LibraryRail`, `SnippetEditor`.
+
+3. Dropped `combined_truncation`'s dead `k` param rather than wiring it: its only caller (`_delta_reading`) never computes a shared k of its own before calling it (it gets `(jsd, is_bounded)` back from `divergence()`, no k), so wiring would mean re-deriving the same `min(...)` one level up for no benefit. Function now always recomputes internally, unchanged behaviour.
+
+4. Removed the redundant `len(top) > 1 and` half of the near-tie guard in `_render_top1`; `near_tie` already returns False below two tokens (tested).
+
+5. `EvalsInspector.compose`'s bare `except Exception: return` now logs via `logger.opt(exception=True).error` and yields a visible `Static(id="evals-inspector-error")`, mirroring ResultsGrid.compose; still narrowly `except Exception`, so CancelledError keeps propagating. Test: `test_inspector_reports_an_unexpected_load_bench_failure_instead_of_going_blank` (test_evals_screen.py) monkeypatches `load_bench` to raise `sqlite3.OperationalError` and asserts both the visible error Static and a captured loguru ERROR record naming the bench. Reverted to the bare except and confirmed the test fails (NoMatches on `#evals-inspector-error`), then restored.
+
+6. Added the defensive clamp to `analysis.effective_k` (`min(cap.k_returned, len(cap.top_k))` per cell), mirroring `divergence()`'s own two-way clamp. Purely defensive per the investigation -- not reachable on any live capture path. This broke 3 existing tests because several fixtures (`clean_run_group`'s s2/s3 rows in particular) deliberately abbreviate `top_k` below their claimed `k_returned` as a pre-existing test-writing shorthand, not corruption. Fixed WITHOUT touching `clean_run_group` (many other tests hard-code divergence/spread/group-mean values derived from its s2/s3/s4 cells, which padding would have shifted): padded the self-contained fixture in `test_effective_k_is_the_minimum_k_returned_across_cells`, and added a new dedicated single-snippet fixture `k_depth_matched_run_group` (a verbatim copy of clean_run_group's already-well-formed s1 cells) for the two UI tests that only ever asserted on s1. Test: new `test_effective_k_clamps_a_k_returned_that_exceeds_the_actual_top_k_length` constructs a CellCapture with k_returned=99 but 2 real tokens and asserts effective_k clamps to 2. Reverted the clamp and confirmed the test fails (99 != 2), then restored.
+
+7. CSV newline: `_export_csv_text`'s `io.StringIO()` -> `io.StringIO(newline="")` (confirmed a no-op byte-for-byte on this host -- StringIO's own default newline='\n' already means "no translation on write", same as ""). The change that actually matters for the documented Windows \r\r\n risk is in `_write_export_file`: the .csv branch's `write_text(...)` call now also passes `newline=""`, since Path.write_text's own default (newline=None) performs os.linesep translation-on-write, which would double an already-embedded \r\n into \r\r\n on a platform where os.linesep == "\r\n". POSIX output confirmed unchanged.
+
+8. `_sample_bench_cancel_token`'s comment in evals_screen.py updated to state plainly "NOTHING READS THIS TODAY" and name PR 3c as the PR expected to wire a Cancel affordance, matching this file's own PR-numbering convention used elsewhere.
+
+Modified: tldw_chatbook/UI/Evals/results_grid.py, tldw_chatbook/UI/Evals/inspector.py, tldw_chatbook/UI/Evals/library_rail.py, tldw_chatbook/UI/Evals/snippet_editor.py, tldw_chatbook/UI/Screens/evals_screen.py, tldw_chatbook/Evals/word_bench/analysis.py, Tests/UI/test_evals_results_grid.py, Tests/UI/test_evals_screen.py, Tests/Evals/word_bench/test_analysis.py. Added: tldw_chatbook/UI/Evals/notify_mixin.py.
+
+Full specified suite green: 207 passed (Tests/UI/test_evals_results_grid.py, test_evals_empty_states.py, test_evals_screen.py, Tests/Evals/word_bench). ruff clean on all touched files.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Evals/word_bench/analysis.py
+++ b/tldw_chatbook/Evals/word_bench/analysis.py
@@ -150,8 +150,24 @@ def effective_k(caps: Sequence[CellCapture]) -> int:
     any larger K would be an artifact of one target's setting (an OpenAI
     legacy target caps at K=5) rather than of what every target in the
     comparison can actually show.
+
+    Each cell's ``k_returned`` is clamped to ``len(cap.top_k)`` before the
+    minimum is taken, mirroring ``divergence()``'s own two-way clamp
+    (``min(a.k_returned, b.k_returned, len(a.top_k), len(b.top_k))``).
+    Purely defensive: on every live capture path ``k_returned ==
+    len(top_k)`` holds by construction (``capture_client.py`` sets
+    ``k_returned=len(tokens)`` from the same list that becomes ``top_k``),
+    so this clamp is a no-op there. It only matters for a ``CellCapture``
+    rebuilt from stored JSON where the two fields were read independently
+    (``storage.py``) and could disagree if the row were corrupted --
+    without it, ``effective_k`` could report a K larger than that cell
+    actually has, and a downstream ``entropy()``/``truncated_mass()`` call
+    at that K would silently fall back to the cell's own unclamped slice.
     """
-    return min((cap.k_returned for cap in caps), default=0)
+    return min(
+        (min(cap.k_returned, len(cap.top_k)) for cap in caps),
+        default=0,
+    )
 
 
 def _aligned(a: CellCapture, b: CellCapture, k: int) -> tuple[list[float], list[float]]:
@@ -229,7 +245,7 @@ def near_tie(cap: CellCapture) -> bool:
     return abs(gap) < NEAR_TIE_LOGPROB_GAP_NATS
 
 
-def combined_truncation(a: CellCapture, b: CellCapture, k: Optional[int] = None) -> float:
+def combined_truncation(a: CellCapture, b: CellCapture) -> float:
     """The combined truncated mass ``divergence()`` uses internally to
     decide ``is_bounded`` -- exposed separately so a caller that already
     has ``(jsd, is_bounded)`` can also explain WHY a comparison was
@@ -249,19 +265,23 @@ def combined_truncation(a: CellCapture, b: CellCapture, k: Optional[int] = None)
     of UI-reconstructed-number risk this module's methodology exists to
     avoid.
 
-    Args:
-        k: Shared truncation point. ``None`` (the default) recomputes it
-            the same way ``divergence()`` does, from ``a``/``b`` alone; a
-            caller that already knows the ``k`` a run's ``divergence()``
-            call used may pass it explicitly to guarantee agreement.
+    Always recomputes the shared truncation point the same way
+    ``divergence()`` does, from ``a``/``b`` alone (there used to be an
+    optional ``k`` override here; TASK-861 dropped it -- every caller
+    passed ``None``, and the only caller (``results_grid.py``'s
+    ``_delta_reading``) never computes a shared ``k`` of its own to hand
+    in: it calls ``divergence()`` first, which returns ``(jsd,
+    is_bounded)`` with no ``k``, so wiring one through would mean
+    ``_delta_reading`` re-deriving ``min(a.k_returned, b.k_returned,
+    len(a.top_k), len(b.top_k))`` itself -- exactly the recomputation this
+    function already does, just duplicated one level up for no benefit).
 
     Returns:
         The combined "other" bucket mass at the shared ``k`` -- the same
         value ``divergence()`` compares against ``TRUNCATION_WARN_
         THRESHOLD`` to set ``is_bounded``.
     """
-    if k is None:
-        k = min(a.k_returned, b.k_returned, len(a.top_k), len(b.top_k))
+    k = min(a.k_returned, b.k_returned, len(a.top_k), len(b.top_k))
     pa, pb = _aligned(a, b, k)
     return pa[-1] + pb[-1]
 

--- a/tldw_chatbook/UI/Evals/inspector.py
+++ b/tldw_chatbook/UI/Evals/inspector.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Optional
 
+from loguru import logger
 from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.widgets import Static
@@ -147,6 +148,31 @@ class EvalsInspector(Vertical):
         try:
             config = load_bench(db, self._bench_id)
         except Exception:
+            # A bare `except Exception: return` here used to yield ZERO
+            # widgets (this is a generator), leaving a blank inspector pane
+            # with no message and no log line -- nothing to diagnose from
+            # (TASK-861). `evals_screen.py`'s `_compose_inspector_pane`
+            # only mounts this widget once `EvalsViewModel.bench_by_id`
+            # already found the bench, so reaching this branch means
+            # either a race (deleted between that read and this one) or an
+            # unexpected failure below it (a locked database, a disk
+            # error, or a corrupted `config_data` payload) -- see
+            # `results_grid.py`'s `ResultsGrid.compose`, which hit the same
+            # class of problem for `load_grid` and now logs + renders a
+            # visible error state instead of guessing which case this is.
+            # Deliberately `Exception`, not `BaseException`:
+            # `asyncio.CancelledError` is a `BaseException` subclass and
+            # must keep propagating, not be swallowed here.
+            logger.opt(exception=True).error(
+                f"Unexpected failure loading bench configuration for the "
+                f"inspector pane, bench {self._bench_id!r}."
+            )
+            yield Static(
+                "This bench's readiness could not be loaded because of an "
+                "unexpected error; see the log for details.",
+                id="evals-inspector-error",
+                markup=False,
+            )
             return
 
         preflight = (

--- a/tldw_chatbook/UI/Evals/library_rail.py
+++ b/tldw_chatbook/UI/Evals/library_rail.py
@@ -58,6 +58,7 @@ from ...Utils.path_validation import validate_path_simple
 from ..Navigation.main_navigation import NavigateToScreen
 from . import sample_bench
 from .evals_state import EvalsSelection, EvalsViewModel
+from .notify_mixin import NotifyMixin
 from .snippet_editor import (
     import_snippets_into_dataset,
     parse_csv_snippets,
@@ -117,7 +118,7 @@ def _run_group_row_label(row: dict[str, Any]) -> str:
     return f"{name} ({count} {target_word})"
 
 
-class LibraryRail(Vertical):
+class LibraryRail(NotifyMixin, Vertical):
     """Left rail: Benches, Datasets, Runs -- each collapsible, with counts."""
 
     class EvalsSelectionChanged(Message, namespace="library_rail"):
@@ -488,16 +489,6 @@ class LibraryRail(Vertical):
             return
         event.stop()
         self.post_message(self.EvalsSelectionChanged(selection))
-
-    def _notify(self, message: str, *, severity: str = "information") -> None:
-        """Mirrors ``snippet_editor.py``'s identical helper: routes through
-        the screen's ``app_instance`` (what a test harness's fake actually
-        observes), falling back to ``self.app.notify``."""
-        app_instance = getattr(self.screen, "app_instance", None)
-        if app_instance is not None and hasattr(app_instance, "notify"):
-            app_instance.notify(message, severity=severity)
-        else:
-            self.app.notify(message, severity=severity)
 
     def _create_new_dataset(self) -> None:
         db = self.view_model.db

--- a/tldw_chatbook/UI/Evals/notify_mixin.py
+++ b/tldw_chatbook/UI/Evals/notify_mixin.py
@@ -1,0 +1,39 @@
+"""Shared ``_notify`` helper for the Evals workbench's nested widgets.
+
+``ResultsGrid``, ``LibraryRail``, and ``SnippetEditor`` each carried a
+byte-identical copy of this method (found during the TASK-861 polish pass;
+``SnippetEditor``'s own copy already said as much in its docstring). Folded
+here rather than left duplicated a third time.
+
+There is no existing shared base class among the three -- each extends
+``textual.containers.Vertical`` directly -- so this is a plain mixin, not a
+widget of its own. It needs no special metaclass handling: it defines no
+``@on``-decorated handlers, which is the case that actually requires
+deriving Textual's message-pump metaclass explicitly (contrast
+``UI/Views/RAGSearch/search_event_handlers.py::SearchEventHandlersMixin``,
+whose ``@on`` registrations would silently never dispatch without it --
+found and fixed in task-251). A plain mixin ahead of ``Vertical`` in the
+MRO is sufficient here.
+"""
+
+from __future__ import annotations
+
+
+class NotifyMixin:
+    """Adds ``_notify`` to a Textual widget that has ``self.screen`` and
+    ``self.app`` (i.e. is mounted, or will be by the time this is called).
+
+    Routes a toast through the screen's ``app_instance`` -- the domain
+    ``TldwCli``/fake a test harness's ``_FakeAppInstance.notifications``
+    list actually observes -- falling back to ``self.app.notify`` for a
+    widget mounted without one (``self.app`` in a test harness is the
+    minimal ``App`` host, not the fake domain object tests assert
+    against).
+    """
+
+    def _notify(self, message: str, *, severity: str = "information") -> None:
+        app_instance = getattr(self.screen, "app_instance", None)
+        if app_instance is not None and hasattr(app_instance, "notify"):
+            app_instance.notify(message, severity=severity)
+        else:
+            self.app.notify(message, severity=severity)

--- a/tldw_chatbook/UI/Evals/notify_mixin.py
+++ b/tldw_chatbook/UI/Evals/notify_mixin.py
@@ -1,9 +1,10 @@
 """Shared ``_notify`` helper for the Evals workbench's nested widgets.
 
 ``ResultsGrid``, ``LibraryRail``, and ``SnippetEditor`` each carried a
-byte-identical copy of this method (found during the TASK-861 polish pass;
-``SnippetEditor``'s own copy already said as much in its docstring). Folded
-here rather than left duplicated a third time.
+byte-identical copy of this method's body (``ResultsGrid`` and
+``LibraryRail``'s own docstrings already said as much, each describing
+itself as mirroring ``SnippetEditor``'s -- the original, most-documented
+copy). Folded here rather than left duplicated a third time.
 
 There is no existing shared base class among the three -- each extends
 ``textual.containers.Vertical`` directly -- so this is a plain mixin, not a

--- a/tldw_chatbook/UI/Evals/results_grid.py
+++ b/tldw_chatbook/UI/Evals/results_grid.py
@@ -125,6 +125,7 @@ from ...Evals.word_bench.storage import load_grid
 from ...Third_Party.textual_fspicker import FileSave, Filters
 from ...Utils.path_validation import validate_path_simple
 from .evals_state import EvalsViewModel
+from .notify_mixin import NotifyMixin
 
 LensKey = Literal["top1", "entropy", "probe", "coverage", "delta"]
 BaselineMode = Literal["column", "row"]
@@ -252,7 +253,36 @@ def render_probe_reading(reading: "analysis.ProbeReading") -> str:
     return f"{reading.logprob:.2f}"
 
 
-class ResultsGrid(Vertical):
+def _probe_observed_in_target(
+    snippets: tuple[dict[str, Any], ...] | list[dict[str, Any]],
+    cells: dict[tuple[str, str], CellCapture | CellError],
+    target_id: str,
+    probe: str,
+) -> bool:
+    """Whether ``probe`` appears in ANY captured cell's top-K for
+    ``target_id``, scanning every snippet in ``snippets``.
+
+    ``ResultsGrid._ever_observed_active_probe`` and
+    ``ResultsGrid._ever_observed_all_probes`` used to each carry their own
+    copy of this exact nested scan (the second's own docstring already
+    admitted as much, before this fold). Both callers hold one axis of the
+    (target, probe) grid fixed and loop the other over this function --
+    ``_ever_observed_active_probe`` fixes the probe and varies target,
+    ``_ever_observed_all_probes`` fixes the target and varies probe -- so
+    this stays a single per-(target, probe) scan. A version that instead
+    precomputed the full {target: {probe: bool}} matrix up front would
+    make the single-active-probe render path pay for every configured
+    probe on every render, not just the one lens is showing; keeping this
+    as the atomic per-pair scan avoids that.
+    """
+    for snippet in snippets:
+        cap = cells.get((snippet["id"], target_id))
+        if isinstance(cap, CellCapture) and any(tok.token == probe for tok in cap.top_k):
+            return True
+    return False
+
+
+class ResultsGrid(NotifyMixin, Vertical):
     """Detail-pane content for a selected run group: the pivoted results
     grid, its lens/baseline controls, and the header stating the effective
     K, cell/failure counts, and which lens/baseline/sort is active."""
@@ -662,7 +692,20 @@ class ResultsGrid(Vertical):
 
         try:
             if validated_path.suffix.lower() == ".csv":
-                validated_path.write_text(self._export_csv_text(), encoding="utf-8")
+                # newline="": the buffer _export_csv_text() built already
+                # carries csv.writer's own "\r\n" line terminators (RFC
+                # 4180). write_text's own default (newline=None) opens the
+                # file in universal-newline TRANSLATING mode, which
+                # rewrites every embedded "\n" to os.linesep on write --
+                # a no-op on POSIX (os.linesep == "\n"), but on Windows
+                # (os.linesep == "\r\n") it would turn the buffer's own
+                # "\r\n" into "\r\r\n" (see the standard library csv
+                # module's own docs for this exact pitfall). newline=""
+                # disables that translation, so the bytes already decided
+                # by _export_csv_text() reach disk unchanged everywhere.
+                validated_path.write_text(
+                    self._export_csv_text(), encoding="utf-8", newline=""
+                )
             else:
                 payload = self._export_json_payload()
                 validated_path.write_text(
@@ -676,23 +719,29 @@ class ResultsGrid(Vertical):
             return
         self._notify(f"Exported to {validated_path}", severity="information")
 
-    def _notify(self, message: str, *, severity: str = "information") -> None:
-        """Mirrors ``snippet_editor.py``'s identical helper: routes through
-        the screen's ``app_instance`` (what a test harness's fake actually
-        observes), falling back to ``self.app.notify``."""
-        app_instance = getattr(self.screen, "app_instance", None)
-        if app_instance is not None and hasattr(app_instance, "notify"):
-            app_instance.notify(message, severity=severity)
-        else:
-            self.app.notify(message, severity=severity)
-
     def _export_csv_text(self) -> str:
         """CSV for the ACTIVE lens -- built from the exact same
         ``_compute_active_lens_rows`` the on-screen ``DataTable`` renders
         from, so this can never show a different lens/baseline/sort than
-        what is currently visible."""
+        what is currently visible.
+
+        ``newline=""`` on the buffer is the convention the ``csv`` module's
+        own docs recommend for whatever it writes into (normally a real
+        file opened with ``newline=""``) -- probed here to have no effect
+        on the buffer's own content (``io.StringIO``'s default ``newline``
+        is already ``"\\n"``, which -- per ``io.TextIOWrapper``'s write
+        semantics -- means "no translation", the same as ``""``; both
+        produced byte-identical ``getvalue()`` output in a direct check).
+        Kept anyway for the same reason ``_write_export_file`` now also
+        passes ``newline=""`` to ``write_text``: that second call is where
+        translation-on-write actually happens by default, and is what
+        would double an already-embedded ``\\r\\n`` into ``\\r\\r\\n`` on a
+        platform where ``os.linesep`` is ``"\\r\\n"`` (Windows) -- not
+        reproducible on this POSIX host, so fixed by removing the
+        ambiguity at both call sites rather than by executing the failure.
+        """
         column_labels, snippet_rows, group_mean_rows = self._compute_active_lens_rows()
-        buffer = io.StringIO()
+        buffer = io.StringIO(newline="")
         writer = csv.writer(buffer)
         writer.writerow(column_labels)
         for _row_key, cells in snippet_rows:
@@ -985,8 +1034,12 @@ class ResultsGrid(Vertical):
         # (``analysis.NEAR_TIE_LOGPROB_GAP_NATS``) so it lives in one place
         # alongside ``TRUNCATION_WARN_THRESHOLD`` and ``divergence``'s own
         # ``is_bounded``, rather than this module recomputing a raw logprob
-        # gap and re-deciding "too close to call" on its own.
-        if len(top) > 1 and analysis.near_tie(cap):
+        # gap and re-deciding "too close to call" on its own. No local
+        # `len(top) > 1` guard here: `near_tie` already returns `False` for
+        # fewer than two ranked tokens (see its own docstring and
+        # `test_near_tie_false_when_fewer_than_two_tokens`), so a second
+        # copy of that guard here would be a provable no-op.
+        if analysis.near_tie(cap):
             second = top[1]
             return (
                 f"{render_token(first.token)}≈{render_token(second.token)}  "
@@ -1149,46 +1202,42 @@ class ResultsGrid(Vertical):
         (``_active_probe``) was EVER observed in that target's top-K across
         the whole run -- computed once per table render (not once per cell)
         and threaded into every ``analysis.resolve_probe`` call for the
-        Probe lens, per its own ``ever_observed`` contract."""
+        Probe lens, per its own ``ever_observed`` contract.
+
+        One probe, every target: holds ``probe`` fixed and varies the
+        target axis over ``_probe_observed_in_target`` -- see that
+        function's own docstring for why this and
+        ``_ever_observed_all_probes`` below share it rather than each
+        carrying its own copy of the nested scan.
+        """
         if probe is None:
             return {}
-        result: dict[str, bool] = {}
-        for target in targets:
-            tid = target["id"]
-            observed = False
-            for snippet in snippets:
-                cap = cells.get((snippet["id"], tid))
-                if isinstance(cap, CellCapture) and any(
-                    tok.token == probe for tok in cap.top_k
-                ):
-                    observed = True
-                    break
-            result[tid] = observed
-        return result
+        return {
+            target["id"]: _probe_observed_in_target(snippets, cells, target["id"], probe)
+            for target in targets
+        }
 
     def _ever_observed_all_probes(self, target_id: str) -> dict[str, bool]:
-        """Same computation as ``_ever_observed_first_probe``, but for
-        EVERY configured probe and one target -- used only when a cell is
-        focused (``_on_cell_highlighted``), for the inspector's full probe
-        table. Kept separate from the render-time helper above so a table
-        render (which only needs the lens's single active probe) does not
-        pay for every probe on every render."""
+        """Same underlying scan as ``_ever_observed_active_probe`` above,
+        but for EVERY configured probe and one target -- used only when a
+        cell is focused (``_on_cell_highlighted``), for the inspector's
+        full probe table.
+
+        One target, every probe: the mirror image of
+        ``_ever_observed_active_probe`` -- holds ``target_id`` fixed and
+        varies the probe axis instead, so a table render (which only ever
+        needs the lens's single active probe) still costs one scan per
+        target rather than paying for every configured probe on every
+        render.
+        """
         snapshot = self._grid["snapshot"] if self._grid else {}
         probes = tuple(snapshot.get("probes") or ())
         snippets = snapshot.get("snippets") or []
         cells = self._grid["cells"] if self._grid else {}
-        result: dict[str, bool] = {}
-        for probe in probes:
-            observed = False
-            for snippet in snippets:
-                cap = cells.get((snippet["id"], target_id))
-                if isinstance(cap, CellCapture) and any(
-                    tok.token == probe for tok in cap.top_k
-                ):
-                    observed = True
-                    break
-            result[probe] = observed
-        return result
+        return {
+            probe: _probe_observed_in_target(snippets, cells, target_id, probe)
+            for probe in probes
+        }
 
     # -- focus -> inspector ----------------------------------------------
 

--- a/tldw_chatbook/UI/Evals/snippet_editor.py
+++ b/tldw_chatbook/UI/Evals/snippet_editor.py
@@ -67,6 +67,7 @@ from ...Evaluations_Interop.evaluation_normalizers import (
 from ...Third_Party.textual_fspicker import FileOpen, Filters
 from ...Utils.path_validation import validate_path_simple
 from .evals_state import EvalsViewModel
+from .notify_mixin import NotifyMixin
 
 #: The glyph anomalous whitespace is replaced with when rendering a
 #: snippet's text. Reverse video (not a design-token colour) is used
@@ -438,7 +439,7 @@ _IMPORT_PARSERS = {
 }
 
 
-class SnippetEditor(Vertical):
+class SnippetEditor(NotifyMixin, Vertical):
     """Detail-pane content for a selected dataset: a read-only snippet
     table (character count, whitespace flag, exact-duplicate flag) and an
     import control (``#evals-import-snippets``)."""
@@ -569,23 +570,9 @@ class SnippetEditor(Vertical):
             self._handle_import_file_selected,
         )
 
-    def _notify(self, message: str, *, severity: str = "information") -> None:
-        """Route notifications through the screen's own ``app_instance``
-        (``BaseAppScreen.__init__`` -- the domain ``TldwCli``/fake, not
-        Textual's own ``App.notify``), the same access path
-        ``self.screen.app_instance`` other nested widgets in this codebase
-        use (e.g. ``Persona_Modules/personas_preview_controller.py``). In
-        production ``TldwCli`` IS the running ``App``, so this reaches the
-        same toast system either way; in tests it is what the harness's
-        ``_FakeAppInstance.notifications`` list actually observes -- unlike
-        ``self.app``, which in a test harness is the minimal ``App`` host,
-        not the fake domain object tests assert against.
-        """
-        app_instance = getattr(self.screen, "app_instance", None)
-        if app_instance is not None and hasattr(app_instance, "notify"):
-            app_instance.notify(message, severity=severity)
-        else:
-            self.app.notify(message, severity=severity)
+    # _notify lives on NotifyMixin (see .notify_mixin) -- shared with
+    # LibraryRail and ResultsGrid, which carried byte-identical copies of
+    # this same method (TASK-861).
 
     def _handle_import_file_selected(self, path: Optional[Any]) -> None:
         """The ``FileOpen`` dialog's selection callback. Public-shaped

--- a/tldw_chatbook/UI/Screens/evals_screen.py
+++ b/tldw_chatbook/UI/Screens/evals_screen.py
@@ -84,12 +84,14 @@ class EvalsScreen(BaseAppScreen):
         #: flag-set line) never runs.
         self._sample_bench_running: bool = False
         #: The active run's cooperative cancel token, or ``None`` when no
-        #: run is in flight. Not currently triggered by anything in this
-        #: screen (the running-guard above prevents the second-click race
-        #: that would otherwise need it) -- kept as a real, threaded
-        #: seam rather than a decorative parameter, since
-        #: ``WordBenchRunner.run`` already accepts one and a future cancel
-        #: affordance should not need a second plumbing pass.
+        #: run is in flight. NOTHING READS THIS TODAY (TASK-861 audited
+        #: it): the running-guard above prevents the second-click race
+        #: that would otherwise need it, and no Cancel affordance exists
+        #: yet in this screen. Kept as a real, threaded seam rather than a
+        #: decorative parameter, since ``WordBenchRunner.run`` already
+        #: accepts one and a future PR wiring an actual Cancel button (PR
+        #: 3c, per this program's own PR numbering) should not need a
+        #: second plumbing pass to reach it.
         self._sample_bench_cancel_token: Optional[CancelToken] = None
 
     def _current_app_config(self) -> dict[str, Any]:


### PR DESCRIPTION
Clears the deferred polish findings from PR 3b's whole-branch review. The one item that was NOT
minor — an escaping exception in `ResultsGrid.compose` exiting the whole app — was already fixed in
#955; these are the remainder.

- **Folded the duplicated probe scan.** `_ever_observed_active_probe` and `_ever_observed_all_probes`
  were the same nested scan twice; now one `_probe_observed_in_target` helper, with each call site
  still holding its own axis fixed so the single-probe case does not do the all-probes work.
- **De-duplicated `_notify`**, byte-identical in three files, into a `NotifyMixin`.
- **Dropped `combined_truncation`'s dead `k` parameter** (every call site passed `None`). Not wired,
  because its only caller has no shared k without re-deriving `divergence()`'s internal `min(...)`
  one level up. The investigation had already established this is not a correctness gap.
- **Removed a provably redundant guard** — `near_tie` already returns `False` below two tokens.
- **Fixed the inspector's silent failure.** `EvalsInspector.compose` had a bare `except Exception:
  return`; as a generator that yielded zero widgets, so the user got a blank pane with no message and
  no log line. Now logs the reason and renders a visible error state. `CancelledError` still
  propagates — it is a `BaseException` and must not be caught here.
- **Added the defensive `effective_k` clamp** that `divergence` already applies. Explicitly *not* a
  live bug fix: `capture_client` sets `k_returned=len(tokens)` from the same list that becomes
  `top_k`, so the invariant holds by construction on every real path. It is reachable only through
  corrupted stored JSON.
- **CSV `newline=""`.** POSIX output is unchanged and was verified correct RFC-4180 `\r\n`; this
  removes the unresolved Windows `\r\r\n` question rather than leaving it to chance.
- **`_sample_bench_cancel_token`** kept as a documented seam, with its comment now stating plainly
  that nothing reads it yet and naming the PR expected to.

Tests: 207 passed on the results-grid / empty-states / screen / word-bench suites. Closes TASK-861.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the Evals results grid and inspector per TASK-861 to dedupe probe scans, unify notifications, harden shared-K handling, and make CSV exports correct on Windows. Aligns entropy/coverage with `divergence()` and prevents blank inspector panes on load errors.

- **Refactors**
  - Folded the duplicated probe scan into a shared `_probe_observed_in_target`; each call site holds its axis fixed to avoid extra work.
  - Extracted `NotifyMixin` to share `_notify` across `ResultsGrid`, `LibraryRail`, and `SnippetEditor`.
  - Removed the unused `k` parameter from `analysis.combined_truncation`; it now always recomputes the shared truncation point.
  - Dropped the redundant guard in `ResultsGrid._render_top1` (ties already handled by `analysis.near_tie`).
  - Documented `_sample_bench_cancel_token` as an unwired cancel seam for a future PR.

- **Bug Fixes**
  - Inspector now logs and shows a visible error state on `load_bench` failures; `CancelledError` still propagates.
  - `effective_k` clamps per cell to `min(k_returned, len(top_k))`, matching `divergence()` and guarding corrupted stored JSON.
  - CSV export passes `newline=""` to both the buffer and `write_text`, preventing `\r\r\n` on Windows; POSIX output unchanged.

<sup>Written for commit 95536b3307e9d31e0da8483aac5e8ff0b8ef598c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

