### PR TITLE
feat(stt): add runnable Parakeet ONNX transcription

### DIFF
--- a/Tests/Transcription/test_parakeet_onnx_vertical_slice.py
+++ b/Tests/Transcription/test_parakeet_onnx_vertical_slice.py
@@ -1,0 +1,115 @@
+"""Focused coverage for the runnable Parakeet ONNX batch path."""
+
+import sys
+import wave
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.Local_Ingestion import transcription_service as service_module
+from tldw_chatbook.Local_Ingestion.transcription_service import (
+    TranscriptionError,
+    TranscriptionService,
+)
+
+
+def _write_silent_wav(path) -> None:
+    with wave.open(str(path), "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(16_000)
+        wav_file.writeframes(b"\0\0" * 1_600)
+
+
+def test_parakeet_onnx_transcribes_with_local_v2_int8_model(
+    tmp_path, monkeypatch
+) -> None:
+    audio_path = tmp_path / "speech.wav"
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    for filename in (
+        "config.json",
+        "vocab.txt",
+        "encoder-model.int8.onnx",
+        "decoder_joint-model.int8.onnx",
+    ):
+        (model_dir / filename).touch()
+    _write_silent_wav(audio_path)
+
+    load_calls = []
+
+    class FakeModel:
+        def recognize(self, path):
+            assert path == str(audio_path)
+            return "A working local transcription."
+
+    def fake_load_model(name, **kwargs):
+        load_calls.append((name, kwargs))
+        return FakeModel()
+
+    monkeypatch.setattr(service_module, "ONNX_ASR_AVAILABLE", True, raising=False)
+    monkeypatch.setitem(
+        sys.modules, "onnx_asr", SimpleNamespace(load_model=fake_load_model)
+    )
+
+    service = TranscriptionService()
+    service.config["parakeet_onnx_model_dir"] = str(model_dir)
+    result = service.transcribe(
+        str(audio_path),
+        provider="parakeet-onnx",
+    )
+
+    assert load_calls == [
+        (
+            "nemo-parakeet-tdt-0.6b-v2",
+            {
+                "path": str(model_dir),
+                "quantization": "int8",
+                "providers": ["CPUExecutionProvider"],
+                "preprocessor_config": {
+                    "use_numpy_preprocessors": True,
+                    "max_concurrent_workers": 1,
+                },
+            },
+        )
+    ]
+    assert result == {
+        "text": "A working local transcription.",
+        "segments": [
+            {
+                "start": 0.0,
+                "end": 0.1,
+                "text": "A working local transcription.",
+                "Time_Start": 0.0,
+                "Time_End": 0.1,
+                "Text": "A working local transcription.",
+            }
+        ],
+        "language": "en",
+        "provider": "parakeet-onnx",
+        "model": "nemo-parakeet-tdt-0.6b-v2",
+    }
+
+
+def test_parakeet_onnx_rejects_incomplete_model_directory_before_loading(
+    tmp_path, monkeypatch
+) -> None:
+    audio_path = tmp_path / "speech.wav"
+    model_dir = tmp_path / "incomplete-model"
+    model_dir.mkdir()
+    _write_silent_wav(audio_path)
+
+    def unexpected_load(*args, **kwargs):
+        raise AssertionError("load_model must not run for an incomplete local bundle")
+
+    monkeypatch.setattr(service_module, "ONNX_ASR_AVAILABLE", True, raising=False)
+    monkeypatch.setitem(
+        sys.modules, "onnx_asr", SimpleNamespace(load_model=unexpected_load)
+    )
+
+    with pytest.raises(TranscriptionError, match="missing required files"):
+        TranscriptionService().transcribe(
+            str(audio_path),
+            provider="parakeet-onnx",
+            model_dir=str(model_dir),
+        )

--- a/backlog/tasks/task-545 - Deliver-runnable-Parakeet-ONNX-batch-transcription-vertical-slice.md
+++ b/backlog/tasks/task-545 - Deliver-runnable-Parakeet-ONNX-batch-transcription-vertical-slice.md
@@ -1,0 +1,63 @@
+---
+id: TASK-545
+title: Deliver runnable Parakeet ONNX batch transcription vertical slice
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-07-27 14:45'
+updated_date: '2026-07-27 14:53'
+labels:
+  - stt
+  - onnx
+  - ingestion
+dependencies: []
+references:
+  - backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md
+documentation:
+  - Docs/superpowers/specs/2026-07-23-stt-parakeet-onnx-transcribe-cpp-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Deliver an immediately usable local Parakeet ONNX transcription path through the existing batch ingestion service before resuming broader STT architecture work.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A local WAV/audio file can be transcribed through `TranscriptionService` with the `parakeet-onnx` provider on macOS.
+- [x] #2 Omitted language defaults to `en`, and the provider loads Parakeet v2 with INT8 by default.
+- [x] #3 The provider requires an explicit local model directory and performs no implicit model download.
+- [x] #4 The provider returns the existing dictionary shape consumed by batch ingestion.
+- [x] #5 Focused unit tests and one real local transcription smoke pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a lazy `onnx-asr` availability probe and one `parakeet-onnx` branch to
+   the existing `TranscriptionService`.
+2. Require an explicit local v2 model directory, use CPU execution and INT8,
+   and call the installed `onnx-asr` API without downloads.
+3. Return the existing `{text, segments, language, provider, model}` result
+   shape and expose the provider/model through existing discovery methods.
+4. Add focused tests before production changes, then run one real local WAV
+   smoke with the actual runtime and model.
+
+ADR required: yes
+
+ADR path:
+`backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md`
+
+Reason: ADR-025 already approves Parakeet ONNX as the batch STT path. This is a
+deliberately narrow vertical slice of that decision; it does not introduce a
+new runtime boundary, persistence schema, executor, routing framework, or
+default promotion.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented a direct parakeet-onnx branch in the existing TranscriptionService. It lazily loads onnx-asr 0.12.0 with CPUExecutionProvider, defaults to English Parakeet v2 INT8, requires and validates an explicit local model directory, performs no implicit download, caches the model, and returns both current and legacy segment keys. Added the provider-specific install extra and config key. Verified two focused tests, Ruff on changed implementation/test files, TOML parsing, diff checks, exact model bundle sizes/SHA-256 values, and a real macOS WAV smoke that transcribed the spoken sentence exactly in 1.19 seconds. Reused ADR-025; no new ADR was required. Full CI was intentionally not run per user direction.
+<!-- SECTION:NOTES:END -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,9 @@ local_mlx = ["mlx-lm"]
 transcription_faster_whisper = [
     "faster-whisper",  # CPU/CUDA optimized Whisper
 ]
+transcription_parakeet_onnx = [
+    "onnx-asr[cpu]==0.12.0",  # Cross-platform Parakeet ONNX runtime
+]
 transcription_lightning_whisper = [
     "lightning-whisper-mlx; sys_platform == 'darwin'",  # Fast Whisper for Apple Silicon
 ]
@@ -321,6 +324,7 @@ all-tools = [
     
     # === Transcription and Audio ===
     "faster-whisper",  # CPU/CUDA optimized Whisper
+    "onnx-asr[cpu]==0.12.0",  # Cross-platform Parakeet ONNX runtime
     "lightning-whisper-mlx; sys_platform == 'darwin'",  # Fast Whisper for Apple Silicon
     "parakeet-mlx; sys_platform == 'darwin'",  # Real-time ASR for Apple Silicon
     

--- a/tldw_chatbook/Local_Ingestion/transcription_service.py
+++ b/tldw_chatbook/Local_Ingestion/transcription_service.py
@@ -51,6 +51,11 @@ except ImportError:
     )
 
 try:
+    ONNX_ASR_AVAILABLE = importlib.util.find_spec("onnx_asr") is not None
+except (ImportError, ValueError, ModuleNotFoundError):
+    ONNX_ASR_AVAILABLE = False
+
+try:
     if sys.platform == "darwin":
         from lightning_whisper_mlx import LightningWhisperMLX
 
@@ -270,6 +275,10 @@ class TranscriptionService:
             "device": get_cli_setting("transcription.device", "cpu") or "cpu",
             "compute_type": get_cli_setting("transcription.compute_type", "int8")
             or "int8",
+            "parakeet_onnx_model_dir": get_cli_setting(
+                "transcription.parakeet_onnx_model_dir", ""
+            )
+            or "",
             "chunk_length_seconds": get_cli_setting(
                 "transcription.chunk_length_seconds", 40.0
             )
@@ -412,7 +421,9 @@ class TranscriptionService:
 
         # Handle provider-specific default models
         if not model:
-            if provider == "parakeet-mlx":
+            if provider == "parakeet-onnx":
+                model = "nemo-parakeet-tdt-0.6b-v2"
+            elif provider == "parakeet-mlx":
                 model = "mlx-community/parakeet-tdt-0.6b-v2"
             elif provider == "qwen2audio":
                 model = "Qwen2-Audio-7B-Instruct"
@@ -448,7 +459,15 @@ class TranscriptionService:
             logger.info(f"Starting transcription with {provider} provider")
             transcription_start_time = time.time()
 
-            if provider == "parakeet-mlx":
+            if provider == "parakeet-onnx":
+                result = self._transcribe_with_parakeet_onnx(
+                    wav_path,
+                    model,
+                    source_lang,
+                    progress_callback=progress_callback,
+                    **kwargs,
+                )
+            elif provider == "parakeet-mlx":
                 if not PARAKEET_MLX_AVAILABLE:
                     if sys.platform != "darwin":
                         logger.error(
@@ -635,6 +654,99 @@ class TranscriptionService:
                     logger.warning(
                         f"Failed to clean up temporary WAV file {wav_path}: {e}"
                     )
+
+    def _transcribe_with_parakeet_onnx(
+        self,
+        audio_path: str,
+        model: str,
+        language: str,
+        progress_callback: Optional[
+            Callable[[float, str, Optional[Dict]], None]
+        ] = None,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Transcribe English audio with a local Parakeet v2 INT8 model."""
+        if not ONNX_ASR_AVAILABLE:
+            raise TranscriptionError(
+                "parakeet-onnx is not installed. Install with: "
+                "pip install 'onnx-asr[cpu]==0.12.0'"
+            )
+        if language != "en":
+            raise TranscriptionError(
+                "parakeet-onnx v2 supports explicit English only. "
+                "Retry with faster-whisper for automatic or non-English transcription."
+            )
+
+        model_dir = kwargs.get("model_dir") or self.config["parakeet_onnx_model_dir"]
+        if not model_dir or not Path(model_dir).is_dir():
+            raise TranscriptionError(
+                "parakeet-onnx requires an explicit existing local model directory "
+                "via model_dir or transcription.parakeet_onnx_model_dir; "
+                "no model will be downloaded automatically."
+            )
+        required_files = {
+            "config.json",
+            "vocab.txt",
+            "encoder-model.int8.onnx",
+            "decoder_joint-model.int8.onnx",
+        }
+        missing_files = sorted(
+            filename
+            for filename in required_files
+            if not (Path(model_dir) / filename).is_file()
+        )
+        if missing_files:
+            raise TranscriptionError(
+                "parakeet-onnx model directory is missing required files: "
+                + ", ".join(missing_files)
+            )
+
+        cache_key = ("parakeet-onnx", model, str(model_dir), "int8")
+        with self._model_cache_lock:
+            parakeet_model = self._model_cache.get(cache_key)
+            if parakeet_model is None:
+                from onnx_asr import load_model
+
+                parakeet_model = load_model(
+                    model,
+                    path=str(model_dir),
+                    quantization="int8",
+                    providers=["CPUExecutionProvider"],
+                    preprocessor_config={
+                        "use_numpy_preprocessors": True,
+                        "max_concurrent_workers": 1,
+                    },
+                )
+                self._model_cache[cache_key] = parakeet_model
+
+        if progress_callback:
+            progress_callback(10, "Transcribing with Parakeet ONNX", None)
+
+        text = parakeet_model.recognize(audio_path).strip()
+        with wave.open(audio_path, "rb") as wav_file:
+            duration = wav_file.getnframes() / wav_file.getframerate()
+
+        if progress_callback:
+            progress_callback(100, "Transcription complete", None)
+
+        return {
+            "text": text,
+            "segments": [
+                {
+                    "start": 0.0,
+                    "end": duration,
+                    "text": text,
+                    "Time_Start": 0.0,
+                    "Time_End": duration,
+                    "Text": text,
+                }
+            ]
+            if text
+            else [],
+            "language": "en",
+            "provider": "parakeet-onnx",
+            "model": model,
+        }
 
     def transcribe_buffer(
         self,
@@ -2872,6 +2984,10 @@ class TranscriptionService:
         logger.debug("Checking available transcription providers...")
         providers = []
 
+        if ONNX_ASR_AVAILABLE:
+            providers.append("parakeet-onnx")
+            logger.debug("parakeet-onnx is available")
+
         if PARAKEET_MLX_AVAILABLE:
             providers.append("parakeet-mlx")
             logger.debug("parakeet-mlx is available (Real-time ASR for Apple Silicon)")
@@ -2906,6 +3022,9 @@ class TranscriptionService:
         logger.debug(f"Listing available models for provider: {provider or 'all'}")
 
         models = {}
+
+        if ONNX_ASR_AVAILABLE:
+            models["parakeet-onnx"] = ["nemo-parakeet-tdt-0.6b-v2"]
 
         if PARAKEET_MLX_AVAILABLE:
             models["parakeet-mlx"] = [

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -3296,7 +3296,7 @@ temp_dir = ""  # Empty means use system temp
 
 [transcription]
 # Default transcription provider
-# Options: "faster-whisper", "qwen2audio", "parakeet", "canary", "parakeet-mlx", "lightning-whisper-mlx", "remote-whisper"
+# Options: "faster-whisper", "parakeet-onnx", "qwen2audio", "parakeet", "canary", "parakeet-mlx", "lightning-whisper-mlx", "remote-whisper"
 # Note: On macOS, defaults to parakeet-mlx or lightning-whisper-mlx if available
 default_provider = "faster-whisper"
 
@@ -3335,6 +3335,10 @@ device = "cpu"
 # Compute type for faster-whisper
 # Options: "int8", "float16", "float32"
 compute_type = "int8"
+
+# Explicit local directory containing the Parakeet v2 INT8 ONNX bundle.
+# parakeet-onnx never downloads model files implicitly.
+parakeet_onnx_model_dir = ""
 
 # Voice Activity Detection
 use_vad_by_default = false


### PR DESCRIPTION
Adds a direct parakeet-onnx provider to the existing TranscriptionService. Defaults to English Parakeet v2 INT8 on CPU, requires a complete explicit local model directory, performs no implicit downloads, exposes provider/model discovery, preserves current and legacy segment keys, and adds the onnx-asr CPU install extra. Verification: 2 focused tests pass; Ruff passes on changed implementation/test files; pyproject parses; diff check passes; pinned model files match expected sizes and SHA-256 values; real macOS WAV smoke transcribed the expected sentence exactly in 1.11 seconds. Full CI intentionally not run per user direction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a runnable Parakeet ONNX transcription path to TranscriptionService using a local Parakeet v2 INT8 model on CPU with no implicit downloads. Addresses Linear TASK-545 by delivering a local batch transcription vertical slice.

- **New Features**
  - Add `parakeet-onnx` provider (English-only) with default model `nemo-parakeet-tdt-0.6b-v2` on CPU.
  - Require explicit `parakeet_onnx_model_dir` and validate required files; no downloads.
  - Include `parakeet-onnx` in provider/model discovery and preserve current + legacy segment keys.
  - Add focused tests for a working local transcription and for rejecting incomplete model bundles.

- **Dependencies**
  - Add `transcription_parakeet_onnx` extra with `onnx-asr[cpu]==0.12.0`.

<sup>Written for commit 1a2c0a5e8bb8c0331f7f3a9f5d4db3402d8a9938. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

