### PR TITLE
Refresh default models for DeepSeek, Anthropic, and OpenAI

### DIFF
--- a/Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md
+++ b/Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md
@@ -1,0 +1,634 @@
+# Provider Default Model Refresh Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make fresh installations default to DeepSeek V4 Flash, Claude Sonnet 5, and GPT-5.6 Terra while preserving compatible request payloads and existing user overrides.
+
+**Architecture:** Update the two bundled catalog representations and all active fallback layers in `config.py`, then add narrowly scoped model-family request shaping in the existing OpenAI and Anthropic handlers. Keep endpoints, response normalization, user-config precedence, and provider boundaries unchanged. Extend both embedded and Python capability metadata for the new vision-capable defaults.
+
+**Tech Stack:** Python 3.11+, requests, TOML/tomllib, pytest, Textual application configuration.
+
+**Spec:** `Docs/superpowers/specs/2026-07-26-provider-default-model-refresh-design.md` (read first; it is the source of truth).
+
+**Backlog:** `backlog/tasks/task-519 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md`
+
+**ADR required:** no
+
+**ADR path:** `backlog/decisions/020-automatic-model-catalog-refresh.md`
+
+**Reason:** This is a bundled-default and request-compatibility refresh within existing provider boundaries. ADR-020 already governs catalog discovery and persistence; no storage, ownership, security, or service-boundary decision is added.
+
+**Worktree:** `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/task-519-provider-default-models`
+
+**Branch:** `codex/task-519-provider-default-models`
+
+**Baseline:** The targeted suite passes in the worktree-local environment: `70 passed` for `Tests/test_config_model_catalog_defaults.py`, `Tests/Chat/test_chat_functions.py`, and `Tests/test_model_capabilities.py`. Use `.venv/bin/python` in the commands below; the shared repository environment contains optional `parakeet_mlx`, which aborts in a headless session without a Metal device. Ruff 0.16 is installed in this local environment for the explicit lint/format checks below.
+
+---
+
+### Task 0: Commit the reviewed planning artifacts
+
+**Files:**
+
+- Add: `Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md`
+- Modify: `backlog/tasks/task-519 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md`
+
+- [x] **Step 1: Verify the planning diff**
+
+```bash
+git diff --check
+git diff -- Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md "backlog/tasks/task-519 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md"
+```
+
+Expected: no whitespace errors; TASK-519 is In Progress and links the approved
+design, this plan, and ADR-020 with `ADR required: no`.
+
+- [x] **Step 2: Commit the planning artifacts before implementation**
+
+```bash
+git add Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md "backlog/tasks/task-519 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md"
+git commit -m "docs: plan provider default model refresh"
+```
+
+Expected: the plan and Backlog task are tracked before any production-code task
+begins.
+
+---
+
+### Task 1: Refresh bundled catalogs and configuration defaults
+
+**Files:**
+
+- Modify: `tldw_chatbook/config.py`
+- Modify: `Tests/test_config_model_catalog_defaults.py`
+- Test: `Tests/test_config_model_catalog_defaults.py`
+
+- [ ] **Step 1: Add failing configuration assertions**
+
+Extend `Tests/test_config_model_catalog_defaults.py` to import
+`API_MODELS_BY_PROVIDER` alongside `CONFIG_TOML_CONTENT`, then add one focused
+test:
+
+```python
+def test_recommended_provider_defaults_and_catalogs_are_current():
+    parsed = tomllib.loads(CONFIG_TOML_CONTENT)
+
+    assert parsed["api_settings"]["deepseek"]["model"] == "deepseek-v4-flash"
+    assert parsed["api_settings"]["anthropic"]["model"] == "claude-sonnet-5"
+    assert parsed["api_settings"]["openai"]["model"] == "gpt-5.6-terra"
+    assert parsed["chat_defaults"]["provider"] == "OpenAI"
+    assert parsed["chat_defaults"]["model"] == "gpt-5.6-terra"
+
+    assert parsed["providers"]["DeepSeek"] == [
+        "deepseek-v4-flash",
+        "deepseek-v4-pro",
+    ]
+    assert parsed["providers"]["Anthropic"][:4] == [
+        "claude-sonnet-5",
+        "claude-opus-5",
+        "claude-fable-5",
+        "claude-haiku-4-5",
+    ]
+    assert parsed["providers"]["OpenAI"][:3] == [
+        "gpt-5.6-terra",
+        "gpt-5.6-sol",
+        "gpt-5.6-luna",
+    ]
+    assert "deepseek-chat" not in parsed["providers"]["DeepSeek"]
+    assert "deepseek-reasoner" not in parsed["providers"]["DeepSeek"]
+    assert API_MODELS_BY_PROVIDER["DeepSeek"] == parsed["providers"]["DeepSeek"]
+    assert API_MODELS_BY_PROVIDER["Anthropic"] == parsed["providers"]["Anthropic"]
+    assert API_MODELS_BY_PROVIDER["OpenAI"] == parsed["providers"]["OpenAI"]
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest Tests/test_config_model_catalog_defaults.py -x -q
+```
+
+Expected: FAIL because the embedded provider catalogs and defaults still contain
+the previous model IDs.
+
+- [ ] **Step 3: Update active configuration defaults**
+
+In `tldw_chatbook/config.py`:
+
+- Lead both the Python catalog literal and embedded TOML `[providers]` with:
+  - OpenAI: `gpt-5.6-terra`, `gpt-5.6-sol`, `gpt-5.6-luna`
+  - Anthropic: `claude-sonnet-5`, `claude-opus-5`, `claude-fable-5`,
+    `claude-haiku-4-5`
+  - DeepSeek: only `deepseek-v4-flash`, `deepseek-v4-pro`
+- Retain the existing supported OpenAI and Anthropic entries after the new
+  entries, preserving their current order.
+- Change embedded `[api_settings.openai].model` to `gpt-5.6-terra`,
+  `[api_settings.anthropic].model` to `claude-sonnet-5`, and
+  `[api_settings.deepseek].model` to `deepseek-v4-flash`.
+- Change `[chat_defaults].model` to `gpt-5.6-terra`; leave its provider as
+  `OpenAI`.
+- Change the corresponding `load_settings()` legacy fallback strings.
+- Change the minimal malformed-catalog fallback to
+  `{"OpenAI": ["gpt-5.6-terra"]}`.
+- Do not change `[character_defaults]`, `[analysis_defaults]`, or specialized
+  model settings.
+
+- [ ] **Step 4: Run the configuration tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest Tests/test_config_model_catalog_defaults.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/config.py Tests/test_config_model_catalog_defaults.py
+git commit -m "config: refresh provider default models"
+```
+
+---
+
+### Task 2: Apply the GPT-5.6 Chat Completions contract
+
+**Files:**
+
+- Modify: `tldw_chatbook/LLM_Calls/LLM_API_Calls.py`
+- Modify: `Tests/Chat/test_chat_functions.py`
+- Test: `Tests/Chat/test_chat_functions.py`
+
+- [ ] **Step 1: Add failing GPT-5.6 payload tests**
+
+In `TestProviderRequestPayloads`, add tests using `_CapturedSession`:
+
+```python
+def test_openai_gpt_5_6_default_uses_chat_completion_contract(self, monkeypatch):
+    from tldw_chatbook.LLM_Calls import LLM_API_Calls
+
+    captured = {}
+    monkeypatch.setattr(
+        LLM_API_Calls,
+        "load_settings",
+        lambda: {"openai_api": {"api_base_url": "https://api.openai.test/v1"}},
+    )
+    monkeypatch.setattr(
+        LLM_API_Calls.requests,
+        "Session",
+        lambda: _CapturedSession(
+            captured,
+            {"id": "chat_test", "choices": [{"message": {"content": "OK"}}]},
+        ),
+    )
+
+    LLM_API_Calls.chat_with_openai(
+        input_data=[{"role": "user", "content": "test"}],
+        api_key=DUMMY_OPENAI_API_KEY,
+        model=None,
+        streaming=False,
+        max_tokens=512,
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "description": "Look up a value",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+    )
+
+    assert captured["url"] == "https://api.openai.test/v1/chat/completions"
+    assert captured["json"]["model"] == "gpt-5.6-terra"
+    assert captured["json"]["reasoning_effort"] == "none"
+    assert captured["json"]["max_completion_tokens"] == 512
+    assert "max_tokens" not in captured["json"]
+    assert "max_output_tokens" not in captured["json"]
+    assert captured["json"]["tools"][0]["type"] == "function"
+
+
+def test_openai_gpt_5_6_explicit_none_stays_on_chat_completions(self, monkeypatch):
+    # Arrange the same captured session, call with reasoning_effort="none",
+    # and assert /chat/completions plus reasoning_effort == "none".
+
+
+def test_openai_gpt_5_6_explicit_reasoning_uses_responses_contract(self, monkeypatch):
+    # Arrange a Responses-shaped result, call with reasoning_effort="high"
+    # and max_tokens=512, then assert /responses, max_output_tokens == 512,
+    # no max_completion_tokens, and reasoning == {"effort": "high"}.
+
+
+@pytest.mark.parametrize(
+    ("control_name", "control_value"),
+    [("reasoning_summary", "auto"), ("verbosity", "medium")],
+)
+def test_openai_none_with_responses_only_control_uses_responses(
+    self, monkeypatch, control_name, control_value
+):
+    # Arrange a Responses-shaped result, call gpt-5.6-terra with
+    # reasoning_effort="none" and **{control_name: control_value}, then assert
+    # /responses and max_output_tokens. This proves "none" stays on Chat only
+    # when no Responses-only control is also present.
+```
+
+Retain the existing `o3` Responses and streaming tests as regression coverage.
+Calling the default-contract test with `model=None` also verifies the OpenAI
+handler fallback.
+
+- [ ] **Step 2: Run the new tests and verify they fail**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest Tests/Chat/test_chat_functions.py -k "gpt_5_6 or openai_reasoning" -x -q
+```
+
+Expected: FAIL because ordinary GPT-5.6 requests currently use `max_tokens`,
+omit `reasoning_effort`, and explicit `"none"` selects Responses.
+
+- [ ] **Step 3: Implement narrowly scoped OpenAI model routing**
+
+In `LLM_API_Calls.py`:
+
+- Add a small predicate that matches OpenAI GPT-5.6 family IDs only (for example,
+  `model_name == "gpt-5.6"` or `model_name.startswith("gpt-5.6-")`).
+- Normalize the reasoning effort once.
+- Change `_openai_use_responses_api()` so `reasoning_effort="none"` alone does
+  not select Responses, while a non-`none` effort, `reasoning_summary`, or
+  `verbosity` still does.
+- On a GPT-5.6 Chat Completions request:
+  - send top-level `reasoning_effort` using the explicit value or `"none"`;
+  - send `max_completion_tokens`;
+  - preserve existing messages, tools, tool choice, streaming, and normalized
+    output behavior.
+- On a Responses request, continue sending `max_output_tokens` and the existing
+  `reasoning` / `text` objects.
+- For older OpenAI models, retain the existing `max_tokens` Chat Completions
+  contract.
+- Change the handler fallback used when the OpenAI config has no model to
+  `gpt-5.6-terra`.
+
+- [ ] **Step 4: Run focused OpenAI tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest Tests/Chat/test_chat_functions.py -k "openai" -q
+```
+
+Expected: PASS, including the existing Responses normalization tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/LLM_Calls/LLM_API_Calls.py Tests/Chat/test_chat_functions.py
+git commit -m "fix: shape GPT-5.6 requests compatibly"
+```
+
+---
+
+### Task 3: Apply the Claude Sonnet 5 thinking and sampling contract
+
+**Files:**
+
+- Modify: `tldw_chatbook/LLM_Calls/LLM_API_Calls.py`
+- Modify: `Tests/Chat/test_chat_functions.py`
+- Test: `Tests/Chat/test_chat_functions.py`
+
+- [ ] **Step 1: Add failing Sonnet 5 and adaptive-effort tests**
+
+Add four captured-payload tests:
+
+```python
+def test_anthropic_sonnet_5_default_omits_thinking_effort_and_sampling(
+    self, monkeypatch
+):
+    # Omit the model argument so the test also verifies the handler fallback to
+    # claude-sonnet-5. The mocked config may contain temperature/top_p/top_k
+    # defaults to prove they are suppressed.
+    assert captured["json"]["model"] == "claude-sonnet-5"
+    assert "thinking" not in captured["json"]
+    assert "output_config" not in captured["json"]
+    assert "temperature" not in captured["json"]
+    assert "top_p" not in captured["json"]
+    assert "top_k" not in captured["json"]
+
+
+@pytest.mark.parametrize("effort", ["low", "medium", "high", "xhigh", "max"])
+def test_anthropic_sonnet_5_effort_uses_output_config(
+    self, monkeypatch, effort
+):
+    # Call claude-sonnet-5 with thinking_effort=effort.
+    assert captured["json"]["output_config"] == {"effort": effort}
+    assert "thinking" not in captured["json"]
+
+
+def test_anthropic_sonnet_5_off_disables_thinking(self, monkeypatch):
+    # Call claude-sonnet-5 with thinking_effort="off".
+    assert captured["json"]["thinking"] == {"type": "disabled"}
+    assert "output_config" not in captured["json"]
+
+
+def test_anthropic_adaptive_model_effort_uses_output_config(self, monkeypatch):
+    # Call an already-recognized adaptive model such as claude-opus-4-8.
+    assert captured["json"]["thinking"] == {"type": "adaptive"}
+    assert captured["json"]["output_config"] == {"effort": "high"}
+    assert "effort" not in captured["json"]["thinking"]
+```
+
+In the Sonnet 5 effort case, also pass `thinking_budget_tokens=4096` and assert
+that no `budget_tokens` field is emitted. In every Sonnet 5 test, assert sampling
+fields are absent.
+
+- [ ] **Step 2: Run the new tests and verify they fail**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest Tests/Chat/test_chat_functions.py -k "sonnet_5 or adaptive_model_effort" -x -q
+```
+
+Expected: FAIL because Sonnet 5 is not recognized and adaptive effort is
+currently nested inside `thinking`.
+
+- [ ] **Step 3: Separate Anthropic thinking mode from output effort**
+
+In `LLM_API_Calls.py`:
+
+- Add an exact Claude Sonnet 5 family predicate.
+- Refactor `_anthropic_thinking_config()` into a helper contract that returns
+  three values: `thinking_config`, `output_config`, and `max_tokens`.
+- For Sonnet 5:
+  - no setting: return neither `thinking` nor `output_config`;
+  - supported effort: return `output_config={"effort": effort}` only;
+  - `"off"`: return `thinking={"type": "disabled"}` only;
+  - ignore fixed budgets and log a warning when one was supplied.
+- For existing adaptive models:
+  - keep `thinking={"type": "adaptive"}`;
+  - put explicit effort in `output_config={"effort": effort}`;
+  - never nest effort in `thinking`.
+- Preserve legacy fixed-budget behavior for older non-adaptive models.
+- In `chat_with_anthropic()`, attach `thinking` and `output_config` separately.
+- Suppress `temperature`, `top_p`, and `top_k` for Sonnet 5 regardless of
+  generic/config defaults or explicit arguments.
+- Preserve the existing sampling behavior for older models.
+- Change the handler fallback used when Anthropic config has no model to
+  `claude-sonnet-5`.
+
+- [ ] **Step 4: Update old adaptive assertions**
+
+Change the two existing adaptive-model tests from:
+
+```python
+assert captured["json"]["thinking"] == {"type": "adaptive", "effort": "high"}
+```
+
+to the documented split:
+
+```python
+assert captured["json"]["thinking"] == {"type": "adaptive"}
+assert captured["json"]["output_config"] == {"effort": "high"}
+```
+
+Keep the legacy Sonnet 4 fixed-budget tests unchanged.
+
+- [ ] **Step 5: Run focused Anthropic tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest Tests/Chat/test_chat_functions.py -k "anthropic" -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/LLM_Calls/LLM_API_Calls.py Tests/Chat/test_chat_functions.py
+git commit -m "fix: shape Claude Sonnet 5 requests compatibly"
+```
+
+---
+
+### Task 4: Refresh the DeepSeek handler fallback without changing its contract
+
+**Files:**
+
+- Modify: `tldw_chatbook/LLM_Calls/LLM_API_Calls.py`
+- Modify: `Tests/Chat/test_chat_functions.py`
+- Test: `Tests/Chat/test_chat_functions.py`
+
+- [ ] **Step 1: Add a failing DeepSeek fallback request test**
+
+Use `_CapturedSession`, monkeypatch the module-level `settings` to contain a
+DeepSeek API key/base URL but no model, call `chat_with_deepseek(model=None)`,
+and assert:
+
+```python
+assert captured["url"] == "https://api.deepseek.test/chat/completions"
+assert captured["json"]["model"] == "deepseek-v4-flash"
+assert captured["json"]["messages"] == [{"role": "user", "content": "test"}]
+assert captured["json"]["max_tokens"] == 128
+```
+
+This test verifies that only the model choice changes; the existing endpoint and
+Chat Completions payload stay intact.
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest Tests/Chat/test_chat_functions.py -k "deepseek" -x -q
+```
+
+Expected: FAIL because the handler fallback remains `deepseek-chat`.
+
+- [ ] **Step 3: Change the DeepSeek handler fallback**
+
+In `chat_with_deepseek()`, replace only its fallback model ID with
+`deepseek-v4-flash`. Do not add new reasoning or endpoint behavior.
+
+- [ ] **Step 4: Run focused DeepSeek tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest Tests/Chat/test_chat_functions.py -k "deepseek" -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/LLM_Calls/LLM_API_Calls.py Tests/Chat/test_chat_functions.py
+git commit -m "fix: refresh DeepSeek handler fallback"
+```
+
+---
+
+### Task 5: Recognize the new defaults as vision-capable
+
+**Files:**
+
+- Modify: `tldw_chatbook/config.py`
+- Modify: `tldw_chatbook/model_capabilities.py`
+- Modify: `Tests/test_config_model_catalog_defaults.py`
+- Modify: `Tests/test_model_capabilities.py`
+- Test: `Tests/test_config_model_catalog_defaults.py`
+- Test: `Tests/test_model_capabilities.py`
+
+- [ ] **Step 1: Add failing capability tests**
+
+In `Tests/test_model_capabilities.py`, extend `TestDefaultModels`:
+
+```python
+assert (
+    model_capabilities_empty.is_vision_capable("OpenAI", "gpt-5.6-terra")
+    is True
+)
+assert (
+    model_capabilities_empty.is_vision_capable("Anthropic", "claude-sonnet-5")
+    is True
+)
+```
+
+In `Tests/test_config_model_catalog_defaults.py`, assert the embedded TOML direct
+capability mappings:
+
+```python
+models = parsed["model_capabilities"]["models"]
+assert models["gpt-5.6-terra"]["vision"] is True
+assert models["claude-sonnet-5"]["vision"] is True
+```
+
+- [ ] **Step 2: Run the capability tests and verify they fail**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest Tests/test_config_model_catalog_defaults.py Tests/test_model_capabilities.py -x -q
+```
+
+Expected: FAIL because neither new default is in the current direct maps or
+patterns.
+
+- [ ] **Step 3: Add matching capability metadata**
+
+In both the embedded `[model_capabilities.models]` table in `config.py` and
+`DEFAULT_MODEL_CAPABILITIES` in `model_capabilities.py`, add:
+
+```python
+"gpt-5.6-terra": {"vision": True, "max_images": 10}
+"claude-sonnet-5": {"vision": True, "max_images": 5}
+```
+
+Use TOML inline-table syntax in the embedded config. Direct mappings are
+sufficient for the selected defaults; do not broaden family patterns or add
+DeepSeek V4 vision metadata without separate vendor evidence.
+
+- [ ] **Step 4: Run capability and configuration tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest Tests/test_config_model_catalog_defaults.py Tests/test_model_capabilities.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/config.py tldw_chatbook/model_capabilities.py Tests/test_config_model_catalog_defaults.py Tests/test_model_capabilities.py
+git commit -m "config: recognize new default model capabilities"
+```
+
+---
+
+### Task 6: Verify, document, and close TASK-519
+
+**Files:**
+
+- Modify: `backlog/tasks/task-519 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md` (via Backlog CLI)
+- Verify: all files changed in Tasks 1–5
+
+- [ ] **Step 1: Run the complete targeted suite**
+
+```bash
+.venv/bin/python -m pytest Tests/test_config_model_catalog_defaults.py Tests/Chat/test_chat_functions.py Tests/test_model_capabilities.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run lint, format, and static checks for changed Python files**
+
+```bash
+.venv/bin/ruff check --select E9,F63,F7,F82 tldw_chatbook/config.py tldw_chatbook/LLM_Calls/LLM_API_Calls.py tldw_chatbook/model_capabilities.py Tests/test_config_model_catalog_defaults.py Tests/Chat/test_chat_functions.py Tests/test_model_capabilities.py
+.venv/bin/ruff format --check tldw_chatbook/LLM_Calls/LLM_API_Calls.py tldw_chatbook/model_capabilities.py Tests/test_config_model_catalog_defaults.py Tests/Chat/test_chat_functions.py Tests/test_model_capabilities.py
+.venv/bin/python -m compileall -q tldw_chatbook/config.py tldw_chatbook/LLM_Calls/LLM_API_Calls.py tldw_chatbook/model_capabilities.py
+git diff --check
+```
+
+Expected: all commands exit 0. `config.py` is included in Ruff's fatal
+syntax/undefined-name lint set and `git diff --check`, but excluded from the
+whole-file format check because the unchanged baseline file is not Ruff-formatted
+and would require a large out-of-scope rewrite. The other five touched Python
+files pass Ruff's formatter check.
+
+- [ ] **Step 3: Audit the diff against the approved scope**
+
+Run:
+
+```bash
+git diff --stat 685a8e0d4...HEAD
+git diff 685a8e0d4...HEAD -- tldw_chatbook/config.py tldw_chatbook/LLM_Calls/LLM_API_Calls.py tldw_chatbook/model_capabilities.py Tests/test_config_model_catalog_defaults.py Tests/Chat/test_chat_functions.py Tests/test_model_capabilities.py
+```
+
+Confirm:
+
+- no existing user config migration was added;
+- character, analysis, TTS, embedding, RAG, and historical fixture defaults are
+  unchanged;
+- retired DeepSeek aliases were removed only from active bundled catalogs and
+  fallback defaults;
+- Responses API normalization and older-model payload behavior remain covered.
+
+- [ ] **Step 4: Update TASK-519 through Backlog CLI**
+
+Add concise implementation notes that list the changed files, model-aware
+compatibility rules, ADR-020/design links, and exact verification results. Mark
+all seven acceptance criteria complete only after the checks above pass, then
+move the task to Done:
+
+```bash
+backlog task edit 519 --notes "<implementation summary and verification>"
+backlog task edit 519 --check-ac 1 --check-ac 2 --check-ac 3 --check-ac 4 --check-ac 5 --check-ac 6 --check-ac 7
+backlog task edit 519 -s Done
+```
+
+- [ ] **Step 5: Commit task closeout**
+
+```bash
+git add "backlog/tasks/task-519 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md"
+git commit -m "docs: close provider default model refresh task"
+```
+
+- [ ] **Step 6: Run final verification from the committed tree**
+
+```bash
+.venv/bin/python -m pytest Tests/test_config_model_catalog_defaults.py Tests/Chat/test_chat_functions.py Tests/test_model_capabilities.py -q
+.venv/bin/ruff check --select E9,F63,F7,F82 tldw_chatbook/config.py tldw_chatbook/LLM_Calls/LLM_API_Calls.py tldw_chatbook/model_capabilities.py Tests/test_config_model_catalog_defaults.py Tests/Chat/test_chat_functions.py Tests/test_model_capabilities.py
+.venv/bin/ruff format --check tldw_chatbook/LLM_Calls/LLM_API_Calls.py tldw_chatbook/model_capabilities.py Tests/test_config_model_catalog_defaults.py Tests/Chat/test_chat_functions.py Tests/test_model_capabilities.py
+.venv/bin/python -m compileall -q tldw_chatbook/config.py tldw_chatbook/LLM_Calls/LLM_API_Calls.py tldw_chatbook/model_capabilities.py
+git diff --check
+git status --short
+```
+
+Expected: tests and static checks pass; `git status --short` is empty.

--- a/Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md
+++ b/Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md
@@ -10,7 +10,7 @@
 
 **Spec:** `Docs/superpowers/specs/2026-07-26-provider-default-model-refresh-design.md` (read first; it is the source of truth).
 
-**Backlog:** `backlog/tasks/task-519 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md`
+**Backlog:** `backlog/tasks/task-869 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md`
 
 **ADR required:** no
 
@@ -31,22 +31,22 @@
 **Files:**
 
 - Add: `Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md`
-- Modify: `backlog/tasks/task-519 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md`
+- Modify: `backlog/tasks/task-869 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md`
 
 - [x] **Step 1: Verify the planning diff**
 
 ```bash
 git diff --check
