### PR TITLE
fix(config): derive MCP, DB and data-dir paths from their real accessors

### DIFF
--- a/.superpowers/sdd/task-854-866-report.md
+++ b/.superpowers/sdd/task-854-866-report.md
@@ -1,0 +1,160 @@
+# TASK-854 / 855 / 858 / 865 / 866 -- path-accessor sweep report
+
+**Worktree:** `/Users/macbook-dev/Documents/GitHub/wt-path-accessors` (branch `fix/path-accessor-sweep`, cut from `origin/dev`)
+**Interpreter:** `PYTHONPATH=/Users/macbook-dev/Documents/GitHub/wt-path-accessors /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python`, verified via `tldw_chatbook.__file__` before every probe.
+**Theme:** derive paths from the accessors the app actually uses instead of re-spelling their values -- the class of bug behind the `mcp_permissions.json` denylist miss the originating audit (TASK-846) found.
+
+---
+
+## TASK-854 -- MCP server media DB lookup
+
+**Bug:** `MCP/server.py`'s `_init_databases()` called `get_cli_setting("database", "media_db", "media_library.db")`. The key `"media_db"` is declared nowhere; the real key is `media_db_path`, accessor `get_media_db_path()`. Because the key never matched, the lookup always fell through to the CWD-relative literal.
+
+**Before/after (sandboxed HOME, no `TLDW_CONFIG_PATH`):**
+
+```
+get_cli_setting("database","media_db","media_library.db") -> 'media_library.db'
+resolved (relative to CWD)  : /Users/macbook-dev/Documents/GitHub/wt-path-accessors/media_library.db
+get_media_db_path()         : /var/folders/.../task854_.../.local/share/tldw_cli/default_user/tldw_chatbook_media_v2.db
+MATCH before fix: False
+```
+
+After the fix, `_init_databases()`'s `self.media_db.db_path` equals `get_media_db_path()` exactly (verified by a real, unmodified call to `_init_databases()` in `Tests/MCP/test_server_media_db_path.py`).
+
+**Fix:** replaced the bad `get_cli_setting` call with `get_media_db_path()`.
+
+**Adjacent bug found and fixed (required to make the module constructible at all, hence in-scope for AC #3):** `MediaDatabase(media_db_path)` was called with **no `client_id`** -- a required positional argument -- so `_init_databases()` has apparently never completed successfully; this always raised `TypeError`. Fixed to `MediaDatabase(db_path=media_db_path, client_id=CLI_APP_CLIENT_ID)`, matching every other `MediaDatabase` call site in the app.
+
+**Adjacent bug found and NOT fixed (separate, out of scope):** the same method also constructs `NotesInteropService(self.chachanotes_db)` (wrong positional arg -- `NotesInteropService.__init__` requires `(base_db_directory, api_client_id, ...)`) and `CharacterInteropService(self.chachanotes_db)`, where **`CharacterInteropService` does not exist anywhere in the codebase** (`grep -rn "class CharacterInteropService"` -> zero hits). This means `_init_databases()` has never run to completion in production. Recommend filing a follow-up task. The new regression test stubs both collaborators (permissive fakes swapped into their real source modules) purely to drive the real, unmodified method far enough to construct `self.media_db` -- it does not fix or mask this separate defect.
+
+**AC #2 grep result (report on findings):** wrote an AST-based (not line-regex) scan of every `get_cli_setting("database", ...)` call site in `tldw_chatbook/`, requiring the key to either match `[a-z0-9_]+_db_path` or be one of the known non-path `[database]` settings (`check_integrity_on_startup`, `integrity_check_timeout`, `USER_DB_BASE_DIR`). Result: **zero other offenders** -- every remaining call site (all 14, all in `config.py`, plus one already-fixed `TASK-658` call in `Local_Ingestion/local_file_ingestion.py`) uses a declared `*_db_path` key. This scan is now `Tests/MCP/test_server_media_db_path.py::test_no_other_undeclared_database_config_keys`, so it re-runs on every future change.
+
+**Files:** `tldw_chatbook/MCP/server.py`; `Tests/MCP/test_server_media_db_path.py` (new).
+
+---
+
+## TASK-855 -- MCP store module defaults
+
+**Bug:** `MCP/local_store.py`, `unified_context_store.py`, `server_target_store.py` all defaulted to `DEFAULT_CONFIG_PATH.parent / <name>` (i.e. `~/.config/tldw_cli/`). Every real construction site (`app.py`) always passes an explicit `get_user_data_dir() / <name>` path, so this was latent, not live -- but the permission store and execution log are both *derived* from a `LocalMCPStore`'s own `.path` via `Path(store.path).with_name(...)`, so a store built with no argument anywhere would place both outside `Utils.sensitive_paths`' denylist coverage.
+
+**Decision: derive lazily, don't require an explicit path.** Considered the two options the task offered. Nothing in the codebase (production or the ~90 test call sites across `Tests/MCP/`/`Tests/RuntimePolicy/`) ever constructs these classes with no argument, so "require an explicit path" would have been equally safe today -- but it would take away a legitimate future escape hatch for no real benefit. Instead each module now computes its default **lazily**, inside `__init__`, via a private `_default_*_path()` helper that calls `get_user_data_dir()` at call time, and the three eager `DEFAULT_*_PATH` module constants were removed (grepped first: nothing outside their own module referenced them). Lazy, not an eager module-level constant, for two reasons:
+1. `get_user_data_dir()` has side effects (reads live config, creates the directory) that an eager import-time constant would trigger merely by importing the module.
+2. An eager constant bakes in whichever profile/HOME was active the first time the module was imported in a process -- exactly the staleness class `Utils/sensitive_paths.py`'s own lazy `_sensitive_db_paths()`/`_sensitive_single_file_paths()` helpers exist to avoid.
+
+**Files:** `tldw_chatbook/MCP/local_store.py`, `unified_context_store.py`, `server_target_store.py`; `Tests/MCP/test_store_default_paths.py` (new, 6 tests: default-path derivation for all three stores, a TLDW_CONFIG_PATH-retargeting proof that the default is resolved at call time not cached, denylist coverage of the default and its permission-store/execution-log derivatives, and explicit-path-sites-unaffected).
+
+---
+
+## TASK-858 -- evals/prompts/media/rag/subscriptions DB path maps
+
+**Already done on this branch's base (verified, not redone):** the Settings screen's maintenance DB-path map (AC #2) and its six-database parity test (AC #4) were already fixed by an earlier, already-merged task (in-code comments reference `TASK-899`): `UI/Tools_Settings_Window.py`'s `_DB_PATH_RESOLVERS` dict (lines ~6823-6830) already delegates to `get_chachanotes_db_path`/`get_media_db_path`/`get_prompts_db_path`/`get_evals_db_path`/`get_rag_indexing_db_path`/`get_subscriptions_db_path`, and `Tests/UI/test_tools_settings_window.py` already has `test_get_database_path_resolves_via_config_resolvers_and_honours_profile` plus per-DB parity tests and a parametrized backup/restore round-trip test over all six databases. Re-ran all of these after my `config.py` change -- still 9/9 pass.
+
+**Genuinely still broken (fixed):** `Event_Handlers/eval_db_operations.py:28` still hardcoded `Path.home() / ".config" / "tldw_cli" / "evals.db"`. Fixed to call `config.get_evals_db_path()` -- the same accessor `Evals/eval_orchestrator.py`'s `EvaluationOrchestrator` delegates to for its own default case, so both agree.
+
+**AC #3 -- declare or delete `evals_db_path` / `rag_db_path` / `subscriptions_db_path`:** none were dead (all three accessors -- note the real, only key ever read is `rag_indexing_db_path`; `rag_db_path` does not appear anywhere in the codebase -- have live callers), so declared all three as real `[database]` config defaults in `config.py`'s TOML template, following the exact sentinel-literal convention the three existing entries (`chachanotes_db_path`/`prompts_db_path`/`media_db_path`) already use, with their correct real fallback filenames (`evals.db`, `rag_indexing.db`, `tldw_chatbook_subscriptions.db`). This is functionally a no-op for existing users -- the accessor's custom-path branch only fires when a value differs from the template's sentinel, and an unset key already fell through to the correct `get_user_data_dir()`-based path before this change -- but closes the "declared nowhere" gap and documents the override for new installs.
+
+**Files:** `tldw_chatbook/Event_Handlers/eval_db_operations.py`, `tldw_chatbook/config.py`; `Tests/Event_Handlers/test_eval_db_operations_path.py` (new).
+
+---
+
+## TASK-865 -- sweep hardcoded `~/.config/tldw_cli` / `~/.local/share/tldw_cli` sites
+
+Status left as **In Progress** (AC #1/#2 not checked off) -- see rationale below.
+
+**100% complete: every site the task named with an explicit file:line reference.**
+- Config-dir group: `UI/Screens/chat_screen.py` (both `ui_state.toml` sites, `_load_sidebar_state`/`_save_sidebar_state`), `Event_Handlers/notes_events.py` + `note_ingest_events.py` (`note_templates.json`), `Subscriptions/website_monitor.py` (`feed_cache/`).
+- Data-dir group: `Chatbooks/chatbook_importer.py` (the highest-value fix -- `temp_dir` now `get_user_data_dir() / "temp" / "imports"`, matching `chatbook_creator.py`'s sibling `get_user_data_dir() / "temp" / "chatbooks"`), `Chatbooks/local_chatbook_service.py`'s `_default_registry_path()` fallback branch, `Character_Chat/Character_Chat_Lib.py` (all 3 `base_directory` sites), `Event_Handlers/conv_char_events.py` (all 3 `export_dir` sites).
+
+**Best-effort additional fixes (not individually named in the task, done as bonus):** `Widgets/emoji_picker.py` (converted the eager `RECENT_EMOJIS_FILE` module constant to a lazy `_recent_emojis_path()` -- an eager constant here would have the same staleness problem TASK-855 fixed for the MCP stores), `Widgets/settings_theme_editor.py`, `Notes/sync_service.py`, `Config_Files/create_custom_template.py` (standalone dev script), `RAG_Search/pipeline_loader.py` + `pipeline_builder_simple.py`.
+
+**Why AC #1/#2 are NOT checked off:** the task also references "~25 lower-value" config-dir sites and "~18" data-dir sites only in aggregate, without file:line references. A full sweep of that remainder was not completed given its size, and I did not want to overclaim.
+
+**A separate, adjacent, larger finding surfaced during the broader grep -- recommend its own follow-up task, deliberately NOT fixed here:** `UI/ChatbookCreationWindow.py`, `UI/ChatbookExportManagementWindow.py`, `UI/Wizards/ChatbookCreationWizard.py` and `UI/Wizards/ChatbookImportWizard.py` each build their own ad-hoc `db_paths` dict straight from `self.app.config_data.get("database", {})` with hardcoded, wrong, non-user-folder fallback literals (e.g. `"~/.local/share/tldw_cli/tldw_prompts_db.db"`) instead of calling `get_prompts_db_path()`/`get_media_db_path()` -- these bypass the `get_*_db_path()` accessors entirely, unlike everything TASK-858/899 reconciled. This is a distinct defect class (wrong-accessor-bypass, not a `Path.home()`-literal sweep site), so it was left alone rather than folded in here.
+
+**Deliberately excluded as a scope decision (not an oversight):** TTS/UI model-weight and voice-cache paths under `~/.config/tldw_cli/models/...` and `.../*_voices` (`STTS_Window.py`, `Dictation_Window.py`, `TTS/backends/kokoro.py`, `TTS/kokoro_pytorch.py`, `TTS/utils/download_models.py`). These are large, shared binary caches/exports, not per-profile config/state -- making them profile-relative would force re-downloading multi-hundred-MB models on every profile switch, which is very unlikely to be intended and is exactly the kind of live-file-relocation the task's hard constraints said to stop and report on rather than silently do.
+
+**AC #3/#4 -- fully satisfied, with tests:** `Tests/Chatbooks/test_chatbook_importer.py` (new tests: `temp_dir == get_user_data_dir() / "temp" / "imports"`, and shares a parent with `ChatbookCreator`'s `temp_dir`). `Tests/UI/test_chat_screen_ui_state_path.py` (new: `TLDW_CONFIG_PATH` retargeted to a scratch profile -> `_save_sidebar_state()` writes `ui_state.toml` under THAT profile's directory; two different profiles do not collide).
+
+**Files:** `tldw_chatbook/UI/Screens/chat_screen.py`, `Event_Handlers/{notes_events,note_ingest_events,conv_char_events}.py`, `Subscriptions/website_monitor.py`, `Chatbooks/{chatbook_importer,local_chatbook_service}.py`, `Character_Chat/Character_Chat_Lib.py`, `Widgets/{emoji_picker,settings_theme_editor}.py`, `Notes/sync_service.py`, `Config_Files/create_custom_template.py`, `RAG_Search/{pipeline_loader,pipeline_builder_simple}.py`; `Tests/Chatbooks/test_chatbook_importer.py`, `Tests/UI/test_chat_screen_ui_state_path.py` (new).
+
+---
+
+## TASK-866 -- sensitive-path and skills-fixture tests must re-derive, not re-spell
+
+**`Tests/Utils/test_sensitive_paths.py`:** its two MCP-store tests re-typed `"mcp_permissions.json"` / `Path(store.path).with_name(...)` the same way `unified_control_plane_service.py`'s `permission_store`/`execution_log` properties do internally, instead of reading the paths off a live instance. Rewrote both to build a real `UnifiedMCPControlPlaneService` (the `SimpleNamespace(store=...)` idiom already used in `Tests/MCP/test_control_plane_permissions.py`) with a default-path `LocalMCPStore()` (TASK-855 made this default itself derive from `get_user_data_dir()`, so no literal filename is spelled anywhere now) and assert directly on `service.permission_store.path` / `service.execution_log.path` / `service.local_service.store.path`.
+
+**`Tests/conftest.py` + `Tests/Skills/test_skills_library_flow.py`:** `make_trust_service` and the two `_real_*_trust_service` builders hardcoded `tmp_path / "skills"` and `tmp_path / "trust"` -- matching, by re-spelling, `LocalSkillsService`'s private `_SKILLS_DIRNAME` and `skill_trust_store`'s private `_TRUST_DIRNAME` constants. Rewrote both to derive `skills_dir` from `LocalSkillsService(store_dir=tmp_path).skills_dir` (a real, side-effect-free constructor call solely to read its computed attribute) and `trust_dir` from the already-public `default_trust_store_dir(tmp_path)` -- the exact function `app.py` itself calls.
+
+**AC #4 verified concretely, not just asserted (and reverted cleanly afterward -- `git diff` empty on every production file touched):**
+1. MCP-store test: temporarily changed `unified_control_plane_service.py`'s `permission_store` property to nest the file under an extra subdirectory. The updated test correctly **FAILED** (`is_sensitive_path` no longer covers the new location).
+2. Skills fixture: temporarily renamed `local_skills_service.py`'s `_SKILLS_DIRNAME` and `skill_trust_store.py`'s `_TRUST_DIRNAME`. The NEW fixture code still passed all 52 tests (correctly re-derives regardless of the constant's name). Then reverted ONLY the test file back to the old re-spelled-literal style (keeping the renamed production constants) -- reproduced **3 real failures**, proving the old style really would have gone silently stale.
+
+**Files:** `Tests/Utils/test_sensitive_paths.py`, `Tests/conftest.py`, `Tests/Skills/test_skills_library_flow.py`.
+
+---
+
+## Test commands run (all foreground, exact commands and results)
+
+```
+PYTHONPATH=/Users/macbook-dev/Documents/GitHub/wt-path-accessors /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/MCP/test_server_media_db_path.py -v
+  -> 4 passed
+
+PYTHONPATH=... python -m pytest Tests/MCP/test_store_default_paths.py -v
+  -> 6 passed
+
+PYTHONPATH=... python -m pytest Tests/MCP/test_local_store.py Tests/MCP/test_unified_context_store.py Tests/MCP/test_server_target_store.py Tests/MCP/test_server_target_store_lane_b.py Tests/MCP/test_control_plane_lifecycle.py Tests/MCP/test_control_plane_permissions.py -q
+  -> 77 passed
+
+PYTHONPATH=... python -m pytest Tests/Event_Handlers/test_eval_db_operations_path.py Tests/Evals/test_eval_orchestrator_db_path.py -v
+  -> 11 passed
+
+PYTHONPATH=... python -m pytest Tests/UI/test_tools_settings_window.py -k "database_path or evals_db_path or rag_indexing_db_path or backup_then_restore" -v
+  -> 9 passed
+
+PYTHONPATH=... python -m pytest Tests/UI/test_tools_settings_window.py -q
+  -> 6 failed (pre-existing test_chat_api_key_* baseline, confirmed identical via git stash), 25 passed, 16 skipped
+
+PYTHONPATH=... python -m pytest Tests/Utils/test_sensitive_paths.py -v
+  -> 31 passed
+
+PYTHONPATH=... python -m pytest Tests/Skills/test_skills_library_flow.py Tests/Library/test_skill_script_grant_panel.py Tests/Skills/test_skill_script_grants.py -q
+  -> 52 passed
+
+PYTHONPATH=... python -m pytest Tests/Chatbooks/test_chatbook_importer.py Tests/Chatbooks/test_chatbook_creator.py -q
+  -> 28 passed
+
+PYTHONPATH=... python -m pytest Tests/UI/test_chat_screen_ui_state_path.py -v
+  -> 3 passed
+
+PYTHONPATH=... python -m pytest Tests/UI/test_chat_screen_worker_groups.py Tests/UI/test_chat_screen_state.py Tests/UI/test_chat_screen_suspend.py Tests/UI/test_chat_screen_context_modal.py Tests/UI/test_chat_screen_ui_state_path.py -q
+  -> 22 passed
+
+PYTHONPATH=... python -m pytest Tests/Utils/ -q
+  -> 460 passed
+
+PYTHONPATH=... python -m pytest Tests/Skills/ -q
+  -> 375 passed
+
+PYTHONPATH=... python -m pytest Tests/MCP/ -q
+  -> 351 passed
+
+PYTHONPATH=... python -m pytest Tests/Evals/ -q
+  -> 436 passed, 13 skipped (optional-dep-gated)
+
+PYTHONPATH=... python -m pytest Tests/Character_Chat/ Tests/Chatbooks/ -q
+  -> 662 passed, 1 skipped
+
+PYTHONPATH=... python -m pytest Tests/Event_Handlers/ -q
+  -> 3 failed (Tests/Event_Handlers/test_worker_local_citation_capture.py -- confirmed pre-existing/unrelated via git stash, identical 3 failures with my changes removed), 47 passed, 1 skipped
+
+PYTHONPATH=... python -m pytest Tests/RAG_Admin/ Tests/Subscriptions/ -q
+  -> 139 passed
+
+PYTHONPATH=... python -m pytest Tests/UI/test_settings_theme_editor.py Tests/Notes/test_library_notes_sync_integration.py -q
+  -> 8 passed
+
+PYTHONPATH=... python -m pytest Tests/RAG/test_fusion.py Tests/RAG/test_scope_pipeline_enforcement.py Tests/RAG/test_local_citation_capture.py Tests/RAG/test_semantic_honest_states.py -q
+  -> 275 passed
+```
+
+No test run modified real user config/data -- every ad-hoc probe redirected `HOME`/`TLDW_CONFIG_PATH` to a scratch directory first, and one accidental unsandboxed probe (checking `DEFAULT_CONFIG_FROM_TOML` right after the `config.py` edit) only performed an idempotent `mkdir(exist_ok=True)` on a directory that already existed since 2025-08-14 -- confirmed via `stat`, no new file/directory created.

--- a/Tests/Chatbooks/test_chatbook_importer.py
+++ b/Tests/Chatbooks/test_chatbook_importer.py
@@ -302,6 +302,32 @@ Keywords: test, sample"""
         assert chatbook_importer.temp_dir.exists()
         assert chatbook_importer.conflict_resolver is not None
 
+    def test_temp_dir_derives_from_get_user_data_dir(
+        self, chatbook_importer, temp_db_paths
+    ):
+        """TASK-865: the extraction root must derive from
+        ``get_user_data_dir()`` -- not a ``Path.home()/".local"/"share"/
+        "tldw_cli"`` literal that omits the per-profile user-folder
+        segment. Before the fix, imports silently extracted outside the
+        per-user tree (a location a live reproduction confirmed already
+        existed on disk in production)."""
+        from tldw_chatbook.config import get_user_data_dir
+
+        assert chatbook_importer.temp_dir == get_user_data_dir() / "temp" / "imports"
+
+    def test_temp_dir_shares_a_parent_with_the_chatbook_creators_temp_root(
+        self, chatbook_importer
+    ):
+        """AC #3: the importer's extraction root and the creator's temp
+        root must derive to the same parent (``get_user_data_dir() /
+        "temp"``), not two different, disagreeing directories."""
+        from tldw_chatbook.Chatbooks.chatbook_creator import ChatbookCreator
+
+        creator = ChatbookCreator(db_paths={})
+
+        assert chatbook_importer.temp_dir.parent == creator.temp_dir.parent
+        assert chatbook_importer.temp_dir.parent.name == "temp"
+
     def test_preview_chatbook_valid(self, chatbook_importer, sample_chatbook_path):
         """Test previewing a valid chatbook."""
         manifest, error = chatbook_importer.preview_chatbook(sample_chatbook_path)

--- a/Tests/Event_Handlers/test_eval_db_operations_path.py
+++ b/Tests/Event_Handlers/test_eval_db_operations_path.py
@@ -1,0 +1,46 @@
+"""TASK-858: EvalDBOperations' default path must agree with
+config.get_evals_db_path() -- the same accessor
+Evals.eval_orchestrator.EvaluationOrchestrator delegates to for its own
+default case.
+
+Before this fix, EvalDBOperations.__init__() hardcoded
+``Path.home() / ".config" / "tldw_cli" / "evals.db"`` -- a profile-unaware
+literal that named a different file than the one the app's real Evals
+database (and the Settings screen's maintenance panel) opens.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tldw_chatbook.Event_Handlers.eval_db_operations import EvalDBOperations
+
+
+def test_default_db_path_matches_get_evals_db_path():
+    from tldw_chatbook.config import get_evals_db_path
+
+    ops = EvalDBOperations()
+
+    assert Path(ops.db.db_path) == get_evals_db_path()
+
+
+def test_default_db_path_tracks_a_retargeted_profile(monkeypatch, tmp_path):
+    """The default must be resolved at construction time against the
+    currently active profile, not a fixed HOME-relative literal."""
+    from tldw_chatbook.config import get_evals_db_path
+
+    retargeted = tmp_path / "profile-two" / "config.toml"
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(retargeted))
+
+    ops = EvalDBOperations()
+
+    assert Path(ops.db.db_path) == get_evals_db_path()
+    assert str(tmp_path) in str(ops.db.db_path)
+
+
+def test_explicit_db_path_is_unaffected(tmp_path):
+    explicit_path = tmp_path / "custom_evals.db"
+
+    ops = EvalDBOperations(db_path=explicit_path)
+
+    assert Path(ops.db.db_path) == explicit_path

--- a/Tests/MCP/test_server_media_db_path.py
+++ b/Tests/MCP/test_server_media_db_path.py
@@ -1,0 +1,165 @@
+"""TASK-854: MCP/server.py's media DB must resolve via the real accessor.
+
+``TldwMCPServer._init_databases()`` used to read a config key ("media_db")
+that is declared nowhere in ``config.py`` -- the real key is
+"media_db_path", whose accessor is ``config.get_media_db_path()`` (already
+used, two lines above, for the chachanotes DB via
+``get_chachanotes_db_path()``). Because the key never matched anything, the
+lookup silently fell through to a CWD-relative literal
+("media_library.db"), so the MCP server opened a database outside the
+per-profile data directory -- and outside ``Utils.sensitive_paths``'
+denylist coverage, since that denylists ``get_media_db_path()``'s result,
+not a CWD-relative file.
+
+``_init_databases()`` also constructs ``NotesInteropService`` and
+``CharacterInteropService`` with call signatures that don't match either
+class (``CharacterInteropService`` does not exist anywhere in the
+codebase at all -- see ``test_no_other_undeclared_database_config_keys``'s
+module docstring reference and this task's Implementation Notes for the
+grep). Both are unrelated, pre-existing defects out of this task's scope;
+the tests below stub just enough of them (permissive fakes swapped in at
+their *source* modules, so ``_init_databases``'s own local imports pick
+them up) to drive the real, unmodified method far enough to construct
+``self.media_db`` -- proving the fix through the actual code path rather
+than by re-implementing its logic in the test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+class _PermissiveFakeService:
+    """Stand-in for a collaborator whose real constructor signature the
+    module under test does not actually match (see module docstring)."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+
+def _build_server_with_databases(monkeypatch):
+    """Construct a bare ``TldwMCPServer`` and run its real ``_init_databases``.
+
+    Bypasses ``__init__`` (which requires the optional ``mcp`` package) via
+    ``__new__``, then calls the real, unmodified ``_init_databases()``
+    directly -- exercising the actual fixed code path.
+    """
+    import tldw_chatbook.Notes.Notes_Library as notes_library_module
+    import tldw_chatbook.Character_Chat.Character_Chat_Lib as character_chat_lib_module
+    from tldw_chatbook.MCP import server as mcp_server_module
+
+    monkeypatch.setattr(
+        notes_library_module, "NotesInteropService", _PermissiveFakeService
+    )
+    # CharacterInteropService does not exist in this module at all (see
+    # docstring) -- raising=False allows creating the attribute rather than
+    # requiring one already be there.
+    monkeypatch.setattr(
+        character_chat_lib_module,
+        "CharacterInteropService",
+        _PermissiveFakeService,
+        raising=False,
+    )
+
+    instance = mcp_server_module.TldwMCPServer.__new__(mcp_server_module.TldwMCPServer)
+    instance._init_databases()
+    return instance
+
+
+def test_media_db_path_matches_get_media_db_path(monkeypatch):
+    """The constructed media DB handle's path must equal
+    ``config.get_media_db_path()`` -- not a hardcoded literal filename."""
+    from tldw_chatbook.config import get_media_db_path
+
+    instance = _build_server_with_databases(monkeypatch)
+
+    assert Path(instance.media_db.db_path) == get_media_db_path()
+
+
+def test_media_db_path_is_not_the_old_cwd_relative_literal(monkeypatch):
+    """Regression guard for the exact bug: the resolved path must not be the
+    bare, CWD-relative literal the old ``get_cli_setting("database",
+    "media_db", "media_library.db")`` call silently fell back to."""
+    instance = _build_server_with_databases(monkeypatch)
+
+    old_buggy_path = (Path.cwd() / "media_library.db").resolve()
+    assert Path(instance.media_db.db_path) != old_buggy_path
+
+
+def test_resolved_media_db_path_is_sensitive(monkeypatch):
+    """AC #4: once the fix lands, the path the MCP server actually opens must
+    be covered by the agent-tool denylist (verified by test, not by
+    inspection -- this is the exact gap TASK-854 closes)."""
+    from tldw_chatbook.Utils.sensitive_paths import is_sensitive_path
+
+    instance = _build_server_with_databases(monkeypatch)
+
+    assert is_sensitive_path(Path(instance.media_db.db_path))
+
+
+def test_no_other_undeclared_database_config_keys():
+    """AC #2: grep-based check that every ``get_cli_setting("database", ...)``
+    call site in the codebase uses one of the declared ``*_db_path`` (or
+    known non-path) keys -- not a key that resolves to nothing, the way
+    "media_db" did.
+
+    See this task's Implementation Notes for the full list of keys this
+    sweep found and how each was classified.
+    """
+    import ast
+    import re
+    from pathlib import Path as _Path
+
+    package_root = _Path(__file__).resolve().parents[2] / "tldw_chatbook"
+
+    # Keys read via get_cli_setting("database", <key>, ...) that are NOT a
+    # ``*_db_path`` accessor key, but are legitimate, declared [database]
+    # settings (not database *paths*) -- see config.py's [database] section.
+    known_non_path_database_keys = {
+        "check_integrity_on_startup",
+        "integrity_check_timeout",
+        "USER_DB_BASE_DIR",
+    }
+
+    offenders: list[str] = []
+
+    for py_file in package_root.rglob("*.py"):
+        try:
+            source = py_file.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        if "get_cli_setting" not in source or '"database"' not in source and "'database'" not in source:
+            continue
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            func_name = getattr(func, "attr", None) or getattr(func, "id", None)
+            if func_name != "get_cli_setting":
+                continue
+            if len(node.args) < 2:
+                continue
+            section_arg, key_arg = node.args[0], node.args[1]
+            section_value = getattr(section_arg, "value", None)
+            if section_value != "database":
+                continue
+            key_value = getattr(key_arg, "value", None)
+            if key_value is None:
+                # Dynamic key (e.g. an f-string or variable) -- can't
+                # statically classify; skip rather than false-flag.
+                continue
+            is_declared_db_path_key = bool(re.fullmatch(r"[a-z0-9_]+_db_path", key_value))
+            if is_declared_db_path_key or key_value in known_non_path_database_keys:
+                continue
+            offenders.append(f"{py_file.relative_to(package_root)}: {key_value!r}")
+
+    assert offenders == [], (
+        "get_cli_setting('database', ...) call(s) using a key that is not a "
+        f"declared '*_db_path' name: {offenders}"
+    )

--- a/Tests/MCP/test_store_default_paths.py
+++ b/Tests/MCP/test_store_default_paths.py
@@ -1,0 +1,87 @@
+"""TASK-855: the three MCP store modules' no-argument defaults must derive
+from ``config.get_user_data_dir()`` -- not a hardcoded ``~/.config/tldw_cli``
+literal the app never actually uses.
+
+Every real construction site (``app.py``) always passes an explicit
+``get_user_data_dir() / <name>`` path, so this covers a *latent* gap: the
+permission store and execution log are both derived from a
+``LocalMCPStore``'s own ``.path`` (see
+``MCP.unified_control_plane_service``'s ``permission_store``/
+``execution_log`` properties, ``Path(store.path).with_name(...)``). A store
+built with no explicit path anywhere -- in a test, or a future call site --
+used to silently place both outside ``Utils.sensitive_paths``' denylist
+coverage.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tldw_chatbook.MCP.local_store import LocalMCPStore
+from tldw_chatbook.MCP.server_target_store import ConfiguredServerTargetStore
+from tldw_chatbook.MCP.unified_context_store import UnifiedMCPContextStore
+
+
+def test_local_mcp_store_default_path_derives_from_get_user_data_dir():
+    from tldw_chatbook.config import get_user_data_dir
+
+    store = LocalMCPStore()
+
+    assert store.path == get_user_data_dir() / "local_mcp_store.json"
+
+
+def test_unified_mcp_context_store_default_path_derives_from_get_user_data_dir():
+    from tldw_chatbook.config import get_user_data_dir
+
+    store = UnifiedMCPContextStore()
+
+    assert store.path == get_user_data_dir() / "unified_mcp_context.json"
+
+
+def test_configured_server_target_store_default_path_derives_from_get_user_data_dir():
+    from tldw_chatbook.config import get_user_data_dir
+
+    store = ConfiguredServerTargetStore()
+
+    assert store.path == get_user_data_dir() / "mcp_server_targets.json"
+
+
+def test_local_mcp_store_default_tracks_a_retargeted_profile(monkeypatch, tmp_path):
+    """The default must be resolved at construction time, not cached from
+    whichever profile happened to be active when the module first loaded --
+    proving it derives via the live accessor rather than a baked-in
+    constant (the exact class of staleness a module-level literal has)."""
+    from tldw_chatbook.config import get_user_data_dir
+
+    retargeted = tmp_path / "profile-two" / "config.toml"
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(retargeted))
+
+    store = LocalMCPStore()
+
+    assert store.path == get_user_data_dir() / "local_mcp_store.json"
+    assert str(tmp_path) in str(store.path)
+
+
+def test_local_mcp_store_default_is_covered_by_the_sensitive_path_denylist():
+    """The whole point of TASK-855: once the default derives from
+    ``get_user_data_dir()``, it (and its permission-store/execution-log
+    companions derived from it) fall under the denylist's ``user_data_dir``
+    file rule -- unlike the old ``~/.config/tldw_cli`` literal default."""
+    from tldw_chatbook.Utils.sensitive_paths import is_sensitive_path
+
+    store = LocalMCPStore()
+
+    assert is_sensitive_path(store.path)
+    assert is_sensitive_path(Path(store.path).with_name("mcp_permissions.json"))
+    assert is_sensitive_path(Path(store.path).with_name("mcp_execution_log.jsonl"))
+
+
+def test_explicit_path_construction_sites_are_unaffected(tmp_path):
+    """AC #3: every real construction site (app.py) always passes an
+    explicit path -- this must keep resolving to exactly the path passed,
+    unaffected by the default's derivation."""
+    explicit_path = tmp_path / "local_mcp_store.json"
+
+    store = LocalMCPStore(explicit_path)
+
+    assert store.path == explicit_path

--- a/Tests/MCP/test_store_default_paths.py
+++ b/Tests/MCP/test_store_default_paths.py
@@ -47,19 +47,31 @@ def test_configured_server_target_store_default_path_derives_from_get_user_data_
 
 
 def test_local_mcp_store_default_tracks_a_retargeted_profile(monkeypatch, tmp_path):
-    """The default must be resolved at construction time, not cached from
-    whichever profile happened to be active when the module first loaded --
-    proving it derives via the live accessor rather than a baked-in
-    constant (the exact class of staleness a module-level literal has)."""
-    from tldw_chatbook.config import get_user_data_dir
+    """The default must resolve at construction time via the live accessor.
 
-    retargeted = tmp_path / "profile-two" / "config.toml"
-    monkeypatch.setenv("TLDW_CONFIG_PATH", str(retargeted))
+    TASK-855's point is that the default is not a module-level constant
+    baked from whichever profile happened to be active at import. Retarget
+    the accessor itself and the next construction must follow it -- a
+    baked constant would keep pointing at the old location.
+
+    Note this patches ``get_user_data_dir`` rather than setting
+    ``TLDW_CONFIG_PATH``: the data directory is resolved from
+    ``[paths] data_dir`` (or the platform default), NOT from where the
+    config file happens to live, so retargeting the config path would not
+    move it and would prove nothing.
+    """
+    import tldw_chatbook.config as config_module
+
+    retargeted = tmp_path / "profile-two"
+    retargeted.mkdir(parents=True, exist_ok=True)
+    # Patch the accessor at its source: the helper imports it inside the
+    # function body, so a module-attribute patch on the store module would
+    # silently not apply and the test would pass for the wrong reason.
+    monkeypatch.setattr(config_module, "get_user_data_dir", lambda: retargeted)
 
     store = LocalMCPStore()
 
-    assert store.path == get_user_data_dir() / "local_mcp_store.json"
-    assert str(tmp_path) in str(store.path)
+    assert store.path == retargeted / "local_mcp_store.json"
 
 
 def test_local_mcp_store_default_is_covered_by_the_sensitive_path_denylist():

--- a/Tests/Skills/test_skills_library_flow.py
+++ b/Tests/Skills/test_skills_library_flow.py
@@ -25,6 +25,7 @@ from tldw_chatbook.Skills_Interop.skill_trust_service import SkillTrustService
 from tldw_chatbook.Skills_Interop.skill_trust_store import (
     FileSkillTrustGenerationMarkerStore,
     SkillTrustStore,
+    default_trust_store_dir,
 )
 from tldw_chatbook.Skills_Interop.skills_scope_service import SkillsScopeService
 from tldw_chatbook.runtime_policy.enforcement import ServicePolicyEnforcer
@@ -79,15 +80,27 @@ def _real_skills_scope_service(
     return local_service, service
 
 
+def _skills_dir_for(tmp_path):
+    """The real, derived skills subdirectory for a store rooted at ``tmp_path``.
+
+    Reads ``LocalSkillsService``'s own computed ``skills_dir`` attribute
+    (rather than re-spelling the "skills" literal) so this stays correct if
+    the class's internal directory-name constant ever changes (TASK-866).
+    """
+    return LocalSkillsService(store_dir=tmp_path).skills_dir
+
+
 def _real_trust_service(tmp_path) -> SkillTrustService:
     """A real, already-unlocked (but not yet bootstrapped) trust service."""
-    marker_path = tmp_path / "marker.json"
+    trust_dir = default_trust_store_dir(tmp_path)
+    trust_dir.mkdir(parents=True, exist_ok=True)
+    marker_path = trust_dir / "marker.json"
     trust_service = SkillTrustService(
-        skills_dir=tmp_path / "skills",
+        skills_dir=_skills_dir_for(tmp_path),
         trust_store=SkillTrustStore(
-            store_dir=tmp_path / "trust",
+            store_dir=trust_dir,
             marker_store=FileSkillTrustGenerationMarkerStore(
-                marker_path, store_dir=marker_path.parent
+                marker_path, store_dir=trust_dir
             ),
         ),
     )
@@ -101,13 +114,15 @@ def _real_uninitialized_trust_service(tmp_path) -> SkillTrustService:
     ``_real_trust_service`` above, which is already unlocked. This is the
     exact fresh-install shape the Phase-1 gate flagged as having no live-UI
     bootstrap path (FIX 2)."""
-    marker_path = tmp_path / "marker.json"
+    trust_dir = default_trust_store_dir(tmp_path)
+    trust_dir.mkdir(parents=True, exist_ok=True)
+    marker_path = trust_dir / "marker.json"
     return SkillTrustService(
-        skills_dir=tmp_path / "skills",
+        skills_dir=_skills_dir_for(tmp_path),
         trust_store=SkillTrustStore(
-            store_dir=tmp_path / "trust",
+            store_dir=trust_dir,
             marker_store=FileSkillTrustGenerationMarkerStore(
-                marker_path, store_dir=marker_path.parent
+                marker_path, store_dir=trust_dir
             ),
         ),
     )

--- a/Tests/UI/test_chat_screen_ui_state_path.py
+++ b/Tests/UI/test_chat_screen_ui_state_path.py
@@ -1,0 +1,95 @@
+"""TASK-865: ChatScreen's sidebar-state persistence must honor
+``TLDW_CONFIG_PATH`` -- not a hardcoded ``Path.home() / ".config" /
+"tldw_cli" / "ui_state.toml"`` literal that always lands in the real
+``~/.config/tldw_cli`` regardless of which profile is active.
+
+``_save_sidebar_state``/``_load_sidebar_state`` are plain methods on
+``ChatScreen`` that only touch ``self.ui_state``/``self.sidebar_state`` --
+this drives the real, unmodified methods directly (via ``object.__new__``,
+bypassing Textual's mount lifecycle, which is irrelevant to path
+derivation) rather than re-implementing their logic in the test.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+
+def _bare_screen_with_ui_state():
+    screen = ChatScreen.__new__(ChatScreen)
+    screen.ui_state = SimpleNamespace(
+        collapsible_states={"notes": True},
+        sidebar_search_query="hello",
+        last_active_section="notes",
+    )
+    return screen
+
+
+def test_save_sidebar_state_writes_under_the_active_profiles_config_dir(
+    monkeypatch, tmp_path
+):
+    """AC #4: with TLDW_CONFIG_PATH pointed at a profile, saving the sidebar
+    state must write under THAT profile's directory, not the real
+    ``~/.config/tldw_cli``."""
+    profile_config = tmp_path / "profile-one" / "config.toml"
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(profile_config))
+
+    screen = _bare_screen_with_ui_state()
+    screen._save_sidebar_state()
+
+    expected_path = tmp_path / "profile-one" / "ui_state.toml"
+    assert expected_path.exists()
+    assert "hello" in expected_path.read_text(encoding="utf-8")
+
+
+def test_save_then_reread_round_trips_under_a_retargeted_profile(monkeypatch, tmp_path):
+    """Confirms the saved content is actually readable back from the SAME
+    path the (real, unmodified) save method wrote to. Reads the file
+    directly rather than calling ``_load_sidebar_state()`` -- that method
+    also assigns a Textual ``reactive`` attribute, which requires a fully
+    mounted widget node unrelated to what this test verifies (path
+    derivation and content round-tripping)."""
+    import toml
+
+    from tldw_chatbook.config import _get_effective_config_path
+
+    profile_config = tmp_path / "profile-two" / "config.toml"
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(profile_config))
+
+    saving_screen = _bare_screen_with_ui_state()
+    saving_screen._save_sidebar_state()
+
+    reread_path = _get_effective_config_path().parent / "ui_state.toml"
+    data = toml.load(reread_path)
+
+    assert data["sidebar"]["collapsible_states"] == {"notes": True}
+    assert data["sidebar"]["search_query"] == "hello"
+    assert data["sidebar"]["last_active_section"] == "notes"
+
+
+def test_two_profiles_do_not_share_sidebar_state(monkeypatch, tmp_path):
+    """Two different active profiles must persist to two different files,
+    not collide into the one real ``~/.config/tldw_cli/ui_state.toml``."""
+    profile_a_config = tmp_path / "profile-a" / "config.toml"
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(profile_a_config))
+    screen_a = _bare_screen_with_ui_state()
+    screen_a._save_sidebar_state()
+
+    profile_b_config = tmp_path / "profile-b" / "config.toml"
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(profile_b_config))
+    screen_b = ChatScreen.__new__(ChatScreen)
+    screen_b.ui_state = SimpleNamespace(
+        collapsible_states={"chat": False},
+        sidebar_search_query="other",
+        last_active_section="chat",
+    )
+    screen_b._save_sidebar_state()
+
+    path_a = tmp_path / "profile-a" / "ui_state.toml"
+    path_b = tmp_path / "profile-b" / "ui_state.toml"
+    assert path_a.exists() and path_b.exists()
+    assert path_a != path_b
+    assert "hello" in path_a.read_text(encoding="utf-8")
+    assert "other" in path_b.read_text(encoding="utf-8")

--- a/Tests/Utils/test_sensitive_paths.py
+++ b/Tests/Utils/test_sensitive_paths.py
@@ -61,38 +61,63 @@ def test_config_toml_override_is_followed_when_retargeted(tmp_path, monkeypatch)
     assert is_sensitive_path(retargeted)
 
 
+def _real_control_plane_service():
+    """Build a real ``UnifiedMCPControlPlaneService`` wired to a real,
+    default-path ``LocalMCPStore`` -- the same store shape ``app.py``
+    constructs -- so ``.permission_store``/``.execution_log`` derive their
+    paths through the actual production property, not a re-typed literal.
+
+    Returns:
+        A ``UnifiedMCPControlPlaneService`` with no server/target/context
+        collaborators wired in (irrelevant to path derivation).
+    """
+    from types import SimpleNamespace
+
+    from tldw_chatbook.MCP.local_store import LocalMCPStore
+    from tldw_chatbook.MCP.unified_control_plane_service import (
+        UnifiedMCPControlPlaneService,
+    )
+
+    # No explicit path: TASK-855 made this default derive from
+    # get_user_data_dir(), the same directory app.py passes explicitly.
+    store = LocalMCPStore()
+    return UnifiedMCPControlPlaneService(
+        local_service=SimpleNamespace(store=store),
+        server_service=None,
+        target_store=None,
+        context_store=None,
+    )
+
+
 def test_mcp_permission_store_is_refused_via_the_actually_used_path():
     """Finding 1 (CRITICAL, substrate review): the permission store's real
     path was never ``~/.config/tldw_cli/mcp_permissions.json`` on any real
-    install -- the app builds it under ``get_user_data_dir()`` (see
-    ``MCP.unified_control_plane_service``'s ``permission_store`` property:
-    ``Path(store.path).with_name("mcp_permissions.json")``, where
-    ``store.path`` is the ``LocalMCPStore`` path ``app.py`` constructs as
-    ``get_user_data_dir() / "local_mcp_store.json"``). Derives the path the
-    SAME way the app does rather than asserting a literal, so this can't
-    silently drift back to matching nothing the way the original bug did.
+    install -- the app builds it under ``get_user_data_dir()``. Reads the
+    path off the LIVE ``UnifiedMCPControlPlaneService.permission_store``
+    property (the actual object the app constructs and consults) rather
+    than re-typing its ``Path(store.path).with_name(...)`` derivation here:
+    if ``permission_store``'s own logic ever changes (e.g. app.py nests
+    ``local_mcp_store.json`` into a subdirectory), this test tracks it
+    automatically instead of drifting alongside it the way a re-spelled
+    literal would -- the original bug's exact failure mode.
     """
-    from tldw_chatbook import config as app_config
-    from tldw_chatbook.MCP.local_store import LocalMCPStore
+    service = _real_control_plane_service()
 
-    store = LocalMCPStore(app_config.get_user_data_dir() / "local_mcp_store.json")
-    permissions_path = Path(store.path).with_name("mcp_permissions.json")
+    permissions_path = service.permission_store.path
 
     assert is_sensitive_path(permissions_path)
 
 
 def test_mcp_permission_store_companions_are_refused():
-    """The execution-audit log and the server-definitions store are built
-    the identical ``Path(...).with_name(...)`` way from the same base path
-    as the permission store and carry the same class of gate-relevant
-    state (server definitions + env, and the decision audit trail).
+    """The execution-audit log and the local server-definitions store carry
+    the same class of gate-relevant state as the permission store (server
+    definitions + env, and the decision audit trail). Both paths are read
+    off the live service/store objects under test, not re-spelled.
     """
-    from tldw_chatbook import config as app_config
+    service = _real_control_plane_service()
 
-    user_data_dir = app_config.get_user_data_dir()
-
-    assert is_sensitive_path(user_data_dir / "local_mcp_store.json")
-    assert is_sensitive_path(user_data_dir / "mcp_execution_log.jsonl")
+    assert is_sensitive_path(service.local_service.store.path)
+    assert is_sensitive_path(service.execution_log.path)
 
 
 def test_matching_is_by_resolved_ancestry_not_substring(tmp_path):

--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -554,16 +554,25 @@ def make_trust_service(tmp_path):
         bound to the same on-disk `skills_dir`/`trust_dir`, so repeated calls
         simulate a fresh process re-reading persisted state.
     """
+    from tldw_chatbook.Skills_Interop.local_skills_service import LocalSkillsService
     from tldw_chatbook.Skills_Interop.skill_trust_service import SkillTrustService
     from tldw_chatbook.Skills_Interop.skill_trust_store import (
         FileSkillTrustGenerationMarkerStore,
         SkillTrustStore,
+        default_trust_store_dir,
     )
 
-    skills_dir = tmp_path / "skills"
-    trust_dir = tmp_path / "trust"
-    skills_dir.mkdir(exist_ok=True)
-    trust_dir.mkdir(exist_ok=True)
+    # Derived from the real accessors/objects rather than re-spelled
+    # "skills"/"trust" literals (TASK-866): `LocalSkillsService` computes
+    # its own `skills_dir` from `_SKILLS_DIRNAME`, and
+    # `default_trust_store_dir()` is the same function `app.py` calls to
+    # build the live `SkillTrustStore`. If either constant's name ever
+    # changed, a hardcoded literal here would silently keep matching
+    # nothing -- the exact class of drift this task closes.
+    skills_dir = LocalSkillsService(store_dir=tmp_path).skills_dir
+    trust_dir = default_trust_store_dir(tmp_path)
+    skills_dir.mkdir(exist_ok=True, parents=True)
+    trust_dir.mkdir(exist_ok=True, parents=True)
 
     def _make() -> "SkillTrustService":
         marker_path = trust_dir / "marker.json"

--- a/backlog/tasks/task-854 - Fix-MCP-servers-media-DB-lookup-to-use-the-real-config-key-accessor.md
+++ b/backlog/tasks/task-854 - Fix-MCP-servers-media-DB-lookup-to-use-the-real-config-key-accessor.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-854
 title: Fix MCP server's media DB lookup to use the real config key/accessor
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-27 04:34'
+updated_date: '2026-07-27 16:28'
 labels:
   - security
   - mcp
@@ -19,8 +21,24 @@ MCP/server.py:154-155 calls get_cli_setting("database", "media_db", "media_libra
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 MCP/server.py resolves the media DB path via get_media_db_path() (or the equivalent media_db_path config key), matching what the rest of the app opens
-- [ ] #2 A grep-based check (or test) confirms no other get_cli_setting("database", ...) call site in the codebase uses a key that isn't one of the declared *_db_path names
-- [ ] #3 A test starts/constructs the MCP server's media DB handle and asserts its resolved path equals get_media_db_path()'s return value, rather than asserting a literal filename
-- [ ] #4 The resolved media DB path is covered by is_sensitive_path() once the fix lands (verified by test, not by inspection)
+- [x] #1 MCP/server.py resolves the media DB path via get_media_db_path() (or the equivalent media_db_path config key), matching what the rest of the app opens
+- [x] #2 A grep-based check (or test) confirms no other get_cli_setting("database", ...) call site in the codebase uses a key that isn't one of the declared *_db_path names
+- [x] #3 A test starts/constructs the MCP server's media DB handle and asserts its resolved path equals get_media_db_path()'s return value, rather than asserting a literal filename
+- [x] #4 The resolved media DB path is covered by is_sensitive_path() once the fix lands (verified by test, not by inspection)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the wrong-db behaviour with a sandboxed HOME/no-TLDW_CONFIG_PATH probe.
+2. Fix MCP/server.py's _init_databases() to call get_media_db_path() instead of the undeclared 'media_db' key.
+3. Grep the codebase (AST-based, in a test) for any other get_cli_setting('database', ...) call using a key that is not a declared *_db_path name.
+4. Add a regression test that drives the real _init_databases() and asserts the resolved media DB path.
+5. Add a test asserting the resolved path is covered by is_sensitive_path().
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed MCP/server.py:154 to call config.get_media_db_path() instead of get_cli_setting("database", "media_db", "media_library.db") (key never existed; real key is media_db_path). Reproduced before/after with a sandboxed HOME probe: before, the buggy key resolved to the CWD-relative literal 'media_library.db' (would land at .../wt-path-accessors/media_library.db); after, it resolves to get_media_db_path()'s real, per-profile path (.../default_user/tldw_chatbook_media_v2.db in the sandbox). While fixing this, discovered _init_databases() also called MediaDatabase(media_db_path) with NO client_id (a required positional arg -- TypeError at construction) and constructed NotesInteropService/CharacterInteropService with signatures that don't match either class (CharacterInteropService does not exist anywhere in the codebase). The missing client_id was fixed (adjacent, required to make AC #3 constructible at all -- CLI_APP_CLIENT_ID, matching every other MediaDatabase call site). The NotesInteropService/CharacterInteropService construction bugs are a SEPARATE, pre-existing defect (the whole _init_databases() method has apparently never been exercised successfully) and were left alone as out of this task's scope -- flagged for a follow-up task rather than fixed here. New test Tests/MCP/test_server_media_db_path.py drives the real _init_databases() (stubbing only the two unrelated broken collaborators) and asserts media_db.db_path == get_media_db_path(), that it is_sensitive_path()-covered, and an AST-based repo-wide grep (also serves AC #2) confirming no other get_cli_setting('database', ...) call site uses an undeclared key -- zero additional offenders found. Files: tldw_chatbook/MCP/server.py, Tests/MCP/test_server_media_db_path.py (new).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-855 - Make-MCP-store-module-defaults-derive-from-get_user_data_dir-not-~-.config-tldw_cli.md
+++ b/backlog/tasks/task-855 - Make-MCP-store-module-defaults-derive-from-get_user_data_dir-not-~-.config-tldw_cli.md
@@ -3,9 +3,11 @@ id: TASK-855
 title: >-
   Make MCP store module defaults derive from get_user_data_dir(), not
   ~/.config/tldw_cli
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-27 04:34'
+updated_date: '2026-07-27 16:29'
 labels:
   - security
   - mcp
@@ -20,7 +22,22 @@ MCP/local_store.py:13 (DEFAULT_LOCAL_MCP_STORE_PATH), MCP/unified_context_store.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The three MCP store modules' default paths derive from get_user_data_dir(), or the classes require an explicit path argument with no config-relative fallback
-- [ ] #2 A test constructs each store with no explicit path and asserts the resulting path matches the get_user_data_dir()-derived location (or that construction without an explicit path is disallowed), not a hardcoded ~/.config/tldw_cli literal
-- [ ] #3 Every current explicit-path construction site (app.py:5241, :5248, :4028) continues to resolve to the same paths as before
+- [x] #1 The three MCP store modules' default paths derive from get_user_data_dir(), or the classes require an explicit path argument with no config-relative fallback
+- [x] #2 A test constructs each store with no explicit path and asserts the resulting path matches the get_user_data_dir()-derived location (or that construction without an explicit path is disallowed), not a hardcoded ~/.config/tldw_cli literal
+- [x] #3 Every current explicit-path construction site (app.py:5241, :5248, :4028) continues to resolve to the same paths as before
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Confirm no real construction site anywhere in the codebase relies on the module-level default (all pass an explicit path).
+2. Decide: derive the default from get_user_data_dir() lazily, vs. require an explicit path. Pick lazy derivation (avoids baking a stale profile into a module-level constant at import time, matching the existing lazy pattern in Utils/sensitive_paths.py).
+3. Replace the three eager DEFAULT_*_PATH module constants with lazy _default_*_path() helper functions, called from each class's __init__ only when no path is given.
+4. Add tests asserting default-construction resolves to get_user_data_dir()-joined paths, that explicit-path sites are unaffected, and that the default is covered by is_sensitive_path().
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Decision: derive lazily rather than require an explicit path. Nothing in the codebase (app.py, or any of the ~90 test call sites across Tests/MCP/ and Tests/RuntimePolicy/) ever constructs these three classes with no argument, so 'require explicit path' would have been equally safe -- but it would make every one of those call sites' intent (an explicit path) implicit and give up a legitimate escape hatch for a future caller that genuinely wants the default. Made the default LAZY (a private _default_*_path() function called from __init__ only when path is falsy) rather than an eager module-level constant computed at get_user_data_dir()'s import time, for two reasons: (1) get_user_data_dir() has side effects (reads live config, creates the directory) that an import-time module constant would trigger merely by importing the module; (2) an eager constant would bake in whichever profile/HOME was active the FIRST time the module was imported in a process (e.g. a test session), silently going stale for every later profile switch -- exactly the staleness class Utils/sensitive_paths.py's own lazy _sensitive_db_paths()/_sensitive_single_file_paths() helpers were written to avoid. Removed the now-unused DEFAULT_LOCAL_MCP_STORE_PATH/DEFAULT_UNIFIED_MCP_CONTEXT_PATH/DEFAULT_SERVER_TARGETS_PATH constants entirely (grepped first: nothing outside their own module referenced them). New tests (Tests/MCP/test_store_default_paths.py) assert: each store's no-argument default equals get_user_data_dir()/<filename>; the default re-resolves correctly after TLDW_CONFIG_PATH is retargeted (proving lazy, not cached); the default (and its permission-store/execution-log derivatives) is covered by is_sensitive_path(); and explicit-path construction is unaffected. Files: tldw_chatbook/MCP/local_store.py, unified_context_store.py, server_target_store.py; Tests/MCP/test_store_default_paths.py (new).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-858 - Reconcile-the-evals-prompts-media-rag-subscriptions-DB-path-maps-with-get_-_db_path.md
+++ b/backlog/tasks/task-858 - Reconcile-the-evals-prompts-media-rag-subscriptions-DB-path-maps-with-get_-_db_path.md
@@ -3,9 +3,11 @@ id: TASK-858
 title: >-
   Reconcile the evals/prompts/media/rag/subscriptions DB path maps with
   get_*_db_path()
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-27 04:35'
+updated_date: '2026-07-27 16:29'
 labels:
   - security
   - db
@@ -23,8 +25,23 @@ The same defect class appears at UI/Tools_Settings_Window.py:6480-6507 and :6631
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 eval_db_operations.py resolves the evals DB path the same way Evals/eval_orchestrator.py does (via get_user_data_dir(), not a Path.home()/'.config' literal)
-- [ ] #2 The DB path map behind the Settings screen's integrity check, backup, vacuum, and chatbook-import features is rebuilt from the real get_*_db_path() accessors for every database it lists, with corrected filenames
-- [ ] #3 evals_db_path, rag_db_path, and subscriptions_db_path are either declared as real config defaults or removed as dead config-key references
-- [ ] #4 A test asserts each maintenance-operation path equals its corresponding get_*_db_path() return value, not a hand-typed literal, for all six databases
+- [x] #1 eval_db_operations.py resolves the evals DB path the same way Evals/eval_orchestrator.py does (via get_user_data_dir(), not a Path.home()/'.config' literal)
+- [x] #2 The DB path map behind the Settings screen's integrity check, backup, vacuum, and chatbook-import features is rebuilt from the real get_*_db_path() accessors for every database it lists, with corrected filenames
+- [x] #3 evals_db_path, rag_db_path, and subscriptions_db_path are either declared as real config defaults or removed as dead config-key references
+- [x] #4 A test asserts each maintenance-operation path equals its corresponding get_*_db_path() return value, not a hand-typed literal, for all six databases
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Check current state: TASK-899 (already on origin/dev before this branch) may already have reconciled the Settings maintenance DB-path map and added get_evals_db_path()/get_rag_indexing_db_path()/get_subscriptions_db_path() accessors -- verify before redoing work.
+2. Fix Event_Handlers/eval_db_operations.py's remaining Path.home()-based literal to call get_evals_db_path().
+3. Declare evals_db_path, rag_indexing_db_path and subscriptions_db_path as real [database] config defaults (they are live, used keys -- not dead references).
+4. Add/confirm tests covering all of the above.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+AC #2 and AC #4 (the Settings screen's DB-path map and its six-database test) were ALREADY DONE on this branch's base -- an earlier, already-merged task (referenced in-code as TASK-899) rebuilt UI/Tools_Settings_Window.py's _DB_PATH_RESOLVERS dict from the real get_*_db_path() accessors (config.py:6823-6830) and Tests/UI/test_tools_settings_window.py already has test_get_database_path_resolves_via_config_resolvers_and_honours_profile plus per-DB parity tests (test_evals_db_path_matches_orchestrator_resolution, test_rag_indexing_db_path_matches_ingestion_module_resolution) and a parametrized backup/restore round-trip test over all six databases. Verified these still pass unchanged. What was genuinely still broken: Event_Handlers/eval_db_operations.py:28 still hardcoded Path.home()/'.config'/'tldw_cli'/'evals.db' -- fixed to call config.get_evals_db_path() (the same accessor Evals/eval_orchestrator.py delegates to), with new regression tests in Tests/Event_Handlers/test_eval_db_operations_path.py (default matches get_evals_db_path(), tracks a retargeted TLDW_CONFIG_PATH profile, explicit db_path unaffected). Also: evals_db_path, rag_indexing_db_path (the task text calls it 'rag_db_path', but the real, only key ever read is rag_indexing_db_path -- 'rag_db_path' does not appear anywhere in the codebase) and subscriptions_db_path were declared nowhere in config.py's [database] TOML template even though their get_*_db_path() accessors are real and already used elsewhere. None were dead (all three accessors have live callers), so declared them as real defaults following the exact sentinel-literal convention the three existing entries (chachanotes/prompts/media) already use, with their correct real fallback filenames (evals.db, rag_indexing.db, tldw_chatbook_subscriptions.db) -- functionally a no-op for existing users (the accessor's custom-path branch only fires when a value differs from this template's sentinel; an unset key already fell through to the correct get_user_data_dir()-based path before this change) but closes the 'declared nowhere' gap and documents the override for new installs. Verified with a sandboxed-HOME probe that the three keys now resolve in DEFAULT_CONFIG_FROM_TOML. Files: tldw_chatbook/Event_Handlers/eval_db_operations.py, tldw_chatbook/config.py, Tests/Event_Handlers/test_eval_db_operations_path.py (new).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-865 - Sweep-hardcoded-~-.config-tldw_cli-and-~-.local-share-tldw_cli-call-sites-onto-the-real-accessors.md
+++ b/backlog/tasks/task-865 - Sweep-hardcoded-~-.config-tldw_cli-and-~-.local-share-tldw_cli-call-sites-onto-the-real-accessors.md
@@ -3,9 +3,11 @@ id: TASK-865
 title: >-
   Sweep hardcoded ~/.config/tldw_cli and ~/.local/share/tldw_cli call sites onto
   the real accessors
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-07-27 04:35'
+updated_date: '2026-07-27 16:29'
 labels:
   - security
   - config
@@ -24,6 +26,27 @@ The data-dir group (~18 sites, including Chatbooks/chatbook_importer.py:77-79, C
 <!-- AC:BEGIN -->
 - [ ] #1 Every listed config-dir call site derives its parent directory from _get_effective_config_path().parent instead of a Path.home()/'.config'/'tldw_cli' literal
 - [ ] #2 Every listed data-dir call site derives its path from get_user_data_dir() instead of a Path.home()/'.local'/'share'/'tldw_cli' literal that omits the user folder segment
-- [ ] #3 The chatbook importer's extraction root matches the chatbook creator's temp root (both under get_user_data_dir()/temp/...) with a test asserting the two derive to the same parent
-- [ ] #4 A test with TLDW_CONFIG_PATH pointed at a profile confirms at least one swept config-dir site (e.g. ui_state.toml) writes under that profile's directory, not the real ~/.config/tldw_cli
+- [x] #3 The chatbook importer's extraction root matches the chatbook creator's temp root (both under get_user_data_dir()/temp/...) with a test asserting the two derive to the same parent
+- [x] #4 A test with TLDW_CONFIG_PATH pointed at a profile confirms at least one swept config-dir site (e.g. ui_state.toml) writes under that profile's directory, not the real ~/.config/tldw_cli
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Enumerate every explicitly named config-dir and data-dir call site from the task description and fix each.
+2. Fix the chatbook importer (highest-value, live-diverged) to match the chatbook creator's sibling temp-root convention; add a parity test.
+3. Add a TLDW_CONFIG_PATH-retargeting test proving at least one swept config-dir site (ui_state.toml) honors the active profile.
+4. Best-effort sweep additional lower-value sites found by a broader grep, time permitting; catalog whatever remains unfixed rather than claim full coverage.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Completed, with tests, every site the task named with an explicit file:line reference: config-dir group -- UI/Screens/chat_screen.py (both ui_state.toml sites), Event_Handlers/notes_events.py and note_ingest_events.py (note_templates.json), Subscriptions/website_monitor.py (feed_cache/); data-dir group -- Chatbooks/chatbook_importer.py (the highest-value fix: temp_dir now derives get_user_data_dir()/'temp'/'imports', matching chatbook_creator.py's sibling get_user_data_dir()/'temp'/'chatbooks'), Chatbooks/local_chatbook_service.py's _default_registry_path() fallback, Character_Chat/Character_Chat_Lib.py (all 3 base_directory sites), Event_Handlers/conv_char_events.py (all 3 export_dir sites). All now derive from _get_effective_config_path().parent or get_user_data_dir() via local imports, matching the codebase's established per-call-site import convention.
+
+As a best-effort addition beyond the explicitly named sites, also fixed: Widgets/emoji_picker.py (converted the eager RECENT_EMOJIS_FILE module constant to a lazy _recent_emojis_path() -- an eager get_user_data_dir()-based constant would itself go stale across a profile switch within one process, the same latent-staleness class TASK-855 closed for the MCP stores), Widgets/settings_theme_editor.py (custom_themes_path), Notes/sync_service.py (sync_profiles.json default), Config_Files/create_custom_template.py (a standalone, non-imported dev helper script), RAG_Search/pipeline_loader.py and pipeline_builder_simple.py (rag_pipelines.toml user-override lookup).
+
+NOT checking AC #1/#2 as fully satisfied: the task also references '~25 lower-value' config-dir sites and '~18' data-dir sites only in aggregate, without file:line references, and a full sweep was not completed given the size of that remainder. A broader grep during this task surfaced a SEPARATE, adjacent, and larger finding worth its own follow-up task: UI/ChatbookCreationWindow.py, UI/ChatbookExportManagementWindow.py, UI/Wizards/ChatbookCreationWizard.py and UI/Wizards/ChatbookImportWizard.py each build their OWN ad-hoc db_paths dict straight from self.app.config_data.get('database', {}) with hardcoded, WRONG, non-user-folder fallback literals (e.g. '~/.local/share/tldw_cli/tldw_prompts_db.db') instead of calling get_prompts_db_path()/get_media_db_path() -- these do NOT go through the get_*_db_path() accessors at all, unlike everything reconciled in TASK-858/899. Deliberately left out of this task's scope (a distinct defect class, not a Path.home()-literal sweep site) and recommend filing separately. Also deliberately left OUT as a scope decision, not an oversight: TTS/UI model-weight and voice-cache paths under ~/.config/tldw_cli/models/... and .../*_voices (STTS_Window.py, Dictation_Window.py, TTS/backends/kokoro.py, TTS/kokoro_pytorch.py, TTS/utils/download_models.py) -- these are large, shared binary caches/exports, not per-profile config/state; making them profile-relative would force re-downloading multi-hundred-MB models on every profile switch, which is very unlikely to be the intended behavior and is exactly the kind of live-file-relocation this task's hard constraints told me to stop and report on rather than silently do.
+
+AC #3 (chatbook importer/creator parity) and AC #4 (a profile-retargeted config-dir site) are both satisfied with concrete tests: Tests/Chatbooks/test_chatbook_importer.py (temp_dir == get_user_data_dir()/'temp'/'imports', and shares a parent with ChatbookCreator's temp_dir), Tests/UI/test_chat_screen_ui_state_path.py (TLDW_CONFIG_PATH retargeted to a scratch profile -> _save_sidebar_state() writes ui_state.toml under THAT profile's directory, two different profiles do not collide). Files: tldw_chatbook/UI/Screens/chat_screen.py, Event_Handlers/{notes_events,note_ingest_events,conv_char_events}.py, Subscriptions/website_monitor.py, Chatbooks/{chatbook_importer,local_chatbook_service}.py, Character_Chat/Character_Chat_Lib.py, Widgets/{emoji_picker,settings_theme_editor}.py, Notes/sync_service.py, Config_Files/create_custom_template.py, RAG_Search/{pipeline_loader,pipeline_builder_simple}.py; new tests in Tests/Chatbooks/test_chatbook_importer.py and Tests/UI/test_chat_screen_ui_state_path.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-866 - Make-sensitive-path-and-skills-fixture-tests-re-derive-paths-instead-of-re-spelling-them.md
+++ b/backlog/tasks/task-866 - Make-sensitive-path-and-skills-fixture-tests-re-derive-paths-instead-of-re-spelling-them.md
@@ -3,9 +3,11 @@ id: TASK-866
 title: >-
   Make sensitive-path and skills-fixture tests re-derive paths instead of
   re-spelling them
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-27 04:35'
+updated_date: '2026-07-27 16:30'
 labels:
   - security
   - tools
@@ -24,8 +26,29 @@ Tests/conftest.py:566-575 and Tests/Skills/test_skills_library_flow.py:84-106 bu
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Tests/Utils/test_sensitive_paths.py's MCP-store-path assertions derive their expected paths from the live store objects (e.g. app.unified_mcp_service.permission_store.path) instead of re-typing the get_user_data_dir()-joined literal
-- [ ] #2 Tests/conftest.py and Tests/Skills/test_skills_library_flow.py's skills-fixture paths derive from the real SkillTrustService/local_skills_service attributes instead of a re-spelled literal
-- [ ] #3 Both updated tests still pass against the current, correct code
-- [ ] #4 A deliberately introduced path change in the corresponding production accessor (temporarily, while verifying) causes each updated test to fail, confirming it actually re-derives rather than re-asserts
+- [x] #1 Tests/Utils/test_sensitive_paths.py's MCP-store-path assertions derive their expected paths from the live store objects (e.g. app.unified_mcp_service.permission_store.path) instead of re-typing the get_user_data_dir()-joined literal
+- [x] #2 Tests/conftest.py and Tests/Skills/test_skills_library_flow.py's skills-fixture paths derive from the real SkillTrustService/local_skills_service attributes instead of a re-spelled literal
+- [x] #3 Both updated tests still pass against the current, correct code
+- [x] #4 A deliberately introduced path change in the corresponding production accessor (temporarily, while verifying) causes each updated test to fail, confirming it actually re-derives rather than re-asserts
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Rewrite Tests/Utils/test_sensitive_paths.py's MCP-permission-store tests to derive the expected path from a live UnifiedMCPControlPlaneService.permission_store/.execution_log property, not a re-typed Path(store.path).with_name(...) literal.
+2. Rewrite Tests/conftest.py's make_trust_service fixture and Tests/Skills/test_skills_library_flow.py's two trust-service builders to derive skills_dir/trust_dir from LocalSkillsService(...).skills_dir and default_trust_store_dir(), not re-spelled 'skills'/'trust' literals.
+3. Run both suites to confirm they still pass against current, correct code.
+4. Deliberately break the corresponding production derivation (temporarily) and confirm the updated tests fail, then revert.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Tests/Utils/test_sensitive_paths.py's two MCP-store tests re-typed 'mcp_permissions.json'/Path(store.path).with_name(...) the same way unified_control_plane_service.py's permission_store/execution_log properties do internally, rather than reading the paths off a live instance -- rewrote both to build a real UnifiedMCPControlPlaneService (the SimpleNamespace(store=...) idiom already used in Tests/MCP/test_control_plane_permissions.py) with a default-path LocalMCPStore() (TASK-855 made this default itself derive from get_user_data_dir(), so no literal filename is spelled at all now), and assert on service.permission_store.path / service.execution_log.path / service.local_service.store.path directly.
+
+Tests/conftest.py's make_trust_service fixture and Tests/Skills/test_skills_library_flow.py's _real_trust_service/_real_uninitialized_trust_service builders hardcoded tmp_path/'skills' and tmp_path/'trust' -- matching, by re-spelling, LocalSkillsService's private _SKILLS_DIRNAME and skill_trust_store's private _TRUST_DIRNAME constants. Rewrote both to derive skills_dir from LocalSkillsService(store_dir=tmp_path).skills_dir (a real, side-effect-free constructor call solely to read its computed attribute) and trust_dir from the already-public default_trust_store_dir(tmp_path) -- the exact function app.py itself calls.
+
+Verified AC #4 concretely for both fixes, not just asserted: (1) for the MCP-store test, temporarily changed unified_control_plane_service.py's permission_store property to nest the file under an extra subdirectory -- the updated test correctly FAILED (is_sensitive_path no longer covers the new location), then reverted cleanly (git diff clean). (2) for the skills fixture, temporarily renamed local_skills_service.py's _SKILLS_DIRNAME and skill_trust_store.py's _TRUST_DIRNAME to different values -- the NEW fixture code still passed all 52 tests (correctly re-derives regardless of the constant's name), then reverting ONLY the test file back to the old re-spelled-literal style (while keeping the renamed production constants) reproduced 3 real failures, proving the old style really would have gone silently stale; reverted everything cleanly afterward (git diff clean on all production files touched during verification).
+
+Files: Tests/Utils/test_sensitive_paths.py, Tests/conftest.py, Tests/Skills/test_skills_library_flow.py.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Character_Chat/Character_Chat_Lib.py
+++ b/tldw_chatbook/Character_Chat/Character_Chat_Lib.py
@@ -1271,7 +1271,9 @@ def extract_json_from_image_file(
             # Validate the file path to prevent directory traversal
             if base_directory is None:
                 # Default to user data directory for character cards
-                base_directory = os.path.expanduser("~/.local/share/tldw_cli/")
+                from tldw_chatbook.config import get_user_data_dir
+
+                base_directory = str(get_user_data_dir())
 
             try:
                 validated_path = validate_path(image_file_input, base_directory)
@@ -2787,7 +2789,9 @@ def load_chat_history_from_file_and_save_to_db(
             # Validate the file path to prevent directory traversal
             if base_directory is None:
                 # Default to user data directory for chat history files
-                base_directory = os.path.expanduser("~/.local/share/tldw_cli/")
+                from tldw_chatbook.config import get_user_data_dir
+
+                base_directory = str(get_user_data_dir())
 
             try:
                 validated_path = validate_path(file_path_or_obj, base_directory)
@@ -3853,7 +3857,9 @@ def export_character_card_to_png(
 
         # Validate output path
         if base_directory is None:
-            base_directory = os.path.expanduser("~/.local/share/tldw_cli/exports/")
+            from tldw_chatbook.config import get_user_data_dir
+
+            base_directory = str(get_user_data_dir() / "exports")
             os.makedirs(base_directory, exist_ok=True)
 
         try:

--- a/tldw_chatbook/Chatbooks/local_chatbook_service.py
+++ b/tldw_chatbook/Chatbooks/local_chatbook_service.py
@@ -99,13 +99,9 @@ class LocalChatbookService:
                 return (
                     Path(db_path).expanduser().with_name("tldw_chatbook_chatbooks.json")
                 )
-        return (
-            Path.home()
-            / ".local"
-            / "share"
-            / "tldw_cli"
-            / "tldw_chatbook_chatbooks.json"
-        )
+        from ..Utils.paths import get_user_data_dir
+
+        return get_user_data_dir() / "tldw_chatbook_chatbooks.json"
 
     @staticmethod
     def _utc_now() -> str:

--- a/tldw_chatbook/Config_Files/create_custom_template.py
+++ b/tldw_chatbook/Config_Files/create_custom_template.py
@@ -6,12 +6,14 @@ This will create/update the user's personal note_templates.json file.
 """
 
 import json
-from pathlib import Path
+
+from tldw_chatbook.config import _get_effective_config_path
 
 
 def create_custom_template():
-    # User config path
-    user_config_dir = Path.home() / ".config" / "tldw_cli"
+    # User config path -- honors TLDW_CONFIG_PATH so this writes to the same
+    # file the running app's profile actually reads (TASK-865).
+    user_config_dir = _get_effective_config_path().parent
     user_templates_path = user_config_dir / "note_templates.json"
 
     # Create directory if needed

--- a/tldw_chatbook/Event_Handlers/conv_char_events.py
+++ b/tldw_chatbook/Event_Handlers/conv_char_events.py
@@ -4241,7 +4241,9 @@ async def handle_conv_char_export_text_button_pressed(
             filename = f"conversation_{app.current_ccp_conversation_id}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.txt"
 
         # Save to default export directory
-        export_dir = Path.home() / ".local" / "share" / "tldw_cli" / "exports"
+        from ..config import get_user_data_dir
+
+        export_dir = get_user_data_dir() / "exports"
         export_dir.mkdir(parents=True, exist_ok=True)
         export_path = export_dir / filename
 
@@ -4302,7 +4304,9 @@ async def handle_conv_char_export_json_button_pressed(
             filename = f"conversation_{app.current_ccp_conversation_id}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
 
         # Save to default export directory
-        export_dir = Path.home() / ".local" / "share" / "tldw_cli" / "exports"
+        from ..config import get_user_data_dir
+
+        export_dir = get_user_data_dir() / "exports"
         export_dir.mkdir(parents=True, exist_ok=True)
         export_path = export_dir / filename
 
@@ -4353,7 +4357,9 @@ async def handle_ccp_export_character_button_pressed(
             char_data.get("name", "character").replace("/", "_").replace("\\", "_")
         )
 
-        export_dir = Path.home() / ".local" / "share" / "tldw_cli" / "exports"
+        from ..config import get_user_data_dir
+
+        export_dir = get_user_data_dir() / "exports"
         export_dir.mkdir(parents=True, exist_ok=True)
 
         # Always export as JSON

--- a/tldw_chatbook/Event_Handlers/eval_db_operations.py
+++ b/tldw_chatbook/Event_Handlers/eval_db_operations.py
@@ -24,8 +24,15 @@ class EvalDBOperations:
     def __init__(self, db_path: Optional[Path] = None):
         """Initialize with database path."""
         if db_path is None:
-            # Use default evals database location
-            db_path = Path.home() / ".config" / "tldw_cli" / "evals.db"
+            # Single source of truth for where the Evals database lives --
+            # the same accessor Evals/eval_orchestrator.py's
+            # EvaluationOrchestrator delegates to for its own default
+            # (db_path=None) case, so this and the orchestrator always agree
+            # (TASK-858; the previous ``~/.config/tldw_cli/evals.db`` literal
+            # named a different, profile-unaware file the app never opens).
+            from ..config import get_evals_db_path
+
+            db_path = get_evals_db_path()
 
         self.db = EvalsDB(db_path)
 

--- a/tldw_chatbook/Event_Handlers/note_ingest_events.py
+++ b/tldw_chatbook/Event_Handlers/note_ingest_events.py
@@ -347,7 +347,9 @@ async def handle_ingest_notes_import_now_button_pressed(
         if import_as_templates:
             # Import as templates
             # Load existing templates
-            user_config_dir = Path.home() / ".config" / "tldw_cli"
+            from ..config import _get_effective_config_path
+
+            user_config_dir = _get_effective_config_path().parent
             user_templates_path = user_config_dir / "note_templates.json"
 
             # Create directory if needed

--- a/tldw_chatbook/Event_Handlers/notes_events.py
+++ b/tldw_chatbook/Event_Handlers/notes_events.py
@@ -140,8 +140,10 @@ from pathlib import Path  # noqa: E402
 
 def load_note_templates():
     """Load note templates from JSON file or use defaults."""
+    from ..config import _get_effective_config_path
+
     # Try to load from user's config directory first
-    user_config_path = Path.home() / ".config" / "tldw_cli" / "note_templates.json"
+    user_config_path = _get_effective_config_path().parent / "note_templates.json"
 
     # Fallback to app's config directory
     app_config_path = (

--- a/tldw_chatbook/MCP/local_store.py
+++ b/tldw_chatbook/MCP/local_store.py
@@ -8,9 +8,32 @@ from pathlib import Path
 from typing import Any, Mapping
 from uuid import uuid4
 
-from tldw_chatbook.config import DEFAULT_CONFIG_PATH
+_LOCAL_MCP_STORE_FILENAME = "local_mcp_store.json"
 
-DEFAULT_LOCAL_MCP_STORE_PATH = DEFAULT_CONFIG_PATH.parent / "local_mcp_store.json"
+
+def _default_local_mcp_store_path() -> Path:
+    """Return this store's path when constructed with no explicit argument.
+
+    Derives from ``config.get_user_data_dir()`` -- the same directory every
+    real construction site (``app.py``) already passes explicitly -- rather
+    than a stale, eagerly-computed module constant. Resolution happens
+    lazily, at call time, because ``get_user_data_dir()`` reads the active
+    profile/config: baking a value in at import time would freeze whichever
+    profile happened to be active the first time this module loaded, which
+    is exactly the kind of latent drift TASK-855 exists to close (see
+    ``MCP.unified_control_plane_service``'s ``permission_store``/
+    ``execution_log`` properties, which derive the permission store and
+    execution log paths from this store's own ``.path`` via
+    ``Path(store.path).with_name(...)`` -- a store built with no argument
+    anywhere would silently place both outside
+    ``Utils.sensitive_paths``' denylist coverage).
+
+    Returns:
+        ``get_user_data_dir() / "local_mcp_store.json"``.
+    """
+    from tldw_chatbook.config import get_user_data_dir
+
+    return get_user_data_dir() / _LOCAL_MCP_STORE_FILENAME
 
 _ENV_PLACEHOLDER_PATTERN = re.compile(
     r"^\$(?:\{[A-Za-z_][A-Za-z0-9_]*\}|[A-Za-z_][A-Za-z0-9_]*)$"
@@ -682,7 +705,7 @@ class LocalMCPStoreState:
 
 class LocalMCPStore:
     def __init__(self, path: str | Path | None = None) -> None:
-        self.path = Path(path or DEFAULT_LOCAL_MCP_STORE_PATH)
+        self.path = Path(path) if path else _default_local_mcp_store_path()
 
     def load(self) -> LocalMCPStoreState:
         payload = self._read_payload()

--- a/tldw_chatbook/MCP/server.py
+++ b/tldw_chatbook/MCP/server.py
@@ -136,8 +136,8 @@ class TldwMCPServer:
         """Initialize database connections."""
         try:
             from ..config import (
-                get_cli_setting,
                 get_chachanotes_db_path,
+                get_media_db_path,
                 CLI_APP_CLIENT_ID,
             )
             from ..DB.ChaChaNotes_DB import CharactersRAGDB
@@ -150,9 +150,15 @@ class TldwMCPServer:
                 db_path=get_chachanotes_db_path(), client_id=CLI_APP_CLIENT_ID
             )
 
-            # Initialize media database
-            media_db_path = get_cli_setting("database", "media_db", "media_library.db")
-            self.media_db = MediaDatabase(media_db_path)
+            # Initialize media database. Uses the same resolver the rest of
+            # the app opens the media DB through -- ``get_cli_setting("database",
+            # "media_db", ...)`` used to read a config key ("media_db") that
+            # was never declared anywhere; the real key is "media_db_path"
+            # and get_media_db_path() is its accessor (see TASK-854).
+            media_db_path = get_media_db_path()
+            self.media_db = MediaDatabase(
+                db_path=media_db_path, client_id=CLI_APP_CLIENT_ID
+            )
 
             # Initialize services
             self.notes_service = NotesInteropService(self.chachanotes_db)

--- a/tldw_chatbook/MCP/server_target_store.py
+++ b/tldw_chatbook/MCP/server_target_store.py
@@ -6,16 +6,31 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
-from tldw_chatbook.config import DEFAULT_CONFIG_PATH
-
 from .unified_control_models import ConfiguredServerTarget, TargetStatusMetadata
 
-DEFAULT_SERVER_TARGETS_PATH = DEFAULT_CONFIG_PATH.parent / "mcp_server_targets.json"
+_SERVER_TARGETS_FILENAME = "mcp_server_targets.json"
+
+
+def _default_server_targets_path() -> Path:
+    """Return this store's path when constructed with no explicit argument.
+
+    Derives from ``config.get_user_data_dir()`` -- the same directory every
+    real construction site (``app.py``) already passes explicitly -- rather
+    than a stale, eagerly-computed module constant. See
+    ``local_store._default_local_mcp_store_path`` for why this is resolved
+    lazily instead of baked in at import time (TASK-855).
+
+    Returns:
+        ``get_user_data_dir() / "mcp_server_targets.json"``.
+    """
+    from tldw_chatbook.config import get_user_data_dir
+
+    return get_user_data_dir() / _SERVER_TARGETS_FILENAME
 
 
 class ConfiguredServerTargetStore:
     def __init__(self, path: str | Path | None = None) -> None:
-        self.path = Path(path or DEFAULT_SERVER_TARGETS_PATH)
+        self.path = Path(path) if path else _default_server_targets_path()
 
     def load(self) -> list[ConfiguredServerTarget]:
         payload = self._read_payload()

--- a/tldw_chatbook/MCP/unified_context_store.py
+++ b/tldw_chatbook/MCP/unified_context_store.py
@@ -7,18 +7,31 @@ from typing import Any
 
 from loguru import logger
 
-from tldw_chatbook.config import DEFAULT_CONFIG_PATH
-
 from .unified_control_models import UnifiedMCPContext
 
-DEFAULT_UNIFIED_MCP_CONTEXT_PATH = (
-    DEFAULT_CONFIG_PATH.parent / "unified_mcp_context.json"
-)
+_UNIFIED_MCP_CONTEXT_FILENAME = "unified_mcp_context.json"
+
+
+def _default_unified_mcp_context_path() -> Path:
+    """Return this store's path when constructed with no explicit argument.
+
+    Derives from ``config.get_user_data_dir()`` -- the same directory every
+    real construction site (``app.py``) already passes explicitly -- rather
+    than a stale, eagerly-computed module constant. See
+    ``local_store._default_local_mcp_store_path`` for why this is resolved
+    lazily instead of baked in at import time (TASK-855).
+
+    Returns:
+        ``get_user_data_dir() / "unified_mcp_context.json"``.
+    """
+    from tldw_chatbook.config import get_user_data_dir
+
+    return get_user_data_dir() / _UNIFIED_MCP_CONTEXT_FILENAME
 
 
 class UnifiedMCPContextStore:
     def __init__(self, path: str | Path | None = None) -> None:
-        self.path = Path(path or DEFAULT_UNIFIED_MCP_CONTEXT_PATH)
+        self.path = Path(path) if path else _default_unified_mcp_context_path()
 
     def load(self) -> UnifiedMCPContext:
         payload = self._read_payload()

--- a/tldw_chatbook/Notes/sync_service.py
+++ b/tldw_chatbook/Notes/sync_service.py
@@ -102,10 +102,12 @@ class NotesSyncService:
             db: Database instance
             config_path: Path to store sync profiles and configuration
         """
+        from ..config import _get_effective_config_path
+
         self.notes_service = notes_service
         self.db = db
-        self.config_path = (
-            config_path or Path.home() / ".config" / "tldw_cli" / "sync_profiles.json"
+        self.config_path = config_path or (
+            _get_effective_config_path().parent / "sync_profiles.json"
         )
         self.sync_engine = NotesSyncEngine(notes_service, db)
         self.profiles: Dict[str, SyncProfile] = {}

--- a/tldw_chatbook/RAG_Search/pipeline_builder_simple.py
+++ b/tldw_chatbook/RAG_Search/pipeline_builder_simple.py
@@ -519,8 +519,10 @@ def load_pipelines_from_toml():
 
     _TOML_PIPELINES = {}
 
+    from tldw_chatbook.config import _get_effective_config_path
+
     # Check user config directory first
-    user_config_dir = Path.home() / ".config" / "tldw_cli"
+    user_config_dir = _get_effective_config_path().parent
     user_config_file = user_config_dir / "rag_pipelines.toml"
 
     # Fall back to default location

--- a/tldw_chatbook/RAG_Search/pipeline_loader.py
+++ b/tldw_chatbook/RAG_Search/pipeline_loader.py
@@ -72,8 +72,10 @@ class PipelineLoader:
     def load_pipeline_config(self, config_file: Optional[Path] = None) -> None:
         """Load pipeline configurations from TOML file."""
         if config_file is None:
+            from tldw_chatbook.config import _get_effective_config_path
+
             # Check user config directory first
-            user_config_dir = Path.home() / ".config" / "tldw_cli"
+            user_config_dir = _get_effective_config_path().parent
             user_config_file = user_config_dir / "rag_pipelines.toml"
             default_config_file = self.config_dir / "rag_pipelines.toml"
 

--- a/tldw_chatbook/Subscriptions/website_monitor.py
+++ b/tldw_chatbook/Subscriptions/website_monitor.py
@@ -66,10 +66,12 @@ class WebsiteMonitor:
         Args:
             db: Subscriptions database instance
         """
+        from ..config import _get_effective_config_path
+
         self.db = db
         self.baseline_manager = BaselineManager(db)
         self.feed_monitor = FeedMonitor(RateLimiter(), SecurityValidator())
-        self.feed_cache_dir = Path.home() / ".config" / "tldw_cli" / "feed_cache"
+        self.feed_cache_dir = _get_effective_config_path().parent / "feed_cache"
         self.feed_cache_dir.mkdir(parents=True, exist_ok=True)
 
     async def monitor_website(self, subscription: Dict[str, Any]) -> Dict[str, Any]:

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -236,6 +236,7 @@ from ...config import (
     DEFAULT_CONSOLE_PASTE_COLLAPSE_THRESHOLD,
     MAX_CONSOLE_PASTE_COLLAPSE_THRESHOLD,
     MIN_CONSOLE_PASTE_COLLAPSE_THRESHOLD,
+    _get_effective_config_path,
     coerce_bool_setting,
     coerce_int_setting,
     delete_settings_from_cli_config,
@@ -16270,7 +16271,7 @@ class ChatScreen(BaseAppScreen):
 
     def _load_sidebar_state(self) -> None:
         """Load sidebar state from config file."""
-        config_path = Path.home() / ".config" / "tldw_cli" / "ui_state.toml"
+        config_path = _get_effective_config_path().parent / "ui_state.toml"
 
         try:
             if config_path.exists():
@@ -16301,7 +16302,7 @@ class ChatScreen(BaseAppScreen):
 
     def _save_sidebar_state(self) -> None:
         """Save sidebar state to config file."""
-        config_path = Path.home() / ".config" / "tldw_cli" / "ui_state.toml"
+        config_path = _get_effective_config_path().parent / "ui_state.toml"
         config_path.parent.mkdir(parents=True, exist_ok=True)
 
         try:

--- a/tldw_chatbook/Widgets/emoji_picker.py
+++ b/tldw_chatbook/Widgets/emoji_picker.py
@@ -54,17 +54,31 @@ ProcessedEmoji = Dict[
 ]  # {'char': str, 'name': str, 'category': str, 'aliases': List[str]}
 
 # Storage for recently used emojis
-RECENT_EMOJIS_FILE = Path.home() / ".config" / "tldw_cli" / "recent_emojis.json"
 MAX_RECENT_EMOJIS = 30
+
+
+def _recent_emojis_path() -> Path:
+    """Return the recent-emojis file path, honoring ``TLDW_CONFIG_PATH``.
+
+    Resolved lazily (at call time, not import time) via
+    ``config._get_effective_config_path()`` -- the same directory the
+    config file itself lives in -- rather than a ``Path.home()/".config"/
+    "tldw_cli"`` literal that always lands in the real config directory
+    regardless of which profile is active (TASK-865).
+    """
+    from ..config import _get_effective_config_path
+
+    return _get_effective_config_path().parent / "recent_emojis.json"
 
 
 def load_recent_emojis() -> List[str]:
     """Load recently used emojis from file."""
     try:
-        if RECENT_EMOJIS_FILE.exists():
+        recent_emojis_file = _recent_emojis_path()
+        if recent_emojis_file.exists():
             import json
 
-            with open(RECENT_EMOJIS_FILE, "r", encoding="utf-8") as f:
+            with open(recent_emojis_file, "r", encoding="utf-8") as f:
                 data = json.load(f)
                 return data.get("recent", [])[:MAX_RECENT_EMOJIS]
     except Exception:
@@ -75,8 +89,9 @@ def load_recent_emojis() -> List[str]:
 def save_recent_emoji(emoji_char: str) -> None:
     """Save an emoji to the recently used list."""
     try:
+        recent_emojis_file = _recent_emojis_path()
         # Ensure config directory exists
-        RECENT_EMOJIS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        recent_emojis_file.parent.mkdir(parents=True, exist_ok=True)
 
         # Load existing recent emojis
         recent = load_recent_emojis()
@@ -94,7 +109,7 @@ def save_recent_emoji(emoji_char: str) -> None:
         # Save back
         import json
 
-        with open(RECENT_EMOJIS_FILE, "w", encoding="utf-8") as f:
+        with open(recent_emojis_file, "w", encoding="utf-8") as f:
             json.dump({"recent": recent}, f, ensure_ascii=False, indent=2)
     except Exception:
         pass  # Fail silently for recent emojis

--- a/tldw_chatbook/Widgets/settings_theme_editor.py
+++ b/tldw_chatbook/Widgets/settings_theme_editor.py
@@ -63,7 +63,9 @@ class SettingsThemeEditor(Vertical):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self.custom_themes_path = Path.home() / ".config" / "tldw_cli" / "themes"
+        from ..config import _get_effective_config_path
+
+        self.custom_themes_path = _get_effective_config_path().parent / "themes"
         self.custom_themes_path.mkdir(parents=True, exist_ok=True)
         self.color_inputs: dict[str, Input] = {}
         self.color_swatches: dict[str, Static] = {}

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -2271,6 +2271,13 @@ writing_db_path = "~/.local/share/tldw_cli/tldw_chatbook_writing.db"
 library_collections_db_path = "~/.local/share/tldw_cli/tldw_chatbook_library_collections.db"
 # Path to the local Workspaces database.
 workspaces_db_path = "~/.local/share/tldw_cli/tldw_chatbook_workspaces.db"
+# Path to the Evals database.
+evals_db_path = "~/.local/share/tldw_cli/evals.db"
+# Path to the RAG indexing-state database (rag_indexing.db; tracks
+# incremental RAG indexing state -- it is not a vector store).
+rag_indexing_db_path = "~/.local/share/tldw_cli/rag_indexing.db"
+# Path to the Subscriptions database.
+subscriptions_db_path = "~/.local/share/tldw_cli/tldw_chatbook_subscriptions.db"
 USER_DB_BASE_DIR = "~/.local/share/tldw_cli/"
 
 # Database integrity checking


### PR DESCRIPTION
Closes TASK-854, TASK-855, TASK-858, TASK-866. Advances TASK-865 (left In Progress — see below).

Continuation of the path-naming audit from #964/#985. Same theme throughout: **a check or default that names a path by literal is wrong the moment the app resolves that path differently.**

## TASK-854 — the MCP server opened the wrong database

`MCP/server.py` read a config key `media_db` that **does not exist**, so `get_cli_setting` returned its default and the server silently opened `./media_library.db` — relative to the current working directory — instead of the real, denylisted media database.

Before: `<cwd>/media_library.db`. After: `get_media_db_path()`'s real path.

An AST-based sweep confirmed no other `get_cli_setting("database", ...)` call site uses an undeclared key, and that sweep is now a permanent test so the next one is caught automatically. Also fixed an adjacent `MediaDatabase()` missing-`client_id` bug that had to be resolved to make the method constructible for testing.

## TASK-855 — MCP store defaults pointed at a directory the app never uses

The three MCP store modules carried `~/.config/tldw_cli/...` defaults while the app passes explicit paths derived from `get_user_data_dir()`. Now derived **lazily, per call** rather than eagerly at import — an import-time constant would freeze whichever profile happened to be active when the module first loaded, which is the same staleness class the audit exists to close.

This matters beyond tidiness: `unified_control_plane_service` derives the permission store and execution log from this store's `.path`, so a store built with no argument would have placed both outside the sensitive-path denylist's coverage.

## TASK-858 — DB path maps reconciled

Fixed `eval_db_operations.py` and three undeclared config keys. The Settings DB-path map turned out to have been fixed already by TASK-899 — verified rather than redone.

## TASK-866 — tests that would go vacuous on drift

Two sites re-spelled an `app.py` literal instead of re-deriving it, so they would have failed silently in lockstep with a drift rather than catching it. Now derived.

## TASK-865 — partial, honestly

All explicitly-named sites are swept, plus a bonus pass. An aggregate remainder of roughly 25 sites is cataloged in the task rather than claimed done, and an adjacent finding (Chatbook window/wizard files bypassing the accessors) is flagged for its own follow-up. The task stays **In Progress**.

## A note on one test

`test_local_mcp_store_default_tracks_a_retargeted_profile` was written on a false premise — it set `TLDW_CONFIG_PATH` and expected the data directory to follow. It does not: `get_user_data_dir()` resolves from `[paths] data_dir` or the platform default, not from where the config file lives. Rewritten to patch the accessor at its source, with a comment explaining that patching the store module's attribute would silently not apply (the helper imports it inside the function body) and the test would then pass for the wrong reason.

## Testing

`Tests/MCP/ Tests/Evals/` → **838 passed, 0 failed**. `Tests/Utils/` 460, `Tests/Skills/` 375 at the time of implementation. The `Tests/Skills/` failures visible on this branch are pre-existing on dev — verified by running that suite on a pristine `origin/dev` worktree, which gives an identical 33 failed / 342 passed.

One conflict resolution worth flagging: dev had independently fixed the `chatbook_importer` extraction root **and hardened it further** with `secure_private_directory(..., application_owned=True)`. Dev's version supersedes ours and was kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes path resolution across the app to derive MCP, DB, and data-dir paths from real accessors, preventing wrong files and ensuring denylist coverage. Corrects the MCP server media DB, aligns evals DB path, and makes store defaults lazy and profile-aware; adds focused tests.

- **Bug Fixes**
  - TASK-854: MCP server now opens the media DB via get_media_db_path() and passes client_id; path is covered by the sensitive-path denylist. Adds an AST-based test to block undeclared `[database]` keys in get_cli_setting("database", ...).
  - TASK-855: `LocalMCPStore`, `UnifiedMCPContextStore`, and `ConfiguredServerTargetStore` now derive defaults lazily from `get_user_data_dir()`, not `~/.config/tldw_cli`. Keeps explicit-path sites unchanged and ensures permission/execution-log companions are denylisted.
  - TASK-858: `eval_db_operations.py` resolves the evals DB via `get_evals_db_path()`. Declares `evals_db_path`, `rag_indexing_db_path`, and `subscriptions_db_path` in the `[database]` template; Settings DB-path map parity remains intact.
  - TASK-865: Sweeps hardcoded `~/.config`/`~/.local/share` literals to accessors: UI `ui_state.toml`, note templates, feed cache, chatbook importer temp root (now matches creator), local chatbook registry fallback, character/chat exports; plus recent emojis file, custom themes, notes sync profiles, RAG pipeline configs, and `create_custom_template`. Adds tests for importer temp root parity and profile-aware UI state.
  - TASK-866: Tests/fixtures now re-derive paths from live objects (no re-spelled literals), covering MCP permission/execution logs and skills trust directories.

<sup>Written for commit b88c03923431338b172fef23931bb2bd3cd7e0c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

