### PR TITLE
feat(stt): expose Parakeet ONNX in batch ingestion

### DIFF
--- a/Tests/App/test_submit_library_ingest_job.py
+++ b/Tests/App/test_submit_library_ingest_job.py
@@ -135,8 +135,9 @@ class TestIngestJobOptions:
             source_path="/tmp/test.mp3",
             ingest_options={
                 "audio_video": {
-                    "transcription_model": "small",
-                    "language": "es",
+                    "transcription_provider": "parakeet-onnx",
+                    "transcription_model": "base",
+                    "language": "en",
                     "timestamps": False,
                     "diarization": True,
                 },
@@ -144,10 +145,26 @@ class TestIngestJobOptions:
         )
         options = app._ingest_job_options(job)
 
-        assert options["transcription_model"] == "small"
-        assert options["language"] == "es"
+        assert options["transcription_provider"] == "parakeet-onnx"
+        assert options["transcription_model"] == "nemo-parakeet-tdt-0.6b-v2"
+        assert options["language"] == "en"
         assert options["timestamps"] is False
         assert options["diarization"] is True
+
+    def test_parakeet_onnx_defaults_language_to_english(self) -> None:
+        app = _minimal_app()
+        job = _make_job(
+            source_path="/tmp/test.mp3",
+            ingest_options={
+                "audio_video": {
+                    "transcription_provider": "parakeet-onnx",
+                },
+            },
+        )
+
+        options = app._ingest_job_options(job)
+
+        assert options["language"] == "en"
 
     def test_ebook_group_options(self) -> None:
         app = _minimal_app()

--- a/Tests/Library/test_ingest_capabilities.py
+++ b/Tests/Library/test_ingest_capabilities.py
@@ -139,15 +139,36 @@ def test_get_capabilities_audio_video() -> None:
     assert caps.required_features == ("audio_processing",)
     assert "faster_whisper" in caps.optional_features
     assert caps.field_names == (
+        "transcription_provider",
         "transcription_model",
         "language",
         "timestamps",
         "diarization",
     )
 
+    provider_field = next(
+        f for f in caps.fields if f.name == "transcription_provider"
+    )
+    assert provider_field.options == ("parakeet-onnx", "faster-whisper")
+    assert provider_field.default == "parakeet-onnx"
+
     model_field = next(f for f in caps.fields if f.name == "transcription_model")
     assert model_field.options == ("tiny", "base", "small", "medium", "large")
     assert model_field.default == "base"
+    assert model_field.enabled_when == "transcription_provider"
+    assert model_field.enabled_when_values == ("faster-whisper",)
+
+
+def test_parakeet_onnx_feature_probes_onnx_asr(monkeypatch) -> None:
+    probed = []
+    monkeypatch.setattr(
+        tldw_chatbook.Library.ingest_capabilities.importlib.util,
+        "find_spec",
+        lambda name: probed.append(name) or object(),
+    )
+
+    assert _is_installed("parakeet_onnx") is True
+    assert probed == ["onnx_asr"]
 
 
 def test_get_capabilities_ebook() -> None:

--- a/Tests/Local_Ingestion/test_local_file_ingestion.py
+++ b/Tests/Local_Ingestion/test_local_file_ingestion.py
@@ -142,8 +142,9 @@ def test_audio_options_are_routed_to_processor(tmp_path: Path, monkeypatch) -> N
     parse_local_file_for_ingest(
         str(source),
         {
-            "transcription_model": "small",
-            "language": "es",
+            "transcription_provider": "parakeet-onnx",
+            "transcription_model": "nemo-parakeet-tdt-0.6b-v2",
+            "language": "en",
             "timestamps": False,
             "diarization": True,
         },
@@ -151,8 +152,9 @@ def test_audio_options_are_routed_to_processor(tmp_path: Path, monkeypatch) -> N
 
     assert len(calls) == 1
     call = calls[0]
-    assert call["transcription_model"] == "small"
-    assert call["transcription_language"] == "es"
+    assert call["transcription_provider"] == "parakeet-onnx"
+    assert call["transcription_model"] == "nemo-parakeet-tdt-0.6b-v2"
+    assert call["transcription_language"] == "en"
     assert call["timestamp_option"] is False
     assert call["diarize"] is True
 
@@ -189,6 +191,7 @@ def test_video_options_are_routed_to_processor(tmp_path: Path, monkeypatch) -> N
     parse_local_file_for_ingest(
         str(source),
         {
+            "transcription_provider": "faster-whisper",
             "transcription_model": "medium",
             "language": "fr",
             "timestamps": True,
@@ -198,6 +201,7 @@ def test_video_options_are_routed_to_processor(tmp_path: Path, monkeypatch) -> N
 
     assert len(calls) == 1
     call = calls[0]
+    assert call["transcription_provider"] == "faster-whisper"
     assert call["transcription_model"] == "medium"
     assert call["transcription_language"] == "fr"
     assert call["timestamp_option"] is True

--- a/Tests/UI/test_library_ingest_canvas.py
+++ b/Tests/UI/test_library_ingest_canvas.py
@@ -790,6 +790,36 @@ async def test_mounting_option_panels_posts_no_option_changes():
 
 
 @pytest.mark.asyncio
+async def test_audio_video_defaults_to_parakeet_onnx_without_whisper_models():
+    state = build_library_ingest_state(
+        (),
+        form=_default_form(),
+        preflight=PreflightResult(
+            type_groups={"audio_video": ["/tmp/a.mp3"]},
+            warnings=[],
+            errors=[],
+            total_size=0,
+            truncated=False,
+            total_files=1,
+        ),
+    )
+    app = _CanvasHost(state)
+    with patch(
+        "tldw_chatbook.Widgets.Library.library_ingest_canvas._is_installed",
+        return_value=True,
+    ):
+        async with app.run_test() as pilot:
+            provider = pilot.app.query_one(
+                "#opt-audio_video-transcription_provider", Select
+            )
+            model = pilot.app.query_one(
+                "#opt-audio_video-transcription_model", Select
+            )
+            assert provider.value == "parakeet-onnx"
+            assert model.disabled is True
+
+
+@pytest.mark.asyncio
 async def test_chunk_size_enabled_when_chunk_checked():
     """Chunk size and overlap become editable once Chunk is on.
 

--- a/backlog/tasks/task-900 - Expose-Parakeet-ONNX-in-batch-ingestion-options.md
+++ b/backlog/tasks/task-900 - Expose-Parakeet-ONNX-in-batch-ingestion-options.md
@@ -1,0 +1,56 @@
+---
+id: TASK-900
+title: Expose Parakeet ONNX in batch ingestion options
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-07-27 15:13'
+updated_date: '2026-07-27 15:20'
+labels:
+  - stt
+  - ingestion
+  - ui
+dependencies: []
+references:
+  - backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md
+documentation:
+  - Docs/superpowers/specs/2026-07-23-stt-parakeet-onnx-transcribe-cpp-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Let Library audio and video ingestion select the already-working local Parakeet ONNX provider without editing Python or changing the transcription runtime architecture.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Audio/video ingestion exposes a transcription provider selector containing Parakeet ONNX and faster-whisper.
+- [x] #2 The selected provider is preserved from the Library form through job option normalization into the local audio/video processor.
+- [x] #3 Parakeet ONNX keeps language default en and model default nemo-parakeet-tdt-0.6b-v2 without exposing incompatible faster-whisper model choices.
+- [x] #4 Focused capability and job-submission tests cover the provider path.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing tests for a provider selector and preservation of parakeet-onnx through Library job normalization.
+2. Add the provider field to the existing audio/video capability schema and forward it through the existing app option map.
+3. Make the model field provider-aware using the existing enabled_when support so Parakeet ONNX does not present faster-whisper model names.
+4. Run the focused capability, submission, and local media option tests, then record the real batch smoke.
+
+ADR required: yes
+ADR path: backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md
+Reason: ADR-025 already governs the approved batch-first provider and language behavior; this task introduces no new boundary.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the existing Library ingestion option path without a new coordinator or runtime layer. Added a Parakeet ONNX/faster-whisper provider selector, provider-aware Whisper model control, en/v2 normalization for Parakeet, and provider forwarding into both local audio and video processors. Registered the optional dependency metadata so install hints resolve to the existing transcription_parakeet_onnx extra. Added capability, UI, job-normalization, and processor-routing coverage.
+
+Verification: 113 focused tests passed; Ruff passed for the changed surface (app.py retains five unrelated baseline findings, so the touched app path was checked with those existing rules ignored); git diff --check passed. A real Library parse_local_file_for_ingest smoke transcribed /private/tmp/tldw-parakeet-smoke.wav with the verified v2 INT8 ONNX bundle in 1.23 seconds and returned the exact expected sentence.
+
+ADR: Reused backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md; no new architectural decision.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Library/ingest_capabilities.py
+++ b/tldw_chatbook/Library/ingest_capabilities.py
@@ -94,6 +94,7 @@ _PYPI_TO_IMPORT: dict[str, str] = {
     "html2text": "html2text",
     "lightning-whisper-mlx": "lightning_whisper_mlx",
     "lxml": "lxml",
+    "parakeet_onnx": "onnx_asr",
     "parakeet-mlx": "parakeet_mlx",
     "pymupdf": "pymupdf",
     "pymupdf4llm": "pymupdf4llm",
@@ -115,6 +116,7 @@ _FEATURE_TO_EXTRA: dict[str, str] = {
     "html2text": "ebook",
     "lightning_whisper_mlx": "transcription_lightning_whisper",
     "lxml": "ebook",
+    "parakeet_onnx": "transcription_parakeet_onnx",
     "parakeet_mlx": "transcription_parakeet",
     "pdf_processing": "pdf",
     "pymupdf": "pdf",
@@ -147,6 +149,7 @@ _FEATURE_LABELS: dict[str, str] = {
     "html2text": "html2text",
     "lightning_whisper_mlx": "Lightning Whisper MLX",
     "lxml": "lxml",
+    "parakeet_onnx": "Parakeet ONNX",
     "parakeet_mlx": "Parakeet MLX",
     "pdf_processing": "PDF processing",
     "pymupdf": "PyMuPDF",
@@ -331,11 +334,20 @@ _TYPE_GROUPS: dict[str, TypeGroupCapabilities] = {
         optional_features=(
             "faster_whisper",
             "lightning_whisper_mlx",
+            "parakeet_onnx",
             "parakeet_mlx",
             "yt_dlp",
             "video_processing",
         ),
         fields=(
+            OptionField(
+                name="transcription_provider",
+                label="Transcription provider",
+                type="select",
+                default="parakeet-onnx",
+                options=("parakeet-onnx", "faster-whisper"),
+                depends_on="audio_processing",
+            ),
             OptionField(
                 name="transcription_model",
                 label="Transcription model",
@@ -343,6 +355,8 @@ _TYPE_GROUPS: dict[str, TypeGroupCapabilities] = {
                 default="base",
                 options=("tiny", "base", "small", "medium", "large"),
                 depends_on="faster_whisper",
+                enabled_when="transcription_provider",
+                enabled_when_values=("faster-whisper",),
             ),
             OptionField(
                 name="language",

--- a/tldw_chatbook/Local_Ingestion/local_file_ingestion.py
+++ b/tldw_chatbook/Local_Ingestion/local_file_ingestion.py
@@ -589,6 +589,9 @@ def parse_local_file_for_ingest(
             # Process single audio file
             results = audio_processor.process_audio_files(
                 inputs=[str(file_path)],
+                transcription_provider=options.get(
+                    "transcription_provider", "faster-whisper"
+                ),
                 transcription_model=options.get('transcription_model', chunk_options.get('transcription_model', 'base')),
                 transcription_language=options.get('language', chunk_options.get('transcription_language', 'en')),
                 perform_chunking=True,
@@ -642,6 +645,9 @@ def parse_local_file_for_ingest(
             results = video_processor.process_videos(
                 inputs=[str(file_path)],
                 download_video_flag=False,  # Extract audio only for transcription
+                transcription_provider=options.get(
+                    "transcription_provider", "faster-whisper"
+                ),
                 transcription_model=options.get('transcription_model', chunk_options.get('transcription_model', 'base')),
                 transcription_language=options.get('language', chunk_options.get('transcription_language', 'en')),
                 perform_chunking=True,

--- a/tldw_chatbook/Utils/optional_deps.py
+++ b/tldw_chatbook/Utils/optional_deps.py
@@ -448,6 +448,15 @@ OPTIONAL_FEATURES: dict[str, OptionalFeatureInfo] = {
         "Parakeet transcription",
         OWNER_LIBRARY_MEDIA,
     ),
+    "transcription_parakeet_onnx": _feature(
+        "transcription_parakeet_onnx",
+        "Parakeet ONNX transcription",
+        AREA_MEDIA,
+        ("onnx-asr[cpu]",),
+        "Library > Import/Export",
+        "Parakeet ONNX transcription",
+        OWNER_LIBRARY_MEDIA,
+    ),
     "video": _feature(
         "video",
         "Video ingestion and transcription",

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -2279,11 +2279,17 @@ class LibraryIngestQueueMixin:
             )
             options["extract_images"] = flat_opts.get("extract_images", False)
         elif group == "audio_video":
+            transcription_provider = (
+                flat_opts.get("transcription_provider") or "parakeet-onnx"
+            )
+            options["transcription_provider"] = transcription_provider
             options["transcription_model"] = (
-                flat_opts.get("model")
+                "nemo-parakeet-tdt-0.6b-v2"
+                if transcription_provider == "parakeet-onnx"
+                else flat_opts.get("model")
                 or flat_opts.get("transcription_model")
             )
-            options["language"] = flat_opts.get("language", "auto")
+            options["language"] = flat_opts.get("language", "en")
             options["timestamps"] = flat_opts.get("timestamps", True)
             options["diarization"] = flat_opts.get("diarization", False)
         elif group == "ebook":


### PR DESCRIPTION
## Summary
- add Parakeet ONNX/faster-whisper provider selection to Library audio/video ingestion
- normalize Parakeet to explicit English and v2 while hiding incompatible Whisper model choices
- preserve the selected provider through batch job normalization into audio/video processing
- register the existing ONNX optional extra in dependency metadata

## Verification
- 113 focused tests passed
- Ruff passed on the changed surface (excluding five unrelated existing app.py baseline findings)
- git diff --check passed
- real `parse_local_file_for_ingest` smoke returned the exact expected transcript using v2 INT8 ONNX in 1.23 seconds

Backlog: TASK-900
ADR: backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a transcription provider selector to Library audio/video batch ingestion with `parakeet-onnx` as default, routing the choice through job normalization to local processors. Parakeet defaults to English and uses the v2 `nemo-parakeet-tdt-0.6b-v2` model; Whisper models remain available only under `faster-whisper`. Satisfies TASK-900.

- **New Features**
  - Added `transcription_provider` select (`parakeet-onnx` default; options: `parakeet-onnx`, `faster-whisper`); `transcription_model` enabled only for `faster-whisper`.
  - Normalized Parakeet: default `language` to `en`; force model `nemo-parakeet-tdt-0.6b-v2`.
  - Preserved provider from the Library form through job option normalization into audio/video processors in `parse_local_file_for_ingest`.
  - Probed Parakeet ONNX via `onnx_asr` and registered optional extra `transcription_parakeet_onnx` with install hint `onnx-asr[cpu]`.
  - Added focused tests for capabilities, UI defaults, job options, and local ingestion routing.

- **Migration**
  - Audio/video `language` defaults to `en` now; set `language` explicitly if you relied on auto-detect.
  - Select `faster-whisper` to choose Whisper model sizes; Parakeet uses its fixed v2 model.

<sup>Written for commit c006dec6da7a1fcf61c264087cad4665f352e483. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