-git diff -- Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md "backlog/tasks/task-519 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md"
+git diff -- Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md "backlog/tasks/task-869 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md"
 ```
 
-Expected: no whitespace errors; TASK-519 is In Progress and links the approved
+Expected: no whitespace errors; TASK-869 is In Progress and links the approved
 design, this plan, and ADR-020 with `ADR required: no`.
 
 - [x] **Step 2: Commit the planning artifacts before implementation**
 
 ```bash
-git add Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md "backlog/tasks/task-519 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md"
+git add Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md "backlog/tasks/task-869 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md"
 git commit -m "docs: plan provider default model refresh"
 ```
 
@@ -552,11 +552,11 @@ git commit -m "config: recognize new default model capabilities"
 
 ---
 
-### Task 6: Verify, document, and close TASK-519
+### Task 6: Verify, document, and close TASK-869
 
 **Files:**
 
-- Modify: `backlog/tasks/task-519 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md` (via Backlog CLI)
+- Modify: `backlog/tasks/task-869 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md` (via Backlog CLI)
 - Verify: all files changed in Tasks 1–5
 
 - [x] **Step 1: Run the complete targeted suite**
@@ -600,7 +600,7 @@ Confirm:
   fallback defaults;
 - Responses API normalization and older-model payload behavior remain covered.
 
-- [x] **Step 4: Update TASK-519 through Backlog CLI**
+- [x] **Step 4: Update TASK-869 through Backlog CLI**
 
 Add concise implementation notes that list the changed files, model-aware
 compatibility rules, ADR-020/design links, and exact verification results. Mark
@@ -616,7 +616,7 @@ backlog task edit 519 -s Done
 - [x] **Step 5: Commit task closeout**
 
 ```bash
-git add "backlog/tasks/task-519 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md"
+git add "backlog/tasks/task-869 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md"
 git commit -m "docs: close provider default model refresh task"
 ```
 
@@ -640,14 +640,14 @@ baseline. Broad default Ruff remains baseline-failing (452 existing findings).
 A broader serial suite attempt was manually interrupted after 448 passed, 1
 skipped, and 0 observed failures at 3% in 140.83s because its projected runtime
 was impractical; xdist is unsuitable because repository tests share state. This
-is not a full-suite pass. The approved scoped exception keeps TASK-519 Done
+is not a full-suite pass. The approved scoped exception keeps TASK-869 Done
 because its acceptance criteria require the focused suite.
 
-Post-rebase addendum (2026-07-27): after replaying the isolated TASK-519 commit
+Post-rebase addendum (2026-07-27): after replaying the isolated TASK-869 commit
 series onto the latest `origin/dev`, the focused suite passes 97 tests. Fatal
 Ruff rules, `compileall`, and `git diff --check origin/dev` pass. A whole-file
 Ruff format pass is no longer claimed: current `dev` contributes unrelated
 formatting findings in `Tests/Chat/test_chat_functions.py` and
 `tldw_chatbook/model_capabilities.py`, and mechanically formatting those files
-would expand this PR beyond TASK-519. The rebase also preserved `dev`'s
+would expand this PR beyond TASK-869. The rebase also preserved `dev`'s
 Anthropic prompt-caching behavior and context-window metadata.

--- a/Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md
+++ b/Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md
@@ -63,7 +63,7 @@ begins.
 - Modify: `Tests/test_config_model_catalog_defaults.py`
 - Test: `Tests/test_config_model_catalog_defaults.py`
 
-- [ ] **Step 1: Add failing configuration assertions**
+- [x] **Step 1: Add failing configuration assertions**
 
 Extend `Tests/test_config_model_catalog_defaults.py` to import
 `API_MODELS_BY_PROVIDER` alongside `CONFIG_TOML_CONTENT`, then add one focused
@@ -101,7 +101,7 @@ def test_recommended_provider_defaults_and_catalogs_are_current():
     assert API_MODELS_BY_PROVIDER["OpenAI"] == parsed["providers"]["OpenAI"]
 ```
 
-- [ ] **Step 2: Run the test and verify it fails**
+- [x] **Step 2: Run the test and verify it fails**
 
 Run:
 
@@ -112,7 +112,7 @@ Run:
 Expected: FAIL because the embedded provider catalogs and defaults still contain
 the previous model IDs.
 
-- [ ] **Step 3: Update active configuration defaults**
+- [x] **Step 3: Update active configuration defaults**
 
 In `tldw_chatbook/config.py`:
 
@@ -134,7 +134,7 @@ In `tldw_chatbook/config.py`:
 - Do not change `[character_defaults]`, `[analysis_defaults]`, or specialized
   model settings.
 
-- [ ] **Step 4: Run the configuration tests**
+- [x] **Step 4: Run the configuration tests**
 
 Run:
 
@@ -144,7 +144,7 @@ Run:
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add tldw_chatbook/config.py Tests/test_config_model_catalog_defaults.py
@@ -161,7 +161,7 @@ git commit -m "config: refresh provider default models"
 - Modify: `Tests/Chat/test_chat_functions.py`
 - Test: `Tests/Chat/test_chat_functions.py`
 
-- [ ] **Step 1: Add failing GPT-5.6 payload tests**
+- [x] **Step 1: Add failing GPT-5.6 payload tests**
 
 In `TestProviderRequestPayloads`, add tests using `_CapturedSession`:
 
