### PR TITLE
feat(stt): install verified Parakeet v2 from Library

### DIFF
--- a/Tests/Local_Ingestion/test_parakeet_v2_installer.py
+++ b/Tests/Local_Ingestion/test_parakeet_v2_installer.py
@@ -1,0 +1,123 @@
+"""Tests for the curated Parakeet v2 INT8 installer."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+import tldw_chatbook.Local_Ingestion.parakeet_v2_installer as installer
+
+
+class _Response(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        self.close()
+
+
+def _tiny_files(payloads: dict[str, bytes]) -> tuple[installer.BundleFile, ...]:
+    return tuple(
+        installer.BundleFile(
+            filename=filename,
+            size_bytes=len(payload),
+            sha256=hashlib.sha256(payload).hexdigest(),
+        )
+        for filename, payload in payloads.items()
+    )
+
+
+def _fake_network(monkeypatch, payloads: dict[str, bytes]) -> list[str]:
+    requested: list[str] = []
+
+    def open_url(request, *, timeout):
+        del timeout
+        filename = request.full_url.rsplit("/", 1)[-1]
+        requested.append(filename)
+        return _Response(payloads[filename])
+
+    monkeypatch.setattr(installer, "_open_url", open_url)
+    return requested
+
+
+def test_curated_descriptor_is_pinned_to_verified_v2_int8() -> None:
+    assert installer.PARAKEET_V2_REVISION == (
+        "0bbb45a3365852604aef28b538a8f066f4ccaa85"
+    )
+    assert installer.PARAKEET_V2_LICENSE == "CC-BY-4.0"
+    assert installer.PARAKEET_V2_TOTAL_BYTES == 661_191_781
+    assert {file.filename for file in installer.PARAKEET_V2_FILES} == {
+        "config.json",
+        "vocab.txt",
+        "encoder-model.int8.onnx",
+        "decoder_joint-model.int8.onnx",
+    }
+
+
+def test_install_verifies_and_atomically_publishes_bundle(
+    tmp_path: Path, monkeypatch
+) -> None:
+    payloads = {
+        "config.json": b"config",
+        "vocab.txt": b"vocab",
+        "encoder-model.int8.onnx": b"encoder",
+        "decoder_joint-model.int8.onnx": b"decoder",
+    }
+    monkeypatch.setattr(installer, "PARAKEET_V2_FILES", _tiny_files(payloads))
+    requested = _fake_network(monkeypatch, payloads)
+    progress: list[tuple[int, int, str]] = []
+    destination = tmp_path / "installed"
+
+    result = installer.install_verified_parakeet_v2(
+        destination=destination,
+        progress=lambda current, total, filename: progress.append(
+            (current, total, filename)
+        ),
+    )
+
+    assert result == destination
+    assert requested == list(payloads)
+    assert installer.verify_parakeet_v2_bundle(destination) is True
+    receipt = json.loads(
+        (destination / installer.VERIFICATION_RECEIPT).read_text(encoding="utf-8")
+    )
+    assert receipt["revision"] == installer.PARAKEET_V2_REVISION
+    assert receipt["files"][0]["sha256"] == _tiny_files(payloads)[0].sha256
+    assert progress[-1][0] == sum(map(len, payloads.values()))
+    assert not list(tmp_path.glob(".parakeet-v2-install-*"))
+
+
+def test_install_hash_failure_leaves_no_loadable_partial(
+    tmp_path: Path, monkeypatch
+) -> None:
+    expected = {"config.json": b"expected"}
+    monkeypatch.setattr(installer, "PARAKEET_V2_FILES", _tiny_files(expected))
+    _fake_network(monkeypatch, {"config.json": b"corrupt!"})
+    destination = tmp_path / "installed"
+
+    with pytest.raises(installer.ParakeetInstallError, match="verification failed"):
+        installer.install_verified_parakeet_v2(destination=destination)
+
+    assert not destination.exists()
+    assert not list(tmp_path.glob(".parakeet-v2-install-*"))
+
+
+def test_valid_existing_bundle_is_reused_without_network(
+    tmp_path: Path, monkeypatch
+) -> None:
+    payloads = {"config.json": b"config"}
+    monkeypatch.setattr(installer, "PARAKEET_V2_FILES", _tiny_files(payloads))
+    _fake_network(monkeypatch, payloads)
+    destination = tmp_path / "installed"
+    installer.install_verified_parakeet_v2(destination=destination)
+
+    def unexpected_network(*_args, **_kwargs):
+        raise AssertionError("network should not be used")
+
+    monkeypatch.setattr(installer, "_open_url", unexpected_network)
+
+    assert installer.install_verified_parakeet_v2(destination=destination) == destination

--- a/Tests/UI/test_library_ingest_canvas.py
+++ b/Tests/UI/test_library_ingest_canvas.py
@@ -43,6 +43,7 @@ class _MessageRecordingHost(App):
         self._state = state
         self.option_changes: list[LibraryIngestCanvas.OptionValueChanged] = []
         self.panel_toggles: list[LibraryIngestCanvas.OptionPanelToggled] = []
+        self.parakeet_install_requests = 0
 
     def compose(self) -> ComposeResult:
         yield LibraryIngestCanvas(self._state, id="library-ingest-canvas")
@@ -54,6 +55,12 @@ class _MessageRecordingHost(App):
     @on(LibraryIngestCanvas.OptionPanelToggled)
     def _record_panel_toggle(self, event: LibraryIngestCanvas.OptionPanelToggled) -> None:
         self.panel_toggles.append(event)
+
+    @on(LibraryIngestCanvas.ParakeetInstallRequested)
+    def _record_parakeet_install_request(
+        self, _event: LibraryIngestCanvas.ParakeetInstallRequested
+    ) -> None:
+        self.parakeet_install_requests += 1
 
 
 def _default_form() -> LibraryIngestFormState:
@@ -791,9 +798,11 @@ async def test_mounting_option_panels_posts_no_option_changes():
 
 @pytest.mark.asyncio
 async def test_audio_video_defaults_to_parakeet_onnx_without_whisper_models():
+    form = _default_form()
+    form.expanded_type_groups.add("audio_video")
     state = build_library_ingest_state(
         (),
-        form=_default_form(),
+        form=form,
         preflight=PreflightResult(
             type_groups={"audio_video": ["/tmp/a.mp3"]},
             warnings=[],
@@ -803,7 +812,7 @@ async def test_audio_video_defaults_to_parakeet_onnx_without_whisper_models():
             total_files=1,
         ),
     )
-    app = _CanvasHost(state)
+    app = _MessageRecordingHost(state)
     with patch(
         "tldw_chatbook.Widgets.Library.library_ingest_canvas._is_installed",
         return_value=True,
@@ -822,6 +831,13 @@ async def test_audio_video_defaults_to_parakeet_onnx_without_whisper_models():
             assert model.disabled is True
             assert model_dir.disabled is False
             assert model_dir.value == ""
+            install = pilot.app.query_one(
+                "#opt-audio_video-install-parakeet-v2", Button
+            )
+            assert "Install verified Parakeet v2 INT8" in str(install.label)
+            install.press()
+            await pilot.pause()
+            assert app.parakeet_install_requests == 1
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_parakeet_v2_install_ui.py
+++ b/Tests/UI/test_parakeet_v2_install_ui.py
@@ -1,0 +1,77 @@
+"""Tests for the Library curated Parakeet install surface."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from textual.app import App
+from textual.widgets import Button, Static
+
+from tldw_chatbook.Library.library_ingest_state import LibraryIngestFormState
+from tldw_chatbook.UI.Screens.library_screen import (
+    LibraryScreen,
+    ParakeetV2InstallModal,
+)
+
+
+class _ModalApp(App):
+    def compose(self):
+        return []
+
+
+@pytest.mark.asyncio
+async def test_install_modal_shows_consent_details_and_confirms(tmp_path: Path) -> None:
+    destination = tmp_path / "parakeet-v2"
+    app = _ModalApp()
+    async with app.run_test() as pilot:
+        captured: list[bool] = []
+        await app.push_screen(
+            ParakeetV2InstallModal(destination),
+            lambda result: captured.append(result),
+        )
+        await pilot.pause()
+
+        text = "\n".join(
+            str(static.renderable) for static in app.screen.query(Static)
+        )
+        assert "istupakov/parakeet-tdt-0.6b-v2-onnx" in text
+        assert "0bbb45a3365852604aef28b538a8f066f4ccaa85" in text
+        assert "CC-BY-4.0" in text
+        assert "630.6 MiB" in text
+        assert str(destination) in text
+
+        await pilot.click(app.screen.query_one("#parakeet-v2-install-confirm", Button))
+        await pilot.pause()
+        assert captured == [True]
+
+
+def test_successful_install_populates_current_batch_model_folder(
+    tmp_path: Path,
+) -> None:
+    installed = tmp_path / "parakeet-v2"
+    screen = object.__new__(LibraryScreen)
+    screen._library_ingest_form = LibraryIngestFormState()
+    screen._parakeet_v2_install_worker = MagicMock()
+    screen.app_instance = MagicMock()
+    screen.refresh = MagicMock()
+
+    screen._apply_parakeet_v2_install_result(installed, None)
+
+    options = screen._library_ingest_form.type_options["audio_video"]
+    assert options["transcription_provider"] == "parakeet-onnx"
+    assert options["transcription_model_dir"] == str(installed)
+    screen.app_instance.notify.assert_called_once()
+    screen.refresh.assert_called_once_with(recompose=True)
+
+
+def test_confirmation_starts_background_installer_worker() -> None:
+    screen = object.__new__(LibraryScreen)
+    screen._parakeet_v2_install_worker = None
+    screen.app_instance = MagicMock()
+    expected_worker = MagicMock()
+    screen._run_parakeet_v2_install = MagicMock(return_value=expected_worker)
+
+    screen._confirm_parakeet_v2_install(True)
+
+    screen._run_parakeet_v2_install.assert_called_once_with()
+    assert screen._parakeet_v2_install_worker is expected_worker

