### PR TITLE
fix(config): config encryption actually encrypts — effective path, real key detection, trust containment

### DIFF
--- a/.superpowers/sdd/task-851-852-report.md
+++ b/.superpowers/sdd/task-851-852-report.md
@@ -1,0 +1,302 @@
+# TASK-851 / TASK-852: config encryption effective-path + detection fix
+
+Branch: `fix/config-encryption-effective-path` (worktree `wt-cfg-crypto`, cut from `origin/dev`).
+
+Together these two defects meant config encryption did not encrypt: the
+encryption entry points wrote to the wrong file when a profile was active
+(851), and the detector that decides whether to offer encryption never
+recognized any of this app's real API-key field names (852).
+
+## TASK-851 — wrong file
+
+### Root cause
+
+`enable_config_encryption`, `disable_config_encryption`, and
+`change_encryption_password` in `tldw_chatbook/config.py` all read/wrote
+`DEFAULT_CONFIG_PATH` (`Path.home()/.config/tldw_cli/config.toml`) directly,
+instead of `_get_effective_config_path()`, which is the only accessor that
+honors the `TLDW_CONFIG_PATH` override (the app's "Override config" /
+profile mechanism). `enable_config_encryption` also wrote with a plain
+`open(path, "w")` + `toml.dump(...)`, unlike its two siblings which already
+used `atomic_write_text`.
+
+### Reproduction — before fix
+
+Script (paraphrased; full version was run via `git stash` against the
+worktree to get a clean unfixed baseline):
+
+```python
+import tldw_chatbook.config as cfg
+# ... HOME redirected to a scratch dir; a prior "normal run" already created
+# DEFAULT_CONFIG_PATH via load_cli_config_and_ensure_existence() ...
+
+profile_path.write_text(
+    '[api_settings.openai]\napi_key = "sk-proj-PLAINTEXT-SENTINEL-abc123"\n'
+)
+os.environ["TLDW_CONFIG_PATH"] = str(profile_path)
+
+result = cfg.enable_config_encryption("hunter2hunter2")
+```
+
+Output:
+
+```
+effective path (should be the profile): .../cfg851profile_7ky1asp8/profile_config.toml
+enable_config_encryption(...) -> True
+---- ACTIVE profile file contents after enable ----
+[api_settings.openai]
+api_key = "sk-proj-PLAINTEXT-SENTINEL-abc123"
+
+plaintext key STILL present in ACTIVE file: True
+DEFAULT_CONFIG_PATH (wrong file) shows an 'encryption' section now: True
+
+BUG REPRODUCED: reported success, but the ACTIVE file's secret is untouched
+plaintext, and a completely different file was rewritten instead.
+```
+
+### After fix
+
+Same script, same inputs, against the fixed code:
+
+```
+enable_config_encryption(...) -> True
+---- ACTIVE profile file contents after enable ----
+[encryption]
+enabled = true
+method = "AES-256-GCM-scrypt"
+version = 1
+password_verifier = "enc:ApDRu5fU7ICrSWiPzI+6DZcc23kDP4VxCyo6H2Pj0GfEQ65gi7pYh4mFuvkKpTvFVuanYQKpuLYiaxaJH6F3fneGifF+5kVVCRSvFGzpYTN4ZpwaTaThXEsP2Z391bAGGXe7wHKYIA3HhoViHOlXva1Cp/MpQzeAXg=="
+
+[api_settings.openai]
+api_key = "enc:Ak49BRW40QdCukYtpdMopTiCoCUhTSUDi0xj/cLiL5lny43CheiQX/yGYQwLDABStNz6kL0DJWq+IFmf8EIUC6jubktAGB8ZSg1CVMmPYqP+bX18JdFDaAYjXwzPUw=="
+
+plaintext key STILL present in ACTIVE file: False
+DEFAULT_CONFIG_PATH (wrong file) shows an 'encryption' section now: False
+```
+
+The active (effective) file is the one that changed; the decoy
+`DEFAULT_CONFIG_PATH` was never created.
+
+### Fix
+
+All three entry points now do:
+
+```python
+config_path = _get_effective_config_path()
+...
+if config_path.exists():
+    with open(config_path, "rb") as f:
+        config_data = tomllib.load(f)
+...
+atomic_write_text(config_path, toml.dumps(encrypted_config), encoding="utf-8")
+```
+
+`atomic_write_text` (`Utils/atomic_file_ops.py`, already used elsewhere in
+this codebase, e.g. `apply_settings_mutation_to_cli_config`) writes to a
+`tempfile.mkstemp` sibling in the same directory, `fsync`s it, then
+`os.replace`s it over the target — so a crash or exception during
+serialization never touches the original file. `disable_config_encryption`
+and `change_encryption_password` already called this helper (just against
+the wrong path); `enable_config_encryption` previously used
+`open(path, "w")` (which truncates on `open()`, before any content — or a
+raised exception — ever reaches the file) and now uses the same helper.
+
+### Tests — `Tests/test_config_encryption_effective_path.py` (new, 6 tests)
+
+- `test_enable_config_encryption_writes_active_file_not_default`
+- `test_disable_config_encryption_reads_and_writes_active_file`
+- `test_change_encryption_password_reads_and_writes_active_file`
+- `test_enable_disable_roundtrip_with_profile_active` (byte-identical
+  restore of the original plaintext config)
+- `test_change_password_roundtrip_with_profile_active` (old password
+  rejected after rotation, new password works)
+- `test_enable_config_encryption_write_is_atomic` (patches both
+  `toml.dump` and `toml.dumps` to raise mid-serialization; asserts the
+  on-disk file is byte-for-byte unchanged)
+
+All 6 were run against the pre-fix code via `git stash` and failed (5 with
+the wrong-file symptom, 1 — the atomicity test — was rewritten once to
+isolate purely the atomicity property, independent of the path bug, after
+an initial version produced a false pass for the wrong reason). All 6 pass
+against the fixed code.
+
+## TASK-852 — detector never fires
+
+### Root cause
+
+`Utils/config_encryption.py`'s `detect_api_keys` matched key names via exact
+equality against six literals (`api_key`, `apikey`, `api-key`, `secret`,
+`token`, `password`). Every real secret-bearing key in this app is prefixed
+or suffixed instead (`bing_search_api_key`, `auth_token`, `api_token`,
+`OPENAI_API_KEY_fallback`, ...), so none of them were ever detected, and
+`check_encryption_needed()` (`config.py:4270`, the `should_encrypt_config()`
+gate referenced by the task) never prompted a user with a config full of
+live plaintext secrets to turn encryption on.
+
+There were also three *other* independent copies of "is this key sensitive,"
+all disagreeing:
+
+- `config.py:515-546` (inside `encrypt_api_keys_in_config`'s
+  `encrypt_sensitive_fields` closure) and `config.py:3691`
+  (`_is_sensitive_setting_key`, a near-duplicate) — bare substring
+  containment, so `max_tokens` (contains `_token`) and `api_key_env_var`
+  (contains `api_key`) were both wrongly flagged.
+- `UI/Screens/settings_privacy_security.py:190` (`_is_sensitive_config_key`)
+  — `endswith`-only plus an `_env_var` guard, safer than substring but
+  missed keys where the sensitive fragment isn't a suffix
+  (`search_engine_api_key_baidu`, the `_fallback` family).
+
+### Reproduction — before fix
+
+```python
+from tldw_chatbook.Utils.config_encryption import ConfigEncryption
+enc = ConfigEncryption()
+config = {
+    "SearchEngines": {"bing_search_api_key": "bing-real-plaintext-secret"},
+    "tldw_api": {"auth_token": "tldw-api-plaintext-secret"},
+    "github": {"api_token": "github-plaintext-secret"},
+}
+enc.detect_api_keys(config)   # -> False (bug)
+enc.detect_api_keys({"x": {"api_key": "sk-1"}})  # -> True (only literal names ever worked)
+```
+
+### Fix
+
+New module `tldw_chatbook/Utils/sensitive_config_keys.py` — the single
+shared predicate, `is_sensitive_config_key(key)`:
+
+1. `_env_var` suffix guard first (env var *names* are never secrets) —
+   overrides everything else.
+2. Exact-name set: `api_key`, `apikey`, `api-key`, `secret`, `token`,
+   `password`, `auth_token`, `api_token`, `access_token`, `secret_key`,
+   `refresh_token`, `client_secret`.
+3. Containment rule for `api_key` / `apikey` / `api-key` — catches
+   provider-prefixed names (`openai_api_key`) and suffix-of-a-suffix names
+   (`OPENAI_API_KEY_fallback`, `search_engine_api_key_baidu`) that an
+   `endswith`-only rule misses.
+4. `endswith` rule (not containment) for `_key`, `_token`, `_secret`,
+   `_password` — deliberately `endswith`, not containment: `max_tokens`
+   contains `_token` as a bare substring but does not end with it, so it is
+   correctly excluded without needing a special case.
+
+All four former call sites now delegate to it:
+`config.py` (`encrypt_sensitive_fields` closure; `_is_sensitive_setting_key`
+was removed and its two callers — `_setting_value_for_log`,
+`_maybe_encrypt_setting_value` — call the shared predicate directly),
+`Utils/config_encryption.py::detect_api_keys`, and
+`UI/Screens/settings_privacy_security.py` (`_is_sensitive_config_key` and its
+two frozensets removed in favor of the shared import).
+
+### After fix
+
+Same repro:
+
+```python
+enc.detect_api_keys(config)  # -> True
+enc.detect_api_keys({"api_settings": {"openai": {"api_key_env_var": "OPENAI_API_KEY", "max_tokens": 4096}}})  # -> False
+```
+
+### Tests
+
+- `Tests/Utils/test_sensitive_config_keys.py` (new, 15 tests) — builds its
+  key list by parsing the real `CONFIG_TOML_CONTENT` (via `tomllib.loads`)
+  and `DEFAULT_APP_TTS_CONFIG`, not by re-typing literals: real
+  `[SearchEngines].*_api_key` names, `[tldw_api].auth_token`,
+  `[github].api_token`, the `*_fallback` family, plus explicit exclusions
+  (`api_key_env_var`, `api_token_env_var`, `max_tokens`, and the
+  `default_keyword_filter` / `extract_keywords` / `max_keywords` /
+  `skip_on_keypress` false positives the old substring-matching copy
+  produced).
+- `Tests/Utils/test_config_encryption.py` — added
+  `TestDetectApiKeysRealProviderNames` (3 tests) exercising
+  `detect_api_keys` itself with the same real-key-sourcing approach.
+- `Tests/test_config_app_config_encryption.py` — added one end-to-end test
+  of `check_encryption_needed()` against a live `TLDW_CONFIG_PATH` config
+  holding a real plaintext provider key.
+
+All new/updated tests were confirmed to fail against the pre-fix code
+(`git stash`) and pass after.
+
+## Where the unified key list lives / semantics chosen
+
+`tldw_chatbook/Utils/sensitive_config_keys.py` — deliberately a small,
+dependency-free module (no `Cryptodome` import) so it can be imported
+eagerly from `config.py` (which otherwise lazy-loads
+`Utils/config_encryption.py` specifically to avoid an eager `Cryptodome`
+import at startup) without changing that startup-cost tradeoff.
+
+Semantics: exact-match ∪ containment(`api_key`/`apikey`/`api-key`) ∪
+endswith(`_key`/`_token`/`_secret`/`_password`), with an `_env_var`-suffix
+guard checked first and winning over everything else. See the module
+docstring for the full "why containment here, endswith there" rationale.
+
+## Atomic write
+
+`enable_config_encryption` now serializes with `toml.dumps(...)` first, then
+passes the resulting string to `atomic_write_text(path, ...)` — the same
+write-temp-then-`os.replace` helper (`Utils/atomic_file_ops.py`) its two
+siblings already used. No new helper was written; this was purely routing
+`enable_config_encryption` onto the existing one.
+
+## Exact pytest commands run and results
+
+```
+# Task-specified starting point (note: pytest collapses "Tests/Utils/ Tests/"
+# to just Tests/Utils/'s 476 tests when both paths are given together in
+# this environment/pytest version -- observed, not something this task
+# fixed; the individual-file runs below cover the top-level Tests/*.py files
+# this quirk excludes).
+python -m pytest Tests/Utils/ Tests/ -k "config or encrypt or privacy" -q
+  -> 83 passed, 393 deselected
+
+# Every file created/edited for this work, run directly:
+python -m pytest Tests/Utils/test_config_encryption.py \
+                 Tests/Utils/test_sensitive_config_keys.py \
+                 Tests/test_config_encryption_effective_path.py \
+                 Tests/test_config_app_config_encryption.py \
+                 Tests/UI/test_settings_privacy_security.py -q
+  -> 71 passed
+
+# Known pre-existing baseline, confirmed unchanged:
+python -m pytest Tests/UI/test_tools_settings_window.py -q
+  -> 6 failed (test_chat_api_key_*, pre-existing per task brief), 9 passed, 16 skipped
+
+# Broader adjacent-file regression sweep (files not directly touched, but
+# config.py-dependent):
+python -m pytest Tests/test_config_delete_settings.py Tests/test_config_console_defaults.py \
+                 Tests/test_config_library_defaults.py Tests/Utils/test_config_nested_settings.py \
+                 Tests/Utils/test_config_import_hygiene.py Tests/UI/test_settings_configuration_hub.py \
+                 Tests/UI/test_settings_tools_section.py Tests/UI/test_settings_image_gen_defaults.py -q
+  -> 1 failed, 402 passed (0:05:16)
+  -- the 1 failure (test_theme_category_opens_without_crashing) is an 8s
+     UI-mount timing wait unrelated to config/encryption; re-run in isolation
+     passed cleanly (9.53s), confirming pre-existing flakiness under load,
+     not a regression from this change.
+```
+
+## Files changed
+
+- `tldw_chatbook/config.py` — three encryption entry points routed through
+  `_get_effective_config_path()`; `enable_config_encryption` now writes via
+  `atomic_write_text`; `encrypt_sensitive_fields` and
+  `_setting_value_for_log`/`_maybe_encrypt_setting_value` delegate to the
+  shared predicate; `_is_sensitive_setting_key` removed.
+- `tldw_chatbook/Utils/config_encryption.py` — `detect_api_keys` delegates
+  to the shared predicate.
+- `tldw_chatbook/UI/Screens/settings_privacy_security.py` —
+  `_is_sensitive_config_key` and its two frozensets removed in favor of the
+  shared import.
+- `tldw_chatbook/Utils/sensitive_config_keys.py` — new shared predicate
+  module.
+- `Tests/test_config_encryption_effective_path.py` — new (task-851).
+- `Tests/Utils/test_sensitive_config_keys.py` — new (task-852).
+- `Tests/Utils/test_config_encryption.py` — extended (task-852).
+- `Tests/test_config_app_config_encryption.py` — extended (task-852).
+
+## Out of scope (noted, not fixed)
+
+`UI/Tools_Settings_Window.py::_save_raw_toml_config` (raw TOML editor save,
+~line 4248-4260) has the same shape of bug (writes `DEFAULT_CONFIG_PATH`
+directly, non-atomically) but is not one of the three named entry points in
+task-851's acceptance criteria, so it was left untouched. Worth a follow-up
+task if this raw-editor path is meant to also honor `TLDW_CONFIG_PATH`.