@@ -239,7 +239,7 @@ Retain the existing `o3` Responses and streaming tests as regression coverage.
 Calling the default-contract test with `model=None` also verifies the OpenAI
 handler fallback.
 
-- [ ] **Step 2: Run the new tests and verify they fail**
+- [x] **Step 2: Run the new tests and verify they fail**
 
 Run:
 
@@ -250,7 +250,7 @@ Run:
 Expected: FAIL because ordinary GPT-5.6 requests currently use `max_tokens`,
 omit `reasoning_effort`, and explicit `"none"` selects Responses.
 
-- [ ] **Step 3: Implement narrowly scoped OpenAI model routing**
+- [x] **Step 3: Implement narrowly scoped OpenAI model routing**
 
 In `LLM_API_Calls.py`:
 
@@ -272,7 +272,7 @@ In `LLM_API_Calls.py`:
 - Change the handler fallback used when the OpenAI config has no model to
   `gpt-5.6-terra`.
 
-- [ ] **Step 4: Run focused OpenAI tests**
+- [x] **Step 4: Run focused OpenAI tests**
 
 Run:
 
@@ -282,7 +282,7 @@ Run:
 
 Expected: PASS, including the existing Responses normalization tests.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add tldw_chatbook/LLM_Calls/LLM_API_Calls.py Tests/Chat/test_chat_functions.py
@@ -299,7 +299,7 @@ git commit -m "fix: shape GPT-5.6 requests compatibly"
 - Modify: `Tests/Chat/test_chat_functions.py`
 - Test: `Tests/Chat/test_chat_functions.py`
 
-- [ ] **Step 1: Add failing Sonnet 5 and adaptive-effort tests**
+- [x] **Step 1: Add failing Sonnet 5 and adaptive-effort tests**
 
 Add four captured-payload tests:
 
@@ -344,7 +344,7 @@ In the Sonnet 5 effort case, also pass `thinking_budget_tokens=4096` and assert
 that no `budget_tokens` field is emitted. In every Sonnet 5 test, assert sampling
 fields are absent.
 
-- [ ] **Step 2: Run the new tests and verify they fail**
+- [x] **Step 2: Run the new tests and verify they fail**
 
 Run:
 
@@ -355,7 +355,7 @@ Run:
 Expected: FAIL because Sonnet 5 is not recognized and adaptive effort is
 currently nested inside `thinking`.
 
-- [ ] **Step 3: Separate Anthropic thinking mode from output effort**
+- [x] **Step 3: Separate Anthropic thinking mode from output effort**
 
 In `LLM_API_Calls.py`:
 
@@ -379,7 +379,7 @@ In `LLM_API_Calls.py`:
 - Change the handler fallback used when Anthropic config has no model to
   `claude-sonnet-5`.
 
-- [ ] **Step 4: Update old adaptive assertions**
+- [x] **Step 4: Update old adaptive assertions**
 
 Change the two existing adaptive-model tests from:
 
@@ -396,7 +396,7 @@ assert captured["json"]["output_config"] == {"effort": "high"}
 
 Keep the legacy Sonnet 4 fixed-budget tests unchanged.
 
-- [ ] **Step 5: Run focused Anthropic tests**
+- [x] **Step 5: Run focused Anthropic tests**
 
 Run:
 
@@ -406,7 +406,7 @@ Run:
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add tldw_chatbook/LLM_Calls/LLM_API_Calls.py Tests/Chat/test_chat_functions.py
@@ -423,7 +423,7 @@ git commit -m "fix: shape Claude Sonnet 5 requests compatibly"
 - Modify: `Tests/Chat/test_chat_functions.py`
 - Test: `Tests/Chat/test_chat_functions.py`
 
-- [ ] **Step 1: Add a failing DeepSeek fallback request test**
+- [x] **Step 1: Add a failing DeepSeek fallback request test**
 
 Use `_CapturedSession`, monkeypatch the module-level `settings` to contain a
 DeepSeek API key/base URL but no model, call `chat_with_deepseek(model=None)`,
@@ -439,7 +439,7 @@ assert captured["json"]["max_tokens"] == 128
 This test verifies that only the model choice changes; the existing endpoint and
 Chat Completions payload stay intact.
 
-- [ ] **Step 2: Run the test and verify it fails**
+- [x] **Step 2: Run the test and verify it fails**
 
 Run:
 
@@ -449,12 +449,12 @@ Run:
 
 Expected: FAIL because the handler fallback remains `deepseek-chat`.
 
-- [ ] **Step 3: Change the DeepSeek handler fallback**
+- [x] **Step 3: Change the DeepSeek handler fallback**
 
 In `chat_with_deepseek()`, replace only its fallback model ID with
 `deepseek-v4-flash`. Do not add new reasoning or endpoint behavior.
 
-- [ ] **Step 4: Run focused DeepSeek tests**
+- [x] **Step 4: Run focused DeepSeek tests**
 
 Run:
 
@@ -464,7 +464,7 @@ Run:
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add tldw_chatbook/LLM_Calls/LLM_API_Calls.py Tests/Chat/test_chat_functions.py
@@ -484,7 +484,7 @@ git commit -m "fix: refresh DeepSeek handler fallback"
 - Test: `Tests/test_config_model_catalog_defaults.py`
 - Test: `Tests/test_model_capabilities.py`
 
-- [ ] **Step 1: Add failing capability tests**
+- [x] **Step 1: Add failing capability tests**
 
 In `Tests/test_model_capabilities.py`, extend `TestDefaultModels`:
 
@@ -508,7 +508,7 @@ assert models["gpt-5.6-terra"]["vision"] is True
 assert models["claude-sonnet-5"]["vision"] is True
 ```
 
-- [ ] **Step 2: Run the capability tests and verify they fail**
+- [x] **Step 2: Run the capability tests and verify they fail**
 
 Run:
 
@@ -519,7 +519,7 @@ Run:
 Expected: FAIL because neither new default is in the current direct maps or
 patterns.
 
-- [ ] **Step 3: Add matching capability metadata**
+- [x] **Step 3: Add matching capability metadata**
 
 In both the embedded `[model_capabilities.models]` table in `config.py` and
 `DEFAULT_MODEL_CAPABILITIES` in `model_capabilities.py`, add:
@@ -533,7 +533,7 @@ Use TOML inline-table syntax in the embedded config. Direct mappings are
 sufficient for the selected defaults; do not broaden family patterns or add
 DeepSeek V4 vision metadata without separate vendor evidence.
 
-- [ ] **Step 4: Run capability and configuration tests**
+- [x] **Step 4: Run capability and configuration tests**
 
 Run:
 
@@ -543,7 +543,7 @@ Run:
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add tldw_chatbook/config.py tldw_chatbook/model_capabilities.py Tests/test_config_model_catalog_defaults.py Tests/test_model_capabilities.py
@@ -559,7 +559,7 @@ git commit -m "config: recognize new default model capabilities"
 - Modify: `backlog/tasks/task-519 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md` (via Backlog CLI)
 - Verify: all files changed in Tasks 1–5
 
-- [ ] **Step 1: Run the complete targeted suite**
+- [x] **Step 1: Run the complete targeted suite**
 
 ```bash
 .venv/bin/python -m pytest Tests/test_config_model_catalog_defaults.py Tests/Chat/test_chat_functions.py Tests/test_model_capabilities.py -q
@@ -567,7 +567,7 @@ git commit -m "config: recognize new default model capabilities"
 
 Expected: all tests pass.
 
-- [ ] **Step 2: Run lint, format, and static checks for changed Python files**
+- [x] **Step 2: Run lint, format, and static checks for changed Python files**
 
 ```bash
 .venv/bin/ruff check --select E9,F63,F7,F82 tldw_chatbook/config.py tldw_chatbook/LLM_Calls/LLM_API_Calls.py tldw_chatbook/model_capabilities.py Tests/test_config_model_catalog_defaults.py Tests/Chat/test_chat_functions.py Tests/test_model_capabilities.py
@@ -582,7 +582,7 @@ whole-file format check because the unchanged baseline file is not Ruff-formatte
 and would require a large out-of-scope rewrite. The other five touched Python
 files pass Ruff's formatter check.
 
-- [ ] **Step 3: Audit the diff against the approved scope**
+- [x] **Step 3: Audit the diff against the approved scope**
 
 Run:
 
@@ -600,7 +600,7 @@ Confirm:
   fallback defaults;
 - Responses API normalization and older-model payload behavior remain covered.
 
-- [ ] **Step 4: Update TASK-519 through Backlog CLI**
+- [x] **Step 4: Update TASK-519 through Backlog CLI**
 
 Add concise implementation notes that list the changed files, model-aware
 compatibility rules, ADR-020/design links, and exact verification results. Mark
@@ -613,7 +613,7 @@ backlog task edit 519 --check-ac 1 --check-ac 2 --check-ac 3 --check-ac 4 --chec
 backlog task edit 519 -s Done
 ```
 
-- [ ] **Step 5: Commit task closeout**
+- [x] **Step 5: Commit task closeout**
 
 ```bash
 git add "backlog/tasks/task-519 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md"

--- a/Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md
+++ b/Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md
@@ -642,3 +642,12 @@ skipped, and 0 observed failures at 3% in 140.83s because its projected runtime
 was impractical; xdist is unsuitable because repository tests share state. This
 is not a full-suite pass. The approved scoped exception keeps TASK-519 Done
 because its acceptance criteria require the focused suite.
+
+Post-rebase addendum (2026-07-27): after replaying the isolated TASK-519 commit
+series onto the latest `origin/dev`, the focused suite passes 97 tests. Fatal
+Ruff rules, `compileall`, and `git diff --check origin/dev` pass. A whole-file
+Ruff format pass is no longer claimed: current `dev` contributes unrelated
+formatting findings in `Tests/Chat/test_chat_functions.py` and
+`tldw_chatbook/model_capabilities.py`, and mechanically formatting those files
+would expand this PR beyond TASK-519. The rebase also preserved `dev`'s
+Anthropic prompt-caching behavior and context-window metadata.

--- a/Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md
+++ b/Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md
@@ -632,3 +632,13 @@ git status --short
 ```
 
 Expected: tests and static checks pass; `git status --short` is empty.
+
+Verification scope note: the approved focused suite passed 89 tests. Fatal Ruff
+rules passed on all six touched files; the formatter passed on the five
+formatter-clean files, while `config.py` retains its pre-existing formatting
+baseline. Broad default Ruff remains baseline-failing (452 existing findings).
+A broader serial suite attempt was manually interrupted after 448 passed, 1
+skipped, and 0 observed failures at 3% in 140.83s because its projected runtime
+was impractical; xdist is unsuitable because repository tests share state. This
+is not a full-suite pass. The approved scoped exception keeps TASK-519 Done
+because its acceptance criteria require the focused suite.

--- a/Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md
+++ b/Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md
@@ -620,7 +620,7 @@ git add "backlog/tasks/task-519 - Refresh-default-models-for-DeepSeek-Anthropic-
 git commit -m "docs: close provider default model refresh task"
 ```
 
-- [ ] **Step 6: Run final verification from the committed tree**
+- [x] **Step 6: Run final verification from the committed tree**
 
 ```bash
 .venv/bin/python -m pytest Tests/test_config_model_catalog_defaults.py Tests/Chat/test_chat_functions.py Tests/test_model_capabilities.py -q

