### PR TITLE
docs(backlog): repoint task-841 after the 839/840 dedupe

### DIFF
--- a/backlog/tasks/task-841 - JSON-and-XML-chunking-crash-on-the-shape-their-own-chunkers-return.md
+++ b/backlog/tasks/task-841 - JSON-and-XML-chunking-crash-on-the-shape-their-own-chunkers-return.md
@@ -36,7 +36,7 @@ A _chunk_to_text normaliser now handles both shapes. A structured record with no
 
 Nearly misdiagnosed as two separate issues. JSON first failed with 'Chunkable key data not found', which reads as a deliberate constraint. Retesting with a data key produced the same .split() error as XML, showing one bug rather than two -- the first message was the JSON chunker's own input validation firing before the real defect could.
 
-Third instance in one session of a caller assuming a shape its callee does not produce, after the remote-ingest pagination defect and the audio chunking call in task-840. All three are the same lesson, now recorded in backlog/docs/lessons-testing-evidence.md.
+Third instance in one session of a caller assuming a shape its callee does not produce, after the remote-ingest pagination defect and the audio chunking call in task-868. All three are the same lesson, now recorded in backlog/docs/lessons-testing-evidence.md.
 
 Verified by exercising all seven methods through the real service; regression test parametrises over every one. Tests/RAG + Tests/Local_Ingestion: 792 passed, 9 skipped.
 


### PR DESCRIPTION
One-line follow-up to PR #968.

That PR resolved the duplicate task ids by renumbering the audio chunking crash from **840 → 868**. `task-841`'s prose still referred to "the audio chunking call in task-840", which now names an unrelated Ruff-formatting task, so the lesson it draws points at the wrong evidence.

Checked the neighbouring references rather than only the obvious one:

- `task-553.15` mentions both 839 (MLX collection abort) and 840 (Ruff drift baseline). Both still resolve correctly, because the dedupe kept those two files at their original ids. Left untouched.
- Commit `b7841515a` — `fix(audio): call the chunking service with its real signature [TASK-840]` — is now likewise misdirected. Commit messages are immutable, so this is flagged rather than fixed.

Backlog guard verified clean on this branch: no duplicate ids in either filenames or frontmatter.

Found while verifying PR #966; unrelated to that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repointed the cross‑reference in `task-841` from `task-840` to `task-868` after the 839/840 dedupe. Also confirmed neighboring references still resolve; the `TASK-840` commit message remains unchanged.

<sup>Written for commit 5da636722d46af85c75a9577c1af87638b4b91f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

