### PR TITLE
feat(console): add local microphone dictation

### DIFF
--- a/Docs/Features/TRANSCRIPTION.md
+++ b/Docs/Features/TRANSCRIPTION.md
@@ -7,6 +7,7 @@ This document describes the transcription capabilities available in tldw_chatboo
 tldw_chatbook provides a unified transcription service that supports multiple backend providers, each with their own strengths:
 
 - **Faster-Whisper**: Fast, accurate transcription with support for many languages
+- **Parakeet ONNX**: Cross-platform local Parakeet v2 INT8 for explicit English
 - **Qwen2Audio**: Advanced multimodal understanding
 - **Parakeet**: NVIDIA's optimized models for real-time transcription
 - **Canary**: NVIDIA's multilingual model with translation capabilities
@@ -17,6 +18,14 @@ tldw_chatbook provides a unified transcription service that supports multiple ba
 ```bash
 pip install -e ".[audio]"
 ```
+
+### Console Microphone Dictation
+```bash
+pip install -e ".[speech_recording,transcription_parakeet_onnx]"
+```
+
+Install the verified **Parakeet v2 INT8** bundle from **Library → Models**
+before using the Console microphone. The Mic action never downloads a model.
 
 ### NVIDIA Models (Parakeet & Canary)
 ```bash
@@ -84,6 +93,19 @@ chunk_length_seconds = 40.0         # For Canary long audio processing
 - **Best for**: Multilingual transcription and translation
 
 ## Usage in the Application
+
+### Console Dictation
+
+1. Open **Console** and expand the composer.
+2. Select **Mic** to record from the default microphone.
+3. Select **Rec ●** to stop, or wait for the 60-second limit.
+4. After the local **STT…** step, the English transcript is inserted at the
+   current caret. It is not sent automatically.
+
+Console dictation uses explicit `en`, Parakeet v2 INT8, and either
+`transcription.parakeet_onnx_model_dir` or the verified Library-installed
+bundle. Missing dependencies, model files, microphone access, empty audio, and
+transcription failures leave the draft unchanged and display an error.
 
 ### Basic Transcription
 

--- a/Docs/superpowers/plans/2026-07-27-console-microphone-dictation.md
+++ b/Docs/superpowers/plans/2026-07-27-console-microphone-dictation.md
@@ -1,0 +1,81 @@
+# Console Microphone Dictation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user record one bounded English utterance from the native Console composer and insert its Parakeet v2 INT8 transcript at the current caret.
+
+**Architecture:** Add a small audio-domain session that composes the existing `AudioRecordingService` and `TranscriptionService`; it records one in-memory PCM buffer and performs one transcription after capture stops. `ChatScreen` owns the session lifecycle, schedules a strict 60-second wall-clock timer, and runs start/stop/transcription work in Textual thread workers, while `ConsoleComposerBar` owns only the microphone button presentation and draft insertion. Extend the existing Parakeet ONNX adapter to pass normalized NumPy audio directly to `onnx-asr`, avoiding a temporary WAV. This is an immediately usable vertical slice under TASK-603; it deliberately does not claim completion of the parent task's future `LocalSTTExecutor`, batch-priority, or bounded-IPC gates.
+
+**Tech Stack:** Python 3.11+, Textual workers/widgets, existing PyAudio/sounddevice recorder, existing `onnx-asr` Parakeet v2 adapter, pytest.
+
+**ADR required:** yes
+
+**ADR path:** `backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md`
+
+**Reason:** ADR-025 already selects explicit English → Parakeet v2 INT8, forbids implicit downloads, preserves buffer transcription, and rejects false streaming claims. No new ADR is needed.
+
+---
+
+### Task 1: Keep captured audio bounded in memory
+
+**Files:**
+- Modify: `tldw_chatbook/Audio/recording_service.py`
+- Test: `Tests/Audio/test_recording_service.py`
+
+- [x] Add a failing test proving a configured byte limit retains only complete PCM frames, stops recording, and invokes one visible limit callback.
+- [x] Run the focused test and confirm it fails because `AudioRecordingService` has no buffer limit.
+- [x] Add optional `max_buffer_bytes` and `on_buffer_limit` constructor arguments; reset the byte count on each recording and stop before the limit can be exceeded.
+- [x] Run `Tests/Audio/test_recording_service.py`.
+
+### Task 2: Add memory-only Parakeet ONNX buffer transcription
+
+**Files:**
+- Modify: `tldw_chatbook/Local_Ingestion/transcription_service.py`
+- Modify: `Tests/Transcription/test_parakeet_onnx_vertical_slice.py`
+
+- [x] Add a failing test that sends PCM bytes through `transcribe_buffer()` and proves Parakeet receives a normalized NumPy waveform plus the original sample rate, without opening or creating an audio file.
+- [x] Run the focused test and confirm the Parakeet buffer path is absent and falls into temporary-WAV staging.
+- [x] Reuse the existing validated/cached Parakeet model loader for file and buffer entry points, and call `onnx-asr` directly with the in-memory NumPy waveform.
+- [x] Run the focused Parakeet ONNX tests.
+
+### Task 3: Add one-shot Parakeet Console dictation session
+
+**Files:**
+- Create: `tldw_chatbook/Audio/console_dictation.py`
+- Create: `Tests/Audio/test_console_dictation.py`
+
+- [x] Add failing tests for explicit `en`, Parakeet v2 INT8, model-directory forwarding, empty capture, failed recorder start, and discard without transcription.
+- [x] Run the focused tests and confirm they fail because the session does not exist.
+- [x] Implement `ConsoleDictationSession` by composing `AudioRecordingService` and `TranscriptionService`, loading native dependencies lazily, and returning only stripped transcript text.
+- [x] Resolve the model directory from the explicit/configured path or the verified Library installer destination; require the four local bundle files and never download.
+- [x] Run the focused audio tests.
+
+### Task 4: Add Console microphone control and lifecycle
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Console/console_composer_bar.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Modify: `tldw_chatbook/css/components/_agentic_terminal.tcss`
+- Modify: `tldw_chatbook/css/tldw_cli_modular.tcss`
+- Create: `Tests/UI/test_console_dictation.py`
+- Modify: `Tests/UI/test_console_internals_decomposition.py`
+
+- [x] Add mounted failing tests proving the Mic control exists, start/stop work is delegated, success inserts at the caret without sending, and state labels are clear.
+- [x] Add mounted failing tests for missing dependency, missing model files, microphone failure, empty audio, and transcription failure; each must assert the user-visible message, unchanged draft, and recovery to idle.
+- [x] Add a mounted test proving start schedules a 60-second wall-clock timer and expiry visibly transitions to transcribing before invoking the stop/transcribe worker.
+- [x] Run the focused mounted tests and confirm they fail because the control and handlers do not exist.
+- [x] Add an eight-cell `Mic` action and composer state synchronizer for idle, starting, recording, and transcribing.
+- [x] Add `ChatScreen` lifecycle methods that run blocking audio/STT calls in exclusive thread workers, guard duplicate requests, retain the originating session identity, cancel the wall-clock timer on manual stop/error, and discard capture on unmount.
+- [x] Insert successful text with boundary-aware spacing at the current caret; update an off-screen originating session draft instead of inserting into the wrong chat.
+- [x] Expand the fixed action-row width in both source and bundled CSS and update the exact CSS contract assertion.
+- [x] Run the focused mounted Console tests.
+
+### Task 5: Verify and close the atomic task
+
+**Files:**
+- Modify: `backlog/tasks/task-603.1 - Add-Console-microphone-transcription-vertical-slice.md`
+
+- [x] Run focused audio and Console tests with the MLX import isolated from this environment's known eager-import abort.
+- [x] Run Ruff on changed Python files and `git diff --check`.
+- [x] Perform a self-review against all TASK-603.1 acceptance criteria.
+- [x] Record implementation notes, check every TASK-603.1 acceptance criterion, and mark only TASK-603.1 Done; leave parent TASK-603 open.

--- a/Tests/Audio/test_console_dictation.py
+++ b/Tests/Audio/test_console_dictation.py
@@ -1,0 +1,190 @@
+"""One-shot Console microphone dictation service contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+from unittest.mock import Mock
+
+import pytest
+
+from tldw_chatbook.Audio.console_dictation import (
+    CONSOLE_DICTATION_MAX_BYTES,
+    CONSOLE_DICTATION_MAX_SECONDS,
+    ConsoleDictationError,
+    ConsoleDictationSession,
+)
+
+
+REQUIRED_MODEL_FILES = (
+    "config.json",
+    "vocab.txt",
+    "encoder-model.int8.onnx",
+    "decoder_joint-model.int8.onnx",
+)
+
+
+def test_console_dictation_import_keeps_legacy_transcription_stack_lazy():
+    repo_root = Path(__file__).resolve().parents[2]
+    probe = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            textwrap.dedent(
+                """
+                import sys
+                import types
+
+                sys.modules["parakeet_mlx"] = types.ModuleType("parakeet_mlx")
+                import tldw_chatbook.Audio.console_dictation  # noqa: F401
+
+                assert (
+                    "tldw_chatbook.Local_Ingestion.transcription_service"
+                    not in sys.modules
+                )
+                """
+            ),
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert probe.returncode == 0, probe.stderr
+
+
+def _model_dir(tmp_path):
+    model_dir = tmp_path / "parakeet-v2-int8"
+    model_dir.mkdir()
+    for filename in REQUIRED_MODEL_FILES:
+        (model_dir / filename).touch()
+    return model_dir
+
+
+class FakeRecorder:
+    def __init__(self, *, start_result=True, audio=b"\0\0" * 160, **kwargs):
+        self.start_result = start_result
+        self.audio = audio
+        self.kwargs = kwargs
+        self.start_recording = Mock(return_value=start_result)
+        self.stop_recording = Mock(return_value=audio)
+
+
+def test_session_records_once_and_transcribes_explicit_english_v2_int8(tmp_path):
+    model_dir = _model_dir(tmp_path)
+    recorders = []
+
+    def recorder_factory(**kwargs):
+        recorder = FakeRecorder(**kwargs)
+        recorders.append(recorder)
+        return recorder
+
+    transcriber = Mock()
+    transcriber.transcribe_buffer.return_value = {"text": "  hello Console  "}
+    on_buffer_limit = Mock()
+    session = ConsoleDictationSession(
+        model_dir=model_dir,
+        recorder_factory=recorder_factory,
+        transcription_service=transcriber,
+    )
+
+    session.start(on_buffer_limit=on_buffer_limit)
+    text = session.stop_and_transcribe()
+
+    assert CONSOLE_DICTATION_MAX_SECONDS == 60.0
+    assert recorders[0].kwargs == {
+        "sample_rate": 16_000,
+        "channels": 1,
+        "use_vad": False,
+        "max_buffer_bytes": CONSOLE_DICTATION_MAX_BYTES,
+        "on_buffer_limit": on_buffer_limit,
+    }
+    transcriber.transcribe_buffer.assert_called_once_with(
+        b"\0\0" * 160,
+        sample_rate=16_000,
+        channels=1,
+        sample_width=2,
+        provider="parakeet-onnx",
+        model="nemo-parakeet-tdt-0.6b-v2",
+        language="en",
+        model_dir=str(model_dir),
+    )
+    assert text == "hello Console"
+
+
+def test_session_accepts_only_verified_default_library_install(tmp_path):
+    installed_dir = _model_dir(tmp_path)
+    verify = Mock(return_value=True)
+    recorder = FakeRecorder()
+    session = ConsoleDictationSession(
+        installed_model_dir=installed_dir,
+        verify_installed_bundle=verify,
+        recorder_factory=lambda **kwargs: recorder,
+        transcription_service=Mock(),
+    )
+
+    session.start()
+
+    verify.assert_called_once_with(installed_dir)
+    assert session.model_dir == installed_dir
+
+
+def test_session_reports_missing_model_without_starting_microphone(tmp_path):
+    recorder_factory = Mock()
+    missing_dir = tmp_path / "missing"
+    session = ConsoleDictationSession(
+        installed_model_dir=missing_dir,
+        verify_installed_bundle=lambda path: False,
+        recorder_factory=recorder_factory,
+        transcription_service=Mock(),
+    )
+
+    with pytest.raises(ConsoleDictationError, match="Parakeet v2 model"):
+        session.start()
+
+    recorder_factory.assert_not_called()
+
+
+def test_session_reports_microphone_start_failure(tmp_path):
+    session = ConsoleDictationSession(
+        model_dir=_model_dir(tmp_path),
+        recorder_factory=lambda **kwargs: FakeRecorder(start_result=False, **kwargs),
+        transcription_service=Mock(),
+    )
+
+    with pytest.raises(ConsoleDictationError, match="microphone"):
+        session.start()
+
+
+def test_session_reports_empty_audio_without_transcribing(tmp_path):
+    transcriber = Mock()
+    session = ConsoleDictationSession(
+        model_dir=_model_dir(tmp_path),
+        recorder_factory=lambda **kwargs: FakeRecorder(audio=b"", **kwargs),
+        transcription_service=transcriber,
+    )
+    session.start()
+
+    with pytest.raises(ConsoleDictationError, match="No audio"):
+        session.stop_and_transcribe()
+
+    transcriber.transcribe_buffer.assert_not_called()
+
+
+def test_session_discard_stops_capture_without_transcribing(tmp_path):
+    recorder = FakeRecorder()
+    transcriber = Mock()
+    session = ConsoleDictationSession(
+        model_dir=_model_dir(tmp_path),
+        recorder_factory=lambda **kwargs: recorder,
+        transcription_service=transcriber,
+    )
+    session.start()
+
+    session.discard()
+
+    recorder.stop_recording.assert_called_once_with()
+    transcriber.transcribe_buffer.assert_not_called()

--- a/Tests/Audio/test_console_dictation.py
+++ b/Tests/Audio/test_console_dictation.py
@@ -174,6 +174,43 @@ def test_session_reports_empty_audio_without_transcribing(tmp_path):
     transcriber.transcribe_buffer.assert_not_called()
 
 
+def test_session_retains_recorder_when_stop_fails_for_cleanup(tmp_path):
+    recorder = FakeRecorder()
+    recorder.stop_recording.side_effect = RuntimeError("device stop failed")
+    session = ConsoleDictationSession(
+        model_dir=_model_dir(tmp_path),
+        recorder_factory=lambda **kwargs: recorder,
+        transcription_service=Mock(),
+    )
+    session.start()
+
+    with pytest.raises(ConsoleDictationError, match="device stop failed"):
+        session.stop_and_transcribe()
+
+    assert session._recorder is recorder
+    recorder.stop_recording.side_effect = None
+    session.discard()
+    assert recorder.stop_recording.call_count == 2
+
+
+def test_session_rejects_unvalidated_configured_model_path(tmp_path):
+    model_dir = _model_dir(tmp_path)
+    nested = model_dir / "unused"
+    nested.mkdir()
+    traversal_path = nested / ".." / ".." / model_dir.name
+    recorder_factory = Mock(return_value=FakeRecorder())
+    session = ConsoleDictationSession(
+        model_dir=traversal_path,
+        recorder_factory=recorder_factory,
+        transcription_service=Mock(),
+    )
+
+    with pytest.raises(ConsoleDictationError, match="invalid"):
+        session.start()
+
+    recorder_factory.assert_not_called()
+
+
 def test_session_discard_stops_capture_without_transcribing(tmp_path):
     recorder = FakeRecorder()
     transcriber = Mock()

--- a/Tests/Audio/test_recording_service.py
+++ b/Tests/Audio/test_recording_service.py
@@ -5,6 +5,7 @@ Tests audio capture, device enumeration, and recording functionality.
 """
 
 import pytest
+import threading
 import time
 from unittest.mock import Mock, patch, MagicMock
 import numpy as np
@@ -257,7 +258,13 @@ class TestAudioRecordingService:
         self, mock_pyaudio
     ):
         """A configured memory limit must stop capture without splitting a frame."""
-        on_limit = Mock()
+        limit_called = threading.Event()
+        limit_calls = []
+
+        def on_limit():
+            limit_calls.append(True)
+            limit_called.set()
+
         service = AudioRecordingService(
             backend="pyaudio",
             channels=2,
@@ -271,7 +278,44 @@ class TestAudioRecordingService:
 
         assert service.audio_buffer == [b"\x01\x02\x03\x04"]
         assert service.is_recording is False
-        on_limit.assert_called_once_with()
+        assert limit_called.wait(timeout=1)
+        assert limit_calls == [True]
+
+    def test_buffer_limit_callback_can_stop_without_joining_recording_thread(
+        self, mock_pyaudio
+    ):
+        """Limit callbacks may synchronously stop capture without self-joining."""
+        callback_done = threading.Event()
+        callback_errors = []
+        callback_result = []
+        service = None
+
+        def on_limit():
+            try:
+                callback_result.append(service.stop_recording())
+            except Exception as exc:
+                callback_errors.append(exc)
+            finally:
+                callback_done.set()
+
+        service = AudioRecordingService(
+            backend="pyaudio",
+            max_buffer_bytes=4,
+            on_buffer_limit=on_limit,
+        )
+        worker = threading.Thread(
+            target=service._handle_audio_chunk,
+            args=(b"\x01\x02\x03\x04",),
+        )
+        service.recording_thread = worker
+        service.is_recording = True
+
+        worker.start()
+        worker.join(timeout=1)
+
+        assert callback_done.wait(timeout=1)
+        assert callback_errors == []
+        assert callback_result == [b"\x01\x02\x03\x04"]
 
     def test_vad_processing(self, mock_pyaudio, mock_vad):
         """Test Voice Activity Detection processing."""

--- a/Tests/Audio/test_recording_service.py
+++ b/Tests/Audio/test_recording_service.py
@@ -253,6 +253,26 @@ class TestAudioRecordingService:
         assert service.audio_buffer[0] == chunk
         callback.assert_called_once_with(chunk)
 
+    def test_buffer_limit_keeps_complete_pcm_frames_and_stops_once(
+        self, mock_pyaudio
+    ):
+        """A configured memory limit must stop capture without splitting a frame."""
+        on_limit = Mock()
+        service = AudioRecordingService(
+            backend="pyaudio",
+            channels=2,
+            max_buffer_bytes=7,
+            on_buffer_limit=on_limit,
+        )
+        service.is_recording = True
+
+        service._handle_audio_chunk(b"\x01\x02\x03\x04\x05\x06\x07\x08")
+        service._handle_audio_chunk(b"\x09\x0a\x0b\x0c")
+
+        assert service.audio_buffer == [b"\x01\x02\x03\x04"]
+        assert service.is_recording is False
+        on_limit.assert_called_once_with()
+
     def test_vad_processing(self, mock_pyaudio, mock_vad):
         """Test Voice Activity Detection processing."""
         # Setup VAD

--- a/Tests/Transcription/test_parakeet_onnx_vertical_slice.py
+++ b/Tests/Transcription/test_parakeet_onnx_vertical_slice.py
@@ -4,6 +4,7 @@ import sys
 import wave
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
 from tldw_chatbook.Local_Ingestion import transcription_service as service_module
@@ -113,3 +114,58 @@ def test_parakeet_onnx_rejects_incomplete_model_directory_before_loading(
             provider="parakeet-onnx",
             model_dir=str(model_dir),
         )
+
+
+def test_parakeet_onnx_transcribes_pcm_buffer_without_staging_a_file(
+    tmp_path, monkeypatch
+) -> None:
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    for filename in (
+        "config.json",
+        "vocab.txt",
+        "encoder-model.int8.onnx",
+        "decoder_joint-model.int8.onnx",
+    ):
+        (model_dir / filename).touch()
+
+    recognized = []
+
+    class FakeModel:
+        def recognize(self, waveform, *, sample_rate):
+            recognized.append((waveform, sample_rate))
+            return "  Memory only.  "
+
+    monkeypatch.setattr(service_module, "ONNX_ASR_AVAILABLE", True, raising=False)
+    monkeypatch.setitem(
+        sys.modules,
+        "onnx_asr",
+        SimpleNamespace(load_model=lambda *args, **kwargs: FakeModel()),
+    )
+
+    def reject_temp_file(*args, **kwargs):
+        raise AssertionError("Parakeet buffer transcription must not stage a file")
+
+    monkeypatch.setattr(service_module.tempfile, "NamedTemporaryFile", reject_temp_file)
+
+    pcm = np.array([-32768, 0, 16384, 32767], dtype=np.int16)
+    result = TranscriptionService().transcribe_buffer(
+        pcm.tobytes(),
+        sample_rate=8_000,
+        channels=1,
+        sample_width=2,
+        provider="parakeet-onnx",
+        model="nemo-parakeet-tdt-0.6b-v2",
+        language="en",
+        model_dir=str(model_dir),
+    )
+
+    assert len(recognized) == 1
+    waveform, sample_rate = recognized[0]
+    assert sample_rate == 8_000
+    np.testing.assert_allclose(
+        waveform,
+        np.array([-1.0, 0.0, 0.5, 32767 / 32768], dtype=np.float32),
+    )
+    assert result["text"] == "Memory only."
+    assert result["segments"][0]["end"] == pytest.approx(4 / 8_000)

--- a/Tests/UI/test_console_dictation.py
+++ b/Tests/UI/test_console_dictation.py
@@ -1,0 +1,226 @@
+"""Mounted Console microphone dictation behavior."""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import Mock
+
+import pytest
+from textual.widgets import Button
+
+from Tests.UI.test_console_native_chat_flow import _configure_native_ready_console
+from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from tldw_chatbook.UI.Screens import chat_screen as chat_screen_module
+from tldw_chatbook.Widgets.Console import ConsoleComposerBar
+
+
+class FakeDictationSession:
+    def __init__(
+        self,
+        *,
+        transcript: str = "dictated words",
+        start_error: str = "",
+        stop_error: str = "",
+        stop_started: threading.Event | None = None,
+        stop_release: threading.Event | None = None,
+    ) -> None:
+        self.transcript = transcript
+        self.start_error = start_error
+        self.stop_error = stop_error
+        self.stop_started = stop_started
+        self.stop_release = stop_release
+        self.start_calls = 0
+        self.stop_calls = 0
+        self.discard_calls = 0
+
+    def start(self, *, on_buffer_limit=None) -> None:
+        self.start_calls += 1
+        self.on_buffer_limit = on_buffer_limit
+        if self.start_error:
+            raise RuntimeError(self.start_error)
+
+    def stop_and_transcribe(self) -> str:
+        self.stop_calls += 1
+        if self.stop_started is not None:
+            self.stop_started.set()
+        if self.stop_release is not None:
+            self.stop_release.wait(timeout=2)
+        if self.stop_error:
+            raise RuntimeError(self.stop_error)
+        return self.transcript
+
+    def discard(self) -> None:
+        self.discard_calls += 1
+
+
+def _ready_host():
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    return app, ConsoleHarness(app)
+
+
+async def _mounted_console(host, pilot):
+    console = host.screen_stack[-1]
+    await _wait_for_selector(console, pilot, "#console-native-composer")
+    return console
+
+
+async def _wait_for_mic_label(composer, pilot, expected: str, timeout=4.0):
+    deadline = time.monotonic() + timeout
+    button = composer.query_one("#console-dictation", Button)
+    await pilot.pause()
+    while time.monotonic() < deadline:
+        if str(button.label) == expected:
+            return button
+        await pilot.pause(0.01)
+    assert str(button.label) == expected
+    return button
+
+
+@pytest.mark.asyncio
+async def test_console_mic_exposes_clear_idle_recording_and_transcribing_states():
+    _, host = _ready_host()
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = await _mounted_console(host, pilot)
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        mic = composer.query_one("#console-dictation", Button)
+
+        assert str(mic.label) == "Mic"
+        composer.sync_dictation_state("recording")
+        assert str(mic.label) == "Rec ●"
+        assert "Stop" in str(mic.tooltip)
+        composer.sync_dictation_state("transcribing")
+        assert str(mic.label) == "STT…"
+        assert mic.disabled is True
+        composer.sync_dictation_state("idle")
+        assert str(mic.label) == "Mic"
+
+
+@pytest.mark.asyncio
+async def test_console_mic_inserts_at_caret_without_sending(monkeypatch):
+    fake = FakeDictationSession()
+    monkeypatch.setattr(
+        chat_screen_module.ChatScreen,
+        "_create_console_dictation_session",
+        lambda self: fake,
+    )
+    _, host = _ready_host()
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = await _mounted_console(host, pilot)
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("hello world")
+        for _ in range(5):
+            composer.move_cursor_left()
+        store = console._ensure_console_chat_store()
+        message_count = len(store.messages_for_session(store.active_session_id))
+
+        await pilot.click("#console-dictation")
+        mic = await _wait_for_mic_label(composer, pilot, "Rec ●")
+        assert mic.disabled is False
+        await pilot.pause(0.6)
+        await pilot.click("#console-dictation")
+        await _wait_for_mic_label(composer, pilot, "Mic")
+
+        assert composer.draft_text() == "hello dictated words world"
+        assert len(store.messages_for_session(store.active_session_id)) == message_count
+        assert fake.start_calls == 1
+        assert fake.stop_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_console_mic_has_strict_wall_timer_and_visible_limit_transition(
+    monkeypatch,
+):
+    stop_started = threading.Event()
+    stop_release = threading.Event()
+    fake = FakeDictationSession(
+        stop_started=stop_started,
+        stop_release=stop_release,
+    )
+    monkeypatch.setattr(
+        chat_screen_module.ChatScreen,
+        "_create_console_dictation_session",
+        lambda self: fake,
+    )
+    _, host = _ready_host()
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = await _mounted_console(host, pilot)
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        scheduled = {}
+        timer = Mock()
+
+        def capture_timer(delay, callback):
+            scheduled.update(delay=delay, callback=callback)
+            return timer
+
+        monkeypatch.setattr(console, "set_timer", capture_timer)
+        await pilot.click("#console-dictation")
+        await _wait_for_mic_label(composer, pilot, "Rec ●")
+
+        assert scheduled["delay"] == 60.0
+        scheduled["callback"]()
+        while not stop_started.is_set():
+            await pilot.pause(0.01)
+        assert str(composer.query_one("#console-dictation", Button).label) == "STT…"
+
+        stop_release.set()
+        await _wait_for_mic_label(composer, pilot, "Mic")
+        assert fake.stop_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_console_mic_failures_are_visible_preserve_draft_and_recover_idle(
+    monkeypatch,
+):
+    cases = (
+        ("start", "onnx-asr is not installed"),
+        ("start", "Parakeet v2 model files are missing"),
+        ("start", "Could not start microphone recording"),
+        ("stop", "No audio was captured"),
+        ("stop", "Parakeet transcription failed"),
+    )
+    app, host = _ready_host()
+    notify = Mock()
+    app.notify = notify
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = await _mounted_console(host, pilot)
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("keep this draft")
+
+        for stage, message in cases:
+            fake = FakeDictationSession(
+                start_error=message if stage == "start" else "",
+                stop_error=message if stage == "stop" else "",
+            )
+            monkeypatch.setattr(
+                chat_screen_module.ChatScreen,
+                "_create_console_dictation_session",
+                lambda self, fake=fake: fake,
+            )
+
+            await pilot.pause(0.6)
+            await pilot.click("#console-dictation")
+            if stage == "stop":
+                await _wait_for_mic_label(composer, pilot, "Rec ●")
+                await pilot.pause(0.6)
+                await pilot.click("#console-dictation")
+            deadline = time.monotonic() + 4
+            while time.monotonic() < deadline and not any(
+                message in str(call.args[0]) for call in notify.call_args_list
+            ):
+                await pilot.pause(0.01)
+            await _wait_for_mic_label(composer, pilot, "Mic")
+
+            assert composer.draft_text() == "keep this draft"
+            assert any(
+                message in str(call.args[0]) and call.kwargs.get("severity") == "error"
+                for call in notify.call_args_list
+            )
+            notify.reset_mock()

--- a/Tests/UI/test_console_dictation.py
+++ b/Tests/UI/test_console_dictation.py
@@ -223,4 +223,6 @@ async def test_console_mic_failures_are_visible_preserve_draft_and_recover_idle(
                 message in str(call.args[0]) and call.kwargs.get("severity") == "error"
                 for call in notify.call_args_list
             )
+            if stage == "stop":
+                assert fake.discard_calls == 1
             notify.reset_mock()

--- a/Tests/UI/test_console_internals_decomposition.py
+++ b/Tests/UI/test_console_internals_decomposition.py
@@ -286,7 +286,7 @@ def test_console_session_surface_uses_flex_height_not_full_percent_height():
             "    height: 1fr;\n"
             "    min-height: 0;"
         ) in css
-        assert ("#console-composer-actions {\n    width: 37;") in css
+        assert ("#console-composer-actions {\n    width: 45;") in css
 
 
 @pytest.mark.asyncio
@@ -391,6 +391,7 @@ async def test_console_native_composer_spans_below_workbench_with_single_input_s
         visible_draft = composer.query_one("#console-command-visible-text", Static)
         send_button = composer.query_one("#console-send-message", Button)
         stop_button = composer.query_one("#console-stop-generation", Button)
+        mic_button = composer.query_one("#console-dictation", Button)
         attach_button = composer.query_one("#console-attach-context", Button)
         save_button = composer.query_one("#console-save-chatbook", Button)
         legacy_inputs = [
@@ -412,7 +413,13 @@ async def test_console_native_composer_spans_below_workbench_with_single_input_s
         assert composer.draft_text() == "visible composer text"
         assert "visible composer text" in visible_draft.renderable.plain
         assert "visible composer text" in _visible_text(composer)
-        for action_button in (send_button, stop_button, attach_button, save_button):
+        for action_button in (
+            send_button,
+            stop_button,
+            mic_button,
+            attach_button,
+            save_button,
+        ):
             assert action_button.compact is True
             # Stop button is hidden when not running, so it has no valid region
             if action_button is not stop_button:
@@ -423,6 +430,7 @@ async def test_console_native_composer_spans_below_workbench_with_single_input_s
                 )
         assert str(send_button.label) == "Send"
         assert str(stop_button.label) == "Stop"
+        assert str(mic_button.label) == "Mic"
         assert str(attach_button.label) == "Attach"
         assert str(save_button.label) == "Save"
         assert save_button.region.width >= len("Save")
@@ -695,11 +703,13 @@ async def test_console_composer_ranks_actions_by_current_availability():
         composer = console.query_one("#console-native-composer", ConsoleComposerBar)
         send_button = composer.query_one("#console-send-message", Button)
         stop_button = composer.query_one("#console-stop-generation", Button)
+        mic_button = composer.query_one("#console-dictation", Button)
         attach_button = composer.query_one("#console-attach-context", Button)
         save_button = composer.query_one("#console-save-chatbook", Button)
 
         assert send_button.disabled is False
         assert stop_button.disabled is False
+        assert mic_button.disabled is False
         assert save_button.disabled is False
         assert attach_button.disabled is False
         assert attach_button.has_class("console-action-secondary")
@@ -823,13 +833,20 @@ async def test_console_composer_actions_remain_visible_inside_composer_bounds():
         actions = composer.query_one("#console-composer-actions")
         send_button = composer.query_one("#console-send-message", Button)
         stop_button = composer.query_one("#console-stop-generation", Button)
+        mic_button = composer.query_one("#console-dictation", Button)
         attach_button = composer.query_one("#console-attach-context", Button)
         save_button = composer.query_one("#console-save-chatbook", Button)
 
         composer_right = composer.region.x + composer.region.width
         assert actions.region.x > visible_draft.region.x
         assert actions.region.x + actions.region.width <= composer_right
-        for button in (send_button, stop_button, attach_button, save_button):
+        for button in (
+            send_button,
+            stop_button,
+            mic_button,
+            attach_button,
+            save_button,
+        ):
             # Stop button is hidden when not running, others remain visible
             if button is stop_button:
                 assert button.display is False

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -788,7 +788,9 @@ async def test_rapid_tab_switch_storm_leaves_no_zombie_widgets():
 
 
 def _build_test_app(configured_default: str | None = None) -> TldwCli:
-    user_data_dir = Path(tempfile.mkdtemp(prefix="tldw-chatbook-test-"))
+    user_data_dir = Path(
+        tempfile.mkdtemp(prefix="tldw-chatbook-test-")
+    ).resolve(strict=True)
 
     def fake_runtime_policy(app):
         context = SimpleNamespace(
@@ -796,8 +798,7 @@ def _build_test_app(configured_default: str | None = None) -> TldwCli:
             persist=lambda: None,
         )
         app.runtime_policy = context
-        app.current_runtime_source = "local"
-        app.current_runtime_backend = "local"
+        app._publish_runtime_policy_projection(context.state)
         return context
 
     def fake_cli_setting(_section, _key=None, default=None):

--- a/backlog/tasks/task-603.1 - Add-Console-microphone-transcription-vertical-slice.md
+++ b/backlog/tasks/task-603.1 - Add-Console-microphone-transcription-vertical-slice.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-27 15:52'
-updated_date: '2026-07-27 16:21'
+updated_date: '2026-07-27 17:30'
 labels:
   - stt
   - dictation
@@ -54,5 +54,5 @@ Reason: ADR-025 already governs English Parakeet v2 INT8 dictation, memory-only 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Implemented the Console Mic vertical slice with idle/recording/transcribing states, a strict 60-second and PCM-byte recording bound, off-event-loop capture/transcription, direct memory-only Parakeet ONNX buffer inference, explicit English Parakeet v2 INT8 routing, configured-or-verified local model resolution with no downloads, caret insertion without auto-send, and clear failure recovery that preserves drafts. Kept optional audio/STT imports lazy, updated Console layout and transcription documentation, and left parent TASK-603 open. Verification: Ruff passed; git diff --check passed; 146 focused audio/transcription/UI tests passed; a real Parakeet v2 INT8 buffer smoke produced the expected transcript. Live microphone hardware was not exercised in this environment because its optional recording backend is not installed.
+Implemented the Console Mic vertical slice with idle/recording/transcribing states, a strict 60-second and PCM-byte recording bound, off-event-loop capture/transcription, direct memory-only Parakeet ONNX buffer inference, explicit English Parakeet v2 INT8 routing, configured-or-verified local model resolution with no downloads, caret insertion without auto-send, and clear failure recovery that preserves drafts. Kept optional audio/STT imports lazy, updated Console layout and transcription documentation, and left parent TASK-603 open. PR review hardening now validates configured model paths through validate_path_simple, retains the recorder handle after stop failures so cleanup can retry, performs best-effort Console cleanup before error recovery, dispatches buffer-limit callbacks away from the recording thread, and documents the public APIs in Google style. Verification: Ruff and diff checks passed; 149 focused audio/transcription/UI tests passed; a real Parakeet v2 INT8 buffer smoke produced the expected transcript. Live microphone hardware was not exercised in this environment because its optional recording backend is not installed.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-603.1 - Add-Console-microphone-transcription-vertical-slice.md
+++ b/backlog/tasks/task-603.1 - Add-Console-microphone-transcription-vertical-slice.md
@@ -1,0 +1,58 @@
+---
+id: TASK-603.1
+title: Add Console microphone transcription vertical slice
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-07-27 15:52'
+updated_date: '2026-07-27 16:21'
+labels:
+  - stt
+  - dictation
+  - console
+  - ui
+dependencies:
+  - TASK-931
+  - TASK-942
+references:
+  - backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md
+documentation:
+  - Docs/superpowers/specs/2026-07-23-stt-parakeet-onnx-transcribe-cpp-design.md
+parent_task_id: TASK-603
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Let a user record speech from the native Console composer and insert the resulting English Parakeet v2 transcript into the active draft without leaving Console.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The expanded Console composer exposes a visible microphone control with clear idle, recording, and transcribing states.
+- [x] #2 Clicking the control records at most 60 seconds from the default microphone and a second click stops capture and transcribes off the Textual event loop.
+- [x] #3 Dictation defaults to explicit en, Parakeet v2 INT8, and the configured or verified Library-installed local bundle without triggering a download.
+- [x] #4 A successful transcript is inserted at the current Console caret with sensible boundary spacing and does not send the message automatically.
+- [x] #5 Missing dependencies, missing model files, microphone failures, empty audio, and transcription errors are shown clearly and leave the existing draft unchanged.
+- [x] #6 Focused service and mounted Console tests cover start, stop, insertion, failure recovery, recording bounds, and composer layout.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add and test a strict 60-second wall-clock stop plus a complete-PCM-frame memory bound in AudioRecordingService/Console lifecycle.
+2. Add a one-shot ConsoleDictationSession and direct NumPy-buffer Parakeet ONNX adapter so captured audio remains memory-only, uses explicit en/v2 INT8, and accepts only a configured or verified installed bundle.
+3. Add the Mic control and thread-worker lifecycle to Console, with visible limit and failure states, caret insertion, no automatic send, and draft preservation.
+4. Verify focused audio/UI behavior including every user-visible failure class, lint, diff hygiene, and document completion.
+
+ADR required: yes
+ADR path: backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md
+Reason: ADR-025 already governs English Parakeet v2 INT8 dictation, memory-only buffer handling, and no implicit downloads; this child task adds the missing user-facing vertical slice without changing the future LocalSTTExecutor boundary.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the Console Mic vertical slice with idle/recording/transcribing states, a strict 60-second and PCM-byte recording bound, off-event-loop capture/transcription, direct memory-only Parakeet ONNX buffer inference, explicit English Parakeet v2 INT8 routing, configured-or-verified local model resolution with no downloads, caret insertion without auto-send, and clear failure recovery that preserves drafts. Kept optional audio/STT imports lazy, updated Console layout and transcription documentation, and left parent TASK-603 open. Verification: Ruff passed; git diff --check passed; 146 focused audio/transcription/UI tests passed; a real Parakeet v2 INT8 buffer smoke produced the expected transcript. Live microphone hardware was not exercised in this environment because its optional recording backend is not installed.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Audio/__init__.py
+++ b/tldw_chatbook/Audio/__init__.py
@@ -25,7 +25,17 @@ _LAZY_DICTATION_EXPORTS = {
 
 
 def __getattr__(name: str) -> Any:
-    """Load the legacy live-dictation stack only when explicitly requested."""
+    """Load the legacy live-dictation stack only when explicitly requested.
+
+    Args:
+        name: Package attribute requested by the caller.
+
+    Returns:
+        The lazily imported legacy dictation attribute.
+
+    Raises:
+        AttributeError: The requested name is not a supported lazy export.
+    """
     if name not in _LAZY_DICTATION_EXPORTS:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
     value = getattr(import_module(".dictation_service", __name__), name)

--- a/tldw_chatbook/Audio/__init__.py
+++ b/tldw_chatbook/Audio/__init__.py
@@ -4,8 +4,10 @@ Audio recording and dictation functionality for tldw_chatbook.
 Provides cross-platform audio capture and real-time transcription.
 """
 
+from importlib import import_module
+from typing import Any
+
 from .recording_service import AudioRecordingService, AudioRecordingError
-from .dictation_service import LiveDictationService, DictationResult, DictationState
 
 __all__ = [
     "AudioRecordingService",
@@ -14,3 +16,18 @@ __all__ = [
     "DictationResult",
     "DictationState",
 ]
+
+_LAZY_DICTATION_EXPORTS = {
+    "LiveDictationService",
+    "DictationResult",
+    "DictationState",
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Load the legacy live-dictation stack only when explicitly requested."""
+    if name not in _LAZY_DICTATION_EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(".dictation_service", __name__), name)
+    globals()[name] = value
+    return value

--- a/tldw_chatbook/Audio/console_dictation.py
+++ b/tldw_chatbook/Audio/console_dictation.py
@@ -1,0 +1,205 @@
+"""One-shot local microphone dictation for the native Console."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any, Callable
+
+from loguru import logger
+
+from tldw_chatbook.Local_Ingestion.parakeet_v2_installer import (
+    PARAKEET_V2_FILES,
+    parakeet_v2_install_dir,
+    verify_parakeet_v2_bundle,
+)
+
+
+CONSOLE_DICTATION_SAMPLE_RATE = 16_000
+CONSOLE_DICTATION_CHANNELS = 1
+CONSOLE_DICTATION_SAMPLE_WIDTH = 2
+CONSOLE_DICTATION_MAX_SECONDS = 60.0
+CONSOLE_DICTATION_MAX_BYTES = int(
+    CONSOLE_DICTATION_SAMPLE_RATE
+    * CONSOLE_DICTATION_CHANNELS
+    * CONSOLE_DICTATION_SAMPLE_WIDTH
+    * CONSOLE_DICTATION_MAX_SECONDS
+)
+PARAKEET_V2_MODEL = "nemo-parakeet-tdt-0.6b-v2"
+
+
+class ConsoleDictationError(RuntimeError):
+    """Raised when a one-shot Console dictation cannot complete."""
+
+
+class ConsoleDictationSession:
+    """Record one bounded PCM buffer and transcribe it with Parakeet v2."""
+
+    def __init__(
+        self,
+        *,
+        model_dir: str | Path | None = None,
+        installed_model_dir: str | Path | None = None,
+        verify_installed_bundle: Callable[[str | Path], bool] | None = None,
+        recorder_factory: Callable[..., Any] | None = None,
+        transcription_service: Any | None = None,
+    ) -> None:
+        self._configured_model_dir = Path(model_dir) if model_dir else None
+        self._installed_model_dir = (
+            Path(installed_model_dir)
+            if installed_model_dir is not None
+            else parakeet_v2_install_dir()
+        )
+        self._verify_installed_bundle = (
+            verify_installed_bundle or verify_parakeet_v2_bundle
+        )
+        self._recorder_factory = recorder_factory
+        self._transcription_service = transcription_service
+        self._recorder: Any | None = None
+        self.model_dir: Path | None = None
+
+    @staticmethod
+    def _required_files_present(directory: Path) -> bool:
+        return directory.is_dir() and all(
+            (directory / descriptor.filename).is_file()
+            for descriptor in PARAKEET_V2_FILES
+        )
+
+    def _resolve_model_dir(self) -> Path:
+        if self.model_dir is not None and self._required_files_present(self.model_dir):
+            return self.model_dir
+
+        configured = self._configured_model_dir
+        if configured is None:
+            from tldw_chatbook.config import get_cli_setting
+
+            configured_value = get_cli_setting(
+                "transcription",
+                "parakeet_onnx_model_dir",
+                "",
+            )
+            if str(configured_value or "").strip():
+                configured = Path(str(configured_value).strip())
+
+        if configured is not None:
+            if not self._required_files_present(configured):
+                raise ConsoleDictationError(
+                    "Parakeet v2 model files are missing from the configured folder."
+                )
+            return configured
+
+        if self._verify_installed_bundle(self._installed_model_dir):
+            return self._installed_model_dir
+
+        raise ConsoleDictationError(
+            "Parakeet v2 model files are missing. Install the verified "
+            "Parakeet v2 INT8 bundle from Library → Models."
+        )
+
+    def _build_recorder(self, *, on_buffer_limit: Callable[[], None] | None) -> Any:
+        factory = self._recorder_factory
+        if factory is None:
+            from tldw_chatbook.Audio.recording_service import AudioRecordingService
+
+            factory = AudioRecordingService
+        return factory(
+            sample_rate=CONSOLE_DICTATION_SAMPLE_RATE,
+            channels=CONSOLE_DICTATION_CHANNELS,
+            use_vad=False,
+            max_buffer_bytes=CONSOLE_DICTATION_MAX_BYTES,
+            on_buffer_limit=on_buffer_limit,
+        )
+
+    def _transcriber(self) -> Any:
+        if self._transcription_service is not None:
+            return self._transcription_service
+        try:
+            available = importlib.util.find_spec("onnx_asr") is not None
+        except (ImportError, ModuleNotFoundError, ValueError):
+            available = False
+        if not available:
+            raise ConsoleDictationError(
+                "onnx-asr is not installed. Install the Parakeet ONNX "
+                "transcription option and retry."
+            )
+        from tldw_chatbook.Local_Ingestion.transcription_service import (
+            TranscriptionService,
+        )
+
+        self._transcription_service = TranscriptionService()
+        return self._transcription_service
+
+    def start(
+        self,
+        *,
+        on_buffer_limit: Callable[[], None] | None = None,
+    ) -> None:
+        """Start capture from the default microphone."""
+        if self._recorder is not None:
+            raise ConsoleDictationError("Microphone dictation is already recording.")
+        self.model_dir = self._resolve_model_dir()
+        self._transcriber()
+        try:
+            recorder = self._build_recorder(on_buffer_limit=on_buffer_limit)
+            if not recorder.start_recording():
+                raise ConsoleDictationError(
+                    "Could not start microphone recording. Check microphone "
+                    "permission and the default input device."
+                )
+        except ConsoleDictationError:
+            raise
+        except Exception as exc:
+            raise ConsoleDictationError(
+                f"Could not start microphone recording: {exc}"
+            ) from exc
+        self._recorder = recorder
+
+    def stop_and_transcribe(self) -> str:
+        """Stop capture and return a stripped English transcript."""
+        recorder = self._recorder
+        if recorder is None:
+            raise ConsoleDictationError("Microphone dictation is not recording.")
+        self._recorder = None
+        try:
+            audio_data = recorder.stop_recording()
+        except Exception as exc:
+            raise ConsoleDictationError(
+                f"Could not stop microphone recording: {exc}"
+            ) from exc
+        if not audio_data:
+            raise ConsoleDictationError("No audio was captured from the microphone.")
+        if self.model_dir is None:
+            raise ConsoleDictationError("Parakeet v2 model files are missing.")
+
+        try:
+            result = self._transcriber().transcribe_buffer(
+                audio_data,
+                sample_rate=CONSOLE_DICTATION_SAMPLE_RATE,
+                channels=CONSOLE_DICTATION_CHANNELS,
+                sample_width=CONSOLE_DICTATION_SAMPLE_WIDTH,
+                provider="parakeet-onnx",
+                model=PARAKEET_V2_MODEL,
+                language="en",
+                model_dir=str(self.model_dir),
+            )
+        except ConsoleDictationError:
+            raise
+        except Exception as exc:
+            raise ConsoleDictationError(
+                f"Parakeet transcription failed: {exc}"
+            ) from exc
+        text = str(result.get("text") or "").strip()
+        if not text:
+            raise ConsoleDictationError("Transcription returned no speech.")
+        return text
+
+    def discard(self) -> None:
+        """Stop and discard any active capture without transcribing."""
+        recorder = self._recorder
+        self._recorder = None
+        if recorder is None:
+            return
+        try:
+            recorder.stop_recording()
+        except Exception as exc:
+            logger.debug("Failed to discard Console dictation cleanly: {}", exc)

--- a/tldw_chatbook/Audio/console_dictation.py
+++ b/tldw_chatbook/Audio/console_dictation.py
@@ -13,6 +13,7 @@ from tldw_chatbook.Local_Ingestion.parakeet_v2_installer import (
     parakeet_v2_install_dir,
     verify_parakeet_v2_bundle,
 )
+from tldw_chatbook.Utils.path_validation import validate_path_simple
 
 
 CONSOLE_DICTATION_SAMPLE_RATE = 16_000
@@ -82,6 +83,12 @@ class ConsoleDictationSession:
                 configured = Path(str(configured_value).strip())
 
         if configured is not None:
+            try:
+                configured = validate_path_simple(configured, require_exists=True)
+            except (OSError, ValueError) as exc:
+                raise ConsoleDictationError(
+                    "The configured Parakeet v2 model folder path is invalid."
+                ) from exc
             if not self._required_files_present(configured):
                 raise ConsoleDictationError(
                     "Parakeet v2 model files are missing from the configured folder."
@@ -134,7 +141,15 @@ class ConsoleDictationSession:
         *,
         on_buffer_limit: Callable[[], None] | None = None,
     ) -> None:
-        """Start capture from the default microphone."""
+        """Start capture from the default microphone.
+
+        Args:
+            on_buffer_limit: Callback invoked when the bounded PCM buffer is full.
+
+        Raises:
+            ConsoleDictationError: The model, dependencies, or microphone are
+                unavailable, or a capture is already active.
+        """
         if self._recorder is not None:
             raise ConsoleDictationError("Microphone dictation is already recording.")
         self.model_dir = self._resolve_model_dir()
@@ -155,17 +170,25 @@ class ConsoleDictationSession:
         self._recorder = recorder
 
     def stop_and_transcribe(self) -> str:
-        """Stop capture and return a stripped English transcript."""
+        """Stop capture and return a stripped English transcript.
+
+        Returns:
+            The non-empty English transcript.
+
+        Raises:
+            ConsoleDictationError: Capture cannot stop, no audio was captured,
+                or local transcription fails.
+        """
         recorder = self._recorder
         if recorder is None:
             raise ConsoleDictationError("Microphone dictation is not recording.")
-        self._recorder = None
         try:
             audio_data = recorder.stop_recording()
         except Exception as exc:
             raise ConsoleDictationError(
                 f"Could not stop microphone recording: {exc}"
             ) from exc
+        self._recorder = None
         if not audio_data:
             raise ConsoleDictationError("No audio was captured from the microphone.")
         if self.model_dir is None:

--- a/tldw_chatbook/Audio/recording_service.py
+++ b/tldw_chatbook/Audio/recording_service.py
@@ -120,7 +120,8 @@ class AudioRecordingService:
             use_vad: Whether to use Voice Activity Detection
             vad_aggressiveness: VAD aggressiveness (0-3, higher is more aggressive)
             max_buffer_bytes: Optional hard limit for retained PCM bytes
-            on_buffer_limit: Optional callback invoked once when the limit is reached
+            on_buffer_limit: Optional callback invoked once on a daemon
+                notification thread when the limit is reached
         """
         # Check for numpy requirement first
         if not NUMPY_AVAILABLE:
@@ -492,11 +493,25 @@ class AudioRecordingService:
             self.is_recording = False
             if not self._buffer_limit_reached:
                 self._buffer_limit_reached = True
-                if self.on_buffer_limit:
-                    try:
-                        self.on_buffer_limit()
-                    except Exception as e:
-                        logger.error(f"Buffer limit callback error: {e}")
+                self._notify_buffer_limit()
+
+    def _notify_buffer_limit(self) -> None:
+        """Invoke the buffer-limit callback away from the recording thread."""
+        callback = self.on_buffer_limit
+        if callback is None:
+            return
+
+        def invoke() -> None:
+            try:
+                callback()
+            except Exception as e:
+                logger.error(f"Buffer limit callback error: {e}")
+
+        threading.Thread(
+            target=invoke,
+            name="AudioBufferLimitCallback",
+            daemon=True,
+        ).start()
 
     def stop_recording(self) -> Optional[bytes]:
         """

--- a/tldw_chatbook/Audio/recording_service.py
+++ b/tldw_chatbook/Audio/recording_service.py
@@ -106,6 +106,8 @@ class AudioRecordingService:
         chunk_size: int = DEFAULT_CHUNK_SIZE,
         use_vad: bool = True,
         vad_aggressiveness: int = 2,
+        max_buffer_bytes: Optional[int] = None,
+        on_buffer_limit: Optional[Callable[[], None]] = None,
     ):
         """
         Initialize audio recording service.
@@ -117,6 +119,8 @@ class AudioRecordingService:
             chunk_size: Number of samples per chunk
             use_vad: Whether to use Voice Activity Detection
             vad_aggressiveness: VAD aggressiveness (0-3, higher is more aggressive)
+            max_buffer_bytes: Optional hard limit for retained PCM bytes
+            on_buffer_limit: Optional callback invoked once when the limit is reached
         """
         # Check for numpy requirement first
         if not NUMPY_AVAILABLE:
@@ -136,6 +140,10 @@ class AudioRecordingService:
         self.chunk_size = chunk_size
         self.use_vad = use_vad and VAD_AVAILABLE
         self.vad_aggressiveness = max(0, min(3, vad_aggressiveness))
+        self.max_buffer_bytes = (
+            max(0, int(max_buffer_bytes)) if max_buffer_bytes is not None else None
+        )
+        self.on_buffer_limit = on_buffer_limit
 
         # Initialize backend
         self.backend = self._initialize_backend(backend)
@@ -148,6 +156,8 @@ class AudioRecordingService:
         self.is_recording = False
         self.audio_queue = queue.Queue()
         self.audio_buffer: List[bytes] = []
+        self._audio_buffer_bytes = 0
+        self._buffer_limit_reached = False
         self.recording_thread = None
         self.callback = None
         self.save_file = None
@@ -309,6 +319,8 @@ class AudioRecordingService:
             self.callback = callback if callback is not None else self.callback
             self.save_file = save_to_file
             self.audio_buffer = []
+            self._audio_buffer_bytes = 0
+            self._buffer_limit_reached = False
             self.is_recording = True
 
             # Start recording thread
@@ -447,18 +459,44 @@ class AudioRecordingService:
 
     def _handle_audio_chunk(self, chunk: bytes):
         """Handle processed audio chunk."""
+        retained = chunk
+        hit_limit = False
+        if self.max_buffer_bytes is not None:
+            frame_bytes = 2 * self.channels
+            remaining = max(0, self.max_buffer_bytes - self._audio_buffer_bytes)
+            retained_bytes = min(len(chunk), remaining)
+            retained_bytes -= retained_bytes % frame_bytes
+            retained = chunk[:retained_bytes]
+            hit_limit = retained_bytes < len(chunk) or (
+                self._audio_buffer_bytes + retained_bytes + frame_bytes
+                > self.max_buffer_bytes
+            )
+
         # Add to buffer
-        self.audio_buffer.append(chunk)
+        if retained:
+            self.audio_buffer.append(retained)
+            self._audio_buffer_bytes += len(retained)
 
         # Add to queue
-        self.audio_queue.put(chunk)
+        if retained:
+            self.audio_queue.put(retained)
 
         # Call callback if provided
-        if self.callback:
+        if retained and self.callback:
             try:
-                self.callback(chunk)
+                self.callback(retained)
             except Exception as e:
                 logger.error(f"Callback error: {e}")
+
+        if hit_limit:
+            self.is_recording = False
+            if not self._buffer_limit_reached:
+                self._buffer_limit_reached = True
+                if self.on_buffer_limit:
+                    try:
+                        self.on_buffer_limit()
+                    except Exception as e:
+                        logger.error(f"Buffer limit callback error: {e}")
 
     def stop_recording(self) -> Optional[bytes]:
         """
@@ -487,6 +525,7 @@ class AudioRecordingService:
 
         # Cleanup
         self.audio_buffer = []
+        self._audio_buffer_bytes = 0
         self.callback = None
 
         # Close PyAudio if needed

--- a/tldw_chatbook/Local_Ingestion/transcription_service.py
+++ b/tldw_chatbook/Local_Ingestion/transcription_service.py
@@ -666,6 +666,32 @@ class TranscriptionService:
         **kwargs,
     ) -> Dict[str, Any]:
         """Transcribe English audio with a local Parakeet v2 INT8 model."""
+        parakeet_model = self._load_parakeet_onnx_model(
+            model=model,
+            language=language,
+            model_dir=kwargs.get("model_dir"),
+        )
+
+        if progress_callback:
+            progress_callback(10, "Transcribing with Parakeet ONNX", None)
+
+        text = parakeet_model.recognize(audio_path).strip()
+        with wave.open(audio_path, "rb") as wav_file:
+            duration = wav_file.getnframes() / wav_file.getframerate()
+
+        if progress_callback:
+            progress_callback(100, "Transcription complete", None)
+
+        return self._parakeet_onnx_result(text, duration=duration, model=model)
+
+    def _load_parakeet_onnx_model(
+        self,
+        *,
+        model: str,
+        language: str,
+        model_dir: str | Path | None,
+    ) -> Any:
+        """Validate and load the configured local Parakeet v2 INT8 model."""
         if not ONNX_ASR_AVAILABLE:
             raise TranscriptionError(
                 "parakeet-onnx is not installed. Install with: "
@@ -677,7 +703,7 @@ class TranscriptionService:
                 "Retry with faster-whisper for automatic or non-English transcription."
             )
 
-        model_dir = kwargs.get("model_dir") or self.config["parakeet_onnx_model_dir"]
+        model_dir = model_dir or self.config["parakeet_onnx_model_dir"]
         if not model_dir or not Path(model_dir).is_dir():
             raise TranscriptionError(
                 "parakeet-onnx requires an explicit existing local model directory "
@@ -718,17 +744,13 @@ class TranscriptionService:
                     },
                 )
                 self._model_cache[cache_key] = parakeet_model
+        return parakeet_model
 
-        if progress_callback:
-            progress_callback(10, "Transcribing with Parakeet ONNX", None)
-
-        text = parakeet_model.recognize(audio_path).strip()
-        with wave.open(audio_path, "rb") as wav_file:
-            duration = wav_file.getnframes() / wav_file.getframerate()
-
-        if progress_callback:
-            progress_callback(100, "Transcription complete", None)
-
+    @staticmethod
+    def _parakeet_onnx_result(
+        text: str, *, duration: float, model: str
+    ) -> Dict[str, Any]:
+        """Build the common Parakeet ONNX transcription result."""
         return {
             "text": text,
             "segments": [
@@ -747,6 +769,47 @@ class TranscriptionService:
             "provider": "parakeet-onnx",
             "model": model,
         }
+
+    def _transcribe_buffer_with_parakeet_onnx(
+        self,
+        audio_data: bytes,
+        sample_rate: int,
+        channels: int,
+        sample_width: int,
+        model: str,
+        language: str,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Transcribe raw 16-bit PCM directly from memory with Parakeet ONNX."""
+        if not NUMPY_AVAILABLE or np is None:
+            raise TranscriptionError(
+                "Parakeet ONNX buffer transcription requires NumPy."
+            )
+        if sample_width != 2:
+            raise TranscriptionError(
+                "Parakeet ONNX microphone transcription requires 16-bit PCM audio."
+            )
+        if sample_rate <= 0 or channels <= 0:
+            raise TranscriptionError("Invalid microphone audio format.")
+        frame_bytes = sample_width * channels
+        if not audio_data or len(audio_data) % frame_bytes:
+            raise TranscriptionError("Invalid or incomplete microphone PCM buffer.")
+
+        waveform = np.frombuffer(audio_data, dtype=np.int16)
+        if channels > 1:
+            waveform = waveform.reshape(-1, channels).mean(axis=1)
+        waveform = waveform.astype(np.float32) / 32768.0
+        parakeet_model = self._load_parakeet_onnx_model(
+            model=model,
+            language=language,
+            model_dir=kwargs.get("model_dir"),
+        )
+        text = parakeet_model.recognize(
+            waveform,
+            sample_rate=sample_rate,
+        ).strip()
+        duration = (len(audio_data) // frame_bytes) / sample_rate
+        return self._parakeet_onnx_result(text, duration=duration, model=model)
 
     def transcribe_buffer(
         self,
@@ -787,6 +850,16 @@ class TranscriptionService:
                 sample_width,
                 model,
                 language,
+                **kwargs,
+            )
+        if provider == "parakeet-onnx":
+            return self._transcribe_buffer_with_parakeet_onnx(
+                audio_data,
+                sample_rate,
+                channels,
+                sample_width,
+                model or "nemo-parakeet-tdt-0.6b-v2",
+                language or "en",
                 **kwargs,
             )
         # Skip qwen2audio for now - it loads a large model

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -3972,6 +3972,7 @@ class ChatScreen(BaseAppScreen):
         try:
             transcript = await asyncio.to_thread(session.stop_and_transcribe)
         except Exception as exc:
+            await asyncio.to_thread(session.discard)
             self._notify_console_dictation_error(exc)
             return
         if not self.is_mounted:

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -371,6 +371,7 @@ if TYPE_CHECKING:
     from tldw_chatbook.app import TldwCli
 
 logger = logger.bind(module="ChatScreen")
+CONSOLE_DICTATION_MAX_SECONDS = 60.0
 CONSOLE_LIBRARY_RAG_SOURCE_SCOPE = ("notes", "media", "conversations")
 CONSOLE_LIBRARY_RAG_RECOVERY_COPY = "Review citations before sending."
 CONSOLE_LIBRARY_RAG_QUERY_MAX_LENGTH = 2_000
@@ -2103,6 +2104,12 @@ class ChatScreen(BaseAppScreen):
         self._console_conversation_browser_total: int | None = None
         self._console_conversation_browser_error = ""
         self._console_visible_draft_session_id: str | None = None
+        self._console_dictation_session: Any | None = None
+        self._console_dictation_state: Literal[
+            "idle", "starting", "recording", "transcribing"
+        ] = "idle"
+        self._console_dictation_timer: Any | None = None
+        self._console_dictation_origin_session_id: str | None = None
         self._console_provider_gateway: Any | None = None
         self._console_chat_controller: ConsoleChatController | None = None
         self._console_command_registry: ConsoleCommandRegistry = (
@@ -3832,6 +3839,172 @@ class ChatScreen(BaseAppScreen):
         if composers and isinstance(composers[0], ConsoleComposerBar):
             return composers[0]
         return None
+
+    def _set_console_dictation_state(
+        self,
+        state: Literal["idle", "starting", "recording", "transcribing"],
+    ) -> None:
+        """Set the one-shot dictation state and refresh its visible control."""
+        self._console_dictation_state = state
+        composer = self._console_composer_or_none()
+        if composer is not None:
+            composer.sync_dictation_state(state)
+
+    def _cancel_console_dictation_timer(self) -> None:
+        timer = self._console_dictation_timer
+        self._console_dictation_timer = None
+        if timer is not None:
+            timer.stop()
+
+    def _notify_console_dictation_error(self, exc: Exception) -> None:
+        """Return dictation to idle and show its actionable failure."""
+        self._cancel_console_dictation_timer()
+        self._console_dictation_origin_session_id = None
+        self._console_dictation_session = None
+        self._set_console_dictation_state("idle")
+        self.app_instance.notify(f"Dictation failed: {exc}", severity="error")
+
+    def _on_console_dictation_buffer_limit(self) -> None:
+        """Marshal a recorder-thread memory-limit signal onto the UI thread."""
+        try:
+            self.app.call_from_thread(self._handle_console_dictation_limit)
+        except NoActiveAppError:
+            return
+
+    def _handle_console_dictation_limit(self) -> None:
+        """Stop and transcribe when the wall-clock or memory bound is reached."""
+        if self._console_dictation_state != "recording":
+            return
+        self.app_instance.notify(
+            "Dictation limit reached; transcribing the captured audio.",
+            severity="warning",
+        )
+        self._request_console_dictation_stop()
+
+    @staticmethod
+    def _create_console_dictation_session() -> Any:
+        """Load the optional local STT stack only when the Mic action is used."""
+        from tldw_chatbook.Audio.console_dictation import ConsoleDictationSession
+
+        return ConsoleDictationSession()
+
+    async def _start_console_dictation(self) -> None:
+        session = (
+            self._console_dictation_session
+            or self._create_console_dictation_session()
+        )
+        self._console_dictation_session = session
+        try:
+            await asyncio.to_thread(
+                session.start,
+                on_buffer_limit=self._on_console_dictation_buffer_limit,
+            )
+        except Exception as exc:
+            self._notify_console_dictation_error(exc)
+            return
+        if not self.is_mounted:
+            await asyncio.to_thread(session.discard)
+            return
+        self._set_console_dictation_state("recording")
+        self._console_dictation_timer = self.set_timer(
+            CONSOLE_DICTATION_MAX_SECONDS,
+            self._handle_console_dictation_limit,
+        )
+
+    @staticmethod
+    def _dictation_insertion(
+        draft: str,
+        cursor: int,
+        transcript: str,
+    ) -> str:
+        """Return transcript text padded only where adjacent text needs spacing."""
+        cursor = max(0, min(cursor, len(draft)))
+        insertion = transcript.strip()
+        if cursor and not draft[cursor - 1].isspace():
+            insertion = " " + insertion
+        if cursor < len(draft) and not draft[cursor].isspace():
+            insertion += " "
+        return insertion
+
+    def _insert_console_dictation(
+        self,
+        *,
+        origin_session_id: str | None,
+        transcript: str,
+    ) -> None:
+        """Insert into the originating draft without sending a message."""
+        if not origin_session_id:
+            return
+        store = self._ensure_console_chat_store()
+        composer = self._console_composer_or_none()
+        if (
+            composer is not None
+            and store.active_session_id == origin_session_id
+            and self._console_visible_draft_session_id == origin_session_id
+        ):
+            insertion = self._dictation_insertion(
+                composer.draft_text(),
+                composer.cursor_index,
+                transcript,
+            )
+            composer.insert_text(insertion)
+            store.set_session_draft(origin_session_id, composer.draft_text())
+            return
+
+        try:
+            draft = store.session_draft(origin_session_id)
+            insertion = self._dictation_insertion(draft, len(draft), transcript)
+            store.set_session_draft(origin_session_id, draft + insertion)
+        except KeyError:
+            self.app_instance.notify(
+                "Dictation finished, but its original Console session is gone.",
+                severity="warning",
+            )
+
+    async def _stop_console_dictation(self) -> None:
+        session = self._console_dictation_session
+        origin_session_id = self._console_dictation_origin_session_id
+        if session is None:
+            self._notify_console_dictation_error(
+                RuntimeError("Microphone dictation is not recording.")
+            )
+            return
+        try:
+            transcript = await asyncio.to_thread(session.stop_and_transcribe)
+        except Exception as exc:
+            self._notify_console_dictation_error(exc)
+            return
+        if not self.is_mounted:
+            return
+        self._insert_console_dictation(
+            origin_session_id=origin_session_id,
+            transcript=transcript,
+        )
+        self._console_dictation_origin_session_id = None
+        self._set_console_dictation_state("idle")
+
+    def _request_console_dictation_stop(self) -> None:
+        if self._console_dictation_state != "recording":
+            return
+        self._cancel_console_dictation_timer()
+        self._set_console_dictation_state("transcribing")
+        self.run_worker(
+            self._stop_console_dictation(),
+            exclusive=True,
+            group="console-dictation-stop",
+        )
+
+    def _request_console_dictation_start(self) -> None:
+        if self._console_dictation_state != "idle":
+            return
+        store = self._ensure_console_chat_store()
+        self._console_dictation_origin_session_id = store.active_session_id
+        self._set_console_dictation_state("starting")
+        self.run_worker(
+            self._start_console_dictation(),
+            exclusive=True,
+            group="console-dictation-start",
+        )
 
     def _capture_console_draft_switch_snapshot(self) -> None:
         """Record the composer state at the moment a session switch begins.
@@ -9947,6 +10120,13 @@ class ChatScreen(BaseAppScreen):
     async def on_unmount(self) -> None:
         """Release Console-native resources owned by this screen."""
         self._stop_console_transcript_sync_timer()
+        self._cancel_console_dictation_timer()
+        dictation_session = self._console_dictation_session
+        self._console_dictation_session = None
+        self._console_dictation_origin_session_id = None
+        self._console_dictation_state = "idle"
+        if dictation_session is not None:
+            await asyncio.to_thread(dictation_session.discard)
         self._console_original_attempt_previews.clear()
         controller = self._console_chat_controller
         if controller is not None:
@@ -14662,6 +14842,7 @@ class ChatScreen(BaseAppScreen):
             send_blocked=send_blocked,
             setup_blocked_reason=setup_blocked_reason or attachment_blocked_reason,
         )
+        composer.sync_dictation_state(self._console_dictation_state)
         # sync_action_state resets the attach button's tooltip to generic copy
         # (console_composer_bar.py L303); apply the pending-attachment label
         # after, not before, so "Attached: ..." wins over the generic tooltip.
@@ -15361,6 +15542,13 @@ class ChatScreen(BaseAppScreen):
 
         if button_id == "console-send-message":
             await self.handle_console_send_message(event)
+            return
+        if button_id == "console-dictation":
+            event.stop()
+            if self._console_dictation_state == "idle":
+                self._request_console_dictation_start()
+            elif self._console_dictation_state == "recording":
+                self._request_console_dictation_stop()
             return
         if button_id in {
             "console-stop-generation",

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -445,7 +445,11 @@ class ConsoleComposerBar(Horizontal):
             self._refresh_visible_draft()
 
     def sync_dictation_state(self, state: _DictationState) -> None:
-        """Refresh the microphone action for the current one-shot lifecycle."""
+        """Refresh the microphone action for the current one-shot lifecycle.
+
+        Args:
+            state: Current one-shot dictation lifecycle state.
+        """
         self._dictation_state = state
         try:
             button = self.query_one("#console-dictation", Button)

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -27,6 +27,7 @@ from ...config import (
 
 
 _CollapseState = Literal["literal", "collapsed", "confirm", "expanded"]
+_DictationState = Literal["idle", "starting", "recording", "transcribing"]
 _DraftStyleRange = tuple[int, int, str]
 
 
@@ -124,6 +125,7 @@ class ConsoleComposerBar(Horizontal):
         self._send_blocked = False
         self._setup_blocked_reason = ""
         self._can_save_chatbook = False
+        self._dictation_state: _DictationState = "idle"
         self._pending_attachment_label: str | None = None
         self._suppress_next_draft_click = False
         self._draft_selection_all = False
@@ -441,6 +443,31 @@ class ConsoleComposerBar(Horizontal):
 
         if setup_reason_changed and not self.draft_text().strip():
             self._refresh_visible_draft()
+
+    def sync_dictation_state(self, state: _DictationState) -> None:
+        """Refresh the microphone action for the current one-shot lifecycle."""
+        self._dictation_state = state
+        try:
+            button = self.query_one("#console-dictation", Button)
+        except NoMatches:
+            return
+        labels = {
+            "idle": "Mic",
+            "starting": "Mic…",
+            "recording": "Rec ●",
+            "transcribing": "STT…",
+        }
+        tooltips = {
+            "idle": "Record one English utterance with local Parakeet v2.",
+            "starting": "Starting the default microphone…",
+            "recording": "Stop microphone recording and transcribe.",
+            "transcribing": "Transcribing locally with Parakeet v2 INT8…",
+        }
+        button.label = labels[state]
+        button.tooltip = tooltips[state]
+        button.disabled = state in {"starting", "transcribing"}
+        button.variant = "warning" if state == "recording" else "default"
+        button.set_class(state == "recording", "console-dictation-recording")
 
     @classmethod
     def _wrap_draft_lines(cls, text: str, width: int) -> list[str]:
@@ -1905,9 +1932,9 @@ class ConsoleComposerBar(Horizontal):
             indicator.styles.width = "auto"
             indicator.styles.max_width = 28
             clear_button.styles.display = "block"
-            actions.styles.width = 42
-            actions.styles.min_width = 42
-            actions.styles.max_width = 42
+            actions.styles.width = 50
+            actions.styles.min_width = 50
+            actions.styles.max_width = 50
             # TASK-380: keep the action verb (the old "📎✓" read as a status,
             # "attached OK", not a control), and make the tooltips count-accurate
             # now that staging appends up to `total` files (task-217).
@@ -1927,9 +1954,9 @@ class ConsoleComposerBar(Horizontal):
             indicator.styles.display = "none"
             indicator.styles.width = 0
             clear_button.styles.display = "none"
-            actions.styles.width = 37
-            actions.styles.min_width = 37
-            actions.styles.max_width = 37
+            actions.styles.width = 45
+            actions.styles.min_width = 45
+            actions.styles.max_width = 45
             attach_button.label = "Attach"
             attach_button.tooltip = (
                 "Attach files or context through the active Console session."
@@ -2022,9 +2049,9 @@ class ConsoleComposerBar(Horizontal):
             actions = Horizontal(
                 id="console-composer-actions", classes="console-composer-actions"
             )
-            actions.styles.width = 37
-            actions.styles.min_width = 37
-            actions.styles.max_width = 37
+            actions.styles.width = 45
+            actions.styles.min_width = 45
+            actions.styles.max_width = 45
             actions.styles.height = 1
             actions.styles.min_height = 1
             actions.styles.max_height = 1
@@ -2046,6 +2073,13 @@ class ConsoleComposerBar(Horizontal):
                 )
                 stop_button.styles.display = "none"
                 yield stop_button
+                yield self._bounded_button(
+                    "Mic",
+                    width=8,
+                    id="console-dictation",
+                    classes="destination-action-button console-dictation-button",
+                    tooltip="Record one English utterance with local Parakeet v2.",
+                )
                 yield self._bounded_button(
                     "Attach",
                     width=10,

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -2826,9 +2826,9 @@ ConsoleSystemPromptModal {
 }
 
 #console-composer-actions {
-    width: 37;
-    min-width: 37;
-    max-width: 37;
+    width: 45;
+    min-width: 45;
+    max-width: 45;
     height: 1;
     min-height: 1;
     layout: horizontal;

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -4226,9 +4226,9 @@ ConsoleSystemPromptModal {
 }
 
 #console-composer-actions {
-    width: 37;
-    min-width: 37;
-    max-width: 37;
+    width: 45;
+    min-width: 45;
+    max-width: 45;
     height: 1;
     min-height: 1;
     layout: horizontal;


### PR DESCRIPTION
## Summary
- add a visible Console Mic action with idle, recording, and transcribing states
- record one bounded utterance and transcribe memory-only PCM with local English Parakeet v2 INT8
- insert the transcript at the current caret without sending; preserve the draft on dependency, model, microphone, empty-audio, or inference failures

## Runtime behavior
- capture is bounded to 60 seconds and 1,920,000 PCM bytes
- blocking capture and inference run off the Textual event loop
- only a configured model directory or verified Library-installed bundle is accepted; the Mic action never downloads models
- optional audio and STT dependencies remain lazy until Mic is selected

## Verification
- 146 focused audio, transcription, legacy dictation, mounted Console, caret, collapse, and layout tests passed
- Ruff passed on changed Python files
- git diff --check passed
- real Parakeet v2 INT8 inference from an in-memory PCM buffer returned the expected transcript

## Testing limitation
Physical microphone hardware was not exercised in this environment because the optional recording backend is not installed. Windows and Linux hardware were not immediately available; the implementation uses the existing cross-platform PyAudio/sounddevice recording abstraction.

Closes TASK-603.1. Parent TASK-603 remains open for the broader executor, streaming-fallback, backpressure, and batch-priority gates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds local microphone dictation to Console. Record up to 60 seconds and insert an English transcript (Parakeet v2 INT8 via `onnx-asr`) at the caret without sending. Hardens the lifecycle with a strict wall timer, correct session insertion, and robust cleanup. Implements TASK-603.1 under TASK-603; broader executor/backpressure work remains open.

- **New Features**
  - Mic button in the Console composer with idle, recording, and transcribing states.
  - One-shot, memory-only capture (≤60s, byte-bounded) and local transcription with Parakeet v2 INT8 (`parakeet-onnx` via `onnx-asr`).
  - Uses a configured model directory or verified Library-installed bundle; never downloads. Inserts at the caret and preserves the draft on errors.

- **Refactors**
  - Hardened lifecycle: strict 60s wall timer with visible transition, cancel on stop/error, origin session–aware insertion, and discard on unmount; user-visible warnings/errors.
  - Services: complete-frame memory bound with off-thread buffer-limit callback; direct in-memory Parakeet v2 buffer path and a shared model loader.
  - Model resolution and imports: validate configured paths via `validate_path_simple`; accept only verified bundles; keep legacy dictation imports lazy.

<sup>Written for commit b6dbb17dcd0aa12e0259dc25fdf3f5a121d5c6c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