--- a/Docs/superpowers/specs/2026-07-26-provider-default-model-refresh-design.md
+++ b/Docs/superpowers/specs/2026-07-26-provider-default-model-refresh-design.md
@@ -1,0 +1,233 @@
+# Provider Default Model Refresh — Design
+
+**Date:** 2026-07-26
+**Backlog:** [TASK-519](../../../backlog/tasks/task-519%20-%20Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md)
+**ADR required:** No
+**ADR path:** [ADR-020](../../../backlog/decisions/020-automatic-model-catalog-refresh.md)
+**Reason:** This refresh changes bundled provider defaults and model-aware request
+shaping inside existing provider boundaries. ADR-020 already governs model catalog
+discovery and persistence; no storage, ownership, service-contract, or provider
+boundary changes are introduced.
+
+## Summary
+
+Refresh the bundled balanced general-purpose defaults to:
+
+| Provider | New default | Role |
+| --- | --- | --- |
+| DeepSeek | `deepseek-v4-flash` | Fast, economical general-purpose model |
+| Anthropic | `claude-sonnet-5` | Balanced speed and intelligence |
+| OpenAI | `gpt-5.6-terra` | Balanced intelligence and cost |
+
+The change is not a blind string replacement. Claude Sonnet 5 rejects non-default
+sampling controls, while GPT-5.6 needs a model-aware Chat Completions token and
+reasoning contract to preserve the current non-reasoning, tool-compatible default
+behavior. The implementation therefore updates both configuration defaults and
+the smallest required provider request-shaping logic.
+
+## Goals
+
+- Give fresh installations current, vendor-supported balanced defaults.
+- Keep provider selectors useful by retaining supported alternative models.
+- Preserve the existing provider endpoints and normalized response contracts.
+- Preserve explicit user configuration; bundled defaults must not overwrite a
+  user's persisted model choices.
+- Keep ordinary GPT-5.6 chat and function-tool requests on the existing Chat
+  Completions path with non-reasoning behavior unless the user explicitly selects
+  Responses-only reasoning controls.
+- Ensure the new OpenAI and Anthropic defaults remain recognized as vision-capable.
+
+## Non-goals
+
+- Automatically rewriting existing user `config.toml` files.
+- Replacing historical examples, eval baselines, fixtures, or tests whose model
+  IDs are part of the scenario under test.
+- Changing specialized TTS, embeddings, transcription, RAG, character-chat, or
+  media-analysis defaults.
+- Removing older models that remain supported.
+- Adding GPT-5.6 optional features such as Pro mode, persisted reasoning,
+  programmatic tool calling, explicit prompt caching, or multi-agent execution.
+- Reworking the existing Responses API tool-call normalization contract.
+- Live provider benchmarking or choosing defaults dynamically by price.
+
+## Vendor Basis
+
+### DeepSeek
+
+DeepSeek describes V4 Flash as the fast, efficient, economical V4 option whose
+reasoning approaches V4 Pro and whose simple-agent performance is comparable to
+V4 Pro. The legacy `deepseek-chat` and `deepseek-reasoner` names retired on
+2026-07-24, so they must no longer be bundled as usable current defaults.
+
+Source: <https://api-docs.deepseek.com/news/news260424/>
+
+### Anthropic
+
+Anthropic describes Claude Sonnet 5 as the best combination of speed and
+intelligence. It is available through the Claude API as `claude-sonnet-5`.
+Sonnet 5 enables adaptive thinking by default and rejects non-default
+`temperature`, `top_p`, and `top_k` values.
+
+Sources:
+
+- <https://platform.claude.com/docs/en/about-claude/models/overview>
+- <https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5>
+
+### OpenAI
+
+OpenAI describes GPT-5.6 Terra as the family tier that balances intelligence and
+cost. It supports both Responses and Chat Completions, including function calling
+and streaming. The explicit `gpt-5.6-terra` ID is preferred over the `gpt-5.6`
+alias because the alias routes to the higher-capability Sol tier.
+
+Sources:
+
+- <https://developers.openai.com/api/docs/guides/latest-model>
+- <https://developers.openai.com/api/docs/models/gpt-5.6-terra>
+- <https://developers.openai.com/api/docs/guides/upgrading-to-gpt-5p6-sol>
+
+## Configuration Design
+
+### Bundled provider catalogs
+
+Update both bundled catalog representations in `tldw_chatbook/config.py` so they
+stay consistent:
+
+- Python `API_MODELS_BY_PROVIDER`
+- Embedded TOML `[providers]`
+
+The relevant leading entries become:
+
+- DeepSeek: `deepseek-v4-flash`, `deepseek-v4-pro`
+- Anthropic: `claude-sonnet-5`, followed by current supported capability and
+  efficiency alternatives
+- OpenAI: `gpt-5.6-terra`, `gpt-5.6-sol`, `gpt-5.6-luna`, followed by supported
+  existing alternatives
+
+Remove `deepseek-chat` and `deepseek-reasoner` from the bundled DeepSeek list
+because the official endpoint no longer serves them. Do not delete historical
+references outside active bundled defaults and catalogs.
+
+### Provider defaults and fallbacks
+
+Update every active provider-default layer for these three providers:
+
+- Embedded TOML `[api_settings.openai].model`,
+  `[api_settings.anthropic].model`, and `[api_settings.deepseek].model`
+- The `load_settings()` legacy fallback values
+- The provider-handler fallback values used when the corresponding configuration
+  entry is absent
+- The global `[chat_defaults].model`, because its provider is OpenAI
+- Minimal hardcoded catalog fallbacks used only when the embedded provider table
+  is absent or malformed
+
+Do not update `[character_defaults]`, `[analysis_defaults]`, or unrelated
+feature-specific model choices in this task.
+
+### Existing user configuration
+
+The embedded defaults continue to seed fresh configuration. Existing persisted
+values keep their current precedence and are not silently migrated. In
+particular, an existing user-selected `deepseek-chat` value is not rewritten at
+load time; the provider will return its normal unsupported-model error until the
+user selects a current model.
+
+## Provider Request Compatibility
+
+### OpenAI GPT-5.6
+
+Add a small model-family predicate for GPT-5.6 IDs and keep endpoint selection
+behavior explicit:
+
+1. For ordinary GPT-5.6 requests with no Responses-only controls, use Chat
+   Completions.
+2. Preserve the pre-migration non-reasoning behavior by sending
+   `reasoning_effort: "none"` on that Chat Completions request.
+3. Use `max_completion_tokens` instead of deprecated `max_tokens` for GPT-5.6
+   Chat Completions requests.
+4. Preserve `max_output_tokens` on Responses requests.
+5. Preserve the existing Chat Completions function-tool schema and response
+   normalization.
+6. Continue using Responses when `reasoning_summary` or `verbosity` is set, or
+   when an explicit reasoning effort other than `none` is selected.
+7. Treat an explicit `reasoning_effort: "none"` without other Responses-only
+   controls as a Chat Completions request, matching the ordinary default path.
+8. Leave older OpenAI model request shaping unchanged.
+
+This is a compatibility migration, not adoption of new GPT-5.6 capabilities.
+
+### Anthropic Claude Sonnet 5
+
+Add model-aware Anthropic predicates so that:
+
+1. `claude-sonnet-5` is recognized as an adaptive-thinking model.
+2. Explicit supported thinking effort maps to Anthropic adaptive thinking.
+3. Fixed thinking budgets are ignored for adaptive-thinking models, matching the
+   existing modern-Opus behavior.
+4. `temperature`, `top_p`, and `top_k` are omitted for Claude Sonnet 5 even when
+   generic or persisted defaults contain them.
+5. Existing sampling behavior remains unchanged for older models that support
+   these fields.
+
+The default Sonnet 5 request may omit a `thinking` object because Anthropic
+enables adaptive thinking by default.
+
+### DeepSeek V4 Flash
+
+The existing DeepSeek Chat Completions endpoint and payload shape are retained.
+Only the model default, bundled catalog, and fallback IDs change. No new
+thinking-mode behavior is introduced.
+
+## Capability Metadata
+
+Update `model_capabilities.py` and the embedded `[model_capabilities]` defaults
+only as needed for the selected defaults:
+
+- Recognize GPT-5.6 text-and-image models as vision-capable.
+- Recognize Claude Sonnet 5 as vision-capable.
+- Do not infer unverified DeepSeek V4 image support.
+
+Existing capability precedence and user overrides remain unchanged.
+
+## Error Handling
+
+- Provider HTTP and configuration errors continue through the existing typed
+  error paths.
+- No silent fallback to a different model occurs after a provider rejects a
+  configured model.
+- Existing user configurations referencing retired models remain visible and
+  actionable rather than being rewritten behind the user's back.
+- Model-aware request shaping must be limited to exact, documented family
+  predicates so unrelated custom or provider-compatible model IDs are unchanged.
+
+## Testing
+
+Add or extend focused tests for:
+
+1. Embedded TOML parsing returns the three new provider defaults.
+2. Bundled provider catalogs lead with the recommended models and exclude the
+   retired DeepSeek aliases.
+3. Legacy and handler fallbacks match the new provider defaults.
+4. GPT-5.6 Terra ordinary Chat Completions requests send
+   `reasoning_effort: "none"` and `max_completion_tokens`.
+5. GPT-5.6 explicit higher reasoning still selects Responses and uses
+   `max_output_tokens`.
+6. GPT-5.6 Chat Completions tool payloads remain in the existing function-tool
+   shape.
+7. Claude Sonnet 5 omits `temperature`, `top_p`, and `top_k`.
+8. Claude Sonnet 5 maps explicit thinking effort to adaptive thinking.
+9. DeepSeek V4 Flash uses the existing `/chat/completions` request contract.
+10. GPT-5.6 Terra and Claude Sonnet 5 are recognized as vision-capable.
+
+Run the smallest relevant configuration, chat-provider, catalog, and capability
+test modules, followed by lint or formatting checks for changed files. Live API
+smoke tests are optional and must run only when the relevant environment keys are
+already available.
+
+## Documentation and Task Closeout
+
+- Link this design and ADR-020 from TASK-519's implementation plan.
+- Record exact changed files, compatibility decisions, and verification evidence
+  in TASK-519 implementation notes.
+- Mark acceptance criteria complete and move TASK-519 to Done only after all
+  required tests and static checks pass.

--- a/Docs/superpowers/specs/2026-07-26-provider-default-model-refresh-design.md
+++ b/Docs/superpowers/specs/2026-07-26-provider-default-model-refresh-design.md
@@ -1,7 +1,7 @@
 # Provider Default Model Refresh — Design
 
 **Date:** 2026-07-26
-**Backlog:** [TASK-519](../../../backlog/tasks/task-519%20-%20Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md)
+**Backlog:** [TASK-869](../../../backlog/tasks/task-869%20-%20Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md)
 **ADR required:** No
 **ADR path:** [ADR-020](../../../backlog/decisions/020-automatic-model-catalog-refresh.md)
 **Reason:** This refresh changes bundled provider defaults and model-aware request
@@ -245,8 +245,8 @@ already available.
 
 ## Documentation and Task Closeout
 
-- Link this design and ADR-020 from TASK-519's implementation plan.
+- Link this design and ADR-020 from TASK-869's implementation plan.
 - Record exact changed files, compatibility decisions, and verification evidence
-  in TASK-519 implementation notes.
-- Mark acceptance criteria complete and move TASK-519 to Done only after all
+  in TASK-869 implementation notes.
+- Mark acceptance criteria complete and move TASK-869 to Done only after all
   required tests and static checks pass.

--- a/Docs/superpowers/specs/2026-07-26-provider-default-model-refresh-design.md
+++ b/Docs/superpowers/specs/2026-07-26-provider-default-model-refresh-design.md
@@ -66,12 +66,14 @@ Source: <https://api-docs.deepseek.com/news/news260424/>
 Anthropic describes Claude Sonnet 5 as the best combination of speed and
 intelligence. It is available through the Claude API as `claude-sonnet-5`.
 Sonnet 5 enables adaptive thinking by default and rejects non-default
-`temperature`, `top_p`, and `top_k` values.
+`temperature`, `top_p`, and `top_k` values. Anthropic's effort control is sent
+as `output_config.effort`; it is not nested inside `thinking`.
 
 Sources:
 
 - <https://platform.claude.com/docs/en/about-claude/models/overview>
 - <https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5>
+- <https://platform.claude.com/docs/en/build-with-claude/effort>
 
 ### OpenAI
 
@@ -99,8 +101,9 @@ stay consistent:
 The relevant leading entries become:
 
 - DeepSeek: `deepseek-v4-flash`, `deepseek-v4-pro`
-- Anthropic: `claude-sonnet-5`, followed by current supported capability and
-  efficiency alternatives
+- Anthropic: `claude-sonnet-5`, `claude-opus-5`, `claude-fable-5`,
+  `claude-haiku-4-5`, followed by the existing older entries in their current
+  order
 - OpenAI: `gpt-5.6-terra`, `gpt-5.6-sol`, `gpt-5.6-luna`, followed by supported
   existing alternatives
 
@@ -158,19 +161,29 @@ This is a compatibility migration, not adoption of new GPT-5.6 capabilities.
 
 ### Anthropic Claude Sonnet 5
 
-Add model-aware Anthropic predicates so that:
+Add model-aware Anthropic request shaping so that the three user-visible
+thinking states have exact payload contracts:
 
-1. `claude-sonnet-5` is recognized as an adaptive-thinking model.
-2. Explicit supported thinking effort maps to Anthropic adaptive thinking.
-3. Fixed thinking budgets are ignored for adaptive-thinking models, matching the
-   existing modern-Opus behavior.
-4. `temperature`, `top_p`, and `top_k` are omitted for Claude Sonnet 5 even when
+1. With no thinking setting, omit both `thinking` and `output_config`; Sonnet 5
+   then uses Anthropic's documented default adaptive thinking at high effort.
+2. With an explicit supported effort (`low`, `medium`, `high`, `xhigh`, or
+   `max`), send `output_config: {"effort": "<level>"}`. Do not nest `effort`
+   inside `thinking`.
+3. With explicit `thinking_effort: "off"`, send
+   `thinking: {"type": "disabled"}` and omit `output_config.effort`.
+4. Fixed thinking budgets are ignored for Sonnet 5 because manual extended
+   thinking is unsupported.
+5. `temperature`, `top_p`, and `top_k` are omitted for Claude Sonnet 5 even when
    generic or persisted defaults contain them.
-5. Existing sampling behavior remains unchanged for older models that support
+6. Existing sampling behavior remains unchanged for older models that support
    these fields.
 
-The default Sonnet 5 request may omit a `thinking` object because Anthropic
-enables adaptive thinking by default.
+The shared helper must return thinking-mode and output-effort data separately so
+the payload builder cannot recreate the current invalid
+`thinking: {"type": "adaptive", "effort": ...}` shape. Existing adaptive-effort
+models already recognized by the helper should use the same documented
+`output_config.effort` shape when an explicit effort is supplied; their existing
+model-specific thinking-disable constraints remain unchanged.
 
 ### DeepSeek V4 Flash
 
@@ -214,10 +227,16 @@ Add or extend focused tests for:
    `max_output_tokens`.
 6. GPT-5.6 Chat Completions tool payloads remain in the existing function-tool
    shape.
-7. Claude Sonnet 5 omits `temperature`, `top_p`, and `top_k`.
-8. Claude Sonnet 5 maps explicit thinking effort to adaptive thinking.
-9. DeepSeek V4 Flash uses the existing `/chat/completions` request contract.
-10. GPT-5.6 Terra and Claude Sonnet 5 are recognized as vision-capable.
+7. Claude Sonnet 5 with no thinking setting omits `thinking`,
+   `output_config`, `temperature`, `top_p`, and `top_k`.
+8. Claude Sonnet 5 maps explicit supported effort to
+   `output_config.effort` without nesting effort inside `thinking`.
+9. Claude Sonnet 5 maps explicit `off` to
+   `thinking: {"type": "disabled"}`.
+10. Existing recognized adaptive-effort Anthropic models use
+    `output_config.effort` rather than a nested effort field.
+11. DeepSeek V4 Flash uses the existing `/chat/completions` request contract.
+12. GPT-5.6 Terra and Claude Sonnet 5 are recognized as vision-capable.
 
 Run the smallest relevant configuration, chat-provider, catalog, and capability
 test modules, followed by lint or formatting checks for changed files. Live API

--- a/Tests/Chat/test_chat_functions.py
+++ b/Tests/Chat/test_chat_functions.py
@@ -600,6 +600,38 @@ class TestProviderRequestPayloads:
         assert "max_tokens" not in captured["json"]
         assert "max_output_tokens" not in captured["json"]
 
+    @pytest.mark.parametrize("model", ["o3", "openai/gpt-5.6-terra"])
+    def test_openai_reasoning_none_for_non_gpt_5_6_uses_responses_api(
+        self, monkeypatch, model
+    ):
+        from tldw_chatbook.LLM_Calls import LLM_API_Calls
+
+        captured = {}
+        monkeypatch.setattr(
+            LLM_API_Calls,
+            "load_settings",
+            lambda: {"openai_api": {"api_base_url": "https://api.openai.test/v1"}},
+        )
+        monkeypatch.setattr(
+            LLM_API_Calls.requests,
+            "Session",
+            lambda: _CapturedSession(captured, {"output_text": "OK"}),
+        )
+
+        LLM_API_Calls.chat_with_openai(
+            input_data=[{"role": "user", "content": "test"}],
+            api_key=DUMMY_OPENAI_API_KEY,
+            model=model,
+            streaming=False,
+            max_tokens=512,
+            reasoning_effort="none",
+        )
+
+        assert captured["url"] == "https://api.openai.test/v1/responses"
+        assert captured["json"]["max_output_tokens"] == 512
+        assert "max_tokens" not in captured["json"]
+        assert "max_completion_tokens" not in captured["json"]
+
     def test_gpt_5_6_non_none_reasoning_effort_uses_responses_api(self, monkeypatch):
         from tldw_chatbook.LLM_Calls import LLM_API_Calls
 

--- a/Tests/Chat/test_chat_functions.py
+++ b/Tests/Chat/test_chat_functions.py
@@ -526,6 +526,145 @@ class TestChatFunction:
 
 @pytest.mark.unit
 class TestProviderRequestPayloads:
