### PR TITLE
chore(backlog): resolve 839/840 duplicate ids

### DIFF
--- a/backlog/tasks/task-867 - macOS-never-gets-its-preferred-transcription-engine.md
+++ b/backlog/tasks/task-867 - macOS-never-gets-its-preferred-transcription-engine.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-839
+id: TASK-867
 title: macOS never gets its preferred transcription engine
 status: To Do
 assignee: []

--- a/backlog/tasks/task-868 - Audio-and-video-ingest-crash-in-chunking-after-transcription.md
+++ b/backlog/tasks/task-868 - Audio-and-video-ingest-crash-in-chunking-after-transcription.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-840
+id: TASK-868
 title: Audio and video ingest crash in chunking after transcription
 status: Done
 assignee: []


### PR DESCRIPTION
Two concurrent sessions each filed a `task-839` and a `task-840` on 2026-07-26, leaving both ids duplicated on dev and the **No duplicate backlog task IDs** guard red for every open PR.

Which one keeps the id was decided by references, not by commit order — and the two disagree. `task-553.15` names TASK-839 as *"the optional MLX import abort"* and TASK-840 as *"the baseline repair ... mechanical churn"*, both of which are the **later**-committed file in their pair. Picking by commit order would have moved the referenced task and broken the reference.

- `839` *Prevent optional MLX imports from aborting test collection* — keeps id (referenced)
- `839` *macOS never gets its preferred transcription engine* → **867**
- `840` *Normalize inherited Ruff format drift in Console citation files* — keeps id (referenced)
- `840` *Audio and video ingest crash in chunking after transcription* → **868**

Backlog-only; no code touched. Duplicate scan over `backlog/tasks` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolved duplicate backlog IDs for 839 and 840 from concurrent sessions, restoring the "No duplicate backlog task IDs" guard. Kept the referenced tasks (per `task-553.15`) as 839/840 and renumbered the other two to 867/868; backlog-only, no code changes.

<sup>Written for commit d72ed4294163a49afe2b9d10c2b416c8024072f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

