### PR TITLE
chore(backlog): renumber the duplicate To Do 930 → 962

### DIFF
--- a/backlog/tasks/task-962 - Tools_Settings_Window-raw-TOML-save-writes-the-wrong-config-path-non-atomically.md
+++ b/backlog/tasks/task-962 - Tools_Settings_Window-raw-TOML-save-writes-the-wrong-config-path-non-atomically.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-930
+id: TASK-962
 title: >-
   Tools_Settings_Window raw-TOML save writes the wrong config path
   non-atomically


### PR DESCRIPTION
Two tasks carried id `TASK-930`:
- `Tools_Settings_Window raw TOML save writes the wrong config path` — **To Do**, created 14:36
- `Use a local Parakeet ONNX bundle in batch ingestion` — **Done**, created 15:23

The standing rule applies cleanly here, unlike the 545 case where both were Done: Done tasks never move, because close-out commits and PR titles reference them. So the Parakeet task keeps 930 and the To Do one moves to 962, chosen with headroom over the all-branches max.

Verified after: 757 tasks, zero duplicates.

Backlog file rename plus its frontmatter id. No code change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renumbered the To Do task "Tools_Settings_Window raw TOML save writes the wrong config path non-atomically" from `TASK-930` to `TASK-962` to resolve a duplicate with the Done Parakeet task. Updated the backlog filename and frontmatter; removes the duplicate and keeps `TASK-930` stable for existing references.

<sup>Written for commit 8c0eee8bb88b1d41abd73a4685e17ec528d91b0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