+    def test_gpt_5_6_defaults_to_chat_completions_with_function_tools(self, monkeypatch):
+        from tldw_chatbook.LLM_Calls import LLM_API_Calls
+
+        captured = {}
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Gets the weather.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        monkeypatch.setattr(
+            LLM_API_Calls,
+            "load_settings",
+            lambda: {"openai_api": {"api_base_url": "https://api.openai.test/v1"}},
+        )
+        monkeypatch.setattr(
+            LLM_API_Calls.requests,
+            "Session",
+            lambda: _CapturedSession(
+                captured, {"choices": [{"message": {"content": "OK"}}]}
+            ),
+        )
+
+        LLM_API_Calls.chat_with_openai(
+            input_data=[{"role": "user", "content": "test"}],
+            api_key=DUMMY_OPENAI_API_KEY,
+            model=None,
+            streaming=False,
+            max_tokens=512,
+            tools=[tool],
+        )
+
+        assert captured["url"] == "https://api.openai.test/v1/chat/completions"
+        assert captured["json"]["model"] == "gpt-5.6-terra"
+        assert captured["json"]["reasoning_effort"] == "none"
+        assert captured["json"]["max_completion_tokens"] == 512
+        assert "max_tokens" not in captured["json"]
+        assert "max_output_tokens" not in captured["json"]
+        assert captured["json"]["tools"] == [tool]
+
+    def test_gpt_5_6_none_reasoning_effort_uses_chat_completions(self, monkeypatch):
+        from tldw_chatbook.LLM_Calls import LLM_API_Calls
+
+        captured = {}
+        monkeypatch.setattr(
+            LLM_API_Calls,
+            "load_settings",
+            lambda: {"openai_api": {"api_base_url": "https://api.openai.test/v1"}},
+        )
+        monkeypatch.setattr(
+            LLM_API_Calls.requests,
+            "Session",
+            lambda: _CapturedSession(
+                captured, {"choices": [{"message": {"content": "OK"}}]}
+            ),
+        )
+
+        LLM_API_Calls.chat_with_openai(
+            input_data=[{"role": "user", "content": "test"}],
+            api_key=DUMMY_OPENAI_API_KEY,
+            model="gpt-5.6-terra",
+            streaming=False,
+            max_tokens=512,
+            reasoning_effort="none",
+        )
+
+        assert captured["url"] == "https://api.openai.test/v1/chat/completions"
+        assert captured["json"]["reasoning_effort"] == "none"
+        assert captured["json"]["max_completion_tokens"] == 512
+        assert "max_tokens" not in captured["json"]
+        assert "max_output_tokens" not in captured["json"]
+
+    def test_gpt_5_6_non_none_reasoning_effort_uses_responses_api(self, monkeypatch):
+        from tldw_chatbook.LLM_Calls import LLM_API_Calls
+
+        captured = {}
+        monkeypatch.setattr(
+            LLM_API_Calls,
+            "load_settings",
+            lambda: {"openai_api": {"api_base_url": "https://api.openai.test/v1"}},
+        )
+        monkeypatch.setattr(
+            LLM_API_Calls.requests,
+            "Session",
+            lambda: _CapturedSession(captured, {"output_text": "OK"}),
+        )
+
+        LLM_API_Calls.chat_with_openai(
+            input_data=[{"role": "user", "content": "test"}],
+            api_key=DUMMY_OPENAI_API_KEY,
+            model="gpt-5.6-terra",
+            streaming=False,
+            max_tokens=512,
+            reasoning_effort="high",
+        )
+
+        assert captured["url"] == "https://api.openai.test/v1/responses"
+        assert captured["json"]["max_output_tokens"] == 512
+        assert "max_completion_tokens" not in captured["json"]
+        assert captured["json"]["reasoning"] == {"effort": "high"}
+
+    @pytest.mark.parametrize(
+        ("reasoning_summary", "verbosity"),
+        [("auto", None), (None, "medium")],
+    )
+    def test_gpt_5_6_none_effort_with_responses_controls_uses_responses_api(
+        self, monkeypatch, reasoning_summary, verbosity
+    ):
+        from tldw_chatbook.LLM_Calls import LLM_API_Calls
+
+        captured = {}
+        monkeypatch.setattr(
+            LLM_API_Calls,
+            "load_settings",
+            lambda: {"openai_api": {"api_base_url": "https://api.openai.test/v1"}},
+        )
+        monkeypatch.setattr(
+            LLM_API_Calls.requests,
+            "Session",
+            lambda: _CapturedSession(captured, {"output_text": "OK"}),
+        )
+
+        LLM_API_Calls.chat_with_openai(
+            input_data=[{"role": "user", "content": "test"}],
+            api_key=DUMMY_OPENAI_API_KEY,
+            model="gpt-5.6-terra",
+            streaming=False,
+            max_tokens=512,
+            reasoning_effort="none",
+            reasoning_summary=reasoning_summary,
+            verbosity=verbosity,
+        )
+
+        assert captured["url"] == "https://api.openai.test/v1/responses"
+        assert captured["json"]["max_output_tokens"] == 512
+        assert "max_completion_tokens" not in captured["json"]
+
     def test_openai_reasoning_uses_responses_api_and_normalizes_output(
         self, monkeypatch
     ):

--- a/Tests/Chat/test_chat_functions.py
+++ b/Tests/Chat/test_chat_functions.py
@@ -560,7 +560,9 @@ class TestProviderRequestPayloads:
         assert captured["json"]["messages"] == [{"role": "user", "content": "test"}]
         assert captured["json"]["max_tokens"] == 128
 
-    def test_gpt_5_6_defaults_to_chat_completions_with_function_tools(self, monkeypatch):
+    def test_gpt_5_6_defaults_to_chat_completions_with_function_tools(
+        self, monkeypatch
+    ):
         from tldw_chatbook.LLM_Calls import LLM_API_Calls
 
         captured = {}

--- a/Tests/Chat/test_chat_functions.py
+++ b/Tests/Chat/test_chat_functions.py
@@ -526,6 +526,40 @@ class TestChatFunction:
 
 @pytest.mark.unit
 class TestProviderRequestPayloads:
+    def test_deepseek_uses_refreshed_handler_fallback_model(self, monkeypatch):
+        captured = {}
+        monkeypatch.setattr(
+            llm_api_calls_module,
+            "settings",
+            {
+                "api_settings": {
+                    "deepseek": {
+                        "api_key": DUMMY_OPENAI_API_KEY,
+                        "api_base_url": "https://api.deepseek.test",
+                    }
+                }
+            },
+        )
+        monkeypatch.setattr(
+            llm_api_calls_module.requests,
+            "Session",
+            lambda: _CapturedSession(
+                captured, {"choices": [{"message": {"content": "OK"}}]}
+            ),
+        )
+
+        llm_api_calls_module.chat_with_deepseek(
+            input_data=[{"role": "user", "content": "test"}],
+            model=None,
+            streaming=False,
+            max_tokens=128,
+        )
+
+        assert captured["url"] == "https://api.deepseek.test/chat/completions"
+        assert captured["json"]["model"] == "deepseek-v4-flash"
+        assert captured["json"]["messages"] == [{"role": "user", "content": "test"}]
+        assert captured["json"]["max_tokens"] == 128
+
     def test_gpt_5_6_defaults_to_chat_completions_with_function_tools(self, monkeypatch):
         from tldw_chatbook.LLM_Calls import LLM_API_Calls
 

--- a/Tests/Chat/test_chat_functions.py
+++ b/Tests/Chat/test_chat_functions.py
@@ -1176,6 +1176,8 @@ class TestProviderRequestPayloads:
         from tldw_chatbook.LLM_Calls import LLM_API_Calls
 
         captured = {}
+        warnings = []
+        monkeypatch.setattr(LLM_API_Calls.logger, "warning", warnings.append)
         monkeypatch.setattr(
             LLM_API_Calls,
             "load_settings",
@@ -1219,6 +1221,10 @@ class TestProviderRequestPayloads:
         assert "temperature" not in payload
         assert "top_p" not in payload
         assert "top_k" not in payload
+        assert warnings == [
+            "Anthropic: omitting temperature/top_p/top_k because Claude Sonnet 5 "
+            "requires default sampling."
+        ]
 
     @pytest.mark.parametrize("effort", ["low", "medium", "high", "xhigh", "max"])
     def test_anthropic_sonnet_5_effort_uses_output_config_without_sampling(

--- a/Tests/Chat/test_chat_functions.py
+++ b/Tests/Chat/test_chat_functions.py
@@ -1093,7 +1093,8 @@ class TestProviderRequestPayloads:
             thinking_budget_tokens=4096,
         )
 
-        assert captured["json"]["thinking"] == {"type": "adaptive", "effort": "xhigh"}
+        assert captured["json"]["thinking"] == {"type": "adaptive"}
+        assert captured["json"]["output_config"] == {"effort": "xhigh"}
 
     def test_anthropic_current_opus_uses_adaptive_thinking_effort(self, monkeypatch):
         from tldw_chatbook.LLM_Calls import LLM_API_Calls
@@ -1130,7 +1131,194 @@ class TestProviderRequestPayloads:
             thinking_effort="high",
         )
 
