### PR TITLE
chore(backlog): renumber the duplicate Parakeet task 545 → 942

### DIFF
--- a/backlog/tasks/task-942 - Deliver-runnable-Parakeet-ONNX-batch-transcription-vertical-slice.md
+++ b/backlog/tasks/task-942 - Deliver-runnable-Parakeet-ONNX-batch-transcription-vertical-slice.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-545
+id: TASK-942
 title: Deliver runnable Parakeet ONNX batch transcription vertical slice
 status: Done
 assignee:


### PR DESCRIPTION
Two **Done** tasks both carried id `TASK-545`:
- `Wire built-in tool executor into MCP permission gate` (created 2026-07-24, merged 07-26)
- `Deliver runnable Parakeet ONNX batch transcription vertical slice` (created and merged 07-27)

The standing rule is that Done tasks never move, because close-out commits and PR titles reference them — which does not resolve a case where **both** are Done. Broke the tie on which id is actually load-bearing:

The MCP task is referenced by 8+ commits, two merged PR titles (`TASK-545 P2`, `TASK-545 P3`) and six specs/plans under `Docs/superpowers/`. Nothing references the Parakeet task by id, and the file body contains no self-references.

So the MCP task keeps 545 and Parakeet moves to 942 — chosen with headroom over the all-branches max of 930.

Verified after the move: 722 tasks, zero duplicates in **both** namespaces (filename prefix and frontmatter `id:`).

Backlog file rename plus its frontmatter id. No code change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve duplicate TASK-545 by keeping the MCP task as 545 and renumbering the Parakeet ONNX batch transcription task to TASK-942. Renamed the backlog file and updated its frontmatter; verified uniqueness across filename and id; no code changes.

<sup>Written for commit 74c6abdeb1b849e650d208473b0a74aabacfab5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