--- a/backlog/tasks/task-931 - Install-verified-Parakeet-v2-INT8-from-Library.md
+++ b/backlog/tasks/task-931 - Install-verified-Parakeet-v2-INT8-from-Library.md
@@ -1,0 +1,58 @@
+---
+id: TASK-931
+title: Install verified Parakeet v2 INT8 from Library
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-07-27 15:29'
+updated_date: '2026-07-27 15:37'
+labels:
+  - stt
+  - ingestion
+  - downloads
+  - ui
+dependencies: []
+references:
+  - backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md
+documentation:
+  - Docs/superpowers/specs/2026-07-23-stt-parakeet-onnx-transcribe-cpp-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Let a user explicitly install the pinned Parakeet v2 INT8 ONNX bundle from the Library ingestion options and immediately use the verified local folder.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The Library audio/video options offer an explicit Parakeet v2 INT8 install action with immutable source revision, CC-BY-4.0 license, download size, and destination shown before confirmation.
+- [x] #2 The installer streams the four pinned files into isolated staging, verifies exact size and SHA-256, and atomically publishes only a complete bundle.
+- [x] #3 Failures leave no loadable partial bundle, an already-valid bundle is reused without network access, and providers cannot trigger installation.
+- [x] #4 Installation runs off the Textual event loop and successful completion fills the local Parakeet model folder for the current batch form.
+- [x] #5 Focused downloader and Library UI tests plus a real verified-bundle transcription smoke pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing tests for immutable v2 metadata, verified staged installation, corruption cleanup, valid-bundle reuse, and the Library install event/result path.
+2. Implement one curated v2 installer with stdlib HTTP streaming, exact byte/digest checks, free-space preflight, a verification receipt, and atomic publication.
+3. Add a Parakeet install button and confirmation modal to the existing Library panel; run the install on a thread worker and populate transcription_model_dir on success.
+4. Run focused tests, lint, a local fixture install, and a real ONNX transcription from the installed result.
+
+ADR required: yes
+ADR path: backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md
+Reason: ADR-025 already establishes explicit consent, pinned verified acquisition, staging, and provider-download prohibition. This task implements only the v2 user path and does not create a generic artifact framework.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added one curated Parakeet v2 INT8 installer directly to the Library audio/video options. The consent modal shows the immutable Hugging Face repository/revision, CC-BY-4.0 license, 630.6 MiB download, destination, and verification behavior. The stdlib installer streams the four pinned files into same-filesystem staging, checks free space, exact byte counts and SHA-256, writes a verification receipt, and atomically renames only a complete bundle. Existing verified installs are reused offline; corrupt downloads and invalid existing destinations fail without a loadable partial. The installer is invoked only by the explicit UI action and runs in a Textual thread worker; successful completion selects the installed directory for the current batch.
+
+Verification: 154 affected installer, Library UI, ingestion, and ONNX tests passed; Ruff and git diff --check passed. A real localhost HTTP smoke streamed all 661,191,781 bytes from the pinned bundle, verified and atomically published it to a fresh directory, then transcribed the smoke WAV from that new install in 1.14 seconds with the exact expected result.
+
+ADR: Reused backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md; no generic artifact framework or provider-initiated acquisition was introduced.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Local_Ingestion/parakeet_v2_installer.py
+++ b/tldw_chatbook/Local_Ingestion/parakeet_v2_installer.py
@@ -1,0 +1,202 @@
+"""Explicit, verified installer for the curated Parakeet v2 INT8 bundle."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Callable
+from urllib.request import Request, urlopen as _open_url
+
+
+PARAKEET_V2_REPOSITORY = "istupakov/parakeet-tdt-0.6b-v2-onnx"
+PARAKEET_V2_REVISION = "0bbb45a3365852604aef28b538a8f066f4ccaa85"
+PARAKEET_V2_LICENSE = "CC-BY-4.0"
+VERIFICATION_RECEIPT = ".tldw-verified.json"
+_DOWNLOAD_CHUNK_BYTES = 1024 * 1024
+_FREE_SPACE_HEADROOM_BYTES = 32 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class BundleFile:
+    """One immutable file in the curated bundle."""
+
+    filename: str
+    size_bytes: int
+    sha256: str
+
+
+PARAKEET_V2_FILES = (
+    BundleFile(
+        "config.json",
+        97,
+        "666903c76b9798caf2c210afd4f6cd60b08a8dbf9800ec8d7a3bc0d2148ac466",
+    ),
+    BundleFile(
+        "vocab.txt",
+        9_384,
+        "ec182b70dd42113aff6c5372c75cac58c952443eb22322f57bbd7f53977d497d",
+    ),
+    BundleFile(
+        "encoder-model.int8.onnx",
+        652_184_014,
+        "3e0581fda6ab843888b51e56d7ee78b6d5bc3237ec113af1f732d1d5286aa155",
+    ),
+    BundleFile(
+        "decoder_joint-model.int8.onnx",
+        8_998_286,
+        "a449f49acd68979d418651dd2dcb737cc0f1bf0225e009e29ee326354edbf7d3",
+    ),
+)
+PARAKEET_V2_TOTAL_BYTES = sum(file.size_bytes for file in PARAKEET_V2_FILES)
+
+
+class ParakeetInstallError(RuntimeError):
+    """Raised when the curated bundle cannot be installed safely."""
+
+
+def parakeet_v2_install_dir() -> Path:
+    """Return the immutable default installation directory."""
+    from tldw_chatbook.Utils.paths import get_user_data_dir
+
+    return (
+        get_user_data_dir()
+        / "models"
+        / "stt"
+        / f"parakeet-v2-int8-{PARAKEET_V2_REVISION[:12]}"
+    )
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(_DOWNLOAD_CHUNK_BYTES), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_parakeet_v2_bundle(directory: str | Path) -> bool:
+    """Return whether ``directory`` is the complete curated bundle."""
+    root = Path(directory)
+    try:
+        receipt_path = root / VERIFICATION_RECEIPT
+        if receipt_path.is_symlink() or not receipt_path.is_file():
+            return False
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+        if (
+            receipt.get("repository") != PARAKEET_V2_REPOSITORY
+            or receipt.get("revision") != PARAKEET_V2_REVISION
+        ):
+            return False
+        for descriptor in PARAKEET_V2_FILES:
+            path = root / descriptor.filename
+            if path.is_symlink() or not path.is_file():
+                return False
+            if path.stat().st_size != descriptor.size_bytes:
+                return False
+            if _sha256(path) != descriptor.sha256:
+                return False
+    except (OSError, ValueError, TypeError, json.JSONDecodeError):
+        return False
+    return True
+
+
+def _source_url(filename: str) -> str:
+    return (
+        f"https://huggingface.co/{PARAKEET_V2_REPOSITORY}/resolve/"
+        f"{PARAKEET_V2_REVISION}/{filename}"
+    )
+
+
+def install_verified_parakeet_v2(
+    *,
+    destination: str | Path | None = None,
+    progress: Callable[[int, int, str], None] | None = None,
+) -> Path:
+    """Download, verify, and atomically publish the curated v2 INT8 bundle."""
+    target = Path(destination) if destination is not None else parakeet_v2_install_dir()
+    if verify_parakeet_v2_bundle(target):
+        return target
+    if target.exists():
+        raise ParakeetInstallError(
+            f"Install destination exists but is not the verified bundle: {target}"
+        )
+
+    parent = target.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    total_bytes = sum(file.size_bytes for file in PARAKEET_V2_FILES)
+    if shutil.disk_usage(parent).free < total_bytes + _FREE_SPACE_HEADROOM_BYTES:
+        raise ParakeetInstallError(
+            f"Not enough free space to install {total_bytes:,} bytes at {parent}"
+        )
+
+    staging = Path(
+        tempfile.mkdtemp(prefix=".parakeet-v2-install-", dir=str(parent))
+    )
+    downloaded = 0
+    try:
+        for descriptor in PARAKEET_V2_FILES:
+            if Path(descriptor.filename).name != descriptor.filename:
+                raise ParakeetInstallError("Invalid curated bundle filename")
+            output_path = staging / descriptor.filename
+            digest = hashlib.sha256()
+            file_bytes = 0
+            request = Request(
+                _source_url(descriptor.filename),
+                headers={"User-Agent": "tldw-chatbook-parakeet-installer/1"},
+            )
+            with _open_url(request, timeout=30) as response, output_path.open(
+                "xb"
+            ) as output:
+                while chunk := response.read(_DOWNLOAD_CHUNK_BYTES):
+                    file_bytes += len(chunk)
+                    if file_bytes > descriptor.size_bytes:
+                        raise ParakeetInstallError(
+                            f"{descriptor.filename} verification failed: "
+                            "download exceeded the expected size"
+                        )
+                    output.write(chunk)
+                    digest.update(chunk)
+                    downloaded += len(chunk)
+                    if progress is not None:
+                        progress(downloaded, total_bytes, descriptor.filename)
+            if (
+                file_bytes != descriptor.size_bytes
+                or digest.hexdigest() != descriptor.sha256
+            ):
+                raise ParakeetInstallError(
+                    f"{descriptor.filename} verification failed: "
+                    "size or SHA-256 did not match"
+                )
+
+        receipt = {
+            "schema_version": 1,
+            "repository": PARAKEET_V2_REPOSITORY,
+            "revision": PARAKEET_V2_REVISION,
+            "license": PARAKEET_V2_LICENSE,
+            "files": [asdict(file) for file in PARAKEET_V2_FILES],
+        }
+        (staging / VERIFICATION_RECEIPT).write_text(
+            json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        if not verify_parakeet_v2_bundle(staging):
+            raise ParakeetInstallError("Staged Parakeet v2 bundle verification failed")
+        try:
+            staging.rename(target)
+        except FileExistsError:
+            if not verify_parakeet_v2_bundle(target):
+                raise ParakeetInstallError(
+                    f"Install destination changed during installation: {target}"
+                )
+        return target
+    except ParakeetInstallError:
+        raise
+    except Exception as exc:
+        raise ParakeetInstallError(f"Parakeet v2 install failed: {exc}") from exc
+    finally:
+        if staging.exists():
+            shutil.rmtree(staging, ignore_errors=True)

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -166,6 +166,14 @@ from ...Library.library_shell_state import (
     LibraryShellInput,
     build_library_shell_state,
 )
+from ...Local_Ingestion.parakeet_v2_installer import (
+    PARAKEET_V2_LICENSE,
+    PARAKEET_V2_REPOSITORY,
+    PARAKEET_V2_REVISION,
+    PARAKEET_V2_TOTAL_BYTES,
+    install_verified_parakeet_v2,
+    parakeet_v2_install_dir,
+)
 from ...Library.row_selection import RowSelection
 from ...runtime_policy.server_event_scope import event_principal_id_from_active_context
 from ...runtime_policy.types import PolicyDeniedError, RuntimeSourceState
@@ -805,6 +813,70 @@ class IngestGuardrailModal(ModalScreen[bool]):
             self.notify("Clipboard not available", severity="warning")
 
 
+class ParakeetV2InstallModal(ModalScreen[bool]):
+    """Consent prompt for the curated Parakeet v2 INT8 download."""
+
+    DEFAULT_CSS = """
+    ParakeetV2InstallModal {
+        align: center middle;
+    }
+
+    #parakeet-v2-install-modal {
+        width: 76;
+        height: auto;
+        border: tall $accent;
+        background: $surface;
+        padding: 1 2;
+    }
+
+    #parakeet-v2-install-actions {
+        height: 3;
+        margin-top: 1;
+        align-horizontal: right;
+    }
+    """
+
+    BINDINGS = [("escape", "dismiss(false)", "Close")]
+
+    def __init__(self, destination: Path) -> None:
+        self.destination = destination
+        super().__init__()
+
+    def compose(self) -> ComposeResult:
+        size_mib = PARAKEET_V2_TOTAL_BYTES / (1024 * 1024)
+        details = (
+            "Install the curated Parakeet v2 INT8 speech model?\n\n"
+            f"Source: {PARAKEET_V2_REPOSITORY}\n"
+            f"Revision: {PARAKEET_V2_REVISION}\n"
+            f"License: {PARAKEET_V2_LICENSE}\n"
+            f"Download: {size_mib:.1f} MiB\n"
+            f"Destination: {self.destination}\n\n"
+            "All four files are checked against pinned sizes and SHA-256 "
+            "digests before the bundle becomes usable."
+        )
+        with Vertical(id="parakeet-v2-install-modal"):
+            yield Static(details, markup=False)
+            with Horizontal(id="parakeet-v2-install-actions"):
+                yield Button(
+                    "Cancel",
+                    id="parakeet-v2-install-cancel",
+                    variant="default",
+                )
+                yield Button(
+                    "Install",
+                    id="parakeet-v2-install-confirm",
+                    variant="primary",
+                )
+
+    @on(Button.Pressed, "#parakeet-v2-install-confirm")
+    def _confirm(self) -> None:
+        self.dismiss(True)
+
+    @on(Button.Pressed, "#parakeet-v2-install-cancel")
+    def _cancel(self) -> None:
+        self.dismiss(False)
+
+
 def _affected_counts(preflight: PreflightResult) -> dict[str, int]:
     """Map each tooling feature to the number of files that depend on it."""
     counts: dict[str, int] = {}
@@ -1215,6 +1287,9 @@ class LibraryScreen(BaseAppScreen):
         # Pre-flight analysis worker for the ingest path field. Cancelled
         # and replaced on every new trigger so rapid edits never stack.
         self._library_ingest_preflight_worker: Worker | None = None
+        # Explicit user-started curated model install. It is separate from
+        # inference: providers never acquire models on first use.
+        self._parakeet_v2_install_worker: Worker | None = None
         # Export canvas state (F4 Task 2). ``_library_export_counts`` is
         # ``None`` until the counts worker lands a result for the current
         # scope (drives ``LibraryExportFormState.counts_loading`` --
@@ -11829,6 +11904,81 @@ class LibraryScreen(BaseAppScreen):
         field = next((f for f in cap.fields if f.name == event.name), None)
         if field is not None and field.type not in ("text", "number"):
             self.refresh(recompose=True)
+
+    @on(LibraryIngestCanvas.ParakeetInstallRequested)
+    def handle_parakeet_v2_install_requested(
+        self,
+        event: LibraryIngestCanvas.ParakeetInstallRequested,
+    ) -> None:
+        """Show immutable source, license, size, and destination before install."""
+        event.stop()
+        worker = getattr(self, "_parakeet_v2_install_worker", None)
+        if worker is not None and not worker.is_finished:
+            self.app_instance.notify(
+                "Parakeet v2 installation is already running.",
+                severity="information",
+            )
+            return
+        self.app.push_screen(
+            ParakeetV2InstallModal(parakeet_v2_install_dir()),
+            self._confirm_parakeet_v2_install,
+        )
+
+    def _confirm_parakeet_v2_install(self, confirmed: bool) -> None:
+        """Start the installer worker after explicit confirmation."""
+        if not confirmed:
+            return
+        worker = getattr(self, "_parakeet_v2_install_worker", None)
+        if worker is not None and not worker.is_finished:
+            return
+        self.app_instance.notify(
+            "Installing verified Parakeet v2 INT8 in the background…",
+            severity="information",
+        )
+        self._parakeet_v2_install_worker = self._run_parakeet_v2_install()
+
+    @work(thread=True, group="library_parakeet_v2_install", exit_on_error=False)
+    def _run_parakeet_v2_install(self) -> None:
+        """Install off the Textual event loop and return one terminal result."""
+        try:
+            installed = install_verified_parakeet_v2()
+        except Exception as exc:
+            logger.opt(exception=True).error("Parakeet v2 installation failed")
+            self.app.call_from_thread(
+                self._apply_parakeet_v2_install_result,
+                None,
+                str(exc),
+            )
+            return
+        self.app.call_from_thread(
+            self._apply_parakeet_v2_install_result,
+            installed,
+            None,
+        )
+
+    def _apply_parakeet_v2_install_result(
+        self,
+        installed: Path | None,
+        error: str | None,
+    ) -> None:
+        """Populate the current batch form only after verified publication."""
+        self._parakeet_v2_install_worker = None
+        if error is not None or installed is None:
+            self.app_instance.notify(
+                f"Parakeet v2 install failed: {error or 'unknown error'}",
+                severity="error",
+            )
+            return
+        options = self._library_ingest_form.type_options.setdefault(
+            "audio_video", {}
+        )
+        options["transcription_provider"] = "parakeet-onnx"
+        options["transcription_model_dir"] = str(installed)
+        self.app_instance.notify(
+            "Parakeet v2 INT8 installed and selected for this batch.",
+            severity="information",
+        )
+        self.refresh(recompose=True)
 
     def _cancel_library_ingest_preflight(self) -> None:
         """Cancel any in-flight pre-flight worker, ignoring a finished one."""

--- a/tldw_chatbook/Widgets/Library/library_ingest_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_ingest_canvas.py
@@ -67,6 +67,9 @@ class LibraryIngestCanvas(VerticalScroll):
             self.group = group
             self.expanded = expanded
 
+    class ParakeetInstallRequested(Message):
+        """The user requested the curated Parakeet v2 installer."""
+
     def __init__(self, state: LibraryIngestCanvasState, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.state = state
@@ -148,6 +151,21 @@ class LibraryIngestCanvas(VerticalScroll):
                         disabled=disabled,
                     )
                 )
+
+        if group == "audio_video":
+            provider = cap_fields_by_name["transcription_provider"]
+            provider_value = values.get(
+                "transcription_provider", provider.default
+            )
+            children.append(
+                Button(
+                    "Install verified Parakeet v2 INT8 (630.6 MiB)…",
+                    id="opt-audio_video-install-parakeet-v2",
+                    classes="library-canvas-action",
+                    compact=True,
+                    disabled=provider_value != "parakeet-onnx",
+                )
+            )
 
         children.append(
             Button(
@@ -583,3 +601,9 @@ class LibraryIngestCanvas(VerticalScroll):
         self.post_message(
             self.OptionPanelToggled(group, expanded=isinstance(event, Collapsible.Expanded))
         )
+
+    @on(Button.Pressed, "#opt-audio_video-install-parakeet-v2")
+    def _request_parakeet_v2_install(self, event: Button.Pressed) -> None:
+        """Request explicit install confirmation from the owning screen."""
+        event.stop()
+        self.post_message(self.ParakeetInstallRequested())


### PR DESCRIPTION
## Summary
- add one explicit curated Parakeet v2 INT8 install action to Library batch ingestion
- show pinned source revision, CC-BY-4.0 license, 630.6 MiB size, and destination before consent
- stream into isolated staging, verify exact size/SHA-256, write a receipt, and atomically publish
- reuse valid installs offline and select the installed folder for the current batch

## Verification
- 154 affected tests passed
- Ruff and git diff --check passed
- real localhost HTTP smoke streamed and verified all 661,191,781 bytes, atomically installed the bundle, and produced the exact transcript via ONNX in 1.14 seconds

Backlog: TASK-931
ADR: backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an explicit, verified installer for Parakeet v2 INT8 directly in the Library. Users review the pinned source, license, and size, then install in the background; the bundle is verified and atomically published, and the installed folder is selected for the current batch. Implements TASK-931.

- New Features
  - Library audio/video panel adds “Install verified Parakeet v2 INT8…”; consent modal shows repository `istupakov/parakeet-tdt-0.6b-v2-onnx`, pinned revision, `CC-BY-4.0`, ~630.6 MiB download, and destination.
  - Installer streams four pinned files to staging, verifies exact sizes and SHA-256, writes a `.tldw-verified.json` receipt, checks free space, and atomically publishes.
  - Runs off the UI thread; on success selects `parakeet-onnx` and sets `transcription_model_dir` for the current batch. Reuses a valid existing install offline; no partials remain on failure.

<sup>Written for commit 3af0fe54a5f46ae6d926ae22f1ac0e160b85a7cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

