### PR TITLE
docs: file 927/928/929 from the TASK-899 fix

### DIFF
--- a/backlog/tasks/task-927 - Bulk-DB-maintenance-workers-carry-the-same-wrong-path-bug-TASK-899-fix.md
+++ b/backlog/tasks/task-927 - Bulk-DB-maintenance-workers-carry-the-same-wrong-path-bug-TASK-899-fix.md
@@ -1,0 +1,35 @@
+---
+id: TASK-927
+title: >-
+  Bulk DB maintenance workers carry the same wrong-path bug TASK-899 fixed
+status: To Do
+assignee: []
+created_date: '2026-07-27 09:00'
+labels:
+  - settings
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-899 fixed `Tools_Settings_Window._get_database_path()` so single-database vacuum, backup, restore and integrity-check resolve through `config.py`'s profile-aware resolvers instead of hardcoded literals.
+
+The **"all databases"** variants of those workers were left untouched and do not go through `_get_database_path()`. They carry their own copies of the same hardcoded paths, so they inherit the identical defect: wrong filenames (`tldw_evals_db.db`, `tldw_prompts_db.db`, `tldw_media_db.db` rather than `evals.db`, `tldw_chatbook_prompts.db`, `tldw_chatbook_media_v2.db`) and no profile directory segment.
+
+The consequence is the same one TASK-899 documented. Vacuum, backup and check guard on `exists()` and therefore silently do nothing. Any restore-style path that writes unconditionally would write to a phantom location while the real database is untouched.
+
+This is the more dangerous half in practice: "back up all databases" is exactly what a cautious user clicks before an upgrade.
+
+The conversation/character export workers were also observed to build database paths independently and should be checked in the same pass.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] The bulk workers resolve every database through the same resolvers the single-database workers now use
+- [ ] No hardcoded database filename or path literal remains in `Tools_Settings_Window.py`
+- [ ] A bulk backup produces files for the databases that actually exist, proven by a test
+- [ ] The conversation/character export workers are audited in the same pass and either fixed or explicitly cleared
+<!-- AC:END -->

--- a/backlog/tasks/task-928 - ChatbookImporter-key-casing-does-not-match-what--import-chatbook-passe.md
+++ b/backlog/tasks/task-928 - ChatbookImporter-key-casing-does-not-match-what--import-chatbook-passe.md
@@ -1,0 +1,32 @@
+---
+id: TASK-928
+title: >-
+  ChatbookImporter key casing does not match what _import_chatbook passes
+status: To Do
+assignee: []
+created_date: '2026-07-27 09:00'
+labels:
+  - settings
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found while fixing TASK-899.
+
+`ChatbookImporter` expects capitalized database keys (`"ChaChaNotes"`, `"Prompts"`, `"Media"`), but `Tools_Settings_Window._import_chatbook` builds its dictionary with lowercase keys (`"chachanotes"`, `"prompts"`, `"media"`).
+
+Pre-existing and independent of the path-resolution work, so it was deliberately left alone there. The effect is that the importer does not receive the database paths under the names it looks for; confirm whether it silently falls back, imports nothing, or raises, and fix the mismatch at whichever end is the real contract.
+
+Worth pinning with a test once resolved, since a casing mismatch between two modules is invisible to type checking and to any test that stubs one side.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] The key casing agrees between `_import_chatbook` and `ChatbookImporter`
+- [ ] The real behaviour of the current mismatch is established and recorded in the task notes
+- [ ] A test fails if the two sides disagree again
+<!-- AC:END -->

--- a/backlog/tasks/task-929 - Audit-remaining-self.call-from-thread-misuse-outside-Tools-Settings-Wi.md
+++ b/backlog/tasks/task-929 - Audit-remaining-self.call-from-thread-misuse-outside-Tools-Settings-Wi.md
@@ -1,0 +1,30 @@
+---
+id: TASK-929
+title: >-
+  Audit remaining self.call_from_thread misuse outside Tools_Settings_Window
+status: To Do
+assignee: []
+created_date: '2026-07-27 09:00'
+labels:
+  - ui
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+While fixing TASK-899 it emerged that all four database-maintenance workers called `self.call_from_thread(...)` on `ToolsSettingsWindow`, which is a `Container`. That method exists only on `App` — verified: `Widget` and `Container` both lack it. Every notification raised from those worker threads would therefore have raised `AttributeError` rather than notifying, which is why the failures were never seen.
+
+All 39 call sites in that file now use `self.app.call_from_thread`, and a guard test asserts the bare form does not come back. That guard is file-scoped.
+
+The same mistake is plausible anywhere a `Widget`/`Container` subclass runs a threaded worker, and it is invisible until the error path executes. Sweep the codebase for `self.call_from_thread` on non-`App` classes and fix or clear each.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] Every `self.call_from_thread` call site outside `App` subclasses is identified
+- [ ] Each is fixed to use `self.app.call_from_thread` or confirmed to be on an `App`
+- [ ] A repo-wide guard replaces or supplements the file-scoped one
+<!-- AC:END -->


### PR DESCRIPTION
Three things deliberately left out of scope while fixing the Settings database-maintenance paths (#978).

**927** — the "all databases" vacuum/backup/check workers never went through `_get_database_path()`, so they still carry their own copies of the hardcoded wrong paths. This is the more dangerous half in practice: "back up all databases" is exactly what a cautious user clicks before an upgrade, and it would silently produce nothing. The conversation/character export workers build paths independently too and should be audited in the same pass.

**928** — `ChatbookImporter` expects capitalized keys (`"ChaChaNotes"`) while `_import_chatbook` passes lowercase. Pre-existing and independent of the path work. A casing mismatch between two modules is invisible to type checking and to any test that stubs one side.

**929** — `self.call_from_thread` exists only on `App`, not `Widget`/`Container`, so those worker-thread notifications were unreachable and raised `AttributeError` instead. Fixed across 39 call sites in `Tools_Settings_Window` with a guard test, but that guard is file-scoped and the same mistake is plausible in any threaded Widget worker.

Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds backlog docs for follow-ups to the Settings DB path fix in TASK-899: new tasks 927/928/929 with clear acceptance criteria. These track fixes for bulk DB maintenance path resolution, `ChatbookImporter` key casing, and repo‑wide `call_from_thread` misuse.

<sup>Written for commit 357f67efcc2e2a8e3bb355e568f5b2f15c4d202e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