--- a/.superpowers/sdd/task-853-report.md
+++ b/.superpowers/sdd/task-853-report.md
@@ -1,0 +1,194 @@
+# TASK-853: Fix the two skills-trust path containment checks that can't actually reject anything
+
+## Summary
+
+Two independent containment checks in the skills-trust code were true by construction and rejected
+nothing:
+
+1. `Skills_Interop/skill_trust_store.py`'s `FileSkillTrustGenerationMarkerStore` validated the
+   marker path against `base_dir=self.marker_path.parent` -- the candidate's own parent -- so
+   `get_safe_relative_path(candidate, base)` could never be `None`.
+2. `Skills_Interop/local_skills_service.py`'s `_is_unsafe_scratch_root` only checked "root nested
+   inside container", never "root encloses container", and `self.store_dir` (which holds the skill
+   index directly) wasn't even in the container list.
+
+Both are now fixed. `tldw_chatbook/Skills_Interop/skill_trust_store.py`,
+`tldw_chatbook/Skills_Interop/local_skills_service.py`, and `tldw_chatbook/app.py` were changed,
+plus 13 test files (call sites of the now-required `store_dir` constructor argument, and new
+containment tests).
+
+## Check #1 -- skill_trust_store.py marker-path validation
+
+### What was passed as the containment base, and why
+
+Added an explicit `store_dir: Path` field to `FileSkillTrustGenerationMarkerStore` (no default --
+every caller must supply the trust store's own real directory). `load_marker`/`save_marker` now
+call `_validated_trust_file_path(self.marker_path, base_dir=self.store_dir)` instead of
+`base_dir=self.marker_path.parent`. `build_skill_trust_marker_store_with_fallback` gained a
+`store_dir` parameter it threads into the fallback `FileSkillTrustGenerationMarkerStore`; `app.py`'s
+live construction site passes `store_dir=trust_store_dir` -- the exact same directory already used
+to build `SkillTrustStore(store_dir=trust_store_dir, ...)`, so the marker's containment base is now
+an independent fact about the real trust store, not something re-derived from the candidate path
+itself.
+
+### Reproduction -- before
+
+```
+$ .venv/bin/python -c "
+from tldw_chatbook.Skills_Interop.skill_trust_store import FileSkillTrustGenerationMarkerStore
+... build a marker at <tmp>/totally-unrelated-elsewhere/marker.json ...
+marker = FileSkillTrustGenerationMarkerStore(marker_path)   # old 1-arg constructor
+marker.save_marker(generation=1, manifest_digest='deadbeef')
+"
+PRE-FIX: save_marker OUTSIDE the trust store SUCCEEDED (vulnerable) -> .../totally-unrelated-elsewhere/marker.json exists: True
+```
+
+(Obtained by `git stash push` on the three touched production files, running the repro, then
+`git stash pop` to restore the fix.)
+
+### Reproduction -- after
+
+```
+marker = FileSkillTrustGenerationMarkerStore(marker_path, store_dir=store_dir)  # store_dir = <tmp>/trust
+marker.save_marker(generation=1, manifest_digest='deadbeef')
+```
+```
+POST-FIX: rejected as expected -> unsafe skill trust path
+```
+
+A legitimate, co-located marker (`store_dir / "marker.json"`) still round-trips:
+```
+POST-FIX legitimate co-located marker round-trips: {'generation': 1, 'manifest_digest': 'cafebabe'}
+```
+
+New regression test: `Tests/Skills/test_skill_trust_store.py::test_file_marker_store_rejects_marker_outside_store_dir`.
+
+## Check #2 -- local_skills_service.py `_is_unsafe_scratch_root`
+
+### What changed and why
+
+`_unsafe_scratch_root_containers` now returns `[self.store_dir, self.skills_dir, <trust store dir
+if wired>]` (previously omitted `self.store_dir`). `_is_unsafe_scratch_root` now checks BOTH
+directions per container:
+
+```python
+return any(
+    get_safe_relative_path(root, container) is not None
+    or get_safe_relative_path(container, root) is not None
+    for container in containers
+)
+```
+
+`self.store_dir` was added to the container list per the audit's explicit recommendation (AC #2),
+even though `skills_dir`/`trust_store_dir` are nested under it and would already be caught
+transitively by the new "root encloses container" direction -- `store_dir` also holds the skill
+index file directly, so it's listed for clarity and defense in depth.
+
+### Reproduction -- before
+
+```
+$ .venv/bin/python -c "
+... build LocalSkillsService(store_dir=<tmp>/user_data, trust_service=...) ...
+service._is_unsafe_scratch_root(<tmp>/user_data/skills/nested-scratch)   # nested inside skills_dir
+service._is_unsafe_scratch_root(<tmp>/user_data)                        # encloses skills_dir + trust_dir
+service._is_unsafe_scratch_root(<tmp>)                                   # encloses store_dir
+"
+nested-inside root flagged unsafe (expect True): True
+enclosing (containing) root flagged unsafe (expect True, but PRE-FIX is False): False
+grandparent (further enclosing) root flagged unsafe (expect True, but PRE-FIX is False): False
+```
+
+### Reproduction -- after
+
+```
+nested-inside root flagged unsafe (expect True): True
+enclosing (containing) root flagged unsafe (expect True): True
+grandparent (further enclosing) root flagged unsafe (expect True): True
+legitimate unrelated root flagged unsafe (expect False): False
+```
+
+New regression test: `Tests/Skills/test_skill_script_service.py::test_is_unsafe_scratch_root_rejects_both_containment_directions`
+(exercises both directions from the real `script_service` fixture's `store_dir`/`skills_dir`/
+`trust_service.trust_store.store_dir`, plus confirms a genuinely unrelated root is still accepted).
+
+## Legitimate-operation regression found and fixed
+
+`Tests/Skills/test_skill_script_service.py::test_scratch_root_config_knob_is_reachable` broke after
+the check #2 fix: its `custom_root = tmp_path / "custom-scratch"` happened to be nested directly
+under `LocalSkillsService.store_dir`, because that fixture's `store_dir` resolves to the same
+`tmp_path` the test also uses (`script_service` -> `make_trust_service` -> `LocalSkillsService(
+store_dir=trust.skills_dir.parent)` == `tmp_path`). Once `store_dir` became a protected container,
+that sibling directory was (correctly) rejected -- a fixture artifact, not a real production
+scenario a user would hit. Fixed by moving `custom_root` onto a genuinely unrelated
+`tmp_path_factory.mktemp("custom-scratch")` directory, matching the realistic shape of a real
+`[skills] script_scratch_root` value. Test passes again post-fix, confirming a legitimate configured
+scratch root is still honored.
+
+## Test call-site migration
+
+`FileSkillTrustGenerationMarkerStore.store_dir` has no default, so every direct construction site
+needed updating (~28 across 13 files: `Tests/conftest.py`, `Tests/Utils/test_sensitive_paths.py`,
+and 11 files under `Tests/Skills/`). Per the audit's "derive, don't re-spell" theme, each was updated
+to re-derive `store_dir` from the marker path already in scope (e.g. `marker_path.parent`, or the
+already-named `trust_store_dir`/`tmp_path` variable), rather than hardcoding a fresh literal. The
+one deliberate exception is the existing symlink-escape test
+(`test_file_marker_store_rejects_marker_parent_symlink_escape`), which passes `store_dir=marker_parent`
+(the symlinked directory itself) to preserve its original intent of testing a symlinked containment
+base.
+
+Verified with a script that parses every `FileSkillTrustGenerationMarkerStore(...)` call site and
+confirms `store_dir` appears in the argument list -- zero misses.
+
+## Tests run
+
+```
+.venv/bin/python -m pytest Tests/Skills Tests/Utils/test_sensitive_paths.py Tests/Library/test_skill_script_grant_panel.py -q
+```
+Result: **411 passed**, 1 pre-existing `RequestsDependencyWarning`, 0 failures, in ~151s.
+
+(Interim runs during the fix: `Tests/Skills` alone 377 passed; `Tests/Skills/test_skill_trust_store.py
++ test_local_skills_service.py + Tests/Utils/test_sensitive_paths.py` 76 passed;
+`Tests/Skills/test_skill_script_service.py` 37 passed; `Tests/Library/test_skill_script_grant_panel.py`
+3 passed.)
+
+No pre-existing failures in scope were touched (`test_tools_settings_window.py`'s six
+`test_chat_api_key_*` failures and the `pytest-mock`/`numpy`-dependent tests were not run, per the
+stated baselines).
+
+## Follow-up task filed
+
+`backlog/tasks/task-900 - Tools_Settings_Window-raw-TOML-save-writes-the-wrong-config-path-non-atomically.md`
+(TASK-900) -- `UI/Tools_Settings_Window.py::_save_raw_toml_config` has the same wrong-config-path
+(`DEFAULT_CONFIG_PATH` literal instead of `config._get_effective_config_path()`) and non-atomic-write
+(`open(path, "w")` + `toml.dump` instead of `atomic_write_text`) shape that TASK-851 fixed in
+`config.py`'s three encryption entry points, but wasn't one of 851's named entry points so was left
+unfixed. Filed with AC requiring a regression test that derives the expected path via
+`config._get_effective_config_path()` rather than a re-spelled literal, plus an atomicity test and a
+no-profile-override round-trip check.
+
+ID collision check: local scan found no duplicates and next-free id 869 pre-filing; `origin/dev`'s
+`backlog/tasks` tree (fetched fresh) had ids up to 899 not yet present in this worktree, so the task
+was filed as **TASK-900** (safely above both) rather than the locally-suggested 869, and a second
+scan post-filing confirmed no local duplicates and no collision against `origin/dev`.
+
+## Files changed
+
+- `tldw_chatbook/Skills_Interop/skill_trust_store.py`
+- `tldw_chatbook/Skills_Interop/local_skills_service.py`
+- `tldw_chatbook/app.py`
+- `Tests/conftest.py`
+- `Tests/Utils/test_sensitive_paths.py`
+- `Tests/Skills/test_verify_content_binary.py`
+- `Tests/Skills/test_e2e_run_skill_script.py`
+- `Tests/Skills/test_skills_library_flow.py`
+- `Tests/Skills/test_skill_trust_service.py`
+- `Tests/Skills/test_skill_remote_fetch.py`
+- `Tests/Skills/test_skill_trust_service_reset_posture.py`
+- `Tests/Skills/test_local_skills_service.py`
+- `Tests/Skills/test_skill_trust_keyring_autounlock.py`
+- `Tests/Skills/test_skill_trust_store_reset.py`
+- `Tests/Skills/test_trust_tolerates_unsupported.py`
+- `Tests/Skills/test_skill_trust_store.py`
+- `Tests/Skills/test_skill_script_service.py`
+- `backlog/tasks/task-853 - ...md` (status, plan, notes, AC checkboxes)
+- `backlog/tasks/task-900 - ...md` (new)

--- a/Docs/superpowers/qa/skills-script-execution-2026-07-25/seed3.py
+++ b/Docs/superpowers/qa/skills-script-execution-2026-07-25/seed3.py
@@ -12,7 +12,9 @@ store = get_user_data_dir() / "skills"; trust_dir = store / "skills" ; trust_dir
 skills_dir = store / "skills"
 scope = skill_trust_account_scope(trust_dir)
 marker_store, reduced = build_skill_trust_marker_store_with_fallback(
-    fallback_marker_path=trust_dir / "generation_marker.json", account_scope=scope)
+    fallback_marker_path=trust_dir / "generation_marker.json",
+    store_dir=trust_dir,
+    account_scope=scope)
 print("marker store:", type(marker_store).__name__, "reduced_rollback:", reduced)
 trust = SkillTrustService(
     skills_dir=skills_dir,

--- a/Tests/Skills/test_e2e_run_skill_script.py
+++ b/Tests/Skills/test_e2e_run_skill_script.py
@@ -163,12 +163,13 @@ def e2e_bridge_env(tmp_path, monkeypatch) -> Callable[..., _E2EEnv]:
         policy_enabled: bool = True,
         trusted: bool = True,
     ) -> _E2EEnv:
+        marker_path = tmp_path / "marker.json"
         trust_service = SkillTrustService(
             skills_dir=tmp_path / "skills",
             trust_store=SkillTrustStore(
                 store_dir=tmp_path / "trust",
                 marker_store=FileSkillTrustGenerationMarkerStore(
-                    tmp_path / "marker.json"
+                    marker_path, store_dir=marker_path.parent
                 ),
             ),
         )

--- a/Tests/Skills/test_local_skills_service.py
+++ b/Tests/Skills/test_local_skills_service.py
@@ -50,11 +50,14 @@ Missing valid Agent Skills metadata.
 
 
 def _trusted_local_service(tmp_path):
+    marker_path = tmp_path / "marker.json"
     trust_service = SkillTrustService(
         skills_dir=tmp_path / "skills",
         trust_store=SkillTrustStore(
             store_dir=tmp_path / "trust",
-            marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json"),
+            marker_store=FileSkillTrustGenerationMarkerStore(
+                marker_path, store_dir=marker_path.parent
+            ),
         ),
     )
     trust_service.unlock_with_passphrase("passphrase", salt=b"7" * 32)

--- a/Tests/Skills/test_skill_remote_fetch.py
+++ b/Tests/Skills/test_skill_remote_fetch.py
@@ -739,7 +739,9 @@ async def test_e2e_install_skill_from_github_tree_url_real_services(tmp_path, mo
         skills_dir=tmp_path / "skills",
         trust_store=SkillTrustStore(
             store_dir=tmp_path / "trust",
-            marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json"),
+            marker_store=FileSkillTrustGenerationMarkerStore(
+                tmp_path / "marker.json", store_dir=tmp_path
+            ),
         ),
     )
     trust_service.unlock_with_passphrase("e2e-passphrase", salt=b"7" * 32)
@@ -950,7 +952,9 @@ def test_e2e_agent_install_skill_confirm_allow(tmp_path, monkeypatch):
         skills_dir=tmp_path / "skills",
         trust_store=SkillTrustStore(
             store_dir=tmp_path / "trust",
-            marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json"),
+            marker_store=FileSkillTrustGenerationMarkerStore(
+                tmp_path / "marker.json", store_dir=tmp_path
+            ),
         ),
     )
     trust_service.unlock_with_passphrase("e2e-passphrase", salt=b"7" * 32)
@@ -1035,7 +1039,9 @@ def test_e2e_agent_install_skill_confirm_deny(tmp_path, monkeypatch):
         skills_dir=tmp_path / "skills",
         trust_store=SkillTrustStore(
             store_dir=tmp_path / "trust",
-            marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json"),
+            marker_store=FileSkillTrustGenerationMarkerStore(
+                tmp_path / "marker.json", store_dir=tmp_path
+            ),
         ),
     )
     trust_service.unlock_with_passphrase("e2e-passphrase", salt=b"7" * 32)

--- a/Tests/Skills/test_skill_script_service.py
+++ b/Tests/Skills/test_skill_script_service.py
@@ -215,7 +215,9 @@ async def test_script_cannot_write_into_its_own_bundle(script_service):
 
 
 @pytest.mark.asyncio
-async def test_scratch_root_config_knob_is_reachable(script_service, tmp_path, monkeypatch):
+async def test_scratch_root_config_knob_is_reachable(
+    script_service, tmp_path, tmp_path_factory, monkeypatch
+):
     """The 3-arg get_cli_setting form actually reaches [skills] via REAL config.
 
     Writes a real config.toml and points TLDW_CONFIG_PATH at it -- the
@@ -228,8 +230,17 @@ async def test_scratch_root_config_knob_is_reachable(script_service, tmp_path, m
     file (the exact thing the section-dict-form bug at config.py:3965 would
     otherwise silently defeat). This exercises the genuine
     `load_cli_config_and_ensure_existence()` -> section-lookup path.
+
+    `custom_root` is deliberately built from `tmp_path_factory`, NOT
+    `tmp_path`: `script_service`'s `LocalSkillsService.store_dir` resolves to
+    this same test's `tmp_path` (see `make_trust_service`), which is now
+    (TASK-853) itself a protected container -- a scratch root nested
+    anywhere under it, including a plain `tmp_path / "custom-scratch"`
+    sibling of `skills`/`trust`, is correctly rejected as unsafe. A distinct
+    `tmp_path_factory` directory is a genuinely unrelated location, the
+    realistic shape of a real `[skills] script_scratch_root` value.
     """
-    custom_root = tmp_path / "custom-scratch"
+    custom_root = tmp_path_factory.mktemp("custom-scratch")
     config_path = tmp_path / "config.toml"
     config_path.write_text(
         f'[skills]\nscript_scratch_root = "{custom_root}"\n', encoding="utf-8"
@@ -289,6 +300,42 @@ async def test_scratch_root_inside_skill_directory_is_rejected(script_service, m
     )
     # The rejected root must never even be created, let alone hold residue.
     assert not unsafe_root.exists()
+
+
+def test_is_unsafe_scratch_root_rejects_both_containment_directions(
+    script_service, tmp_path_factory
+):
+    """TASK-853: `_is_unsafe_scratch_root` must reject BOTH containment
+    directions, not just the one that already worked.
+
+    Pre-fix, this check only tested `get_safe_relative_path(root, container)`
+    -- root NESTED INSIDE a container -- so a root that instead ENCLOSES a
+    store (e.g. the skills service's own `store_dir`, which contains both
+    `skills_dir` and the trust store) passed uncaught. A reproduction
+    confirmed `store_dir` itself, and an ancestor of it, were both accepted
+    pre-fix. Every candidate here is derived from the service's own live
+    attributes (`service.store_dir`, `service.skills_dir`,
+    `service.trust_service.trust_store.store_dir`) rather than a re-spelled
+    literal, so this tracks the real containers instead of a copy that
+    could silently drift from them.
+    """
+    service, name = script_service
+    trust_store_dir = service.trust_service.trust_store.store_dir
+
+    # Direction 1 (already worked pre-fix): root NESTED INSIDE a store.
+    assert service._is_unsafe_scratch_root(service.skills_dir / "nested") is True
+    assert service._is_unsafe_scratch_root(trust_store_dir / "nested") is True
+
+    # Direction 2 (the bug): root that ENCLOSES a store. `store_dir` itself
+    # (now an explicit container) contains both `skills_dir` and the trust
+    # store, and its own parent encloses `store_dir` in turn.
+    assert service._is_unsafe_scratch_root(service.store_dir) is True
+    assert service._is_unsafe_scratch_root(service.store_dir.parent) is True
+
+    # A genuinely unrelated root -- neither inside nor enclosing any store --
+    # must still be accepted; the fix must not turn into "reject everything".
+    legitimate_root = tmp_path_factory.mktemp("legit-scratch")
+    assert service._is_unsafe_scratch_root(legitimate_root) is False
 
 
 @pytest.mark.asyncio

--- a/Tests/Skills/test_skill_trust_keyring_autounlock.py
+++ b/Tests/Skills/test_skill_trust_keyring_autounlock.py
@@ -28,7 +28,9 @@ def _fresh_service(tmp_path, skills_dir, key_cache):
         skills_dir=skills_dir,
         trust_store=SkillTrustStore(
             store_dir=tmp_path / "trust",
-            marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json"),
+            marker_store=FileSkillTrustGenerationMarkerStore(
+                tmp_path / "marker.json", store_dir=tmp_path
+            ),
         ),
         key_cache=key_cache,
     )
@@ -84,7 +86,9 @@ def test_no_key_cache_still_reports_locked(tmp_path):
         skills_dir=skills_dir,
         trust_store=SkillTrustStore(
             store_dir=tmp_path / "trust",
-            marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json"),
+            marker_store=FileSkillTrustGenerationMarkerStore(
+                tmp_path / "marker.json", store_dir=tmp_path
+            ),
         ),
     )
     assert fresh.trust_posture() == "locked"

--- a/Tests/Skills/test_skill_trust_service.py
+++ b/Tests/Skills/test_skill_trust_service.py
@@ -32,7 +32,9 @@ def _service(tmp_path, passphrase="passphrase", key_cache=None):
     skills_dir = tmp_path / "skills"
     trust_store = SkillTrustStore(
         store_dir=tmp_path / "trust",
-        marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json"),
+        marker_store=FileSkillTrustGenerationMarkerStore(
+            tmp_path / "marker.json", store_dir=tmp_path
+        ),
     )
     service = SkillTrustService(
         skills_dir=skills_dir,
@@ -257,7 +259,9 @@ def test_existing_manifest_without_unlock_reports_locked_status(tmp_path):
         skills_dir=skills_dir,
         trust_store=SkillTrustStore(
             store_dir=tmp_path / "trust",
-            marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json"),
+            marker_store=FileSkillTrustGenerationMarkerStore(
+                tmp_path / "marker.json", store_dir=tmp_path
+            ),
         ),
     )
     status = locked_service.status_for_skill("demo")
