### PR TITLE
feat(console): per-session agent runs with a global cap (parallel agents PR1)

### DIFF
--- a/Docs/superpowers/plans/2026-07-26-parallel-agents-per-session-runs.md
+++ b/Docs/superpowers/plans/2026-07-26-parallel-agents-per-session-runs.md
@@ -1,0 +1,1108 @@
+# Parallel Agents Across Workspaces Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the two-PR train from
+`Docs/superpowers/specs/2026-07-26-parallel-agents-across-workspaces-design.md`:
+PR1 makes Console runs per-session (capped globally, Settings-adjustable),
+PR2 adds the fleet UX (markers, parked approvals, toasts).
+
+**Architecture:** `ConsoleRunState` becomes a per-session map inside
+`ConsoleChatController` behind an **active-session facade property** named
+`run_state` — the ~16 existing read sites in `chat_screen.py` keep working
+untouched for the viewed session, while run lifecycle WRITES gain an
+explicit `session_id` so background completions never stamp the viewed
+session. Workers move to per-session exclusive groups; the send gate
+becomes per-session + global cap. PR2 layers marker state, parked
+approval badges, and toasts on top.
+
+**Tech Stack:** Python 3.11+, Textual, pytest (venv-only:
+`/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest`
+from the repo/worktree root, FOREGROUND only — background pytest runs never
+report back).
+
+## Global Constraints
+
+- Branches: PR1 `feat/console-per-session-runs`, PR2
+  `feat/console-agent-fleet-ux` stacked on PR1; both off `origin/dev`;
+  merged as one train.
+- Concurrency rule: one in-flight run per session; global cap
+  `[console] max_parallel_runs`, integer minimum 1, **default 3**, no
+  upper bound.
+- Lowering the cap NEVER kills in-flight runs (count drains naturally).
+- No hidden send queue: cap-exceeded sends are refused with the toast in
+  Task 2 (exact copy there).
+- The run-bound folder-roots behavior from PRs #943/#944 is untouched;
+  Task 6 pins it under real concurrency.
+- Approvals never auto-resolve; a parked background approval blocks only
+  its own session's run.
+- Toast-once contracts: one toast per approval card, one per run
+  completion/failure.
+- Copy strings given in tasks are verbatim requirements.
+- Line numbers in this plan are hints only — locate every site by grep,
+  never by number (this file was written against dev @ 5d1229eba).
+- The plan's implementer-facing rules: work only in the designated
+  worktree; foreground pytest in one blocking call; never touch
+  `/Users/macbook-dev/Documents/GitHub/tldw_chatbook`.
+
+---
+
+## PR1 — per-session runs + cap
+
+### Task 1: per-session run-state map with active-session facade
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py` (init ~line 596:
+  `self.run_state = ConsoleRunState()` and `self.run_state_history`;
+  `_set_run_state` ~753; `_clear_terminal_run_state` ~893;
+  `switch_session` ~991)
+- Test: `Tests/Chat/test_console_run_state_per_session.py` (new)
+
+**Interfaces:**
+- Consumes: existing `ConsoleRunState` (frozen dataclass,
+  `console_chat_models.py:153` — `status`, `visible_copy`,
+  `is_send_allowed`, `is_stop_allowed`), `self.store.active_session_id`,
+  `ConsoleRunStatus` enum.
+- Produces (later tasks rely on these exact names):
+  - `controller.run_state` — property returning the ACTIVE session's
+    state (a fresh `ConsoleRunState()` when none recorded). Read-only
+    facade; assignment raises `AttributeError` (frozen out so stray
+    writers are caught loudly).
+  - `controller.run_state_for(session_id: str) -> ConsoleRunState`
+  - `controller._set_run_state(state, *, session_id: str | None = None)`
+    — `None` means the active session (existing call sites keep working).
+  - `controller._clear_terminal_run_state(session_id: str | None = None)`
+  - `controller.run_states() -> dict[str, ConsoleRunState]` — snapshot
+    copy for fleet displays (PR2) and the cap count (Task 2).
+  - `controller.in_flight_run_count() -> int` — sessions whose state has
+    `is_send_allowed == False`.
+  - Per-session history: `controller.run_state_history_for(session_id)`;
+    the legacy `run_state_history` attribute becomes a property for the
+    active session.
+
+- [ ] **Step 1: Write the failing tests** (new file; build the controller
+  the way `Tests/Chat/test_console_chat_controller*.py` files do — copy the
+  minimal fixture idiom from the smallest existing controller test file,
+  found via `ls Tests/Chat/ | grep controller`):
+
+```python
+"""Per-session Console run state (parallel-agents spec §2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tldw_chatbook.Chat.console_chat_models import ConsoleRunState, ConsoleRunStatus
+
+
+def test_run_states_are_isolated_per_session(controller_with_two_sessions):
+    controller, session_a, session_b = controller_with_two_sessions
+
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STREAMING, "run A"),
+        session_id=session_a,
+    )
+
+    assert controller.run_state_for(session_a).status is ConsoleRunStatus.STREAMING
+    assert controller.run_state_for(session_b).is_send_allowed
+    assert controller.in_flight_run_count() == 1
+
+
+def test_facade_property_tracks_active_session(controller_with_two_sessions):
+    controller, session_a, session_b = controller_with_two_sessions
+    controller.store.set_active_session(session_a)
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STREAMING, "run A"),
+        session_id=session_a,
+    )
+
+    assert controller.run_state.status is ConsoleRunStatus.STREAMING
+    controller.store.set_active_session(session_b)
+    assert controller.run_state.is_send_allowed  # B is idle
+
+    with pytest.raises(AttributeError):
+        controller.run_state = ConsoleRunState()  # facade is read-only
+
+
+def test_terminal_clear_is_session_scoped(controller_with_two_sessions):
+    controller, session_a, session_b = controller_with_two_sessions
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.COMPLETED, "done A"), session_id=session_a
+    )
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STREAMING, "run B"), session_id=session_b
+    )
+
+    controller._clear_terminal_run_state(session_id=session_a)
+
+    assert controller.run_state_for(session_a).status is ConsoleRunStatus.IDLE
+    assert controller.run_state_for(session_b).status is ConsoleRunStatus.STREAMING
+```
+
+  Write the `controller_with_two_sessions` fixture in the same file using
+  the real store + controller construction idiom you copied (two sessions
+  via the store's `new_session`, returning `(controller, id_a, id_b)`).
+  Check the store's real method name for activating a session
+  (`switch_session` on the controller or `set_active_session` on the
+  store — grep and use what exists; adjust the test to the code, never
+  the reverse).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv-path python -m pytest "Tests/Chat/test_console_run_state_per_session.py" -q`
+Expected: FAIL — no `run_state_for` attribute.
+
+- [ ] **Step 3: Implement.** In the controller `__init__`, replace the two
+  attributes:
+
+```python
+        self._run_states: dict[str, ConsoleRunState] = {}
+        self._run_state_histories: dict[str, list[ConsoleRunStatus]] = {}
+```
+
+  Facade + accessors (place near the old attribute site):
+
+```python
+    @property
+    def run_state(self) -> ConsoleRunState:
+        """The ACTIVE session's run state (parallel-agents spec §2).
+
+        Read-only facade: the ~16 pre-existing read sites in chat_screen
+        keep their semantics ("the viewed session's run"), while writes go
+        through _set_run_state with an explicit owning session id.
+        """
+        return self.run_state_for(self.store.active_session_id or "")
+
+    def run_state_for(self, session_id: str) -> ConsoleRunState:
+        return self._run_states.get(session_id) or ConsoleRunState()
+
+    def run_states(self) -> dict[str, ConsoleRunState]:
+        return dict(self._run_states)
+
+    def in_flight_run_count(self) -> int:
+        return sum(
+            1 for state in self._run_states.values() if not state.is_send_allowed
+        )
+
+    @property
+    def run_state_history(self) -> list[ConsoleRunStatus]:
+        return self.run_state_history_for(self.store.active_session_id or "")
+
+    def run_state_history_for(self, session_id: str) -> list[ConsoleRunStatus]:
+        return self._run_state_histories.setdefault(
+            session_id, [ConsoleRunStatus.IDLE]
+        )
+```
+
+  Rework `_set_run_state` to accept `*, session_id: str | None = None`,
+  resolving `None` to `self.store.active_session_id`, writing into both
+  maps. Rework `_clear_terminal_run_state(session_id=None)` the same way
+  (only clears when that session's state is terminal — preserve the
+  existing terminal-check logic). `switch_session` keeps calling
+  `_clear_terminal_run_state()` (now clearing the PREVIOUS active
+  session — check the call's position relative to the active-session
+  swap and pass the correct explicit id so the semantic "clear the
+  session you are leaving if terminal" is preserved; state the choice in
+  a comment). Grep every `self.run_state =` assignment in the controller
+  (~9 sites) and convert to `_set_run_state(...)` calls with the correct
+  session id — sites inside run/completion callbacks must use the run's
+  OWNING session id, which those code paths already have in scope as
+  `session_id`/`owner_id` locals (grep the enclosing function; if a site
+  truly has no session in scope, use `None` and add a comment saying it
+  is an active-session UI path).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv-path python -m pytest "Tests/Chat/test_console_run_state_per_session.py" "Tests/Chat/" -q -k "run_state or controller"`
+Expected: PASS (new file + existing controller suites).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_chat_controller.py Tests/Chat/test_console_run_state_per_session.py
+git commit -m "feat(console): per-session run state behind an active-session facade"
+```
+
+### Task 2: per-session send gate + global cap + copy retirement
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+  (`CONSOLE_RUN_ALREADY_RUNNING_COPY` ~373 and its 3 use sites ~11285,
+  ~12245, ~12259 — grep the constant), `tldw_chatbook/Chat/console_chat_controller.py`
+- Test: `Tests/Chat/test_console_run_state_per_session.py` (append) +
+  the chat_screen gate's existing tests (grep
+  `CONSOLE_RUN_ALREADY_RUNNING_COPY` in Tests/ and update pins)
+
+**Interfaces:**
+- Consumes: Task 1's `in_flight_run_count`, `run_state_for`.
+- Produces:
+  - `controller.max_parallel_runs` — property reading
+    `[console] max_parallel_runs` via the controller's existing config
+    seam (grep how the controller reads `[console]` values — mirror it;
+    if the controller has no config seam, read via
+    `tldw_chatbook.config.get_cli_setting("console", "max_parallel_runs", 3)`),
+    coerced `int`, clamped to `>= 1`.
+  - `controller.send_refusal_copy(session_id) -> str | None` — `None`
+    when the send is allowed; the per-session copy
+    `"A run is already running in this tab."` when THAT session is busy;
+    otherwise the cap copy when `in_flight_run_count() >= max_parallel_runs`:
+    `f"{count} agents already running ({titles}). Wait for one to finish or interrupt it."`
+    where `titles` = first 3 busy sessions' titles joined with ", ",
+    plus `f" and {k} more"` when more than 3.
+  - chat_screen: the three `CONSOLE_RUN_ALREADY_RUNNING_COPY` sites call
+    `send_refusal_copy` and toast its result; the module constant is
+    deleted.
+
+- [ ] **Step 1: Write the failing tests** (append):
+
+```python
+def test_send_refusal_is_per_session_and_capped(controller_with_two_sessions, monkeypatch):
+    controller, session_a, session_b = controller_with_two_sessions
+    monkeypatch.setattr(
+        type(controller), "max_parallel_runs", property(lambda self: 1)
+    )
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STREAMING, "run A"), session_id=session_a
+    )
+
+    assert controller.send_refusal_copy(session_a) == (
+        "A run is already running in this tab."
+    )
+    refusal = controller.send_refusal_copy(session_b)
+    assert refusal is not None and "1 agents already running" in refusal
+    assert "Wait for one to finish or interrupt it." in refusal
+
+
+def test_cap_default_and_floor(controller_with_two_sessions, monkeypatch):
+    controller, _, _ = controller_with_two_sessions
+    import tldw_chatbook.Chat.console_chat_controller as ccc
+    monkeypatch.setattr(
+        ccc, "get_cli_setting", lambda *a, **k: 0, raising=False
+    )
+    assert controller.max_parallel_runs == 1  # floor
+    monkeypatch.setattr(
+        ccc, "get_cli_setting", lambda *a, **k: None, raising=False
+    )
+    assert controller.max_parallel_runs == 3  # default
+
+
+def test_lowering_cap_never_kills_running(controller_with_two_sessions, monkeypatch):
+    controller, session_a, session_b = controller_with_two_sessions
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STREAMING, "A"), session_id=session_a
+    )
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STREAMING, "B"), session_id=session_b
+    )
+    monkeypatch.setattr(
+        type(controller), "max_parallel_runs", property(lambda self: 1)
+    )
+    # Both stay streaming; only NEW sends are refused.
+    assert controller.run_state_for(session_a).status is ConsoleRunStatus.STREAMING
+    assert controller.run_state_for(session_b).status is ConsoleRunStatus.STREAMING
+    assert controller.in_flight_run_count() == 2
+```
+
+  (Adjust the config monkeypatch target to the real import the
+  implementation uses — the test must patch where the name is LOOKED UP.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv-path python -m pytest "Tests/Chat/test_console_run_state_per_session.py" -q`
+Expected: FAIL — no `send_refusal_copy`.
+
+- [ ] **Step 3: Implement** `max_parallel_runs` + `send_refusal_copy` on
+  the controller:
+
+```python
+    @property
+    def max_parallel_runs(self) -> int:
+        """User-adjustable global cap (spec §4); floor 1, default 3."""
+        raw = get_cli_setting("console", "max_parallel_runs", 3)
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            value = 3
+        if raw is None:
+            value = 3
+        return max(1, value)
+
+    def send_refusal_copy(self, session_id: str) -> str | None:
+        """Why a send to ``session_id`` must be refused, or None if allowed."""
+        if not self.run_state_for(session_id).is_send_allowed:
+            return "A run is already running in this tab."
+        busy = [
+            sid
+            for sid, state in self._run_states.items()
+            if not state.is_send_allowed
+        ]
+        if len(busy) < self.max_parallel_runs:
+            return None
+        titles = []
+        for sid in busy[:3]:
+            session = next(
+                (s for s in self.store.sessions() if s.id == sid), None
+            )
+            titles.append(session.title if session is not None else sid)
+        suffix = f" and {len(busy) - 3} more" if len(busy) > 3 else ""
+        return (
+            f"{len(busy)} agents already running "
+            f"({', '.join(titles)}{suffix}). "
+            "Wait for one to finish or interrupt it."
+        )
+```
+
+  Then in chat_screen: grep `CONSOLE_RUN_ALREADY_RUNNING_COPY` — at each
+  of the 3 use sites, replace the `is_send_allowed` check + constant
+  toast with `refusal = controller.send_refusal_copy(<target session id>)`
+  / `if refusal: notify(refusal, severity="warning"); return`. The target
+  session id at those sites is the active session (they are the composer
+  send/retry paths) — pass `controller.store.active_session_id`. Delete
+  the constant; update any test pinning it (grep Tests/) to the new
+  per-session copy.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv-path python -m pytest "Tests/Chat/test_console_run_state_per_session.py" -q` then the pinned-copy suites you touched.
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_chat_controller.py tldw_chatbook/UI/Screens/chat_screen.py Tests/
+git commit -m "feat(console): per-session send gate with user-adjustable global cap"
+```
+
+### Task 3: per-session worker groups + scoped interrupt
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` — all 7
+  `group="console-run"` sites (grep `group="console-run"`)
+- Test: `Tests/UI/test_console_parallel_runs.py` (new, mounted
+  ConsoleHarness — import idiom from
+  `Tests/UI/test_console_new_workspace.py`)
+
+**Interfaces:**
+- Consumes: Tasks 1-2.
+- Produces: every run worker dispatched as
+  `group=f"console-run-{session_id}", exclusive=True` where `session_id`
+  is the TARGET session at dispatch time (the active session in the
+  composer paths; the owning session in retry/regenerate paths — those
+  handlers already resolve a message/session, grep the enclosing
+  functions). Interrupt/stop paths cancel only their session's group
+  (grep how the stop action cancels workers today — if it uses
+  `workers.cancel_group` or the run worker handle, scope it by the same
+  session-derived group name).
+
+- [ ] **Step 1: Write the failing test:**
+
+```python
+"""Two sessions run concurrently; interrupt is session-scoped (spec §2)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from Tests.UI.test_screen_navigation import _build_test_app
+from tldw_chatbook.Chat.console_chat_models import ConsoleRunState, ConsoleRunStatus
+
+
+@pytest.mark.asyncio
+async def test_two_sessions_run_concurrently_and_interrupt_is_scoped() -> None:
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        await pilot.pause(0.2)
+        console = host.screen_stack[-1]
+        controller = console._ensure_console_chat_controller()
+        store = controller.store
+        session_a = store.active_session_id
+        session_b = controller.new_session().id  # check real API by grep
+
+        release_a = asyncio.Event()
+        release_b = asyncio.Event()
+
+        async def fake_run(session_id, release):
+            controller._set_run_state(
+                ConsoleRunState(ConsoleRunStatus.STREAMING, "run"),
+                session_id=session_id,
+            )
+            await release.wait()
+            controller._set_run_state(
+                ConsoleRunState(ConsoleRunStatus.COMPLETED, "done"),
+                session_id=session_id,
+            )
+
+        console.run_worker(
+            fake_run(session_a, release_a),
+            exclusive=True,
+            group=f"console-run-{session_a}",
+        )
+        console.run_worker(
+            fake_run(session_b, release_b),
+            exclusive=True,
+            group=f"console-run-{session_b}",
+        )
+        await pilot.pause(0.2)
+        assert controller.in_flight_run_count() == 2  # truly concurrent
+
+        # Cancelling A's group leaves B running.
+        console.workers.cancel_group(console, f"console-run-{session_a}")
+        release_b.set()
+        await pilot.pause(0.3)
+        assert controller.run_state_for(session_b).status is ConsoleRunStatus.COMPLETED
+```
+
+  (Verify `new_session` and `workers.cancel_group` signatures by grep and
+  adjust the TEST to reality.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv-path python -m pytest "Tests/UI/test_console_parallel_runs.py" -q`
+Expected: FAIL only if the harness idioms are wrong OR — after Task 1-2 —
+this test may pass at the worker level; the REAL red for this task is
+production sites still using the shared group. Verify with:
+`grep -c 'group="console-run"' tldw_chatbook/UI/Screens/chat_screen.py`
+Expected before implementation: 7.
+
+- [ ] **Step 3: Implement.** At each of the 7 sites, derive the target
+  session id already in scope (the send path computes it before
+  dispatch; retry/regenerate paths resolve it from the message/action
+  context — grep the enclosing function for `session_id`/`active_session_id`)
+  and change to `group=f"console-run-{target_session_id}"`. Then grep any
+  stop/interrupt handler that cancels the `"console-run"` group and scope
+  it identically. After the change:
+  `grep -c 'group="console-run"' ...` must be 0 (the literal), and
+  `grep -c 'group=f"console-run-' ...` must be 7 (+ any cancel sites).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv-path python -m pytest "Tests/UI/test_console_parallel_runs.py" "Tests/UI/test_console_native_chat_flow.py" -q`
+Expected: PASS (native flow is the big regression net for send paths; ~4 min).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/chat_screen.py Tests/UI/test_console_parallel_runs.py
+git commit -m "feat(console): per-session run worker groups with scoped interrupt"
+```
+
+### Task 4: background-write audit (store-first discipline)
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` and/or
+  `tldw_chatbook/Chat/console_chat_controller.py` (sites found by the
+  audit)
+- Test: `Tests/UI/test_console_parallel_runs.py` (append)
+
+**Interfaces:**
+- Consumes: Tasks 1-3.
+- Produces: every streaming-delta, tool-marker, generation-card, and
+  run-status view write is gated on
+  `writing_session_id == store.active_session_id`; store writes are
+  unconditional. No new names — this is a discipline pass.
+
+- [ ] **Step 1: Run the audit.** Grep the streaming/tool paths for view
+  writes: candidates are the callbacks that append/patch transcript
+  widgets (`grep -n "call_from_thread\|_append_.*message\|update_stream\|stream_delta\|tool_marker" tldw_chatbook/UI/Screens/chat_screen.py tldw_chatbook/Chat/console_chat_controller.py`).
+  For each hit, answer: does this mutate a VIEW object (widget/transcript)
+  without checking the owning session? List every such site in the
+  commit message. (The store-tree writes are already per-session — leave
+  them.)
+
+- [ ] **Step 2: Write the failing test** (append; drive a fake background
+  run against a NON-active session using the same seam the audit found —
+  the test must fail if any audited site writes the viewed transcript):
+
+```python
+@pytest.mark.asyncio
+async def test_background_run_never_mutates_viewed_transcript() -> None:
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        await pilot.pause(0.2)
+        console = host.screen_stack[-1]
+        controller = console._ensure_console_chat_controller()
+        store = controller.store
+        viewed = store.active_session_id
+        background = controller.new_session().id
+        store.set_active_session(viewed)  # keep viewing the first session
+
+        before = console.query_one("#console-native-transcript").render()
+        # Drive the audited append path for the BACKGROUND session directly
+        # (use the real method the audit gated, e.g. the assistant-delta
+        # apply seam, with session_id=background).
+        console._apply_console_stream_delta(background, "SHOULD-NOT-APPEAR")
+        await pilot.pause(0.2)
+        after = console.query_one("#console-native-transcript").render()
+        assert "SHOULD-NOT-APPEAR" not in str(after)
+        assert str(before) == str(after)
+```
+
+  The seam name `_apply_console_stream_delta` is illustrative — use the
+  REAL method the audit identifies, and assert on the real transcript
+  widget id (grep `console-native-transcript` for the actual id; adjust
+  the test to the code).
+
+- [ ] **Step 3: Implement the gates** at every audited site:
+  `if session_id != self.store.active_session_id: return` (view portion
+  only — store writes stay). Where a callback lacks the session id, thread
+  it from the dispatch site (the run knows its session from Task 3).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv-path python -m pytest "Tests/UI/test_console_parallel_runs.py" "Tests/UI/test_console_native_chat_flow.py" -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit** (list the audited sites in the body)
+
+```bash
+git add -A tldw_chatbook/ Tests/UI/test_console_parallel_runs.py
+git commit -m "fix(console): gate view writes on viewed session (background-run audit)"
+```
+
+### Task 5: Settings row for the cap (Console Behavior)
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/settings_screen.py` (Console Behavior
+  card + staging + guidance — mirror an existing numeric `[console]` row:
+  grep `_console_behavior_loaded_values` ~2597 and the card renderer)
+- Test: `Tests/UI/test_settings_configuration_hub.py` (append)
+
+**Interfaces:**
+- Consumes: the guided Console Behavior draft machinery
+  (`GUIDED_SETTINGS_MUTATION_CATEGORIES` already contains
+  CONSOLE_BEHAVIOR; staging via the card's existing `_stage_*` pattern).
+- Produces: input id `settings-console-max-parallel-runs`, config key
+  `console.max_parallel_runs`, validation integer `>= 1` (non-numeric and
+  `< 1` rejected inline with the category's standard validation copy).
+  Focused-field guidance copy VERBATIM:
+  purpose `"How many agent runs may be in flight at once, across all tabs."`;
+  consequences `"Each concurrent run holds a provider generation, its own tool activity, and memory for its transcript. Local providers (llama.cpp) typically serialize or slow under concurrent generations; high values can exhaust provider slots, rate limits, or RAM. Raise it as far as you like - the app enforces no ceiling."`;
+  saved-as `console.max_parallel_runs`; applies-to-new-sends note
+  `"Applies to new sends on save; running agents are never stopped by lowering it."`
+
+- [ ] **Step 1: Write the failing test** (append to the hub suite,
+  mirroring an existing Console Behavior save test found via
+  `grep -n "console_behavior" Tests/UI/test_settings_configuration_hub.py`):
+
+```python
+@pytest.mark.asyncio
+async def test_console_behavior_exposes_max_parallel_runs(monkeypatch):
+    saved = {}
+    # mirror the existing console-behavior save test's monkeypatch of the
+    # settings persistence seam, capturing section values into `saved`.
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _open_settings_category(pilot, "#settings-category-console-behavior")
+        field = screen.query_one("#settings-console-max-parallel-runs", Input)
+        assert field.value == "3"  # default surfaced
+
+        field.value = "0"
+        # stage + save via the category's existing save action; assert the
+        # inline validation copy appears and nothing was persisted.
+        screen.action_settings_save_category()
+        await pilot.pause(0.3)
+        assert "must be an integer of at least 1" in _visible_text(screen)
+
+        field.value = "12"
+        screen.action_settings_save_category()
+        await pilot.pause(0.3)
+        assert saved.get("console", {}).get("max_parallel_runs") == 12
+```
+
+  (Adapt harness/save/staging idioms to the neighboring Console Behavior
+  tests — they are the source of truth for how staging and the save
+  action are driven; the validation copy
+  `"must be an integer of at least 1"` is the verbatim requirement.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv-path python -m pytest "Tests/UI/test_settings_configuration_hub.py" -q -k max_parallel`
+Expected: FAIL — no such input id.
+
+- [ ] **Step 3: Implement**: loaded-values entry (default `3`), card row
+  (label `"Max parallel agent runs"`, `Input` with the id above,
+  `settings-compact-input` class), staging on `Input.Changed` via the
+  card's existing pattern, validation in the category's validator
+  (integer, `>= 1`, inline copy
+  `"Max parallel agent runs must be an integer of at least 1."`),
+  save-section wiring so it persists under `[console]`, and the
+  focused-field guidance rows with the four verbatim strings from
+  **Interfaces**.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv-path python -m pytest "Tests/UI/test_settings_configuration_hub.py" -q`
+Expected: PASS (full hub).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/settings_screen.py Tests/UI/test_settings_configuration_hub.py
+git commit -m "feat(settings): user-adjustable max parallel agent runs (Console Behavior)"
+```
+
+### Task 6: workspace-isolation concurrency pin + PR1 assembly
+
+**Files:**
+- Test: `Tests/Agents/test_builtin_provider_workspace_binding.py` (append)
+- No production changes expected.
+
+**Interfaces:**
+- Consumes: `BuiltinToolProvider(gate=..., workspace_id=...)`,
+  `workspace_file_roots.run_workspace/current_run_workspace_id` (merged
+  #943), `_ProbeTool`/`_OpenGate` idioms already in the test file.
+
+- [ ] **Step 1: Write the failing-or-green pin** (this is a regression
+  pin; it should pass immediately — its value is catching future breaks):
+
+```python
+def test_concurrent_providers_keep_distinct_workspace_bindings() -> None:
+    """Spec §7: two overlapping runs resolve different roots (ContextVar
+    isolation across interleaved invokes)."""
+    import threading
+
+    results: dict[str, str | None] = {}
+
+    class _EchoTool:
+        name = "probe_workspace"
+        description = "echo bound workspace"
+        parameters = {"type": "object", "properties": {}}
+
+        async def execute(self, **kwargs):
+            import asyncio
+            from tldw_chatbook.Tools import workspace_file_roots as wfr
+            await asyncio.sleep(0.05)  # force overlap window
+            return {"workspace": wfr.current_run_workspace_id()}
+
+    def run(workspace_id: str) -> None:
+        provider = BuiltinToolProvider(gate=_OpenGate(), workspace_id=workspace_id)
+        provider._tools["probe_workspace"] = _EchoTool()
+        result = provider.invoke("builtin:probe_workspace", {})
+        results[workspace_id] = result.content
+
+    threads = [
+        threading.Thread(target=run, args=("ws-alpha",)),
+        threading.Thread(target=run, args=("ws-beta",)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert '"workspace": "ws-alpha"' in (results["ws-alpha"] or "")
+    assert '"workspace": "ws-beta"' in (results["ws-beta"] or "")
+```
+
+- [ ] **Step 2: Run it** — Expected: PASS (ContextVars are thread-local;
+  if it fails, STOP: that is a real isolation bug — report BLOCKED).
+
+- [ ] **Step 3: PR1 full verification**
+
+Run: `.venv-path python -m pytest "Tests/Chat/" "Tests/UI/test_console_parallel_runs.py" "Tests/UI/test_settings_configuration_hub.py" "Tests/Agents/" -q`
+then: `.venv-path python -m pytest "Tests/UI/test_console_native_chat_flow.py" -q`
+Expected: PASS both (theme-editor mount flake under load is a documented
+baseline exception; native flow must be 201 passed).
+
+- [ ] **Step 4: Commit** (no push — controller handles PR creation after
+  the final review + smoke)
+
+```bash
+git add Tests/Agents/test_builtin_provider_workspace_binding.py
+git commit -m "test(agents): pin workspace-binding isolation under concurrent runs"
+```
+
+---
+
+## PR2 — fleet UX
+*(branch `feat/console-agent-fleet-ux` off PR1's branch)*
+
+### Task 7: run-marker state + clear-on-visit
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_models.py` (marker enum),
+  `tldw_chatbook/Chat/console_chat_controller.py` (marker map)
+- Test: `Tests/Chat/test_console_run_markers.py` (new)
+
+**Interfaces:**
+- Consumes: Task 1's per-session states; run completion paths.
+- Produces:
+  - `class ConsoleRunMarker(str, Enum)` in `console_chat_models.py`:
+    `NONE = "none"`, `RUNNING = "running"`,
+    `NEEDS_APPROVAL = "needs-approval"`, `FINISHED_OK = "finished-ok"`,
+    `FINISHED_FAILED = "finished-failed"`.
+  - Controller: `run_marker_for(session_id) -> ConsoleRunMarker` derived
+    live: `RUNNING` when in-flight; `NEEDS_APPROVAL` when the session's
+    run has a pending approval (Task 9 supplies
+    `set_pending_approval(session_id, bool)` — Task 7 stores the flag:
+    `self._pending_approvals: set[str]`); `FINISHED_OK`/`FINISHED_FAILED`
+    when the session's terminal state is COMPLETED/FAILED AND the session
+    is in `self._unvisited_outcomes: dict[str, ConsoleRunMarker]`
+    (stamped by the terminal `_set_run_state`); `NONE` otherwise.
+  - `mark_session_visited(session_id)` — clears the unvisited outcome and
+    pending-approval flag; called from `switch_session`.
+  - `fleet_summary_counts() -> tuple[int, int]` — (other running, other
+    pending-approval) relative to the active session.
+
+- [ ] **Step 1: Write the failing tests:**
+
+```python
+"""Run markers: running/needs-approval/finished-unvisited (spec §6)."""
+
+from __future__ import annotations
+
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleRunMarker,
+    ConsoleRunState,
+    ConsoleRunStatus,
+)
+
+
+def test_marker_lifecycle(controller_with_two_sessions):
+    controller, session_a, session_b = controller_with_two_sessions
+    assert controller.run_marker_for(session_a) is ConsoleRunMarker.NONE
+
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STREAMING, "run"), session_id=session_a
+    )
+    assert controller.run_marker_for(session_a) is ConsoleRunMarker.RUNNING
+
+    controller.set_pending_approval(session_a, True)
+    assert controller.run_marker_for(session_a) is ConsoleRunMarker.NEEDS_APPROVAL
+    controller.set_pending_approval(session_a, False)
+
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.COMPLETED, "done"), session_id=session_a
+    )
+    assert controller.run_marker_for(session_a) is ConsoleRunMarker.FINISHED_OK
+
+    controller.mark_session_visited(session_a)
+    assert controller.run_marker_for(session_a) is ConsoleRunMarker.NONE
+
+
+def test_failed_marker_and_fleet_counts(controller_with_two_sessions):
+    controller, session_a, session_b = controller_with_two_sessions
+    controller.store.set_active_session(session_a)
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STREAMING, "run"), session_id=session_b
+    )
+    running, pending = controller.fleet_summary_counts()
+    assert (running, pending) == (1, 0)
+
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.FAILED, "boom"), session_id=session_b
+    )
+    assert controller.run_marker_for(session_b) is ConsoleRunMarker.FINISHED_FAILED
+```
+
+  (Reuse the Task 1 fixture via import or a conftest move — put
+  `controller_with_two_sessions` into `Tests/Chat/conftest.py` if both
+  files need it.)
+
+- [ ] **Step 2: Run to verify failure** — Expected: FAIL, no
+  `ConsoleRunMarker`.
+
+- [ ] **Step 3: Implement** per Interfaces (marker derivation lives in
+  the controller; `_set_run_state` stamps `_unvisited_outcomes` on
+  COMPLETED/FAILED terminal transitions for NON-active sessions only —
+  the viewed session's outcome is seen live and never becomes
+  "unvisited"; `switch_session` calls `mark_session_visited(new_id)`).
+
+- [ ] **Step 4: Run to verify pass** — the new file + Task 1's file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_chat_models.py tldw_chatbook/Chat/console_chat_controller.py Tests/Chat/
+git commit -m "feat(console): per-session run markers with clear-on-visit"
+```
+
+### Task 8: tab + sidebar marker rendering and fleet summary line
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` (tab-bar label build —
+  grep the session-tab label builder; Agent rail section body),
+  `tldw_chatbook/Workspaces/conversation_browser_state.py` +
+  `tldw_chatbook/Widgets/Console/console_workspace_context.py`
+  (browser-row marker glyph)
+- Test: `Tests/UI/test_console_parallel_runs.py` (append)
+
+**Interfaces:**
+- Consumes: Task 7's `run_marker_for`, `fleet_summary_counts`.
+- Produces: glyph map (verbatim): RUNNING `"●"`, NEEDS_APPROVAL `"◆"`,
+  FINISHED_OK `"✓"`, FINISHED_FAILED `"✗"`, NONE `""` — exposed as
+  `CONSOLE_RUN_MARKER_GLYPHS: dict[ConsoleRunMarker, str]` in
+  `console_chat_models.py`; tab labels prefix the glyph; browser input
+  rows gain `run_marker: str = ""` (threaded like `openable` was in
+  TASK-717 — input row → normalize → display row → row label); Agent
+  rail renders `f"{running} other agents running, {pending} waiting for approval."`
+  only when `running + pending > 0`, id
+  `console-agent-fleet-summary`.
+
+- [ ] **Step 1: Write the failing tests** (append; mounted):
+
+```python
+@pytest.mark.asyncio
+async def test_tab_and_sidebar_show_run_markers_and_fleet_line() -> None:
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        await pilot.pause(0.2)
+        console = host.screen_stack[-1]
+        controller = console._ensure_console_chat_controller()
+        background = controller.new_session().id
+        controller.store.set_active_session(controller.store.sessions()[0].id)
+        controller._set_run_state(
+            ConsoleRunState(ConsoleRunStatus.STREAMING, "bg"),
+            session_id=background,
+        )
+        await console._sync_native_console_chat_ui()
+        await pilot.pause(0.3)
+
+        text = _visible_text(console)
+        assert "●" in text  # running glyph on tab/row
+        assert "1 other agents running, 0 waiting for approval." in text
+```
+
+  (Import `_visible_text` from the workspace-context rail test module as
+  other files do; adjust session-creation idioms to the real API.)
+
+- [ ] **Step 2: Run to verify failure** — Expected: FAIL, no glyph/line.
+
+- [ ] **Step 3: Implement** per Interfaces: glyph dict; tab label builder
+  prefixes `CONSOLE_RUN_MARKER_GLYPHS[marker]`; browser rows thread
+  `run_marker` exactly like TASK-717 threaded `openable`
+  (input dataclass field → `_normalize_input_row` → `_to_browser_row` →
+  row label prefix in the tray); chat_screen populates it from
+  `controller.run_marker_for(...)` when building browser input rows;
+  Agent rail body appends the fleet Static when counts are non-zero.
+
+- [ ] **Step 4: Run to verify pass** — the parallel-runs file +
+  `Tests/UI/test_console_workspace_context_rail.py` +
+  `Tests/UI/test_console_rail_sections.py`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A tldw_chatbook/ Tests/UI/test_console_parallel_runs.py
+git commit -m "feat(console): fleet markers on tabs and sidebar + Agent rail summary"
+```
+
+### Task 9: parked background approvals
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py`
+  (`build_tool_review_hook` ~line 279 — grep it) and the chat_screen
+  approval-card mount path (grep `Approval required` / the card widget's
+  mount site)
+- Test: `Tests/UI/test_console_parallel_runs.py` (append)
+
+**Interfaces:**
+- Consumes: Task 7's `set_pending_approval`; the review hook's existing
+  await-decision flow; Task 3's session-scoped runs.
+- Produces: when the hook raises a card for a session that is NOT the
+  active session: no card mounts; `set_pending_approval(session_id, True)`;
+  ONE toast `f"Agent in {session_title} ({workspace_name}) needs approval."`
+  (workspace name resolved via the session's workspace_id through the
+  registry; fall back to the raw id). Visiting the session
+  (`switch_session`) mounts the pending card through the existing mount
+  path and the flag clears when the decision is submitted (approve or
+  deny), not merely on visit — `set_pending_approval(sid, False)` hooks
+  the decision-submit path. Card state derives from the run's pending
+  review state, so switching away and back re-mounts it.
+
+- [ ] **Step 1: Write the failing test** (append):
+
+```python
+@pytest.mark.asyncio
+async def test_background_approval_parks_with_badge_and_single_toast() -> None:
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        await pilot.pause(0.2)
+        console = host.screen_stack[-1]
+        controller = console._ensure_console_chat_controller()
+        viewed = controller.store.active_session_id
+        background = controller.new_session().id
+        controller.store.set_active_session(viewed)
+
+        notifications: list[str] = []
+        app.notify = lambda message, **kwargs: notifications.append(str(message))
+
+        # Drive the review hook's park path for the background session via
+        # the seam the implementation adds (grep its real name after
+        # implementing; the test asserts observable behavior):
+        console._park_console_approval(background)
+        await pilot.pause(0.3)
+
+        assert not console.query("#console-approval-card")  # not mounted
+        approval_toasts = [n for n in notifications if "needs approval" in n]
+        assert len(approval_toasts) == 1
+        from tldw_chatbook.Chat.console_chat_models import ConsoleRunMarker
+        assert (
+            controller.run_marker_for(background)
+            is ConsoleRunMarker.NEEDS_APPROVAL
+        )
+
+        # Visiting mounts the card.
+        controller.switch_session(background)
+        await console._sync_native_console_chat_ui()
+        await pilot.pause(0.3)
+        assert console.query("#console-approval-card")
+```
+
+  (`_park_console_approval` and `#console-approval-card` are the
+  interface names this task produces — if the existing card widget has a
+  different stable id, use the REAL id in both code and test; grep the
+  approval-card compose site first and record the actual id in the commit
+  message.)
+
+- [ ] **Step 2: Run to verify failure** — Expected: FAIL, no park seam.
+
+- [ ] **Step 3: Implement** per Interfaces. The review hook already knows
+  its run's session (Task 3 threads it); the park branch replaces the
+  unconditional card mount with: active-session check → mount as today
+  OR park (flag + toast-once guard per card + no mount). `switch_session`
+  checks for a parked card on the newly-viewed session and mounts it.
+  Decision submit clears the flag via `set_pending_approval(sid, False)`.
+
+- [ ] **Step 4: Run to verify pass** — the parallel-runs file + the
+  approval-related suites (grep Tests/ for the review-hook tests:
+  `grep -rln "build_tool_review_hook\|Approve all" Tests/ | head` and run
+  those files).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A tldw_chatbook/ Tests/UI/test_console_parallel_runs.py
+git commit -m "feat(console): park background approvals with badge and single toast"
+```
+
+### Task 10: completion toasts + PR2 assembly
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py` (terminal
+  `_set_run_state` transitions) or chat_screen's completion callbacks —
+  wherever Task 1 routed terminal states; put the toast beside the
+  `_unvisited_outcomes` stamp so it fires exactly once per run
+- Test: `Tests/UI/test_console_parallel_runs.py` (append)
+
+**Interfaces:**
+- Consumes: Task 7's stamp point.
+- Produces: on a NON-active session's terminal transition, ONE toast:
+  `f"Agent in {session_title} ({workspace_name}) finished."` or
+  `"... failed."` (same workspace-name resolution as Task 9). Active
+  session: no toast (the user is watching).
+
+- [ ] **Step 1: Write the failing test** (append):
+
+```python
+@pytest.mark.asyncio
+async def test_background_completion_fires_single_toast() -> None:
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        await pilot.pause(0.2)
+        console = host.screen_stack[-1]
+        controller = console._ensure_console_chat_controller()
+        viewed = controller.store.active_session_id
+        background = controller.new_session().id
+        controller.store.set_active_session(viewed)
+        notifications: list[str] = []
+        app.notify = lambda message, **kwargs: notifications.append(str(message))
+
+        controller._set_run_state(
+            ConsoleRunState(ConsoleRunStatus.STREAMING, "bg"), session_id=background
+        )
+        controller._set_run_state(
+            ConsoleRunState(ConsoleRunStatus.COMPLETED, "done"), session_id=background
+        )
+        finished = [n for n in notifications if "finished" in n]
+        assert len(finished) == 1
+
+        # Re-setting the same terminal state must not double-toast.
+        controller._set_run_state(
+            ConsoleRunState(ConsoleRunStatus.COMPLETED, "done"), session_id=background
+        )
+        assert len([n for n in notifications if "finished" in n]) == 1
+```
+
+  (The controller needs a notify seam for toasts — grep how the
+  controller currently surfaces notifications to the app; if toasts are
+  screen-level today, put the toast in the screen's completion callback
+  instead and drive that seam in the test. Adjust test to reality.)
+
+- [ ] **Step 2: Run to verify failure** — Expected: FAIL, no toast.
+
+- [ ] **Step 3: Implement** with a once-guard (toast only on the
+  transition INTO the terminal state, i.e. when the previous status for
+  that session was non-terminal).
+
+- [ ] **Step 4: PR2 full verification**
+
+Run: `.venv-path python -m pytest "Tests/Chat/" "Tests/UI/test_console_parallel_runs.py" "Tests/UI/test_console_workspace_context_rail.py" "Tests/UI/test_console_rail_sections.py" "Tests/UI/test_settings_configuration_hub.py" -q`
+then `.venv-path python -m pytest "Tests/UI/test_console_native_chat_flow.py" -q`
+Expected: PASS (native flow 201).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A tldw_chatbook/ Tests/UI/test_console_parallel_runs.py
+git commit -m "feat(console): background-run completion toasts (once per run)"
+```
+
+### Task 11: live smoke (non-negotiable before merge)
+
+**Files:** none (verification only; controller-driven).
+
+- [ ] **Step 1:** Launch per the folder-roots smoke recipe: scratch
+  profile (`TLDW_CONFIG_PATH`, fresh `users_name`), llama.cpp at :9099,
+  tmux socket `wssmoke`, `[tools] read_file_enabled = true`, from the PR2
+  worktree. Create TWO workspaces in Settings ▸ Workspaces, bind a
+  distinct temp folder to each (rw not required).
+- [ ] **Step 2:** Open a tab in each workspace (switch active workspace,
+  Ctrl+T). Start an agent turn in BOTH tabs (read_file instructions
+  targeting each tab's own bound folder). Verify: both run concurrently
+  (Agent rail fleet line "1 other agents running…" while viewing either),
+  no cap refusal at default 3.
+- [ ] **Step 3:** While viewing tab A, let tab B's run hit its approval
+  card: verify NO card over tab A, `◆` on tab B + its sidebar row, one
+  toast. Visit tab B, Approve all THEN Submit (row-level clicks do not
+  stamp). Verify each run's read succeeds only inside its OWN workspace's
+  folder (transcripts show the two distinct markers/contents).
+- [ ] **Step 4:** Let both complete; verify one completion toast each and
+  ✓ markers that clear on visit. Capture pane dumps of the fleet line,
+  the parked badge, and both transcripts into the session scratchpad.
+- [ ] **Step 5:** Teardown: kill the tmux server, delete the scratch
+  profile dir.
+
+## Self-review notes (already applied)
+
+- Spec coverage: §2→Tasks 1-3, §3→Task 4, §4→Tasks 2+5, §5→Task 9,
+  §6→Tasks 7-8+10, §7→per-task tests + Tasks 6 and 11, §8→PR boundaries,
+  §9 honored (no queues, no per-workspace caps, no approval-semantics
+  changes).
+- Name consistency: `run_state_for`, `run_states`, `in_flight_run_count`,
+  `send_refusal_copy`, `max_parallel_runs`, `ConsoleRunMarker`,
+  `CONSOLE_RUN_MARKER_GLYPHS`, `run_marker_for`, `set_pending_approval`,
+  `mark_session_visited`, `fleet_summary_counts`, group
+  `f"console-run-{session_id}"` — used identically across tasks.
+- Deliberate verify-at-implementation flags: store's activate-session
+  API name (T1), config lookup target for monkeypatch (T2), retry-path
+  session resolution (T3), audit seam + transcript widget id (T4),
+  Console Behavior staging idiom (T5), approval-card real id + hook
+  session threading (T9), controller notify seam (T10).

--- a/Docs/superpowers/specs/2026-07-26-parallel-agents-across-workspaces-design.md
+++ b/Docs/superpowers/specs/2026-07-26-parallel-agents-across-workspaces-design.md
@@ -1,0 +1,164 @@
+# Parallel agents across workspaces — per-session runs from the sidebar
+
+Date: 2026-07-26
+Status: approved design, pending implementation
+Companion to: `Docs/superpowers/specs/2026-07-26-settings-workspaces-category-design.md`
+(merged as PRs #943/#944) — that train's **run-bound folder roots** are this
+program's enabling primitive and need no changes here (ADR-028).
+Builds on: workspace UX program (PRs #928/#932/#943/#944, ADR-027/028).
+
+## 1. Goal and decisions (locked with the user)
+
+Users run **multiple agents in parallel, each in its own workspace**, and
+swap between them from the Console sidebar. Today runs are globally
+serialized: one `ConsoleRunState` on the controller, one exclusive
+`"console-run"` worker group, and an is-send-allowed gate that refuses a
+second send anywhere (confirmed live during the folder-roots smoke).
+
+- **Concurrency rule: one in-flight run per session, capped globally.**
+  Any number of sessions (same or different workspaces) run in parallel
+  under the cap. "Each tab is an agent."
+- **Background approvals: badge + park.** A background session's run pauses
+  at its approval card; the tab and sidebar row badge; one toast fires;
+  the user jumps to the tab to decide. Never auto-approve.
+- **Background completion: toast + markers.** One toast naming session,
+  workspace, and outcome; sidebar row and tab carry a done/failed marker
+  until visited.
+- **The cap is user-adjustable in Settings** (§4): default 3, raiseable to
+  whatever the user wants, with guidance copy owning the consequences.
+
+## 2. Per-session run model (PR1)
+
+- `ConsoleRunState` moves from a single controller attribute to a
+  **per-session map** owned alongside the session store's other per-session
+  state (settings, drafts): `run_state_for(session_id)`,
+  `set_run_state(session_id, ...)`, terminal-state clears scoped to their
+  session. `run_state_history` becomes per-session likewise.
+- Send gate: allowed iff (a) the TARGET session has no in-flight run and
+  (b) `count(in-flight runs) < max_parallel_runs`. (a) failing keeps
+  today's per-session copy ("a run is already running in this tab"); (b)
+  failing produces the cap toast (§4).
+- Workers: `group=f"console-run-{session_id}"`, still `exclusive=True`
+  within the group — one run per session by construction, N groups in
+  parallel. The TASK-228 lesson (UI-sync kicks must never share a group
+  with runs) carries over: sync workers keep their own groups.
+- Run completion/error/interrupt paths (`_set_run_state`,
+  `_clear_terminal_run_state`, retry/regenerate entries) all become
+  session-scoped; the send-stash and follow-intent state that assume "the"
+  run are audited and keyed the same way.
+- Workspace binding: unchanged. Each run already resolves folder roots
+  from its session's workspace (`session_workspace_id` →
+  `BuiltinToolProvider` → `run_workspace`); parallel runs in different
+  workspaces enforce different roots with no cross-talk — this is the
+  merged #943 behavior and a required regression pin here (§7).
+
+## 3. Background streaming discipline (PR1)
+
+Message and tool writes already land in per-session store trees; the risk
+is view-seam bleed. Rule: **store-first writes; view application gated on
+"is the writing session the viewed session."** PR1 includes an audit of the
+streaming/tool-marker/generation-card paths for any write that targets the
+visible view directly without a session check; each such site is gated.
+Switching tabs rebuilds the view from the store (existing switch path),
+so a background session's accumulated output appears on visit. The
+`CONSOLE_RUN_ALREADY_RUNNING_COPY` gate copy is retired in favor of the
+per-session/cap messages.
+
+## 4. The cap — config + Settings exposure
+
+- Config: `[console] max_parallel_runs`, integer `>= 1`, **default 3**.
+  Values above the default are allowed without an upper bound — the user
+  owns the trade-off.
+- **Settings exposure (user-requested): the cap is editable in
+  Settings ▸ Console Behavior** (the guided category that already owns
+  `[console]` values — draft + Save/Revert semantics, not immediate).
+  The row ships with everything that comes with a guided setting:
+  - Input with validation (integer, minimum 1; non-numeric and `< 1`
+    rejected inline with the category's standard validation copy).
+  - Focused-field guidance in the Scope Inspector: purpose ("How many
+    agent runs may be in flight at once, across all tabs"), saved-as
+    (`console.max_parallel_runs`), and an explicit consequences note:
+    "Each concurrent run holds a provider generation, its own tool
+    activity, and memory for its transcript. Local providers (llama.cpp)
+    typically serialize or slow under concurrent generations; high values
+    can exhaust provider slots, rate limits, or RAM. Raise it as far as
+    you like — the app enforces no ceiling."
+  - Applies to NEW sends on save (in-flight runs are never killed by
+    lowering the cap; the count simply drains below the new value).
+- Cap-exceeded send: honest toast naming the busy sessions —
+  `"N agents already running (<session titles, comma-separated, truncated
+  to 3 + 'and K more'>). Wait for one to finish or interrupt it."` No
+  hidden queue: queued sends that fire later without the user watching
+  are worse than a clear refusal.
+
+## 5. Background approvals — badge + park (PR2)
+
+- The per-run review hook already awaits its approval decision; a parked
+  run is just that await with nobody looking. New behavior when the owning
+  session is not viewed: the approval card does NOT mount over the current
+  tab; instead
+  - the owning TAB and the sidebar conversation row get a
+    `needs-approval` badge,
+  - ONE toast fires per card: `"Agent in <session title> (<workspace
+    name>) needs approval."`,
+  - visiting the tab mounts the card exactly as today.
+- Approvals never auto-resolve; other sessions' runs are unaffected while
+  one is parked. Card state survives tab switches (it derives from the
+  run's pending-approval state, not from mounted-widget lifetime).
+
+## 6. Sidebar/tab fleet indicators (PR2)
+
+- Three-state marker on Console tabs AND sidebar conversation-browser
+  rows: `running` / `needs-approval` / `finished-unvisited` (distinct
+  glyphs; cleared when the session is viewed). `finished-unvisited`
+  renders success and failure with distinct glyphs (e.g. ✓ vs ✗) but
+  shares the same clear-on-visit lifecycle. Display-state additions
+  flow through the existing browser-row builders (workspace groups
+  included, so "which workspace's agents are busy" is visible at a
+  glance).
+- Completion/failure toast: `"Agent in <session title> (<workspace name>)
+  <finished|failed>."` — once per run.
+- The Agent rail section shows the VIEWED session's run state (as today)
+  plus a one-line fleet summary when other runs exist: `"2 other agents
+  running, 1 waiting for approval."`
+
+## 7. Testing
+
+- **PR1:** per-session state unit tests (two sessions run concurrently;
+  same-session second send refused with per-session copy; cap refusal at
+  N; lowering cap never kills in-flight runs); worker-group isolation
+  (interrupting session A's run leaves B's running); background-write
+  audit regression (a background run's stream never mutates the viewed
+  transcript — store-only until visit); **workspace-isolation pin**: two
+  concurrent runs in different workspaces resolve different folder roots
+  (extends the #943 provider tests to overlap in time).
+- **PR2:** badge/marker state tests (running/needs-approval/
+  finished-unvisited transitions incl. clear-on-visit); parked-approval
+  flow (card absent while unviewed, badge present, mounts on visit,
+  decision releases the run); toast-once contracts; Settings cap row
+  (validation, guidance copy, save→config write, cap honored on next
+  send).
+- **Live smoke (non-negotiable before merge):** two workspaces with
+  distinct bound folders; start agent runs in both tabs; verify both run
+  concurrently (Agent rail fleet line), each run's file tool confined to
+  its own workspace's folder; park an approval on the background session,
+  see badge + toast, visit, approve, both complete with correct markers.
+  Reuse the folder-roots smoke recipe (scratch profile, llama.cpp :9099,
+  `wssmoke` socket; Approve-all THEN Submit).
+
+## 8. Phasing
+
+Two stacked PRs, merged as one train (no released state where the engine
+allows parallel runs but the UI can't show them, or vice versa):
+- **PR1 `feat/console-per-session-runs`**: §2 + §3 + §4's config/gate
+  (Settings row included — it is a plain guided-category addition) +
+  PR1 tests.
+- **PR2 `feat/console-agent-fleet-ux`** (stacked): §5 + §6 + PR2 tests +
+  live smoke.
+
+## 9. Out of scope
+
+Cross-run coordination or shared context between agents; run queues;
+per-workspace caps; changes to approval semantics; ACP/external runtimes
+(the `runtimeWorkspaceRoots`-shaped export surface from ADR-028 stands
+ready); multi-window UI.

--- a/Tests/Agents/test_builtin_provider_workspace_binding.py
+++ b/Tests/Agents/test_builtin_provider_workspace_binding.py
@@ -39,3 +39,40 @@ def test_invoke_without_workspace_leaves_context_unset() -> None:
 
     assert result.ok, result.error
     assert '"workspace": null' in result.content
+
+
+def test_concurrent_providers_keep_distinct_workspace_bindings() -> None:
+    """Spec §7: two overlapping runs resolve different roots (ContextVar
+    isolation across interleaved invokes)."""
+    import threading
+
+    results: dict[str, str | None] = {}
+
+    class _EchoTool:
+        name = "probe_workspace"
+        description = "echo bound workspace"
+        parameters = {"type": "object", "properties": {}}
+
+        async def execute(self, **kwargs):
+            import asyncio
+            from tldw_chatbook.Tools import workspace_file_roots as wfr
+            await asyncio.sleep(0.05)  # force overlap window
+            return {"workspace": wfr.current_run_workspace_id()}
+
+    def run(workspace_id: str) -> None:
+        provider = BuiltinToolProvider(gate=_OpenGate(), workspace_id=workspace_id)
+        provider._tools["probe_workspace"] = _EchoTool()
+        result = provider.invoke("builtin:probe_workspace", {})
+        results[workspace_id] = result.content
+
+    threads = [
+        threading.Thread(target=run, args=("ws-alpha",)),
+        threading.Thread(target=run, args=("ws-beta",)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert '"workspace": "ws-alpha"' in (results["ws-alpha"] or "")
+    assert '"workspace": "ws-beta"' in (results["ws-beta"] or "")

--- a/Tests/Chat/test_console_agent_swap.py
+++ b/Tests/Chat/test_console_agent_swap.py
@@ -494,7 +494,12 @@ async def test_stop_cancels_tree_and_persists_cancelled(tmp_path):
     original = controller._agent_bridge.run_reply
 
     def cancel_after_first(*args, **kwargs):
-        controller._stop_requested = True  # simulate Stop during the run
+        # Fix round 1 (Critical 1): `should_cancel` now reads only its own
+        # run's per-session cancel_event, never the shared `_stop_requested`
+        # flag -- simulate Stop during the run via the real internal
+        # signalling path (`_run_agent_reply` already populated this run's
+        # `_active_cancel_events[session_id]` before dispatching here).
+        controller._signal_stop(session_id=kwargs["session_id"])
         return original(*args, **kwargs)
 
     controller._agent_bridge.run_reply = cancel_after_first
@@ -804,7 +809,10 @@ async def test_stop_before_first_token_persists_cancelled_no_agent_run_failed(tm
             if m.role is ConsoleMessageRole.ASSISTANT
         )
         store.mark_message_stopped(assistant_message_id)
-        controller._stop_requested = True
+        # Fix round 1 (Critical 1): should_cancel now reads only its own
+        # run's per-session cancel_event, never the shared `_stop_requested`
+        # flag -- simulate Stop via the real internal signalling path.
+        controller._signal_stop(session_id=session_id)
         async for chunk in real_stream_chat(resolution, messages):
             yield chunk
 

--- a/Tests/Chat/test_console_agent_swap.py
+++ b/Tests/Chat/test_console_agent_swap.py
@@ -593,7 +593,7 @@ async def test_stop_during_parked_bridge_thread_persists_cancelled_not_done(tmp_
     # _run_agent_reply's finally -- exactly the moment the pre-fix bug
     # discarded the signal the still-running bridge thread depends on.
     assert controller._stop_requested is False
-    assert controller._active_stream_task is None
+    assert controller._active_stream_tasks.get(session_id) is None
 
     # Release the parked thread now -- it is STILL RUNNING on its own OS
     # thread, oblivious to the coroutine having already returned.
@@ -689,7 +689,7 @@ async def test_finalize_after_already_stopped_regenerate_no_phantom_variant(tmp_
         # AND status) -- simulating a real Stop landing in the window
         # after the bridge has already produced RUN_DONE but before
         # _finalize_agent_reply runs.
-        controller._active_cancel_event.set()
+        controller._active_cancel_events[session_id].set()
         store.mark_message_stopped(assistant_message_id)
         return "run-test", RunOutcome(
             status=RUN_DONE, steps=[], final_text="late regenerate text"
@@ -735,7 +735,7 @@ async def test_finalize_after_already_stopped_regenerate_error_no_wedge(tmp_path
     assert assistant.status == "complete"
 
     def parked_regenerate_error_reply(*, assistant_message_id, **_kwargs):
-        controller._active_cancel_event.set()
+        controller._active_cancel_events[session_id].set()
         store.mark_message_stopped(assistant_message_id)
         return "run-test", RunOutcome(
             status=RUN_ERROR,

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -756,7 +756,10 @@ def test_stop_active_run_falls_back_to_visible_streaming_assistant_message():
             "Streaming response.",
         )
     )
-    controller._active_assistant_message_id = None
+    # No entry registered in `_active_assistant_message_ids` for this
+    # session -- `stop_active_run` must fall back to the visible streaming
+    # assistant message in the store.
+    assert session.id not in controller._active_assistant_message_ids
 
     assert controller.stop_active_run() is True
 
@@ -901,7 +904,7 @@ async def test_shutdown_stops_and_awaits_active_stream_task():
     assert messages[-1].content == "partial"
     assert messages[-1].status == "stopped"
     assert controller.run_state.status is ConsoleRunStatus.STOPPED
-    assert controller._active_stream_task is None
+    assert controller._active_stream_tasks.get(store.active_session_id) is None
 
 
 @pytest.mark.asyncio
@@ -910,17 +913,18 @@ async def test_shutdown_ignores_failed_active_stream_task():
         raise RuntimeError("stream task failed before shutdown")
 
     store = ConsoleChatStore()
+    session = store.ensure_session()
     controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
     task = asyncio.create_task(fail_before_shutdown())
     await asyncio.sleep(0)
     assert task.done()
 
-    controller._active_stream_task = task
+    controller._active_stream_tasks[session.id] = task
     controller._stop_requested = True
 
     await controller.shutdown()
 
-    assert controller._active_stream_task is None
+    assert controller._active_stream_tasks == {}
     assert controller._stop_requested is False
 
 
@@ -3322,8 +3326,8 @@ async def test_agent_finalization_remains_inside_outer_active_stream_ownership()
             **kwargs,
         ):
             self.active_during_finalization = (
-                self._active_assistant_message_id,
-                self._active_stream_task,
+                self._active_assistant_message_ids.get(session_id),
+                self._active_stream_tasks.get(session_id),
                 self._stop_requested,
             )
             return await super()._finalize_agent_reply(
@@ -3367,8 +3371,8 @@ async def test_agent_finalization_remains_inside_outer_active_stream_ownership()
         current_task,
         False,
     )
-    assert controller._active_assistant_message_id is None
-    assert controller._active_stream_task is None
+    assert controller._active_assistant_message_ids.get(store.active_session_id) is None
+    assert controller._active_stream_tasks.get(store.active_session_id) is None
     assert controller._stop_requested is False
 
 

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -2983,7 +2983,13 @@ async def test_stop_mid_stream_consumes_one_shot():
 
         async def stream_chat(self, resolution, messages):
             yield "partial"
-            self.controller._stop_requested = True
+            # Fix round 1 (Critical 1): the direct/legacy stream loop now
+            # reads only its OWN run's per-session cancel_event, never the
+            # shared `_stop_requested` flag -- simulate Stop via the real
+            # internal signalling path instead of the flag directly.
+            self.controller._signal_stop(
+                session_id=self.controller.store.active_session_id
+            )
             yield "never-shown"
 
     gateway = StopAfterFirstChunkGateway()

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -212,43 +212,58 @@ def test_controller_session_changes_clear_terminal_run_copy() -> None:
     controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
     first = store.ensure_session(title="Chat 1")
 
-    controller.run_state = ConsoleRunState(
-        ConsoleRunStatus.COMPLETED, "Response complete."
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete.")
     )
     controller.new_session(title="Chat 2")
 
     assert controller.run_state.status is ConsoleRunStatus.IDLE
     assert controller.run_state.visible_copy == ""
 
-    controller.run_state = ConsoleRunState(
-        ConsoleRunStatus.BLOCKED, "Provider blocked."
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.BLOCKED, "Provider blocked.")
     )
     controller.switch_session(first.id)
 
+    # `switch_session` clears a stale TERMINAL run copy on the session being
+    # ARRIVED AT (the swap above already moved active_session_id to `first`
+    # before this clear runs) -- `first`'s own COMPLETED state (set at the
+    # very top of this test) is what gets swept here.
     assert controller.run_state.status is ConsoleRunStatus.IDLE
     assert controller.run_state.visible_copy == ""
 
 
 def test_controller_session_changes_preserve_active_run_copy() -> None:
+    """A non-terminal run state is never reset by session-change cleanup --
+    `_clear_terminal_run_state`'s guard only fires for TERMINAL statuses.
+
+    Parallel-agents spec §2: run state is per-session now, so this checks
+    `first`'s OWN state survives a sibling session being created (rather
+    than asserting the facade -- which after `new_session()` is viewing the
+    brand-new sibling, not `first` -- shows the same value).
+    """
     store = ConsoleChatStore()
     controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
     first = store.ensure_session(title="Chat 1")
 
-    controller.run_state = ConsoleRunState(
-        ConsoleRunStatus.STREAMING, "Streaming response."
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STREAMING, "Streaming response.")
     )
-    controller.new_session(title="Chat 2")
+    second = controller.new_session(title="Chat 2")
 
-    assert controller.run_state.status is ConsoleRunStatus.STREAMING
-    assert controller.run_state.visible_copy == "Streaming response."
+    assert controller.run_state_for(first.id).status is ConsoleRunStatus.STREAMING
+    assert controller.run_state_for(first.id).visible_copy == "Streaming response."
 
-    controller.run_state = ConsoleRunState(
-        ConsoleRunStatus.VALIDATING, "Validating provider."
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.VALIDATING, "Validating provider."),
+        session_id=second.id,
     )
     controller.switch_session(first.id)
 
-    assert controller.run_state.status is ConsoleRunStatus.VALIDATING
-    assert controller.run_state.visible_copy == "Validating provider."
+    # Arriving back at `first`: its own STREAMING state is non-terminal, so
+    # the arrival-side clear leaves it untouched.
+    assert controller.run_state.status is ConsoleRunStatus.STREAMING
+    assert controller.run_state.visible_copy == "Streaming response."
 
 
 def test_controller_new_session_accepts_settings_snapshot() -> None:
@@ -715,9 +730,11 @@ def test_stop_active_run_falls_back_to_visible_streaming_assistant_message():
         content="",
     )
     store.append_stream_chunk(assistant.id, "partial")
-    controller.run_state = ConsoleRunState(
-        ConsoleRunStatus.STREAMING,
-        "Streaming response.",
+    controller._set_run_state(
+        ConsoleRunState(
+            ConsoleRunStatus.STREAMING,
+            "Streaming response.",
+        )
     )
     controller._active_assistant_message_id = None
 
@@ -918,7 +935,13 @@ async def test_close_streaming_session_stops_run_without_key_error():
     assert result.accepted is True
     assert result.visible_copy == "Session closed."
     assert store.sessions() == []
-    assert controller.run_state.status is ConsoleRunStatus.STOPPED
+    # No session is active anymore (the only session was just closed), so
+    # the `run_state` FACADE (keyed by the now-None active_session_id) is no
+    # longer meaningful here -- check the closed session's own recorded
+    # state instead, proving the stop was actually processed rather than
+    # silently swallowed by a KeyError.
+    assert store.active_session_id is None
+    assert controller.run_state_for(session_id).status is ConsoleRunStatus.STOPPED
 
 
 @pytest.mark.asyncio

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -208,6 +208,13 @@ def test_controller_creates_and_switches_sessions():
 
 
 def test_controller_session_changes_clear_terminal_run_copy() -> None:
+    """A session's own TERMINAL run copy is cleared only when it is the
+    session being LEFT for another one -- never the session being arrived
+    at, and never a session nothing has switched away from yet (spec §2:
+    "clear the session you are leaving if terminal", implemented explicitly
+    in `switch_session` -- see its own comment for why the id must be
+    resolved before the store's active-session swap).
+    """
     store = ConsoleChatStore()
     controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
     first = store.ensure_session(title="Chat 1")
@@ -215,22 +222,32 @@ def test_controller_session_changes_clear_terminal_run_copy() -> None:
     controller._set_run_state(
         ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete.")
     )
-    controller.new_session(title="Chat 2")
+    second = controller.new_session(title="Chat 2")
 
-    assert controller.run_state.status is ConsoleRunStatus.IDLE
-    assert controller.run_state.visible_copy == ""
+    # `new_session()`'s clear call targets the just-created session (always
+    # a no-op, since it starts idle) -- `first`'s own COMPLETED state is
+    # untouched by creating a sibling.
+    assert controller.run_state_for(first.id).status is ConsoleRunStatus.COMPLETED
+    assert controller.run_state_for(first.id).visible_copy == "Response complete."
+    assert controller.run_state_for(second.id).status is ConsoleRunStatus.IDLE
 
+    # Leaving `second` (idle, non-terminal) for `first`: nothing to clear,
+    # so the facade now shows `first`'s still-untouched COMPLETED state.
+    controller.switch_session(first.id)
+    assert controller.run_state.status is ConsoleRunStatus.COMPLETED
+
+    # Put the CURRENTLY ACTIVE session (`first`) into a terminal state, then
+    # leave it for `second`: this is the case `switch_session` actually
+    # clears -- the session being LEFT, because it was terminal.
     controller._set_run_state(
         ConsoleRunState(ConsoleRunStatus.BLOCKED, "Provider blocked.")
     )
-    controller.switch_session(first.id)
+    controller.switch_session(second.id)
 
-    # `switch_session` clears a stale TERMINAL run copy on the session being
-    # ARRIVED AT (the swap above already moved active_session_id to `first`
-    # before this clear runs) -- `first`'s own COMPLETED state (set at the
-    # very top of this test) is what gets swept here.
-    assert controller.run_state.status is ConsoleRunStatus.IDLE
-    assert controller.run_state.visible_copy == ""
+    assert controller.run_state_for(first.id).status is ConsoleRunStatus.IDLE
+    assert controller.run_state_for(first.id).visible_copy == ""
+    # `second` (the session arrived at) was never targeted by this switch.
+    assert controller.run_state_for(second.id).status is ConsoleRunStatus.IDLE
 
 
 def test_controller_session_changes_preserve_active_run_copy() -> None:
@@ -260,10 +277,13 @@ def test_controller_session_changes_preserve_active_run_copy() -> None:
     )
     controller.switch_session(first.id)
 
-    # Arriving back at `first`: its own STREAMING state is non-terminal, so
-    # the arrival-side clear leaves it untouched.
+    # Leaving `second` (VALIDATING -- non-terminal) for `first`: nothing to
+    # clear either way, so `first`'s own untouched STREAMING state is what
+    # the facade shows back.
     assert controller.run_state.status is ConsoleRunStatus.STREAMING
     assert controller.run_state.visible_copy == "Streaming response."
+    # `second`'s own non-terminal state also survives being left.
+    assert controller.run_state_for(second.id).status is ConsoleRunStatus.VALIDATING
 
 
 def test_controller_new_session_accepts_settings_snapshot() -> None:

--- a/Tests/Chat/test_console_generation_actions.py
+++ b/Tests/Chat/test_console_generation_actions.py
@@ -1280,7 +1280,11 @@ async def test_generate_image_handler_restores_draft_when_batch_raises(monkeypat
 
     system_messages: list[str] = []
 
-    async def _fake_append_system(text: str) -> None:
+    async def _fake_append_system(text: str, *, session_id: str | None = None) -> None:
+        # Task 4 (background-write audit): the real handler now threads
+        # `session_id=session.id` explicitly on every append in this path
+        # (the batch's owning session, captured before the raising call) --
+        # this fake must accept the same keyword the real method does.
         system_messages.append(text)
 
     screen._append_native_console_system_message = _fake_append_system

--- a/Tests/Chat/test_console_local_citation_boundary.py
+++ b/Tests/Chat/test_console_local_citation_boundary.py
@@ -544,6 +544,30 @@ def _assistant(store: ConsoleChatStore):
     )
 
 
+# Task 3b rebase note: the controller's in-flight bookkeeping is now a
+# PER-SESSION map (keyed by owning session id), not a single shared slot --
+# these tests predate that and read the ACTIVE session's own entry, which is
+# equivalent for every single-session scenario in this file (including
+# post-close/post-second-submit re-checks, where `active_session_id` still
+# resolves to whichever session -- or `""` -- the assertion cares about).
+def _active_citation_repair_session(controller: ConsoleChatController):
+    return controller._active_citation_repair_sessions.get(
+        controller.store.active_session_id or ""
+    )
+
+
+def _active_assistant_message_id(controller: ConsoleChatController):
+    return controller._active_assistant_message_ids.get(
+        controller.store.active_session_id or ""
+    )
+
+
+def _active_stream_task(controller: ConsoleChatController):
+    return controller._active_stream_tasks.get(
+        controller.store.active_session_id or ""
+    )
+
+
 def _citation_calls(
     persistence: _ReadyCitationPersistence,
 ) -> list[dict[str, Any]]:
@@ -1219,11 +1243,11 @@ async def test_citation_repair_direct_initial_session_defers_without_persistence
     assert append_kwargs["terminal_citation_finalizer"] is None
     assert append_kwargs["defer_terminal_persistence"] is True
     assert store.completion_calls == [_assistant(store).id]
-    assert controller._active_citation_repair_session is None
+    assert _active_citation_repair_session(controller) is None
 
     def observe_session(call_index):
         if call_index == 0:
-            session = controller._active_citation_repair_session
+            session = _active_citation_repair_session(controller)
             observed.append((session.contract, session.resolution, session.phase))
 
     second_store = _recording_citation_store()
@@ -1283,7 +1307,7 @@ async def test_citation_repair_cleaned_session_contains_no_governed_text(
 
     def retain_session(call_index: int) -> None:
         if call_index == 0:
-            retained_sessions.append(controller._active_citation_repair_session)
+            retained_sessions.append(_active_citation_repair_session(controller))
 
     gateway.on_call = retain_session
 
@@ -1332,7 +1356,7 @@ async def test_citation_repair_cleaned_session_contains_no_governed_text(
         store._provisional_terminal_selection_ids,
         store._terminal_persistence_deferred_ids,
     )
-    assert controller._active_citation_repair_session is None
+    assert _active_citation_repair_session(controller) is None
 
 
 @pytest.mark.asyncio
@@ -1467,7 +1491,7 @@ async def test_citation_repair_failure_privacy_sentinels_are_confined_to_selecte
 
     def retain_session(call_index: int) -> None:
         if call_index == 0:
-            retained_sessions.append(controller._active_citation_repair_session)
+            retained_sessions.append(_active_citation_repair_session(controller))
 
     gateway.on_call = retain_session
 
@@ -1518,9 +1542,9 @@ async def test_citation_repair_failure_privacy_sentinels_are_confined_to_selecte
     cleaned_session = retained_sessions[0]
     assert cleaned_session.contract is None
     assert cleaned_session.resolution is None
-    assert controller._active_citation_repair_session is None
-    assert controller._active_assistant_message_id is None
-    assert controller._active_stream_task is None
+    assert _active_citation_repair_session(controller) is None
+    assert _active_assistant_message_id(controller) is None
+    assert _active_stream_task(controller) is None
     assert controller.original_attempt_for_message(assistant.id) is None
     _assert_content_free_repair_state(
         caplog.text,
@@ -1908,7 +1932,7 @@ def _observe_clean_lifecycle_request(controller, store, observed):
             return
         observed.append(
             {
-                "repair_session": controller._active_citation_repair_session,
+                "repair_session": _active_citation_repair_session(controller),
                 "finalizers": dict(store._terminal_citation_finalizers),
                 "provisional_ids": set(store._provisional_terminal_selection_ids),
                 "deferred_ids": set(store._terminal_persistence_deferred_ids),
@@ -1930,7 +1954,7 @@ def _assert_clean_lifecycle_call(controller, store, gateway, observed):
     assert len(gateway.calls) == 2
     assert gateway.calls[0]["signals"] is not _OMITTED
     assert gateway.calls[1]["signals"] is _OMITTED
-    assert controller._active_citation_repair_session is None
+    assert _active_citation_repair_session(controller) is None
     assert store._terminal_citation_finalizers == {}
     assert store._provisional_terminal_selection_ids == set()
     assert store._terminal_persistence_deferred_ids == set()
@@ -2457,7 +2481,7 @@ async def test_citation_repair_user_cancellation_privacy_sentinels(
     try:
         task = asyncio.create_task(controller.submit_draft("question"))
         await gateway.repair_started.wait()
-        retained_session = controller._active_citation_repair_session
+        retained_session = _active_citation_repair_session(controller)
         assert retained_session is not None
         assert controller.stop_active_run() is True
         await task
@@ -2483,9 +2507,9 @@ async def test_citation_repair_user_cancellation_privacy_sentinels(
         _sanitize_selected_persistence(persistence, initial_body),
         controller.run_state,
         controller.run_state_history,
-        controller._active_citation_repair_session,
-        controller._active_assistant_message_id,
-        controller._active_stream_task,
+        _active_citation_repair_session(controller),
+        _active_assistant_message_id(controller),
+        _active_stream_task(controller),
     )
 
 
@@ -2516,7 +2540,7 @@ async def test_citation_repair_late_chunk_privacy_sentinels(
     try:
         task = asyncio.create_task(controller.submit_draft("question"))
         await gateway.first_repair_chunk_collected.wait()
-        retained_session = controller._active_citation_repair_session
+        retained_session = _active_citation_repair_session(controller)
         assert retained_session is not None
         assert controller.stop_active_run() is True
         await task
@@ -2536,9 +2560,9 @@ async def test_citation_repair_late_chunk_privacy_sentinels(
         _sanitize_selected_persistence(persistence, initial_body),
         controller.run_state,
         controller.run_state_history,
-        controller._active_citation_repair_session,
-        controller._active_assistant_message_id,
-        controller._active_stream_task,
+        _active_citation_repair_session(controller),
+        _active_assistant_message_id(controller),
+        _active_stream_task(controller),
     )
 
 
@@ -2569,7 +2593,7 @@ async def test_citation_repair_session_close_privacy_sentinels(
     try:
         task = asyncio.create_task(controller.submit_draft("question"))
         await gateway.repair_started.wait()
-        retained_session = controller._active_citation_repair_session
+        retained_session = _active_citation_repair_session(controller)
         assert retained_session is not None
         session_id = store.active_session_id
         assert session_id is not None
@@ -2589,9 +2613,9 @@ async def test_citation_repair_session_close_privacy_sentinels(
         persistence.create_calls,
         controller.run_state,
         controller.run_state_history,
-        controller._active_citation_repair_session,
-        controller._active_assistant_message_id,
-        controller._active_stream_task,
+        _active_citation_repair_session(controller),
+        _active_assistant_message_id(controller),
+        _active_stream_task(controller),
         store.sessions(),
     )
 
@@ -2790,11 +2814,11 @@ async def test_citation_repair_close_unrelated_session_preserves_cancel_ownershi
     controller.switch_session(owner_session_id)
     task = asyncio.create_task(controller.submit_draft("question"))
     await gateway.repair_started.wait()
-    repair_session = controller._active_citation_repair_session
+    repair_session = _active_citation_repair_session(controller)
 
     controller.close_session(unrelated.id)
 
-    assert controller._active_citation_repair_session is repair_session
+    assert _active_citation_repair_session(controller) is repair_session
     assert controller.stop_active_run() is True
     await task
     _assert_user_citation_repair_cancel(
@@ -2929,7 +2953,7 @@ async def test_citation_repair_shutdown_during_collection_privacy_has_no_user_st
     )
     task = asyncio.create_task(controller.submit_draft("question"))
     await gateway.repair_started.wait()
-    retained_session = controller._active_citation_repair_session
+    retained_session = _active_citation_repair_session(controller)
     assert retained_session is not None
 
     await controller.shutdown()
@@ -2968,9 +2992,9 @@ async def test_citation_repair_close_during_collection_never_resurrects_session_
     assert result.visible_copy == "Session closed."
     assert store.sessions() == []
     assert store.active_session_id is None
-    assert controller._active_citation_repair_session is None
-    assert controller._active_assistant_message_id is None
-    assert controller._active_stream_task is None
+    assert _active_citation_repair_session(controller) is None
+    assert _active_assistant_message_id(controller) is None
+    assert _active_stream_task(controller) is None
     assert not any(
         call["sender"] == ConsoleMessageRole.SYSTEM.value
         for call in persistence.create_calls

--- a/Tests/Chat/test_console_run_state_per_session.py
+++ b/Tests/Chat/test_console_run_state_per_session.py
@@ -14,6 +14,7 @@ from tldw_chatbook.Chat.console_chat_models import (
     ConsoleRunStatus,
 )
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_provider_gateway import ConsoleProviderStreamSignals
 
 
 class StreamingGateway:
@@ -514,3 +515,151 @@ async def test_stopping_one_session_does_not_truncate_a_concurrent_untouched_ses
     gateway.release["b"].set()
     result_b = await task_b
     assert result_b.accepted is True
+
+
+# -- F4 fix (Qodo wave): `submit_draft` must target the session it was  --
+# -- DISPATCHED for, not whichever session is active once its own body  --
+# -- actually starts running.                                          --
+
+
+@pytest.mark.asyncio
+async def test_submit_draft_targets_dispatched_session_not_active_session_at_execution():
+    """F4(b) regression (Qodo wave): before this fix, ``submit_draft``
+    always resolved "the session to submit into" via ``store.
+    ensure_session()``/``store.active_session_id`` -- i.e. whichever
+    session is active AT THE MOMENT THIS COROUTINE BODY RUNS, not whatever
+    session ``chat_screen._dispatch_console_draft_send`` captured at
+    dispatch time. ``run_worker`` schedules the coroutine as a Task rather
+    than running it inline, so a tab switch racing that scheduling gap
+    (plausible: at least one event-loop iteration, often several Textual
+    message-pump ticks) used to submit the draft into whichever session
+    the user switched TO, not the one showing when Send was pressed.
+
+    This drives the exact shape the real dispatch path
+    (``ChatScreen._submit_console_native_draft``) now produces: session A
+    dispatched, active session already moved to B by the time
+    ``submit_draft`` actually runs -- passing A's id explicitly, exactly
+    as the fixed ``_submit_console_native_draft`` does. Session A must get
+    the write; session B (the one merely being *viewed*) must stay
+    untouched.
+    """
+    store = ConsoleChatStore()
+    gateway = StreamingGateway()
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+
+    session_a = store.ensure_session(title="A")
+    # Simulate the scheduling gap: the user switches tabs to a brand new
+    # session B AFTER Send was dispatched for A but BEFORE `submit_draft`'s
+    # body actually runs (in production this happens between `run_worker`
+    # scheduling the task and the event loop actually running it).
+    session_b = controller.new_session(title="B")
+    assert store.active_session_id == session_b.id
+
+    result = await controller.submit_draft("hello-from-a", session_id=session_a.id)
+
+    assert result.accepted is True
+    messages_a = store.messages_for_session(session_a.id)
+    assert any(m.content == "hello-from-a" for m in messages_a)
+    messages_b = store.messages_for_session(session_b.id)
+    assert messages_b == []
+
+
+@pytest.mark.asyncio
+async def test_submit_draft_session_id_none_preserves_active_session_bootstrap():
+    """``session_id=None`` (the default) must keep resolving/creating the
+    ACTIVE session exactly as before this fix -- direct-call test idioms
+    and the very first send of a fresh app (no session yet) both rely on
+    this. Guards against a regression where threading `session_id` through
+    accidentally broke the "no session exists yet" bootstrap path (which
+    ``store.ensure_session()`` -- not a session lookup -- must still
+    handle)."""
+    store = ConsoleChatStore()
+    gateway = StreamingGateway()
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+    assert store.active_session_id is None
+
+    result = await controller.submit_draft("hello")
+
+    assert result.accepted is True
+    assert store.active_session_id is not None
+    messages = store.messages_for_session(store.active_session_id)
+    assert any(m.content == "hello" for m in messages)
+
+
+@pytest.mark.asyncio
+async def test_submit_draft_closed_session_id_fails_closed_without_touching_active():
+    """F4(b) edge case: if the dispatched session was closed during the
+    scheduling gap (not just switched away from), there is nothing left
+    to submit into. The fix must fail closed (``_session_closed_result``)
+    rather than silently falling back to ``ensure_session()`` and
+    submitting into whatever is active now."""
+    store = ConsoleChatStore()
+    gateway = StreamingGateway()
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+
+    session_a = store.ensure_session(title="A")
+    closed_session_id = session_a.id
+    session_b = controller.new_session(title="B")
+    controller.close_session(closed_session_id)
+    assert store.active_session_id == session_b.id
+
+    result = await controller.submit_draft("hello", session_id=closed_session_id)
+
+    assert result.accepted is True
+    assert result.visible_copy == "Session closed."
+    messages_b = store.messages_for_session(session_b.id)
+    assert messages_b == []
+
+
+@pytest.mark.asyncio
+async def test_finalize_agent_success_citation_repair_keyerror_stamps_owning_session_not_active():
+    """F4(a) regression (Qodo wave): `_finalize_agent_success`'s two
+    citation-repair-selection ``except KeyError`` branches used to call
+    ``_session_closed_result()`` with NO session id -- even though
+    ``session_id`` is a REQUIRED parameter of this method (always known,
+    never re-derived from anything that could go stale). The bare no-arg
+    call defaulted to whichever session is ACTIVE right now, wrongly
+    stamping ITS run state STOPPED even though it has nothing to do with
+    this run.
+
+    Drives ``_finalize_agent_success`` directly (mirrors this codebase's
+    existing pattern of unit-testing controller internals directly, e.g.
+    ``_stream_assistant_response`` in test_console_chat_controller.py),
+    with a monkeypatched ``_select_post_generation_body`` that raises
+    ``KeyError`` (the message's session vanished mid-run), while a
+    DIFFERENT, untouched session B is the one currently active.
+    """
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+
+    session_a = store.ensure_session(title="A")
+    assistant = store.append_message(
+        session_a.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="partial reply",
+        persist=False,
+    )
+
+    session_b = controller.new_session(title="B")  # also activates B
+    assert store.active_session_id == session_b.id
+
+    async def _raise_key_error(**_kwargs):
+        raise KeyError("message gone")
+
+    controller._select_post_generation_body = _raise_key_error
+
+    outcome = type("Outcome", (), {"final_text": "final text"})()
+    result = await controller._finalize_agent_success(
+        assistant.id,
+        session_a.id,
+        outcome,
+        variant_mode=False,
+        citation_repair_session=object(),
+        stream_signals=ConsoleProviderStreamSignals(),
+    )
+
+    assert result.visible_copy == "Session closed."
+    # Session A (the run's own owning session) got the STOPPED stamp...
+    assert controller.run_state_for(session_a.id).status is ConsoleRunStatus.STOPPED
+    # ...session B (merely the one being VIEWED) is untouched.
+    assert controller.run_state_for(session_b.id).status is ConsoleRunStatus.IDLE

--- a/Tests/Chat/test_console_run_state_per_session.py
+++ b/Tests/Chat/test_console_run_state_per_session.py
@@ -140,3 +140,76 @@ def test_in_flight_run_count_and_run_states_snapshot(controller_with_two_session
     # Snapshot is a copy: mutating it must not affect the controller's map.
     snapshot[session_a] = ConsoleRunState()
     assert controller.run_state_for(session_a).status is ConsoleRunStatus.STREAMING
+
+
+def test_send_refusal_is_per_session_and_capped(controller_with_two_sessions, monkeypatch):
+    controller, session_a, session_b = controller_with_two_sessions
+    monkeypatch.setattr(
+        type(controller), "max_parallel_runs", property(lambda self: 1)
+    )
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STREAMING, "run A"), session_id=session_a
+    )
+
+    assert controller.send_refusal_copy(session_a) == (
+        "A run is already running in this tab."
+    )
+    refusal = controller.send_refusal_copy(session_b)
+    assert refusal is not None and "1 agents already running" in refusal
+    assert "Wait for one to finish or interrupt it." in refusal
+
+
+def test_cap_default_and_floor(controller_with_two_sessions, monkeypatch):
+    controller, _, _ = controller_with_two_sessions
+    import tldw_chatbook.Chat.console_chat_controller as ccc
+    monkeypatch.setattr(
+        ccc, "get_cli_setting", lambda *a, **k: 0, raising=False
+    )
+    assert controller.max_parallel_runs == 1  # floor
+    monkeypatch.setattr(
+        ccc, "get_cli_setting", lambda *a, **k: None, raising=False
+    )
+    assert controller.max_parallel_runs == 3  # default
+
+
+def test_lowering_cap_never_kills_running(controller_with_two_sessions, monkeypatch):
+    controller, session_a, session_b = controller_with_two_sessions
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STREAMING, "A"), session_id=session_a
+    )
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STREAMING, "B"), session_id=session_b
+    )
+    monkeypatch.setattr(
+        type(controller), "max_parallel_runs", property(lambda self: 1)
+    )
+    # Both stay streaming; only NEW sends are refused.
+    assert controller.run_state_for(session_a).status is ConsoleRunStatus.STREAMING
+    assert controller.run_state_for(session_b).status is ConsoleRunStatus.STREAMING
+    assert controller.in_flight_run_count() == 2
+
+
+def test_orphaned_closed_session_does_not_consume_cap_slot(
+    controller_with_two_sessions, monkeypatch
+):
+    """Carried finding from Task 1's review: closing a session mid-VALIDATING
+    leaves an orphaned entry in the per-session run-state map (``close_session``
+    never touches ``controller._run_states``). The cap must not count it --
+    ``send_refusal_copy`` intersects its busy list with ``store.sessions()``
+    so a session that no longer exists can't consume a cap slot or appear in
+    the refusal copy's session list.
+    """
+    controller, session_a, session_b = controller_with_two_sessions
+    monkeypatch.setattr(
+        type(controller), "max_parallel_runs", property(lambda self: 1)
+    )
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.VALIDATING, "orphan"), session_id=session_a
+    )
+    controller.store.close_session(session_a)
+
+    assert session_a not in {session.id for session in controller.store.sessions()}
+    # The orphaned entry is still in the map...
+    assert controller.in_flight_run_count() == 1
+    # ...but it must not occupy the cap's single slot for the surviving session.
+    assert controller.send_refusal_copy(session_b) is None

--- a/Tests/Chat/test_console_run_state_per_session.py
+++ b/Tests/Chat/test_console_run_state_per_session.py
@@ -1,0 +1,142 @@
+"""Per-session Console run state (parallel-agents spec §2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_models import ConsoleRunState, ConsoleRunStatus
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+
+
+class StreamingGateway:
+    """Minimal provider gateway stub -- copied from test_console_chat_controller.py's
+    idiom (no network I/O, `ready=True` resolution) since this file's tests never
+    actually run a send/stream, only drive run-state bookkeeping directly."""
+
+    async def resolve_for_send(self, selection):
+        return type(
+            "Resolution",
+            (),
+            {
+                "ready": True,
+                "provider": "llama_cpp",
+                "model": "test-model",
+                "base_url": "http://127.0.0.1:9099",
+                "visible_copy": "",
+            },
+        )()
+
+    async def stream_chat(self, resolution, messages):
+        for chunk in ("hel", "lo"):
+            yield chunk
+
+
+@pytest.fixture
+def controller_with_two_sessions():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    # `store.new_session` does not exist (verified by grep) -- the real
+    # session-creation surface is `store.ensure_session`/`store.create_session`
+    # and `controller.new_session`. `controller.new_session()` also activates
+    # the session it creates (`ConsoleChatStore.create_session` sets
+    # `active_session_id`), matching how `test_controller_creates_and_
+    # switches_sessions` in test_console_chat_controller.py builds two
+    # sessions.
+    session_a = store.ensure_session(title="Session A")
+    session_b = controller.new_session(title="Session B")
+    return controller, session_a.id, session_b.id
+
+
+def test_run_states_are_isolated_per_session(controller_with_two_sessions):
+    controller, session_a, session_b = controller_with_two_sessions
+
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STREAMING, "run A"),
+        session_id=session_a,
+    )
+
+    assert controller.run_state_for(session_a).status is ConsoleRunStatus.STREAMING
+    assert controller.run_state_for(session_b).is_send_allowed
+    assert controller.in_flight_run_count() == 1
+
+
+def test_facade_property_tracks_active_session(controller_with_two_sessions):
+    controller, session_a, session_b = controller_with_two_sessions
+    # `ConsoleChatStore` has no `set_active_session` method (verified by
+    # grep) -- activation is `store.switch_session(session_id)`, which sets
+    # `active_session_id` directly (see console_chat_store.py:490-494).
+    controller.store.switch_session(session_a)
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STREAMING, "run A"),
+        session_id=session_a,
+    )
+
+    assert controller.run_state.status is ConsoleRunStatus.STREAMING
+    controller.store.switch_session(session_b)
+    assert controller.run_state.is_send_allowed  # B is idle
+
+    with pytest.raises(AttributeError):
+        controller.run_state = ConsoleRunState()  # facade is read-only
+
+
+def test_terminal_clear_is_session_scoped(controller_with_two_sessions):
+    controller, session_a, session_b = controller_with_two_sessions
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.COMPLETED, "done A"), session_id=session_a
+    )
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STREAMING, "run B"), session_id=session_b
+    )
+
+    controller._clear_terminal_run_state(session_id=session_a)
+
+    assert controller.run_state_for(session_a).status is ConsoleRunStatus.IDLE
+    assert controller.run_state_for(session_b).status is ConsoleRunStatus.STREAMING
+
+
+def test_run_state_history_is_per_session(controller_with_two_sessions):
+    controller, session_a, session_b = controller_with_two_sessions
+
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.VALIDATING, "v"), session_id=session_a
+    )
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STREAMING, "s"), session_id=session_a
+    )
+
+    history_a = controller.run_state_history_for(session_a)
+    history_b = controller.run_state_history_for(session_b)
+    assert history_a == [
+        ConsoleRunStatus.IDLE,
+        ConsoleRunStatus.VALIDATING,
+        ConsoleRunStatus.STREAMING,
+    ]
+    assert history_b == [ConsoleRunStatus.IDLE]
+
+    # Legacy `run_state_history` property mirrors the ACTIVE session's history.
+    controller.store.switch_session(session_a)
+    assert controller.run_state_history == history_a
+
+
+def test_in_flight_run_count_and_run_states_snapshot(controller_with_two_sessions):
+    controller, session_a, session_b = controller_with_two_sessions
+
+    assert controller.in_flight_run_count() == 0
+    assert controller.run_states() == {}
+
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STREAMING, "run A"), session_id=session_a
+    )
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.VALIDATING, "run B"), session_id=session_b
+    )
+
+    assert controller.in_flight_run_count() == 2
+    snapshot = controller.run_states()
+    assert snapshot[session_a].status is ConsoleRunStatus.STREAMING
+    assert snapshot[session_b].status is ConsoleRunStatus.VALIDATING
+
+    # Snapshot is a copy: mutating it must not affect the controller's map.
+    snapshot[session_a] = ConsoleRunState()
+    assert controller.run_state_for(session_a).status is ConsoleRunStatus.STREAMING

--- a/Tests/Chat/test_console_run_state_per_session.py
+++ b/Tests/Chat/test_console_run_state_per_session.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
+import threading
+
 import pytest
 
 from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
-from tldw_chatbook.Chat.console_chat_models import ConsoleRunState, ConsoleRunStatus
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleMessageRole,
+    ConsoleRunState,
+    ConsoleRunStatus,
+)
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
 
 
@@ -219,3 +226,178 @@ def test_orphaned_closed_session_does_not_consume_cap_slot(
     assert session_a in controller.run_states()
     # It must not occupy the cap's single slot for the surviving session.
     assert controller.send_refusal_copy(session_b) is None
+
+
+# -- Task 3b: per-session stream/cancel state + scoped Stop/shutdown --------
+
+
+def _seed_streaming_assistant(store: ConsoleChatStore, session_id: str) -> str:
+    """Append a real user+assistant pair so `_mark_stream_stopped` (which
+    calls `store.mark_message_stopped`) has a real row to act on -- a bare
+    string id would raise KeyError deep inside `stop_active_run`."""
+    store.append_message(session_id, role=ConsoleMessageRole.USER, content="hi")
+    assistant = store.append_message(
+        session_id, role=ConsoleMessageRole.ASSISTANT, content=""
+    )
+    store.append_stream_chunk(assistant.id, "partial")
+    return assistant.id
+
+
+@pytest.mark.asyncio
+async def test_stop_active_run_cancels_only_viewed_sessions_task(
+    controller_with_two_sessions,
+):
+    """Requirement 5a: two fake tasks registered for two sessions --
+    `stop_active_run()` with A viewed cancels only A's task; B's task
+    survives untouched and completes on its own."""
+    controller, session_a, session_b = controller_with_two_sessions
+    store = controller.store
+    assistant_a = _seed_streaming_assistant(store, session_a)
+    assistant_b = _seed_streaming_assistant(store, session_b)
+
+    started_a = asyncio.Event()
+    started_b = asyncio.Event()
+    cancelled_a = asyncio.Event()
+    completed_b = asyncio.Event()
+    release_b = asyncio.Event()
+    never_release_a = asyncio.Event()  # never set -- A is only ever cancelled
+
+    async def never_ending():
+        started_a.set()
+        try:
+            await never_release_a.wait()
+        except asyncio.CancelledError:
+            cancelled_a.set()
+            raise
+
+    async def finishes_on_release():
+        started_b.set()
+        await release_b.wait()
+        completed_b.set()
+
+    task_a = asyncio.create_task(never_ending())
+    task_b = asyncio.create_task(finishes_on_release())
+    # A task cancelled before its first scheduled step never runs its body
+    # at all (asyncio discards it outright) -- wait for both to actually
+    # reach their own `await` so cancellation exercises the SAME suspended-
+    # mid-run state a real streaming task would be in.
+    await started_a.wait()
+    await started_b.wait()
+
+    controller._active_stream_tasks[session_a] = task_a
+    controller._active_assistant_message_ids[session_a] = assistant_a
+    controller._active_stream_tasks[session_b] = task_b
+    controller._active_assistant_message_ids[session_b] = assistant_b
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STREAMING, "run A"), session_id=session_a
+    )
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STREAMING, "run B"), session_id=session_b
+    )
+
+    store.switch_session(session_a)  # A is VIEWED
+    assert controller.stop_active_run() is True
+
+    with pytest.raises(asyncio.CancelledError):
+        await task_a
+    assert cancelled_a.is_set()
+
+    # B is completely untouched: still registered, still running.
+    assert controller._active_stream_tasks.get(session_b) is task_b
+    assert not task_b.done()
+    assert controller.run_state_for(session_b).status is ConsoleRunStatus.STREAMING
+
+    release_b.set()
+    await task_b
+    assert completed_b.is_set()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_cancels_and_awaits_every_sessions_task(
+    controller_with_two_sessions,
+):
+    """Requirement 5b/3: shutdown's teardown path is GLOBAL -- it cancels
+    and awaits every session's task, not just the viewed one, and leaves
+    no stale entries behind for either session."""
+    controller, session_a, session_b = controller_with_two_sessions
+    store = controller.store
+    assistant_a = _seed_streaming_assistant(store, session_a)
+    assistant_b = _seed_streaming_assistant(store, session_b)
+
+    cancelled = {"a": False, "b": False}
+    started = {"a": asyncio.Event(), "b": asyncio.Event()}
+    never_release = asyncio.Event()  # never set -- both are only ever cancelled
+
+    async def never_ending(key: str):
+        started[key].set()
+        try:
+            await never_release.wait()
+        except asyncio.CancelledError:
+            cancelled[key] = True
+            raise
+
+    task_a = asyncio.create_task(never_ending("a"))
+    task_b = asyncio.create_task(never_ending("b"))
+    # See test_stop_active_run_cancels_only_viewed_sessions_task: a task
+    # cancelled before its first scheduled step never runs its body at all.
+    await started["a"].wait()
+    await started["b"].wait()
+
+    controller._active_stream_tasks[session_a] = task_a
+    controller._active_assistant_message_ids[session_a] = assistant_a
+    controller._active_stream_tasks[session_b] = task_b
+    controller._active_assistant_message_ids[session_b] = assistant_b
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STREAMING, "run A"), session_id=session_a
+    )
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STREAMING, "run B"), session_id=session_b
+    )
+    # Viewed session is irrelevant to shutdown's scope -- only A is viewed,
+    # yet B must be cancelled too.
+    store.switch_session(session_a)
+
+    await controller.shutdown()
+
+    assert cancelled == {"a": True, "b": True}
+    assert controller._active_stream_tasks == {}
+    assert controller._active_assistant_message_ids == {}
+    assert controller._active_cancel_events == {}
+
+
+@pytest.mark.asyncio
+async def test_completing_run_pops_only_its_own_session_entries(
+    controller_with_two_sessions,
+):
+    """Requirement 4: a session's own terminal path pops ONLY its own
+    entries from the per-session stream/cancel maps -- a different
+    session's still-registered (fake) entries are left untouched."""
+    controller, session_a, session_b = controller_with_two_sessions
+    store = controller.store
+    store.switch_session(session_a)
+
+    # Session B has its own, still in-flight (fake, never-completing) run.
+    task_b = asyncio.create_task(asyncio.Event().wait())
+    controller._active_stream_tasks[session_b] = task_b
+    controller._active_assistant_message_ids[session_b] = "assistant-b"
+    controller._active_cancel_events[session_b] = threading.Event()
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STREAMING, "run B"), session_id=session_b
+    )
+
+    result = await controller.submit_draft("hello")
+    assert result.accepted is True
+
+    # Session A's own run completed and cleaned up entirely after itself.
+    assert session_a not in controller._active_stream_tasks
+    assert session_a not in controller._active_assistant_message_ids
+    assert session_a not in controller._active_cancel_events
+
+    # Session B's unrelated registered entries are untouched.
+    assert controller._active_stream_tasks.get(session_b) is task_b
+    assert controller._active_assistant_message_ids.get(session_b) == "assistant-b"
+    assert not task_b.done()
+
+    task_b.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task_b

--- a/Tests/Chat/test_console_run_state_per_session.py
+++ b/Tests/Chat/test_console_run_state_per_session.py
@@ -401,3 +401,116 @@ async def test_completing_run_pops_only_its_own_session_entries(
     task_b.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task_b
+
+
+# -- Fix round 1 (Critical 1): the shared `_stop_requested` flag must    --
+# -- never be read by a specific run's OWN cancellation-check loop.      --
+
+
+class TwoStreamGateway:
+    """Two independently blockable, genuinely concurrent streams,
+    distinguished by the draft text embedded in each call's own
+    ``provider_messages`` (each session sends a differently-worded
+    prompt) -- not by call order, which under real concurrency is not
+    guaranteed to match dispatch order."""
+
+    def __init__(self) -> None:
+        self.started = {"a": asyncio.Event(), "b": asyncio.Event()}
+        self.release = {"a": asyncio.Event(), "b": asyncio.Event()}
+
+    async def resolve_for_send(self, selection):
+        return type(
+            "Resolution",
+            (),
+            {
+                "ready": True,
+                "provider": "llama_cpp",
+                "model": "test-model",
+                "base_url": "http://127.0.0.1:9099",
+                "visible_copy": "",
+            },
+        )()
+
+    @staticmethod
+    def _key_for(messages: list[dict]) -> str:
+        for row in reversed(messages):
+            content = row.get("content")
+            if row.get("role") == "user" and isinstance(content, str):
+                if "prompt-a" in content:
+                    return "a"
+                if "prompt-b" in content:
+                    return "b"
+        raise AssertionError(f"unrecognized draft in {messages!r}")
+
+    async def stream_chat(self, resolution, messages):
+        key = self._key_for(messages)
+        yield f"{key}-chunk-1-"
+        self.started[key].set()
+        await self.release[key].wait()
+        yield f"{key}-chunk-2-"
+        yield f"{key}-chunk-3"
+
+
+@pytest.mark.asyncio
+async def test_stopping_one_session_does_not_truncate_a_concurrent_untouched_session():
+    """Critical 1 regression (Fix round 1): the direct/legacy stream loop's
+    cancellation check used to read the SHARED ``_stop_requested`` flag,
+    which ``_signal_stop`` sets unconditionally on ANY session's Stop/
+    Close -- so stopping session B silently truncated session A's still-
+    streaming, completely untouched reply (live-reproduced by the
+    reviewer). This drives two REAL, genuinely concurrent
+    ``submit_draft()`` calls through the ACTUAL cancellation-check code
+    path (``_stream_assistant_response``'s per-chunk check), not a
+    registered fake.
+
+    Deliberately signals B's stop via ``controller._signal_stop`` (the
+    exact call ``stop_active_run``/``close_session`` make) WITHOUT
+    task-cancelling B: B's own ``finally`` resetting the shared flag back
+    to ``False`` the moment its task unwinds would otherwise mask the bug
+    -- awaiting B to completion before touching A (as a full ``stop_
+    active_run()`` + ``await task_b`` sequence would) closes that exact
+    race window this test needs open. Isolating the bare flag WRITE from
+    task-cancellation timing is also more precise: it is the write alone,
+    independent of when/whether the writer's own task later unwinds, that
+    the fix (Critical 1) had to stop being read by an unrelated run's
+    loop.
+    """
+    store = ConsoleChatStore()
+    gateway = TwoStreamGateway()
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+
+    session_a = store.ensure_session(title="A")
+    task_a = asyncio.create_task(controller.submit_draft("prompt-a"))
+    await asyncio.wait_for(gateway.started["a"].wait(), timeout=1)
+
+    session_b = controller.new_session(title="B")  # also activates B
+    task_b = asyncio.create_task(controller.submit_draft("prompt-b"))
+    await asyncio.wait_for(gateway.started["b"].wait(), timeout=1)
+
+    # Both genuinely mid-stream and suspended at the same time.
+    assert controller.in_flight_run_count() == 2
+    assert not task_a.done()
+    assert not task_b.done()
+
+    # Signal B's stop via the same internal path stop_active_run uses --
+    # WITHOUT cancelling B's task (still parked on its own release, its
+    # own `finally` never runs during this test, so the shared flag stays
+    # poisoned for the whole window A's own check runs in).
+    assert store.active_session_id == session_b.id
+    controller._signal_stop(session_id=session_b.id)
+
+    # A is still blocked mid-stream -- release it now, while the shared
+    # flag is poisoned by B's Stop, and let it run to completion.
+    gateway.release["a"].set()
+    result_a = await task_a
+    assert result_a.accepted is True
+
+    messages_a = store.messages_for_session(session_a.id)
+    assistant_a = next(m for m in messages_a if m.role is ConsoleMessageRole.ASSISTANT)
+    assert assistant_a.status == "complete"
+    assert assistant_a.content == "a-chunk-1-a-chunk-2-a-chunk-3"
+
+    # Clean up B (still parked on its own release) so nothing leaks.
+    gateway.release["b"].set()
+    result_b = await task_b
+    assert result_b.accepted is True

--- a/Tests/Chat/test_console_run_state_per_session.py
+++ b/Tests/Chat/test_console_run_state_per_session.py
@@ -194,10 +194,13 @@ def test_orphaned_closed_session_does_not_consume_cap_slot(
 ):
     """Carried finding from Task 1's review: closing a session mid-VALIDATING
     leaves an orphaned entry in the per-session run-state map (``close_session``
-    never touches ``controller._run_states``). The cap must not count it --
-    ``send_refusal_copy`` intersects its busy list with ``store.sessions()``
-    so a session that no longer exists can't consume a cap slot or appear in
-    the refusal copy's session list.
+    never touches ``controller._run_states``). Neither cap/fleet math
+    (``in_flight_run_count``) nor the refusal copy (``send_refusal_copy``) may
+    count or name a session that no longer exists in the store -- both share
+    the ``_live_busy_session_ids`` filter. ``run_states()`` stays the RAW map
+    on purpose (contract split, review round 2): it still surfaces the
+    orphaned entry for callers that want the full recorded history, while
+    every cap/fleet consumer must go through the live-filtered accessors.
     """
     controller, session_a, session_b = controller_with_two_sessions
     monkeypatch.setattr(
@@ -209,7 +212,10 @@ def test_orphaned_closed_session_does_not_consume_cap_slot(
     controller.store.close_session(session_a)
 
     assert session_a not in {session.id for session in controller.store.sessions()}
-    # The orphaned entry is still in the map...
-    assert controller.in_flight_run_count() == 1
-    # ...but it must not occupy the cap's single slot for the surviving session.
+    # Live-filtered cap/fleet math excludes the orphan entirely...
+    assert controller.in_flight_run_count() == 0
+    # ...but the RAW map snapshot still holds it (contract split: run_states()
+    # is not cap/fleet math and is never filtered).
+    assert session_a in controller.run_states()
+    # It must not occupy the cap's single slot for the surviving session.
     assert controller.send_refusal_copy(session_b) is None

--- a/Tests/Chat/test_console_stop_reliability.py
+++ b/Tests/Chat/test_console_stop_reliability.py
@@ -96,7 +96,7 @@ async def test_stop_freezes_message_content_at_stop_point(tmp_path):
     gateway.release.set()
     for _ in range(200):
         await asyncio.sleep(0.02)
-        if controller._active_stream_task is None:
+        if controller._active_stream_tasks.get(session_id) is None:
             break
     await asyncio.sleep(0.3)
 

--- a/Tests/UI/test_chat_screen_worker_groups.py
+++ b/Tests/UI/test_chat_screen_worker_groups.py
@@ -76,6 +76,34 @@ def test_every_exclusive_worker_on_chat_screen_names_a_group():
     )
 
 
+def _group_family(group_node: ast.AST | None) -> str | None:
+    """Resolve a ``group=`` value to a comparable "family" name.
+
+    A plain string literal (``ast.Constant``) resolves to itself. TASK-3 of
+    the parallel-agents spec (Sec3) rewrote the run-worker dispatch sites to
+    ``group=f"console-run-{session_id}"`` — an ``ast.JoinedStr`` whose first
+    segment is the literal prefix, followed by the interpolated session id.
+    Per-session dispatch sites are still all members of the SAME family, so a
+    ``JoinedStr`` whose first value is a ``Constant`` string starting with
+    ``"console-run-"`` resolves to the family name ``"console-run"`` — this
+    keeps the disjointness invariant below meaningful (every run-worker site
+    is in one family, and that family never collides with a sync group)
+    instead of the guard going blind (``None`` for every site) the moment the
+    literal became an f-string.
+    """
+    if isinstance(group_node, ast.Constant):
+        return group_node.value
+    if isinstance(group_node, ast.JoinedStr) and group_node.values:
+        first = group_node.values[0]
+        if (
+            isinstance(first, ast.Constant)
+            and isinstance(first.value, str)
+            and first.value.startswith("console-run-")
+        ):
+            return "console-run"
+    return None
+
+
 def test_console_run_and_sync_workers_use_disjoint_groups():
     """Pin the separation this fix exists for: the sync kicks must never share
     a group with the run workers. The names-a-group guard alone would pass if
@@ -101,13 +129,17 @@ def test_console_run_and_sync_workers_use_disjoint_groups():
         target = _call_name(first) if isinstance(first, ast.Call) else ""
         keywords = {kw.arg: kw.value for kw in node.keywords if kw.arg}
         group = keywords.get("group")
-        group_name = group.value if isinstance(group, ast.Constant) else None
+        group_name = _group_family(group)
         if target in RUN_COROUTINES:
             run_groups.add(group_name)
         elif target == SYNC_COROUTINE:
             sync_groups.add(group_name)
     assert run_groups == {"console-run"}, run_groups
     assert sync_groups == {"console-sync"}, sync_groups
+    # Explicit disjointness, independent of the exact-set assertions above:
+    # the invariant this test exists to guard is that the run-worker family
+    # and the sync-worker group(s) never overlap.
+    assert run_groups.isdisjoint(sync_groups), (run_groups, sync_groups)
 
 
 class TestTextualExclusiveGroupSemantics:

--- a/Tests/UI/test_console_edit_resend_wiring.py
+++ b/Tests/UI/test_console_edit_resend_wiring.py
@@ -32,7 +32,7 @@ from tldw_chatbook.Chat.console_chat_models import (
 from tldw_chatbook.Widgets.Console import ConsoleTranscript
 
 
-CONSOLE_RUN_ALREADY_RUNNING_COPY = "A Console run is already running."
+CONSOLE_RUN_ALREADY_RUNNING_COPY = "A run is already running in this tab."
 
 
 async def _open_edit_modal(console, pilot, message_id: str):

--- a/Tests/UI/test_console_mcp_approval.py
+++ b/Tests/UI/test_console_mcp_approval.py
@@ -739,6 +739,14 @@ def test_request_mcp_approvals_timeout_denies_with_timeout_for_all_undecided():
 
 
 def test_request_mcp_approvals_cancellation_denies_undecided():
+    """F5 fix (Qodo wave): this test's INTENT is "global stop denies every
+    in-flight approval round" -- real process teardown, not a single
+    session's Stop. It used to flip the bare, session-agnostic
+    `_stop_requested` flag to exercise that; F5 removed `_stop_requested`
+    from the bridge's poll (a single session's Stop must not cross-cancel
+    an unrelated session's approval round any more), so the equivalent
+    "global" signal is now the never-reset `_shutdown_requested` (set only
+    by `shutdown()`)."""
     controller, _ = _build_controller()
     received: list[dict | None] = []
     controller.app = _FakeApp()
@@ -747,7 +755,7 @@ def test_request_mcp_approvals_cancellation_denies_undecided():
 
     def _cancel_soon() -> None:
         time.sleep(0.05)
-        controller._stop_requested = True
+        controller._shutdown_requested.set()
 
     canceller = threading.Thread(target=_cancel_soon)
     canceller.start()
@@ -785,6 +793,44 @@ def test_request_mcp_approvals_active_cancel_event_denies_undecided():
     assert decisions == {"mcp__srv__tool": "deny"}
 
 
+def test_request_mcp_approvals_unrelated_session_stop_does_not_cross_cancel():
+    """F5 fix (Qodo wave): stopping a DIFFERENT session must not deny THIS
+    session's in-flight approval round. Before the fix, `_stop_requested`
+    (set globally by `_signal_stop` for ANY session's Stop/Close) was OR'd
+    into the bridge's own poll check, so any session's Stop denied every
+    session's in-flight approval round -- a narrower, approval-round-only
+    echo of the stream cross-cancellation Critical-1 already fixed for
+    the stream itself. `_signal_stop` still flips the (now bridge-inert)
+    `_stop_requested` flag here; only the UNRELATED session's own cancel
+    event is registered, and the store has no active session at all
+    (fresh `ConsoleChatStore()`), so `_is_active_session_cancelled` cannot
+    match it either -- the round must resolve via the real, explicit
+    decision below, not get denied out from under it."""
+    controller, _ = _build_controller()
+    received: list[dict | None] = []
+    controller.app = _FakeApp()
+    controller.set_pending_approval = received.append
+    controller.mcp_approval_timeout_seconds = lambda: 30.0
+
+    def _stop_unrelated_session_soon() -> None:
+        time.sleep(0.05)
+        controller._signal_stop(session_id="unrelated-session-id")
+
+    def _resolve_soon() -> None:
+        time.sleep(0.2)
+        controller.resolve_pending_approval({"mcp__srv__tool": "approve_once"})
+
+    stopper = threading.Thread(target=_stop_unrelated_session_soon)
+    resolver = threading.Thread(target=_resolve_soon)
+    stopper.start()
+    resolver.start()
+    decisions = controller.request_mcp_approvals([_pending()])
+    stopper.join()
+    resolver.join()
+
+    assert decisions == {"mcp__srv__tool": "approve_once"}
+
+
 def test_request_mcp_approvals_cancellation_records_denied_decision_to_execution_log(
     tmp_path,
 ):
@@ -799,7 +845,11 @@ def test_request_mcp_approvals_cancellation_records_denied_decision_to_execution
     logged there, since a timeout is not a cancellation). Uses the REAL
     `UnifiedMCPControlPlaneService` + JSONL-backed execution log (not the
     lighter `FakeMCPService`) so this proves the fix end-to-end through
-    the actual persistence path."""
+    the actual persistence path.
+
+    F5 fix (Qodo wave): flips `_shutdown_requested` rather than the bare
+    `_stop_requested` -- see `test_request_mcp_approvals_cancellation_
+    denies_undecided`'s own docstring for why."""
     from types import SimpleNamespace
 
     from tldw_chatbook.MCP.execution_log import MCPExecutionLog
@@ -830,7 +880,7 @@ def test_request_mcp_approvals_cancellation_records_denied_decision_to_execution
 
     def _cancel_soon() -> None:
         time.sleep(0.05)
-        controller._stop_requested = True
+        controller._shutdown_requested.set()
 
     canceller = threading.Thread(target=_cancel_soon)
     canceller.start()

--- a/Tests/UI/test_console_mcp_approval.py
+++ b/Tests/UI/test_console_mcp_approval.py
@@ -759,13 +759,19 @@ def test_request_mcp_approvals_cancellation_denies_undecided():
 
 
 def test_request_mcp_approvals_active_cancel_event_denies_undecided():
-    """The per-run `_active_cancel_event` (stop/close_session/shutdown's
+    """The per-run cancel event (stop/close_session/shutdown's
     `_signal_stop`) is observed even when `_stop_requested` has already
-    been reset by the coroutine side (task-227's own documented race)."""
+    been reset by the coroutine side (task-227's own documented race).
+    Task 3b: registered under the ACTIVE session's key -- `request_mcp_
+    approvals` has no session id of its own to key by (see
+    `_is_active_session_cancelled`'s docstring), so it falls back to
+    whatever session is currently active, same as `stop_active_run`."""
     controller, _ = _build_controller()
     controller.mcp_approval_timeout_seconds = lambda: 30.0
     cancel_event = threading.Event()
-    controller._active_cancel_event = cancel_event
+    controller._active_cancel_events[controller.store.active_session_id or ""] = (
+        cancel_event
+    )
 
     def _cancel_soon() -> None:
         time.sleep(0.05)

--- a/Tests/UI/test_console_parallel_runs.py
+++ b/Tests/UI/test_console_parallel_runs.py
@@ -1,0 +1,112 @@
+"""Two sessions run concurrently; interrupt is session-scoped (spec §2)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from Tests.UI.test_screen_navigation import _build_test_app
+from tldw_chatbook.Chat.console_chat_models import ConsoleRunState, ConsoleRunStatus
+
+
+@pytest.mark.asyncio
+async def test_two_sessions_run_concurrently_and_interrupt_is_scoped() -> None:
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        await pilot.pause(0.2)
+        console = host.screen_stack[-1]
+        controller = console._ensure_console_chat_controller()
+        store = controller.store
+        session_a = store.active_session_id
+        session_b = controller.new_session().id
+
+        release_a = asyncio.Event()
+        release_b = asyncio.Event()
+
+        async def fake_run(session_id, release):
+            controller._set_run_state(
+                ConsoleRunState(ConsoleRunStatus.STREAMING, "run"),
+                session_id=session_id,
+            )
+            await release.wait()
+            controller._set_run_state(
+                ConsoleRunState(ConsoleRunStatus.COMPLETED, "done"),
+                session_id=session_id,
+            )
+
+        console.run_worker(
+            fake_run(session_a, release_a),
+            exclusive=True,
+            group=f"console-run-{session_a}",
+        )
+        console.run_worker(
+            fake_run(session_b, release_b),
+            exclusive=True,
+            group=f"console-run-{session_b}",
+        )
+        await pilot.pause(0.2)
+        assert controller.in_flight_run_count() == 2  # truly concurrent
+
+        # Cancelling A's group leaves B running.
+        console.workers.cancel_group(console, f"console-run-{session_a}")
+        release_b.set()
+        await pilot.pause(0.3)
+        assert controller.run_state_for(session_b).status is ConsoleRunStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_second_session_send_does_not_cancel_first_sessions_worker() -> None:
+    """Regression guard for the shared-group bug this task fixes: before the
+    per-session group name, two `run_worker(..., exclusive=True,
+    group="console-run")` dispatches from DIFFERENT sessions shared Textual's
+    exclusive group and silently cancelled each other. Dispatching two long-
+    running fake workers under the real per-session group names must leave
+    both alive simultaneously.
+    """
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        await pilot.pause(0.2)
+        console = host.screen_stack[-1]
+        controller = console._ensure_console_chat_controller()
+        store = controller.store
+        session_a = store.active_session_id
+        session_b = controller.new_session().id
+
+        started_a = asyncio.Event()
+        started_b = asyncio.Event()
+        never = asyncio.Event()  # never set -- both workers just hang until cancelled
+
+        async def fake_run(session_id, started):
+            started.set()
+            await never.wait()
+
+        worker_a = console.run_worker(
+            fake_run(session_a, started_a),
+            exclusive=True,
+            group=f"console-run-{session_a}",
+        )
+        await started_a.wait()
+        worker_b = console.run_worker(
+            fake_run(session_b, started_b),
+            exclusive=True,
+            group=f"console-run-{session_b}",
+        )
+        await started_b.wait()
+        await pilot.pause(0.1)
+
+        # If the groups collided, starting worker_b would have cancelled
+        # worker_a via Textual's exclusive-group semantics.
+        assert worker_a.is_running
+        assert worker_b.is_running
+
+        console.workers.cancel_group(console, f"console-run-{session_a}")
+        console.workers.cancel_group(console, f"console-run-{session_b}")
+        await pilot.pause(0.1)

--- a/Tests/UI/test_console_parallel_runs.py
+++ b/Tests/UI/test_console_parallel_runs.py
@@ -6,6 +6,8 @@ import asyncio
 
 import pytest
 
+from textual.widgets import Static
+
 from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
     ConsoleHarness,
 )
@@ -15,6 +17,21 @@ from tldw_chatbook.Chat.console_chat_models import (
     ConsoleRunState,
     ConsoleRunStatus,
 )
+from tldw_chatbook.Widgets.Console.console_transcript import ConsoleTranscript
+
+
+def _transcript_text(console) -> str:
+    """Return the plain text of every Static descendant of the native
+    transcript widget -- scoped to the transcript itself (not the whole
+    screen), so mode-bar/rail text changes elsewhere can't make an
+    equality assertion on this flaky.
+    """
+    transcript = console.query_one("#console-native-transcript", ConsoleTranscript)
+    return " ".join(
+        getattr(widget.renderable, "plain", str(widget.renderable))
+        for widget in transcript.query(Static)
+        if widget.display and hasattr(widget, "renderable")
+    )
 
 
 @pytest.mark.asyncio
@@ -204,3 +221,98 @@ async def test_stop_visible_action_only_cancels_viewed_session_background_comple
         release_b.set()
         await pilot.pause(0.2)
         assert controller.run_state_for(session_b).status is ConsoleRunStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_background_run_never_mutates_viewed_transcript() -> None:
+    """Task 4 (background-write audit): the real seam the audit found is
+    ``ChatScreen._append_native_console_system_message``, the function every
+    slash-command handler funnels its system-row output through (the
+    "candidates ... callbacks that append/patch transcript widgets" grep in
+    the task brief -- ``_append_.*message``). Its previous behavior always
+    resolved "the store's currently ACTIVE session" via
+    ``store.ensure_session()``, even for callers (like ``/generate-image``'s
+    failure path) that had already anchored themselves to a specific
+    OWNING session before an ``asyncio.to_thread`` await let the user
+    switch tabs. Driving the gated ``session_id=`` keyword directly (the
+    same seam ``_console_command_generate_image`` now uses) proves a
+    background session's append can never land on the viewed transcript --
+    and, per the store-first design, that switching to the background
+    session later reveals it with no separate replay mechanism needed.
+    """
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        await pilot.pause(0.2)
+        console = host.screen_stack[-1]
+        controller = console._ensure_console_chat_controller()
+        store = controller.store
+        viewed = store.active_session_id
+        background = controller.new_session().id
+        store.switch_session(viewed)  # keep viewing the first session
+
+        before = _transcript_text(console)
+        # Drive the audited append path for the BACKGROUND session directly,
+        # via the real gated seam (not the illustrative
+        # `_apply_console_stream_delta` name from the brief -- there is no
+        # such method; this IS the method the audit found and fixed).
+        await console._append_native_console_system_message(
+            "SHOULD-NOT-APPEAR", session_id=background
+        )
+        await pilot.pause(0.2)
+        after = _transcript_text(console)
+        assert "SHOULD-NOT-APPEAR" not in after
+        assert before == after
+
+        # Store-first: the row IS there for the background session -- no
+        # deferred-replay mechanism needed, switching tabs just rebuilds the
+        # view from the store.
+        store.switch_session(background)
+        await console._sync_native_console_chat_ui()
+        await pilot.pause(0.2)
+        assert "SHOULD-NOT-APPEAR" in _transcript_text(console)
+
+
+@pytest.mark.asyncio
+async def test_background_run_sensitivity_reverting_the_gate_fails() -> None:
+    """Sensitivity check for the test above (TDD requirement): with the
+    ``session_id`` gate temporarily bypassed -- reproducing the pre-fix
+    behavior where the append always targeted whatever session is active
+    RIGHT NOW instead of the caller-supplied owning session -- the SAME
+    background-session append DOES leak onto the viewed transcript. This
+    proves the prior test is actually exercising the gate rather than
+    passing vacuously.
+    """
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        await pilot.pause(0.2)
+        console = host.screen_stack[-1]
+        controller = console._ensure_console_chat_controller()
+        store = controller.store
+        viewed = store.active_session_id
+        background = controller.new_session().id
+        store.switch_session(viewed)
+
+        # Reproduce the pre-fix seam: ignore the caller-supplied
+        # `session_id` and always append to the currently-active session
+        # (exactly what `_append_native_console_system_message` did before
+        # Task 4's fix).
+        async def leaky_append(message: str, *, session_id: str | None = None) -> None:
+            active = store.ensure_session()
+            store.append_message(
+                active.id, role=ConsoleMessageRole.SYSTEM, content=message
+            )
+            await console._sync_native_console_chat_ui()
+
+        console._append_native_console_system_message = leaky_append
+        try:
+            await console._append_native_console_system_message(
+                "SHOULD-LEAK", session_id=background
+            )
+            await pilot.pause(0.2)
+            assert "SHOULD-LEAK" in _transcript_text(console)
+        finally:
+            del console._append_native_console_system_message

--- a/Tests/UI/test_console_parallel_runs.py
+++ b/Tests/UI/test_console_parallel_runs.py
@@ -10,7 +10,11 @@ from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
     ConsoleHarness,
 )
 from Tests.UI.test_screen_navigation import _build_test_app
-from tldw_chatbook.Chat.console_chat_models import ConsoleRunState, ConsoleRunStatus
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleMessageRole,
+    ConsoleRunState,
+    ConsoleRunStatus,
+)
 
 
 @pytest.mark.asyncio
@@ -110,3 +114,93 @@ async def test_second_session_send_does_not_cancel_first_sessions_worker() -> No
         console.workers.cancel_group(console, f"console-run-{session_a}")
         console.workers.cancel_group(console, f"console-run-{session_b}")
         await pilot.pause(0.1)
+
+
+@pytest.mark.asyncio
+async def test_stop_visible_action_only_cancels_viewed_session_background_completes() -> None:
+    """Requirement 5c (Task 3b): two concurrent fake runs, mirroring the
+    tests above, but this time each REGISTERS itself in the controller's
+    per-session stream/cancel maps like a real run would. Pressing the
+    visible Stop action (the Stop button's own handler) for the VIEWED
+    session must cancel only that session's run; the background session's
+    run is untouched and reaches COMPLETED on its own.
+    """
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        await pilot.pause(0.2)
+        console = host.screen_stack[-1]
+        controller = console._ensure_console_chat_controller()
+        store = controller.store
+        session_a = store.active_session_id
+        session_b = controller.new_session().id
+        store.switch_session(session_a)  # A is VIEWED (new_session() activates B)
+
+        def _seed(session_id: str) -> str:
+            store.append_message(
+                session_id, role=ConsoleMessageRole.USER, content="hi"
+            )
+            assistant = store.append_message(
+                session_id, role=ConsoleMessageRole.ASSISTANT, content=""
+            )
+            store.append_stream_chunk(assistant.id, "partial")
+            return assistant.id
+
+        assistant_a = _seed(session_a)
+        assistant_b = _seed(session_b)
+
+        started_a = asyncio.Event()
+        started_b = asyncio.Event()
+        never_release_a = asyncio.Event()  # A is only ever stopped, not released
+        release_b = asyncio.Event()
+
+        async def fake_run(session_id, assistant_id, started, release):
+            task = asyncio.current_task()
+            controller._active_stream_tasks[session_id] = task
+            controller._active_assistant_message_ids[session_id] = assistant_id
+            controller._set_run_state(
+                ConsoleRunState(ConsoleRunStatus.STREAMING, "run"),
+                session_id=session_id,
+            )
+            started.set()
+            try:
+                await release.wait()
+                controller._set_run_state(
+                    ConsoleRunState(ConsoleRunStatus.COMPLETED, "done"),
+                    session_id=session_id,
+                )
+            except asyncio.CancelledError:
+                raise
+            finally:
+                if controller._active_stream_tasks.get(session_id) is task:
+                    controller._active_stream_tasks.pop(session_id, None)
+                    controller._active_assistant_message_ids.pop(session_id, None)
+
+        console.run_worker(
+            fake_run(session_a, assistant_a, started_a, never_release_a),
+            exclusive=True,
+            group=f"console-run-{session_a}",
+        )
+        console.run_worker(
+            fake_run(session_b, assistant_b, started_b, release_b),
+            exclusive=True,
+            group=f"console-run-{session_b}",
+        )
+        await started_a.wait()
+        await started_b.wait()
+        await pilot.pause(0.1)
+        assert controller.in_flight_run_count() == 2  # truly concurrent
+
+        # A is the VIEWED session -- press the visible Stop action.
+        assert store.active_session_id == session_a
+        await console._stop_console_generation_from_visible_action()
+        await pilot.pause(0.2)
+
+        assert controller.run_state_for(session_a).status is ConsoleRunStatus.STOPPED
+        # B is completely untouched by A's Stop.
+        assert controller.run_state_for(session_b).status is ConsoleRunStatus.STREAMING
+
+        release_b.set()
+        await pilot.pause(0.2)
+        assert controller.run_state_for(session_b).status is ConsoleRunStatus.COMPLETED

--- a/Tests/UI/test_console_rewind_restore.py
+++ b/Tests/UI/test_console_rewind_restore.py
@@ -167,7 +167,8 @@ async def test_none_choice_just_refocuses_composer_without_mutation():
 @pytest.mark.asyncio
 async def test_summarize_up_to_choice_dispatches_console_run_worker_without_mutation():
     """SP2 Task 3: the summarize-up-to choice runs the boundary-summary flow on
-    the exclusive ``console-run`` worker group and never does tree surgery."""
+    the exclusive per-session ``console-run-{session_id}`` worker group (see
+    the parallel-agents spec Sec3) and never does tree surgery."""
     app = _build_test_app()
     host = ConsoleHarness(app)
 
@@ -192,7 +193,9 @@ async def test_summarize_up_to_choice_dispatches_console_run_worker_without_muta
         await pilot.pause()
 
     assert spy_worker.call_count == 1
-    assert spy_worker.call_args.kwargs.get("group") == "console-run"
+    group = spy_worker.call_args.kwargs.get("group")
+    assert isinstance(group, str) and group.startswith("console-run-"), group
+    assert group == f"console-run-{session.id}", group
     # Summarize never mutates the transcript tree, and nothing is stored until
     # the (unrun) worker succeeds.
     assert store.active_path_message_ids(session.id) == original_path

--- a/Tests/UI/test_console_rewind_restore.py
+++ b/Tests/UI/test_console_rewind_restore.py
@@ -37,7 +37,7 @@ from tldw_chatbook.Widgets.Console.console_rewind_modal import (
 )
 
 
-CONSOLE_RUN_ALREADY_RUNNING_COPY = "A Console run is already running."
+CONSOLE_RUN_ALREADY_RUNNING_COPY = "A run is already running in this tab."
 
 
 async def _seed_u1_a1_u2_a2(console):

--- a/Tests/UI/test_console_run_gate.py
+++ b/Tests/UI/test_console_run_gate.py
@@ -21,7 +21,7 @@ from tldw_chatbook.Chat.console_chat_models import (
     ConsoleRunStatus,
 )
 
-ALREADY_RUNNING_COPY = "A Console run is already running."
+ALREADY_RUNNING_COPY = "A run is already running in this tab."
 
 
 def _build_screen():

--- a/Tests/UI/test_console_run_gate.py
+++ b/Tests/UI/test_console_run_gate.py
@@ -125,10 +125,13 @@ async def test_mid_run_action_notifies_instead_of_spawning(action_id, target):
 )
 async def test_idle_action_still_spawns_console_run_worker(action_id, target):
     """Regression guard: with no active run, the actions dispatch exactly one
-    worker in the console-run group."""
+    worker in THIS session's per-session console-run group (parallel-agents
+    spec Sec3 — group=f"console-run-{session_id}", not the shared literal)."""
     app, screen = _build_screen()
     failed, completed = _seed_messages(screen)
     spawned, notices = _instrument(app, screen)
+    controller = screen._ensure_console_chat_controller()
+    active_session_id = controller.store.active_session_id
 
     message = failed if target == "failed" else completed
     handled = await screen.handle_console_message_action(
@@ -137,6 +140,8 @@ async def test_idle_action_still_spawns_console_run_worker(action_id, target):
 
     assert handled is True
     assert len(spawned) == 1
-    assert spawned[0].get("group") == "console-run"
+    group = spawned[0].get("group")
+    assert isinstance(group, str) and group.startswith("console-run-"), group
+    assert group == f"console-run-{active_session_id}", group
     assert spawned[0].get("exclusive") is True
     assert not any(ALREADY_RUNNING_COPY in note for note in notices)

--- a/Tests/UI/test_console_session_settings.py
+++ b/Tests/UI/test_console_session_settings.py
@@ -3303,8 +3303,8 @@ async def test_console_settings_modal_save_disabled_during_active_run() -> None:
         )
         await console._sync_native_console_chat_ui()
         controller = console._ensure_console_chat_controller()
-        controller.run_state = ConsoleRunState(
-            ConsoleRunStatus.STREAMING, "Streaming response."
+        controller._set_run_state(
+            ConsoleRunState(ConsoleRunStatus.STREAMING, "Streaming response.")
         )
 
         settings_button = await _visible_console_settings_button(console, pilot)
@@ -3346,7 +3346,7 @@ async def test_console_settings_save_clears_stale_terminal_run_status() -> None:
 
         controller = console._ensure_console_chat_controller()
         stale_copy = "Provider blocked: old llama.cpp failure."
-        controller.run_state = ConsoleRunState.blocked(stale_copy)
+        controller._set_run_state(ConsoleRunState.blocked(stale_copy))
         console._sync_console_mode_bar()
         assert stale_copy in str(
             console.query_one("#console-mode-bar", Static).renderable

--- a/Tests/UI/test_console_workbench_contract.py
+++ b/Tests/UI/test_console_workbench_contract.py
@@ -1175,9 +1175,11 @@ async def test_console_workbench_send_action_disables_during_active_run():
         await pilot.pause()
 
         controller = console._ensure_console_chat_controller()
-        controller.run_state = ConsoleRunState(
-            ConsoleRunStatus.STREAMING,
-            "Streaming response.",
+        controller._set_run_state(
+            ConsoleRunState(
+                ConsoleRunStatus.STREAMING,
+                "Streaming response.",
+            )
         )
         console._sync_console_control_bar()
         await pilot.pause()
@@ -1205,9 +1207,11 @@ async def test_console_active_stream_sync_skips_unchanged_chrome_and_inspector(
         await _wait_for_selector(console, pilot, "#console-shell")
 
         controller = console._ensure_console_chat_controller()
-        controller.run_state = ConsoleRunState(
-            ConsoleRunStatus.STREAMING,
-            "Streaming response.",
+        controller._set_run_state(
+            ConsoleRunState(
+                ConsoleRunStatus.STREAMING,
+                "Streaming response.",
+            )
         )
         control_state = console._build_console_control_state(
             console._pending_console_launch_context

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -696,6 +696,7 @@ def test_settings_ownership_records_cover_categories_and_runtime_boundaries():
     ].owns_config_sections == (
         "console.collapse_large_pastes",
         "console.paste_collapse_threshold",
+        "console.max_parallel_runs",
         "console.background_effects.*",
         "chat_defaults.streaming",
         "chat_defaults.temperature",
@@ -3317,6 +3318,56 @@ async def test_settings_console_behavior_saves_paste_threshold(monkeypatch):
 
     assert saved == [{"console": {"paste_collapse_threshold": 120}}]
     assert app.app_config["console"]["paste_collapse_threshold"] == 120
+
+
+@pytest.mark.asyncio
+async def test_settings_console_behavior_saves_max_parallel_runs(monkeypatch):
+    app = _build_test_app()
+    saved = []
+
+    class FakeAdapter:
+        def save_sections(self, section_values):
+            saved.append(section_values)
+            return True
+
+    monkeypatch.setattr(settings_screen_module, "SettingsConfigAdapter", FakeAdapter)
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-console-behavior")
+        screen = _active_destination_screen(host)
+        field = screen.query_one("#settings-console-max-parallel-runs", Input)
+
+        assert field.restrict == r"^[0-9]*$"
+        assert field.value == "3"
+
+        field.value = "0"
+        screen.handle_console_max_parallel_runs_changed(
+            Input.Changed(field, field.value)
+        )
+        await pilot.click("#settings-save-category")
+        # A pump between clicks on the same Button is required here: without
+        # it, the Button's own "-active" press-state class (and internal
+        # timer that clears it) never settles before the second click lands,
+        # and the second Button.Pressed is silently dropped.
+        await pilot.pause(0.5)
+        assert (
+            "Max parallel agent runs must be an integer of at least 1."
+            in _visible_text(screen)
+        )
+        assert saved == []
+
+        field.value = "12"
+        screen.handle_console_max_parallel_runs_changed(
+            Input.Changed(field, field.value)
+        )
+        assert "Unsaved" in _visible_text(screen)
+
+        await pilot.click("#settings-save-category")
+        await _wait_for_settings_text(screen, pilot, "Console behavior settings saved.")
+
+    assert saved == [{"console": {"max_parallel_runs": 12}}]
+    assert app.app_config["console"]["max_parallel_runs"] == 12
 
 
 @pytest.mark.asyncio

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1346,17 +1346,25 @@ class ConsoleChatController:
         """Set the shared UI-facing stop flag AND ``session_id``'s own
         permanent per-run cancel signal.
 
-        ``_stop_requested`` stays a single shared flag (Task 3b did not
-        rescope it -- see ``_is_active_session_cancelled``) reset by the
-        run's own ``finally`` block as soon as the coroutine side of
-        ``_run_agent_reply`` is done handling a cancellation -- but
-        ``asyncio.to_thread`` survives Task cancellation, so the agent
-        bridge's background OS thread can still be running at that point
-        and poll ``should_cancel()`` afterward (task-227).
+        ``_stop_requested`` stays a single shared flag, but as of Fix
+        round 1 (Critical 1) NO run's own cancellation-check loop reads it
+        any more -- ``should_cancel`` (``_run_agent_reply``) and the
+        direct/legacy stream path's own checks (``_stream_assistant_
+        response``) read ONLY their run's own ``_active_cancel_events[
+        owner_id]``, captured by closure. Reading the shared flag from
+        inside a specific run's loop let ANY session's Stop/Close silently
+        truncate an unrelated, untouched session's still-streaming reply
+        (Fix round 1 finding). ``_stop_requested``'s remaining, INTENTIONAL
+        uses: ``shutdown()`` (global reach is correct there -- it stops
+        every session), and the three worker-thread approval/confirm
+        bridges' own best-effort check (see ``_is_active_session_
+        cancelled``), which predates per-session scoping and has its own,
+        narrower, documented limitation.
+
         ``_active_cancel_events[session_id]``, once set here, is never
         reset for that run, so a still-running bridge thread always
         observes the Stop correctly regardless of what the coroutine side
-        has already reset. Every caller (``close_session``,
+        has already reset (task-227). Every caller (``close_session``,
         ``stop_active_run``, ``shutdown``) already knows the exact session
         it is signalling -- there is deliberately no active-session
         fallback here, unlike ``_set_run_state``.
@@ -1367,27 +1375,41 @@ class ConsoleChatController:
             cancel_event.set()
 
     def _is_active_session_cancelled(self) -> bool:
-        """Best-effort cancel-signal check for the three worker-thread
-        approval/confirm bridges below (``request_mcp_approvals``,
-        ``request_skill_install_confirm``, ``request_skill_script_confirm``).
+        """Best-effort ADDITIONAL cancel-signal check for the three
+        worker-thread approval/confirm bridges below (``request_mcp_
+        approvals``, ``request_skill_install_confirm``, ``request_skill_
+        script_confirm``) -- OR'd with the shared ``_stop_requested`` flag
+        at each of their own poll sites (unchanged; an existing,
+        pre-Task-3b test (`test_request_mcp_approvals_cancellation_denies_
+        undecided`) asserts a bare ``_stop_requested = True`` flip is
+        itself sufficient to deny an approval round, so that OR-branch is
+        NOT removed here).
 
         KNOWN LIMITATION (Task 3b): these bridges are plain bound-method
         callbacks handed straight to ``ConsoleAgentBridge.run_reply``
         (fixed arity -- ``approval_callback(pending)``,
         ``confirm(url)``/``confirm(payload)`` -- no session id threaded
-        through), unlike ``should_cancel`` inside ``_run_agent_reply``,
-        which safely closes over ITS OWN run's ``cancel_event`` by value.
-        Falling back to the VIEWED session's cancel event here (mirroring
-        ``stop_active_run``'s own "the active session" convention) is
-        correct for the overwhelmingly common single-run case, but does
-        NOT correctly scope to a BACKGROUND session's own pending
-        approval -- and neither does ``_stop_requested`` above, which
-        stayed a single shared flag. Properly scoping concurrent
-        approvals/confirms to their own run is PA-T9 ("parked background
-        approvals"); until then, stopping the VIEWED session's run can
-        spuriously deny an unrelated background approval, and a Stop
-        aimed at a background run's own approval isn't observed by this
-        check at all.
+        through), unlike ``should_cancel`` inside ``_run_agent_reply``
+        (Fix round 1: now reads ONLY its own run's ``cancel_event``, never
+        the shared flag). Falling back to the VIEWED session's cancel
+        event here (mirroring ``stop_active_run``'s own "the active
+        session" convention) is correct for the overwhelmingly common
+        single-run case.
+
+        Post-Fix-round-1 scope: the STREAM itself (content/completion) of
+        an unrelated session is no longer affected by any session's Stop
+        -- that was Critical 1, now fixed via per-run ``cancel_event``s
+        with no shared-flag fallback. The residual gap here is narrower
+        and specific to these three bridges: a BACKGROUND session's own
+        pending approval is not found by this VIEWED-session-only lookup
+        (so its own Stop isn't observed here), and -- because
+        ``_stop_requested`` is still OR'd in at each bridge's own poll
+        site, unchanged -- stopping ANY session still denies every
+        in-flight approval/confirm round for every session (a narrower,
+        approval-round-only version of the old poisoning, not a stream-
+        truncation bug). Properly scoping concurrent approvals/confirms to
+        their own run (both problems) is PA-T9 ("parked background
+        approvals").
         """
         cancel_event = self._active_cancel_events.get(self.store.active_session_id or "")
         return cancel_event is not None and cancel_event.is_set()
@@ -4230,6 +4252,19 @@ class ConsoleChatController:
                     "content": prefill,
                 },
             ]
+        # Fix round 1 (Critical 1): a per-session cancel signal for this
+        # direct/legacy stream path too, mirroring `_run_agent_reply`'s own
+        # `cancel_event` -- the shared `_stop_requested` flag below is
+        # GLOBAL (set by ANY session's Stop/Close via `_signal_stop`), so
+        # reading it inside a specific run's own loop let stopping session
+        # B silently truncate an untouched session A's still-streaming
+        # reply. Captured by closure/local (not re-read off `self.
+        # _active_cancel_events` each poll) for the same reason
+        # `should_cancel` isn't: a concurrent NEXT run for this same
+        # session (after this one's own finally already popped its entry)
+        # must never be torn down by a stale reference to THIS run's event.
+        cancel_event = threading.Event()
+        self._active_cancel_events[owner_id] = cancel_event
         if variant_mode:
             self.store.begin_variant_stream(assistant_message_id)
         if prefill and not prepare_retry:
@@ -4258,7 +4293,7 @@ class ConsoleChatController:
             async for chunk in provider_stream:
                 if not chunk:
                     continue
-                if self._stop_requested:
+                if cancel_event.is_set():
                     try:
                         stopped = self._mark_stream_stopped(
                             assistant_message_id,
@@ -4286,7 +4321,7 @@ class ConsoleChatController:
                     return self._session_closed_result(session_id=owner_id)
                 if chunk:
                     emitted_content = True
-            if self._stop_requested:
+            if cancel_event.is_set():
                 try:
                     stopped = self._mark_stream_stopped(
                         assistant_message_id,
@@ -4345,7 +4380,7 @@ class ConsoleChatController:
             self._consume_one_shot_prefill(assistant_message_id, one_shot_used)
             return ConsoleSubmitResult(True, True, completed.content)
         except asyncio.CancelledError:
-            if self._stop_requested:
+            if cancel_event.is_set():
                 try:
                     stopped = self._mark_stream_stopped(
                         assistant_message_id,
@@ -4379,6 +4414,18 @@ class ConsoleChatController:
                 session_id=owner_id,
             )
             return ConsoleSubmitResult(True, True, visible_copy)
+        finally:
+            # Fix round 1 (Critical 1): this run's own per-session cancel
+            # signal (created above, mirroring `_run_agent_reply`'s own)
+            # must not survive the run -- a stale entry would let a LATER,
+            # unrelated run on this same session inherit an already-set
+            # Event. Not `cancel_event.clear()`: `_select_post_generation_
+            # body` (already returned by the time this fires) captured this
+            # by session-id lookup rather than closure, so identity-gated
+            # pop (not reset-in-place) is what matches `_run_agent_reply`'s
+            # own matching pop.
+            if self._active_cancel_events.get(owner_id) is cancel_event:
+                self._active_cancel_events.pop(owner_id, None)
 
     async def _select_post_generation_body(
         self,
@@ -4418,9 +4465,19 @@ class ConsoleChatController:
                 return False
 
         def cancellation_requested() -> bool:
+            # Fix round 1 (Critical 1): this run's own per-session cancel
+            # signal, not the shared `_stop_requested` flag -- reading the
+            # global flag here let an UNRELATED session's Stop/Close
+            # silently cancel this session's still-running citation repair,
+            # the exact hazard this fix closes for the sibling stream
+            # loops. `_run_direct_provider_reply` registers this session's
+            # `cancel_event` in `_active_cancel_events[owner_session_id]`
+            # before ever calling this method.
+            cancel_event = self._active_cancel_events.get(owner_session_id)
             return (
                 repair_session.cancel_reason is not None
-                and self._stop_requested
+                and cancel_event is not None
+                and cancel_event.is_set()
                 and not repair_session.selection_committed
                 and repair_session.phase in {"checking", "repair_streaming"}
             )
@@ -4729,20 +4786,24 @@ class ConsoleChatController:
             agent_messages = agent_messages[1:]
 
         conversation_id = self._agent_conversation_id(session_id)
-        # noqa: E731 — tiny closure. Reads BOTH signals: `_stop_requested`
-        # for same-tick responsiveness (and test doubles that flip it
-        # directly), and `cancel_event` -- captured by value, not via
-        # `self._active_cancel_events[session_id]` -- for correctness once this run's
+        # noqa: E731 — tiny closure. Fix round 1 (Critical 1): reads ONLY
+        # `cancel_event` -- captured by value, not via `self.
+        # _active_cancel_events[session_id]` -- never the shared
+        # `_stop_requested` flag. `_stop_requested` is GLOBAL (set by ANY
+        # session's Stop/Close via `_signal_stop`), so OR'ing it in here
+        # let stopping an unrelated session silently cancel THIS run too.
+        # `cancel_event` alone is still correct once this run's own
         # `finally` below has already reset `_stop_requested` while the
         # bridge's background thread is still running (task-227: an
         # `asyncio.to_thread` call survives Task cancellation, so the
         # coroutine can finish handling a Stop and reset its own shared
         # bookkeeping well before the OS thread it detached from actually
-        # returns). `stop_active_run`/`close_session`/`shutdown` all set
-        # `cancel_event` via `_signal_stop()` the moment Stop is
-        # requested, and nothing ever clears it again for this run, so a
-        # late poll from the surviving thread still sees the cancellation.
-        should_cancel = lambda: self._stop_requested or cancel_event.is_set()  # noqa: E731
+        # returns) -- `stop_active_run`/`close_session`/`shutdown` all set
+        # THIS session's `cancel_event` via `_signal_stop(session_id=...)`
+        # the moment Stop is requested, and nothing ever clears it again
+        # for this run, so a late poll from the surviving thread still
+        # sees the cancellation regardless of `_stop_requested`'s state.
+        should_cancel = lambda: cancel_event.is_set()  # noqa: E731
 
         # P5-T6: compose this run's MCP tool provider (if eligible) HERE,
         # on the running main loop, BEFORE the bridge is dispatched onto
@@ -4839,7 +4900,7 @@ class ConsoleChatController:
                 ),
             )
         except asyncio.CancelledError:
-            if self._stop_requested:
+            if cancel_event.is_set():
                 try:
                     stopped = self._mark_stream_stopped(
                         assistant_message_id, visible_copy="Response stopped."

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -650,20 +650,39 @@ class ConsoleChatController:
         #: persisted, run about to start) so the composer can clear immediately
         #: instead of holding the sent text for the whole run.
         self.on_submission_accepted: Callable[[], None] | None = None
-        self._active_assistant_message_id: str | None = None
-        self._active_stream_task: asyncio.Task | None = None
+        # Task 3b: PER-SESSION maps, mirroring `_run_states`' own keying --
+        # two sessions can each have their own in-flight stream/cancel state
+        # without clobbering each other. Written/cleared at the SAME
+        # lifecycle points the old singulars were (`_stream_assistant_
+        # response`/`_run_agent_reply`'s start and `finally`), keyed by the
+        # run's OWNING session id (the same `owner_id`/`session_id` locals
+        # Task 1 threaded), never by whatever session the user currently has
+        # open. `stop_active_run` is the one place that DELIBERATELY reads
+        # by the ACTIVE (viewed) session -- see its own docstring.
+        self._active_assistant_message_ids: dict[str, str] = {}
+        self._active_stream_tasks: dict[str, asyncio.Task] = {}
         self._stop_requested = False
-        self._active_citation_repair_session: ConsoleCitationRepairSession | None = None
+        # Rebase note (dev citation-repair vs. Task 3b): dev added this as a
+        # singular slot (no per-session awareness); rescoped here the same
+        # way as the two maps above -- keyed by the run's OWNING session id,
+        # so a background session's in-flight repair can never be read/
+        # cleared by another session's close/stop/teardown path.
+        self._active_citation_repair_sessions: dict[str, ConsoleCitationRepairSession] = {}
         self._original_attempts: OrderedDict[str, str] = OrderedDict()
         #: Per-run cancellation flag for the agent bridge's background
-        #: thread (see ``_run_agent_reply``). ``threading.Event`` rather
-        #: than a shared bool: ``asyncio.to_thread`` survives Task
-        #: cancellation (the coroutine detaches from the still-running OS
-        #: thread), so the closure handed to that thread must observe a
-        #: signal that, once set, is never reset for THIS run -- unlike
+        #: thread (see ``_run_agent_reply``), keyed by owning session id
+        #: like the two maps above. ``threading.Event`` rather than a
+        #: shared bool: ``asyncio.to_thread`` survives Task cancellation
+        #: (the coroutine detaches from the still-running OS thread), so
+        #: the closure handed to that thread must observe a signal that,
+        #: once set, is never reset for THIS run -- unlike
         #: ``_stop_requested``, which the run's own ``finally`` block
         #: resets as soon as the coroutine side is done (task-227).
-        self._active_cancel_event: threading.Event | None = None
+        #: ``_stop_requested`` itself stays a single shared flag (Task 3b
+        #: did not rescope it) -- see ``_is_active_session_cancelled``'s
+        #: docstring for the resulting, deliberately-scoped-down, limit on
+        #: the three worker-thread approval/confirm bridges below.
+        self._active_cancel_events: dict[str, threading.Event] = {}
         #: The composed MCP provider for the current agent run, captured
         #: on the main loop in ``_run_agent_reply`` so ``build_context_snapshot``
         #: can read tool metadata later without recomposing.
@@ -1223,18 +1242,16 @@ class ConsoleChatController:
         Returns:
             The session activated after closing, or ``None`` when no sessions remain.
         """
-        repair_session = self._active_citation_repair_session
+        repair_session = self._active_citation_repair_sessions.get(session_id)
         self.clear_original_attempts_for_session(session_id)
         owns_active_stream = self._active_stream_belongs_to_session(session_id)
         if repair_session is not None and owns_active_stream:
             repair_session.cancel_reason = "session_close"
         if owns_active_stream:
-            self._signal_stop()
-            if (
-                self._active_stream_task is not None
-                and self._active_stream_task is not asyncio.current_task()
-            ):
-                self._active_stream_task.cancel()
+            self._signal_stop(session_id=session_id)
+            task = self._active_stream_tasks.get(session_id)
+            if task is not None and task is not asyncio.current_task():
+                task.cancel()
             self._set_run_state(
                 ConsoleRunState(ConsoleRunStatus.STOPPED, "Session closed."),
                 # `session_id` here is the session being CLOSED, which the
@@ -1249,9 +1266,9 @@ class ConsoleChatController:
         if (
             owns_active_stream
             and repair_session is not None
-            and self._active_citation_repair_session is repair_session
+            and self._active_citation_repair_sessions.get(session_id) is repair_session
         ):
-            self._active_citation_repair_session = None
+            self._active_citation_repair_sessions.pop(session_id, None)
         return closed
 
     def original_attempt_for_message(self, message_id: str) -> str | None:
@@ -1325,23 +1342,55 @@ class ConsoleChatController:
             ),
         )
 
-    def _signal_stop(self) -> None:
-        """Set the shared UI-facing stop flag AND the active run's own
+    def _signal_stop(self, *, session_id: str) -> None:
+        """Set the shared UI-facing stop flag AND ``session_id``'s own
         permanent per-run cancel signal.
 
-        ``_stop_requested`` is reset by the run's own ``finally`` block as
-        soon as the coroutine side of ``_run_agent_reply`` is done handling
-        a cancellation -- but ``asyncio.to_thread`` survives Task
-        cancellation, so the agent bridge's background OS thread can still
-        be running at that point and poll ``should_cancel()`` afterward
-        (task-227). ``_active_cancel_event``, once set here, is never reset
-        for that run, so a still-running bridge thread always observes the
-        Stop correctly regardless of what the coroutine side has already
-        reset.
+        ``_stop_requested`` stays a single shared flag (Task 3b did not
+        rescope it -- see ``_is_active_session_cancelled``) reset by the
+        run's own ``finally`` block as soon as the coroutine side of
+        ``_run_agent_reply`` is done handling a cancellation -- but
+        ``asyncio.to_thread`` survives Task cancellation, so the agent
+        bridge's background OS thread can still be running at that point
+        and poll ``should_cancel()`` afterward (task-227).
+        ``_active_cancel_events[session_id]``, once set here, is never
+        reset for that run, so a still-running bridge thread always
+        observes the Stop correctly regardless of what the coroutine side
+        has already reset. Every caller (``close_session``,
+        ``stop_active_run``, ``shutdown``) already knows the exact session
+        it is signalling -- there is deliberately no active-session
+        fallback here, unlike ``_set_run_state``.
         """
         self._stop_requested = True
-        if self._active_cancel_event is not None:
-            self._active_cancel_event.set()
+        cancel_event = self._active_cancel_events.get(session_id)
+        if cancel_event is not None:
+            cancel_event.set()
+
+    def _is_active_session_cancelled(self) -> bool:
+        """Best-effort cancel-signal check for the three worker-thread
+        approval/confirm bridges below (``request_mcp_approvals``,
+        ``request_skill_install_confirm``, ``request_skill_script_confirm``).
+
+        KNOWN LIMITATION (Task 3b): these bridges are plain bound-method
+        callbacks handed straight to ``ConsoleAgentBridge.run_reply``
+        (fixed arity -- ``approval_callback(pending)``,
+        ``confirm(url)``/``confirm(payload)`` -- no session id threaded
+        through), unlike ``should_cancel`` inside ``_run_agent_reply``,
+        which safely closes over ITS OWN run's ``cancel_event`` by value.
+        Falling back to the VIEWED session's cancel event here (mirroring
+        ``stop_active_run``'s own "the active session" convention) is
+        correct for the overwhelmingly common single-run case, but does
+        NOT correctly scope to a BACKGROUND session's own pending
+        approval -- and neither does ``_stop_requested`` above, which
+        stayed a single shared flag. Properly scoping concurrent
+        approvals/confirms to their own run is PA-T9 ("parked background
+        approvals"); until then, stopping the VIEWED session's run can
+        spuriously deny an unrelated background approval, and a Stop
+        aimed at a background run's own approval isn't observed by this
+        check at all.
+        """
+        cancel_event = self._active_cancel_events.get(self.store.active_session_id or "")
+        return cancel_event is not None and cancel_event.is_set()
 
     # -- MCP batch-approval bridge (task-5) ----------------------------------
 
@@ -1362,9 +1411,11 @@ class ConsoleChatController:
         happens: the user submits a decision (``resolve_pending_approval``,
         called from the UI thread, sets the Event), the run is
         cancelled/stopped/torn down (``_stop_requested``/
-        ``_active_cancel_event`` -- already wired by ``stop_active_run``,
-        ``close_session``, and ``shutdown`` via ``_signal_stop``), or the
-        configured approval timeout elapses. Whichever unique ``llm_name``
+        ``_is_active_session_cancelled()`` -- already wired by
+        ``stop_active_run``, ``close_session``, and ``shutdown`` via
+        ``_signal_stop``; see that helper's docstring for its VIEWED-
+        session limitation), or the configured approval timeout elapses.
+        Whichever unique ``llm_name``
         never received an explicit decision by then fails closed to
         ``"deny"`` (cancellation) or ``"timeout"`` (deadline) -- see
         ``MCPToolProvider._apply_verdict`` for how each decision string is
@@ -1418,10 +1469,7 @@ class ConsoleChatController:
         try:
             self._marshal_pending_approval(payload)
             while not event.wait(_MCP_APPROVAL_POLL_SECONDS):
-                if self._stop_requested or (
-                    self._active_cancel_event is not None
-                    and self._active_cancel_event.is_set()
-                ):
+                if self._stop_requested or self._is_active_session_cancelled():
                     # Finding I3: a stop/unmount that resolves THIS round
                     # denies every still-undecided call, but
                     # `run_agent_loop`'s own `should_cancel()` check fires
@@ -1721,10 +1769,7 @@ class ConsoleChatController:
         try:
             self._marshal_pending_skill_install(payload)
             while not event.wait(_MCP_APPROVAL_POLL_SECONDS):
-                if self._stop_requested or (
-                    self._active_cancel_event is not None
-                    and self._active_cancel_event.is_set()
-                ):
+                if self._stop_requested or self._is_active_session_cancelled():
                     break
                 if time.monotonic() >= deadline:
                     break
@@ -1820,10 +1865,7 @@ class ConsoleChatController:
         try:
             self._marshal_pending_skill_script(card_payload)
             while not event.wait(_MCP_APPROVAL_POLL_SECONDS):
-                if self._stop_requested or (
-                    self._active_cancel_event is not None
-                    and self._active_cancel_event.is_set()
-                ):
+                if self._stop_requested or self._is_active_session_cancelled():
                     break
                 if time.monotonic() >= deadline:
                     break
@@ -1916,7 +1958,16 @@ class ConsoleChatController:
             return list(self._pending_skill_script_rounds)
 
     def stop_active_run(self, *, record_user_stop: bool = True) -> bool:
-        """Request the active stream to stop at the next safe boundary.
+        """Request the ACTIVE (viewed) session's stream to stop at the next
+        safe boundary.
+
+        Task 3b requirement 2: name and public semantics are unchanged --
+        this is the Stop button's contract, and it only ever targets
+        whatever session ``self.store.active_session_id`` currently is,
+        never a background run in another tab. A background run is
+        completely unaffected by this call (its own entries in the
+        per-session maps below are untouched); see ``shutdown`` for the
+        teardown path that stops every session at once.
 
         Args:
             record_user_stop: Append the explicit "stopped by user"
@@ -1924,24 +1975,24 @@ class ConsoleChatController:
                 ``False`` — a teardown stop is not a user action.
 
         Returns:
-            True when an active run was found and stopped.
+            True when the viewed session had an active run and it was
+            stopped; False (a no-op) when it did not.
         """
-        repair_session = self._active_citation_repair_session
+        session_id = self.store.active_session_id or ""
+        repair_session = self._active_citation_repair_sessions.get(session_id)
         if repair_session is not None and repair_session.selection_committed:
             return False
         if repair_session is not None and repair_session.phase in {
             "checking",
             "repair_streaming",
         }:
-            if self._active_assistant_message_id is None:
+            if self._active_assistant_message_ids.get(session_id) is None:
                 return False
             repair_session.cancel_reason = "user" if record_user_stop else "shutdown"
-            self._signal_stop()
-            if (
-                self._active_stream_task is not None
-                and self._active_stream_task is not asyncio.current_task()
-            ):
-                self._active_stream_task.cancel()
+            self._signal_stop(session_id=session_id)
+            task = self._active_stream_tasks.get(session_id)
+            if task is not None and task is not asyncio.current_task():
+                task.cancel()
             return True
 
         if self.run_state.status is not ConsoleRunStatus.STREAMING:
@@ -1950,12 +2001,12 @@ class ConsoleChatController:
                 return False
         else:
             assistant_message_id = (
-                self._active_assistant_message_id
+                self._active_assistant_message_ids.get(session_id)
                 or self._active_streaming_assistant_message_id()
             )
         if assistant_message_id is None:
             return False
-        self._signal_stop()
+        self._signal_stop(session_id=session_id)
         self._mark_stream_stopped(
             assistant_message_id,
             visible_copy="Response stopped.",
@@ -1965,47 +2016,82 @@ class ConsoleChatController:
             # copy is transient and the review found nothing else marked
             # the interruption.
             try:
-                session_id = self.store.session_id_for_message(assistant_message_id)
+                owner_id = self.store.session_id_for_message(assistant_message_id)
                 self.store.append_message(
-                    session_id,
+                    owner_id,
                     role=ConsoleMessageRole.SYSTEM,
                     content="Response stopped by user.",
                 )
             except KeyError:
                 pass
-        if (
-            self._active_stream_task is not None
-            and self._active_stream_task is not asyncio.current_task()
-        ):
-            self._active_stream_task.cancel()
+        task = self._active_stream_tasks.get(session_id)
+        if task is not None and task is not asyncio.current_task():
+            task.cancel()
         return True
 
     async def shutdown(self) -> None:
-        """Stop and await the active stream task before owner teardown."""
+        """Stop and await EVERY session's active stream task before owner
+        teardown.
+
+        Task 3b requirement 3: unlike ``stop_active_run`` (deliberately
+        scoped to the VIEWED session only), teardown is global -- a
+        background run must never survive owner shutdown just because the
+        user was looking at a different tab when the app closed. Mirrors
+        ``stop_active_run``'s manual signal-then-cancel fallback for every
+        session with a live entry, rather than reusing ``stop_active_run``
+        itself, which by contract only ever resolves the active session.
+        """
         for message_id in tuple(self._original_attempts):
             self.clear_original_attempt(message_id)
-        task = self._active_stream_task
-        if task is None:
+        tasks = dict(self._active_stream_tasks)
+        if not tasks:
             return
-        if not self.stop_active_run(record_user_stop=False):
-            self._signal_stop()
-            if task is not asyncio.current_task():
+        current = asyncio.current_task()
+        for session_id in tasks:
+            # Dev's citation-repair feature threads a `cancel_reason`
+            # ("user" vs "shutdown") through `ConsoleCitationRepairSession`
+            # so `commit_canceled()` knows whether to append a "canceled by
+            # user" system row (`stop_active_run` sets this for the VIEWED
+            # session it targets) -- global teardown must set the same
+            # field for EVERY session's own in-flight repair, or a
+            # still-checking/repair-streaming session falls back to
+            # whatever `cancel_reason` (if any) was already there.
+            repair_session = self._active_citation_repair_sessions.get(session_id)
+            if (
+                repair_session is not None
+                and not repair_session.selection_committed
+                and repair_session.phase in {"checking", "repair_streaming"}
+            ):
+                repair_session.cancel_reason = "shutdown"
+            self._signal_stop(session_id=session_id)
+        for session_id, task in tasks.items():
+            if task is not current:
                 task.cancel()
-        if task is asyncio.current_task():
-            return
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
-        except Exception:
-            # Shutdown is a teardown path; stale task failures should not crash owner cleanup.
-            pass
-        finally:
-            if self._active_stream_task is task:
-                self._active_assistant_message_id = None
-                self._active_stream_task = None
-                self._stop_requested = False
-                self._active_cancel_event = None
+        for session_id, task in tasks.items():
+            if task is current:
+                # Shutdown was invoked from within its own run's task --
+                # cannot cancel/await itself; that run's own finally will
+                # still fire once this coroutine naturally unwinds.
+                continue
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                # Shutdown is a teardown path; stale task failures should not crash owner cleanup.
+                pass
+        self._stop_requested = False
+        # Safety net: each task's own `finally` (in `_stream_assistant_
+        # response`/`_run_agent_reply`) already pops ITS OWN session's
+        # entries on the happy path -- this only catches a task that
+        # somehow never reached that finally (e.g. a test double, or a
+        # task that failed before it), so teardown never leaves a stale
+        # entry behind for any session.
+        for session_id, task in tasks.items():
+            if self._active_stream_tasks.get(session_id) is task:
+                self._active_stream_tasks.pop(session_id, None)
+                self._active_assistant_message_ids.pop(session_id, None)
+                self._active_cancel_events.pop(session_id, None)
 
     def _active_streaming_assistant_message_id(self) -> str | None:
         """Return the visible streaming assistant message for the active session."""
@@ -4050,10 +4136,10 @@ class ConsoleChatController:
             # swallows a store-close race that happens during the append.
             self._append_history_trimmed_note(owner_id, bound.dropped_count)
         active_task = asyncio.current_task()
-        self._active_assistant_message_id = assistant_message_id
-        self._active_stream_task = active_task
+        self._active_assistant_message_ids[owner_id] = assistant_message_id
+        self._active_stream_tasks[owner_id] = active_task
         self._stop_requested = False
-        self._active_citation_repair_session = citation_repair_session
+        self._active_citation_repair_sessions[owner_id] = citation_repair_session
         stream_signals = (
             ConsoleProviderStreamSignals()
             if citation_repair_session is not None
@@ -4090,14 +4176,25 @@ class ConsoleChatController:
             )
         finally:
             if (
-                self._active_stream_task is active_task
-                and self._active_assistant_message_id == assistant_message_id
+                self._active_stream_tasks.get(owner_id) is active_task
+                and self._active_assistant_message_ids.get(owner_id)
+                == assistant_message_id
             ):
-                self._active_assistant_message_id = None
-                self._active_stream_task = None
+                self._active_stream_tasks.pop(owner_id, None)
+                self._active_assistant_message_ids.pop(owner_id, None)
                 self._stop_requested = False
-                if self._active_citation_repair_session is citation_repair_session:
-                    self._active_citation_repair_session = None
+                if self._active_citation_repair_sessions.get(owner_id) is citation_repair_session:
+                    self._active_citation_repair_sessions.pop(owner_id, None)
+                # Task 3b (agent path): `_run_agent_reply`'s own finally
+                # deliberately leaves its cancel_event live past its own
+                # return (see that finally's docstring) so the citation-
+                # repair post-generation check -- which runs afterward, on
+                # this same task, via `_finalize_agent_reply` -- still
+                # observes it. This is the one place left to retire it, now
+                # that the whole run (agent OR direct) has fully finished.
+                # A no-op for the direct path, whose own finally already
+                # popped its own cancel_event before returning.
+                self._active_cancel_events.pop(owner_id, None)
 
     async def _run_direct_provider_reply(
         self,
@@ -4112,6 +4209,18 @@ class ConsoleChatController:
         citation_repair_session: ConsoleCitationRepairSession | None,
         stream_signals: ConsoleProviderStreamSignals | None,
     ) -> ConsoleSubmitResult:
+        # Dev's citation-repair refactor extracted this streaming body out of
+        # the wrapper (`_stream_assistant_response_inner`) into its own
+        # method, which left it without the `owner_id` the wrapper already
+        # resolved for ITSELF -- re-resolve independently here, same as
+        # `_run_agent_reply` does for its own `session_id`, rather than
+        # threading it through as a parameter (`None` on KeyError mirrors
+        # every other guarded call site below: no owning session to
+        # attribute a closed-session result to).
+        try:
+            owner_id = self.store.session_id_for_message(assistant_message_id)
+        except KeyError:
+            return self._session_closed_result()
         one_shot_used = prefill if prefill_from_one_shot else None
         if prefill:
             provider_messages = [
@@ -4288,10 +4397,16 @@ class ConsoleChatController:
         initial_body = initial_message.content
 
         def owns_request() -> bool:
+            # Task 3b: check the OWNING session's own map entries, not a
+            # global singular slot -- a concurrent session's own in-flight
+            # stream/repair must never be mistaken for this one.
             if (
-                self._active_assistant_message_id != assistant_message_id
-                or self._active_stream_task is not asyncio.current_task()
-                or self._active_citation_repair_session is not repair_session
+                self._active_assistant_message_ids.get(owner_session_id)
+                != assistant_message_id
+                or self._active_stream_tasks.get(owner_session_id)
+                is not asyncio.current_task()
+                or self._active_citation_repair_sessions.get(owner_session_id)
+                is not repair_session
             ):
                 return False
             try:
@@ -4349,7 +4464,8 @@ class ConsoleChatController:
                 ConsoleRunState(
                     ConsoleRunStatus.STOPPED,
                     "Citation repair canceled.",
-                )
+                ),
+                session_id=owner_session_id,
             )
             if repair_session.cancel_reason == "user":
                 try:
@@ -4442,7 +4558,8 @@ class ConsoleChatController:
             ConsoleRunState(
                 ConsoleRunStatus.CHECKING_CITATIONS,
                 "Checking citations…",
-            )
+            ),
+            session_id=owner_session_id,
         )
         repaired_chunks: list[str] = []
         repair_output_available = False
@@ -4570,22 +4687,27 @@ class ConsoleChatController:
             variant_mode=variant_mode,
             prepare_retry=prepare_retry,
         )
-        self._mcp_provider = None
-        # A fresh per-run Event, captured by `should_cancel` below by
-        # closure (not read off `self` each time) -- see
-        # `_active_cancel_event`'s docstring for why this, rather than
-        # `_stop_requested` alone, is what makes a still-running bridge
-        # thread observe a Stop correctly (task-227).
-        cancel_event = threading.Event()
-        self._active_cancel_event = cancel_event
-        # Resolve the run's OWNING session BEFORE stamping run state, so the
-        # very first _set_run_state below (and every other one in this
-        # method) targets it explicitly rather than falling back to
-        # whatever the user currently has open (parallel-agents spec §2).
+        # Resolve the run's OWNING session FIRST (Task 3b): every write
+        # below -- the per-session stream/cancel maps AND run state -- must
+        # target it explicitly rather than whatever the user currently has
+        # open (parallel-agents spec §2). Moved ahead of those writes
+        # (previously ran after them, back when they were single shared
+        # slots with no session to key by).
         try:
             session_id = self.store.session_id_for_message(assistant_message_id)
         except KeyError:
             return self._session_closed_result()
+        self._active_assistant_message_ids[session_id] = assistant_message_id
+        self._active_stream_tasks[session_id] = asyncio.current_task()
+        self._stop_requested = False
+        self._mcp_provider = None
+        # A fresh per-run Event, captured by `should_cancel` below by
+        # closure (not read off `self` each time) -- see
+        # `_active_cancel_events`'s docstring for why this, rather than
+        # `_stop_requested` alone, is what makes a still-running bridge
+        # thread observe a Stop correctly (task-227).
+        cancel_event = threading.Event()
+        self._active_cancel_events[session_id] = cancel_event
         self._set_run_state(
             ConsoleRunState(ConsoleRunStatus.STREAMING, "Agent running."),
             session_id=session_id,
@@ -4610,7 +4732,7 @@ class ConsoleChatController:
         # noqa: E731 — tiny closure. Reads BOTH signals: `_stop_requested`
         # for same-tick responsiveness (and test doubles that flip it
         # directly), and `cancel_event` -- captured by value, not via
-        # `self._active_cancel_event` -- for correctness once this run's
+        # `self._active_cancel_events[session_id]` -- for correctness once this run's
         # `finally` below has already reset `_stop_requested` while the
         # bridge's background thread is still running (task-227: an
         # `asyncio.to_thread` call survives Task cancellation, so the
@@ -4771,15 +4893,19 @@ class ConsoleChatController:
             )
             return ConsoleSubmitResult(True, True, visible_copy)
         finally:
-            if self._active_cancel_event is cancel_event:
-                # NOT cancel_event.clear(): the closure above captured
-                # this exact Event object by value, so any still-running
-                # bridge thread keeps observing whatever it was last set
-                # to, forever, regardless of this attribute now pointing
-                # elsewhere (or nowhere) for the NEXT run (task-227).
-                self._active_cancel_event = None
-            # `session_id` (not the facade): this run's OWN outcome, not
-            # whatever the user currently has open (parallel-agents spec §2).
+            # Task 3b: this finally intentionally pops NONE of the three
+            # per-session entries (stream task, assistant message id,
+            # cancel event) -- `_finalize_agent_reply` below (and, through
+            # it, `_finalize_agent_success`'s citation-repair post-
+            # generation check) still runs AFTER this try/finally, on this
+            # SAME task, and both `owns_request()` (stream task/assistant
+            # message id) and `cancellation_requested()` (cancel_event,
+            # NOT clear()'d for the same reason noted where it was created
+            # above -- task-227) need to see this run as still live and
+            # still cancellable. The wrapper (`_stream_assistant_response_
+            # inner`), which awaits this entire call including
+            # `_finalize_agent_reply`, is what clears every per-session
+            # entry once everything has actually finished.
             run_state = self.run_state_for(session_id)
             logger.info(
                 "console agent reply end",
@@ -5518,24 +5644,32 @@ class ConsoleChatController:
             self._set_run_state(ConsoleRunState(), session_id=target)
 
     def _active_stream_belongs_to_session(self, session_id: str) -> bool:
-        if self._active_assistant_message_id is None:
-            return False
-        try:
-            return (
-                self.store.session_id_for_message(self._active_assistant_message_id)
-                == session_id
-            )
-        except KeyError:
-            return False
+        """Whether ``session_id`` has its own registered in-flight stream.
+
+        Task 3b: a direct membership check now that the underlying map is
+        keyed by session id -- no lookup (or ``KeyError`` guard) needed.
+        """
+        return session_id in self._active_assistant_message_ids
 
     def streaming_session_id(self) -> str | None:
-        """Return the session with an in-flight stream, for tab status glyphs."""
-        if self._active_assistant_message_id is None:
-            return None
-        try:
-            return self.store.session_id_for_message(self._active_assistant_message_id)
-        except KeyError:
-            return None
+        """Return A session with an in-flight stream, for tab status glyphs.
+
+        Task 3b: this single-value contract predates true concurrency
+        (Task 3) -- under concurrent runs there can be MULTIPLE streaming
+        sessions at once, and this still returns only one. Prefers the
+        ACTIVE (viewed) session when it has a live entry (keeps today's
+        "the tab you're looking at shows the spinner" behavior), else an
+        arbitrary (insertion-order) live entry. Full multi-session tab/
+        fleet markers are PA-T8's job; this just keeps the existing
+        single-glyph caller (``console_session_surface``'s tab strip) from
+        going stale now that the underlying map is per-session.
+        """
+        active = self.store.active_session_id
+        if active is not None and active in self._active_assistant_message_ids:
+            return active
+        for session_id in self._active_assistant_message_ids:
+            return session_id
+        return None
 
     def _session_closed_result(
         self, *, session_id: str | None = None

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -636,8 +636,16 @@ class ConsoleChatController:
         self._chat_dictionary_applier = chat_dictionary_applier
         self._world_info_applier = world_info_applier
         self._rag_capture_provider = rag_capture_provider
-        self.run_state = ConsoleRunState()
-        self.run_state_history: list[ConsoleRunStatus] = [self.run_state.status]
+        # Parallel-agents spec §2: run state is a PER-SESSION map, not a
+        # single global slot -- two sessions can each have their own
+        # in-flight/terminal run without stamping each other. `run_state`/
+        # `run_state_history` below become read-only facades over these maps
+        # (see the property block right after `__init__`); every WRITE goes
+        # through `_set_run_state`/`_clear_terminal_run_state`, which take an
+        # explicit `session_id` so a background completion can target its
+        # OWNING session instead of whatever the user currently has open.
+        self._run_states: dict[str, ConsoleRunState] = {}
+        self._run_state_histories: dict[str, list[ConsoleRunStatus]] = {}
         #: Optional owner hook invoked once a submit is accepted (user message
         #: persisted, run about to start) so the composer can clear immediately
         #: instead of holding the sent text for the whole run.
@@ -719,6 +727,45 @@ class ConsoleChatController:
         #: late button press from a torn-down round 1 from authorizing
         #: round 2's script. `None` whenever no round is armed.
 
+    @property
+    def run_state(self) -> ConsoleRunState:
+        """The ACTIVE session's run state (parallel-agents spec §2).
+
+        Read-only facade: the ~16 pre-existing read sites in chat_screen
+        keep their semantics ("the viewed session's run"), while writes go
+        through ``_set_run_state``/``_clear_terminal_run_state`` with an
+        explicit owning session id. There is deliberately no setter --
+        assigning ``controller.run_state = ...`` now raises ``AttributeError``
+        so a stray direct-assignment writer (bypassing the per-session map)
+        fails loudly instead of silently reintroducing the single-slot bug.
+        """
+        return self.run_state_for(self.store.active_session_id or "")
+
+    def run_state_for(self, session_id: str) -> ConsoleRunState:
+        """Return ``session_id``'s own run state (a fresh idle one when unset)."""
+        return self._run_states.get(session_id) or ConsoleRunState()
+
+    def run_states(self) -> dict[str, ConsoleRunState]:
+        """Snapshot copy of every session with a recorded run state (fleet UX, cap count)."""
+        return dict(self._run_states)
+
+    def in_flight_run_count(self) -> int:
+        """Count of sessions whose recorded run currently disallows a new send."""
+        return sum(
+            1 for state in self._run_states.values() if not state.is_send_allowed
+        )
+
+    @property
+    def run_state_history(self) -> list[ConsoleRunStatus]:
+        """The ACTIVE session's run-status history (read-only facade, mirrors ``run_state``)."""
+        return self.run_state_history_for(self.store.active_session_id or "")
+
+    def run_state_history_for(self, session_id: str) -> list[ConsoleRunStatus]:
+        """Return (creating if absent) ``session_id``'s run-status history."""
+        return self._run_state_histories.setdefault(
+            session_id, [ConsoleRunStatus.IDLE]
+        )
+
     async def submit_draft(self, draft: str) -> ConsoleSubmitResult:
         """Submit a composer draft through native Console validation and provider resolution."""
         active_rejection = self._active_run_rejection()
@@ -796,7 +843,8 @@ class ConsoleChatController:
         )
 
         self._set_run_state(
-            ConsoleRunState(ConsoleRunStatus.VALIDATING, "Validating provider.")
+            ConsoleRunState(ConsoleRunStatus.VALIDATING, "Validating provider."),
+            session_id=session.id,
         )
         try:
             resolution = await self.provider_gateway.resolve_for_send(
@@ -951,6 +999,14 @@ class ConsoleChatController:
             title=title or f"Chat {next_number}",
             settings=settings,
         )
+        # `create_session` above already activated the new session, so the
+        # default (no explicit session_id -> active session) targets the
+        # session JUST created here -- which is fresh/never-recorded and
+        # therefore already idle, making this call a no-op today. Left
+        # unchanged (rather than reaching for the session being replaced)
+        # for the same reason `switch_session` below is: per-session run
+        # state is meant to persist on the session you're leaving, not be
+        # wiped just because a sibling session appeared.
         self._clear_terminal_run_state()
         return session
 
@@ -1030,6 +1086,10 @@ class ConsoleChatController:
             self.system_prompt,
         )
         if current_selection != previous_selection:
+            # No session in scope here -- this is a global provider/model
+            # settings change, not tied to any particular session's run.
+            # Active-session UI path: clears whatever the user is currently
+            # looking at (parallel-agents spec §2).
             self._clear_terminal_run_state()
 
     def update_agent_runtime(
@@ -1052,6 +1112,17 @@ class ConsoleChatController:
     def switch_session(self, session_id: str) -> ConsoleChatSession:
         """Activate an existing native Console session."""
         session = self.store.switch_session(session_id)
+        # `store.switch_session` above has ALREADY moved `active_session_id`
+        # to `session_id`, so the no-arg default here (active session)
+        # targets the session being ARRIVED AT, not the one being left --
+        # verified against `test_controller_session_changes_clear_terminal_
+        # run_copy` (Tests/Chat/test_console_chat_controller.py), which
+        # requires a stale terminal banner on the destination session to be
+        # cleared the moment you switch back to it. Per-session run state is
+        # otherwise preserved (this only fires for TERMINAL statuses), so a
+        # session you're LEAVING keeps its own in-flight/terminal state
+        # untouched -- only the newly-viewed session's stale terminal copy
+        # is swept (parallel-agents spec §2).
         self._clear_terminal_run_state()
         # Binding threading contract (task-5): a conversation switch denies
         # any pending MCP approval round rather than leaving its worker
@@ -1087,7 +1158,14 @@ class ConsoleChatController:
             ):
                 self._active_stream_task.cancel()
             self._set_run_state(
-                ConsoleRunState(ConsoleRunStatus.STOPPED, "Session closed.")
+                ConsoleRunState(ConsoleRunStatus.STOPPED, "Session closed."),
+                # `session_id` here is the session being CLOSED, which the
+                # `_active_stream_belongs_to_session` guard above confirms
+                # owns the active stream -- not necessarily the currently
+                # ACTIVE session (you can close a background tab while
+                # viewing another one), so this must be explicit rather
+                # than falling back to the active-session default.
+                session_id=session_id,
             )
         closed = self.store.close_session(session_id)
         if (
@@ -1881,12 +1959,17 @@ class ConsoleChatController:
         message_session_id = self.store.session_id_for_message(message_id)
         if message_session_id != session_id:
             visible_copy = "Open the original session before retrying this message."
-            self._set_run_state(ConsoleRunState.blocked(visible_copy))
+            self._set_run_state(
+                ConsoleRunState.blocked(visible_copy), session_id=session_id
+            )
             return ConsoleSubmitResult(False, False, visible_copy)
         if message.status != "failed":
             return self._block(session_id, "Only failed messages can be retried.")
 
-        self._set_run_state(ConsoleRunState.retrying("Retrying failed response."))
+        self._set_run_state(
+            ConsoleRunState.retrying("Retrying failed response."),
+            session_id=session_id,
+        )
         resolution = await self.provider_gateway.resolve_for_send(
             self._provider_selection()
         )
@@ -1948,11 +2031,14 @@ class ConsoleChatController:
             visible_copy = (
                 "Open the original session before continuing from this message."
             )
-            self._set_run_state(ConsoleRunState.blocked(visible_copy))
+            self._set_run_state(
+                ConsoleRunState.blocked(visible_copy), session_id=session_id
+            )
             return ConsoleSubmitResult(False, False, visible_copy)
 
         self._set_run_state(
-            ConsoleRunState(ConsoleRunStatus.VALIDATING, "Validating provider.")
+            ConsoleRunState(ConsoleRunStatus.VALIDATING, "Validating provider."),
+            session_id=session_id,
         )
         resolution = await self.provider_gateway.resolve_for_send(
             self._provider_selection()
@@ -2051,11 +2137,14 @@ class ConsoleChatController:
             )
         if self.store.session_id_for_message(message_id) != session_id:
             visible_copy = "Open the original session before regenerating this message."
-            self._set_run_state(ConsoleRunState.blocked(visible_copy))
+            self._set_run_state(
+                ConsoleRunState.blocked(visible_copy), session_id=session_id
+            )
             return ConsoleSubmitResult(False, False, visible_copy)
 
         self._set_run_state(
-            ConsoleRunState(ConsoleRunStatus.VALIDATING, "Validating provider.")
+            ConsoleRunState(ConsoleRunStatus.VALIDATING, "Validating provider."),
+            session_id=session_id,
         )
         resolution = await self.provider_gateway.resolve_for_send(
             self._provider_selection()
@@ -2157,14 +2246,18 @@ class ConsoleChatController:
             return ConsoleSubmitResult(False, False, "No active Console session.")
 
         if message_id not in self.store.active_path_message_ids(session_id):
-            return self._summarize_block("Switch to that branch before summarizing.")
+            return self._summarize_block(
+                session_id, "Switch to that branch before summarizing."
+            )
         try:
             target = self.store.get_message(message_id)
         except KeyError:
-            return self._summarize_block("Switch to that branch before summarizing.")
+            return self._summarize_block(
+                session_id, "Switch to that branch before summarizing."
+            )
         if target.role is not ConsoleMessageRole.USER:
             return self._summarize_block(
-                "Only your own messages can be summarized up to here."
+                session_id, "Only your own messages can be summarized up to here."
             )
 
         messages = self.store.messages_for_session(session_id)
@@ -2172,14 +2265,18 @@ class ConsoleChatController:
             (i for i, m in enumerate(messages) if m.id == message_id), None
         )
         if target_index is None:
-            return self._summarize_block("Switch to that branch before summarizing.")
+            return self._summarize_block(
+                session_id, "Switch to that branch before summarizing."
+            )
         before = [
             m
             for m in messages[:target_index]
             if m.role in {ConsoleMessageRole.USER, ConsoleMessageRole.ASSISTANT}
         ]
         if not before:
-            return self._summarize_block("Nothing to summarize before that message.")
+            return self._summarize_block(
+                session_id, "Nothing to summarize before that message."
+            )
 
         # Rolling compaction: when a prior boundary sits on this path BEFORE the
         # target, the prior summary already covers everything strictly before
@@ -2203,14 +2300,16 @@ class ConsoleChatController:
 
         # "Summarizing..." run state, set the way regenerate sets VALIDATING.
         self._set_run_state(
-            ConsoleRunState(ConsoleRunStatus.VALIDATING, "Summarizing conversation…")
+            ConsoleRunState(ConsoleRunStatus.VALIDATING, "Summarizing conversation…"),
+            session_id=session_id,
         )
         resolution = await self.provider_gateway.resolve_for_send(
             self._provider_selection()
         )
         if not getattr(resolution, "ready", False):
             return self._summarize_block(
-                self._blocked_visible_copy(getattr(resolution, "visible_copy", ""))
+                session_id,
+                self._blocked_visible_copy(getattr(resolution, "visible_copy", "")),
             )
 
         span_text = self._build_summary_span_text(
@@ -2234,26 +2333,38 @@ class ConsoleChatController:
                 "Console summarize-up-to failed", error=str(error)
             )
             visible_copy = "Couldn't summarize the conversation. Try again."
-            self._set_run_state(ConsoleRunState(ConsoleRunStatus.FAILED, visible_copy))
+            self._set_run_state(
+                ConsoleRunState(ConsoleRunStatus.FAILED, visible_copy),
+                session_id=session_id,
+            )
             return ConsoleSubmitResult(False, False, visible_copy)
 
         if not summary_text.strip():
-            return self._summarize_block("The model returned an empty summary.")
+            return self._summarize_block(
+                session_id, "The model returned an empty summary."
+            )
 
         self.store.set_session_context_summary(session_id, summary_text, message_id)
         turns = sum(1 for m in before if m.role is ConsoleMessageRole.USER)
         visible_copy = f"Summarized {turns} earlier turn{'s' if turns != 1 else ''}."
-        self._set_run_state(ConsoleRunState(ConsoleRunStatus.COMPLETED, visible_copy))
+        self._set_run_state(
+            ConsoleRunState(ConsoleRunStatus.COMPLETED, visible_copy),
+            session_id=session_id,
+        )
         return ConsoleSubmitResult(True, False, visible_copy)
 
-    def _summarize_block(self, visible_copy: str) -> ConsoleSubmitResult:
+    def _summarize_block(
+        self, session_id: str, visible_copy: str
+    ) -> ConsoleSubmitResult:
         """Blocked-summarize result that mutates NO transcript state.
 
         Unlike ``_block`` (which appends a SYSTEM row), a blocked summarize
         must leave the transcript untouched -- the run-state copy alone carries
         the reason to the control surfaces (Phase B discipline).
         """
-        self._set_run_state(ConsoleRunState.blocked(visible_copy))
+        self._set_run_state(
+            ConsoleRunState.blocked(visible_copy), session_id=session_id
+        )
         return ConsoleSubmitResult(False, False, visible_copy)
 
     def _build_summary_span_text(
@@ -2386,7 +2497,9 @@ class ConsoleChatController:
             )
         if self.store.session_id_for_message(message_id) != session_id:
             visible_copy = "Open the original session before editing this message."
-            self._set_run_state(ConsoleRunState.blocked(visible_copy))
+            self._set_run_state(
+                ConsoleRunState.blocked(visible_copy), session_id=session_id
+            )
             return ConsoleSubmitResult(False, False, visible_copy)
         if message_id not in self.store.active_path_message_ids(session_id):
             # Task 2 review fix (Qodo finding 2): `_provider_messages_for_session`
@@ -2418,7 +2531,8 @@ class ConsoleChatController:
                 return self._block(session_id, block_reason)
 
         self._set_run_state(
-            ConsoleRunState(ConsoleRunStatus.VALIDATING, "Validating provider.")
+            ConsoleRunState(ConsoleRunStatus.VALIDATING, "Validating provider."),
+            session_id=session_id,
         )
         resolution = await self.provider_gateway.resolve_for_send(
             self._provider_selection()
@@ -3530,7 +3644,9 @@ class ConsoleChatController:
         return copy or "Provider blocked."
 
     def _block(self, session_id: str, visible_copy: str) -> ConsoleSubmitResult:
-        self._set_run_state(ConsoleRunState.blocked(visible_copy))
+        self._set_run_state(
+            ConsoleRunState.blocked(visible_copy), session_id=session_id
+        )
         self.store.append_message(
             session_id,
             role=ConsoleMessageRole.SYSTEM,
@@ -3803,6 +3919,9 @@ class ConsoleChatController:
         try:
             owner_id = self.store.session_id_for_message(assistant_message_id)
         except KeyError:
+            # The message itself is already gone -- no owning session to
+            # attribute this to; default (active session) is a harmless
+            # no-op since nothing will ever read a closed session's state.
             return self._session_closed_result()
         owner = next((s for s in self.store.sessions() if s.id == owner_id), None)
         # task-427: a character session always takes the plain-provider
@@ -3930,9 +4049,10 @@ class ConsoleChatController:
             try:
                 self.store.append_stream_chunk(assistant_message_id, prefill)
             except KeyError:
-                return self._session_closed_result()
+                return self._session_closed_result(session_id=owner_id)
         self._set_run_state(
-            ConsoleRunState(ConsoleRunStatus.STREAMING, "Streaming response.")
+            ConsoleRunState(ConsoleRunStatus.STREAMING, "Streaming response."),
+            session_id=owner_id,
         )
         retry_prepared = False
         emitted_content = False
@@ -3960,7 +4080,7 @@ class ConsoleChatController:
                             retry_prepared=retry_prepared,
                         )
                     except KeyError:
-                        return self._session_closed_result()
+                        return self._session_closed_result(session_id=owner_id)
                     self._consume_one_shot_prefill(assistant_message_id, one_shot_used)
                     return ConsoleSubmitResult(True, True, stopped.content)
                 if prepare_retry and not retry_prepared:
@@ -3972,11 +4092,11 @@ class ConsoleChatController:
                                 assistant_message_id, prefill
                             )
                         except KeyError:
-                            return self._session_closed_result()
+                            return self._session_closed_result(session_id=owner_id)
                 try:
                     self.store.append_stream_chunk(assistant_message_id, chunk)
                 except KeyError:
-                    return self._session_closed_result()
+                    return self._session_closed_result(session_id=owner_id)
                 if chunk:
                     emitted_content = True
             if self._stop_requested:
@@ -3988,25 +4108,26 @@ class ConsoleChatController:
                         retry_prepared=retry_prepared,
                     )
                 except KeyError:
-                    return self._session_closed_result()
+                    return self._session_closed_result(session_id=owner_id)
                 self._consume_one_shot_prefill(assistant_message_id, one_shot_used)
                 return ConsoleSubmitResult(True, True, stopped.content)
             if not emitted_content:
                 try:
                     failed = self.store.get_message(assistant_message_id)
                 except KeyError:
-                    return self._session_closed_result()
+                    return self._session_closed_result(session_id=owner_id)
                 self._set_run_state(
                     ConsoleRunState(
                         ConsoleRunStatus.FAILED,
                         "Provider stream ended without content.",
-                    )
+                    ),
+                    session_id=owner_id,
                 )
                 if not prepare_retry:
                     try:
                         failed = self.store.mark_message_failed(assistant_message_id)
                     except KeyError:
-                        return self._session_closed_result()
+                        return self._session_closed_result(session_id=owner_id)
                 return ConsoleSubmitResult(True, True, failed.content)
             if citation_repair_session is not None and stream_signals is not None:
                 try:
@@ -4029,9 +4150,10 @@ class ConsoleChatController:
                 else:
                     completed = self.store.mark_message_complete(assistant_message_id)
             except KeyError:
-                return self._session_closed_result()
+                return self._session_closed_result(session_id=owner_id)
             self._set_run_state(
-                ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete.")
+                ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete."),
+                session_id=owner_id,
             )
             self._consume_one_shot_prefill(assistant_message_id, one_shot_used)
             return ConsoleSubmitResult(True, True, completed.content)
@@ -4045,7 +4167,7 @@ class ConsoleChatController:
                         retry_prepared=retry_prepared,
                     )
                 except KeyError:
-                    return self._session_closed_result()
+                    return self._session_closed_result(session_id=owner_id)
                 self._consume_one_shot_prefill(assistant_message_id, one_shot_used)
                 return ConsoleSubmitResult(True, True, stopped.content)
             raise
@@ -4060,14 +4182,15 @@ class ConsoleChatController:
                 else:
                     self.store.get_message(assistant_message_id)
             except KeyError:
-                return self._session_closed_result()
-            try:
-                session_id = self.store.session_id_for_message(assistant_message_id)
-            except KeyError:
-                session_id = None
-            if session_id is not None:
-                self._append_failure_system_row(session_id, visible_copy)
-            self._set_run_state(ConsoleRunState(ConsoleRunStatus.FAILED, visible_copy))
+                return self._session_closed_result(session_id=owner_id)
+            # Reuse the guarded owner_id resolved at the top of this method
+            # (rather than re-deriving it) -- this is the run's OWNING
+            # session regardless of whatever the user currently has open.
+            self._append_failure_system_row(owner_id, visible_copy)
+            self._set_run_state(
+                ConsoleRunState(ConsoleRunStatus.FAILED, visible_copy),
+                session_id=owner_id,
+            )
             return ConsoleSubmitResult(True, True, visible_copy)
 
     async def _select_post_generation_body(
@@ -4377,13 +4500,18 @@ class ConsoleChatController:
         # thread observe a Stop correctly (task-227).
         cancel_event = threading.Event()
         self._active_cancel_event = cancel_event
-        self._set_run_state(
-            ConsoleRunState(ConsoleRunStatus.STREAMING, "Agent running.")
-        )
+        # Resolve the run's OWNING session BEFORE stamping run state, so the
+        # very first _set_run_state below (and every other one in this
+        # method) targets it explicitly rather than falling back to
+        # whatever the user currently has open (parallel-agents spec §2).
         try:
             session_id = self.store.session_id_for_message(assistant_message_id)
         except KeyError:
             return self._session_closed_result()
+        self._set_run_state(
+            ConsoleRunState(ConsoleRunStatus.STREAMING, "Agent running."),
+            session_id=session_id,
+        )
         if variant_mode:
             self.store.begin_variant_stream(assistant_message_id)
         elif prepare_retry:
@@ -4517,7 +4645,7 @@ class ConsoleChatController:
                         assistant_message_id, visible_copy="Response stopped."
                     )
                 except KeyError:
-                    return self._session_closed_result()
+                    return self._session_closed_result(session_id=session_id)
                 # task-543: this is the dominant user-Stop path --
                 # ``task.cancel()`` raised before ``(run_id, outcome)`` ever
                 # bound, so recover the active run's id via the bridge's
@@ -4557,9 +4685,12 @@ class ConsoleChatController:
             try:
                 self.store.mark_message_failed(assistant_message_id)
             except KeyError:
-                return self._session_closed_result()
+                return self._session_closed_result(session_id=session_id)
             self._append_failure_system_row(session_id, visible_copy)
-            self._set_run_state(ConsoleRunState(ConsoleRunStatus.FAILED, visible_copy))
+            self._set_run_state(
+                ConsoleRunState(ConsoleRunStatus.FAILED, visible_copy),
+                session_id=session_id,
+            )
             return ConsoleSubmitResult(True, True, visible_copy)
         finally:
             if self._active_cancel_event is cancel_event:
@@ -4569,11 +4700,14 @@ class ConsoleChatController:
                 # to, forever, regardless of this attribute now pointing
                 # elsewhere (or nowhere) for the NEXT run (task-227).
                 self._active_cancel_event = None
+            # `session_id` (not the facade): this run's OWN outcome, not
+            # whatever the user currently has open (parallel-agents spec §2).
+            run_state = self.run_state_for(session_id)
             logger.info(
                 "console agent reply end",
                 assistant_message_id=assistant_message_id,
-                run_status=self.run_state.status.value,
-                run_copy=self.run_state.visible_copy,
+                run_status=run_state.status.value,
+                run_copy=run_state.visible_copy,
             )
 
         # Captured here, before `_finalize_agent_reply` runs: this run's own
@@ -4650,7 +4784,8 @@ class ConsoleChatController:
             # fallback -- correct).
             self._record_run_assistant_message(run_id, current)
             self._set_run_state(
-                ConsoleRunState(ConsoleRunStatus.STOPPED, "Response stopped.")
+                ConsoleRunState(ConsoleRunStatus.STOPPED, "Response stopped."),
+                session_id=session_id,
             )
             return ConsoleSubmitResult(True, True, current.content if current is not None else "")
 
@@ -4738,7 +4873,10 @@ class ConsoleChatController:
         else:
             failed = self._append_failed_assistant(session_id, visible_copy)
         self._record_run_assistant_message(run_id, failed)
-        self._set_run_state(ConsoleRunState(ConsoleRunStatus.FAILED, visible_copy))
+        self._set_run_state(
+            ConsoleRunState(ConsoleRunStatus.FAILED, visible_copy),
+            session_id=session_id,
+        )
         return ConsoleSubmitResult(True, True, failed.content)
 
     def _finalize_agent_failure(
@@ -4769,7 +4907,10 @@ class ConsoleChatController:
             failed = self.store.mark_message_failed(assistant_message_id)
             self._record_run_assistant_message(run_id, failed)
             self._append_failure_system_row(session_id, visible_copy)
-            self._set_run_state(ConsoleRunState(ConsoleRunStatus.FAILED, visible_copy))
+            self._set_run_state(
+                ConsoleRunState(ConsoleRunStatus.FAILED, visible_copy),
+                session_id=session_id,
+            )
             return ConsoleSubmitResult(True, True, failed.content)
 
         runtime_written = self._find_runtime_written_assistant(session_id)
@@ -4779,7 +4920,10 @@ class ConsoleChatController:
         else:
             failed = self._append_failed_assistant(session_id, visible_copy)
         self._record_run_assistant_message(run_id, failed)
-        self._set_run_state(ConsoleRunState(ConsoleRunStatus.FAILED, visible_copy))
+        self._set_run_state(
+            ConsoleRunState(ConsoleRunStatus.FAILED, visible_copy),
+            session_id=session_id,
+        )
         return ConsoleSubmitResult(True, True, failed.content)
 
     async def _finalize_agent_success(
@@ -4834,21 +4978,30 @@ class ConsoleChatController:
                     )
             completed = self._complete_agent_message(assistant_message_id, variant_mode, outcome)
             self._record_run_assistant_message(run_id, completed)
-            self._set_run_state(ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete."))
+            self._set_run_state(
+                ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete."),
+                session_id=session_id,
+            )
             return ConsoleSubmitResult(True, True, completed.content)
 
         runtime_written = self._find_runtime_written_assistant(session_id)
         if runtime_written is not None and runtime_written.status in {"pending", "streaming"}:
             completed = self._complete_agent_message(runtime_written.id, variant_mode=False, outcome=outcome)
             self._record_run_assistant_message(run_id, completed)
-            self._set_run_state(ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete."))
+            self._set_run_state(
+                ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete."),
+                session_id=session_id,
+            )
             return ConsoleSubmitResult(True, True, completed.content)
 
         final_text = getattr(outcome, "final_text", "") or "No response was generated."
         completed = self.store.append_message(
             session_id, role=ConsoleMessageRole.ASSISTANT, content=final_text)
         self._record_run_assistant_message(run_id, completed)
-        self._set_run_state(ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete."))
+        self._set_run_state(
+            ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete."),
+            session_id=session_id,
+        )
         return ConsoleSubmitResult(True, True, completed.content)
 
     def _record_run_assistant_message(
@@ -5231,22 +5384,60 @@ class ConsoleChatController:
                 stopped = self.store.mark_message_stopped(assistant_message_id)
             except ValueError:
                 stopped = self.store.get_message(assistant_message_id)
-        self._set_run_state(ConsoleRunState(ConsoleRunStatus.STOPPED, visible_copy))
+        # Derive the owning session the same way `_active_stream_belongs_to_
+        # session`/`streaming_session_id` do, rather than requiring every
+        # caller to thread it through -- `assistant_message_id` is stable
+        # even once the run finishes, so this is always resolvable unless
+        # the session was closed out from under the run (in which case
+        # there is nothing left to attribute the STOPPED stamp to).
+        try:
+            owner_id = self.store.session_id_for_message(assistant_message_id)
+        except KeyError:
+            owner_id = None
+        self._set_run_state(
+            ConsoleRunState(ConsoleRunStatus.STOPPED, visible_copy),
+            session_id=owner_id,
+        )
         return stopped
 
-    def _set_run_state(self, run_state: ConsoleRunState) -> None:
-        self.run_state = run_state
-        self.run_state_history.append(run_state.status)
+    def _set_run_state(
+        self, run_state: ConsoleRunState, *, session_id: str | None = None
+    ) -> None:
+        """Write ``run_state`` for ``session_id`` (default: the active session).
 
-    def _clear_terminal_run_state(self) -> None:
-        """Clear stale terminal status copy when the active session changes."""
-        if self.run_state.status in {
+        Parallel-agents spec §2: this is the ONLY path that mutates the
+        per-session run-state map -- ``run_state``/``run_state_history``
+        stay read-only facades (see their property definitions near
+        ``__init__``). ``session_id=None`` preserves every pre-existing
+        call site's behavior (targets whatever session is currently active);
+        callers that know the run's OWNING session (which may not be the
+        active one once a background run outlives a session switch) pass it
+        explicitly.
+        """
+        target = session_id if session_id is not None else (
+            self.store.active_session_id or ""
+        )
+        self._run_states[target] = run_state
+        self.run_state_history_for(target).append(run_state.status)
+
+    def _clear_terminal_run_state(self, session_id: str | None = None) -> None:
+        """Clear stale terminal status copy for ``session_id`` (default: active).
+
+        Parallel-agents spec §2: terminal-only guard preserved verbatim --
+        a NON-terminal (e.g. STREAMING) run is never reset by this, so a
+        background run in progress on another session is untouched when the
+        viewed session changes.
+        """
+        target = session_id if session_id is not None else (
+            self.store.active_session_id or ""
+        )
+        if self.run_state_for(target).status in {
             ConsoleRunStatus.BLOCKED,
             ConsoleRunStatus.COMPLETED,
             ConsoleRunStatus.FAILED,
             ConsoleRunStatus.STOPPED,
         }:
-            self._set_run_state(ConsoleRunState())
+            self._set_run_state(ConsoleRunState(), session_id=target)
 
     def _active_stream_belongs_to_session(self, session_id: str) -> bool:
         if self._active_assistant_message_id is None:
@@ -5268,9 +5459,25 @@ class ConsoleChatController:
         except KeyError:
             return None
 
-    def _session_closed_result(self) -> ConsoleSubmitResult:
+    def _session_closed_result(
+        self, *, session_id: str | None = None
+    ) -> ConsoleSubmitResult:
+        """Result for a KeyError caused by the message's session vanishing mid-run.
+
+        ``session_id`` is the run's owning session when the caller still has
+        it in scope (most call sites do -- ``owner_id``/``session_id``
+        resolved earlier in the same method); ``None`` only where the very
+        first lookup of that owning session is what failed, i.e. there is
+        genuinely nothing to attribute the STOPPED stamp to. Either way the
+        owning session no longer exists in the store (``close_session``
+        purges it), so this write is at worst an orphaned map entry -- never
+        a stamp on a live, currently-viewed session.
+        """
         visible_copy = "Session closed."
-        self._set_run_state(ConsoleRunState(ConsoleRunStatus.STOPPED, visible_copy))
+        self._set_run_state(
+            ConsoleRunState(ConsoleRunStatus.STOPPED, visible_copy),
+            session_id=session_id,
+        )
         return ConsoleSubmitResult(True, True, visible_copy)
 
     def _active_run_rejection(self) -> ConsoleSubmitResult | None:

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1111,19 +1111,19 @@ class ConsoleChatController:
 
     def switch_session(self, session_id: str) -> ConsoleChatSession:
         """Activate an existing native Console session."""
+        # Resolve the OUTGOING session BEFORE `store.switch_session` below
+        # moves `active_session_id` -- the no-arg default on
+        # `_clear_terminal_run_state` would otherwise target the session
+        # being ARRIVED AT (active_session_id already points there by the
+        # time it runs). Per the spec's "clear the session you are leaving
+        # if terminal" semantic, every session-scoped write in this refactor
+        # is explicit, so this one is too: pass the outgoing session's id
+        # directly. A session you're ARRIVING AT keeps whatever terminal/
+        # in-flight state it already had (parallel-agents spec §2).
+        previous_session_id = self.store.active_session_id
         session = self.store.switch_session(session_id)
-        # `store.switch_session` above has ALREADY moved `active_session_id`
-        # to `session_id`, so the no-arg default here (active session)
-        # targets the session being ARRIVED AT, not the one being left --
-        # verified against `test_controller_session_changes_clear_terminal_
-        # run_copy` (Tests/Chat/test_console_chat_controller.py), which
-        # requires a stale terminal banner on the destination session to be
-        # cleared the moment you switch back to it. Per-session run state is
-        # otherwise preserved (this only fires for TERMINAL statuses), so a
-        # session you're LEAVING keeps its own in-flight/terminal state
-        # untouched -- only the newly-viewed session's stale terminal copy
-        # is swept (parallel-agents spec §2).
-        self._clear_terminal_run_state()
+        if previous_session_id is not None:
+            self._clear_terminal_run_state(session_id=previous_session_id)
         # Binding threading contract (task-5): a conversation switch denies
         # any pending MCP approval round rather than leaving its worker
         # thread blocked on a card the user just navigated away from. Only

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -756,6 +756,60 @@ class ConsoleChatController:
         )
 
     @property
+    def max_parallel_runs(self) -> int:
+        """User-adjustable global cap on simultaneous runs (parallel-agents spec §4).
+
+        Reads ``[console] max_parallel_runs`` through the same
+        ``get_cli_setting`` seam used elsewhere in this module (see
+        ``_resolve_mcp_approval_timeout_seconds``). Floored at 1 and
+        defaulted to 3 so a bad/blank config value can never lock every
+        session out of sending.
+        """
+        raw = get_cli_setting("console", "max_parallel_runs", 3)
+        if raw is None:
+            return 3
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            value = 3
+        return max(1, value)
+
+    def send_refusal_copy(self, session_id: str) -> str | None:
+        """Why a send to ``session_id`` must be refused right now, or ``None``.
+
+        Parallel-agents spec §4. Two gates, checked in order:
+
+        1. Per-session -- ``session_id``'s own run is still in flight.
+        2. Global cap -- ``max_parallel_runs`` busy sessions already exist,
+           so a NEW send (from any session, including an idle one) must
+           wait.
+
+        The cap's busy list is intersected with ``store.sessions()``: a
+        session closed mid-VALIDATING leaves its entry in
+        ``self._run_states`` behind (``ConsoleChatStore.close_session``
+        never touches the controller's map -- Task 1 review finding), and
+        a session that no longer exists must not consume a cap slot or be
+        named in the refusal copy.
+        """
+        if not self.run_state_for(session_id).is_send_allowed:
+            return "A run is already running in this tab."
+        live_sessions = {session.id: session for session in self.store.sessions()}
+        busy_ids = [
+            sid
+            for sid, state in self._run_states.items()
+            if sid in live_sessions and not state.is_send_allowed
+        ]
+        if len(busy_ids) < self.max_parallel_runs:
+            return None
+        titles = [live_sessions[sid].title for sid in busy_ids[:3]]
+        suffix = f" and {len(busy_ids) - 3} more" if len(busy_ids) > 3 else ""
+        return (
+            f"{len(busy_ids)} agents already running "
+            f"({', '.join(titles)}{suffix}). "
+            "Wait for one to finish or interrupt it."
+        )
+
+    @property
     def run_state_history(self) -> list[ConsoleRunStatus]:
         """The ACTIVE session's run-status history (read-only facade, mirrors ``run_state``)."""
         return self.run_state_history_for(self.store.active_session_id or "")

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -746,14 +746,42 @@ class ConsoleChatController:
         return self._run_states.get(session_id) or ConsoleRunState()
 
     def run_states(self) -> dict[str, ConsoleRunState]:
-        """Snapshot copy of every session with a recorded run state (fleet UX, cap count)."""
+        """Raw map snapshot incl. entries for closed sessions.
+
+        This is the UNFILTERED ``self._run_states`` copy -- it can contain
+        orphaned entries for sessions ``ConsoleChatStore.close_session`` has
+        already removed (closing never touches the controller's map). Use
+        ``in_flight_run_count`` (or ``_live_busy_session_ids``) for cap/fleet
+        math; those exclude orphans. This raw snapshot is for callers that
+        want the full recorded history regardless of session lifetime.
+        """
         return dict(self._run_states)
 
+    def _live_busy_session_ids(self) -> list[str]:
+        """Busy session ids that still exist in the store, insertion-ordered.
+
+        Intersects ``self._run_states`` with ``store.sessions()``: a session
+        closed mid-VALIDATING leaves its entry in the map behind (Task 1
+        review finding), and neither cap/fleet math nor the refusal copy's
+        session list may count or name a session that no longer exists.
+        Shared by ``in_flight_run_count`` and ``send_refusal_copy`` so both
+        apply the same live-session filter.
+        """
+        live_ids = {session.id for session in self.store.sessions()}
+        return [
+            sid
+            for sid, state in self._run_states.items()
+            if sid in live_ids and not state.is_send_allowed
+        ]
+
     def in_flight_run_count(self) -> int:
-        """Count of sessions whose recorded run currently disallows a new send."""
-        return sum(
-            1 for state in self._run_states.values() if not state.is_send_allowed
-        )
+        """Count of LIVE sessions whose recorded run currently disallows a new send.
+
+        Excludes orphaned entries for sessions the store no longer has (see
+        ``_live_busy_session_ids``) -- consumers (cap math, fleet UX) must
+        never see a closed session's stale run inflate this count.
+        """
+        return len(self._live_busy_session_ids())
 
     @property
     def max_parallel_runs(self) -> int:
@@ -784,23 +812,19 @@ class ConsoleChatController:
            so a NEW send (from any session, including an idle one) must
            wait.
 
-        The cap's busy list is intersected with ``store.sessions()``: a
-        session closed mid-VALIDATING leaves its entry in
-        ``self._run_states`` behind (``ConsoleChatStore.close_session``
-        never touches the controller's map -- Task 1 review finding), and
-        a session that no longer exists must not consume a cap slot or be
-        named in the refusal copy.
+        The cap's busy list comes from ``_live_busy_session_ids`` (shared
+        with ``in_flight_run_count``): a session closed mid-VALIDATING
+        leaves its entry in ``self._run_states`` behind
+        (``ConsoleChatStore.close_session`` never touches the controller's
+        map -- Task 1 review finding), and a session that no longer exists
+        must not consume a cap slot or be named in the refusal copy.
         """
         if not self.run_state_for(session_id).is_send_allowed:
             return "A run is already running in this tab."
-        live_sessions = {session.id: session for session in self.store.sessions()}
-        busy_ids = [
-            sid
-            for sid, state in self._run_states.items()
-            if sid in live_sessions and not state.is_send_allowed
-        ]
+        busy_ids = self._live_busy_session_ids()
         if len(busy_ids) < self.max_parallel_runs:
             return None
+        live_sessions = {session.id: session for session in self.store.sessions()}
         titles = [live_sessions[sid].title for sid in busy_ids[:3]]
         suffix = f" and {len(busy_ids) - 3} more" if len(busy_ids) > 3 else ""
         return (
@@ -4720,7 +4744,7 @@ class ConsoleChatController:
             # (append_steps/set_status), and `supersede_run_tree` are not
             # covered). Left uncaught here, run_state would stay STREAMING
             # forever and every future send on every session would be
-            # rejected ("A Console run is already running.") until app
+            # rejected ("A run is already running in this tab.") until app
             # restart (Plan-B Task 6 Critical 1). Mirror the legacy stream
             # path's catch-all above, including the Task-1 variant-restore
             # semantics: `begin_variant_stream`/`prepare_message_retry`
@@ -5540,5 +5564,11 @@ class ConsoleChatController:
         return ConsoleSubmitResult(
             accepted=False,
             should_clear_draft=False,
-            visible_copy="A Console run is already running.",
+            # Must match the screen gate's `send_refusal_copy` own-session
+            # copy (parallel-agents spec §4) -- a rapid double-send can hit
+            # this internal defense-in-depth check instead of the screen's
+            # gate (the loser of the exclusive-worker creation race), and a
+            # mismatched copy there would read as two different bugs instead
+            # of one lost race.
+            visible_copy="A run is already running in this tab.",
         )

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -20,6 +20,8 @@ from tldw_chatbook.Chat.attachment_core import (
     vision_block_reason,
 )
 from tldw_chatbook.Chat.console_chat_models import (
+    CONSOLE_CAP_REFUSAL_TITLE_LIMIT,
+    CONSOLE_DEFAULT_MAX_PARALLEL_RUNS,
     ConsoleChatMessage,
     ConsoleCitationNoticeCode,
     ConsoleCitationPhase,
@@ -662,6 +664,20 @@ class ConsoleChatController:
         self._active_assistant_message_ids: dict[str, str] = {}
         self._active_stream_tasks: dict[str, asyncio.Task] = {}
         self._stop_requested = False
+        #: F5 fix (Qodo wave): set ONLY by ``shutdown()`` and NEVER reset
+        #: (unlike ``_stop_requested``, which every run's own lifecycle
+        #: resets to ``False`` -- see ``shutdown``/``_run_agent_reply``/
+        #: ``_stream_assistant_response``'s own resets -- making it
+        #: race-dependent whether a still-polling bridge thread observes a
+        #: Stop that raced a reset). The three worker-thread approval/
+        #: confirm bridges (``request_mcp_approvals``, ``request_skill_
+        #: install_confirm``, ``request_skill_script_confirm``) OR this
+        #: with ``_is_active_session_cancelled()`` at their poll sites
+        #: instead of the old, session-agnostic ``_stop_requested`` --
+        #: a single session's Stop must never deny another session's
+        #: unrelated approval round; only real process teardown (the one
+        #: case where every session's run legitimately ends at once) does.
+        self._shutdown_requested = threading.Event()
         # Rebase note (dev citation-repair vs. Task 3b): dev added this as a
         # singular slot (no per-session awareness); rescoped here the same
         # way as the two maps above -- keyed by the run's OWNING session id,
@@ -757,11 +773,23 @@ class ConsoleChatController:
         assigning ``controller.run_state = ...`` now raises ``AttributeError``
         so a stray direct-assignment writer (bypassing the per-session map)
         fails loudly instead of silently reintroducing the single-slot bug.
+
+        Returns:
+            The active session's recorded ``ConsoleRunState`` (a fresh idle
+            state when the active session has no recorded run).
         """
         return self.run_state_for(self.store.active_session_id or "")
 
     def run_state_for(self, session_id: str) -> ConsoleRunState:
-        """Return ``session_id``'s own run state (a fresh idle one when unset)."""
+        """Return ``session_id``'s own run state (a fresh idle one when unset).
+
+        Args:
+            session_id: The session id to look up.
+
+        Returns:
+            The session's recorded ``ConsoleRunState``, or a fresh idle
+            ``ConsoleRunState`` when the session has no recorded run.
+        """
         return self._run_states.get(session_id) or ConsoleRunState()
 
     def run_states(self) -> dict[str, ConsoleRunState]:
@@ -773,6 +801,10 @@ class ConsoleChatController:
         ``in_flight_run_count`` (or ``_live_busy_session_ids``) for cap/fleet
         math; those exclude orphans. This raw snapshot is for callers that
         want the full recorded history regardless of session lifetime.
+
+        Returns:
+            A shallow copy of the internal session-id -> ``ConsoleRunState``
+            map, including entries for sessions the store has since closed.
         """
         return dict(self._run_states)
 
@@ -799,6 +831,10 @@ class ConsoleChatController:
         Excludes orphaned entries for sessions the store no longer has (see
         ``_live_busy_session_ids``) -- consumers (cap math, fleet UX) must
         never see a closed session's stale run inflate this count.
+
+        Returns:
+            The number of live sessions whose recorded run currently
+            disallows a new send.
         """
         return len(self._live_busy_session_ids())
 
@@ -809,16 +845,21 @@ class ConsoleChatController:
         Reads ``[console] max_parallel_runs`` through the same
         ``get_cli_setting`` seam used elsewhere in this module (see
         ``_resolve_mcp_approval_timeout_seconds``). Floored at 1 and
-        defaulted to 3 so a bad/blank config value can never lock every
-        session out of sending.
+        defaulted to ``CONSOLE_DEFAULT_MAX_PARALLEL_RUNS`` so a bad/blank
+        config value can never lock every session out of sending.
+
+        Returns:
+            The configured cap on simultaneous runs, floored at 1.
         """
-        raw = get_cli_setting("console", "max_parallel_runs", 3)
+        raw = get_cli_setting(
+            "console", "max_parallel_runs", CONSOLE_DEFAULT_MAX_PARALLEL_RUNS
+        )
         if raw is None:
-            return 3
+            return CONSOLE_DEFAULT_MAX_PARALLEL_RUNS
         try:
             value = int(raw)
         except (TypeError, ValueError):
-            value = 3
+            value = CONSOLE_DEFAULT_MAX_PARALLEL_RUNS
         return max(1, value)
 
     def send_refusal_copy(self, session_id: str) -> str | None:
@@ -837,6 +878,13 @@ class ConsoleChatController:
         (``ConsoleChatStore.close_session`` never touches the controller's
         map -- Task 1 review finding), and a session that no longer exists
         must not consume a cap slot or be named in the refusal copy.
+
+        Args:
+            session_id: The session id attempting to send.
+
+        Returns:
+            A human-readable refusal message if the send must be blocked
+            right now, otherwise ``None`` when the send is allowed.
         """
         if not self.run_state_for(session_id).is_send_allowed:
             return "A run is already running in this tab."
@@ -844,8 +892,9 @@ class ConsoleChatController:
         if len(busy_ids) < self.max_parallel_runs:
             return None
         live_sessions = {session.id: session for session in self.store.sessions()}
-        titles = [live_sessions[sid].title for sid in busy_ids[:3]]
-        suffix = f" and {len(busy_ids) - 3} more" if len(busy_ids) > 3 else ""
+        limit = CONSOLE_CAP_REFUSAL_TITLE_LIMIT
+        titles = [live_sessions[sid].title for sid in busy_ids[:limit]]
+        suffix = f" and {len(busy_ids) - limit} more" if len(busy_ids) > limit else ""
         return (
             f"{len(busy_ids)} agents already running "
             f"({', '.join(titles)}{suffix}). "
@@ -854,24 +903,80 @@ class ConsoleChatController:
 
     @property
     def run_state_history(self) -> list[ConsoleRunStatus]:
-        """The ACTIVE session's run-status history (read-only facade, mirrors ``run_state``)."""
+        """The ACTIVE session's run-status history (read-only facade, mirrors ``run_state``).
+
+        Returns:
+            The active session's list of recorded ``ConsoleRunStatus`` values.
+        """
         return self.run_state_history_for(self.store.active_session_id or "")
 
     def run_state_history_for(self, session_id: str) -> list[ConsoleRunStatus]:
-        """Return (creating if absent) ``session_id``'s run-status history."""
+        """Return (creating if absent) ``session_id``'s run-status history.
+
+        Args:
+            session_id: The session id to look up.
+
+        Returns:
+            The session's list of recorded ``ConsoleRunStatus`` values,
+            initialized to ``[ConsoleRunStatus.IDLE]`` when absent.
+        """
         return self._run_state_histories.setdefault(
             session_id, [ConsoleRunStatus.IDLE]
         )
 
-    async def submit_draft(self, draft: str) -> ConsoleSubmitResult:
-        """Submit a composer draft through native Console validation and provider resolution."""
-        active_rejection = self._active_run_rejection()
+    async def submit_draft(
+        self, draft: str, *, session_id: str | None = None
+    ) -> ConsoleSubmitResult:
+        """Submit a composer draft through native Console validation and provider resolution.
+
+        F4 fix (Qodo wave, parallel-agents spec §2): sends are dispatched
+        per-session -- ``chat_screen._dispatch_console_draft_send`` captures
+        the target session at DISPATCH time and threads it through
+        ``run_worker``'s coroutine args (see ``_submit_console_native_
+        draft``). Before this fix, this method always re-resolved "the
+        session to submit into" via ``store.ensure_session()``/
+        ``store.active_session_id`` at EXECUTION time instead -- a session
+        switch during the scheduling gap between ``run_worker(...)`` and
+        this coroutine's body actually running could silently submit the
+        draft into whichever session the user switched TO, not the one
+        that was showing when Send was pressed.
+
+        Args:
+            draft: The raw composer text to submit.
+            session_id: The session this draft was dispatched for, captured
+                by the caller at dispatch time. ``None`` (the default)
+                preserves the pre-fix behavior -- resolve/create the
+                CURRENTLY active session -- for direct-call test idioms and
+                other callers that have no per-session dispatch to capture.
+                An empty string is treated the same as ``None`` (the
+                dispatch-time sentinel for "no session existed yet").
+
+        Returns:
+            The submission outcome: ``accepted`` False (with an explanatory
+            ``visible_copy``) when blocked before any provider call, or
+            when ``session_id`` names a session that no longer exists by
+            the time this runs (see ``_session_closed_result``); ``True``
+            once the turn actually proceeds.
+        """
+        active_rejection = self._active_run_rejection(session_id=session_id)
         if active_rejection is not None:
             return active_rejection
 
-        session = self.store.ensure_session(
-            workspace_id=self.store.workspace_context.active_workspace_id,
-        )
+        if session_id:
+            session = next(
+                (s for s in self.store.sessions() if s.id == session_id), None
+            )
+            if session is None:
+                # The dispatching session was closed during the gap between
+                # dispatch and this coroutine actually running -- there is
+                # nothing left to submit into. Stamp the (now-orphaned)
+                # session id, never whatever is active now (see
+                # `_session_closed_result`'s own docstring).
+                return self._session_closed_result(session_id=session_id)
+        else:
+            session = self.store.ensure_session(
+                workspace_id=self.store.workspace_context.active_workspace_id,
+            )
         pendings = self.store.pending_attachments(session.id)
         attachment_mode_pendings = [
             pending
@@ -1354,12 +1459,19 @@ class ConsoleChatController:
         owner_id]``, captured by closure. Reading the shared flag from
         inside a specific run's loop let ANY session's Stop/Close silently
         truncate an unrelated, untouched session's still-streaming reply
-        (Fix round 1 finding). ``_stop_requested``'s remaining, INTENTIONAL
-        uses: ``shutdown()`` (global reach is correct there -- it stops
-        every session), and the three worker-thread approval/confirm
-        bridges' own best-effort check (see ``_is_active_session_
-        cancelled``), which predates per-session scoping and has its own,
-        narrower, documented limitation.
+        (Fix round 1 finding).
+
+        F5 fix (Qodo wave): the three worker-thread approval/confirm
+        bridges no longer read ``_stop_requested`` either (see
+        ``_is_active_session_cancelled``) -- a single session's Stop/Close
+        must not deny an unrelated session's in-flight approval round any
+        more than it may truncate an unrelated session's stream. Real
+        process teardown (``shutdown()``) is the one case where denying
+        every session's round at once is correct; that now goes through
+        the dedicated, never-reset ``_shutdown_requested`` instead.
+        ``_stop_requested`` itself is left set here for any other/legacy
+        reader (kept for back-compat; this method's own contract has
+        always been "set it," not "this is its only reader").
 
         ``_active_cancel_events[session_id]``, once set here, is never
         reset for that run, so a still-running bridge thread always
@@ -1378,38 +1490,40 @@ class ConsoleChatController:
         """Best-effort ADDITIONAL cancel-signal check for the three
         worker-thread approval/confirm bridges below (``request_mcp_
         approvals``, ``request_skill_install_confirm``, ``request_skill_
-        script_confirm``) -- OR'd with the shared ``_stop_requested`` flag
-        at each of their own poll sites (unchanged; an existing,
-        pre-Task-3b test (`test_request_mcp_approvals_cancellation_denies_
-        undecided`) asserts a bare ``_stop_requested = True`` flip is
-        itself sufficient to deny an approval round, so that OR-branch is
-        NOT removed here).
+        script_confirm``) -- OR'd with ``_shutdown_requested`` (F5 fix,
+        Qodo wave) at each of their own poll sites, no longer with the
+        shared, per-session-agnostic ``_stop_requested`` flag. That flag
+        also gets reset mid-run-lifecycle (``shutdown``/``_run_agent_
+        reply``/``_stream_assistant_response`` all reset it to ``False``
+        once their own run settles), which made whether a still-polling
+        bridge thread observed an earlier Stop a race, on top of any
+        session's Stop being able to deny an unrelated session's approval
+        round outright. ``_shutdown_requested`` is set exactly once, only
+        by ``shutdown()``, and never reset -- both problems solved for the
+        one case (real process teardown) where denying every round at
+        once actually is correct.
 
-        KNOWN LIMITATION (Task 3b): these bridges are plain bound-method
-        callbacks handed straight to ``ConsoleAgentBridge.run_reply``
-        (fixed arity -- ``approval_callback(pending)``,
-        ``confirm(url)``/``confirm(payload)`` -- no session id threaded
-        through), unlike ``should_cancel`` inside ``_run_agent_reply``
-        (Fix round 1: now reads ONLY its own run's ``cancel_event``, never
-        the shared flag). Falling back to the VIEWED session's cancel
-        event here (mirroring ``stop_active_run``'s own "the active
-        session" convention) is correct for the overwhelmingly common
-        single-run case.
+        KNOWN LIMITATION (Task 3b, unchanged by F5): these bridges are
+        plain bound-method callbacks handed straight to
+        ``ConsoleAgentBridge.run_reply`` (fixed arity --
+        ``approval_callback(pending)``, ``confirm(url)``/``confirm(
+        payload)`` -- no session id threaded through), unlike
+        ``should_cancel`` inside ``_run_agent_reply`` (Fix round 1: now
+        reads ONLY its own run's ``cancel_event``, never the shared flag).
+        Falling back to the VIEWED session's cancel event here (mirroring
+        ``stop_active_run``'s own "the active session" convention) is
+        correct for the overwhelmingly common single-run case.
 
-        Post-Fix-round-1 scope: the STREAM itself (content/completion) of
-        an unrelated session is no longer affected by any session's Stop
-        -- that was Critical 1, now fixed via per-run ``cancel_event``s
-        with no shared-flag fallback. The residual gap here is narrower
-        and specific to these three bridges: a BACKGROUND session's own
-        pending approval is not found by this VIEWED-session-only lookup
-        (so its own Stop isn't observed here), and -- because
-        ``_stop_requested`` is still OR'd in at each bridge's own poll
-        site, unchanged -- stopping ANY session still denies every
-        in-flight approval/confirm round for every session (a narrower,
-        approval-round-only version of the old poisoning, not a stream-
-        truncation bug). Properly scoping concurrent approvals/confirms to
-        their own run (both problems) is PA-T9 ("parked background
-        approvals").
+        Post-F5 scope: a session's Stop/Close no longer denies an
+        UNRELATED session's in-flight approval/confirm round (the bug this
+        fix addresses) -- only that session's own Stop (when it happens to
+        be the VIEWED one) or real shutdown does. The residual gap is
+        narrower and specific to these three bridges: a BACKGROUND
+        session's own pending approval is still not found by this
+        VIEWED-session-only lookup, so its own Stop still isn't observed
+        here (it times out instead, same as before). Properly scoping
+        concurrent approvals/confirms to their own run is PA-T9 ("parked
+        background approvals").
         """
         cancel_event = self._active_cancel_events.get(self.store.active_session_id or "")
         return cancel_event is not None and cancel_event.is_set()
@@ -1432,11 +1546,12 @@ class ConsoleChatController:
         cancel signals and a deadline every second until one of three things
         happens: the user submits a decision (``resolve_pending_approval``,
         called from the UI thread, sets the Event), the run is
-        cancelled/stopped/torn down (``_stop_requested``/
-        ``_is_active_session_cancelled()`` -- already wired by
-        ``stop_active_run``, ``close_session``, and ``shutdown`` via
-        ``_signal_stop``; see that helper's docstring for its VIEWED-
-        session limitation), or the configured approval timeout elapses.
+        cancelled/torn down (``_shutdown_requested``/``_is_active_session_
+        cancelled()`` -- F5 fix, Qodo wave: real process teardown or the
+        VIEWED session's own cancel event, no longer any session's bare
+        ``_stop_requested`` flip; see ``_is_active_session_cancelled``'s
+        docstring for the VIEWED-session limitation that remains), or the
+        configured approval timeout elapses.
         Whichever unique ``llm_name``
         never received an explicit decision by then fails closed to
         ``"deny"`` (cancellation) or ``"timeout"`` (deadline) -- see
@@ -1491,7 +1606,7 @@ class ConsoleChatController:
         try:
             self._marshal_pending_approval(payload)
             while not event.wait(_MCP_APPROVAL_POLL_SECONDS):
-                if self._stop_requested or self._is_active_session_cancelled():
+                if self._shutdown_requested.is_set() or self._is_active_session_cancelled():
                     # Finding I3: a stop/unmount that resolves THIS round
                     # denies every still-undecided call, but
                     # `run_agent_loop`'s own `should_cancel()` check fires
@@ -1791,7 +1906,7 @@ class ConsoleChatController:
         try:
             self._marshal_pending_skill_install(payload)
             while not event.wait(_MCP_APPROVAL_POLL_SECONDS):
-                if self._stop_requested or self._is_active_session_cancelled():
+                if self._shutdown_requested.is_set() or self._is_active_session_cancelled():
                     break
                 if time.monotonic() >= deadline:
                     break
@@ -1887,7 +2002,7 @@ class ConsoleChatController:
         try:
             self._marshal_pending_skill_script(card_payload)
             while not event.wait(_MCP_APPROVAL_POLL_SECONDS):
-                if self._stop_requested or self._is_active_session_cancelled():
+                if self._shutdown_requested.is_set() or self._is_active_session_cancelled():
                     break
                 if time.monotonic() >= deadline:
                     break
@@ -2062,7 +2177,14 @@ class ConsoleChatController:
         ``stop_active_run``'s manual signal-then-cancel fallback for every
         session with a live entry, rather than reusing ``stop_active_run``
         itself, which by contract only ever resolves the active session.
+
+        F5 fix (Qodo wave): sets ``_shutdown_requested`` unconditionally
+        and FIRST -- before the no-tasks early return below -- so a
+        worker-thread approval/confirm bridge polling on behalf of a run
+        this method doesn't (yet) see in ``_active_stream_tasks`` still
+        observes real process teardown.
         """
+        self._shutdown_requested.set()
         for message_id in tuple(self._original_attempts):
             self.clear_original_attempt(message_id)
         tasks = dict(self._active_stream_tasks)
@@ -4359,7 +4481,14 @@ class ConsoleChatController:
                         stream_signals=stream_signals,
                     )
                 except KeyError:
-                    return self._session_closed_result()
+                    # F4 fix (Qodo wave): `owner_id` was already resolved
+                    # above (line ~4290) and is in scope here, same as
+                    # every other guarded call site in this method -- the
+                    # bare no-arg call defaulted to whatever session is
+                    # ACTIVE right now, wrongly stamping a STOPPED run
+                    # state on an unrelated live session instead of this
+                    # run's own (now-orphaned) one.
+                    return self._session_closed_result(session_id=owner_id)
                 if selection.state == "canceled":
                     self._consume_one_shot_prefill(
                         assistant_message_id,
@@ -5227,14 +5356,20 @@ class ConsoleChatController:
                         stream_signals=stream_signals,
                     )
                 except KeyError:
-                    return self._session_closed_result()
+                    # F4 fix (Qodo wave): `session_id` is a REQUIRED
+                    # parameter of this method (always known, never
+                    # re-derived) -- the bare no-arg call defaulted to
+                    # whatever session is ACTIVE right now, wrongly
+                    # stamping a STOPPED run state on an unrelated live
+                    # session instead of this run's own owning session.
+                    return self._session_closed_result(session_id=session_id)
                 if selection.state == "canceled":
                     completed = self._ensure_assistant_placeholder(
                         assistant_message_id,
                         session_id,
                     )
                     if completed is None:
-                        return self._session_closed_result()
+                        return self._session_closed_result(session_id=session_id)
                     self._record_run_assistant_message(run_id, completed)
                     return ConsoleSubmitResult(
                         True,
@@ -5753,8 +5888,32 @@ class ConsoleChatController:
         )
         return ConsoleSubmitResult(True, True, visible_copy)
 
-    def _active_run_rejection(self) -> ConsoleSubmitResult | None:
-        if self.run_state.is_send_allowed:
+    def _active_run_rejection(
+        self, *, session_id: str | None = None
+    ) -> ConsoleSubmitResult | None:
+        """Defense-in-depth double-send guard for ``submit_draft``.
+
+        F4 fix (Qodo wave): accepts an optional ``session_id`` so
+        ``submit_draft`` can check the DISPATCHED session's own run state
+        rather than whichever session happens to be active right now (the
+        two can differ once a session switch races a background
+        dispatch -- see ``submit_draft``'s own docstring). Every
+        pre-existing caller (``retry_message``/``continue_from_message``/
+        etc., which operate only on the active session by construction --
+        each already blocks with "Open the original session..." if a
+        target message belongs elsewhere) omits ``session_id`` and keeps
+        checking the active session exactly as before.
+
+        Args:
+            session_id: The session to check, or ``None``/empty to check
+                the currently active session (the pre-fix behavior).
+
+        Returns:
+            ``None`` when a new send may proceed; otherwise a blocked
+            ``ConsoleSubmitResult`` carrying the refusal copy.
+        """
+        target_id = session_id if session_id else (self.store.active_session_id or "")
+        if self.run_state_for(target_id).is_send_allowed:
             return None
         return ConsoleSubmitResult(
             accepted=False,

--- a/tldw_chatbook/Chat/console_chat_models.py
+++ b/tldw_chatbook/Chat/console_chat_models.py
@@ -41,6 +41,16 @@ DEFAULT_CONSOLE_SESSION_TITLE = "Chat 1"
 CONSOLE_AUTO_TITLE_MAX_LENGTH = 30
 _DEFAULT_CONSOLE_SESSION_TITLE_RE = re.compile(r"^Chat \d+$")
 
+# Parallel-agents spec S4 (task-5): user-adjustable global cap on
+# simultaneous Console runs. Single source of truth for the default --
+# ConsoleChatController.max_parallel_runs reads it as the get_cli_setting
+# fallback, and settings_screen.py's DEFAULT_CONSOLE_MAX_PARALLEL_RUNS
+# aliases it so the settings UI and the controller can never drift apart.
+CONSOLE_DEFAULT_MAX_PARALLEL_RUNS = 3
+# send_refusal_copy names at most this many busy sessions before folding
+# the rest into an "and N more" suffix.
+CONSOLE_CAP_REFUSAL_TITLE_LIMIT = 3
+
 
 class ConsoleCitationPhase(str, Enum):
     """Approved structural phases for transient citation presentation."""

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -370,7 +370,6 @@ if TYPE_CHECKING:
     from tldw_chatbook.app import TldwCli
 
 logger = logger.bind(module="ChatScreen")
-CONSOLE_RUN_ALREADY_RUNNING_COPY = "A Console run is already running."
 CONSOLE_LIBRARY_RAG_SOURCE_SCOPE = ("notes", "media", "conversations")
 CONSOLE_LIBRARY_RAG_RECOVERY_COPY = "Review citations before sending."
 CONSOLE_LIBRARY_RAG_QUERY_MAX_LENGTH = 2_000
@@ -11308,11 +11307,10 @@ class ChatScreen(BaseAppScreen):
             self._focus_console_composer_if_needed(force=True)
             return False
         controller = self._ensure_console_chat_controller()
-        if not controller.run_state.is_send_allowed:
+        refusal = controller.send_refusal_copy(controller.store.active_session_id)
+        if refusal:
             self._restore_console_send_stash(stash)
-            self.app_instance.notify(
-                CONSOLE_RUN_ALREADY_RUNNING_COPY, severity="warning"
-            )
+            self.app_instance.notify(refusal, severity="warning")
             return False
         self._console_inflight_send_stash = stash
         self._note_console_follow_intent()
@@ -12269,10 +12267,9 @@ class ChatScreen(BaseAppScreen):
             # Gate BEFORE spawning: an exclusive console-run worker cancels any
             # in-flight run at creation time, before the controller's own
             # rejection can run -- refuse first, like the regenerate path.
-            if not controller.run_state.is_send_allowed:
-                self.app_instance.notify(
-                    CONSOLE_RUN_ALREADY_RUNNING_COPY, severity="warning"
-                )
+            refusal = controller.send_refusal_copy(controller.store.active_session_id)
+            if refusal:
+                self.app_instance.notify(refusal, severity="warning")
                 return
             self.run_worker(
                 self._summarize_console_up_to(controller, choice.message_id),
@@ -12283,10 +12280,9 @@ class ChatScreen(BaseAppScreen):
         if choice.kind != "restore":
             return
         controller = self._ensure_console_chat_controller()
-        if not controller.run_state.is_send_allowed:
-            self.app_instance.notify(
-                CONSOLE_RUN_ALREADY_RUNNING_COPY, severity="warning"
-            )
+        refusal = controller.send_refusal_copy(controller.store.active_session_id)
+        if refusal:
+            self.app_instance.notify(refusal, severity="warning")
             return
         try:
             path = store.active_path_message_ids(session_id)
@@ -13291,10 +13287,9 @@ class ChatScreen(BaseAppScreen):
             # Gate BEFORE spawning: an exclusive console-run worker cancels the
             # in-flight run at creation time, before the controller's own
             # rejection can run — the screen must refuse, like the submit path.
-            if not controller.run_state.is_send_allowed:
-                self.app_instance.notify(
-                    CONSOLE_RUN_ALREADY_RUNNING_COPY, severity="warning"
-                )
+            refusal = controller.send_refusal_copy(controller.store.active_session_id)
+            if refusal:
+                self.app_instance.notify(refusal, severity="warning")
                 return True
             self.run_worker(
                 self._retry_console_message(controller, message_id),
@@ -13312,10 +13307,9 @@ class ChatScreen(BaseAppScreen):
                 await self._regenerate_console_generation_variant(message_id)
                 return True
             controller = self._ensure_console_chat_controller()
-            if not controller.run_state.is_send_allowed:
-                self.app_instance.notify(
-                    CONSOLE_RUN_ALREADY_RUNNING_COPY, severity="warning"
-                )
+            refusal = controller.send_refusal_copy(controller.store.active_session_id)
+            if refusal:
+                self.app_instance.notify(refusal, severity="warning")
                 return True
             self.run_worker(
                 self._regenerate_console_message(controller, message_id),
@@ -13401,10 +13395,9 @@ class ChatScreen(BaseAppScreen):
             return True
         if action_id == "continue" and result.status == "continue_requested":
             controller = self._ensure_console_chat_controller()
-            if not controller.run_state.is_send_allowed:
-                self.app_instance.notify(
-                    CONSOLE_RUN_ALREADY_RUNNING_COPY, severity="warning"
-                )
+            refusal = controller.send_refusal_copy(controller.store.active_session_id)
+            if refusal:
+                self.app_instance.notify(refusal, severity="warning")
                 return True
             self.run_worker(
                 self._continue_console_message(controller, message_id),
@@ -13945,10 +13938,9 @@ class ChatScreen(BaseAppScreen):
             # Gate BEFORE spawning: an exclusive console-run worker cancels the
             # in-flight run at creation time, before the controller's own
             # rejection can run -- the screen must refuse, like the submit path.
-            if not controller.run_state.is_send_allowed:
-                self.app_instance.notify(
-                    CONSOLE_RUN_ALREADY_RUNNING_COPY, severity="warning"
-                )
+            refusal = controller.send_refusal_copy(controller.store.active_session_id)
+            if refusal:
+                self.app_instance.notify(refusal, severity="warning")
                 return
             self.run_worker(
                 self._edit_resend_console_message(

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -2030,8 +2030,31 @@ class ChatScreen(BaseAppScreen):
         self._console_effective_scope_cache: Dict[str, ConsoleRetrievalScopeState] = {}
         # TASK-340: keyboard-send draft stashes — keypress->handler handoff,
         # then the queued submit's accept/refuse consumption slot.
+        # `_console_pending_send_stash` stays a single slot: it is consumed
+        # within the same keypress -> Button.press() handoff for whichever
+        # composer currently has focus (bounded to one UI action, never
+        # spans a provider round-trip), unlike the map below.
         self._console_pending_send_stash: ConsoleDraftStash | None = None
-        self._console_inflight_send_stash: ConsoleDraftStash | None = None
+        # Task 3b: PER-SESSION -- a keyboard send's stash is written at
+        # dispatch (keyed by the dispatching session) and read/cleared much
+        # later, at that SAME session's own accept/refuse (`_notify_
+        # submission_accepted` fires only after the provider-readiness
+        # probe/skill-substitution awaits, which can run for seconds). A
+        # single shared slot let a DIFFERENT session's concurrent dispatch
+        # clobber this one's entry mid-flight (Task 3 made that genuinely
+        # concurrent) -- e.g. session A's still-pending stash getting
+        # silently replaced by session B's `None`, or a stale entry
+        # restoring/clearing the WRONG session's composer. See
+        # `_console_submit_session_by_task` for how the no-arg
+        # `on_submission_accepted` hook still resolves its own session.
+        self._console_inflight_send_stashes: dict[str, ConsoleDraftStash] = {}
+        #: `asyncio.Task -> owning session id`, registered for the duration
+        #: of `_submit_console_native_draft`'s own `await controller.
+        #: submit_draft(...)` call so the no-arg `on_submission_accepted`
+        #: callback (fired synchronously from deep inside that same await,
+        #: on the SAME task) can resolve which session's stash entry above
+        #: is its own, without changing that hook's public no-arg contract.
+        self._console_submit_session_by_task: dict[asyncio.Task, str] = {}
         # TASK-339: (visible session id, draft text, edit serial) captured at
         # switch initiation; consumed by the deferred draft swap.
         self._console_draft_switch_snapshot: tuple[str | None, str, int] | None = None
@@ -11021,22 +11044,37 @@ class ChatScreen(BaseAppScreen):
             self._record_ui_timer_stopped("console-transcript-sync")
             self._console_transcript_sync_timer = None
 
-    async def _submit_console_native_draft(self, draft: str) -> None:
+    async def _submit_console_native_draft(
+        self, draft: str, session_id: str | None = None
+    ) -> None:
         controller = self._ensure_console_chat_controller()
         self._start_console_transcript_sync_timer()
+        # Task 3b: `session_id` is the session THIS worker was dispatched
+        # for (`_dispatch_console_draft_send` already resolved it via the
+        # `console-run-{session_id}` group). Defaulted to the currently
+        # active session only for direct-call test idioms that predate the
+        # per-session stash map -- equivalent to the old singular-slot
+        # behavior for the (overwhelmingly common) single-session case.
+        if session_id is None:
+            session_id = controller.store.active_session_id or ""
+        task = asyncio.current_task()
+        if task is not None:
+            # See `_on_console_submission_accepted`: it fires synchronously
+            # from deep inside the `submit_draft` await below, on this SAME
+            # task, and has no session id of its own to key by.
+            self._console_submit_session_by_task[task] = session_id
         # TASK-340: a keyboard send already cleared the composer at the Enter
         # keypress. The accepted-hook consumes this slot; a refusal below
         # restores it instead. Snapshot before submit_draft so the hook's
         # consumption is observable here.
-        inflight_stash = self._console_inflight_send_stash
+        inflight_stash = self._console_inflight_send_stashes.get(session_id)
         try:
             result = await controller.submit_draft(draft)
         except Exception:
             # An unexpected submit crash must not eat the keypress-cleared
             # draft — and must not escape the worker (exit_on_error would
             # take the whole app down with it).
-            leaked_stash = self._console_inflight_send_stash
-            self._console_inflight_send_stash = None
+            leaked_stash = self._console_inflight_send_stashes.pop(session_id, None)
             if leaked_stash is not None:
                 self._restore_console_send_stash(leaked_stash)
             logger.exception("Console submit failed unexpectedly")
@@ -11045,6 +11083,9 @@ class ChatScreen(BaseAppScreen):
                 severity="error",
             )
             return
+        finally:
+            if task is not None:
+                self._console_submit_session_by_task.pop(task, None)
         # TASK-251: a submit may have created/updated a persisted
         # conversation (title, updated_at) -- invalidate so the browser
         # reflects it on the very next sync instead of the TTL window.
@@ -11053,18 +11094,22 @@ class ChatScreen(BaseAppScreen):
             composer = self.query_one("#console-native-composer", ConsoleComposerBar)
         except QueryError:
             composer = None
-        if not result.accepted and self._console_inflight_send_stash is not None:
+        # Task 3b: only the composer that STILL SHOWS this session gets
+        # mutated on its behalf. A background session's dispatch can
+        # complete long after the user switched away -- restoring an
+        # abandoned draft (or clearing should_clear_draft below) into
+        # whatever composer happens to be visible would leak this
+        # session's text into a DIFFERENT session's tab.
+        composer_reflects_session = (
+            composer is not None and controller.store.active_session_id == session_id
+        )
+        stash = self._console_inflight_send_stashes.pop(session_id, None)
+        if not result.accepted and stash is not None and composer_reflects_session:
             # Controller-level refusal of a keyboard send: the composer was
             # cleared at the keypress, so hand the draft back (ahead of any
             # keystrokes typed since).
-            if composer is not None:
-                composer.restore_stashed_draft(self._console_inflight_send_stash)
-        self._console_inflight_send_stash = None
-        if (
-            result.should_clear_draft
-            and composer is not None
-            and inflight_stash is None
-        ):
+            composer.restore_stashed_draft(stash)
+        if result.should_clear_draft and composer_reflects_session and inflight_stash is None:
             # Stashed sends were cleared at the keypress — clearing again
             # here would eat keystrokes typed after Enter (the next draft).
             composer.clear_draft()
@@ -11091,17 +11136,35 @@ class ChatScreen(BaseAppScreen):
         actually proceeds (Qodo finding 3, PR #636 bot review) -- a
         substitution refusal, like any other blocked submit, never reaches
         it, so a refused draft stays in the composer too.
+
+        Task 3b: this fires synchronously from deep inside ``submit_draft``,
+        on the SAME task as the ``_submit_console_native_draft`` worker that
+        awaited it -- ``_console_submit_session_by_task`` resolves which
+        session's stash entry (if any) is this call's own, without changing
+        this hook's public no-arg ``Callable[[], None]`` contract (still
+        assignable via ``controller.on_submission_accepted = ...`` exactly
+        as before). A lookup miss (direct-call test idioms, or no wrapping
+        task) falls back to the active session -- the pre-Task-3b behavior.
         """
         try:
             composer = self.query_one("#console-native-composer", ConsoleComposerBar)
         except QueryError:
             composer = None
-        if self._console_inflight_send_stash is not None:
+        task = asyncio.current_task()
+        session_id = (
+            self._console_submit_session_by_task.get(task)
+            if task is not None
+            else None
+        )
+        active_session_id = self._ensure_console_chat_store().active_session_id or ""
+        if session_id is None:
+            session_id = active_session_id
+        if session_id in self._console_inflight_send_stashes:
             # TASK-340: this submit's draft was captured and cleared at the
             # Enter keypress — clearing now would eat keystrokes typed since
             # (they are the NEXT draft). Consume the stash instead.
-            self._console_inflight_send_stash = None
-        elif composer is not None:
+            self._console_inflight_send_stashes.pop(session_id, None)
+        elif composer is not None and active_session_id == session_id:
             composer.clear_draft()
         # task-351(a): echo the just-appended USER message immediately rather
         # than waiting up to a full 0.2s transcript-poll cycle (and a heavy
@@ -11313,7 +11376,15 @@ class ChatScreen(BaseAppScreen):
             self._restore_console_send_stash(stash)
             self.app_instance.notify(refusal, severity="warning")
             return False
-        self._console_inflight_send_stash = stash
+        # Task 3b: keyed by THIS dispatch's own session -- a bare `= stash`
+        # assignment (the old singular slot) would let a DIFFERENT
+        # session's concurrent dispatch either clobber this entry with its
+        # own stash, or wipe it to None before this session's worker ever
+        # reads it (Task 3 made two dispatches genuinely interleave).
+        if stash is not None:
+            self._console_inflight_send_stashes[target_session_id] = stash
+        else:
+            self._console_inflight_send_stashes.pop(target_session_id, None)
         self._note_console_follow_intent()
         # group=f"console-run-{session_id}": a PER-SESSION group (parallel-
         # agents spec Sec2) so UI-sync kicks -- and sends in OTHER sessions --
@@ -11321,14 +11392,25 @@ class ChatScreen(BaseAppScreen):
         # the dedicated group; scoping it per session keeps concurrent
         # sessions' exclusive workers from cancelling each other).
         self.run_worker(
-            self._submit_console_native_draft(draft),
+            self._submit_console_native_draft(draft, target_session_id),
             exclusive=True,
             group=f"console-run-{target_session_id}",
         )
         return True
 
     def _note_console_follow_intent(self) -> None:
-        """Stamp a programmatic jump-to-tail intent on the transcript (TASK-336)."""
+        """Stamp a programmatic jump-to-tail intent on the transcript (TASK-336).
+
+        Task 3b audit: stays singular/view-only on purpose. Unlike the
+        stash maps above, this never carries session-owned DATA across a
+        send's lifetime -- it is a one-shot directive consumed by whichever
+        session's transcript happens to be `#console-native-transcript`
+        (a single widget instance reflecting the ACTIVE session) at the
+        next render. A background session's send stamping this while a
+        different session is viewed just requests an extra, harmless
+        tail-follow on whatever the transcript renders next; there is no
+        cross-session data to leak or clobber.
+        """
         try:
             transcript = self.query_one(
                 "#console-native-transcript", ConsoleTranscript

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -11307,20 +11307,23 @@ class ChatScreen(BaseAppScreen):
             self._focus_console_composer_if_needed(force=True)
             return False
         controller = self._ensure_console_chat_controller()
-        refusal = controller.send_refusal_copy(controller.store.active_session_id)
+        target_session_id = controller.store.active_session_id
+        refusal = controller.send_refusal_copy(target_session_id)
         if refusal:
             self._restore_console_send_stash(stash)
             self.app_instance.notify(refusal, severity="warning")
             return False
         self._console_inflight_send_stash = stash
         self._note_console_follow_intent()
-        # group="console-run": a dedicated group so UI-sync kicks can never
-        # cancel an in-flight run (TASK-228 — ungrouped exclusive workers all
-        # share Textual's default group and cancel each other).
+        # group=f"console-run-{session_id}": a PER-SESSION group (parallel-
+        # agents spec Sec2) so UI-sync kicks -- and sends in OTHER sessions --
+        # can never cancel this session's in-flight run (TASK-228 originated
+        # the dedicated group; scoping it per session keeps concurrent
+        # sessions' exclusive workers from cancelling each other).
         self.run_worker(
             self._submit_console_native_draft(draft),
             exclusive=True,
-            group="console-run",
+            group=f"console-run-{target_session_id}",
         )
         return True
 
@@ -12237,8 +12240,8 @@ class ChatScreen(BaseAppScreen):
         selected prompt's own text is written back into the composer via the
         same paste-semantics seam `/prompt` uses.
         `"summarize-up-to"` runs the boundary-summary flow (SP2 Task 3) on an
-        exclusive `console-run` worker, gated on `is_send_allowed` the same way
-        restore is (never mutates while a run is streaming).
+        exclusive `console-run-{session_id}` worker, gated on `is_send_allowed`
+        the same way restore is (never mutates while a run is streaming).
 
         A `ModalScreen` blocks session switching while the rewind modal is up,
         so today this is theoretical -- but the callback still re-checks the
@@ -12267,14 +12270,15 @@ class ChatScreen(BaseAppScreen):
             # Gate BEFORE spawning: an exclusive console-run worker cancels any
             # in-flight run at creation time, before the controller's own
             # rejection can run -- refuse first, like the regenerate path.
-            refusal = controller.send_refusal_copy(controller.store.active_session_id)
+            target_session_id = controller.store.active_session_id
+            refusal = controller.send_refusal_copy(target_session_id)
             if refusal:
                 self.app_instance.notify(refusal, severity="warning")
                 return
             self.run_worker(
                 self._summarize_console_up_to(controller, choice.message_id),
                 exclusive=True,
-                group="console-run",
+                group=f"console-run-{target_session_id}",
             )
             return
         if choice.kind != "restore":
@@ -13287,14 +13291,15 @@ class ChatScreen(BaseAppScreen):
             # Gate BEFORE spawning: an exclusive console-run worker cancels the
             # in-flight run at creation time, before the controller's own
             # rejection can run — the screen must refuse, like the submit path.
-            refusal = controller.send_refusal_copy(controller.store.active_session_id)
+            target_session_id = controller.store.active_session_id
+            refusal = controller.send_refusal_copy(target_session_id)
             if refusal:
                 self.app_instance.notify(refusal, severity="warning")
                 return True
             self.run_worker(
                 self._retry_console_message(controller, message_id),
                 exclusive=True,
-                group="console-run",
+                group=f"console-run-{target_session_id}",
             )
             return True
         if action_id == "regenerate" and result.status == "wip":
@@ -13307,14 +13312,15 @@ class ChatScreen(BaseAppScreen):
                 await self._regenerate_console_generation_variant(message_id)
                 return True
             controller = self._ensure_console_chat_controller()
-            refusal = controller.send_refusal_copy(controller.store.active_session_id)
+            target_session_id = controller.store.active_session_id
+            refusal = controller.send_refusal_copy(target_session_id)
             if refusal:
                 self.app_instance.notify(refusal, severity="warning")
                 return True
             self.run_worker(
                 self._regenerate_console_message(controller, message_id),
                 exclusive=True,
-                group="console-run",
+                group=f"console-run-{target_session_id}",
             )
             return True
         if (
@@ -13395,14 +13401,15 @@ class ChatScreen(BaseAppScreen):
             return True
         if action_id == "continue" and result.status == "continue_requested":
             controller = self._ensure_console_chat_controller()
-            refusal = controller.send_refusal_copy(controller.store.active_session_id)
+            target_session_id = controller.store.active_session_id
+            refusal = controller.send_refusal_copy(target_session_id)
             if refusal:
                 self.app_instance.notify(refusal, severity="warning")
                 return True
             self.run_worker(
                 self._continue_console_message(controller, message_id),
                 exclusive=True,
-                group="console-run",
+                group=f"console-run-{target_session_id}",
             )
             return True
         severity = "information" if result.status in {"completed", "wip"} else "warning"
@@ -13938,7 +13945,8 @@ class ChatScreen(BaseAppScreen):
             # Gate BEFORE spawning: an exclusive console-run worker cancels the
             # in-flight run at creation time, before the controller's own
             # rejection can run -- the screen must refuse, like the submit path.
-            refusal = controller.send_refusal_copy(controller.store.active_session_id)
+            target_session_id = controller.store.active_session_id
+            refusal = controller.send_refusal_copy(target_session_id)
             if refusal:
                 self.app_instance.notify(refusal, severity="warning")
                 return
@@ -13947,7 +13955,7 @@ class ChatScreen(BaseAppScreen):
                     controller, message_id, result.text
                 ),
                 exclusive=True,
-                group="console-run",
+                group=f"console-run-{target_session_id}",
             )
 
         await self.app.push_screen(

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -11370,7 +11370,13 @@ class ChatScreen(BaseAppScreen):
             self._focus_console_composer_if_needed(force=True)
             return False
         controller = self._ensure_console_chat_controller()
-        target_session_id = controller.store.active_session_id
+        # Fix round 1 (minor): normalize the same way the controller side
+        # already does (`store.active_session_id or ""`) -- `None` is a
+        # valid (if unlikely, post-mount) dict key, but every other
+        # per-session map in this train keys on the normalized string, so
+        # a stray `None` here would silently start a SEPARATE bucket for
+        # "no session" instead of colliding predictably.
+        target_session_id = controller.store.active_session_id or ""
         refusal = controller.send_refusal_copy(target_session_id)
         if refusal:
             self._restore_console_send_stash(stash)

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -10999,20 +10999,55 @@ class ChatScreen(BaseAppScreen):
             streaming_session_id=streaming_session_id,
         )
 
-    async def _append_native_console_system_message(self, message: str) -> None:
-        """Append a system message to native Console state and refresh the bridge."""
+    async def _append_native_console_system_message(
+        self, message: str, *, session_id: str | None = None
+    ) -> None:
+        """Append a system message to native Console state and refresh the bridge.
+
+        Task 4 (background-write audit): most callers are synchronous
+        command handlers with no ``await`` between "the user's intended
+        session" and this call, so the default (``session_id=None``,
+        resolving whichever session is active RIGHT NOW via
+        ``store.ensure_session``) is safe -- there is no gap in which the
+        active session could have changed underneath them.
+
+        A handler that spans a real await gap while already anchored to a
+        specific session (e.g. `/generate-image`'s in-flight batch, tracked
+        per session in ``_console_imagegen_inflight_sessions``) must pass
+        that session's id explicitly instead -- re-resolving "active" at
+        append time would let a session switch during the awaited work
+        misattribute the row to whatever the user is looking at NOW rather
+        than the session that actually produced it. The resync below is
+        unconditional either way and stays harmless: it only ever renders
+        the store's CURRENTLY active session, so a background session's
+        just-appended row simply doesn't show until the user visits it
+        (store-first discipline; no view write needs gating here beyond
+        that existing pull-based rebuild).
+        """
         store = self._ensure_console_chat_store()
-        session = store.ensure_session(
-            title=self._console_initial_session_title_for_workspace(
-                store.workspace_context.active_workspace_id
-            ),
-            workspace_id=store.workspace_context.active_workspace_id,
-        )
-        store.append_message(
-            session.id,
-            role=ConsoleMessageRole.SYSTEM,
-            content=message,
-        )
+        if session_id is not None:
+            try:
+                store.append_message(
+                    session_id,
+                    role=ConsoleMessageRole.SYSTEM,
+                    content=message,
+                )
+            except KeyError:
+                # Session vanished (closed) before its background operation's
+                # outcome could be attributed to it -- nothing to append to.
+                pass
+        else:
+            session = store.ensure_session(
+                title=self._console_initial_session_title_for_workspace(
+                    store.workspace_context.active_workspace_id
+                ),
+                workspace_id=store.workspace_context.active_workspace_id,
+            )
+            store.append_message(
+                session.id,
+                role=ConsoleMessageRole.SYSTEM,
+                content=message,
+            )
         await self._sync_native_console_chat_ui()
 
     def _start_console_transcript_sync_timer(self) -> None:
@@ -12075,14 +12110,24 @@ class ChatScreen(BaseAppScreen):
             prepare_generation_request, args, conversation_pairs, llm_context
         )
         if isinstance(prepared, GenerationRefusal):
-            await self._append_native_console_system_message(prepared.reason)
+            # Task 4 (background-write audit): every append below threads
+            # `session_id=session.id` explicitly -- this handler already
+            # spans real await gaps (the two `asyncio.to_thread` calls
+            # above/below), and `session` is this batch's owning session,
+            # captured once at the top. Re-resolving "active" implicitly
+            # (the old behavior) would misattribute the outcome to whatever
+            # session the user switched to while the batch was running.
+            await self._append_native_console_system_message(
+                prepared.reason, session_id=session.id
+            )
             return
         backend = args.backend or cfg.default_backend
         if not backend:
             await self._append_native_console_system_message(
                 "No image generation backend configured. Set "
                 "[image_generation].default_backend, or use "
-                "/generate-image :backend <prompt>."
+                "/generate-image :backend <prompt>.",
+                session_id=session.id,
             )
             return
         catalog = list_image_models_for_catalog()
@@ -12092,13 +12137,15 @@ class ChatScreen(BaseAppScreen):
         if entry is None or not entry.get("is_configured"):
             await self._append_native_console_system_message(
                 f"Image backend '{backend}' is not enabled/configured. "
-                "Check [image_generation] settings."
+                "Check [image_generation] settings.",
+                session_id=session.id,
             )
             return
         inflight = self._console_imagegen_inflight_sessions()
         if session.id in inflight:
             await self._append_native_console_system_message(
-                "An image generation is already running for this session."
+                "An image generation is already running for this session.",
+                session_id=session.id,
             )
             return
         inflight.add(session.id)
@@ -12128,7 +12175,7 @@ class ChatScreen(BaseAppScreen):
                     composer.insert_text_as_paste(saved_draft)
                 detail = "; ".join(batch.errors) or "unknown error"
                 await self._append_native_console_system_message(
-                    f"Image generation failed: {detail}"
+                    f"Image generation failed: {detail}", session_id=session.id
                 )
                 return
             store.append_generation_message(
@@ -12161,7 +12208,7 @@ class ChatScreen(BaseAppScreen):
                 f"Image generation batch raised for session {session.id}: {exc}"
             )
             await self._append_native_console_system_message(
-                f"Image generation failed: {exc}"
+                f"Image generation failed: {exc}", session_id=session.id
             )
         finally:
             inflight.discard(session.id)

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -11104,7 +11104,14 @@ class ChatScreen(BaseAppScreen):
         # consumption is observable here.
         inflight_stash = self._console_inflight_send_stashes.get(session_id)
         try:
-            result = await controller.submit_draft(draft)
+            # F4 fix (Qodo wave): thread the session THIS worker was
+            # dispatched for all the way into the controller -- previously
+            # `submit_draft` re-resolved "the session to submit into" via
+            # `store.active_session_id` at execution time, so a tab switch
+            # racing the scheduling gap between `run_worker(...)` and this
+            # coroutine body actually running could submit into whichever
+            # session the user switched TO instead of the dispatching one.
+            result = await controller.submit_draft(draft, session_id=session_id)
         except Exception:
             # An unexpected submit crash must not eat the keypress-cleared
             # draft — and must not escape the worker (exit_on_error would

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -293,8 +293,16 @@ CONSOLE_BEHAVIOR_CONSOLE_KEYS = frozenset(
     {
         "collapse_large_pastes",
         "paste_collapse_threshold",
+        "max_parallel_runs",
     }
 )
+# Parallel-agents spec S4 (task-5): user-adjustable global cap on
+# simultaneous Console runs. Mirrors console_chat_controller.py's own
+# fallback -- see ConsoleChatController.max_parallel_runs, which reads
+# [console] max_parallel_runs via get_cli_setting with the same default and
+# floor. No upper bound is deliberate (user-owned trade-off).
+DEFAULT_CONSOLE_MAX_PARALLEL_RUNS = 3
+MIN_CONSOLE_MAX_PARALLEL_RUNS = 1
 CONSOLE_BACKGROUND_EFFECT_KEYS = frozenset(
     {
         "background_effects.enabled",
@@ -348,6 +356,7 @@ CONSOLE_BEHAVIOR_CHAT_DEFAULT_KEYS = frozenset(
 CONSOLE_BEHAVIOR_SAVE_ORDER = (
     "collapse_large_pastes",
     "paste_collapse_threshold",
+    "max_parallel_runs",
     "streaming",
     "temperature",
     "top_p",
@@ -1480,6 +1489,7 @@ class SettingsScreen(BaseAppScreen):
         self._syncing_provider_manual = False
         self._syncing_provider_selection = False
         self._syncing_console_threshold = False
+        self._syncing_console_max_parallel_runs = False
         self._syncing_console_defaults = False
         self._syncing_console_background_effects = False
         self._syncing_library_rag_defaults = False
@@ -2356,6 +2366,7 @@ class SettingsScreen(BaseAppScreen):
                 owns_config_sections=(
                     "console.collapse_large_pastes",
                     "console.paste_collapse_threshold",
+                    "console.max_parallel_runs",
                     "console.background_effects.*",
                     "chat_defaults.streaming",
                     "chat_defaults.temperature",
@@ -2495,6 +2506,18 @@ class SettingsScreen(BaseAppScreen):
             maximum=MAX_CONSOLE_PASTE_COLLAPSE_THRESHOLD,
         )
 
+    def _loaded_console_max_parallel_runs(self) -> int:
+        # No maximum -- deliberately unbounded (user-owned trade-off), see
+        # DEFAULT_CONSOLE_MAX_PARALLEL_RUNS's docstring.
+        return coerce_int_setting(
+            self._console_settings().get(
+                "max_parallel_runs",
+                DEFAULT_CONSOLE_MAX_PARALLEL_RUNS,
+            ),
+            DEFAULT_CONSOLE_MAX_PARALLEL_RUNS,
+            minimum=MIN_CONSOLE_MAX_PARALLEL_RUNS,
+        )
+
     @staticmethod
     def _coerce_float_default(
         value: object,
@@ -2598,6 +2621,7 @@ class SettingsScreen(BaseAppScreen):
         return {
             "collapse_large_pastes": self._loaded_collapse_large_pastes_enabled(),
             "paste_collapse_threshold": self._loaded_paste_collapse_threshold(),
+            "max_parallel_runs": self._loaded_console_max_parallel_runs(),
             "streaming": self._loaded_console_default_streaming(),
             "temperature": self._loaded_console_default_temperature(),
             "top_p": self._loaded_console_default_top_p(),
@@ -2747,6 +2771,12 @@ class SettingsScreen(BaseAppScreen):
         except ValueError:
             return f"Invalid threshold: {value}"
         return f"{threshold} characters"
+
+    def _console_max_parallel_runs_value(self) -> int | str:
+        draft = self._settings_drafts.get(SettingsCategoryId.CONSOLE_BEHAVIOR)
+        if draft is not None and "max_parallel_runs" in draft.values:
+            return draft.values["max_parallel_runs"]
+        return self._loaded_console_max_parallel_runs()
 
     def _update_console_paste_summary(self) -> None:
         try:
@@ -4000,6 +4030,82 @@ class SettingsScreen(BaseAppScreen):
         )
         if not draft.is_dirty:
             self._settings_drafts.pop(category, None)
+
+    def _normalise_console_max_parallel_runs(self, value: object) -> int:
+        # Parallel-agents spec S4 (task-5): integer, >= 1, no upper bound --
+        # mirrors ConsoleChatController.max_parallel_runs' own floor.
+        text_value = str(value).strip()
+        if not text_value.isdigit() or int(text_value) < MIN_CONSOLE_MAX_PARALLEL_RUNS:
+            raise ValueError(
+                "Max parallel agent runs must be an integer of at least "
+                f"{MIN_CONSOLE_MAX_PARALLEL_RUNS}."
+            )
+        return int(text_value)
+
+    def _stage_console_max_parallel_runs_value(self, value: object) -> None:
+        category = SettingsCategoryId.CONSOLE_BEHAVIOR
+        draft = self._settings_drafts.setdefault(
+            category, SettingsDraft(category=category)
+        )
+        try:
+            staged_value: object = self._normalise_console_max_parallel_runs(value)
+        except ValueError:
+            staged_value = str(value)
+        draft.set_value(
+            "max_parallel_runs",
+            self._loaded_console_max_parallel_runs(),
+            staged_value,
+        )
+        if not draft.is_dirty:
+            self._settings_drafts.pop(category, None)
+
+    def _console_behavior_field_guidance_rows(self) -> tuple[tuple[str, str], ...]:
+        """Focused-field guidance for Console Behavior (task-5).
+
+        Only the "Max parallel agent runs" field has dedicated guidance
+        today; other Console Behavior fields keep the always-visible
+        "Control guide" static block rendered in
+        `_render_category_impact_pane` instead of per-field guidance.
+        """
+        if self._active_settings_field_id == "settings-console-max-parallel-runs":
+            return (
+                (
+                    "Purpose",
+                    "How many agent runs may be in flight at once, across all tabs.",
+                ),
+                (
+                    "Consequences",
+                    "Each concurrent run holds a provider generation, its own tool "
+                    "activity, and memory for its transcript. Local providers "
+                    "(llama.cpp) typically serialize or slow under concurrent "
+                    "generations; high values can exhaust provider slots, rate "
+                    "limits, or RAM. Raise it as far as you like - the app "
+                    "enforces no ceiling.",
+                ),
+                ("Saved as", "console.max_parallel_runs"),
+                (
+                    "Applies",
+                    "Applies to new sends on save; running agents are never "
+                    "stopped by lowering it.",
+                ),
+            )
+        return (
+            ("Purpose", "Focus a Console Behavior field for setting-specific guidance."),
+            ("Consequences", "No field-specific guidance is active right now."),
+            ("Saved as", "varies by field"),
+            ("Applies", "varies by field"),
+        )
+
+    def _refresh_console_behavior_field_guidance(self) -> None:
+        if self._active_category_id() is not SettingsCategoryId.CONSOLE_BEHAVIOR:
+            return
+        for index, (label, value) in enumerate(
+            self._console_behavior_field_guidance_rows()
+        ):
+            self._set_static_text(
+                f"#settings-console-behavior-field-guide-{index}",
+                f"{label}: {value}",
+            )
 
     @staticmethod
     def _normalise_library_rag_int(value: object) -> int | str:
@@ -8679,6 +8785,18 @@ class SettingsScreen(BaseAppScreen):
                 "Normal typing stays literal. The canonical message payload is preserved.",
                 id="settings-console-collapse-large-pastes-help",
             )
+            yield Static("Parallel agent runs", classes="destination-section")
+            with Horizontal(classes="settings-input-row"):
+                yield Static(
+                    "Max parallel agent runs", classes="settings-input-label"
+                )
+                yield Input(
+                    value=str(self._console_max_parallel_runs_value()),
+                    id="settings-console-max-parallel-runs",
+                    classes="settings-compact-input",
+                    placeholder=str(DEFAULT_CONSOLE_MAX_PARALLEL_RUNS),
+                    restrict=r"^[0-9]*$",
+                )
             yield Static("Global fallback defaults", classes="destination-section")
             yield Static(
                 "Used when no provider+model profile or active Console session overrides them.",
@@ -10869,6 +10987,15 @@ class SettingsScreen(BaseAppScreen):
                 "Threshold",
                 "Minimum pasted chunk size before collapse",
             )
+            yield Static("Focused field guide", classes="destination-section")
+            for index, (label, value) in enumerate(
+                self._console_behavior_field_guidance_rows()
+            ):
+                yield self._detail_row(
+                    label,
+                    value,
+                    identifier=f"settings-console-behavior-field-guide-{index}",
+                )
             yield Static("Override rules", classes="destination-section")
             yield self._detail_row(
                 "Priority",
@@ -11432,6 +11559,16 @@ class SettingsScreen(BaseAppScreen):
             )
             self._refresh_rag_field_guidance()
             return
+        if active_category is SettingsCategoryId.CONSOLE_BEHAVIOR:
+            # task-5: only the "Max parallel agent runs" field has dedicated
+            # focused-field guidance today; other Console Behavior fields
+            # keep the always-visible "Control guide" static block.
+            console_behavior_field_ids = {"settings-console-max-parallel-runs"}
+            self._active_settings_field_id = (
+                widget_id if widget_id in console_behavior_field_ids else None
+            )
+            self._refresh_console_behavior_field_guidance()
+            return
         if active_category is not SettingsCategoryId.PROVIDERS_MODELS:
             self._active_settings_field_id = None
             return
@@ -11990,6 +12127,17 @@ class SettingsScreen(BaseAppScreen):
             "#settings-console-behavior-result", self._console_behavior_result_text()
         )
         self._update_console_paste_summary()
+        self._update_draft_status_widgets(SettingsCategoryId.CONSOLE_BEHAVIOR)
+
+    @on(Input.Changed, "#settings-console-max-parallel-runs")
+    def handle_console_max_parallel_runs_changed(self, event: Input.Changed) -> None:
+        if self._syncing_console_max_parallel_runs:
+            return
+        self._stage_console_max_parallel_runs_value(event.value)
+        self._console_behavior_result = "Console behavior settings staged."
+        self._set_static_text(
+            "#settings-console-behavior-result", self._console_behavior_result_text()
+        )
         self._update_draft_status_widgets(SettingsCategoryId.CONSOLE_BEHAVIOR)
 
     @on(Input.Changed, "#settings-console-default-streaming")
@@ -13789,6 +13937,12 @@ class SettingsScreen(BaseAppScreen):
                             dirty_values["paste_collapse_threshold"]
                         )
                     )
+                if "max_parallel_runs" in dirty_values:
+                    dirty_values["max_parallel_runs"] = (
+                        self._normalise_console_max_parallel_runs(
+                            dirty_values["max_parallel_runs"]
+                        )
+                    )
                 if "streaming" in dirty_values:
                     dirty_values["streaming"] = (
                         self._normalise_console_default_streaming(
@@ -14594,6 +14748,16 @@ class SettingsScreen(BaseAppScreen):
                 ).value = str(self._paste_collapse_threshold_value())
             finally:
                 self._syncing_console_threshold = False
+        except QueryError:
+            pass
+        try:
+            self._syncing_console_max_parallel_runs = True
+            try:
+                self.query_one(
+                    "#settings-console-max-parallel-runs", Input
+                ).value = str(self._console_max_parallel_runs_value())
+            finally:
+                self._syncing_console_max_parallel_runs = False
         except QueryError:
             pass
         input_values = {

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -37,6 +37,7 @@ from textual.widgets import (
     TextArea,
 )
 
+from ...Chat.console_chat_models import CONSOLE_DEFAULT_MAX_PARALLEL_RUNS
 from ...Chat.console_provider_endpoints import URL_BASED_PROVIDER_KEYS
 from ...Chat.provider_readiness import get_provider_readiness, provider_config_key
 from ...Chat.console_provider_support import (
@@ -297,11 +298,12 @@ CONSOLE_BEHAVIOR_CONSOLE_KEYS = frozenset(
     }
 )
 # Parallel-agents spec S4 (task-5): user-adjustable global cap on
-# simultaneous Console runs. Mirrors console_chat_controller.py's own
-# fallback -- see ConsoleChatController.max_parallel_runs, which reads
-# [console] max_parallel_runs via get_cli_setting with the same default and
-# floor. No upper bound is deliberate (user-owned trade-off).
-DEFAULT_CONSOLE_MAX_PARALLEL_RUNS = 3
+# simultaneous Console runs. Aliases console_chat_models' single source of
+# truth so the settings UI and ConsoleChatController.max_parallel_runs
+# (which reads [console] max_parallel_runs via get_cli_setting with the
+# same default and floor) can never drift apart. No upper bound is
+# deliberate (user-owned trade-off).
+DEFAULT_CONSOLE_MAX_PARALLEL_RUNS = CONSOLE_DEFAULT_MAX_PARALLEL_RUNS
 MIN_CONSOLE_MAX_PARALLEL_RUNS = 1
 CONSOLE_BACKGROUND_EFFECT_KEYS = frozenset(
     {


### PR DESCRIPTION
## Summary
PR1 of the two-PR parallel-agents train (spec: `Docs/superpowers/specs/2026-07-26-parallel-agents-across-workspaces-design.md`). Console runs stop being globally serialized: each session (tab) owns its run.

- `ConsoleRunState` moves to per-session maps behind a read-only active-session facade (`run_state`); all writes carry the owning `session_id`; run history, stream tasks, assistant-message ids, and cancel events are per-session.
- Send gate: refuse only when the TARGET session has a run in flight, or when total in-flight runs reach the cap — honest refusal copy naming the busy sessions; no hidden queue. `CONSOLE_RUN_ALREADY_RUNNING_COPY` retired.
- Workers: `group=f"console-run-{session_id}"`, exclusive within the group — one run per session by construction, N sessions in parallel. Sync workers keep disjoint groups (TASK-228 pin updated).
- Cancellation scoped per session: Stop affects only the viewed session's run; a background session's stream can no longer be truncated by another tab's Stop/Close (live-reproduced pre-fix, regression-tested). Global stop remains for shutdown.
- Cap: `[console] max_parallel_runs` (default 3, floor 1, no ceiling), read per-send; user-editable in Settings ▸ Console Behavior with validation and consequence guidance copy.
- Background-write audit: view writes gated on the viewed session; fixed `/generate-image` misattributing system messages across await gaps.
- Workspace isolation pin: two temporally-overlapping runs resolve their own workspace folder roots (extends the #943 provider tests; ContextVar isolation mutation-tested).

## Do not merge without PR2
This PR alone enables parallel runs while approvals remain single-slot and mount over the viewed tab. The train (spec §8) must land as one unit — PR2 (`feat/console-agent-fleet-ux`) supplies the fleet UX and approval parking. Merge both in order or neither.

## Testing
- Full PR1 gate: 2982 passed / 60 skipped (Tests/Chat, Tests/Agents, parallel-runs, Settings hub) + native chat flow green.
- Post-rebase onto dev (100 commits incl. citation-repair program): combined gate 3372 passed / 60 skipped / 1 known theme-editor flake; native flow 210/210. Three semantic integration bugs with the citation-repair lifecycle found by test during rebase and fixed at the originating commits.
- Two-workspace live smoke on the real TUI at the train tip (see PR2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable per-session Console runs so multiple tabs can run agents in parallel, bounded by a user-adjustable global cap. Run workers, stream/cancel state, and Stop are all scoped to the active session; add a Console Behavior setting for `max_parallel_runs`.

- **New Features**
  - Per-session run state: each tab owns its run and history; `run_state` stays a read-only facade for the active tab.
  - Per-session send gate with global cap: refuse only if this tab is busy or the cap is reached; no hidden queue.
  - Per-session workers and cancel: runs dispatch to `console-run-{session_id}`; Stop affects only this tab, while global shutdown cancels all.
  - Settings: `[console] max_parallel_runs` (default 3, min 1) in Console Behavior.

- **Bug Fixes**
  - Stopping one tab no longer truncates another tab’s stream; stream tasks and cancel signals are per session (no global flag leakage).
  - `submit_draft` now targets the session captured at dispatch, avoiding misroutes on quick tab switches.
  - In-flight run count excludes orphaned sessions; refusal copy now reads “A run is already running in this tab.”
  - Fixed `/generate-image` system messages misattributing to the wrong tab across await gaps; background runs never mutate the viewed tab’s UI.

<sup>Written for commit 46b7efeb652ecef4188776da40f9dd63ee73049e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

