### PR TITLE
feat(tools): agent path-hardening — denylist coverage, workspace-root search, killable grep

### DIFF
--- a/.superpowers/sdd/task-843-850-fixes.md
+++ b/.superpowers/sdd/task-843-850-fixes.md
@@ -1,0 +1,112 @@
+# TASK-843/TASK-850 follow-up hardening review — fixes
+
+**Worktree:** `/Users/macbook-dev/Documents/GitHub/wt-path-hardening` (branch `feat/agent-path-hardening`)
+**Interpreter:** `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python`, run from this worktree.
+
+This addresses five findings from a follow-up review of `7fd033f1b` (TASK-850, scope `glob_files`/`grep_files` to workspace roots) and `8d66becf9` (TASK-843, killable-subprocess regex search) — both already `Done` on this branch. All work is in `tldw_chatbook/Tools/file_operation_tools.py`, `tldw_chatbook/Utils/sensitive_paths.py`, and `Tests/Tools/test_glob_grep_files.py`.
+
+---
+
+## Finding 1 (Important) — enumeration ran away before the subprocess ever started
+
+**Gap.** TASK-843 split `grep_files` into two sequential phases: candidate discovery (`_iter_candidates_across_roots`, in-process, bounded by `_MAX_CANDIDATES` = 20,000) then one subprocess call over the *entire* resulting list. The pre-subprocess implementation had checked `len(matches) >= _MAX_MATCHES` / `lines_scanned >= _MAX_GREP_LINES_SCANNED` *during* enumeration and broke out immediately; the split lost that early exit; `GrepFiles.execute` drained discovery to completion regardless of how quickly the match budget would have been satisfied.
+
+Consequences, both real:
+- A high-hit-rate pattern over a large tree paid for candidates the match budget never needed.
+- `_GREP_SUBPROCESS_TIMEOUT_SECONDS`'s comment claimed its ~2s headroom below `GrepFiles.timeout_seconds` (20.0s) meant the kill fires "at or before" the agent is told the call failed. With unbounded discovery time added on top of the subprocess's own 18s, that was false.
+
+**Fix.** Discovery and search are now streamed together by a new `_run_grep_search` (`tldw_chatbook/Tools/file_operation_tools.py`), called from `GrepFiles.execute` in place of the old "collect everything, then one subprocess call":
+
+- Candidates are pulled from `_iter_candidates_across_roots` in **growing batches** — `_GREP_INITIAL_CANDIDATE_BATCH_SIZE = 256`, doubling up to `_GREP_MAX_CANDIDATE_BATCH_SIZE = 4096` — each batch searched by its **own** `_run_grep_subprocess` call with whatever `max_matches`/`max_lines_scanned` budget remains.
+- The loop stops **without pulling another candidate** the moment the remaining budget is `0` (i.e. `_MAX_MATCHES` matches found or `_MAX_GREP_LINES_SCANNED` lines scanned) — this is the restored early exit.
+- A small initial batch keeps a high-hit-rate search's pre-first-call enumeration cost close to what the old in-process early-break paid; growing the batch on later rounds keeps a rare/zero-hit search (which must still examine up to `_MAX_CANDIDATES`) from paying for dozens of small, separately-spawned subprocesses to get there (doubling from 256 reaches 20,000 in ~8 rounds).
+- **Killability is unaffected** — every batch is still searched by its own fully killable child process; only how many candidates reach it, and in how many calls, changed.
+- Every existing guard (containment, sensitive-path denylist, hidden-component rule, the global `_MAX_CANDIDATES` counter shared across all roots) still runs inside `_iter_candidates_across_roots` exactly as before — `_run_grep_search` performs none of that itself and trusts every candidate completely, same contract as before.
+
+**The comment is now true, restated precisely.** The wall-clock deadline (`deadline = time.monotonic() + deadline_seconds`) now starts **before the first candidate is even pulled**, not after discovery finishes, and is re-derived before pulling each batch and again before spawning each batch's subprocess call. Discovery time and every batch's subprocess wait are drawn from the *same* 18.0s window, so however that time is spent — a slow disk during discovery, one long subprocess wait, or several short ones — the aggregate cannot exceed it. `_GREP_SUBPROCESS_TIMEOUT_SECONDS`'s docstring and `GrepFiles.timeout_seconds`'s docstring were rewritten to say exactly this rather than the old claim (which implicitly assumed discovery was already finished when the clock started). What now actually holds: the kill (or a timeout-error return before ever starting another batch) fires at or before `GrepFiles.timeout_seconds`'s 20.0s ceiling for the *aggregate* of however many batches one `grep_files` call needed — not, as the old comment implied, for one subprocess call alone with discovery assumed free.
+
+**Benchmark test added** (`test_grep_files_high_hit_rate_pattern_does_not_over_enumerate`, `Tests/Tools/test_glob_grep_files.py`): reproduces the reviewer's exact scenario — a 5,000-file tree where the pattern matches every file. Pins two things: (a) a structural, machine-speed-independent proof that the number of candidates actually *pulled* from discovery before the match budget is satisfied is far below the tree size (`< 2,500`, actual measured value: 256 — exactly one initial batch), and (b) a generous wall-clock sanity bound (`< 2.0s`). **Verified this test fails against the pre-fix code**: stashed only the two source files (kept the new test), re-ran it, and got `enumerated 5000 of 5,000 candidates ... assert 5000 < 2500` — confirming it would have caught the shipped regression. Restored the fix afterward; full targeted suite still green.
+
+Two more tests pin the two halves of the mechanism directly:
+- `test_grep_files_aggregates_matches_across_multiple_batches` — forces several small batches (batch size 2, 10 files) and confirms every match survives the multi-batch merge, with more than one subprocess call actually happening.
+- `test_grep_files_search_deadline_starts_before_the_first_candidate_is_pulled` — makes discovery itself slow (a monkeypatched sleep inside a wrapped `_iter_candidates_across_roots`) with a tiny deadline, and confirms the call reports a timeout rather than silently proceeding to search — proving the deadline really does start before discovery, not after.
+
+### Measured before/after timing (the exact scenario given: 5,000 files, pattern matching in every file)
+
+Measured directly on this branch (`git stash push -- <the two source files>` to get the pre-fix behavior, `git stash pop` to restore; same 5,000-file `tmp_path` sandbox, `pattern="DEBUG"`, `glob="**/*.py"`, `loguru.logger.remove()` to strip logging overhead from the timing):
+
+| | run 1 | run 2 | run 3 |
+|---|---|---|---|
+| **BEFORE** (this review's fix reverted, TASK-843/850 code as shipped) | 1.2892s | 0.9636s | 0.9409s |
+| **AFTER** (this fix) | 0.3609s (cold) | 0.0752s | 0.0773s |
+
+Candidates actually pulled from discovery, after the fix: **256** (one initial batch) — vs. all **5,000** before. Consistent with the reviewer's own estimate (~0.32ms/candidate × 5,000 ≈ 1.6s before; ×256 ≈ 82μs... negligible after) and with the old in-process early-break's ~0.1s ballpark this restores.
+
+---
+
+## Finding 3 (Minor) — grep worker subprocess isolation
+
+**Gap.** The worker subprocess inherited the parent's full environment, actual cwd, and (via the script's own directory being prepended to `sys.path`) exposed `sys.path[0] == .../Tools/`. Confirmed directly: a parent-only env var was visible in a probe child process, and `sys.path[0]` pointed at this project's own source directory when the worker was spawned without `-P`.
+
+**Fix.**
+- Added `-P` to the interpreter flags (`[sys.executable, "-S", "-P", _GREP_WORKER_SCRIPT]`) — available since Python 3.11, this project's floor. Verified directly: without `-P`, `sys.path[0]` inside a spawned worker-shaped script is its own script directory; with `-P`, it becomes the interpreter's own zip path, never the source tree.
+- Added an explicit `cwd=_GREP_WORKER_CWD` (`tempfile.gettempdir()`) — the worker only ever touches absolute paths handed to it on stdin, so it has no legitimate use for the parent's actual working directory.
+- Added an explicit, minimal `env=_grep_worker_env()`: just `PATH` (needed for the interpreter's own startup), plus `SystemRoot` on Windows only (an empty `env={}` can make `subprocess.Popen` fail outright on Windows). Verified: a fake secret (`MY_FAKE_SECRET_9f21`) set in the parent's environment is absent from `_grep_worker_env()`'s output and from the captured `Popen` kwargs in a real call.
+
+Tests: `test_run_grep_subprocess_isolates_worker_cwd_and_env` (spies on `subprocess.Popen`, asserts `-P` present, `cwd` differs from the real cwd, and a parent-only secret env var is absent from the passed `env`), `test_grep_worker_env_omits_arbitrary_parent_variables` (direct unit test of the helper).
+
+This is not an escalation on its own (planting a module to exploit a leaked `sys.path[0]` already requires source-tree write access — full compromise) — it removes a needless surface for free, as the finding states.
+
+---
+
+## Finding 4 (Minor) — worker payload validated before returning
+
+**Gap.** `_run_grep_subprocess` returned `json.loads(stdout)` verbatim once confirmed to be *a dict* — never confirming `matches` was actually a list, or that each entry / `lines_scanned` had the documented shape. A worker emitting `{"matches": "not-a-list"}` would have propagated that shape straight to the agent.
+
+**Fix.** New `_validated_grep_worker_payload(parsed)` checks, on the worker's claimed-success path: `matches` is a list; every entry is a dict with `path: str`, `line_number: int`, `line: str`; `lines_scanned` is an int. Any violation returns `{"error": "grep worker produced malformed output"}` — consistent with the tool's never-raise contract and reusing the exact error string already used for other malformed-output cases. The `"error"` path itself is also now checked (a non-string `error` value is likewise normalized to that same message).
+
+Tests: `test_run_grep_subprocess_rejects_a_matches_field_that_is_not_a_list`, `test_run_grep_subprocess_rejects_a_malformed_match_entry`, `test_run_grep_subprocess_rejects_a_non_int_lines_scanned`, and a sanity check that a genuinely well-formed payload still passes through unchanged (`test_run_grep_subprocess_still_accepts_a_well_formed_payload`).
+
+---
+
+## Finding 2 (Minor, documented not changed) — `refuses_new_directory_chain` over-refuses new containers
+
+Added a paragraph to `refuses_new_directory_chain`'s docstring (`tldw_chatbook/Utils/sensitive_paths.py`) naming the consequence: because a not-yet-existing name always fails `is_sensitive_path`'s `is_dir()` gate, this refuses creating **any** brand-new subdirectory directly inside a protected container (e.g. the ChromaDB persist directory), not only one that collides with a specific state-file name — reproduced: `write_file("chromadb/newcoll/x.txt", create_directories=True)` is refused while `write_file("chromadb/coll1/new.txt", ...)` succeeds once `coll1` already exists. Documented as deliberate (distinguishing "legitimate new container" from "shadow directory" by name alone would require the enumeration this design avoids) and only reachable under a widened sandbox root. No behavior changed.
+
+---
+
+## Finding 5 (Minor, documented not changed) — `_MAX_CANDIDATES` consumed root-by-root, starving later roots
+
+Added a paragraph to `_iter_candidates_across_roots`'s docstring naming the consequence: the global `_MAX_CANDIDATES` budget is consumed in root order, so a first root holding `_MAX_CANDIDATES` or more matches starves every later root entirely, indistinguishable from those roots genuinely having nothing. Documented as correct (the bound must stay global; there is no principled way to split it fairly across an arbitrary number of roots) with a suggested workaround (narrow the search with a root-scoped glob). No behavior changed.
+
+---
+
+## Hard constraints re-checked
+
+- Every agent tool still returns a result dict and never raises — `_run_grep_search`'s only non-dict exit is `next(candidates)`'s pre-existing `ValueError`/`NotImplementedError` for a syntactically invalid glob, caught in `GrepFiles.execute` exactly as before this change.
+- Killability unaffected: every batch is still searched by its own `Popen`-spawned, `communicate(timeout=)`+`kill()`-bounded child process; `test_grep_subprocess_kills_the_worker_process_on_timeout` (pre-existing) still passes unmodified.
+- Every guard (containment, sensitive-path denylist, hidden-component rule, dotted-root rule) still applies to every candidate from every root — unchanged, since `_iter_candidates_across_roots` itself was not modified beyond its docstring.
+- `SensitivePathContext` still resolved exactly once per call (`resolve_sensitive_context()` in `GrepFiles.execute`, threaded through to the shared generator).
+- No tool's default-OFF posture changed; the sandbox root and its default are untouched.
+
+## Test run
+
+```
+$ .venv/bin/python -m pytest Tests/Tools/test_glob_grep_files.py Tests/Tools/test_file_tools_workspace_roots.py Tests/Utils/test_sensitive_paths.py -q
+97 passed, 1 warning in 10.89s
+```
+
+Full required command:
+
+```
+$ .venv/bin/python -m pytest Tests/Utils/ Tests/Tools/ Tests/Agents/ -q
+919 passed, 12 warnings in 240.64s (0:04:00)
+```
+
+919 = the pre-existing 910-pass baseline (per the prior TASK-843/850 report) + the 9 new tests added here. No failures. All warnings match the known, pre-existing set (RequestsDependencyWarning, pydub/audioop and SWIG DeprecationWarnings, two unrelated MCP-provider "coroutine was never awaited" RuntimeWarnings) — none introduced by this change.
+
+## Files
+
+- `tldw_chatbook/Tools/file_operation_tools.py` — `_run_grep_search` (new), `_grep_worker_env`/`_GREP_WORKER_CWD`/`_validated_grep_worker_payload` (new), `_GREP_INITIAL_CANDIDATE_BATCH_SIZE`/`_GREP_MAX_CANDIDATE_BATCH_SIZE` (new constants), `_run_grep_subprocess` (Popen call + return-path validation), `GrepFiles.execute`/`GrepFiles.timeout_seconds` (docstrings + body), `_GREP_SUBPROCESS_TIMEOUT_SECONDS`/`_iter_candidates_across_roots` (docstrings).
+- `tldw_chatbook/Utils/sensitive_paths.py` — `refuses_new_directory_chain` docstring.
+- `Tests/Tools/test_glob_grep_files.py` — 9 new tests (benchmark/batching/deadline for Finding 1, isolation for Finding 3, payload validation for Finding 4).

--- a/.superpowers/sdd/task-846-audit.md
+++ b/.superpowers/sdd/task-846-audit.md
@@ -1,0 +1,765 @@
+# TASK-846 — Audit: security checks that name filesystem paths vs. where the app actually writes
+
+**Worktree:** `/Users/macbook-dev/Documents/GitHub/wt-path-hardening` (branch `feat/agent-path-hardening`)
+**Mode:** READ-ONLY. Nothing was fixed; no tracked file was modified.
+**Interpreter:** `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python`
+**Date of on-disk comparison:** 2026-07-26, this machine.
+
+## Ground truth resolved on this machine
+
+```
+DEFAULT_CONFIG_PATH        : /Users/macbook-dev/.config/tldw_cli/config.toml       exists=True
+_get_effective_config_path : /Users/macbook-dev/.config/tldw_cli/config.toml
+get_user_data_dir()        : /Users/macbook-dev/.local/share/tldw_cli/default_user  exists=True
+get_media_db_path()        : /Users/macbook-dev/.local/share/tldw_cli/default_user/tldw_chatbook_media_v2.db  exists=True
+```
+
+Two facts drive most findings:
+
+1. `get_user_data_dir()` = `<base>/<user_folder>`. Every literal of the shape
+   `~/.local/share/tldw_cli/<file>` omits the `<user_folder>` segment and is therefore
+   **never** the path the app uses.
+2. `_get_effective_config_path()` honors `TLDW_CONFIG_PATH`; `DEFAULT_CONFIG_PATH` does not.
+   Any security decision built on `DEFAULT_CONFIG_PATH` diverges the moment a profile is active.
+
+---
+
+## Inventory
+
+30 security-relevant checks that name a filesystem path, config key, or database location.
+"Match" = does the literal resolve to what the app really uses, on this machine, right now.
+
+| # | Check | Literal it names | Path/key the app really uses | Match |
+|---|---|---|---|---|
+| 1 | `config.py:4322/4323/4330/4362/4363/4393/4425/4426/4458` — `enable/disable_config_encryption`, `change_encryption_password` | `DEFAULT_CONFIG_PATH` (`config.py:46`) | `_get_effective_config_path()` (`config.py:49`) | **NO** |
+| 2 | `Utils/config_encryption.py:245-256` `detect_api_keys` → `should_encrypt_config()` | `["api_key","apikey","api-key","secret","token","password"]` exact-match | real keys are `openai_api_key`, `bing_search_api_key`, `api_token`, `auth_token`, `OPENAI_API_KEY_fallback`, … | **NO** |
+| 3 | `Utils/sensitive_paths.py` denylist vs. skill **trust/grant** store | (absent — no entry) | `get_user_data_dir()/skills/trust/{skill_trust_manifest.json, skill_script_grants.json, generation_marker.json, snapshots/}` (`app.py:5181-5194`) | **NO (uncovered)** |
+| 4 | `Utils/sensitive_paths.py` denylist vs. `config.toml` **sidecars** | `_get_effective_config_path()` only | app also writes `config.toml.bak` + `config.toml.tmp` (`UI/Screens/settings_screen.py:5596-5605`) | **NO (uncovered)** |
+| 5 | `Skills_Interop/skill_trust_store.py:93-96,110` `_validated_trust_file_path(..., base_dir=self.marker_path.parent)` | `base_dir = path.parent` | correct pattern is `base_dir=self.store_dir` (`skill_trust_store.py:491`) | **NO (vacuous)** |
+| 6 | `Skills_Interop/local_skills_service.py:1765-1804` `_unsafe_scratch_root` | containment tested root-**inside**-container only | must also reject a root that **contains** the stores | **NO (inverted)** |
+| 7 | `MCP/server.py:154` media DB | `get_cli_setting("database","media_db","media_library.db")` | key is `media_db_path`; accessor is `get_media_db_path()` (`config.py:4622`) | **NO** |
+| 8 | `MCP/local_store.py:13` `DEFAULT_LOCAL_MCP_STORE_PATH` | `~/.config/tldw_cli/local_mcp_store.json` | `get_user_data_dir()/local_mcp_store.json` (`app.py:5241`) | **NO (latent)** |
+| 9 | `MCP/unified_context_store.py:14` | `~/.config/tldw_cli/unified_mcp_context.json` | `get_user_data_dir()/unified_mcp_context.json` (`app.py:5248`) | **NO (latent)** |
+| 10 | `MCP/server_target_store.py:13` | `~/.config/tldw_cli/mcp_server_targets.json` | `get_user_data_dir()/mcp_server_targets.json` (`app.py:4028`) | **NO (latent)** |
+| 11 | `config.py:4299` `get_detected_api_providers()` | `section_name.startswith("api_settings.")` | tomllib nests → top-level key is `"api_settings"` | **NO** |
+| 12 | `config.py:3691` `_is_sensitive_setting_key` (substring) vs `UI/Screens/settings_privacy_security.py:190` (endswith) | identical literal sets, different semantics | — | **DIVERGENT** |
+| 13 | `Utils/log_sanitizer.py` (whole module) | 20+ key/pattern literals | zero production importers | **NO** |
+| 14 | `Utils/log_sanitizer.py:16` `claude-[a-zA-Z0-9-]+` | Anthropic **key** prefix | `claude-*` is the **model-id** prefix; keys are `sk-ant-…` | **NO (inverted)** |
+| 15 | `Event_Handlers/eval_db_operations.py:28` | `~/.config/tldw_cli/evals.db` | `get_user_data_dir()/<user>/evals.db` (`Evals/eval_orchestrator.py:94`) | **NO** |
+| 16 | `UI/Tools_Settings_Window.py:6480-6507`, `:6631-6652` DB path map (integrity check / backup / vacuum / chatbook import) | `~/.local/share/tldw_cli/tldw_{media,prompts,evals,rag,subscriptions}_db.db` | `get_*_db_path()` → `get_user_data_dir()/tldw_chatbook_*.db` | **NO** |
+| 17 | `Chatbooks/chatbook_importer.py:77-79` extraction root | `~/.local/share/tldw_cli/temp/imports` | `get_user_data_dir()/temp/…` (`chatbook_creator.py:97`) | **NO** |
+| 18 | `Chatbooks/local_chatbook_service.py:102-107` | `~/.local/share/tldw_cli/tldw_chatbook_chatbooks.json` | `get_user_data_dir()/…` | **NO** |
+| 19 | `Workspaces/registry_service.py:673-707` folder-binding denylist | `Path(resolved.anchor)` and `Path.home()` only | `Utils/sensitive_paths.is_sensitive_path` is never consulted | **NO (incomplete)** |
+| 20 | `DB/sql_validation.py:14-24` `VALID_TABLES["chachanotes"]` | 9 names | 35 real tables; `keyword_collections` missing | **NO (over-blocks)** |
+| 21 | `DB/sql_validation.py:308` `VALID_COLUMNS` gate | 8 table keys | callers pass `sync_profile_state`, `Transcripts`, `MediaChunks`, `UnvectorizedMediaChunks`, `DocumentVersions` | **NO (no-ops)** |
+| 22 | `Utils/path_validation.py:311` `dangerous_patterns` contains `"~/"` | rejects `~/` | 6 `Evals/task_loader.py` sites pass raw user input un-expanded | **NO (over-blocks)** |
+| 23 | `Subscriptions/security.py:79,85-89` `BLOCKED_SCHEMES`, `METADATA_ENDPOINTS` | 5 schemes + 3 metadata hosts | real enforcer is `Utils/egress.py:35-44`; these have zero readers | **NO (dead + stale)** |
+| 24 | `config.py:3471-3476` `[subscriptions.security]` 5 keys | `enable_ssrf_protection`, `verify_ssl_certificates`, `max_redirects=5`, … | zero readers; real controls are `[web_security] enabled`, per-source `ssl_verify`, `egress.MAX_REDIRECT_HOPS=10` | **NO** |
+| 25 | `Tools/file_operation_tools.py:28` `[tools] file_sandbox_root` | key read | key is declared in no default TOML and written by no UI | **read-only/undeclared** |
+| 26 | `config.py:3541-3542,3562` `[github] respect_gitignore`, `show_hidden_files`, `profiles_directory` | 3 keys | zero readers; `CodeRepoCopyPasteWindow.py:392-429` uses a hardcoded 10-name list, never parses `.gitignore` | **NO** |
+| 27 | `Metrics/logger_config.py:21-22` | `~/.local/tldw_cli/Logs/tldw_app.log` | `get_cli_log_file_path()` → `get_user_data_dir()/tldw_cli_app.log`; `setup_logger` has zero callers | **NO** |
+| 28 | `Utils/Utils.py:77-79` `USER_DB_DIR`/`USER_DB_PATH` + `Utils/paths.py:205` `get_user_database_path` | `~/.config/tldw_cli/tldw_cli_Media.db` | `get_media_db_path()` | **NO (dead)** |
+| 29 | `UI/Screens/chat_screen.py:15394`, `Event_Handlers/notes_events.py:144`, `note_ingest_events.py:350`, `Subscriptions/website_monitor.py:72` | `Path.home()/".config"/"tldw_cli"/…` | `_get_effective_config_path().parent` | **NO** |
+| 30 | `Utils/sensitive_paths.py` — the module this task was cut from | derives config.toml, 3 MCP files, 11 DBs + sidecars, `user_data_dir` file rule | all match on this machine | **YES** |
+
+---
+
+## Findings, in severity order
+
+Severity per the task's rule: **Critical** when the unprotected/mis-protected thing *grants
+privilege* (permission stores, trust stores, credentials, config that turns gates off);
+**Important** when it only discloses or corrupts data.
+
+---
+
+### CRITICAL-1 — Config encryption encrypts the wrong file and reports success
+
+`tldw_chatbook/config.py:4309-4470`. All three encryption entry points
+(`enable_config_encryption`, `disable_config_encryption`, `change_encryption_password`) open
+`DEFAULT_CONFIG_PATH` directly instead of `_get_effective_config_path()`. Every other read and
+write in the app (`config.py:681`, `:3597`, `:3893`, `:3994`) goes through the accessor.
+
+```python
+def enable_config_encryption(password: str) -> bool:          # config.py:4309
+        config_data = {}
+        if DEFAULT_CONFIG_PATH.exists():                       # :4322
+            with open(DEFAULT_CONFIG_PATH, "rb") as f:         # :4323
+                config_data = tomllib.load(f)
+        encrypted_config = encrypt_api_keys_in_config(config_data, password)
+        with open(DEFAULT_CONFIG_PATH, "w", encoding="utf-8") as f:   # :4330
+            toml.dump(encrypted_config, f)
+```
+
+Live callers: `UI/Tools_Settings_Window.py:3857`, `:3897`, `:6787`, `:6838`, `:6936`.
+
+**What it fails to protect:** the user's API keys. `TLDW_CONFIG_PATH` is a supported mode
+(surfaced as "Override config" at `UI/Screens/settings_screen.py:5035-5058`, described at
+`runtime_policy/bootstrap.py:30`, and used throughout this project's own test suite). With a
+profile active, "Enable encryption" leaves the live config's keys plaintext, silently rewrites a
+*different* config file, and returns `True`. `disable_config_encryption` /
+`change_encryption_password` then read `encryption.password_verifier` from the wrong file
+(`:4372`, `:4435`) and abort with "No password verifier found" — the user cannot rotate or
+remove the password either.
+
+**Verification** (sandboxed `HOME`, real `enable_config_encryption` call, scratchpad `verify4.py`):
+
+```
+TLDW_CONFIG_PATH             : …/task846_b0elztkp/profiles/work.toml
+_get_effective_config_path() : /private/…/task846_b0elztkp/profiles/work.toml   <- what the app reads/saves
+DEFAULT_CONFIG_PATH          : …/task846_b0elztkp/.config/tldw_cli/config.toml  <- what encryption uses
+MATCH: False
+enable_config_encryption('hunter2hunter2') -> True
+ACTIVE profile changed?  False | still plaintext secret present: True
+DEFAULT config changed?  True  | plaintext secret still there: False
+--> encryption reported success while the ACTIVE config's key stayed plaintext
+```
+
+Secondary: `:4330` writes with plain `open(..., "w")` while its two siblings use
+`atomic_write_text` (`:4393`, `:4458`) — an interrupted enable truncates the config.
+
+---
+
+### CRITICAL-2 — `should_encrypt_config()` never fires for real provider credentials
+
+`tldw_chatbook/Utils/config_encryption.py:245-256`. `detect_api_keys` matches key names by
+**exact equality** against six literals:
+
+```python
+                if key.lower() in [
+                    "api_key", "apikey", "api-key", "secret", "token", "password",
+                ]:
+```
+
+The app's real secret-bearing key names are all *prefixed or suffixed*: `openai_api_key`,
+`anthropic_api_key`, `cohere_api_key`, `bing_search_api_key`, `tavily_search_api_key`,
+`api_token` (github/confluence), `auth_token` (`[tldw_api]`), `OPENAI_API_KEY_fallback`,
+`ELEVENLABS_API_KEY_fallback` (`config.py:66,70`, written by
+`UI/Tools_Settings_Window.py:5521,5541`). None of them equals any of the six.
+
+**What it fails to protect:** the gate that offers at-rest encryption at all. `config.py:4285`
+`should_encrypt_config()` returns `enc_module.detect_api_keys(config)` — so a config full of
+plaintext provider keys is reported as having nothing to encrypt, and the user is never
+prompted.
+
+**Verification** (scratchpad `verify2.py`):
+
+```
+detect_api_keys(config full of REAL provider secrets) -> False
+detect_api_keys({'x':{'api_key':'sk-1'}})             -> True
+```
+(the first dict contains `openai_api_key`, `anthropic_api_key`, `cohere_api_key`,
+`bing_search_api_key`, `tavily_search_api_key`, `github.api_token`, both `*_fallback` keys and
+`tldw_api.auth_token` — all live-plaintext, all reported clean.)
+
+---
+
+### CRITICAL-3 — The skill **script-grant and trust** store is not on the agent-tool denylist
+
+`tldw_chatbook/app.py:5181-5200` builds the trust store at
+`get_user_data_dir()/skills/trust/`. `skill_script_grants.json`
+(`Skills_Interop/skill_trust_service.py:49`, joined at `:661`) is the file
+`has_script_grant` (`:1452-1465`) consults to authorize **script execution**, and it is
+*deliberately* outside the MAC'd manifest (`:653-661`) so it is plain, unauthenticated JSON.
+
+`Utils/sensitive_paths.py` names none of it, and the module's own
+`resolved.parent == ctx.user_data_dir` rule structurally cannot reach it: `skills` is an existing
+directory, so it is exempted by design (the rule's comment at `sensitive_paths.py:48-51` names
+`skills` among the intentionally-reachable containers), and everything nested under it inherits
+that exemption.
+
+**What it fails to protect:** the script-execution grant gate and the trust manifest/snapshots
+that back trust review — exactly the "one-step gate bypass" class the `mcp_permissions.json`
+entry exists to prevent. Reachability still requires a widened `[tools] file_sandbox_root` or a
+bound workspace folder root (see IMPORTANT-6), so this is uncovered surface rather than a live
+bypass today.
+
+**Verification** (scratchpad `verify3.py`):
+
+```
+…/default_user/skills/trust/skill_trust_manifest.json   sensitive=False
+…/default_user/skills/trust/skill_script_grants.json    sensitive=False
+…/default_user/skills/trust/generation_marker.json      sensitive=False
+…/default_user/skills/trust/snapshots                   sensitive=False
+…/default_user/skills/tldw_chatbook_skills.json         sensitive=False
+```
+
+---
+
+### CRITICAL-4 — `config.toml.bak` (a byte-for-byte copy of the config, API keys included) is not denylisted
+
+`UI/Screens/settings_screen.py:5596-5605` — Advanced config save writes a full backup before
+overwriting:
+
+```python
+        tmp_path = config_path.with_suffix(config_path.suffix + ".tmp")
+        backup_path = config_path.with_suffix(config_path.suffix + ".bak")
+        ...
+            if config_path.exists():
+                backup_path.write_text(
+                    config_path.read_text(encoding="utf-8"), encoding="utf-8"
+                )
+```
+
+The denylist names `_get_effective_config_path()` and nothing else in that directory. `.bak` and
+`.tmp` carry identical content — including every plaintext API key.
+
+Note the asymmetry: `sensitive_paths.py` *does* handle the equivalent case for databases
+(`_DB_SIDECAR_SUFFIXES` = `-wal`/`-shm`/`-journal`, `_db_sidecar_paths`) and for the MCP
+permission store's own `.bak` (`MCP/permission_store.py:232`) via the `user_data_dir` file rule
+— but the config file lives in `~/.config/tldw_cli/`, which that rule does not cover.
+
+**What it fails to protect:** the user's API keys, in a file created by a first-party UI action.
+
+**Verification** (scratchpad `verify3.py`; `.bak` absent right now only because Advanced save
+has not been used on this machine — the directory does hold two hand-made copies,
+`config.toml.bak-1785079350` and `config.toml.pre-lab-cleanup`, both 45 KB, both unprotected):
+
+```
+/Users/macbook-dev/.config/tldw_cli/config.toml.bak      exists=False sensitive=False
+/Users/macbook-dev/.config/tldw_cli/config.toml.tmp      exists=False sensitive=False
+/Users/macbook-dev/.config/tldw_cli/ui_state.toml        exists=True  sensitive=False
+/Users/macbook-dev/.config/tldw_cli/runtime_policy.json  exists=True  sensitive=False
+/Users/macbook-dev/.config/tldw_cli/config.toml.bak-1785079350  exists=True  sensitive=False
+```
+
+---
+
+### CRITICAL-5 — Trust-store path validator's containment test is true by construction
+
+`Skills_Interop/skill_trust_store.py:93-96` and `:110` call the trust-path validator with
+`base_dir` set to the candidate's own parent:
+
+```python
+        marker_path = _validated_trust_file_path(
+            self.marker_path,
+            base_dir=self.marker_path.parent,
+        )
+```
+
+`_validated_trust_file_path` (`:544-554`) rejects when
+`get_safe_relative_path(candidate, base) is None`. With `base = candidate.parent` that branch can
+never be taken. The correct pattern exists two methods away —
+`_validated_manifest_path` (`:490-491`) passes `base_dir=self.store_dir` — and `store_dir` was
+available at the marker's construction site (`app.py:5186`).
+
+**What it fails to protect:** confinement of the trust generation marker (the rollback-protection
+anchor) to the trust store directory.
+
+**Verification** (scratchpad `verify3.py`, temp dir):
+
+```
+base_dir=path.parent  -> ACCEPTED …/totally/elsewhere/generation_marker.json   (containment test is true by construction)
+base_dir=real store   -> rejected: unsafe skill trust path  (correct)
+```
+
+---
+
+### CRITICAL-6 — Skill scratch-root safety check tests containment in the wrong direction
+
+`Skills_Interop/local_skills_service.py:1765-1804`. The container list is correctly *derived*
+(`self.skills_dir`, `trust_store.store_dir`), but the predicate is
+
+```python
+        return any(
+            get_safe_relative_path(root, container) is not None
+            for container in self._unsafe_scratch_root_containers()
+        )
+```
+
+and `get_safe_relative_path(a, b)` (`Utils/path_validation.py:268-273`) is non-`None` only when
+`a` is *inside* `b`. So a scratch root **nested in** the stores is refused, while a scratch root
+that **contains** them passes. The docstring at `:1782-1791` claims the opposite guarantee.
+
+**What it fails to protect:** the "a script must never be able to tamper with its own bundle or
+the trust store" property. `[skills] script_scratch_root = ~/.local/share/tldw_cli/<user>/skills`
+passes while placing the script's cwd one level above both `skills/skills/` (every trusted
+bundle) and `skills/trust/` (manifest, snapshots, marker, grants). `self.store_dir` — which holds
+the skill index `tldw_chatbook_skills.json` — is not in the container list at all.
+
+**Verification** (scratchpad `verify3.py`, real container paths):
+
+```
+candidate=…/default_user/skills/skills/sub  flagged_unsafe=True   [root INSIDE skills_dir  (should be unsafe)]
+candidate=…/default_user/skills             flagged_unsafe=False  [root CONTAINS both stores (should be unsafe)]
+candidate=…/default_user                    flagged_unsafe=False  [root CONTAINS everything (should be unsafe)]
+```
+
+---
+
+### IMPORTANT-1 — MCP server opens a media DB that is on no denylist, via a config key that does not exist
+
+`tldw_chatbook/MCP/server.py:154-155`:
+
+```python
+            media_db_path = get_cli_setting("database", "media_db", "media_library.db")
+            self.media_db = MediaDatabase(media_db_path)
+```
+
+The key is `media_db_path` (`config.py:4624`, declared `config.py:2233`, present in the live
+config at line 30). `media_db` does not exist, so the lookup always falls to the relative literal
+and the MCP server creates/opens `./media_library.db` in whatever CWD it was launched from. Two
+lines above, the same function correctly calls `get_chachanotes_db_path()`.
+
+**What it fails to protect:** `Utils/sensitive_paths.py:98` denylists `get_media_db_path` — the
+DB the MCP server does *not* use. Everything the MCP media tools write lands in a CWD-relative
+file with no denylist coverage at all.
+
+**Verification** (scratchpad `verify1.py`, then `verify2.py` for the denylist half):
+
+```
+get_cli_setting("database","media_db","media_library.db") -> 'media_library.db'
+get_cli_setting("database","media_db_path", None)         -> '~/.local/share/tldw_cli/tldw_cli_media_v2.db'
+resolved by MCP server  : /Users/macbook-dev/Documents/GitHub/wt-path-hardening/media_library.db exists= False
+resolved by app         : /Users/macbook-dev/.local/share/tldw_cli/default_user/tldw_chatbook_media_v2.db
+MATCH: False
+
+is_sensitive_path(…/wt-path-hardening/media_library.db) -> False
+is_sensitive_path(…/default_user/tldw_chatbook_media_v2.db) -> True
+```
+
+---
+
+### IMPORTANT-2 — Three MCP stores default to a directory the app never uses (latent gate-state split)
+
+`MCP/local_store.py:13`, `MCP/unified_context_store.py:14-16`, `MCP/server_target_store.py:13`
+all default to `DEFAULT_CONFIG_PATH.parent / <name>` — i.e. `~/.config/tldw_cli/`. The app always
+passes `get_user_data_dir() / <name>` explicitly (`app.py:5241`, `:5248`, `:4028`).
+
+This matters more than a normal stale default because the **permission store and execution log
+are derived from `store.path`**: `MCP/unified_control_plane_service.py:2430` builds
+`Path(store.path).with_name("mcp_permissions.json")` and `:2073` builds
+`…with_name("mcp_execution_log.jsonl")`. A `LocalMCPStore()` constructed with no argument
+anywhere would place the permission store in `~/.config/tldw_cli/`, where **neither**
+`_sensitive_single_file_paths()` (which joins to `get_user_data_dir()`) nor the
+`parent == user_data_dir` rule matches.
+
+**What it fails to protect:** nothing today — every construction site passes an explicit path.
+Rated Important, not Critical, because it is a latent second location for the permission store
+rather than a live bypass.
+
+**Verification** (scratchpad `verify2.py`):
+
+```
+local_mcp_store.json
+  module default : /Users/macbook-dev/.config/tldw_cli/local_mcp_store.json  exists=False
+  app builds     : /Users/macbook-dev/.local/share/tldw_cli/default_user/local_mcp_store.json  exists=True
+  MATCH: False
+unified_mcp_context.json      module default exists=False ; app-built exists=True ; MATCH: False
+mcp_server_targets.json       module default exists=False ; app-built exists=True ; MATCH: False
+```
+Also verified uncovered: `is_sensitive_path(~/.config/tldw_cli/mcp_permissions.json) -> False`,
+`is_sensitive_path(~/.config/tldw_cli/local_mcp_store.json) -> False`.
+
+---
+
+### IMPORTANT-3 — `Utils/log_sanitizer.py` has zero production importers, and its Anthropic rule is inverted
+
+```
+$ grep -rn "log_sanitizer" tldw_chatbook/ Tests/ --include="*.py"
+Tests/Utils/test_security_enhancements.py:6:from tldw_chatbook.Utils.log_sanitizer import (
+```
+
+Nothing in `tldw_chatbook/` imports it. (The 40+ `sanitize_string` hits elsewhere resolve to a
+different function in `Utils/input_validation.py`.) Every literal in the module protects nothing
+at runtime — only the test file exercises it, so the tests are green and vacuous.
+
+Worse, the rules are wrong in both directions. `log_sanitizer.py:16` names
+`claude-[a-zA-Z0-9-]+` as "Anthropic keys" — that is the **model-id** prefix. `:15`'s
+`sk-[a-zA-Z0-9]{20,}` character class excludes `-`, so it stops at `sk-ant`/`sk-proj`.
+
+**Verification** (scratchpad `verify2.py`):
+
+```
+IN : Using model claude-opus-4-20250514 for chat
+OUT: Using model ***ANTHROPIC_KEY*** for chat                 <- model name destroyed
+IN : key sk-ant-api03-AbCdEf0123456789AbCdEf0123456789
+OUT: key sk-ant-api03-AbCdEf0123456789AbCdEf0123456789        <- real Anthropic key SURVIVES
+IN : key sk-proj-AbCdEf0123456789AbCdEf0123456789
+OUT: key sk-proj-AbCdEf0123456789AbCdEf0123456789             <- real OpenAI key SURVIVES
+
+sanitize_dict(...) -> {'x-api-key': 'sk-ant-secret',   <- NOT redacted
+                       'cohere_api_key': 'abc',        <- NOT redacted
+                       'openai_api_key': '***REDACTED***',
+                       'api_token': 'ghp_x',           <- NOT redacted
+                       'secret_key': 's',              <- NOT redacted
+                       'refresh_token': 'r',           <- NOT redacted
+                       'auth_token': '***REDACTED***'}
+```
+
+If this module is ever wired in as-is, it will redact model names in logs while passing real keys
+through. Its `SENSITIVE_FIELDS` also names ten literals that appear nowhere in this codebase
+(`aws_access_key_id`, `aws_secret_access_key`, `connection_string`, `api_secret`, `api-secret`,
+`credentials`, `pwd`, `passwd`, `api-key`, `private_key`) and misses ~30 real ones.
+
+---
+
+### IMPORTANT-4 — Two "identical" sensitive-key checks disagree in both directions
+
+`config.py:3691` `_is_sensitive_setting_key` (substring `in`) and
+`UI/Screens/settings_privacy_security.py:190` `_is_sensitive_config_key` (`endswith`) enumerate
+the *same* literal sets with *different* matching semantics, and only the second guards
+`_env_var`. A third, strictly smaller copy lives at `Utils/config_encryption.py:250`
+(CRITICAL-2), and a fourth duplicates `config.py:3693-3718` verbatim at `config.py:515-546`.
+
+**Verification** (scratchpad `verify2.py`):
+
+```
+key                              config._is_sensitive_setting_key   settings_privacy._is_sensitive_config_key
+api_key_env_var                  True                               False
+max_tokens                       True                               False
+OPENAI_API_KEY_fallback          True                               False
+ELEVENLABS_API_KEY_fallback      True                               False
+search_engine_api_key_bing       True                               False
+api_key                          True                               True
+openai_api_key                   True                               True
+```
+
+Two concrete consequences. **Over-reach:** `config.py` treats `api_key_env_var` (an env-var
+*name*, appearing 20× in the default TOML at `config.py:2330+`) and `max_tokens` (30+
+occurrences) as secrets — `encrypt_sensitive_fields` (`:554`) encrypts the env-var name into an
+`enc:` blob and `_setting_value_for_log` (`:3721`) logs `max_tokens` as `<redacted>`.
+**Under-reach:** the Privacy & Security panel's counts (`settings_privacy_security.py:153,160`)
+miss the real `[app_tts]` `*_fallback` keys and the `search_engine_api_key_*` keys.
+
+Both lists also name seven literals that are not config keys anywhere (`apikey`, `api-key`,
+`secret`, `secret_key`, `access_token`, `refresh_token`, `client_secret`).
+
+---
+
+### IMPORTANT-5 — `get_detected_api_providers()` always returns `[]`
+
+`config.py:4297-4303` iterates `config.items()` looking for `section_name.startswith("api_settings.")`.
+`tomllib` parses `[api_settings.openai]` into a *nested* dict, so the top-level key is
+`"api_settings"` and the prefix test is never true.
+
+**What it fails to protect:** nothing directly — but four live UI call sites
+(`UI/Tools_Settings_Window.py:998, 3161, 3837, 6757`) use it to tell the user which providers
+have keys stored, so the encryption/privacy surface always reports zero.
+
+**Verification** (scratchpad `verify1.py`):
+
+```
+get_detected_api_providers() -> []
+top-level keys containing 'api_settings': ['api_settings']
+any key startswith('api_settings.') : False
+raw['api_settings'] subkey count    : 28
+```
+
+---
+
+### IMPORTANT-6 — Workspace folder-binding denies only `Path.home()`, never consults the denylist
+
+`Workspaces/registry_service.py:673-707`. The docstring (`:666-669`) claims it denies "the
+filesystem root, the home directory itself, non-directories, and duplicate/nested roots":
+
+```python
+        if resolved == Path(resolved.anchor):                  # :683
+        if resolved == Path.home().resolve():                  # :688
+```
+
+Two exact-equality literals. `grep -rn sensitive_paths tldw_chatbook/Workspaces/` → nothing.
+
+**What it fails to protect:** binding `~/.config/tldw_cli` (the live config with API keys),
+`~/.local/share/tldw_cli` (every app DB), or `~/.ssh` as a workspace folder root all pass. Since
+a bound folder root widens what the agent file tools may reach, this is the mechanism by which
+CRITICAL-3's uncovered trust store becomes reachable. `is_sensitive_path` still refuses the
+individual enumerated files, so this is *scope widening*, not a direct bypass — but it widens the
+scope right up to the boundary of the paths the denylist does not enumerate.
+
+---
+
+### IMPORTANT-7 — Evals DB named three different ways; two of them create empty databases
+
+| Source | Path |
+|---|---|
+| `Event_Handlers/eval_db_operations.py:28` | `Path.home()/".config"/"tldw_cli"/"evals.db"` |
+| `Evals/eval_orchestrator.py:90-99` (the real one) | `get_user_data_dir()/<user_id>/"evals.db"` |
+| `UI/Tools_Settings_Window.py:6493` | key `evals_db_path`, default `~/.local/share/tldw_cli/tldw_evals_db.db` |
+
+`evals_db_path`, `rag_db_path` and `subscriptions_db_path` are **declared nowhere** in
+`config.py`'s `[database]` defaults (`config.py:2226-2246`).
+
+**Verification** (scratchpad `verify4.py`, sandboxed HOME):
+
+```
+eval_db_operations.py:28 literal : …/.config/tldw_cli/evals.db
+eval_orchestrator.py:94 derived  : …/.local/share/tldw_cli/default_user/evals.db
+Tools_Settings_Window:6493 key   : evals_db_path -> '<undeclared>'
+```
+
+Same defect class at `UI/Tools_Settings_Window.py:6480-6507` and `:6631-6652`: the DB path map
+backing integrity check, backup, vacuum and chatbook import omits the `<user_folder>` segment for
+all six DBs *and* uses wrong filenames (`tldw_prompts_db.db` vs. real `tldw_chatbook_prompts.db`;
+`tldw_media_db.db` vs. real `tldw_chatbook_media_v2.db`). Those maintenance operations run
+against files the app never opens.
+
+---
+
+### IMPORTANT-8 — `[subscriptions.security]` declares five security switches that nothing reads
+
+`config.py:3471-3476`, present in the live config at lines 1142-1148. Per-key grep across
+`tldw_chatbook/` returns exactly one occurrence each — the declaration.
+
+| Declared key | What actually governs it |
+|---|---|
+| `enable_ssrf_protection` | `get_cli_setting("web_security","enabled",True)` — `Utils/egress.py:88` |
+| `max_redirects = 5` | `egress.MAX_REDIRECT_HOPS = 10` — hard-coded, `egress.py:44` |
+| `verify_ssl_certificates` | per-subscription DB column `ssl_verify` — `Subscriptions/monitoring_engine.py:393,397` |
+| `enable_xxe_protection` | unconditional `defusedxml` import — `Subscriptions/security.py:24-33` |
+| `request_timeout` | per-call `timeout=` arguments |
+
+**What it fails to protect:** an operator who hardens their config here gets no change in
+behavior — the app still follows 10 redirect hops and still fetches with `verify=False` for any
+subscription whose `ssl_verify` column is 0. The inverse is worse: `enable_ssrf_protection = false`
+reads as a documented escape hatch that silently does nothing.
+
+**Verification** (scratchpad `verify4.py`):
+
+```
+get_cli_setting('subscriptions.security','max_redirects')          -> 5
+egress.MAX_REDIRECT_HOPS (the real limit)                          = 10
+get_cli_setting('subscriptions.security','verify_ssl_certificates') -> True
+get_cli_setting('subscriptions.security','enable_ssrf_protection')  -> True
+```
+
+---
+
+### IMPORTANT-9 — `Subscriptions/security.py` ships a stale, unread cloud-metadata denylist
+
+`Subscriptions/security.py:79,85-89` defines `BLOCKED_SCHEMES` and `METADATA_ENDPOINTS`. Both
+have exactly one occurrence in `tldw_chatbook/` — the definition. The real enforcement is
+`Utils/egress.py:35-44`, reached from `security.py:129-135` via `evaluate_url_policy`.
+
+**Verification** (scratchpad `verify4.py`):
+
+```
+security.SecurityValidator.METADATA_ENDPOINTS : {'metadata.azure.com','metadata.google.internal','169.254.169.254'}
+egress.METADATA_HOSTNAMES                     : frozenset({'metadata.azure.com','metadata.google.internal'})
+egress._METADATA_IPS                          : frozenset({169.254.169.254, 100.100.100.200, fd00:ec2::254})
+in security's list but NOT enforced by egress : []
+enforced by egress but MISSING from security  : ['100.100.100.200', 'fd00:ec2::254']
+```
+
+Harmless today (egress is strictly stronger), but it is an authoritative-looking denylist that
+enforces nothing and is already two endpoints behind the real one — a trap for the next reader
+who extends "the" metadata list.
+
+---
+
+### IMPORTANT-10 — App-state files written to `Path.home()/".config"/"tldw_cli"` ignore `TLDW_CONFIG_PATH`
+
+`UI/Screens/chat_screen.py:15394,15425` (`ui_state.toml`),
+`Event_Handlers/notes_events.py:144` and `note_ingest_events.py:350` (`note_templates.json`),
+`Subscriptions/website_monitor.py:72` (`feed_cache/`), plus ~25 lower-value sites listed in the
+inventory. All should derive from `_get_effective_config_path().parent`.
+
+Separately, ~18 sites use `Path.home()/".local"/"share"/"tldw_cli"/…` and omit the
+`<user_folder>` segment (`Chatbooks/chatbook_importer.py:77-79`,
+`Chatbooks/local_chatbook_service.py:102-107`, `Character_Chat/Character_Chat_Lib.py:1274,2790,3856`,
+`Event_Handlers/conv_char_events.py:4152,4213,4264`, …), so multi-user profiles collide.
+
+**Verification** (scratchpad `verify3.py`):
+
+```
+chatbook_importer.py:77 literal : /Users/macbook-dev/.local/share/tldw_cli/temp/imports          exists=True
+get_user_data_dir()-derived     : /Users/macbook-dev/.local/share/tldw_cli/default_user/temp/imports  exists=False
+chatbook_creator.py:97 derived  : /Users/macbook-dev/.local/share/tldw_cli/default_user/temp/chatbooks
+MATCH: False
+```
+Note the literal directory **exists** while the derived one does not — the importer has been
+extracting outside the per-user tree in production.
+
+---
+
+### IMPORTANT-11 — `[tools] file_sandbox_root` is declared in no config and written by no UI
+
+`Tools/file_operation_tools.py:23-28` reads `get_cli_setting("tools", "file_sandbox_root", default_root)`.
+`file_sandbox_root` appears **zero times** in `config.py`'s `CONFIG_TOML_CONTENT` and zero times
+in the live config. The Settings screen writes only the seven `*_enabled` gate keys
+(`UI/Tools_Settings_Window.py:4206` over `Agents/tool_catalog.py:213-238`).
+
+**Verification** (scratchpad `verify3.py`):
+
+```
+get_cli_setting('tools','file_sandbox_root', '<default>') -> '<default>'
+default the tool falls back to: …/default_user/tool_sandbox exists= True
+declared in CONFIG_TOML_CONTENT: False
+[tools] section in CONFIG_TOML_CONTENT: False
+```
+
+Consequence: the `_sandbox_root_is_hidden` guard (`file_operation_tools.py:674-699`, called at
+`:759` and `:915`) that exists to handle a dotted sandbox root is unreachable in practice, and a
+user cannot narrow or relocate the sandbox through any surfaced path. Already filed as
+`backlog/tasks/task-693`.
+
+---
+
+### Inverse findings — checks that over-block
+
+**INV-1 (verified live) — `sql_validation.VALID_TABLES["chachanotes"]` omits 26 real tables, and one omission breaks a shipped feature.**
+`DB/sql_validation.py:14-24` lists 9 tables; the schema has 35. It lists the *link* table
+`collection_keywords` but not the *entity* table `keyword_collections`.
+`ChaChaNotes_DB.py:9309` `update_keyword_collection` → `_update_generic_item` → `:4312`
+`validate_table_name(table_name, "chachanotes")` → `ValueError`.
+
+```
+$ python -c "... db.add_keyword_collection('Coll A'); db.update_keyword_collection(1, {'name':'Coll B'}, expected_version=1)"
+created collection id: 1
+update_keyword_collection -> ValueError: Invalid table name: keyword_collections
+```
+Full allowlist/schema diff (scratchpad `verify4.py`):
+```
+listed but NOT a real table : []
+real but NOT in allowlist   : ['character_expression_images','chat_dictionaries','conversation_dictionaries',
+ 'conversation_local_marks','conversation_world_books','db_schema_version','decks','flashcard_assets',
+ 'flashcard_templates','flashcards','keyword_collections','learning_paths','message_attachments',
+ 'message_generation_metadata','mindmap_nodes','mindmaps','quiz_attempts','quiz_questions','quizzes',
+ 'review_history','study_sessions','sync_conflicts','sync_sessions','topics','world_book_entries','world_books']
+```
+
+**INV-2 — `sql_validation.py:308` `VALID_COLUMNS` gate silently no-ops for five tables.**
+The gate is `if table_name and table_name in VALID_COLUMNS`. Call sites pass
+`"sync_profile_state"` (`Sync_Interop/sync_state_repository.py:1875`, immediately before an
+`ALTER TABLE … ADD COLUMN` f-string) and `Transcripts`/`MediaChunks`/`UnvectorizedMediaChunks`/
+`DocumentVersions` (`DB/Client_Media_DB_v2.py:2950-2952`, `:3180-3182`) — none is a
+`VALID_COLUMNS` key, so only the generic `\w+`/reserved-word filter applies. Not exploitable
+today (all inputs are in-file literals), but the schema check those call sites' comments claim is
+not delivered.
+
+**INV-3 — `validate_path_simple`'s `dangerous_patterns` rejects `~/`.**
+`Utils/path_validation.py:311`. Six `Evals/task_loader.py` sites (`:217, :340, :393, :477, :671,
+:812`) pass raw user input without `expanduser()` first, so a user typing `~/evals/task.json` is
+rejected as a "dangerous pattern". `UI/Screens/library_screen.py:5519,7336,9536,11438,11966` all
+expand first — the handling is inconsistent.
+
+**INV-4 — `config.py`'s substring matcher over-encrypts and over-redacts.** See IMPORTANT-4:
+`api_key_env_var` (an env-var *name*) is encrypted into the config, and `max_tokens` is logged as
+`<redacted>`.
+
+**INV-5 — Two stale comments assert a `validate_path` behavior removed on 2026-07-24.**
+`Chatbooks/chatbook_importer.py:544-549` and `app.py:7584-7585` both claim `validate_path`
+"rejects ANY resolved path containing a dot component". Commit `bc804b792d` changed it to inspect
+only the user portion; `path_validation.py:59-64` now states the opposite explicitly. Both files
+hand-roll a replacement whose stated justification is false.
+
+**INV-6 — Dead config keys that read as security controls.**
+`[github] respect_gitignore` / `show_hidden_files` / `profiles_directory` (`config.py:3541-3542,3562`)
+have zero readers. What actually runs is a hardcoded ten-name list at
+`UI/CodeRepoCopyPasteWindow.py:392-406`; no `.gitignore` is parsed anywhere at runtime (`pathspec`
+is not a dependency). Two entries in that list (`.venv`, `.env`) are unreachable — the preceding
+`not d.startswith(".")` already excluded them. The config comment promises hidden files are shown
+"except .gitignore"; `:425` skips every dotfile including `.gitignore` itself.
+
+```
+get_cli_setting('github','respect_gitignore')  -> True
+get_cli_setting('github','show_hidden_files')  -> False
+get_cli_setting('github','profiles_directory') -> '~/.config/tldw_cli/github_profiles'
+```
+
+**INV-7 — Dead path constants contradicting the real accessors.**
+`Metrics/logger_config.py:21-22` (`~/.local/tldw_cli/Logs/…` — missing `share` *and*
+`<user_folder>`, on a `setup_logger` with zero callers) and `Utils/Utils.py:77-79` /
+`Utils/paths.py:205-249` (`~/.config/tldw_cli/tldw_cli_Media.db`, zero callers, contradicting
+`get_media_db_path()`). `Utils/paths.py` therefore ships two contradictory answers to "where is
+the user's data" — its own `get_user_data_dir()` at `:123` correctly delegates to `config`.
+
+---
+
+## Is `Utils/sensitive_paths.py` clean?
+
+**Yes, for everything it enumerates.** Every entry resolves through the app's own accessor and
+matches the real on-disk path on this machine. Verified (scratchpad `verify2.py`):
+
+```
+ctx.user_data_dir: /Users/macbook-dev/.local/share/tldw_cli/default_user
+  file : /Users/macbook-dev/.config/tldw_cli/config.toml                                  exists=True
+  file : …/default_user/mcp_permissions.json      exists=False   (not yet created; path is correct)
+  file : …/default_user/local_mcp_store.json      exists=True
+  file : …/default_user/mcp_execution_log.jsonl   exists=False
+  db   : 11 accessors resolved, ALL exist on disk
+
+is_sensitive_path(…/default_user/mcp_permissions.json)      -> True
+is_sensitive_path(…/default_user/local_mcp_store.json)      -> True
+is_sensitive_path(…/default_user/mcp_execution_log.jsonl)   -> True
+is_sensitive_path(/Users/macbook-dev/.config/tldw_cli/config.toml) -> True
+is_sensitive_path(…/default_user/tldw_chatbook_media_v2.db) -> True
+is_sensitive_path(…/default_user/mcp_permissions.json.bak)  -> True   (user_data_dir file rule)
+is_sensitive_path(…/default_user/mcp_execution_log.jsonl.1) -> True   (user_data_dir file rule)
+is_sensitive_path(~/.ssh/id_rsa)                            -> True
+```
+
+Enforcement is genuinely wired: `Tools/file_operation_tools.py:67, 148, 278, 329, 492, 771, 937`
+call `is_sensitive_path` / `resolve_sensitive_context` across `ReadFileTool`, `WriteFileTool`,
+`ListDirectoryTool`, `GlobFiles` and `GrepFiles`.
+
+The remaining gaps are **omissions, not drift**: `skills/trust/*` (CRITICAL-3, structurally
+excluded by the directory-exemption rule), `config.toml`'s `.bak`/`.tmp` sidecars (CRITICAL-4),
+and the rest of `~/.config/tldw_cli/` (`runtime_policy.json`, `ui_state.toml`, and the
+`~/.config/tldw_cli/` variants of the MCP stores from IMPORTANT-2). Nothing the module names
+points at a path that does not exist.
+
+One residual fragility worth recording: `sensitive_paths.py:209-211` re-spells the three MCP
+filenames as its own literals, joined to `get_user_data_dir()`. They agree with
+`unified_control_plane_service.py:2430`/`:2073` today only because `store.path`'s parent happens
+to be `get_user_data_dir()`. If `app.py:5241` ever moves `local_mcp_store.json` into a
+subdirectory, lines 209-211 stop matching **and** the `parent == user_data_dir` fallback stops
+firing — Finding 1 reintroduced, one refactor away. `Tests/Utils/test_sensitive_paths.py:73-75`
+re-derives from the same `app.py` expression rather than from
+`app.unified_mcp_service.permission_store.path`, so it would not catch that variant.
+
+---
+
+## Recommended backlog tasks
+
+1. **Route the three config-encryption entry points through `_get_effective_config_path()`**
+   (CRITICAL-1). Regression test must set `TLDW_CONFIG_PATH` and assert the *active* file changed.
+   Fold in the non-atomic write at `config.py:4330`.
+2. **Replace `detect_api_keys`'s six-literal exact-match with the shared predicate** (CRITICAL-2),
+   and collapse the four duplicate sensitive-key lists (`config.py:515`, `config.py:3693`,
+   `config_encryption.py:250`, `settings_privacy_security.py:10`) into one module with one
+   semantics, keeping the `_env_var` guard and excluding `max_tokens` (CRITICAL-2 + IMPORTANT-4 +
+   INV-4). Tests must enumerate real key names read out of `CONFIG_TOML_CONTENT`, not literals.
+3. **Cover the skill trust/grant store in `sensitive_paths.py`** (CRITICAL-3) — derive from
+   `SkillTrustService`/`SkillTrustStore` attributes, not from a re-spelled `skills/trust` literal,
+   and reconcile with the deliberate `skills` directory exemption.
+4. **Cover `config.toml`'s `.bak`/`.tmp` sidecars** (CRITICAL-4), mirroring the existing
+   `_DB_SIDECAR_SUFFIXES` treatment; consider whether the whole effective-config *directory*
+   should get the same file-rule the user data dir has.
+5. **Fix the two skills-trust containment checks** (CRITICAL-5 + CRITICAL-6): pass
+   `base_dir=store_dir` for the marker, and make `_unsafe_scratch_root` reject roots that
+   *contain* the stores as well as roots inside them (add `self.store_dir` to the container list).
+6. **Fix `MCP/server.py:154` to call `get_media_db_path()`** (IMPORTANT-1), and grep for any other
+   `get_cli_setting("database", ...)` whose key is not one of the declared `*_db_path` names.
+7. **Make the three MCP store module defaults derive from `get_user_data_dir()`** or drop the
+   defaults entirely and require an explicit path (IMPORTANT-2).
+8. **Decide `Utils/log_sanitizer.py`'s fate** (IMPORTANT-3): delete it, or fix the regexes and
+   field list and actually wire it in. Shipping it unimported with an inverted Anthropic rule is
+   the worst of both.
+9. **Have `Workspaces.add_folder_binding` consult `is_sensitive_path`** before accepting a root
+   (IMPORTANT-6) — this is the reachability gate for finding 3.
+10. **Reconcile the evals-DB and settings DB-path maps with the `get_*_db_path()` accessors**
+    (IMPORTANT-7), and declare or delete `evals_db_path` / `rag_db_path` / `subscriptions_db_path`.
+11. **Delete or implement `[subscriptions.security]` and `Subscriptions/security.py`'s unread
+    denylists** (IMPORTANT-8 + IMPORTANT-9). A config switch named `enable_ssrf_protection` that
+    does nothing is worse than no switch.
+12. **Add `keyword_collections` (and audit the other 25 omissions) in
+    `sql_validation.VALID_TABLES`** (INV-1) — this is a live, reproducible feature break — and
+    decide whether `validate_column_name` should fail closed for tables absent from `VALID_COLUMNS`
+    (INV-2).
+13. **Sweep `Path.home()/".config"/"tldw_cli"` and `Path.home()/".local"/"share"/"tldw_cli"` call
+    sites onto the accessors** (IMPORTANT-10); the `chatbook_importer` extraction root is the
+    highest-value one since its literal directory demonstrably exists in production.
+14. **Cross-cutting test rule (task AC #3):** any test asserting one of these paths must
+    re-derive it from the same accessor the app uses. Two existing tests currently re-spell an
+    `app.py` literal instead (`Tests/Utils/test_sensitive_paths.py:73-75`,
+    `Tests/conftest.py:566-575` + `Tests/Skills/test_skills_library_flow.py:84-106`), so they
+    would go vacuous in lockstep with a drift rather than catch it.
+
+### Lower priority (record, don't schedule separately)
+
+- INV-3 `~/` in `dangerous_patterns` vs. `Evals/task_loader.py` (6 sites).
+- INV-5 two stale comments citing removed `validate_path` behavior.
+- INV-6 dead `[github]` keys + the unreachable `.venv`/`.env` entries.
+- INV-7 dead `Metrics/logger_config.py` and `Utils/Utils.py` path constants.
+- IMPORTANT-5 `get_detected_api_providers()` always `[]`.
+- IMPORTANT-11 `[tools] file_sandbox_root` undeclared (already `task-693`).

--- a/.superpowers/sdd/task-846-filing.md
+++ b/.superpowers/sdd/task-846-filing.md
@@ -1,0 +1,65 @@
+# TASK-846 audit — backlog filing report
+
+**Worktree:** `/Users/macbook-dev/Documents/GitHub/wt-path-hardening` (branch `feat/agent-path-hardening`)
+**Source:** `.superpowers/sdd/task-846-audit.md`, "Recommended backlog tasks" section (14 items).
+**ID range used:** task-851 through task-862 (12 new tasks). Range was free at filing time (pre-scan showed
+`dups: NONE`, `next free: 851`); post-filing scan below also shows `NONE` — but a concurrent session could
+still file into 851-862 before merge, so re-run the scan immediately before merging.
+
+## Tasks filed
+
+| ID | Title | Priority | Labels | Source recommendation(s) |
+|---|---|---|---|---|
+| task-851 | Route config encryption through the effective config path, not the default one | **High** | security, config | Rec 1 (CRITICAL-1) |
+| task-852 | Make should_encrypt_config() detect real provider API keys, and unify the four sensitive-key lists | **High** | security, config | Rec 2 (CRITICAL-2 + IMPORTANT-4 + INV-4) |
+| task-853 | Fix the two skills-trust path containment checks that can't actually reject anything | **High** | security, skills | Rec 5 (CRITICAL-5 + CRITICAL-6) |
+| task-854 | Fix MCP server's media DB lookup to use the real config key/accessor | medium | security, mcp, config | Rec 6 (IMPORTANT-1) |
+| task-855 | Make MCP store module defaults derive from get_user_data_dir(), not ~/.config/tldw_cli | medium | security, mcp | Rec 7 (IMPORTANT-2) |
+| task-856 | Decide the fate of Utils/log_sanitizer.py: wire it in fixed, or delete it | medium | security, config | Rec 8 (IMPORTANT-3) |
+| task-857 | Make workspace folder-binding consult the sensitive-path denylist, not just home/root | medium | security, tools | Rec 9 (IMPORTANT-6) |
+| task-858 | Reconcile the evals/prompts/media/rag/subscriptions DB path maps with get_*_db_path() | medium | security, db, config | Rec 10 (IMPORTANT-7) |
+| task-859 | Delete or implement the unread [subscriptions.security] switches and stale metadata denylist | medium | security, config | Rec 11 (IMPORTANT-8 + IMPORTANT-9) |
+| task-860 | Fix sql_validation.VALID_TABLES to match the real schema (keyword_collections is live-broken) | medium | security, db | Rec 12 (INV-1 + INV-2) |
+| task-861 | Sweep hardcoded ~/.config/tldw_cli and ~/.local/share/tldw_cli call sites onto the real accessors | medium | security, config | Rec 13 (IMPORTANT-10) |
+| task-862 | Make sensitive-path and skills-fixture tests re-derive paths instead of re-spelling them | medium | security, tools | Rec 14's two named test sites (`Tests/Utils/test_sensitive_paths.py:73-75`, `Tests/conftest.py:566-575` + `Tests/Skills/test_skills_library_flow.py:84-106`) |
+
+Three Criticals (CRITICAL-1, CRITICAL-2, CRITICAL-5+6) map to three new tasks (851, 852, 853) — all set
+`priority: high`. The other three Criticals (CRITICAL-3 skill trust/grant store, CRITICAL-4 config.toml
+sidecars) were **not** filed as new tasks per the exception below; they're folded into TASK-848.
+
+Recommendation 14 itself (the cross-cutting "tests must re-derive, not re-assert" rule) was **not** filed
+as a new task — it is already TASK-846's own acceptance criterion #3 ("Tests for those checks derive their
+paths the way the app does rather than asserting literals"). Only the two concrete test sites it named were
+filed, as task-862.
+
+## TASK-848 amendment (not a new task)
+
+Recommendations 3 (skill trust/grant store coverage, CRITICAL-3) and 4 (`config.toml` `.bak`/`.tmp` sidecars,
+CRITICAL-4) were appended to **TASK-848** ("Extend agent file-tool denylist beyond the active user data
+folder") rather than filed separately, per instruction — they're extensions of that task's existing scope
+(the agent file-tool denylist).
+
+- **Description**: two new paragraphs appended after the original text — "Skill trust/grant store." (naming
+  `get_user_data_dir()/skills/trust/*`, the `skills` directory-exemption rule that structurally hides it,
+  and the plain-unauthenticated-JSON status of `skill_script_grants.json`) and "config.toml sidecars." (naming
+  `.bak`/`.tmp` written by `UI/Screens/settings_screen.py:5596-5605`, the existing DB-sidecar pattern to
+  mirror, and the two real unprotected copies already on disk).
+- **Acceptance criteria**: appended 3 new AC items (#2, #3, #4) alongside the original #1 — trust/grant store
+  coverage, config.toml sidecar coverage, and a test requiring both to be derived from the real accessors
+  (`SkillTrustStore`/`SkillTrustService` attributes, `_get_effective_config_path()`) rather than literals.
+- TASK-848's priority was left as-is (unset/default) — the instruction to set `priority: high` applied to
+  newly-filed tasks derived from Critical findings, and 848 was not newly filed.
+
+## Post-filing duplicate scan
+
+```
+dups: NONE
+next free: 863
+```
+
+Files present for the new range: `task-851` through `task-862`, twelve files, no collisions with any
+pre-existing task id.
+
+**Re-check before merge**: this scan is a snapshot from this filing session. Per the collision protocol,
+re-run the scanner script against `backlog/tasks/` immediately before merging this branch, since a
+concurrent session could file into 851-862 in the meantime.

--- a/.superpowers/sdd/task-847-849-report.md
+++ b/.superpowers/sdd/task-847-849-report.md
@@ -1,0 +1,144 @@
+# TASK-847 / TASK-848 / TASK-849 — implementation report
+
+**Worktree:** `/Users/macbook-dev/Documents/GitHub/wt-path-hardening` (branch `feat/agent-path-hardening`)
+**Interpreter:** `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python`, run from this worktree.
+
+All three defects were reproduced first (real, unmocked repro scripts under the scratchpad), confirmed to fail against the pre-fix code, then fixed, then re-confirmed to pass. Full pytest run below.
+
+---
+
+## TASK-847 — `is_sensitive_path` fail-closed on unresolvable paths
+
+**Defect.** `_resolved()` caught only `(OSError, RuntimeError)`. A path containing an embedded NUL byte raises `ValueError` from `Path.resolve()`, which escaped `is_sensitive_path` as an uncaught exception instead of the promised `True`.
+
+**Reproduction (before fix):**
+```
+$ .venv/bin/python3 - <<'EOF'
+from pathlib import Path
+from tldw_chatbook.Utils.sensitive_paths import is_sensitive_path
+is_sensitive_path(Path("bad\x00path"))
+EOF
+```
+Result: `ValueError: lstat: embedded null character in path` raised out of `is_sensitive_path`, not `True` returned.
+
+**After fix:**
+Same script → `is_sensitive_path(...)` returns `True`.
+
+**What changed.** `_resolved()`'s except clause broadened from `(OSError, RuntimeError)` to bare `Exception` (with a debug log, `# noqa: BLE001`, matching the module's existing lazy-accessor pattern). `_resolved()` got a new docstring explaining why the catch must be unconditional: the fail-closed guarantee has to hold for *any* resolution failure, not just the two most common ones. `is_sensitive_path`'s own docstring already stated the guarantee correctly (it was aspirational, not yet true) — no textual change was needed there.
+
+**Derived from:** nothing new to derive; this was a pure implementation-narrower-than-promise gap, fixed at the one function that owns path resolution.
+
+**Test:** `Tests/Utils/test_sensitive_paths.py::test_nul_byte_path_fails_closed_for_real` — real (unmocked) NUL-byte path, alongside the pre-existing `test_unresolvable_path_fails_closed` (which monkeypatches `_resolved` itself and stays useful as a "no matter how it fails" pin).
+
+**Files:** `tldw_chatbook/Utils/sensitive_paths.py`, `Tests/Utils/test_sensitive_paths.py`.
+
+---
+
+## TASK-848 — extend the denylist beyond the active user data folder
+
+Three sub-gaps, all explicitly in scope per the task description and the TASK-846 audit's CRITICAL-3/CRITICAL-4.
+
+### AC#1 — vector-store and sibling-profile paths under a widened sandbox root
+
+**Defect.** `chromadb/chroma.sqlite3` (plaintext chunks of the same conversations/notes `ChaChaNotes.db` protects) and files directly inside `rag_profiles/` (plaintext RAG/embedding-provider config) were reachable once a sandbox root was widened to contain them. `chromadb`/`rag_profiles` are themselves in the existing-directory exemption list (legitimate containers), but nothing refused a *file* sitting directly inside either.
+
+**Reproduction (before fix):** wrote `chroma.sqlite3` under `default_chroma_persist_directory()` and a profile JSON under `default_rag_profiles_dir()`; `is_sensitive_path()` returned `False` for both.
+
+**After fix:** both return `True`; the container directories themselves, and an existing per-collection subdirectory nested inside `chromadb/`, still return `False` (stay reachable).
+
+**Derived from:** `RAG_Search.simplified.config.default_chroma_persist_directory()` (already existed, honors `RAG_PERSIST_DIR`/config overrides — used as-is). `RAG_Search.config_profiles.default_rag_profiles_dir()` — **new**, added because no accessor existed before (only an inline `get_user_data_dir() / "rag_profiles"` literal in `ConfigProfileManager.__init__`); `ConfigProfileManager.__init__` now calls it too, so there is exactly one spelling of the name.
+
+**Mechanism:** generalized the existing "any file directly in `get_user_data_dir()` is refused, existing directories stay reachable" rule (previously hardcoded to one directory) to a new `SensitivePathContext.direct_child_denied_dirs` tuple, populated by `_direct_child_rule_container_dirs()`: `user_data_dir`, the effective config directory, the chroma persist directory, the rag_profiles directory.
+
+**Tests:**
+- `Tests/Utils/test_sensitive_paths.py::test_chroma_vector_store_file_is_refused`, `::test_rag_profile_file_is_refused` (unit-level, both directions: file refused, container + nested existing subdir reachable).
+- `Tests/Tools/test_file_tool_sandbox.py::test_read_file_refuses_chroma_vector_store_file_even_when_sandbox_root_contains_it` (tool-level, widened root).
+- `Tests/Tools/test_file_tool_sandbox.py::test_default_sandbox_configuration_still_works_end_to_end` (pre-existing, unmodified) covers the "default still works" direction — the default sandbox root (`tool_sandbox`) is a sibling of `chromadb`/`rag_profiles`, never touching them.
+
+### AC#2 — skill trust/grant store (audit CRITICAL-3)
+
+**Defect.** `get_user_data_dir() / "skills" / "trust"` (manifest, script grants, generation marker, snapshots) was structurally unreachable by any existing rule: `skills` is an existing-directory exemption by design, so everything nested under it — including `trust/` — inherited that exemption. `skill_script_grants.json` in particular is the plain, unauthenticated JSON file that authorizes script *execution*.
+
+**Reproduction (before fix):** wrote all four (manifest, grants, marker, a snapshot file) under the real trust store dir; all four returned `is_sensitive_path() == False`.
+
+**After fix:** all four return `True`; a sibling file directly in `skills/` (outside `trust/`) still returns `False` (the container exemption still holds everywhere except this one carve-out).
+
+**Derived from:** two **new** small pure accessor functions, added because none existed before (app.py built both directory names as inline literals):
+- `Skills_Interop.local_skills_service.default_local_skills_store_dir(user_data_dir)` → `user_data_dir / "skills"`.
+- `Skills_Interop.skill_trust_store.default_trust_store_dir(local_skills_store_dir)` → `local_skills_store_dir / "trust"`.
+
+`app.py`'s service-wiring block (previously `local_skills_store_dir = get_user_data_dir() / "skills"` / `trust_store_dir = local_skills_store_dir / "trust"`) now calls both functions, so `sensitive_paths.py` derives the identical path `app.py` uses to build the live `SkillTrustStore` — never a re-spelled `"skills"`/`"trust"` literal. Also promoted the generation-marker filename from an inline `"generation_marker.json"` literal in `app.py` to a public `MARKER_FILENAME` constant in `skill_trust_store.py`, used by both `app.py` and the test.
+
+**Mechanism:** the whole `trust/` subtree is refused by **ancestry** (added to `SensitivePathContext.dirs`, the same list `~/.ssh` etc. use), not just direct children — a file several levels inside `snapshots/` is refused exactly like the manifest itself. This is a deliberate, documented exception carved back out of the `skills/` container exemption (see the module docstring and `_sensitive_skill_trust_dir()`'s own docstring).
+
+**Test:** `Tests/Utils/test_sensitive_paths.py::test_skill_trust_store_paths_are_refused_via_the_actually_used_accessors` (constructs a real `SkillTrustStore` + `FileSkillTrustGenerationMarkerStore`, derives `manifest_path`/`snapshots_dir` from the instance and `_SCRIPT_GRANTS_FILENAME`/`MARKER_FILENAME` from the owning modules — no literal path spelled in the test) and `::test_skills_directory_itself_stays_reachable_outside_the_trust_carve_out`.
+
+### AC#3 — config.toml's `.bak`/`.tmp` sidecars (audit CRITICAL-4)
+
+**Defect.** `UI/Screens/settings_screen.py`'s Advanced config save writes a full plaintext `.bak` backup before overwriting, plus a `.tmp` during the atomic swap — both byte-identical to the live config, API keys included. The denylist named only `_get_effective_config_path()` itself, nothing else in that directory.
+
+**Reproduction (before fix):** wrote `config.toml.bak`, `config.toml.tmp`, and an arbitrarily-named `config.toml.pre-lab-cleanup` (matching what the audit found live on the audit machine) beside the real effective config path; all three returned `False`.
+
+**After fix:** all three return `True`.
+
+**Decision — generalized, not sidecar-suffix-mirrored.** The task asked to consider mirroring `_DB_SIDECAR_SUFFIXES` (`-wal`/`-shm`/`-journal`) *or* applying the user-data-dir's direct-child-file rule to the effective config directory. Chose the **general direct-child-file rule**, not a `.bak`/`.tmp`-suffix enumeration, because the audit's own live evidence showed the problem is broader than two suffixes: `runtime_policy.json`, `ui_state.toml`, and an arbitrarily-named hand-made backup (`config.toml.pre-lab-cleanup`) were all unprotected too, and a suffix enumeration would still miss the next one. The effective config directory was added to the same `direct_child_denied_dirs` set used for AC#1 above — one mechanism, reused, rather than a second parallel one. Existing directories placed directly in the config dir (the real `feed_cache`/`themes`/`tokenizers` this app already writes there) stay reachable via the same "is it a directory" gate.
+
+**Derived from:** `config._get_effective_config_path().parent` — the same accessor the app itself uses (honors `TLDW_CONFIG_PATH`).
+
+**Tests:** `test_config_toml_bak_and_tmp_sidecars_are_refused`, `test_any_other_file_directly_in_the_effective_config_dir_is_refused` (the `.pre-lab-cleanup`-style arbitrary name), `test_existing_directory_directly_in_the_effective_config_dir_stays_reachable`.
+
+### The MCP-filename residual fragility (assessed, not fixed)
+
+The audit noted `sensitive_paths.py` re-spells the three MCP filenames (`mcp_permissions.json`, `local_mcp_store.json`, `mcp_execution_log.jsonl`) as its own literals joined to `get_user_data_dir()`. Investigated: **no single source of truth exists anywhere in the codebase for these three names** — `app.py` (lines ~4028/5241/5248) and `MCP/unified_control_plane_service.py` (`Path(store.path).with_name(...)` at lines ~2073/2430) each independently spell them as inline literals too. Fixing this properly means introducing shared constants across `MCP/local_store.py`, `MCP/unified_context_store.py`, `MCP/server_target_store.py`, `MCP/unified_control_plane_service.py`, and `app.py` — none of which is named in TASK-848's four ACs, and none of which `sensitive_paths.py` alone can fix without touching those other modules' own construction sites. **Decision: left as-is**, documented as a known, deliberately out-of-scope residual fragility (matches the audit's own framing — "one refactor away," not a live bug). Recommend a follow-up task scoped explicitly to the MCP store-path family if this is to be closed.
+
+**Files:** `tldw_chatbook/Utils/sensitive_paths.py`, `tldw_chatbook/Skills_Interop/local_skills_service.py`, `tldw_chatbook/Skills_Interop/skill_trust_store.py`, `tldw_chatbook/Skills_Interop/__init__.py`, `tldw_chatbook/RAG_Search/config_profiles.py`, `tldw_chatbook/app.py`, `Tests/Utils/test_sensitive_paths.py`, `Tests/Tools/test_file_tool_sandbox.py`.
+
+---
+
+## TASK-849 — agent-created directory shadowing a not-yet-created state file
+
+**Defect.** The direct-child-file rule is gated on "is this an existing directory" so a *pre-existing* container stays reachable. But `WriteFileTool`'s `create_directories=True` path only ever validated the **final file** being written (e.g. `search_history.db/note.txt`), never the new directory levels `Path.mkdir(parents=True)` creates on the way there (`search_history.db` itself). Nothing stopped an agent from planting a directory at that exact name before the app ever created `search_history.db` as a SQLite file; the app's later `sqlite3.connect(...)` on that path then fails outright — a denial of service, no disclosure.
+
+**Reproduction (before fix), full chain:**
+```python
+# widened sandbox root == get_user_data_dir()
+await WriteFileTool().execute(
+    file_path="search_history.db/note.txt", content="hello", create_directories=True,
+)
+# -> {'action': 'created', ...}; search_history.db/ now exists as a DIRECTORY.
+import sqlite3; sqlite3.connect(str(shadow_dir))
+# -> sqlite3.OperationalError: unable to open database file
+```
+Also confirmed directly: `is_sensitive_path(user_data_dir / "search_history.db")` returned `False` once that directory existed.
+
+**After fix:** the same `WriteFileTool.execute` call returns `{'error': "Refused: creating '.../search_history.db' would collide with a protected path"}`; the directory is never created.
+
+**What changed.** Added `refuses_new_directory_chain(target_dir, context=None)` to `sensitive_paths.py`: walks upward from `target_dir` while each level does not yet exist, calling `is_sensitive_path` on each (reusing the *existing* direct-child-file rule verbatim, never a separate check or a loosened gate), stopping at the first already-existing ancestor (mirroring exactly what `Path.mkdir(parents=True)` would actually create). `WriteFileTool.execute` now calls it immediately before `path.parent.mkdir(parents=True, exist_ok=True)` and refuses if it returns `True`.
+
+Critically, `is_sensitive_path`'s own "is an existing directory" gate was **not** changed — an already-existing `search_history.db/` directory (predating this fix, or created by any other means) still reads as an ordinary container, by design: there is no name-independent way to tell "legitimate pre-existing container" from "illegitimate pre-existing collision," and the whole point of the existing-directory gate is to avoid a name enumeration. The fix closes the hole at **creation time** instead, which is also the only place the agent tools can actually cause the collision.
+
+**Reconciliation with containers.** Verified both directions end to end through the real `WriteFileTool`:
+- legitimate: writing into a brand-new subdirectory nested inside an *already-existing* container (`tool_sandbox/brand_new_subdir/note.txt`) still succeeds, under both the default sandbox root and a widened one.
+- legitimate: the real, unmocked default sandbox configuration (`get_user_data_dir()/tool_sandbox`, a sibling of `search_history.db`) still works end to end for write/read/list/glob/grep (pre-existing test, unmodified, still passes).
+- illegitimate: the exact `search_history.db/note.txt` collision is refused before any directory is created.
+
+**Tests:**
+- `Tests/Utils/test_sensitive_paths.py::test_refuses_new_directory_chain_blocks_the_collision` (multi-level: collision is one level above the leaf target, not at the leaf itself), `::test_refuses_new_directory_chain_allows_existing_containers`, `::test_an_already_existing_directory_still_reads_as_an_ordinary_container` (documents the deliberate is-dir-gate boundary above).
+- `Tests/Tools/test_file_tool_sandbox.py::test_write_file_refuses_to_plant_a_directory_shadowing_a_state_file` (tool-level, end to end), `::test_write_file_still_creates_legitimate_new_nested_directories` (companion "still works" test, same widened-root config).
+
+**Files:** `tldw_chatbook/Utils/sensitive_paths.py`, `tldw_chatbook/Tools/file_operation_tools.py`, `Tests/Utils/test_sensitive_paths.py`, `Tests/Tools/test_file_tool_sandbox.py`.
+
+---
+
+## Test run
+
+```
+cd /Users/macbook-dev/Documents/GitHub/wt-path-hardening
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Utils/ Tests/Tools/ Tests/Agents/ -q
+```
+
+First run: 1 failed (my own `test_directory_shadowing_a_not_yet_created_state_file_is_refused`, which incorrectly asserted `is_sensitive_path` should flag an *already-existing* directory — inconsistent with the deliberate "existing directory stays reachable" design; rewritten to `test_an_already_existing_directory_still_reads_as_an_ordinary_container` asserting the correct, unchanged behavior), 892 passed, in 232.84s.
+
+Second run (after the test fix, no production-code changes): **893 passed, 0 failed, 12 warnings, in 230.56s.**
+
+No pre-existing baseline failures encountered beyond the ones already known (`pytest-mock`/`numpy` absent; six `test_chat_api_key_*` failures in `Tests/UI/test_tools_settings_window.py` are out of the run scope for this task — not in `Tests/Utils/`, `Tests/Tools/`, or `Tests/Agents/`).

--- a/.superpowers/sdd/task-850-843-report.md
+++ b/.superpowers/sdd/task-850-843-report.md
@@ -1,0 +1,151 @@
+# TASK-850 / TASK-843 — implementation report
+
+**Worktree:** `/Users/macbook-dev/Documents/GitHub/wt-path-hardening` (branch `feat/agent-path-hardening`)
+**Interpreter:** `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python`, run from this worktree (the venv's editable install resolves `tldw_chatbook` to the ORIGINAL checkout at `/Users/macbook-dev/Documents/GitHub/tldw_chatbook` unless cwd-relative `sys.path[0]` resolution picks up this worktree first — true for `python -m pytest`/`python -c` invoked from this directory, NOT true for a standalone script file, which uses its own directory instead. Every ad-hoc verification below was run via `-c` from this worktree, or with an explicit `sys.path.insert(0, ...)`, after one false start caught by this exact trap).
+
+Commits: `7fd033f1b` (TASK-850), `8d66becf9` (TASK-843), both on `feat/agent-path-hardening`.
+
+---
+
+## TASK-850 — scope `glob_files`/`grep_files` to workspace folder roots
+
+**Gap.** `read_file`/`write_file`/`list_directory` all resolve their root set via `allowed_file_roots(write=…, sandbox_root=…)` (the tool sandbox plus every workspace folder bound to the run). `glob_files`/`grep_files` globbed `_tool_sandbox_root()` directly — strictly narrower, so safe, but inconsistent: an agent could `read_file` a path inside a bound workspace folder that `glob_files`/`grep_files` could never surface.
+
+### Root-set resolution
+
+Both tools now call the exact same accessor the other three use:
+```python
+roots = allowed_file_roots(write=False, sandbox_root=_tool_sandbox_root())
+```
+
+### Merging across roots without multiplying the worst case
+
+A new shared generator, `_iter_candidates_across_roots(pattern, roots, sensitive_ctx)`, globs each usable root in turn and yields validated candidates. Every existing guard applies to every candidate from every root:
+
+- **Containment** (`is_within`, which also applies the sensitive-path denylist) — checked per candidate against the SPECIFIC root that produced it (a candidate from `root.glob()` is checked against that same `root`, not "any root").
+- **Hidden-component rule** (`_is_hidden_within`) — same per-root pairing.
+- **`_MAX_CANDIDATES`** — a single `examined` counter shared across ALL roots (declared once, outside the per-root loop), so N configured roots cannot multiply the worst-case walk by N. Verified by `test_grep_candidate_bound_is_shared_across_roots_not_multiplied` (5 sandbox files + 5 bound-folder files, cap set to 3, matches ≤ 3).
+- **Deduplication** — a `seen_resolved: set[Path]` shared across roots, so a path reachable through more than one root (e.g. an accidental overlap between the sandbox and a bound folder) is yielded once, not once per root that can see it.
+
+### Dotted-root rule, decided and documented
+
+`_sandbox_root_is_hidden(root)` previously ran once against the single sandbox root; a dotted root refused the WHOLE call (mirroring `validate_path`'s hidden-base-directory rejection). With a root SET, the decision made and documented in both `_sandbox_root_is_hidden`'s and `_iter_candidates_across_roots`'s docstrings:
+
+> Each root is checked independently. A dotted root is **excluded from the search**, not fatal to every other, still-valid root's results. The call is refused outright only when **zero roots survive** that filter — which is exactly the pre-existing single-root (sandbox-only, dotted) case, so that behavior is byte-for-byte unchanged.
+
+```python
+usable_roots = tuple(root for root in roots if not _sandbox_root_is_hidden(root))
+if not usable_roots:
+    return {"error": "Access to hidden files/directories is not allowed"}
+```
+
+Pinned by `test_dotted_workspace_root_is_skipped_not_fatal_to_other_roots`: a dotted bound folder and an ordinary bound folder both configured; the dotted one's content never appears, the ordinary one's does, and the call succeeds (no error) — as opposed to the single-root case (`test_glob_files_refuses_a_dotted_sandbox_root`, pre-existing, still passing unmodified) where the identical dotted-root misconfiguration DOES refuse the whole call because it's the only root there is.
+
+### `SensitivePathContext` resolved once per call
+
+Unchanged in shape from before this task (`resolve_sensitive_context()` called once in `execute()`), now threaded through every root's candidates via `_iter_candidates_across_roots` rather than just the sandbox's.
+
+### Proof: no reach beyond `read_file`
+
+`test_glob_grep_and_the_read_family_all_refuse_a_path_outside_every_root` exercises all five tools against a path outside every configured root (sandbox + bound workspace folder):
+
+- `read_file`/`write_file`/`list_directory` — refused directly, against the literal outside path (each takes a target-path argument).
+- `glob_files`/`grep_files` — take no target-path argument, only a relative glob pattern, and `_rejects_traversal` already refuses any absolute form or `..` component outright, so the meaningful equivalent is a **symlink planted inside an allowed root** pointing at the outside directory (the one real avenue a search tool could otherwise reach it through). `is_within`'s resolved-ancestry containment check refuses the symlinked target exactly like it refuses everything else outside every root — neither tool's `matches` ever contains the outside file's name or content.
+
+### Tests
+
+`Tests/Tools/test_file_tools_workspace_roots.py` (+165 lines): `test_glob_finds_file_in_bound_workspace_folder`, `test_grep_finds_content_in_bound_workspace_folder`, `test_glob_merges_matches_across_sandbox_and_bound_folder`, `test_grep_candidate_bound_is_shared_across_roots_not_multiplied`, `test_dotted_workspace_root_is_skipped_not_fatal_to_other_roots`, `test_glob_grep_and_the_read_family_all_refuse_a_path_outside_every_root`.
+
+Every pre-existing test in `Tests/Tools/test_glob_grep_files.py` (34 tests, sandbox-only configuration) still passes unmodified — including `test_default_sandbox_configuration_still_works_end_to_end` in `test_file_tool_sandbox.py`, which exercises the real, unmocked default configuration through all five tools.
+
+**Files:** `tldw_chatbook/Tools/file_operation_tools.py` (`GlobFiles.execute`, `GrepFiles.execute`, new `_iter_candidates_across_roots`, `_sandbox_root_is_hidden` docstring generalized), `Tests/Tools/test_file_tools_workspace_roots.py`.
+
+---
+
+## TASK-843 — complete the `grep_files` catastrophic-backtracking mitigation
+
+**Gap.** `_MAX_GREP_LINE_SEARCH_CHARS`/`_MAX_GREP_LINES_SCANNED`/`GrepFiles.timeout_seconds` made the worst case finite and small, but didn't stop it: Python's `re` has no match timeout, and `Agents/agent_service.py`'s `_call_with_timeout` runs each tool call on a daemon thread and, on timeout, **abandons** that thread rather than killing it (Python cannot forcibly kill a thread). A pathological pattern kept burning real CPU after the agent was told the call failed, and repeated calls would accumulate abandoned, still-running threads.
+
+### Options weighed
+
+1. **Killable subprocess** (chosen). Only approach that actually bounds CPU past return, since a process — unlike a thread — genuinely can be killed (`SIGKILL`/`TerminateProcess`).
+2. **Third-party `regex` module** (supports `timeout=`). Checked whether it's already a dependency before proposing it, per the task's instruction: it **is** importable in this dev venv, but only **transitively**, via `nltk`/`transformers`/`dateparser` (all pulled in by the optional `embeddings_rag`/similar extras — confirmed via `pip show regex` → `Required-by: dateparser, nltk, transformers`, and `pyproject.toml` has no `regex` entry anywhere, direct or under `[project.optional-dependencies]`). `grep_files` is a core built-in, reachable with **zero** extras installed. Depending on `regex` here would silently turn a currently-optional, transitive package into a hard requirement of the base install — a real cost this project's own optional-dependency convention (`Utils/optional_deps.py`, lazy-checked extras) exists specifically to avoid. Ruled out for that reason, not for any deficiency in `regex` itself.
+3. Nothing else considered materially better: `signal.alarm`-based timeouts don't work across threads and are POSIX-only; `multiprocessing` with the default `'spawn'` start method risks re-executing whatever the ORIGINAL entry-point script's module-level code is (a real hazard for a long-lived TUI app or under pytest) — a plain `subprocess.Popen` running a dependency-free worker script sidesteps that entirely and gives the same guarantee.
+
+### What changed
+
+The actual line-by-line regex search moved into a new standalone worker, `tldw_chatbook/Tools/_grep_worker.py`: stdlib-only (`json`/`re`/`sys`/`pathlib`, optionally `resource`), **no import of `tldw_chatbook` at all** — deliberately, so the child carries none of the host process's live state (open DB connections, loaded config, the running Textual app) and starts fast. Protocol: one JSON request on stdin (`pattern`, `file_paths`, the four existing bound constants), one JSON response on stdout (`matches`/`lines_scanned` or `error`); always exits 0.
+
+`GrepFiles.execute` still does candidate discovery in-process (containment, sensitive-path denylist, hidden-component rule, `_MAX_CANDIDATES`, via the same `_iter_candidates_across_roots` TASK-850 added) — none of that runs the user-supplied regex, so none of it needs the subprocess boundary. Only the resulting file list crosses it, via `_run_grep_subprocess`, run off the event loop with `asyncio.to_thread`:
+
+```python
+proc = subprocess.Popen([sys.executable, "-S", _GREP_WORKER_SCRIPT], ...)
+try:
+    stdout, stderr = proc.communicate(input=request, timeout=timeout_seconds)
+except subprocess.TimeoutExpired:
+    proc.kill()          # SIGKILL — the line that actually stops the CPU burn
+    proc.communicate(timeout=5.0)
+    return {"error": f"grep search timed out after {timeout_seconds:g}s and was terminated"}
+```
+
+`_GREP_SUBPROCESS_TIMEOUT_SECONDS = 18.0`, deliberately shorter than `GrepFiles.timeout_seconds = 20.0` so the kill fires (and CPU consumption actually stops) at or before the point the run loop's own outer timeout gives up and reports failure — not sometime after.
+
+The worker also self-limits via POSIX `RLIMIT_CPU` (`_apply_cpu_limit`, best-effort, `resource` unavailable on Windows): defense in depth for the case where the **parent itself** dies before ever reaching the `kill()` call — an orphaned worker otherwise has nothing left to stop it.
+
+Every existing bound (`_MAX_GREP_LINE_SEARCH_CHARS`, `_MAX_GREP_LINES_SCANNED`, `_MAX_GREP_FILE_BYTES`) stays in place, read from the module's own globals at call time and passed into the subprocess as arguments — so pre-existing tests that monkeypatch these (`fot._MAX_GREP_LINE_SEARCH_CHARS = 10`, etc.) still take effect correctly through the subprocess boundary.
+
+### Verification that CPU actually stops (not just wall-clock proxy)
+
+`test_grep_subprocess_kills_the_worker_process_on_timeout` spies on `subprocess.Popen` to capture the worker's real pid, runs `_run_grep_subprocess` directly against `(a+)+$` over `"a"*28 + "X"` (line-cap deliberately widened to 10,000 so the full pathological line reaches the worker, isolating what the subprocess boundary alone buys) with a 1.5s timeout, and asserts:
+
+- the call returns in `< 4.0s` (bounded near 1.5s, not the ~11.7s this exact pattern costs uncapped), and
+- `psutil.pid_exists(pid)` is **`False`** immediately after return.
+
+Manually re-verified outside pytest (see below) with a clean, single-pid check (an earlier attempt using a broad `psutil.process_iter` substring scan for `"_grep_worker.py"` produced a false positive — the scanning script's OWN command-line text, visible to `process_iter`, contained that literal substring; re-checking by the captured pid specifically eliminated the false positive).
+
+### Benchmark
+
+Realistic tree: this project's own `Tools/`, `Utils/`, `Chat/`, `Agents/` source (221 `.py` files), pattern `"def execute"`, median of 5 runs each, apples-to-apples (both the "before" reimplementation and "after" real implementation pay the identical `is_within`/`resolve_sensitive_context` candidate-discovery cost — an earlier draft of this benchmark omitted that from the "before" side and produced a misleadingly large gap):
+
+| | median |
+|---|---|
+| BEFORE (in-process, this task's TASK-850-only checkpoint) | **78.5ms** |
+| AFTER (subprocess-based) | **97.7ms** |
+
+Added overhead ≈ **19ms** (~24% relative), matching an isolated pure round-trip measurement of the subprocess call with zero files to search (~18ms, `python -S` startup dominates). Comfortably negligible against the 20s tool-call ceiling and against `grep_files`' own `"reads"`-risk-tag `ask` permission floor (a human approves every individual call regardless).
+
+Pathological case (`(a+)+$` against a 28–30 character adversarial line, line-cap disabled to isolate this task's fix):
+
+- **Before** this task (documented in the pre-existing `_MAX_GREP_LINE_SEARCH_CHARS` comment, reproduced again here): an uncapped search of this exact pattern takes ~11.7s (28 chars) to ~47s (30 chars) and keeps running past whatever timeout the agent is told about, since the thread is abandoned, not killed — growing worse per additional character with nothing to stop it.
+- **After**: bounded to the production ceiling, measured directly: `elapsed=18.00s`, `result={'error': 'grep search timed out after 18s and was terminated'}`, child pid confirmed dead (`pid_exists` → `False`) immediately on return.
+
+### Residual exposure — stated precisely, not claimed closed
+
+- The child can still burn real CPU for up to `_GREP_SUBPROCESS_TIMEOUT_SECONDS` (18s) before it is killed. Down from unbounded, **not zero**.
+- Every `grep_files` call now pays a small, fixed process-spawn/teardown cost (~15–20ms) whether or not the pattern is pathological.
+- `RLIMIT_CPU` is POSIX-only (no-op on Windows) and is explicitly documented as additive, not the primary guarantee; `communicate(timeout=)` + `kill()` is what holds on every platform.
+- A pathological file-path string containing bytes that cannot round-trip through UTF-8 text-mode JSON (an unusual, not project-specific edge case — e.g. non-UTF-8 filenames on some POSIX filesystems) is a known, pre-existing class of risk not specifically hardened by this task; out of scope of both ACs.
+
+This is documented in the same terms in `_run_grep_subprocess`'s and `_grep_worker.py`'s own docstrings, not only here.
+
+### Tests
+
+`Tests/Tools/test_glob_grep_files.py` (+297 lines): subprocess-kill proof (`test_grep_subprocess_kills_the_worker_process_on_timeout`), end-to-end never-raises (`test_grep_files_execute_survives_a_pathological_pattern_without_raising`), `_run_grep_subprocess` error handling (`Popen` spawn failure, nonzero worker exit, malformed worker output), a regression guard that the ordinary path still delegates to the subprocess (`test_grep_files_ordinary_search_still_delegates_to_a_subprocess`), and the worker script exercised directly (`run_search` unit tests) and as a real subprocess (malformed stdin, end-to-end match).
+
+**Files:** `tldw_chatbook/Tools/_grep_worker.py` (new), `tldw_chatbook/Tools/file_operation_tools.py` (`GrepFiles.execute`, new `_run_grep_subprocess`/`_GREP_SUBPROCESS_TIMEOUT_SECONDS`/`_GREP_WORKER_SCRIPT`, updated docstrings on `_MAX_GREP_LINE_SEARCH_CHARS`/`GrepFiles.timeout_seconds`/`GrepFiles.execute`), `Tests/Tools/test_glob_grep_files.py`.
+
+---
+
+## Full test run
+
+```
+$ .venv/bin/python -m pytest Tests/Utils/ Tests/Tools/ Tests/Agents/ -q
+910 passed, 12 warnings in 237.27s (0:03:57)
+```
+
+No regressions. Pre-existing warnings (RequestsDependencyWarning, a couple of loguru/pydub DeprecationWarnings, two unrelated MCP-provider `RuntimeWarning: coroutine … was never awaited`) are unrelated to this change and present on the pre-TASK-850 baseline too.
+
+**Hard constraints re-checked:**
+- Both tools' gates (`glob_files_enabled`/`grep_files_enabled` in `Agents/tool_catalog.py`) untouched — still default `False` (`get_cli_setting(..., False)`), still gateable built-ins. Nothing in this change reads or writes those keys.
+- Matching stays resolved-ancestry (`is_within`/`is_sensitive_path`, both `Path.resolve()`-based) throughout; no string-prefix comparison was introduced.
+- Default configuration proven end to end: `test_default_sandbox_configuration_still_works_end_to_end` (no monkeypatching of the sandbox root/config at all) covers `write_file`/`read_file`/`list_directory`/`glob_files`/`grep_files` back to back, and now genuinely exercises the real subprocess spawn for `grep_files` since nothing in that test forces a bypass.

--- a/Tests/Tools/test_file_tool_sandbox.py
+++ b/Tests/Tools/test_file_tool_sandbox.py
@@ -308,6 +308,64 @@ def test_read_file_refuses_chroma_vector_store_file_even_when_sandbox_root_conta
     assert "plaintext vector chunk marker" not in str(result)
 
 
+def test_write_file_refuses_to_plant_a_directory_shadowing_a_state_file(monkeypatch):
+    """TASK-849: an agent must not be able to create a directory named
+    after a state file this app has not created yet -- verified before this
+    fix: ``search_history.db/`` (``get_user_data_dir() / "search_history.db"``,
+    see ``UI/Views/RAGSearch/search_rag_window.py``) was permitted, and the
+    app's own later ``sqlite3.connect(...)`` on that path would fail
+    outright (a denial of service, not a disclosure).
+
+    Widened sandbox root = ``get_user_data_dir()`` itself, the same
+    reachability precondition the other TASK-848 gaps share -- under the
+    shipped default (``tool_sandbox``, a SIBLING of ``search_history.db``)
+    this path is never reachable at all.
+    """
+    from tldw_chatbook import config as app_config
+
+    user_data_dir = app_config.get_user_data_dir()
+    user_data_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(fot, "_tool_sandbox_root", lambda: user_data_dir.resolve())
+
+    result = asyncio.run(
+        fot.WriteFileTool().execute(
+            file_path="search_history.db/note.txt",
+            content="hello",
+            create_directories=True,
+        )
+    )
+
+    assert "error" in result
+    assert not (user_data_dir / "search_history.db").exists()
+
+
+def test_write_file_still_creates_legitimate_new_nested_directories(monkeypatch):
+    """The TASK-849 fix must not block ordinary nested directory creation:
+    an agent creating a brand-new subdirectory INSIDE an EXISTING container
+    (``tool_sandbox``) must still succeed end to end, even under the same
+    widened-root configuration the collision test above uses.
+    """
+    from tldw_chatbook import config as app_config
+
+    user_data_dir = app_config.get_user_data_dir()
+    sandbox_root = user_data_dir / "tool_sandbox"
+    sandbox_root.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(fot, "_tool_sandbox_root", lambda: user_data_dir.resolve())
+
+    result = asyncio.run(
+        fot.WriteFileTool().execute(
+            file_path="tool_sandbox/brand_new_subdir/note.txt",
+            content="hello",
+            create_directories=True,
+        )
+    )
+
+    assert "error" not in result, result
+    assert (sandbox_root / "brand_new_subdir" / "note.txt").read_text() == "hello"
+
+
 # ---------------------------------------------------------------------------
 # Finding 2's guardrail must not break the shipped DEFAULT configuration:
 # the default sandbox root is `get_user_data_dir() / "tool_sandbox"`, a

--- a/Tests/Tools/test_file_tool_sandbox.py
+++ b/Tests/Tools/test_file_tool_sandbox.py
@@ -282,6 +282,32 @@ def test_read_file_refuses_wal_sidecar_of_this_apps_own_sqlite_db(monkeypatch):
     assert "recent-uncommitted-row-marker" not in str(result)
 
 
+def test_read_file_refuses_chroma_vector_store_file_even_when_sandbox_root_contains_it(
+    monkeypatch,
+):
+    """TASK-848 AC#1: ``chromadb/chroma.sqlite3`` -- plaintext chunks of the
+    same conversations and notes ``ChaChaNotes.db`` protects -- must not
+    become readable just because a widened sandbox root happens to contain
+    it. ``chromadb`` itself stays reachable as a container (per the
+    existing-directory exemption); only the file directly inside it is
+    refused.
+    """
+    from tldw_chatbook.RAG_Search.simplified.config import (
+        default_chroma_persist_directory,
+    )
+
+    chroma_dir = default_chroma_persist_directory()
+    chroma_dir.mkdir(parents=True, exist_ok=True)
+    (chroma_dir / "chroma.sqlite3").write_text("plaintext vector chunk marker")
+
+    monkeypatch.setattr(fot, "_tool_sandbox_root", lambda: chroma_dir.resolve())
+
+    result = asyncio.run(fot.ReadFileTool().execute(file_path="chroma.sqlite3"))
+
+    assert "error" in result
+    assert "plaintext vector chunk marker" not in str(result)
+
+
 # ---------------------------------------------------------------------------
 # Finding 2's guardrail must not break the shipped DEFAULT configuration:
 # the default sandbox root is `get_user_data_dir() / "tool_sandbox"`, a

--- a/Tests/Tools/test_file_tools_workspace_roots.py
+++ b/Tests/Tools/test_file_tools_workspace_roots.py
@@ -12,6 +12,8 @@ from tldw_chatbook.Workspaces import LocalWorkspaceRegistryService
 from tldw_chatbook.Tools import file_operation_tools as fot
 from tldw_chatbook.Tools import workspace_file_roots as wfr
 from tldw_chatbook.Tools.file_operation_tools import (
+    GlobFiles,
+    GrepFiles,
     ListDirectoryTool,
     ReadFileTool,
     WriteFileTool,
@@ -159,3 +161,166 @@ async def test_symlink_inside_bound_folder_cannot_escape(
     # (b) Listing the symlink directly is denied outright — the resolved
     # target sits outside every allowed root.
     assert direct_link_result.get("error")
+
+
+# ---------------------------------------------------------------------------
+# TASK-850: glob_files/grep_files previously searched the tool sandbox root
+# only -- strictly narrower than, and inconsistent with, the three tools
+# above, all of which already honour every workspace folder root bound to
+# the run. These pin the fix: the search tools now honour the SAME root
+# set, merge results across every root, and never widen reach beyond what
+# read_file already has.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_glob_finds_file_in_bound_workspace_folder(bound_workspace) -> None:
+    (bound_workspace["ro"] / "notes.md").write_text("hello")
+    with wfr.run_workspace("ws-a"):
+        result = await GlobFiles().execute(pattern="**/*.md")
+    assert "notes.md" in {Path(p).name for p in result["matches"]}
+
+
+@pytest.mark.asyncio
+async def test_grep_finds_content_in_bound_workspace_folder(bound_workspace) -> None:
+    (bound_workspace["ro"] / "notes.md").write_text("UNIQUE_WORKSPACE_MARKER_71a2\n")
+    with wfr.run_workspace("ws-a"):
+        result = await GrepFiles().execute(pattern="UNIQUE_WORKSPACE_MARKER_71a2")
+    assert any(m["path"].endswith("notes.md") for m in result["matches"])
+
+
+@pytest.mark.asyncio
+async def test_glob_merges_matches_across_sandbox_and_bound_folder(
+    bound_workspace,
+) -> None:
+    """Results are MERGED across every root into one result set -- a match
+    reachable only through a bound folder, not the sandbox, is not lost.
+    """
+    (bound_workspace["sandbox"] / "a.py").write_text("x = 1\n")
+    (bound_workspace["ro"] / "b.py").write_text("y = 2\n")
+    with wfr.run_workspace("ws-a"):
+        result = await GlobFiles().execute(pattern="**/*.py")
+    assert {Path(p).name for p in result["matches"]} == {"a.py", "b.py"}
+
+
+@pytest.mark.asyncio
+async def test_grep_candidate_bound_is_shared_across_roots_not_multiplied(
+    bound_workspace, monkeypatch
+) -> None:
+    """`_MAX_CANDIDATES` must bound candidates examined across ALL roots
+    COMBINED -- N configured roots must not multiply the worst-case walk
+    by N. Each matching file here produces exactly one match, so the
+    match count directly pins how many candidates were actually examined.
+    """
+    monkeypatch.setattr(fot, "_MAX_CANDIDATES", 3)
+    monkeypatch.setattr(fot, "_MAX_MATCHES", 1_000)
+    for i in range(5):
+        (bound_workspace["sandbox"] / f"s{i}.txt").write_text("DEBUG\n")
+    for i in range(5):
+        (bound_workspace["ro"] / f"r{i}.txt").write_text("DEBUG\n")
+
+    with wfr.run_workspace("ws-a"):
+        result = await GrepFiles().execute(pattern="DEBUG")
+
+    assert len(result["matches"]) <= 3
+
+
+@pytest.mark.asyncio
+async def test_dotted_workspace_root_is_skipped_not_fatal_to_other_roots(
+    tmp_path, monkeypatch
+) -> None:
+    """Dotted-root rule, extended to a root SET: with a single root (the
+    sandbox alone), a dotted root refuses the WHOLE call (see
+    ``test_glob_files_refuses_a_dotted_sandbox_root`` /
+    ``test_grep_files_refuses_a_dotted_sandbox_root`` in
+    ``test_glob_grep_files.py``). With several roots, this pins the
+    documented decision for the multi-root case instead: each root is
+    checked independently, a dotted one is excluded from the search, and
+    every OTHER, still-valid root's results are returned normally rather
+    than the whole call being refused.
+    """
+    registry = LocalWorkspaceRegistryService(
+        WorkspaceDB(tmp_path / "ws.sqlite", client_id="dotted-root-tests")
+    )
+    registry.ensure_default_workspace()
+    registry.create_workspace(workspace_id="ws-a", name="Client A")
+
+    dotted_folder = tmp_path / ".hidden-project"
+    dotted_folder.mkdir()
+    (dotted_folder / "secret.txt").write_text("SHOULD_NOT_BE_FOUND_8b21\n")
+
+    ok_folder = tmp_path / "ok-project"
+    ok_folder.mkdir()
+    (ok_folder / "notes.txt").write_text("SHOULD_BE_FOUND_8b21\n")
+
+    registry.add_folder_binding("ws-a", dotted_folder)
+    registry.add_folder_binding("ws-a", ok_folder)
+    monkeypatch.setattr(wfr, "_registry_factory", lambda: registry)
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    monkeypatch.setattr(fot, "_resolve_sandbox_config", lambda: str(sandbox))
+
+    with wfr.run_workspace("ws-a"):
+        glob_result = await GlobFiles().execute(pattern="**/*.txt")
+        grep_result = await GrepFiles().execute(pattern="8b21")
+
+    assert "error" not in glob_result
+    names = {Path(p).name for p in glob_result["matches"]}
+    assert "notes.txt" in names
+    assert "secret.txt" not in names
+
+    assert grep_result["matches"] != []
+    assert all("SHOULD_NOT_BE_FOUND" not in m["line"] for m in grep_result["matches"])
+
+
+@pytest.mark.asyncio
+async def test_glob_grep_and_the_read_family_all_refuse_a_path_outside_every_root(
+    bound_workspace, tmp_path
+) -> None:
+    """Prove TASK-850 does not widen reach beyond what read_file already
+    has: a path outside EVERY configured root (sandbox + every bound
+    workspace folder) stays refused across all five tools.
+
+    read_file/write_file/list_directory are proven directly, against the
+    exact outside path. glob_files/grep_files take no target-path
+    argument at all -- only a relative glob PATTERN, which
+    ``_rejects_traversal`` refuses outright for any absolute form or
+    ``..`` component -- so the meaningful equivalent for them is a
+    SYMLINK planted INSIDE an allowed root pointing at the outside
+    directory: the one real avenue a search tool could otherwise reach it
+    through despite never accepting an absolute/traversal pattern.
+    ``is_within``'s resolved-ancestry containment check must refuse the
+    symlinked target exactly like it refuses everything else outside
+    every root.
+    """
+    outside_dir = tmp_path / "elsewhere"
+    outside_dir.mkdir()
+    outside_file = outside_dir / "secret.txt"
+    outside_file.write_text("OUTSIDE_EVERY_ROOT_MARKER_9f3c1a")
+
+    with wfr.run_workspace("ws-a"):
+        read_result = await ReadFileTool().execute(file_path=str(outside_file))
+        write_result = await WriteFileTool().execute(
+            file_path=str(outside_file), content="pwned"
+        )
+        list_result = await ListDirectoryTool().execute(
+            directory_path=str(outside_dir)
+        )
+
+        link = bound_workspace["ro"] / "escape"
+        os.symlink(outside_dir, link)
+        glob_result = await GlobFiles().execute(pattern="**/*")
+        grep_result = await GrepFiles().execute(
+            pattern="OUTSIDE_EVERY_ROOT_MARKER_9f3c1a"
+        )
+
+    assert "error" in read_result
+    assert "OUTSIDE_EVERY_ROOT_MARKER_9f3c1a" not in str(read_result)
+
+    assert "error" in write_result
+    assert outside_file.read_text() == "OUTSIDE_EVERY_ROOT_MARKER_9f3c1a"  # untouched
+
+    assert "error" in list_result
+
+    assert "secret.txt" not in {Path(p).name for p in glob_result["matches"]}
+    assert grep_result["matches"] == []

--- a/Tests/Tools/test_glob_grep_files.py
+++ b/Tests/Tools/test_glob_grep_files.py
@@ -9,9 +9,12 @@ indirection to work around -- patching `fot._resolve_sandbox_config`
 reaches every caller directly.
 """
 
+import json
+import subprocess
 import time
 from pathlib import Path
 
+import psutil
 import pytest
 
 import tldw_chatbook.Tools.file_operation_tools as fot
@@ -563,3 +566,297 @@ def test_grep_files_timeout_resolves_through_the_tool_catalog_registry():
 
     assert registry.timeout_for("grep_files") == GrepFiles().timeout_seconds
     assert registry.timeout_for("grep_files") == 20.0
+
+
+# ---------------------------------------------------------------------------
+# TASK-843: the regex search itself now runs in a killable child process
+# (`_run_grep_subprocess` / `_grep_worker.py`) rather than in-process, so a
+# catastrophic-backtracking pattern's CPU burn is bounded even AFTER the
+# tool call has returned -- unlike the run loop's own thread-based
+# `_call_with_timeout` (`Agents/agent_service.py`), which abandons a hung
+# worker thread rather than killing it, because Python cannot forcibly kill
+# a thread. These pin that guarantee directly, at the process level.
+# ---------------------------------------------------------------------------
+
+
+def test_grep_subprocess_kills_the_worker_process_on_timeout(tmp_path, monkeypatch):
+    """The core TASK-843 guarantee: once the internal subprocess timeout
+    elapses, the child is actually killed -- not merely abandoned. Proven
+    two ways: (a) the call returns close to the timeout, not the many
+    seconds the pathological pattern would otherwise cost, and (b) the
+    captured child pid no longer exists immediately after return.
+    """
+    real_popen = subprocess.Popen
+    captured: dict = {}
+
+    def spying_popen(*args, **kwargs):
+        proc = real_popen(*args, **kwargs)
+        captured["pid"] = proc.pid
+        return proc
+
+    monkeypatch.setattr(fot.subprocess, "Popen", spying_popen)
+
+    danger = tmp_path / "danger.txt"
+    danger.write_text("a" * 28 + "X\n")
+
+    start = time.perf_counter()
+    result = fot._run_grep_subprocess(
+        pattern=r"(a+)+$",
+        file_paths=[str(danger)],
+        max_matches=fot._MAX_MATCHES,
+        # Deliberately large so the FULL pathological line reaches
+        # regex.search inside the worker, unclamped by the line-length
+        # cap -- isolates what the subprocess boundary alone buys,
+        # independent of _MAX_GREP_LINE_SEARCH_CHARS.
+        max_line_search_chars=10_000,
+        max_lines_scanned=fot._MAX_GREP_LINES_SCANNED,
+        max_file_bytes=fot._MAX_GREP_FILE_BYTES,
+        timeout_seconds=1.5,
+    )
+    elapsed = time.perf_counter() - start
+
+    assert "error" in result
+    assert "timed out" in result["error"]
+    # Bounded near the 1.5s ceiling -- NOT the ~11.7s this exact pattern
+    # takes to complete uncapped (see the module-level comment on
+    # `_MAX_GREP_LINE_SEARCH_CHARS` for that measurement).
+    assert elapsed < 4.0, f"took {elapsed:.2f}s -- is the subprocess actually being killed?"
+    assert "pid" in captured
+    assert not psutil.pid_exists(captured["pid"]), (
+        "child process must be killed on timeout, not left running"
+    )
+
+
+@pytest.mark.asyncio
+async def test_grep_files_execute_survives_a_pathological_pattern_without_raising(
+    sandbox, monkeypatch
+):
+    """End-to-end through the async `GrepFiles.execute()` -- never raises,
+    reports a timeout error, and returns well within a bounded wall-clock
+    budget even for a pattern that would otherwise run for many seconds.
+    """
+    monkeypatch.setattr(fot, "_GREP_SUBPROCESS_TIMEOUT_SECONDS", 1.5)
+    (sandbox / "danger.txt").write_text("a" * 28 + "X\n")
+
+    start = time.perf_counter()
+    result = await fot.GrepFiles().execute(pattern=r"(a+)+$", glob="danger.txt")
+    elapsed = time.perf_counter() - start
+
+    assert "error" in result
+    assert elapsed < 4.0
+
+
+def test_run_grep_subprocess_returns_error_dict_when_popen_cannot_start(monkeypatch):
+    """Never raises, even if the OS refuses to spawn the worker at all."""
+
+    def boom(*args, **kwargs):
+        raise OSError("no more processes")
+
+    monkeypatch.setattr(fot.subprocess, "Popen", boom)
+
+    result = fot._run_grep_subprocess(
+        pattern="x",
+        file_paths=["/tmp/does-not-matter.txt"],
+        max_matches=200,
+        max_line_search_chars=500,
+        max_lines_scanned=200_000,
+        max_file_bytes=5_000_000,
+        timeout_seconds=5.0,
+    )
+
+    assert "error" in result
+
+
+def test_run_grep_subprocess_reports_a_nonzero_worker_exit(monkeypatch):
+    """A worker that exits nonzero (crash, not a normal error-JSON path) is
+    reported as a plain error dict, never raised.
+    """
+
+    class _FakeProc:
+        pid = 999999
+        returncode = 1
+
+        def communicate(self, input=None, timeout=None):
+            return "", "boom: unhandled exception in worker"
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(fot.subprocess, "Popen", lambda *a, **k: _FakeProc())
+
+    result = fot._run_grep_subprocess(
+        pattern="x",
+        file_paths=[],
+        max_matches=200,
+        max_line_search_chars=500,
+        max_lines_scanned=200_000,
+        max_file_bytes=5_000_000,
+        timeout_seconds=5.0,
+    )
+
+    assert "error" in result
+    assert "boom" in result["error"]
+
+
+def test_run_grep_subprocess_reports_malformed_worker_output(monkeypatch):
+    """Non-JSON (or non-dict-JSON) stdout from the worker is a plain error,
+    never an uncaught exception.
+    """
+
+    class _FakeProc:
+        pid = 999998
+        returncode = 0
+
+        def communicate(self, input=None, timeout=None):
+            return "not valid json {{{", ""
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(fot.subprocess, "Popen", lambda *a, **k: _FakeProc())
+
+    result = fot._run_grep_subprocess(
+        pattern="x",
+        file_paths=[],
+        max_matches=200,
+        max_line_search_chars=500,
+        max_lines_scanned=200_000,
+        max_file_bytes=5_000_000,
+        timeout_seconds=5.0,
+    )
+
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_grep_files_ordinary_search_still_delegates_to_a_subprocess(
+    sandbox, monkeypatch
+):
+    """Sanity check that the normal (non-pathological) path still routes
+    through `_run_grep_subprocess` -- i.e. this isn't accidentally bypassed
+    for the common case, which would silently regress the TASK-843 fix.
+    """
+    calls: list[str] = []
+    real = fot._run_grep_subprocess
+
+    def spy(pattern, file_paths, **kwargs):
+        calls.append(pattern)
+        return real(pattern, file_paths, **kwargs)
+
+    monkeypatch.setattr(fot, "_run_grep_subprocess", spy)
+
+    result = await fot.GrepFiles().execute(pattern="DEBUG", glob="**/*.py")
+
+    assert calls == ["DEBUG"]
+    assert len(result["matches"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# `_grep_worker.py` itself: a standalone script, deliberately with no import
+# of `tldw_chatbook`. Exercised directly (both as a plain function and as a
+# real subprocess) so its own error handling is pinned independently of
+# `_run_grep_subprocess`.
+# ---------------------------------------------------------------------------
+
+
+def _load_worker_module():
+    import importlib.util
+
+    worker_path = Path(fot.__file__).with_name("_grep_worker.py")
+    spec = importlib.util.spec_from_file_location("_grep_worker_under_test", worker_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_grep_worker_run_search_matches_ordinary_content(tmp_path):
+    worker = _load_worker_module()
+    target = tmp_path / "a.txt"
+    target.write_text("hello DEBUG world\n")
+
+    result = worker.run_search(
+        {
+            "pattern": "DEBUG",
+            "file_paths": [str(target)],
+            "max_matches": 200,
+            "max_line_search_chars": 500,
+            "max_lines_scanned": 200_000,
+            "max_file_bytes": 5_000_000,
+        }
+    )
+
+    assert len(result["matches"]) == 1
+    assert result["matches"][0]["line"] == "hello DEBUG world"
+
+
+def test_grep_worker_run_search_rejects_invalid_regex():
+    worker = _load_worker_module()
+    result = worker.run_search(
+        {
+            "pattern": "([",
+            "file_paths": [],
+            "max_matches": 200,
+            "max_line_search_chars": 500,
+            "max_lines_scanned": 200_000,
+            "max_file_bytes": 5_000_000,
+        }
+    )
+    assert "error" in result
+
+
+def test_grep_worker_run_search_handles_a_malformed_request():
+    worker = _load_worker_module()
+    result = worker.run_search({"pattern": "x"})  # missing required keys
+    assert "error" in result
+
+
+def test_grep_worker_script_reports_malformed_json_on_stdin_without_crashing():
+    """Exercises the worker as a REAL subprocess -- confirms it always
+    exits 0 and always writes valid JSON, even fed garbage.
+    """
+    import sys
+
+    worker_path = Path(fot.__file__).with_name("_grep_worker.py")
+    proc = subprocess.run(
+        [sys.executable, "-S", str(worker_path)],
+        input="not json {{{",
+        text=True,
+        capture_output=True,
+        timeout=10,
+    )
+    assert proc.returncode == 0
+    parsed = json.loads(proc.stdout)
+    assert "error" in parsed
+
+
+def test_grep_worker_script_end_to_end_via_real_subprocess(tmp_path):
+    """The worker script invoked exactly the way `_run_grep_subprocess`
+    invokes it in production -- proves the protocol works, not just the
+    in-process `run_search` function.
+    """
+    import sys
+
+    target = tmp_path / "notes.txt"
+    target.write_text("first line\nDEBUG marker line\nlast line\n")
+    worker_path = Path(fot.__file__).with_name("_grep_worker.py")
+    request = json.dumps(
+        {
+            "pattern": "DEBUG",
+            "file_paths": [str(target)],
+            "max_matches": 200,
+            "max_line_search_chars": 500,
+            "max_lines_scanned": 200_000,
+            "max_file_bytes": 5_000_000,
+        }
+    )
+    proc = subprocess.run(
+        [sys.executable, "-S", str(worker_path)],
+        input=request,
+        text=True,
+        capture_output=True,
+        timeout=10,
+    )
+    assert proc.returncode == 0
+    parsed = json.loads(proc.stdout)
+    assert len(parsed["matches"]) == 1
+    assert parsed["matches"][0]["line"] == "DEBUG marker line"

--- a/Tests/Tools/test_glob_grep_files.py
+++ b/Tests/Tools/test_glob_grep_files.py
@@ -1193,3 +1193,51 @@ def test_run_grep_subprocess_still_accepts_a_well_formed_payload(monkeypatch):
         "matches": [{"path": "x.txt", "line_number": 3, "line": "hi"}],
         "lines_scanned": 3,
     }
+
+
+def test_grep_worker_script_path_is_absolute_and_exists():
+    """The worker script path must be absolute, because cwd is not the parent's.
+
+    `_run_grep_subprocess` launches the worker with `cwd=_GREP_WORKER_CWD`
+    (a temp dir) rather than inheriting the parent's working directory. A
+    relative `_GREP_WORKER_SCRIPT` would therefore be resolved against that
+    temp dir and fail to open, breaking `grep_files` outright.
+
+    Honest limitation: `__file__` is absolute under this loader, so this
+    test does NOT fail if `.resolve()` is removed today. It guards against a
+    future refactor reintroducing a relative path -- the cwd hardening is
+    what makes that class of change fatal rather than merely untidy.
+    """
+    from pathlib import Path
+
+    from tldw_chatbook.Tools.file_operation_tools import _GREP_WORKER_SCRIPT
+
+    script = Path(_GREP_WORKER_SCRIPT)
+    assert script.is_absolute(), f"worker script path is relative: {script}"
+    assert script.is_file(), f"worker script missing: {script}"
+
+
+def test_grep_files_works_when_process_cwd_is_unrelated(tmp_path, monkeypatch):
+    """grep_files must not depend on the parent process's working directory.
+
+    Exercises the real failure the absolute-path requirement prevents: with
+    the interpreter's cwd somewhere with no `_grep_worker.py` in it, a
+    search must still succeed.
+    """
+    import asyncio
+
+    import tldw_chatbook.Tools.file_operation_tools as fot
+
+    sandbox = tmp_path / "sbx"
+    sandbox.mkdir()
+    (sandbox / "hit.txt").write_text("alpha SENTINEL omega\n", encoding="utf-8")
+    monkeypatch.setattr(fot, "_resolve_sandbox_config", lambda: str(sandbox))
+
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    result = asyncio.run(fot.GrepFiles().execute(pattern="SENTINEL", glob="**/*"))
+
+    assert "error" not in result, result
+    assert len(result["matches"]) == 1

--- a/Tests/Tools/test_glob_grep_files.py
+++ b/Tests/Tools/test_glob_grep_files.py
@@ -10,6 +10,7 @@ reaches every caller directly.
 """
 
 import json
+import os
 import subprocess
 import time
 from pathlib import Path
@@ -860,3 +861,335 @@ def test_grep_worker_script_end_to_end_via_real_subprocess(tmp_path):
     parsed = json.loads(proc.stdout)
     assert len(parsed["matches"]) == 1
     assert parsed["matches"][0]["line"] == "DEBUG marker line"
+
+
+# ---------------------------------------------------------------------------
+# Follow-up hardening review (post TASK-843/TASK-850), Finding 1: draining
+# `_iter_candidates_across_roots` all the way to `_MAX_CANDIDATES` before
+# ever spawning the search subprocess undid the pre-subprocess early-break
+# (`len(matches) >= _MAX_MATCHES` / `lines_scanned >=
+# _MAX_GREP_LINES_SCANNED`, checked DURING enumeration). Reviewer-measured:
+# ~0.32ms/candidate means a 5,000-file tree with a pattern matching every
+# file went from ~0.1s (old early-break, ~200 files examined) to ~1.58s (all
+# 5,000 examined first). `_run_grep_search` restores the early exit by
+# streaming candidate discovery and the subprocess search together in
+# growing batches, and starts its wall-clock deadline before the first
+# candidate is even pulled -- these pin both halves of that fix.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_grep_files_high_hit_rate_pattern_does_not_over_enumerate(
+    tmp_path, monkeypatch
+):
+    """Reproduces the reviewer's exact regression scenario: a 5,000-file
+    tree where the pattern matches every file. Pins BOTH symptoms of the
+    fix rather than either alone:
+
+    - Structural (the real proof, immune to machine speed): the number of
+      candidates actually PULLED from `_iter_candidates_across_roots`
+      before the match budget (`_MAX_MATCHES` = 200) is satisfied must be
+      a small fraction of the 5,000-file tree, not the whole thing.
+    - Wall-clock (a generous sanity check): the call completes well
+      within the ballpark the fix targets, not the ~1s+ the drained-
+      enumeration bug cost (measured directly on this branch: median
+      ~1.0-1.3s before this fix, ~0.07-0.36s after).
+    """
+    monkeypatch.setattr(fot, "_resolve_sandbox_config", lambda: str(tmp_path))
+    for i in range(5_000):
+        (tmp_path / f"f{i}.py").write_text("DEBUG = True\n")
+
+    pulled = 0
+    real_iter = fot._iter_candidates_across_roots
+
+    def counting_iter(*args, **kwargs):
+        nonlocal pulled
+        for path in real_iter(*args, **kwargs):
+            pulled += 1
+            yield path
+
+    monkeypatch.setattr(fot, "_iter_candidates_across_roots", counting_iter)
+
+    start = time.perf_counter()
+    result = await fot.GrepFiles().execute(pattern="DEBUG", glob="**/*.py")
+    elapsed = time.perf_counter() - start
+
+    assert len(result["matches"]) == fot._MAX_MATCHES
+    assert pulled < 2_500, (
+        f"enumerated {pulled} of 5,000 candidates before the match budget "
+        "was satisfied -- expected a small fraction, not most/all of the "
+        "tree (is discovery being drained before the subprocess ever "
+        "starts searching?)"
+    )
+    assert elapsed < 2.0, (
+        f"grep_files took {elapsed:.2f}s for a high-hit-rate pattern over "
+        "a large tree -- is candidate discovery running away before the "
+        "search subprocess is ever spawned?"
+    )
+
+
+@pytest.mark.asyncio
+async def test_grep_files_aggregates_matches_across_multiple_batches(
+    sandbox, monkeypatch
+):
+    """`_run_grep_search` must correctly accumulate matches (and the
+    lines-scanned budget) across MULTIPLE batches/subprocess calls, not
+    just the common single-batch case every other test exercises. Forces
+    several small batches by shrinking the batch-size constants, and
+    confirms every match survives into the final, merged result -- and
+    that more than one subprocess call actually happened.
+    """
+    monkeypatch.setattr(fot, "_GREP_INITIAL_CANDIDATE_BATCH_SIZE", 2)
+    monkeypatch.setattr(fot, "_GREP_MAX_CANDIDATE_BATCH_SIZE", 2)
+    monkeypatch.setattr(fot, "_MAX_MATCHES", 1_000)
+    for i in range(10):
+        (sandbox / f"extra{i}.py").write_text(f"DEBUG_MARKER_{i}\n")
+
+    calls: list[list[str]] = []
+    real = fot._run_grep_subprocess
+
+    def spy(pattern, file_paths, **kwargs):
+        calls.append(list(file_paths))
+        return real(pattern, file_paths, **kwargs)
+
+    monkeypatch.setattr(fot, "_run_grep_subprocess", spy)
+
+    result = await fot.GrepFiles().execute(
+        pattern=r"DEBUG_MARKER_\d+", glob="extra*.py"
+    )
+
+    assert len(result["matches"]) == 10
+    assert len(calls) > 1, (
+        "expected multiple batched subprocess calls with a batch size of 2 "
+        "and 10 candidates"
+    )
+    # Every candidate handed to any one call stays within that call's batch
+    # size -- proves batching, not one call quietly given everything anyway.
+    assert all(len(batch) <= 2 for batch in calls)
+
+
+@pytest.mark.asyncio
+async def test_grep_files_search_deadline_starts_before_the_first_candidate_is_pulled(
+    sandbox, monkeypatch
+):
+    """Finding 1's second half: the wall-clock deadline must start
+    counting BEFORE candidate discovery begins, not after it finishes --
+    otherwise a slow discovery phase could push the real wall-clock past
+    `GrepFiles.timeout_seconds` without this deadline ever catching it
+    (exactly the false invariant the pre-fix `_GREP_SUBPROCESS_TIMEOUT_
+    SECONDS` comment claimed held). Proven by making discovery itself
+    slow and setting the deadline shorter than that delay: the call must
+    report a timeout rather than silently proceeding to search anyway.
+    """
+    monkeypatch.setattr(fot, "_GREP_SUBPROCESS_TIMEOUT_SECONDS", 0.05)
+    (sandbox / "slow.py").write_text("DEBUG\n")
+
+    real_iter = fot._iter_candidates_across_roots
+
+    def slow_iter(*args, **kwargs):
+        time.sleep(0.2)
+        yield from real_iter(*args, **kwargs)
+
+    monkeypatch.setattr(fot, "_iter_candidates_across_roots", slow_iter)
+
+    result = await fot.GrepFiles().execute(pattern="DEBUG", glob="slow.py")
+
+    assert "error" in result
+    assert "timed out" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Finding 3 (follow-up hardening review): the search subprocess previously
+# inherited the parent's full environment, actual cwd, and (via the
+# script's own directory) `sys.path[0]` -- a probe confirmed a parent-only
+# secret env var visible in the child, and `sys.path[0]` pointing at this
+# project's own `Tools/` source directory. Not an escalation on its own
+# (planting a shadow module there already requires source-tree write
+# access), but removing the surface costs nothing. These pin the fix:
+# explicit `-P`, `cwd=`, and a minimal `env=`.
+# ---------------------------------------------------------------------------
+
+
+def test_run_grep_subprocess_isolates_worker_cwd_and_env(tmp_path, monkeypatch):
+    """The worker must not inherit the parent's real cwd or its full
+    environment -- it only ever needs the absolute paths handed to it on
+    stdin.
+    """
+    monkeypatch.setenv("MY_FAKE_SECRET_9f21", "sk-should-not-leak")
+    captured: dict = {}
+    real_popen = subprocess.Popen
+
+    def spying_popen(args, **kwargs):
+        captured["args"] = args
+        captured["cwd"] = kwargs.get("cwd")
+        captured["env"] = kwargs.get("env")
+        return real_popen(args, **kwargs)
+
+    monkeypatch.setattr(fot.subprocess, "Popen", spying_popen)
+
+    target = tmp_path / "a.txt"
+    target.write_text("DEBUG\n")
+
+    result = fot._run_grep_subprocess(
+        pattern="DEBUG",
+        file_paths=[str(target)],
+        max_matches=200,
+        max_line_search_chars=500,
+        max_lines_scanned=200_000,
+        max_file_bytes=5_000_000,
+        timeout_seconds=5.0,
+    )
+
+    assert len(result["matches"]) == 1
+    assert "-P" in captured["args"]
+    assert captured["cwd"] is not None
+    assert os.path.realpath(captured["cwd"]) != os.path.realpath(os.getcwd())
+    assert captured["env"] is not None
+    assert "MY_FAKE_SECRET_9f21" not in captured["env"]
+
+
+def test_grep_worker_env_omits_arbitrary_parent_variables(monkeypatch):
+    """Direct unit test of the helper itself: only the small, named
+    allowlist survives, never an arbitrary parent-set variable.
+    """
+    monkeypatch.setenv("MY_FAKE_API_KEY_TEST_71a2", "sk-LEAKED")
+
+    env = fot._grep_worker_env()
+
+    assert "MY_FAKE_API_KEY_TEST_71a2" not in env
+
+
+# ---------------------------------------------------------------------------
+# Finding 4 (follow-up hardening review): `_run_grep_subprocess` previously
+# returned the worker's parsed JSON verbatim once it was confirmed to be a
+# dict -- never confirming `matches` was actually a list of well-formed
+# entries, or that `lines_scanned` was actually an int. A worker emitting
+# `{"matches": "not-a-list"}` would propagate that shape straight through.
+# These pin the added validation.
+# ---------------------------------------------------------------------------
+
+
+def test_run_grep_subprocess_rejects_a_matches_field_that_is_not_a_list(monkeypatch):
+    class _FakeProc:
+        pid = 999_994
+        returncode = 0
+
+        def communicate(self, input=None, timeout=None):
+            return '{"matches": "not-a-list", "lines_scanned": 1}', ""
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(fot.subprocess, "Popen", lambda *a, **k: _FakeProc())
+
+    result = fot._run_grep_subprocess(
+        pattern="x",
+        file_paths=[],
+        max_matches=200,
+        max_line_search_chars=500,
+        max_lines_scanned=200_000,
+        max_file_bytes=5_000_000,
+        timeout_seconds=5.0,
+    )
+
+    assert "error" in result
+    assert "matches" not in result
+
+
+def test_run_grep_subprocess_rejects_a_malformed_match_entry(monkeypatch):
+    """Each match entry must be `{"path": str, "line_number": int, "line":
+    str}` -- a worker omitting `line_number` (or any other required key)
+    must not slip through.
+    """
+
+    class _FakeProc:
+        pid = 999_993
+        returncode = 0
+
+        def communicate(self, input=None, timeout=None):
+            return (
+                '{"matches": [{"path": "x.txt", "line": "hi"}], '
+                '"lines_scanned": 1}',
+                "",
+            )
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(fot.subprocess, "Popen", lambda *a, **k: _FakeProc())
+
+    result = fot._run_grep_subprocess(
+        pattern="x",
+        file_paths=[],
+        max_matches=200,
+        max_line_search_chars=500,
+        max_lines_scanned=200_000,
+        max_file_bytes=5_000_000,
+        timeout_seconds=5.0,
+    )
+
+    assert "error" in result
+
+
+def test_run_grep_subprocess_rejects_a_non_int_lines_scanned(monkeypatch):
+    class _FakeProc:
+        pid = 999_992
+        returncode = 0
+
+        def communicate(self, input=None, timeout=None):
+            return '{"matches": [], "lines_scanned": "many"}', ""
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(fot.subprocess, "Popen", lambda *a, **k: _FakeProc())
+
+    result = fot._run_grep_subprocess(
+        pattern="x",
+        file_paths=[],
+        max_matches=200,
+        max_line_search_chars=500,
+        max_lines_scanned=200_000,
+        max_file_bytes=5_000_000,
+        timeout_seconds=5.0,
+    )
+
+    assert "error" in result
+
+
+def test_run_grep_subprocess_still_accepts_a_well_formed_payload(monkeypatch):
+    """Sanity check alongside the malformed-payload tests above: a
+    genuinely well-formed worker payload must still pass validation
+    unchanged, not just be rejected less often by accident.
+    """
+
+    class _FakeProc:
+        pid = 999_991
+        returncode = 0
+
+        def communicate(self, input=None, timeout=None):
+            return (
+                '{"matches": [{"path": "x.txt", "line_number": 3, '
+                '"line": "hi"}], "lines_scanned": 3}',
+                "",
+            )
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(fot.subprocess, "Popen", lambda *a, **k: _FakeProc())
+
+    result = fot._run_grep_subprocess(
+        pattern="x",
+        file_paths=[],
+        max_matches=200,
+        max_line_search_chars=500,
+        max_lines_scanned=200_000,
+        max_file_bytes=5_000_000,
+        timeout_seconds=5.0,
+    )
+
+    assert result == {
+        "matches": [{"path": "x.txt", "line_number": 3, "line": "hi"}],
+        "lines_scanned": 3,
+    }

--- a/Tests/Utils/test_sensitive_paths.py
+++ b/Tests/Utils/test_sensitive_paths.py
@@ -280,3 +280,189 @@ def test_context_reuse_matches_fresh_resolution(tmp_path):
 
     db_path = app_config.get_chachanotes_db_path()
     assert is_sensitive_path(db_path, context=ctx) == is_sensitive_path(db_path)
+
+
+# ---------------------------------------------------------------------------
+# TASK-848: the skill trust/grant store (audit CRITICAL-3).
+# ---------------------------------------------------------------------------
+
+
+def test_skill_trust_store_paths_are_refused_via_the_actually_used_accessors():
+    """Audit CRITICAL-3 / TASK-848 AC#2 + AC#4.
+
+    ``get_user_data_dir() / "skills"`` is one of the existing-directory
+    exemptions the direct-child-file rule carves out, so everything nested
+    under it -- including ``skills/trust/`` -- used to inherit that
+    exemption with nothing refusing it specifically. Every path here is
+    derived from the SAME functions ``app.py`` calls to build the live
+    ``SkillTrustStore`` (``default_local_skills_store_dir`` +
+    ``default_trust_store_dir``) and from ``SkillTrustStore``'s own
+    ``manifest_path``/``snapshots_dir`` properties -- never a re-spelled
+    ``skills/trust`` literal, so this can't silently drift back to
+    matching nothing the way the MCP permission-store literal once did.
+    """
+    from tldw_chatbook import config as app_config
+    from tldw_chatbook.Skills_Interop.local_skills_service import (
+        default_local_skills_store_dir,
+    )
+    from tldw_chatbook.Skills_Interop.skill_trust_service import (
+        _SCRIPT_GRANTS_FILENAME,
+    )
+    from tldw_chatbook.Skills_Interop.skill_trust_store import (
+        MARKER_FILENAME,
+        FileSkillTrustGenerationMarkerStore,
+        SkillTrustStore,
+        default_trust_store_dir,
+    )
+
+    user_data_dir = app_config.get_user_data_dir()
+    local_skills_store_dir = default_local_skills_store_dir(user_data_dir)
+    trust_store_dir = default_trust_store_dir(local_skills_store_dir)
+
+    store = SkillTrustStore(
+        store_dir=trust_store_dir,
+        marker_store=FileSkillTrustGenerationMarkerStore(
+            trust_store_dir / MARKER_FILENAME
+        ),
+    )
+
+    assert is_sensitive_path(store.manifest_path), "skill_trust_manifest.json"
+    assert is_sensitive_path(
+        store.store_dir / _SCRIPT_GRANTS_FILENAME
+    ), "skill_script_grants.json (the plain, unauthenticated script-execution grant file)"
+    assert is_sensitive_path(
+        store.store_dir / MARKER_FILENAME
+    ), "generation_marker.json"
+    assert is_sensitive_path(
+        store.snapshots_dir / "some-snapshot-id.json"
+    ), "a file nested inside snapshots/"
+
+
+def test_skills_directory_itself_stays_reachable_outside_the_trust_carve_out():
+    """The ``skills/`` container exemption must still hold for everything
+    OTHER than the ``trust`` subtree -- this carve-out is deliberately
+    narrow, not a blanket refusal of the whole ``skills`` directory.
+    """
+    from tldw_chatbook import config as app_config
+    from tldw_chatbook.Skills_Interop.local_skills_service import (
+        default_local_skills_store_dir,
+    )
+
+    local_skills_store_dir = default_local_skills_store_dir(
+        app_config.get_user_data_dir()
+    )
+    sibling_skill_file = local_skills_store_dir / "skills" / "some-skill" / "SKILL.md"
+
+    assert not is_sensitive_path(sibling_skill_file)
+
+
+# ---------------------------------------------------------------------------
+# TASK-848: config.toml's .bak/.tmp sidecars, and the effective config
+# directory's direct-child-file rule more generally (audit CRITICAL-4).
+# ---------------------------------------------------------------------------
+
+
+def test_config_toml_bak_and_tmp_sidecars_are_refused():
+    """Audit CRITICAL-4 / TASK-848 AC#3 + AC#4.
+
+    ``UI/Screens/settings_screen.py``'s Advanced config save writes a
+    full plaintext ``.bak`` backup before overwriting, plus a ``.tmp``
+    during the atomic swap -- both byte-identical to the live config,
+    API keys included. Derived from ``config._get_effective_config_path()``
+    (the same accessor the app itself uses, honoring ``TLDW_CONFIG_PATH``),
+    never a hardcoded ``~/.config/tldw_cli/config.toml`` literal.
+    """
+    from tldw_chatbook import config as app_config
+
+    config_path = app_config._get_effective_config_path()
+    bak = config_path.with_name(config_path.name + ".bak")
+    tmp = config_path.with_name(config_path.name + ".tmp")
+
+    assert is_sensitive_path(bak)
+    assert is_sensitive_path(tmp)
+
+
+def test_any_other_file_directly_in_the_effective_config_dir_is_refused():
+    """TASK-848 AC#3: not just the two named sidecar suffixes -- ANY file
+    sitting directly in the effective config directory is refused, the
+    same generalization the user-data-dir rule already applies (a hand-made
+    backup under an arbitrary name, e.g. ``config.toml.pre-lab-cleanup``,
+    was found unprotected on the audit machine; an enumeration of specific
+    suffixes would have missed it too).
+    """
+    from tldw_chatbook import config as app_config
+
+    config_dir = app_config._get_effective_config_path().parent
+    arbitrary_file = config_dir / "config.toml.pre-lab-cleanup"
+
+    assert is_sensitive_path(arbitrary_file)
+
+
+def test_existing_directory_directly_in_the_effective_config_dir_stays_reachable():
+    """The direct-child-file rule must not blanket the whole effective
+    config directory: an existing DIRECTORY placed directly inside it
+    (mirroring the real ``feed_cache``/``themes``/``tokenizers``
+    directories this app already writes there) stays reachable, the same
+    directory/file distinction the user-data-dir rule already makes for
+    ``tool_sandbox``.
+    """
+    from tldw_chatbook import config as app_config
+
+    config_dir = app_config._get_effective_config_path().parent
+    existing_subdir = config_dir / "themes"
+    existing_subdir.mkdir(parents=True, exist_ok=True)
+    nested_file = existing_subdir / "custom.css"
+
+    assert not is_sensitive_path(nested_file)
+
+
+# ---------------------------------------------------------------------------
+# TASK-848 AC#1: vector-store and sibling-profile paths, under a widened
+# sandbox root.
+# ---------------------------------------------------------------------------
+
+
+def test_chroma_vector_store_file_is_refused():
+    """``chromadb`` is one of the existing-directory container exemptions
+    (it must stay reachable so the file tools can list/traverse it), but
+    ``chroma.sqlite3`` itself -- plaintext chunks of the same conversations
+    and notes ``ChaChaNotes.db`` protects -- was never covered by any rule.
+    Derived from the app's own
+    ``RAG_Search.simplified.config.default_chroma_persist_directory()``
+    accessor (which also honors ``RAG_PERSIST_DIR``/config overrides),
+    never a hardcoded ``<user data dir>/chromadb`` literal.
+    """
+    from tldw_chatbook.RAG_Search.simplified.config import (
+        default_chroma_persist_directory,
+    )
+
+    chroma_dir = default_chroma_persist_directory()
+    chroma_dir.mkdir(parents=True, exist_ok=True)
+    chroma_sqlite = chroma_dir / "chroma.sqlite3"
+
+    assert is_sensitive_path(chroma_sqlite)
+
+    # The container directory itself, and an existing per-collection
+    # subdirectory nested inside it, must both stay reachable -- only a
+    # same-level FILE is refused.
+    assert not is_sensitive_path(chroma_dir)
+    collection_dir = chroma_dir / "some-collection-uuid"
+    collection_dir.mkdir(exist_ok=True)
+    assert not is_sensitive_path(collection_dir)
+
+
+def test_rag_profile_file_is_refused():
+    """A RAG profile file dropped directly in ``rag_profiles/`` holds
+    plaintext RAG/embedding-provider config -- refused via
+    ``RAG_Search.config_profiles.default_rag_profiles_dir()``, the app's
+    own accessor (also what ``ConfigProfileManager`` itself now calls for
+    its default), never a re-spelled ``rag_profiles`` literal.
+    """
+    from tldw_chatbook.RAG_Search.config_profiles import default_rag_profiles_dir
+
+    profiles_dir = default_rag_profiles_dir()
+    profiles_dir.mkdir(parents=True, exist_ok=True)
+    profile_file = profiles_dir / "my_custom_profile.json"
+
+    assert is_sensitive_path(profile_file)
+    assert not is_sensitive_path(profiles_dir)

--- a/Tests/Utils/test_sensitive_paths.py
+++ b/Tests/Utils/test_sensitive_paths.py
@@ -2,7 +2,10 @@ from pathlib import Path
 
 import pytest
 
-from tldw_chatbook.Utils.sensitive_paths import is_sensitive_path
+from tldw_chatbook.Utils.sensitive_paths import (
+    is_sensitive_path,
+    refuses_new_directory_chain,
+)
 
 
 @pytest.mark.parametrize(
@@ -466,3 +469,77 @@ def test_rag_profile_file_is_refused():
 
     assert is_sensitive_path(profile_file)
     assert not is_sensitive_path(profiles_dir)
+
+
+# ---------------------------------------------------------------------------
+# TASK-849: an agent-created directory must not shadow a not-yet-created
+# state file.
+# ---------------------------------------------------------------------------
+
+
+def test_an_already_existing_directory_still_reads_as_an_ordinary_container():
+    """Documents the deliberate boundary of this fix, so it isn't mistaken
+    for a regression later: ``is_sensitive_path``'s "is this an existing
+    directory" gate is UNCHANGED -- an ALREADY-EXISTING directory named
+    ``search_history.db`` (e.g. one that predates this fix, or was created
+    by some other means) still reads as an ordinary reachable container,
+    exactly like ``tool_sandbox``/``chromadb``/etc. There is no way to
+    distinguish "this existing directory is a legitimate container" from
+    "this existing directory is an illegitimate collision" by name alone
+    without reintroducing the enumeration this rule deliberately avoids
+    (see the module docstring). The actual fix is at CREATION time instead
+    -- see ``test_refuses_new_directory_chain_blocks_the_collision`` below
+    and ``test_write_file_refuses_to_plant_a_directory_shadowing_a_state_file``
+    in ``Tests/Tools/test_file_tool_sandbox.py`` for the reachable
+    end-to-end path an agent could otherwise use to create one.
+    """
+    from tldw_chatbook import config as app_config
+
+    user_data_dir = app_config.get_user_data_dir()
+    user_data_dir.mkdir(parents=True, exist_ok=True)
+    shadow_dir = user_data_dir / "search_history.db"
+    shadow_dir.mkdir(parents=True, exist_ok=True)
+
+    assert not is_sensitive_path(shadow_dir)
+
+
+def test_refuses_new_directory_chain_blocks_the_collision():
+    """``refuses_new_directory_chain`` is the guard ``WriteFileTool``
+    consults BEFORE calling ``Path.mkdir(parents=True)`` -- unlike
+    ``is_sensitive_path`` on the shadow directory itself (which only helps
+    once the collision already exists on disk), this must refuse it before
+    it is ever created, walking every not-yet-existing ancestor.
+    """
+    from tldw_chatbook import config as app_config
+
+    user_data_dir = app_config.get_user_data_dir()
+    user_data_dir.mkdir(parents=True, exist_ok=True)
+
+    # A brand-new, multi-level target: neither `search_history.db` nor
+    # `sub` exists yet. The collision is at `search_history.db` (one level
+    # deep), not at the leaf `sub` -- the walk must catch it there, not
+    # only when the leaf itself happens to be the direct child.
+    target = user_data_dir / "search_history.db" / "sub" / "note.txt"
+
+    assert refuses_new_directory_chain(target.parent)
+    assert not (user_data_dir / "search_history.db").exists()
+
+
+def test_refuses_new_directory_chain_allows_existing_containers():
+    """Existing container subdirectories under the user data dir (and any
+    brand-new subdirectory nested inside one of them) must stay reachable
+    -- the whole point of gating on "does this already exist", not a name.
+    """
+    from tldw_chatbook import config as app_config
+
+    user_data_dir = app_config.get_user_data_dir()
+    sandbox_root = user_data_dir / "tool_sandbox"
+    sandbox_root.mkdir(parents=True, exist_ok=True)
+
+    # The container itself already exists.
+    assert not refuses_new_directory_chain(sandbox_root)
+
+    # A brand-new subdirectory nested inside an EXISTING container is not
+    # itself a direct child of the user data dir, so it must stay allowed.
+    new_nested_dir = sandbox_root / "brand_new_subdir"
+    assert not refuses_new_directory_chain(new_nested_dir)

--- a/Tests/Utils/test_sensitive_paths.py
+++ b/Tests/Utils/test_sensitive_paths.py
@@ -252,6 +252,21 @@ def test_unresolvable_path_fails_closed(monkeypatch):
     assert is_sensitive_path(Path("/does/not/matter"))
 
 
+def test_nul_byte_path_fails_closed_for_real():
+    """TASK-847: the fail-closed guarantee must hold for a resolution
+    failure of ANY kind, not just the ones ``_resolved`` used to catch.
+
+    ``Path("bad\\x00path").resolve()`` raises ``ValueError`` (an embedded
+    NUL byte), not ``OSError``/``RuntimeError`` -- narrowing ``_resolved``'s
+    except clause to those two let this case escape ``is_sensitive_path``
+    as an uncaught exception instead of the promised ``True``. Exercises
+    the real (unmocked) resolution path end to end, unlike the
+    monkeypatched test above, so a future narrowing of that except clause
+    would be caught here even if it still covered ``OSError``/``RuntimeError``.
+    """
+    assert is_sensitive_path(Path("bad\x00path"))
+
+
 def test_context_reuse_matches_fresh_resolution(tmp_path):
     """A caller-supplied ``SensitivePathContext`` must agree with the
     default (``context=None``) fresh-resolution path for the same candidate."""

--- a/backlog/tasks/task-843 - Complete-the-grep_files-catastrophic-backtracking-mitigation.md
+++ b/backlog/tasks/task-843 - Complete-the-grep_files-catastrophic-backtracking-mitigation.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-843
 title: Complete the grep_files catastrophic-backtracking mitigation
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-27 02:36'
+updated_date: '2026-07-27 05:55'
 labels:
   - tools
   - security
@@ -19,5 +21,46 @@ grep_files bounds the regex input via a line-length cap, a total-lines-scanned c
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A pathological regex cannot consume CPU after its tool call has returned,Ordinary searches are not measurably slower,The chosen approach is documented with its trade-offs
+- [x] #1 A pathological regex cannot consume CPU after its tool call has returned,Ordinary searches are not measurably slower,The chosen approach is documented with its trade-offs
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Confirm the third-party regex module (timeout= support) is not a direct/declared-optional dependency of this project -- only present transitively via unrelated optional extras (nltk/transformers/dateparser). Rule it out: grep_files is a core built-in with no extras gate, so depending on it would make an optional/transitive package a hard requirement.
+2. Choose the killable-subprocess approach: move the actual regex-vs-file-content search into a standalone worker script (_grep_worker.py, stdlib-only, no import of tldw_chatbook) invoked via subprocess.Popen, JSON over stdin/stdout, so the OS can actually kill it (Popen.kill()) rather than abandon it the way _call_with_timeout does for threads.
+3. Keep candidate discovery (containment/sensitivity/hidden-component/_MAX_CANDIDATES) in-process in GrepFiles.execute -- none of that runs the user-supplied regex, so it doesn't need the subprocess boundary. Only the line-by-line regex search moves into the worker.
+4. Add _run_grep_subprocess(): spawns the worker with `-S`, writes the request, waits up to a subprocess-specific timeout (_GREP_SUBPROCESS_TIMEOUT_SECONDS, shorter than GrepFiles.timeout_seconds), kills+reaps on TimeoutExpired, never raises.
+5. Add a POSIX RLIMIT_CPU self-limit inside the worker as defense-in-depth for the orphaned-parent case.
+6. Keep every existing bound in place (_MAX_GREP_LINE_SEARCH_CHARS, _MAX_GREP_LINES_SCANNED, _MAX_GREP_FILE_BYTES, GrepFiles.timeout_seconds) as the cheap first line of defence.
+7. Update every docstring/comment that previously described the mitigation as partial/incomplete to describe what the subprocess boundary now guarantees and what it still does not.
+8. Add tests: subprocess is actually killed on timeout (process-level proof via psutil), GrepFiles.execute never raises for a pathological pattern, worker error-handling (bad Popen spawn, nonzero exit, malformed output, malformed request), and the worker script exercised as a real subprocess.
+9. Benchmark before/after on a realistic tree (ordinary search) and the pathological case (bounded post-return CPU), report both.
+10. Run Tests/Utils Tests/Tools Tests/Agents to confirm no regressions.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Chose the killable-subprocess approach (option 1), not the third-party regex module (option 2): `regex` (which supports timeout=) is installed in this dev venv but only transitively, via nltk/transformers/dateparser pulled in by the optional embeddings/RAG extras -- it is not a direct or declared-optional dependency of this project (checked pyproject.toml). grep_files is a core built-in reachable with zero extras installed, so depending on `regex` here would silently turn a currently-optional, transitive package into a hard requirement for the base install. A subprocess adds no new dependency.
+
+The regex-vs-file-content search now runs in a standalone child process (new tldw_chatbook/Tools/_grep_worker.py -- stdlib-only, no import of tldw_chatbook at all, deliberately: it must be trivially killable without dragging along the host app's live state). GrepFiles.execute still does candidate discovery in-process (containment, sensitive-path denylist, hidden-component rule, _MAX_CANDIDATES) since none of that runs the user-supplied regex; only the actual line-by-line search is handed off, via _run_grep_subprocess(), to `sys.executable -S _grep_worker.py` with the pattern/file list/bounds sent as one JSON request over stdin and the matches read back as one JSON response over stdout.
+
+_run_grep_subprocess uses Popen.communicate(timeout=_GREP_SUBPROCESS_TIMEOUT_SECONDS=18.0, deliberately shorter than GrepFiles.timeout_seconds=20.0) and calls proc.kill() (SIGKILL) + reaps on TimeoutExpired -- unlike Agents/agent_service.py's _call_with_timeout, which abandons a hung worker THREAD because Python cannot kill a thread, a subprocess genuinely can be killed. Verified directly (not just by wall-clock proxy): captured the child's pid via a Popen spy, confirmed psutil.pid_exists(pid) is False immediately after a timed-out call returns (test_grep_subprocess_kills_the_worker_process_on_timeout). The worker also self-limits via POSIX RLIMIT_CPU (best-effort, defense-in-depth for the case where the PARENT dies before ever calling kill()).
+
+Every existing bound (_MAX_GREP_LINE_SEARCH_CHARS, _MAX_GREP_LINES_SCANNED, _MAX_GREP_FILE_BYTES, GrepFiles.timeout_seconds=20.0) stays in place as the cheap first line of defence and is still passed into the worker as call arguments (read from the module's own globals at call time, so existing tests that monkeypatch them continue to work through the subprocess boundary unchanged).
+
+Benchmark (realistic tree: this project's own Tools/Utils/Chat/Agents source, 221 .py files, pattern "def execute", median of 5 runs, apples-to-apples -- both include the same is_within/resolve_sensitive_context candidate-discovery cost):
+  BEFORE (in-process, same containment/sensitivity checks): median 78.5ms
+  AFTER  (subprocess-based):                                median 97.7ms
+  Added overhead: ~19ms (~24% relative, ~20ms absolute) -- consistent with the isolated pure-subprocess-round-trip measurement (~18ms with zero files). Comfortably negligible against the 20s tool-call ceiling and against grep_files' own "ask" permission floor (a human approves every call).
+Pathological case ((a+)+$ against a 28-30 character adversarial line, line-length cap deliberately disabled to isolate this task's fix): BEFORE this task, an uncapped in-process search of this exact pattern took ~11.7s (28 chars) to ~47s (30 chars) and kept running past any reported timeout, since _call_with_timeout abandons the thread; growing worse per additional character with nothing to stop it. AFTER: bounded to the production ceiling (18.00s measured), subprocess confirmed killed (pid_exists False) immediately on return.
+
+Residual exposure, stated precisely (not claimed closed): the child can still burn real CPU for up to _GREP_SUBPROCESS_TIMEOUT_SECONDS (18s) before it is killed -- down from unbounded, not zero. Every grep_files call now pays a small, fixed process-spawn/teardown cost (~15-20ms) whether or not the pattern is pathological. RLIMIT_CPU is POSIX-only (no-op on Windows); the communicate(timeout=)+kill() path is what actually holds on every platform. All of this is documented in _run_grep_subprocess's and _grep_worker.py's own docstrings, not just here.
+
+Added: tldw_chatbook/Tools/_grep_worker.py (new).
+Modified: tldw_chatbook/Tools/file_operation_tools.py (GrepFiles.execute, new _run_grep_subprocess/_GREP_SUBPROCESS_TIMEOUT_SECONDS/_GREP_WORKER_SCRIPT, updated docstrings/comments on _MAX_GREP_LINE_SEARCH_CHARS, GrepFiles.timeout_seconds).
+Added tests: Tests/Tools/test_glob_grep_files.py (subprocess-kill proof, execute()-never-raises, worker error handling, worker-as-real-subprocess, ordinary-path-still-uses-subprocess).
+
+Implemented together with TASK-850 (same file, same commit sequence).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-846 - Audit-security-checks-that-name-filesystem-paths-against-where-the-app-actually-writes.md
+++ b/backlog/tasks/task-846 - Audit-security-checks-that-name-filesystem-paths-against-where-the-app-actually-writes.md
@@ -3,9 +3,10 @@ id: TASK-846
 title: >-
   Audit security checks that name filesystem paths against where the app
   actually writes
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-27 03:46'
+updated_date: '2026-07-27 06:41'
 labels:
   - security
   - tools
@@ -23,3 +24,9 @@ The agent file-tool denylist shipped broken on two branches: it hardcoded the pe
 <!-- AC:BEGIN -->
 - [ ] #1 Every security-relevant check that names a filesystem path is inventoried,Each one is confirmed against the accessor the app really uses or corrected to derive from it,Tests for those checks derive their paths the way the app does rather than asserting literals,Any check found broken is recorded with what it failed to protect
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Audited 30 security-relevant checks that name filesystem paths, config keys or database locations by literal, and verified each against the accessor the application actually uses by resolving both sides on-disk. 27 were broken. Six Critical, including: all three config-encryption entry points writing to DEFAULT_CONFIG_PATH rather than the effective path, so 'Enable encryption' returns True while leaving the active profile's API key plaintext; detect_api_keys exact-matching six literals when every real key name is prefixed, so should_encrypt_config() never prompts; the skill script-grant store (which authorizes script execution) uncovered by the denylist; and two skills-trust containment checks that are true by construction. Findings and evidence in .superpowers/sdd/task-846-audit.md. Filed as tasks 851-862; recommendations 3 and 4 were folded into TASK-848 rather than duplicated, and recommendation 14's two test sites became task-862. TASK-848's fixes on this branch closed the two Critical denylist omissions.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-847 - Harden-is_sensitive_path-fail-closed-on-unresolvable-paths.md
+++ b/backlog/tasks/task-847 - Harden-is_sensitive_path-fail-closed-on-unresolvable-paths.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-847
 title: Harden is_sensitive_path fail-closed on unresolvable paths
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-27 02:36'
+updated_date: '2026-07-27 05:06'
 labels:
   - tools
   - security
@@ -19,5 +20,26 @@ is_sensitive_path's docstring promises it fails CLOSED for a path it cannot reso
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 is_sensitive_path returns True (refused) for a path that cannot be resolved for any reason including ValueError,A regression test covers the NUL-byte case,The docstring's fail-closed claim matches the code
+- [x] #1 is_sensitive_path returns True (refused) for a path that cannot be resolved for any reason including ValueError,A regression test covers the NUL-byte case,The docstring's fail-closed claim matches the code
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce first: confirm is_sensitive_path raises ValueError (uncaught) for a NUL-byte path instead of returning True, proving the fail-closed docstring promise does not hold for every resolution failure.
+2. Broaden _resolved()'s except clause from (OSError, RuntimeError) to Exception, matching the lazy-accessor pattern already used elsewhere in the module (log at debug, return None).
+3. Add a real (unmocked) regression test exercising the NUL-byte path end to end, alongside the existing monkeypatched fail-closed test.
+4. Re-verify the docstring's fail-closed claim now matches the implementation.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reproduced first: `is_sensitive_path(Path("bad\x00path"))` raised `ValueError: lstat: embedded null character in path` instead of returning True -- `_resolved()`'s except clause only caught `(OSError, RuntimeError)`. Broadened it to catch any `Exception` (matching the lazy-accessor pattern already used elsewhere in the module: debug-log then return None), so ANY resolution failure now returns None and is_sensitive_path returns True. `_resolved()` got a new docstring explaining why the broad catch is required for the fail-closed guarantee to actually hold; `is_sensitive_path`'s own docstring already stated the guarantee correctly (it was aspirational until now), so no separate docstring rewrite was needed there.
+
+Added a real (unmocked) regression test, `test_nul_byte_path_fails_closed_for_real`, alongside the pre-existing monkeypatched `test_unresolvable_path_fails_closed`.
+
+Verified: `pytest Tests/Utils/ Tests/Tools/ Tests/Agents/ -q` -> 893 passed, 0 failed.
+
+Files: tldw_chatbook/Utils/sensitive_paths.py, Tests/Utils/test_sensitive_paths.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-848 - Extend-agent-file-tool-denylist-beyond-the-active-user-data-folder.md
+++ b/backlog/tasks/task-848 - Extend-agent-file-tool-denylist-beyond-the-active-user-data-folder.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-848
 title: Extend agent file-tool denylist beyond the active user data folder
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-27 02:36'
-updated_date: '2026-07-27 04:36'
+updated_date: '2026-07-27 05:07'
 labels:
   - tools
   - security
@@ -26,8 +26,39 @@ config.toml sidecars. UI/Screens/settings_screen.py:5596-5605's Advanced config 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Vector-store and sibling-profile paths are refused under a widened sandbox root,The default sandbox configuration still works end to end,A test pins both directions
-- [ ] #2 The skill trust/grant store (skill_trust_manifest.json, skill_script_grants.json, generation_marker.json, snapshots/) under get_user_data_dir()/skills/trust/ is refused by the denylist even though skills/ itself remains reachable
-- [ ] #3 config.toml's .bak and .tmp sidecars (and any other file directly in the effective config's directory) are refused by the denylist
-- [ ] #4 A test derives the trust-store and config-sidecar paths from the same accessors the app uses (SkillTrustStore/SkillTrustService attributes; _get_effective_config_path()) rather than asserting literals
+- [x] #1 Vector-store and sibling-profile paths are refused under a widened sandbox root,The default sandbox configuration still works end to end,A test pins both directions
+- [x] #2 The skill trust/grant store (skill_trust_manifest.json, skill_script_grants.json, generation_marker.json, snapshots/) under get_user_data_dir()/skills/trust/ is refused by the denylist even though skills/ itself remains reachable
+- [x] #3 config.toml's .bak and .tmp sidecars (and any other file directly in the effective config's directory) are refused by the denylist
+- [x] #4 A test derives the trust-store and config-sidecar paths from the same accessors the app uses (SkillTrustStore/SkillTrustService attributes; _get_effective_config_path()) rather than asserting literals
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce all three explicitly-scoped gaps first: (a) the skill trust/grant store is not sensitive despite being nested under the exempted `skills` container; (b) config.toml's .bak/.tmp sidecars are not sensitive; (c) chromadb/chroma.sqlite3 and a rag_profiles file are not sensitive under a widened sandbox root.
+2. Add single-source-of-truth path accessors so sensitive_paths.py can derive these locations instead of re-spelling literals: default_local_skills_store_dir()/default_trust_store_dir() (Skills_Interop) and default_rag_profiles_dir() (RAG_Search.config_profiles); wire app.py/ConfigProfileManager through them too so there is exactly one spelling of each name.
+3. Refuse the whole skills/trust subtree by ancestry (a deliberate carve-out from the skills/ container exemption), documented in both the module docstring and the new resolver's own docstring.
+4. Generalize the existing "any file directly in get_user_data_dir()" rule to three more container directories via a new SensitivePathContext.direct_child_denied_dirs field: the effective config directory, the ChromaDB persist directory, and the rag_profiles directory.
+5. Assess the audit's residual-fragility note about the three MCP filenames being re-spelled literals in sensitive_paths.py; decide whether to fix within this task's scope.
+6. Add regression tests deriving every new path from the same accessors the app uses (never literals); prove existing containers (skills/ itself, chromadb/, rag_profiles/, tool_sandbox/, an existing config-dir subdirectory) stay reachable, and that the default sandbox configuration still works end to end.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reproduced all three explicitly-scoped gaps first (real, unmocked repro scripts), confirmed each returned is_sensitive_path()==False before the fix, then confirmed True after.
+
+AC#1 (vector-store/sibling-profile paths, widened root): generalized the existing "any file directly in get_user_data_dir(), existing directories stay reachable" rule into a new SensitivePathContext.direct_child_denied_dirs tuple covering four container directories instead of one: get_user_data_dir(), the effective config directory, the ChromaDB persist directory (RAG_Search.simplified.config.default_chroma_persist_directory(), already existed), and the RAG-profile store (RAG_Search.config_profiles.default_rag_profiles_dir(), newly added -- no accessor existed before; ConfigProfileManager.__init__ now calls it too). chroma.sqlite3 and a rag_profiles file are now refused; the container directories and an existing per-collection subdirectory nested in chromadb/ stay reachable.
+
+AC#2 (skill trust/grant store, audit CRITICAL-3): get_user_data_dir()/skills/trust/ was structurally unreachable because `skills` is an existing-directory container exemption and everything nested under it inherited that exemption. Added two new small pure accessors (no prior single source of truth existed -- app.py built both names as inline literals): Skills_Interop.local_skills_service.default_local_skills_store_dir() and Skills_Interop.skill_trust_store.default_trust_store_dir(); app.py's service wiring now calls both instead of re-spelling "skills"/"trust", and the generation-marker filename was promoted from an app.py literal to a public MARKER_FILENAME constant in skill_trust_store.py. The whole trust/ subtree is refused by ancestry (like ~/.ssh), not just direct children, so manifest/grants/marker/every nested snapshot file are all covered; skills/ itself (outside trust/) stays reachable.
+
+AC#3 (config.toml .bak/.tmp sidecars, audit CRITICAL-4): DECISION -- generalized the direct-child-file rule to the effective config directory (config._get_effective_config_path().parent) rather than enumerating .bak/.tmp suffixes, because the audit's own live evidence showed unprotected files beyond those two suffixes (runtime_policy.json, ui_state.toml, an arbitrarily-named hand-made backup). One mechanism, reused from AC#1, catches all of them plus any future one; existing directories placed directly in the config dir (the real feed_cache/themes/tokenizers) stay reachable via the same is-a-directory gate.
+
+Assessed the audit's note that sensitive_paths.py re-spells the three MCP filenames (mcp_permissions.json, local_mcp_store.json, mcp_execution_log.jsonl) as its own literals. DECISION -- left as-is: no single source of truth exists anywhere in the codebase for these names (app.py and MCP/unified_control_plane_service.py each independently spell them too); fixing it properly requires touching MCP/local_store.py, MCP/unified_context_store.py, MCP/server_target_store.py, MCP/unified_control_plane_service.py, and app.py, none of which is named in this task's ACs. Documented as a known, deliberately out-of-scope residual fragility; recommend a follow-up task scoped to the MCP store-path family.
+
+AC#4: every new test derives its path from the actual accessor/constructor the app uses (default_local_skills_store_dir/default_trust_store_dir, a real constructed SkillTrustStore's own manifest_path/snapshots_dir, _SCRIPT_GRANTS_FILENAME/MARKER_FILENAME, config._get_effective_config_path(), default_chroma_persist_directory(), default_rag_profiles_dir()) -- never a re-spelled literal.
+
+Verified: `pytest Tests/Utils/ Tests/Tools/ Tests/Agents/ -q` -> 893 passed, 0 failed.
+
+Files: tldw_chatbook/Utils/sensitive_paths.py, tldw_chatbook/Skills_Interop/local_skills_service.py, tldw_chatbook/Skills_Interop/skill_trust_store.py, tldw_chatbook/Skills_Interop/__init__.py, tldw_chatbook/RAG_Search/config_profiles.py, tldw_chatbook/app.py, Tests/Utils/test_sensitive_paths.py, Tests/Tools/test_file_tool_sandbox.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-848 - Extend-agent-file-tool-denylist-beyond-the-active-user-data-folder.md
+++ b/backlog/tasks/task-848 - Extend-agent-file-tool-denylist-beyond-the-active-user-data-folder.md
@@ -4,6 +4,7 @@ title: Extend agent file-tool denylist beyond the active user data folder
 status: To Do
 assignee: []
 created_date: '2026-07-27 02:36'
+updated_date: '2026-07-27 04:36'
 labels:
   - tools
   - security
@@ -15,9 +16,18 @@ dependencies: []
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
 The denylist refuses files sitting directly in get_user_data_dir(), which covers the app's own state. Under a deliberately widened sandbox root, chromadb/chroma.sqlite3 (plaintext chunks of the same conversations and notes ChaChaNotes.db protects) and sibling profile folders remain readable. Reviewed as a disclosure asymmetry rather than a permission-gate bypass -- skill trust manifests are HMAC+keyring authenticated and script grants are digest-pinned, so tampering fails closed. Filed from the PR #953 review.
+
+Also explicitly in scope for this task (folded in from the TASK-846 path-hardening audit, recommendations 3 and 4):
+
+Skill trust/grant store. get_user_data_dir()/skills/trust/ (skill_trust_manifest.json, skill_script_grants.json, generation_marker.json, snapshots/, built at app.py:5181-5200) is not named by Utils/sensitive_paths.py at all, and the module's existing resolved.parent == user_data_dir rule cannot reach it: skills is an existing directory, so it is exempted by design (sensitive_paths.py:48-51 names skills among the intentionally-reachable containers), and everything nested under it inherits that exemption. skill_script_grants.json (Skills_Interop/skill_trust_service.py:49, joined at :661) is deliberately kept outside the MAC'd manifest -- it is the plain, unauthenticated JSON file that has_script_grant (:1452-1465) consults to authorize script execution, so it is not covered by the manifest's own HMAC+keyring integrity check either. A live check confirmed is_sensitive_path() returns False for skill_trust_manifest.json, skill_script_grants.json, generation_marker.json, the snapshots directory, and the skill index tldw_chatbook_skills.json. Reachability still requires a widened sandbox root or a bound workspace folder (the reachability path this task already covers), so this is uncovered surface rather than a live bypass today -- but it is the exact "one-step gate bypass" class the mcp_permissions.json denylist entry exists to prevent, and it sits squarely alongside the vector-store/sibling-profile gap this task was filed for.
+
+config.toml sidecars. UI/Screens/settings_screen.py:5596-5605's Advanced config save writes a full plaintext backup (config.toml.bak) before overwriting, plus a config.toml.tmp during the atomic swap; both carry every plaintext API key the live config holds. The denylist only names _get_effective_config_path() itself -- nothing else in that directory -- so neither sidecar is covered, and the equivalent DB-sidecar treatment the module already has (_DB_SIDECAR_SUFFIXES for -wal/-shm/-journal, and the MCP permission store's own .bak via the user_data_dir file rule) does not extend to ~/.config/tldw_cli, where config.toml actually lives. Two hand-made copies already sit unprotected on disk on the audit machine (config.toml.bak-1785079350, config.toml.pre-lab-cleanup, both 45 KB).
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [ ] #1 Vector-store and sibling-profile paths are refused under a widened sandbox root,The default sandbox configuration still works end to end,A test pins both directions
+- [ ] #2 The skill trust/grant store (skill_trust_manifest.json, skill_script_grants.json, generation_marker.json, snapshots/) under get_user_data_dir()/skills/trust/ is refused by the denylist even though skills/ itself remains reachable
+- [ ] #3 config.toml's .bak and .tmp sidecars (and any other file directly in the effective config's directory) are refused by the denylist
+- [ ] #4 A test derives the trust-store and config-sidecar paths from the same accessors the app uses (SkillTrustStore/SkillTrustService attributes; _get_effective_config_path()) rather than asserting literals
 <!-- AC:END -->

--- a/backlog/tasks/task-849 - Agent-created-directory-can-shadow-a-not-yet-created-state-file.md
+++ b/backlog/tasks/task-849 - Agent-created-directory-can-shadow-a-not-yet-created-state-file.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-849
 title: Agent-created directory can shadow a not-yet-created state file
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-27 02:36'
+updated_date: '2026-07-27 05:07'
 labels:
   - tools
   - security
@@ -19,5 +20,32 @@ The denylist's direct-child rule is gated on whether a path is an existing direc
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 An agent cannot create a directory whose name collides with a known app state file,Existing container subdirectories under the user data dir stay reachable,A regression test covers the collision
+- [x] #1 An agent cannot create a directory whose name collides with a known app state file,Existing container subdirectories under the user data dir stay reachable,A regression test covers the collision
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the exact defect: create get_user_data_dir()/search_history.db as a directory and confirm is_sensitive_path returns False; then confirm the full attack chain is reachable via WriteFileTool.execute(create_directories=True) under a widened sandbox root, and that the app's own sqlite3.connect on that path then fails (denial of service).
+2. Add refuses_new_directory_chain(), which walks upward from a not-yet-created target directory, consulting is_sensitive_path on each not-yet-existing ancestor (reusing the existing gate, never loosening it) and stopping at the first EXISTING ancestor -- so a legitimate pre-existing container is never blocked.
+3. Wire it into WriteFileTool.execute's create_directories=True path, before Path.mkdir(parents=True).
+4. Add regression tests: the collision itself (unit-level walk + tool-level end to end through WriteFileTool), plus two "still works" tests (a brand-new subdirectory nested inside an existing container, and the real default sandbox configuration end to end).
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reproduced the full chain first: created get_user_data_dir()/search_history.db as a directory and confirmed is_sensitive_path() returned False; then, under a widened sandbox root (== get_user_data_dir()), called the real WriteFileTool.execute(file_path="search_history.db/note.txt", create_directories=True) and confirmed it silently created search_history.db/ as a directory (the tool never validated the intermediate directory level, only the final leaf file); then confirmed sqlite3.connect() on that path fails outright (denial of service).
+
+Root cause: WriteFileTool's is_sensitive_path(path) check only ever validated the FINAL file being written, never the new directory levels Path.mkdir(parents=True) creates on the way there.
+
+Fix: added refuses_new_directory_chain(target_dir, context=None) to Utils/sensitive_paths.py. It walks upward from target_dir while each level does not yet exist, calling the EXISTING is_sensitive_path on each such level (never a separate check, never a loosened gate) and stopping at the first already-existing ancestor -- mirroring exactly what Path.mkdir(parents=True) would actually create. Wired into WriteFileTool.execute immediately before its own mkdir call.
+
+Deliberately did NOT change is_sensitive_path's own "is an existing directory" gate: an already-existing search_history.db/ directory (predating this fix, or created by any other means) still reads as an ordinary reachable container, since there is no name-independent way to distinguish a legitimate pre-existing container from an illegitimate one, and the whole point of that gate is to avoid a name enumeration. The fix closes the hole at CREATION time instead, which is also the only place the agent tools can actually cause the collision.
+
+Verified both directions end to end through the real WriteFileTool: the collision (search_history.db/note.txt) is now refused before any directory is created; a brand-new subdirectory nested inside an EXISTING container (tool_sandbox/brand_new_subdir/note.txt) still succeeds, under both the default and a widened sandbox root; the real unmocked default sandbox configuration still works end to end (pre-existing test, unmodified, still passes).
+
+Verified: `pytest Tests/Utils/ Tests/Tools/ Tests/Agents/ -q` -> 893 passed, 0 failed.
+
+Files: tldw_chatbook/Utils/sensitive_paths.py, tldw_chatbook/Tools/file_operation_tools.py, Tests/Utils/test_sensitive_paths.py, Tests/Tools/test_file_tool_sandbox.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-850 - Scope-glob_files-and-grep_files-to-workspace-folder-roots.md
+++ b/backlog/tasks/task-850 - Scope-glob_files-and-grep_files-to-workspace-folder-roots.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-850
 title: Scope glob_files and grep_files to workspace folder roots
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-27 02:36'
+updated_date: '2026-07-27 05:54'
 labels:
   - tools
   - security
@@ -19,5 +21,35 @@ read_file, write_file and list_directory honour dev's allowed_file_roots workspa
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 glob_files and grep_files honour the same root set as read_file,Sandbox-only configurations behave exactly as before,A test covers a workspace-bound folder for both tools
+- [x] #1 glob_files and grep_files honour the same root set as read_file,Sandbox-only configurations behave exactly as before,A test covers a workspace-bound folder for both tools
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Read how ReadFileTool/WriteFileTool/ListDirectoryTool resolve allowed_file_roots() and reuse the exact same call for GlobFiles/GrepFiles.
+2. Add a shared _iter_candidates_across_roots() generator that globs each usable root in turn, applying containment (is_within), the sensitive-path denylist, and the hidden-component rule to every candidate from every root, with _MAX_CANDIDATES enforced globally across all roots (not per root) and results deduplicated by resolved identity.
+3. Decide and implement the dotted-root rule for a root SET: check _sandbox_root_is_hidden per root, exclude a dotted root from the search rather than failing the whole call; refuse the call only when zero roots survive that filter (preserves the existing single-root/sandbox-only behavior exactly).
+4. Resolve SensitivePathContext once per call in both GlobFiles.execute and GrepFiles.execute, threaded through to every candidate check.
+5. Add tests: workspace-bound-folder coverage for both tools, cross-root merge without duplication, shared candidate bound across roots, the dotted-root-is-skipped-not-fatal decision, and a proof that a path outside every configured root stays refused by all five file tools (read/write/list directly, glob/grep via a symlink planted inside an allowed root).
+6. Run Tests/Utils Tests/Tools Tests/Agents to confirm no regressions.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+GlobFiles.execute/GrepFiles.execute now call allowed_file_roots(write=False, sandbox_root=_tool_sandbox_root()) -- the SAME accessor read_file/write_file/list_directory already use -- instead of globbing the sandbox root alone.
+
+A new shared generator, _iter_candidates_across_roots(pattern, roots, sensitive_ctx), globs each usable root in turn and yields validated candidates: containment (is_within, which also applies the sensitive-path denylist) and the hidden-component rule (_is_hidden_within) apply to every candidate from every root. _MAX_CANDIDATES is enforced as a single counter shared across all roots (not reset per root), so N configured roots cannot multiply the worst-case walk by N, and a candidate reachable through more than one root is deduplicated by resolved identity so it is never reported twice.
+
+Dotted-root rule, decided and documented: _sandbox_root_is_hidden is now checked once per root (via a usable_roots = [r for r in roots if not _sandbox_root_is_hidden(r)] filter) rather than once against a single sandbox root. A dotted root is excluded from the search; the whole call is refused only when NO root survives that filter -- which is exactly the pre-existing single-root (sandbox-only, dotted) case, so that behavior is unchanged. This is documented in _sandbox_root_is_hidden's and _iter_candidates_across_roots's docstrings and pinned by test_dotted_workspace_root_is_skipped_not_fatal_to_other_roots.
+
+SensitivePathContext is still resolved exactly once per call (resolve_sensitive_context()), now threaded through every root's candidates rather than just the sandbox's.
+
+Tests added in Tests/Tools/test_file_tools_workspace_roots.py: glob/grep find files in a bound workspace folder, results merge across sandbox+bound folder without duplication, _MAX_CANDIDATES bounds the total examined across roots (not per root), the dotted-root decision, and a proof that a path outside every configured root stays refused across all five file tools (read/write/list directly against the path; glob/grep via a symlink planted inside an allowed root, since they take no target-path argument at all).
+
+Modified: tldw_chatbook/Tools/file_operation_tools.py (GlobFiles.execute, GrepFiles.execute, new _iter_candidates_across_roots, _sandbox_root_is_hidden docstring update).
+Added tests: Tests/Tools/test_file_tools_workspace_roots.py.
+
+This task was implemented together with TASK-843 (same file, same commit sequence) since both touch GrepFiles.execute.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-851 - Route-config-encryption-through-the-effective-config-path-not-the-default-one.md
+++ b/backlog/tasks/task-851 - Route-config-encryption-through-the-effective-config-path-not-the-default-one.md
@@ -1,0 +1,30 @@
+---
+id: TASK-851
+title: 'Route config encryption through the effective config path, not the default one'
+status: To Do
+assignee: []
+created_date: '2026-07-27 04:34'
+labels:
+  - security
+  - config
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+tldw_chatbook/config.py's three encryption entry points -- enable_config_encryption (:4309-4330), disable_config_encryption (:4362-4393), and change_encryption_password (:4425-4458) -- open DEFAULT_CONFIG_PATH (config.py:46) directly instead of _get_effective_config_path() (config.py:49), the accessor every other read/write in the app uses (config.py:681, :3597, :3893, :3994) and that honors TLDW_CONFIG_PATH. TLDW_CONFIG_PATH is a supported, user-facing mode (the "Override config" control at UI/Screens/settings_screen.py:5035-5058, documented at runtime_policy/bootstrap.py:30, and exercised by this project's own test suite), so any user running with a profile active hits this gap.
+
+A sandboxed reproduction (real enable_config_encryption call, HOME redirected, a profile config active via TLDW_CONFIG_PATH) showed: enable_config_encryption('hunter2hunter2') returns True, the ACTIVE profile's plaintext secret is still present afterward, and a completely different file -- DEFAULT_CONFIG_PATH -- was the one actually rewritten. disable_config_encryption and change_encryption_password then read encryption.password_verifier from that same wrong file and fail with "No password verifier found", so a user who did get encrypted (on the default path, no profile active) cannot rotate or remove the password once a profile becomes active. Live UI callers are UI/Tools_Settings_Window.py:3857, :3897, :6787, :6838, :6936, so this is reachable from the Settings screen, not just internal API misuse.
+
+Secondary defect in the same code: config.py:4330 writes with plain open(path, "w") while the sibling entry points (:4393, :4458) use atomic_write_text, so an interrupted "enable encryption" can truncate the config it does manage to hit.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All three encryption entry points (enable_config_encryption, disable_config_encryption, change_encryption_password) read and write through _get_effective_config_path() instead of DEFAULT_CONFIG_PATH
+- [ ] #2 All three entry points use the same atomic-write helper (atomic_write_text) as their siblings
+- [ ] #3 A regression test sets TLDW_CONFIG_PATH to a profile file, calls each entry point, and asserts the change landed in the file _get_effective_config_path() returns, not in a hardcoded literal
+- [ ] #4 Enabling, disabling, and rotating encryption with a profile active round-trips correctly (password verifier readable, secrets encrypted/decrypted in the active file)
+<!-- AC:END -->

--- a/backlog/tasks/task-852 - Make-should_encrypt_config-detect-real-provider-API-keys-and-unify-the-four-sensitive-key-lists.md
+++ b/backlog/tasks/task-852 - Make-should_encrypt_config-detect-real-provider-API-keys-and-unify-the-four-sensitive-key-lists.md
@@ -1,0 +1,30 @@
+---
+id: TASK-852
+title: >-
+  Make should_encrypt_config() detect real provider API keys, and unify the four
+  sensitive-key lists
+status: To Do
+assignee: []
+created_date: '2026-07-27 04:34'
+labels:
+  - security
+  - config
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Utils/config_encryption.py:245-256 detect_api_keys flags a key only when it exactly equals one of six literals ("api_key", "apikey", "api-key", "secret", "token", "password"). Every real secret-bearing key in this app is prefixed or suffixed instead: openai_api_key, anthropic_api_key, cohere_api_key, bing_search_api_key, tavily_search_api_key, api_token (github/confluence), auth_token ([tldw_api]), OPENAI_API_KEY_fallback, ELEVENLABS_API_KEY_fallback (config.py:66,70, written by UI/Tools_Settings_Window.py:5521,5541) -- none of them equals any of the six literals, so none of them is ever detected. config.py:4285 should_encrypt_config() returns detect_api_keys(config) directly, so a live config full of plaintext provider keys is reported as having nothing worth encrypting and the user is never prompted to turn encryption on. A direct check against a config populated with all of the above real keys returned False; the same function against a synthetic {'x': {'api_key': 'sk-1'}} returned True.
+
+This exact-match/substring mismatch is one of four independent, disagreeing copies of "what counts as a sensitive config key": config.py:3691 _is_sensitive_setting_key (substring match), UI/Screens/settings_privacy_security.py:190 _is_sensitive_config_key (endswith match, guards _env_var), config_encryption.py:250 (exact match, this finding), and a fourth block at config.py:515-546 that duplicates :3693-3718 verbatim. A side-by-side check found keys the two main copies disagree on in both directions: config._is_sensitive_setting_key treats api_key_env_var (an env-var name, not a secret, appearing 20+ times in the default TOML) and max_tokens (30+ occurrences) as sensitive -- so encrypt_sensitive_fields (config.py:554) encrypts an env-var name into an enc: blob and _setting_value_for_log (:3721) logs max_tokens as <redacted> -- while settings_privacy_security's counts (:153,160) miss the real [app_tts] *_fallback keys and search_engine_api_key_* entirely, undercounting what the Privacy & Security panel reports as protected.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 should_encrypt_config()/detect_api_keys() recognizes all real provider-key config names (the *_api_key, *_token, and *_fallback families actually written by the app), not just the six literal names
+- [ ] #2 The four independent sensitive-key-matching implementations (config.py:3691, config.py:515-546, config_encryption.py:250, settings_privacy_security.py:190) are collapsed into a single shared predicate with one semantics
+- [ ] #3 The unified predicate excludes non-secret keys such as api_key_env_var and max_tokens that the substring-matching copy currently over-flags
+- [ ] #4 A test builds its key list by reading the real key names out of CONFIG_TOML_CONTENT (or the equivalent live default config), not by re-asserting a hand-picked literal list, and confirms every one of them is detected
+<!-- AC:END -->

--- a/backlog/tasks/task-853 - Fix-the-two-skills-trust-path-containment-checks-that-cant-actually-reject-anything.md
+++ b/backlog/tasks/task-853 - Fix-the-two-skills-trust-path-containment-checks-that-cant-actually-reject-anything.md
@@ -1,0 +1,32 @@
+---
+id: TASK-853
+title: >-
+  Fix the two skills-trust path containment checks that can't actually reject
+  anything
+status: To Do
+assignee: []
+created_date: '2026-07-27 04:34'
+labels:
+  - security
+  - skills
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Two independent containment checks in the skills-trust code are broken in ways that make them pass by construction.
+
+Skills_Interop/skill_trust_store.py:93-96 and :110 call _validated_trust_file_path(self.marker_path, base_dir=self.marker_path.parent) -- i.e. the base directory is the candidate path's own parent. _validated_trust_file_path (:544-554) rejects when get_safe_relative_path(candidate, base) is None, but with base == candidate.parent that condition can never be true, so the check accepts any path. The correct pattern already exists two methods away: _validated_manifest_path (:490-491) passes base_dir=self.store_dir, and store_dir was available at the marker's construction site (app.py:5186). A reproduction confirmed base_dir=path.parent accepts a marker path in a totally unrelated directory, while base_dir=the real store correctly rejects it.
+
+Skills_Interop/local_skills_service.py:1765-1804 _unsafe_scratch_root derives its container list correctly (self.skills_dir, trust_store.store_dir) but tests containment backwards: get_safe_relative_path(root, container) is non-None only when root is INSIDE container, so a scratch root nested inside the stores is flagged unsafe while a scratch root that CONTAINS both stores is not -- the opposite of what the docstring (:1782-1791) promises. A reproduction with real container paths showed: a root inside skills_dir is (correctly) flagged unsafe, but skills/ itself and the user's whole default_user directory -- both of which contain the stores -- are not flagged. self.store_dir (which holds the skill index tldw_chatbook_skills.json) isn't even in the container list. [skills] script_scratch_root = ~/.local/share/tldw_cli/<user>/skills would pass today and place a script's cwd one level above every trusted bundle and the trust manifest/snapshots/grants.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 skill_trust_store.py's marker-path validation passes base_dir=self.store_dir (or an equivalent real containing directory), not the candidate's own parent
+- [ ] #2 _unsafe_scratch_root rejects a candidate root that is inside a container AND a candidate root that contains a container (both directions), and includes self.store_dir in its container list
+- [ ] #3 A test exercises both containment directions for each check using the real store/scratch-root attributes (not hardcoded literal paths) and confirms both a nested-inside and a containing candidate are rejected
+- [ ] #4 Existing trust-store and scratch-root tests that only asserted the working direction are extended to cover the previously-vacuous direction
+<!-- AC:END -->

--- a/backlog/tasks/task-854 - Fix-MCP-servers-media-DB-lookup-to-use-the-real-config-key-accessor.md
+++ b/backlog/tasks/task-854 - Fix-MCP-servers-media-DB-lookup-to-use-the-real-config-key-accessor.md
@@ -1,0 +1,26 @@
+---
+id: TASK-854
+title: Fix MCP server's media DB lookup to use the real config key/accessor
+status: To Do
+assignee: []
+created_date: '2026-07-27 04:34'
+labels:
+  - security
+  - mcp
+  - config
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+MCP/server.py:154-155 calls get_cli_setting("database", "media_db", "media_library.db"); the actual config key is media_db_path (declared config.py:2233, live in config at line 30, read via get_media_db_path() at config.py:4622). Because the key "media_db" doesn't exist, the lookup always falls through to the relative literal, so the MCP server creates/opens ./media_library.db relative to whatever directory it was launched from -- a live reproduction showed it landing at .../wt-path-hardening/media_library.db (a repo checkout) rather than the app's real .../default_user/tldw_chatbook_media_v2.db. The two lines immediately above this one correctly call get_chachanotes_db_path() for the conversations DB, so this is an isolated miss, not a pattern. Utils/sensitive_paths.py:98 denylists get_media_db_path()'s result -- the DB the MCP server does not actually use -- so everything the MCP media tools read or write through this path has no denylist coverage at all.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 MCP/server.py resolves the media DB path via get_media_db_path() (or the equivalent media_db_path config key), matching what the rest of the app opens
+- [ ] #2 A grep-based check (or test) confirms no other get_cli_setting("database", ...) call site in the codebase uses a key that isn't one of the declared *_db_path names
+- [ ] #3 A test starts/constructs the MCP server's media DB handle and asserts its resolved path equals get_media_db_path()'s return value, rather than asserting a literal filename
+- [ ] #4 The resolved media DB path is covered by is_sensitive_path() once the fix lands (verified by test, not by inspection)
+<!-- AC:END -->

--- a/backlog/tasks/task-855 - Make-MCP-store-module-defaults-derive-from-get_user_data_dir-not-~-.config-tldw_cli.md
+++ b/backlog/tasks/task-855 - Make-MCP-store-module-defaults-derive-from-get_user_data_dir-not-~-.config-tldw_cli.md
@@ -1,0 +1,26 @@
+---
+id: TASK-855
+title: >-
+  Make MCP store module defaults derive from get_user_data_dir(), not
+  ~/.config/tldw_cli
+status: To Do
+assignee: []
+created_date: '2026-07-27 04:34'
+labels:
+  - security
+  - mcp
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+MCP/local_store.py:13 (DEFAULT_LOCAL_MCP_STORE_PATH), MCP/unified_context_store.py:14-16, and MCP/server_target_store.py:13 all default to DEFAULT_CONFIG_PATH.parent / <name> -- i.e. ~/.config/tldw_cli/. Every real construction site instead passes get_user_data_dir() / <name> explicitly (app.py:5241, :5248, :4028), so today nothing actually uses the module defaults. This is rated latent rather than live because of what those defaults would produce if ever hit: MCP/unified_control_plane_service.py:2430 derives the permission-store path as Path(store.path).with_name("mcp_permissions.json"), and :2073 derives the execution-log path the same way from store.path. A LocalMCPStore() built with no explicit argument anywhere in the codebase, in a test, or in a future call site would silently place the permission store and execution log in ~/.config/tldw_cli/ -- a location neither _sensitive_single_file_paths() (which joins to get_user_data_dir()) nor the parent == user_data_dir rule in Utils/sensitive_paths.py covers. A reproduction confirmed is_sensitive_path() returns False for both ~/.config/tldw_cli/mcp_permissions.json and ~/.config/tldw_cli/local_mcp_store.json.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The three MCP store modules' default paths derive from get_user_data_dir(), or the classes require an explicit path argument with no config-relative fallback
+- [ ] #2 A test constructs each store with no explicit path and asserts the resulting path matches the get_user_data_dir()-derived location (or that construction without an explicit path is disallowed), not a hardcoded ~/.config/tldw_cli literal
+- [ ] #3 Every current explicit-path construction site (app.py:5241, :5248, :4028) continues to resolve to the same paths as before
+<!-- AC:END -->

--- a/backlog/tasks/task-856 - Decide-the-fate-of-Utils-log_sanitizer.py-wire-it-in-fixed-or-delete-it.md
+++ b/backlog/tasks/task-856 - Decide-the-fate-of-Utils-log_sanitizer.py-wire-it-in-fixed-or-delete-it.md
@@ -1,0 +1,26 @@
+---
+id: TASK-856
+title: 'Decide the fate of Utils/log_sanitizer.py: wire it in fixed, or delete it'
+status: To Do
+assignee: []
+created_date: '2026-07-27 04:35'
+labels:
+  - security
+  - config
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Utils/log_sanitizer.py has zero production importers -- a repo-wide grep for log_sanitizer under tldw_chatbook/ and Tests/ finds only Tests/Utils/test_security_enhancements.py. The 40+ sanitize_string call sites elsewhere in the app resolve to a different function in Utils/input_validation.py. So every literal in this module protects nothing at runtime today; only the test file exercises it, making that test green and vacuous.
+
+Independent of the dead-import problem, the module's rules are wrong in both directions. log_sanitizer.py:16 labels the pattern claude-[a-zA-Z0-9-]+ as matching "Anthropic keys", but claude-* is the model-id prefix (e.g. claude-opus-4-20250514), not a key format; a reproduction showed a log line naming the model claude-opus-4-20250514 gets its model name destroyed (replaced with ***ANTHROPIC_KEY***) while a real Anthropic key (sk-ant-api03-...) and a real OpenAI key (sk-proj-...) both survive sanitize_string unredacted, because :15's sk-[a-zA-Z0-9]{20,} character class excludes "-" and stops at "sk-ant"/"sk-proj". sanitize_dict() similarly redacts openai_api_key and auth_token but passes x-api-key, cohere_api_key, api_token, secret_key, and refresh_token through untouched. SENSITIVE_FIELDS also names ten literals that appear nowhere in this codebase (aws_access_key_id, connection_string, private_key, etc.) and misses roughly 30 real ones. If this module is ever wired in as-is, it will strip model names from logs while letting real credentials through.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A decision is made and implemented: either log_sanitizer.py is deleted (along with its now-vacuous test), or it is fixed (correct key-format regexes, a field list that matches the app's real key names, an inverted Anthropic-key rule corrected) and wired into at least the log paths that currently rely on Utils/input_validation.sanitize_string for secret redaction
+- [ ] #2 If kept, a test builds its expected-redacted-field list from the app's real config key names (not the module's own literal list) and confirms every real provider key format (openai, anthropic, cohere, etc.) is actually redacted from a sample log line
+- [ ] #3 If deleted, its test file is removed and no remaining code references the module
+<!-- AC:END -->

--- a/backlog/tasks/task-857 - Make-workspace-folder-binding-consult-the-sensitive-path-denylist-not-just-home-root.md
+++ b/backlog/tasks/task-857 - Make-workspace-folder-binding-consult-the-sensitive-path-denylist-not-just-home-root.md
@@ -1,0 +1,26 @@
+---
+id: TASK-857
+title: >-
+  Make workspace folder-binding consult the sensitive-path denylist, not just
+  home/root
+status: To Do
+assignee: []
+created_date: '2026-07-27 04:35'
+labels:
+  - security
+  - tools
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Workspaces/registry_service.py:673-707 validates a folder root to bind as a workspace. Its docstring (:666-669) claims it denies "the filesystem root, the home directory itself, non-directories, and duplicate/nested roots", but the implementation only checks two exact equalities: resolved == Path(resolved.anchor) (:683) and resolved == Path.home().resolve() (:688). There is no reference to Utils/sensitive_paths anywhere under tldw_chatbook/Workspaces/. As a result, binding ~/.config/tldw_cli (the live config, API keys included), ~/.local/share/tldw_cli (every app database), or ~/.ssh as a workspace folder root all pass this check. Because a bound folder root widens what the agent file tools may reach, this is the mechanism by which the uncovered skill trust store (and any other path the denylist doesn't individually enumerate) becomes reachable in practice: is_sensitive_path() still refuses the specific enumerated files once inside such a root, so this is scope-widening up to the edge of what the denylist enumerates, not a direct bypass of an individual file check.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Folder-binding validation rejects a candidate root that is, or resolves inside, any path flagged by is_sensitive_path() / the app's sensitive-path containers (user data dir, effective config dir, etc.), not just the filesystem root and home directory
+- [ ] #2 A test attempts to bind ~/.config/tldw_cli, get_user_data_dir(), and a subdirectory of get_user_data_dir() as workspace folder roots (derived from the real accessors, not literal strings) and confirms all are rejected
+- [ ] #3 A test confirms an ordinary, non-sensitive folder root still binds successfully (no regression on the common case)
+<!-- AC:END -->

--- a/backlog/tasks/task-858 - Reconcile-the-evals-prompts-media-rag-subscriptions-DB-path-maps-with-get_-_db_path.md
+++ b/backlog/tasks/task-858 - Reconcile-the-evals-prompts-media-rag-subscriptions-DB-path-maps-with-get_-_db_path.md
@@ -1,0 +1,30 @@
+---
+id: TASK-858
+title: >-
+  Reconcile the evals/prompts/media/rag/subscriptions DB path maps with
+  get_*_db_path()
+status: To Do
+assignee: []
+created_date: '2026-07-27 04:35'
+labels:
+  - security
+  - db
+  - config
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The evals DB alone is named three different, disagreeing ways: Event_Handlers/eval_db_operations.py:28 hardcodes Path.home()/".config"/"tldw_cli"/"evals.db"; the real accessor, Evals/eval_orchestrator.py:90-99, derives get_user_data_dir()/<user_id>/"evals.db"; and UI/Tools_Settings_Window.py:6493 reads a config key evals_db_path that is declared nowhere in config.py's [database] defaults (nor are rag_db_path or subscriptions_db_path). A sandboxed reproduction showed the literal resolving to .../.config/tldw_cli/evals.db, the real accessor resolving to .../.local/share/tldw_cli/default_user/evals.db, and the settings key resolving to '<undeclared>'.
+
+The same defect class appears at UI/Tools_Settings_Window.py:6480-6507 and :6631-6652: the DB path map backing the integrity-check, backup, vacuum, and chatbook-import maintenance operations omits the <user_folder> segment for all six databases it lists, AND uses wrong filenames for at least two of them (tldw_prompts_db.db vs. the real tldw_chatbook_prompts.db; tldw_media_db.db vs. the real tldw_chatbook_media_v2.db). Run as written, these maintenance operations operate on files the app never opens -- an integrity check or vacuum against these paths silently does nothing to the real, live databases.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 eval_db_operations.py resolves the evals DB path the same way Evals/eval_orchestrator.py does (via get_user_data_dir(), not a Path.home()/'.config' literal)
+- [ ] #2 The DB path map behind the Settings screen's integrity check, backup, vacuum, and chatbook-import features is rebuilt from the real get_*_db_path() accessors for every database it lists, with corrected filenames
+- [ ] #3 evals_db_path, rag_db_path, and subscriptions_db_path are either declared as real config defaults or removed as dead config-key references
+- [ ] #4 A test asserts each maintenance-operation path equals its corresponding get_*_db_path() return value, not a hand-typed literal, for all six databases
+<!-- AC:END -->

--- a/backlog/tasks/task-859 - Delete-or-implement-the-unread-subscriptions.security-switches-and-stale-metadata-denylist.md
+++ b/backlog/tasks/task-859 - Delete-or-implement-the-unread-subscriptions.security-switches-and-stale-metadata-denylist.md
@@ -1,0 +1,29 @@
+---
+id: TASK-859
+title: >-
+  Delete or implement the unread [subscriptions.security] switches and stale
+  metadata denylist
+status: To Do
+assignee: []
+created_date: '2026-07-27 04:35'
+labels:
+  - security
+  - config
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+config.py:3471-3476 declares five keys under [subscriptions.security] (enable_ssrf_protection, max_redirects=5, verify_ssl_certificates, enable_xxe_protection, request_timeout), present in the live config at lines 1142-1148. A per-key grep across tldw_chatbook/ finds exactly one occurrence of each -- the declaration itself. The behavior these keys claim to control is actually governed elsewhere and does not read them: SSRF protection is really get_cli_setting("web_security","enabled",True) (Utils/egress.py:88); the redirect cap is really the hardcoded egress.MAX_REDIRECT_HOPS = 10 (egress.py:44), not the configured 5; SSL verification is really a per-subscription DB column ssl_verify (Subscriptions/monitoring_engine.py:393,397); XXE protection is an unconditional defusedxml import (Subscriptions/security.py:24-33). An operator who sets enable_ssrf_protection = false in [subscriptions.security] to intentionally relax SSRF protection changes nothing -- egress.py's real gate is untouched -- which reads as a documented escape hatch that silently does nothing (and, in the opposite direction, an operator "hardening" these keys gets no behavior change either).
+
+Separately, Subscriptions/security.py:79,85-89 defines its own BLOCKED_SCHEMES and METADATA_ENDPOINTS, each with exactly one occurrence in the codebase (the definition). The real enforcement path is Utils/egress.py:35-44 (reached via security.py:129-135's evaluate_url_policy). A side-by-side diff found this list is already missing two hosts/IPs that egress.py does enforce (100.100.100.200, fd00:ec2::254). Harmless today only because egress is strictly stronger, but it is an authoritative-looking denylist that enforces nothing and is already stale -- a trap for the next person who extends "the" metadata list in the wrong place.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The [subscriptions.security] keys either actually gate the behavior they claim to (SSRF protection, redirect cap, SSL verification, XXE protection, timeout), routed through the real egress.py/monitoring_engine.py controls, or are removed from config.py and the default TOML
+- [ ] #2 Subscriptions/security.py's BLOCKED_SCHEMES and METADATA_ENDPOINTS are either removed in favor of Utils/egress.py's enforcement, or kept in sync with it (including the two currently-missing entries) and demonstrably consulted somewhere
+- [ ] #3 A test confirms that toggling whichever [subscriptions.security] keys survive actually changes runtime behavior (e.g. redirect count, SSL verification), not just that the config value round-trips
+- [ ] #4 No security-relevant metadata/scheme denylist exists in more than one place without a test tying them together
+<!-- AC:END -->

--- a/backlog/tasks/task-860 - Fix-sql_validation.VALID_TABLES-to-match-the-real-schema-keyword_collections-is-live-broken.md
+++ b/backlog/tasks/task-860 - Fix-sql_validation.VALID_TABLES-to-match-the-real-schema-keyword_collections-is-live-broken.md
@@ -1,0 +1,29 @@
+---
+id: TASK-860
+title: >-
+  Fix sql_validation.VALID_TABLES to match the real schema (keyword_collections
+  is live-broken)
+status: To Do
+assignee: []
+created_date: '2026-07-27 04:35'
+labels:
+  - security
+  - db
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+DB/sql_validation.py:14-24's VALID_TABLES['chachanotes'] allowlists 9 table names; the ChaChaNotes schema actually has 35 tables. This is a live, reproducible feature break, not just a theoretical gap: the allowlist includes the link table collection_keywords but omits the entity table keyword_collections, and ChaChaNotes_DB.py:9309 update_keyword_collection() -> _update_generic_item() -> :4312 validate_table_name(table_name, "chachanotes") raises ValueError for it. A direct reproduction -- add_keyword_collection('Coll A') followed by update_keyword_collection(1, {'name': 'Coll B'}, expected_version=1) -- created the collection successfully and then failed the update with "Invalid table name: keyword_collections". A full diff against the live schema found 25 more real tables missing from the allowlist (character_expression_images, chat_dictionaries, conversation_dictionaries, conversation_local_marks, conversation_world_books, db_schema_version, decks, flashcard_assets, flashcard_templates, flashcards, learning_paths, message_attachments, message_generation_metadata, mindmap_nodes, mindmaps, quiz_attempts, quiz_questions, quizzes, review_history, study_sessions, sync_conflicts, sync_sessions, topics, world_book_entries, world_books).
+
+Separately, DB/sql_validation.py:308's VALID_COLUMNS gate (if table_name and table_name in VALID_COLUMNS) silently no-ops for any table_name not among its 8 keys. Real call sites pass table names it doesn't recognize -- "sync_profile_state" (Sync_Interop/sync_state_repository.py:1875, immediately before an ALTER TABLE ... ADD COLUMN f-string) and Transcripts/MediaChunks/UnvectorizedMediaChunks/DocumentVersions (DB/Client_Media_DB_v2.py:2950-2952, :3180-3182) -- so only the generic \w+/reserved-word filter applies to them, not the column-specific check their surrounding code comments claim is in effect. Not exploitable today since all of these inputs are in-file literals, but the schema validation those call sites document is not actually delivered.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 sql_validation.VALID_TABLES['chachanotes'] includes keyword_collections and every other real table in the live schema (all 26 currently-missing names reconciled, added or deliberately excluded with a documented reason)
+- [ ] #2 update_keyword_collection() succeeds end to end (create then update) without a false-positive ValueError
+- [ ] #3 A test derives its expected table list from the live schema (e.g. sqlite_master or the DB's own migration-applied table set) rather than re-typing a literal list, so it catches future schema/allowlist drift
+- [ ] #4 A decision is made and implemented for VALID_COLUMNS: either it fails closed for table names absent from its key set, or every real caller's table name is added to it
+<!-- AC:END -->

--- a/backlog/tasks/task-861 - Sweep-hardcoded-~-.config-tldw_cli-and-~-.local-share-tldw_cli-call-sites-onto-the-real-accessors.md
+++ b/backlog/tasks/task-861 - Sweep-hardcoded-~-.config-tldw_cli-and-~-.local-share-tldw_cli-call-sites-onto-the-real-accessors.md
@@ -1,0 +1,29 @@
+---
+id: TASK-861
+title: >-
+  Sweep hardcoded ~/.config/tldw_cli and ~/.local/share/tldw_cli call sites onto
+  the real accessors
+status: To Do
+assignee: []
+created_date: '2026-07-27 04:35'
+labels:
+  - security
+  - config
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Around 30 call sites build config/state paths from Path.home()/".config"/"tldw_cli"/... or Path.home()/".local"/"share"/"tldw_cli"/... directly instead of using _get_effective_config_path().parent or get_user_data_dir(). The config-dir group (UI/Screens/chat_screen.py:15394,15425 for ui_state.toml; Event_Handlers/notes_events.py:144 and note_ingest_events.py:350 for note_templates.json; Subscriptions/website_monitor.py:72 for feed_cache/, plus ~25 lower-value sites) silently ignores TLDW_CONFIG_PATH -- these files land in the real ~/.config/tldw_cli regardless of which profile is active.
+
+The data-dir group (~18 sites, including Chatbooks/chatbook_importer.py:77-79, Chatbooks/local_chatbook_service.py:102-107, Character_Chat/Character_Chat_Lib.py:1274,2790,3856, Event_Handlers/conv_char_events.py:4152,4213,4264) additionally omits the <user_folder> segment that get_user_data_dir() appends, so multi-user profiles collide into the same directory. The chatbook importer is the highest-value fix in this group because the drift is already live in production, not latent: a reproduction showed chatbook_importer.py:77's literal ~/.local/share/tldw_cli/temp/imports already exists on disk, while the derived, correct .../default_user/temp/imports (matching chatbook_creator.py:97's sibling path) does not -- meaning imports have been extracting to a path outside the per-user tree that any other local user account, or a future multi-profile user, would also read and write.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Every listed config-dir call site derives its parent directory from _get_effective_config_path().parent instead of a Path.home()/'.config'/'tldw_cli' literal
+- [ ] #2 Every listed data-dir call site derives its path from get_user_data_dir() instead of a Path.home()/'.local'/'share'/'tldw_cli' literal that omits the user folder segment
+- [ ] #3 The chatbook importer's extraction root matches the chatbook creator's temp root (both under get_user_data_dir()/temp/...) with a test asserting the two derive to the same parent
+- [ ] #4 A test with TLDW_CONFIG_PATH pointed at a profile confirms at least one swept config-dir site (e.g. ui_state.toml) writes under that profile's directory, not the real ~/.config/tldw_cli
+<!-- AC:END -->

--- a/backlog/tasks/task-862 - Make-sensitive-path-and-skills-fixture-tests-re-derive-paths-instead-of-re-spelling-them.md
+++ b/backlog/tasks/task-862 - Make-sensitive-path-and-skills-fixture-tests-re-derive-paths-instead-of-re-spelling-them.md
@@ -1,0 +1,31 @@
+---
+id: TASK-862
+title: >-
+  Make sensitive-path and skills-fixture tests re-derive paths instead of
+  re-spelling them
+status: To Do
+assignee: []
+created_date: '2026-07-27 04:35'
+labels:
+  - security
+  - tools
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Two existing test sites assert one of the app's security-relevant paths by re-typing a literal that happens to match today's code rather than deriving it from the same accessor the app uses, so they would go vacuous in lockstep with a future refactor instead of catching it. This is the exact defect class TASK-846 was opened to inventory, so its own test suite should not carry an instance of it.
+
+Tests/Utils/test_sensitive_paths.py:73-75 re-spells the three MCP store filenames joined to get_user_data_dir(), the same way Utils/sensitive_paths.py:209-211 does internally -- both agree with unified_control_plane_service.py:2430/:2073 today only because store.path's parent happens to be get_user_data_dir(). If app.py:5241 ever moves local_mcp_store.json into a subdirectory, the test and the production module drift together and neither the parent == user_data_dir fallback nor this test would catch the reintroduced bug -- the test should instead derive its expected path from app.unified_mcp_service.permission_store.path (the live object), not from a re-typed app.py expression.
+
+Tests/conftest.py:566-575 and Tests/Skills/test_skills_library_flow.py:84-106 build their skills-fixture paths the same re-spelling way rather than reading them off the real SkillTrustService/local_skills_service objects under test.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Tests/Utils/test_sensitive_paths.py's MCP-store-path assertions derive their expected paths from the live store objects (e.g. app.unified_mcp_service.permission_store.path) instead of re-typing the get_user_data_dir()-joined literal
+- [ ] #2 Tests/conftest.py and Tests/Skills/test_skills_library_flow.py's skills-fixture paths derive from the real SkillTrustService/local_skills_service attributes instead of a re-spelled literal
+- [ ] #3 Both updated tests still pass against the current, correct code
+- [ ] #4 A deliberately introduced path change in the corresponding production accessor (temporarily, while verifying) causes each updated test to fail, confirming it actually re-derives rather than re-asserts
+<!-- AC:END -->

--- a/backlog/tasks/task-864 - Fix-sql_validation.VALID_TABLES-to-match-the-real-schema-keyword_collections-is-live-broken.md
+++ b/backlog/tasks/task-864 - Fix-sql_validation.VALID_TABLES-to-match-the-real-schema-keyword_collections-is-live-broken.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-860
+id: TASK-864
 title: >-
   Fix sql_validation.VALID_TABLES to match the real schema (keyword_collections
   is live-broken)

--- a/backlog/tasks/task-865 - Sweep-hardcoded-~-.config-tldw_cli-and-~-.local-share-tldw_cli-call-sites-onto-the-real-accessors.md
+++ b/backlog/tasks/task-865 - Sweep-hardcoded-~-.config-tldw_cli-and-~-.local-share-tldw_cli-call-sites-onto-the-real-accessors.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-861
+id: TASK-865
 title: >-
   Sweep hardcoded ~/.config/tldw_cli and ~/.local/share/tldw_cli call sites onto
   the real accessors

--- a/backlog/tasks/task-866 - Make-sensitive-path-and-skills-fixture-tests-re-derive-paths-instead-of-re-spelling-them.md
+++ b/backlog/tasks/task-866 - Make-sensitive-path-and-skills-fixture-tests-re-derive-paths-instead-of-re-spelling-them.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-862
+id: TASK-866
 title: >-
   Make sensitive-path and skills-fixture tests re-derive paths instead of
   re-spelling them

--- a/tldw_chatbook/RAG_Search/config_profiles.py
+++ b/tldw_chatbook/RAG_Search/config_profiles.py
@@ -30,6 +30,27 @@ def _slugify(name: str) -> str:
     return slug or "profile"
 
 
+#: Name of this app's RAG-profile store directory, directly under
+#: ``get_user_data_dir()``.
+_RAG_PROFILES_DIRNAME = "rag_profiles"
+
+
+def default_rag_profiles_dir() -> Path:
+    """Return this app's default RAG-profile store directory.
+
+    Single source of truth for the ``rag_profiles`` subdirectory name --
+    ``ConfigProfileManager.__init__`` calls this for its own default (rather
+    than re-spelling the name inline), and ``Utils.sensitive_paths`` calls
+    it to refuse a profile file placed directly inside it (the same class
+    of plaintext RAG-provider config a widened sandbox root would otherwise
+    expose next to the vector store; see that module's docstring).
+
+    Returns:
+        ``get_user_data_dir() / "rag_profiles"``.
+    """
+    return get_user_data_dir() / _RAG_PROFILES_DIRNAME
+
+
 # Filenames under profiles_dir that are never treated as user-profile files.
 _RESERVED_PROFILE_FILES = {"custom_profiles.json", "custom_profiles.json.migrated"}
 
@@ -186,7 +207,7 @@ class ConfigProfileManager:
     """
 
     def __init__(self, profiles_dir: Optional[Path] = None):
-        self.profiles_dir = profiles_dir or (get_user_data_dir() / "rag_profiles")
+        self.profiles_dir = profiles_dir or default_rag_profiles_dir()
         self.profiles_dir.mkdir(parents=True, exist_ok=True)
 
         self._profiles: Dict[str, ProfileConfig] = {}

--- a/tldw_chatbook/Skills_Interop/__init__.py
+++ b/tldw_chatbook/Skills_Interop/__init__.py
@@ -1,6 +1,6 @@
 """Local and server SKILL.md interoperability services."""
 
-from .local_skills_service import LocalSkillsService
+from .local_skills_service import LocalSkillsService, default_local_skills_store_dir
 from .server_skills_service import ServerSkillsService
 from .skill_trust_service import SkillTrustService
 from .skill_trust_models import SkillTrustBlockedError, SkillTrustStatus
@@ -14,4 +14,5 @@ __all__ = [
     "SkillTrustStatus",
     "SkillsBackend",
     "SkillsScopeService",
+    "default_local_skills_store_dir",
 ]

--- a/tldw_chatbook/Skills_Interop/local_skills_service.py
+++ b/tldw_chatbook/Skills_Interop/local_skills_service.py
@@ -32,6 +32,38 @@ if TYPE_CHECKING:
 _INDEX_FILENAME = "tldw_chatbook_skills.json"
 _SKILLS_DIRNAME = "skills"
 _SKILL_FILENAME = "SKILL.md"
+
+#: Name of this app's top-level local-skills store directory, directly
+#: under ``get_user_data_dir()``. Distinct from ``_SKILLS_DIRNAME`` above --
+#: that one names the BUNDLE subdirectory nested one level inside a store
+#: dir built from this constant (``<user_data_dir>/skills/skills``). Both
+#: happen to be spelled "skills", but they name different levels of the
+#: tree; keep that straight when reading ``default_local_skills_store_dir``
+#: below.
+_LOCAL_SKILLS_STORE_DIRNAME = "skills"
+
+
+def default_local_skills_store_dir(user_data_dir: str | Path) -> Path:
+    """Return this app's local-skills store directory for a user data dir.
+
+    Single source of truth for the top-level ``skills`` subdirectory name.
+    ``app.py`` calls this to build the live ``LocalSkillsService``/
+    ``SkillTrustService`` wiring, and ``Utils.sensitive_paths`` calls it to
+    carve the trust/grant store back out of the directory-exemption rule
+    that would otherwise let everything under ``skills/`` inherit
+    reachability (see ``skill_trust_store.default_trust_store_dir`` for the
+    ``trust`` subdirectory nested inside this one, and
+    ``Utils/sensitive_paths.py``'s module docstring for why a re-spelled
+    literal here is the exact class of drift a past finding was filed
+    against).
+
+    Args:
+        user_data_dir: ``config.get_user_data_dir()``.
+
+    Returns:
+        ``Path(user_data_dir) / "skills"``.
+    """
+    return Path(user_data_dir) / _LOCAL_SKILLS_STORE_DIRNAME
 _FRONT_MATTER_PATTERN = re.compile(r"\A---\s*\n(.*?)\n---\s*(?:\n|\Z)", re.DOTALL)
 _METADATA_FIELDS = {
     "name",

--- a/tldw_chatbook/Skills_Interop/skill_trust_store.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_store.py
@@ -27,6 +27,15 @@ from .skill_trust_crypto import (
 
 _MANIFEST_FILENAME = "skill_trust_manifest.json"
 _SNAPSHOTS_DIRNAME = "snapshots"
+_TRUST_DIRNAME = "trust"
+
+#: Name of the local generation-marker fallback file, used when no secure
+#: keyring backend is available (see ``build_skill_trust_marker_store_with_fallback``).
+#: Public (no leading underscore) because ``app.py`` needs it to build the
+#: live marker store's fallback path, and ``Utils.sensitive_paths`` needs it
+#: too -- see ``default_trust_store_dir``'s docstring for why a shared
+#: constant beats each caller re-spelling the filename as its own literal.
+MARKER_FILENAME = "generation_marker.json"
 _DEFAULT_MARKER_SERVICE_NAME = "tldw_chatbook.skill_trust"
 _DEFAULT_KEY_CACHE_SERVICE_NAME = "tldw_chatbook.skill_trust.keys"
 _MARKER_USERNAME = "local-skills:generation-marker:v1"
@@ -57,6 +66,27 @@ def skill_trust_account_scope(store_dir: Path) -> str:
     """
     resolved = str(Path(store_dir).resolve())
     return hashlib.sha256(resolved.encode("utf-8")).hexdigest()[:16]
+
+
+def default_trust_store_dir(local_skills_store_dir: str | Path) -> Path:
+    """Return the trust/grant store directory nested under a skills store dir.
+
+    Single source of truth for the ``trust`` subdirectory name: ``app.py``
+    calls this to build the live ``SkillTrustStore`` (``store_dir=``), and
+    ``Utils.sensitive_paths`` calls it to refuse the whole subtree on the
+    agent-tool denylist -- both must name it identically or the denylist
+    silently stops matching the moment either drifted, the same class of
+    bug a re-spelled literal caused elsewhere in this app (see
+    ``Utils/sensitive_paths.py``'s module docstring).
+
+    Args:
+        local_skills_store_dir: The local-skills store directory, i.e.
+            ``Skills_Interop.default_local_skills_store_dir(user_data_dir)``.
+
+    Returns:
+        ``Path(local_skills_store_dir) / "trust"``.
+    """
+    return Path(local_skills_store_dir) / _TRUST_DIRNAME
 
 
 class SkillTrustMarkerUnavailable(RuntimeError):

--- a/tldw_chatbook/Tools/_grep_worker.py
+++ b/tldw_chatbook/Tools/_grep_worker.py
@@ -1,0 +1,181 @@
+"""Standalone child-process worker for `GrepFiles`'s regex search step.
+
+TASK-843. Spawned by `Tools.file_operation_tools._run_grep_subprocess` as
+``sys.executable -S <this file>``. Deliberately a PLAIN SCRIPT with NO
+import of `tldw_chatbook` itself, and no import of anything beyond the
+Python standard library: the whole point of running in a separate
+process is to be trivially killable (`Popen.kill()`, SIGKILL on POSIX)
+without dragging along whatever state the running `tldw_chatbook`
+process happens to hold (a live Textual app, open DB connections, loaded
+config) into a new process whose only job is to run a possibly-
+adversarial regular expression against file content. Importing the
+parent package here would reintroduce exactly the "child inherits
+surprising state" risk this design exists to avoid, and would slow down
+every single invocation for no benefit -- this worker needs none of it.
+
+Trust boundary: every path handed to this worker via stdin MUST already
+be fully validated by the parent (containment against the sandbox/
+workspace roots, the sensitive-path denylist, the hidden-component rule
+-- see `file_operation_tools._iter_candidates_across_roots`). This worker
+performs NONE of that validation itself; it trusts its input completely
+and exists to do exactly one thing: run a regex over lines read from a
+fixed list of files, under the same bounds `GrepFiles` already enforces
+in-process (line-length cap, per-file byte cap, total-lines-scanned cap).
+
+Protocol: a single JSON object read from stdin --
+``{"pattern": str, "file_paths": [str, ...], "max_matches": int,
+"max_line_search_chars": int, "max_lines_scanned": int,
+"max_file_bytes": int}`` -- and a single JSON object written to stdout --
+either ``{"matches": [{"path", "line_number", "line"}, ...],
+"lines_scanned": int}`` or ``{"error": str}``. Always exits 0: a bad
+pattern or an unreadable file is reported as part of the JSON payload,
+never as a nonzero exit code (a nonzero exit means something
+unanticipated escaped every try/except below, which `_run_grep_subprocess`
+treats as a hard failure).
+
+What this process's own `RLIMIT_CPU` self-limit (see `_apply_cpu_limit`)
+does and does not add: it is a defense-in-depth measure for the case
+where the PARENT itself dies before it can ever call `Popen.kill()` on
+this worker (e.g. the whole host application crashes) -- without it, an
+orphaned worker would have nothing left to stop it. It is POSIX-only
+(the `resource` module does not exist on Windows) and is NOT the primary
+guarantee: `_run_grep_subprocess`'s `communicate(timeout=...)` +
+`kill()` is what actually bounds this worker's runtime on every
+platform, including Windows, in the ordinary (non-orphaned) case.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+#: Generous relative to `GrepFiles`'s own ~18s subprocess ceiling
+#: (`_GREP_SUBPROCESS_TIMEOUT_SECONDS`) -- this is a backstop for the
+#: orphaned-parent case, not the primary timeout, so it deliberately does
+#: not try to match that ceiling exactly.
+_CPU_LIMIT_SECONDS = 60
+
+
+def _apply_cpu_limit() -> None:
+    """Best-effort self-imposed CPU cap (POSIX only). See module docstring.
+
+    Silently does nothing if the `resource` module is unavailable
+    (Windows) or if the limit cannot be set for any reason -- this is
+    additive defense in depth, never the primary guarantee, so a failure
+    here must not stop the worker from running the actual search.
+    """
+    try:
+        import resource
+    except ImportError:
+        return
+    try:
+        _soft, hard = resource.getrlimit(resource.RLIMIT_CPU)
+        # A process cannot raise its own hard limit without privilege, so
+        # keep whatever hard limit is already in force unless it is
+        # infinite (the common case), in which case cap it to something
+        # generous. The soft limit -- the one that actually triggers
+        # SIGXCPU -- is the smaller of our desired cap and that hard
+        # limit, since setrlimit rejects soft > hard.
+        new_hard = (
+            _CPU_LIMIT_SECONDS + 5 if hard == resource.RLIM_INFINITY else hard
+        )
+        new_soft = min(_CPU_LIMIT_SECONDS, new_hard)
+        resource.setrlimit(resource.RLIMIT_CPU, (new_soft, new_hard))
+    except (ValueError, OSError):
+        pass
+
+
+def run_search(request: dict) -> dict:
+    """Execute one grep request in-process. Never raises.
+
+    Args:
+        request: Parsed JSON request; see this module's docstring for
+            the required keys.
+
+    Returns:
+        ``{"matches": [...], "lines_scanned": int}`` on success
+        (including a legitimate zero-match result), or ``{"error": str}``.
+    """
+    try:
+        pattern = request["pattern"]
+        file_paths = request["file_paths"]
+        max_matches = int(request["max_matches"])
+        max_line_search_chars = int(request["max_line_search_chars"])
+        max_lines_scanned = int(request["max_lines_scanned"])
+        max_file_bytes = int(request["max_file_bytes"])
+    except (KeyError, TypeError, ValueError) as exc:
+        return {"error": f"malformed grep worker request: {exc}"}
+
+    try:
+        regex = re.compile(pattern)
+    except re.error as exc:
+        return {"error": f"invalid regular expression: {exc}"}
+
+    matches: list[dict] = []
+    lines_scanned = 0
+    for path_str in file_paths:
+        if len(matches) >= max_matches or lines_scanned >= max_lines_scanned:
+            break
+        path = Path(path_str)
+        try:
+            if path.stat().st_size > max_file_bytes:
+                continue
+        except OSError:
+            continue
+        # Streamed line-by-line rather than `read_text()` + `splitlines()`
+        # -- same rationale as the in-process implementation this replaces:
+        # a single pathological file with no newlines would otherwise force
+        # a large peak allocation. `max_file_bytes` still bounds that worst
+        # case independent of this.
+        try:
+            with path.open("r", encoding="utf-8", errors="replace") as fh:
+                for number, line in enumerate(fh, start=1):
+                    lines_scanned += 1
+                    # Search only a length-capped slice of the line, never
+                    # the full line -- this is the FIRST line of defence
+                    # against a catastrophic-backtracking pattern; the
+                    # subprocess boundary this worker runs inside of is
+                    # what actually bounds CPU exposure once a pattern gets
+                    # past this cap (see `_run_grep_subprocess`'s
+                    # docstring in `file_operation_tools.py`).
+                    if regex.search(line[:max_line_search_chars]):
+                        matches.append(
+                            {
+                                "path": path_str,
+                                "line_number": number,
+                                "line": line.rstrip("\n")[:500],
+                            }
+                        )
+                    if (
+                        len(matches) >= max_matches
+                        or lines_scanned >= max_lines_scanned
+                    ):
+                        break
+        except OSError:
+            continue
+
+    return {"matches": matches, "lines_scanned": lines_scanned}
+
+
+def main() -> int:
+    """Entry point: read one JSON request from stdin, write one to stdout."""
+    _apply_cpu_limit()
+    raw_request = sys.stdin.read()
+    try:
+        request = json.loads(raw_request)
+    except json.JSONDecodeError as exc:
+        json.dump({"error": f"malformed grep worker request: {exc}"}, sys.stdout)
+        return 0
+    if not isinstance(request, dict):
+        json.dump({"error": "malformed grep worker request"}, sys.stdout)
+        return 0
+    result = run_search(request)
+    json.dump(result, sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tldw_chatbook/Tools/file_operation_tools.py
+++ b/tldw_chatbook/Tools/file_operation_tools.py
@@ -15,6 +15,7 @@ from ..Utils.path_validation import validate_path_multi
 from ..Utils.sensitive_paths import (
     SensitivePathContext,
     is_sensitive_path,
+    refuses_new_directory_chain,
     resolve_sensitive_context,
 )
 from .workspace_file_roots import allowed_file_roots
@@ -500,6 +501,28 @@ class WriteFileTool(Tool):
 
             # Create parent directories if requested
             if create_directories and not path.parent.exists():
+                # TASK-849: `is_sensitive_path(path)` just above only ever
+                # validated the FINAL file being written, never the new
+                # directory levels `mkdir(parents=True)` is about to create
+                # on the way there -- so nothing stopped an agent from
+                # planting a directory at a name this app expects to use
+                # for its own state file later (e.g. `search_history.db/`,
+                # created here as a side effect of writing
+                # `search_history.db/note.txt`, before the app ever
+                # creates `search_history.db` itself as a SQLite file).
+                # This app's later attempt to open it then fails outright --
+                # a denial of service. See
+                # `Utils.sensitive_paths.refuses_new_directory_chain` for
+                # why this walks every not-yet-existing ancestor rather
+                # than just `path.parent` itself.
+                if refuses_new_directory_chain(path.parent):
+                    return {
+                        "file_path": file_path,
+                        "error": (
+                            f"Refused: creating '{path.parent}' would collide "
+                            "with a protected path"
+                        ),
+                    }
                 path.parent.mkdir(parents=True, exist_ok=True)
                 logger.info(f"Created directories: {path.parent}")
 

--- a/tldw_chatbook/Tools/file_operation_tools.py
+++ b/tldw_chatbook/Tools/file_operation_tools.py
@@ -6,9 +6,12 @@ These tools allow LLMs to perform safe file operations with proper validation.
 
 import asyncio
 import json
+import os
 import re
 import subprocess
 import sys
+import tempfile
+import time
 from pathlib import Path, PureWindowsPath
 from typing import Dict, Any, Iterator
 
@@ -628,17 +631,58 @@ _MAX_GREP_LINE_SEARCH_CHARS = 500
 #: cost of any single catastrophic one.
 _MAX_GREP_LINES_SCANNED = 200_000
 
-#: Wall-clock ceiling for the grep worker SUBPROCESS itself (TASK-843),
-#: passed to `_run_grep_subprocess`. Deliberately shorter than
-#: `GrepFiles.timeout_seconds` (20.0s): this is the timeout that actually
-#: matters for bounding CPU, because unlike the run loop's own
-#: thread-based `_call_with_timeout` (which ABANDONS a hung worker
-#: thread), this one ends in `Popen.kill()` -- a subprocess genuinely can
-#: be killed. Leaving ~2s of headroom below the outer 20.0s covers
-#: candidate-gathering plus process spawn/teardown, so the kill fires (and
-#: the child's CPU consumption actually stops) at or before the point the
-#: agent is told the call failed, not sometime after.
+#: Wall-clock ceiling for the ENTIRE grep search phase (TASK-843; widened
+#: by the follow-up hardening review's Finding 1 -- see `_run_grep_search`).
+#: Deliberately shorter than `GrepFiles.timeout_seconds` (20.0s): this is
+#: the timeout that actually matters for bounding CPU, because unlike the
+#: run loop's own thread-based `_call_with_timeout` (which ABANDONS a hung
+#: worker thread), every subprocess spawned within this budget ends in
+#: `Popen.kill()` -- a subprocess genuinely can be killed.
+#:
+#: What this covers changed with Finding 1: candidate discovery and the
+#: regex search used to be sequential phases -- discovery ran to
+#: completion, in-process, un-timed, THEN one subprocess call got this
+#: whole budget. That let a slow discovery phase (a large, high-hit-rate
+#: tree; see `_run_grep_search`'s docstring for the measured regression)
+#: eat into time this constant never accounted for, pushing the REAL
+#: worst-case wall-clock past `GrepFiles.timeout_seconds` and making the
+#: "kill fires before the agent is told the call failed" guarantee false.
+#: `_run_grep_search` now starts this deadline before pulling the first
+#: candidate and re-derives the remaining budget before every subsequent
+#: batch/subprocess call, so discovery time and every batch's subprocess
+#: wait are drawn from the SAME 18.0s window rather than the former
+#: (discovery) + 18.0s (search). Leaving ~2s of headroom below the outer
+#: 20.0s still covers process spawn/teardown for whichever batch is in
+#: flight when the deadline is reached, so the kill (or the timeout-error
+#: return before ever starting another batch) fires at or before the
+#: point the agent is told the call failed, not sometime after -- for the
+#: aggregate of however many batches this call actually needed, not just
+#: one.
 _GREP_SUBPROCESS_TIMEOUT_SECONDS = 18.0
+
+#: Initial number of candidates `_run_grep_search` pulls from
+#: `_iter_candidates_across_roots` before the FIRST subprocess call
+#: (Finding 1, follow-up hardening review). Chosen small enough that an
+#: ordinary, high-hit-rate search's enumeration cost before that first
+#: call stays close to what the old in-process, single-phase
+#: implementation paid before its early-break -- at the reviewer's
+#: measured ~0.32ms/candidate, 256 candidates costs ~82ms, comfortably in
+#: the same ballpark as the ~0.1s the old early-break stopped at (~200
+#: files). Doubles on each subsequent round, up to
+#: `_GREP_MAX_CANDIDATE_BATCH_SIZE` -- see that constant for why a fixed
+#: small size is not used throughout.
+_GREP_INITIAL_CANDIDATE_BATCH_SIZE = 256
+
+#: Ceiling `_run_grep_search`'s per-round batch size grows to (doubling
+#: from `_GREP_INITIAL_CANDIDATE_BATCH_SIZE`) before it stops growing
+#: further. Exists so a pattern with few or zero hits -- which must still
+#: examine candidates up to `_MAX_CANDIDATES` (20,000) to confirm that --
+#: does not pay for a large number of small, separately-spawned
+#: subprocess calls to get there: capped at this size, covering
+#: `_MAX_CANDIDATES` costs on the order of a handful of subprocess spawns
+#: (doubling from 256: 256, 512, 1024, 2048, 4096, 4096, ... -- roughly 8
+#: rounds to reach 20,000), not one call per few hundred candidates.
+_GREP_MAX_CANDIDATE_BATCH_SIZE = 4096
 
 
 def _rejects_traversal(pattern: str) -> bool:
@@ -776,6 +820,22 @@ def _iter_candidates_across_roots(
     (e.g. a bound workspace folder that happens to nest the sandbox, or
     two bound folders that overlap) is yielded at most once, deduplicated
     by resolved identity.
+
+    Finding 5 (follow-up hardening review): that global bound is consumed
+    root-by-root IN ORDER, not split fairly across roots -- ``roots[0]``'s
+    candidates are drained (up to ``_MAX_CANDIDATES``) before ``roots[1]``
+    is ever globbed at all. A first root that alone holds
+    ``_MAX_CANDIDATES`` or more matching entries therefore starves every
+    later root completely, and the caller cannot distinguish that from
+    those later roots genuinely containing no matches -- both look like
+    "no results from root N" from the outside. This is judged correct,
+    not a bug to fix: the bound must stay global (see above), and there is
+    no principled way to divide a single global budget fairly across an
+    arbitrary number of roots without either wasting it on roots with
+    nothing to find or starving one that has plenty. A caller that needs a
+    specific root's results reliably included should narrow the search
+    (e.g. a ``glob``/``pattern`` scoped under that root specifically)
+    rather than rely on root ordering.
 
     Args:
         pattern: A glob pattern, already checked by ``_rejects_traversal``.
@@ -950,6 +1010,93 @@ class GlobFiles(Tool):
 #: is a plain script with no import of this package at all.
 _GREP_WORKER_SCRIPT = str(Path(__file__).with_name("_grep_worker.py"))
 
+#: Working directory for the grep worker subprocess (Finding 3, follow-up
+#: hardening review). Every path the worker ever touches is one of the
+#: already-fully-resolved, ABSOLUTE candidates `_iter_candidates_across_roots`
+#: yielded (every root -- the sandbox and every bound workspace folder --
+#: is itself absolute; see `_tool_sandbox_root`/`allowed_file_roots`), so
+#: the worker has no legitimate use for the PARENT's actual working
+#: directory. Inheriting it for free (the default when `cwd=` is omitted)
+#: would still expose that directory's identity to a process whose only
+#: job is running a possibly-adversarial regex, for no benefit -- a
+#: neutral, always-present directory costs nothing to pass explicitly
+#: instead.
+_GREP_WORKER_CWD = tempfile.gettempdir()
+
+
+def _grep_worker_env() -> Dict[str, str]:
+    """Minimal environment for the grep worker subprocess (Finding 3).
+
+    Inheriting the parent's full environment (the default when `env=` is
+    omitted from `subprocess.Popen`) costs nothing under this worker's
+    existing trust model -- it only ever runs a regex against paths the
+    PARENT has already fully validated, and a module shadow-attack via a
+    leaked `sys.path` entry would require source-tree write access, i.e.
+    already-complete compromise. It is still a needless surface: a probe
+    confirmed a secret set in the parent's environment (e.g.
+    `MY_FAKE_API_KEY=sk-...`) is visible verbatim inside the child. The
+    worker imports nothing beyond the standard library and never shells
+    out, so it needs none of the parent's environment to do its job.
+
+    Returns:
+        A dict containing `PATH` (needed for the interpreter's own
+        startup/library resolution, not for anything the worker itself
+        invokes) plus, on Windows only, `SystemRoot` -- `subprocess.Popen`
+        with a genuinely empty `env={}` can fail outright on Windows,
+        since several CRT/socket-initialization paths read it
+        unconditionally regardless of what the child program needs.
+    """
+    env: Dict[str, str] = {}
+    path = os.environ.get("PATH")
+    if path:
+        env["PATH"] = path
+    if sys.platform == "win32":
+        system_root = os.environ.get("SystemRoot")
+        if system_root:
+            env["SystemRoot"] = system_root
+    return env
+
+
+def _validated_grep_worker_payload(parsed: dict) -> dict:
+    """Validate the shape of a successfully-parsed worker JSON payload.
+
+    Finding 4 (follow-up hardening review): `_run_grep_subprocess`
+    previously returned `parsed` straight from `json.loads(stdout)` once
+    it was confirmed to be *a dict* -- but never confirmed `matches` was
+    actually a list, or that `lines_scanned` was actually an int. A worker
+    emitting `{"matches": "not-a-list"}` (a bug, not plausibly an attack:
+    both ends of this pipe -- `_grep_worker.py` and this module -- are
+    code this project owns) would propagate that shape straight through
+    to `GrepFiles.execute` and on to the agent, instead of the documented
+    `{"path": str, "line_number": int, "line": str}` per-match shape.
+
+    Args:
+        parsed: A JSON value already confirmed to be a `dict` (see the
+            caller), with no `"error"` key -- i.e. the worker's claimed
+            success path.
+
+    Returns:
+        `parsed` unchanged if `matches` is a list of well-formed
+        `{"path": str, "line_number": int, "line": str}` dicts and
+        `lines_scanned` is an int; otherwise a fresh
+        `{"error": "grep worker produced malformed output"}` dict --
+        never raises.
+    """
+    matches = parsed.get("matches")
+    if not isinstance(matches, list):
+        return {"error": "grep worker produced malformed output"}
+    for entry in matches:
+        if (
+            not isinstance(entry, dict)
+            or not isinstance(entry.get("path"), str)
+            or not isinstance(entry.get("line_number"), int)
+            or not isinstance(entry.get("line"), str)
+        ):
+            return {"error": "grep worker produced malformed output"}
+    if not isinstance(parsed.get("lines_scanned"), int):
+        return {"error": "grep worker produced malformed output"}
+    return parsed
+
 
 def _run_grep_subprocess(
     pattern: str,
@@ -1005,10 +1152,19 @@ def _run_grep_subprocess(
     up to `timeout_seconds` before it is killed (down from unbounded
     before this task, but not zero), and every `grep_files` call now pays
     a small, fixed process spawn/teardown cost (~15-20ms locally with the
-    `-S` flag below, negligible against the ~18s ceiling) whether the
-    pattern is pathological or not. `RLIMIT_CPU` is POSIX-only; the
+    `-S`/`-P` flags below, negligible against the ~18s ceiling) whether
+    the pattern is pathological or not. `RLIMIT_CPU` is POSIX-only; the
     `communicate(timeout=)` + `kill()` path is the guarantee that holds on
     every platform, including Windows.
+
+    Note (Finding 1, follow-up hardening review): `GrepFiles.execute` no
+    longer calls this once with every candidate -- `_run_grep_search`
+    calls it once per BATCH, with a shrinking `timeout_seconds` and a
+    shrinking `max_matches`/`max_lines_scanned` reflecting the budget
+    already spent by earlier batches. Nothing about this function's own
+    guarantee changes: every individual call it makes is still bounded
+    and killable exactly as documented above, independent of how many
+    times it is called in one `grep_files` invocation.
 
     Args:
         pattern: The regular expression to search for. `GrepFiles.execute`
@@ -1021,17 +1177,26 @@ def _run_grep_subprocess(
             neither this function nor the worker it spawns performs any
             of that validation, and must never be handed a path the
             caller has not already cleared.
-        max_matches: Same bound as `_MAX_MATCHES` -- stop once this many
-            matches are found.
+        max_matches: Stop once this many matches are found from THIS
+            batch -- the caller (`_run_grep_search`) passes the REMAINING
+            budget out of `_MAX_MATCHES`, not always the same constant.
         max_line_search_chars: Same bound as `_MAX_GREP_LINE_SEARCH_CHARS`.
-        max_lines_scanned: Same bound as `_MAX_GREP_LINES_SCANNED`.
+        max_lines_scanned: Same per-batch-remaining-budget treatment as
+            `max_matches`, out of `_MAX_GREP_LINES_SCANNED`.
         max_file_bytes: Same bound as `_MAX_GREP_FILE_BYTES`.
-        timeout_seconds: Wall-clock ceiling for the whole subprocess call
-            (typically `_GREP_SUBPROCESS_TIMEOUT_SECONDS`).
+        timeout_seconds: Wall-clock ceiling for THIS subprocess call --
+            the caller passes whatever remains of the overall search
+            deadline (see `_GREP_SUBPROCESS_TIMEOUT_SECONDS`), not always
+            that same constant.
 
     Returns:
-        Dict with a `matches` list of `{path, line_number, line}` dicts on
-        success, or an `error` string -- never raises.
+        Dict with a `matches` list of `{path, line_number, line}` dicts
+        and a `lines_scanned` int on success, or an `error` string --
+        never raises. The success shape is validated (Finding 4; see
+        `_validated_grep_worker_payload`) before being returned, so a
+        worker emitting a malformed payload (e.g. `matches` not actually a
+        list) surfaces as an error dict here rather than propagating that
+        shape onward.
     """
     request = json.dumps(
         {
@@ -1050,11 +1215,25 @@ def _run_grep_subprocess(
             # none of which needs site-packages, and this measurably
             # shrinks interpreter startup (~15ms vs ~20ms, locally) paid
             # on every single grep_files call.
-            [sys.executable, "-S", _GREP_WORKER_SCRIPT],
+            # "-P" (Finding 3, follow-up hardening review; Python >=3.11,
+            # matching this project's floor): don't prepend the script's
+            # own directory to `sys.path`. Without it, a probe confirmed
+            # `sys.path[0]` inside the worker is `Tools/` -- this
+            # project's own source directory -- for no reason the worker
+            # needs; planting a shadow module there to exploit that would
+            # already require source-tree write access (full compromise
+            # on its own), so this is not an escalation, just a needless
+            # surface removed for free.
+            [sys.executable, "-S", "-P", _GREP_WORKER_SCRIPT],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            # Explicit `cwd=`/`env=` (Finding 3): see `_GREP_WORKER_CWD`/
+            # `_grep_worker_env` for why the worker needs neither the
+            # parent's actual working directory nor its environment.
+            cwd=_GREP_WORKER_CWD,
+            env=_grep_worker_env(),
         )
     except OSError as exc:
         return {"error": f"could not start grep worker process: {exc}"}
@@ -1090,7 +1269,158 @@ def _run_grep_subprocess(
         return {"error": "grep worker produced malformed output"}
     if not isinstance(parsed, dict):
         return {"error": "grep worker produced malformed output"}
-    return parsed
+    if "error" in parsed:
+        error_value = parsed.get("error")
+        if not isinstance(error_value, str):
+            return {"error": "grep worker produced malformed output"}
+        return parsed
+    return _validated_grep_worker_payload(parsed)
+
+
+async def _run_grep_search(
+    pattern: str,
+    candidates: Iterator[Path],
+    *,
+    max_matches: int,
+    max_line_search_chars: int,
+    max_lines_scanned: int,
+    max_file_bytes: int,
+    deadline_seconds: float,
+) -> dict:
+    """Search ``candidates`` for ``pattern``, streaming batches to killable subprocesses.
+
+    Finding 1 (follow-up hardening review). TASK-843 moved the regex
+    search into a killable child process, but `GrepFiles.execute` still
+    drained `candidates` (bounded by `_MAX_CANDIDATES`, up to 20,000)
+    all the way to completion, in-process, BEFORE ever spawning that
+    subprocess -- undoing the early-break the pre-subprocess implementation
+    had (`len(matches) >= _MAX_MATCHES` / `lines_scanned >=
+    _MAX_GREP_LINES_SCANNED`, checked during enumeration itself). That
+    made an ordinary, HIGH-HIT-RATE search over a large tree pay for every
+    candidate the match/line budget never needed just to reach the point
+    of spawning a subprocess at all -- measured: a 5,000-file tree with a
+    pattern matching every file went from the old ~0.1s (in-process,
+    early-broken after ~200 files) to ~1.6s (all 5,000 candidates
+    enumerated first).
+
+    This function restores that early exit without giving up the
+    subprocess boundary TASK-843 added: it pulls candidates from
+    ``candidates`` (already fully validated -- containment, the
+    sensitive-path denylist, the hidden-component rule, and
+    ``_MAX_CANDIDATES`` -- by ``_iter_candidates_across_roots``) in
+    GROWING batches, starting at ``_GREP_INITIAL_CANDIDATE_BATCH_SIZE`` and
+    doubling up to ``_GREP_MAX_CANDIDATE_BATCH_SIZE``, running each batch
+    through its OWN call to ``_run_grep_subprocess`` with whatever
+    match/line/time budget remains, and stopping -- WITHOUT pulling
+    another candidate -- the moment that budget is satisfied. A small
+    initial batch keeps a high-hit-rate search's pre-first-call
+    enumeration cost close to what the old in-process early-break paid;
+    growing it on later rounds keeps a rare/zero-hit search (which must
+    still examine candidates up to ``_MAX_CANDIDATES`` to confirm that)
+    from paying for a large number of small, separately-spawned
+    subprocesses to get there.
+
+    Killability is unchanged: every batch is still searched by its own
+    fully killable child process (see ``_run_grep_subprocess``) -- this
+    function only changes HOW MANY candidates are handed to it and in how
+    many calls, never how a batch is searched once handed off. A
+    catastrophic-backtracking pattern inside any one batch is bounded and
+    killed exactly as before, independent of batching.
+
+    The wall-clock deadline (``deadline_seconds``) starts the moment this
+    function is entered -- i.e. BEFORE the first candidate is even pulled,
+    not after candidate discovery finishes. This is what makes
+    ``_GREP_SUBPROCESS_TIMEOUT_SECONDS``'s ~2s headroom below
+    ``GrepFiles.timeout_seconds`` an honest bound again: discovery time
+    and every batch's subprocess wait are drawn from the SAME window, so
+    the aggregate -- however it is spent across batches -- cannot exceed
+    it. The deadline is re-checked before pulling each batch and again
+    before spawning each subprocess call; between those checks, pulling
+    one batch of up to the current (capped) batch size from an
+    already-validated iterator is itself bounded, so the worst-case
+    overshoot before a check catches it is small and fixed, not unbounded.
+
+    Args:
+        pattern: The already-`re.compile`-checked pattern to search for.
+        candidates: Iterator of already-validated candidate paths (see
+            ``_iter_candidates_across_roots``). This function performs
+            NONE of that validation itself and trusts every path it pulls
+            completely.
+        max_matches: Same bound as ``_MAX_MATCHES`` -- the TOTAL across
+            every batch, not per batch.
+        max_line_search_chars: Same bound as ``_MAX_GREP_LINE_SEARCH_CHARS``.
+        max_lines_scanned: Same bound as ``_MAX_GREP_LINES_SCANNED`` --
+            the TOTAL across every batch, not per batch.
+        max_file_bytes: Same bound as ``_MAX_GREP_FILE_BYTES``.
+        deadline_seconds: Wall-clock budget for this ENTIRE search phase
+            -- candidate discovery interleaved with every batch's
+            subprocess call, together -- starting now, not after
+            discovery. Typically ``_GREP_SUBPROCESS_TIMEOUT_SECONDS``.
+
+    Returns:
+        Dict with a `matches` list (capped at `max_matches`) on success,
+        or an `error` string -- never raises for a worker-level failure
+        (see ``_run_grep_subprocess``). A syntactically invalid glob
+        pattern can still raise ``ValueError``/``NotImplementedError`` out
+        of ``next(candidates)`` (``Path.glob()``'s lazy validation) --
+        exactly as before this function existed -- and callers must still
+        handle that themselves.
+    """
+    deadline = time.monotonic() + deadline_seconds
+    all_matches: list[dict] = []
+    lines_scanned_total = 0
+    batch_size = _GREP_INITIAL_CANDIDATE_BATCH_SIZE
+
+    while len(all_matches) < max_matches and lines_scanned_total < max_lines_scanned:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return {
+                "error": (
+                    f"grep search timed out after {deadline_seconds:g}s and "
+                    "was terminated"
+                )
+            }
+
+        batch: list[str] = []
+        for _ in range(batch_size):
+            try:
+                batch.append(str(next(candidates)))
+            except StopIteration:
+                break
+        if not batch:
+            break
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return {
+                "error": (
+                    f"grep search timed out after {deadline_seconds:g}s and "
+                    "was terminated"
+                )
+            }
+
+        result = await asyncio.to_thread(
+            _run_grep_subprocess,
+            pattern,
+            batch,
+            max_matches=max_matches - len(all_matches),
+            max_line_search_chars=max_line_search_chars,
+            max_lines_scanned=max_lines_scanned - lines_scanned_total,
+            max_file_bytes=max_file_bytes,
+            timeout_seconds=remaining,
+        )
+        if "error" in result:
+            return result
+        all_matches.extend(result["matches"])
+        lines_scanned_total += result["lines_scanned"]
+
+        if len(batch) < batch_size:
+            # The iterator ran out mid-batch -- no candidates remain, so
+            # there is no point looping again only to find that out.
+            break
+        batch_size = min(batch_size * 2, _GREP_MAX_CANDIDATE_BATCH_SIZE)
+
+    return {"matches": all_matches[:max_matches]}
 
 
 class GrepFiles(Tool):
@@ -1138,9 +1468,10 @@ class GrepFiles(Tool):
         A legitimate search over the candidate bound (`_MAX_CANDIDATES`
         files, `_MAX_GREP_LINES_SCANNED` lines total) is comfortably fast:
         locally measured, 200,000 lines against a realistic non-pathological
-        pattern complete in well under a second, plus the search
-        subprocess's own small, fixed spawn cost (TASK-843; see
-        `_run_grep_subprocess`). 20s leaves generous headroom above that
+        pattern complete in well under a second, plus however many search
+        subprocesses that takes (TASK-843/Finding 1; see
+        `_run_grep_search`) -- each with its own small, fixed spawn cost
+        (`_run_grep_subprocess`). 20s leaves generous headroom above that
         for a slower disk or a loaded system, while still being far
         tighter than the run's own default (`RunBudget.max_tool_call_
         seconds`, 300s at defaults) -- so a pathological call is reported
@@ -1148,14 +1479,16 @@ class GrepFiles(Tool):
 
         Unlike before TASK-843, a pathological pattern's CPU burn no
         longer keeps running unbounded past this deadline: the actual
-        search now runs in a subprocess bounded by its OWN, shorter
-        internal ceiling (`_GREP_SUBPROCESS_TIMEOUT_SECONDS`), which ends
-        in `Popen.kill()` rather than `_call_with_timeout`
-        (`Agents/agent_service.py`) abandoning a worker thread it cannot
-        actually kill. This property's value still governs when the run
-        loop itself gives up and reports failure; see
-        `_run_grep_subprocess`'s docstring for exactly what does and does
-        not stop once that happens.
+        search now runs in one or more subprocesses (`_run_grep_search`
+        batches candidate discovery and the search together; see its
+        docstring), bounded by their OWN, shorter internal ceiling
+        (`_GREP_SUBPROCESS_TIMEOUT_SECONDS`, counted from before the first
+        candidate is even pulled), which ends in `Popen.kill()` rather
+        than `_call_with_timeout` (`Agents/agent_service.py`) abandoning a
+        worker thread it cannot actually kill. This property's value
+        still governs when the run loop itself gives up and reports
+        failure; see `_run_grep_subprocess`'s docstring for exactly what
+        does and does not stop once that happens.
 
         Returns:
             20.0 seconds.
@@ -1181,10 +1514,20 @@ class GrepFiles(Tool):
         small, finite amount of work, and remain in place as the cheap
         first line of defence. What actually stops a pathological
         pattern's CPU burn from continuing after this call returns is
-        that the search itself now runs in a separate, killable
-        subprocess (`_run_grep_subprocess`) rather than in this process --
+        that the search itself now runs in one or more separate, killable
+        subprocesses (`_run_grep_subprocess`) rather than in this process --
         see that function's docstring for exactly what it does and does
         not guarantee.
+
+        Finding 1 (follow-up hardening review): candidate discovery
+        (`_iter_candidates_across_roots`) and the search are STREAMED
+        together via `_run_grep_search` rather than fully separated into
+        "discover everything, then search everything" -- draining
+        discovery all the way to `_MAX_CANDIDATES` before ever spawning a
+        subprocess made an ordinary, high-hit-rate search over a large
+        tree pay for candidates the match budget never needed. See
+        `_run_grep_search`'s docstring for exactly how batching restores
+        that early exit without giving up killability.
 
         Args:
             pattern: Python regular expression to search for.
@@ -1223,34 +1566,26 @@ class GrepFiles(Tool):
             sensitive_ctx = resolve_sensitive_context()
 
             # Candidate discovery (containment, sensitivity, hidden-component,
-            # _MAX_CANDIDATES) happens HERE, in-process -- none of it runs the
-            # user-supplied regex, so none of it needs the subprocess
-            # boundary below. Only the actual content search does.
-            candidate_paths: list[str] = []
+            # _MAX_CANDIDATES) and the search are STREAMED together, in
+            # growing batches, by `_run_grep_search` (Finding 1, follow-up
+            # hardening review) -- neither discovery nor the deadline that
+            # bounds it waits for the other to fully finish first. See that
+            # function's docstring for exactly why and how.
+            candidates = _iter_candidates_across_roots(
+                glob_pattern, usable_roots, sensitive_ctx
+            )
             try:
-                for path in _iter_candidates_across_roots(
-                    glob_pattern, usable_roots, sensitive_ctx
-                ):
-                    candidate_paths.append(str(path))
+                return await _run_grep_search(
+                    raw_pattern,
+                    candidates,
+                    max_matches=_MAX_MATCHES,
+                    max_line_search_chars=_MAX_GREP_LINE_SEARCH_CHARS,
+                    max_lines_scanned=_MAX_GREP_LINES_SCANNED,
+                    max_file_bytes=_MAX_GREP_FILE_BYTES,
+                    deadline_seconds=_GREP_SUBPROCESS_TIMEOUT_SECONDS,
+                )
             except (ValueError, NotImplementedError) as exc:
                 return {"error": f"invalid glob: {exc}"}
-
-            if not candidate_paths:
-                return {"matches": []}
-
-            result = await asyncio.to_thread(
-                _run_grep_subprocess,
-                raw_pattern,
-                candidate_paths,
-                max_matches=_MAX_MATCHES,
-                max_line_search_chars=_MAX_GREP_LINE_SEARCH_CHARS,
-                max_lines_scanned=_MAX_GREP_LINES_SCANNED,
-                max_file_bytes=_MAX_GREP_FILE_BYTES,
-                timeout_seconds=_GREP_SUBPROCESS_TIMEOUT_SECONDS,
-            )
-            if "error" in result:
-                return result
-            return {"matches": result.get("matches", [])}
         except OSError as exc:
             return {"error": f"sandbox root is not usable: {exc}"}
         except Exception as exc:

--- a/tldw_chatbook/Tools/file_operation_tools.py
+++ b/tldw_chatbook/Tools/file_operation_tools.py
@@ -1008,7 +1008,14 @@ class GlobFiles(Tool):
 #: so it works identically whether `tldw_chatbook` is installed editable
 #: or as a built wheel -- see `_grep_worker.py`'s own docstring for why it
 #: is a plain script with no import of this package at all.
-_GREP_WORKER_SCRIPT = str(Path(__file__).with_name("_grep_worker.py"))
+#:
+#: ``.resolve()`` is load-bearing, not cosmetic: ``__file__`` is not
+#: guaranteed absolute under every loader, and the worker is spawned with
+#: ``cwd=_GREP_WORKER_CWD`` (the temp dir) rather than inheriting the
+#: parent's. A relative script path would therefore be resolved against the
+#: temp dir and fail to open, breaking `grep_files` outright -- the cwd
+#: hardening below turned a latent portability wart into a hard failure.
+_GREP_WORKER_SCRIPT = str(Path(__file__).resolve().with_name("_grep_worker.py"))
 
 #: Working directory for the grep worker subprocess (Finding 3, follow-up
 #: hardening review). Every path the worker ever touches is one of the

--- a/tldw_chatbook/Tools/file_operation_tools.py
+++ b/tldw_chatbook/Tools/file_operation_tools.py
@@ -4,7 +4,11 @@ File Operation Tools for LLM function calling.
 These tools allow LLMs to perform safe file operations with proper validation.
 """
 
+import asyncio
+import json
 import re
+import subprocess
+import sys
 from pathlib import Path, PureWindowsPath
 from typing import Dict, Any, Iterator
 
@@ -584,7 +588,8 @@ _MAX_CANDIDATES = 20_000
 _MAX_GREP_FILE_BYTES = 5_000_000
 
 #: Length cap on the slice of each line actually handed to `regex.search`
-#: in `GrepFiles.execute`. Python's `re` module has no match timeout, and a
+#: in the grep worker (`_grep_worker.py`, spawned by `_run_grep_subprocess`
+#: -- TASK-843). Python's `re` module has no match timeout, and a
 #: catastrophic-backtracking pattern (e.g. `(a+)+$`) burns CPU
 #: superlinearly in input length -- measured on this branch,
 #: `re.compile(r'(a+)+$').search('a' * 30 + 'X')` alone took ~47s, and the
@@ -593,24 +598,20 @@ _MAX_GREP_FILE_BYTES = 5_000_000
 #: result was truncated (to 500 chars, below) -- and since
 #: `_MAX_GREP_FILE_BYTES` bounds one *file*, not one *line*, that full
 #: line could be up to ~5,000,000 characters for a file with no
-#: newlines. This is the only mitigation here that genuinely constrains
-#: that worst case, because a tool call that times out (see
-#: `GrepFiles.timeout_seconds` below) does NOT stop the search already in
-#: flight: `Agents/agent_service.py`'s `_call_with_timeout` abandons the
-#: still-running worker thread rather than killing it -- Python has no
-#: way to kill a thread. Capping the input size turns "scales with file
-#: size, effectively unbounded" into "bounded by a small, fixed
-#: constant" -- it does NOT make catastrophic backtracking fast. A
-#: sufficiently adversarial pattern run against even a
+#: newlines. This remains the FIRST line of defence -- cheap, and it
+#: shrinks the ordinary (non-pathological) cost of every search -- but on
+#: its own it does not make catastrophic backtracking fast, only smaller:
+#: a sufficiently adversarial pattern run against even a
 #: `_MAX_GREP_LINE_SEARCH_CHARS`-length slice can still be expensive (our
-#: own repro above needed only 30 characters to already run ~47s); this
-#: constant shrinks the exposure, it does not eliminate it. A complete
-#: fix needs either a regex engine that supports match timeouts or
-#: running the search in a killable subprocess. The partial mitigation
-#: here is acceptable because `grep_files` carries the `"reads"` risk
-#: tag (see `GrepFiles.risk_tags`), which floors its permission to
-#: `ask`: a human approves every individual call, which is part of why
-#: this is an acceptable trade-off rather than a full fix.
+#: own repro above needed only 30 characters to already run ~47s). What
+#: actually bounds the CPU a pathological pattern can consume AFTER the
+#: tool call returns is `_run_grep_subprocess`/`_grep_worker.py`: the
+#: search itself now runs in a separate, killable process rather than the
+#: in-process worker THREAD `Agents/agent_service.py`'s
+#: `_call_with_timeout` uses for every other tool -- a timed-out THREAD is
+#: abandoned (Python cannot kill one), but a timed-out PROCESS is
+#: `Popen.kill()`ed. See `_run_grep_subprocess`'s docstring for exactly
+#: what that does and does not guarantee.
 _MAX_GREP_LINE_SEARCH_CHARS = 500
 
 #: Total number of lines `GrepFiles.execute` will read across ALL
@@ -626,6 +627,18 @@ _MAX_GREP_LINE_SEARCH_CHARS = 500
 #: cost of many ordinary (non-pathological) per-line searches, not the
 #: cost of any single catastrophic one.
 _MAX_GREP_LINES_SCANNED = 200_000
+
+#: Wall-clock ceiling for the grep worker SUBPROCESS itself (TASK-843),
+#: passed to `_run_grep_subprocess`. Deliberately shorter than
+#: `GrepFiles.timeout_seconds` (20.0s): this is the timeout that actually
+#: matters for bounding CPU, because unlike the run loop's own
+#: thread-based `_call_with_timeout` (which ABANDONS a hung worker
+#: thread), this one ends in `Popen.kill()` -- a subprocess genuinely can
+#: be killed. Leaving ~2s of headroom below the outer 20.0s covers
+#: candidate-gathering plus process spawn/teardown, so the kill fires (and
+#: the child's CPU consumption actually stops) at or before the point the
+#: agent is told the call failed, not sometime after.
+_GREP_SUBPROCESS_TIMEOUT_SECONDS = 18.0
 
 
 def _rejects_traversal(pattern: str) -> bool:
@@ -930,6 +943,155 @@ class GlobFiles(Tool):
             return {"error": f"Failed to glob files: {exc}"}
 
 
+#: Absolute path to the standalone worker module `_run_grep_subprocess`
+#: spawns (TASK-843). Resolved relative to this file (not a package import)
+#: so it works identically whether `tldw_chatbook` is installed editable
+#: or as a built wheel -- see `_grep_worker.py`'s own docstring for why it
+#: is a plain script with no import of this package at all.
+_GREP_WORKER_SCRIPT = str(Path(__file__).with_name("_grep_worker.py"))
+
+
+def _run_grep_subprocess(
+    pattern: str,
+    file_paths: list[str],
+    *,
+    max_matches: int,
+    max_line_search_chars: int,
+    max_lines_scanned: int,
+    max_file_bytes: int,
+    timeout_seconds: float,
+) -> dict:
+    """Run the regex-vs-file-content search in a killable child process.
+
+    TASK-843: completes the catastrophic-backtracking mitigation
+    `_MAX_GREP_LINE_SEARCH_CHARS`/`_MAX_GREP_LINES_SCANNED`/
+    `GrepFiles.timeout_seconds` left open by themselves. Those bound the
+    WORST CASE to a small, finite amount of work, but none of them can
+    stop a pathological pattern's CPU burn once it starts: Python's `re`
+    has no match timeout, and `Agents/agent_service.py`'s
+    `_call_with_timeout` (the run loop's own per-tool-call ceiling)
+    ABANDONS its worker thread on timeout rather than killing it --
+    Python cannot forcibly kill a thread, so that CPU burn outlives the
+    agent's own timeout report, and repeated calls accumulate. A
+    subprocess is different: `Popen.kill()` sends SIGKILL (POSIX) /
+    calls `TerminateProcess` (Windows), and the OS enforces that
+    unconditionally, regardless of what the process is doing.
+
+    Why a subprocess rather than the third-party `regex` module (which
+    supports `timeout=`): `regex` is not a direct OR declared optional
+    dependency of this project (checked against `pyproject.toml`) -- it is
+    only present at all, transitively, through unrelated optional extras
+    (`nltk`/`transformers`/`dateparser`, pulled in by the RAG/embeddings
+    extras). `grep_files` is a core built-in, reachable with no extras
+    installed; depending on `regex` here would make a currently-optional,
+    transitive package a hard requirement for the base install. A
+    subprocess adds no new dependency and works with the stdlib `re`
+    already in use.
+
+    This function is a BLOCKING call (`Popen.communicate(timeout=...)`);
+    `GrepFiles.execute` runs it via `asyncio.to_thread` rather than
+    awaiting it directly, so it never blocks the event loop.
+
+    What this DOES guarantee: once `timeout_seconds` elapses, the child
+    process is killed and its CPU consumption stops -- the search cannot
+    keep burning CPU past that deadline the way the in-process,
+    thread-based mitigation could. The worker also self-limits its own
+    CPU time via `resource.setrlimit(RLIMIT_CPU, ...)` on POSIX (see
+    `_grep_worker.py`), so an ORPHANED worker -- e.g. if this process
+    itself were killed before ever reaching the `kill()` call below --
+    still self-terminates rather than running unbounded.
+
+    What this does NOT guarantee: the child can still burn real CPU for
+    up to `timeout_seconds` before it is killed (down from unbounded
+    before this task, but not zero), and every `grep_files` call now pays
+    a small, fixed process spawn/teardown cost (~15-20ms locally with the
+    `-S` flag below, negligible against the ~18s ceiling) whether the
+    pattern is pathological or not. `RLIMIT_CPU` is POSIX-only; the
+    `communicate(timeout=)` + `kill()` path is the guarantee that holds on
+    every platform, including Windows.
+
+    Args:
+        pattern: The regular expression to search for. `GrepFiles.execute`
+            already validates (compiles) it before ever calling this
+            function, so a malformed pattern should never reach here --
+            the worker re-validates anyway rather than trusting that.
+        file_paths: Absolute paths to search, in order. Every path here
+            MUST already be fully validated by the caller (containment,
+            the sensitive-path denylist, the hidden-component rule) --
+            neither this function nor the worker it spawns performs any
+            of that validation, and must never be handed a path the
+            caller has not already cleared.
+        max_matches: Same bound as `_MAX_MATCHES` -- stop once this many
+            matches are found.
+        max_line_search_chars: Same bound as `_MAX_GREP_LINE_SEARCH_CHARS`.
+        max_lines_scanned: Same bound as `_MAX_GREP_LINES_SCANNED`.
+        max_file_bytes: Same bound as `_MAX_GREP_FILE_BYTES`.
+        timeout_seconds: Wall-clock ceiling for the whole subprocess call
+            (typically `_GREP_SUBPROCESS_TIMEOUT_SECONDS`).
+
+    Returns:
+        Dict with a `matches` list of `{path, line_number, line}` dicts on
+        success, or an `error` string -- never raises.
+    """
+    request = json.dumps(
+        {
+            "pattern": pattern,
+            "file_paths": file_paths,
+            "max_matches": max_matches,
+            "max_line_search_chars": max_line_search_chars,
+            "max_lines_scanned": max_lines_scanned,
+            "max_file_bytes": max_file_bytes,
+        }
+    )
+    try:
+        proc = subprocess.Popen(
+            # "-S": skip `site` initialization. The worker imports only
+            # stdlib (`json`/`re`/`sys`/`pathlib`, optionally `resource`),
+            # none of which needs site-packages, and this measurably
+            # shrinks interpreter startup (~15ms vs ~20ms, locally) paid
+            # on every single grep_files call.
+            [sys.executable, "-S", _GREP_WORKER_SCRIPT],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        return {"error": f"could not start grep worker process: {exc}"}
+
+    try:
+        stdout, stderr = proc.communicate(input=request, timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        # The ONE line that actually bounds a pathological pattern's CPU
+        # exposure past this call's return: a thread cannot be killed, a
+        # process can.
+        proc.kill()
+        try:
+            proc.communicate(timeout=5.0)
+        except subprocess.TimeoutExpired:
+            logger.error(f"grep worker (pid {proc.pid}) did not exit even after SIGKILL")
+        return {
+            "error": (
+                f"grep search timed out after {timeout_seconds:g}s and was "
+                "terminated"
+            )
+        }
+
+    if proc.returncode != 0:
+        return {
+            "error": (
+                f"grep worker failed (exit {proc.returncode}): "
+                f"{(stderr or '').strip()[:500]}"
+            )
+        }
+    try:
+        parsed = json.loads(stdout)
+    except (json.JSONDecodeError, TypeError):
+        return {"error": "grep worker produced malformed output"}
+    if not isinstance(parsed, dict):
+        return {"error": "grep worker produced malformed output"}
+    return parsed
+
 
 class GrepFiles(Tool):
     """`grep_files` -- content search across the sandbox and workspace roots."""
@@ -971,22 +1133,29 @@ class GrepFiles(Tool):
 
     @property
     def timeout_seconds(self) -> float:
-        """Modest per-call ceiling; does NOT stop a search already running.
+        """Overall per-call ceiling for the run loop's own accounting.
 
         A legitimate search over the candidate bound (`_MAX_CANDIDATES`
         files, `_MAX_GREP_LINES_SCANNED` lines total) is comfortably fast:
         locally measured, 200,000 lines against a realistic non-pathological
-        pattern complete in well under a second. 20s leaves generous
-        headroom above that for a slower disk or a loaded system, while
-        still being far tighter than the run's own default
-        (`RunBudget.max_tool_call_seconds`, 300s at defaults) -- so a
-        pathological call is reported back to the agent as timed out much
-        sooner. It does NOT bound how long a pathological pattern's search
-        itself keeps running: see `_MAX_GREP_LINE_SEARCH_CHARS` for that,
-        and note that `_call_with_timeout` (`Agents/agent_service.py`)
-        abandons the worker thread rather than killing it, so the search
-        keeps burning CPU in the background past this deadline regardless
-        of the value chosen here.
+        pattern complete in well under a second, plus the search
+        subprocess's own small, fixed spawn cost (TASK-843; see
+        `_run_grep_subprocess`). 20s leaves generous headroom above that
+        for a slower disk or a loaded system, while still being far
+        tighter than the run's own default (`RunBudget.max_tool_call_
+        seconds`, 300s at defaults) -- so a pathological call is reported
+        back to the agent as timed out much sooner.
+
+        Unlike before TASK-843, a pathological pattern's CPU burn no
+        longer keeps running unbounded past this deadline: the actual
+        search now runs in a subprocess bounded by its OWN, shorter
+        internal ceiling (`_GREP_SUBPROCESS_TIMEOUT_SECONDS`), which ends
+        in `Popen.kill()` rather than `_call_with_timeout`
+        (`Agents/agent_service.py`) abandoning a worker thread it cannot
+        actually kill. This property's value still governs when the run
+        loop itself gives up and reports failure; see
+        `_run_grep_subprocess`'s docstring for exactly what does and does
+        not stop once that happens.
 
         Returns:
             20.0 seconds.
@@ -1003,13 +1172,19 @@ class GrepFiles(Tool):
         merged via `_iter_candidates_across_roots`, with
         `_MAX_CANDIDATES` applied globally across all roots, not per root.
 
-        The supplied `pattern` is compiled with Python's `re`, which has no
-        match timeout. To keep a catastrophic-backtracking pattern's worst
-        case finite and small rather than scaling with file size, each
-        line is searched only up to `_MAX_GREP_LINE_SEARCH_CHARS`, and the
-        total number of lines read across the whole call is capped at
-        `_MAX_GREP_LINES_SCANNED`. Neither bound makes such a pattern fast
-        -- see the comments on those constants -- only bounded.
+        TASK-843: the supplied `pattern` is compiled with Python's `re`,
+        which has no match timeout. Each candidate file's content is only
+        ever searched a length-capped slice at a time
+        (`_MAX_GREP_LINE_SEARCH_CHARS`), and the total number of lines
+        read across the whole call is capped
+        (`_MAX_GREP_LINES_SCANNED`) -- both bound the WORST CASE to a
+        small, finite amount of work, and remain in place as the cheap
+        first line of defence. What actually stops a pathological
+        pattern's CPU burn from continuing after this call returns is
+        that the search itself now runs in a separate, killable
+        subprocess (`_run_grep_subprocess`) rather than in this process --
+        see that function's docstring for exactly what it does and does
+        not guarantee.
 
         Args:
             pattern: Python regular expression to search for.
@@ -1026,7 +1201,7 @@ class GrepFiles(Tool):
         if not raw_pattern:
             return {"error": "pattern is required"}
         try:
-            regex = re.compile(raw_pattern)
+            re.compile(raw_pattern)
         except re.error as exc:
             return {"error": f"invalid regular expression: {exc}"}
 
@@ -1047,63 +1222,35 @@ class GrepFiles(Tool):
             # GlobFiles.execute above.
             sensitive_ctx = resolve_sensitive_context()
 
-            matches: list[dict] = []
-            # Total lines read across ALL files this invocation, checked
-            # alongside `len(matches)` below so a corpus of many small-line
-            # files can't extend the invocation's total scan cost past
-            # _MAX_GREP_LINES_SCANNED even though each file individually
-            # stays under _MAX_GREP_FILE_BYTES.
-            lines_scanned = 0
+            # Candidate discovery (containment, sensitivity, hidden-component,
+            # _MAX_CANDIDATES) happens HERE, in-process -- none of it runs the
+            # user-supplied regex, so none of it needs the subprocess
+            # boundary below. Only the actual content search does.
+            candidate_paths: list[str] = []
             try:
                 for path in _iter_candidates_across_roots(
                     glob_pattern, usable_roots, sensitive_ctx
                 ):
-                    if (
-                        len(matches) >= _MAX_MATCHES
-                        or lines_scanned >= _MAX_GREP_LINES_SCANNED
-                    ):
-                        break
-                    try:
-                        if path.stat().st_size > _MAX_GREP_FILE_BYTES:
-                            continue
-                    except OSError:
-                        continue
-                    # Streamed line-by-line rather than `read_text()` +
-                    # `splitlines()` (which would materialize the whole
-                    # file, and a second full copy split into lines, in
-                    # memory at once): one large file in an allowed root
-                    # previously forced a large peak allocation. The
-                    # per-file byte cap above still bounds the worst case
-                    # for a single pathological line with no newline.
-                    try:
-                        with path.open("r", encoding="utf-8", errors="replace") as fh:
-                            for number, line in enumerate(fh, start=1):
-                                lines_scanned += 1
-                                # Search only a length-capped slice of the
-                                # line, never the full line -- see
-                                # _MAX_GREP_LINE_SEARCH_CHARS above for why
-                                # this is the only genuine bound on a
-                                # catastrophic-backtracking pattern's
-                                # worst-case runtime, and what it does NOT
-                                # buy.
-                                if regex.search(line[:_MAX_GREP_LINE_SEARCH_CHARS]):
-                                    matches.append(
-                                        {
-                                            "path": str(path),
-                                            "line_number": number,
-                                            "line": line.rstrip("\n")[:500],
-                                        }
-                                    )
-                                if (
-                                    len(matches) >= _MAX_MATCHES
-                                    or lines_scanned >= _MAX_GREP_LINES_SCANNED
-                                ):
-                                    break
-                    except OSError:
-                        continue
+                    candidate_paths.append(str(path))
             except (ValueError, NotImplementedError) as exc:
                 return {"error": f"invalid glob: {exc}"}
-            return {"matches": matches}
+
+            if not candidate_paths:
+                return {"matches": []}
+
+            result = await asyncio.to_thread(
+                _run_grep_subprocess,
+                raw_pattern,
+                candidate_paths,
+                max_matches=_MAX_MATCHES,
+                max_line_search_chars=_MAX_GREP_LINE_SEARCH_CHARS,
+                max_lines_scanned=_MAX_GREP_LINES_SCANNED,
+                max_file_bytes=_MAX_GREP_FILE_BYTES,
+                timeout_seconds=_GREP_SUBPROCESS_TIMEOUT_SECONDS,
+            )
+            if "error" in result:
+                return result
+            return {"matches": result.get("matches", [])}
         except OSError as exc:
             return {"error": f"sandbox root is not usable: {exc}"}
         except Exception as exc:

--- a/tldw_chatbook/Tools/file_operation_tools.py
+++ b/tldw_chatbook/Tools/file_operation_tools.py
@@ -6,7 +6,7 @@ These tools allow LLMs to perform safe file operations with proper validation.
 
 import re
 from pathlib import Path, PureWindowsPath
-from typing import Dict, Any
+from typing import Dict, Any, Iterator
 
 from loguru import logger
 
@@ -704,17 +704,25 @@ def _sandbox_root_is_hidden(root: Path) -> bool:
     because each routes through `validate_path_multi` -> `validate_path`
     against this same root, and that check fires unconditionally once the
     root's own name starts with `.` -- independent of the candidate.
-    `glob_files`/`grep_files` instead glob `_tool_sandbox_root()` directly
-    and never pass through `validate_path` at all, so without this
-    mirrored guard a dotted root INVERTS the hidden-file protection: the
-    three siblings refuse everything while these two enumerate/read it
-    normally (live-reproduced: `grep_files` returned a plain, non-hidden
-    file's contents from inside a dotted root while `read_file` refused
-    the identical path).
+    `glob_files`/`grep_files` instead glob their roots directly and never
+    pass through `validate_path` at all, so without this mirrored guard a
+    dotted root INVERTS the hidden-file protection: the three siblings
+    refuse everything while these two enumerate/read it normally
+    (live-reproduced: `grep_files` returned a plain, non-hidden file's
+    contents from inside a dotted root while `read_file` refused the
+    identical path).
+
+    TASK-850 generalizes this from a single sandbox root to the whole
+    ``allowed_file_roots`` set: called once per root by
+    ``GlobFiles.execute``/``GrepFiles.execute`` when building
+    ``usable_roots``, so a dotted root is excluded from the search rather
+    than checked only once against the sandbox. See those callers for how
+    a dotted root's absence is handled when it leaves zero usable roots.
 
     Args:
-        root: The resolved sandbox root, as returned by
-            ``_tool_sandbox_root()``.
+        root: One of the resolved roots ``allowed_file_roots`` returned
+            (the sandbox root, or one of the run's bound workspace
+            folders) -- not necessarily the sandbox root itself.
 
     Returns:
         True if ``root``'s final path component starts with ``.``.
@@ -722,8 +730,99 @@ def _sandbox_root_is_hidden(root: Path) -> bool:
     return root.name.startswith(".")
 
 
+def _iter_candidates_across_roots(
+    pattern: str,
+    roots: tuple[Path, ...],
+    sensitive_ctx: SensitivePathContext,
+) -> Iterator[Path]:
+    """Yield validated file candidates across every allowed root, once each.
+
+    Shared by ``GlobFiles.execute`` and ``GrepFiles.execute`` (TASK-850):
+    both previously globbed the tool sandbox root only, which was strictly
+    narrower than -- and inconsistent with -- `read_file`/`write_file`/
+    `list_directory`, all three of which already honour every root
+    ``allowed_file_roots`` returns (the sandbox plus any workspace folder
+    bound to the run). They now search the SAME root set, so an agent can
+    no longer read a file by path that it cannot find by search.
+
+    Every existing guard applies to every candidate from every root, not
+    just the first: containment (``is_within``, which also applies the
+    sensitive-path denylist) and the hidden-component rule
+    (``_is_hidden_within``, mirroring ``validate_path``'s dotfile
+    refusal). Callers must pre-filter ``roots`` down to the ones that pass
+    the dotted-root rule (``_sandbox_root_is_hidden``) themselves -- this
+    function assumes every entry in ``roots`` already qualifies; see
+    ``GlobFiles.execute``/``GrepFiles.execute`` for where that filtering
+    (and the "refuse the whole call only if none survive" decision)
+    happens.
+
+    ``_MAX_CANDIDATES`` bounds the TOTAL number of candidates pulled from
+    the underlying ``Path.glob()`` iterators across ALL roots COMBINED,
+    never per root -- otherwise N configured roots would multiply the
+    worst-case walk by N. A candidate reachable through more than one root
+    (e.g. a bound workspace folder that happens to nest the sandbox, or
+    two bound folders that overlap) is yielded at most once, deduplicated
+    by resolved identity.
+
+    Args:
+        pattern: A glob pattern, already checked by ``_rejects_traversal``.
+        roots: Roots to search, in priority order. Every entry must
+            already have passed ``_sandbox_root_is_hidden`` (i.e. none is
+            itself dot-prefixed) -- this function does not check that
+            again.
+        sensitive_ctx: A ``SensitivePathContext`` resolved ONCE by the
+            caller for this whole invocation (see
+            ``Utils.sensitive_paths.resolve_sensitive_context``) and
+            reused for every candidate from every root here -- never
+            re-resolved per root or per candidate.
+
+    Yields:
+        Each qualifying candidate ``Path`` (as returned by ``glob()``,
+        not pre-resolved), at most ``_MAX_CANDIDATES`` total across every
+        root and never repeated.
+
+    Raises:
+        ValueError: The pattern is syntactically invalid for the root
+            currently being searched. ``Path.glob()`` validates lazily --
+            on the first ``next()`` pulled from it, not at construction --
+            so this can surface from a ``next()`` call deep inside
+            iteration; it propagates straight out of this generator so
+            callers can distinguish a bad pattern from a legitimate empty
+            result.
+        NotImplementedError: Same lazy-validation timing, for a pattern
+            form ``pathlib`` does not support.
+    """
+    seen_resolved: set[Path] = set()
+    examined = 0
+    for root in roots:
+        if examined >= _MAX_CANDIDATES:
+            return
+        root_resolved = root.resolve()
+        candidates = root.glob(pattern)
+        while examined < _MAX_CANDIDATES:
+            try:
+                path = next(candidates)
+            except StopIteration:
+                break
+            examined += 1
+            if not path.is_file() or not is_within(path, root, context=sensitive_ctx):
+                continue
+            # A dotfile/dotdir must be invisible here even though it
+            # passed `is_within` -- see `_is_hidden_within`.
+            try:
+                resolved = path.resolve()
+            except (OSError, RuntimeError):
+                continue
+            if _is_hidden_within(resolved, root_resolved):
+                continue
+            if resolved in seen_resolved:
+                continue
+            seen_resolved.add(resolved)
+            yield path
+
+
 class GlobFiles(Tool):
-    """`glob_files` -- path-pattern search inside the sandbox root."""
+    """`glob_files` -- path-pattern search across the sandbox and workspace roots."""
 
     @property
     def name(self) -> str:
@@ -732,8 +831,9 @@ class GlobFiles(Tool):
     @property
     def description(self) -> str:
         return (
-            "Find files by path pattern inside the tool sandbox. Supports "
-            "glob syntax including ** for recursive matches, e.g. '**/*.py'. "
+            "Find files by path pattern inside the tool sandbox and any "
+            "bound workspace folders. Supports glob syntax including ** "
+            "for recursive matches, e.g. '**/*.py'. "
             f"Returns at most {_MAX_MATCHES} paths."
         )
 
@@ -756,7 +856,18 @@ class GlobFiles(Tool):
         return ("reads",)
 
     async def execute(self, **kwargs) -> dict:
-        """Search for files under the sandbox root by glob pattern.
+        """Search for files by glob pattern across every allowed root.
+
+        TASK-850: previously globbed the tool sandbox root only -- strictly
+        narrower than, and inconsistent with, `read_file`/`write_file`/
+        `list_directory`, which already honour every root
+        `allowed_file_roots` returns (the sandbox plus any workspace
+        folder bound to the current run). Now searches that SAME root
+        set: each root is globbed and results are merged, with
+        `_MAX_CANDIDATES`/`_MAX_MATCHES` still applied GLOBALLY across all
+        roots combined, not per root -- so N configured roots do not
+        multiply the worst-case walk by N (see
+        `_iter_candidates_across_roots`).
 
         Args:
             pattern: Glob pattern, e.g. ``"**/*.py"``. Absolute patterns and
@@ -772,57 +883,38 @@ class GlobFiles(Tool):
         if _rejects_traversal(pattern):
             return {"error": "pattern must stay inside the sandbox root"}
         try:
-            root = _tool_sandbox_root()
-            # Mirrors validate_path's hidden-base-directory rejection, which
-            # is why read_file/write_file/list_directory refuse EVERYTHING
-            # once the sandbox root is itself dotted -- those three route
-            # through validate_path against this same root; glob()ing it
-            # directly here bypasses that check entirely without this
-            # mirrored guard. See _sandbox_root_is_hidden.
-            if _sandbox_root_is_hidden(root):
+            roots = allowed_file_roots(write=False, sandbox_root=_tool_sandbox_root())
+            # Dotted-root rule, extended to a ROOT SET (TASK-850): with a
+            # single root (the sandbox alone, the sandbox-only
+            # configuration), a dotted root refuses the WHOLE call, exactly
+            # as before -- see _sandbox_root_is_hidden. With several roots,
+            # each is checked independently here and a dotted one is simply
+            # excluded from `usable_roots` rather than failing every other,
+            # still-valid root's results too; the call is refused outright
+            # only when NONE survive that filter (which is exactly the
+            # single-dotted-root case, so sandbox-only behavior is
+            # unchanged).
+            usable_roots = tuple(
+                root for root in roots if not _sandbox_root_is_hidden(root)
+            )
+            if not usable_roots:
                 return {"error": "Access to hidden files/directories is not allowed"}
+            # Resolved ONCE for this call and reused for every candidate
+            # from every root, rather than letting `is_within` ->
+            # `is_sensitive_path` re-resolve the sensitive-path set (11
+            # config accessors) per candidate -- see
+            # Utils.sensitive_paths.resolve_sensitive_context.
+            sensitive_ctx = resolve_sensitive_context()
+            matches: list[str] = []
             try:
-                candidates = root.glob(pattern)
+                for path in _iter_candidates_across_roots(
+                    pattern, usable_roots, sensitive_ctx
+                ):
+                    matches.append(str(path))
+                    if len(matches) >= _MAX_MATCHES:
+                        break
             except (ValueError, NotImplementedError) as exc:
                 return {"error": f"invalid pattern: {exc}"}
-            matches: list[str] = []
-            examined = 0
-            # Resolved ONCE for this call and reused for every candidate
-            # below, rather than letting `is_within` -> `is_sensitive_path`
-            # re-resolve the sensitive-path set (11 config accessors) per
-            # candidate -- see Utils.sensitive_paths.resolve_sensitive_context.
-            sensitive_ctx = resolve_sensitive_context()
-            root_resolved = root.resolve()
-            while True:
-                # `Path.glob()` validates lazily: a malformed pattern (e.g.
-                # "**foo/*") doesn't raise at construction above, it raises
-                # on the first `next()` here. Only the `next()` call is
-                # inside this try -- `path.is_file()`/`is_within()` below
-                # run outside it, so a ValueError from the loop body is
-                # never misreported as an invalid pattern.
-                try:
-                    path = next(candidates)
-                except StopIteration:
-                    break
-                except (ValueError, NotImplementedError) as exc:
-                    return {"error": f"invalid pattern: {exc}"}
-                examined += 1
-                if len(matches) >= _MAX_MATCHES or examined > _MAX_CANDIDATES:
-                    break
-                if not path.is_file() or not is_within(path, root, context=sensitive_ctx):
-                    continue
-                # A dotfile/dotdir must be invisible here even though it
-                # passed `is_within` -- that call applies the
-                # credential/app-state denylist, not the hidden-component
-                # rule `read_file`/`write_file` enforce via `validate_path`.
-                # See `_is_hidden_within`.
-                try:
-                    resolved = path.resolve()
-                except (OSError, RuntimeError):
-                    continue
-                if _is_hidden_within(resolved, root_resolved):
-                    continue
-                matches.append(str(path))
             return {"matches": sorted(matches)}
         except OSError as exc:
             return {"error": f"sandbox root is not usable: {exc}"}
@@ -838,8 +930,9 @@ class GlobFiles(Tool):
             return {"error": f"Failed to glob files: {exc}"}
 
 
+
 class GrepFiles(Tool):
-    """`grep_files` -- content search inside the sandbox root."""
+    """`grep_files` -- content search across the sandbox and workspace roots."""
 
     @property
     def name(self) -> str:
@@ -849,8 +942,9 @@ class GrepFiles(Tool):
     def description(self) -> str:
         return (
             "Search file contents by regular expression inside the tool "
-            "sandbox, optionally narrowed by a path glob. Returns matching "
-            f"lines with their file and line number, at most {_MAX_MATCHES}."
+            "sandbox and any bound workspace folders, optionally narrowed "
+            "by a path glob. Returns matching lines with their file and "
+            f"line number, at most {_MAX_MATCHES}."
         )
 
     @property
@@ -900,7 +994,14 @@ class GrepFiles(Tool):
         return 20.0
 
     async def execute(self, **kwargs) -> dict:
-        """Search file contents under the sandbox root by regular expression.
+        """Search file contents across every allowed root by regular expression.
+
+        TASK-850: previously searched the tool sandbox root only; now
+        searches every root `allowed_file_roots` returns (the sandbox plus
+        any workspace folder bound to the run), the same root set
+        `read_file`/`write_file`/`list_directory` already honour --
+        merged via `_iter_candidates_across_roots`, with
+        `_MAX_CANDIDATES` applied globally across all roots, not per root.
 
         The supplied `pattern` is compiled with Python's `re`, which has no
         match timeout. To keep a catastrophic-backtracking pattern's worst
@@ -930,103 +1031,78 @@ class GrepFiles(Tool):
             return {"error": f"invalid regular expression: {exc}"}
 
         try:
-            root = _tool_sandbox_root()
-            # Mirrors validate_path's hidden-base-directory rejection, which
-            # is why read_file/write_file/list_directory refuse EVERYTHING
-            # once the sandbox root is itself dotted -- see the matching
-            # comment in GlobFiles.execute and _sandbox_root_is_hidden.
-            if _sandbox_root_is_hidden(root):
-                return {"error": "Access to hidden files/directories is not allowed"}
             glob_pattern = str(kwargs.get("glob") or "**/*")
             if _rejects_traversal(glob_pattern):
                 return {"error": "glob must stay inside the sandbox root"}
-            try:
-                candidates = root.glob(glob_pattern)
-            except (ValueError, NotImplementedError) as exc:
-                return {"error": f"invalid glob: {exc}"}
+            roots = allowed_file_roots(write=False, sandbox_root=_tool_sandbox_root())
+            # Dotted-root rule, extended to a ROOT SET (TASK-850) -- see the
+            # matching comment in GlobFiles.execute.
+            usable_roots = tuple(
+                root for root in roots if not _sandbox_root_is_hidden(root)
+            )
+            if not usable_roots:
+                return {"error": "Access to hidden files/directories is not allowed"}
+            # Resolved ONCE for this call and reused for every candidate
+            # from every root -- see the matching comment in
+            # GlobFiles.execute above.
+            sensitive_ctx = resolve_sensitive_context()
 
             matches: list[dict] = []
-            # Deliberately NOT sorted(candidates): materialising and sorting
-            # the generator defeats _MAX_CANDIDATES on a broad pattern.
-            examined = 0
             # Total lines read across ALL files this invocation, checked
-            # alongside `examined`/`len(matches)` below so a corpus of many
-            # small-line files can't extend the invocation's total scan
-            # cost past _MAX_GREP_LINES_SCANNED even though each file
-            # individually stays under _MAX_GREP_FILE_BYTES.
+            # alongside `len(matches)` below so a corpus of many small-line
+            # files can't extend the invocation's total scan cost past
+            # _MAX_GREP_LINES_SCANNED even though each file individually
+            # stays under _MAX_GREP_FILE_BYTES.
             lines_scanned = 0
-            # Resolved ONCE for this call and reused for every candidate
-            # below -- see the matching comment in GlobFiles.execute above.
-            sensitive_ctx = resolve_sensitive_context()
-            root_resolved = root.resolve()
-            while True:
-                # As in GlobFiles: `Path.glob()` validates lazily, so a bad
-                # pattern raises here, on `next()`, not at the call above.
-                # Only `next()` is inside this try -- the body below
-                # (is_file, is_within, the streamed read, regex.search) runs
-                # outside it, so a ValueError raised there is never
-                # misreported as a bad glob.
-                try:
-                    path = next(candidates)
-                except StopIteration:
-                    break
-                except (ValueError, NotImplementedError) as exc:
-                    return {"error": f"invalid glob: {exc}"}
-                examined += 1
-                if (
-                    len(matches) >= _MAX_MATCHES
-                    or examined > _MAX_CANDIDATES
-                    or lines_scanned >= _MAX_GREP_LINES_SCANNED
+            try:
+                for path in _iter_candidates_across_roots(
+                    glob_pattern, usable_roots, sensitive_ctx
                 ):
-                    break
-                if not path.is_file() or not is_within(path, root, context=sensitive_ctx):
-                    continue
-                # A dotfile/dotdir must be unreadable here even though it
-                # passed `is_within` -- see the matching comment in
-                # GlobFiles.execute and `_is_hidden_within`.
-                try:
-                    resolved = path.resolve()
-                except (OSError, RuntimeError):
-                    continue
-                if _is_hidden_within(resolved, root_resolved):
-                    continue
-                try:
-                    if path.stat().st_size > _MAX_GREP_FILE_BYTES:
+                    if (
+                        len(matches) >= _MAX_MATCHES
+                        or lines_scanned >= _MAX_GREP_LINES_SCANNED
+                    ):
+                        break
+                    try:
+                        if path.stat().st_size > _MAX_GREP_FILE_BYTES:
+                            continue
+                    except OSError:
                         continue
-                except OSError:
-                    continue
-                # Streamed line-by-line rather than `read_text()` +
-                # `splitlines()` (which would materialize the whole file,
-                # and a second full copy split into lines, in memory at
-                # once): one large file in the sandbox previously forced a
-                # large peak allocation. The per-file byte cap above still
-                # bounds the worst case for a single pathological line with
-                # no newline.
-                try:
-                    with path.open("r", encoding="utf-8", errors="replace") as fh:
-                        for number, line in enumerate(fh, start=1):
-                            lines_scanned += 1
-                            # Search only a length-capped slice of the line,
-                            # never the full line -- see
-                            # _MAX_GREP_LINE_SEARCH_CHARS above for why this
-                            # is the only genuine bound on a
-                            # catastrophic-backtracking pattern's worst-case
-                            # runtime, and what it does NOT buy.
-                            if regex.search(line[:_MAX_GREP_LINE_SEARCH_CHARS]):
-                                matches.append(
-                                    {
-                                        "path": str(path),
-                                        "line_number": number,
-                                        "line": line.rstrip("\n")[:500],
-                                    }
-                                )
-                            if (
-                                len(matches) >= _MAX_MATCHES
-                                or lines_scanned >= _MAX_GREP_LINES_SCANNED
-                            ):
-                                break
-                except OSError:
-                    continue
+                    # Streamed line-by-line rather than `read_text()` +
+                    # `splitlines()` (which would materialize the whole
+                    # file, and a second full copy split into lines, in
+                    # memory at once): one large file in an allowed root
+                    # previously forced a large peak allocation. The
+                    # per-file byte cap above still bounds the worst case
+                    # for a single pathological line with no newline.
+                    try:
+                        with path.open("r", encoding="utf-8", errors="replace") as fh:
+                            for number, line in enumerate(fh, start=1):
+                                lines_scanned += 1
+                                # Search only a length-capped slice of the
+                                # line, never the full line -- see
+                                # _MAX_GREP_LINE_SEARCH_CHARS above for why
+                                # this is the only genuine bound on a
+                                # catastrophic-backtracking pattern's
+                                # worst-case runtime, and what it does NOT
+                                # buy.
+                                if regex.search(line[:_MAX_GREP_LINE_SEARCH_CHARS]):
+                                    matches.append(
+                                        {
+                                            "path": str(path),
+                                            "line_number": number,
+                                            "line": line.rstrip("\n")[:500],
+                                        }
+                                    )
+                                if (
+                                    len(matches) >= _MAX_MATCHES
+                                    or lines_scanned >= _MAX_GREP_LINES_SCANNED
+                                ):
+                                    break
+                    except OSError:
+                        continue
+            except (ValueError, NotImplementedError) as exc:
+                return {"error": f"invalid glob: {exc}"}
             return {"matches": matches}
         except OSError as exc:
             return {"error": f"sandbox root is not usable: {exc}"}

--- a/tldw_chatbook/Utils/sensitive_paths.py
+++ b/tldw_chatbook/Utils/sensitive_paths.py
@@ -574,3 +574,62 @@ def is_sensitive_path(
             return True
 
     return False
+
+
+def refuses_new_directory_chain(
+    target_dir: Path, context: SensitivePathContext | None = None
+) -> bool:
+    """Whether creating ``target_dir`` (or any not-yet-existing parent of it)
+    would plant a directory where this app expects a plain state file.
+
+    ``is_sensitive_path``'s direct-child-file rule is deliberately gated on
+    "does this candidate already exist as a directory", so a pre-existing
+    container (``tool_sandbox``, ``chromadb``, ``skills``, ...) stays fully
+    reachable. That same gate means a candidate that does NOT yet exist is
+    judged as if it were a plain file -- correctly refused. But
+    ``WriteFileTool``'s ``create_directories=True`` path only ever validates
+    the FINAL file being written, never the new directory levels
+    ``Path.mkdir(parents=True)`` creates on the way there: a target like
+    ``search_history.db/note.txt`` has a parent (``.../search_history.db``)
+    that is never itself checked, so nothing stopped an agent from planting
+    a directory at that exact name before this app ever created
+    ``search_history.db`` as a SQLite file (TASK-849, verified reachable
+    end to end through ``WriteFileTool`` under a widened sandbox root). The
+    app's own later ``sqlite3.connect(...)`` (or equivalent open) then fails
+    outright -- a denial of service, not a disclosure: the collision itself
+    carries no credential and grants no elevated access.
+
+    Walking upward from ``target_dir`` while each level still does not
+    exist mirrors exactly what ``Path.mkdir(parents=True)`` is about to
+    create, and checks each such level with ``is_sensitive_path`` --
+    reusing the exact same direct-child-file rule, never a separate check.
+    Any level found to already exist ends the walk immediately: an existing
+    ancestor is never touched by ``mkdir(parents=True)``, so nothing new
+    needs checking above it -- which is what keeps every legitimate
+    container directory (created by the app itself before an agent tool
+    ever runs) fully reachable.
+
+    Args:
+        target_dir: The directory ``mkdir(parents=True)`` is about to
+            create -- typically a write target's parent directory.
+        context: Optional pre-resolved ``SensitivePathContext``; see
+            ``resolve_sensitive_context``.
+
+    Returns:
+        True if ``target_dir`` or any of its not-yet-existing ancestors
+        would be a sensitive path once created.
+    """
+    ctx = context if context is not None else resolve_sensitive_context()
+    node = target_dir
+    while True:
+        resolved = _resolved(str(node))
+        if resolved is None:
+            return True
+        if resolved.exists():
+            return False
+        if is_sensitive_path(resolved, context=ctx):
+            return True
+        parent = node.parent
+        if parent == node:
+            return False
+        node = parent

--- a/tldw_chatbook/Utils/sensitive_paths.py
+++ b/tldw_chatbook/Utils/sensitive_paths.py
@@ -40,15 +40,43 @@ went stale (Finding 1) and how a ``TLDW_CONFIG_PATH`` override defeated the
 ``config.toml`` entry (Finding 3).
 
 Every file this app creates directly under ``get_user_data_dir()`` is also
-refused, as a RULE rather than an enumeration (see the
-``resolved.parent == ctx.user_data_dir`` check in ``is_sensitive_path``):
-new state files land there constantly (agent-run logs, eval/RAG-indexing/
-search-history/event/kanban/sync-state DBs, ...) without ever touching
-``config.py``, so an accessor-name enumeration permanently trails reality.
-Existing DIRECTORIES nested there -- most importantly the default file-tool
-sandbox root, ``get_user_data_dir() / "tool_sandbox"`` -- are excluded from
-that rule and stay fully reachable; see that check's own comment for why a
-directory/file distinction, not a name, is what exempts them.
+refused, as a RULE rather than an enumeration (see the direct-child-file
+loop in ``is_sensitive_path``): new state files land there constantly
+(agent-run logs, eval/RAG-indexing/search-history/event/kanban/sync-state
+DBs, ...) without ever touching ``config.py``, so an accessor-name
+enumeration permanently trails reality. The SAME rule is applied to three
+more directories, for the same reason: the effective config directory
+(``config._get_effective_config_path().parent``, which honors
+``TLDW_CONFIG_PATH`` the same way the config file itself does -- it holds
+``config.toml``'s own ``.bak``/``.tmp`` backup sidecars plus
+``runtime_policy.json``/``ui_state.toml``, none of which is enumerated by
+name here either); the ChromaDB vector-store persist directory
+(``RAG_Search.simplified.config.default_chroma_persist_directory()``,
+which holds ``chroma.sqlite3`` -- plaintext chunks of the same
+conversations and notes ``ChaChaNotes.db`` protects); and the RAG-profile
+store (``RAG_Search.config_profiles.default_rag_profiles_dir()``, plaintext
+per-profile RAG/embedding-provider config). Existing DIRECTORIES nested
+directly under any of these four are excluded from the rule and stay fully
+reachable -- most importantly the default file-tool sandbox root,
+``get_user_data_dir() / "tool_sandbox"``; see that check's own comment for
+why a directory/file distinction, not a name, is what exempts them.
+
+The skill trust/grant store gets a DIFFERENT treatment: the WHOLE
+``get_user_data_dir() / "skills" / "trust"`` subtree is refused, not just
+its direct children, because ``skills`` itself is one of the exempted
+container directories above and everything nested under it would otherwise
+inherit that exemption -- see ``_sensitive_skill_trust_dir`` for why that
+one subtree needs an explicit carve-out.
+
+A directory can also be CREATED to collide with a not-yet-existing state
+file at one of these locations (e.g. an agent asking ``write_file`` to
+create parent directories for ``search_history.db/note.txt`` before this
+app has ever created ``search_history.db`` as a file) -- the app's later
+attempt to open its own state file then fails outright, a denial of
+service. ``refuses_new_directory_chain`` is the guard against that: callers
+that create directories on the agent's behalf (``WriteFileTool``'s
+``create_directories=True`` path) must consult it before calling
+``Path.mkdir(parents=True, ...)``.
 
 This is a guardrail, not a security boundary: it stops accidents and naive
 injected payloads, not a determined ``python -c``. The sandbox/workspace-root
@@ -229,6 +257,126 @@ def _sensitive_single_file_paths() -> tuple[Path, ...]:
     return tuple(resolved)
 
 
+def _sensitive_skill_trust_dir() -> Path | None:
+    """Resolve this app's skill trust/grant store directory, lazily.
+
+    ``get_user_data_dir() / "skills"`` is one of the existing-directory
+    exemptions the direct-child-file rule (applied in ``is_sensitive_path``)
+    carves out -- every trusted skill bundle lives as a named subdirectory
+    under it, so a file inside it is deliberately NOT covered by that rule,
+    letting agent tools browse/read a user's own skill bundles.
+
+    The ``trust`` subdirectory nested one level inside it is the ONE
+    exception carved back OUT of that exemption: it holds
+    ``skill_trust_manifest.json`` (the authenticated trust manifest),
+    ``skill_script_grants.json`` (the plain, UNAUTHENTICATED JSON file
+    ``SkillTrustService.has_script_grant`` consults to authorize script
+    EXECUTION -- deliberately kept outside the manifest's own HMAC+keyring
+    integrity check; see ``Skills_Interop/skill_trust_service.py``),
+    ``generation_marker.json`` (the local rollback-protection marker), and
+    ``snapshots/`` (encrypted trusted-skill snapshots). A tool able to
+    rewrite the grants file can authorize its own future script execution
+    -- the same class of one-step gate bypass the MCP permission store's
+    entry exists to prevent (see this module's docstring) -- so this
+    caller refuses the WHOLE subtree by ancestry (the same way
+    ``_SENSITIVE_DIRS`` is matched), not just its direct children: a file
+    several levels inside ``snapshots/`` must be refused exactly like the
+    manifest itself.
+
+    Resolved via ``Skills_Interop.local_skills_service.default_local_skills_store_dir``
+    and ``Skills_Interop.skill_trust_store.default_trust_store_dir`` -- the
+    SAME functions ``app.py`` calls to build the live ``SkillTrustStore`` --
+    never a re-spelled ``"skills"``/``"trust"`` literal, which would drift
+    the moment either name changed (see this module's docstring for why
+    that class of drift is exactly how a past finding went stale).
+
+    Returns:
+        The trust store directory, or ``None`` if ``get_user_data_dir()``
+        could not be resolved.
+    """
+    from .. import config as _config
+    from ..Skills_Interop.local_skills_service import default_local_skills_store_dir
+    from ..Skills_Interop.skill_trust_store import default_trust_store_dir
+
+    try:
+        user_data_dir = _config.get_user_data_dir()
+    except Exception as exc:  # noqa: BLE001 - defensive, additive coverage only
+        logger.debug(f"sensitive_paths: could not resolve user data dir: {exc}")
+        return None
+
+    local_skills_store_dir = default_local_skills_store_dir(user_data_dir)
+    return default_trust_store_dir(local_skills_store_dir)
+
+
+def _direct_child_rule_container_dirs() -> tuple[Path, ...]:
+    """Resolve every directory whose direct (non-recursive) child FILES are refused, lazily.
+
+    Each of these is a directory this app treats as a bounded container for
+    its own state, where new files land constantly without ever being
+    named here individually -- this is the set the "Finding 2" rule in
+    ``is_sensitive_path`` applies to. Existing DIRECTORIES nested directly
+    inside any one of them (``tool_sandbox``, ``chat_dicts``, ``chromadb``,
+    ``exports``, ``rag_profiles``, ``skills``, and any future sibling) are
+    exempt from the rule and stay fully reachable; only a same-level FILE
+    is refused. See that rule's own comment for why "is an existing
+    directory", not a name, is what exempts them.
+
+    Returns:
+        Every container directory whose accessor could be resolved:
+
+        * ``config.get_user_data_dir()``.
+        * The effective config directory
+          (``config._get_effective_config_path().parent``) -- honors
+          ``TLDW_CONFIG_PATH`` the same way the config file itself does.
+          This is what covers ``config.toml``'s own ``.bak``/``.tmp``
+          backup sidecars (``UI/Screens/settings_screen.py``'s Advanced
+          config save writes both, byte-identical to the live config,
+          API keys included) and any other loose file dropped beside it
+          (``runtime_policy.json``, ``ui_state.toml``, a hand-made backup
+          copy under any other name) -- none of which is enumerated here
+          by name either, for the same reason the user-data-dir rule
+          isn't: an enumeration permanently trails whatever gets written
+          there next.
+        * The ChromaDB vector-store persist directory
+          (``RAG_Search.simplified.config.default_chroma_persist_directory()``),
+          which holds ``chroma.sqlite3`` -- plaintext chunks of the same
+          conversations and notes ``ChaChaNotes.db`` protects.
+        * The RAG-profile store directory
+          (``RAG_Search.config_profiles.default_rag_profiles_dir()``),
+          plaintext per-profile RAG/embedding-provider config.
+
+        An accessor that raises is skipped rather than failing the whole
+        check, as elsewhere in this module.
+    """
+    from .. import config as _config
+    from ..RAG_Search.config_profiles import default_rag_profiles_dir
+    from ..RAG_Search.simplified.config import default_chroma_persist_directory
+
+    resolved: list[Path] = []
+
+    try:
+        resolved.append(_config.get_user_data_dir())
+    except Exception as exc:  # noqa: BLE001 - defensive, additive coverage only
+        logger.debug(f"sensitive_paths: could not resolve user data dir: {exc}")
+
+    try:
+        resolved.append(_config._get_effective_config_path().parent)
+    except Exception as exc:  # noqa: BLE001 - defensive, additive coverage only
+        logger.debug(f"sensitive_paths: could not resolve effective config dir: {exc}")
+
+    try:
+        resolved.append(default_chroma_persist_directory())
+    except Exception as exc:  # noqa: BLE001 - defensive, additive coverage only
+        logger.debug(f"sensitive_paths: could not resolve chroma persist dir: {exc}")
+
+    try:
+        resolved.append(default_rag_profiles_dir())
+    except Exception as exc:  # noqa: BLE001 - defensive, additive coverage only
+        logger.debug(f"sensitive_paths: could not resolve rag profiles dir: {exc}")
+
+    return tuple(resolved)
+
+
 def _db_sidecar_paths(db_path: Path) -> tuple[Path, ...]:
     """Build the WAL/SHM/rollback-journal sidecar paths for one DB path.
 
@@ -267,12 +415,18 @@ class SensitivePathContext(NamedTuple):
     dirs: tuple[Path, ...]
     db_paths: tuple[Path, ...]
     #: Resolved ``config.get_user_data_dir()``, or ``None`` if it could not
-    #: be resolved. Backs the Finding-2 rule in ``is_sensitive_path``: every
-    #: FILE sitting directly (non-recursively) inside this directory is
-    #: refused, regardless of whether it is one of the enumerated DBs above.
-    #: ``None`` simply means that rule does not fire for this context --
-    #: ``files``/``dirs``/``db_paths`` coverage is unaffected either way.
+    #: be resolved. Kept as its own field for callers/tests that care about
+    #: this one specific directory; the direct-child-file rule itself now
+    #: consults ``direct_child_denied_dirs`` below, which already includes
+    #: this value alongside the other container directories that get the
+    #: same treatment.
     user_data_dir: Path | None
+    #: Every directory whose direct (non-recursive) child FILES are
+    #: refused -- ``user_data_dir``, the effective config directory, the
+    #: ChromaDB persist directory, and the RAG-profile store directory (see
+    #: ``_direct_child_rule_container_dirs``). Entries that failed to
+    #: resolve are dropped, same as ``files``/``dirs``/``db_paths``.
+    direct_child_denied_dirs: tuple[Path, ...]
 
 
 def resolve_sensitive_context() -> SensitivePathContext:
@@ -301,6 +455,9 @@ def resolve_sensitive_context() -> SensitivePathContext:
         logger.debug(f"sensitive_paths: could not resolve user data dir: {exc}")
         user_data_dir = None
 
+    skill_trust_dir = _sensitive_skill_trust_dir()
+    dynamic_dirs = (skill_trust_dir,) if skill_trust_dir is not None else ()
+
     return SensitivePathContext(
         files=tuple(
             p
@@ -308,7 +465,9 @@ def resolve_sensitive_context() -> SensitivePathContext:
             if p is not None
         ),
         dirs=tuple(
-            p for p in (_resolved(entry) for entry in _SENSITIVE_DIRS) if p is not None
+            p
+            for p in (_resolved(str(entry)) for entry in _SENSITIVE_DIRS + dynamic_dirs)
+            if p is not None
         ),
         db_paths=tuple(
             p
@@ -316,6 +475,13 @@ def resolve_sensitive_context() -> SensitivePathContext:
             if p is not None
         ),
         user_data_dir=user_data_dir,
+        direct_child_denied_dirs=tuple(
+            p
+            for p in (
+                _resolved(str(raw)) for raw in _direct_child_rule_container_dirs()
+            )
+            if p is not None
+        ),
     )
 
 
@@ -373,27 +539,38 @@ def is_sensitive_path(
         if resolved == root or root in resolved.parents:
             return True
 
-    # Finding 2 (substrate review): refuse every FILE sitting directly
-    # (non-recursively) inside `get_user_data_dir()`, as a RULE rather than
-    # an enumeration. New state files land there constantly without ever
-    # touching config.py -- agent-run logs, eval/RAG-indexing/search-
-    # history/event/kanban/sync-state DBs, the MCP local-store/context JSON
-    # files, the rotating app log -- and an accessor-name enumeration
+    # Finding 2 (substrate review), generalized beyond `get_user_data_dir()`
+    # to every container directory `_direct_child_rule_container_dirs()`
+    # resolves (also the effective config directory, the ChromaDB persist
+    # directory, and the RAG-profile store -- TASK-848): refuse every FILE
+    # sitting directly (non-recursively) inside one of them, as a RULE
+    # rather than an enumeration. New state files land there constantly
+    # without ever touching config.py -- agent-run logs, eval/RAG-indexing/
+    # search-history/event/kanban/sync-state DBs, the MCP local-store/
+    # context JSON files, the rotating app log, config.toml's own
+    # `.bak`/`.tmp` backup sidecars -- and an accessor-name enumeration
     # (`_DB_PATH_ACCESSOR_NAMES` above) permanently trails whatever the app
     # actually creates there next.
     #
     # Checked by "is it a directory", never by name: every legitimate use
-    # of this directory as a CONTAINER creates a named subdirectory instead
-    # of a loose file directly inside it -- `tool_sandbox` (the default
-    # file-tool sandbox root itself), `chat_dicts`, `chromadb`, `exports`,
-    # `rag_profiles`, `skills`. Excluding "is an existing directory" rather
-    # than hardcoding any of those names keeps every one of them reachable,
-    # including ones added later, without needing this rule to be updated
-    # in lockstep -- while a candidate that does not exist yet (e.g. a
-    # `write_file` target for a brand-new file) is NOT a directory either,
-    # so it still fails closed and is refused.
-    if ctx.user_data_dir is not None and resolved.parent == ctx.user_data_dir:
-        if not resolved.is_dir():
+    # of one of these directories as a CONTAINER creates a named
+    # subdirectory instead of a loose file directly inside it -- e.g.
+    # `tool_sandbox` (the default file-tool sandbox root itself),
+    # `chat_dicts`, `chromadb`, `exports`, `rag_profiles`, `skills` nested
+    # under `get_user_data_dir()`. Excluding "is an existing directory"
+    # rather than hardcoding any of those names keeps every one of them
+    # reachable, including ones added later, without needing this rule to
+    # be updated in lockstep -- while a candidate that does not exist yet
+    # (e.g. a `write_file` target for a brand-new file) is NOT a directory
+    # either, so it still fails closed and is refused. TASK-849: that same
+    # gate means an agent COULD plant a directory at a name the app has
+    # never used yet (before this check ever sees it as "existing") --
+    # closing that hole is `refuses_new_directory_chain` below, consulted
+    # by callers BEFORE they create a directory on the agent's behalf,
+    # never by loosening this check's own "is a directory" gate (which
+    # would break every legitimate container above).
+    for denied_parent in ctx.direct_child_denied_dirs:
+        if resolved.parent == denied_parent and not resolved.is_dir():
             return True
 
     return False

--- a/tldw_chatbook/Utils/sensitive_paths.py
+++ b/tldw_chatbook/Utils/sensitive_paths.py
@@ -609,6 +609,30 @@ def refuses_new_directory_chain(
     container directory (created by the app itself before an agent tool
     ever runs) fully reachable.
 
+    Consequence worth naming (Finding 2, follow-up hardening review): a
+    not-yet-existing name always fails ``is_sensitive_path``'s ``is_dir()``
+    gate, so this refuses creating **any** brand-new subdirectory directly
+    inside one of the container directories the direct-child-file rule
+    protects (``get_user_data_dir()``, the ChromaDB persist directory,
+    ...) -- not only a name that happens to collide with a state file this
+    app actually uses. Reproduced: with the sandbox root widened to
+    contain the ChromaDB persist directory,
+    ``write_file("chromadb/newcoll/x.txt", create_directories=True)`` is
+    refused (``newcoll`` does not exist yet, so it fails the same gate a
+    genuine collision would), while ``write_file("chromadb/coll1/new.txt",
+    create_directories=True)`` succeeds once ``coll1`` already exists as a
+    directory -- the walk stops at the first already-existing ancestor, as
+    documented above. This is deliberate, not a bug to fix here: telling
+    "a legitimate brand-new container" apart from "a shadow directory
+    aimed at a not-yet-created state file" by name alone would require
+    exactly the enumeration this design avoids (see the module
+    docstring), so failing closed is the right default. It is only
+    reachable when the sandbox root (or a bound workspace folder) is
+    widened to actually contain one of these container directories -- the
+    default sandbox root never does. Noted here so the next reader is not
+    surprised by an agent's brand-new-subdirectory `write_file` call being
+    refused under such a configuration.
+
     Args:
         target_dir: The directory ``mkdir(parents=True)`` is about to
             create -- typically a write target's parent directory.

--- a/tldw_chatbook/Utils/sensitive_paths.py
+++ b/tldw_chatbook/Utils/sensitive_paths.py
@@ -122,9 +122,25 @@ _DB_SIDECAR_SUFFIXES = ("-wal", "-shm", "-journal")
 
 
 def _resolved(path_str: str) -> Path | None:
+    """Resolve a path string, returning ``None`` on ANY resolution failure.
+
+    ``is_sensitive_path``'s fail-closed guarantee ("a path that cannot be
+    resolved is treated as sensitive") depends on this returning ``None``
+    for every way resolution can fail, not just the two most common ones.
+    ``Path.resolve()``/``expanduser()`` normally raise ``OSError`` (e.g. a
+    symlink loop) or ``RuntimeError`` (older Pythons' own loop-detection),
+    but a path containing an embedded NUL byte raises ``ValueError``
+    instead -- narrowing this catch to ``(OSError, RuntimeError)`` let that
+    case escape ``is_sensitive_path`` entirely as an uncaught exception
+    rather than the promised ``True`` (TASK-847). Broad by design: whatever
+    exception ``pathlib`` raises for a candidate this function cannot make
+    sense of, the caller must still get ``None`` back, never a propagated
+    error.
+    """
     try:
         return Path(path_str).expanduser().resolve()
-    except (OSError, RuntimeError):
+    except Exception as exc:  # noqa: BLE001 - fail-closed for ANY resolution failure
+        logger.debug(f"sensitive_paths: could not resolve {path_str!r}: {exc}")
         return None
 
 

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -436,11 +436,14 @@ from tldw_chatbook.Skills_Interop import (  # noqa: E402
     ServerSkillsService,
     SkillTrustService,
     SkillsScopeService,
+    default_local_skills_store_dir,
 )
 from tldw_chatbook.Skills_Interop.skill_trust_store import (  # noqa: E402
+    MARKER_FILENAME as _SKILL_TRUST_MARKER_FILENAME,
     SkillTrustStore,
     build_default_skill_trust_key_cache,
     build_skill_trust_marker_store_with_fallback,
+    default_trust_store_dir,
     skill_trust_account_scope,
 )
 from tldw_chatbook.Sync_Interop import (  # noqa: E402
@@ -5178,12 +5181,12 @@ class TldwCli(
                 client=None,
                 policy_enforcer=self.service_policy_enforcer,
             )
-        local_skills_store_dir = get_user_data_dir() / "skills"
-        trust_store_dir = local_skills_store_dir / "trust"
+        local_skills_store_dir = default_local_skills_store_dir(get_user_data_dir())
+        trust_store_dir = default_trust_store_dir(local_skills_store_dir)
         trust_account_scope = skill_trust_account_scope(trust_store_dir)
         skill_trust_marker_store, reduced_rollback_protection = (
             build_skill_trust_marker_store_with_fallback(
-                fallback_marker_path=trust_store_dir / "generation_marker.json",
+                fallback_marker_path=trust_store_dir / _SKILL_TRUST_MARKER_FILENAME,
                 account_scope=trust_account_scope,
             )
         )


### PR DESCRIPTION
Closes TASK-843, TASK-846, TASK-847, TASK-848, TASK-849, TASK-850.

Follow-on hardening to #953. The theme throughout: **a security check that names a path by literal protects nothing once the app resolves that path differently.** #953 shipped a denylist that hardcoded the permission store at `~/.config/tldw_cli/mcp_permissions.json` while the app builds it under `get_user_data_dir()` — the literal never existed, so the check never matched once, and `write_file` could overwrite the real store.

## TASK-846 — the audit that motivated most of this

Inventoried 30 security-relevant checks that name filesystem paths, config keys or database locations by literal, and verified each by resolving both sides on disk. **27 were broken.** Findings and evidence in `.superpowers/sdd/task-846-audit.md`; filed as tasks 851-859 and 864-866.

**Two Critical findings are not fixed here and deserve attention ahead of this PR** — together they mean config encryption does not encrypt:
- **TASK-851** — all three config-encryption entry points open `DEFAULT_CONFIG_PATH` rather than `_get_effective_config_path()`. Reproduced live under `TLDW_CONFIG_PATH`: "Enable encryption" returned `True`, left the active profile's `sk-proj-…` key plaintext, and silently rewrote a different file.
- **TASK-852** — `detect_api_keys` exact-matches six literals while every real key name is prefixed (`openai_api_key`, `bing_search_api_key`, …), so `should_encrypt_config()` never prompts.

Two of the audit's Criticals *are* fixed here, folded into TASK-848 rather than duplicated.

## What this branch changes

**TASK-847** — `is_sensitive_path` now fails closed on *any* resolution failure. A NUL byte previously raised `ValueError` and escaped a docstring promising fail-closed.

**TASK-848** — closes two Critical coverage gaps:
- The **skill trust and script-grant store** (`skill_script_grants.json` authorizes script execution) was unprotected and structurally unreachable, because `skills` is an exempted container directory. Now derived from `SkillTrustService`/`SkillTrustStore`'s own attributes, with a documented exception to the exemption — `skills/mypack/SKILL.md` stays reachable while `skills/trust/**` does not.
- **`config.toml`'s `.bak`/`.tmp` sidecars** are byte-identical copies including API keys; two existed unprotected on the audit machine. Now covered, mirroring the existing DB-sidecar treatment.

**TASK-849** — an agent could create a *directory* named after a not-yet-created state file (`search_history.db/`), breaking the app's later open. Refused before creation.

**TASK-850** — `glob_files`/`grep_files` now honour the same workspace folder roots as `read_file`, searching each and merging under **global** bounds so N roots cannot multiply the worst case by N. This aligns search with reading and deliberately does not widen reach — a path outside every configured root stays refused by all five tools.

**TASK-843** — `grep_files` now runs its regex in a **killable subprocess**. The previous bounds made the worst case finite but could not satisfy the criterion that a pathological regex stop consuming CPU after its call returns: Python's `re` has no timeout and `_call_with_timeout` *abandons* the worker thread rather than killing it. Chose a subprocess over the third-party `regex` module because `regex` is only a transitive dependency here via unrelated RAG extras, and `grep_files` is a core built-in with no extras gate. Before: `(a+)+$` ran 11.7-47s and kept burning CPU past the reported timeout. After: bounded to the subprocess ceiling with the child confirmed dead on return.

## Review findings, fixed

The whole-branch review found one Important regression introduced by 843+850 interacting — neither task's own review could see it. Splitting discovery from search drained candidate enumeration to `_MAX_CANDIDATES` before spawning the child, losing the early exit: a high-hit-rate pattern over 5,000 files went from ~0.1s to 1.29s, and it falsified a documented timeout-ordering invariant. Fixed by streaming discovery and search together in growing batches, each its own killable subprocess. **1.29s → 0.077s; candidates enumerated 5,000 → 256.** The new benchmark test was verified to fail against the pre-fix code.

Also fixed: the search subprocess no longer inherits the parent's environment, cwd or `sys.path[0]` (`-P`, explicit `cwd`, minimal `env`); the child's payload shape is validated before returning. Two Minors were documented rather than changed — no new subdirectory can be created inside a container dir under a widened root, and `_MAX_CANDIDATES` is consumed root-by-root so a huge first root can starve later ones.

## Testing

`Tests/Utils/ Tests/Tools/ Tests/Agents/` → **919 passed, 0 failed**, re-run after rebasing onto current dev.

Verified by execution under a scratch `HOME` with the sandbox root widened to `get_user_data_dir()`: every container directory stays listable/readable/globbable/greppable while `chroma.sqlite3`, `rag_profiles/*.json`, `config.toml.{bak,tmp}`, `search_history.db`, `mcp_permissions.json` and the whole `skills/trust/` subtree are refused; glob leaked zero protected paths. The default configuration keeps working end to end — that regression would have been worse than the bugs being fixed.

## Backlog note

Tasks originally filed as 860-862 moved to 864-866: dev filed into that range concurrently and landed first. Separately, **`task-839` and `task-840` are each duplicated on dev right now** from two other concurrent sessions — not introduced here, flagged for their owners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens agent file-tool path checks and aligns search tools with workspace roots, while making `grep_files` killable to stop runaway regex CPU burn. Addresses TASK-843 and TASK-846–TASK-850.

- **Bug Fixes**
  - TASK-847: `is_sensitive_path` now fails closed on any resolution error (incl. NUL bytes).
  - TASK-848: Denylist now covers `skills/trust/**` (skill trust and script-grant store), config sidecars in the effective config dir, and direct-child files in user data, config, Chroma persist, and RAG profiles dirs; container dirs stay reachable.
  - TASK-849: Blocks creating parent dirs that would shadow state files (e.g., `search_history.db/`) via `refuses_new_directory_chain` before `mkdir`.
  - TASK-850: `glob_files`/`grep_files` search all allowed workspace roots with global caps; paths outside every root remain denied.
  - TASK-843: `grep_files` runs regex in a killable subprocess; hardened with `-P`, explicit `cwd`, minimal `env`; streamed batches restore early exit and improve high-hit patterns (~1.29s → ~0.077s); child is terminated on timeout.
  - Tests: Added focused tests; suite now 919 passed. Audit (TASK-846) filed follow-ups; two critical items tracked in TASK-851 and TASK-852.
  - Fix: Grep worker script path is now resolved to an absolute path and asserted to exist; ensures subprocess works with a hardened `cwd` and unrelated parent `cwd` (test added).

<sup>Written for commit e3e0a35076c61281c21ea1437bcd990da7eb8a6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

