### PR TITLE
chore(backlog): renumber 876 → 899 (collision with the Watchlist task)

### DIFF
--- a/backlog/tasks/task-899 - Settings-DB-maintenance-backs-up-and-restores-the-wrong-paths.md
+++ b/backlog/tasks/task-899 - Settings-DB-maintenance-backs-up-and-restores-the-wrong-paths.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-876
+id: TASK-899
 title: >-
   Settings DB maintenance backs up and restores paths that are not the real databases
 status: To Do


### PR DESCRIPTION
A concurrent session filed 'Watchlist tree has no selection highlight' as task-876 (created 2026-07-26 23:20, merged 06:48). Mine was created 07:00 and landed 07:06, so per the standing rule the older task keeps the number and the newer one moves.

Caught by the post-merge duplicate scan rather than the pre-filing sweep: when I claimed 876 the all-branches max was 866, so the colliding branch was either not yet pushed or not yet fetched. That is exactly why the scan runs after merge as well as before filing.

Backlog file rename plus its frontmatter `id:`. No code change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renumbered backlog task from 876 to 899 to resolve an ID collision with the Watchlist task. Renamed the backlog file and updated the frontmatter `id`; no code changes.

<sup>Written for commit 5520b9910bc5f9f8ac7c8aa41c3f1120dd8bf6ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

