### PR TITLE
Add minimal disk-backed File Notes workspace

### DIFF
--- a/Docs/superpowers/plans/2026-07-27-minimal-file-notes.md
+++ b/Docs/superpowers/plans/2026-07-27-minimal-file-notes.md
@@ -23,7 +23,7 @@ Reason: Disk authority, the independent replica, conflict policy, and Library ow
 - Create `Tests/Notes/test_file_notes_replica.py`.
 - Create `Tests/Notes/test_file_notes_service.py`.
 - Create `Tests/UI/test_library_file_notes_workspace.py`.
-- Modify `backlog/tasks/task-900 - Add-minimal-disk-backed-File-Notes-editor.md` only for final AC/notes/status.
+- Modify `backlog/tasks/task-969 - Add-minimal-disk-backed-File-Notes-editor.md` only for final AC/notes/status.
 
 ## Task 1: SQLite replica
 
@@ -107,7 +107,7 @@ Reason: Disk authority, the independent replica, conflict policy, and Library ow
 - [ ] Run only:
   `../../.venv/bin/python -m pytest -q Tests/Notes/test_file_notes_replica.py Tests/Notes/test_file_notes_service.py Tests/UI/test_library_file_notes_workspace.py --tb=short`
 - [ ] Run `git diff --check`.
-- [ ] Check all TASK-900 acceptance criteria only when proven by those tests, add concise Implementation Notes, and set TASK-900 to Done through the Backlog CLI.
+- [ ] Check all TASK-969 acceptance criteria only when proven by those tests, add concise Implementation Notes, and set TASK-969 to Done through the Backlog CLI.
 - [ ] Commit task closeout:
   `docs(notes): complete minimal file notes task`.
 

--- a/Docs/superpowers/plans/2026-07-27-minimal-file-notes.md
+++ b/Docs/superpowers/plans/2026-07-27-minimal-file-notes.md
@@ -1,0 +1,116 @@
+# Minimal File Notes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add one usable disk-backed Markdown/text notes workspace to Library without changing Database Notes or Git.
+
+**Architecture:** A small filesystem service owns path-safe operations and exact-byte parsing. One SQLite module owns the current replica, FTS, protected checkpoints, and tombstones. One composite Textual widget owns the File Notes UI and retained draft; `LibraryScreen` only switches sources and delegates its existing leave guard.
+
+**Tech Stack:** Python standard library, SQLite/FTS5, Textual, pytest.
+
+---
+
+ADR required: yes  
+ADR path: `backlog/decisions/029-file-notes-disk-authority.md`  
+Reason: Disk authority, the independent replica, conflict policy, and Library ownership are long-lived storage/UI boundaries.
+
+## Files
+
+- Create `tldw_chatbook/Notes/file_notes_replica.py` — SQLite schema and replica/recovery operations.
+- Create `tldw_chatbook/Notes/file_notes_service.py` — safe scanning, exact-byte documents, writes, moves, deletion, restore, and reconciliation.
+- Create `tldw_chatbook/Widgets/Library/library_file_notes_workspace.py` — tree/search/editor, autosave, polling, root selection, narrow mode, and session changes.
+- Modify `tldw_chatbook/UI/Screens/library_screen.py` — Database/Files switch and leave-guard delegation only.
+- Create `Tests/Notes/test_file_notes_replica.py`.
+- Create `Tests/Notes/test_file_notes_service.py`.
+- Create `Tests/UI/test_library_file_notes_workspace.py`.
+- Modify `backlog/tasks/task-900 - Add-minimal-disk-backed-File-Notes-editor.md` only for final AC/notes/status.
+
+## Task 1: SQLite replica
+
+- [ ] In each new test module, stub the optional `parakeet_mlx` module before
+  importing Chatbook code so the repository's pre-existing macOS MLX collection
+  abort does not block these focused tests. Do not change production config.
+- [ ] Write failing replica tests for:
+  - root-namespaced current-byte upsert and FTS search;
+  - protected file/folder-prefix matching;
+  - one pre-edit checkpoint per supplied session key;
+  - snapshot+tombstone preparation, rollback, persistent deleted listing, and exact-byte restore lookup.
+- [ ] Run:
+  `../../.venv/bin/python -m pytest -q Tests/Notes/test_file_notes_replica.py --tb=short`
+  and confirm failures are for the missing module.
+- [ ] Implement `FileNotesReplica` with three ordinary tables plus manually maintained FTS5:
+  - `files(root, relative_path, raw_bytes, content_hash, decoded_text, size, mtime_ns, deleted_at)`;
+  - `revisions(root, relative_path, raw_bytes, content_hash, kind, session_key, created_at)`;
+  - `protected_paths(root, relative_path, is_prefix)`.
+- [ ] Use one connection/transaction context, parameterized SQL, and `UNIQUE(root, relative_path)`. Do not add migrations, repositories, interfaces, triggers, quotas, or pairing metadata.
+- [ ] Run the replica test file and commit:
+  `feat(notes): add file notes replica`.
+
+## Task 2: Filesystem service
+
+- [ ] Write failing service tests for:
+  - `.git`/symlink exclusion and resolved-root containment;
+  - UTF-8/BOM/frontmatter split plus LF/CRLF/final-newline preservation;
+  - mixed-newline, undecodable, and over-limit read-only results;
+  - hash-conflict save, protected-checkpoint-before-write, exact atomic save,
+    and preservation of `stat.S_IMODE` permission bits;
+  - exclusive create and no-clobber move;
+  - delete snapshot, immediate pre-unlink hash recheck, tombstone clearing on
+    mismatch/unlink failure, and restore only to an absent path;
+  - offline-root reconciliation without mass deletion;
+  - external create/modify/delete projection updates and Chatbook-only session changes.
+- [ ] Run:
+  `../../.venv/bin/python -m pytest -q Tests/Notes/test_file_notes_service.py --tb=short`
+  and confirm failures are for the missing module.
+- [ ] Implement `FileNotesService` using:
+  - `os.walk(..., followlinks=False)`, `hashlib.sha256`, `tempfile`,
+    `os.replace`, `stat.S_IMODE`, exclusive create, and filesystem-enforced
+    no-clobber move (`os.link` then source unlink; failure leaves the source);
+  - the existing Library 2,000,000-character/8,000,000-byte guard values;
+  - `get_safe_relative_path()`/`validate_filename()` where their behavior matches the spec;
+  - plain dataclasses for entries, open documents, and operation results.
+- [ ] Keep the final hash recheck immediately before `os.replace`. Do not reuse the bidirectional sync engine or add a watcher/dependency.
+- [ ] Run service and replica tests and commit:
+  `feat(notes): add disk-authoritative file notes service`.
+
+## Task 3: Library workspace
+
+- [ ] Write failing mounted tests for:
+  - `Choose folder…`, offline root, and persisted root;
+  - tree mode replaced by search results;
+  - file open/body edit/save-state flow;
+  - create, rename/move, delete, protect/unprotect, and persistent restore
+    controls invoking the real service;
+  - conflict Reload and Save Copy plus conflict/error leave veto and successful flush;
+  - Recently deleted restore after a new workspace instance;
+  - polling and a background Database Notes snapshot update keeping the same
+    mounted workspace and `TextArea`;
+  - narrow Navigator → Editor → Back behavior;
+  - Database Notes composition remaining unchanged in Database mode.
+- [ ] Run:
+  `../../.venv/bin/python -m pytest -q Tests/UI/test_library_file_notes_workspace.py --tb=short`
+  and confirm failures are for the missing widget/integration.
+- [ ] Implement `LibraryFileNotesWorkspace` with Textual `Tree`, `Input`, `TextArea`, `Button`, timers, and workers. Keep draft/hash/session state on the retained widget; never recompose the editor for polling or status changes.
+- [ ] Add the smallest `LibraryScreen` seam:
+  - a `Database | Files` source strip while Notes is selected;
+  - early Files-workspace composition instead of the normal rail/canvas;
+  - File Notes delegation from `flush_pending_work()` and source/rail changes;
+  - suppress only the existing full-screen recompose in
+    `_apply_local_source_snapshot()` while Files mode is active, retaining the
+    snapshot for later Database mode.
+- [ ] Persist only the canonical selected root through existing config helpers. Use existing `SelectDirectory`; add no picker or global CSS.
+- [ ] Run the three new focused test files and commit:
+  `feat(library): add file notes workspace`.
+
+## Task 4: Focused closeout
+
+- [ ] Run only:
+  `../../.venv/bin/python -m pytest -q Tests/Notes/test_file_notes_replica.py Tests/Notes/test_file_notes_service.py Tests/UI/test_library_file_notes_workspace.py --tb=short`
+- [ ] Run `git diff --check`.
+- [ ] Check all TASK-900 acceptance criteria only when proven by those tests, add concise Implementation Notes, and set TASK-900 to Done through the Backlog CLI.
+- [ ] Commit task closeout:
+  `docs(notes): complete minimal file notes task`.
+
+## Explicit omissions
+
+No full test suite, CI run, performance certification, native filesystem adapter, cross-process lease, paired database, Git commands, RAG/MCP integration, multiple active roots, folder mutation, quota UI, or recovery tooling.

--- a/Docs/superpowers/plans/2026-07-27-minimal-file-notes.md
+++ b/Docs/superpowers/plans/2026-07-27-minimal-file-notes.md
@@ -10,8 +10,8 @@
 
 ---
 
-ADR required: yes  
-ADR path: `backlog/decisions/029-file-notes-disk-authority.md`  
+ADR required: yes
+ADR path: `backlog/decisions/029-file-notes-disk-authority.md`
 Reason: Disk authority, the independent replica, conflict policy, and Library ownership are long-lived storage/UI boundaries.
 
 ## Files

--- a/Docs/superpowers/specs/2026-07-27-minimal-file-notes-design.md
+++ b/Docs/superpowers/specs/2026-07-27-minimal-file-notes-design.md
@@ -1,7 +1,7 @@
 # Minimal File Notes Design
 
-Date: 2026-07-27  
-Task: [TASK-900](../../../backlog/tasks/task-900%20-%20Add-minimal-disk-backed-File-Notes-editor.md)  
+Date: 2026-07-27
+Task: [TASK-900](../../../backlog/tasks/task-900%20-%20Add-minimal-disk-backed-File-Notes-editor.md)
 Decision: [ADR-029](../../../backlog/decisions/029-file-notes-disk-authority.md)
 
 ## Goal

--- a/Docs/superpowers/specs/2026-07-27-minimal-file-notes-design.md
+++ b/Docs/superpowers/specs/2026-07-27-minimal-file-notes-design.md
@@ -1,0 +1,132 @@
+# Minimal File Notes Design
+
+Date: 2026-07-27  
+Task: [TASK-900](../../../backlog/tasks/task-900%20-%20Add-minimal-disk-backed-File-Notes-editor.md)  
+Decision: [ADR-029](../../../backlog/decisions/029-file-notes-disk-authority.md)
+
+## Goal
+
+Make one existing Git-managed Markdown/text folder usable as Chatbook's File
+Notes interface without changing the files' authority, the user's Git workflow,
+or existing Database Notes.
+
+## User experience
+
+Library Notes gets a `Database | Files` source switch. Database mode remains
+unchanged.
+
+Files mode has:
+
+- a collapsible folder tree in the left navigator;
+- search results replacing the tree while a search is active;
+- an editor with a relative-path breadcrumb, save state, and file actions;
+- `dirty`, `saving`, `saved`, `conflict`, and `error` save states;
+- a current-session list of paths Chatbook created, modified, moved, deleted,
+  or restored;
+- Navigator and Editor views on narrow terminals instead of squeezed panes.
+
+The initial file actions are create, rename/move into an existing directory,
+delete, restore, and protect/unprotect history. Create and move require an
+absent destination; they never replace another file. Folder creation and Git
+commands are not included.
+
+## Storage and file rules
+
+The selected root and relative path identify a note. Supported files are
+`.md`, `.markdown`, `.txt`, and `.text`. Scans ignore `.git`, do not traverse
+symlink directories or files, and reject any read or mutation whose resolved
+path is outside the root.
+
+The editor always loads the current file from disk. UTF-8 and UTF-8-with-BOM
+files are editable. Files that cannot be decoded are visible but read-only.
+
+Chatbook always removes an optional UTF-8 BOM from the editable body and keeps
+its exact bytes in the preserved prefix. After that BOM, a frontmatter block is
+recognized only when the first line is exactly `---` and a later line is
+exactly `---` or `...`. The preserved prefix extends through the closing
+delimiter, including that line's terminating newline when present, and only the
+remaining bytes are exposed as the body. Saving concatenates the untouched
+prefix with the edited body using the original newline convention. Without both
+delimiter lines, only the optional BOM is preserved separately and the rest is
+edited as one body.
+
+## Save and external-change flow
+
+1. Opening records the SHA-256 of the exact disk bytes.
+2. Body changes schedule the existing debounced autosave behavior.
+3. Before writing, Chatbook reads and hashes the file again.
+4. If the hash differs, autosave stops and the editor shows a conflict with
+   Reload and Save Copy actions. It never silently overwrites.
+5. Otherwise Chatbook writes a same-directory temporary file, preserves the
+   original permission bits, rechecks the source hash immediately before
+   publication, and publishes it with `os.replace` only if it still matches.
+6. The new hash becomes the editor baseline and the SQLite replica is updated.
+
+This prevents every external change detected before publication from being
+overwritten. No portable filesystem API can eliminate a non-cooperating
+writer's final race after the last check.
+
+A lightweight timer polls path, size, and modification time every one to two
+seconds. Only changed candidates are rehashed. A manual Refresh action runs the
+same reconciliation. External creates enter the tree, replica, and FTS;
+external modifications refresh those surfaces unless the file has a dirty open
+editor, which becomes a conflict; external deletions leave their last replica
+bytes recoverable but disappear from tree/search; and external renames are
+treated as one deletion plus one creation. No file-watcher dependency is added.
+
+## SQLite replica and recovery
+
+One separate `file_notes.sqlite` in Chatbook's user-data directory contains:
+
+- `files`: relative path, latest exact bytes, hash, observed metadata, and
+  optional deletion timestamp;
+- `revisions`: relative path, exact prior bytes, hash, reason, and timestamp;
+- `protected_paths`: protected file paths or folder prefixes;
+- an FTS5 index over decoded current content.
+
+All linked files receive a current replica for search and recovery. Historical
+revisions are recorded only for paths selected with Protect and are coalesced
+to one pre-edit checkpoint per open editing session. Unprotect stops future
+history without deleting existing recovery data. Delete always requires a
+committed snapshot and tombstone, then rechecks that the disk hash still matches
+that snapshot immediately before unlinking. A mismatch clears the tombstone and
+becomes a conflict. If the transaction or unlink fails, the file is not deleted
+and Chatbook clears the tombstone; the next reconciliation also clears any
+stale tombstone for a file still present. Restore writes the stored exact bytes
+only when the target path is absent.
+
+If the replica is unavailable, disk browsing and unprotected editing continue
+with an error state. Protected edits and deletion stop because their promised
+recovery copy cannot be recorded.
+
+## Existing code boundaries
+
+- Reuse the Library screen and `LibraryNotesCanvas` styling/state patterns.
+- Reuse Textual's existing tree, input, text-area, and timer primitives.
+- Reuse the enhanced directory picker for selecting the root.
+- Add a small File Notes service and replica module; do not extend ChaChaNotes
+  or the existing bidirectional sync engine.
+- Initialize File Notes only when Files mode is opened.
+
+## Focused verification
+
+Tests cover only the data-loss and primary-use boundaries:
+
+- body edits preserve frontmatter/BOM/newline bytes;
+- a changed disk hash blocks autosave overwrite;
+- atomic save updates the real file and replica;
+- delete cannot unlink before its snapshot/tombstone commits;
+- create and move refuse an existing destination;
+- restore reproduces exact bytes;
+- reads and mutations cannot follow symlinks or escape the selected root;
+- tree, search replacement, editor state, and narrow switching work in the
+  mounted Library surface.
+
+No full-suite or platform qualification gate is part of this implementation.
+
+## Explicit non-goals
+
+Multiple active roots, folder mutation, Git staging/commit/push controls, RAG,
+MCP, keywords, templates, non-UTF-8 editing, native filesystem adapters,
+cross-process leases, paired databases, recovery quotas, bulk recovery tools,
+and crash/power-cut certification.

--- a/Docs/superpowers/specs/2026-07-27-minimal-file-notes-design.md
+++ b/Docs/superpowers/specs/2026-07-27-minimal-file-notes-design.md
@@ -13,7 +13,8 @@ or existing Database Notes.
 ## User experience
 
 Library Notes gets a `Database | Files` source switch. Database mode remains
-unchanged.
+unchanged. Files mode replaces the normal Library rail and canvas with its own
+two-pane workspace; it is not nested as a third pane.
 
 Files mode has:
 
@@ -23,22 +24,34 @@ Files mode has:
 - `dirty`, `saving`, `saved`, `conflict`, and `error` save states;
 - a current-session list of paths Chatbook created, modified, moved, deleted,
   or restored;
+- a small `Recently deleted` group, shown only when restorable tombstones
+  exist;
 - Navigator and Editor views on narrow terminals instead of squeezed panes.
 
 The initial file actions are create, rename/move into an existing directory,
 delete, restore, and protect/unprotect history. Create and move require an
-absent destination; they never replace another file. Folder creation and Git
+absent destination enforced by the filesystem operation, not only by a prior
+existence check; they never replace another file. Folder creation and Git
 commands are not included.
+
+With no configured root, Files mode shows one `Choose folder…` action. The
+chosen canonical path persists across restarts. Changing roots first passes the
+same editor-leave guard as changing files. A missing or unreadable root is shown
+as offline and is never created automatically or interpreted as mass deletion.
 
 ## Storage and file rules
 
-The selected root and relative path identify a note. Supported files are
-`.md`, `.markdown`, `.txt`, and `.text`. Scans ignore `.git`, do not traverse
-symlink directories or files, and reject any read or mutation whose resolved
-path is outside the root.
+The canonical selected root and relative path together identify a note and
+namespace its replica/recovery rows. Supported files are `.md`, `.markdown`,
+`.txt`, and `.text`. Scans ignore `.git`, do not traverse symlink directories
+or files, and reject any read or mutation whose resolved path is outside the
+root.
 
 The editor always loads the current file from disk. UTF-8 and UTF-8-with-BOM
-files are editable. Files that cannot be decoded are visible but read-only.
+files with uniform LF or CRLF body newlines are editable; their newline style
+and final-newline state are preserved. Files that cannot be decoded, contain
+mixed newline styles, or exceed the existing Library note size guard remain
+path-visible but read-only.
 
 Chatbook always removes an optional UTF-8 BOM from the editable body and keeps
 its exact bytes in the preserved prefix. After that BOM, a frontmatter block is
@@ -54,13 +67,17 @@ edited as one body.
 
 1. Opening records the SHA-256 of the exact disk bytes.
 2. Body changes schedule the existing debounced autosave behavior.
-3. Before writing, Chatbook reads and hashes the file again.
-4. If the hash differs, autosave stops and the editor shows a conflict with
+3. Before the first save of a protected note in an editing session, SQLite
+   commits the exact current bytes as that session's pre-edit checkpoint. If
+   this fails, the file is not written. An editing session begins on open or
+   reload and ends when that file is left.
+4. Before writing, Chatbook reads and hashes the file again.
+5. If the hash differs, autosave stops and the editor shows a conflict with
    Reload and Save Copy actions. It never silently overwrites.
-5. Otherwise Chatbook writes a same-directory temporary file, preserves the
+6. Otherwise Chatbook writes a same-directory temporary file, preserves the
    original permission bits, rechecks the source hash immediately before
    publication, and publishes it with `os.replace` only if it still matches.
-6. The new hash becomes the editor baseline and the SQLite replica is updated.
+7. The new hash becomes the editor baseline and the SQLite replica is updated.
 
 This prevents every external change detected before publication from being
 overwritten. No portable filesystem API can eliminate a non-cooperating
@@ -72,16 +89,28 @@ same reconciliation. External creates enter the tree, replica, and FTS;
 external modifications refresh those surfaces unless the file has a dirty open
 editor, which becomes a conflict; external deletions leave their last replica
 bytes recoverable but disappear from tree/search; and external renames are
-treated as one deletion plus one creation. No file-watcher dependency is added.
+treated as one deletion plus one creation. Initial scans and reconciliation run
+off the UI thread. They update navigator/search/status widgets directly and
+never trigger a full Library recompose while an editor is open. No file-watcher
+dependency is added.
+
+Changing the selected file, source, root, Library rail destination, or app
+screen first awaits pending autosave. A remaining dirty, conflict, or error
+state vetoes that navigation and keeps the editor and its retained draft
+mounted. Narrow mode switches programmatically from the actual available
+canvas width: selecting a file opens Editor and Back returns to Navigator
+without remounting the draft.
 
 ## SQLite replica and recovery
 
 One separate `file_notes.sqlite` in Chatbook's user-data directory contains:
 
-- `files`: relative path, latest exact bytes, hash, observed metadata, and
-  optional deletion timestamp;
-- `revisions`: relative path, exact prior bytes, hash, reason, and timestamp;
-- `protected_paths`: protected file paths or folder prefixes;
+- `files`: canonical root, relative path, latest exact bytes, hash, observed
+  metadata, and optional deletion timestamp;
+- `revisions`: canonical root, relative path, exact prior bytes, hash, reason,
+  and timestamp;
+- `protected_paths`: canonical root plus a protected file path or folder
+  prefix;
 - an FTS5 index over decoded current content.
 
 All linked files receive a current replica for search and recovery. Historical
@@ -93,7 +122,9 @@ that snapshot immediately before unlinking. A mismatch clears the tombstone and
 becomes a conflict. If the transaction or unlink fails, the file is not deleted
 and Chatbook clears the tombstone; the next reconciliation also clears any
 stale tombstone for a file still present. Restore writes the stored exact bytes
-only when the target path is absent.
+only when the target path is absent. Tombstones remain available from
+`Recently deleted` after restart; the current-session list additionally exposes
+Restore for deletions made during that Chatbook session.
 
 If the replica is unavailable, disk browsing and unprotected editing continue
 with an error state. Protected edits and deletion stop because their promised
@@ -102,10 +133,12 @@ recovery copy cannot be recorded.
 ## Existing code boundaries
 
 - Reuse the Library screen and `LibraryNotesCanvas` styling/state patterns.
-- Reuse Textual's existing tree, input, text-area, and timer primitives.
-- Reuse the enhanced directory picker for selecting the root.
+- Reuse Textual's existing tree, input, text-area, timer, and worker primitives.
+- Reuse the existing `SelectDirectory` picker for selecting the root.
 - Add a small File Notes service and replica module; do not extend ChaChaNotes
   or the existing bidirectional sync engine.
+- Keep the Files workspace in one composite Library widget so polling and
+  background Database Notes refreshes cannot remount its editor.
 - Initialize File Notes only when Files mode is opened.
 
 ## Focused verification
@@ -115,10 +148,15 @@ Tests cover only the data-loss and primary-use boundaries:
 - body edits preserve frontmatter/BOM/newline bytes;
 - a changed disk hash blocks autosave overwrite;
 - atomic save updates the real file and replica;
+- protected save cannot write before its pre-edit checkpoint commits;
+- dirty/conflicted drafts veto file, root, source, rail, and screen changes;
+- polling updates mounted widgets without remounting the editor;
 - delete cannot unlink before its snapshot/tombstone commits;
 - create and move refuse an existing destination;
-- restore reproduces exact bytes;
+- restore remains discoverable after restart and reproduces exact bytes;
 - reads and mutations cannot follow symlinks or escape the selected root;
+- unavailable roots do not create directories or mark every note deleted;
+- root changes cannot collide with another root's replica/recovery rows;
 - tree, search replacement, editor state, and narrow switching work in the
   mounted Library surface.
 

--- a/Docs/superpowers/specs/2026-07-27-minimal-file-notes-design.md
+++ b/Docs/superpowers/specs/2026-07-27-minimal-file-notes-design.md
@@ -1,7 +1,7 @@
 # Minimal File Notes Design
 
 Date: 2026-07-27
-Task: [TASK-900](../../../backlog/tasks/task-900%20-%20Add-minimal-disk-backed-File-Notes-editor.md)
+Task: [TASK-969](../../../backlog/tasks/task-969%20-%20Add-minimal-disk-backed-File-Notes-editor.md)
 Decision: [ADR-029](../../../backlog/decisions/029-file-notes-disk-authority.md)
 
 ## Goal

--- a/Tests/Notes/test_file_notes_replica.py
+++ b/Tests/Notes/test_file_notes_replica.py
@@ -457,3 +457,27 @@ def test_prepared_deletion_persists_and_returns_exact_restore_bytes(
         assert second.get_restore_bytes(root, relative_path) == restore_bytes
     finally:
         second.close()
+
+
+def test_database_path_expands_user_home(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.chdir(tmp_path)
+    expected_path = home / "state" / "file_notes.sqlite"
+
+    replica = FileNotesReplica("~/state/file_notes.sqlite")
+    try:
+        database_path = replica._connection.execute(
+            "SELECT file FROM pragma_database_list WHERE name = 'main'"
+        ).fetchone()["file"]
+    finally:
+        replica.close()
+
+    assert Path(database_path) == expected_path
+    assert expected_path.is_file()
+    assert not (tmp_path / "~").exists()

--- a/Tests/Notes/test_file_notes_replica.py
+++ b/Tests/Notes/test_file_notes_replica.py
@@ -253,6 +253,7 @@ def test_prepare_deletion_rolls_back_snapshot_when_tombstone_write_fails(
             relative_path,
             b"deletion snapshot",
             content_hash=_digest(b"deletion snapshot"),
+            decoded_text="deletion snapshot",
             deleted_at="2026-07-27T10:00:00Z",
         )
 
@@ -265,6 +266,38 @@ def test_prepare_deletion_rolls_back_snapshot_when_tombstone_write_fails(
         == 0
     )
     assert replica.search(root, "present") == [relative_path]
+
+
+def test_clear_tombstone_reindexes_the_prepared_snapshot_text(
+    replica: FileNotesReplica,
+) -> None:
+    root = "/notes"
+    _upsert(replica, root, "changed.md", b"old searchable text")
+    _upsert(replica, root, "undecodable.txt", b"old indexed text")
+
+    replica.prepare_deletion(
+        root,
+        "changed.md",
+        b"replacement searchable text",
+        content_hash=_digest(b"replacement searchable text"),
+        decoded_text="replacement searchable text",
+    )
+    replica.prepare_deletion(
+        root,
+        "undecodable.txt",
+        b"\xff\xfe",
+        content_hash=_digest(b"\xff\xfe"),
+        decoded_text=None,
+    )
+
+    assert replica.clear_tombstone(root, "changed.md")
+    assert replica.get_bytes(root, "changed.md") == b"replacement searchable text"
+    assert replica.search(root, "replacement") == ["changed.md"]
+    assert replica.search(root, "old") == []
+
+    assert replica.clear_tombstone(root, "undecodable.txt")
+    assert replica.get_bytes(root, "undecodable.txt") == b"\xff\xfe"
+    assert replica.search(root, "indexed") == []
 
 
 def test_prepared_deletion_persists_and_returns_exact_restore_bytes(
@@ -283,6 +316,7 @@ def test_prepared_deletion_persists_and_returns_exact_restore_bytes(
         relative_path,
         restore_bytes,
         content_hash=_digest(restore_bytes),
+        decoded_text=restore_bytes.decode("utf-8"),
         deleted_at="2026-07-27T10:00:00Z",
         created_at="2026-07-27T10:00:00Z",
     )

--- a/Tests/Notes/test_file_notes_replica.py
+++ b/Tests/Notes/test_file_notes_replica.py
@@ -4,7 +4,9 @@ import hashlib
 import sqlite3
 import sys
 import types
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from threading import Event
 
 import pytest
 
@@ -12,6 +14,7 @@ import pytest
 sys.modules.setdefault("parakeet_mlx", types.ModuleType("parakeet_mlx"))
 
 from tldw_chatbook.Notes.file_notes_replica import FileNotesReplica  # noqa: E402
+from tldw_chatbook.Notes.file_notes_replica import ReplicaFileInfo  # noqa: E402
 
 
 def _digest(raw_bytes: bytes) -> str:
@@ -45,6 +48,82 @@ def replica() -> FileNotesReplica:
     value = FileNotesReplica(":memory:")
     yield value
     value.close()
+
+
+def test_connection_operations_are_serialized_across_worker_threads(
+    replica: FileNotesReplica,
+) -> None:
+    root = "/notes"
+    _upsert(replica, root, "worker.md", b"thread-safe bytes")
+    transaction_started = Event()
+    release_transaction = Event()
+    read_started = Event()
+    read_finished = Event()
+
+    def hold_transaction() -> None:
+        with replica._transaction():
+            transaction_started.set()
+            assert release_transaction.wait(timeout=2)
+
+    def read_from_worker() -> bytes | None:
+        read_started.set()
+        try:
+            return replica.get_bytes(root, "worker.md")
+        finally:
+            read_finished.set()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        holder = executor.submit(hold_transaction)
+        assert transaction_started.wait(timeout=1)
+        reader = executor.submit(read_from_worker)
+        assert read_started.wait(timeout=1)
+        try:
+            assert not read_finished.wait(timeout=0.05)
+        finally:
+            release_transaction.set()
+        holder.result(timeout=1)
+        assert reader.result(timeout=1) == b"thread-safe bytes"
+
+
+def test_commit_failure_rolls_back_and_leaves_connection_usable(
+    replica: FileNotesReplica,
+) -> None:
+    with replica._lock:
+        replica._connection.execute("PRAGMA foreign_keys = ON")
+        replica._connection.executescript(
+            """
+            CREATE TEMP TABLE commit_parent (
+                id INTEGER PRIMARY KEY
+            );
+            CREATE TEMP TABLE commit_child (
+                parent_id INTEGER,
+                FOREIGN KEY(parent_id) REFERENCES commit_parent(id)
+                    DEFERRABLE INITIALLY DEFERRED
+            );
+            """
+        )
+
+    insert_completed = False
+    with pytest.raises(sqlite3.IntegrityError, match="FOREIGN KEY constraint failed"):
+        with replica._transaction() as cursor:
+            cursor.execute(
+                "INSERT INTO commit_child (parent_id) VALUES (?)",
+                (1,),
+            )
+            insert_completed = True
+
+    assert insert_completed
+    with replica._lock:
+        assert not replica._connection.in_transaction
+        assert (
+            replica._connection.execute(
+                "SELECT COUNT(*) FROM commit_child"
+            ).fetchone()[0]
+            == 0
+        )
+
+    _upsert(replica, "/notes", "after-failure.md", b"still usable")
+    assert replica.get_bytes("/notes", "after-failure.md") == b"still usable"
 
 
 def test_schema_has_only_required_tables_and_no_triggers(
@@ -111,6 +190,41 @@ def test_upsert_is_root_namespaced_and_manually_replaces_fts_content(
         ).fetchone()[0]
         == 1
     )
+
+
+def test_active_inventory_is_root_scoped_and_excludes_tombstones(
+    replica: FileNotesReplica,
+) -> None:
+    root_a = "/notes/a"
+    root_b = "/notes/b"
+    _upsert(replica, root_a, "b.md", b"second", mtime_ns=22)
+    _upsert(replica, root_a, "a.md", b"first", mtime_ns=11)
+    _upsert(replica, root_a, "gone.md", b"deleted", mtime_ns=33)
+    _upsert(replica, root_b, "a.md", b"other root", mtime_ns=44)
+    replica.mark_deleted(root_a, "gone.md")
+
+    assert replica.list_active_files(root_a) == [
+        ReplicaFileInfo(
+            relative_path="a.md",
+            content_hash=_digest(b"first"),
+            size=5,
+            mtime_ns=11,
+        ),
+        ReplicaFileInfo(
+            relative_path="b.md",
+            content_hash=_digest(b"second"),
+            size=6,
+            mtime_ns=22,
+        ),
+    ]
+    assert replica.list_active_files(root_b) == [
+        ReplicaFileInfo(
+            relative_path="a.md",
+            content_hash=_digest(b"other root"),
+            size=10,
+            mtime_ns=44,
+        )
+    ]
 
 
 def test_search_ignores_undecodable_and_deleted_rows_and_quotes_user_input(

--- a/Tests/Notes/test_file_notes_replica.py
+++ b/Tests/Notes/test_file_notes_replica.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Avoid importing the unrelated optional MLX stack during focused Notes tests.
+sys.modules.setdefault("parakeet_mlx", types.ModuleType("parakeet_mlx"))
+
+from tldw_chatbook.Notes.file_notes_replica import FileNotesReplica  # noqa: E402
+
+
+def _digest(raw_bytes: bytes) -> str:
+    return hashlib.sha256(raw_bytes).hexdigest()
+
+
+def _upsert(
+    replica: FileNotesReplica,
+    root: str,
+    relative_path: str,
+    raw_bytes: bytes,
+    *,
+    decoded_text: str | None = None,
+    mtime_ns: int = 1,
+) -> None:
+    if decoded_text is None:
+        decoded_text = raw_bytes.decode("utf-8")
+    replica.upsert_file(
+        root,
+        relative_path,
+        raw_bytes,
+        content_hash=_digest(raw_bytes),
+        decoded_text=decoded_text,
+        size=len(raw_bytes),
+        mtime_ns=mtime_ns,
+    )
+
+
+@pytest.fixture
+def replica() -> FileNotesReplica:
+    value = FileNotesReplica(":memory:")
+    yield value
+    value.close()
+
+
+def test_schema_has_only_required_tables_and_no_triggers(
+    replica: FileNotesReplica,
+) -> None:
+    rows = replica._connection.execute(
+        """
+        SELECT name, sql
+        FROM sqlite_master
+        WHERE type = 'table'
+          AND name NOT LIKE 'sqlite_%'
+          AND name NOT LIKE 'files_fts_%'
+        """
+    ).fetchall()
+
+    assert {row["name"] for row in rows} == {
+        "files",
+        "revisions",
+        "protected_paths",
+        "files_fts",
+    }
+    assert next(row["sql"] for row in rows if row["name"] == "files_fts").startswith(
+        "CREATE VIRTUAL TABLE"
+    )
+    assert (
+        replica._connection.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger'"
+        ).fetchone()[0]
+        == 0
+    )
+
+
+def test_upsert_is_root_namespaced_and_manually_replaces_fts_content(
+    replica: FileNotesReplica,
+) -> None:
+    root_a = "/notes/a"
+    root_b = "/notes/b"
+    _upsert(replica, root_a, "shared.md", b"alpha current")
+    _upsert(replica, root_b, "shared.md", b"beta current")
+
+    assert replica.get_bytes(root_a, "shared.md") == b"alpha current"
+    assert replica.get_bytes(root_b, "shared.md") == b"beta current"
+    assert replica.search(root_a, "alpha") == ["shared.md"]
+    assert replica.search(root_b, "alpha") == []
+
+    _upsert(
+        replica,
+        root_a,
+        "shared.md",
+        b"gamma replacement",
+        mtime_ns=2,
+    )
+
+    assert replica.search(root_a, "alpha") == []
+    assert replica.search(root_a, "gamma") == ["shared.md"]
+    assert (
+        replica._connection.execute(
+            """
+            SELECT COUNT(*)
+            FROM files
+            WHERE root = ? AND relative_path = ?
+            """,
+            (root_a, "shared.md"),
+        ).fetchone()[0]
+        == 1
+    )
+
+
+def test_search_ignores_undecodable_and_deleted_rows_and_quotes_user_input(
+    replica: FileNotesReplica,
+) -> None:
+    root = "/notes"
+    _upsert(replica, root, "active.md", b"literal OR searchable")
+    replica.upsert_file(
+        root,
+        "unsafe.txt",
+        b"\xff\xfe",
+        content_hash=_digest(b"\xff\xfe"),
+        decoded_text=None,
+        size=2,
+        mtime_ns=1,
+    )
+    _upsert(replica, root, "gone.md", b"searchable but deleted")
+    assert replica.mark_deleted(root, "gone.md", deleted_at="2026-07-27T10:00:00Z")
+
+    assert replica.search(root, "searchable") == ["active.md"]
+    for unsafe_query in ('"', 'searchable OR "', "') OR 1=1 --", "\x00"):
+        assert isinstance(replica.search(root, unsafe_query), list)
+    assert replica.search(root, "searchable") == ["active.md"]
+
+
+def test_mark_deleted_retains_bytes_and_clear_tombstone_restores_search(
+    replica: FileNotesReplica,
+) -> None:
+    root = "/notes"
+    raw_bytes = b"recover this exact payload\r\n"
+    _upsert(replica, root, "folder/gone.md", raw_bytes)
+
+    assert replica.mark_deleted(
+        root,
+        "folder/gone.md",
+        deleted_at="2026-07-27T10:00:00Z",
+    )
+    assert replica.get_bytes(root, "folder/gone.md") == raw_bytes
+    assert replica.get_restore_bytes(root, "folder/gone.md") == raw_bytes
+    assert replica.list_deleted(root) == ["folder/gone.md"]
+    assert replica.search(root, "recover") == []
+    assert not replica.mark_deleted(root, "missing.md")
+
+    assert replica.clear_tombstone(root, "folder/gone.md")
+    assert replica.list_deleted(root) == []
+    assert replica.search(root, "recover") == ["folder/gone.md"]
+    assert not replica.clear_tombstone(root, "folder/gone.md")
+
+
+def test_protection_matches_exact_files_and_component_bounded_prefixes(
+    replica: FileNotesReplica,
+) -> None:
+    root = "/notes"
+    replica.protect(root, "important.md")
+    replica.protect(root, "archive", is_prefix=True)
+    replica.protect(root, "team%", is_prefix=True)
+
+    assert replica.is_protected(root, "important.md")
+    assert not replica.is_protected(root, "folder/important.md")
+    assert replica.is_protected(root, "archive")
+    assert replica.is_protected(root, "archive/2026/note.md")
+    assert not replica.is_protected(root, "archives/note.md")
+    assert replica.is_protected(root, "team%/note.md")
+    assert not replica.is_protected(root, "teamX/note.md")
+    assert not replica.is_protected("/other", "important.md")
+
+    assert replica.unprotect(root, "important.md")
+    assert replica.unprotect(root, "archive", is_prefix=True)
+    assert not replica.is_protected(root, "important.md")
+    assert not replica.is_protected(root, "archive/2026/note.md")
+    assert not replica.unprotect(root, "archive", is_prefix=True)
+
+
+def test_checkpoint_coalesces_exact_bytes_once_per_session_key(
+    replica: FileNotesReplica,
+) -> None:
+    root = "/notes"
+    relative_path = "important.md"
+
+    assert replica.checkpoint(
+        root,
+        relative_path,
+        b"first exact bytes",
+        content_hash=_digest(b"first exact bytes"),
+        session_key="session-1",
+        created_at="2026-07-27T10:00:00Z",
+    )
+    assert not replica.checkpoint(
+        root,
+        relative_path,
+        b"must not replace first",
+        content_hash=_digest(b"must not replace first"),
+        session_key="session-1",
+        created_at="2026-07-27T10:01:00Z",
+    )
+    assert replica.checkpoint(
+        root,
+        relative_path,
+        b"second session bytes",
+        content_hash=_digest(b"second session bytes"),
+        session_key="session-2",
+        created_at="2026-07-27T10:02:00Z",
+    )
+
+    rows = replica._connection.execute(
+        """
+        SELECT raw_bytes, session_key
+        FROM revisions
+        WHERE root = ? AND relative_path = ? AND kind = 'pre_edit'
+        ORDER BY session_key
+        """,
+        (root, relative_path),
+    ).fetchall()
+    assert [(row["raw_bytes"], row["session_key"]) for row in rows] == [
+        (b"first exact bytes", "session-1"),
+        (b"second session bytes", "session-2"),
+    ]
+
+
+def test_prepare_deletion_rolls_back_snapshot_when_tombstone_write_fails(
+    replica: FileNotesReplica,
+) -> None:
+    root = "/notes"
+    relative_path = "keep.md"
+    _upsert(replica, root, relative_path, b"still present")
+    replica._connection.execute(
+        """
+        CREATE TEMP TRIGGER fail_tombstone
+        BEFORE UPDATE OF deleted_at ON files
+        WHEN NEW.deleted_at IS NOT NULL
+        BEGIN
+            SELECT RAISE(ABORT, 'forced tombstone failure');
+        END
+        """
+    )
+
+    with pytest.raises(sqlite3.IntegrityError, match="forced tombstone failure"):
+        replica.prepare_deletion(
+            root,
+            relative_path,
+            b"deletion snapshot",
+            content_hash=_digest(b"deletion snapshot"),
+            deleted_at="2026-07-27T10:00:00Z",
+        )
+
+    assert replica.get_bytes(root, relative_path) == b"still present"
+    assert replica.list_deleted(root) == []
+    assert (
+        replica._connection.execute(
+            "SELECT COUNT(*) FROM revisions WHERE kind = 'delete'"
+        ).fetchone()[0]
+        == 0
+    )
+    assert replica.search(root, "present") == [relative_path]
+
+
+def test_prepared_deletion_persists_and_returns_exact_restore_bytes(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "nested" / "file_notes.sqlite"
+    root = "/notes"
+    relative_path = "binary/data.text"
+    initial_bytes = b"old replica"
+    restore_bytes = b"\xef\xbb\xbf---\r\ntitle: Exact\r\n---\r\nbody\x00\r\n"
+
+    first = FileNotesReplica(db_path)
+    _upsert(first, root, relative_path, initial_bytes)
+    first.prepare_deletion(
+        root,
+        relative_path,
+        restore_bytes,
+        content_hash=_digest(restore_bytes),
+        deleted_at="2026-07-27T10:00:00Z",
+        created_at="2026-07-27T10:00:00Z",
+    )
+    assert first.get_restore_bytes(root, relative_path) == restore_bytes
+    deletion_revision = first._connection.execute(
+        """
+        SELECT raw_bytes, content_hash, session_key
+        FROM revisions
+        WHERE root = ? AND relative_path = ? AND kind = 'delete'
+        """,
+        (root, relative_path),
+    ).fetchone()
+    assert deletion_revision["raw_bytes"] == restore_bytes
+    assert deletion_revision["content_hash"] == _digest(restore_bytes)
+    assert deletion_revision["session_key"] is None
+    first.close()
+
+    assert db_path.parent.is_dir()
+    second = FileNotesReplica(db_path)
+    try:
+        assert second.list_deleted(root) == [relative_path]
+        assert second.list_deleted("/other") == []
+        assert second.get_bytes(root, relative_path) == restore_bytes
+        assert second.get_restore_bytes(root, relative_path) == restore_bytes
+    finally:
+        second.close()

--- a/Tests/Notes/test_file_notes_service.py
+++ b/Tests/Notes/test_file_notes_service.py
@@ -107,6 +107,37 @@ def test_open_and_save_preserve_bom_frontmatter_crlf_final_newline_and_mode(
     ]
 
 
+def test_save_copy_preserves_exact_format_and_never_clobbers(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    source = root / "source.md"
+    source_bytes = b"\xef\xbb\xbf---\r\ntitle: Exact\r\n---\r\nold\r\nbody\r\n"
+    source.write_bytes(source_bytes)
+    occupied = root / "occupied.md"
+    occupied.write_bytes(b"keep me")
+    service = FileNotesService(root, replica)
+    opened = service.open_file(source.name)
+
+    result = service.save_copy(opened, "copied\nbody", "copy.md")
+
+    expected = b"\xef\xbb\xbf---\r\ntitle: Exact\r\n---\r\ncopied\r\nbody\r\n"
+    assert result.status == "ok"
+    assert source.read_bytes() == source_bytes
+    assert (root / "copy.md").read_bytes() == expected
+    assert replica.get_bytes(str(root.resolve()), "copy.md") == expected
+    assert service.session_changes[-1].action == "created"
+    changes = service.session_changes
+
+    existing = service.save_copy(opened, "replacement", occupied.name)
+
+    assert existing.status == "exists"
+    assert occupied.read_bytes() == b"keep me"
+    assert service.session_changes == changes
+
+
 @pytest.mark.parametrize("operation", ["save", "create", "restore"])
 def test_post_publication_stat_failure_still_records_success(
     operation: str,

--- a/Tests/Notes/test_file_notes_service.py
+++ b/Tests/Notes/test_file_notes_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import io
 import os
 import sqlite3
 import stat
@@ -11,6 +12,7 @@ from pathlib import Path
 from threading import Event
 
 import pytest
+from loguru import logger
 
 # Avoid importing the unrelated optional MLX stack during focused Notes tests.
 sys.modules.setdefault("parakeet_mlx", types.ModuleType("parakeet_mlx"))
@@ -71,6 +73,61 @@ def test_scan_excludes_git_and_symlinks_and_rejects_unsafe_paths(
     assert (root / "ignored.rst").exists()
 
 
+def test_service_uses_shared_path_confinement(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    service = FileNotesService(root, replica)
+    calls: list[tuple[Path, Path]] = []
+
+    def reject_path(candidate: Path, base: Path) -> None:
+        calls.append((candidate, base))
+        return None
+
+    monkeypatch.setattr(
+        service_module,
+        "get_safe_relative_path",
+        reject_path,
+        raising=False,
+    )
+
+    result = service.create_file("blocked.md", "blocked")
+
+    assert result.status == "unsafe"
+    assert calls == [(root / "blocked.md", root.resolve())]
+    assert not (root / "blocked.md").exists()
+
+
+def test_root_replacement_cannot_move_confinement_boundary(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "notes"
+    outside = tmp_path / "outside"
+    root.mkdir()
+    outside.mkdir()
+    service = FileNotesService(root, replica)
+
+    def replace_root_with_symlink() -> bool:
+        root.rmdir()
+        try:
+            root.symlink_to(outside, target_is_directory=True)
+        except OSError as error:
+            pytest.skip(f"directory symlinks unavailable: {error}")
+        return True
+
+    monkeypatch.setattr(service, "_root_is_online", replace_root_with_symlink)
+
+    result = service.create_file("escaped.md", "blocked")
+
+    assert result.status == "unsafe"
+    assert not (outside / "escaped.md").exists()
+
+
 def test_open_and_save_preserve_bom_frontmatter_crlf_final_newline_and_mode(
     tmp_path: Path,
     replica: FileNotesReplica,
@@ -101,11 +158,34 @@ def test_open_and_save_preserve_bom_frontmatter_crlf_final_newline_and_mode(
     assert path.read_bytes() == (
         b"\xef\xbb\xbf---\r\ntitle: Exact\r\n...\r\nnew\r\nbody\r\n"
     )
-    assert stat.S_IMODE(path.stat().st_mode) == 0o640
+    if os.name != "nt":
+        assert stat.S_IMODE(path.stat().st_mode) == 0o640
     assert replica.get_bytes(str(root.resolve()), "note.md") == path.read_bytes()
     assert [(change.action, change.relative_path) for change in service.session_changes] == [
         ("modified", "note.md")
     ]
+
+
+def test_save_preserves_mode_when_fchmod_is_unavailable(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    path = root / "note.md"
+    path.write_text("old\n", encoding="utf-8")
+    path.chmod(0o640)
+    service = FileNotesService(root, replica)
+    opened = service.open_file("note.md")
+    monkeypatch.delattr(service_module.os, "fchmod", raising=False)
+
+    result = service.save_file(opened, "new\n", session_key="open-1")
+
+    assert result.status == "ok"
+    assert path.read_text(encoding="utf-8") == "new\n"
+    if os.name != "nt":
+        assert stat.S_IMODE(path.stat().st_mode) == 0o640
 
 
 def test_save_copy_preserves_exact_format_and_never_clobbers(
@@ -353,6 +433,49 @@ def test_save_rechecks_hash_immediately_before_replace_and_cleans_temp(
     assert result.status == "conflict"
     assert path.read_text(encoding="utf-8") == "external race\n"
     assert list(root.glob("*.tmp")) == []
+
+
+def test_save_logs_temp_cleanup_failure(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    path = root / "race.md"
+    path.write_text("baseline\n", encoding="utf-8")
+    service = FileNotesService(root, replica)
+    opened = service.open_file("race.md")
+    real_mkstemp = service_module.tempfile.mkstemp
+    real_unlink = service_module.os.unlink
+
+    def change_after_temp(*args: object, **kwargs: object) -> tuple[int, str]:
+        fd, temp_path = real_mkstemp(*args, **kwargs)
+        path.write_text("external race\n", encoding="utf-8")
+        return fd, temp_path
+
+    def fail_temp_cleanup(
+        target: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        if os.fspath(target).endswith(".tmp"):
+            raise PermissionError("cleanup denied")
+        real_unlink(target, *args, **kwargs)
+
+    messages = io.StringIO()
+    sink_id = logger.add(messages, format="{message}")
+    try:
+        monkeypatch.setattr(service_module.tempfile, "mkstemp", change_after_temp)
+        monkeypatch.setattr(service_module.os, "unlink", fail_temp_cleanup)
+        result = service.save_file(opened, "draft\n", session_key="open-race")
+    finally:
+        logger.remove(sink_id)
+
+    assert result.status == "conflict"
+    assert path.read_text(encoding="utf-8") == "external race\n"
+    assert "Could not remove File Notes temporary file" in messages.getvalue()
+    assert "cleanup denied" in messages.getvalue()
 
 
 def test_create_is_exclusive_and_move_is_no_clobber_with_rollback(

--- a/Tests/Notes/test_file_notes_service.py
+++ b/Tests/Notes/test_file_notes_service.py
@@ -1,0 +1,414 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Avoid importing the unrelated optional MLX stack during focused Notes tests.
+sys.modules.setdefault("parakeet_mlx", types.ModuleType("parakeet_mlx"))
+
+import tldw_chatbook.Notes.file_notes_service as service_module  # noqa: E402
+from tldw_chatbook.Notes.file_notes_replica import FileNotesReplica  # noqa: E402
+from tldw_chatbook.Notes.file_notes_service import (  # noqa: E402
+    MAX_FILE_BYTES,
+    MAX_FILE_CHARS,
+    FileNotesService,
+)
+
+
+def _digest(raw_bytes: bytes) -> str:
+    return hashlib.sha256(raw_bytes).hexdigest()
+
+
+@pytest.fixture
+def replica() -> FileNotesReplica:
+    value = FileNotesReplica(":memory:")
+    yield value
+    value.close()
+
+
+def test_scan_excludes_git_and_symlinks_and_rejects_unsafe_paths(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+) -> None:
+    root = tmp_path / "notes"
+    outside = tmp_path / "outside"
+    (root / ".git").mkdir(parents=True)
+    (root / "nested").mkdir()
+    outside.mkdir()
+    (root / "visible.md").write_text("visible", encoding="utf-8")
+    (root / "nested" / "also.TEXT").write_text("also", encoding="utf-8")
+    (root / ".git" / "hidden.md").write_text("hidden", encoding="utf-8")
+    (root / "ignored.rst").write_text("ignored", encoding="utf-8")
+    (outside / "secret.md").write_text("secret", encoding="utf-8")
+    (root / "linked.md").symlink_to(outside / "secret.md")
+    (root / "linked-dir").symlink_to(outside, target_is_directory=True)
+    service = FileNotesService(root, replica)
+
+    result = service.scan()
+
+    assert not result.offline
+    assert [entry.relative_path for entry in result.entries] == [
+        "nested/also.TEXT",
+        "visible.md",
+    ]
+    with pytest.raises(ValueError, match="unsafe"):
+        service.open_file("../outside/secret.md")
+    with pytest.raises(ValueError, match="symlink"):
+        service.open_file("linked.md")
+    assert service.create_file("linked-dir/new.md", "nope").status == "unsafe"
+    assert service.move_file("ignored.rst", "moved.md").status == "unsupported"
+    assert (root / "ignored.rst").exists()
+    assert service.delete_file("ignored.rst").status == "unsupported"
+    assert (root / "ignored.rst").exists()
+
+
+def test_open_and_save_preserve_bom_frontmatter_crlf_final_newline_and_mode(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    path = root / "note.md"
+    raw = b"\xef\xbb\xbf---\r\ntitle: Exact\r\n...\r\nold\r\nbody\r\n"
+    path.write_bytes(raw)
+    path.chmod(0o640)
+    service = FileNotesService(root, replica)
+
+    opened = service.open_file("note.md")
+
+    assert opened.preserved_prefix == b"\xef\xbb\xbf---\r\ntitle: Exact\r\n...\r\n"
+    assert opened.body == "old\nbody\n"
+    assert opened.newline == "\r\n"
+    assert opened.has_final_newline
+    assert opened.content_hash == _digest(raw)
+
+    result = service.save_file(
+        opened,
+        "new\nbody",
+        session_key="open-1",
+    )
+
+    assert result.status == "ok"
+    assert path.read_bytes() == (
+        b"\xef\xbb\xbf---\r\ntitle: Exact\r\n...\r\nnew\r\nbody\r\n"
+    )
+    assert stat.S_IMODE(path.stat().st_mode) == 0o640
+    assert replica.get_bytes(str(root.resolve()), "note.md") == path.read_bytes()
+    assert [(change.action, change.relative_path) for change in service.session_changes] == [
+        ("modified", "note.md")
+    ]
+
+
+def test_open_keeps_unclosed_frontmatter_in_body_and_marks_unsafe_text_read_only(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert MAX_FILE_BYTES == 8_000_000
+    assert MAX_FILE_CHARS == 2_000_000
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "unclosed.md").write_bytes(b"\xef\xbb\xbf---\ntitle: Open\nbody")
+    (root / "mixed.md").write_bytes(b"one\r\ntwo\n")
+    (root / "binary.txt").write_bytes(b"\xef\xbb\xbf---\ntitle: Raw\n---\n\xff\xfe")
+    (root / "bytes.text").write_bytes(b"12345")
+    (root / "chars.markdown").write_text("abcd", encoding="utf-8")
+    service = FileNotesService(root, replica)
+
+    unclosed = service.open_file("unclosed.md")
+    assert unclosed.preserved_prefix == b"\xef\xbb\xbf"
+    assert unclosed.body == "---\ntitle: Open\nbody"
+    assert unclosed.editable
+    assert (
+        service.save_file(unclosed, "edited\n\n", session_key="no-final").status
+        == "ok"
+    )
+    assert (root / "unclosed.md").read_bytes() == b"\xef\xbb\xbfedited"
+    assert service.open_file("mixed.md").read_only_reason == "mixed-newlines"
+    binary = service.open_file("binary.txt")
+    assert binary.read_only_reason == "undecodable-utf8"
+    assert binary.preserved_prefix == b"\xef\xbb\xbf---\ntitle: Raw\n---\n"
+
+    monkeypatch.setattr(service_module, "MAX_FILE_BYTES", 4)
+
+    def reject_large_read(path: Path) -> tuple[bytes, os.stat_result]:
+        if path.name == "bytes.text":
+            raise AssertionError("over-limit file must not be read")
+        return real_read(path)
+
+    real_read = service_module._read_regular_file
+    monkeypatch.setattr(service_module, "_read_regular_file", reject_large_read)
+    large = service.open_file("bytes.text")
+    assert large.read_only_reason == "too-many-bytes"
+    assert large.raw_bytes == b""
+    assert service.delete_file("bytes.text").status == "readonly"
+    monkeypatch.setattr(service_module, "MAX_FILE_BYTES", 8_000_000)
+    monkeypatch.setattr(service_module, "MAX_FILE_CHARS", 3)
+    assert service.open_file("chars.markdown").read_only_reason == "too-many-chars"
+
+
+def test_save_conflict_and_protected_checkpoint_failure_never_write(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    path = root / "protected.md"
+    path.write_text("original\n", encoding="utf-8")
+    service = FileNotesService(root, replica)
+    opened = service.open_file("protected.md")
+
+    path.write_text("external\n", encoding="utf-8")
+    assert service.save_file(opened, "draft\n", session_key="open-1").status == (
+        "conflict"
+    )
+    assert path.read_text(encoding="utf-8") == "external\n"
+
+    opened = service.open_file("protected.md")
+    replica.protect(str(root.resolve()), "protected.md")
+
+    def fail_checkpoint(*args: object, **kwargs: object) -> bool:
+        raise RuntimeError("replica unavailable")
+
+    monkeypatch.setattr(replica, "checkpoint", fail_checkpoint)
+    result = service.save_file(opened, "must not write\n", session_key="open-2")
+
+    assert result.status == "replica-error"
+    assert path.read_text(encoding="utf-8") == "external\n"
+
+
+def test_save_rechecks_hash_immediately_before_replace_and_cleans_temp(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    path = root / "race.md"
+    path.write_text("baseline\n", encoding="utf-8")
+    service = FileNotesService(root, replica)
+    opened = service.open_file("race.md")
+    real_mkstemp = service_module.tempfile.mkstemp
+
+    def change_after_temp(*args: object, **kwargs: object) -> tuple[int, str]:
+        fd, temp_path = real_mkstemp(*args, **kwargs)
+        path.write_text("external race\n", encoding="utf-8")
+        return fd, temp_path
+
+    monkeypatch.setattr(service_module.tempfile, "mkstemp", change_after_temp)
+    result = service.save_file(opened, "draft\n", session_key="open-race")
+
+    assert result.status == "conflict"
+    assert path.read_text(encoding="utf-8") == "external race\n"
+    assert list(root.glob("*.tmp")) == []
+
+
+def test_create_is_exclusive_and_move_is_no_clobber_with_rollback(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "notes"
+    (root / "folder").mkdir(parents=True)
+    service = FileNotesService(root, replica)
+
+    assert service.create_file("source.md", "source").status == "ok"
+    assert service.create_file("source.md", "replacement").status == "exists"
+    (root / "folder" / "target.md").write_text("target", encoding="utf-8")
+    assert service.move_file("source.md", "folder/target.md").status == "exists"
+    assert (root / "source.md").read_text(encoding="utf-8") == "source"
+
+    real_unlink = service_module.os.unlink
+
+    def fail_source_unlink(path: str | os.PathLike[str], *args: object, **kwargs: object) -> None:
+        if Path(path) == root / "source.md":
+            raise PermissionError("forced source failure")
+        real_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(service_module.os, "unlink", fail_source_unlink)
+    result = service.move_file("source.md", "folder/moved.md")
+
+    assert result.status == "error"
+    assert (root / "source.md").exists()
+    assert not (root / "folder" / "moved.md").exists()
+
+
+def test_delete_rechecks_after_tombstone_and_restore_requires_absent_destination(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    path = root / "delete.md"
+    original = b"exact deletion bytes\r\n"
+    path.write_bytes(original)
+    service = FileNotesService(root, replica)
+    opened = service.open_file("delete.md")
+    real_prepare = replica.prepare_deletion
+
+    def change_after_prepare(*args: object, **kwargs: object) -> None:
+        real_prepare(*args, **kwargs)
+        path.write_bytes(b"external change")
+
+    monkeypatch.setattr(replica, "prepare_deletion", change_after_prepare)
+    result = service.delete_file("delete.md", expected_hash=opened.content_hash)
+
+    assert result.status == "conflict"
+    assert path.read_bytes() == b"external change"
+    assert replica.list_deleted(str(root.resolve())) == []
+
+    monkeypatch.setattr(replica, "prepare_deletion", real_prepare)
+    opened = service.open_file("delete.md")
+    assert (
+        service.delete_file("delete.md", expected_hash=opened.content_hash).status
+        == "ok"
+    )
+    assert not path.exists()
+    path.write_bytes(b"occupied")
+    assert service.restore_file("delete.md").status == "exists"
+    assert path.read_bytes() == b"occupied"
+    path.unlink()
+    assert service.restore_file("delete.md").status == "ok"
+    assert path.read_bytes() == b"external change"
+
+
+def test_delete_clears_tombstone_when_unlink_fails(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    path = root / "keep.md"
+    path.write_text("keep", encoding="utf-8")
+    service = FileNotesService(root, replica)
+    opened = service.open_file("keep.md")
+
+    def fail_unlink(*args: object, **kwargs: object) -> None:
+        raise PermissionError("forced")
+
+    monkeypatch.setattr(service_module.os, "unlink", fail_unlink)
+    result = service.delete_file("keep.md", expected_hash=opened.content_hash)
+
+    assert result.status == "error"
+    assert path.exists()
+    assert replica.list_deleted(str(root.resolve())) == []
+
+
+def test_reconcile_projects_external_changes_without_session_changes(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "modified.md").write_text("old", encoding="utf-8")
+    (root / "deleted.md").write_text("gone", encoding="utf-8")
+    service = FileNotesService(root, replica)
+    assert not service.scan().offline
+    real_read = service_module._read_regular_file
+    reads: list[str] = []
+
+    def count_reads(path: Path) -> tuple[bytes, os.stat_result]:
+        reads.append(path.name)
+        return real_read(path)
+
+    monkeypatch.setattr(service_module, "_read_regular_file", count_reads)
+    unchanged = service.reconcile()
+    assert unchanged.created == unchanged.modified == unchanged.deleted == ()
+    assert reads == []
+
+    (root / "modified.md").write_text("new content", encoding="utf-8")
+    (root / "deleted.md").unlink()
+    (root / "created.txt").write_text("created", encoding="utf-8")
+    result = service.reconcile()
+
+    assert result.status == "ok"
+    assert result.created == ("created.txt",)
+    assert result.modified == ("modified.md",)
+    assert result.deleted == ("deleted.md",)
+    assert sorted(reads) == ["created.txt", "modified.md"]
+    assert service.session_changes == ()
+    assert replica.search(str(root.resolve()), "created") == ["created.txt"]
+    assert replica.list_deleted(str(root.resolve())) == ["deleted.md"]
+
+
+def test_reconcile_does_not_tombstone_a_present_file_when_its_read_fails(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    keep = root / "keep.md"
+    gone = root / "gone.md"
+    keep.write_text("old", encoding="utf-8")
+    gone.write_text("gone", encoding="utf-8")
+    service = FileNotesService(root, replica)
+    service.scan()
+    gone.unlink()
+    keep.write_text("changed", encoding="utf-8")
+    real_read = service_module._read_regular_file
+
+    def fail_keep(path: Path) -> tuple[bytes, os.stat_result]:
+        if path == keep:
+            raise PermissionError("transient")
+        return real_read(path)
+
+    monkeypatch.setattr(service_module, "_read_regular_file", fail_keep)
+    result = service.reconcile()
+
+    assert result.deleted == ("gone.md",)
+    assert replica.list_deleted(str(root.resolve())) == ["gone.md"]
+    assert "keep.md" in {
+        item.relative_path
+        for item in replica.list_active_files(str(root.resolve()))
+    }
+
+
+def test_offline_reconcile_does_not_create_or_touch_replica(tmp_path: Path) -> None:
+    class FailingReplica:
+        def __getattr__(self, name: str) -> object:
+            raise AssertionError(f"replica must not be touched: {name}")
+
+    root = tmp_path / "missing"
+    service = FileNotesService(root, FailingReplica())  # type: ignore[arg-type]
+
+    result = service.reconcile()
+
+    assert result.status == "offline"
+    assert result.offline
+    assert not root.exists()
+
+
+def test_replica_failure_warns_but_allows_unprotected_save_and_blocks_delete(
+    tmp_path: Path,
+) -> None:
+    class UnavailableReplica:
+        def __getattr__(self, name: str) -> object:
+            raise RuntimeError(f"{name} unavailable")
+
+    root = tmp_path / "notes"
+    root.mkdir()
+    path = root / "note.md"
+    path.write_text("old\n", encoding="utf-8")
+    service = FileNotesService(root, UnavailableReplica())  # type: ignore[arg-type]
+    opened = service.open_file("note.md")
+
+    saved = service.save_file(opened, "new\n", session_key="open-1")
+
+    assert saved.status == "ok"
+    assert saved.replica_warning
+    assert path.read_text(encoding="utf-8") == "new\n"
+    assert service.delete_file("note.md", expected_hash=saved.content_hash).status == (
+        "replica-error"
+    )
+    assert path.exists()

--- a/Tests/Notes/test_file_notes_service.py
+++ b/Tests/Notes/test_file_notes_service.py
@@ -137,20 +137,69 @@ def test_open_keeps_unclosed_frontmatter_in_body_and_marks_unsafe_text_read_only
 
     monkeypatch.setattr(service_module, "MAX_FILE_BYTES", 4)
 
-    def reject_large_read(path: Path) -> tuple[bytes, os.stat_result]:
-        if path.name == "bytes.text":
-            raise AssertionError("over-limit file must not be read")
-        return real_read(path)
-
-    real_read = service_module._read_regular_file
-    monkeypatch.setattr(service_module, "_read_regular_file", reject_large_read)
     large = service.open_file("bytes.text")
     assert large.read_only_reason == "too-many-bytes"
-    assert large.raw_bytes == b""
-    assert service.delete_file("bytes.text").status == "readonly"
+    assert large.raw_bytes == b"12345"
     monkeypatch.setattr(service_module, "MAX_FILE_BYTES", 8_000_000)
     monkeypatch.setattr(service_module, "MAX_FILE_CHARS", 3)
     assert service.open_file("chars.markdown").read_only_reason == "too-many-chars"
+
+
+def test_oversized_file_keeps_exact_replica_and_can_delete_and_restore(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    large_path = root / "large.md"
+    grows_path = root / "grows.md"
+    large_path.write_bytes(b"12345")
+    grows_path.write_bytes(b"old")
+    monkeypatch.setattr(service_module, "MAX_FILE_BYTES", 4)
+    service = FileNotesService(root, replica)
+
+    scanned = service.scan()
+
+    scanned_by_path = {entry.relative_path: entry for entry in scanned.entries}
+    assert scanned_by_path["large.md"].read_only_reason == "too-many-bytes"
+    assert replica.get_bytes(str(root.resolve()), "large.md") == b"12345"
+    replica_by_path = {
+        item.relative_path: item
+        for item in replica.list_active_files(str(root.resolve()))
+    }
+    assert replica_by_path["large.md"].content_hash == _digest(b"12345")
+
+    upsert_calls = 0
+    real_upsert = replica.upsert_file
+
+    def record_upsert(*args: object, **kwargs: object) -> None:
+        nonlocal upsert_calls
+        upsert_calls += 1
+        real_upsert(*args, **kwargs)
+
+    monkeypatch.setattr(replica, "upsert_file", record_upsert)
+    assert service.reconcile().modified == ()
+    assert upsert_calls == 0
+
+    assert replica.search(str(root.resolve()), "old") == ["grows.md"]
+    grows_path.write_bytes(b"changed")
+    reconciled = service.reconcile()
+    assert reconciled.modified == ("grows.md",)
+    assert upsert_calls == 1
+    assert replica.get_bytes(str(root.resolve()), "grows.md") == b"changed"
+    assert replica.search(str(root.resolve()), "old") == []
+
+    opened = service.open_file("large.md")
+    assert opened.content_hash == _digest(b"12345")
+    deleted = service.delete_file("large.md", expected_hash=opened.content_hash)
+    assert deleted.status == "ok"
+    assert not large_path.exists()
+    assert replica.get_restore_bytes(str(root.resolve()), "large.md") == b"12345"
+
+    restored = service.restore_file("large.md")
+    assert restored.status == "ok"
+    assert large_path.read_bytes() == b"12345"
 
 
 def test_save_conflict_and_protected_checkpoint_failure_never_write(
@@ -301,6 +350,66 @@ def test_delete_clears_tombstone_when_unlink_fails(
     assert result.status == "error"
     assert path.exists()
     assert replica.list_deleted(str(root.resolve())) == []
+
+
+def test_delete_clears_tombstone_when_final_reread_becomes_non_regular(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    path = root / "changed-kind.md"
+    path.write_text("keep", encoding="utf-8")
+    service = FileNotesService(root, replica)
+    opened = service.open_file("changed-kind.md")
+    real_read = service_module._read_regular_file
+    read_count = 0
+
+    def fail_final_read(candidate: Path) -> tuple[bytes, os.stat_result]:
+        nonlocal read_count
+        read_count += 1
+        if read_count == 2:
+            raise ValueError("unsafe non-regular file")
+        return real_read(candidate)
+
+    monkeypatch.setattr(service_module, "_read_regular_file", fail_final_read)
+    result = service.delete_file(
+        "changed-kind.md",
+        expected_hash=opened.content_hash,
+    )
+
+    assert result.status in {"conflict", "error"}
+    assert path.exists()
+    assert replica.list_deleted(str(root.resolve())) == []
+
+
+def test_double_dot_filename_is_safe_for_file_mutations(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    service = FileNotesService(root, replica)
+
+    created = service.create_file("meeting..draft.md", "draft")
+    assert created.status == "ok"
+    opened = service.open_file("meeting..draft.md")
+    assert service.save_file(opened, "edited", session_key="double-dot").status == "ok"
+    assert (
+        service.move_file("meeting..draft.md", "meeting..final.md").status
+        == "ok"
+    )
+    moved = service.open_file("meeting..final.md")
+    assert (
+        service.delete_file(
+            "meeting..final.md",
+            expected_hash=moved.content_hash,
+        ).status
+        == "ok"
+    )
+    assert service.restore_file("meeting..final.md").status == "ok"
+    assert (root / "meeting..final.md").read_text(encoding="utf-8") == "edited"
 
 
 def test_reconcile_projects_external_changes_without_session_changes(

--- a/Tests/Notes/test_file_notes_service.py
+++ b/Tests/Notes/test_file_notes_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import sqlite3
 import stat
 import sys
 import types
@@ -687,3 +688,35 @@ def test_replica_failure_warns_but_allows_unprotected_save_and_blocks_delete(
         "replica-error"
     )
     assert path.exists()
+
+
+def test_close_waits_for_active_operation_before_closing_replica(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "note.md").write_text("body", encoding="utf-8")
+    replica = FileNotesReplica(":memory:")
+    service = FileNotesService(root, replica)
+    scan_started = Event()
+    release_scan = Event()
+    real_walk = service._walk_candidates
+
+    def delayed_walk():
+        scan_started.set()
+        release_scan.wait(5)
+        return real_walk()
+
+    monkeypatch.setattr(service, "_walk_candidates", delayed_walk)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        scan = executor.submit(service.scan)
+        assert scan_started.wait(1)
+        close = executor.submit(service.close)
+        assert not close.done()
+        release_scan.set()
+        assert scan.result().status == "ok"
+        close.result()
+
+    with pytest.raises(sqlite3.ProgrammingError):
+        replica.list_deleted(str(root.resolve()))

--- a/Tests/Notes/test_file_notes_service.py
+++ b/Tests/Notes/test_file_notes_service.py
@@ -5,7 +5,9 @@ import os
 import stat
 import sys
 import types
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from threading import Event
 
 import pytest
 
@@ -103,6 +105,68 @@ def test_open_and_save_preserve_bom_frontmatter_crlf_final_newline_and_mode(
     assert [(change.action, change.relative_path) for change in service.session_changes] == [
         ("modified", "note.md")
     ]
+
+
+@pytest.mark.parametrize("operation", ["save", "create", "restore"])
+def test_post_publication_stat_failure_still_records_success(
+    operation: str,
+    tmp_path: Path,
+    replica: FileNotesReplica,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    service = FileNotesService(root, replica)
+    target = root / f"{operation}.md"
+    if operation == "save":
+        target.write_bytes(b"before")
+        opened = service.open_file(target.name)
+        expected = b"after"
+        action = "modified"
+    elif operation == "restore":
+        target.write_bytes(b"restore me")
+        opened = service.open_file(target.name)
+        assert (
+            service.delete_file(
+                target.name,
+                expected_hash=opened.content_hash,
+            ).status
+            == "ok"
+        )
+        expected = b"restore me"
+        action = "restored"
+    else:
+        expected = b"created"
+        action = "created"
+
+    real_stat = Path.stat
+
+    def fail_published_stat(
+        candidate: Path,
+        *args: object,
+        **kwargs: object,
+    ) -> os.stat_result:
+        if candidate == target:
+            raise FileNotFoundError("forced post-publication race")
+        return real_stat(candidate, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", fail_published_stat)
+    if operation == "save":
+        result = service.save_file(opened, "after", session_key="post-publish")
+    elif operation == "restore":
+        result = service.restore_file(target.name)
+    else:
+        result = service.create_file(target.name, "created")
+    monkeypatch.setattr(Path, "stat", real_stat)
+
+    assert result.status == "ok"
+    assert result.content_hash == _digest(expected)
+    assert result.replica_warning
+    assert target.read_bytes() == expected
+    assert service.session_changes[-1].action == action
+
+    service.reconcile()
+    assert replica.get_bytes(str(root.resolve()), target.name) == expected
 
 
 def test_open_keeps_unclosed_frontmatter_in_body_and_marks_unsafe_text_read_only(
@@ -384,6 +448,57 @@ def test_delete_clears_tombstone_when_final_reread_becomes_non_regular(
     assert replica.list_deleted(str(root.resolve())) == []
 
 
+def test_public_operations_and_session_changes_share_one_service_lock(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    path = root / "locked.md"
+    path.write_text("locked", encoding="utf-8")
+    service = FileNotesService(root, replica)
+    opened = service.open_file("locked.md")
+    prepared = Event()
+    release_delete = Event()
+    reconcile_entered = Event()
+    real_prepare = replica.prepare_deletion
+    real_list_active = replica.list_active_files
+
+    def block_after_prepare(*args: object, **kwargs: object) -> None:
+        real_prepare(*args, **kwargs)
+        prepared.set()
+        assert release_delete.wait(timeout=2)
+
+    def record_reconcile_entry(*args: object, **kwargs: object) -> object:
+        reconcile_entered.set()
+        return real_list_active(*args, **kwargs)
+
+    monkeypatch.setattr(replica, "prepare_deletion", block_after_prepare)
+    monkeypatch.setattr(replica, "list_active_files", record_reconcile_entry)
+
+    with ThreadPoolExecutor(max_workers=3) as executor:
+        deletion = executor.submit(
+            service.delete_file,
+            "locked.md",
+            expected_hash=opened.content_hash,
+        )
+        assert prepared.wait(timeout=1)
+        reconciliation = executor.submit(service.reconcile)
+        session_read = executor.submit(lambda: service.session_changes)
+        try:
+            assert not reconcile_entered.wait(timeout=0.1)
+            assert not session_read.done()
+        finally:
+            release_delete.set()
+
+        assert deletion.result(timeout=1).status == "ok"
+        assert reconciliation.result(timeout=1).status == "ok"
+        assert session_read.result(timeout=1)[-1].action == "deleted"
+
+    assert replica.list_deleted(str(root.resolve())) == ["locked.md"]
+
+
 def test_double_dot_filename_is_safe_for_file_mutations(
     tmp_path: Path,
     replica: FileNotesReplica,
@@ -410,6 +525,26 @@ def test_double_dot_filename_is_safe_for_file_mutations(
     )
     assert service.restore_file("meeting..final.md").status == "ok"
     assert (root / "meeting..final.md").read_text(encoding="utf-8") == "edited"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Backslash is a separator on Windows")
+def test_paths_require_canonical_posix_spelling_but_allow_backslash_filename(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+) -> None:
+    root = tmp_path / "notes"
+    (root / "folder").mkdir(parents=True)
+    (root / "folder" / "note.md").write_text("note", encoding="utf-8")
+    service = FileNotesService(root, replica)
+
+    with pytest.raises(ValueError, match="canonical"):
+        service.open_file("folder//note.md")
+    assert service.create_file("./new.md", "nope").status == "unsafe"
+
+    backslash_name = r"meeting\notes.md"
+    assert service.create_file(backslash_name, "legal").status == "ok"
+    opened = service.open_file(backslash_name)
+    assert opened.body == "legal"
 
 
 def test_reconcile_projects_external_changes_without_session_changes(

--- a/Tests/UI/test_library_file_notes_workspace.py
+++ b/Tests/UI/test_library_file_notes_workspace.py
@@ -16,6 +16,7 @@ sys.modules.setdefault("parakeet_mlx", types.ModuleType("parakeet_mlx"))
 
 import tldw_chatbook.Widgets.Library.library_file_notes_workspace as workspace_module  # noqa: E402
 from tldw_chatbook.Library.library_shell_state import (  # noqa: E402
+    LIBRARY_ROW_BROWSE_MEDIA,
     LIBRARY_ROW_BROWSE_NOTES,
 )
 from tldw_chatbook.Notes.file_notes_replica import FileNotesReplica  # noqa: E402
@@ -179,17 +180,26 @@ async def test_tree_search_open_dirty_and_autosave_keep_one_editor(
             "search results did not replace the tree",
         )
         assert not tree.display
-        assert "folder/alpha.md" in _tree_labels(
-            workspace.query_one("#file-notes-search-results", Tree)
+        results = workspace.query_one("#file-notes-search-results", Tree)
+        assert "folder/alpha.md" in _tree_labels(results)
+        editor = workspace.query_one("#file-notes-editor", TextArea)
+        match = next(
+            node
+            for node in results.root.children
+            if node.data == ("file", "folder/alpha.md")
         )
+        results.select_node(match)
+        await _wait_until(
+            pilot,
+            lambda: workspace.current_path == "folder/alpha.md",
+            "selecting the visible search result did not open its file",
+        )
+        assert editor.text == "needle in this body\n"
+
         search.value = ""
         await _wait_until(pilot, lambda: tree.display, "tree did not return")
 
-        editor = workspace.query_one("#file-notes-editor", TextArea)
-        assert await workspace.open_path("folder/alpha.md")
-        await pilot.pause()
         assert workspace.query_one("#file-notes-editor", TextArea) is editor
-        assert editor.text == "needle in this body\n"
         assert workspace.save_state == "saved"
 
         _replace_editor_text(editor, "changed body")
@@ -550,6 +560,9 @@ async def test_library_database_files_switch_retains_workspace_and_database_canv
     root = tmp_path / "notes"
     root.mkdir()
     (root / "library.md").write_text("library file", encoding="utf-8")
+    (root / "other.md").write_text("other file", encoding="utf-8")
+    replacement_root = tmp_path / "replacement"
+    replacement_root.mkdir()
     replica = FileNotesReplica(":memory:")
     workspace = LibraryFileNotesWorkspace(
         root=root,
@@ -619,6 +632,24 @@ async def test_library_database_files_switch_retains_workspace_and_database_canv
         (root / "library.md").write_text("external", encoding="utf-8")
         await retained.refresh_files()
         assert retained.save_state == "conflict"
+
+        assert not await retained.open_path("other.md")
+        assert retained.current_path == "library.md"
+        assert editor.text == "draft"
+
+        assert not await retained.set_root(replacement_root, persist=False)
+        assert retained.root == root.resolve()
+        assert editor.text == "draft"
+
+        assert not await screen.flush_pending_work()
+        assert screen._library_selected_row_id == LIBRARY_ROW_BROWSE_NOTES
+        assert screen.query_one("#library-file-notes-workspace") is retained
+
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_MEDIA)
+        assert screen._library_selected_row_id == LIBRARY_ROW_BROWSE_NOTES
+        assert screen.query_one("#library-file-notes-workspace") is retained
+        assert editor.text == "draft"
+
         screen.query_one("#library-notes-source-database", Button).press()
         await pilot.pause()
         assert screen._library_notes_source == "files"

--- a/Tests/UI/test_library_file_notes_workspace.py
+++ b/Tests/UI/test_library_file_notes_workspace.py
@@ -169,8 +169,6 @@ async def test_root_transition_retains_and_freezes_old_document_until_scan_finis
     original_scan = FileNotesService.scan
     scan_started = threading.Event()
     release_scan = threading.Event()
-    open_started = threading.Event()
-    release_open = threading.Event()
 
     def delayed_scan(service):
         if service.root == new_root.resolve():
@@ -189,19 +187,6 @@ async def test_root_transition_retains_and_freezes_old_document_until_scan_finis
             lambda: workspace.save_state == "dirty",
             "root-change draft did not become dirty",
         )
-        service = workspace._service
-        assert service is not None
-        original_open = service.open_file
-
-        def delayed_open(relative_path):
-            open_started.set()
-            release_open.wait(5)
-            return original_open(relative_path)
-
-        monkeypatch.setattr(service, "open_file", delayed_open)
-        opening = asyncio.create_task(workspace.open_path("old.md"))
-        await _wait_until(pilot, open_started.is_set, "old-root open did not start")
-
         transition = asyncio.create_task(
             workspace.set_root(new_root, persist=False)
         )
@@ -226,10 +211,7 @@ async def test_root_transition_retains_and_freezes_old_document_until_scan_finis
         assert workspace.current_path == ""
         assert editor.text == ""
         assert "new.md" in workspace.entries
-        release_open.set()
-        assert not await opening
     release_scan.set()
-    release_open.set()
     replica.close()
 
 
@@ -679,6 +661,8 @@ async def test_library_database_files_switch_retains_workspace_and_database_canv
     host = LibraryHarness(app, screen=screen)
     save_started = threading.Event()
     release_save = threading.Event()
+    open_started = threading.Event()
+    release_open = threading.Event()
     detail_started = threading.Event()
     release_detail = threading.Event()
 
@@ -747,6 +731,31 @@ async def test_library_database_files_switch_retains_workspace_and_database_canv
         screen._library_notes_view = "list"
         screen._selected_note_id = None
 
+        assert await retained.open_path("library.md")
+        service = retained._service
+        assert service is not None
+        original_open = service.open_file
+
+        def delayed_open(relative_path):
+            if relative_path == "other.md":
+                open_started.set()
+                release_open.wait(5)
+            return original_open(relative_path)
+
+        monkeypatch.setattr(service, "open_file", delayed_open)
+        opening = asyncio.create_task(retained.open_path("other.md"))
+        await _wait_until(pilot, open_started.is_set, "slow open did not start")
+        before_open = editor.text
+        editor.focus()
+        await pilot.press("x")
+        competing_open = await retained.open_path("library.md")
+        frozen_during_open = editor.read_only
+        text_during_open = editor.text
+        release_open.set()
+        assert await opening
+        monkeypatch.setattr(service, "open_file", original_open)
+        assert await retained.open_path("library.md")
+
         screen._apply_local_source_snapshot(
             {
                 "notes": ({"title": "Updated DB note", "id": "db-note-2"},),
@@ -760,7 +769,6 @@ async def test_library_database_files_switch_retains_workspace_and_database_canv
         assert screen.query_one("#library-file-notes-workspace") is retained
         assert retained.query_one("#file-notes-editor", TextArea) is editor
 
-        await retained.open_path("library.md")
         _replace_editor_text(editor, "draft")
         await pilot.pause()
         (root / "library.md").write_text("external", encoding="utf-8")
@@ -834,16 +842,14 @@ async def test_library_database_files_switch_retains_workspace_and_database_canv
             "#file-notes-session-changes",
         )
 
-        service = retained._service
-        assert service is not None
-        original_save = service.save_file
+        original_finish = service._finish_published_file
 
-        def delayed_save(*args, **kwargs):
+        def delayed_finish(*args, **kwargs):
             save_started.set()
             release_save.wait(5)
-            return original_save(*args, **kwargs)
+            return original_finish(*args, **kwargs)
 
-        monkeypatch.setattr(service, "save_file", delayed_save)
+        monkeypatch.setattr(service, "_finish_published_file", delayed_finish)
         _replace_editor_text(editor, "draft across forced remount")
         await _wait_until(
             pilot,
@@ -856,23 +862,33 @@ async def test_library_database_files_switch_retains_workspace_and_database_canv
             lambda: save_started.is_set() and retained.save_state == "saving",
             "forced-remount save did not start",
         )
+        session_key = retained._session_key
 
         screen.refresh(recompose=True)
         await _wait_until(
             pilot,
             lambda: retained.save_state == "dirty"
-            and retained._autosave_timer is not None
+            and retained._active
             and bool(screen.query("#library-file-notes-workspace")),
             "Files workspace did not remount during save",
         )
-        assert retained.save_state == "dirty"
-        assert retained._autosave_timer is not None
-        assert retained.query_one("#file-notes-editor", TextArea).text == (
+        timer_before_release = retained._autosave_timer
+        release_save.set()
+        await _wait_until(
+            pilot,
+            lambda: retained.save_state == "saved",
+            "published remount draft was not adopted",
+        )
+        assert timer_before_release is None
+        assert (root / "library.md").read_text(encoding="utf-8") == (
             "draft across forced remount"
         )
-        release_save.set()
-        await pilot.pause()
+        assert editor.text == "draft across forced remount"
+        assert retained._session_key == session_key
         assert retained.query_one("#file-notes-editor", TextArea) is editor
+        assert not competing_open
+        assert frozen_during_open
+        assert text_during_open == before_open
     assert workspace._shutdown
     await workspace.shutdown()
     with pytest.raises(sqlite3.ProgrammingError):

--- a/Tests/UI/test_library_file_notes_workspace.py
+++ b/Tests/UI/test_library_file_notes_workspace.py
@@ -1,0 +1,671 @@
+"""Focused mounted tests for Library File Notes."""
+
+from __future__ import annotations
+
+import sys
+import types
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button, Input, Static, TextArea, Tree
+
+# Avoid importing the unrelated optional MLX stack during focused UI tests.
+sys.modules.setdefault("parakeet_mlx", types.ModuleType("parakeet_mlx"))
+
+import tldw_chatbook.Widgets.Library.library_file_notes_workspace as workspace_module  # noqa: E402
+from tldw_chatbook.Library.library_shell_state import (  # noqa: E402
+    LIBRARY_ROW_BROWSE_NOTES,
+)
+from tldw_chatbook.Notes.file_notes_replica import FileNotesReplica  # noqa: E402
+from tldw_chatbook.UI.Screens.library_screen import LibraryScreen  # noqa: E402
+from tldw_chatbook.Widgets.Library.library_file_notes_workspace import (  # noqa: E402
+    LibraryFileNotesWorkspace,
+)
+from Tests.UI.test_library_shell import (  # noqa: E402
+    LIBRARY_TEST_SIZE,
+    LibraryHarness,
+    _seed_conversations,
+    _two_conversations,
+    _wait_for_library_shell,
+)
+from Tests.UI.test_screen_navigation import _build_test_app  # noqa: E402
+
+
+class _WorkspaceHarness(App[None]):
+    """Mount one retained workspace without the rest of Library."""
+
+    def __init__(self, workspace: LibraryFileNotesWorkspace) -> None:
+        super().__init__()
+        self.workspace = workspace
+
+    def compose(self) -> ComposeResult:
+        yield self.workspace
+
+
+async def _wait_until(
+    pilot,
+    predicate: Callable[[], bool],
+    message: str,
+    *,
+    attempts: int = 150,
+) -> None:
+    for _ in range(attempts):
+        if predicate():
+            return
+        await pilot.pause(0.02)
+    raise AssertionError(message)
+
+
+def _static_text(workspace: LibraryFileNotesWorkspace, selector: str) -> str:
+    renderable = workspace.query_one(selector, Static).renderable
+    return getattr(renderable, "plain", str(renderable))
+
+
+def _tree_labels(tree: Tree) -> list[str]:
+    labels: list[str] = []
+
+    def visit(node) -> None:
+        label = getattr(node.label, "plain", str(node.label))
+        labels.append(label)
+        for child in node.children:
+            visit(child)
+
+    visit(tree.root)
+    return labels
+
+
+def _replace_editor_text(editor: TextArea, text: str) -> None:
+    editor.select_all()
+    editor.replace(text, editor.selection.start, editor.selection.end)
+
+
+@pytest.mark.asyncio
+async def test_empty_offline_and_persisted_root_states(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    replica = FileNotesReplica(":memory:")
+    empty = LibraryFileNotesWorkspace(root=None, replica=replica)
+    async with _WorkspaceHarness(empty).run_test() as pilot:
+        await pilot.pause()
+        assert empty.query_one("#file-notes-choose-root", Button).display
+        assert (
+            _static_text(empty, "#file-notes-root-status") == "Choose a notes folder."
+        )
+
+        root = tmp_path / "chosen"
+        root.mkdir()
+        saved: list[tuple[str, str, str]] = []
+        monkeypatch.setattr(
+            workspace_module,
+            "save_setting_to_cli_config",
+            lambda section, key, value: saved.append((section, key, value)) or True,
+        )
+        assert await empty.set_root(root)
+        assert saved == [("file_notes", "root", str(root.resolve()))]
+    replica.close()
+
+    missing_root = tmp_path / "missing"
+    offline_replica = FileNotesReplica(":memory:")
+    offline = LibraryFileNotesWorkspace(root=missing_root, replica=offline_replica)
+    async with _WorkspaceHarness(offline).run_test() as pilot:
+        await _wait_until(
+            pilot,
+            lambda: offline.initialized,
+            "offline root scan did not finish",
+        )
+        assert not missing_root.exists()
+        assert "Offline" in _static_text(offline, "#file-notes-root-status")
+    offline_replica.close()
+
+    persisted_root = tmp_path / "persisted"
+    persisted_root.mkdir()
+    (persisted_root / "kept.md").write_text("persisted body", encoding="utf-8")
+    monkeypatch.setattr(
+        workspace_module,
+        "get_cli_setting",
+        lambda section, key=None, default=None: (
+            str(persisted_root) if (section, key) == ("file_notes", "root") else default
+        ),
+    )
+    persisted_replica = FileNotesReplica(":memory:")
+    persisted = LibraryFileNotesWorkspace(replica=persisted_replica)
+    async with _WorkspaceHarness(persisted).run_test() as pilot:
+        await _wait_until(
+            pilot,
+            lambda: persisted.initialized and "kept.md" in persisted.entries,
+            "persisted root was not scanned",
+        )
+        assert persisted.root == persisted_root.resolve()
+        assert "kept.md" in _tree_labels(persisted.query_one("#file-notes-tree", Tree))
+    persisted_replica.close()
+
+
+@pytest.mark.asyncio
+async def test_tree_search_open_dirty_and_autosave_keep_one_editor(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "notes"
+    (root / "folder").mkdir(parents=True)
+    (root / "folder" / "alpha.md").write_text(
+        "needle in this body\n",
+        encoding="utf-8",
+    )
+    (root / "beta.txt").write_text("other body", encoding="utf-8")
+    replica = FileNotesReplica(":memory:")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica=replica,
+        autosave_delay=0.08,
+        poll_interval=10,
+    )
+
+    async with _WorkspaceHarness(workspace).run_test(size=(110, 36)) as pilot:
+        await _wait_until(
+            pilot,
+            lambda: workspace.initialized and len(workspace.entries) == 2,
+            "initial tree did not load",
+        )
+        tree = workspace.query_one("#file-notes-tree", Tree)
+        assert {"folder", "alpha.md", "beta.txt"}.issubset(_tree_labels(tree))
+
+        search = workspace.query_one("#file-notes-search", Input)
+        search.value = "needle"
+        await _wait_until(
+            pilot,
+            lambda: workspace.query_one("#file-notes-search-results", Tree).display,
+            "search results did not replace the tree",
+        )
+        assert not tree.display
+        assert "folder/alpha.md" in _tree_labels(
+            workspace.query_one("#file-notes-search-results", Tree)
+        )
+        search.value = ""
+        await _wait_until(pilot, lambda: tree.display, "tree did not return")
+
+        editor = workspace.query_one("#file-notes-editor", TextArea)
+        assert await workspace.open_path("folder/alpha.md")
+        await pilot.pause()
+        assert workspace.query_one("#file-notes-editor", TextArea) is editor
+        assert editor.text == "needle in this body\n"
+        assert workspace.save_state == "saved"
+
+        _replace_editor_text(editor, "changed body")
+        await _wait_until(
+            pilot,
+            lambda: workspace.save_state == "dirty",
+            "body edit did not become dirty",
+        )
+        assert not workspace.leave_allowed
+        await _wait_until(
+            pilot,
+            lambda: workspace.save_state == "saved",
+            "debounced autosave did not complete",
+        )
+        assert (root / "folder" / "alpha.md").read_text(encoding="utf-8") == (
+            "changed body\n"
+        )
+        assert workspace.query_one("#file-notes-editor", TextArea) is editor
+    replica.close()
+
+
+@pytest.mark.asyncio
+async def test_create_move_delete_protect_and_restore_use_real_service(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "start.md").write_text("start", encoding="utf-8")
+    replica = FileNotesReplica(":memory:")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica=replica,
+        poll_interval=10,
+    )
+
+    async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        assert await workspace.open_path("start.md")
+
+        path_input = workspace.query_one("#file-notes-path", Input)
+        path_input.value = "created.md"
+        workspace.query_one("#file-notes-new", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.current_path == "created.md",
+            "new file did not open",
+        )
+        assert (root / "created.md").exists()
+
+        workspace.query_one("#file-notes-protect", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: (
+                workspace.current_document is not None
+                and workspace.current_document.protected
+            ),
+            "protect did not apply",
+        )
+        assert str(workspace.query_one("#file-notes-protect", Button).label) == (
+            "Unprotect"
+        )
+        workspace.query_one("#file-notes-protect", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: (
+                workspace.current_document is not None
+                and not workspace.current_document.protected
+            ),
+            "unprotect did not apply",
+        )
+
+        path_input.value = "moved.md"
+        workspace.query_one("#file-notes-move", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.current_path == "moved.md",
+            "move did not open destination",
+        )
+        assert not (root / "created.md").exists()
+        assert (root / "moved.md").exists()
+
+        workspace.query_one("#file-notes-delete", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: (
+                str(workspace.query_one("#file-notes-delete", Button).label)
+                == "Confirm delete"
+            ),
+            "delete confirmation did not arm",
+        )
+        assert (root / "moved.md").exists()
+        assert str(workspace.query_one("#file-notes-delete", Button).label) == (
+            "Confirm delete"
+        )
+        workspace.query_one("#file-notes-delete", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: not (root / "moved.md").exists(),
+            "confirmed delete did not remove the file",
+        )
+        assert "Recently deleted" in _tree_labels(
+            workspace.query_one("#file-notes-tree", Tree)
+        )
+
+        workspace.query_one("#file-notes-restore", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: (root / "moved.md").exists(),
+            "restore did not recreate exact file",
+        )
+        changes = _static_text(workspace, "#file-notes-session-changes")
+        assert all(
+            action in changes for action in ("created", "moved", "deleted", "restored")
+        )
+    replica.close()
+
+
+@pytest.mark.asyncio
+async def test_conflict_reload_save_copy_and_leave_guards_preserve_draft(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    source = root / "source.md"
+    source.write_bytes(b"\xef\xbb\xbf---\r\ntitle: Exact\r\n---\r\nold\r\nbody\r\n")
+    replica = FileNotesReplica(":memory:")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica=replica,
+        autosave_delay=10,
+        poll_interval=10,
+    )
+
+    async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        assert await workspace.open_path("source.md")
+        first_session = workspace.session_key
+        editor = workspace.query_one("#file-notes-editor", TextArea)
+        _replace_editor_text(editor, "dirty reload guard")
+        await _wait_until(
+            pilot,
+            lambda: workspace.save_state == "dirty",
+            "dirty Reload setup did not arm",
+        )
+        workspace.query_one("#file-notes-reload", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: (
+                workspace.save_state == "saved"
+                and editor.text == "dirty reload guard\n"
+            ),
+            "Reload discarded a merely dirty draft instead of flushing it",
+        )
+        assert source.read_bytes().endswith(b"dirty reload guard\r\n")
+
+        _replace_editor_text(editor, "kept\ndraft")
+        await _wait_until(
+            pilot,
+            lambda: workspace.save_state == "dirty",
+            "draft did not become dirty",
+        )
+
+        source.write_bytes(b"\xef\xbb\xbf---\r\ntitle: External\r\n---\r\nexternal\r\n")
+        await workspace.refresh_files()
+        assert workspace.save_state == "conflict"
+        assert editor.text == "kept\ndraft"
+        assert not await workspace.flush_pending_work()
+
+        workspace.query_one("#file-notes-path", Input).value = "copy.md"
+        workspace.query_one("#file-notes-save-copy", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.current_path == "copy.md",
+            "save copy did not open the safe copy",
+        )
+        assert (root / "copy.md").read_bytes() == (
+            b"\xef\xbb\xbf---\r\ntitle: Exact\r\n---\r\nkept\r\ndraft\r\n"
+        )
+
+        assert await workspace.open_path("source.md")
+        _replace_editor_text(editor, "another draft")
+        await pilot.pause()
+        source.write_bytes(
+            b"\xef\xbb\xbf---\r\ntitle: External 2\r\n---\r\nreload me\r\n"
+        )
+        await workspace.refresh_files()
+        assert workspace.save_state == "conflict"
+        workspace.query_one("#file-notes-reload", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: (
+                workspace.save_state == "saved"
+                and workspace.query_one("#file-notes-editor", TextArea).text
+                == "reload me\n"
+            ),
+            "reload did not resolve the conflict",
+        )
+        assert workspace.session_key != first_session
+        assert workspace.query_one("#file-notes-editor", TextArea) is editor
+
+        _replace_editor_text(editor, "flush me")
+        await pilot.pause()
+        assert await workspace.flush_pending_work()
+        assert source.read_bytes().endswith(b"flush me\r\n")
+
+        workspace.query_one("#file-notes-protect", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: (
+                workspace.current_document is not None
+                and workspace.current_document.protected
+            ),
+            "protected error setup did not finish",
+        )
+        replica.close()
+        _replace_editor_text(editor, "surviving error draft")
+        await pilot.pause()
+        assert not await workspace.flush_pending_work()
+        assert workspace.save_state == "error"
+        assert editor.text == "surviving error draft"
+    replica.close()
+
+
+@pytest.mark.asyncio
+async def test_recently_deleted_survives_a_second_workspace(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    original = b"recover me exactly\r\n"
+    (root / "recover.md").write_bytes(original)
+    replica_path = tmp_path / "file_notes.sqlite"
+
+    first_replica = FileNotesReplica(replica_path)
+    first = LibraryFileNotesWorkspace(
+        root=root,
+        replica=first_replica,
+        poll_interval=10,
+    )
+    async with _WorkspaceHarness(first).run_test() as pilot:
+        await _wait_until(pilot, lambda: first.initialized, "first scan did not finish")
+        assert await first.open_path("recover.md")
+        first.query_one("#file-notes-delete", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: (
+                str(first.query_one("#file-notes-delete", Button).label)
+                == "Confirm delete"
+            ),
+            "delete confirmation did not arm",
+        )
+        first.query_one("#file-notes-delete", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: not (root / "recover.md").exists(),
+            "delete did not finish",
+        )
+    first_replica.close()
+
+    second_replica = FileNotesReplica(replica_path)
+    second = LibraryFileNotesWorkspace(
+        root=root,
+        replica=second_replica,
+        poll_interval=10,
+    )
+    async with _WorkspaceHarness(second).run_test() as pilot:
+        await _wait_until(
+            pilot, lambda: second.initialized, "second scan did not finish"
+        )
+        assert "Recently deleted" in _tree_labels(
+            second.query_one("#file-notes-tree", Tree)
+        )
+        assert second.select_deleted("recover.md")
+        second.query_one("#file-notes-restore", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: (root / "recover.md").exists(),
+            "second workspace could not restore tombstone",
+        )
+        assert (root / "recover.md").read_bytes() == original
+    second_replica.close()
+
+
+@pytest.mark.asyncio
+async def test_poll_and_narrow_navigation_retain_the_text_area(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "open.md").write_text("first", encoding="utf-8")
+    (root / "delete.md").write_text("gone soon", encoding="utf-8")
+    (root / "folder").mkdir()
+    (root / "folder" / "nested.md").write_text("nested", encoding="utf-8")
+    replica = FileNotesReplica(":memory:")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica=replica,
+        poll_interval=0.05,
+        autosave_delay=10,
+    )
+
+    async with _WorkspaceHarness(workspace).run_test(size=(64, 28)) as pilot:
+        await _wait_until(
+            pilot,
+            lambda: workspace.initialized and workspace.narrow,
+            "workspace did not choose narrow mode from its width",
+        )
+        editor = workspace.query_one("#file-notes-editor", TextArea)
+        assert workspace.navigator_visible
+        assert not workspace.editor_visible
+        tree = workspace.query_one("#file-notes-tree", Tree)
+        folder = next(
+            node
+            for node in tree.root.children
+            if getattr(node.label, "plain", str(node.label)) == "folder"
+        )
+        folder.expand()
+
+        assert await workspace.open_path("open.md")
+        assert workspace.editor_visible
+        assert not workspace.navigator_visible
+        assert workspace.query_one("#file-notes-editor", TextArea) is editor
+
+        (root / "open.md").write_text("external", encoding="utf-8")
+        (root / "created.md").write_text("new", encoding="utf-8")
+        (root / "delete.md").unlink()
+        await _wait_until(
+            pilot,
+            lambda: (
+                set(workspace.entries) == {"created.md", "folder/nested.md", "open.md"}
+                and editor.text == "external"
+            ),
+            "poll did not reconcile external create/modify/delete",
+        )
+        assert workspace.query_one("#file-notes-editor", TextArea) is editor
+        refreshed_folder = next(
+            node
+            for node in workspace.query_one("#file-notes-tree", Tree).root.children
+            if getattr(node.label, "plain", str(node.label)) == "folder"
+        )
+        assert refreshed_folder.is_expanded
+        await pilot.pause(0.15)
+        assert len(workspace._workers) <= 1
+
+        workspace.query_one("#file-notes-back", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.navigator_visible and not workspace.editor_visible,
+            "Back did not return to the retained navigator",
+        )
+    replica.close()
+
+
+@pytest.mark.asyncio
+async def test_library_database_files_switch_retains_workspace_and_database_canvas(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "library.md").write_text("library file", encoding="utf-8")
+    replica = FileNotesReplica(":memory:")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica=replica,
+        poll_interval=10,
+        autosave_delay=10,
+    )
+    app = _build_test_app()
+    _seed_conversations(
+        app,
+        _two_conversations(),
+        notes=[{"title": "Database note", "id": "db-note-1"}],
+    )
+    screen = LibraryScreen(
+        app,
+        file_notes_workspace_factory=lambda: workspace,
+    )
+    host = LibraryHarness(app, screen=screen)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_NOTES)
+        await _wait_until(
+            pilot,
+            lambda: bool(screen.query("#library-notes-canvas")),
+            "Database Notes canvas did not compose",
+        )
+        assert screen.query_one("#library-rail")
+        assert screen.query_one("#library-notes-source-strip")
+        assert screen._library_file_notes_workspace is None
+
+        screen.query_one("#library-notes-source-files", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: screen._library_notes_source == "files",
+            "Files source handler did not run",
+        )
+        await _wait_until(
+            pilot,
+            lambda: bool(screen.query("#library-file-notes-workspace")),
+            "Files workspace did not replace the Database rail/canvas",
+        )
+        retained = screen.query_one(
+            "#library-file-notes-workspace",
+            LibraryFileNotesWorkspace,
+        )
+        editor = retained.query_one("#file-notes-editor", TextArea)
+        assert retained is workspace
+        assert not screen.query("#library-rail")
+
+        screen._apply_local_source_snapshot(
+            {
+                "notes": ({"title": "Updated DB note", "id": "db-note-2"},),
+                "media": (),
+                "conversations": (),
+            },
+            {"notes": 1, "media": 0, "conversations": 0},
+            {"notes": True, "media": True, "conversations": True},
+        )
+        await pilot.pause()
+        assert screen.query_one("#library-file-notes-workspace") is retained
+        assert retained.query_one("#file-notes-editor", TextArea) is editor
+
+        await retained.open_path("library.md")
+        _replace_editor_text(editor, "draft")
+        await pilot.pause()
+        (root / "library.md").write_text("external", encoding="utf-8")
+        await retained.refresh_files()
+        assert retained.save_state == "conflict"
+        screen.query_one("#library-notes-source-database", Button).press()
+        await pilot.pause()
+        assert screen._library_notes_source == "files"
+        assert screen.query_one("#library-file-notes-workspace") is retained
+
+        retained.query_one("#file-notes-reload", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: retained.save_state == "saved",
+            "reload did not clear the source-switch veto",
+        )
+        _replace_editor_text(editor, "saved before hiding")
+        await _wait_until(
+            pilot,
+            lambda: retained.save_state == "dirty",
+            "pre-remount edit did not become dirty",
+        )
+        assert await retained.flush_pending_work()
+        assert "modified library.md" in _static_text(
+            retained,
+            "#file-notes-session-changes",
+        )
+        screen.query_one("#library-notes-source-database", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: bool(screen.query("#library-notes-canvas")),
+            "Database Notes did not return",
+        )
+        assert screen.query_one("#library-rail")
+        assert screen._local_source_records["notes"][0]["title"] == "Updated DB note"
+
+        (root / "library.md").write_text("changed while hidden", encoding="utf-8")
+        screen.query_one("#library-notes-source-files", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: bool(screen.query("#library-file-notes-workspace")),
+            "retained Files workspace did not remount",
+        )
+        assert screen.query_one("#library-file-notes-workspace") is retained
+        assert retained.query_one("#file-notes-editor", TextArea) is editor
+        await _wait_until(
+            pilot,
+            lambda: editor.text == "changed while hidden",
+            "remount did not reconcile the retained open file",
+        )
+        assert "modified library.md" in _static_text(
+            retained,
+            "#file-notes-session-changes",
+        )
+    replica.close()

--- a/Tests/UI/test_library_file_notes_workspace.py
+++ b/Tests/UI/test_library_file_notes_workspace.py
@@ -23,7 +23,10 @@ from tldw_chatbook.Library.library_shell_state import (  # noqa: E402
     LIBRARY_ROW_BROWSE_NOTES,
 )
 from tldw_chatbook.Notes.file_notes_replica import FileNotesReplica  # noqa: E402
-from tldw_chatbook.Notes.file_notes_service import FileNotesService  # noqa: E402
+from tldw_chatbook.Notes.file_notes_service import (  # noqa: E402
+    FileNotesService,
+    OperationResult,
+)
 from tldw_chatbook.UI.Screens.library_screen import LibraryScreen  # noqa: E402
 from tldw_chatbook.Widgets.Library.library_file_notes_workspace import (  # noqa: E402
     LibraryFileNotesWorkspace,
@@ -415,6 +418,85 @@ async def test_create_move_delete_protect_and_restore_use_real_service(
         assert all(
             action in changes for action in ("created", "moved", "deleted", "restored")
         )
+    replica.close()
+
+
+@pytest.mark.parametrize(
+    ("button_id", "handler_name", "service_method", "action"),
+    (
+        ("#file-notes-new", "_new_file", "create_file", "Create"),
+        ("#file-notes-move", "_move_file", "move_file", "Move"),
+        ("#file-notes-restore", "_restore_file", "restore_file", "Restore"),
+        ("#file-notes-save-copy", "_save_copy", "save_copy", "Save Copy"),
+    ),
+)
+@pytest.mark.asyncio
+async def test_raw_path_actions_validate_input_before_service_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    button_id: str,
+    handler_name: str,
+    service_method: str,
+    action: str,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "start.md").write_text("start", encoding="utf-8")
+    replica = FileNotesReplica(":memory:")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica=replica,
+        poll_interval=10,
+    )
+
+    async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        assert await workspace.open_path("start.md")
+        service = workspace._service
+        assert service is not None
+        validation_calls: list[tuple[str, int, bool]] = []
+        calls: list[tuple[object, ...]] = []
+        raw_path = (" " * 4097) + r"nested/double..dots\<script>note.md"
+        destination = raw_path.strip()
+        real_validate_text_input = workspace_module.validate_text_input
+
+        def capture_path_validation(
+            text: str,
+            max_length: int = 10000,
+            allow_html: bool = False,
+        ) -> bool:
+            validation_calls.append((text, max_length, allow_html))
+            return real_validate_text_input(
+                text,
+                max_length=max_length,
+                allow_html=allow_html,
+            )
+
+        def capture_call(*args: object) -> OperationResult:
+            calls.append(args)
+            return OperationResult(
+                status="error",
+                relative_path=destination,
+                message="service should not receive invalid input",
+            )
+
+        monkeypatch.setattr(
+            workspace_module,
+            "validate_text_input",
+            capture_path_validation,
+        )
+        monkeypatch.setattr(service, service_method, capture_call)
+        workspace.query_one("#file-notes-path", Input).value = raw_path
+        button = workspace.query_one(button_id, Button)
+        await getattr(workspace, handler_name)(Button.Pressed(button))
+
+        assert validation_calls == [(raw_path, 4096, True)]
+        assert calls == []
+        assert _static_text(
+            workspace,
+            "#file-notes-action-status",
+        ) == f"{action} failed: unsupported path text."
+        assert workspace.current_path == "start.md"
     replica.close()
 
 

--- a/Tests/UI/test_library_file_notes_workspace.py
+++ b/Tests/UI/test_library_file_notes_workspace.py
@@ -86,6 +86,18 @@ def _replace_editor_text(editor: TextArea, text: str) -> None:
     editor.replace(text, editor.selection.start, editor.selection.end)
 
 
+def _delayed_call(call):
+    started = threading.Event()
+    release = threading.Event()
+
+    def delayed(*args, **kwargs):
+        started.set()
+        release.wait(5)
+        return call(*args, **kwargs)
+
+    return delayed, started, release
+
+
 @pytest.mark.asyncio
 async def test_empty_offline_and_persisted_root_states(
     tmp_path: Path,
@@ -297,6 +309,7 @@ async def test_tree_search_open_dirty_and_autosave_keep_one_editor(
 @pytest.mark.asyncio
 async def test_create_move_delete_protect_and_restore_use_real_service(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     root = tmp_path / "notes"
     root.mkdir()
@@ -312,14 +325,29 @@ async def test_create_move_delete_protect_and_restore_use_real_service(
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
         assert await workspace.open_path("start.md")
 
+        editor = workspace.query_one("#file-notes-editor", TextArea)
+        service = workspace._service
+        assert service is not None
+        delayed_create, create_started, release_create = _delayed_call(
+            service.create_file
+        )
+        monkeypatch.setattr(service, "create_file", delayed_create)
         path_input = workspace.query_one("#file-notes-path", Input)
         path_input.value = "created.md"
-        workspace.query_one("#file-notes-new", Button).press()
+        create_button = workspace.query_one("#file-notes-new", Button)
+        creating = asyncio.create_task(workspace._new_file(Button.Pressed(create_button)))
+        await _wait_until(pilot, create_started.is_set, "new file did not start")
+        editor.focus()
+        await pilot.press("x")
+        state_during_create = (editor.read_only, workspace.leave_allowed, editor.text)
+        release_create.set()
+        await creating
         await _wait_until(
             pilot,
             lambda: workspace.current_path == "created.md",
             "new file did not open",
         )
+        assert state_during_create == (True, False, "start")
         assert (root / "created.md").exists()
 
         workspace.query_one("#file-notes-protect", Button).press()
@@ -559,6 +587,7 @@ async def test_recently_deleted_survives_a_second_workspace(
 @pytest.mark.asyncio
 async def test_poll_and_narrow_navigation_retain_the_text_area(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     root = tmp_path / "notes"
     root.mkdir()
@@ -596,17 +625,36 @@ async def test_poll_and_narrow_navigation_retain_the_text_area(
         assert not workspace.navigator_visible
         assert workspace.query_one("#file-notes-editor", TextArea) is editor
 
+        service = workspace._service
+        assert service is not None
+        delayed_open, reload_started, release_reload = _delayed_call(
+            service.open_file
+        )
+        monkeypatch.setattr(service, "open_file", delayed_open)
         (root / "open.md").write_text("external", encoding="utf-8")
         (root / "created.md").write_text("new", encoding="utf-8")
         (root / "delete.md").unlink()
         await _wait_until(
             pilot,
+            reload_started.is_set,
+            "external reload did not start",
+        )
+        _replace_editor_text(editor, "draft during reload")
+        await _wait_until(
+            pilot,
+            lambda: workspace.save_state == "dirty",
+            "reload-window edit did not become dirty",
+        )
+        release_reload.set()
+        await _wait_until(
+            pilot,
             lambda: (
                 set(workspace.entries) == {"created.md", "folder/nested.md", "open.md"}
-                and editor.text == "external"
+                and workspace.save_state == "conflict"
             ),
             "poll did not reconcile external create/modify/delete",
         )
+        assert editor.text == "draft during reload"
         assert workspace.query_one("#file-notes-editor", TextArea) is editor
         refreshed_folder = next(
             node

--- a/Tests/UI/test_library_file_notes_workspace.py
+++ b/Tests/UI/test_library_file_notes_workspace.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
+import sqlite3
 import sys
+import threading
 import types
 from collections.abc import Callable
 from pathlib import Path
@@ -20,6 +23,7 @@ from tldw_chatbook.Library.library_shell_state import (  # noqa: E402
     LIBRARY_ROW_BROWSE_NOTES,
 )
 from tldw_chatbook.Notes.file_notes_replica import FileNotesReplica  # noqa: E402
+from tldw_chatbook.Notes.file_notes_service import FileNotesService  # noqa: E402
 from tldw_chatbook.UI.Screens.library_screen import LibraryScreen  # noqa: E402
 from tldw_chatbook.Widgets.Library.library_file_notes_workspace import (  # noqa: E402
     LibraryFileNotesWorkspace,
@@ -145,6 +149,91 @@ async def test_empty_offline_and_persisted_root_states(
 
 
 @pytest.mark.asyncio
+async def test_root_transition_retains_and_freezes_old_document_until_scan_finishes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old_root = tmp_path / "old"
+    old_root.mkdir()
+    (old_root / "old.md").write_text("old body", encoding="utf-8")
+    new_root = tmp_path / "new"
+    new_root.mkdir()
+    (new_root / "new.md").write_text("new body", encoding="utf-8")
+    replica = FileNotesReplica(":memory:")
+    workspace = LibraryFileNotesWorkspace(
+        root=old_root,
+        replica=replica,
+        autosave_delay=10,
+        poll_interval=10,
+    )
+    original_scan = FileNotesService.scan
+    scan_started = threading.Event()
+    release_scan = threading.Event()
+    open_started = threading.Event()
+    release_open = threading.Event()
+
+    def delayed_scan(service):
+        if service.root == new_root.resolve():
+            scan_started.set()
+            release_scan.wait(5)
+        return original_scan(service)
+
+    monkeypatch.setattr(FileNotesService, "scan", delayed_scan)
+    async with _WorkspaceHarness(workspace).run_test(size=(110, 36)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        assert await workspace.open_path("old.md")
+        editor = workspace.query_one("#file-notes-editor", TextArea)
+        _replace_editor_text(editor, "saved before root change")
+        await _wait_until(
+            pilot,
+            lambda: workspace.save_state == "dirty",
+            "root-change draft did not become dirty",
+        )
+        service = workspace._service
+        assert service is not None
+        original_open = service.open_file
+
+        def delayed_open(relative_path):
+            open_started.set()
+            release_open.wait(5)
+            return original_open(relative_path)
+
+        monkeypatch.setattr(service, "open_file", delayed_open)
+        opening = asyncio.create_task(workspace.open_path("old.md"))
+        await _wait_until(pilot, open_started.is_set, "old-root open did not start")
+
+        transition = asyncio.create_task(
+            workspace.set_root(new_root, persist=False)
+        )
+        await _wait_until(
+            pilot,
+            scan_started.is_set,
+            "candidate root scan did not start",
+        )
+        assert workspace.root == old_root.resolve()
+        assert workspace.current_path == "old.md"
+        assert editor.text == "saved before root change"
+        assert editor.read_only
+        assert workspace.query_one("#file-notes-new", Button).disabled
+        assert workspace.query_one("#file-notes-search", Input).disabled
+        assert (old_root / "old.md").read_text(encoding="utf-8") == (
+            "saved before root change"
+        )
+
+        release_scan.set()
+        assert await transition
+        assert workspace.root == new_root.resolve()
+        assert workspace.current_path == ""
+        assert editor.text == ""
+        assert "new.md" in workspace.entries
+        release_open.set()
+        assert not await opening
+    release_scan.set()
+    release_open.set()
+    replica.close()
+
+
+@pytest.mark.asyncio
 async def test_tree_search_open_dirty_and_autosave_keep_one_editor(
     tmp_path: Path,
 ) -> None:
@@ -218,6 +307,8 @@ async def test_tree_search_open_dirty_and_autosave_keep_one_editor(
             "changed body\n"
         )
         assert workspace.query_one("#file-notes-editor", TextArea) is editor
+    await workspace.shutdown()
+    assert replica.list_deleted(str(root.resolve())) == []
     replica.close()
 
 
@@ -542,7 +633,12 @@ async def test_poll_and_narrow_navigation_retain_the_text_area(
         )
         assert refreshed_folder.is_expanded
         await pilot.pause(0.15)
-        assert len(workspace._workers) <= 1
+        active = [
+            worker
+            for worker in workspace.workers
+            if worker.node is workspace and not worker.is_finished
+        ]
+        assert len(active) <= 1
 
         workspace.query_one("#file-notes-back", Button).press()
         await _wait_until(
@@ -556,6 +652,7 @@ async def test_poll_and_narrow_navigation_retain_the_text_area(
 @pytest.mark.asyncio
 async def test_library_database_files_switch_retains_workspace_and_database_canvas(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     root = tmp_path / "notes"
     root.mkdir()
@@ -563,10 +660,9 @@ async def test_library_database_files_switch_retains_workspace_and_database_canv
     (root / "other.md").write_text("other file", encoding="utf-8")
     replacement_root = tmp_path / "replacement"
     replacement_root.mkdir()
-    replica = FileNotesReplica(":memory:")
     workspace = LibraryFileNotesWorkspace(
         root=root,
-        replica=replica,
+        replica_path=tmp_path / "owned.sqlite",
         poll_interval=10,
         autosave_delay=10,
     )
@@ -581,6 +677,20 @@ async def test_library_database_files_switch_retains_workspace_and_database_canv
         file_notes_workspace_factory=lambda: workspace,
     )
     host = LibraryHarness(app, screen=screen)
+    save_started = threading.Event()
+    release_save = threading.Event()
+    detail_started = threading.Event()
+    release_detail = threading.Event()
+
+    def delayed_detail(**_kwargs):
+        detail_started.set()
+        release_detail.wait(5)
+        return {
+            "id": "db-note-1",
+            "title": "Database note",
+            "content": "body",
+            "version": 1,
+        }
 
     async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
         await _wait_for_library_shell(screen, pilot)
@@ -594,6 +704,17 @@ async def test_library_database_files_switch_retains_workspace_and_database_canv
         assert screen.query_one("#library-notes-source-strip")
         assert screen._library_file_notes_workspace is None
 
+        app.notes_scope_service.get_note_detail = delayed_detail
+        screen._selected_note_id = "db-note-1"
+        screen._library_notes_view = "editor"
+        detail_task = asyncio.create_task(
+            screen._refresh_library_note_detail("db-note-1")
+        )
+        await _wait_until(
+            pilot,
+            detail_started.is_set,
+            "Database detail fetch did not start",
+        )
         screen.query_one("#library-notes-source-files", Button).press()
         await _wait_until(
             pilot,
@@ -605,13 +726,26 @@ async def test_library_database_files_switch_retains_workspace_and_database_canv
             lambda: bool(screen.query("#library-file-notes-workspace")),
             "Files workspace did not replace the Database rail/canvas",
         )
+        await _wait_until(
+            pilot,
+            lambda: workspace.initialized and workspace._replica is not None,
+            "Files workspace did not initialize",
+        )
         retained = screen.query_one(
             "#library-file-notes-workspace",
             LibraryFileNotesWorkspace,
         )
         editor = retained.query_one("#file-notes-editor", TextArea)
+        owned_replica = retained._replica
+        assert owned_replica is not None
         assert retained is workspace
         assert not screen.query("#library-rail")
+
+        release_detail.set()
+        await detail_task
+        assert screen._library_note_detail is None
+        screen._library_notes_view = "list"
+        screen._selected_note_id = None
 
         screen._apply_local_source_snapshot(
             {
@@ -699,4 +833,47 @@ async def test_library_database_files_switch_retains_workspace_and_database_canv
             retained,
             "#file-notes-session-changes",
         )
-    replica.close()
+
+        service = retained._service
+        assert service is not None
+        original_save = service.save_file
+
+        def delayed_save(*args, **kwargs):
+            save_started.set()
+            release_save.wait(5)
+            return original_save(*args, **kwargs)
+
+        monkeypatch.setattr(service, "save_file", delayed_save)
+        _replace_editor_text(editor, "draft across forced remount")
+        await _wait_until(
+            pilot,
+            lambda: retained.save_state == "dirty",
+            "forced-remount draft did not become dirty",
+        )
+        retained._start_autosave()
+        await _wait_until(
+            pilot,
+            lambda: save_started.is_set() and retained.save_state == "saving",
+            "forced-remount save did not start",
+        )
+
+        screen.refresh(recompose=True)
+        await _wait_until(
+            pilot,
+            lambda: retained.save_state == "dirty"
+            and retained._autosave_timer is not None
+            and bool(screen.query("#library-file-notes-workspace")),
+            "Files workspace did not remount during save",
+        )
+        assert retained.save_state == "dirty"
+        assert retained._autosave_timer is not None
+        assert retained.query_one("#file-notes-editor", TextArea).text == (
+            "draft across forced remount"
+        )
+        release_save.set()
+        await pilot.pause()
+        assert retained.query_one("#file-notes-editor", TextArea) is editor
+    assert workspace._shutdown
+    await workspace.shutdown()
+    with pytest.raises(sqlite3.ProgrammingError):
+        owned_replica.list_deleted(str(root.resolve()))

--- a/backlog/decisions/029-file-notes-disk-authority.md
+++ b/backlog/decisions/029-file-notes-disk-authority.md
@@ -1,0 +1,42 @@
+# 029 - File Notes use disk authority with one SQLite replica
+
+Date: 2026-07-27
+Status: accepted
+Related task: [TASK-900](../tasks/task-900%20-%20Add-minimal-disk-backed-File-Notes-editor.md)
+
+## Context
+
+Users already keep Markdown and text notes in Git-managed folders. Chatbook must
+edit those files directly so ordinary `git status`, `git add`, and `git commit`
+continue to work. Database Notes and the existing bidirectional sync engine use
+different ownership rules and must not become an equal authority for these
+files.
+
+## Decision
+
+- The selected folder and its relative paths are authoritative.
+- Chatbook reads editor content from disk and writes ordinary filesystem
+  changes beneath that folder.
+- One dedicated SQLite database outside the selected folder stores the latest
+  observed bytes for search/recovery plus coalesced revisions for explicitly
+  protected paths.
+- SQLite is never an editor authority. It can be rebuilt from disk; a stale row
+  cannot overwrite a file.
+- Every save compares the current disk hash with the hash observed when the
+  editor loaded or last saved. A mismatch becomes a visible conflict.
+- A valid leading frontmatter block is kept as untouched bytes while only the
+  body is edited.
+- Delete commits a recovery snapshot and tombstone before unlinking the file.
+- Git remains external. Chatbook only reports files changed during the current
+  Chatbook session.
+
+## Consequences
+
+- Database Notes, ChaChaNotes, RAG, MCP, Sync, and Git integrations need no
+  schema or behavior changes.
+- One selected root, UTF-8 text files, moves into existing directories, and
+  polling-based external-change detection are sufficient for the first release.
+- Multiple roots, Git controls, folder mutation, watcher dependencies,
+  platform-specific filesystem adapters, storage pairing, quotas, and recovery
+  tooling are deferred until demonstrated need.
+

--- a/backlog/decisions/029-file-notes-disk-authority.md
+++ b/backlog/decisions/029-file-notes-disk-authority.md
@@ -2,7 +2,7 @@
 
 Date: 2026-07-27
 Status: accepted
-Related task: [TASK-900](../tasks/task-900%20-%20Add-minimal-disk-backed-File-Notes-editor.md)
+Related task: [TASK-969](../tasks/task-969%20-%20Add-minimal-disk-backed-File-Notes-editor.md)
 
 ## Context
 

--- a/backlog/decisions/029-file-notes-disk-authority.md
+++ b/backlog/decisions/029-file-notes-disk-authority.md
@@ -14,7 +14,8 @@ files.
 
 ## Decision
 
-- The selected folder and its relative paths are authoritative.
+- The selected canonical folder plus each relative path are authoritative and
+  namespace replica/recovery rows.
 - Chatbook reads editor content from disk and writes ordinary filesystem
   changes beneath that folder.
 - One dedicated SQLite database outside the selected folder stores the latest
@@ -24,9 +25,12 @@ files.
   cannot overwrite a file.
 - Every save compares the current disk hash with the hash observed when the
   editor loaded or last saved. A mismatch becomes a visible conflict.
+- A protected note's exact pre-edit bytes commit before its first write in an
+  editing session; failure stops that write.
 - A valid leading frontmatter block is kept as untouched bytes while only the
   body is edited.
 - Delete commits a recovery snapshot and tombstone before unlinking the file.
+- A missing root is offline, never auto-created or treated as mass deletion.
 - Git remains external. Chatbook only reports files changed during the current
   Chatbook session.
 
@@ -39,4 +43,3 @@ files.
 - Multiple roots, Git controls, folder mutation, watcher dependencies,
   platform-specific filesystem adapters, storage pairing, quotas, and recovery
   tooling are deferred until demonstrated need.
-

--- a/backlog/tasks/task-900 - Add-minimal-disk-backed-File-Notes-editor.md
+++ b/backlog/tasks/task-900 - Add-minimal-disk-backed-File-Notes-editor.md
@@ -24,14 +24,15 @@ Let users manage one existing Git-backed Markdown/text folder from Library while
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 User can select one notes root and browse its folder tree.
+- [ ] #1 User can choose and persist one notes root, browse its folder tree, and see a missing root as offline without filesystem or replica mutation.
 - [ ] #2 Search replaces the tree and opens matching Markdown/text files.
-- [ ] #3 Editor changes write directly to disk with debounced hash-checked saves.
-- [ ] #4 Valid leading frontmatter is preserved byte-for-byte while the body is edited.
+- [ ] #3 Editor changes write directly to disk with debounced hash-checked saves, while unresolved dirty/conflict/error states prevent navigation from discarding the draft.
+- [ ] #4 Valid leading frontmatter, BOM, uniform newline style, and final-newline state are preserved while the body is edited; unsafe text files remain path-visible and read-only.
 - [ ] #5 Create, rename, move, delete, and restore operate on actual files beneath the root.
 - [ ] #6 Delete commits a SQLite recovery snapshot and tombstone before unlinking.
-- [ ] #7 SQLite is a separate replica with opt-in history for protected paths.
+- [ ] #7 SQLite is a separate root-namespaced replica with opt-in history for protected paths, and protected writes cannot occur before their pre-edit checkpoint commits.
 - [ ] #8 Changed this session lists only Chatbook mutations.
 - [ ] #9 Existing Database Notes and Git behavior remain unchanged.
-- [ ] #10 External changes detected before publication are never silently overwritten.
+- [ ] #10 External changes detected before publication are never silently overwritten, reconciliation does not remount an open editor, and scanning does not block the UI.
+- [ ] #11 Restorable deletions remain discoverable after restart.
 <!-- AC:END -->

--- a/backlog/tasks/task-900 - Add-minimal-disk-backed-File-Notes-editor.md
+++ b/backlog/tasks/task-900 - Add-minimal-disk-backed-File-Notes-editor.md
@@ -1,0 +1,37 @@
+---
+id: TASK-900
+title: Add minimal disk-backed File Notes editor
+status: To Do
+assignee: []
+created_date: '2026-07-27 14:32'
+updated_date: '2026-07-27 14:37'
+labels:
+  - notes
+  - library
+  - files
+dependencies: []
+documentation:
+  - Docs/superpowers/specs/2026-07-27-minimal-file-notes-design.md
+  - backlog/decisions/029-file-notes-disk-authority.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Let users manage one existing Git-backed Markdown/text folder from Library while disk and filename/path remain authoritative. Chatbook writes ordinary filesystem changes and keeps one separate SQLite replica for search and recovery without changing Database Notes or Git workflows.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 User can select one notes root and browse its folder tree.
+- [ ] #2 Search replaces the tree and opens matching Markdown/text files.
+- [ ] #3 Editor changes write directly to disk with debounced hash-checked saves.
+- [ ] #4 Valid leading frontmatter is preserved byte-for-byte while the body is edited.
+- [ ] #5 Create, rename, move, delete, and restore operate on actual files beneath the root.
+- [ ] #6 Delete commits a SQLite recovery snapshot and tombstone before unlinking.
+- [ ] #7 SQLite is a separate replica with opt-in history for protected paths.
+- [ ] #8 Changed this session lists only Chatbook mutations.
+- [ ] #9 Existing Database Notes and Git behavior remain unchanged.
+- [ ] #10 External changes detected before publication are never silently overwritten.
+<!-- AC:END -->

--- a/backlog/tasks/task-900 - Add-minimal-disk-backed-File-Notes-editor.md
+++ b/backlog/tasks/task-900 - Add-minimal-disk-backed-File-Notes-editor.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-900
 title: Add minimal disk-backed File Notes editor
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2026-07-27 14:32'
-updated_date: '2026-07-27 14:37'
+updated_date: '2026-07-27 14:51'
 labels:
   - notes
   - library
@@ -12,6 +13,7 @@ labels:
 dependencies: []
 documentation:
   - Docs/superpowers/specs/2026-07-27-minimal-file-notes-design.md
+  - Docs/superpowers/plans/2026-07-27-minimal-file-notes.md
   - backlog/decisions/029-file-notes-disk-authority.md
 priority: high
 ---
@@ -36,3 +38,16 @@ Let users manage one existing Git-backed Markdown/text folder from Library while
 - [ ] #10 External changes detected before publication are never silently overwritten, reconciliation does not remount an open editor, and scanning does not block the UI.
 - [ ] #11 Restorable deletions remain discoverable after restart.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: yes
+ADR path: backlog/decisions/029-file-notes-disk-authority.md
+Reason: Implements the accepted disk-authority, independent-replica, conflict, and Library ownership boundaries.
+
+1. Build the single SQLite replica with FTS, protected checkpoints, and tombstones.
+2. Build the exact-byte, hash-checked filesystem service.
+3. Mount one retained File Notes workspace in Library and delegate leave guards.
+4. Run only focused File Notes tests and close the task.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-900 - Add-minimal-disk-backed-File-Notes-editor.md
+++ b/backlog/tasks/task-900 - Add-minimal-disk-backed-File-Notes-editor.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-900
 title: Add minimal disk-backed File Notes editor
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-27 14:32'
-updated_date: '2026-07-27 14:51'
+updated_date: '2026-07-27 17:29'
 labels:
   - notes
   - library
@@ -26,17 +26,17 @@ Let users manage one existing Git-backed Markdown/text folder from Library while
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 User can choose and persist one notes root, browse its folder tree, and see a missing root as offline without filesystem or replica mutation.
-- [ ] #2 Search replaces the tree and opens matching Markdown/text files.
-- [ ] #3 Editor changes write directly to disk with debounced hash-checked saves, while unresolved dirty/conflict/error states prevent navigation from discarding the draft.
-- [ ] #4 Valid leading frontmatter, BOM, uniform newline style, and final-newline state are preserved while the body is edited; unsafe text files remain path-visible and read-only.
-- [ ] #5 Create, rename, move, delete, and restore operate on actual files beneath the root.
-- [ ] #6 Delete commits a SQLite recovery snapshot and tombstone before unlinking.
-- [ ] #7 SQLite is a separate root-namespaced replica with opt-in history for protected paths, and protected writes cannot occur before their pre-edit checkpoint commits.
-- [ ] #8 Changed this session lists only Chatbook mutations.
-- [ ] #9 Existing Database Notes and Git behavior remain unchanged.
-- [ ] #10 External changes detected before publication are never silently overwritten, reconciliation does not remount an open editor, and scanning does not block the UI.
-- [ ] #11 Restorable deletions remain discoverable after restart.
+- [x] #1 User can choose and persist one notes root, browse its folder tree, and see a missing root as offline without filesystem or replica mutation.
+- [x] #2 Search replaces the tree and opens matching Markdown/text files.
+- [x] #3 Editor changes write directly to disk with debounced hash-checked saves, while unresolved dirty/conflict/error states prevent navigation from discarding the draft.
+- [x] #4 Valid leading frontmatter, BOM, uniform newline style, and final-newline state are preserved while the body is edited; unsafe text files remain path-visible and read-only.
+- [x] #5 Create, rename, move, delete, and restore operate on actual files beneath the root.
+- [x] #6 Delete commits a SQLite recovery snapshot and tombstone before unlinking.
+- [x] #7 SQLite is a separate root-namespaced replica with opt-in history for protected paths, and protected writes cannot occur before their pre-edit checkpoint commits.
+- [x] #8 Changed this session lists only Chatbook mutations.
+- [x] #9 Existing Database Notes and Git behavior remain unchanged.
+- [x] #10 External changes detected before publication are never silently overwritten, reconciliation does not remount an open editor, and scanning does not block the UI.
+- [x] #11 Restorable deletions remain discoverable after restart.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -51,3 +51,15 @@ Reason: Implements the accepted disk-authority, independent-replica, conflict, a
 3. Mount one retained File Notes workspace in Library and delegate leave guards.
 4. Run only focused File Notes tests and close the task.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the accepted disk-authoritative File Notes design from ADR-029.
+
+- Added a root-namespaced SQLite current replica with FTS, protected editing-session checkpoints, recovery snapshots, and persistent tombstones.
+- Added path-safe exact-byte filesystem operations for scanning, opening, hash-checked atomic saving, no-clobber create/move, delete, restore, polling reconciliation, and Chatbook-only session changes.
+- Added a retained Library Database | Files workspace with folder tree/search replacement, body-only editing, autosave/conflict actions, protection and recovery controls, narrow navigation, and leave guards.
+- Hardened async transitions, remount autosave reconciliation, stale-result rejection, and owned replica shutdown without adding Git controls, watchers, or new dependencies.
+- Focused verification: 42 tests passed; targeted Ruff passed. Full-suite/CI was intentionally outside the approved plan.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-969 - Add-minimal-disk-backed-File-Notes-editor.md
+++ b/backlog/tasks/task-969 - Add-minimal-disk-backed-File-Notes-editor.md
@@ -1,11 +1,11 @@
 ---
-id: TASK-900
+id: TASK-969
 title: Add minimal disk-backed File Notes editor
 status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-27 14:32'
-updated_date: '2026-07-27 17:29'
+updated_date: '2026-07-27 18:00'
 labels:
   - notes
   - library
@@ -61,5 +61,7 @@ Implemented the accepted disk-authoritative File Notes design from ADR-029.
 - Added path-safe exact-byte filesystem operations for scanning, opening, hash-checked atomic saving, no-clobber create/move, delete, restore, polling reconciliation, and Chatbook-only session changes.
 - Added a retained Library Database | Files workspace with folder tree/search replacement, body-only editing, autosave/conflict actions, protection and recovery controls, narrow navigation, and leave guards.
 - Hardened async transitions, remount autosave reconciliation, stale-result rejection, and owned replica shutdown without adding Git controls, watchers, or new dependencies.
-- Focused verification: 42 tests passed; targeted Ruff passed. Full-suite/CI was intentionally outside the approved plan.
+- Addressed PR review with portable save permissions, consistent SQLite home expansion, visible temporary-file cleanup failures, shared path/input validation boundaries, stable polling teardown, and complete public API docstrings.
+- Rebased onto current `dev` and renumbered the task from TASK-900 to TASK-969 after `dev` independently claimed the intervening IDs.
+- Focused verification: 51 tests passed; targeted Ruff, module compilation, the duplicate-task guard, and `git diff --check` passed. Full-suite execution remains outside this focused task.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Notes/file_notes_replica.py
+++ b/tldw_chatbook/Notes/file_notes_replica.py
@@ -33,7 +33,8 @@ class FileNotesReplica:
         """
         path = os.fspath(db_path)
         if path != ":memory:":
-            Path(path).expanduser().parent.mkdir(parents=True, exist_ok=True)
+            path = os.fspath(Path(path).expanduser())
+            Path(path).parent.mkdir(parents=True, exist_ok=True)
         self._lock = RLock()
         with self._lock:
             self._connection = sqlite3.connect(
@@ -60,7 +61,17 @@ class FileNotesReplica:
         size: int,
         mtime_ns: int,
     ) -> None:
-        """Replace one root-namespaced current-byte replica and its FTS row."""
+        """Replace one root-namespaced current-byte replica and its FTS row.
+
+        Args:
+            root: Canonical notes-root identifier.
+            relative_path: File path relative to ``root``.
+            raw_bytes: Exact bytes read from disk.
+            content_hash: Digest of ``raw_bytes``.
+            decoded_text: Searchable text, or ``None`` for non-text content.
+            size: File size in bytes.
+            mtime_ns: File modification time in nanoseconds.
+        """
         with self._transaction() as cursor:
             cursor.execute(
                 """
@@ -96,7 +107,15 @@ class FileNotesReplica:
             self._replace_fts(cursor, root, relative_path, decoded_text)
 
     def get_bytes(self, root: str, relative_path: str) -> bytes | None:
-        """Return exact current or tombstoned bytes for a path."""
+        """Return exact current or tombstoned bytes for a path.
+
+        Args:
+            root: Canonical notes-root identifier.
+            relative_path: File path relative to ``root``.
+
+        Returns:
+            Stored bytes, or ``None`` when the path is not replicated.
+        """
         with self._lock:
             row = self._connection.execute(
                 """
@@ -109,7 +128,14 @@ class FileNotesReplica:
         return None if row is None else bytes(row["raw_bytes"])
 
     def list_active_files(self, root: str) -> list[ReplicaFileInfo]:
-        """Return active replica metadata for one canonical root."""
+        """Return active replica metadata for one canonical root.
+
+        Args:
+            root: Canonical notes-root identifier.
+
+        Returns:
+            Active files ordered by relative path.
+        """
         with self._lock:
             rows = self._connection.execute(
                 """
@@ -131,7 +157,16 @@ class FileNotesReplica:
         ]
 
     def search(self, root: str, query: str, *, limit: int = 50) -> list[str]:
-        """Return active paths whose decoded current content matches user text."""
+        """Return active paths whose decoded current content matches user text.
+
+        Args:
+            root: Canonical notes-root identifier.
+            query: Literal text to find in replicated file content.
+            limit: Maximum number of paths to return.
+
+        Returns:
+            Matching relative paths ordered by relevance.
+        """
         query = query.strip()
         if not query or limit <= 0 or "\x00" in query:
             return []
@@ -165,7 +200,16 @@ class FileNotesReplica:
         *,
         deleted_at: str | None = None,
     ) -> bool:
-        """Tombstone a missing file while retaining its last observed bytes."""
+        """Tombstone a missing file while retaining its last observed bytes.
+
+        Args:
+            root: Canonical notes-root identifier.
+            relative_path: File path relative to ``root``.
+            deleted_at: Optional UTC deletion timestamp.
+
+        Returns:
+            ``True`` when an existing replica row was tombstoned.
+        """
         with self._transaction() as cursor:
             cursor.execute(
                 """
@@ -181,7 +225,15 @@ class FileNotesReplica:
         return True
 
     def clear_tombstone(self, root: str, relative_path: str) -> bool:
-        """Clear a deletion marker and restore searchable current content."""
+        """Clear a deletion marker and restore searchable current content.
+
+        Args:
+            root: Canonical notes-root identifier.
+            relative_path: File path relative to ``root``.
+
+        Returns:
+            ``True`` when a tombstone was cleared.
+        """
         with self._transaction() as cursor:
             row = cursor.execute(
                 """
@@ -212,7 +264,14 @@ class FileNotesReplica:
         return True
 
     def list_deleted(self, root: str) -> list[str]:
-        """List tombstoned paths for one canonical root."""
+        """List tombstoned paths for one canonical root.
+
+        Args:
+            root: Canonical notes-root identifier.
+
+        Returns:
+            Tombstoned relative paths, newest deletion first.
+        """
         with self._lock:
             rows = self._connection.execute(
                 """
@@ -226,7 +285,15 @@ class FileNotesReplica:
         return [str(row["relative_path"]) for row in rows]
 
     def get_restore_bytes(self, root: str, relative_path: str) -> bytes | None:
-        """Return exact bytes only when a path has a deletion tombstone."""
+        """Return exact bytes only when a path has a deletion tombstone.
+
+        Args:
+            root: Canonical notes-root identifier.
+            relative_path: File path relative to ``root``.
+
+        Returns:
+            Restorable bytes, or ``None`` when no tombstone exists.
+        """
         with self._lock:
             row = self._connection.execute(
                 """
@@ -247,7 +314,13 @@ class FileNotesReplica:
         *,
         is_prefix: bool = False,
     ) -> None:
-        """Protect one exact path or a path-component-bounded folder prefix."""
+        """Protect one exact path or a path-component-bounded folder prefix.
+
+        Args:
+            root: Canonical notes-root identifier.
+            relative_path: Exact file path or folder prefix.
+            is_prefix: Whether ``relative_path`` identifies a folder prefix.
+        """
         with self._transaction() as cursor:
             cursor.execute(
                 """
@@ -268,7 +341,16 @@ class FileNotesReplica:
         *,
         is_prefix: bool = False,
     ) -> bool:
-        """Remove one exact protection entry."""
+        """Remove one exact protection entry.
+
+        Args:
+            root: Canonical notes-root identifier.
+            relative_path: Exact file path or folder prefix.
+            is_prefix: Whether ``relative_path`` identifies a folder prefix.
+
+        Returns:
+            ``True`` when a protection entry was removed.
+        """
         with self._transaction() as cursor:
             cursor.execute(
                 """
@@ -283,7 +365,15 @@ class FileNotesReplica:
         return removed
 
     def is_protected(self, root: str, relative_path: str) -> bool:
-        """Return whether an exact or component-bounded prefix protects a path."""
+        """Return whether an exact or component-bounded prefix protects a path.
+
+        Args:
+            root: Canonical notes-root identifier.
+            relative_path: File path relative to ``root``.
+
+        Returns:
+            ``True`` when an exact entry or folder prefix protects the path.
+        """
         with self._lock:
             row = self._connection.execute(
                 """
@@ -318,7 +408,19 @@ class FileNotesReplica:
         session_key: str,
         created_at: str | None = None,
     ) -> bool:
-        """Record exact pre-edit bytes once for a supplied editing session."""
+        """Record exact pre-edit bytes once for a supplied editing session.
+
+        Args:
+            root: Canonical notes-root identifier.
+            relative_path: File path relative to ``root``.
+            raw_bytes: Exact bytes captured before editing.
+            content_hash: Digest of ``raw_bytes``.
+            session_key: Identifier used to coalesce session checkpoints.
+            created_at: Optional UTC checkpoint timestamp.
+
+        Returns:
+            ``True`` when a new checkpoint was inserted.
+        """
         with self._transaction() as cursor:
             cursor.execute(
                 """
@@ -357,6 +459,15 @@ class FileNotesReplica:
         created_at: str | None = None,
     ) -> None:
         """Atomically store a deletion snapshot and tombstone its current row.
+
+        Args:
+            root: Canonical notes-root identifier.
+            relative_path: File path relative to ``root``.
+            raw_bytes: Exact bytes captured before deletion.
+            content_hash: Digest of ``raw_bytes``.
+            decoded_text: Searchable text, or ``None`` for non-text content.
+            deleted_at: Optional UTC deletion timestamp.
+            created_at: Optional UTC revision timestamp.
 
         Raises:
             KeyError: If the path has no current replica row to tombstone.

--- a/tldw_chatbook/Notes/file_notes_replica.py
+++ b/tldw_chatbook/Notes/file_notes_replica.py
@@ -307,6 +307,7 @@ class FileNotesReplica:
         raw_bytes: bytes,
         *,
         content_hash: str,
+        decoded_text: str | None,
         deleted_at: str | None = None,
         created_at: str | None = None,
     ) -> None:
@@ -343,6 +344,7 @@ class FileNotesReplica:
                 UPDATE files
                 SET raw_bytes = ?,
                     content_hash = ?,
+                    decoded_text = ?,
                     size = ?,
                     deleted_at = ?
                 WHERE root = ? AND relative_path = ?
@@ -350,6 +352,7 @@ class FileNotesReplica:
                 (
                     raw_bytes,
                     content_hash,
+                    decoded_text,
                     len(raw_bytes),
                     deletion_time,
                     root,

--- a/tldw_chatbook/Notes/file_notes_replica.py
+++ b/tldw_chatbook/Notes/file_notes_replica.py
@@ -8,6 +8,17 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
+from threading import RLock
+from typing import NamedTuple
+
+
+class ReplicaFileInfo(NamedTuple):
+    """Metadata needed to reconcile one active disk file with its replica."""
+
+    relative_path: str
+    content_hash: str
+    size: int
+    mtime_ns: int
 
 
 class FileNotesReplica:
@@ -23,13 +34,20 @@ class FileNotesReplica:
         path = os.fspath(db_path)
         if path != ":memory:":
             Path(path).expanduser().parent.mkdir(parents=True, exist_ok=True)
-        self._connection = sqlite3.connect(path, isolation_level=None)
-        self._connection.row_factory = sqlite3.Row
+        self._lock = RLock()
+        with self._lock:
+            self._connection = sqlite3.connect(
+                path,
+                isolation_level=None,
+                check_same_thread=False,
+            )
+            self._connection.row_factory = sqlite3.Row
         self._initialize_schema()
 
     def close(self) -> None:
         """Close the persistent SQLite connection."""
-        self._connection.close()
+        with self._lock:
+            self._connection.close()
 
     def upsert_file(
         self,
@@ -79,15 +97,38 @@ class FileNotesReplica:
 
     def get_bytes(self, root: str, relative_path: str) -> bytes | None:
         """Return exact current or tombstoned bytes for a path."""
-        row = self._connection.execute(
-            """
-            SELECT raw_bytes
-            FROM files
-            WHERE root = ? AND relative_path = ?
-            """,
-            (root, relative_path),
-        ).fetchone()
+        with self._lock:
+            row = self._connection.execute(
+                """
+                SELECT raw_bytes
+                FROM files
+                WHERE root = ? AND relative_path = ?
+                """,
+                (root, relative_path),
+            ).fetchone()
         return None if row is None else bytes(row["raw_bytes"])
+
+    def list_active_files(self, root: str) -> list[ReplicaFileInfo]:
+        """Return active replica metadata for one canonical root."""
+        with self._lock:
+            rows = self._connection.execute(
+                """
+                SELECT relative_path, content_hash, size, mtime_ns
+                FROM files
+                WHERE root = ? AND deleted_at IS NULL
+                ORDER BY relative_path
+                """,
+                (root,),
+            ).fetchall()
+        return [
+            ReplicaFileInfo(
+                relative_path=str(row["relative_path"]),
+                content_hash=str(row["content_hash"]),
+                size=int(row["size"]),
+                mtime_ns=int(row["mtime_ns"]),
+            )
+            for row in rows
+        ]
 
     def search(self, root: str, query: str, *, limit: int = 50) -> list[str]:
         """Return active paths whose decoded current content matches user text."""
@@ -97,21 +138,22 @@ class FileNotesReplica:
         escaped_query = query.replace('"', '""')
         literal_query = f'"{escaped_query}"'
         try:
-            rows = self._connection.execute(
-                """
-                SELECT files.relative_path
-                FROM files_fts
-                JOIN files
-                  ON files.root = files_fts.root
-                 AND files.relative_path = files_fts.relative_path
-                WHERE files_fts MATCH ?
-                  AND files.root = ?
-                  AND files.deleted_at IS NULL
-                ORDER BY bm25(files_fts), files.relative_path
-                LIMIT ?
-                """,
-                (literal_query, root, limit),
-            ).fetchall()
+            with self._lock:
+                rows = self._connection.execute(
+                    """
+                    SELECT files.relative_path
+                    FROM files_fts
+                    JOIN files
+                      ON files.root = files_fts.root
+                     AND files.relative_path = files_fts.relative_path
+                    WHERE files_fts MATCH ?
+                      AND files.root = ?
+                      AND files.deleted_at IS NULL
+                    ORDER BY bm25(files_fts), files.relative_path
+                    LIMIT ?
+                    """,
+                    (literal_query, root, limit),
+                ).fetchall()
         except sqlite3.OperationalError:
             return []
         return [str(row["relative_path"]) for row in rows]
@@ -171,29 +213,31 @@ class FileNotesReplica:
 
     def list_deleted(self, root: str) -> list[str]:
         """List tombstoned paths for one canonical root."""
-        rows = self._connection.execute(
-            """
-            SELECT relative_path
-            FROM files
-            WHERE root = ? AND deleted_at IS NOT NULL
-            ORDER BY deleted_at DESC, relative_path
-            """,
-            (root,),
-        ).fetchall()
+        with self._lock:
+            rows = self._connection.execute(
+                """
+                SELECT relative_path
+                FROM files
+                WHERE root = ? AND deleted_at IS NOT NULL
+                ORDER BY deleted_at DESC, relative_path
+                """,
+                (root,),
+            ).fetchall()
         return [str(row["relative_path"]) for row in rows]
 
     def get_restore_bytes(self, root: str, relative_path: str) -> bytes | None:
         """Return exact bytes only when a path has a deletion tombstone."""
-        row = self._connection.execute(
-            """
-            SELECT raw_bytes
-            FROM files
-            WHERE root = ?
-              AND relative_path = ?
-              AND deleted_at IS NOT NULL
-            """,
-            (root, relative_path),
-        ).fetchone()
+        with self._lock:
+            row = self._connection.execute(
+                """
+                SELECT raw_bytes
+                FROM files
+                WHERE root = ?
+                  AND relative_path = ?
+                  AND deleted_at IS NOT NULL
+                """,
+                (root, relative_path),
+            ).fetchone()
         return None if row is None else bytes(row["raw_bytes"])
 
     def protect(
@@ -240,27 +284,28 @@ class FileNotesReplica:
 
     def is_protected(self, root: str, relative_path: str) -> bool:
         """Return whether an exact or component-bounded prefix protects a path."""
-        row = self._connection.execute(
-            """
-            SELECT 1
-            FROM protected_paths
-            WHERE root = ?
-              AND (
-                    (is_prefix = 0 AND relative_path = ?)
-                 OR (
-                        is_prefix = 1
-                    AND (
-                           relative_path = ''
-                        OR relative_path = ?
-                        OR substr(?, 1, length(relative_path) + 1)
-                           = relative_path || '/'
-                    )
-                 )
-              )
-            LIMIT 1
-            """,
-            (root, relative_path, relative_path, relative_path),
-        ).fetchone()
+        with self._lock:
+            row = self._connection.execute(
+                """
+                SELECT 1
+                FROM protected_paths
+                WHERE root = ?
+                  AND (
+                        (is_prefix = 0 AND relative_path = ?)
+                     OR (
+                            is_prefix = 1
+                        AND (
+                               relative_path = ''
+                            OR relative_path = ?
+                            OR substr(?, 1, length(relative_path) + 1)
+                               = relative_path || '/'
+                        )
+                     )
+                  )
+                LIMIT 1
+                """,
+                (root, relative_path, relative_path, relative_path),
+            ).fetchone()
         return row is not None
 
     def checkpoint(
@@ -364,60 +409,61 @@ class FileNotesReplica:
             self._delete_fts(cursor, root, relative_path)
 
     def _initialize_schema(self) -> None:
-        self._connection.executescript(
-            """
-            CREATE TABLE IF NOT EXISTS files (
-                root TEXT NOT NULL,
-                relative_path TEXT NOT NULL,
-                raw_bytes BLOB NOT NULL,
-                content_hash TEXT NOT NULL,
-                decoded_text TEXT,
-                size INTEGER NOT NULL,
-                mtime_ns INTEGER NOT NULL,
-                deleted_at TEXT,
-                UNIQUE(root, relative_path)
-            );
+        with self._lock:
+            self._connection.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS files (
+                    root TEXT NOT NULL,
+                    relative_path TEXT NOT NULL,
+                    raw_bytes BLOB NOT NULL,
+                    content_hash TEXT NOT NULL,
+                    decoded_text TEXT,
+                    size INTEGER NOT NULL,
+                    mtime_ns INTEGER NOT NULL,
+                    deleted_at TEXT,
+                    UNIQUE(root, relative_path)
+                );
 
-            CREATE TABLE IF NOT EXISTS revisions (
-                root TEXT NOT NULL,
-                relative_path TEXT NOT NULL,
-                raw_bytes BLOB NOT NULL,
-                content_hash TEXT NOT NULL,
-                kind TEXT NOT NULL,
-                session_key TEXT,
-                created_at TEXT NOT NULL,
-                UNIQUE(root, relative_path, kind, session_key)
-            );
+                CREATE TABLE IF NOT EXISTS revisions (
+                    root TEXT NOT NULL,
+                    relative_path TEXT NOT NULL,
+                    raw_bytes BLOB NOT NULL,
+                    content_hash TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    session_key TEXT,
+                    created_at TEXT NOT NULL,
+                    UNIQUE(root, relative_path, kind, session_key)
+                );
 
-            CREATE TABLE IF NOT EXISTS protected_paths (
-                root TEXT NOT NULL,
-                relative_path TEXT NOT NULL,
-                is_prefix INTEGER NOT NULL CHECK(is_prefix IN (0, 1)),
-                UNIQUE(root, relative_path, is_prefix)
-            );
+                CREATE TABLE IF NOT EXISTS protected_paths (
+                    root TEXT NOT NULL,
+                    relative_path TEXT NOT NULL,
+                    is_prefix INTEGER NOT NULL CHECK(is_prefix IN (0, 1)),
+                    UNIQUE(root, relative_path, is_prefix)
+                );
 
-            CREATE VIRTUAL TABLE IF NOT EXISTS files_fts USING fts5(
-                root UNINDEXED,
-                relative_path UNINDEXED,
-                decoded_text,
-                tokenize = 'unicode61'
-            );
-            """
-        )
+                CREATE VIRTUAL TABLE IF NOT EXISTS files_fts USING fts5(
+                    root UNINDEXED,
+                    relative_path UNINDEXED,
+                    decoded_text,
+                    tokenize = 'unicode61'
+                );
+                """
+            )
 
     @contextmanager
     def _transaction(self) -> Iterator[sqlite3.Cursor]:
-        cursor = self._connection.cursor()
-        cursor.execute("BEGIN IMMEDIATE")
-        try:
-            yield cursor
-        except BaseException:
-            self._connection.rollback()
-            raise
-        else:
-            self._connection.commit()
-        finally:
-            cursor.close()
+        with self._lock:
+            cursor = self._connection.cursor()
+            try:
+                cursor.execute("BEGIN IMMEDIATE")
+                yield cursor
+                self._connection.commit()
+            except BaseException:
+                self._connection.rollback()
+                raise
+            finally:
+                cursor.close()
 
     @staticmethod
     def _delete_fts(

--- a/tldw_chatbook/Notes/file_notes_replica.py
+++ b/tldw_chatbook/Notes/file_notes_replica.py
@@ -1,0 +1,453 @@
+"""SQLite replica, search index, and recovery snapshots for File Notes."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+class FileNotesReplica:
+    """Store current File Notes bytes without becoming their editor authority."""
+
+    def __init__(self, db_path: str | os.PathLike[str]) -> None:
+        """Open the replica and initialize its fixed schema.
+
+        Args:
+            db_path: SQLite database path, or ``":memory:"`` for a transient
+                replica.
+        """
+        path = os.fspath(db_path)
+        if path != ":memory:":
+            Path(path).expanduser().parent.mkdir(parents=True, exist_ok=True)
+        self._connection = sqlite3.connect(path, isolation_level=None)
+        self._connection.row_factory = sqlite3.Row
+        self._initialize_schema()
+
+    def close(self) -> None:
+        """Close the persistent SQLite connection."""
+        self._connection.close()
+
+    def upsert_file(
+        self,
+        root: str,
+        relative_path: str,
+        raw_bytes: bytes,
+        *,
+        content_hash: str,
+        decoded_text: str | None,
+        size: int,
+        mtime_ns: int,
+    ) -> None:
+        """Replace one root-namespaced current-byte replica and its FTS row."""
+        with self._transaction() as cursor:
+            cursor.execute(
+                """
+                INSERT INTO files (
+                    root,
+                    relative_path,
+                    raw_bytes,
+                    content_hash,
+                    decoded_text,
+                    size,
+                    mtime_ns,
+                    deleted_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
+                ON CONFLICT(root, relative_path) DO UPDATE SET
+                    raw_bytes = excluded.raw_bytes,
+                    content_hash = excluded.content_hash,
+                    decoded_text = excluded.decoded_text,
+                    size = excluded.size,
+                    mtime_ns = excluded.mtime_ns,
+                    deleted_at = NULL
+                """,
+                (
+                    root,
+                    relative_path,
+                    raw_bytes,
+                    content_hash,
+                    decoded_text,
+                    size,
+                    mtime_ns,
+                ),
+            )
+            self._replace_fts(cursor, root, relative_path, decoded_text)
+
+    def get_bytes(self, root: str, relative_path: str) -> bytes | None:
+        """Return exact current or tombstoned bytes for a path."""
+        row = self._connection.execute(
+            """
+            SELECT raw_bytes
+            FROM files
+            WHERE root = ? AND relative_path = ?
+            """,
+            (root, relative_path),
+        ).fetchone()
+        return None if row is None else bytes(row["raw_bytes"])
+
+    def search(self, root: str, query: str, *, limit: int = 50) -> list[str]:
+        """Return active paths whose decoded current content matches user text."""
+        query = query.strip()
+        if not query or limit <= 0 or "\x00" in query:
+            return []
+        escaped_query = query.replace('"', '""')
+        literal_query = f'"{escaped_query}"'
+        try:
+            rows = self._connection.execute(
+                """
+                SELECT files.relative_path
+                FROM files_fts
+                JOIN files
+                  ON files.root = files_fts.root
+                 AND files.relative_path = files_fts.relative_path
+                WHERE files_fts MATCH ?
+                  AND files.root = ?
+                  AND files.deleted_at IS NULL
+                ORDER BY bm25(files_fts), files.relative_path
+                LIMIT ?
+                """,
+                (literal_query, root, limit),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            return []
+        return [str(row["relative_path"]) for row in rows]
+
+    def mark_deleted(
+        self,
+        root: str,
+        relative_path: str,
+        *,
+        deleted_at: str | None = None,
+    ) -> bool:
+        """Tombstone a missing file while retaining its last observed bytes."""
+        with self._transaction() as cursor:
+            cursor.execute(
+                """
+                UPDATE files
+                SET deleted_at = ?
+                WHERE root = ? AND relative_path = ?
+                """,
+                (deleted_at or _utc_now(), root, relative_path),
+            )
+            if cursor.rowcount == 0:
+                return False
+            self._delete_fts(cursor, root, relative_path)
+        return True
+
+    def clear_tombstone(self, root: str, relative_path: str) -> bool:
+        """Clear a deletion marker and restore searchable current content."""
+        with self._transaction() as cursor:
+            row = cursor.execute(
+                """
+                SELECT decoded_text
+                FROM files
+                WHERE root = ?
+                  AND relative_path = ?
+                  AND deleted_at IS NOT NULL
+                """,
+                (root, relative_path),
+            ).fetchone()
+            if row is None:
+                return False
+            cursor.execute(
+                """
+                UPDATE files
+                SET deleted_at = NULL
+                WHERE root = ? AND relative_path = ?
+                """,
+                (root, relative_path),
+            )
+            self._replace_fts(
+                cursor,
+                root,
+                relative_path,
+                row["decoded_text"],
+            )
+        return True
+
+    def list_deleted(self, root: str) -> list[str]:
+        """List tombstoned paths for one canonical root."""
+        rows = self._connection.execute(
+            """
+            SELECT relative_path
+            FROM files
+            WHERE root = ? AND deleted_at IS NOT NULL
+            ORDER BY deleted_at DESC, relative_path
+            """,
+            (root,),
+        ).fetchall()
+        return [str(row["relative_path"]) for row in rows]
+
+    def get_restore_bytes(self, root: str, relative_path: str) -> bytes | None:
+        """Return exact bytes only when a path has a deletion tombstone."""
+        row = self._connection.execute(
+            """
+            SELECT raw_bytes
+            FROM files
+            WHERE root = ?
+              AND relative_path = ?
+              AND deleted_at IS NOT NULL
+            """,
+            (root, relative_path),
+        ).fetchone()
+        return None if row is None else bytes(row["raw_bytes"])
+
+    def protect(
+        self,
+        root: str,
+        relative_path: str,
+        *,
+        is_prefix: bool = False,
+    ) -> None:
+        """Protect one exact path or a path-component-bounded folder prefix."""
+        with self._transaction() as cursor:
+            cursor.execute(
+                """
+                INSERT OR IGNORE INTO protected_paths (
+                    root,
+                    relative_path,
+                    is_prefix
+                )
+                VALUES (?, ?, ?)
+                """,
+                (root, relative_path, int(is_prefix)),
+            )
+
+    def unprotect(
+        self,
+        root: str,
+        relative_path: str,
+        *,
+        is_prefix: bool = False,
+    ) -> bool:
+        """Remove one exact protection entry."""
+        with self._transaction() as cursor:
+            cursor.execute(
+                """
+                DELETE FROM protected_paths
+                WHERE root = ?
+                  AND relative_path = ?
+                  AND is_prefix = ?
+                """,
+                (root, relative_path, int(is_prefix)),
+            )
+            removed = cursor.rowcount > 0
+        return removed
+
+    def is_protected(self, root: str, relative_path: str) -> bool:
+        """Return whether an exact or component-bounded prefix protects a path."""
+        row = self._connection.execute(
+            """
+            SELECT 1
+            FROM protected_paths
+            WHERE root = ?
+              AND (
+                    (is_prefix = 0 AND relative_path = ?)
+                 OR (
+                        is_prefix = 1
+                    AND (
+                           relative_path = ''
+                        OR relative_path = ?
+                        OR substr(?, 1, length(relative_path) + 1)
+                           = relative_path || '/'
+                    )
+                 )
+              )
+            LIMIT 1
+            """,
+            (root, relative_path, relative_path, relative_path),
+        ).fetchone()
+        return row is not None
+
+    def checkpoint(
+        self,
+        root: str,
+        relative_path: str,
+        raw_bytes: bytes,
+        *,
+        content_hash: str,
+        session_key: str,
+        created_at: str | None = None,
+    ) -> bool:
+        """Record exact pre-edit bytes once for a supplied editing session."""
+        with self._transaction() as cursor:
+            cursor.execute(
+                """
+                INSERT OR IGNORE INTO revisions (
+                    root,
+                    relative_path,
+                    raw_bytes,
+                    content_hash,
+                    kind,
+                    session_key,
+                    created_at
+                )
+                VALUES (?, ?, ?, ?, 'pre_edit', ?, ?)
+                """,
+                (
+                    root,
+                    relative_path,
+                    raw_bytes,
+                    content_hash,
+                    session_key,
+                    created_at or _utc_now(),
+                ),
+            )
+            inserted = cursor.rowcount > 0
+        return inserted
+
+    def prepare_deletion(
+        self,
+        root: str,
+        relative_path: str,
+        raw_bytes: bytes,
+        *,
+        content_hash: str,
+        deleted_at: str | None = None,
+        created_at: str | None = None,
+    ) -> None:
+        """Atomically store a deletion snapshot and tombstone its current row.
+
+        Raises:
+            KeyError: If the path has no current replica row to tombstone.
+        """
+        deletion_time = deleted_at or _utc_now()
+        with self._transaction() as cursor:
+            cursor.execute(
+                """
+                INSERT INTO revisions (
+                    root,
+                    relative_path,
+                    raw_bytes,
+                    content_hash,
+                    kind,
+                    session_key,
+                    created_at
+                )
+                VALUES (?, ?, ?, ?, 'delete', NULL, ?)
+                """,
+                (
+                    root,
+                    relative_path,
+                    raw_bytes,
+                    content_hash,
+                    created_at or deletion_time,
+                ),
+            )
+            cursor.execute(
+                """
+                UPDATE files
+                SET raw_bytes = ?,
+                    content_hash = ?,
+                    size = ?,
+                    deleted_at = ?
+                WHERE root = ? AND relative_path = ?
+                """,
+                (
+                    raw_bytes,
+                    content_hash,
+                    len(raw_bytes),
+                    deletion_time,
+                    root,
+                    relative_path,
+                ),
+            )
+            if cursor.rowcount == 0:
+                raise KeyError((root, relative_path))
+            self._delete_fts(cursor, root, relative_path)
+
+    def _initialize_schema(self) -> None:
+        self._connection.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS files (
+                root TEXT NOT NULL,
+                relative_path TEXT NOT NULL,
+                raw_bytes BLOB NOT NULL,
+                content_hash TEXT NOT NULL,
+                decoded_text TEXT,
+                size INTEGER NOT NULL,
+                mtime_ns INTEGER NOT NULL,
+                deleted_at TEXT,
+                UNIQUE(root, relative_path)
+            );
+
+            CREATE TABLE IF NOT EXISTS revisions (
+                root TEXT NOT NULL,
+                relative_path TEXT NOT NULL,
+                raw_bytes BLOB NOT NULL,
+                content_hash TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                session_key TEXT,
+                created_at TEXT NOT NULL,
+                UNIQUE(root, relative_path, kind, session_key)
+            );
+
+            CREATE TABLE IF NOT EXISTS protected_paths (
+                root TEXT NOT NULL,
+                relative_path TEXT NOT NULL,
+                is_prefix INTEGER NOT NULL CHECK(is_prefix IN (0, 1)),
+                UNIQUE(root, relative_path, is_prefix)
+            );
+
+            CREATE VIRTUAL TABLE IF NOT EXISTS files_fts USING fts5(
+                root UNINDEXED,
+                relative_path UNINDEXED,
+                decoded_text,
+                tokenize = 'unicode61'
+            );
+            """
+        )
+
+    @contextmanager
+    def _transaction(self) -> Iterator[sqlite3.Cursor]:
+        cursor = self._connection.cursor()
+        cursor.execute("BEGIN IMMEDIATE")
+        try:
+            yield cursor
+        except BaseException:
+            self._connection.rollback()
+            raise
+        else:
+            self._connection.commit()
+        finally:
+            cursor.close()
+
+    @staticmethod
+    def _delete_fts(
+        cursor: sqlite3.Cursor,
+        root: str,
+        relative_path: str,
+    ) -> None:
+        cursor.execute(
+            """
+            DELETE FROM files_fts
+            WHERE root = ? AND relative_path = ?
+            """,
+            (root, relative_path),
+        )
+
+    @classmethod
+    def _replace_fts(
+        cls,
+        cursor: sqlite3.Cursor,
+        root: str,
+        relative_path: str,
+        decoded_text: str | None,
+    ) -> None:
+        cls._delete_fts(cursor, root, relative_path)
+        if decoded_text is not None:
+            cursor.execute(
+                """
+                INSERT INTO files_fts (root, relative_path, decoded_text)
+                VALUES (?, ?, ?)
+                """,
+                (root, relative_path, decoded_text),
+            )
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/tldw_chatbook/Notes/file_notes_service.py
+++ b/tldw_chatbook/Notes/file_notes_service.py
@@ -7,9 +7,12 @@ import hashlib
 import os
 import stat
 import tempfile
+from collections.abc import Callable
 from dataclasses import dataclass, replace
+from functools import wraps
 from pathlib import Path
-from typing import Literal
+from threading import RLock
+from typing import Literal, TypeVar, cast
 
 from tldw_chatbook.Notes.file_notes_replica import FileNotesReplica, ReplicaFileInfo
 
@@ -30,6 +33,20 @@ OperationStatus = Literal[
     "replica-error",
     "error",
 ]
+_ServiceMethod = TypeVar("_ServiceMethod", bound=Callable[..., object])
+
+
+def _serialized(method: _ServiceMethod) -> _ServiceMethod:
+    @wraps(method)
+    def wrapper(
+        service: FileNotesService,
+        *args: object,
+        **kwargs: object,
+    ) -> object:
+        with service._operation_lock:
+            return method(service, *args, **kwargs)
+
+    return cast(_ServiceMethod, wrapper)
 
 
 @dataclass(frozen=True)
@@ -132,14 +149,17 @@ class FileNotesService:
         self.root = Path(root).expanduser().resolve(strict=False)
         self.root_key = str(self.root)
         self._replica = replica
+        self._operation_lock = RLock()
         self._session_changes: list[SessionChange] = []
         self._entry_cache: dict[str, FileNoteEntry] = {}
 
     @property
+    @_serialized
     def session_changes(self) -> tuple[SessionChange, ...]:
         """Return Chatbook-only changes made by this service instance."""
         return tuple(self._session_changes)
 
+    @_serialized
     def scan(self) -> ScanResult:
         """Scan supported regular files without following symlinks."""
         if not self._root_is_online():
@@ -179,6 +199,7 @@ class FileNotesService:
             replica_warning=warning,
         )
 
+    @_serialized
     def open_file(self, relative_path: str) -> OpenedFileNote:
         """Read a supported file from disk and record its exact-byte replica."""
         if not self._root_is_online():
@@ -201,6 +222,7 @@ class FileNotesService:
             replica_warning=warning,
         )
 
+    @_serialized
     def save_file(
         self,
         opened: OpenedFileNote,
@@ -308,23 +330,17 @@ class FileNotesService:
                 except OSError:
                     pass
 
-        new_stat = path.stat()
         new_hash = _digest(new_bytes)
-        replica_warning = self._upsert_bytes(
+        return self._finish_published_file(
+            "modified",
             relative_path,
+            path,
             new_bytes,
             content_hash=new_hash,
-            file_stat=new_stat,
-        )
-        warning = _merge_warnings(warning, replica_warning)
-        self._session_changes.append(SessionChange("modified", relative_path))
-        return OperationResult(
-            status="ok",
-            relative_path=relative_path,
-            content_hash=new_hash,
-            replica_warning=warning,
+            warning=warning,
         )
 
+    @_serialized
     def create_file(self, relative_path: str, body: str = "") -> OperationResult:
         """Create one supported UTF-8 file with an exclusive filesystem open."""
         if not self._root_is_online():
@@ -359,22 +375,16 @@ class FileNotesService:
                 pass
             return _result("error", relative_path, str(error))
 
-        file_stat = path.stat()
         content_hash = _digest(raw_bytes)
-        warning = self._upsert_bytes(
+        return self._finish_published_file(
+            "created",
             relative_path,
+            path,
             raw_bytes,
             content_hash=content_hash,
-            file_stat=file_stat,
-        )
-        self._session_changes.append(SessionChange("created", relative_path))
-        return OperationResult(
-            status="ok",
-            relative_path=relative_path,
-            content_hash=content_hash,
-            replica_warning=warning,
         )
 
+    @_serialized
     def move_file(
         self,
         relative_path: str,
@@ -468,6 +478,7 @@ class FileNotesService:
             replica_warning=warning,
         )
 
+    @_serialized
     def delete_file(
         self,
         relative_path: str,
@@ -563,6 +574,7 @@ class FileNotesService:
             content_hash=content_hash,
         )
 
+    @_serialized
     def restore_file(self, relative_path: str) -> OperationResult:
         """Restore exact tombstoned bytes with an exclusive filesystem create."""
         if not self._root_is_online():
@@ -614,22 +626,16 @@ class FileNotesService:
                 pass
             return _result("error", relative_path, str(error))
 
-        file_stat = path.stat()
         content_hash = _digest(raw_bytes)
-        warning = self._upsert_bytes(
+        return self._finish_published_file(
+            "restored",
             relative_path,
+            path,
             raw_bytes,
             content_hash=content_hash,
-            file_stat=file_stat,
-        )
-        self._session_changes.append(SessionChange("restored", relative_path))
-        return OperationResult(
-            status="ok",
-            relative_path=relative_path,
-            content_hash=content_hash,
-            replica_warning=warning,
         )
 
+    @_serialized
     def reconcile(self) -> ReconcileResult:
         """Project external create/modify/delete changes into the replica."""
         if not self._root_is_online():
@@ -739,6 +745,7 @@ class FileNotesService:
             replica_warning=warning,
         )
 
+    @_serialized
     def protect_path(
         self,
         relative_path: str,
@@ -766,6 +773,7 @@ class FileNotesService:
             )
         return OperationResult(status="ok", relative_path=relative_path)
 
+    @_serialized
     def unprotect_path(
         self,
         relative_path: str,
@@ -852,9 +860,11 @@ class FileNotesService:
     def _safe_path(self, relative_path: str) -> Path:
         if not isinstance(relative_path, str) or not relative_path:
             raise ValueError("unsafe empty relative path")
-        if "\x00" in relative_path or "\\" in relative_path:
+        if "\x00" in relative_path:
             raise ValueError("unsafe relative path")
         candidate_path = Path(relative_path)
+        if candidate_path.as_posix() != relative_path:
+            raise ValueError(f"unsafe non-canonical path: {relative_path}")
         if candidate_path.is_absolute():
             raise ValueError("unsafe absolute path")
         parts = candidate_path.parts
@@ -893,6 +903,41 @@ class FileNotesService:
     @staticmethod
     def _is_supported(path: Path) -> bool:
         return path.suffix.lower() in SUPPORTED_EXTENSIONS
+
+    def _finish_published_file(
+        self,
+        action: Literal["created", "modified", "restored"],
+        relative_path: str,
+        path: Path,
+        raw_bytes: bytes,
+        *,
+        content_hash: str,
+        warning: str | None = None,
+    ) -> OperationResult:
+        self._session_changes.append(SessionChange(action, relative_path))
+        try:
+            file_stat = path.stat()
+        except OSError as error:
+            warning = _merge_warnings(
+                warning,
+                f"Replica update deferred: {error}",
+            )
+        else:
+            warning = _merge_warnings(
+                warning,
+                self._upsert_bytes(
+                    relative_path,
+                    raw_bytes,
+                    content_hash=content_hash,
+                    file_stat=file_stat,
+                ),
+            )
+        return OperationResult(
+            status="ok",
+            relative_path=relative_path,
+            content_hash=content_hash,
+            replica_warning=warning,
+        )
 
     def _upsert_opened(self, opened: OpenedFileNote) -> str | None:
         return self._upsert_bytes(

--- a/tldw_chatbook/Notes/file_notes_service.py
+++ b/tldw_chatbook/Notes/file_notes_service.py
@@ -14,7 +14,10 @@ from pathlib import Path
 from threading import RLock
 from typing import Literal, TypeVar, cast
 
+from loguru import logger
+
 from tldw_chatbook.Notes.file_notes_replica import FileNotesReplica, ReplicaFileInfo
+from tldw_chatbook.Utils.path_validation import get_safe_relative_path
 
 MAX_FILE_BYTES = 8_000_000
 MAX_FILE_CHARS = 2_000_000
@@ -164,7 +167,11 @@ class FileNotesService:
     @property
     @_serialized
     def session_changes(self) -> tuple[SessionChange, ...]:
-        """Return Chatbook-only changes made by this service instance."""
+        """Return Chatbook-only changes made by this service instance.
+
+        Returns:
+            An immutable snapshot of this session's disk changes.
+        """
         return tuple(self._session_changes)
 
     @_serialized
@@ -177,7 +184,11 @@ class FileNotesService:
 
     @_serialized
     def scan(self) -> ScanResult:
-        """Scan supported regular files without following symlinks."""
+        """Scan supported regular files without following symlinks.
+
+        Returns:
+            Current file entries and any replica warning.
+        """
         if not self._root_is_online():
             return ScanResult(status="offline", offline=True)
 
@@ -217,7 +228,19 @@ class FileNotesService:
 
     @_serialized
     def open_file(self, relative_path: str) -> OpenedFileNote:
-        """Read a supported file from disk and record its exact-byte replica."""
+        """Read a supported file from disk and record its exact-byte replica.
+
+        Args:
+            relative_path: File path relative to the configured notes root.
+
+        Returns:
+            The decoded note body and exact on-disk metadata.
+
+        Raises:
+            FileNotFoundError: If the notes root or file is unavailable.
+            ValueError: If the path or file content is unsafe or unsupported.
+            OSError: If the file cannot be read.
+        """
         if not self._root_is_online():
             raise FileNotFoundError(f"File Notes root is offline: {self.root}")
         opened = self._load_file(relative_path)
@@ -246,7 +269,16 @@ class FileNotesService:
         *,
         session_key: str,
     ) -> OperationResult:
-        """Atomically save an editable body after exact hash checks."""
+        """Atomically save an editable body after exact hash checks.
+
+        Args:
+            opened: Snapshot returned by :meth:`open_file`.
+            body: Replacement note body.
+            session_key: Editing-session identifier for protected checkpoints.
+
+        Returns:
+            Save status, resulting hash, and any replica warning.
+        """
         relative_path = opened.relative_path
         if opened.root != self.root_key:
             return _result("unsafe", relative_path, "Opened note belongs to another root")
@@ -328,7 +360,12 @@ class FileNotesService:
             with os.fdopen(descriptor, "wb") as temporary:
                 temporary.write(new_bytes)
                 temporary.flush()
-                os.fchmod(temporary.fileno(), stat.S_IMODE(current_stat.st_mode))
+                file_mode = stat.S_IMODE(current_stat.st_mode)
+                fchmod = getattr(os, "fchmod", None)
+                if fchmod is not None:
+                    fchmod(temporary.fileno(), file_mode)
+            if fchmod is None:
+                os.chmod(temporary_path, file_mode)
 
             rechecked_bytes, _ = _read_regular_file(path)
             if _digest(rechecked_bytes) != opened.content_hash:
@@ -343,8 +380,12 @@ class FileNotesService:
             if temporary_path is not None:
                 try:
                     os.unlink(temporary_path)
-                except OSError:
-                    pass
+                except OSError as error:
+                    logger.warning(
+                        "Could not remove File Notes temporary file '{}': {}",
+                        temporary_path,
+                        error,
+                    )
 
         new_hash = _digest(new_bytes)
         return self._finish_published_file(
@@ -363,7 +404,16 @@ class FileNotesService:
         body: str,
         destination_path: str,
     ) -> OperationResult:
-        """Save an opened note's exact format to a new path without clobbering."""
+        """Save an opened note's exact format to a new path without clobbering.
+
+        Args:
+            opened: Snapshot whose encoding and frontmatter are preserved.
+            body: Note body to write.
+            destination_path: New path relative to the notes root.
+
+        Returns:
+            Copy status, resulting hash, and any replica warning.
+        """
         if opened.root != self.root_key:
             return _result(
                 "unsafe",
@@ -416,7 +466,15 @@ class FileNotesService:
 
     @_serialized
     def create_file(self, relative_path: str, body: str = "") -> OperationResult:
-        """Create one supported UTF-8 file with an exclusive filesystem open."""
+        """Create one supported UTF-8 file with an exclusive filesystem open.
+
+        Args:
+            relative_path: New file path relative to the notes root.
+            body: Initial UTF-8 note content.
+
+        Returns:
+            Creation status, resulting hash, and any replica warning.
+        """
         if not self._root_is_online():
             return _result("offline", relative_path)
         try:
@@ -464,7 +522,15 @@ class FileNotesService:
         relative_path: str,
         destination_path: str,
     ) -> OperationResult:
-        """Move a file without clobbering by linking then unlinking the source."""
+        """Move a file without clobbering by linking then unlinking the source.
+
+        Args:
+            relative_path: Existing file path relative to the notes root.
+            destination_path: New path relative to the notes root.
+
+        Returns:
+            Move status and any replica warning.
+        """
         if not self._root_is_online():
             return _result("offline", relative_path, destination=destination_path)
         try:
@@ -559,7 +625,15 @@ class FileNotesService:
         *,
         expected_hash: str | None = None,
     ) -> OperationResult:
-        """Commit a recovery tombstone, recheck bytes, and only then unlink."""
+        """Commit a recovery tombstone, recheck bytes, and only then unlink.
+
+        Args:
+            relative_path: File path relative to the notes root.
+            expected_hash: Optional digest required to match current disk bytes.
+
+        Returns:
+            Deletion status, deleted-content hash, and any replica warning.
+        """
         if not self._root_is_online():
             return _result("offline", relative_path)
         try:
@@ -650,7 +724,14 @@ class FileNotesService:
 
     @_serialized
     def restore_file(self, relative_path: str) -> OperationResult:
-        """Restore exact tombstoned bytes with an exclusive filesystem create."""
+        """Restore exact tombstoned bytes with an exclusive filesystem create.
+
+        Args:
+            relative_path: Tombstoned file path relative to the notes root.
+
+        Returns:
+            Restore status, resulting hash, and any replica warning.
+        """
         if not self._root_is_online():
             return _result("offline", relative_path)
         if self._replica is None:
@@ -711,7 +792,11 @@ class FileNotesService:
 
     @_serialized
     def reconcile(self) -> ReconcileResult:
-        """Project external create/modify/delete changes into the replica."""
+        """Project external create/modify/delete changes into the replica.
+
+        Returns:
+            Reconciled entries, external change sets, and any replica warning.
+        """
         if not self._root_is_online():
             return ReconcileResult(status="offline", offline=True)
 
@@ -826,7 +911,15 @@ class FileNotesService:
         *,
         is_prefix: bool = False,
     ) -> OperationResult:
-        """Enable future pre-edit checkpoints for a file or folder prefix."""
+        """Enable future pre-edit checkpoints for a file or folder prefix.
+
+        Args:
+            relative_path: Exact file path or folder prefix.
+            is_prefix: Whether ``relative_path`` identifies a folder prefix.
+
+        Returns:
+            Protection status and any replica warning.
+        """
         if self._replica is None:
             return _result("replica-error", relative_path)
         try:
@@ -854,7 +947,15 @@ class FileNotesService:
         *,
         is_prefix: bool = False,
     ) -> OperationResult:
-        """Stop future checkpoints without removing existing revisions."""
+        """Stop future checkpoints without removing existing revisions.
+
+        Args:
+            relative_path: Exact file path or folder prefix.
+            is_prefix: Whether ``relative_path`` identifies a folder prefix.
+
+        Returns:
+            Unprotection status and any replica warning.
+        """
         if self._replica is None:
             return _result("replica-error", relative_path)
         try:
@@ -958,6 +1059,8 @@ class FileNotesService:
                 raise ValueError(f"symlink traversal is not allowed: {relative_path}")
 
         resolved = current.resolve(strict=False)
+        if get_safe_relative_path(current, self.root) is None:
+            raise ValueError(f"unsafe path outside root: {relative_path}")
         try:
             resolved.relative_to(self.root)
         except ValueError as error:

--- a/tldw_chatbook/Notes/file_notes_service.py
+++ b/tldw_chatbook/Notes/file_notes_service.py
@@ -1,0 +1,1229 @@
+"""Disk-authoritative filesystem operations for a single File Notes root."""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import os
+import stat
+import tempfile
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Literal
+
+from tldw_chatbook.Notes.file_notes_replica import FileNotesReplica, ReplicaFileInfo
+from tldw_chatbook.Utils.path_validation import validate_filename
+
+MAX_FILE_BYTES = 8_000_000
+MAX_FILE_CHARS = 2_000_000
+SUPPORTED_EXTENSIONS = frozenset({".md", ".markdown", ".txt", ".text"})
+UTF8_BOM = b"\xef\xbb\xbf"
+
+OperationStatus = Literal[
+    "ok",
+    "offline",
+    "unsafe",
+    "unsupported",
+    "missing",
+    "exists",
+    "readonly",
+    "conflict",
+    "replica-error",
+    "error",
+]
+
+
+@dataclass(frozen=True)
+class FileNoteEntry:
+    """One supported regular file discovered below the selected root."""
+
+    relative_path: str
+    size: int
+    mtime_ns: int
+    content_hash: str
+    editable: bool
+    read_only_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class OpenedFileNote:
+    """Exact disk baseline and editable body for one opened note."""
+
+    root: str
+    relative_path: str
+    body: str
+    preserved_prefix: bytes
+    content_hash: str
+    newline: Literal["\n", "\r\n"]
+    has_final_newline: bool
+    size: int
+    mtime_ns: int
+    editable: bool
+    read_only_reason: str | None
+    protected: bool
+    raw_bytes: bytes
+    replica_warning: str | None = None
+
+
+@dataclass(frozen=True)
+class SessionChange:
+    """One successful filesystem mutation initiated by this service instance."""
+
+    action: Literal["created", "modified", "moved", "deleted", "restored"]
+    relative_path: str
+    destination_path: str | None = None
+
+
+@dataclass(frozen=True)
+class OperationResult:
+    """Typed result for an expected filesystem or recovery outcome."""
+
+    status: OperationStatus
+    relative_path: str
+    destination_path: str | None = None
+    content_hash: str | None = None
+    replica_warning: str | None = None
+    message: str | None = None
+
+    @property
+    def succeeded(self) -> bool:
+        """Return whether the disk mutation completed."""
+        return self.status == "ok"
+
+
+@dataclass(frozen=True)
+class ScanResult:
+    """Supported files currently visible under the selected root."""
+
+    status: Literal["ok", "offline"]
+    entries: tuple[FileNoteEntry, ...] = ()
+    offline: bool = False
+    replica_warning: str | None = None
+
+
+@dataclass(frozen=True)
+class ReconcileResult:
+    """Disk scan plus root-scoped replica projection changes."""
+
+    status: Literal["ok", "offline"]
+    entries: tuple[FileNoteEntry, ...] = ()
+    created: tuple[str, ...] = ()
+    modified: tuple[str, ...] = ()
+    deleted: tuple[str, ...] = ()
+    offline: bool = False
+    replica_warning: str | None = None
+
+
+@dataclass(frozen=True)
+class _ObservedFile:
+    relative_path: str
+    path: Path
+    size: int
+    mtime_ns: int
+
+
+class _FileTooLargeError(OSError):
+    def __init__(self, file_stat: os.stat_result) -> None:
+        super().__init__("File exceeds the File Notes byte limit")
+        self.file_stat = file_stat
+
+
+class FileNotesService:
+    """Operate on one canonical notes root while disk remains authoritative."""
+
+    def __init__(
+        self,
+        root: str | os.PathLike[str],
+        replica: FileNotesReplica | None,
+    ) -> None:
+        """Bind the service to one canonical root and optional SQLite replica."""
+        self.root = Path(root).expanduser().resolve(strict=False)
+        self.root_key = str(self.root)
+        self._replica = replica
+        self._session_changes: list[SessionChange] = []
+        self._entry_cache: dict[str, FileNoteEntry] = {}
+
+    @property
+    def session_changes(self) -> tuple[SessionChange, ...]:
+        """Return Chatbook-only changes made by this service instance."""
+        return tuple(self._session_changes)
+
+    def scan(self) -> ScanResult:
+        """Scan supported regular files without following symlinks."""
+        if not self._root_is_online():
+            return ScanResult(status="offline", offline=True)
+
+        entries: list[FileNoteEntry] = []
+        warning: str | None = None
+        observed, uncertain_paths, _ = self._walk_candidates()
+        for relative_path, observed_file in observed.items():
+            if observed_file.size > MAX_FILE_BYTES:
+                entries.append(_oversize_entry(observed_file))
+                continue
+            try:
+                opened = self._load_file(relative_path)
+            except (OSError, ValueError):
+                entries.append(_unreadable_entry(observed_file))
+                continue
+            entries.append(_entry_from_opened(opened))
+            replica_warning = self._upsert_opened(opened)
+            warning = _merge_warnings(warning, replica_warning)
+        entries.extend(
+            FileNoteEntry(
+                relative_path=relative_path,
+                size=0,
+                mtime_ns=0,
+                content_hash="",
+                editable=False,
+                read_only_reason="unreadable",
+            )
+            for relative_path in uncertain_paths
+        )
+        entries.sort(key=lambda entry: entry.relative_path)
+        self._entry_cache = {
+            entry.relative_path: entry
+            for entry in entries
+        }
+        return ScanResult(
+            status="ok",
+            entries=tuple(entries),
+            replica_warning=warning,
+        )
+
+    def open_file(self, relative_path: str) -> OpenedFileNote:
+        """Read a supported file from disk and record its exact-byte replica."""
+        if not self._root_is_online():
+            raise FileNotFoundError(f"File Notes root is offline: {self.root}")
+        opened = self._load_file(relative_path)
+        protected = False
+        warning: str | None = None
+        if self._replica is not None:
+            try:
+                protected = self._replica.is_protected(
+                    self.root_key,
+                    opened.relative_path,
+                )
+            except Exception as error:
+                warning = _replica_warning(error)
+        if opened.read_only_reason != "too-many-bytes":
+            warning = _merge_warnings(warning, self._upsert_opened(opened))
+        return _replace_opened(
+            opened,
+            protected=protected,
+            replica_warning=warning,
+        )
+
+    def save_file(
+        self,
+        opened: OpenedFileNote,
+        body: str,
+        *,
+        session_key: str,
+    ) -> OperationResult:
+        """Atomically save an editable body after exact hash checks."""
+        relative_path = opened.relative_path
+        if opened.root != self.root_key:
+            return _result("unsafe", relative_path, "Opened note belongs to another root")
+        if not opened.editable:
+            return _result("readonly", relative_path, opened.read_only_reason)
+        if not self._root_is_online():
+            return _result("offline", relative_path)
+        try:
+            path = self._safe_path(relative_path)
+            current_bytes, current_stat = _read_regular_file(path)
+        except ValueError as error:
+            return _result("unsafe", relative_path, str(error))
+        except _FileTooLargeError:
+            return _result("conflict", relative_path, "Disk bytes changed")
+        except FileNotFoundError:
+            return _result("missing", relative_path)
+        except OSError as error:
+            return _result("error", relative_path, str(error))
+
+        current_hash = _digest(current_bytes)
+        if current_hash != opened.content_hash:
+            return _result("conflict", relative_path, "Disk bytes changed")
+
+        new_bytes = _serialize_body(opened, body)
+        if len(body) > MAX_FILE_CHARS or len(new_bytes) > MAX_FILE_BYTES:
+            return _result("readonly", relative_path, "Edited content exceeds limits")
+
+        warning: str | None = None
+        protected = opened.protected
+        if self._replica is not None:
+            try:
+                protected = self._replica.is_protected(
+                    self.root_key,
+                    relative_path,
+                )
+            except Exception as error:
+                warning = _replica_warning(error)
+                if opened.protected:
+                    return _result(
+                        "replica-error",
+                        relative_path,
+                        "Protected path status is unavailable",
+                        warning=warning,
+                    )
+        if protected:
+            if self._replica is None:
+                return _result(
+                    "replica-error",
+                    relative_path,
+                    "Protected saves require the replica",
+                )
+            if not session_key:
+                return _result(
+                    "replica-error",
+                    relative_path,
+                    "Protected saves require an editing session key",
+                )
+            try:
+                self._replica.checkpoint(
+                    self.root_key,
+                    relative_path,
+                    current_bytes,
+                    content_hash=current_hash,
+                    session_key=session_key,
+                )
+            except Exception as error:
+                return _result(
+                    "replica-error",
+                    relative_path,
+                    "Could not commit the protected pre-edit checkpoint",
+                    warning=_replica_warning(error),
+                )
+
+        temporary_path: str | None = None
+        try:
+            descriptor, temporary_path = tempfile.mkstemp(
+                prefix=f"{path.name}.",
+                suffix=".tmp",
+                dir=path.parent,
+            )
+            with os.fdopen(descriptor, "wb") as temporary:
+                temporary.write(new_bytes)
+                temporary.flush()
+                os.fchmod(temporary.fileno(), stat.S_IMODE(current_stat.st_mode))
+
+            rechecked_bytes, _ = _read_regular_file(path)
+            if _digest(rechecked_bytes) != opened.content_hash:
+                return _result("conflict", relative_path, "Disk bytes changed")
+            os.replace(temporary_path, path)
+            temporary_path = None
+        except FileNotFoundError:
+            return _result("missing", relative_path)
+        except OSError as error:
+            return _result("error", relative_path, str(error))
+        finally:
+            if temporary_path is not None:
+                try:
+                    os.unlink(temporary_path)
+                except OSError:
+                    pass
+
+        new_stat = path.stat()
+        new_hash = _digest(new_bytes)
+        replica_warning = self._upsert_bytes(
+            relative_path,
+            new_bytes,
+            content_hash=new_hash,
+            file_stat=new_stat,
+        )
+        warning = _merge_warnings(warning, replica_warning)
+        self._session_changes.append(SessionChange("modified", relative_path))
+        return OperationResult(
+            status="ok",
+            relative_path=relative_path,
+            content_hash=new_hash,
+            replica_warning=warning,
+        )
+
+    def create_file(self, relative_path: str, body: str = "") -> OperationResult:
+        """Create one supported UTF-8 file with an exclusive filesystem open."""
+        if not self._root_is_online():
+            return _result("offline", relative_path)
+        try:
+            path = self._safe_path(relative_path)
+        except ValueError as error:
+            return _result("unsafe", relative_path, str(error))
+        if not self._is_supported(path):
+            return _result("unsupported", relative_path)
+        raw_bytes = body.encode("utf-8")
+        if len(body) > MAX_FILE_CHARS or len(raw_bytes) > MAX_FILE_BYTES:
+            return _result("readonly", relative_path, "Content exceeds limits")
+
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        try:
+            descriptor = os.open(path, flags, 0o666)
+        except FileExistsError:
+            return _result("exists", relative_path)
+        except OSError as error:
+            if error.errno in {errno.ELOOP, errno.ENOTDIR}:
+                return _result("unsafe", relative_path, str(error))
+            return _result("error", relative_path, str(error))
+        try:
+            with os.fdopen(descriptor, "wb") as destination:
+                destination.write(raw_bytes)
+        except OSError as error:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+            return _result("error", relative_path, str(error))
+
+        file_stat = path.stat()
+        content_hash = _digest(raw_bytes)
+        warning = self._upsert_bytes(
+            relative_path,
+            raw_bytes,
+            content_hash=content_hash,
+            file_stat=file_stat,
+        )
+        self._session_changes.append(SessionChange("created", relative_path))
+        return OperationResult(
+            status="ok",
+            relative_path=relative_path,
+            content_hash=content_hash,
+            replica_warning=warning,
+        )
+
+    def move_file(
+        self,
+        relative_path: str,
+        destination_path: str,
+    ) -> OperationResult:
+        """Move a file without clobbering by linking then unlinking the source."""
+        if not self._root_is_online():
+            return _result("offline", relative_path, destination=destination_path)
+        try:
+            source = self._safe_path(relative_path)
+            destination = self._safe_path(destination_path)
+            if not self._is_supported(source) or not self._is_supported(destination):
+                return _result(
+                    "unsupported",
+                    relative_path,
+                    destination=destination_path,
+                )
+            source_stat = os.lstat(source)
+            if not stat.S_ISREG(source_stat.st_mode):
+                return _result(
+                    "unsafe",
+                    relative_path,
+                    "Source is not a regular file",
+                    destination=destination_path,
+                )
+        except ValueError as error:
+            return _result(
+                "unsafe",
+                relative_path,
+                str(error),
+                destination=destination_path,
+            )
+        except FileNotFoundError:
+            return _result("missing", relative_path, destination=destination_path)
+        except OSError as error:
+            return _result(
+                "error",
+                relative_path,
+                str(error),
+                destination=destination_path,
+            )
+        try:
+            os.link(source, destination, follow_symlinks=False)
+        except FileExistsError:
+            return _result("exists", relative_path, destination=destination_path)
+        except OSError as error:
+            return _result(
+                "error",
+                relative_path,
+                str(error),
+                destination=destination_path,
+            )
+        try:
+            os.unlink(source)
+        except OSError as error:
+            rollback_error: OSError | None = None
+            try:
+                os.unlink(destination)
+            except OSError as caught:
+                rollback_error = caught
+            message = str(error)
+            if rollback_error is not None:
+                message = f"{message}; destination rollback failed: {rollback_error}"
+            return _result(
+                "error",
+                relative_path,
+                message,
+                destination=destination_path,
+            )
+
+        warning: str | None = None
+        try:
+            moved = self._load_file(destination_path)
+            if moved.read_only_reason == "too-many-bytes":
+                warning = "Replica not updated: file exceeds the byte limit"
+            else:
+                warning = self._upsert_opened(moved)
+        except (OSError, ValueError) as error:
+            warning = f"Replica refresh failed: {error}"
+        if self._replica is not None:
+            try:
+                self._replica.mark_deleted(self.root_key, relative_path)
+            except Exception as error:
+                warning = _merge_warnings(warning, _replica_warning(error))
+        else:
+            warning = _merge_warnings(warning, "Replica unavailable")
+        self._session_changes.append(
+            SessionChange("moved", relative_path, destination_path)
+        )
+        return OperationResult(
+            status="ok",
+            relative_path=relative_path,
+            destination_path=destination_path,
+            replica_warning=warning,
+        )
+
+    def delete_file(
+        self,
+        relative_path: str,
+        *,
+        expected_hash: str | None = None,
+    ) -> OperationResult:
+        """Commit a recovery tombstone, recheck bytes, and only then unlink."""
+        if not self._root_is_online():
+            return _result("offline", relative_path)
+        try:
+            path = self._safe_path(relative_path)
+            if not self._is_supported(path):
+                return _result("unsupported", relative_path)
+            observed_stat = os.lstat(path)
+            if not stat.S_ISREG(observed_stat.st_mode):
+                return _result("unsafe", relative_path, "Not a regular file")
+            if observed_stat.st_size > MAX_FILE_BYTES:
+                return _result(
+                    "readonly",
+                    relative_path,
+                    "File is too large to snapshot safely",
+                )
+            if self._replica is None:
+                return _result(
+                    "replica-error",
+                    relative_path,
+                    "Delete requires the recovery replica",
+                )
+            raw_bytes, file_stat = _read_regular_file(path)
+        except ValueError as error:
+            return _result("unsafe", relative_path, str(error))
+        except _FileTooLargeError:
+            return _result(
+                "readonly",
+                relative_path,
+                "File is too large to snapshot safely",
+            )
+        except FileNotFoundError:
+            return _result("missing", relative_path)
+        except OSError as error:
+            return _result("error", relative_path, str(error))
+
+        content_hash = _digest(raw_bytes)
+        if expected_hash is not None and content_hash != expected_hash:
+            return _result("conflict", relative_path, "Disk bytes changed")
+        decoded_text = _decode_for_replica(raw_bytes)
+        try:
+            self._replica.upsert_file(
+                self.root_key,
+                relative_path,
+                raw_bytes,
+                content_hash=content_hash,
+                decoded_text=decoded_text,
+                size=len(raw_bytes),
+                mtime_ns=file_stat.st_mtime_ns,
+            )
+            self._replica.prepare_deletion(
+                self.root_key,
+                relative_path,
+                raw_bytes,
+                content_hash=content_hash,
+                decoded_text=decoded_text,
+            )
+        except Exception as error:
+            return _result(
+                "replica-error",
+                relative_path,
+                "Could not commit deletion recovery data",
+                warning=_replica_warning(error),
+            )
+
+        try:
+            rechecked_bytes, _ = _read_regular_file(path)
+        except OSError as error:
+            warning = self._clear_tombstone(relative_path)
+            return _result(
+                "error",
+                relative_path,
+                str(error),
+                warning=warning,
+            )
+        if _digest(rechecked_bytes) != content_hash:
+            warning = self._clear_tombstone(relative_path)
+            return _result(
+                "conflict",
+                relative_path,
+                "Disk bytes changed",
+                warning=warning,
+            )
+        try:
+            os.unlink(path)
+        except OSError as error:
+            warning = self._clear_tombstone(relative_path)
+            return _result(
+                "error",
+                relative_path,
+                str(error),
+                warning=warning,
+            )
+
+        self._session_changes.append(SessionChange("deleted", relative_path))
+        return OperationResult(
+            status="ok",
+            relative_path=relative_path,
+            content_hash=content_hash,
+        )
+
+    def restore_file(self, relative_path: str) -> OperationResult:
+        """Restore exact tombstoned bytes with an exclusive filesystem create."""
+        if not self._root_is_online():
+            return _result("offline", relative_path)
+        if self._replica is None:
+            return _result(
+                "replica-error",
+                relative_path,
+                "Restore requires the recovery replica",
+            )
+        try:
+            path = self._safe_path(relative_path)
+        except ValueError as error:
+            return _result("unsafe", relative_path, str(error))
+        if not self._is_supported(path):
+            return _result("unsupported", relative_path)
+        try:
+            raw_bytes = self._replica.get_restore_bytes(
+                self.root_key,
+                relative_path,
+            )
+        except Exception as error:
+            return _result(
+                "replica-error",
+                relative_path,
+                "Could not load restore bytes",
+                warning=_replica_warning(error),
+            )
+        if raw_bytes is None:
+            return _result("missing", relative_path, "No tombstone exists")
+
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        try:
+            descriptor = os.open(path, flags, 0o666)
+        except FileExistsError:
+            return _result("exists", relative_path)
+        except OSError as error:
+            if error.errno in {errno.ELOOP, errno.ENOTDIR}:
+                return _result("unsafe", relative_path, str(error))
+            return _result("error", relative_path, str(error))
+        try:
+            with os.fdopen(descriptor, "wb") as destination:
+                destination.write(raw_bytes)
+        except OSError as error:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+            return _result("error", relative_path, str(error))
+
+        file_stat = path.stat()
+        content_hash = _digest(raw_bytes)
+        warning = self._upsert_bytes(
+            relative_path,
+            raw_bytes,
+            content_hash=content_hash,
+            file_stat=file_stat,
+        )
+        self._session_changes.append(SessionChange("restored", relative_path))
+        return OperationResult(
+            status="ok",
+            relative_path=relative_path,
+            content_hash=content_hash,
+            replica_warning=warning,
+        )
+
+    def reconcile(self) -> ReconcileResult:
+        """Project external create/modify/delete changes into the replica."""
+        if not self._root_is_online():
+            return ReconcileResult(status="offline", offline=True)
+
+        old_files: dict[str, ReplicaFileInfo] | None = None
+        warning: str | None = None
+        if self._replica is not None:
+            try:
+                old_files = {
+                    item.relative_path: item
+                    for item in self._replica.list_active_files(self.root_key)
+                }
+            except Exception as error:
+                warning = _replica_warning(error)
+        else:
+            warning = "Replica unavailable"
+
+        observed, uncertain_paths, had_walk_error = self._walk_candidates()
+        entries: list[FileNoteEntry] = []
+        created: list[str] = []
+        modified: list[str] = []
+        for relative_path, observed_file in observed.items():
+            previous = None if old_files is None else old_files.get(relative_path)
+            cached = self._entry_cache.get(relative_path)
+            unchanged = (
+                previous is not None
+                and previous.size == observed_file.size
+                and previous.mtime_ns == observed_file.mtime_ns
+            ) or (
+                old_files is None
+                and cached is not None
+                and cached.size == observed_file.size
+                and cached.mtime_ns == observed_file.mtime_ns
+            )
+            if unchanged:
+                if (
+                    cached is not None
+                    and cached.size == observed_file.size
+                    and cached.mtime_ns == observed_file.mtime_ns
+                ):
+                    entries.append(cached)
+                elif observed_file.size > MAX_FILE_BYTES:
+                    entries.append(_oversize_entry(observed_file))
+                else:
+                    entries.append(
+                        FileNoteEntry(
+                            relative_path=relative_path,
+                            size=observed_file.size,
+                            mtime_ns=observed_file.mtime_ns,
+                            content_hash=previous.content_hash,
+                            editable=True,
+                        )
+                    )
+                continue
+
+            if observed_file.size > MAX_FILE_BYTES:
+                entries.append(_oversize_entry(observed_file))
+                if previous is None:
+                    created.append(relative_path)
+                else:
+                    modified.append(relative_path)
+                continue
+            try:
+                opened = self._load_file(relative_path)
+            except (OSError, ValueError):
+                entries.append(_unreadable_entry(observed_file))
+                uncertain_paths.add(relative_path)
+                continue
+            entry = _entry_from_opened(opened)
+            entries.append(entry)
+            warning = _merge_warnings(warning, self._upsert_opened(opened))
+            if previous is None:
+                if old_files is not None:
+                    created.append(relative_path)
+            elif opened.content_hash != previous.content_hash:
+                modified.append(relative_path)
+
+        entries.extend(
+            FileNoteEntry(
+                relative_path=relative_path,
+                size=0,
+                mtime_ns=0,
+                content_hash="",
+                editable=False,
+                read_only_reason="unreadable",
+            )
+            for relative_path in uncertain_paths
+            if relative_path not in observed
+        )
+        deleted: list[str] = []
+        if old_files is not None and not had_walk_error:
+            deleted = sorted(
+                set(old_files) - set(observed) - uncertain_paths
+            )
+            for relative_path in deleted:
+                try:
+                    assert self._replica is not None
+                    self._replica.mark_deleted(self.root_key, relative_path)
+                except Exception as error:
+                    warning = _merge_warnings(warning, _replica_warning(error))
+        entries.sort(key=lambda entry: entry.relative_path)
+        self._entry_cache = {
+            entry.relative_path: entry
+            for entry in entries
+        }
+        return ReconcileResult(
+            status="ok",
+            entries=tuple(entries),
+            created=tuple(sorted(created)),
+            modified=tuple(sorted(modified)),
+            deleted=tuple(deleted),
+            replica_warning=warning,
+        )
+
+    def protect_path(
+        self,
+        relative_path: str,
+        *,
+        is_prefix: bool = False,
+    ) -> OperationResult:
+        """Enable future pre-edit checkpoints for a file or folder prefix."""
+        if self._replica is None:
+            return _result("replica-error", relative_path)
+        try:
+            if relative_path or not is_prefix:
+                self._safe_path(relative_path)
+            self._replica.protect(
+                self.root_key,
+                relative_path,
+                is_prefix=is_prefix,
+            )
+        except ValueError as error:
+            return _result("unsafe", relative_path, str(error))
+        except Exception as error:
+            return _result(
+                "replica-error",
+                relative_path,
+                warning=_replica_warning(error),
+            )
+        return OperationResult(status="ok", relative_path=relative_path)
+
+    def unprotect_path(
+        self,
+        relative_path: str,
+        *,
+        is_prefix: bool = False,
+    ) -> OperationResult:
+        """Stop future checkpoints without removing existing revisions."""
+        if self._replica is None:
+            return _result("replica-error", relative_path)
+        try:
+            if relative_path or not is_prefix:
+                self._safe_path(relative_path)
+            self._replica.unprotect(
+                self.root_key,
+                relative_path,
+                is_prefix=is_prefix,
+            )
+        except ValueError as error:
+            return _result("unsafe", relative_path, str(error))
+        except Exception as error:
+            return _result(
+                "replica-error",
+                relative_path,
+                warning=_replica_warning(error),
+            )
+        return OperationResult(status="ok", relative_path=relative_path)
+
+    def _walk_candidates(
+        self,
+    ) -> tuple[dict[str, _ObservedFile], set[str], bool]:
+        observed: dict[str, _ObservedFile] = {}
+        uncertain_paths: set[str] = set()
+        had_walk_error = False
+
+        def collect_error(error: OSError) -> None:
+            nonlocal had_walk_error
+            had_walk_error = True
+
+        for current, directory_names, file_names in os.walk(
+            self.root,
+            followlinks=False,
+            onerror=collect_error,
+        ):
+            current_path = Path(current)
+            directory_names[:] = sorted(
+                name
+                for name in directory_names
+                if name != ".git" and not _is_symlink(current_path / name)
+            )
+            for name in sorted(file_names):
+                path = current_path / name
+                if not self._is_supported(path) or _is_symlink(path):
+                    continue
+                relative_path = path.relative_to(self.root).as_posix()
+                try:
+                    file_stat = os.lstat(path)
+                except OSError:
+                    uncertain_paths.add(relative_path)
+                    continue
+                if not stat.S_ISREG(file_stat.st_mode):
+                    continue
+                observed[relative_path] = _ObservedFile(
+                    relative_path=relative_path,
+                    path=path,
+                    size=file_stat.st_size,
+                    mtime_ns=file_stat.st_mtime_ns,
+                )
+        return dict(sorted(observed.items())), uncertain_paths, had_walk_error
+
+    def _load_file(self, relative_path: str) -> OpenedFileNote:
+        path = self._safe_path(relative_path)
+        if not self._is_supported(path):
+            raise ValueError(f"Unsupported File Notes extension: {relative_path}")
+        file_stat = os.lstat(path)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise ValueError(f"unsafe non-regular file: {relative_path}")
+        if file_stat.st_size > MAX_FILE_BYTES:
+            return _oversize_opened(
+                self.root_key,
+                relative_path,
+                file_stat,
+            )
+        try:
+            raw_bytes, file_stat = _read_regular_file(path)
+        except _FileTooLargeError as error:
+            return _oversize_opened(
+                self.root_key,
+                relative_path,
+                error.file_stat,
+            )
+        return _parse_opened(
+            self.root_key,
+            relative_path,
+            raw_bytes,
+            file_stat,
+        )
+
+    def _safe_path(self, relative_path: str) -> Path:
+        if not isinstance(relative_path, str) or not relative_path:
+            raise ValueError("unsafe empty relative path")
+        if "\x00" in relative_path or "\\" in relative_path:
+            raise ValueError("unsafe relative path")
+        candidate_path = Path(relative_path)
+        if candidate_path.is_absolute():
+            raise ValueError("unsafe absolute path")
+        parts = candidate_path.parts
+        if not parts or any(part in {"", ".", ".."} for part in parts):
+            raise ValueError("unsafe path traversal")
+
+        current = self.root
+        for part in parts:
+            if part == ".git":
+                raise ValueError("unsafe .git path")
+            validate_filename(part)
+            current = current / part
+            try:
+                file_stat = os.lstat(current)
+            except FileNotFoundError:
+                continue
+            if stat.S_ISLNK(file_stat.st_mode):
+                raise ValueError(f"symlink traversal is not allowed: {relative_path}")
+
+        resolved = current.resolve(strict=False)
+        try:
+            resolved.relative_to(self.root)
+        except ValueError as error:
+            raise ValueError(f"unsafe path outside root: {relative_path}") from error
+        return current
+
+    def _root_is_online(self) -> bool:
+        try:
+            return (
+                self.root.is_dir()
+                and not self.root.is_symlink()
+                and os.access(self.root, os.R_OK | os.X_OK)
+            )
+        except OSError:
+            return False
+
+    @staticmethod
+    def _is_supported(path: Path) -> bool:
+        return path.suffix.lower() in SUPPORTED_EXTENSIONS
+
+    def _upsert_opened(self, opened: OpenedFileNote) -> str | None:
+        return self._upsert_bytes(
+            opened.relative_path,
+            opened.raw_bytes,
+            content_hash=opened.content_hash,
+            mtime_ns=opened.mtime_ns,
+        )
+
+    def _upsert_bytes(
+        self,
+        relative_path: str,
+        raw_bytes: bytes,
+        *,
+        content_hash: str,
+        file_stat: os.stat_result | None = None,
+        mtime_ns: int | None = None,
+    ) -> str | None:
+        if self._replica is None:
+            return "Replica unavailable"
+        observed_mtime_ns = (
+            file_stat.st_mtime_ns if file_stat is not None else mtime_ns
+        )
+        if observed_mtime_ns is None:
+            raise ValueError("mtime_ns is required for replica upsert")
+        try:
+            self._replica.upsert_file(
+                self.root_key,
+                relative_path,
+                raw_bytes,
+                content_hash=content_hash,
+                decoded_text=_decode_for_replica(raw_bytes),
+                size=len(raw_bytes),
+                mtime_ns=observed_mtime_ns,
+            )
+        except Exception as error:
+            return _replica_warning(error)
+        return None
+
+    def _clear_tombstone(self, relative_path: str) -> str | None:
+        try:
+            assert self._replica is not None
+            self._replica.clear_tombstone(self.root_key, relative_path)
+        except Exception as error:
+            return _replica_warning(error)
+        return None
+
+
+def _oversize_opened(
+    root: str,
+    relative_path: str,
+    file_stat: os.stat_result,
+) -> OpenedFileNote:
+    return OpenedFileNote(
+        root=root,
+        relative_path=relative_path,
+        body="",
+        preserved_prefix=b"",
+        content_hash="",
+        newline="\n",
+        has_final_newline=False,
+        size=file_stat.st_size,
+        mtime_ns=file_stat.st_mtime_ns,
+        editable=False,
+        read_only_reason="too-many-bytes",
+        protected=False,
+        raw_bytes=b"",
+    )
+
+
+def _oversize_entry(observed: _ObservedFile) -> FileNoteEntry:
+    return FileNoteEntry(
+        relative_path=observed.relative_path,
+        size=observed.size,
+        mtime_ns=observed.mtime_ns,
+        content_hash="",
+        editable=False,
+        read_only_reason="too-many-bytes",
+    )
+
+
+def _unreadable_entry(observed: _ObservedFile) -> FileNoteEntry:
+    return FileNoteEntry(
+        relative_path=observed.relative_path,
+        size=observed.size,
+        mtime_ns=observed.mtime_ns,
+        content_hash="",
+        editable=False,
+        read_only_reason="unreadable",
+    )
+
+
+def _parse_opened(
+    root: str,
+    relative_path: str,
+    raw_bytes: bytes,
+    file_stat: os.stat_result,
+) -> OpenedFileNote:
+    prefix = UTF8_BOM if raw_bytes.startswith(UTF8_BOM) else b""
+    content = raw_bytes[len(prefix) :]
+    frontmatter_end = _frontmatter_end(content)
+    if frontmatter_end is not None:
+        prefix += content[:frontmatter_end]
+        body_bytes = content[frontmatter_end:]
+    else:
+        body_bytes = content
+    reason: str | None = None
+    body = ""
+    newline: Literal["\n", "\r\n"] = "\n"
+    has_final_newline = False
+    try:
+        decoded_content = content.decode("utf-8")
+        body_text = body_bytes.decode("utf-8")
+    except UnicodeDecodeError:
+        decoded_content = ""
+        body_text = ""
+        reason = "undecodable-utf8"
+
+    if reason is None:
+        newline, mixed = _body_newline(body_text, prefix)
+        body = body_text.replace("\r\n", "\n")
+        has_final_newline = body.endswith("\n")
+        if mixed:
+            reason = "mixed-newlines"
+        elif len(decoded_content) > MAX_FILE_CHARS:
+            reason = "too-many-chars"
+        elif len(raw_bytes) > MAX_FILE_BYTES:
+            reason = "too-many-bytes"
+    elif len(raw_bytes) > MAX_FILE_BYTES:
+        reason = "too-many-bytes"
+
+    if len(raw_bytes) > MAX_FILE_BYTES:
+        reason = "too-many-bytes"
+        body = ""
+    elif reason == "too-many-chars":
+        body = ""
+
+    return OpenedFileNote(
+        root=root,
+        relative_path=relative_path,
+        body=body,
+        preserved_prefix=prefix,
+        content_hash=_digest(raw_bytes),
+        newline=newline,
+        has_final_newline=has_final_newline,
+        size=len(raw_bytes),
+        mtime_ns=file_stat.st_mtime_ns,
+        editable=reason is None,
+        read_only_reason=reason,
+        protected=False,
+        raw_bytes=raw_bytes,
+    )
+
+
+def _frontmatter_end(content: bytes) -> int | None:
+    lines = content.splitlines(keepends=True)
+    if not lines or _line_without_ending(lines[0]) != b"---":
+        return None
+    offset = len(lines[0])
+    for line in lines[1:]:
+        offset += len(line)
+        if _line_without_ending(line) in {b"---", b"..."}:
+            return offset
+    return None
+
+
+def _line_without_ending(line: bytes) -> bytes:
+    if line.endswith(b"\r\n"):
+        return line[:-2]
+    if line.endswith(b"\n") or line.endswith(b"\r"):
+        return line[:-1]
+    return line
+
+
+def _body_newline(
+    body: str,
+    prefix: bytes,
+) -> tuple[Literal["\n", "\r\n"], bool]:
+    crlf_count = body.count("\r\n")
+    without_crlf = body.replace("\r\n", "")
+    has_bare_lf = "\n" in without_crlf
+    has_bare_cr = "\r" in without_crlf
+    mixed = has_bare_cr or (crlf_count > 0 and has_bare_lf)
+    if crlf_count:
+        return "\r\n", mixed
+    if has_bare_lf:
+        return "\n", mixed
+    return ("\r\n" if b"\r\n" in prefix else "\n"), mixed
+
+
+def _serialize_body(opened: OpenedFileNote, body: str) -> bytes:
+    normalized = body.replace("\r\n", "\n").replace("\r", "\n")
+    if opened.has_final_newline and not normalized.endswith("\n"):
+        normalized += "\n"
+    elif not opened.has_final_newline and normalized.endswith("\n"):
+        normalized = normalized.rstrip("\n")
+    if opened.newline == "\r\n":
+        normalized = normalized.replace("\n", "\r\n")
+    return opened.preserved_prefix + normalized.encode("utf-8")
+
+
+def _read_regular_file(path: Path) -> tuple[bytes, os.stat_result]:
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        file_stat = os.fstat(descriptor)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise ValueError(f"unsafe non-regular file: {path}")
+        if file_stat.st_size > MAX_FILE_BYTES:
+            raise _FileTooLargeError(file_stat)
+        with os.fdopen(descriptor, "rb") as source:
+            descriptor = -1
+            return source.read(), file_stat
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def _entry_from_opened(opened: OpenedFileNote) -> FileNoteEntry:
+    return FileNoteEntry(
+        relative_path=opened.relative_path,
+        size=opened.size,
+        mtime_ns=opened.mtime_ns,
+        content_hash=opened.content_hash,
+        editable=opened.editable,
+        read_only_reason=opened.read_only_reason,
+    )
+
+
+def _replace_opened(
+    opened: OpenedFileNote,
+    *,
+    protected: bool,
+    replica_warning: str | None,
+) -> OpenedFileNote:
+    return replace(
+        opened,
+        protected=protected,
+        replica_warning=replica_warning,
+    )
+
+
+def _decode_for_replica(raw_bytes: bytes) -> str | None:
+    try:
+        return raw_bytes.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+
+
+def _digest(raw_bytes: bytes) -> str:
+    return hashlib.sha256(raw_bytes).hexdigest()
+
+
+def _is_symlink(path: Path) -> bool:
+    try:
+        return path.is_symlink()
+    except OSError:
+        return True
+
+
+def _replica_warning(error: Exception) -> str:
+    return f"Replica unavailable: {error}"
+
+
+def _merge_warnings(*warnings: str | None) -> str | None:
+    unique = tuple(dict.fromkeys(warning for warning in warnings if warning))
+    return "; ".join(unique) if unique else None
+
+
+def _result(
+    status: OperationStatus,
+    relative_path: str,
+    message: str | None = None,
+    *,
+    destination: str | None = None,
+    warning: str | None = None,
+) -> OperationResult:
+    return OperationResult(
+        status=status,
+        relative_path=relative_path,
+        destination_path=destination,
+        replica_warning=warning,
+        message=message,
+    )

--- a/tldw_chatbook/Notes/file_notes_service.py
+++ b/tldw_chatbook/Notes/file_notes_service.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import Literal
 
 from tldw_chatbook.Notes.file_notes_replica import FileNotesReplica, ReplicaFileInfo
-from tldw_chatbook.Utils.path_validation import validate_filename
 
 MAX_FILE_BYTES = 8_000_000
 MAX_FILE_CHARS = 2_000_000
@@ -117,15 +116,8 @@ class ReconcileResult:
 @dataclass(frozen=True)
 class _ObservedFile:
     relative_path: str
-    path: Path
     size: int
     mtime_ns: int
-
-
-class _FileTooLargeError(OSError):
-    def __init__(self, file_stat: os.stat_result) -> None:
-        super().__init__("File exceeds the File Notes byte limit")
-        self.file_stat = file_stat
 
 
 class FileNotesService:
@@ -157,9 +149,6 @@ class FileNotesService:
         warning: str | None = None
         observed, uncertain_paths, _ = self._walk_candidates()
         for relative_path, observed_file in observed.items():
-            if observed_file.size > MAX_FILE_BYTES:
-                entries.append(_oversize_entry(observed_file))
-                continue
             try:
                 opened = self._load_file(relative_path)
             except (OSError, ValueError):
@@ -205,8 +194,7 @@ class FileNotesService:
                 )
             except Exception as error:
                 warning = _replica_warning(error)
-        if opened.read_only_reason != "too-many-bytes":
-            warning = _merge_warnings(warning, self._upsert_opened(opened))
+        warning = _merge_warnings(warning, self._upsert_opened(opened))
         return _replace_opened(
             opened,
             protected=protected,
@@ -233,8 +221,6 @@ class FileNotesService:
             current_bytes, current_stat = _read_regular_file(path)
         except ValueError as error:
             return _result("unsafe", relative_path, str(error))
-        except _FileTooLargeError:
-            return _result("conflict", relative_path, "Disk bytes changed")
         except FileNotFoundError:
             return _result("missing", relative_path)
         except OSError as error:
@@ -462,10 +448,7 @@ class FileNotesService:
         warning: str | None = None
         try:
             moved = self._load_file(destination_path)
-            if moved.read_only_reason == "too-many-bytes":
-                warning = "Replica not updated: file exceeds the byte limit"
-            else:
-                warning = self._upsert_opened(moved)
+            warning = self._upsert_opened(moved)
         except (OSError, ValueError) as error:
             warning = f"Replica refresh failed: {error}"
         if self._replica is not None:
@@ -501,12 +484,6 @@ class FileNotesService:
             observed_stat = os.lstat(path)
             if not stat.S_ISREG(observed_stat.st_mode):
                 return _result("unsafe", relative_path, "Not a regular file")
-            if observed_stat.st_size > MAX_FILE_BYTES:
-                return _result(
-                    "readonly",
-                    relative_path,
-                    "File is too large to snapshot safely",
-                )
             if self._replica is None:
                 return _result(
                     "replica-error",
@@ -516,12 +493,6 @@ class FileNotesService:
             raw_bytes, file_stat = _read_regular_file(path)
         except ValueError as error:
             return _result("unsafe", relative_path, str(error))
-        except _FileTooLargeError:
-            return _result(
-                "readonly",
-                relative_path,
-                "File is too large to snapshot safely",
-            )
         except FileNotFoundError:
             return _result("missing", relative_path)
         except OSError as error:
@@ -558,7 +529,7 @@ class FileNotesService:
 
         try:
             rechecked_bytes, _ = _read_regular_file(path)
-        except OSError as error:
+        except (OSError, ValueError) as error:
             warning = self._clear_tombstone(relative_path)
             return _result(
                 "error",
@@ -684,44 +655,38 @@ class FileNotesService:
         for relative_path, observed_file in observed.items():
             previous = None if old_files is None else old_files.get(relative_path)
             cached = self._entry_cache.get(relative_path)
-            unchanged = (
+            replica_matches = (
                 previous is not None
                 and previous.size == observed_file.size
                 and previous.mtime_ns == observed_file.mtime_ns
-            ) or (
-                old_files is None
-                and cached is not None
+            )
+            cache_matches = (
+                cached is not None
                 and cached.size == observed_file.size
                 and cached.mtime_ns == observed_file.mtime_ns
             )
+            unchanged = replica_matches or (old_files is None and cache_matches)
             if unchanged:
-                if (
-                    cached is not None
-                    and cached.size == observed_file.size
-                    and cached.mtime_ns == observed_file.mtime_ns
-                ):
+                if cache_matches:
+                    assert cached is not None
                     entries.append(cached)
-                elif observed_file.size > MAX_FILE_BYTES:
-                    entries.append(_oversize_entry(observed_file))
                 else:
+                    assert previous is not None
+                    oversized = observed_file.size > MAX_FILE_BYTES
                     entries.append(
                         FileNoteEntry(
                             relative_path=relative_path,
                             size=observed_file.size,
                             mtime_ns=observed_file.mtime_ns,
                             content_hash=previous.content_hash,
-                            editable=True,
+                            editable=not oversized,
+                            read_only_reason=(
+                                "too-many-bytes" if oversized else None
+                            ),
                         )
                     )
                 continue
 
-            if observed_file.size > MAX_FILE_BYTES:
-                entries.append(_oversize_entry(observed_file))
-                if previous is None:
-                    created.append(relative_path)
-                else:
-                    modified.append(relative_path)
-                continue
             try:
                 opened = self._load_file(relative_path)
             except (OSError, ValueError):
@@ -864,7 +829,6 @@ class FileNotesService:
                     continue
                 observed[relative_path] = _ObservedFile(
                     relative_path=relative_path,
-                    path=path,
                     size=file_stat.st_size,
                     mtime_ns=file_stat.st_mtime_ns,
                 )
@@ -877,20 +841,7 @@ class FileNotesService:
         file_stat = os.lstat(path)
         if not stat.S_ISREG(file_stat.st_mode):
             raise ValueError(f"unsafe non-regular file: {relative_path}")
-        if file_stat.st_size > MAX_FILE_BYTES:
-            return _oversize_opened(
-                self.root_key,
-                relative_path,
-                file_stat,
-            )
-        try:
-            raw_bytes, file_stat = _read_regular_file(path)
-        except _FileTooLargeError as error:
-            return _oversize_opened(
-                self.root_key,
-                relative_path,
-                error.file_stat,
-            )
+        raw_bytes, file_stat = _read_regular_file(path)
         return _parse_opened(
             self.root_key,
             relative_path,
@@ -914,7 +865,6 @@ class FileNotesService:
         for part in parts:
             if part == ".git":
                 raise ValueError("unsafe .git path")
-            validate_filename(part)
             current = current / part
             try:
                 file_stat = os.lstat(current)
@@ -989,39 +939,6 @@ class FileNotesService:
         except Exception as error:
             return _replica_warning(error)
         return None
-
-
-def _oversize_opened(
-    root: str,
-    relative_path: str,
-    file_stat: os.stat_result,
-) -> OpenedFileNote:
-    return OpenedFileNote(
-        root=root,
-        relative_path=relative_path,
-        body="",
-        preserved_prefix=b"",
-        content_hash="",
-        newline="\n",
-        has_final_newline=False,
-        size=file_stat.st_size,
-        mtime_ns=file_stat.st_mtime_ns,
-        editable=False,
-        read_only_reason="too-many-bytes",
-        protected=False,
-        raw_bytes=b"",
-    )
-
-
-def _oversize_entry(observed: _ObservedFile) -> FileNoteEntry:
-    return FileNoteEntry(
-        relative_path=observed.relative_path,
-        size=observed.size,
-        mtime_ns=observed.mtime_ns,
-        content_hash="",
-        editable=False,
-        read_only_reason="too-many-bytes",
-    )
 
 
 def _unreadable_entry(observed: _ObservedFile) -> FileNoteEntry:
@@ -1151,8 +1068,6 @@ def _read_regular_file(path: Path) -> tuple[bytes, os.stat_result]:
         file_stat = os.fstat(descriptor)
         if not stat.S_ISREG(file_stat.st_mode):
             raise ValueError(f"unsafe non-regular file: {path}")
-        if file_stat.st_size > MAX_FILE_BYTES:
-            raise _FileTooLargeError(file_stat)
         with os.fdopen(descriptor, "rb") as source:
             descriptor = -1
             return source.read(), file_stat

--- a/tldw_chatbook/Notes/file_notes_service.py
+++ b/tldw_chatbook/Notes/file_notes_service.py
@@ -144,12 +144,20 @@ class FileNotesService:
         self,
         root: str | os.PathLike[str],
         replica: FileNotesReplica | None,
+        *,
+        operation_lock: RLock | None = None,
     ) -> None:
-        """Bind the service to one canonical root and optional SQLite replica."""
+        """Bind the service to one canonical root and optional SQLite replica.
+
+        Args:
+            root: Filesystem directory kept authoritative by this service.
+            replica: Optional SQLite search and recovery replica.
+            operation_lock: Optional lock shared by services using one replica.
+        """
         self.root = Path(root).expanduser().resolve(strict=False)
         self.root_key = str(self.root)
         self._replica = replica
-        self._operation_lock = RLock()
+        self._operation_lock = operation_lock or RLock()
         self._session_changes: list[SessionChange] = []
         self._entry_cache: dict[str, FileNoteEntry] = {}
 
@@ -158,6 +166,14 @@ class FileNotesService:
     def session_changes(self) -> tuple[SessionChange, ...]:
         """Return Chatbook-only changes made by this service instance."""
         return tuple(self._session_changes)
+
+    @_serialized
+    def close(self) -> None:
+        """Close the bound replica after any active service operation."""
+        replica = self._replica
+        self._replica = None
+        if replica is not None:
+            replica.close()
 
     @_serialized
     def scan(self) -> ScanResult:

--- a/tldw_chatbook/Notes/file_notes_service.py
+++ b/tldw_chatbook/Notes/file_notes_service.py
@@ -341,6 +341,64 @@ class FileNotesService:
         )
 
     @_serialized
+    def save_copy(
+        self,
+        opened: OpenedFileNote,
+        body: str,
+        destination_path: str,
+    ) -> OperationResult:
+        """Save an opened note's exact format to a new path without clobbering."""
+        if opened.root != self.root_key:
+            return _result(
+                "unsafe",
+                destination_path,
+                "Opened note belongs to another root",
+            )
+        if not opened.editable:
+            return _result("readonly", destination_path, opened.read_only_reason)
+        if not self._root_is_online():
+            return _result("offline", destination_path)
+        try:
+            path = self._safe_path(destination_path)
+        except ValueError as error:
+            return _result("unsafe", destination_path, str(error))
+        if not self._is_supported(path):
+            return _result("unsupported", destination_path)
+
+        raw_bytes = _serialize_body(opened, body)
+        if len(body) > MAX_FILE_CHARS or len(raw_bytes) > MAX_FILE_BYTES:
+            return _result("readonly", destination_path, "Edited content exceeds limits")
+
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        try:
+            descriptor = os.open(path, flags, 0o666)
+        except FileExistsError:
+            return _result("exists", destination_path)
+        except OSError as error:
+            if error.errno in {errno.ELOOP, errno.ENOTDIR}:
+                return _result("unsafe", destination_path, str(error))
+            return _result("error", destination_path, str(error))
+        try:
+            with os.fdopen(descriptor, "wb") as destination:
+                destination.write(raw_bytes)
+        except OSError as error:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+            return _result("error", destination_path, str(error))
+
+        content_hash = _digest(raw_bytes)
+        return self._finish_published_file(
+            "created",
+            destination_path,
+            path,
+            raw_bytes,
+            content_hash=content_hash,
+        )
+
+    @_serialized
     def create_file(self, relative_path: str, body: str = "") -> OperationResult:
         """Create one supported UTF-8 file with an exclusive filesystem open."""
         if not self._root_is_online():

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -8,11 +8,11 @@ import inspect
 import re
 import threading
 import time
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from datetime import datetime, timezone
 from functools import partial
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from loguru import logger
 from rich.markup import escape as escape_markup
@@ -230,6 +230,9 @@ from ...Widgets.Library import (
     skill_trust_state_line,
     skill_trust_unlock_enabled,
     skill_user_invocable_label,
+)
+from ...Widgets.Library.library_file_notes_workspace import (
+    LibraryFileNotesWorkspace,
 )
 from ..Navigation.base_app_screen import BaseAppScreen
 from ..Navigation.main_navigation import NavigateToScreen
@@ -1015,10 +1018,38 @@ class LibraryScreen(BaseAppScreen):
         background: transparent;
         content-align: left middle;
     }
+
+    #library-notes-source-strip {
+        height: 1;
+        min-height: 1;
+    }
+
+    #library-notes-source-strip Button {
+        width: auto;
+        min-width: 0;
+        height: 1;
+        min-height: 1;
+        padding: 0 1;
+        border: none;
+        background: transparent;
+    }
     """
 
-    def __init__(self, app_instance: Any, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        app_instance: Any,
+        *,
+        file_notes_workspace_factory: (
+            Callable[[], LibraryFileNotesWorkspace] | None
+        ) = None,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(app_instance, "library", **kwargs)
+        self._library_notes_source: Literal["database", "files"] = "database"
+        self._library_file_notes_workspace: LibraryFileNotesWorkspace | None = None
+        self._library_file_notes_workspace_factory = (
+            file_notes_workspace_factory or LibraryFileNotesWorkspace
+        )
         self._local_source_records: dict[str, tuple[Mapping[str, Any], ...]] = {
             "notes": (),
             "media": (),
@@ -1678,6 +1709,22 @@ class LibraryScreen(BaseAppScreen):
             max_length=200,
         )
 
+    def _file_notes_active(self) -> bool:
+        """Return whether the retained File Notes workspace owns the canvas."""
+        return (
+            getattr(self, "_library_notes_source", "database") == "files"
+            and getattr(self, "_library_selected_row_id", "")
+            == LIBRARY_ROW_BROWSE_NOTES
+            and getattr(self, "_library_file_notes_workspace", None) is not None
+        )
+
+    async def _flush_active_file_notes(self) -> bool:
+        """Delegate the common leave guard only while Files owns Notes."""
+        if not self._file_notes_active():
+            return True
+        assert self._library_file_notes_workspace is not None
+        return await self._library_file_notes_workspace.flush_pending_work()
+
     async def flush_pending_work(self) -> bool:
         """Persist pending note edits before the app navigates away.
 
@@ -1694,6 +1741,7 @@ class LibraryScreen(BaseAppScreen):
             Both veto the navigation so the screen instance holding the
             edits is not discarded. True once nothing dirty remains.
         """
+        file_notes_flush_allowed = await self._flush_active_file_notes()
         await self._flush_library_note_save()
         prompt_flush_allowed = await self._flush_library_prompt_save()
         skill_flush_allowed = await self._flush_library_skill_save()
@@ -1705,7 +1753,8 @@ class LibraryScreen(BaseAppScreen):
             # so only the skill veto reports here.
             self._notify_skill_dirty_veto()
         return (
-            not self._library_note_dirty
+            file_notes_flush_allowed
+            and not self._library_note_dirty
             and prompt_flush_allowed
             and skill_flush_allowed
         )
@@ -1730,7 +1779,7 @@ class LibraryScreen(BaseAppScreen):
         """
         if not isinstance(context, Mapping):
             return
-        if self.is_mounted and self._library_note_dirty:
+        if self.is_mounted and (self._library_note_dirty or self._file_notes_active()):
             # Defense in depth for direct callers: navigation always
             # composes a fresh (unmounted) screen, but a future palette
             # shortcut could invoke this on a live, mounted editor mid-edit. Applying it synchronously would
@@ -1757,6 +1806,8 @@ class LibraryScreen(BaseAppScreen):
         leaves the editor in place -- the same guard
         ``_select_library_rail_row`` applies.
         """
+        if not await self._flush_active_file_notes():
+            return
         await self._flush_library_note_save()
         if self._library_note_dirty:
             return
@@ -2010,7 +2061,7 @@ class LibraryScreen(BaseAppScreen):
         )
         self._library_loaded = True
         self._invalidate_library_workspace_depth_state()
-        if self.is_mounted:
+        if self.is_mounted and not self._file_notes_active():
             self.refresh(recompose=True)
 
     def _apply_source_snapshot_timeout(self) -> None:
@@ -3611,6 +3662,34 @@ class LibraryScreen(BaseAppScreen):
             id="library-header-line",
             classes="destination-status-row",
         )
+        if shell.canvas_kind == "notes":
+            with Horizontal(id="library-notes-source-strip"):
+                database_source = Button(
+                    "Database",
+                    id="library-notes-source-database",
+                    compact=True,
+                )
+                database_source.disabled = self._library_notes_source == "database"
+                yield database_source
+                yield Static("|", markup=False)
+                files_source = Button(
+                    "Files",
+                    id="library-notes-source-files",
+                    compact=True,
+                )
+                files_source.disabled = self._library_notes_source == "files"
+                yield files_source
+            if self._library_notes_source == "files":
+                workspace = self._library_file_notes_workspace
+                if workspace is not None:
+                    yield workspace
+                else:
+                    yield Static(
+                        "Opening File Notes…",
+                        id="library-file-notes-loading",
+                        markup=False,
+                    )
+                return
         shell_grid = Horizontal(
             id="library-shell-grid", classes="ds-panel destination-workbench"
         )
@@ -6634,6 +6713,33 @@ class LibraryScreen(BaseAppScreen):
         event.stop()
         await self._select_library_rail_row(LIBRARY_ROW_INGEST_MEDIA)
 
+    @on(Button.Pressed, "#library-notes-source-files")
+    async def _show_library_file_notes(self, event: Button.Pressed) -> None:
+        """Leave Database Notes safely and lazily mount File Notes."""
+        event.stop()
+        if self._library_notes_source == "files":
+            return
+        await self._flush_library_note_save()
+        if self._library_note_dirty:
+            return
+        if self._library_file_notes_workspace is None:
+            self._library_file_notes_workspace = (
+                self._library_file_notes_workspace_factory()
+            )
+        self._library_notes_source = "files"
+        self.refresh(recompose=True)
+
+    @on(Button.Pressed, "#library-notes-source-database")
+    async def _show_library_database_notes(self, event: Button.Pressed) -> None:
+        """Return to Database Notes only after the File Notes leave guard."""
+        event.stop()
+        if self._library_notes_source == "database":
+            return
+        if not await self._flush_active_file_notes():
+            return
+        self._library_notes_source = "database"
+        self.refresh(recompose=True)
+
     @on(Button.Pressed, ".library-rail-row")
     async def handle_library_rail_row(self, event: Button.Pressed) -> None:
         """Dispatch a Library rail row press: navigate, browse, or open a canvas."""
@@ -6675,6 +6781,8 @@ class LibraryScreen(BaseAppScreen):
         originally omitted here, so a rail switch silently discarded dirty
         skill edits while Back/row-switch exits vetoed them.
         """
+        if not await self._flush_active_file_notes():
+            return
         await self._flush_library_note_save()
         if self._library_note_dirty:
             return

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -1513,7 +1513,7 @@ class LibraryScreen(BaseAppScreen):
             # the intent explicit and is cheap insurance).
             self._start_library_export_counts_worker()
 
-    def on_unmount(self) -> None:
+    async def on_unmount(self) -> None:
         """Unregister the ingest registry listener registered in ``on_mount``.
 
         ``on_unmount`` (not ``on_screen_suspend``) is the correct pairing:
@@ -1533,6 +1533,9 @@ class LibraryScreen(BaseAppScreen):
         ``False`` after removal) -- so this call is what actually closes
         the window, not the guard.
         """
+        workspace = self._library_file_notes_workspace
+        if workspace is not None:
+            await workspace.shutdown()
         super().on_unmount()
         registry = self._library_ingest_registry()
         if registry is not None:
@@ -4420,7 +4423,11 @@ class LibraryScreen(BaseAppScreen):
         # different note (or left the editor), a slower in-flight fetch for
         # the previous selection must not overwrite the current one -- the
         # same stale-race guard as ``_refresh_library_media_detail``.
-        if note_id != self._selected_note_id or self._library_notes_view != "editor":
+        if (
+            note_id != self._selected_note_id
+            or self._library_notes_view != "editor"
+            or self._library_notes_source != "database"
+        ):
             return
         if not isinstance(detail, Mapping):
             # The note no longer exists -- deleted elsewhere, or a stale
@@ -4445,7 +4452,11 @@ class LibraryScreen(BaseAppScreen):
         # same way ``_refresh_library_media_detail`` re-checks after its own
         # second (highlights) fetch, so a switch that happened during that
         # fetch cannot land keywords for the wrong note.
-        if note_id != self._selected_note_id or self._library_notes_view != "editor":
+        if (
+            note_id != self._selected_note_id
+            or self._library_notes_view != "editor"
+            or self._library_notes_source != "database"
+        ):
             return
         if keywords is not None and isinstance(self._library_note_detail, Mapping):
             enriched_detail = dict(self._library_note_detail)

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import replace
 from pathlib import Path, PurePosixPath
-from threading import Lock
+from threading import Lock, RLock
 from typing import Any, Literal
 from uuid import uuid4
 
@@ -15,7 +15,7 @@ from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.events import Resize
 from textual.timer import Timer
-from textual.worker import Worker, WorkerState
+from textual.worker import Worker
 from textual.widgets import Button, Input, Static, TextArea, Tree
 
 from tldw_chatbook.config import (
@@ -181,14 +181,16 @@ class LibraryFileNotesWorkspace(Vertical):
         self._autosave_delay = max(0.01, autosave_delay)
         self._poll_timer: Timer | None = None
         self._autosave_timer: Timer | None = None
-        self._workers: set[Worker[Any]] = set()
         self._poll_worker: Worker[Any] | None = None
         self._save_worker: Worker[Any] | None = None
         self._active = False
         self._refresh_lock = asyncio.Lock()
         self._save_lock = asyncio.Lock()
         self._runtime_lock = Lock()
+        self._service_lock = RLock()
         self._root_generation = 0
+        self._root_transitioning = False
+        self._shutdown = False
 
         self._entries: dict[str, FileNoteEntry] = {}
         self._deleted_paths: tuple[str, ...] = ()
@@ -198,7 +200,6 @@ class LibraryFileNotesWorkspace(Vertical):
         self._session_key = ""
         self._save_state: SaveState = "idle"
         self._save_detail = ""
-        self._programmatic_editor_text: str | None = None
         self._delete_confirmation_path = ""
         self._search_generation = 0
         self._search_query = ""
@@ -353,6 +354,8 @@ class LibraryFileNotesWorkspace(Vertical):
 
     def on_mount(self) -> None:
         """Start background initialization and polling for this mount."""
+        if self._shutdown:
+            return
         self._active = True
         self._apply_responsive_layout(self.size.width)
         if self._opened is not None:
@@ -367,51 +370,65 @@ class LibraryFileNotesWorkspace(Vertical):
         self._set_action_status(self._action_detail)
         self._update_root_surface()
         self._update_controls()
-        self._track_worker(
-            self.run_worker(
-                self._initialize(),
-                name="file-notes-initialize",
-                group="file-notes-initialize",
-                exclusive=True,
-            )
+        self.run_worker(
+            self._initialize(),
+            name="file-notes-initialize",
+            group="file-notes-initialize",
+            exclusive=True,
         )
         self._poll_timer = self.set_interval(
             self._poll_interval,
             self._start_poll,
             pause=False,
         )
+        if self._save_state == "dirty":
+            self._arm_autosave()
 
     def on_unmount(self) -> None:
-        """Pause timers and cancel workspace-owned workers."""
+        """Pause timers; Textual cancels node workers during removal."""
+        self._active = False
+        if self._save_state == "saving":
+            self._save_state = "dirty"
+            self._save_detail = "save interrupted"
+        for timer in (self._poll_timer, self._autosave_timer):
+            if timer is not None:
+                timer.stop()
+        self._poll_timer = None
+        self._autosave_timer = None
+        self._poll_worker = None
+        self._save_worker = None
+
+    async def shutdown(self) -> None:
+        """Permanently close this workspace's owned replica once."""
+        if self._shutdown:
+            return
+        self._shutdown = True
         self._active = False
         for timer in (self._poll_timer, self._autosave_timer):
             if timer is not None:
                 timer.stop()
         self._poll_timer = None
         self._autosave_timer = None
-        for worker in tuple(self._workers):
-            if not worker.is_finished:
-                worker.cancel()
-        self._workers.clear()
-        self._poll_worker = None
-        self._save_worker = None
+        if self._owns_replica:
+            await asyncio.to_thread(self._close_owned_replica)
 
-    def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
-        """Forget completed workers so long-running polling stays bounded."""
-        if event.state in {
-            WorkerState.CANCELLED,
-            WorkerState.ERROR,
-            WorkerState.SUCCESS,
-        }:
-            self._workers.discard(event.worker)
+    def _close_owned_replica(self) -> None:
+        with self._runtime_lock:
+            replica = self._replica
+            if replica is None:
+                return
+            service = self._service
+            if service is not None:
+                service.close()
+            else:
+                with self._service_lock:
+                    replica.close()
+            self._replica = None
+            self._service = None
 
     def on_resize(self, event: Resize) -> None:
         """Choose wide or narrow panes from the mounted workspace width."""
         self._apply_responsive_layout(event.size.width)
-
-    def _track_worker(self, worker: Worker[Any]) -> Worker[Any]:
-        self._workers.add(worker)
-        return worker
 
     async def _initialize(self) -> None:
         generation = self._root_generation
@@ -465,6 +482,8 @@ class LibraryFileNotesWorkspace(Vertical):
         str,
     ]:
         with self._runtime_lock:
+            if self._shutdown:
+                return self._root, self._replica, None, ""
             configured_root = self._root
             if self._root_seed is _UNSET and configured_root is None:
                 configured_root = get_cli_setting("file_notes", "root", None)
@@ -493,7 +512,11 @@ class LibraryFileNotesWorkspace(Vertical):
                 or service.root_key != str(root)
                 or previous_replica is not replica
             ):
-                service = FileNotesService(root, replica)
+                service = FileNotesService(
+                    root,
+                    replica,
+                    operation_lock=self._service_lock,
+                )
             return root, replica, service, warning
 
     async def _load_deleted_paths(
@@ -559,6 +582,7 @@ class LibraryFileNotesWorkspace(Vertical):
         status = self.query_one("#file-notes-root-status", Static)
         body = self.query_one("#file-notes-body")
         choose = self.query_one("#file-notes-choose-root", Button)
+        choose.disabled = self._root_transitioning
         if self._root is None:
             status.update("Choose a notes folder.")
             body.display = False
@@ -702,9 +726,10 @@ class LibraryFileNotesWorkspace(Vertical):
     def _update_controls(self) -> None:
         if not self._active or not self.is_mounted:
             return
-        has_service = self._service is not None
-        has_document = self._opened is not None
-        has_deleted = bool(self._selected_deleted_path)
+        transitioning = self._root_transitioning
+        has_service = self._service is not None and not transitioning
+        has_document = self._opened is not None and not transitioning
+        has_deleted = bool(self._selected_deleted_path) and not transitioning
         self.query_one("#file-notes-new", Button).disabled = not has_service
         for selector in ("move", "delete", "protect", "reload"):
             self.query_one(
@@ -723,73 +748,107 @@ class LibraryFileNotesWorkspace(Vertical):
             if self._opened is not None and self._opened.protected
             else "Protect"
         )
+        self.query_one("#file-notes-search", Input).disabled = transitioning
+        self.query_one("#file-notes-path", Input).disabled = transitioning
+        self.query_one("#file-notes-tree", Tree).disabled = transitioning
+        self.query_one("#file-notes-search-results", Tree).disabled = transitioning
         editor = self.query_one("#file-notes-editor", TextArea)
-        editor.read_only = not (self._opened is not None and self._opened.editable)
+        editor.read_only = transitioning or not (
+            self._opened is not None and self._opened.editable
+        )
 
     async def set_root(self, path: str | Path, *, persist: bool = True) -> bool:
         """Adopt one canonical root after the common draft leave guard."""
-        if not self._active:
+        if not self._active or self._shutdown:
             return False
         if not await self.flush_pending_work():
             return False
-        canonical = await asyncio.to_thread(self._canonical_root, path)
-        if canonical is None:
-            return False
         self._root_generation += 1
         generation = self._root_generation
-        if self._replica_seed is _UNSET and self._replica is None:
-            _, replica, _, warning = await asyncio.to_thread(self._build_runtime)
-            self._replica = replica
-            self._runtime_warning = warning
-        service = await asyncio.to_thread(FileNotesService, canonical, self._replica)
-        if not self._active or generation != self._root_generation:
-            return False
-        self._root = canonical
-        self._service = service
-        self._clear_open_document()
-        self._entries = {}
-        self._deleted_paths = ()
-        self._initialized = False
+        self._root_transitioning = True
         self._update_root_surface()
-        if persist:
-            await asyncio.to_thread(
-                save_setting_to_cli_config,
-                "file_notes",
-                "root",
-                str(canonical),
+        self._update_controls()
+        try:
+            canonical = await asyncio.to_thread(self._canonical_root, path)
+            if canonical is None:
+                return False
+            if self._replica_seed is _UNSET and self._replica is None:
+                _, replica, _, warning = await asyncio.to_thread(
+                    self._build_runtime
+                )
+                if not self._active or generation != self._root_generation:
+                    return False
+                self._replica = replica
+                self._runtime_warning = warning
+            service = await asyncio.to_thread(
+                FileNotesService,
+                canonical,
+                self._replica,
+                operation_lock=self._service_lock,
             )
             if not self._active or generation != self._root_generation:
                 return False
-        result = await asyncio.to_thread(service.scan)
-        deleted = await self._load_deleted_paths(
-            replica=self._replica,
-            service=service,
-        )
+            if persist:
+                await asyncio.to_thread(
+                    save_setting_to_cli_config,
+                    "file_notes",
+                    "root",
+                    str(canonical),
+                )
+                if not self._active or generation != self._root_generation:
+                    return False
+            result = await asyncio.to_thread(service.scan)
+            deleted = await self._load_deleted_paths(
+                replica=self._replica,
+                service=service,
+            )
+            if not self._active or generation != self._root_generation:
+                return False
+            self._root = canonical
+            self._service = service
+            self._clear_open_document()
+            self._initialized = True
+            self._apply_scan(result, deleted)
+            return True
+        finally:
+            if generation == self._root_generation:
+                self._root_transitioning = False
+                self._update_root_surface()
+                self._update_controls()
+
+    async def open_path(self, relative_path: str) -> bool:
+        """Flush the old draft, then open a disk file into the same editor."""
+        service = self._service
+        generation = self._root_generation
         if (
             not self._active
+            or self._root_transitioning
+            or self._shutdown
+            or service is None
+        ):
+            return False
+        if self._opened is not None and not await self.flush_pending_work():
+            return False
+        if (
+            not self._active
+            or self._root_transitioning
             or generation != self._root_generation
             or service is not self._service
         ):
             return False
-        self._initialized = True
-        self._apply_scan(result, deleted)
-        return True
-
-    async def open_path(self, relative_path: str) -> bool:
-        """Flush the old draft, then open a disk file into the same editor."""
-        if not self._active or self._service is None:
-            return False
-        if self._opened is not None and not await self.flush_pending_work():
-            return False
         try:
             opened = await asyncio.to_thread(
-                self._service.open_file,
+                service.open_file,
                 relative_path,
             )
         except Exception as error:
             self._set_action_status(f"Open failed: {error}")
             return False
-        if not self._active:
+        if (
+            not self._active
+            or generation != self._root_generation
+            or service is not self._service
+        ):
             return False
         self._apply_opened_document(opened)
         return True
@@ -803,8 +862,8 @@ class LibraryFileNotesWorkspace(Vertical):
         self._session_key = uuid4().hex
         self._delete_confirmation_path = ""
         editor = self.query_one("#file-notes-editor", TextArea)
-        self._programmatic_editor_text = opened.body
-        editor.load_text(opened.body)
+        with editor.prevent(TextArea.Changed):
+            editor.load_text(opened.body)
         editor.read_only = not opened.editable
         self.query_one("#file-notes-path", Input).value = opened.relative_path
         self.query_one("#file-notes-breadcrumb", Static).update(opened.relative_path)
@@ -830,8 +889,8 @@ class LibraryFileNotesWorkspace(Vertical):
         self._session_key = ""
         self._delete_confirmation_path = ""
         editor = self.query_one("#file-notes-editor", TextArea)
-        self._programmatic_editor_text = ""
-        editor.load_text("")
+        with editor.prevent(TextArea.Changed):
+            editor.load_text("")
         editor.read_only = True
         if not keep_restore_path:
             self._selected_deleted_path = ""
@@ -919,17 +978,16 @@ class LibraryFileNotesWorkspace(Vertical):
     def _start_poll(self) -> None:
         if (
             not self._active
+            or self._root_transitioning
             or self._service is None
             or (self._poll_worker is not None and not self._poll_worker.is_finished)
         ):
             return
-        self._poll_worker = self._track_worker(
-            self.run_worker(
-                self.refresh_files(),
-                name="file-notes-poll",
-                group="file-notes-poll",
-                exclusive=True,
-            )
+        self._poll_worker = self.run_worker(
+            self.refresh_files(),
+            name="file-notes-poll",
+            group="file-notes-poll",
+            exclusive=True,
         )
 
     def _arm_autosave(self) -> None:
@@ -951,13 +1009,11 @@ class LibraryFileNotesWorkspace(Vertical):
             )
         ):
             return
-        self._save_worker = self._track_worker(
-            self.run_worker(
-                self._save_draft(),
-                name="file-notes-autosave",
-                group="file-notes-save",
-                exclusive=False,
-            )
+        self._save_worker = self.run_worker(
+            self._save_draft(),
+            name="file-notes-autosave",
+            group="file-notes-save",
+            exclusive=False,
         )
 
     async def _save_draft(self) -> bool:
@@ -1053,13 +1109,11 @@ class LibraryFileNotesWorkspace(Vertical):
     @on(TextArea.Changed, "#file-notes-editor")
     def _editor_changed(self, event: TextArea.Changed) -> None:
         event.stop()
-        text = event.text_area.text
-        if self._programmatic_editor_text is not None:
-            expected = self._programmatic_editor_text
-            self._programmatic_editor_text = None
-            if text == expected:
-                return
-        if self._opened is None or not self._opened.editable:
+        if (
+            self._root_transitioning
+            or self._opened is None
+            or not self._opened.editable
+        ):
             return
         self._delete_confirmation_path = ""
         self.query_one("#file-notes-delete", Button).label = "Delete"
@@ -1086,13 +1140,11 @@ class LibraryFileNotesWorkspace(Vertical):
     def _start_search(self, query: str) -> None:
         self._search_generation += 1
         generation = self._search_generation
-        self._track_worker(
-            self.run_worker(
-                self._run_search(query, generation),
-                name="file-notes-search",
-                group="file-notes-search",
-                exclusive=True,
-            )
+        self.run_worker(
+            self._run_search(query, generation),
+            name="file-notes-search",
+            group="file-notes-search",
+            exclusive=True,
         )
 
     async def _run_search(self, query: str, generation: int) -> None:
@@ -1143,13 +1195,11 @@ class LibraryFileNotesWorkspace(Vertical):
     def _root_selected(self, path: Path | None) -> None:
         if path is None or not self._active:
             return
-        self._track_worker(
-            self.run_worker(
-                self.set_root(path),
-                name="file-notes-root-change",
-                group="file-notes-root-change",
-                exclusive=True,
-            )
+        self.run_worker(
+            self.set_root(path),
+            name="file-notes-root-change",
+            group="file-notes-root-change",
+            exclusive=True,
         )
 
     @on(Button.Pressed, "#file-notes-back")

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -1,0 +1,1374 @@
+"""Retained disk-backed File Notes workspace for Library."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+from pathlib import Path, PurePosixPath
+from threading import Lock
+from typing import Any, Literal
+from uuid import uuid4
+
+from rich.text import Text
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.events import Resize
+from textual.timer import Timer
+from textual.worker import Worker, WorkerState
+from textual.widgets import Button, Input, Static, TextArea, Tree
+
+from tldw_chatbook.config import (
+    get_cli_setting,
+    get_user_data_dir,
+    save_setting_to_cli_config,
+)
+from tldw_chatbook.Notes.file_notes_replica import FileNotesReplica
+from tldw_chatbook.Notes.file_notes_service import (
+    FileNoteEntry,
+    FileNotesService,
+    OpenedFileNote,
+    OperationResult,
+    ReconcileResult,
+    ScanResult,
+)
+from tldw_chatbook.Third_Party.textual_fspicker import SelectDirectory
+
+SaveState = Literal["idle", "dirty", "saving", "saved", "conflict", "error"]
+_UNSET = object()
+_TreeData = tuple[Literal["file", "folder", "deleted"], str]
+
+
+class LibraryFileNotesWorkspace(Vertical):
+    """Browse and edit one disk-authoritative Markdown/text root."""
+
+    DEFAULT_CSS = """
+    LibraryFileNotesWorkspace {
+        height: 1fr;
+        min-height: 12;
+        min-width: 0;
+    }
+
+    #file-notes-root-row {
+        height: auto;
+        min-height: 1;
+    }
+
+    #file-notes-root-status {
+        width: 1fr;
+        height: auto;
+        color: $text-muted;
+    }
+
+    #file-notes-choose-root {
+        width: auto;
+        min-width: 0;
+        height: 1;
+        min-height: 1;
+        padding: 0 1;
+        border: none;
+        background: transparent;
+    }
+
+    #file-notes-body {
+        height: 1fr;
+        min-height: 8;
+    }
+
+    #file-notes-navigator {
+        width: 3fr;
+        min-width: 24;
+        height: 100%;
+        padding-right: 1;
+        border-right: solid $surface-lighten-1;
+    }
+
+    #file-notes-editor-pane {
+        width: 7fr;
+        min-width: 32;
+        height: 100%;
+        padding-left: 1;
+    }
+
+    #file-notes-search,
+    #file-notes-path {
+        height: 3;
+        min-height: 3;
+    }
+
+    #file-notes-tree,
+    #file-notes-search-results {
+        height: 1fr;
+        min-height: 4;
+    }
+
+    #file-notes-breadcrumb,
+    #file-notes-save-status,
+    #file-notes-action-status,
+    #file-notes-session-changes {
+        height: auto;
+        min-height: 1;
+    }
+
+    #file-notes-breadcrumb {
+        text-style: bold;
+    }
+
+    #file-notes-save-status,
+    #file-notes-action-status,
+    #file-notes-session-changes {
+        color: $text-muted;
+    }
+
+    #file-notes-editor {
+        height: 1fr;
+        min-height: 5;
+    }
+
+    .file-notes-toolbar {
+        height: auto;
+        min-height: 1;
+    }
+
+    .file-notes-toolbar Button,
+    #file-notes-back {
+        width: auto;
+        min-width: 0;
+        height: 1;
+        min-height: 1;
+        padding: 0 1;
+        border: none;
+        background: transparent;
+    }
+    """
+
+    def __init__(
+        self,
+        *,
+        root: str | Path | None | object = _UNSET,
+        replica: FileNotesReplica | None | object = _UNSET,
+        replica_path: str | Path | None = None,
+        poll_interval: float = 1.5,
+        autosave_delay: float = 2.0,
+        **kwargs: Any,
+    ) -> None:
+        """Create a retained workspace.
+
+        Args:
+            root: Explicit root for tests/embedding. When omitted, the
+                canonical persisted root is loaded from CLI config.
+            replica: Optional injected replica. When omitted, the standard
+                user-data replica is opened off the UI loop.
+            replica_path: Optional persistent replica location.
+            poll_interval: Reconciliation cadence in seconds.
+            autosave_delay: Debounce delay in seconds.
+            **kwargs: Textual widget arguments.
+        """
+        kwargs.setdefault("id", "library-file-notes-workspace")
+        super().__init__(**kwargs)
+        self._root_seed = root
+        self._root = None if root is _UNSET else self._configured_root(root)
+        self._replica_seed = replica
+        self._replica_path = Path(replica_path) if replica_path is not None else None
+        self._replica: FileNotesReplica | None = (
+            replica if isinstance(replica, FileNotesReplica) else None
+        )
+        self._owns_replica = replica is _UNSET
+        self._service: FileNotesService | None = None
+        self._runtime_warning = ""
+
+        self._poll_interval = max(0.02, poll_interval)
+        self._autosave_delay = max(0.01, autosave_delay)
+        self._poll_timer: Timer | None = None
+        self._autosave_timer: Timer | None = None
+        self._workers: set[Worker[Any]] = set()
+        self._poll_worker: Worker[Any] | None = None
+        self._save_worker: Worker[Any] | None = None
+        self._active = False
+        self._refresh_lock = asyncio.Lock()
+        self._save_lock = asyncio.Lock()
+        self._runtime_lock = Lock()
+        self._root_generation = 0
+
+        self._entries: dict[str, FileNoteEntry] = {}
+        self._deleted_paths: tuple[str, ...] = ()
+        self._opened: OpenedFileNote | None = None
+        self._current_path = ""
+        self._selected_deleted_path = ""
+        self._session_key = ""
+        self._save_state: SaveState = "idle"
+        self._save_detail = ""
+        self._programmatic_editor_text: str | None = None
+        self._delete_confirmation_path = ""
+        self._search_generation = 0
+        self._search_query = ""
+        self._action_detail = ""
+        self._initialized = False
+        self._root_offline: bool | None = None
+        self._narrow = False
+        self._narrow_view: Literal["navigator", "editor"] = "navigator"
+        # The editor itself is retained across parent Library recompositions.
+        # Textual calls ``compose`` again when this same workspace object is
+        # remounted, so constructing it inside ``compose`` would silently
+        # replace the user's draft with a new TextArea instance.
+        self._editor_widget = TextArea(
+            "",
+            id="file-notes-editor",
+            read_only=True,
+        )
+
+    @staticmethod
+    def _configured_root(value: object) -> Path | None:
+        if not isinstance(value, (str, Path)) or not str(value).strip():
+            return None
+        return Path(value).expanduser()
+
+    @staticmethod
+    def _canonical_root(value: object) -> Path | None:
+        if not isinstance(value, (str, Path)) or not str(value).strip():
+            return None
+        return Path(value).expanduser().resolve(strict=False)
+
+    @property
+    def root(self) -> Path | None:
+        """Return the canonical configured root."""
+        return self._root
+
+    @property
+    def initialized(self) -> bool:
+        """Return whether the initial background scan has completed."""
+        return self._initialized
+
+    @property
+    def entries(self) -> dict[str, FileNoteEntry]:
+        """Return a snapshot of visible active files keyed by relative path."""
+        return dict(self._entries)
+
+    @property
+    def current_path(self) -> str:
+        """Return the open relative path, if any."""
+        return self._current_path
+
+    @property
+    def current_document(self) -> OpenedFileNote | None:
+        """Return the exact-byte baseline for the open editor."""
+        return self._opened
+
+    @property
+    def session_key(self) -> str:
+        """Return the current open/reload editing-session key."""
+        return self._session_key
+
+    @property
+    def save_state(self) -> SaveState:
+        """Return the current editor save state."""
+        return self._save_state
+
+    @property
+    def leave_allowed(self) -> bool:
+        """Return whether the retained draft can be left without a flush."""
+        return self._save_state not in {"dirty", "saving", "conflict", "error"}
+
+    @property
+    def narrow(self) -> bool:
+        """Return whether actual mounted width selected narrow navigation."""
+        return self._narrow
+
+    @property
+    def navigator_visible(self) -> bool:
+        """Return whether the navigator pane is currently displayed."""
+        return self.query_one("#file-notes-navigator").display
+
+    @property
+    def editor_visible(self) -> bool:
+        """Return whether the editor pane is currently displayed."""
+        return self.query_one("#file-notes-editor-pane").display
+
+    def compose(self) -> ComposeResult:
+        with Horizontal(id="file-notes-root-row"):
+            yield Static(
+                "Choose a notes folder.",
+                id="file-notes-root-status",
+                markup=False,
+            )
+            yield Button(
+                "Choose folder…",
+                id="file-notes-choose-root",
+                compact=True,
+            )
+        with Horizontal(id="file-notes-body"):
+            with Vertical(id="file-notes-navigator"):
+                yield Input(
+                    placeholder="Search file contents…",
+                    id="file-notes-search",
+                    value=self._search_query,
+                )
+                yield Tree[object]("Files", id="file-notes-tree")
+                search_results = Tree[object](
+                    "Search results",
+                    id="file-notes-search-results",
+                )
+                search_results.display = False
+                yield search_results
+                yield Static(
+                    "Session changes: none",
+                    id="file-notes-session-changes",
+                    markup=False,
+                )
+            with Vertical(id="file-notes-editor-pane"):
+                back = Button(
+                    "‹ Navigator",
+                    id="file-notes-back",
+                    compact=True,
+                )
+                back.display = False
+                yield back
+                yield Static(
+                    "No file selected",
+                    id="file-notes-breadcrumb",
+                    markup=False,
+                )
+                yield Static("Idle", id="file-notes-save-status", markup=False)
+                yield Input(
+                    placeholder="relative/path.md",
+                    id="file-notes-path",
+                    value=self._selected_deleted_path or self._current_path,
+                )
+                yield self._editor_widget
+                with Horizontal(classes="file-notes-toolbar"):
+                    yield Button("New", id="file-notes-new", compact=True)
+                    yield Button("Move", id="file-notes-move", compact=True)
+                    yield Button("Delete", id="file-notes-delete", compact=True)
+                    yield Button("Restore", id="file-notes-restore", compact=True)
+                    yield Button("Protect", id="file-notes-protect", compact=True)
+                with Horizontal(classes="file-notes-toolbar"):
+                    yield Button("Reload", id="file-notes-reload", compact=True)
+                    yield Button(
+                        "Save Copy",
+                        id="file-notes-save-copy",
+                        compact=True,
+                    )
+                    yield Button("Refresh", id="file-notes-refresh", compact=True)
+                yield Static("", id="file-notes-action-status", markup=False)
+
+    def on_mount(self) -> None:
+        """Start background initialization and polling for this mount."""
+        self._active = True
+        self._apply_responsive_layout(self.size.width)
+        if self._opened is not None:
+            self.query_one("#file-notes-breadcrumb", Static).update(
+                self._opened.relative_path
+            )
+        elif self._selected_deleted_path:
+            self.query_one("#file-notes-breadcrumb", Static).update(
+                f"Recently deleted: {self._selected_deleted_path}"
+            )
+        self._set_save_state(self._save_state, self._save_detail)
+        self._set_action_status(self._action_detail)
+        self._update_root_surface()
+        self._update_controls()
+        self._track_worker(
+            self.run_worker(
+                self._initialize(),
+                name="file-notes-initialize",
+                group="file-notes-initialize",
+                exclusive=True,
+            )
+        )
+        self._poll_timer = self.set_interval(
+            self._poll_interval,
+            self._start_poll,
+            pause=False,
+        )
+
+    def on_unmount(self) -> None:
+        """Pause timers and cancel workspace-owned workers."""
+        self._active = False
+        for timer in (self._poll_timer, self._autosave_timer):
+            if timer is not None:
+                timer.stop()
+        self._poll_timer = None
+        self._autosave_timer = None
+        for worker in tuple(self._workers):
+            if not worker.is_finished:
+                worker.cancel()
+        self._workers.clear()
+        self._poll_worker = None
+        self._save_worker = None
+
+    def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
+        """Forget completed workers so long-running polling stays bounded."""
+        if event.state in {
+            WorkerState.CANCELLED,
+            WorkerState.ERROR,
+            WorkerState.SUCCESS,
+        }:
+            self._workers.discard(event.worker)
+
+    def on_resize(self, event: Resize) -> None:
+        """Choose wide or narrow panes from the mounted workspace width."""
+        self._apply_responsive_layout(event.size.width)
+
+    def _track_worker(self, worker: Worker[Any]) -> Worker[Any]:
+        self._workers.add(worker)
+        return worker
+
+    async def _initialize(self) -> None:
+        generation = self._root_generation
+        previous_service = self._service
+        was_initialized = self._initialized
+        root, replica, service, warning = await asyncio.to_thread(self._build_runtime)
+        if not self._active or generation != self._root_generation:
+            return
+        resuming = was_initialized and service is previous_service
+        self._root = root
+        self._replica = replica
+        self._service = service
+        self._runtime_warning = warning
+        if service is None:
+            self._initialized = True
+            self._update_root_surface()
+            self._update_controls()
+            return
+        if resuming:
+            result = await asyncio.to_thread(service.reconcile)
+            deleted = await self._load_deleted_paths(
+                replica=replica,
+                service=service,
+            )
+            if (
+                not self._active
+                or generation != self._root_generation
+                or service is not self._service
+            ):
+                return
+            self._apply_reconcile(result, deleted)
+            await self._handle_open_external_change(result)
+            return
+        result = await asyncio.to_thread(service.scan)
+        deleted = await self._load_deleted_paths(replica=replica, service=service)
+        if (
+            not self._active
+            or generation != self._root_generation
+            or service is not self._service
+        ):
+            return
+        self._initialized = True
+        self._apply_scan(result, deleted)
+
+    def _build_runtime(
+        self,
+    ) -> tuple[
+        Path | None,
+        FileNotesReplica | None,
+        FileNotesService | None,
+        str,
+    ]:
+        with self._runtime_lock:
+            configured_root = self._root
+            if self._root_seed is _UNSET and configured_root is None:
+                configured_root = get_cli_setting("file_notes", "root", None)
+            root = self._canonical_root(configured_root)
+            replica = self._replica
+            previous_replica = replica
+            warning = ""
+            if self._replica_seed is _UNSET and replica is None:
+                try:
+                    replica_path = self._replica_path or (
+                        get_user_data_dir() / "file_notes.sqlite"
+                    )
+                    replica = FileNotesReplica(replica_path)
+                    # Keep the handle even if the awaiting mount is cancelled.
+                    # A rapid remount will reuse it instead of opening a second
+                    # connection after the background thread completes.
+                    self._replica = replica
+                except Exception as error:
+                    replica = None
+                    warning = f"Recovery unavailable: {error}"
+            service = self._service
+            if root is None:
+                service = None
+            elif (
+                service is None
+                or service.root_key != str(root)
+                or previous_replica is not replica
+            ):
+                service = FileNotesService(root, replica)
+            return root, replica, service, warning
+
+    async def _load_deleted_paths(
+        self,
+        *,
+        replica: FileNotesReplica | None = None,
+        service: FileNotesService | None = None,
+    ) -> tuple[str, ...]:
+        replica = self._replica if replica is None else replica
+        service = self._service if service is None else service
+        if replica is None or service is None:
+            return ()
+        try:
+            paths = await asyncio.to_thread(
+                replica.list_deleted,
+                service.root_key,
+            )
+        except Exception as error:
+            self._runtime_warning = f"Recovery unavailable: {error}"
+            return ()
+        return tuple(paths)
+
+    def _apply_scan(
+        self,
+        result: ScanResult,
+        deleted: tuple[str, ...],
+    ) -> None:
+        self._entries = {entry.relative_path: entry for entry in result.entries}
+        self._deleted_paths = deleted
+        self._root_offline = result.offline
+        if result.replica_warning:
+            self._runtime_warning = result.replica_warning
+        self._update_root_surface(offline=result.offline)
+        self._rebuild_tree()
+        self._refresh_active_search()
+        self._refresh_session_changes()
+        self._update_controls()
+
+    def _apply_reconcile(
+        self,
+        result: ReconcileResult,
+        deleted: tuple[str, ...],
+    ) -> None:
+        new_entries = {entry.relative_path: entry for entry in result.entries}
+        navigator_changed = (
+            new_entries != self._entries or deleted != self._deleted_paths
+        )
+        self._entries = new_entries
+        self._deleted_paths = deleted
+        self._root_offline = result.offline
+        if result.replica_warning:
+            self._runtime_warning = result.replica_warning
+        self._update_root_surface(offline=result.offline)
+        if navigator_changed:
+            self._rebuild_tree()
+        self._refresh_active_search()
+        self._refresh_session_changes()
+        self._update_controls()
+
+    def _update_root_surface(self, *, offline: bool | None = None) -> None:
+        if not self._active or not self.is_mounted:
+            return
+        status = self.query_one("#file-notes-root-status", Static)
+        body = self.query_one("#file-notes-body")
+        choose = self.query_one("#file-notes-choose-root", Button)
+        if self._root is None:
+            status.update("Choose a notes folder.")
+            body.display = False
+            choose.display = True
+            return
+        is_offline = self._root_offline if offline is None else offline
+        state = (
+            "Checking"
+            if is_offline is None
+            else ("Offline" if is_offline else "Linked")
+        )
+        detail = f"{state} — {self._root}"
+        if self._runtime_warning:
+            detail = f"{detail} · {self._runtime_warning}"
+        status.update(detail)
+        body.display = True
+        choose.display = True
+        self._apply_responsive_layout(self.size.width)
+
+    def _apply_responsive_layout(self, width: int) -> None:
+        if not self._active or not self.is_mounted:
+            return
+        self._narrow = width < 80
+        navigator = self.query_one("#file-notes-navigator")
+        editor = self.query_one("#file-notes-editor-pane")
+        back = self.query_one("#file-notes-back", Button)
+        if self._narrow:
+            navigator.display = self._narrow_view == "navigator"
+            editor.display = self._narrow_view == "editor"
+            back.display = self._narrow_view == "editor"
+        else:
+            navigator.display = True
+            editor.display = True
+            back.display = False
+
+    def _rebuild_tree(self) -> None:
+        if not self._active or not self.is_mounted:
+            return
+        tree = self.query_one("#file-notes-tree", Tree)
+        expanded_folders: set[str] = set()
+
+        def remember_expanded(node: Any) -> None:
+            data = node.data
+            if (
+                node.is_expanded
+                and isinstance(data, tuple)
+                and len(data) == 2
+                and data[0] == "folder"
+            ):
+                expanded_folders.add(data[1])
+            for child in node.children:
+                remember_expanded(child)
+
+        for child in tree.root.children:
+            remember_expanded(child)
+        root_label = self._root.name if self._root is not None else "Files"
+        tree.reset(Text(root_label or "Files"))
+        folder_nodes: dict[str, Any] = {"": tree.root}
+        for relative_path in sorted(self._entries):
+            parts = PurePosixPath(relative_path).parts
+            parent_key = ""
+            parent = tree.root
+            for part in parts[:-1]:
+                key = f"{parent_key}/{part}".lstrip("/")
+                node = folder_nodes.get(key)
+                if node is None:
+                    node = parent.add(
+                        Text(part),
+                        data=("folder", key),
+                        expand=key in expanded_folders,
+                    )
+                    folder_nodes[key] = node
+                parent = node
+                parent_key = key
+            parent.add_leaf(
+                Text(parts[-1]),
+                data=("file", relative_path),
+            )
+        if self._deleted_paths:
+            deleted = tree.root.add(
+                Text("Recently deleted"),
+                data=("folder", "recently-deleted"),
+                expand=True,
+            )
+            for relative_path in self._deleted_paths:
+                deleted.add_leaf(
+                    Text(relative_path),
+                    data=("deleted", relative_path),
+                )
+        tree.root.expand()
+
+    def _rebuild_search_results(self, paths: tuple[str, ...]) -> None:
+        if not self._active or not self.is_mounted:
+            return
+        results = self.query_one("#file-notes-search-results", Tree)
+        results.reset(Text("Search results"))
+        for path in paths:
+            results.root.add_leaf(Text(path), data=("file", path))
+        results.root.expand()
+
+    def _refresh_active_search(self) -> None:
+        if not self._active or not self.is_mounted:
+            return
+        query = self.query_one("#file-notes-search", Input).value.strip()
+        if query:
+            self._start_search(query)
+
+    def _refresh_session_changes(self) -> None:
+        if not self._active or not self.is_mounted:
+            return
+        changes = () if self._service is None else self._service.session_changes
+        text = "Session changes: none"
+        if changes:
+            parts = []
+            for change in changes:
+                if change.destination_path:
+                    parts.append(
+                        f"{change.action} {change.relative_path} → "
+                        f"{change.destination_path}"
+                    )
+                else:
+                    parts.append(f"{change.action} {change.relative_path}")
+            text = "Session changes: " + "; ".join(parts)
+        self.query_one("#file-notes-session-changes", Static).update(text)
+
+    def _set_save_state(self, state: SaveState, detail: str = "") -> None:
+        self._save_state = state
+        self._save_detail = detail
+        if self._active and self.is_mounted:
+            label = state.capitalize()
+            if detail:
+                label = f"{label} — {detail}"
+            self.query_one("#file-notes-save-status", Static).update(label)
+            self._update_controls()
+
+    def _set_action_status(self, text: str) -> None:
+        self._action_detail = text
+        if self._active and self.is_mounted:
+            self.query_one("#file-notes-action-status", Static).update(text)
+
+    def _update_controls(self) -> None:
+        if not self._active or not self.is_mounted:
+            return
+        has_service = self._service is not None
+        has_document = self._opened is not None
+        has_deleted = bool(self._selected_deleted_path)
+        self.query_one("#file-notes-new", Button).disabled = not has_service
+        for selector in ("move", "delete", "protect", "reload"):
+            self.query_one(
+                f"#file-notes-{selector}", Button
+            ).disabled = not has_document
+        self.query_one("#file-notes-save-copy", Button).disabled = (
+            not has_document or self._save_state not in {"dirty", "conflict", "error"}
+        )
+        self.query_one("#file-notes-restore", Button).disabled = (
+            not has_service or not has_deleted
+        )
+        self.query_one("#file-notes-refresh", Button).disabled = not has_service
+        protect = self.query_one("#file-notes-protect", Button)
+        protect.label = (
+            "Unprotect"
+            if self._opened is not None and self._opened.protected
+            else "Protect"
+        )
+        editor = self.query_one("#file-notes-editor", TextArea)
+        editor.read_only = not (self._opened is not None and self._opened.editable)
+
+    async def set_root(self, path: str | Path, *, persist: bool = True) -> bool:
+        """Adopt one canonical root after the common draft leave guard."""
+        if not self._active:
+            return False
+        if not await self.flush_pending_work():
+            return False
+        canonical = await asyncio.to_thread(self._canonical_root, path)
+        if canonical is None:
+            return False
+        self._root_generation += 1
+        generation = self._root_generation
+        if self._replica_seed is _UNSET and self._replica is None:
+            _, replica, _, warning = await asyncio.to_thread(self._build_runtime)
+            self._replica = replica
+            self._runtime_warning = warning
+        service = await asyncio.to_thread(FileNotesService, canonical, self._replica)
+        if not self._active or generation != self._root_generation:
+            return False
+        self._root = canonical
+        self._service = service
+        self._clear_open_document()
+        self._entries = {}
+        self._deleted_paths = ()
+        self._initialized = False
+        self._update_root_surface()
+        if persist:
+            await asyncio.to_thread(
+                save_setting_to_cli_config,
+                "file_notes",
+                "root",
+                str(canonical),
+            )
+            if not self._active or generation != self._root_generation:
+                return False
+        result = await asyncio.to_thread(service.scan)
+        deleted = await self._load_deleted_paths(
+            replica=self._replica,
+            service=service,
+        )
+        if (
+            not self._active
+            or generation != self._root_generation
+            or service is not self._service
+        ):
+            return False
+        self._initialized = True
+        self._apply_scan(result, deleted)
+        return True
+
+    async def open_path(self, relative_path: str) -> bool:
+        """Flush the old draft, then open a disk file into the same editor."""
+        if not self._active or self._service is None:
+            return False
+        if self._opened is not None and not await self.flush_pending_work():
+            return False
+        try:
+            opened = await asyncio.to_thread(
+                self._service.open_file,
+                relative_path,
+            )
+        except Exception as error:
+            self._set_action_status(f"Open failed: {error}")
+            return False
+        if not self._active:
+            return False
+        self._apply_opened_document(opened)
+        return True
+
+    def _apply_opened_document(self, opened: OpenedFileNote) -> None:
+        if not self._active:
+            return
+        self._opened = opened
+        self._current_path = opened.relative_path
+        self._selected_deleted_path = ""
+        self._session_key = uuid4().hex
+        self._delete_confirmation_path = ""
+        editor = self.query_one("#file-notes-editor", TextArea)
+        self._programmatic_editor_text = opened.body
+        editor.load_text(opened.body)
+        editor.read_only = not opened.editable
+        self.query_one("#file-notes-path", Input).value = opened.relative_path
+        self.query_one("#file-notes-breadcrumb", Static).update(opened.relative_path)
+        self.query_one("#file-notes-delete", Button).label = "Delete"
+        if opened.editable:
+            self._set_save_state("saved")
+        else:
+            self._set_save_state(
+                "saved",
+                f"read only: {opened.read_only_reason or 'unsupported content'}",
+            )
+        self._set_action_status(opened.replica_warning or "")
+        if self._narrow:
+            self._narrow_view = "editor"
+            self._apply_responsive_layout(self.size.width)
+        self._update_controls()
+
+    def _clear_open_document(self, *, keep_restore_path: bool = False) -> None:
+        if not self._active:
+            return
+        self._opened = None
+        self._current_path = ""
+        self._session_key = ""
+        self._delete_confirmation_path = ""
+        editor = self.query_one("#file-notes-editor", TextArea)
+        self._programmatic_editor_text = ""
+        editor.load_text("")
+        editor.read_only = True
+        if not keep_restore_path:
+            self._selected_deleted_path = ""
+            self.query_one("#file-notes-path", Input).value = ""
+            self.query_one("#file-notes-breadcrumb", Static).update("No file selected")
+        self.query_one("#file-notes-delete", Button).label = "Delete"
+        self._set_save_state("idle")
+        self._update_controls()
+
+    def select_deleted(self, relative_path: str) -> bool:
+        """Select one persistent tombstone for the Restore action."""
+        if not self._active or relative_path not in self._deleted_paths:
+            return False
+        self._clear_open_document()
+        self._selected_deleted_path = relative_path
+        self.query_one("#file-notes-path", Input).value = relative_path
+        self.query_one("#file-notes-breadcrumb", Static).update(
+            f"Recently deleted: {relative_path}"
+        )
+        self._set_action_status("Ready to restore.")
+        if self._narrow:
+            self._narrow_view = "editor"
+            self._apply_responsive_layout(self.size.width)
+        self._update_controls()
+        return True
+
+    async def refresh_files(self) -> bool:
+        """Run one reconciliation off the UI loop and update retained widgets."""
+        service = self._service
+        generation = self._root_generation
+        if service is None:
+            return False
+        async with self._refresh_lock:
+            if (
+                not self._active
+                or generation != self._root_generation
+                or service is not self._service
+            ):
+                return False
+            try:
+                result = await asyncio.to_thread(service.reconcile)
+                deleted = await self._load_deleted_paths(
+                    replica=self._replica,
+                    service=service,
+                )
+            except Exception as error:
+                self._set_action_status(f"Refresh failed: {error}")
+                return False
+            if (
+                not self._active
+                or generation != self._root_generation
+                or service is not self._service
+            ):
+                return False
+            self._apply_reconcile(result, deleted)
+            await self._handle_open_external_change(result)
+        return True
+
+    async def _handle_open_external_change(
+        self,
+        result: ReconcileResult,
+    ) -> None:
+        opened = self._opened
+        if opened is None:
+            return
+        path = opened.relative_path
+        if path in result.deleted:
+            self._set_save_state("conflict", "file deleted on disk")
+            return
+        if path not in result.modified:
+            return
+        if self._save_state in {"dirty", "saving", "conflict", "error"}:
+            self._set_save_state("conflict", "file changed on disk")
+            return
+        assert self._service is not None
+        try:
+            reloaded = await asyncio.to_thread(self._service.open_file, path)
+        except Exception as error:
+            self._set_save_state("error", f"reload failed: {error}")
+            return
+        if not self._active:
+            return
+        self._apply_opened_document(reloaded)
+
+    def _start_poll(self) -> None:
+        if (
+            not self._active
+            or self._service is None
+            or (self._poll_worker is not None and not self._poll_worker.is_finished)
+        ):
+            return
+        self._poll_worker = self._track_worker(
+            self.run_worker(
+                self.refresh_files(),
+                name="file-notes-poll",
+                group="file-notes-poll",
+                exclusive=True,
+            )
+        )
+
+    def _arm_autosave(self) -> None:
+        if self._autosave_timer is not None:
+            self._autosave_timer.stop()
+        self._autosave_timer = self.set_timer(
+            self._autosave_delay,
+            self._start_autosave,
+        )
+
+    def _start_autosave(self) -> None:
+        self._autosave_timer = None
+        if (
+            not self._active
+            or self._save_state != "dirty"
+            or (
+                self._save_worker is not None
+                and not self._save_worker.is_finished
+            )
+        ):
+            return
+        self._save_worker = self._track_worker(
+            self.run_worker(
+                self._save_draft(),
+                name="file-notes-autosave",
+                group="file-notes-save",
+                exclusive=False,
+            )
+        )
+
+    async def _save_draft(self) -> bool:
+        async with self._save_lock:
+            opened = self._opened
+            service = self._service
+            if opened is None or service is None:
+                return True
+            if self._save_state in {"conflict", "error"}:
+                return False
+            editor = self.query_one("#file-notes-editor", TextArea)
+            body = editor.text
+            self._set_save_state("saving")
+            try:
+                result = await asyncio.to_thread(
+                    service.save_file,
+                    opened,
+                    body,
+                    session_key=self._session_key,
+                )
+            except Exception as error:
+                self._set_save_state("error", str(error))
+                return False
+            if not self._active:
+                return False
+            if result.status == "ok" and result.content_hash is not None:
+                self._opened = replace(
+                    opened,
+                    body=body,
+                    content_hash=result.content_hash,
+                )
+                if editor.text == body:
+                    self._set_save_state("saved")
+                else:
+                    self._set_save_state("dirty")
+                    self._arm_autosave()
+                self._set_action_status(result.replica_warning or "")
+                self._refresh_session_changes()
+                return True
+            if result.status in {"conflict", "missing"}:
+                self._set_save_state("conflict", result.message or result.status)
+            else:
+                self._set_save_state("error", result.message or result.status)
+            self._set_action_status(result.replica_warning or "")
+            return False
+
+    async def flush_pending_work(self) -> bool:
+        """Flush a pending autosave; unresolved draft states veto leaving."""
+        if not self._active:
+            return self.leave_allowed
+        if self._autosave_timer is not None:
+            self._autosave_timer.stop()
+            self._autosave_timer = None
+        worker = self._save_worker
+        if worker is not None and not worker.is_finished:
+            try:
+                await worker.wait()
+            except Exception:
+                pass
+        if self._save_state in {"conflict", "error"}:
+            return False
+        if self._save_state == "dirty":
+            await self._save_draft()
+        return self.leave_allowed
+
+    async def _rescan_after_action(self) -> bool:
+        service = self._service
+        generation = self._root_generation
+        if not self._active or service is None:
+            return False
+        result = await asyncio.to_thread(service.scan)
+        deleted = await self._load_deleted_paths(
+            replica=self._replica,
+            service=service,
+        )
+        if (
+            not self._active
+            or generation != self._root_generation
+            or service is not self._service
+        ):
+            return False
+        self._apply_scan(result, deleted)
+        return True
+
+    def _operation_error(self, action: str, result: OperationResult) -> None:
+        detail = result.message or result.status
+        self._set_action_status(f"{action} failed: {detail}")
+        if self._opened is not None and result.status in {"conflict", "missing"}:
+            self._set_save_state("conflict", detail)
+        elif self._save_state in {"dirty", "saving"}:
+            self._set_save_state("error", detail)
+
+    @on(TextArea.Changed, "#file-notes-editor")
+    def _editor_changed(self, event: TextArea.Changed) -> None:
+        event.stop()
+        text = event.text_area.text
+        if self._programmatic_editor_text is not None:
+            expected = self._programmatic_editor_text
+            self._programmatic_editor_text = None
+            if text == expected:
+                return
+        if self._opened is None or not self._opened.editable:
+            return
+        self._delete_confirmation_path = ""
+        self.query_one("#file-notes-delete", Button).label = "Delete"
+        self._set_save_state("dirty")
+        self._arm_autosave()
+
+    @on(Input.Changed, "#file-notes-search")
+    def _search_changed(self, event: Input.Changed) -> None:
+        event.stop()
+        query = event.value.strip()
+        self._search_query = event.value
+        tree = self.query_one("#file-notes-tree", Tree)
+        results = self.query_one("#file-notes-search-results", Tree)
+        if not query:
+            self._search_generation += 1
+            tree.display = True
+            results.display = False
+            results.reset(Text("Search results"))
+            return
+        tree.display = False
+        results.display = True
+        self._start_search(query)
+
+    def _start_search(self, query: str) -> None:
+        self._search_generation += 1
+        generation = self._search_generation
+        self._track_worker(
+            self.run_worker(
+                self._run_search(query, generation),
+                name="file-notes-search",
+                group="file-notes-search",
+                exclusive=True,
+            )
+        )
+
+    async def _run_search(self, query: str, generation: int) -> None:
+        if self._replica is not None and self._service is not None:
+            try:
+                paths = await asyncio.to_thread(
+                    self._replica.search,
+                    self._service.root_key,
+                    query,
+                )
+            except Exception:
+                paths = []
+        else:
+            folded = query.casefold()
+            paths = [path for path in self._entries if folded in path.casefold()]
+        if generation != self._search_generation or not self._active:
+            return
+        self._rebuild_search_results(tuple(paths))
+
+    @on(Tree.NodeSelected)
+    async def _tree_node_selected(self, event: Tree.NodeSelected[object]) -> None:
+        data = event.node.data
+        if not isinstance(data, tuple) or len(data) != 2:
+            return
+        kind, relative_path = data
+        if kind == "file":
+            event.stop()
+            await self.open_path(relative_path)
+        elif kind == "deleted":
+            event.stop()
+            if self._opened is not None and not await self.flush_pending_work():
+                return
+            self.select_deleted(relative_path)
+
+    @on(Button.Pressed, "#file-notes-choose-root")
+    async def _choose_root(self, event: Button.Pressed) -> None:
+        event.stop()
+        location = (
+            self._root
+            if self._root is not None and self._root_offline is False
+            else Path.home()
+        )
+        await self.app.push_screen(
+            SelectDirectory(location, title="Choose File Notes Folder"),
+            callback=self._root_selected,
+        )
+
+    def _root_selected(self, path: Path | None) -> None:
+        if path is None or not self._active:
+            return
+        self._track_worker(
+            self.run_worker(
+                self.set_root(path),
+                name="file-notes-root-change",
+                group="file-notes-root-change",
+                exclusive=True,
+            )
+        )
+
+    @on(Button.Pressed, "#file-notes-back")
+    def _back_to_navigator(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._narrow_view = "navigator"
+        self._apply_responsive_layout(self.size.width)
+
+    @on(Button.Pressed, "#file-notes-new")
+    async def _new_file(self, event: Button.Pressed) -> None:
+        event.stop()
+        if self._service is None or not await self.flush_pending_work():
+            return
+        destination = self.query_one("#file-notes-path", Input).value.strip()
+        result = await asyncio.to_thread(
+            self._service.create_file,
+            destination,
+        )
+        if not self._active:
+            return
+        if not result.succeeded:
+            self._operation_error("Create", result)
+            return
+        if not await self._rescan_after_action():
+            return
+        try:
+            opened = await asyncio.to_thread(
+                self._service.open_file,
+                destination,
+            )
+        except Exception as error:
+            self._set_action_status(f"Open failed: {error}")
+            return
+        if not self._active:
+            return
+        self._apply_opened_document(opened)
+
+    @on(Button.Pressed, "#file-notes-move")
+    async def _move_file(self, event: Button.Pressed) -> None:
+        event.stop()
+        opened = self._opened
+        if (
+            self._service is None
+            or opened is None
+            or not await self.flush_pending_work()
+        ):
+            return
+        destination = self.query_one("#file-notes-path", Input).value.strip()
+        result = await asyncio.to_thread(
+            self._service.move_file,
+            opened.relative_path,
+            destination,
+        )
+        if not self._active:
+            return
+        if not result.succeeded:
+            self._operation_error("Move", result)
+            return
+        if not await self._rescan_after_action():
+            return
+        try:
+            moved = await asyncio.to_thread(
+                self._service.open_file,
+                destination,
+            )
+        except Exception as error:
+            self._set_action_status(f"Open failed: {error}")
+            return
+        if not self._active:
+            return
+        self._apply_opened_document(moved)
+
+    @on(Button.Pressed, "#file-notes-delete")
+    async def _delete_file(self, event: Button.Pressed) -> None:
+        event.stop()
+        opened = self._opened
+        if self._service is None or opened is None:
+            return
+        if self._delete_confirmation_path != opened.relative_path:
+            self._delete_confirmation_path = opened.relative_path
+            event.button.label = "Confirm delete"
+            self._set_action_status("Click Delete again to confirm.")
+            return
+        if not await self.flush_pending_work():
+            return
+        opened = self._opened
+        if opened is None:
+            return
+        result = await asyncio.to_thread(
+            self._service.delete_file,
+            opened.relative_path,
+            expected_hash=opened.content_hash,
+        )
+        if not self._active:
+            return
+        if not result.succeeded:
+            self._operation_error("Delete", result)
+            return
+        deleted_path = opened.relative_path
+        self._clear_open_document()
+        self._selected_deleted_path = deleted_path
+        self.query_one("#file-notes-path", Input).value = deleted_path
+        self.query_one("#file-notes-breadcrumb", Static).update(
+            f"Recently deleted: {deleted_path}"
+        )
+        if not await self._rescan_after_action():
+            return
+        self._set_action_status("Deleted. Restore remains available.")
+        self._update_controls()
+
+    @on(Button.Pressed, "#file-notes-restore")
+    async def _restore_file(self, event: Button.Pressed) -> None:
+        event.stop()
+        if self._service is None:
+            return
+        relative_path = (
+            self._selected_deleted_path
+            or self.query_one("#file-notes-path", Input).value.strip()
+        )
+        result = await asyncio.to_thread(
+            self._service.restore_file,
+            relative_path,
+        )
+        if not self._active:
+            return
+        if not result.succeeded:
+            self._operation_error("Restore", result)
+            return
+        if not await self._rescan_after_action():
+            return
+        try:
+            restored = await asyncio.to_thread(
+                self._service.open_file,
+                relative_path,
+            )
+        except Exception as error:
+            self._set_action_status(f"Open failed: {error}")
+            return
+        if not self._active:
+            return
+        self._apply_opened_document(restored)
+
+    @on(Button.Pressed, "#file-notes-protect")
+    async def _toggle_protect(self, event: Button.Pressed) -> None:
+        event.stop()
+        opened = self._opened
+        if self._service is None or opened is None:
+            return
+        target = not opened.protected
+        operation = (
+            self._service.protect_path if target else self._service.unprotect_path
+        )
+        result = await asyncio.to_thread(operation, opened.relative_path)
+        if not self._active:
+            return
+        if not result.succeeded:
+            self._operation_error("Protect" if target else "Unprotect", result)
+            return
+        self._opened = replace(opened, protected=target)
+        self._set_action_status("Protected." if target else "Unprotected.")
+        self._update_controls()
+
+    @on(Button.Pressed, "#file-notes-reload")
+    async def _reload_file(self, event: Button.Pressed) -> None:
+        event.stop()
+        opened = self._opened
+        if self._service is None or opened is None:
+            return
+        if self._save_state == "dirty" and not await self.flush_pending_work():
+            return
+        opened = self._opened
+        if opened is None:
+            return
+        try:
+            reloaded = await asyncio.to_thread(
+                self._service.open_file,
+                opened.relative_path,
+            )
+        except Exception as error:
+            self._set_save_state("error", f"reload failed: {error}")
+            return
+        if not self._active:
+            return
+        self._apply_opened_document(reloaded)
+
+    @on(Button.Pressed, "#file-notes-save-copy")
+    async def _save_copy(self, event: Button.Pressed) -> None:
+        event.stop()
+        opened = self._opened
+        if self._service is None or opened is None:
+            return
+        destination = self.query_one("#file-notes-path", Input).value.strip()
+        body = self.query_one("#file-notes-editor", TextArea).text
+        result = await asyncio.to_thread(
+            self._service.save_copy,
+            opened,
+            body,
+            destination,
+        )
+        if not self._active:
+            return
+        if not result.succeeded:
+            self._operation_error("Save Copy", result)
+            return
+        if not await self._rescan_after_action():
+            return
+        try:
+            copied = await asyncio.to_thread(
+                self._service.open_file,
+                destination,
+            )
+        except Exception as error:
+            self._set_action_status(f"Open failed: {error}")
+            return
+        if not self._active:
+            return
+        self._apply_opened_document(copied)
+
+    @on(Button.Pressed, "#file-notes-refresh")
+    async def _refresh_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        await self.refresh_files()

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import replace
 from pathlib import Path, PurePosixPath
 from threading import Lock, RLock
@@ -190,7 +192,7 @@ class LibraryFileNotesWorkspace(Vertical):
         self._service_lock = RLock()
         self._root_generation = 0
         self._root_transitioning = False
-        self._open_transitioning = False
+        self._path_transitioning = False
         self._shutdown = False
 
         self._entries: dict[str, FileNoteEntry] = {}
@@ -269,7 +271,11 @@ class LibraryFileNotesWorkspace(Vertical):
     @property
     def leave_allowed(self) -> bool:
         """Return whether the retained draft can be left without a flush."""
-        return self._save_state not in {"dirty", "saving", "conflict", "error"}
+        return (
+            not self._root_transitioning
+            and not self._path_transitioning
+            and self._save_state not in {"dirty", "saving", "conflict", "error"}
+        )
 
     @property
     def narrow(self) -> bool:
@@ -588,7 +594,7 @@ class LibraryFileNotesWorkspace(Vertical):
         status = self.query_one("#file-notes-root-status", Static)
         body = self.query_one("#file-notes-body")
         choose = self.query_one("#file-notes-choose-root", Button)
-        choose.disabled = self._root_transitioning or self._open_transitioning
+        choose.disabled = self._root_transitioning or self._path_transitioning
         if self._root is None:
             status.update("Choose a notes folder.")
             body.display = False
@@ -732,7 +738,7 @@ class LibraryFileNotesWorkspace(Vertical):
     def _update_controls(self) -> None:
         if not self._active or not self.is_mounted:
             return
-        transitioning = self._root_transitioning or self._open_transitioning
+        transitioning = self._root_transitioning or self._path_transitioning
         has_service = self._service is not None and not transitioning
         has_document = self._opened is not None and not transitioning
         has_deleted = bool(self._selected_deleted_path) and not transitioning
@@ -763,11 +769,47 @@ class LibraryFileNotesWorkspace(Vertical):
             self._opened is not None and self._opened.editable
         )
 
+    @contextmanager
+    def _hold_path_transition(
+        self,
+    ) -> Iterator[tuple[FileNotesService, int] | None]:
+        service = self._service
+        if (
+            not self._active
+            or self._root_transitioning
+            or self._path_transitioning
+            or service is None
+        ):
+            yield None
+            return
+        self._path_transitioning = True
+        self._update_root_surface()
+        self._update_controls()
+        try:
+            yield service, self._root_generation
+        finally:
+            self._path_transitioning = False
+            self._update_root_surface()
+            self._update_controls()
+
+    def _path_result_is_stale(
+        self,
+        service: FileNotesService,
+        generation: int,
+    ) -> bool:
+        return (
+            not self._active
+            or generation != self._root_generation
+            or service is not self._service
+        )
+
     async def set_root(self, path: str | Path, *, persist: bool = True) -> bool:
         """Adopt one canonical root after the common draft leave guard."""
-        if not self._active or self._open_transitioning or self._shutdown:
+        if not self._active or self._path_transitioning or self._shutdown:
             return False
         if not await self.flush_pending_work():
+            return False
+        if not self._active or self._path_transitioning or self._shutdown:
             return False
         self._root_generation += 1
         generation = self._root_generation
@@ -829,7 +871,7 @@ class LibraryFileNotesWorkspace(Vertical):
         if (
             not self._active
             or self._root_transitioning
-            or self._open_transitioning
+            or self._path_transitioning
             or self._shutdown
             or service is None
         ):
@@ -839,15 +881,14 @@ class LibraryFileNotesWorkspace(Vertical):
         if (
             not self._active
             or self._root_transitioning
-            or self._open_transitioning
+            or self._path_transitioning
             or generation != self._root_generation
             or service is not self._service
         ):
             return False
-        self._open_transitioning = True
-        self._update_root_surface()
-        self._update_controls()
-        try:
+        with self._hold_path_transition() as transition:
+            if transition is None:
+                return False
             try:
                 opened = await asyncio.to_thread(
                     service.open_file,
@@ -864,10 +905,6 @@ class LibraryFileNotesWorkspace(Vertical):
                 return False
             self._apply_opened_document(opened)
             return True
-        finally:
-            self._open_transitioning = False
-            self._update_root_surface()
-            self._update_controls()
 
     def _apply_opened_document(self, opened: OpenedFileNote) -> None:
         if not self._active:
@@ -937,11 +974,12 @@ class LibraryFileNotesWorkspace(Vertical):
         """Run one reconciliation off the UI loop and update retained widgets."""
         service = self._service
         generation = self._root_generation
-        if service is None:
+        if service is None or self._path_transitioning:
             return False
         async with self._refresh_lock:
             if (
                 not self._active
+                or self._path_transitioning
                 or generation != self._root_generation
                 or service is not self._service
             ):
@@ -957,6 +995,7 @@ class LibraryFileNotesWorkspace(Vertical):
                 return False
             if (
                 not self._active
+                or self._path_transitioning
                 or generation != self._root_generation
                 or service is not self._service
             ):
@@ -998,11 +1037,13 @@ class LibraryFileNotesWorkspace(Vertical):
         except Exception as error:
             self._set_save_state("error", f"reload failed: {error}")
             return
-        if (
-            not self._active
-            or generation != self._root_generation
-            or service is not self._service
-        ):
+        if self._path_result_is_stale(service, generation):
+            return
+        if self._opened is not opened:
+            return
+        if self._save_state != state:
+            if self._save_state in {"dirty", "saving", "conflict", "error"}:
+                self._set_save_state("conflict", "file changed on disk")
             return
         if resuming and state in {"dirty", "saving"}:
             editor = self.query_one("#file-notes-editor", TextArea)
@@ -1019,7 +1060,7 @@ class LibraryFileNotesWorkspace(Vertical):
         if (
             not self._active
             or self._root_transitioning
-            or self._open_transitioning
+            or self._path_transitioning
             or self._service is None
             or (self._poll_worker is not None and not self._poll_worker.is_finished)
         ):
@@ -1103,6 +1144,8 @@ class LibraryFileNotesWorkspace(Vertical):
 
     async def flush_pending_work(self) -> bool:
         """Flush a pending autosave; unresolved draft states veto leaving."""
+        if self._root_transitioning or self._path_transitioning:
+            return False
         if not self._active:
             return self.leave_allowed
         if self._autosave_timer is not None:
@@ -1130,11 +1173,7 @@ class LibraryFileNotesWorkspace(Vertical):
             replica=self._replica,
             service=service,
         )
-        if (
-            not self._active
-            or generation != self._root_generation
-            or service is not self._service
-        ):
+        if self._path_result_is_stale(service, generation):
             return False
         self._apply_scan(result, deleted)
         return True
@@ -1150,25 +1189,29 @@ class LibraryFileNotesWorkspace(Vertical):
     async def _complete_path_action(
         self,
         action: str,
-        result: OperationResult,
         relative_path: str,
+        operation: Callable[..., OperationResult],
+        *args: object,
     ) -> None:
-        if not self._active:
-            return
-        if not result.succeeded:
-            self._operation_error(action, result)
-            return
-        if not await self._rescan_after_action():
-            return
-        service = self._service
-        if service is None:
-            return
-        try:
-            opened = await asyncio.to_thread(service.open_file, relative_path)
-        except Exception as error:
-            self._set_action_status(f"Open failed: {error}")
-            return
-        if self._active:
+        with self._hold_path_transition() as transition:
+            if transition is None:
+                return
+            service, generation = transition
+            result = await asyncio.to_thread(operation, *args)
+            if self._path_result_is_stale(service, generation):
+                return
+            if not result.succeeded:
+                self._operation_error(action, result)
+                return
+            if not await self._rescan_after_action():
+                return
+            try:
+                opened = await asyncio.to_thread(service.open_file, relative_path)
+            except Exception as error:
+                self._set_action_status(f"Open failed: {error}")
+                return
+            if self._path_result_is_stale(service, generation):
+                return
             self._apply_opened_document(opened)
 
     @on(TextArea.Changed, "#file-notes-editor")
@@ -1176,7 +1219,7 @@ class LibraryFileNotesWorkspace(Vertical):
         event.stop()
         if (
             self._root_transitioning
-            or self._open_transitioning
+            or self._path_transitioning
             or self._opened is None
             or not self._opened.editable
         ):
@@ -1277,32 +1320,36 @@ class LibraryFileNotesWorkspace(Vertical):
     @on(Button.Pressed, "#file-notes-new")
     async def _new_file(self, event: Button.Pressed) -> None:
         event.stop()
-        if self._service is None or not await self.flush_pending_work():
+        if not await self.flush_pending_work():
+            return
+        service = self._service
+        if service is None:
             return
         destination = self.query_one("#file-notes-path", Input).value.strip()
-        result = await asyncio.to_thread(
-            self._service.create_file,
+        await self._complete_path_action(
+            "Create",
+            destination,
+            service.create_file,
             destination,
         )
-        await self._complete_path_action("Create", result, destination)
 
     @on(Button.Pressed, "#file-notes-move")
     async def _move_file(self, event: Button.Pressed) -> None:
         event.stop()
         opened = self._opened
-        if (
-            self._service is None
-            or opened is None
-            or not await self.flush_pending_work()
-        ):
+        if opened is None or not await self.flush_pending_work():
+            return
+        service = self._service
+        if service is None:
             return
         destination = self.query_one("#file-notes-path", Input).value.strip()
-        result = await asyncio.to_thread(
-            self._service.move_file,
+        await self._complete_path_action(
+            "Move",
+            destination,
+            service.move_file,
             opened.relative_path,
             destination,
         )
-        await self._complete_path_action("Move", result, destination)
 
     @on(Button.Pressed, "#file-notes-delete")
     async def _delete_file(self, event: Button.Pressed) -> None:
@@ -1320,60 +1367,74 @@ class LibraryFileNotesWorkspace(Vertical):
         opened = self._opened
         if opened is None:
             return
-        result = await asyncio.to_thread(
-            self._service.delete_file,
-            opened.relative_path,
-            expected_hash=opened.content_hash,
-        )
-        if not self._active:
-            return
-        if not result.succeeded:
-            self._operation_error("Delete", result)
-            return
-        deleted_path = opened.relative_path
-        self._clear_open_document()
-        self._selected_deleted_path = deleted_path
-        self.query_one("#file-notes-path", Input).value = deleted_path
-        self.query_one("#file-notes-breadcrumb", Static).update(
-            f"Recently deleted: {deleted_path}"
-        )
-        if not await self._rescan_after_action():
-            return
-        self._set_action_status("Deleted. Restore remains available.")
-        self._update_controls()
+        with self._hold_path_transition() as transition:
+            if transition is None:
+                return
+            service, generation = transition
+            result = await asyncio.to_thread(
+                service.delete_file,
+                opened.relative_path,
+                expected_hash=opened.content_hash,
+            )
+            if (
+                self._path_result_is_stale(service, generation)
+                or self._opened is not opened
+            ):
+                return
+            if not result.succeeded:
+                self._operation_error("Delete", result)
+                return
+            deleted_path = opened.relative_path
+            self._clear_open_document()
+            self._selected_deleted_path = deleted_path
+            self.query_one("#file-notes-path", Input).value = deleted_path
+            self.query_one("#file-notes-breadcrumb", Static).update(
+                f"Recently deleted: {deleted_path}"
+            )
+            if not await self._rescan_after_action():
+                return
+            self._set_action_status("Deleted. Restore remains available.")
+            self._update_controls()
 
     @on(Button.Pressed, "#file-notes-restore")
     async def _restore_file(self, event: Button.Pressed) -> None:
         event.stop()
-        if self._service is None:
+        service = self._service
+        if service is None:
             return
         relative_path = (
             self._selected_deleted_path
             or self.query_one("#file-notes-path", Input).value.strip()
         )
-        result = await asyncio.to_thread(
-            self._service.restore_file,
+        await self._complete_path_action(
+            "Restore",
+            relative_path,
+            service.restore_file,
             relative_path,
         )
-        await self._complete_path_action("Restore", result, relative_path)
 
     @on(Button.Pressed, "#file-notes-protect")
     async def _toggle_protect(self, event: Button.Pressed) -> None:
         event.stop()
         opened = self._opened
-        if self._service is None or opened is None:
+        service = self._service
+        generation = self._root_generation
+        if service is None or opened is None:
             return
         target = not opened.protected
         operation = (
-            self._service.protect_path if target else self._service.unprotect_path
+            service.protect_path if target else service.unprotect_path
         )
         result = await asyncio.to_thread(operation, opened.relative_path)
-        if not self._active:
+        if self._path_result_is_stale(service, generation):
+            return
+        current = self._opened
+        if current is None or current.relative_path != opened.relative_path:
             return
         if not result.succeeded:
             self._operation_error("Protect" if target else "Unprotect", result)
             return
-        self._opened = replace(opened, protected=target)
+        self._opened = replace(current, protected=target)
         self._set_action_status("Protected." if target else "Unprotected.")
         self._update_controls()
 
@@ -1381,40 +1442,51 @@ class LibraryFileNotesWorkspace(Vertical):
     async def _reload_file(self, event: Button.Pressed) -> None:
         event.stop()
         opened = self._opened
-        if self._service is None or opened is None:
+        service = self._service
+        generation = self._root_generation
+        if service is None or opened is None:
             return
         if self._save_state == "dirty" and not await self.flush_pending_work():
             return
         opened = self._opened
         if opened is None:
             return
-        try:
-            reloaded = await asyncio.to_thread(
-                self._service.open_file,
-                opened.relative_path,
-            )
-        except Exception as error:
-            self._set_save_state("error", f"reload failed: {error}")
-            return
-        if not self._active:
-            return
-        self._apply_opened_document(reloaded)
+        with self._hold_path_transition() as transition:
+            if transition is None:
+                return
+            service, generation = transition
+            try:
+                reloaded = await asyncio.to_thread(
+                    service.open_file,
+                    opened.relative_path,
+                )
+            except Exception as error:
+                self._set_save_state("error", f"reload failed: {error}")
+                return
+            if (
+                self._path_result_is_stale(service, generation)
+                or self._opened is not opened
+            ):
+                return
+            self._apply_opened_document(reloaded)
 
     @on(Button.Pressed, "#file-notes-save-copy")
     async def _save_copy(self, event: Button.Pressed) -> None:
         event.stop()
         opened = self._opened
-        if self._service is None or opened is None:
+        service = self._service
+        if service is None or opened is None:
             return
         destination = self.query_one("#file-notes-path", Input).value.strip()
         body = self.query_one("#file-notes-editor", TextArea).text
-        result = await asyncio.to_thread(
-            self._service.save_copy,
+        await self._complete_path_action(
+            "Save Copy",
+            destination,
+            service.save_copy,
             opened,
             body,
             destination,
         )
-        await self._complete_path_action("Save Copy", result, destination)
 
     @on(Button.Pressed, "#file-notes-refresh")
     async def _refresh_pressed(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -35,6 +35,7 @@ from tldw_chatbook.Notes.file_notes_service import (
     ScanResult,
 )
 from tldw_chatbook.Third_Party.textual_fspicker import SelectDirectory
+from tldw_chatbook.Utils.input_validation import validate_text_input
 
 SaveState = Literal["idle", "dirty", "saving", "saved", "conflict", "error"]
 _UNSET = object()
@@ -979,6 +980,8 @@ class LibraryFileNotesWorkspace(Vertical):
         async with self._refresh_lock:
             if (
                 not self._active
+                or not self.is_mounted
+                or not self.children
                 or self._path_transitioning
                 or generation != self._root_generation
                 or service is not self._service
@@ -995,6 +998,8 @@ class LibraryFileNotesWorkspace(Vertical):
                 return False
             if (
                 not self._active
+                or not self.is_mounted
+                or not self.children
                 or self._path_transitioning
                 or generation != self._root_generation
                 or service is not self._service
@@ -1186,6 +1191,19 @@ class LibraryFileNotesWorkspace(Vertical):
         elif self._save_state in {"dirty", "saving"}:
             self._set_save_state("error", detail)
 
+    def _validated_path_input(self, action: str) -> str | None:
+        raw_path = self.query_one("#file-notes-path", Input).value
+        relative_path = raw_path.strip()
+        valid_text = validate_text_input(
+            raw_path,
+            max_length=4096,
+            allow_html=True,
+        )
+        if not relative_path or not valid_text:
+            self._set_action_status(f"{action} failed: unsupported path text.")
+            return None
+        return relative_path
+
     async def _complete_path_action(
         self,
         action: str,
@@ -1325,7 +1343,9 @@ class LibraryFileNotesWorkspace(Vertical):
         service = self._service
         if service is None:
             return
-        destination = self.query_one("#file-notes-path", Input).value.strip()
+        destination = self._validated_path_input("Create")
+        if destination is None:
+            return
         await self._complete_path_action(
             "Create",
             destination,
@@ -1342,7 +1362,9 @@ class LibraryFileNotesWorkspace(Vertical):
         service = self._service
         if service is None:
             return
-        destination = self.query_one("#file-notes-path", Input).value.strip()
+        destination = self._validated_path_input("Move")
+        if destination is None:
+            return
         await self._complete_path_action(
             "Move",
             destination,
@@ -1402,10 +1424,11 @@ class LibraryFileNotesWorkspace(Vertical):
         service = self._service
         if service is None:
             return
-        relative_path = (
-            self._selected_deleted_path
-            or self.query_one("#file-notes-path", Input).value.strip()
-        )
+        relative_path = self._selected_deleted_path
+        if not relative_path:
+            relative_path = self._validated_path_input("Restore")
+            if relative_path is None:
+                return
         await self._complete_path_action(
             "Restore",
             relative_path,
@@ -1477,7 +1500,9 @@ class LibraryFileNotesWorkspace(Vertical):
         service = self._service
         if service is None or opened is None:
             return
-        destination = self.query_one("#file-notes-path", Input).value.strip()
+        destination = self._validated_path_input("Save Copy")
+        if destination is None:
+            return
         body = self.query_one("#file-notes-editor", TextArea).text
         await self._complete_path_action(
             "Save Copy",

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -190,6 +190,7 @@ class LibraryFileNotesWorkspace(Vertical):
         self._service_lock = RLock()
         self._root_generation = 0
         self._root_transitioning = False
+        self._open_transitioning = False
         self._shutdown = False
 
         self._entries: dict[str, FileNoteEntry] = {}
@@ -381,8 +382,6 @@ class LibraryFileNotesWorkspace(Vertical):
             self._start_poll,
             pause=False,
         )
-        if self._save_state == "dirty":
-            self._arm_autosave()
 
     def on_unmount(self) -> None:
         """Pause timers; Textual cancels node workers during removal."""
@@ -460,7 +459,14 @@ class LibraryFileNotesWorkspace(Vertical):
             ):
                 return
             self._apply_reconcile(result, deleted)
-            await self._handle_open_external_change(result)
+            await self._handle_open_external_change(result, resuming=True)
+            if (
+                self._active
+                and generation == self._root_generation
+                and service is self._service
+                and self._save_state == "dirty"
+            ):
+                self._arm_autosave()
             return
         result = await asyncio.to_thread(service.scan)
         deleted = await self._load_deleted_paths(replica=replica, service=service)
@@ -582,7 +588,7 @@ class LibraryFileNotesWorkspace(Vertical):
         status = self.query_one("#file-notes-root-status", Static)
         body = self.query_one("#file-notes-body")
         choose = self.query_one("#file-notes-choose-root", Button)
-        choose.disabled = self._root_transitioning
+        choose.disabled = self._root_transitioning or self._open_transitioning
         if self._root is None:
             status.update("Choose a notes folder.")
             body.display = False
@@ -726,7 +732,7 @@ class LibraryFileNotesWorkspace(Vertical):
     def _update_controls(self) -> None:
         if not self._active or not self.is_mounted:
             return
-        transitioning = self._root_transitioning
+        transitioning = self._root_transitioning or self._open_transitioning
         has_service = self._service is not None and not transitioning
         has_document = self._opened is not None and not transitioning
         has_deleted = bool(self._selected_deleted_path) and not transitioning
@@ -759,7 +765,7 @@ class LibraryFileNotesWorkspace(Vertical):
 
     async def set_root(self, path: str | Path, *, persist: bool = True) -> bool:
         """Adopt one canonical root after the common draft leave guard."""
-        if not self._active or self._shutdown:
+        if not self._active or self._open_transitioning or self._shutdown:
             return False
         if not await self.flush_pending_work():
             return False
@@ -823,6 +829,7 @@ class LibraryFileNotesWorkspace(Vertical):
         if (
             not self._active
             or self._root_transitioning
+            or self._open_transitioning
             or self._shutdown
             or service is None
         ):
@@ -832,26 +839,35 @@ class LibraryFileNotesWorkspace(Vertical):
         if (
             not self._active
             or self._root_transitioning
+            or self._open_transitioning
             or generation != self._root_generation
             or service is not self._service
         ):
             return False
+        self._open_transitioning = True
+        self._update_root_surface()
+        self._update_controls()
         try:
-            opened = await asyncio.to_thread(
-                service.open_file,
-                relative_path,
-            )
-        except Exception as error:
-            self._set_action_status(f"Open failed: {error}")
-            return False
-        if (
-            not self._active
-            or generation != self._root_generation
-            or service is not self._service
-        ):
-            return False
-        self._apply_opened_document(opened)
-        return True
+            try:
+                opened = await asyncio.to_thread(
+                    service.open_file,
+                    relative_path,
+                )
+            except Exception as error:
+                self._set_action_status(f"Open failed: {error}")
+                return False
+            if (
+                not self._active
+                or generation != self._root_generation
+                or service is not self._service
+            ):
+                return False
+            self._apply_opened_document(opened)
+            return True
+        finally:
+            self._open_transitioning = False
+            self._update_root_surface()
+            self._update_controls()
 
     def _apply_opened_document(self, opened: OpenedFileNote) -> None:
         if not self._active:
@@ -952,6 +968,8 @@ class LibraryFileNotesWorkspace(Vertical):
     async def _handle_open_external_change(
         self,
         result: ReconcileResult,
+        *,
+        resuming: bool = False,
     ) -> None:
         opened = self._opened
         if opened is None:
@@ -960,18 +978,40 @@ class LibraryFileNotesWorkspace(Vertical):
         if path in result.deleted:
             self._set_save_state("conflict", "file deleted on disk")
             return
-        if path not in result.modified:
+        changed = path in result.modified
+        if resuming and not changed:
+            entry = self._entries.get(path)
+            changed = entry is not None and entry.content_hash != opened.content_hash
+        if not changed:
             return
-        if self._save_state in {"dirty", "saving", "conflict", "error"}:
+        state = self._save_state
+        if state in {"conflict", "error"} or (
+            state in {"dirty", "saving"} and not resuming
+        ):
             self._set_save_state("conflict", "file changed on disk")
             return
-        assert self._service is not None
+        service = self._service
+        generation = self._root_generation
+        assert service is not None
         try:
-            reloaded = await asyncio.to_thread(self._service.open_file, path)
+            reloaded = await asyncio.to_thread(service.open_file, path)
         except Exception as error:
             self._set_save_state("error", f"reload failed: {error}")
             return
-        if not self._active:
+        if (
+            not self._active
+            or generation != self._root_generation
+            or service is not self._service
+        ):
+            return
+        if resuming and state in {"dirty", "saving"}:
+            editor = self.query_one("#file-notes-editor", TextArea)
+            if reloaded.body != editor.text:
+                self._set_save_state("conflict", "file changed on disk")
+                return
+            self._opened = reloaded
+            self._set_save_state("saved")
+            self._set_action_status(reloaded.replica_warning or "")
             return
         self._apply_opened_document(reloaded)
 
@@ -979,6 +1019,7 @@ class LibraryFileNotesWorkspace(Vertical):
         if (
             not self._active
             or self._root_transitioning
+            or self._open_transitioning
             or self._service is None
             or (self._poll_worker is not None and not self._poll_worker.is_finished)
         ):
@@ -1106,11 +1147,36 @@ class LibraryFileNotesWorkspace(Vertical):
         elif self._save_state in {"dirty", "saving"}:
             self._set_save_state("error", detail)
 
+    async def _complete_path_action(
+        self,
+        action: str,
+        result: OperationResult,
+        relative_path: str,
+    ) -> None:
+        if not self._active:
+            return
+        if not result.succeeded:
+            self._operation_error(action, result)
+            return
+        if not await self._rescan_after_action():
+            return
+        service = self._service
+        if service is None:
+            return
+        try:
+            opened = await asyncio.to_thread(service.open_file, relative_path)
+        except Exception as error:
+            self._set_action_status(f"Open failed: {error}")
+            return
+        if self._active:
+            self._apply_opened_document(opened)
+
     @on(TextArea.Changed, "#file-notes-editor")
     def _editor_changed(self, event: TextArea.Changed) -> None:
         event.stop()
         if (
             self._root_transitioning
+            or self._open_transitioning
             or self._opened is None
             or not self._opened.editable
         ):
@@ -1218,24 +1284,7 @@ class LibraryFileNotesWorkspace(Vertical):
             self._service.create_file,
             destination,
         )
-        if not self._active:
-            return
-        if not result.succeeded:
-            self._operation_error("Create", result)
-            return
-        if not await self._rescan_after_action():
-            return
-        try:
-            opened = await asyncio.to_thread(
-                self._service.open_file,
-                destination,
-            )
-        except Exception as error:
-            self._set_action_status(f"Open failed: {error}")
-            return
-        if not self._active:
-            return
-        self._apply_opened_document(opened)
+        await self._complete_path_action("Create", result, destination)
 
     @on(Button.Pressed, "#file-notes-move")
     async def _move_file(self, event: Button.Pressed) -> None:
@@ -1253,24 +1302,7 @@ class LibraryFileNotesWorkspace(Vertical):
             opened.relative_path,
             destination,
         )
-        if not self._active:
-            return
-        if not result.succeeded:
-            self._operation_error("Move", result)
-            return
-        if not await self._rescan_after_action():
-            return
-        try:
-            moved = await asyncio.to_thread(
-                self._service.open_file,
-                destination,
-            )
-        except Exception as error:
-            self._set_action_status(f"Open failed: {error}")
-            return
-        if not self._active:
-            return
-        self._apply_opened_document(moved)
+        await self._complete_path_action("Move", result, destination)
 
     @on(Button.Pressed, "#file-notes-delete")
     async def _delete_file(self, event: Button.Pressed) -> None:
@@ -1323,24 +1355,7 @@ class LibraryFileNotesWorkspace(Vertical):
             self._service.restore_file,
             relative_path,
         )
-        if not self._active:
-            return
-        if not result.succeeded:
-            self._operation_error("Restore", result)
-            return
-        if not await self._rescan_after_action():
-            return
-        try:
-            restored = await asyncio.to_thread(
-                self._service.open_file,
-                relative_path,
-            )
-        except Exception as error:
-            self._set_action_status(f"Open failed: {error}")
-            return
-        if not self._active:
-            return
-        self._apply_opened_document(restored)
+        await self._complete_path_action("Restore", result, relative_path)
 
     @on(Button.Pressed, "#file-notes-protect")
     async def _toggle_protect(self, event: Button.Pressed) -> None:
@@ -1399,24 +1414,7 @@ class LibraryFileNotesWorkspace(Vertical):
             body,
             destination,
         )
-        if not self._active:
-            return
-        if not result.succeeded:
-            self._operation_error("Save Copy", result)
-            return
-        if not await self._rescan_after_action():
-            return
-        try:
-            copied = await asyncio.to_thread(
-                self._service.open_file,
-                destination,
-            )
-        except Exception as error:
-            self._set_action_status(f"Open failed: {error}")
-            return
-        if not self._active:
-            return
-        self._apply_opened_document(copied)
+        await self._complete_path_action("Save Copy", result, destination)
 
     @on(Button.Pressed, "#file-notes-refresh")
     async def _refresh_pressed(self, event: Button.Pressed) -> None:


### PR DESCRIPTION
## Summary
- add a disk-authoritative Markdown/text notes service with exact-byte, hash-checked file operations
- add a separate root-namespaced SQLite replica with FTS, protected checkpoints, tombstones, and restore
- add a retained Library `Database | Files` workspace with tree/search, autosave conflicts, file actions, polling, and narrow navigation

## Review fixes
- preserve save permissions when `os.fchmod` is unavailable, expand SQLite `~` paths consistently, and log failed temporary-file cleanup
- retain fixed-root confinement while routing through shared path validation; validate raw terminal path input before normalization
- harden poll teardown, complete public API docstrings, and renumber the task to collision-free TASK-969 after rebasing onto current `dev`

## Test plan
- [x] `../../.venv/bin/python -m pytest -q Tests/Notes/test_file_notes_replica.py Tests/Notes/test_file_notes_service.py Tests/UI/test_library_file_notes_workspace.py --tb=short` (51 passed)
- [x] targeted Ruff on changed production/test files
- [x] module compilation, duplicate-task guard, and `git diff --check origin/dev...HEAD`
- [x] `dev` has no protected/required status checks; queued non-required Actions were not used as a merge gate

Closes TASK-969. ADR: `backlog/decisions/029-file-notes-disk-authority.md`.