@@ -451,7 +455,9 @@ def test_keyring_convenience_loads_only_salt_bound_cached_keys(tmp_path):
         skills_dir=skills_dir,
         trust_store=SkillTrustStore(
             store_dir=tmp_path / "trust",
-            marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json"),
+            marker_store=FileSkillTrustGenerationMarkerStore(
+                tmp_path / "marker.json", store_dir=tmp_path
+            ),
         ),
         key_cache=key_cache,
     )
@@ -469,7 +475,9 @@ def test_keyring_convenience_loads_only_salt_bound_cached_keys(tmp_path):
         skills_dir=skills_dir,
         trust_store=SkillTrustStore(
             store_dir=tmp_path / "trust",
-            marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json"),
+            marker_store=FileSkillTrustGenerationMarkerStore(
+                tmp_path / "marker.json", store_dir=tmp_path
+            ),
         ),
         key_cache=key_cache,
     )

--- a/Tests/Skills/test_skill_trust_service_reset_posture.py
+++ b/Tests/Skills/test_skill_trust_service_reset_posture.py
@@ -9,7 +9,9 @@ from tldw_chatbook.Skills_Interop.skill_trust_store import (
 
 
 def _service(tmp_path, marker=None):
-    marker = marker or FileSkillTrustGenerationMarkerStore(tmp_path / "trust" / "marker.json")
+    marker = marker or FileSkillTrustGenerationMarkerStore(
+        tmp_path / "trust" / "marker.json", store_dir=tmp_path / "trust"
+    )
     (tmp_path / "trust").mkdir(parents=True, exist_ok=True)
     (tmp_path / "skills").mkdir(parents=True, exist_ok=True)
     return SkillTrustService(
@@ -25,7 +27,9 @@ def test_posture_needs_setup_on_pristine(tmp_path):
 
 
 def test_posture_needs_resetup_when_marker_present_but_no_manifest(tmp_path):
-    marker = FileSkillTrustGenerationMarkerStore(tmp_path / "trust" / "marker.json")
+    marker = FileSkillTrustGenerationMarkerStore(
+        tmp_path / "trust" / "marker.json", store_dir=tmp_path / "trust"
+    )
     (tmp_path / "trust").mkdir(parents=True, exist_ok=True)
     marker.save_marker(generation=1, manifest_digest="d")  # foreign/inherited marker
     svc = _service(tmp_path, marker=marker)
@@ -73,7 +77,9 @@ def test_posture_unavailable_beats_needs_setup_when_no_manifest_and_marker_raise
 
 
 def test_reset_then_bootstrap_recovers_from_poison(tmp_path):
-    marker = FileSkillTrustGenerationMarkerStore(tmp_path / "trust" / "marker.json")
+    marker = FileSkillTrustGenerationMarkerStore(
+        tmp_path / "trust" / "marker.json", store_dir=tmp_path / "trust"
+    )
     (tmp_path / "trust").mkdir(parents=True, exist_ok=True)
     marker.save_marker(generation=9, manifest_digest="stale")  # poison
     svc = _service(tmp_path, marker=marker)

--- a/Tests/Skills/test_skill_trust_store.py
+++ b/Tests/Skills/test_skill_trust_store.py
@@ -61,7 +61,9 @@ class AlwaysFailingMarkerStore:
 
 def test_trust_store_round_trips_manifest_snapshot_marker_and_salt(tmp_path):
     keys = derive_skill_trust_keys("passphrase", salt=b"3" * 32)
-    marker = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json")
+    marker = FileSkillTrustGenerationMarkerStore(
+        tmp_path / "marker.json", store_dir=tmp_path
+    )
     store = SkillTrustStore(store_dir=tmp_path / "trust", marker_store=marker)
 
     manifest = {
@@ -104,7 +106,9 @@ def test_trust_store_round_trips_manifest_snapshot_marker_and_salt(tmp_path):
 
 def test_trust_store_rejects_tampered_manifest(tmp_path):
     keys = derive_skill_trust_keys("passphrase", salt=b"4" * 32)
-    marker = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json")
+    marker = FileSkillTrustGenerationMarkerStore(
+        tmp_path / "marker.json", store_dir=tmp_path
+    )
     store = SkillTrustStore(store_dir=tmp_path / "trust", marker_store=marker)
 
     store.save_manifest(
@@ -120,7 +124,9 @@ def test_trust_store_rejects_tampered_manifest(tmp_path):
 
 def test_trust_store_rejects_marker_mismatch(tmp_path):
     keys = derive_skill_trust_keys("passphrase", salt=b"5" * 32)
-    marker = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json")
+    marker = FileSkillTrustGenerationMarkerStore(
+        tmp_path / "marker.json", store_dir=tmp_path
+    )
     store = SkillTrustStore(store_dir=tmp_path / "trust", marker_store=marker)
 
     store.save_manifest(
@@ -135,7 +141,7 @@ def test_trust_store_rejects_marker_mismatch(tmp_path):
 def test_trust_store_rejects_missing_marker_after_manifest_exists(tmp_path):
     keys = derive_skill_trust_keys("passphrase", salt=b"6" * 32)
     marker_path = tmp_path / "marker.json"
-    marker = FileSkillTrustGenerationMarkerStore(marker_path)
+    marker = FileSkillTrustGenerationMarkerStore(marker_path, store_dir=marker_path.parent)
     store = SkillTrustStore(store_dir=tmp_path / "trust", marker_store=marker)
 
     store.save_manifest(
@@ -150,7 +156,7 @@ def test_trust_store_rejects_missing_marker_after_manifest_exists(tmp_path):
 def test_trust_store_marker_failure_preserves_previous_manifest_and_marker(tmp_path):
     keys = derive_skill_trust_keys("passphrase", salt=b"7" * 32)
     marker = FailingMarkerStore(
-        FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json"),
+        FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json", store_dir=tmp_path),
         fail_on_save_number=2,
     )
     store = SkillTrustStore(store_dir=tmp_path / "trust", marker_store=marker)
@@ -176,7 +182,9 @@ def test_trust_store_marker_failure_preserves_previous_manifest_and_marker(tmp_p
 
 def test_trust_store_marker_rollback_preserves_original_failure(tmp_path):
     keys = derive_skill_trust_keys("passphrase", salt=b"7" * 32)
-    marker = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json")
+    marker = FileSkillTrustGenerationMarkerStore(
+        tmp_path / "marker.json", store_dir=tmp_path
+    )
     store = SkillTrustStore(store_dir=tmp_path / "trust", marker_store=marker)
     previous_manifest = {"version": 1, "generation": 1, "skills": {}, "audit": []}
     advanced_manifest = {"version": 1, "generation": 2, "skills": {}, "audit": []}
@@ -193,7 +201,9 @@ def test_trust_store_marker_rollback_preserves_original_failure(tmp_path):
 
 def test_trust_store_rejects_snapshot_directory_symlink_escape(tmp_path):
     keys = derive_skill_trust_keys("passphrase", salt=b"7" * 32)
-    marker = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json")
+    marker = FileSkillTrustGenerationMarkerStore(
+        tmp_path / "marker.json", store_dir=tmp_path
+    )
     store_dir = tmp_path / "trust"
     outside_dir = tmp_path / "outside"
     store_dir.mkdir()
@@ -214,7 +224,9 @@ def test_file_marker_store_rejects_marker_parent_symlink_escape(tmp_path):
     outside_dir.mkdir()
     marker_parent = tmp_path / "marker-parent"
     marker_parent.symlink_to(outside_dir, target_is_directory=True)
-    marker = FileSkillTrustGenerationMarkerStore(marker_parent / "marker.json")
+    marker = FileSkillTrustGenerationMarkerStore(
+        marker_parent / "marker.json", store_dir=marker_parent
+    )
 
     with pytest.raises(ValueError, match="unsafe skill trust path"):
         marker.save_marker(generation=1, manifest_digest="digest")
@@ -222,9 +234,42 @@ def test_file_marker_store_rejects_marker_parent_symlink_escape(tmp_path):
     assert not (outside_dir / "marker.json").exists()
 
 
+def test_file_marker_store_rejects_marker_outside_store_dir(tmp_path):
+    """TASK-853: a marker path outside the trust store's own directory must
+    be rejected, not silently accepted.
+
+    Pre-fix, ``FileSkillTrustGenerationMarkerStore`` validated the marker
+    path against ``marker_path.parent`` -- the candidate's own parent -- so
+    the containment check was true by construction and rejected nothing. A
+    reproduction confirmed a marker file living in a totally unrelated
+    directory was silently accepted and written to. Passing the trust
+    store's real ``store_dir`` (independent of the marker path itself) as
+    the containment base closes that hole.
+    """
+    store_dir = tmp_path / "trust"
+    store_dir.mkdir()
+    outside_dir = tmp_path / "totally-unrelated-elsewhere"
+    outside_dir.mkdir()
+    marker_path = outside_dir / "marker.json"
+
+    marker = FileSkillTrustGenerationMarkerStore(marker_path, store_dir=store_dir)
+
+    with pytest.raises(ValueError, match="unsafe skill trust path"):
+        marker.save_marker(generation=1, manifest_digest="digest")
+    assert not marker_path.exists()
+
+    # A legitimate marker co-located with the store must still round-trip.
+    legit_marker_path = store_dir / "marker.json"
+    legit = FileSkillTrustGenerationMarkerStore(legit_marker_path, store_dir=store_dir)
+    legit.save_marker(generation=1, manifest_digest="digest")
+    assert legit.load_marker() == {"generation": 1, "manifest_digest": "digest"}
+
+
 def test_marker_store_builder_falls_back_to_reduced_protection_file_marker(tmp_path):
+    trust_store_dir = tmp_path / "trust"
     marker_store, reduced = build_skill_trust_marker_store_with_fallback(
-        fallback_marker_path=tmp_path / "trust" / "marker.json",
+        fallback_marker_path=trust_store_dir / "marker.json",
+        store_dir=trust_store_dir,
         keyring_backend=FakePlaintextKeyring(),
     )
 
@@ -236,7 +281,9 @@ def test_marker_store_builder_falls_back_to_reduced_protection_file_marker(tmp_p
 
 def test_trust_store_load_salt_requires_32_bytes(tmp_path):
     keys = derive_skill_trust_keys("passphrase", salt=b"7" * 32)
-    marker = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json")
+    marker = FileSkillTrustGenerationMarkerStore(
+        tmp_path / "marker.json", store_dir=tmp_path
+    )
     store = SkillTrustStore(store_dir=tmp_path / "trust", marker_store=marker)
 
     store.save_manifest(
@@ -252,7 +299,9 @@ def test_trust_store_load_salt_requires_32_bytes(tmp_path):
 
 def test_trust_store_snapshot_accepts_immutable_mapping_payloads(tmp_path):
     keys = derive_skill_trust_keys("passphrase", salt=b"8" * 32)
-    marker = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json")
+    marker = FileSkillTrustGenerationMarkerStore(
+        tmp_path / "marker.json", store_dir=tmp_path
+    )
     store = SkillTrustStore(store_dir=tmp_path / "trust", marker_store=marker)
     payload = {"files": MappingProxyType({"SKILL.md": "# Demo"})}
 
@@ -265,7 +314,9 @@ def test_trust_store_snapshot_accepts_immutable_mapping_payloads(tmp_path):
 
 def test_trust_store_rejects_non_string_mapping_keys(tmp_path):
     keys = derive_skill_trust_keys("passphrase", salt=b"9" * 32)
-    marker = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json")
+    marker = FileSkillTrustGenerationMarkerStore(
+        tmp_path / "marker.json", store_dir=tmp_path
+    )
     store = SkillTrustStore(store_dir=tmp_path / "trust", marker_store=marker)
 
     with pytest.raises(ValueError, match="mapping keys must be strings"):

--- a/Tests/Skills/test_skill_trust_store.py
+++ b/Tests/Skills/test_skill_trust_store.py
@@ -265,6 +265,48 @@ def test_file_marker_store_rejects_marker_outside_store_dir(tmp_path):
     assert legit.load_marker() == {"generation": 1, "manifest_digest": "digest"}
 
 
+def test_file_marker_store_clear_rejects_marker_outside_store_dir(tmp_path):
+    """Regression test for task-851 review finding 4.
+
+    ``load_marker``/``save_marker`` both validate ``marker_path`` against
+    ``store_dir`` via ``_validated_trust_file_path`` (see the two tests
+    above). ``clear()`` skipped that check entirely and unlinked
+    ``self.marker_path`` unconditionally -- not reachable through today's
+    constructors (which always co-locate the marker under the store dir),
+    but the same invariant the other two methods enforce should hold here
+    too. This plants a file at a path outside ``store_dir`` (standing in
+    for a misconfigured or attacker-influenced marker path) and asserts
+    ``clear()`` refuses to remove it.
+    """
+    store_dir = tmp_path / "trust"
+    store_dir.mkdir()
+    outside_dir = tmp_path / "totally-unrelated-elsewhere"
+    outside_dir.mkdir()
+    marker_path = outside_dir / "marker.json"
+    marker_path.write_text(json.dumps({"generation": 1, "manifest_digest": "d"}))
+
+    marker = FileSkillTrustGenerationMarkerStore(marker_path, store_dir=store_dir)
+
+    # clear() stays non-raising by contract, but must not delete the file.
+    marker.clear()
+
+    assert marker_path.exists()
+
+
+def test_file_marker_store_clear_removes_legitimate_marker(tmp_path):
+    """A marker co-located with the store must still be cleared normally."""
+    store_dir = tmp_path / "trust"
+    store_dir.mkdir()
+    marker_path = store_dir / "marker.json"
+    marker = FileSkillTrustGenerationMarkerStore(marker_path, store_dir=store_dir)
+    marker.save_marker(generation=1, manifest_digest="digest")
+    assert marker_path.exists()
+
+    marker.clear()
+
+    assert not marker_path.exists()
+
+
 def test_marker_store_builder_falls_back_to_reduced_protection_file_marker(tmp_path):
     trust_store_dir = tmp_path / "trust"
     marker_store, reduced = build_skill_trust_marker_store_with_fallback(

--- a/Tests/Skills/test_skill_trust_store_reset.py
+++ b/Tests/Skills/test_skill_trust_store_reset.py
@@ -24,7 +24,7 @@ class _FakeKeyring:
 
 
 def test_file_marker_clear_is_idempotent(tmp_path):
-    store = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json")
+    store = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json", store_dir=tmp_path)
     store.save_marker(generation=1, manifest_digest="d")
     assert store.load_marker() is not None
     store.clear()
@@ -59,7 +59,7 @@ def test_keyring_key_cache_clear(monkeypatch):
 
 
 def test_store_delete_manifest_removes_file_and_snapshots(tmp_path):
-    marker = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json")
+    marker = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json", store_dir=tmp_path)
     store = SkillTrustStore(store_dir=tmp_path, marker_store=marker)
     store.manifest_path.parent.mkdir(parents=True, exist_ok=True)
     store.manifest_path.write_text("{}", encoding="utf-8")

--- a/Tests/Skills/test_skills_library_flow.py
+++ b/Tests/Skills/test_skills_library_flow.py
@@ -81,11 +81,14 @@ def _real_skills_scope_service(
 
 def _real_trust_service(tmp_path) -> SkillTrustService:
     """A real, already-unlocked (but not yet bootstrapped) trust service."""
+    marker_path = tmp_path / "marker.json"
     trust_service = SkillTrustService(
         skills_dir=tmp_path / "skills",
         trust_store=SkillTrustStore(
             store_dir=tmp_path / "trust",
-            marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json"),
+            marker_store=FileSkillTrustGenerationMarkerStore(
+                marker_path, store_dir=marker_path.parent
+            ),
         ),
     )
     trust_service.unlock_with_passphrase("trust-passphrase", salt=b"7" * 32)
@@ -98,11 +101,14 @@ def _real_uninitialized_trust_service(tmp_path) -> SkillTrustService:
     ``_real_trust_service`` above, which is already unlocked. This is the
     exact fresh-install shape the Phase-1 gate flagged as having no live-UI
     bootstrap path (FIX 2)."""
+    marker_path = tmp_path / "marker.json"
     return SkillTrustService(
         skills_dir=tmp_path / "skills",
         trust_store=SkillTrustStore(
             store_dir=tmp_path / "trust",
-            marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json"),
+            marker_store=FileSkillTrustGenerationMarkerStore(
+                marker_path, store_dir=marker_path.parent
+            ),
         ),
     )
 

--- a/Tests/Skills/test_trust_tolerates_unsupported.py
+++ b/Tests/Skills/test_trust_tolerates_unsupported.py
@@ -10,11 +10,14 @@ from tldw_chatbook.Skills_Interop.skill_trust_store import (
 def _svc(tmp_path):
     (tmp_path / "trust").mkdir(exist_ok=True)
     (tmp_path / "skills").mkdir(exist_ok=True)
+    trust_store_dir = tmp_path / "trust"
     return SkillTrustService(
         skills_dir=tmp_path / "skills",
         trust_store=SkillTrustStore(
-            store_dir=tmp_path / "trust",
-            marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "trust" / "m.json"),
+            store_dir=trust_store_dir,
+            marker_store=FileSkillTrustGenerationMarkerStore(
+                trust_store_dir / "m.json", store_dir=trust_store_dir
+            ),
         ),
         key_cache=None,
     )

--- a/Tests/Skills/test_verify_content_binary.py
+++ b/Tests/Skills/test_verify_content_binary.py
@@ -8,11 +8,14 @@ from tldw_chatbook.Skills_Interop.skill_trust_store import (
 def _svc(tmp_path):
     (tmp_path / "trust").mkdir(exist_ok=True)
     (tmp_path / "skills").mkdir(exist_ok=True)
+    trust_store_dir = tmp_path / "trust"
     return SkillTrustService(
         skills_dir=tmp_path / "skills",
         trust_store=SkillTrustStore(
-            store_dir=tmp_path / "trust",
-            marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "trust" / "m.json"),
+            store_dir=trust_store_dir,
+            marker_store=FileSkillTrustGenerationMarkerStore(
+                trust_store_dir / "m.json", store_dir=trust_store_dir
+            ),
         ),
         key_cache=None,
     )

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -6794,6 +6794,28 @@ def test_settings_config_path_validates_env_override(monkeypatch):
         screen._config_path()
 
 
+def test_settings_config_path_delegates_to_shared_accessor(monkeypatch, tmp_path):
+    """Regression test for task-851 review finding 5.
+
+    ``SettingsScreen._config_path()`` used to re-spell
+    ``config._get_effective_config_path()``'s override/validate logic
+    verbatim instead of calling it -- the exact re-spelled-accessor drift
+    shape this whole audit is about. Monkeypatching the shared accessor
+    must change what ``_config_path()`` returns; a re-implementation
+    would not react to that patch (it would keep resolving the override
+    itself instead).
+    """
+    app = _build_test_app()
+    screen = SettingsScreen(app)
+
+    sentinel = tmp_path / "sentinel-config.toml"
+    monkeypatch.setattr(
+        settings_screen_module, "_get_effective_config_path", lambda: sentinel
+    )
+
+    assert screen._config_path() == sentinel
+
+
 def test_settings_overview_config_path_label_hides_local_directory(
     monkeypatch, tmp_path
 ):

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -6801,16 +6801,17 @@ def test_settings_config_path_delegates_to_shared_accessor(monkeypatch, tmp_path
     ``config._get_effective_config_path()``'s override/validate logic
     verbatim instead of calling it -- the exact re-spelled-accessor drift
     shape this whole audit is about. Monkeypatching the shared accessor
-    must change what ``_config_path()`` returns; a re-implementation
-    would not react to that patch (it would keep resolving the override
-    itself instead).
+    (``config.get_cli_config_path``, the public wrapper every other
+    effective-path call site in this app uses) must change what
+    ``_config_path()`` returns; a re-implementation would not react to
+    that patch (it would keep resolving the override itself instead).
     """
     app = _build_test_app()
     screen = SettingsScreen(app)
 
     sentinel = tmp_path / "sentinel-config.toml"
     monkeypatch.setattr(
-        settings_screen_module, "_get_effective_config_path", lambda: sentinel
+        settings_screen_module, "get_cli_config_path", lambda: sentinel
     )
 
     assert screen._config_path() == sentinel

--- a/Tests/Utils/test_atomic_file_ops.py
+++ b/Tests/Utils/test_atomic_file_ops.py
@@ -1,0 +1,74 @@
+"""Tests for ``Utils/atomic_file_ops.py``, in particular the
+``preserve_existing_mode`` parameter added by the task-851 review (finding
+2): ``atomic_write_text`` used to always ``chmod`` the replacement file to
+its ``mode`` parameter's default (0o644), which widened permissions on any
+target file that had been deliberately tightened (e.g. a config file
+holding secrets, chmod'd to 0o600). Enabling then disabling config
+encryption measured 0600 -> 0644 -> (still) 0644 with plaintext keys.
+"""
+
+import stat
+
+import pytest
+
+from tldw_chatbook.Utils.atomic_file_ops import atomic_write_text
+
+
+def _mode(path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+def test_preserve_existing_mode_keeps_restrictive_permissions(tmp_path):
+    """A pre-existing 0600 file must stay 0600 after an atomic rewrite."""
+    target = tmp_path / "secrets.toml"
+    target.write_text("a = 1\n")
+    target.chmod(0o600)
+
+    atomic_write_text(
+        target, "a = 2\n", mode=0o644, preserve_existing_mode=True
+    )
+
+    assert _mode(target) == 0o600
+    assert target.read_text() == "a = 2\n"
+
+
+def test_preserve_existing_mode_keeps_permissive_permissions(tmp_path):
+    """The preserve path must not *tighten* an existing file either --
+    it carries forward whatever mode the file already had, in either
+    direction."""
+    target = tmp_path / "public.toml"
+    target.write_text("a = 1\n")
+    target.chmod(0o644)
+
+    atomic_write_text(
+        target, "a = 2\n", mode=0o600, preserve_existing_mode=True
+    )
+
+    assert _mode(target) == 0o644
+
+
+def test_preserve_existing_mode_uses_fallback_mode_for_new_file(tmp_path):
+    """When the target does not exist yet, there is nothing to preserve --
+    the caller-supplied ``mode`` (e.g. a restrictive default for a secrets
+    file) is applied instead."""
+    target = tmp_path / "new_secrets.toml"
+    assert not target.exists()
+
+    atomic_write_text(
+        target, "a = 1\n", mode=0o600, preserve_existing_mode=True
+    )
+
+    assert _mode(target) == 0o600
+
+
+def test_preserve_existing_mode_false_keeps_legacy_behavior(tmp_path):
+    """Default (``preserve_existing_mode=False``) behavior for existing
+    callers must be unchanged: the file is always chmod'd to ``mode``,
+    even if it previously had a different mode."""
+    target = tmp_path / "notes.md"
+    target.write_text("hello\n")
+    target.chmod(0o600)
+
+    atomic_write_text(target, "hello again\n")
+
+    assert _mode(target) == 0o644

--- a/Tests/Utils/test_config_encryption.py
+++ b/Tests/Utils/test_config_encryption.py
@@ -5,10 +5,19 @@ Tests AES-256-GCM encryption with scrypt key derivation.
 """
 
 import base64
+import sys
+
 import pytest
 from unittest.mock import patch
 
 from tldw_chatbook.Utils.config_encryption import ConfigEncryption, config_encryption
+
+if sys.version_info < (3, 11):
+    import tomli as tomllib
+else:
+    import tomllib
+
+from tldw_chatbook.config import CONFIG_TOML_CONTENT, DEFAULT_APP_TTS_CONFIG
 
 
 class TestConfigEncryption:
@@ -468,6 +477,68 @@ class TestConfigEncryptionEdgeCases:
 
         for i in range(10):
             assert results_dict[i] == f"test_{i}"
+
+
+class TestDetectApiKeysRealProviderNames:
+    """Regression coverage for task-852.
+
+    ``detect_api_keys`` used to match only six literal key names
+    (``api_key``, ``apikey``, ``api-key``, ``secret``, ``token``,
+    ``password``), so a config populated with this app's actual
+    provider-key field names -- all prefixed or suffixed -- reported
+    nothing worth encrypting. These tests read the real key names out of
+    ``CONFIG_TOML_CONTENT`` / ``DEFAULT_APP_TTS_CONFIG`` rather than
+    re-typing a hand-picked literal list, so a future rename of those
+    fields fails this test instead of silently going vacuous.
+    """
+
+    @pytest.fixture
+    def encryptor(self):
+        return ConfigEncryption()
+
+    def test_detects_config_full_of_real_plaintext_provider_keys(self, encryptor):
+        default_config = tomllib.loads(CONFIG_TOML_CONTENT)
+        search_engines = default_config["SearchEngines"]
+        search_key_name = next(
+            key for key in search_engines if key.endswith("_api_key")
+        )
+        assert "auth_token" in default_config["tldw_api"]
+        assert "api_token" in default_config["github"]
+
+        config = {
+            "SearchEngines": {search_key_name: "search-engine-plaintext-secret"},
+            "tldw_api": {"auth_token": "tldw-api-plaintext-secret"},
+            "github": {"api_token": "github-plaintext-secret"},
+        }
+        assert encryptor.detect_api_keys(config) is True
+
+    def test_detects_tts_fallback_key_family(self, encryptor):
+        fallback_key_names = [
+            key
+            for key in DEFAULT_APP_TTS_CONFIG
+            if "api_key" in key.lower()
+        ]
+        assert fallback_key_names, "expected the *_fallback API key family to exist"
+        config = {
+            "app_tts": {name: "fallback-plaintext-secret" for name in fallback_key_names}
+        }
+        assert encryptor.detect_api_keys(config) is True
+
+    def test_ignores_env_var_name_and_max_tokens_only_config(self, encryptor):
+        default_config = tomllib.loads(CONFIG_TOML_CONTENT)
+        openai_section = default_config["api_settings"]["openai"]
+        assert "api_key_env_var" in openai_section
+        assert "max_tokens" in openai_section
+
+        config = {
+            "api_settings": {
+                "openai": {
+                    "api_key_env_var": "OPENAI_API_KEY",
+                    "max_tokens": 4096,
+                }
+            }
+        }
+        assert encryptor.detect_api_keys(config) is False
 
 
 if __name__ == "__main__":

--- a/Tests/Utils/test_sensitive_config_keys.py
+++ b/Tests/Utils/test_sensitive_config_keys.py
@@ -1,0 +1,197 @@
+"""Tests for the shared sensitive-config-key predicate (task-852).
+
+Before ``Utils/sensitive_config_keys.py`` existed, four independent copies of
+"is this config key a secret" disagreed with each other: an exact-6-literal
+match in ``Utils/config_encryption.py`` never matched any real provider key
+name in this app (they are all prefixed/suffixed, e.g. ``openai_api_key``,
+``bing_search_api_key``, ``OPENAI_API_KEY_fallback``); a substring match in
+``config.py`` over-flagged ``max_tokens`` and ``api_key_env_var``; an
+endswith match in ``settings_privacy_security.py`` under-counted keys where
+the sensitive fragment isn't a suffix (``search_engine_api_key_baidu``,
+``OPENAI_API_KEY_fallback``).
+
+The real-key-name tests below deliberately read key names out of
+``tldw_chatbook.config.CONFIG_TOML_CONTENT`` (the app's actual shipped
+default config) and ``DEFAULT_APP_TTS_CONFIG`` (the other real default
+source for the ``_fallback`` key family), rather than re-typing a
+hand-picked literal list -- a hand-typed list would silently go vacuous the
+next time the real config drifted, which is exactly the failure mode that
+produced this bug in the first place.
+"""
+
+import sys
+
+if sys.version_info < (3, 11):
+    import tomli as tomllib
+else:
+    import tomllib
+
+from tldw_chatbook.config import CONFIG_TOML_CONTENT, DEFAULT_APP_TTS_CONFIG
+from tldw_chatbook.Utils.sensitive_config_keys import is_sensitive_config_key
+
+
+DEFAULT_CONFIG = tomllib.loads(CONFIG_TOML_CONTENT)
+
+
+def _iter_leaf_key_names(mapping):
+    """Yield every leaf key name (not path) found anywhere in ``mapping``."""
+    for key, value in mapping.items():
+        if isinstance(value, dict):
+            yield from _iter_leaf_key_names(value)
+        else:
+            yield key
+
+
+class TestRealConfigKeyNamesAreDetected:
+    """AC #1/#4: real provider-key config names, sourced from the app's own
+    default config, must be detected -- not just synthetic literals."""
+
+    def test_search_engine_provider_keys_are_detected(self):
+        # Real TOML keys under [SearchEngines], read from the shipped
+        # default config rather than typed by hand.
+        search_engines = DEFAULT_CONFIG["SearchEngines"]
+        provider_key_names = [
+            key for key in search_engines if key.endswith("_api_key")
+        ]
+        # Sanity: the default config still actually ships this family.
+        assert len(provider_key_names) >= 5
+        for key_name in provider_key_names:
+            assert is_sensitive_config_key(key_name), (
+                f"expected {key_name!r} (a real [SearchEngines] key) to be "
+                "detected as sensitive"
+            )
+
+    def test_provider_api_settings_key_is_detected(self):
+        # [api_settings.google] is the one provider section that ships an
+        # uncommented literal "api_key" in the real default config (every
+        # other provider defaults to *_api_key_env_var instead); read the
+        # key name from there rather than typing "api_key" disconnected
+        # from the source.
+        google_section = DEFAULT_CONFIG["api_settings"]["google"]
+        (real_key_name,) = [key for key in google_section if key == "api_key"]
+        assert is_sensitive_config_key(real_key_name)
+
+    def test_tldw_api_auth_token_is_detected(self):
+        assert "auth_token" in DEFAULT_CONFIG["tldw_api"]
+        assert is_sensitive_config_key("auth_token")
+
+    def test_github_api_token_is_detected(self):
+        assert "api_token" in DEFAULT_CONFIG["github"]
+        assert is_sensitive_config_key("api_token")
+
+    def test_tts_fallback_api_key_family_is_detected(self):
+        # Real keys from the other live default source referenced by
+        # task-852 (config.py:66,70), written by the TTS settings form.
+        fallback_key_names = [
+            key
+            for key in DEFAULT_APP_TTS_CONFIG
+            if "api_key" in key.lower() or "apikey" in key.lower()
+        ]
+        assert len(fallback_key_names) >= 2
+        for key_name in fallback_key_names:
+            assert is_sensitive_config_key(key_name), (
+                f"expected {key_name!r} (a real DEFAULT_APP_TTS_CONFIG key) "
+                "to be detected as sensitive"
+            )
+
+
+class TestRealNonSecretKeyNamesAreExcluded:
+    """AC #3: keys the old substring-matching copy over-flagged must not be
+    treated as secrets, using the real key names that triggered the bug."""
+
+    def test_env_var_name_keys_are_excluded(self):
+        api_settings = DEFAULT_CONFIG["api_settings"]
+        env_var_key_names = {
+            key
+            for section in api_settings.values()
+            for key in section
+            if key.endswith("_env_var")
+        }
+        assert "api_key_env_var" in env_var_key_names
+        for key_name in env_var_key_names:
+            assert not is_sensitive_config_key(key_name), (
+                f"{key_name!r} names an environment variable, not a secret"
+            )
+
+        assert "api_token_env_var" in DEFAULT_CONFIG["github"]
+        assert not is_sensitive_config_key("api_token_env_var")
+
+    def test_max_tokens_is_excluded(self):
+        # config.py's old substring-matching copy flagged this because it
+        # contains "_token" as a bare substring.
+        assert "max_tokens" in DEFAULT_CONFIG["api_settings"]["openai"]
+        assert not is_sensitive_config_key("max_tokens")
+
+    def test_keyword_and_keypress_settings_are_not_flagged(self):
+        """Real non-secret keys from the default config that a naive bare
+        "_key" substring match (the old config.py behavior) wrongly flagged,
+        because each embeds "_key" as part of an unrelated word
+        (keyword/keypress), not as a suffix."""
+        keyword_settings = {
+            "default_keyword_filter",
+            "extract_keywords",
+            "max_keywords",
+            "skip_on_keypress",
+            "auto_save_on_every_key",
+        }
+        for key_name in keyword_settings:
+            assert key_name in set(_iter_leaf_key_names(DEFAULT_CONFIG)), (
+                f"expected {key_name!r} to still be a real default config key"
+            )
+        # "auto_save_on_every_key" genuinely ends with "_key" (it is about
+        # keystrokes, not API keys); it is a boolean setting so it is never
+        # encrypted regardless, but it is not asserted here as excluded.
+        for key_name in keyword_settings - {"auto_save_on_every_key"}:
+            assert not is_sensitive_config_key(key_name), (
+                f"expected {key_name!r} to NOT be treated as a secret"
+            )
+
+
+class TestSensitiveConfigKeyPredicateSemantics:
+    """Direct unit coverage of the predicate's documented rules."""
+
+    def test_exact_literal_names(self):
+        for key_name in (
+            "api_key",
+            "apikey",
+            "api-key",
+            "secret",
+            "token",
+            "password",
+            "auth_token",
+            "api_token",
+            "access_token",
+            "secret_key",
+            "refresh_token",
+            "client_secret",
+        ):
+            assert is_sensitive_config_key(key_name)
+
+    def test_case_insensitive(self):
+        assert is_sensitive_config_key("API_KEY")
+        assert is_sensitive_config_key("Auth_Token")
+
+    def test_prefixed_and_suffixed_api_key_variants(self):
+        assert is_sensitive_config_key("openai_api_key")
+        assert is_sensitive_config_key("bing_search_api_key")
+        assert is_sensitive_config_key("search_engine_api_key_baidu")
+        assert is_sensitive_config_key("OPENAI_API_KEY_fallback")
+        assert is_sensitive_config_key("ELEVENLABS_API_KEY_fallback")
+
+    def test_env_var_guard_overrides_everything(self):
+        assert not is_sensitive_config_key("api_key_env_var")
+        assert not is_sensitive_config_key("ANYTHING_API_KEY_ENV_VAR")
+
+    def test_max_tokens_style_false_positive_excluded(self):
+        assert not is_sensitive_config_key("max_tokens")
+        assert not is_sensitive_config_key("chat_default_max_tokens")
+
+    def test_non_secret_settings_excluded(self):
+        assert not is_sensitive_config_key("default_tab")
+        assert not is_sensitive_config_key("timeout")
+        assert not is_sensitive_config_key("model")
+
+    def test_empty_and_non_string_keys(self):
+        assert not is_sensitive_config_key("")
+        assert not is_sensitive_config_key(None)
+        assert is_sensitive_config_key(123) is False

--- a/Tests/Utils/test_sensitive_paths.py
+++ b/Tests/Utils/test_sensitive_paths.py
@@ -325,7 +325,7 @@ def test_skill_trust_store_paths_are_refused_via_the_actually_used_accessors():
     store = SkillTrustStore(
         store_dir=trust_store_dir,
         marker_store=FileSkillTrustGenerationMarkerStore(
-            trust_store_dir / MARKER_FILENAME
+            trust_store_dir / MARKER_FILENAME, store_dir=trust_store_dir
         ),
     )
 

--- a/Tests/Widgets/test_password_dialog_encryption_warning.py
+++ b/Tests/Widgets/test_password_dialog_encryption_warning.py
@@ -1,0 +1,92 @@
+"""Regression test for task-851 review finding 3.
+
+Config encryption rewrites config.toml through a TOML parse/serialize
+round-trip (``tomllib.load`` + ``toml.dumps``): every value and type
+round-trips losslessly, but comments and table ordering do not survive.
+That was already true before this branch, but task-851 pointed encryption
+at whichever profile file is actually active (previously it silently
+no-op'd under a profile) and task-852 makes the "you should encrypt this"
+prompt actually fire -- so users now hit the comment/formatting loss where
+they didn't before. The fix is to warn in the enable-encryption
+confirmation flow rather than silently rewrite an annotated config; see
+``Widgets/password_dialog.py``'s ``EncryptionSetupDialog`` and
+``UI/Tools_Settings_Window.py``'s checkbox-toggle enable path.
+"""
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+
+from tldw_chatbook.Widgets.password_dialog import (
+    COMMENT_LOSS_WARNING,
+    EncryptionSetupDialog,
+)
+
+
+class _EncryptionSetupDialogHostApp(App):
+    def compose(self) -> ComposeResult:
+        yield from ()
+
+    async def show_dialog(self) -> None:
+        await self.push_screen(
+            EncryptionSetupDialog(detected_providers=["openai"])
+        )
+
+
+@pytest.mark.asyncio
+async def test_encryption_setup_dialog_warns_about_comment_loss():
+    """The confirmation dialog shown before the very first "enable
+    encryption" write must tell the user comments/formatting will not
+    survive the rewrite."""
+    app = _EncryptionSetupDialogHostApp()
+    async with app.run_test() as pilot:
+        await app.show_dialog()
+        await pilot.pause()
+
+        dialog = app.screen
+        assert isinstance(dialog, EncryptionSetupDialog)
+        rendered_texts = [
+            str(widget.render()) for widget in dialog.query(Static)
+        ]
+        assert any(COMMENT_LOSS_WARNING in text for text in rendered_texts), (
+            "EncryptionSetupDialog no longer warns about comment/formatting "
+            f"loss; rendered Static widgets: {rendered_texts!r}"
+        )
+
+
+def test_tools_settings_window_checkbox_toggle_path_warns_about_comment_loss():
+    """The OTHER enable-encryption entry point (the General Settings
+    "encryption enabled" checkbox toggle in ``Tools_Settings_Window.py``)
+    saves directly via a ``PasswordDialog`` and never shows
+    ``EncryptionSetupDialog``, so it needs its own copy of the warning
+    rather than relying on the dialog test above.
+
+    A source-level check (matching this codebase's existing
+    grep-gate idiom, e.g. ``test_unified_mcp_panel_modules_have_zero_importers_repo_wide``)
+    rather than a full UI mount: driving that flow end-to-end requires
+    toggling a mounted Checkbox, intercepting ``push_screen`` for two
+    separate modal dialogs, and stubbing ``enable_config_encryption``,
+    which is disproportionate to what is being asserted here.
+    """
+    from pathlib import Path
+
+    module_path = (
+        Path(__file__).resolve().parents[2]
+        / "tldw_chatbook"
+        / "UI"
+        / "Tools_Settings_Window.py"
+    )
+    source = module_path.read_text(encoding="utf-8")
+    checkbox_toggle_marker = 'title="Setup Config Encryption"'
+    assert checkbox_toggle_marker in source, (
+        "checkbox-toggle encryption setup dialog call site not found; "
+        "update this test's anchor if it was renamed"
+    )
+    anchor = source.index(checkbox_toggle_marker)
+    # The warning must live in the same PasswordDialog(...) call as the
+    # anchor, not merely somewhere else in this large file.
+    window = source[anchor : anchor + 800]
+    assert "comments or custom formatting" in window, (
+        "the checkbox-toggle encryption enable path lost its "
+        "comment/formatting-loss warning"
+    )

--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -566,12 +566,13 @@ def make_trust_service(tmp_path):
     trust_dir.mkdir(exist_ok=True)
 
     def _make() -> "SkillTrustService":
+        marker_path = trust_dir / "marker.json"
         return SkillTrustService(
             skills_dir=skills_dir,
             trust_store=SkillTrustStore(
                 store_dir=trust_dir,
                 marker_store=FileSkillTrustGenerationMarkerStore(
-                    trust_dir / "marker.json"
+                    marker_path, store_dir=marker_path.parent
                 ),
             ),
         )

--- a/Tests/test_config_app_config_encryption.py
+++ b/Tests/test_config_app_config_encryption.py
@@ -57,6 +57,25 @@ def test_load_settings_decrypts_api_settings_when_encrypted(
     assert not config_encryption.is_encrypted(key)
 
 
+def test_check_encryption_needed_detects_real_plaintext_provider_key(
+    tmp_path, monkeypatch, reset_config_state
+):
+    """Regression test for task-852: check_encryption_needed() (the
+    should_encrypt_config() gate) must return True for a live config
+    holding a real, prefixed provider key name, not just the six literal
+    names detect_api_keys() used to match exactly."""
+    cfg_path = tmp_path / "config.toml"
+    cfg_path.write_text(
+        '[SearchEngines]\n'
+        'bing_search_api_key = "bing-real-plaintext-secret"\n'
+    )
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(cfg_path))
+    cfg._CONFIG_CACHE = None
+    cfg._CONFIG_CACHE_SOURCE = None
+
+    assert cfg.check_encryption_needed() is True
+
+
 def test_set_encryption_password_invalidates_stale_ciphertext_cache(
     tmp_path, monkeypatch, reset_config_state
 ):

--- a/Tests/test_config_encryption_effective_path.py
+++ b/Tests/test_config_encryption_effective_path.py
@@ -18,11 +18,17 @@ holding every API key at once must never be left truncated by a crash
 mid-write.
 """
 
+import stat
+
 import toml
 import pytest
 
 import tldw_chatbook.config as cfg
 from tldw_chatbook.Utils.config_encryption import config_encryption
+
+
+def _mode(path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
 
 PASSWORD = "test-master-pw"
 NEW_PASSWORD = "test-master-pw-2"
@@ -192,3 +198,122 @@ def test_enable_config_encryption_write_is_atomic(tmp_path, monkeypatch):
     cfg._SETTINGS_CACHE_SOURCE = None
     cfg._CONFIG_CACHE = None
     cfg._CONFIG_CACHE_SOURCE = None
+
+
+def test_app_quit_save_writes_active_file_not_default(isolated_config_paths):
+    """Regression test for task-851 review finding 1.
+
+    ``enable_config_encryption``/``disable_config_encryption``/
+    ``change_encryption_password`` are all user-initiated and were fixed to
+    read/write ``_get_effective_config_path()`` above. But there is a
+    fourth, *automatic* write path this task's original fix missed:
+    ``TldwCli.action_quit()``'s on-exit "save encrypted config if enabled"
+    block, which still hardcoded ``DEFAULT_CONFIG_PATH``.
+
+    This is the dangerous one specifically *because* the other three were
+    fixed: before that fix, enabling encryption under a profile wrote
+    ``[encryption] enabled=true`` into the *default* file (which the
+    profile-reading loader never saw), so this quit-time block -- reading
+    the active profile via ``load_cli_config_and_ensure_existence()`` --
+    never saw ``enabled=True`` either and stayed a no-op. Once enable/
+    disable/change started reading and writing the *active* file, every
+    quit began serializing the merged active-profile config over the
+    user's separate default config file: silently destroying its content
+    and replacing its identity with the profile's, while the profile
+    itself was never re-encrypted.
+
+    Reproduced live before fixing (see
+    ``.superpowers/sdd/review-fixes-report.md``): the default config file
+    grew from 56 to 31004 bytes and its original API key was replaced by
+    the profile's merged/encrypted content.
+    """
+    profile_path, decoy_path = isolated_config_paths
+    profile_path.write_text(
+        "[encryption]\n"
+        "enabled = true\n\n"
+        "[api_settings.openai]\n"
+        f'api_key = "{PLAINTEXT_KEY}"\n'
+    )
+
+    decoy_path.parent.mkdir(parents=True, exist_ok=True)
+    decoy_path.write_text(
+        '[api_settings.openai]\napi_key = "sk-DEFAULT-CONFIG-UNRELATED-KEY"\n'
+    )
+    decoy_before = decoy_path.read_bytes()
+
+    cfg.set_encryption_password(PASSWORD)
+
+    from tldw_chatbook.app import TldwCli
+
+    app = TldwCli()
+    try:
+        app.action_quit()
+    finally:
+        cfg.clear_encryption_password()
+
+    # The decoy DEFAULT_CONFIG_PATH file must be byte-for-byte untouched --
+    # the on-quit save must never write it once a profile is active.
+    assert decoy_path.read_bytes() == decoy_before
+
+    # The active profile file is the one that got encrypted on exit.
+    active_data = toml.load(profile_path)
+    assert active_data["encryption"]["enabled"] is True
+    active_key = active_data["api_settings"]["openai"]["api_key"]
+    assert config_encryption.is_encrypted(active_key)
+
+
+def test_encrypt_decrypt_preserve_pre_existing_restrictive_mode(
+    isolated_config_paths,
+):
+    """Regression test for task-851 review finding 2.
+
+    ``enable_config_encryption``/``disable_config_encryption`` write through
+    ``atomic_write_text``, which used to always ``chmod`` the replacement
+    file to its generic 0o644 default -- widening permissions on a config
+    file the user (or a prior write) had tightened to 0o600. Measured live
+    before fixing: 0600 -> 0644 after enabling encryption, and disabling
+    again left it at 0644 while holding plaintext API keys.
+
+    This asserts the file's pre-existing 0600 mode survives both the
+    enable and the disable rewrite.
+    """
+    profile_path, _decoy_path = isolated_config_paths
+    _write_plain_profile(profile_path)
+    profile_path.chmod(0o600)
+    assert _mode(profile_path) == 0o600
+
+    assert cfg.enable_config_encryption(PASSWORD) is True
+    assert _mode(profile_path) == 0o600
+
+    assert cfg.disable_config_encryption(PASSWORD) is True
+    assert _mode(profile_path) == 0o600
+    # Still holds the (now decrypted) plaintext key, so the restrictive
+    # mode matters just as much post-disable as pre-enable.
+    assert toml.load(profile_path)["api_settings"]["openai"]["api_key"] == (
+        PLAINTEXT_KEY
+    )
+
+
+def test_enable_config_encryption_creates_new_file_with_restrictive_mode(
+    tmp_path, monkeypatch
+):
+    """When there is no pre-existing config file to preserve the mode of,
+    a freshly created one must still get a restrictive (not 0o644) mode --
+    it can hold plaintext API keys and the password verifier.
+    """
+    monkeypatch.delenv("TLDW_CONFIG_PATH", raising=False)
+    config_path = tmp_path / "profile" / "config.toml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(cfg, "DEFAULT_CONFIG_PATH", config_path)
+    assert not config_path.exists()
+
+    try:
+        assert cfg.enable_config_encryption(PASSWORD) is True
+        assert _mode(config_path) == cfg.CONFIG_SECRETS_FILE_MODE
+        assert _mode(config_path) == 0o600
+    finally:
+        cfg.clear_encryption_password()
+        cfg._SETTINGS_CACHE = None
+        cfg._SETTINGS_CACHE_SOURCE = None
+        cfg._CONFIG_CACHE = None
+        cfg._CONFIG_CACHE_SOURCE = None

--- a/Tests/test_config_encryption_effective_path.py
+++ b/Tests/test_config_encryption_effective_path.py
@@ -1,0 +1,194 @@
+"""Regression tests for task-851.
+
+``enable_config_encryption``, ``disable_config_encryption`` and
+``change_encryption_password`` used to read/write ``DEFAULT_CONFIG_PATH``
+directly instead of ``_get_effective_config_path()``. Any user running with a
+``TLDW_CONFIG_PATH`` override active (e.g. the "Override config" profile
+control) would have encryption silently operate on a *different* file than
+the one actually in use: "enable encryption" reported success while leaving
+the active profile's secrets in plaintext and rewriting an unrelated file.
+
+These tests set ``TLDW_CONFIG_PATH`` to a profile file, point
+``DEFAULT_CONFIG_PATH`` at a separate "decoy" path (standing in for the
+wrong file the bug used to write), and assert the change lands only in the
+file ``_get_effective_config_path()`` resolves to.
+
+A companion test asserts the "enable" write path is atomic: a config.toml
+holding every API key at once must never be left truncated by a crash
+mid-write.
+"""
+
+import toml
+import pytest
+
+import tldw_chatbook.config as cfg
+from tldw_chatbook.Utils.config_encryption import config_encryption
+
+PASSWORD = "test-master-pw"
+NEW_PASSWORD = "test-master-pw-2"
+PLAINTEXT_KEY = "sk-proj-test-plaintext-openai-key"
+
+
+@pytest.fixture
+def isolated_config_paths(tmp_path, monkeypatch):
+    """Point the active (effective) config at a profile file, and point
+    DEFAULT_CONFIG_PATH at a distinct decoy file that a correct fix must
+    never touch.
+
+    Returns:
+        (profile_path, decoy_path) tuple.
+    """
+    profile_path = tmp_path / "profile" / "config.toml"
+    profile_path.parent.mkdir(parents=True, exist_ok=True)
+    decoy_path = tmp_path / "default_home" / ".config" / "tldw_cli" / "config.toml"
+
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(profile_path))
+    monkeypatch.setattr(cfg, "DEFAULT_CONFIG_PATH", decoy_path)
+
+    yield profile_path, decoy_path
+
+    cfg.clear_encryption_password()
+    cfg._SETTINGS_CACHE = None
+    cfg._SETTINGS_CACHE_SOURCE = None
+    cfg._CONFIG_CACHE = None
+    cfg._CONFIG_CACHE_SOURCE = None
+
+
+def _write_plain_profile(profile_path, extra_toml: str = "") -> None:
+    profile_path.write_text(
+        '[api_settings.openai]\n'
+        f'api_key = "{PLAINTEXT_KEY}"\n' + extra_toml
+    )
+
+
+def test_enable_config_encryption_writes_active_file_not_default(
+    isolated_config_paths,
+):
+    """enable_config_encryption must read/write the effective path."""
+    profile_path, decoy_path = isolated_config_paths
+    _write_plain_profile(profile_path)
+
+    assert cfg.enable_config_encryption(PASSWORD) is True
+
+    # The active (effective) file was rewritten with the secret encrypted.
+    active_data = toml.load(profile_path)
+    assert active_data["encryption"]["enabled"] is True
+    active_key = active_data["api_settings"]["openai"]["api_key"]
+    assert config_encryption.is_encrypted(active_key)
+    assert active_key != PLAINTEXT_KEY
+
+    # The decoy DEFAULT_CONFIG_PATH was never created or touched.
+    assert not decoy_path.exists()
+
+
+def test_disable_config_encryption_reads_and_writes_active_file(
+    isolated_config_paths,
+):
+    """disable_config_encryption must read/write the effective path."""
+    profile_path, decoy_path = isolated_config_paths
+    _write_plain_profile(profile_path)
+    assert cfg.enable_config_encryption(PASSWORD) is True
+
+    assert cfg.disable_config_encryption(PASSWORD) is True
+
+    active_data = toml.load(profile_path)
+    assert "encryption" not in active_data
+    assert active_data["api_settings"]["openai"]["api_key"] == PLAINTEXT_KEY
+    assert not decoy_path.exists()
+
+
+def test_change_encryption_password_reads_and_writes_active_file(
+    isolated_config_paths,
+):
+    """change_encryption_password must read/write the effective path."""
+    profile_path, decoy_path = isolated_config_paths
+    _write_plain_profile(profile_path)
+    assert cfg.enable_config_encryption(PASSWORD) is True
+
+    assert cfg.change_encryption_password(PASSWORD, NEW_PASSWORD) is True
+
+    active_data = toml.load(profile_path)
+    verifier = active_data["encryption"]["password_verifier"]
+    assert config_encryption.verify_password(NEW_PASSWORD, verifier) is True
+    assert config_encryption.verify_password(PASSWORD, verifier) is False
+    assert not decoy_path.exists()
+
+
+def test_enable_disable_roundtrip_with_profile_active(isolated_config_paths):
+    """Enabling then disabling encryption must restore the original secret,
+    byte for byte, with a profile active via TLDW_CONFIG_PATH."""
+    profile_path, _decoy_path = isolated_config_paths
+    _write_plain_profile(profile_path)
+    original = toml.load(profile_path)
+
+    assert cfg.enable_config_encryption(PASSWORD) is True
+    encrypted = toml.load(profile_path)
+    assert config_encryption.is_encrypted(
+        encrypted["api_settings"]["openai"]["api_key"]
+    )
+
+    assert cfg.disable_config_encryption(PASSWORD) is True
+    restored = toml.load(profile_path)
+    assert restored == original
+
+
+def test_change_password_roundtrip_with_profile_active(isolated_config_paths):
+    """Rotating the password must keep the config decryptable under the new
+    password only, with a profile active via TLDW_CONFIG_PATH."""
+    profile_path, _decoy_path = isolated_config_paths
+    _write_plain_profile(profile_path)
+
+    assert cfg.enable_config_encryption(PASSWORD) is True
+    assert cfg.change_encryption_password(PASSWORD, NEW_PASSWORD) is True
+
+    # Wrong (old) password must now fail to disable.
+    assert cfg.disable_config_encryption(PASSWORD) is False
+    active_data = toml.load(profile_path)
+    assert active_data["encryption"]["enabled"] is True
+
+    # New password disables and decrypts correctly.
+    assert cfg.disable_config_encryption(NEW_PASSWORD) is True
+    restored = toml.load(profile_path)
+    assert restored["api_settings"]["openai"]["api_key"] == PLAINTEXT_KEY
+
+
+def test_enable_config_encryption_write_is_atomic(tmp_path, monkeypatch):
+    """A failure while serializing the encrypted config must never truncate
+    the on-disk config: the write must go through a write-temp-then-replace
+    helper, not a plain ``open(path, "w")`` (which truncates on open, before
+    any new content -- or a raised exception -- ever reaches the file).
+
+    Deliberately does not exercise the TLDW_CONFIG_PATH-vs-DEFAULT_CONFIG_PATH
+    routing from the tests above: this isolates the atomic-write property by
+    pointing DEFAULT_CONFIG_PATH itself straight at the target file, so the
+    only variable under test is whether a mid-write failure can truncate it.
+    """
+    monkeypatch.delenv("TLDW_CONFIG_PATH", raising=False)
+    config_path = tmp_path / "config.toml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(cfg, "DEFAULT_CONFIG_PATH", config_path)
+    _write_plain_profile(config_path)
+    original_bytes = config_path.read_bytes()
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("simulated crash while serializing config")
+
+    # Patch both the string-returning and file-writing serializers: which
+    # one is called is an implementation detail we are deliberately trying
+    # not to assume here (a plain ``open(path, "w")`` implementation calls
+    # ``toml.dump(data, fh)``; a write-temp-then-replace implementation
+    # calls ``toml.dumps(data)`` first). Either way, this simulates the
+    # serialization step failing before persistence completes.
+    monkeypatch.setattr(cfg.toml, "dumps", _boom)
+    monkeypatch.setattr(cfg.toml, "dump", _boom)
+
+    assert cfg.enable_config_encryption(PASSWORD) is False
+    # The file must be byte-for-byte unchanged: a plain open(path, "w")
+    # would have already truncated it before toml.dumps ever ran.
+    assert config_path.read_bytes() == original_bytes
+
+    cfg.clear_encryption_password()
+    cfg._SETTINGS_CACHE = None
+    cfg._SETTINGS_CACHE_SOURCE = None
+    cfg._CONFIG_CACHE = None
+    cfg._CONFIG_CACHE_SOURCE = None

--- a/backlog/tasks/task-851 - Route-config-encryption-through-the-effective-config-path-not-the-default-one.md
+++ b/backlog/tasks/task-851 - Route-config-encryption-through-the-effective-config-path-not-the-default-one.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-851
 title: 'Route config encryption through the effective config path, not the default one'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-27 04:34'
+updated_date: '2026-07-27 14:08'
 labels:
   - security
   - config
@@ -23,8 +25,26 @@ Secondary defect in the same code: config.py:4330 writes with plain open(path, "
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 All three encryption entry points (enable_config_encryption, disable_config_encryption, change_encryption_password) read and write through _get_effective_config_path() instead of DEFAULT_CONFIG_PATH
-- [ ] #2 All three entry points use the same atomic-write helper (atomic_write_text) as their siblings
-- [ ] #3 A regression test sets TLDW_CONFIG_PATH to a profile file, calls each entry point, and asserts the change landed in the file _get_effective_config_path() returns, not in a hardcoded literal
-- [ ] #4 Enabling, disabling, and rotating encryption with a profile active round-trips correctly (password verifier readable, secrets encrypted/decrypted in the active file)
+- [x] #1 All three encryption entry points (enable_config_encryption, disable_config_encryption, change_encryption_password) read and write through _get_effective_config_path() instead of DEFAULT_CONFIG_PATH
+- [x] #2 All three entry points use the same atomic-write helper (atomic_write_text) as their siblings
+- [x] #3 A regression test sets TLDW_CONFIG_PATH to a profile file, calls each entry point, and asserts the change landed in the file _get_effective_config_path() returns, not in a hardcoded literal
+- [x] #4 Enabling, disabling, and rotating encryption with a profile active round-trips correctly (password verifier readable, secrets encrypted/decrypted in the active file)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Repro the wrong-path bug live: set TLDW_CONFIG_PATH to a profile config, call enable_config_encryption, show DEFAULT_CONFIG_PATH gets rewritten instead.\n2. Route enable/disable/change_encryption_password through _get_effective_config_path() instead of DEFAULT_CONFIG_PATH.\n3. Replace enable_config_encryption's plain open(path,'w')+toml.dump with atomic_write_text(path, toml.dumps(...)), matching its two siblings.\n4. Add regression tests (Tests/test_config_encryption_effective_path.py) that set TLDW_CONFIG_PATH to a profile file + a decoy DEFAULT_CONFIG_PATH, and assert each entry point reads/writes only the active file; add a round-trip test (enable->disable, enable->change_password) and an atomicity test that simulates a mid-serialization crash and asserts the file is untouched.\n5. Run targeted pytest, confirm tests fail pre-fix and pass post-fix.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Routed enable_config_encryption, disable_config_encryption, and change_encryption_password (config.py) through _get_effective_config_path() instead of the DEFAULT_CONFIG_PATH literal, so a TLDW_CONFIG_PATH override (active profile) is the file actually read and rewritten. Replaced enable_config_encryption's plain open(path,'w')+toml.dump with atomic_write_text(path, toml.dumps(...)), matching its two siblings (disable/change already used atomic_write_text, just against the wrong path).
+
+Reproduced live before fixing: with TLDW_CONFIG_PATH pointed at a profile config holding a plaintext sk-proj-... key, enable_config_encryption returned True, left the profile's key in plaintext, and instead wrote an [encryption] section into the unrelated DEFAULT_CONFIG_PATH file. Confirmed fixed after the change (same repro now encrypts the active file in place; DEFAULT_CONFIG_PATH untouched).
+
+Tests added: Tests/test_config_encryption_effective_path.py -- 6 tests covering all three entry points writing to the effective path (with a decoy DEFAULT_CONFIG_PATH asserted untouched), an enable->disable round trip, an enable->change_password round trip (old password rejected, new password works), and an atomicity test that patches toml.dump/dumps to raise mid-serialization and asserts the on-disk file is byte-for-byte unchanged (a plain open(path,'w') would have already truncated it). All 6 fail against the pre-fix code (via `git stash`) and pass after.
+
+Files changed: tldw_chatbook/config.py (three entry points); Tests/test_config_encryption_effective_path.py (new).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-852 - Make-should_encrypt_config-detect-real-provider-API-keys-and-unify-the-four-sensitive-key-lists.md
+++ b/backlog/tasks/task-852 - Make-should_encrypt_config-detect-real-provider-API-keys-and-unify-the-four-sensitive-key-lists.md
@@ -3,9 +3,11 @@ id: TASK-852
 title: >-
   Make should_encrypt_config() detect real provider API keys, and unify the four
   sensitive-key lists
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-27 04:34'
+updated_date: '2026-07-27 14:08'
 labels:
   - security
   - config
@@ -23,8 +25,28 @@ This exact-match/substring mismatch is one of four independent, disagreeing copi
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 should_encrypt_config()/detect_api_keys() recognizes all real provider-key config names (the *_api_key, *_token, and *_fallback families actually written by the app), not just the six literal names
-- [ ] #2 The four independent sensitive-key-matching implementations (config.py:3691, config.py:515-546, config_encryption.py:250, settings_privacy_security.py:190) are collapsed into a single shared predicate with one semantics
-- [ ] #3 The unified predicate excludes non-secret keys such as api_key_env_var and max_tokens that the substring-matching copy currently over-flags
-- [ ] #4 A test builds its key list by reading the real key names out of CONFIG_TOML_CONTENT (or the equivalent live default config), not by re-asserting a hand-picked literal list, and confirms every one of them is detected
+- [x] #1 should_encrypt_config()/detect_api_keys() recognizes all real provider-key config names (the *_api_key, *_token, and *_fallback families actually written by the app), not just the six literal names
+- [x] #2 The four independent sensitive-key-matching implementations (config.py:3691, config.py:515-546, config_encryption.py:250, settings_privacy_security.py:190) are collapsed into a single shared predicate with one semantics
+- [x] #3 The unified predicate excludes non-secret keys such as api_key_env_var and max_tokens that the substring-matching copy currently over-flags
+- [x] #4 A test builds its key list by reading the real key names out of CONFIG_TOML_CONTENT (or the equivalent live default config), not by re-asserting a hand-picked literal list, and confirms every one of them is detected
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Repro the detector bug live: build a config with real prefixed/suffixed provider key names (openai_api_key-style, bing_search_api_key, api_token, OPENAI_API_KEY_fallback) and show detect_api_keys()/check_encryption_needed() return False.\n2. Create Utils/sensitive_config_keys.py as the single shared predicate (exact-name set + api_key-family containment + suffix rules + _env_var guard), documenting why substring vs endswith vs containment differ per family.\n3. Rewire config.py (encrypt_sensitive_fields closure, _is_sensitive_setting_key removed in favor of the shared predicate), Utils/config_encryption.py detect_api_keys, and UI/Screens/settings_privacy_security.py _is_sensitive_config_key to all import and delegate to the shared predicate.\n4. Add tests that enumerate real key names out of CONFIG_TOML_CONTENT/DEFAULT_APP_TTS_CONFIG (not hand-typed literals) and confirm detection, plus explicit exclusions (api_key_env_var, max_tokens).\n5. Run targeted pytest across all four former call sites, confirm tests fail pre-fix and pass post-fix.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created tldw_chatbook/Utils/sensitive_config_keys.py as the single shared predicate (is_sensitive_config_key): an exact-name set for bare secrets (api_key, token, auth_token, ...), a containment rule for the api_key/apikey/api-key family (catches provider-prefixed names like openai_api_key and suffix-of-a-suffix names like OPENAI_API_KEY_fallback and search_engine_api_key_baidu, which endswith-only matching missed), an endswith rule for _key/_token/_secret/_password suffixes (deliberately not containment, so max_tokens is not caught by a bare "_token" substring), and an _env_var suffix guard (an env-var *name* is never a secret).
+
+Rewired all four former call sites to delegate to it: config.py's encrypt_api_keys_in_config (encrypt_sensitive_fields closure) and the removed _is_sensitive_setting_key (now callers use the shared predicate directly), Utils/config_encryption.py's detect_api_keys (previously an exact 6-literal match that matched none of this app's real key names), and UI/Screens/settings_privacy_security.py's _is_sensitive_config_key (previously endswith-only, undercounting the *_fallback and mid-name api_key families).
+
+Reproduced live before fixing: detect_api_keys({"SearchEngines": {"bing_search_api_key": "..."}, ...}) returned False against a config full of real plaintext provider keys; check_encryption_needed() likewise never fired for any of this app's actual key names. Confirmed True after the fix, with max_tokens/api_key_env_var-only configs still correctly returning False.
+
+Tests: Tests/Utils/test_sensitive_config_keys.py (new, 15 tests) builds its assertions from real key names parsed out of CONFIG_TOML_CONTENT (tomllib.loads) and DEFAULT_APP_TTS_CONFIG rather than hand-typed literals -- per the audit's core lesson, a hand-re-spelled literal goes vacuous in lockstep with drift. Tests/Utils/test_config_encryption.py gained a TestDetectApiKeysRealProviderNames class (3 tests) doing the same at the detect_api_keys level. Tests/test_config_app_config_encryption.py gained an end-to-end check_encryption_needed() test. All new/updated tests fail against the pre-fix code and pass after.
+
+Files changed: tldw_chatbook/Utils/sensitive_config_keys.py (new); tldw_chatbook/config.py; tldw_chatbook/Utils/config_encryption.py; tldw_chatbook/UI/Screens/settings_privacy_security.py; Tests/Utils/test_sensitive_config_keys.py (new); Tests/Utils/test_config_encryption.py; Tests/test_config_app_config_encryption.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-853 - Fix-the-two-skills-trust-path-containment-checks-that-cant-actually-reject-anything.md
+++ b/backlog/tasks/task-853 - Fix-the-two-skills-trust-path-containment-checks-that-cant-actually-reject-anything.md
@@ -3,9 +3,11 @@ id: TASK-853
 title: >-
   Fix the two skills-trust path containment checks that can't actually reject
   anything
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-27 04:34'
+updated_date: '2026-07-27 14:38'
 labels:
   - security
   - skills
@@ -25,8 +27,37 @@ Skills_Interop/local_skills_service.py:1765-1804 _unsafe_scratch_root derives it
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 skill_trust_store.py's marker-path validation passes base_dir=self.store_dir (or an equivalent real containing directory), not the candidate's own parent
-- [ ] #2 _unsafe_scratch_root rejects a candidate root that is inside a container AND a candidate root that contains a container (both directions), and includes self.store_dir in its container list
-- [ ] #3 A test exercises both containment directions for each check using the real store/scratch-root attributes (not hardcoded literal paths) and confirms both a nested-inside and a containing candidate are rejected
-- [ ] #4 Existing trust-store and scratch-root tests that only asserted the working direction are extended to cover the previously-vacuous direction
+- [x] #1 skill_trust_store.py's marker-path validation passes base_dir=self.store_dir (or an equivalent real containing directory), not the candidate's own parent
+- [x] #2 _unsafe_scratch_root rejects a candidate root that is inside a container AND a candidate root that contains a container (both directions), and includes self.store_dir in its container list
+- [x] #3 A test exercises both containment directions for each check using the real store/scratch-root attributes (not hardcoded literal paths) and confirms both a nested-inside and a containing candidate are rejected
+- [x] #4 Existing trust-store and scratch-root tests that only asserted the working direction are extended to cover the previously-vacuous direction
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce check #1 (skill_trust_store.py marker-path validation): construct FileSkillTrustGenerationMarkerStore with a marker path in an unrelated directory, show base_dir=marker_path.parent accepts it.
+2. Reproduce check #2 (local_skills_service.py _is_unsafe_scratch_root): show a scratch root that CONTAINS skills_dir/trust store (e.g. store_dir or its parent) is NOT flagged unsafe, while a root nested inside skills_dir already is.
+3. Fix check #1: add an explicit store_dir field to FileSkillTrustGenerationMarkerStore (and thread it through build_skill_trust_marker_store_with_fallback + app.py's construction site), replacing base_dir=self.marker_path.parent with base_dir=self.store_dir.
+4. Fix check #2: add self.store_dir to _unsafe_scratch_root_containers, and check containment in both directions (root inside container OR root contains container) in _is_unsafe_scratch_root.
+5. Update every test call site constructing FileSkillTrustGenerationMarkerStore directly (now requires store_dir) to derive it from the marker path already in scope rather than a fresh literal.
+6. Re-run both reproductions post-fix to confirm rejection; add new tests covering both containment directions for each check using real store/service attributes; run the Tests/Skills + Tests/Utils/test_sensitive_paths.py + Tests/Library/test_skill_script_grant_panel.py suites to confirm no regressions to install/trust/script-execution flows.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed both tautological containment checks.
+
+Check #1 (skill_trust_store.py): FileSkillTrustGenerationMarkerStore gained an explicit `store_dir: Path` field (no default), and `_validated_trust_file_path` is now called with `base_dir=self.store_dir` in both load_marker and save_marker, instead of `base_dir=self.marker_path.parent` (which made the check true by construction). `build_skill_trust_marker_store_with_fallback` now takes `store_dir` and threads it into the fallback marker store; app.py's construction site passes `store_dir=trust_store_dir` (the same real trust-store directory already used for SkillTrustStore itself). Reproduced pre-fix: a marker file in a totally unrelated directory was accepted and written to. Post-fix: rejected with "unsafe skill trust path"; a legitimate marker co-located with store_dir still round-trips.
+
+Check #2 (local_skills_service.py): `_unsafe_scratch_root_containers` now includes `self.store_dir` alongside `self.skills_dir` and the trust store's directory. `_is_unsafe_scratch_root` now checks containment in BOTH directions (`get_safe_relative_path(root, container)` OR `get_safe_relative_path(container, root)`), so a root that ENCLOSES a store is rejected in addition to a root nested inside one. Reproduced pre-fix: `store_dir` itself and its parent (both of which enclose skills_dir/trust_dir) were silently accepted as scratch roots, while a root nested inside skills_dir was already (correctly) rejected. Post-fix: both directions are rejected; a genuinely unrelated sibling directory is still accepted.
+
+All ~28 test call sites constructing FileSkillTrustGenerationMarkerStore directly were updated to pass store_dir, re-derived from the marker path already in scope (e.g. `store_dir=marker_path.parent`) rather than a fresh literal, per the audit's "derive, don't re-spell" theme. Added a dedicated containment test to each file (test_skill_trust_store.py::test_file_marker_store_rejects_marker_outside_store_dir, test_skill_script_service.py::test_is_unsafe_scratch_root_rejects_both_containment_directions) covering both directions from the real store/service attributes, plus extended the existing marker-parent-symlink test to pass its own store_dir. One existing test (test_scratch_root_config_knob_is_reachable) needed its "custom" scratch root moved off of tmp_path (which happened to equal the service's own store_dir in that fixture) onto a genuinely unrelated tmp_path_factory directory, since a plain tmp_path-nested root is now correctly rejected -- this was a fixture artifact, not a real legitimate-use regression.
+
+Verification: Tests/Skills (377 passed), Tests/Utils/test_sensitive_paths.py + Tests/Library/test_skill_script_grant_panel.py (all green). Baselines noted (pytest-mock/numpy absent, pre-existing test_tools_settings_window.py failures) were not touched by this change.
+
+Filed TASK-900 for the sibling wrong-path/non-atomic-write defect found in UI/Tools_Settings_Window.py::_save_raw_toml_config (same shape as TASK-851's config.py fixes, a fourth entry point TASK-851 didn't cover), left unfixed per scope.
+
+Files changed: tldw_chatbook/Skills_Interop/skill_trust_store.py, tldw_chatbook/Skills_Interop/local_skills_service.py, tldw_chatbook/app.py; 13 test files under Tests/Skills, Tests/Utils, Tests/conftest.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-900 - Tools_Settings_Window-raw-TOML-save-writes-the-wrong-config-path-non-atomically.md
+++ b/backlog/tasks/task-900 - Tools_Settings_Window-raw-TOML-save-writes-the-wrong-config-path-non-atomically.md
@@ -1,0 +1,32 @@
+---
+id: TASK-900
+title: >-
+  Tools_Settings_Window raw-TOML save writes the wrong config path
+  non-atomically
+status: To Do
+assignee: []
+created_date: '2026-07-27 14:36'
+labels:
+  - security
+  - config
+  - ui
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+_save_raw_toml_config in UI/Tools_Settings_Window.py (the Settings screen's raw-TOML editor Save action) writes the user's edited config to the hardcoded DEFAULT_CONFIG_PATH via a plain open(path,'w')+toml.dump, instead of the effective config path the rest of the app reads and writes through (config._get_effective_config_path(), which honors a TLDW_CONFIG_PATH profile override) and instead of the atomic_write_text helper TASK-851 standardized on for config.py's three encryption entry points. This is the same wrong-path-plus-non-atomic-write shape TASK-851 fixed, on a fourth, previously unnamed write path into the live config file. A user running with a profile active (TLDW_CONFIG_PATH set) who edits the raw TOML in Settings and clicks Save would have their edits silently land in DEFAULT_CONFIG_PATH instead of their active profile file -- the exact same class of silent-data-loss-to-the-wrong-file bug TASK-851 fixed for encryption -- and an interrupted write (crash, kill -9) partway through toml.dump could truncate whichever file it did hit, corrupting the on-disk config.
+
+Filed from TASK-853's audit sweep: the agent fixing TASK-851 (config.py's enable/disable/change_encryption_password) found this sibling defect but left it out of scope since it wasn't one of 851's three named entry points. Same shape, fourth call site.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 _save_raw_toml_config reads and writes through config._get_effective_config_path() instead of the DEFAULT_CONFIG_PATH literal
+- [ ] #2 _save_raw_toml_config's file write uses the same atomic_write_text helper TASK-851's three entry points use, not a plain open(path,'w')+toml.dump
+- [ ] #3 A regression test sets TLDW_CONFIG_PATH to a profile file, invokes the Save action, and asserts the change landed in the file config._get_effective_config_path() returns (derived via that accessor, not a re-spelled literal path) while a decoy DEFAULT_CONFIG_PATH is left untouched
+- [ ] #4 A regression test simulates a mid-write failure (e.g. toml.dumps raising) and asserts the on-disk config file is byte-for-byte unchanged, proving the write is atomic
+- [ ] #5 Saving raw TOML config with no profile override active still round-trips correctly (existing default-path behavior is not regressed)
+<!-- AC:END -->

--- a/backlog/tasks/task-930 - Tools_Settings_Window-raw-TOML-save-writes-the-wrong-config-path-non-atomically.md
+++ b/backlog/tasks/task-930 - Tools_Settings_Window-raw-TOML-save-writes-the-wrong-config-path-non-atomically.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-900
+id: TASK-930
 title: >-
   Tools_Settings_Window raw-TOML save writes the wrong config path
   non-atomically

--- a/tldw_chatbook/Skills_Interop/local_skills_service.py
+++ b/tldw_chatbook/Skills_Interop/local_skills_service.py
@@ -1796,14 +1796,17 @@ class LocalSkillsService:
         )
 
     def _unsafe_scratch_root_containers(self) -> list[Path]:
-        """Directories a configured scratch root must never resolve inside.
+        """Directories a configured scratch root must never resolve inside OR enclose.
 
         Returns:
-            The skills store, plus the trust store's own directory when a
+            This service's own ``store_dir`` (which holds the skill index
+            directly), its ``skills_dir`` (nested under ``store_dir``, listed
+            explicitly for clarity even though it is already covered
+            transitively), plus the trust store's own directory when a
             trust service is wired (best-effort: absent/duck-typed trust
             services simply contribute nothing extra).
         """
-        containers = [self.skills_dir]
+        containers = [self.store_dir, self.skills_dir]
         trust_store = getattr(self.trust_service, "trust_store", None)
         trust_store_dir = getattr(trust_store, "store_dir", None)
         if trust_store_dir is not None:
@@ -1811,27 +1814,34 @@ class LocalSkillsService:
         return containers
 
     def _is_unsafe_scratch_root(self, root: Path) -> bool:
-        """Return True if ``root`` resolves inside the skills or trust store.
+        """Return True if ``root`` resolves inside, or resolves to enclose, a protected store.
 
-        A scratch root under either store would let a script's cwd land
+        A scratch root NESTED INSIDE a store would let a script's cwd land
         inside its own (or a sibling's) trusted bundle -- exactly the
         "a script must never tamper with its own bundle" property this
         service exists to guarantee, since any file the script leaves
         behind re-fingerprints the bundle and permanently quarantines it.
-        Uses ``get_safe_relative_path`` (which resolves both sides, so
-        symlinks and ``..`` segments cannot hide the containment) rather
+
+        A scratch root that instead ENCLOSES a store is just as dangerous in
+        the other direction: the script's cwd would sit one level above
+        every trusted bundle and the trust manifest/snapshots/grants,
+        exposing them as scratch-writable siblings. Both directions are
+        checked with ``get_safe_relative_path`` (which resolves both sides,
+        so symlinks and ``..`` segments cannot hide the containment) rather
         than a string prefix check.
 
         Args:
             root: The (not-yet-created) candidate scratch root.
 
         Returns:
-            True when ``root`` resolves inside any store directory that
-            must stay off limits.
+            True when ``root`` resolves inside, or resolves to enclose, any
+            store directory that must stay off limits.
         """
+        containers = self._unsafe_scratch_root_containers()
         return any(
             get_safe_relative_path(root, container) is not None
-            for container in self._unsafe_scratch_root_containers()
+            or get_safe_relative_path(container, root) is not None
+            for container in containers
         )
 
     def _script_scratch_root(self) -> str | None:
@@ -1843,10 +1853,11 @@ class LocalSkillsService:
         it would make this knob permanently unreachable.
 
         A configured root that resolves inside the skills store or the trust
-        store is REJECTED (see ``_is_unsafe_scratch_root``) and treated the
-        same as unconfigured -- checked BEFORE the directory is created, so a
-        rejected root is never actually made on disk. The safety check is
-        best-effort containment, consistent with the rest of this module.
+        store -- or that instead ENCLOSES either store -- is REJECTED (see
+        ``_is_unsafe_scratch_root``) and treated the same as unconfigured --
+        checked BEFORE the directory is created, so a rejected root is never
+        actually made on disk. The safety check is best-effort containment,
+        consistent with the rest of this module.
 
         Returns:
             The configured scratch root, or None to use the OS temp dir
@@ -1865,8 +1876,8 @@ class LocalSkillsService:
         if self._is_unsafe_scratch_root(root):
             logger.warning(
                 "Ignoring [skills] script_scratch_root={!r}: it resolves "
-                "inside a skills or trust store; falling back to the OS "
-                "temp dir",
+                "inside, or encloses, a skills or trust store; falling "
+                "back to the OS temp dir",
                 configured,
             )
             return None

--- a/tldw_chatbook/Skills_Interop/skill_trust_store.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_store.py
@@ -156,9 +156,24 @@ class FileSkillTrustGenerationMarkerStore:
         _atomic_write_json(self.marker_path, payload, base_dir=self.store_dir)
 
     def clear(self) -> None:
-        """Remove the on-disk marker file (missing-ok, no raise)."""
+        """Remove the on-disk marker file (missing-ok, no raise).
+
+        Validates ``marker_path`` against ``store_dir`` the same way
+        ``load_marker``/``save_marker`` do before touching disk, so an
+        unsafe or misconfigured path (symlink escape, path outside the
+        trust store) is refused rather than unlinked -- see task-851
+        review finding 4. Invalid paths are treated the same as "nothing
+        to clear": this method stays non-raising by contract.
+        """
         try:
-            self.marker_path.unlink(missing_ok=True)
+            marker_path = _validated_trust_file_path(
+                self.marker_path,
+                base_dir=self.store_dir,
+            )
+        except ValueError:
+            return
+        try:
+            marker_path.unlink(missing_ok=True)
         except OSError:
             pass
 

--- a/tldw_chatbook/Skills_Interop/skill_trust_store.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_store.py
@@ -113,16 +113,31 @@ class SkillTrustGenerationMarkerStore(Protocol):
 
 @dataclass(slots=True)
 class FileSkillTrustGenerationMarkerStore:
-    """Reduced-protection marker store intended for tests and explicit recovery."""
+    """Reduced-protection marker store intended for tests and explicit recovery.
+
+    Attributes:
+        marker_path: File path for the persisted marker.
+        store_dir: The trust store's own directory -- the real containing
+            directory ``marker_path`` must resolve inside. This is passed in
+            independently rather than derived as ``marker_path.parent``: a
+            containment check against a candidate's own parent is true by
+            construction (a path is always inside its own parent) and so
+            rejects nothing, letting a misconfigured or attacker-controlled
+            ``marker_path`` point anywhere on disk. Callers that legitimately
+            keep the marker file directly under the trust store (the only
+            supported layout, e.g. ``build_skill_trust_marker_store_with_fallback``)
+            simply pass that same directory as ``store_dir``.
+    """
 
     marker_path: Path
+    store_dir: Path
 
     def load_marker(self) -> dict[str, Any] | None:
         """Load the file-backed generation marker if it exists."""
 
         marker_path = _validated_trust_file_path(
             self.marker_path,
-            base_dir=self.marker_path.parent,
+            base_dir=self.store_dir,
         )
         if not marker_path.exists():
             return None
@@ -138,7 +153,7 @@ class FileSkillTrustGenerationMarkerStore:
             "generation": generation,
             "manifest_digest": manifest_digest,
         }
-        _atomic_write_json(self.marker_path, payload, base_dir=self.marker_path.parent)
+        _atomic_write_json(self.marker_path, payload, base_dir=self.store_dir)
 
     def clear(self) -> None:
         """Remove the on-disk marker file (missing-ok, no raise)."""
@@ -234,17 +249,38 @@ class KeyringSkillTrustGenerationMarkerStore:
 def build_skill_trust_marker_store_with_fallback(
     *,
     fallback_marker_path: Path,
+    store_dir: Path,
     keyring_backend: Any | None = None,
     account_scope: str = "",
 ) -> tuple[SkillTrustGenerationMarkerStore, bool]:
-    """Return a marker store and whether reduced rollback protection is active."""
+    """Return a marker store and whether reduced rollback protection is active.
+
+    Args:
+        fallback_marker_path: File path for the reduced-protection marker,
+            used only when no secure OS keyring backend is available.
+        store_dir: The trust store's own directory -- the real containing
+            directory used to validate that ``fallback_marker_path`` stays
+            inside the trust store. See ``FileSkillTrustGenerationMarkerStore``
+            for why this must be an independently supplied real directory
+            rather than derived from ``fallback_marker_path`` itself.
+        keyring_backend: Optional keyring backend override, primarily for tests.
+        account_scope: Per-profile keyring account scope suffix.
+
+    Returns:
+        A tuple of ``(marker_store, reduced_rollback_protection)``.
+    """
 
     try:
         return KeyringSkillTrustGenerationMarkerStore(
             keyring_backend=keyring_backend, account_scope=account_scope
         ), False
     except Exception:
-        return FileSkillTrustGenerationMarkerStore(fallback_marker_path), True
+        return (
+            FileSkillTrustGenerationMarkerStore(
+                fallback_marker_path, store_dir=store_dir
+            ),
+            True,
+        )
 
 
 @dataclass(slots=True, repr=False)

--- a/tldw_chatbook/UI/Screens/settings_privacy_security.py
+++ b/tldw_chatbook/UI/Screens/settings_privacy_security.py
@@ -6,32 +6,9 @@ import os
 from collections.abc import Mapping
 from dataclasses import dataclass
 
+from tldw_chatbook.Utils.sensitive_config_keys import is_sensitive_config_key
 
-SENSITIVE_CONFIG_EXACT_KEYS = frozenset(
-    {
-        "api_key",
-        "apikey",
-        "api-key",
-        "api_token",
-        "auth_token",
-        "access_token",
-        "refresh_token",
-        "client_secret",
-        "secret_key",
-        "secret",
-        "token",
-        "password",
-    }
-)
-SENSITIVE_CONFIG_KEY_PATTERNS = (
-    "api_key",
-    "apikey",
-    "api-key",
-    "_key",
-    "_token",
-    "_secret",
-    "_password",
-)
+
 SAFE_SKILL_TRUST_STATUSES = frozenset(
     {
         "trusted",
@@ -187,15 +164,6 @@ def _safe_bool(value: object) -> bool:
     return value is True
 
 
-def _is_sensitive_config_key(key: object) -> bool:
-    key_text = str(key).strip().lower()
-    if not key_text or key_text.endswith("_env_var"):
-        return False
-    return key_text in SENSITIVE_CONFIG_EXACT_KEYS or any(
-        key_text.endswith(pattern) for pattern in SENSITIVE_CONFIG_KEY_PATTERNS
-    )
-
-
 def _is_configured_secret_value(value: object) -> bool:
     if value is None:
         return False
@@ -227,7 +195,7 @@ def _sensitive_config_field_count(app_config: object) -> int:
     return sum(
         1
         for key, value in _iter_config_leaf_values(app_config)
-        if _is_sensitive_config_key(key) and _is_configured_secret_value(value)
+        if is_sensitive_config_key(key) and _is_configured_secret_value(value)
     )
 
 
@@ -270,6 +238,6 @@ def _provider_config_secret_count(app_config: object) -> int:
         count += sum(
             1
             for key, value in _iter_config_leaf_values(provider_config)
-            if _is_sensitive_config_key(key) and _is_configured_secret_value(value)
+            if is_sensitive_config_key(key) and _is_configured_secret_value(value)
         )
     return count

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -5138,6 +5138,14 @@ class SettingsScreen(BaseAppScreen):
         return divider
 
     def _config_path(self) -> Path:
+        """Return the active CLI config path.
+
+        Thin wrapper kept only so call sites in this module read naturally
+        (``self._config_path()``); it must delegate to the shared effective-
+        path resolver rather than re-spell the override/validate logic,
+        since a second hand-copy would drift the moment either
+        implementation changed -- see task-851 review finding 5.
+        """
         return validate_path_simple(
             get_cli_config_path(),
             require_exists=False,

--- a/tldw_chatbook/UI/Tools_Settings_Window.py
+++ b/tldw_chatbook/UI/Tools_Settings_Window.py
@@ -3884,12 +3884,22 @@ Thank you for using tldw-chatbook! 🎉
                             severity="information",
                         )
 
-                    # Get password from user
+                    # Get password from user. Note: this toggle path saves
+                    # directly (unlike _setup_encryption()'s EncryptionSetupDialog
+                    # detour), so the comment-loss caveat has to live in this
+                    # dialog's own message instead -- see task-851 review
+                    # finding 3.
                     password = await self.app_instance.push_screen(
                         PasswordDialog(
                             mode="setup",
                             title="Setup Config Encryption",
-                            message="Create a master password to encrypt your configuration file:",
+                            message=(
+                                "Create a master password to encrypt your "
+                                "configuration file.\n\n"
+                                "Note: saving will rewrite config.toml -- any "
+                                "comments or custom formatting in it will be "
+                                "lost (all values are preserved)."
+                            ),
                             on_submit=lambda p: None,
                             on_cancel=lambda: None,
                         ),

--- a/tldw_chatbook/Utils/atomic_file_ops.py
+++ b/tldw_chatbook/Utils/atomic_file_ops.py
@@ -6,6 +6,7 @@ from partial writes due to crashes, power failures, or other interruptions.
 """
 
 import os
+import stat
 import tempfile
 from pathlib import Path
 from typing import Union, Optional
@@ -13,11 +14,37 @@ import shutil
 from loguru import logger
 
 
+def _resolve_target_mode(
+    file_path: Path, mode: int, preserve_existing_mode: bool
+) -> int:
+    """Resolve the permission mode to apply to a rewritten file.
+
+    Args:
+        file_path: Path to the file being (re)written.
+        mode: Caller-supplied fallback mode, used verbatim when
+            ``preserve_existing_mode`` is False or the file does not exist yet.
+        preserve_existing_mode: When True and ``file_path`` already exists,
+            reuse its current permission bits instead of ``mode`` -- this is
+            what stops a rewrite from silently widening a secrets file that a
+            user (or a previous write) had tightened, e.g. to 0o600.
+
+    Returns:
+        The permission mode to ``os.chmod`` the replacement file to.
+    """
+    if preserve_existing_mode:
+        try:
+            return stat.S_IMODE(file_path.stat().st_mode)
+        except FileNotFoundError:
+            pass
+    return mode
+
+
 def atomic_write_text(
     file_path: Union[str, Path],
     content: str,
     encoding: str = "utf-8",
     mode: int = 0o644,
+    preserve_existing_mode: bool = False,
 ) -> None:
     """
     Write text content to a file atomically.
@@ -30,7 +57,13 @@ def atomic_write_text(
         file_path: Path to the target file
         content: Text content to write
         encoding: Text encoding (default: utf-8)
-        mode: File permissions (default: 0o644)
+        mode: File permissions applied when the target does not already exist,
+            or when ``preserve_existing_mode`` is False (default: 0o644)
+        preserve_existing_mode: When True and the target file already exists,
+            carry its current permission bits forward instead of applying
+            ``mode``. Use this for secrets-bearing files (e.g. the app config)
+            so a rewrite never widens permissions a user has tightened.
+            Defaults to False to keep existing callers' behavior unchanged.
 
     Raises:
         OSError: If the write or rename operation fails
@@ -41,6 +74,8 @@ def atomic_write_text(
 
     # Ensure parent directory exists
     parent_dir.mkdir(parents=True, exist_ok=True)
+
+    target_mode = _resolve_target_mode(file_path, mode, preserve_existing_mode)
 
     # Create temporary file in the same directory (for atomic rename)
     fd = None
@@ -60,7 +95,7 @@ def atomic_write_text(
             os.fsync(f.fileno())
 
         # Set file permissions
-        os.chmod(temp_path, mode)
+        os.chmod(temp_path, target_mode)
 
         # Atomic rename (on POSIX) or replace (cross-platform)
         # os.replace is atomic on POSIX and does best-effort on Windows

--- a/tldw_chatbook/Utils/config_encryption.py
+++ b/tldw_chatbook/Utils/config_encryption.py
@@ -14,6 +14,8 @@ from Cryptodome.Cipher import AES
 from Cryptodome.Protocol.KDF import scrypt
 from loguru import logger
 
+from tldw_chatbook.Utils.sensitive_config_keys import is_sensitive_config_key
+
 
 class ConfigEncryption:
     """Handles encryption/decryption of configuration values with authenticated encryption."""
@@ -267,6 +269,13 @@ class ConfigEncryption:
         """
         Detect if there are API keys in the configuration that should be encrypted.
 
+        Uses the same sensitive-key predicate as every other
+        encryption/redaction/reporting path in the app (see
+        ``Utils/sensitive_config_keys.py``), so a config full of real
+        provider keys (``openai_api_key``, ``bing_search_api_key``,
+        ``OPENAI_API_KEY_fallback``, ...) is detected, not just configs using
+        the six bare literal names this used to match exactly.
+
         Args:
             config: Configuration dictionary to check
 
@@ -279,14 +288,7 @@ class ConfigEncryption:
                 full_key = f"{parent_key}.{key}" if parent_key else key
 
                 # Check for API key patterns
-                if key.lower() in [
-                    "api_key",
-                    "apikey",
-                    "api-key",
-                    "secret",
-                    "token",
-                    "password",
-                ]:
+                if is_sensitive_config_key(key):
                     if (
                         isinstance(value, str)
                         and value.strip()

--- a/tldw_chatbook/Utils/sensitive_config_keys.py
+++ b/tldw_chatbook/Utils/sensitive_config_keys.py
@@ -1,0 +1,103 @@
+# tldw_chatbook/Utils/sensitive_config_keys.py
+"""Single source of truth for "is this config key a secret".
+
+Before this module existed, four call sites each carried their own
+hand-rolled notion of a sensitive config key, and they disagreed with each
+other in both directions:
+
+* ``config.py`` (``encrypt_api_keys_in_config``'s ``encrypt_sensitive_fields``
+  closure, and the near-duplicate ``_is_sensitive_setting_key``) matched via
+  bare substring containment, so ``max_tokens`` (contains ``_token``) and
+  ``api_key_env_var`` (contains ``api_key``) were both wrongly flagged as
+  secrets -- the former got redacted in logs for no reason, the latter risked
+  encrypting an *environment variable name* rather than the secret it points
+  to.
+* ``Utils/config_encryption.py``'s ``detect_api_keys`` matched only six exact
+  literal names (``api_key``, ``apikey``, ``api-key``, ``secret``, ``token``,
+  ``password``). Every real secret-bearing key in this app is prefixed or
+  suffixed instead (``openai_api_key``, ``bing_search_api_key``,
+  ``api_token``, ``OPENAI_API_KEY_fallback``, ...), so none of them were ever
+  detected and a config full of live plaintext secrets reported nothing
+  worth encrypting.
+* ``UI/Screens/settings_privacy_security.py``'s ``_is_sensitive_config_key``
+  used ``endswith`` (safer than substring) plus an ``_env_var`` guard, but
+  being ``endswith``-only it missed keys where the sensitive fragment is not
+  the suffix, e.g. ``search_engine_api_key_baidu`` or the ``_fallback``
+  family (``OPENAI_API_KEY_fallback``), undercounting what Settings > Privacy
+  & Security reports as protected.
+
+This module fixes all three failure modes in one predicate, used by every
+one of those call sites so they cannot drift from each other again.
+"""
+
+from __future__ import annotations
+
+# Keys that are secrets outright, regardless of prefix/suffix.
+SENSITIVE_CONFIG_EXACT_KEYS = frozenset(
+    {
+        "api_key",
+        "apikey",
+        "api-key",
+        "secret",
+        "token",
+        "password",
+        "auth_token",
+        "api_token",
+        "access_token",
+        "secret_key",
+        "refresh_token",
+        "client_secret",
+    }
+)
+
+# Fragments that mark a key as a secret no matter where they appear in it.
+# Unlike the suffix list below, these are matched by containment: real
+# provider keys embed "api_key" mid-name in both directions -- as a prefix
+# (``search_engine_api_key_baidu``) and as a suffix-of-a-suffix
+# (``OPENAI_API_KEY_fallback``, ``ELEVENLABS_API_KEY_fallback``) -- so an
+# endswith-only rule misses them.
+SENSITIVE_CONFIG_KEY_CONTAINS_PATTERNS = (
+    "api_key",
+    "apikey",
+    "api-key",
+)
+
+# Suffixes that mark a key as a secret. These are endswith-only (not
+# containment) on purpose: ``_token`` as a containment check would also
+# match ``max_tokens`` (which merely *limits* a token count, it does not
+# hold one), turning a numeric setting into a false positive.
+SENSITIVE_CONFIG_KEY_SUFFIXES = (
+    "_key",
+    "_token",
+    "_secret",
+    "_password",
+)
+
+# Keys ending in this suffix name an *environment variable* that holds the
+# secret (e.g. ``api_key_env_var = "OPENAI_API_KEY"``); the env var name
+# itself is not a secret and must never be encrypted or redacted as one.
+_ENV_VAR_NAME_SUFFIX = "_env_var"
+
+
+def is_sensitive_config_key(key: object) -> bool:
+    """Return whether a config key name is expected to hold a secret value.
+
+    Args:
+        key: The config key name to check. Coerced to ``str`` so callers may
+            pass non-string mapping keys without raising.
+
+    Returns:
+        True if the key should be treated as secret-bearing (encrypted when
+        config encryption is enabled, redacted in logs, counted as a
+        protected field in the Privacy & Security posture).
+    """
+    key_text = str(key).strip().lower()
+    if not key_text or key_text.endswith(_ENV_VAR_NAME_SUFFIX):
+        return False
+    if key_text in SENSITIVE_CONFIG_EXACT_KEYS:
+        return True
+    if any(
+        pattern in key_text for pattern in SENSITIVE_CONFIG_KEY_CONTAINS_PATTERNS
+    ):
+        return True
+    return any(key_text.endswith(suffix) for suffix in SENSITIVE_CONFIG_KEY_SUFFIXES)

--- a/tldw_chatbook/Widgets/password_dialog.py
+++ b/tldw_chatbook/Widgets/password_dialog.py
@@ -15,6 +15,18 @@ from textual.widgets import Button, Label, Input, Static
 from textual.validation import Length
 from loguru import logger
 
+#: Shown wherever a user is about to enable config encryption for the first
+#: time. Encrypting rewrites config.toml through a TOML parse/serialize
+#: round-trip (tomllib.load + toml.dumps), which preserves every value and
+#: type losslessly but drops comments and reorders tables -- there is no
+#: comment-preserving TOML writer in use here, and the fix for this review
+#: is to warn, not to silently rewrite an annotated config (see task-851
+#: review finding 3).
+COMMENT_LOSS_WARNING = (
+    "• Saving will rewrite config.toml: any comments or custom formatting "
+    "in it will be lost (all values are preserved)"
+)
+
 
 class PasswordDialog(ModalScreen):
     """Dialog for entering master password for config encryption."""
@@ -386,6 +398,7 @@ class EncryptionSetupDialog(ModalScreen):
                         "• If you forget the password, you'll need to re-enter your API keys"
                     )
                     yield Static("• Make sure to use a strong, memorable password")
+                    yield Static(COMMENT_LOSS_WARNING)
 
                 # Buttons
                 with Horizontal(classes="button-container"):

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -5307,6 +5307,7 @@ class TldwCli(
         skill_trust_marker_store, reduced_rollback_protection = (
             build_skill_trust_marker_store_with_fallback(
                 fallback_marker_path=trust_store_dir / _SKILL_TRUST_MARKER_FILENAME,
+                store_dir=trust_store_dir,
                 account_scope=trust_account_scope,
             )
         )

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -123,6 +123,17 @@ _ENCRYPTION_PASSWORD = None  # Cached password for the session
 _ENCRYPTION_MODULE = None  # Lazily loaded encryption module
 _CONFIG_GENERATION = 0
 
+#: Permission mode used the first time an encryption-related rewrite of the
+#: config file creates it from scratch (no pre-existing file whose mode can
+#: be preserved). The config file can hold plaintext API keys and the
+#: encryption password verifier, so a freshly created one gets a
+#: user-only-readable mode rather than ``atomic_write_text``'s generic
+#: 0o644 default. Every encryption entry point passes this alongside
+#: ``preserve_existing_mode=True`` so an already-existing file's mode
+#: (e.g. a user-tightened 0o600) is never widened by the rewrite -- see
+#: task-851 review finding 2.
+CONFIG_SECRETS_FILE_MODE = 0o600
+
 # --- Chunking Settings (Default, can be overridden by TOML) ---
 global_default_chunk_language = "en"
 

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -51,6 +51,7 @@ from tldw_chatbook.Utils.private_paths import (
     secure_private_directory,
     verify_trusted_directory,
 )
+from tldw_chatbook.Utils.sensitive_config_keys import is_sensitive_config_key
 #
 #######################################################################################################################
 #
@@ -586,43 +587,11 @@ def encrypt_api_keys_in_config(
                 # Recursively encrypt nested dictionaries
                 result[key] = encrypt_sensitive_fields(value)
             elif isinstance(value, str) and value.strip():
-                # Check if this is a sensitive field
-                key_lower = key.lower()
-                # Check exact matches and also patterns
-                sensitive_exact = [
-                    "api_key",
-                    "apikey",
-                    "api-key",
-                    "secret",
-                    "token",
-                    "password",
-                    "auth_token",
-                    "api_token",
-                    "access_token",
-                    "secret_key",
-                    "refresh_token",
-                    "client_secret",
-                ]
-                # Also check if key contains these patterns
-                sensitive_patterns = [
-                    "api_key",
-                    "apikey",
-                    "api-key",
-                    "_key",
-                    "_token",
-                    "_secret",
-                    "_password",
-                ]
-
-                is_sensitive = key_lower in sensitive_exact
-                if not is_sensitive:
-                    # Check if key contains any sensitive pattern
-                    for pattern in sensitive_patterns:
-                        if pattern in key_lower:
-                            is_sensitive = True
-                            break
-
-                if is_sensitive:
+                # Check if this is a sensitive field, using the same
+                # predicate every other encryption/redaction/reporting path
+                # in the app uses (see Utils/sensitive_config_keys.py for
+                # why this used to disagree with itself).
+                if is_sensitive_config_key(key):
                     # Skip if already encrypted or is a placeholder
                     if not (
                         enc_module.is_encrypted(value)
@@ -3758,39 +3727,9 @@ def load_cli_config_and_ensure_existence(
     return _load_cli_config_bootstrap(force_reload=force_reload).config
 
 
-def _is_sensitive_setting_key(key: Any) -> bool:
-    key_lower = str(key).lower()
-    sensitive_exact = [
-        "api_key",
-        "apikey",
-        "api-key",
-        "secret",
-        "token",
-        "password",
-        "auth_token",
-        "api_token",
-        "access_token",
-        "secret_key",
-        "refresh_token",
-        "client_secret",
-    ]
-    sensitive_patterns = [
-        "api_key",
-        "apikey",
-        "api-key",
-        "_key",
-        "_token",
-        "_secret",
-        "_password",
-    ]
-    return key_lower in sensitive_exact or any(
-        pattern in key_lower for pattern in sensitive_patterns
-    )
-
-
 def _setting_value_for_log(key: Any, value: Any) -> str:
     """Return a safe representation of a config setting value for logs."""
-    if _is_sensitive_setting_key(key):
+    if is_sensitive_config_key(key):
         return repr("<redacted>")
     return repr(value)
 
@@ -3802,7 +3741,7 @@ def _maybe_encrypt_setting_value(
     if not (
         isinstance(encryption_config, dict)
         and encryption_config.get("enabled", False)
-        and _is_sensitive_setting_key(key)
+        and is_sensitive_config_key(key)
         and isinstance(value, str)
         and value
         and not value.startswith("enc:")
@@ -4088,7 +4027,7 @@ def _contains_unencrypted_sensitive_value(config_data: Mapping[str, Any]) -> boo
                 return True
             continue
         if not (
-            _is_sensitive_setting_key(key)
+            is_sensitive_config_key(key)
             and isinstance(value, str)
             and value.strip()
         ):


### PR DESCRIPTION
Closes TASK-851, TASK-852, TASK-853. Follow-on to the path-naming audit in #964.

**Together, 851 and 852 meant config encryption did not encrypt.**

## The three Criticals

**TASK-851 — encryption wrote to the wrong file.** All three entry points in `config.py` opened `DEFAULT_CONFIG_PATH` rather than `_get_effective_config_path()`. Reproduced: with `TLDW_CONFIG_PATH` set, "Enable encryption" returned `True`, left the active profile's `sk-proj-…` key in **plaintext**, and silently rewrote a different file. Now routed through the effective path, and the write is atomic — a crash mid-write previously truncated the file holding every API key.

**TASK-852 — the detector never fired.** `detect_api_keys` exact-matched six literals while every real key name is prefixed (`openai_api_key`, `bing_search_api_key`, `api_token`, `*_fallback`), so a config full of live plaintext secrets returned `False` and `should_encrypt_config()` never prompted. Replaced by a unified predicate in `Utils/sensitive_config_keys.py`, collapsing four previously-disagreeing lists. Verified across 777 real config key names: zero coverage lost against either removed list; the only newly-flagged keys are two genuine `*_API_KEY_fallback` secrets. The `_env_var` guard holds and `max_tokens` stays excluded.

**TASK-853 — two containment checks that could not reject anything.** One passed the candidate's own parent as the containment base (a path is always inside its own parent); the other tested nesting in only one direction, so a scratch root *enclosing* the trust store passed. These guard the trust and script-grant stores that authorize skill script execution. The new base derives from `default_trust_store_dir` — the same value passed to `SkillTrustStore(store_dir=...)` — not a re-spelled literal.

## What the review caught: a regression this branch activated

TASK-851 fixed three encryption write paths. There was a **fourth**, and it was the only automatic one — the on-quit save in `app.py`.

Before the fix, enabling encryption under a profile wrote `[encryption] enabled=true` into the *default* file, which the profile-reading loader never saw, so the quit handler stayed a no-op. After the fix the profile carried that flag, so **every quit serialized the merged profile config over the user's default config**: measured 122 → 31,007 bytes with the default's own key destroyed, and the profile never re-encrypted. Fixed, with a regression test that fails without it.

Also fixed from the review:
- The atomic write was chmod'ing to `0644` — widening a file full of API keys, and leaving it `0644` with plaintext after a later decrypt. Now preserves the target's existing mode (`0600` verified across both encrypt and decrypt), with a restrictive default for new files. Atomicity itself was sound and is unchanged: mkstemp sibling in the target directory, `0600` during the write window, fsync, `os.replace`.
- `tomllib.load` + `toml.dumps` drops comments and reorders tables. Values and types are fully lossless — ints, bools, floats, arrays, datetimes, non-ASCII and multiline strings all round-trip with zero semantic diff — so this is documentation loss, not data loss. It predates this branch, but 851 points it at profile files and 852 makes the prompt actually appear, so users will now hit it. Surfaced as a warning in the enable-encryption dialog rather than silently rewriting annotated configs.
- `skill_trust_store.clear()` now validates before unlinking, so the invariant holds on all three methods.
- `settings_screen._config_path()` now calls `_get_effective_config_path()` instead of re-spelling it — the exact drift shape this audit is about.

## Testing

`Tests/Skills/ Tests/Utils/` plus both config-encryption test files → **873 passed, 0 failed**, run after rebasing onto current dev.

Independently verified end to end: the plaintext sentinel is removed from the effective file while the real user config stays byte-identical; encrypt→decrypt round-trips; file mode holds at `0600` through both; the default config is untouched across the quit path. Every new regression test was checked to fail pre-fix.

## Notes

- The task filed for the remaining sibling defect (`Tools_Settings_Window._save_raw_toml_config`, same wrong-path and non-atomic shape) is **task-930** — `900` was taken on dev by a concurrent session while this branch was in flight.
- `task-545` is duplicated on dev from a concurrent session. Not introduced here; flagged for its owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make config encryption actually encrypt and keep it safe. Writes now target the active config file, detect real keys, preserve permissions, and harden trust/scratch containment (TASK-851, TASK-852, TASK-853).

- **Bug Fixes**
  - Route `enable_config_encryption`, `disable_config_encryption`, `change_encryption_password`, and the on-quit save through `_get_effective_config_path()`; writes are atomic and preserve the target’s mode (new files default to `0600`).
  - Unify sensitive-key detection in `Utils/sensitive_config_keys.py` and use it across config, `config_encryption.detect_api_keys()`, and the privacy/security UI; it flags real provider keys (e.g., `*_api_key`, `*_token`, `*_fallback`) and ignores non-secrets like `*_env_var` and `max_tokens`.
  - Show a warning that enabling encryption rewrites TOML formatting and drops comments in `Widgets/password_dialog.py` and the settings toggle in `UI/Tools_Settings_Window.py`.
  - Fix trust containment: `FileSkillTrustGenerationMarkerStore` validates `marker_path` against a provided `store_dir`, and `LocalSkillsService` treats both `self.store_dir` and `self.skills_dir` as containers with checks for both “nested inside” and “enclosing” cases.
  - Delegate `SettingsScreen._config_path()` to the shared `get_cli_config_path()` accessor and validate `skill_trust_store.clear()` before unlinking.
  - Update QA seed script `Docs/superpowers/qa/skills-script-execution-2026-07-25/seed3.py` to pass `store_dir=...` to `build_skill_trust_marker_store_with_fallback`.

- **Migration**
  - Update any direct construction of `FileSkillTrustGenerationMarkerStore` to pass `store_dir=...` (the trust store directory).

<sup>Written for commit 58f8f1b54f002f6788fc18a878442f3657cdbf9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