-        assert captured["json"]["thinking"] == {"type": "adaptive", "effort": "high"}
+        assert captured["json"]["thinking"] == {"type": "adaptive"}
+        assert captured["json"]["output_config"] == {"effort": "high"}
+
+    def test_anthropic_sonnet_5_default_omits_thinking_effort_and_sampling(
+        self, monkeypatch
+    ):
+        from tldw_chatbook.LLM_Calls import LLM_API_Calls
+
+        captured = {}
+        monkeypatch.setattr(
+            LLM_API_Calls,
+            "load_settings",
+            lambda: {
+                "anthropic_api": {
+                    "api_base_url": "https://api.anthropic.test/v1",
+                    "temperature": 0.7,
+                    "top_p": 0.9,
+                    "top_k": 40,
+                }
+            },
+        )
+        monkeypatch.setattr(
+            LLM_API_Calls.requests,
+            "Session",
+            lambda: _CapturedSession(
+                captured,
+                {
+                    "id": "msg_test",
+                    "model": "claude-sonnet-5",
+                    "content": [{"type": "text", "text": "Sonnet 5 answer"}],
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 4, "output_tokens": 5},
+                },
+            ),
+        )
+
+        LLM_API_Calls.chat_with_anthropic(
+            input_data=[{"role": "user", "content": "test"}],
+            api_key=DUMMY_ANTHROPIC_API_KEY,
+            streaming=False,
+            temp=0.2,
+            topp=0.8,
+            topk=20,
+        )
+
+        payload = captured["json"]
+        assert payload["model"] == "claude-sonnet-5"
+        assert "thinking" not in payload
+        assert "output_config" not in payload
+        assert "temperature" not in payload
+        assert "top_p" not in payload
+        assert "top_k" not in payload
+
+    @pytest.mark.parametrize("effort", ["low", "medium", "high", "xhigh", "max"])
+    def test_anthropic_sonnet_5_effort_uses_output_config_without_sampling(
+        self, monkeypatch, effort
+    ):
+        from tldw_chatbook.LLM_Calls import LLM_API_Calls
+
+        captured = {}
+        monkeypatch.setattr(
+            LLM_API_Calls,
+            "load_settings",
+            lambda: {
+                "anthropic_api": {"api_base_url": "https://api.anthropic.test/v1"}
+            },
+        )
+        monkeypatch.setattr(
+            LLM_API_Calls.requests,
+            "Session",
+            lambda: _CapturedSession(
+                captured,
+                {
+                    "id": "msg_test",
+                    "model": "claude-sonnet-5",
+                    "content": [{"type": "text", "text": "Sonnet 5 answer"}],
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 4, "output_tokens": 5},
+                },
+            ),
+        )
+
+        LLM_API_Calls.chat_with_anthropic(
+            input_data=[{"role": "user", "content": "test"}],
+            api_key=DUMMY_ANTHROPIC_API_KEY,
+            model="claude-sonnet-5",
+            streaming=False,
+            temp=0.2,
+            topp=0.8,
+            topk=20,
+            thinking_effort=effort,
+            thinking_budget_tokens=4096,
+        )
+
+        payload = captured["json"]
+        assert payload["output_config"] == {"effort": effort}
+        assert "thinking" not in payload
+        assert "budget_tokens" not in json.dumps(payload)
+        assert "temperature" not in payload
+        assert "top_p" not in payload
+        assert "top_k" not in payload
+
+    def test_anthropic_sonnet_5_off_disables_thinking_without_sampling(
+        self, monkeypatch
+    ):
+        from tldw_chatbook.LLM_Calls import LLM_API_Calls
+
+        captured = {}
+        monkeypatch.setattr(
+            LLM_API_Calls,
+            "load_settings",
+            lambda: {
+                "anthropic_api": {"api_base_url": "https://api.anthropic.test/v1"}
+            },
+        )
+        monkeypatch.setattr(
+            LLM_API_Calls.requests,
+            "Session",
+            lambda: _CapturedSession(
+                captured,
+                {
+                    "id": "msg_test",
+                    "model": "claude-sonnet-5",
+                    "content": [{"type": "text", "text": "Sonnet 5 answer"}],
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 4, "output_tokens": 5},
+                },
+            ),
+        )
+
+        LLM_API_Calls.chat_with_anthropic(
+            input_data=[{"role": "user", "content": "test"}],
+            api_key=DUMMY_ANTHROPIC_API_KEY,
+            model="claude-sonnet-5",
+            streaming=False,
+            temp=0.2,
+            topp=0.8,
+            topk=20,
+            thinking_effort="off",
+        )
+
+        payload = captured["json"]
+        assert payload["thinking"] == {"type": "disabled"}
+        assert "output_config" not in payload
+        assert "temperature" not in payload
+        assert "top_p" not in payload
+        assert "top_k" not in payload
+
+    def test_anthropic_adaptive_model_effort_uses_split_thinking_config(
+        self, monkeypatch
+    ):
+        from tldw_chatbook.LLM_Calls import LLM_API_Calls
+
+        captured = {}
+        monkeypatch.setattr(
+            LLM_API_Calls,
+            "load_settings",
+            lambda: {
+                "anthropic_api": {"api_base_url": "https://api.anthropic.test/v1"}
+            },
+        )
+        monkeypatch.setattr(
+            LLM_API_Calls.requests,
+            "Session",
+            lambda: _CapturedSession(
+                captured,
+                {
+                    "id": "msg_test",
+                    "model": "claude-opus-4-8",
+                    "content": [{"type": "text", "text": "adaptive answer"}],
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 4, "output_tokens": 5},
+                },
+            ),
+        )
+
+        LLM_API_Calls.chat_with_anthropic(
+            input_data=[{"role": "user", "content": "test"}],
+            api_key=DUMMY_ANTHROPIC_API_KEY,
+            model="claude-opus-4-8",
+            streaming=False,
+            thinking_effort="high",
+        )
+
+        payload = captured["json"]
+        assert payload["thinking"] == {"type": "adaptive"}
+        assert payload["output_config"] == {"effort": "high"}
+        assert "effort" not in payload["thinking"]
 
     def test_huggingface_legacy_router_base_uses_openai_compatible_router_url(
         self, monkeypatch

--- a/Tests/test_config_model_catalog_defaults.py
+++ b/Tests/test_config_model_catalog_defaults.py
@@ -1,6 +1,28 @@
+import os
+from contextlib import contextmanager
 import tomllib
 
+from tldw_chatbook import config as config_module
 from tldw_chatbook.config import API_MODELS_BY_PROVIDER, CONFIG_TOML_CONTENT
+
+
+@contextmanager
+def _temporary_config(tmp_path, monkeypatch, toml_text):
+    """Load settings from an isolated scratch config and restore both caches."""
+    config_path = tmp_path / "provider-model-defaults.toml"
+    config_path.write_text(toml_text, encoding="utf-8")
+    original_env = os.environ.get("TLDW_CONFIG_PATH")
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    config_module.load_cli_config_and_ensure_existence(force_reload=True)
+    try:
+        yield config_module.load_settings(force_reload=True)
+    finally:
+        if original_env is not None:
+            monkeypatch.setenv("TLDW_CONFIG_PATH", original_env)
+        else:
+            monkeypatch.delenv("TLDW_CONFIG_PATH", raising=False)
+        config_module.load_cli_config_and_ensure_existence(force_reload=True)
+        config_module.load_settings(force_reload=True)
 
 
 def test_zai_provider_and_settings_defaults_exist():
@@ -57,3 +79,28 @@ def test_bundled_provider_defaults_use_current_models():
 
     for provider in ("DeepSeek", "Anthropic", "OpenAI"):
         assert API_MODELS_BY_PROVIDER[provider] == providers[provider]
+
+
+def test_load_settings_uses_current_models_when_legacy_api_models_are_omitted(
+    tmp_path, monkeypatch
+):
+    with _temporary_config(tmp_path, monkeypatch, "[API]\n") as settings:
+        assert settings["anthropic_api"]["model"] == "claude-sonnet-5"
+        assert settings["deepseek_api"]["model"] == "deepseek-v4-flash"
+        assert settings["openai_api"]["model"] == "gpt-5.6-terra"
+
+
+def test_load_settings_preserves_explicit_legacy_api_models(tmp_path, monkeypatch):
+    explicit_models = {
+        "anthropic_model": "user-anthropic-model",
+        "deepseek_model": "user-deepseek-model",
+        "openai_model": "user-openai-model",
+    }
+    config_text = "[API]\n" + "\n".join(
+        f'{key} = "{model}"' for key, model in explicit_models.items()
+    )
+
+    with _temporary_config(tmp_path, monkeypatch, config_text) as settings:
+        assert settings["anthropic_api"]["model"] == explicit_models["anthropic_model"]
+        assert settings["deepseek_api"]["model"] == explicit_models["deepseek_model"]
+        assert settings["openai_api"]["model"] == explicit_models["openai_model"]

--- a/Tests/test_config_model_catalog_defaults.py
+++ b/Tests/test_config_model_catalog_defaults.py
@@ -1,4 +1,3 @@
-import os
 from contextlib import contextmanager
 import tomllib
 
@@ -11,18 +10,19 @@ def _temporary_config(tmp_path, monkeypatch, toml_text):
     """Load settings from an isolated scratch config and restore both caches."""
     config_path = tmp_path / "provider-model-defaults.toml"
     config_path.write_text(toml_text, encoding="utf-8")
-    original_env = os.environ.get("TLDW_CONFIG_PATH")
+    original_config_cache = config_module._CONFIG_CACHE
+    original_config_cache_source = config_module._CONFIG_CACHE_SOURCE
+    original_settings_cache = config_module._SETTINGS_CACHE
+    original_settings_cache_source = config_module._SETTINGS_CACHE_SOURCE
     monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
     config_module.load_cli_config_and_ensure_existence(force_reload=True)
     try:
         yield config_module.load_settings(force_reload=True)
     finally:
-        if original_env is not None:
-            monkeypatch.setenv("TLDW_CONFIG_PATH", original_env)
-        else:
-            monkeypatch.delenv("TLDW_CONFIG_PATH", raising=False)
-        config_module.load_cli_config_and_ensure_existence(force_reload=True)
-        config_module.load_settings(force_reload=True)
+        config_module._CONFIG_CACHE = original_config_cache
+        config_module._CONFIG_CACHE_SOURCE = original_config_cache_source
+        config_module._SETTINGS_CACHE = original_settings_cache
+        config_module._SETTINGS_CACHE_SOURCE = original_settings_cache_source
 
 
 def test_zai_provider_and_settings_defaults_exist():

--- a/Tests/test_config_model_catalog_defaults.py
+++ b/Tests/test_config_model_catalog_defaults.py
@@ -1,6 +1,6 @@
 import tomllib
 
-from tldw_chatbook.config import CONFIG_TOML_CONTENT
+from tldw_chatbook.config import API_MODELS_BY_PROVIDER, CONFIG_TOML_CONTENT
 
 
 def test_zai_provider_and_settings_defaults_exist():
@@ -18,3 +18,32 @@ def test_model_catalog_defaults_exist():
     assert section["stale_after_hours"] == 24
     assert section["auto_refresh_disabled"] == []
     assert section["write_to_config"] == []
+
+
+def test_bundled_provider_defaults_use_current_models():
+    parsed = tomllib.loads(CONFIG_TOML_CONTENT)
+
+    assert parsed["api_settings"]["deepseek"]["model"] == "deepseek-v4-flash"
+    assert parsed["api_settings"]["anthropic"]["model"] == "claude-sonnet-5"
+    assert parsed["api_settings"]["openai"]["model"] == "gpt-5.6-terra"
+    assert parsed["chat_defaults"]["provider"] == "OpenAI"
+    assert parsed["chat_defaults"]["model"] == "gpt-5.6-terra"
+
+    providers = parsed["providers"]
+    assert providers["DeepSeek"] == ["deepseek-v4-flash", "deepseek-v4-pro"]
+    assert providers["Anthropic"][:4] == [
+        "claude-sonnet-5",
+        "claude-opus-5",
+        "claude-fable-5",
+        "claude-haiku-4-5",
+    ]
+    assert providers["OpenAI"][:3] == [
+        "gpt-5.6-terra",
+        "gpt-5.6-sol",
+        "gpt-5.6-luna",
+    ]
+    assert "deepseek-chat" not in providers["DeepSeek"]
+    assert "deepseek-reasoner" not in providers["DeepSeek"]
+
+    for provider in ("DeepSeek", "Anthropic", "OpenAI"):
+        assert API_MODELS_BY_PROVIDER[provider] == providers[provider]

--- a/Tests/test_config_model_catalog_defaults.py
+++ b/Tests/test_config_model_catalog_defaults.py
@@ -29,6 +29,16 @@ def test_bundled_provider_defaults_use_current_models():
     assert parsed["chat_defaults"]["provider"] == "OpenAI"
     assert parsed["chat_defaults"]["model"] == "gpt-5.6-terra"
 
+    model_capabilities = parsed["model_capabilities"]
+    assert model_capabilities["models"]["gpt-5.6-terra"] == {
+        "vision": True,
+        "max_images": 10,
+    }
+    assert model_capabilities["models"]["claude-sonnet-5"] == {
+        "vision": True,
+        "max_images": 5,
+    }
+
     providers = parsed["providers"]
     assert providers["DeepSeek"] == ["deepseek-v4-flash", "deepseek-v4-pro"]
     assert providers["Anthropic"][:4] == [

--- a/Tests/test_model_capabilities.py
+++ b/Tests/test_model_capabilities.py
@@ -235,6 +235,10 @@ class TestDefaultModels:
         assert (
             model_capabilities_empty.is_vision_capable("OpenAI", "gpt-4o-mini") is True
         )
+        assert (
+            model_capabilities_empty.is_vision_capable("OpenAI", "gpt-5.6-terra")
+            is True
+        )
 
         # Pattern matching
         assert (
@@ -265,6 +269,10 @@ class TestDefaultModels:
             model_capabilities_empty.is_vision_capable(
                 "Anthropic", "claude-3-sonnet-20240229"
             )
+            is True
+        )
+        assert (
+            model_capabilities_empty.is_vision_capable("Anthropic", "claude-sonnet-5")
             is True
         )
 

--- a/backlog/tasks/task-519 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md
+++ b/backlog/tasks/task-519 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-519
 title: 'Refresh default models for DeepSeek, Anthropic, and OpenAI'
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2026-07-27 03:58'
-updated_date: '2026-07-27 03:59'
+updated_date: '2026-07-27 04:12'
 labels: []
 dependencies: []
 ---
@@ -25,3 +26,13 @@ Replace stale provider defaults with current vendor-supported balanced general-p
 - [ ] #6 Focused configuration, provider-payload, and capability tests pass
 - [ ] #7 ADR-020 and the approved design are linked; no new ADR is required
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Implementation plan: Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md
+Design: Docs/superpowers/specs/2026-07-26-provider-default-model-refresh-design.md
+ADR required: no
+ADR path: backlog/decisions/020-automatic-model-catalog-refresh.md
+Reason: bundled defaults and request shaping stay within existing provider boundaries; ADR-020 already governs catalog discovery and persistence.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-519 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md
+++ b/backlog/tasks/task-519 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-27 03:58'
-updated_date: '2026-07-27 06:01'
+updated_date: '2026-07-27 06:14'
 labels: []
 dependencies: []
 ---
@@ -46,5 +46,7 @@ Changed production/test/doc files: tldw_chatbook/config.py; tldw_chatbook/LLM_Ca
 
 ADR required: no. Existing ADR: backlog/decisions/020-automatic-model-catalog-refresh.md (ADR-020). Approved design: Docs/superpowers/specs/2026-07-26-provider-default-model-refresh-design.md. Implementation plan: Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md.
 
-Verification (2026-07-26): .venv/bin/python -m pytest Tests/test_config_model_catalog_defaults.py Tests/Chat/test_chat_functions.py Tests/test_model_capabilities.py -q -> 89 passed in 4.18s. Ruff fatal lint (E9,F63,F7,F82) -> All checks passed. Ruff format check -> 5 files already formatted. compileall -> exit 0. git diff --check -> exit 0. Final whole-change review approved with no Critical or Important issues.
+Verification scope (2026-07-26): the approved focused suite, .venv/bin/python -m pytest Tests/test_config_model_catalog_defaults.py Tests/Chat/test_chat_functions.py Tests/test_model_capabilities.py -q, passed 89 tests. Fatal Ruff rules (E9,F63,F7,F82) passed on all six touched files. Ruff format passed for the five formatter-clean files; config.py remains excluded because of its pre-existing formatting baseline. compileall and git diff --check passed. Broad default Ruff is baseline-failing with 452 existing findings. A broader serial suite attempt was manually interrupted after 448 passed, 1 skipped, and 0 observed failures at 3% in 140.83s because its projected runtime was impractical; xdist was also attempted but is unsuitable because this repository tests share state. This was not a full-suite pass.
+
+Approved scoped exception: TASK-519 remains Done because its acceptance criteria and approved implementation plan require the focused 89-test suite, not a full-suite pass; the broader-suite limitation is documented here transparently.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-519 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md
+++ b/backlog/tasks/task-519 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md
@@ -1,0 +1,27 @@
+---
+id: TASK-519
+title: 'Refresh default models for DeepSeek, Anthropic, and OpenAI'
+status: To Do
+assignee: []
+created_date: '2026-07-27 03:58'
+updated_date: '2026-07-27 03:59'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace stale provider defaults with current vendor-supported balanced general-purpose models while preserving supported alternatives and keeping provider request payloads compatible with the selected model families.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Fresh installations default DeepSeek to deepseek-v4-flash, Anthropic to claude-sonnet-5, and OpenAI to gpt-5.6-terra
+- [ ] #2 Provider catalogs retain supported alternatives and exclude retired DeepSeek aliases from active defaults
+- [ ] #3 OpenAI GPT-5.6 default requests use a compatible token and reasoning contract without regressing explicit Responses API reasoning flows
+- [ ] #4 Anthropic Claude Sonnet 5 requests omit unsupported sampling parameters and honor supported adaptive-thinking settings
+- [ ] #5 The selected OpenAI and Anthropic defaults are recognized by capability metadata
+- [ ] #6 Focused configuration, provider-payload, and capability tests pass
+- [ ] #7 ADR-020 and the approved design are linked; no new ADR is required
+<!-- AC:END -->

--- a/backlog/tasks/task-519 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md
+++ b/backlog/tasks/task-519 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-519
 title: 'Refresh default models for DeepSeek, Anthropic, and OpenAI'
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-27 03:58'
-updated_date: '2026-07-27 04:12'
+updated_date: '2026-07-27 06:01'
 labels: []
 dependencies: []
 ---
@@ -18,13 +18,13 @@ Replace stale provider defaults with current vendor-supported balanced general-p
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Fresh installations default DeepSeek to deepseek-v4-flash, Anthropic to claude-sonnet-5, and OpenAI to gpt-5.6-terra
-- [ ] #2 Provider catalogs retain supported alternatives and exclude retired DeepSeek aliases from active defaults
-- [ ] #3 OpenAI GPT-5.6 default requests use a compatible token and reasoning contract without regressing explicit Responses API reasoning flows
-- [ ] #4 Anthropic Claude Sonnet 5 requests omit unsupported sampling parameters and honor supported adaptive-thinking settings
-- [ ] #5 The selected OpenAI and Anthropic defaults are recognized by capability metadata
-- [ ] #6 Focused configuration, provider-payload, and capability tests pass
-- [ ] #7 ADR-020 and the approved design are linked; no new ADR is required
+- [x] #1 Fresh installations default DeepSeek to deepseek-v4-flash, Anthropic to claude-sonnet-5, and OpenAI to gpt-5.6-terra
+- [x] #2 Provider catalogs retain supported alternatives and exclude retired DeepSeek aliases from active defaults
+- [x] #3 OpenAI GPT-5.6 default requests use a compatible token and reasoning contract without regressing explicit Responses API reasoning flows
+- [x] #4 Anthropic Claude Sonnet 5 requests omit unsupported sampling parameters and honor supported adaptive-thinking settings
+- [x] #5 The selected OpenAI and Anthropic defaults are recognized by capability metadata
+- [x] #6 Focused configuration, provider-payload, and capability tests pass
+- [x] #7 ADR-020 and the approved design are linked; no new ADR is required
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -36,3 +36,15 @@ ADR required: no
 ADR path: backlog/decisions/020-automatic-model-catalog-refresh.md
 Reason: bundled defaults and request shaping stay within existing provider boundaries; ADR-020 already governs catalog discovery and persistence.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented provider default refresh. New bundled/catalog and fresh-install defaults: OpenAI gpt-5.6-terra, Anthropic claude-sonnet-5, DeepSeek deepseek-v4-flash; supported alternatives remain and existing user config precedence is preserved (no migration). GPT-5.6 uses Chat Completions with max_completion_tokens and top-level reasoning_effort=none for ordinary/tool requests, while explicit reasoning, summary, or verbosity continues through Responses with max_output_tokens. Sonnet 5 omits unsupported sampling fields, uses output_config effort where supported, and keeps adaptive thinking/output_config handling compatible. DeepSeek changes only the fallback model; its /chat/completions endpoint and payload contract are unchanged. Direct vision capability mappings now cover the OpenAI and Anthropic defaults without broad family patterns.
+
+Changed production/test/doc files: tldw_chatbook/config.py; tldw_chatbook/LLM_Calls/LLM_API_Calls.py; tldw_chatbook/model_capabilities.py; Tests/test_config_model_catalog_defaults.py; Tests/Chat/test_chat_functions.py; Tests/test_model_capabilities.py; Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md; backlog/tasks/task-519 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md.
+
+ADR required: no. Existing ADR: backlog/decisions/020-automatic-model-catalog-refresh.md (ADR-020). Approved design: Docs/superpowers/specs/2026-07-26-provider-default-model-refresh-design.md. Implementation plan: Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md.
+
+Verification (2026-07-26): .venv/bin/python -m pytest Tests/test_config_model_catalog_defaults.py Tests/Chat/test_chat_functions.py Tests/test_model_capabilities.py -q -> 89 passed in 4.18s. Ruff fatal lint (E9,F63,F7,F82) -> All checks passed. Ruff format check -> 5 files already formatted. compileall -> exit 0. git diff --check -> exit 0. Final whole-change review approved with no Critical or Important issues.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-869 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md
+++ b/backlog/tasks/task-869 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md
@@ -1,11 +1,11 @@
 ---
-id: TASK-519
+id: TASK-869
 title: 'Refresh default models for DeepSeek, Anthropic, and OpenAI'
 status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-27 03:58'
-updated_date: '2026-07-27 06:14'
+updated_date: '2026-07-27 13:37'
 labels: []
 dependencies: []
 ---
@@ -42,11 +42,13 @@ Reason: bundled defaults and request shaping stay within existing provider bound
 <!-- SECTION:NOTES:BEGIN -->
 Implemented provider default refresh. New bundled/catalog and fresh-install defaults: OpenAI gpt-5.6-terra, Anthropic claude-sonnet-5, DeepSeek deepseek-v4-flash; supported alternatives remain and existing user config precedence is preserved (no migration). GPT-5.6 uses Chat Completions with max_completion_tokens and top-level reasoning_effort=none for ordinary/tool requests, while explicit reasoning, summary, or verbosity continues through Responses with max_output_tokens. Sonnet 5 omits unsupported sampling fields, uses output_config effort where supported, and keeps adaptive thinking/output_config handling compatible. DeepSeek changes only the fallback model; its /chat/completions endpoint and payload contract are unchanged. Direct vision capability mappings now cover the OpenAI and Anthropic defaults without broad family patterns.
 
-Changed production/test/doc files: tldw_chatbook/config.py; tldw_chatbook/LLM_Calls/LLM_API_Calls.py; tldw_chatbook/model_capabilities.py; Tests/test_config_model_catalog_defaults.py; Tests/Chat/test_chat_functions.py; Tests/test_model_capabilities.py; Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md; backlog/tasks/task-519 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md.
+Changed production/test/doc files: tldw_chatbook/config.py; tldw_chatbook/LLM_Calls/LLM_API_Calls.py; tldw_chatbook/model_capabilities.py; Tests/test_config_model_catalog_defaults.py; Tests/Chat/test_chat_functions.py; Tests/test_model_capabilities.py; Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md; backlog/tasks/task-869 - Refresh-default-models-for-DeepSeek-Anthropic-and-OpenAI.md.
 
 ADR required: no. Existing ADR: backlog/decisions/020-automatic-model-catalog-refresh.md (ADR-020). Approved design: Docs/superpowers/specs/2026-07-26-provider-default-model-refresh-design.md. Implementation plan: Docs/superpowers/plans/2026-07-26-provider-default-model-refresh.md.
 
 Verification scope (2026-07-26): the approved focused suite, .venv/bin/python -m pytest Tests/test_config_model_catalog_defaults.py Tests/Chat/test_chat_functions.py Tests/test_model_capabilities.py -q, passed 89 tests. Fatal Ruff rules (E9,F63,F7,F82) passed on all six touched files. Ruff format passed for the five formatter-clean files; config.py remains excluded because of its pre-existing formatting baseline. compileall and git diff --check passed. Broad default Ruff is baseline-failing with 452 existing findings. A broader serial suite attempt was manually interrupted after 448 passed, 1 skipped, and 0 observed failures at 3% in 140.83s because its projected runtime was impractical; xdist was also attempted but is unsuitable because this repository tests share state. This was not a full-suite pass.
 
-Approved scoped exception: TASK-519 remains Done because its acceptance criteria and approved implementation plan require the focused 89-test suite, not a full-suite pass; the broader-suite limitation is documented here transparently.
+Approved scoped exception: TASK-869 remains Done because its acceptance criteria and approved implementation plan require the focused 89-test suite, not a full-suite pass; the broader-suite limitation is documented here transparently.
+
+Post-rebase verification (2026-07-27): rebased the isolated TASK-869 series onto latest origin/dev and preserved newer Anthropic prompt-caching plus context-window metadata behavior. The focused suite passes 97 tests; Ruff fatal rules, compileall, and git diff --check origin/dev pass. A whole-file Ruff format pass is not claimed after the rebase because current dev contributes unrelated formatting findings in Tests/Chat/test_chat_functions.py and tldw_chatbook/model_capabilities.py; those files were not mechanically reformatted out of scope. Added a regression assertion and corrected the Sonnet 5 sampling-omission warning so it no longer incorrectly says thinking is enabled. Renumbered this task from TASK-519 to TASK-869 after latest dev introduced an unrelated TASK-519, preventing a duplicate-ID backlog guard failure.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -187,14 +187,30 @@ def _is_present_setting(value: object) -> bool:
     return value is not None and str(value).strip() != ""
 
 
+def _is_openai_gpt_5_6_model(model: object) -> bool:
+    """Return whether ``model`` is an unprefixed OpenAI GPT-5.6 family ID."""
+    if not isinstance(model, str):
+        return False
+    normalized_model = model.strip().lower()
+    return normalized_model == "gpt-5.6" or normalized_model.startswith("gpt-5.6-")
+
+
+def _normalize_openai_reasoning_effort(value: object) -> Optional[str]:
+    """Return a normalized OpenAI reasoning effort, if one was provided."""
+    if not _is_present_setting(value):
+        return None
+    return str(value).strip().lower()
+
+
 def _openai_use_responses_api(
-    reasoning_effort: object,
+    normalized_reasoning_effort: Optional[str],
     reasoning_summary: object,
     verbosity: object,
 ) -> bool:
-    return any(
-        _is_present_setting(value)
-        for value in (reasoning_effort, reasoning_summary, verbosity)
+    return (
+        normalized_reasoning_effort not in {None, "none"}
+        or _is_present_setting(reasoning_summary)
+        or _is_present_setting(verbosity)
     )
 
 
@@ -509,7 +525,7 @@ def chat_with_openai(
 
     # Resolve parameters: User-provided > Function arg default > Config default > Hardcoded default
     final_model = (
-        model if model is not None else openai_config.get("model", "gpt-4o-mini")
+        model if model is not None else openai_config.get("model", "gpt-5.6-terra")
     )
     final_temp = (
         temp if temp is not None else float(openai_config.get("temperature", 0.7))
@@ -547,11 +563,15 @@ def chat_with_openai(
         api_messages.append({"role": "system", "content": system_message})
     api_messages.extend(input_data)
 
+    normalized_reasoning_effort = _normalize_openai_reasoning_effort(
+        reasoning_effort
+    )
     use_responses_api = _openai_use_responses_api(
-        reasoning_effort,
+        normalized_reasoning_effort,
         reasoning_summary,
         verbosity,
     )
+    is_gpt_5_6_model = _is_openai_gpt_5_6_model(final_model)
     payload = {
         "model": final_model,
         "stream": final_streaming,
@@ -578,6 +598,8 @@ def chat_with_openai(
             payload["top_p"] = final_top_p  # OpenAI uses top_p
     if final_max_tokens is not None and use_responses_api:
         payload["max_output_tokens"] = final_max_tokens
+    elif final_max_tokens is not None and is_gpt_5_6_model:
+        payload["max_completion_tokens"] = final_max_tokens
     elif final_max_tokens is not None:
         payload["max_tokens"] = final_max_tokens
     if frequency_penalty is not None:
@@ -609,8 +631,8 @@ def chat_with_openai(
         payload["tools"] = tools
     if use_responses_api:
         reasoning_options = {}
-        if _is_present_setting(reasoning_effort):
-            reasoning_options["effort"] = str(reasoning_effort).strip().lower()
+        if normalized_reasoning_effort is not None:
+            reasoning_options["effort"] = normalized_reasoning_effort
         if _is_present_setting(reasoning_summary):
             summary_value = str(reasoning_summary).strip().lower()
             if summary_value != "none":
@@ -619,6 +641,8 @@ def chat_with_openai(
             payload["reasoning"] = reasoning_options
         if _is_present_setting(verbosity):
             payload.setdefault("text", {})["verbosity"] = str(verbosity).strip().lower()
+    elif is_gpt_5_6_model:
+        payload["reasoning_effort"] = normalized_reasoning_effort or "none"
 
     # Then conditionally add tool_choice:
     if payload.get("tools") and tool_choice is not None:

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -2477,7 +2477,7 @@ def chat_with_deepseek(
 
     logger.debug("DeepSeek: API key provided.")
     current_model = model or deepseek_config.get(
-        "model", "deepseek-chat"
+        "model", "deepseek-v4-flash"
     )  # Or deepseek-coder
     current_temp = (
         temp if temp is not None else float(deepseek_config.get("temperature", 0.1))

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -181,6 +181,7 @@ _ANTHROPIC_ADAPTIVE_THINKING_MODEL_MARKERS = (
     "sonnet-4-6",
     "sonnet-4.6",
 )
+_ANTHROPIC_SONNET_5_EFFORTS = frozenset({"low", "medium", "high", "xhigh", "max"})
 
 
 def _is_present_setting(value: object) -> bool:
@@ -348,30 +349,54 @@ def _anthropic_uses_adaptive_thinking(model: object) -> bool:
     )
 
 
+def _anthropic_is_sonnet_5(model: object) -> bool:
+    """Return whether model is the documented unprefixed Claude Sonnet 5 family."""
+    model_name = str(model or "").lower()
+    return model_name == "claude-sonnet-5" or model_name.startswith("claude-sonnet-5-")
+
+
 def _anthropic_thinking_config(
     *,
     model: object,
     thinking_effort: object,
     thinking_budget_tokens: object,
     max_tokens: int,
-) -> tuple[dict[str, object] | None, int]:
+) -> tuple[dict[str, object] | None, dict[str, object] | None, int]:
+    """Map Anthropic thinking settings to thinking and output configuration."""
     effort = str(thinking_effort or "").strip().lower()
+    is_sonnet_5 = _anthropic_is_sonnet_5(model)
     if effort == "off":
-        return None, max_tokens
+        if is_sonnet_5:
+            if thinking_budget_tokens is not None:
+                logger.warning(
+                    "Anthropic: ignoring fixed thinking budget for Claude Sonnet 5 model %s",
+                    model,
+                )
+            return {"type": "disabled"}, None, max_tokens
+        return None, None, max_tokens
     budget = _safe_cast(thinking_budget_tokens, int)
+    if is_sonnet_5:
+        if thinking_budget_tokens is not None:
+            logger.warning(
+                "Anthropic: ignoring fixed thinking budget for Claude Sonnet 5 model %s",
+                model,
+            )
+        if effort in _ANTHROPIC_SONNET_5_EFFORTS:
+            return None, {"effort": effort}, max_tokens
+        return None, None, max_tokens
     if _anthropic_uses_adaptive_thinking(model):
         if effort:
-            return {"type": "adaptive", "effort": effort}, max_tokens
+            return {"type": "adaptive"}, {"effort": effort}, max_tokens
         if budget is not None:
             logger.warning(
                 "Anthropic: ignoring fixed thinking budget for adaptive-thinking model %s",
                 model,
             )
-        return None, max_tokens
+        return None, None, max_tokens
     if budget is None and effort:
         budget = _ANTHROPIC_THINKING_BUDGETS_BY_EFFORT.get(effort)
     if budget is None:
-        return None, max_tokens
+        return None, None, max_tokens
     final_budget = max(1024, int(budget))
     final_max_tokens = max_tokens
     if final_budget >= final_max_tokens:
@@ -381,7 +406,7 @@ def _anthropic_thinking_config(
             final_max_tokens,
             final_budget,
         )
-    return {"type": "enabled", "budget_tokens": final_budget}, final_max_tokens
+    return {"type": "enabled", "budget_tokens": final_budget}, None, final_max_tokens
 
 
 def get_openai_embeddings(input_data: str, model: str) -> List[float]:
@@ -1000,7 +1025,7 @@ def chat_with_anthropic(
 
     logger.debug("Anthropic: API key provided.")
 
-    current_model = model or anthropic_config.get("model", "claude-3-haiku-20240307")
+    current_model = model or anthropic_config.get("model", "claude-sonnet-5")
     default_temperature = float(anthropic_config.get("temperature", 0.7))
     current_temp = temp if temp is not None else default_temperature
     current_top_p = topp
@@ -1023,7 +1048,7 @@ def chat_with_anthropic(
         )
     )
     current_max_tokens = max_tokens if max_tokens is not None else default_max_tokens
-    thinking_config, current_max_tokens = _anthropic_thinking_config(
+    thinking_config, output_config, current_max_tokens = _anthropic_thinking_config(
         model=current_model,
         thinking_effort=thinking_effort,
         thinking_budget_tokens=thinking_budget_tokens,
@@ -1182,7 +1207,7 @@ def chat_with_anthropic(
             ]
         else:
             data["system"] = system_prompt  # unchanged for non-caching models
-    if thinking_config is None:
+    if thinking_config is None and not _anthropic_is_sonnet_5(current_model):
         if temp is not None:
             data["temperature"] = current_temp
             if current_top_p is not None:
@@ -1213,6 +1238,8 @@ def chat_with_anthropic(
         data["tools"] = tools_payload
     if thinking_config is not None:
         data["thinking"] = thinking_config
+    if output_config is not None:
+        data["output_config"] = output_config
 
     api_url = (
         anthropic_config.get("api_base_url", "https://api.anthropic.com/v1").rstrip("/")

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -206,10 +206,13 @@ def _openai_use_responses_api(
     normalized_reasoning_effort: Optional[str],
     reasoning_summary: object,
     verbosity: object,
+    is_gpt_5_6_model: bool,
 ) -> bool:
     return (
-        normalized_reasoning_effort not in {None, "none"}
-        or _is_present_setting(reasoning_summary)
+        normalized_reasoning_effort is not None
+        and (normalized_reasoning_effort != "none" or not is_gpt_5_6_model)
+    ) or (
+        _is_present_setting(reasoning_summary)
         or _is_present_setting(verbosity)
     )
 
@@ -506,7 +509,9 @@ def chat_with_openai(
         tools: A list of tools the model may call.
         tool_choice: Controls which (if any) function is called by the model.
         user: A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
-        reasoning_effort: Responses API reasoning effort for supported models.
+        reasoning_effort: Uses the Responses API for supported models; GPT-5.6
+            keeps an explicit ``none`` effort on Chat Completions for
+            non-reasoning compatibility.
         reasoning_summary: Responses API reasoning summary detail for supported models.
         verbosity: Responses API text verbosity for GPT-5-style models.
         custom_prompt_arg: Legacy, largely ignored.
@@ -566,12 +571,13 @@ def chat_with_openai(
     normalized_reasoning_effort = _normalize_openai_reasoning_effort(
         reasoning_effort
     )
+    is_gpt_5_6_model = _is_openai_gpt_5_6_model(final_model)
     use_responses_api = _openai_use_responses_api(
         normalized_reasoning_effort,
         reasoning_summary,
         verbosity,
+        is_gpt_5_6_model,
     )
-    is_gpt_5_6_model = _is_openai_gpt_5_6_model(final_model)
     payload = {
         "model": final_model,
         "stream": final_streaming,

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -1216,9 +1216,15 @@ def chat_with_anthropic(
         if current_top_k is not None:
             data["top_k"] = current_top_k
     elif any(value is not None for value in (temp, current_top_p, current_top_k)):
-        logger.warning(
-            "Anthropic: omitting temperature/top_p/top_k because thinking is enabled."
-        )
+        if _anthropic_is_sonnet_5(current_model):
+            logger.warning(
+                "Anthropic: omitting temperature/top_p/top_k because Claude Sonnet 5 "
+                "requires default sampling."
+            )
+        else:
+            logger.warning(
+                "Anthropic: omitting temperature/top_p/top_k because thinking is enabled."
+            )
     if stop_sequences is not None:
         data["stop_sequences"] = stop_sequences
     if tools is not None:

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -212,10 +212,7 @@ def _openai_use_responses_api(
     return (
         normalized_reasoning_effort is not None
         and (normalized_reasoning_effort != "none" or not is_gpt_5_6_model)
-    ) or (
-        _is_present_setting(reasoning_summary)
-        or _is_present_setting(verbosity)
-    )
+    ) or (_is_present_setting(reasoning_summary) or _is_present_setting(verbosity))
 
 
 _OPENAI_REASONING_MODEL_FAMILIES = ("o1", "o3", "o4", "gpt-5")
@@ -593,9 +590,7 @@ def chat_with_openai(
         api_messages.append({"role": "system", "content": system_message})
     api_messages.extend(input_data)
 
-    normalized_reasoning_effort = _normalize_openai_reasoning_effort(
-        reasoning_effort
-    )
+    normalized_reasoning_effort = _normalize_openai_reasoning_effort(reasoning_effort)
     is_gpt_5_6_model = _is_openai_gpt_5_6_model(final_model)
     use_responses_api = _openai_use_responses_api(
         normalized_reasoning_effort,

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -922,7 +922,7 @@ def load_settings(force_reload: bool = False) -> Dict:
         "anthropic_api": {
             "api_key": anthropic_api_key,
             "model": api_section_legacy.get(
-                "anthropic_model", "claude-sonnet-4-20250514"
+                "anthropic_model", "claude-sonnet-5"
             ),
             "streaming": api_section_legacy.get("anthropic_streaming", False),
             "temperature": api_section_legacy.get("anthropic_temperature", 0.7),
@@ -951,7 +951,7 @@ def load_settings(force_reload: bool = False) -> Dict:
         },
         "deepseek_api": {
             "api_key": deepseek_api_key,
-            "model": api_section_legacy.get("deepseek_model", "deepseek-chat"),
+            "model": api_section_legacy.get("deepseek_model", "deepseek-v4-flash"),
             "streaming": api_section_legacy.get("deepseek_streaming", False),
             "temperature": api_section_legacy.get("deepseek_temperature", 0.7),
             "top_p": api_section_legacy.get("deepseek_top_p", 0.95),
@@ -1039,7 +1039,7 @@ def load_settings(force_reload: bool = False) -> Dict:
         },
         "openai_api": {  # OpenAI specific model params, API key is separate
             "api_key": openai_api_key,  # This is now the primary OpenAI API key
-            "model": api_section_legacy.get("openai_model", "gpt-4o"),
+            "model": api_section_legacy.get("openai_model", "gpt-5.6-terra"),
             "streaming": api_section_legacy.get("openai_streaming", False),
             "temperature": api_section_legacy.get("openai_temperature", 0.7),
             "top_p": api_section_legacy.get("openai_top_p", 0.95),
@@ -1997,6 +1997,9 @@ def load_settings(force_reload: bool = False) -> Dict:
 # (Keep your existing API_MODELS_BY_PROVIDER and LOCAL_PROVIDERS dictionaries)
 API_MODELS_BY_PROVIDER = {
     "OpenAI": [
+        "gpt-5.6-terra",
+        "gpt-5.6-sol",
+        "gpt-5.6-luna",
         "gpt-4.1-2025-04-14",
         "o4-mini-2025-04-16",
         "o3-2025-04-16",
@@ -2010,6 +2013,10 @@ API_MODELS_BY_PROVIDER = {
         "gpt-4o-mini-2024-07-18",
     ],
     "Anthropic": [
+        "claude-sonnet-5",
+        "claude-opus-5",
+        "claude-fable-5",
+        "claude-haiku-4-5",
         "claude-opus-4-20250514",
         "claude-sonnet-4-20250514",
         "claude-3-7-sonnet-20250219",
@@ -2034,7 +2041,7 @@ API_MODELS_BY_PROVIDER = {
         "command-light",
         "command-light-nightly",
     ],
-    "DeepSeek": ["deepseek-chat", "deepseek-reasoner"],
+    "DeepSeek": ["deepseek-v4-flash", "deepseek-v4-pro"],
     "Groq": [
         "gemma2-9b-it",
         "mmeta-llama/Llama-Guard-4-12B",
@@ -2286,10 +2293,10 @@ Custom_6 = "http://localhost:5678/v1"
 [providers]
 # This section primarily lists providers and their *available* models for the UI dropdown.
 # Actual default model/settings used for calls are defined in [api_settings.*] or [chat_defaults]/[character_defaults].
-OpenAI = ["gpt-4.1-2025-04-14", "o4-mini-2025-04-16", "o3-2025-04-16", "o3-mini-2025-01-31", "o1-2024-12-17", "chatgpt-4o-latest", "gpt-4o-2024-11-20", "gpt-4o-2024-08-06", "gpt-4.1-mini-2025-04-14", "gpt-4.1-nano-2025-04-14", "gpt-4o-mini-2024-07-18", ]
-Anthropic = ["claude-opus-4-20250514", "claude-sonnet-4-20250514", "claude-3-7-sonnet-20250219", "claude-3-5-sonnet-20241022", "claude-3-5-haiku-20241022", "claude-3-5-sonnet-20240620", "claude-3-haiku-20240307", "claude-3-opus-20240229", "claude-3-sonnet-20240229", "claude-2.1", "claude-2.0"]
+OpenAI = ["gpt-5.6-terra", "gpt-5.6-sol", "gpt-5.6-luna", "gpt-4.1-2025-04-14", "o4-mini-2025-04-16", "o3-2025-04-16", "o3-mini-2025-01-31", "o1-2024-12-17", "chatgpt-4o-latest", "gpt-4o-2024-11-20", "gpt-4o-2024-08-06", "gpt-4.1-mini-2025-04-14", "gpt-4.1-nano-2025-04-14", "gpt-4o-mini-2024-07-18", ]
+Anthropic = ["claude-sonnet-5", "claude-opus-5", "claude-fable-5", "claude-haiku-4-5", "claude-opus-4-20250514", "claude-sonnet-4-20250514", "claude-3-7-sonnet-20250219", "claude-3-5-sonnet-20241022", "claude-3-5-haiku-20241022", "claude-3-5-sonnet-20240620", "claude-3-haiku-20240307", "claude-3-opus-20240229", "claude-3-sonnet-20240229", "claude-2.1", "claude-2.0"]
 Cohere = ["command-a-03-2025", "command-r7b-12-2024", "command-r-plus-04-2024", "command-r-plus", "command-r-08-2024", "command-r-03-2024", "command", "command-nightly", "command-light", "command-light-nightly"]
-DeepSeek = ["deepseek-chat", "deepseek-reasoner"]
+DeepSeek = ["deepseek-v4-flash", "deepseek-v4-pro"]
 Groq = ["gemma2-9b-it", "mmeta-llama/Llama-Guard-4-12B", "llama-3.3-70b-versatile", "llama-3.1-8b-instant", "llama3-70b-8192", "llama3-70b-8192", "llama3-8b-8192",]
 Google = ["gemini-2.5-flash", "gemini-2.5-flash-preview-05-20", "gemini-2.5-pro-preview-05-06", "gemini-2.0-flash", "gemini-2.0-flash-lite", "gemini-1.5-flash", "gemini-1.5-flash-8b", "gemini-1.5-pro", ]
 HuggingFace = ["openai/gpt-oss-120b", "meta-llama/Meta-Llama-3.1-8B-Instruct", "meta-llama/Meta-Llama-3.1-70B-Instruct",]
@@ -2329,7 +2336,7 @@ write_to_config = [] # exact [providers] keys whose new models append to this fi
     [api_settings.openai]
     api_key_env_var = "OPENAI_API_KEY"
     # api_key = "" # Less secure fallback - use env var instead
-    model = "gpt-4o" # Default model for direct calls (if not overridden)
+    model = "gpt-5.6-terra" # Default model for direct calls (if not overridden)
     temperature = 0.7
     top_p = 1.0 # OpenAI uses top_p (represented as maxp sometimes in UI)
     max_tokens = 4096
@@ -2341,7 +2348,7 @@ write_to_config = [] # exact [providers] keys whose new models append to this fi
     [api_settings.anthropic]
     api_key_env_var = "ANTHROPIC_API_KEY"
     # api_key = "" # Less secure fallback - use env var instead
-    model = "claude-sonnet-4-20250514"
+    model = "claude-sonnet-5"
     temperature = 0.7
     top_p = 1.0 # Anthropic uses top_p (represented as topp in UI)
     top_k = 0 # Anthropic specific, 0 or -1 usually disables it
@@ -2367,7 +2374,7 @@ write_to_config = [] # exact [providers] keys whose new models append to this fi
     [api_settings.deepseek]
     api_key_env_var = "DEEPSEEK_API_KEY"
     # api_key = "" # Less secure fallback - use env var instead
-    model = "deepseek-chat"
+    model = "deepseek-v4-flash"
     temperature = 0.7
     top_p = 1.0 # Deepseek uses top_p (represented as topp in UI)
     max_tokens = 4096
@@ -2727,7 +2734,7 @@ write_to_config = [] # exact [providers] keys whose new models append to this fi
 [chat_defaults]
 # Default settings specifically for the 'Chat' tab
 provider = "OpenAI"
-model = "gpt-4o"
+model = "gpt-5.6-terra"
 system_prompt = "You are a helpful AI assistant."
 temperature = 0.6
 top_p = 0.95
@@ -4958,7 +4965,7 @@ if (
     logger.warning(
         "No providers found in CONFIG_TOML_CONTENT's [providers] section. Using hardcoded fallbacks for API_MODELS_BY_PROVIDER and LOCAL_PROVIDERS."
     )
-    API_MODELS_BY_PROVIDER = {"OpenAI": ["gpt-4o"]}  # Minimal fallback
+    API_MODELS_BY_PROVIDER = {"OpenAI": ["gpt-5.6-terra"]}  # Minimal fallback
     LOCAL_PROVIDERS = {"Ollama": ["llama3"]}  # Minimal fallback
 
 

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -3185,6 +3185,7 @@ llm_context_document_limit = 10
 "gpt-4-turbo-2024-04-09" = { vision = true, max_images = 10 }
 "gpt-4o" = { vision = true, max_images = 10 }
 "gpt-4o-mini" = { vision = true, max_images = 10 }
+"gpt-5.6-terra" = { vision = true, max_images = 10 }
 
 # Anthropic models
 "claude-3-opus-20240229" = { vision = true, max_images = 5 }
@@ -3192,6 +3193,7 @@ llm_context_document_limit = 10
 "claude-3-haiku-20240307" = { vision = true, max_images = 5 }
 "claude-3-5-sonnet-20240620" = { vision = true, max_images = 5 }
 "claude-3-5-sonnet-20241022" = { vision = true, max_images = 5 }
+"claude-sonnet-5" = { vision = true, max_images = 5 }
 
 # Google models
 "gemini-pro-vision" = { vision = true, max_images = 1 }

--- a/tldw_chatbook/model_capabilities.py
+++ b/tldw_chatbook/model_capabilities.py
@@ -91,6 +91,7 @@ DEFAULT_MODEL_CAPABILITIES = {
     "gpt-4-turbo-2024-04-09": {"vision": True, "max_images": 10, "context_window": 128000},
     "gpt-4o": {"vision": True, "max_images": 10, "context_window": 128000},
     "gpt-4o-mini": {"vision": True, "max_images": 10, "context_window": 128000},
+    "gpt-5.6-terra": {"vision": True, "max_images": 10},
     "gpt-4.1-2025-04-14": {"vision": True, "max_images": 10, "context_window": 1047576},
     "o4-mini-2025-04-16": {"vision": True, "max_images": 10, "context_window": 200000},
     "o3-2025-04-16": {"vision": True, "max_images": 10, "context_window": 200000},
@@ -103,6 +104,7 @@ DEFAULT_MODEL_CAPABILITIES = {
     "claude-3-haiku-20240307": {"vision": True, "max_images": 5, "context_window": 200000},
     "claude-3-5-sonnet-20240620": {"vision": True, "max_images": 5, "context_window": 200000},
     "claude-3-5-sonnet-20241022": {"vision": True, "max_images": 5, "context_window": 200000},
+    "claude-sonnet-5": {"vision": True, "max_images": 5},
     # Google
     "gemini-pro-vision": {"vision": True, "max_images": 1, "context_window": 12288},
     "gemini-1.5-pro": {"vision": True, "max_images": 10, "context_window": 2097152},


### PR DESCRIPTION
## Summary

- Refresh fresh-install and bundled catalog defaults to `deepseek-v4-flash`, `claude-sonnet-5`, and `gpt-5.6-terra` while preserving supported alternatives and existing user-config precedence.
- Shape GPT-5.6 and Claude Sonnet 5 request payloads to match their current vendor contracts without changing DeepSeek endpoint behavior.
- Add exact capability metadata, regression coverage, implementation documentation, and TASK-869 closeout notes.
- Rebase the isolated feature commit series onto the latest `dev`, preserving newer Anthropic prompt-caching and capability metadata behavior.
- Renumber the provider-default task from historical TASK-519 to TASK-869 to avoid the unrelated TASK-519 already present on current `dev`.

## Test plan

- [x] `.venv/bin/python -m pytest Tests/test_config_model_catalog_defaults.py Tests/Chat/test_chat_functions.py Tests/test_model_capabilities.py -q` — 97 passed after rebase onto latest `dev`
- [x] Ruff fatal rules `E9,F63,F7,F82` on all six touched Python files
- [x] `compileall` on the three production modules
- [x] `git diff --check origin/dev`
- [x] Backlog Guard duplicate filename/frontmatter ID logic — no duplicates

## Verification scope

The repository-wide suite was not claimed as passing. A serial attempt before the rebase was manually interrupted at 3% after 448 passed, 1 skipped, and no observed failures because its projected runtime was impractical; xdist is unsuitable because repository tests share state. Broad default Ruff also has 452 existing baseline findings. Current `dev` contributes unrelated whole-file Ruff formatting findings in two touched files, so no post-rebase whole-file format pass is claimed.

## Architecture

No new ADR is required. ADR-020 already governs model catalog discovery and persistence.