### PR TITLE
fix(db,workspaces): make sql_validation match the real schema; gate folder binding on the denylist

### DIFF
--- a/.superpowers/sdd/task-864-857-report.md
+++ b/.superpowers/sdd/task-864-857-report.md
@@ -1,0 +1,368 @@
+# TASK-864 + TASK-857 — implementation report
+
+Worktree: `/Users/macbook-dev/Documents/GitHub/wt-864-857`
+Branch: `fix/sql-validation-and-workspace-denylist` (cut from `origin/dev`)
+Commits:
+- `a3d0a5189` — fix(db): reconcile sql_validation VALID_TABLES/VALID_COLUMNS with live schema
+- `b234c92ff` — fix(workspaces): consult the sensitive-path denylist at the folder-binding gate
+
+Shared theme: a check that cannot reject anything, or that rejects something
+real, is worse than no check. Both fixes below were reproduced broken first,
+fixed, and reproduced fixed, with the exact commands and output kept here.
+
+---
+
+## TASK-864 — `sql_validation.VALID_TABLES` / `VALID_COLUMNS`
+
+### Reproduction — before
+
+Ran from the worktree, `tldw_chatbook.__file__` confirmed resolving to the
+worktree (not the main checkout), `HOME`/`TLDW_CONFIG_PATH` redirected to a
+scratch temp dir:
+
+```
+PYTHONPATH=/Users/macbook-dev/Documents/GitHub/wt-864-857 \
+HOME=<scratch tmp> TLDW_CONFIG_PATH=<scratch tmp>/config.toml \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python - <<'EOF'
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+db = CharactersRAGDB(":memory:", client_id="repro-client")
+cid = db.add_keyword_collection("Coll A")
+print("created collection id:", cid)
+db.update_keyword_collection(cid, {"name": "Coll B"}, expected_version=1)
+EOF
+```
+
+Output (before the fix, on the branch point / `origin/dev`):
+
+```
+created collection id: 1
+WARNING  sql_validation:validate_table_name:287 - Table 'keyword_collections' not in whitelist for chachanotes database
+UPDATE FAILED: ValueError Invalid table name: keyword_collections
+```
+
+Confirms the task's claim exactly: `add_keyword_collection` succeeds,
+`update_keyword_collection` raises unconditionally.
+
+### Reproduction — after
+
+Same script, after the fix:
+
+```
+created collection id: 1
+UPDATE SUCCEEDED: True
+[{'id': 1, 'name': 'Coll B', 'parent_id': None, ..., 'version': 2}]
+```
+
+### How the table list was reconciled
+
+Instantiated a real, fully-migrated `CharactersRAGDB(":memory:")` (runs
+`_FULL_SCHEMA_SQL_V4` plus every `_migrate_from_vX_to_vY` step up to
+`_CURRENT_SCHEMA_VERSION = 27`) and read `sqlite_master` directly:
+
+```python
+db = CharactersRAGDB(":memory:", client_id="probe")
+rows = db.get_connection().execute(
+    "SELECT name, type FROM sqlite_master WHERE type IN ('table','view')"
+).fetchall()
+```
+
+This produced 108 `sqlite_master` rows. Filtering out `sqlite_sequence` and
+every name containing `_fts` (the FTS5 virtual tables and their
+`_data`/`_idx`/`_docsize`/`_config` shadow tables — written to exclusively by
+SQL triggers, never through a generic CRUD helper that calls
+`validate_table_name`) leaves **47 substantive tables**.
+
+This is where deriving from the *live* schema mattered rather than trusting
+the task's own audit text: the audit listed 26 missing names
+(`keyword_collections` + 25 others). The live schema actually has **38**
+tables missing from the old 9-name allowlist — the 26 the audit found, plus
+**12 more `rag_*` tables** (`rag_answer_attempt_payloads`,
+`rag_artifact_owner_leases`, `rag_artifact_owner_operations`,
+`rag_citation_traces`, `rag_evidence_runs`, `rag_evidence_snapshots`,
+`rag_identity_context`, `rag_legacy_migration_journal`,
+`rag_message_trace_owners`, `rag_payload_tombstones`,
+`rag_source_observations`, `rag_trace_evidence_refs`) that schema v27 (RAG
+citation provenance, merged since the audit ran) added. A hand-copy of the
+audit's own list would already have been incomplete on today's `dev`.
+
+### Was the list derived, or hand-reconciled?
+
+**Hand-reconciled**, deliberately, not derived at import/runtime. Reasoning
+kept as a comment above `VALID_TABLES` in `sql_validation.py`:
+
+- Building a live `CharactersRAGDB(":memory:")` as a side effect of
+  validating a table name would mean a lightweight, dependency-free SQL
+  identifier validator — shared by three otherwise-unrelated DB modules
+  (chachanotes/media/prompts, each with its own schema) — running all 27
+  migrations (with ~30 log lines) every time it needs the chachanotes table
+  set.
+- It would also require a lazy in-function import back into
+  `ChaChaNotes_DB.py` (which itself imports from `sql_validation` at module
+  scope) to avoid a circular import — workable, but adds a hidden runtime
+  dependency in the wrong direction for what should be the app's most
+  foundational, dependency-free validation module.
+
+Instead: the allowlist stays a hand-maintained `set`, and
+`Tests/DB/test_sql_validation.py::TestChachanotesValidTablesMatchesLiveSchema`
+derives the real table set the same way (`sqlite_master` on a live migrated
+DB) and asserts equality in **both** directions — `test_no_missing_tables`
+and `test_no_stale_tables` — so the next schema/allowlist divergence fails a
+test immediately, in CI, rather than surfacing as a user's `ValueError`. This
+is what the task's own AC #3 asked for ("if deriving is not practical, say
+why, and add a test that compares the list against the real schema").
+
+### `VALID_COLUMNS` decision (AC #4)
+
+Chose **both** options together, not either alone:
+
+1. Enumerated every real call site of `validate_column_name(column,
+   table_name)` across the repo. The only tables ever passed with a concrete
+   `table_name` (i.e. real code paths, not the two `_get_next_version` dead
+   helpers in `Prompts_DB.py`/`Client_Media_DB_v2.py` that have zero
+   callers) are: `character_cards`, `conversations`, `messages`, `notes`,
+   `keywords` (already present); `keyword_collections`
+   (`update_keyword_collection`/`soft_delete_keyword_collection`);
+   `sync_profile_state` (`Sync_Interop/sync_state_repository.py`'s
+   `_ensure_sync_v2_profile_columns`, immediately before an `ALTER TABLE ...
+   ADD COLUMN` f-string); and `Transcripts`/`MediaChunks`/
+   `UnvectorizedMediaChunks`/`DocumentVersions` (`Client_Media_DB_v2.py`'s
+   soft-delete/undelete cascade loops).
+2. Added `VALID_COLUMNS` entries for all six, columns verified against each
+   table's real `CREATE TABLE` statement (and `PRAGMA table_info` for
+   `keyword_collections`, to be certain — it has no `uuid`/`deleted_at`
+   unlike its siblings).
+3. Changed `validate_column_name`'s fallback from "table not in
+   `VALID_COLUMNS` → skip the per-table check, return whatever
+   `validate_identifier` alone decided" to "table not in `VALID_COLUMNS` →
+   return `False`" (fail closed). `table_name=None` (no schema context) is
+   unaffected and still skips the per-table check entirely.
+
+Justification: failing closed with nothing backfilled would have repeated
+the exact TASK-864 pattern — an absent allowlist entry unconditionally
+breaking a currently-working call site (this time `sync_profile_state`'s
+migration path, or the Media cascade tables). Backfilling without failing
+closed leaves the exact silent-no-op gap the audit flagged, where a future
+caller passing an unregistered table gets no column-specific check at all
+and no signal that it's missing. Doing both closes the gap without
+repeating 864's mistake. The two dead `_get_next_version` helpers were left
+untouched (no live callers today); if ever revived for a table without a
+`VALID_COLUMNS` entry, failing closed is the correct, safe behavior for them
+too — not a regression, since nothing calls them currently.
+
+### Test results
+
+- `Tests/DB/test_sql_validation.py` — 23 passed (was 21; 2 new test methods
+  in `TestChachanotesValidTablesMatchesLiveSchema`).
+- `Tests/ChaChaNotesDB/test_chachanotes_db.py` + `Tests/DB/` — 769 passed, 1
+  skipped, 1 pre-existing failure (`test_private_sqlite_inventory.py`,
+  confirmed failing identically on pristine `origin/dev` via `git stash` —
+  unrelated raw-`sqlite3.connect()` census drift in `Subscriptions_DB.py`,
+  not touched by this change).
+
+---
+
+## TASK-857 — workspace folder-binding vs. the sensitive-path denylist
+
+### Reproduction — before
+
+```
+PYTHONPATH=/Users/macbook-dev/Documents/GitHub/wt-864-857 \
+HOME=<scratch tmp> TLDW_CONFIG_PATH=<scratch tmp>/.config/tldw_cli/config.toml \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python - <<'EOF'
+from tldw_chatbook.config import get_user_data_dir, _get_effective_config_path
+from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+from tldw_chatbook.Workspaces import LocalWorkspaceRegistryService
+registry = LocalWorkspaceRegistryService(WorkspaceDB(<tmp path>, client_id="repro"))
+registry.ensure_default_workspace()
+registry.create_workspace(workspace_id="ws-a", name="Client A")
+registry.add_folder_binding("ws-a", get_user_data_dir())
+registry.add_folder_binding("ws-a", _get_effective_config_path().parent)
+registry.add_folder_binding("ws-a", Path.home() / ".ssh")
+EOF
+```
+
+Output (before the fix, on the branch point):
+
+```
+BOUND get_user_data_dir() SUCCESSFULLY: .../.local/share/tldw_cli/default_user
+BOUND ~/.config/tldw_cli SUCCESSFULLY: .../.config/tldw_cli
+BOUND ~/.ssh SUCCESSFULLY: .../.ssh
+```
+
+All three — this app's own database directory, its own config/API-key
+directory, and the user's SSH key directory — bound as workspace folder
+roots without any rejection. An ordinary project folder also bound
+successfully (as it must continue to).
+
+### Reproduction — after
+
+Same script, after the fix, plus two more cases (ancestor-of and
+subdirectory-of `get_user_data_dir()`):
+
+```
+REJECTED get_user_data_dir(): '.../default_user' cannot be bound: it is, or
+  contains, the protected path '.../default_user'. Choose a folder that does
+  not overlap this application's own data, configuration, or credential
+  directories.
+REJECTED ~/.config/tldw_cli: '.../.config/tldw_cli' cannot be bound: it is,
+  or contains, the protected path '.../.config/tldw_cli'. ...
+REJECTED ~/.ssh: '.../.ssh' cannot be bound: it is, or contains, the
+  protected path '.../.ssh'. ...
+REJECTED parent-of-user-data-dir: '.../.local/share/tldw_cli' cannot be
+  bound: it is, or contains, the protected path
+  '.../.local/share/tldw_cli/default_user'. ...
+REJECTED subdir-of-user-data-dir: '.../default_user/some_new_subdir' cannot
+  be bound: it is, or contains, the protected path '.../default_user'. ...
+BOUND ordinary project dir: <tmp>/Projects/myapp
+```
+
+Every message names the exact conflicting path (see "priority ordering"
+below for why `get_user_data_dir()` itself is reported as *itself*, not as
+containing the skill-trust subtree three levels down).
+
+### The containment rule chosen
+
+Reject a candidate root `R` (already resolved) if `R`:
+
+1. **IS** one of: the fixed sensitive directories (`~/.ssh`, `~/.aws`,
+   `~/.gnupg`, `~/.config/gcloud`, `~/.docker`, `~/.kube`,
+   `~/.local/share/keyrings`, plus the skill-trust subtree), or one of this
+   app's own state-container directories (`get_user_data_dir()`, the
+   effective config directory, the ChromaDB persist directory, the
+   RAG-profile directory), or one of the app's sensitive single
+   files/database paths (+ WAL/SHM/journal sidecars); **or**
+2. is **NESTED INSIDE** one of those directories (a subdirectory of
+   `get_user_data_dir()`, even one that doesn't look sensitive by name);
+   **or**
+3. **CONTAINS** one of those directories or files as a descendant (e.g.
+   `~/.local/share`, which contains `get_user_data_dir()`; `~/.config`,
+   which contains `~/.config/tldw_cli`).
+
+Implemented as `Utils.sensitive_paths.find_root_binding_conflict()`, reusing
+the exact same `SensitivePathContext` (`resolve_sensitive_context()`) that
+`is_sensitive_path` already resolves for read/write-time checks — so the
+binding gate can never enumerate a different protected-path set than the
+file tools do.
+
+**Why "any subdirectory of `get_user_data_dir()`", not just the specific
+files/dirs `is_sensitive_path` would flag on a per-path basis:** `
+is_sensitive_path`'s direct-child-file rule deliberately treats an
+*existing directory* nested inside `get_user_data_dir()` (e.g.
+`tool_sandbox`) as exempt, so individual file reads under it stay reachable
+— that rule exists to catch stray loose files landing directly in the data
+directory, not to certify the whole directory safe as a *binding root*.
+Binding grants blanket, recursive reachability to everything under the
+root; nothing legitimate needs to bind `get_user_data_dir()` (or anything
+inside it) directly in the first place, because
+`Tools.workspace_file_roots.allowed_file_roots` already includes the
+sandbox root (`get_user_data_dir()/tool_sandbox`) automatically, without
+ever going through `add_folder_binding`. So the binding gate is
+deliberately *coarser* than the per-path read-time check — refusing the
+whole container and everything in it — while the per-path check stays
+exactly as permissive as before for actual reads/writes (nothing about
+`is_sensitive_path` itself changed).
+
+**Why this doesn't degenerate into "refuse everything above home":**
+nothing hardcodes home as a boundary. The rule is purely "is, is nested in,
+or contains one of the *concrete* protected paths" — `~/.local/share` gets
+refused because it happens to contain `get_user_data_dir()`, not because of
+any home-relative rule. An ordinary project folder elsewhere on disk
+(`~/Projects/myapp`, or anywhere else that isn't an ancestor/descendant of
+one of the concrete protected paths) is untouched. In practice, on this
+platform, refusing every root that would reach one of the protected
+directories does end up refusing most coarse ancestors up to and including
+home — because most of the protected directories live under home — but
+that is a consequence of where the protected paths happen to live, not a
+rule written in terms of home itself.
+
+**Priority/tie-breaking when several protected paths match at once:**
+checked in three ordered passes — (1) exact self-match, (2) nested-inside
+(tie-broken toward the *deepest*/closest enclosing directory), (3) contains
+(tie-broken toward the *shallowest*/closest contained path). This is why
+binding `get_user_data_dir()` itself is reported as case (1) — "it IS the
+protected path" — even though it also technically *contains* the
+skill-trust subtree nested three levels down; and why binbinding its
+*parent* is reported as containing `get_user_data_dir()` itself (the
+nearest contained protected item), not the more deeply nested skill-trust
+subtree beneath it. Verified with a dedicated regression test
+(`test_find_root_binding_conflict_when_root_is_the_user_data_dir` /
+`..._when_root_contains_a_container`) after an initial implementation
+picked the wrong (more obscure) match on the first pass.
+
+### Rejection message / no silent failure
+
+`add_folder_binding` raises `WorkspaceRegistryServiceError` with the exact
+conflicting path named:
+
+```
+'{resolved}' cannot be bound: it is, or contains, the protected path
+'{conflict}'. Choose a folder that does not overlap this application's own
+data, configuration, or credential directories.
+```
+
+`UI/Screens/settings_screen.py`'s existing handler for this exact call site
+already catches `WorkspaceRegistryServiceError` and displays `str(exc)`
+verbatim in the Settings → Workspaces pane — no UI change was needed for
+the message to reach the user; it was already wired to surface whatever
+`add_folder_binding` raises.
+
+### Read-time behavior, and existing bindings
+
+**Unchanged.** `is_sensitive_path`'s own per-path checks (and the
+direct-child-file exemption for existing containers like `tool_sandbox`)
+were not touched — this fix is scoped to the binding *gate*, per the task.
+Consequence worth stating plainly: a folder bound **before** this fix that
+is, or contains, a protected path is **not retroactively unbound or
+re-validated**. Such a binding could still be unsafe until a user removes
+it (or re-adds it, which now goes through the new check) — no migration or
+background re-validation was added, since the task scoped this to the
+binding gate and asked to say so rather than silently attempt a migration.
+
+### Test results
+
+- `Tests/Utils/test_sensitive_paths.py` — all pass (5 new tests for
+  `find_root_binding_conflict`, covering all three cases plus the
+  ordinary-folder no-conflict case).
+- `Tests/Workspaces/test_workspace_folder_bindings.py` — all pass except one
+  **pre-existing** failure (`test_add_folder_binding_rejects_duplicates_and_nesting`),
+  confirmed failing identically on pristine `origin/dev` via `git stash`
+  (unrelated `private_paths` "missing_directory" issue when a second
+  `WorkspaceDB` is constructed under a not-yet-created subdirectory — not
+  caused by this change). One pre-existing test
+  (`test_add_folder_binding_validation_matrix`) needed a one-line update:
+  it previously bound `tmp_path` directly to test unknown-workspace
+  precedence; this suite's own `Tests/conftest.py` autouse HOME-redirection
+  fixture nests its fake config directory under `tmp_path`
+  (`tmp_path/test_data/config`), so `tmp_path` itself is now *correctly*
+  rejected as a folder-binding root under the new rule. Updated to bind a
+  freshly created subdirectory instead, which is what the test actually
+  intended to exercise.
+- `Tests/DB/` — 596 passed, 1 skipped, the same one pre-existing
+  `test_private_sqlite_inventory.py` failure as above (unrelated).
+- `Tests/Tools/test_workspace_file_roots.py` +
+  `test_file_tools_workspace_roots.py` + `test_file_tool_sandbox.py` — 31
+  passed.
+- `Tests/Utils/` (full directory) — 553 passed.
+
+---
+
+## Environment notes for anyone re-running these reproductions
+
+- Pin the interpreter and `PYTHONPATH` to the worktree explicitly:
+  `PYTHONPATH=/Users/macbook-dev/Documents/GitHub/wt-864-857
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python`. The
+  worktree has no `.venv` of its own, and an editable install resolves
+  `tldw_chatbook` to the main checkout unless `PYTHONPATH` wins.
+  `tldw_chatbook.__file__` was checked before trusting every probe in this
+  session.
+- Every ad hoc probe redirected `HOME` to a fresh scratch temp directory and
+  set `TLDW_CONFIG_PATH` to a file inside it — never the real user config or
+  databases. `WorkspaceDB`/`CharactersRAGDB` construction with a
+  `TLDW_CONFIG_PATH` under a not-yet-existing directory needs that
+  directory pre-created (`private_paths` verification fails closed
+  otherwise) — e.g. `mkdir -p "$HOME/.config/tldw_cli"` before setting
+  `TLDW_CONFIG_PATH=$HOME/.config/tldw_cli/config.toml`.
+- `CharactersRAGDB(":memory:")` works fine as a single-process probe;
+  `WorkspaceDB(":memory:")` does not (each connection gets its own private
+  `:memory:` database) — use a real temp file path for `WorkspaceDB` in ad
+  hoc scripts, as the existing test suite already does.

--- a/Tests/ChaChaNotesDB/test_chachanotes_db.py
+++ b/Tests/ChaChaNotesDB/test_chachanotes_db.py
@@ -844,6 +844,42 @@ class TestNotesAndKeywords:
         assert db_instance.unlink_conversation_from_keyword(conv_id, kw_id) is False
 
 
+class TestKeywordCollections:
+    """TASK-864: ``keyword_collections`` was omitted from
+    ``sql_validation.VALID_TABLES['chachanotes']``, so ``update_keyword_collection``
+    (and ``soft_delete_keyword_collection``) raised ``ValueError`` for every
+    caller, unconditionally -- this feature had no test coverage at all until
+    this class, which is exactly how the omission went unnoticed.
+    """
+
+    def test_add_then_update_keyword_collection(self, db_instance: CharactersRAGDB):
+        collection_id = db_instance.add_keyword_collection("Coll A")
+        assert isinstance(collection_id, int)
+
+        updated = db_instance.update_keyword_collection(
+            collection_id, {"name": "Coll B"}, expected_version=1
+        )
+        assert updated is True
+
+        collections = db_instance.list_keyword_collections()
+        names = {c["name"] for c in collections}
+        assert "Coll B" in names
+        assert "Coll A" not in names
+
+    def test_add_then_soft_delete_keyword_collection(
+        self, db_instance: CharactersRAGDB
+    ):
+        collection_id = db_instance.add_keyword_collection("Coll To Delete")
+
+        deleted = db_instance.soft_delete_keyword_collection(
+            collection_id, expected_version=1
+        )
+        assert deleted is True
+
+        names = {c["name"] for c in db_instance.list_keyword_collections()}
+        assert "Coll To Delete" not in names
+
+
 class TestGetAllNoteIds:
     """``get_all_note_ids`` -- the truncation-proof id source for Library
     chatbook export (see ``Library/library_export_scope.py``).

--- a/Tests/DB/test_sql_validation.py
+++ b/Tests/DB/test_sql_validation.py
@@ -3,6 +3,7 @@ Unit tests for SQL validation module.
 """
 
 from tldw_chatbook.DB.sql_validation import (
+    VALID_TABLES,
     validate_identifier,
     validate_table_name,
     validate_column_name,
@@ -75,6 +76,7 @@ class TestValidateTableName:
             "messages",
             "notes",
             "keywords",
+            "keyword_collections",
             "conversation_keywords",
             "collection_keywords",
             "note_keywords",
@@ -322,3 +324,78 @@ class TestSQLValidationIntegration:
 
         for identifier in unicode_identifiers:
             assert validate_identifier(identifier) is True
+
+
+def _live_chachanotes_table_names() -> set[str]:
+    """Derive the real, substantive ChaChaNotes table set from a live DB.
+
+    Builds a real ``CharactersRAGDB(":memory:")`` -- which runs the full
+    ``_FULL_SCHEMA_SQL_V4`` script plus every ``_migrate_from_vX_to_vY``
+    step up to ``_CURRENT_SCHEMA_VERSION`` -- and reads its
+    ``sqlite_master`` directly, rather than re-typing a literal table list
+    that could just as easily go stale as ``VALID_TABLES`` itself did
+    (TASK-864). This is the "real schema" ``VALID_TABLES['chachanotes']``
+    is meant to allowlist.
+
+    Excludes:
+
+    * ``sqlite_sequence`` -- SQLite's own AUTOINCREMENT bookkeeping table,
+      never a validation target.
+    * FTS5 shadow/virtual tables (anything with ``_fts`` in its name --
+      the virtual table itself, e.g. ``notes_fts``, plus its ``_data``/
+      ``_idx``/``_docsize``/``_config`` shadow tables). These are written
+      to exclusively by SQL triggers, never through a generic CRUD helper
+      that calls ``validate_table_name``, and the omissions TASK-864 found
+      were all substantive data tables, not search-index plumbing.
+
+    Returns:
+        The set of real, substantive table names the live schema defines.
+    """
+    from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+    db = CharactersRAGDB(":memory:", client_id="sql-validation-schema-sync-test")
+    try:
+        conn = db.get_connection()
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"
+        ).fetchall()
+    finally:
+        db.close_connection()
+
+    return {
+        row["name"]
+        for row in rows
+        if row["name"] != "sqlite_sequence" and "_fts" not in row["name"]
+    }
+
+
+class TestChachanotesValidTablesMatchesLiveSchema:
+    """TASK-864: catch the next allowlist/schema drift automatically.
+
+    ``VALID_TABLES['chachanotes']`` is hand-maintained (see the comment
+    above its definition in ``sql_validation.py`` for why it is not derived
+    at import time), so nothing stops a future migration from adding a
+    table without updating it -- exactly how ``keyword_collections`` was
+    missed. This test is the guard: it fails the moment the two diverge,
+    instead of waiting for a user to hit an unconditional ``ValueError``.
+    """
+
+    def test_no_missing_tables(self):
+        """Every real, substantive table in the live schema must be allowlisted."""
+        live_tables = _live_chachanotes_table_names()
+        missing = live_tables - VALID_TABLES["chachanotes"]
+        assert not missing, (
+            f"Live schema has tables not in VALID_TABLES['chachanotes']: "
+            f"{sorted(missing)}. Add them (or document a deliberate "
+            f"exclusion) in tldw_chatbook/DB/sql_validation.py."
+        )
+
+    def test_no_stale_tables(self):
+        """Every allowlisted name must correspond to a real, live table."""
+        live_tables = _live_chachanotes_table_names()
+        stale = VALID_TABLES["chachanotes"] - live_tables
+        assert not stale, (
+            f"VALID_TABLES['chachanotes'] allowlists tables that no longer "
+            f"exist in the live schema: {sorted(stale)}. Remove them from "
+            f"tldw_chatbook/DB/sql_validation.py."
+        )

--- a/Tests/Utils/test_sensitive_paths.py
+++ b/Tests/Utils/test_sensitive_paths.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from tldw_chatbook.Utils.sensitive_paths import (
+    find_root_binding_conflict,
     is_sensitive_path,
     refuses_new_directory_chain,
 )
@@ -523,6 +524,81 @@ def test_refuses_new_directory_chain_blocks_the_collision():
 
     assert refuses_new_directory_chain(target.parent)
     assert not (user_data_dir / "search_history.db").exists()
+
+
+# ---------------------------------------------------------------------------
+# TASK-857: the folder-binding reachability gate (``find_root_binding_conflict``).
+# ---------------------------------------------------------------------------
+
+
+def test_find_root_binding_conflict_when_root_is_a_sensitive_dir():
+    """``root`` resolving exactly to one of the fixed sensitive directories
+    (e.g. ``~/.ssh``) must be reported -- ``is_sensitive_path`` alone would
+    also catch this candidate, but the binding gate needs the conflicting
+    path back, not just a bool, so it can name it in its own message.
+    """
+    ssh_dir = Path("~/.ssh").expanduser()
+    ssh_dir.mkdir(parents=True, exist_ok=True)
+
+    conflict = find_root_binding_conflict(ssh_dir.resolve())
+
+    assert conflict == ssh_dir.resolve()
+
+
+def test_find_root_binding_conflict_when_root_is_the_user_data_dir():
+    """``root`` resolving exactly to ``get_user_data_dir()`` must be
+    reported as itself (case (1): "root IS the protected path"), not as
+    some unrelated descendant like the skill-trust subtree -- see the
+    priority-ordering note in ``find_root_binding_conflict``'s docstring.
+    """
+    from tldw_chatbook import config as app_config
+
+    user_data_dir = app_config.get_user_data_dir()
+    user_data_dir.mkdir(parents=True, exist_ok=True)
+
+    conflict = find_root_binding_conflict(user_data_dir)
+
+    assert conflict == user_data_dir
+
+
+def test_find_root_binding_conflict_when_root_is_nested_inside_a_container():
+    """A subdirectory of ``get_user_data_dir()`` must be reported as a
+    conflict too -- it doesn't look sensitive by name, but binding it would
+    grant blanket, recursive reachability under an app-state directory.
+    """
+    from tldw_chatbook import config as app_config
+
+    user_data_dir = app_config.get_user_data_dir()
+    nested = user_data_dir / "some_subdir"
+    nested.mkdir(parents=True, exist_ok=True)
+
+    conflict = find_root_binding_conflict(nested)
+
+    assert conflict == user_data_dir
+
+
+def test_find_root_binding_conflict_when_root_contains_a_container():
+    """The reverse direction: ``root`` itself doesn't look sensitive, but
+    it is coarse enough to CONTAIN ``get_user_data_dir()`` as a descendant.
+    """
+    from tldw_chatbook import config as app_config
+
+    user_data_dir = app_config.get_user_data_dir()
+    user_data_dir.mkdir(parents=True, exist_ok=True)
+    ancestor = user_data_dir.parent
+
+    conflict = find_root_binding_conflict(ancestor)
+
+    assert conflict == user_data_dir
+
+
+def test_find_root_binding_conflict_is_none_for_an_ordinary_folder(tmp_path):
+    """No regression on the common case: an ordinary project folder
+    unrelated to any of this app's own state has no conflict."""
+    ordinary = tmp_path / "ordinary-project"
+    ordinary.mkdir()
+
+    assert find_root_binding_conflict(ordinary) is None
 
 
 def test_refuses_new_directory_chain_allows_existing_containers():

--- a/Tests/Workspaces/test_workspace_folder_bindings.py
+++ b/Tests/Workspaces/test_workspace_folder_bindings.py
@@ -68,8 +68,84 @@ def test_add_folder_binding_validation_matrix(
         service.add_folder_binding("ws-a", Path("/"))
     with pytest.raises(WorkspaceRegistryServiceError):
         service.add_folder_binding("ws-a", Path.home())
+    # TASK-857: an ordinary subdirectory, not `tmp_path` itself -- this
+    # suite's own autouse HOME-redirection fixture (Tests/conftest.py)
+    # nests the test's effective config directory under `tmp_path`
+    # (`tmp_path/test_data/config`), so `tmp_path` is now correctly
+    # rejected as a folder-binding root in its own right; that is not what
+    # this assertion is testing (unknown-workspace precedence), so use an
+    # ordinary carved-out folder instead.
+    ok_folder = tmp_path / "ok"
+    ok_folder.mkdir()
     with pytest.raises(WorkspaceNotFound):
-        service.add_folder_binding("ws-missing", tmp_path)
+        service.add_folder_binding("ws-missing", ok_folder)
+
+
+def test_add_folder_binding_rejects_sensitive_paths(
+    service: LocalWorkspaceRegistryService,
+) -> None:
+    """TASK-857: folder binding must consult the sensitive-path denylist,
+    not just the filesystem root and home directory. Every candidate here
+    is derived from the app's own accessors (never a re-spelled literal),
+    per the AC, so this can't silently drift the way the read-time
+    denylist's own literals once did.
+    """
+    from tldw_chatbook import config as app_config
+
+    # Case 1: root IS a protected directory (this app's own config dir).
+    config_dir = app_config._get_effective_config_path().parent
+    config_dir.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(WorkspaceRegistryServiceError):
+        service.add_folder_binding("ws-a", config_dir)
+
+    # Case 2: root IS a protected directory (this app's own data dir).
+    user_data_dir = app_config.get_user_data_dir()
+    user_data_dir.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(WorkspaceRegistryServiceError):
+        service.add_folder_binding("ws-a", user_data_dir)
+
+    # Case 3: root is NESTED INSIDE a protected directory -- a subdirectory
+    # of get_user_data_dir() must be refused too, even though it doesn't
+    # look sensitive by name alone.
+    nested = user_data_dir / "some_subdir"
+    nested.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(WorkspaceRegistryServiceError):
+        service.add_folder_binding("ws-a", nested)
+
+    # Case 4: root is coarse enough to CONTAIN a protected directory --
+    # the reverse direction, where the root itself doesn't look sensitive.
+    ancestor_of_user_data_dir = user_data_dir.parent
+    with pytest.raises(WorkspaceRegistryServiceError):
+        service.add_folder_binding("ws-a", ancestor_of_user_data_dir)
+
+
+def test_add_folder_binding_rejection_names_the_protected_path(
+    service: LocalWorkspaceRegistryService,
+) -> None:
+    """The rejection must be actionable -- name what was protected -- not a
+    silent failure or a bare/opaque exception."""
+    from tldw_chatbook import config as app_config
+
+    user_data_dir = app_config.get_user_data_dir()
+    user_data_dir.mkdir(parents=True, exist_ok=True)
+
+    with pytest.raises(WorkspaceRegistryServiceError) as excinfo:
+        service.add_folder_binding("ws-a", user_data_dir)
+
+    assert str(user_data_dir) in str(excinfo.value)
+
+
+def test_add_folder_binding_still_binds_an_ordinary_project_folder(
+    service: LocalWorkspaceRegistryService, tmp_path: Path
+) -> None:
+    """TASK-857 AC#3: no regression on the common case -- an ordinary
+    project folder unrelated to any of this app's own state still binds."""
+    folder = tmp_path / "ordinary-project"
+    folder.mkdir()
+
+    binding = service.add_folder_binding("ws-a", folder)
+
+    assert binding.locator == str(folder.resolve())
 
 
 def test_add_folder_binding_rejects_default_workspace(

--- a/backlog/tasks/task-857 - Make-workspace-folder-binding-consult-the-sensitive-path-denylist-not-just-home-root.md
+++ b/backlog/tasks/task-857 - Make-workspace-folder-binding-consult-the-sensitive-path-denylist-not-just-home-root.md
@@ -3,9 +3,11 @@ id: TASK-857
 title: >-
   Make workspace folder-binding consult the sensitive-path denylist, not just
   home/root
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-27 04:35'
+updated_date: '2026-07-27 17:43'
 labels:
   - security
   - tools
@@ -20,7 +22,38 @@ Workspaces/registry_service.py:673-707 validates a folder root to bind as a work
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Folder-binding validation rejects a candidate root that is, or resolves inside, any path flagged by is_sensitive_path() / the app's sensitive-path containers (user data dir, effective config dir, etc.), not just the filesystem root and home directory
-- [ ] #2 A test attempts to bind ~/.config/tldw_cli, get_user_data_dir(), and a subdirectory of get_user_data_dir() as workspace folder roots (derived from the real accessors, not literal strings) and confirms all are rejected
-- [ ] #3 A test confirms an ordinary, non-sensitive folder root still binds successfully (no regression on the common case)
+- [x] #1 Folder-binding validation rejects a candidate root that is, or resolves inside, any path flagged by is_sensitive_path() / the app's sensitive-path containers (user data dir, effective config dir, etc.), not just the filesystem root and home directory
+- [x] #2 A test attempts to bind ~/.config/tldw_cli, get_user_data_dir(), and a subdirectory of get_user_data_dir() as workspace folder roots (derived from the real accessors, not literal strings) and confirms all are rejected
+- [x] #3 A test confirms an ordinary, non-sensitive folder root still binds successfully (no regression on the common case)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the gap: bind get_user_data_dir(), the effective config directory, and ~/.ssh as workspace folder roots against origin/dev and confirm add_folder_binding accepts all three.
+2. Add a containment-aware helper in Utils/sensitive_paths.py (find_root_binding_conflict) that answers the question the binding gate actually needs -- not "is this one candidate sensitive" (is_sensitive_path) but "would granting recursive access under this root reach a protected path", in both directions (root is/is-nested-in a protected dir, or root contains one), reusing the same resolved sensitive-path context so it can never drift from the read-time denylist.
+3. Wire add_folder_binding to consult it and raise a clear, actionable WorkspaceRegistryServiceError naming the specific conflicting path.
+4. Confirm the same three scenarios are now rejected, and that an ordinary project folder still binds.
+5. Add unit tests for the new helper (both containment directions, priority/tie-breaking when several protected paths match) and integration tests on add_folder_binding (denylist paths derived from real accessors, rejection message content, ordinary-folder regression check).
+6. Run Tests/Utils/, Tests/Workspaces/, Tests/DB/, and the workspace-file-roots tests in Tests/Tools/ to confirm no regressions.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reproduced first (see report): binding get_user_data_dir(), the effective config directory (~/.config/tldw_cli), and ~/.ssh as workspace folder roots all succeeded on origin/dev via add_folder_binding -- confirmed the audit's claim that only the filesystem-root/home-directory checks existed, with no reference to Utils.sensitive_paths anywhere under Workspaces/. All three are rejected after this change; an ordinary project folder still binds.
+
+Added Utils/sensitive_paths.find_root_binding_conflict(root, context=None) -> Path | None: reuses the same SensitivePathContext (dirs, direct_child_denied_dirs, files, db_paths) the read-time is_sensitive_path already resolves, so the binding gate can never enumerate a different set of protected paths than file-tool reads do. It answers a different question than is_sensitive_path though: not "is this one candidate sensitive" but "would granting recursive, blanket access under this root reach a protected path", checked in three passes in priority order: (1) root IS a protected path itself, (2) root is nested INSIDE a protected directory (tie-broken toward the deepest/closest enclosing one), (3) root CONTAINS a protected directory or file (tie-broken toward the shallowest/closest contained one, so an ancestor of get_user_data_dir() is reported as containing user_data_dir itself, not an obscure subtree three levels further down).
+
+Containment rule chosen: reject a root that IS, is NESTED INSIDE, or CONTAINS any of: the fixed sensitive directories (~/.ssh et al + the skill-trust subtree), this app's own state-container directories (get_user_data_dir(), the effective config directory, the ChromaDB persist directory, the RAG-profile directory), or its sensitive single files/DB paths (+ WAL/SHM/journal sidecars). This deliberately goes further than is_sensitive_path's own per-path rule: is_sensitive_path's direct-child-file exemption for existing directories (e.g. tool_sandbox nested under get_user_data_dir()) exists to keep specific, already-known-good containers reachable for individual file reads -- it was never meant to make an entire application-state directory safe to grant as a BINDING ROOT, since that hands over everything else nested inside it too, known-good or not. Concretely: binding get_user_data_dir() itself, or ANY subdirectory of it (not just the specific ones the direct-child rule would flag), is refused -- nothing legitimate needs to bind it directly, since Tools.workspace_file_roots.allowed_file_roots already includes the sandbox root automatically without ever going through this gate. The reverse direction (binding a coarse ancestor like ~/.local/share or ~/.config, which merely *contains* one of these directories) is refused via the same rule, which is what keeps this from degenerating into "just refuse everything below home": nothing hardcodes home as a boundary, it falls out naturally from containment of the concrete protected paths, most of which live under home in practice.
+
+Left unchanged (per the task): what already-bound folders do at read time. is_sensitive_path's own per-path checks (and the direct-child-file exemption) are untouched; this fix is scoped to the binding gate only. Any folder bound before this fix that happens to be, or contain, a protected path is NOT retroactively unbound or re-validated -- an existing binding could still be unsafe until removed and re-added, or until a future task adds binding re-validation. Not addressed here to keep this change scoped to the acceptance criteria.
+
+The rejection message names the specific conflicting path directly (not just "a sensitive path exists somewhere"), and is surfaced verbatim to the user via UI/Screens/settings_screen.py's existing WorkspaceRegistryServiceError handler (already displays str(exc) in the workspaces pane) -- no UI change needed, satisfying "not a silent failure or bare exception" for free.
+
+Modified/added files:
+- tldw_chatbook/Utils/sensitive_paths.py (new find_root_binding_conflict)
+- tldw_chatbook/Workspaces/registry_service.py (add_folder_binding consults it, raises a message naming the protected path)
+- Tests/Utils/test_sensitive_paths.py (unit tests for the new helper: is/nested-in/contains, tie-breaking, ordinary-folder no-conflict)
+- Tests/Workspaces/test_workspace_folder_bindings.py (integration tests: rejects ~/.config/tldw_cli, get_user_data_dir(), a subdirectory of it, and an ancestor of it -- all derived from real accessors; rejection message names the path; ordinary folder still binds); one pre-existing test (test_add_folder_binding_validation_matrix) updated to bind a carved-out subdirectory instead of tmp_path itself, since this suite's own HOME-redirection fixture nests its fake config directory under tmp_path, which is now correctly rejected in its own right
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-864 - Fix-sql_validation.VALID_TABLES-to-match-the-real-schema-keyword_collections-is-live-broken.md
+++ b/backlog/tasks/task-864 - Fix-sql_validation.VALID_TABLES-to-match-the-real-schema-keyword_collections-is-live-broken.md
@@ -3,9 +3,11 @@ id: TASK-864
 title: >-
   Fix sql_validation.VALID_TABLES to match the real schema (keyword_collections
   is live-broken)
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-27 04:35'
+updated_date: '2026-07-27 17:28'
 labels:
   - security
   - db
@@ -22,8 +24,36 @@ Separately, DB/sql_validation.py:308's VALID_COLUMNS gate (if table_name and tab
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 sql_validation.VALID_TABLES['chachanotes'] includes keyword_collections and every other real table in the live schema (all 26 currently-missing names reconciled, added or deliberately excluded with a documented reason)
-- [ ] #2 update_keyword_collection() succeeds end to end (create then update) without a false-positive ValueError
-- [ ] #3 A test derives its expected table list from the live schema (e.g. sqlite_master or the DB's own migration-applied table set) rather than re-typing a literal list, so it catches future schema/allowlist drift
-- [ ] #4 A decision is made and implemented for VALID_COLUMNS: either it fails closed for table names absent from its key set, or every real caller's table name is added to it
+- [x] #1 sql_validation.VALID_TABLES['chachanotes'] includes keyword_collections and every other real table in the live schema (all 26 currently-missing names reconciled, added or deliberately excluded with a documented reason)
+- [x] #2 update_keyword_collection() succeeds end to end (create then update) without a false-positive ValueError
+- [x] #3 A test derives its expected table list from the live schema (e.g. sqlite_master or the DB's own migration-applied table set) rather than re-typing a literal list, so it catches future schema/allowlist drift
+- [x] #4 A decision is made and implemented for VALID_COLUMNS: either it fails closed for table names absent from its key set, or every real caller's table name is added to it
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the update_keyword_collection break against origin/dev (add_keyword_collection then update_keyword_collection) and capture the ValueError.
+2. Instantiate a real, fully-migrated CharactersRAGDB(":memory:") and read sqlite_master to get the true, current table set (excluding FTS5 shadow/virtual tables and sqlite_sequence); diff it against VALID_TABLES['chachanotes'].
+3. Reconcile VALID_TABLES['chachanotes'] by hand against that derived list (documenting why derivation-at-runtime is not done inside sql_validation.py itself: circular-import/heavyweight-DB-construction concerns), and add a test that re-derives the live set and fails on any future divergence in either direction.
+4. Re-run the reproduction to confirm update_keyword_collection now succeeds; add regression tests for add/update/soft-delete of keyword_collections (currently zero coverage).
+5. Enumerate every real caller of validate_column_name(column, table_name) across the codebase to see which table names are passed; decide whether to fail closed for tables missing from VALID_COLUMNS or backfill every real caller's table -- do both: add the missing tables (keyword_collections, sync_profile_state, Transcripts, MediaChunks, UnvectorizedMediaChunks, DocumentVersions) so nothing currently working regresses, then make the fallback fail closed.
+6. Run the sql_validation, ChaChaNotesDB, and related DB test suites to confirm no regressions.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reproduced the break first (see report): add_keyword_collection('Coll A') then update_keyword_collection(1, {'name': 'Coll B'}, expected_version=1) raised ValueError: Invalid table name: keyword_collections on origin/dev. Confirmed fixed after this change.
+
+Reconciled VALID_TABLES['chachanotes']: instantiated a real, fully-migrated CharactersRAGDB(":memory:") and read sqlite_master directly rather than trusting the task's own 26-name list, which turned out to already be stale -- schema v27 (RAG citation provenance, merged since the audit) added 12 more rag_* tables the audit never saw. The live schema has 47 substantive tables (excluding FTS5 shadow/virtual tables and sqlite_sequence); all 47 are now allowlisted (38 were missing: the 26 the audit found + 12 newer rag_* tables + keyword_collections itself was already counted in the 26).
+
+Did NOT derive VALID_TABLES at runtime/import time from a live DB: doing so would mean sql_validation.py -- a lightweight, dependency-free identifier validator shared by three otherwise-unrelated DB modules (chachanotes/media/prompts) -- constructing a full CharactersRAGDB (running all 27 migrations, ~30 log lines) as a side effect of validating a table name, and would require a lazy in-function import back into ChaChaNotes_DB.py to avoid a circular import. Instead: the allowlist stays hand-maintained (with a comment explaining why), and Tests/DB/test_sql_validation.py::TestChachanotesValidTablesMatchesLiveSchema derives the real table set the same way (sqlite_master on a live migrated DB) and fails in both directions (missing OR stale) the moment they diverge -- this is what actually "catches future schema/allowlist drift" per AC #3, since a hand-copied list (like the task's own 26 names) demonstrably goes stale.
+
+VALID_COLUMNS decision (AC #4): chose BOTH options together rather than either alone. Enumerated every real call site of validate_column_name(column, table_name) across the repo: the only tables ever passed with a concrete table_name are character_cards/conversations/messages/notes/keywords (already present), keyword_collections (ChaChaNotes_DB.update_keyword_collection/soft_delete_keyword_collection), sync_profile_state (Sync_Interop/sync_state_repository._ensure_sync_v2_profile_columns, right before an ALTER TABLE ADD COLUMN f-string), and Transcripts/MediaChunks/UnvectorizedMediaChunks/DocumentVersions (Client_Media_DB_v2's soft-delete/undelete cascade loops). Added VALID_COLUMNS entries for all of these (columns verified against each table's real CREATE TABLE / PRAGMA table_info), then changed validate_column_name's fallback from "silently skip the check" to "return False" for any table_name that still isn't registered. Rationale: failing closed with nothing backfilled would have repeated the exact 864 pattern (an absent entry unconditionally breaking a currently-working call site); backfilling without failing closed leaves the exact silent-no-op gap the audit flagged. Two currently-dead, fully-dynamic helper methods (Prompts_DB._get_next_version, Client_Media_DB_v2._get_next_version) have no live callers today, so they were left as-is -- if ever revived for a table without a VALID_COLUMNS entry, fail-closed is the correct (safe) behavior for them too, not a regression since nothing calls them now.
+
+Modified/added files:
+- tldw_chatbook/DB/sql_validation.py (VALID_TABLES['chachanotes'] reconciled to 47 real tables with rationale comment; VALID_COLUMNS gained keyword_collections/sync_profile_state/Transcripts/MediaChunks/UnvectorizedMediaChunks/DocumentVersions; validate_column_name fails closed for unregistered tables)
+- Tests/DB/test_sql_validation.py (added keyword_collections to the existing valid-tables test; added TestChachanotesValidTablesMatchesLiveSchema deriving the expected table set from sqlite_master on a live migrated DB, both directions)
+- Tests/ChaChaNotesDB/test_chachanotes_db.py (added TestKeywordCollections: add+update and add+soft-delete lifecycle tests -- this table had zero test coverage before, which is how the omission went unnoticed)
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/DB/sql_validation.py
+++ b/tldw_chatbook/DB/sql_validation.py
@@ -10,17 +10,79 @@ from typing import Optional
 from loguru import logger
 
 # Define valid table names for each database
+#
+# NOTE (TASK-864): the "chachanotes" set below used to only allowlist 9 of the
+# ~47 real tables the live schema creates (``ChaChaNotes_DB._FULL_SCHEMA_SQL_V4``
+# plus every ``_migrate_from_vX_to_vY`` step run up to
+# ``CharactersRAGDB._CURRENT_SCHEMA_VERSION``), which made
+# ``update_keyword_collection()`` raise ``ValueError`` unconditionally --
+# ``keyword_collections`` itself was one of the omissions. This set is kept
+# hand-maintained rather than derived at import time from a live
+# ``CharactersRAGDB(":memory:")`` for two reasons: (1) building one runs the
+# full schema-creation + every migration step as a side effect of importing a
+# lightweight identifier-validation module used by three otherwise-unrelated
+# DB modules (chachanotes/media/prompts each have their own schema; deriving
+# for just one would be inconsistent), and (2) it would make this module
+# depend on ``ChaChaNotes_DB`` at runtime, which itself imports from this
+# module -- a lazy in-function import avoids a hard cycle but the
+# heavyweight, logging-generating DB construction as a side effect of
+# validating a table name is worse than the alternative below.
+# Instead, ``Tests/DB/test_sql_validation.py`` asserts this set against
+# ``sqlite_master`` of a real, fully-migrated ``CharactersRAGDB(":memory:")``
+# (excluding FTS5 shadow/virtual tables and ``sqlite_sequence`` -- see that
+# test for the exact filter) so any future migration that adds, renames, or
+# removes a table fails the test immediately instead of surfacing as a user
+# hitting an unconditional ``ValueError`` the next time they touch the new
+# table through a generic CRUD helper.
 VALID_TABLES = {
     "chachanotes": {
         "character_cards",
-        "conversations",
-        "messages",
-        "notes",
-        "keywords",
-        "conversation_keywords",
+        "character_expression_images",
+        "chat_dictionaries",
         "collection_keywords",
+        "conversation_dictionaries",
+        "conversation_keywords",
+        "conversation_local_marks",
+        "conversation_world_books",
+        "conversations",
+        "db_schema_version",
+        "decks",
+        "flashcard_assets",
+        "flashcard_templates",
+        "flashcards",
+        "keyword_collections",
+        "keywords",
+        "learning_paths",
+        "message_attachments",
+        "message_generation_metadata",
+        "messages",
+        "mindmap_nodes",
+        "mindmaps",
         "note_keywords",
+        "notes",
+        "quiz_attempts",
+        "quiz_questions",
+        "quizzes",
+        "rag_answer_attempt_payloads",
+        "rag_artifact_owner_leases",
+        "rag_artifact_owner_operations",
+        "rag_citation_traces",
+        "rag_evidence_runs",
+        "rag_evidence_snapshots",
+        "rag_identity_context",
+        "rag_legacy_migration_journal",
+        "rag_message_trace_owners",
+        "rag_payload_tombstones",
+        "rag_source_observations",
+        "rag_trace_evidence_refs",
+        "review_history",
+        "study_sessions",
+        "sync_conflicts",
         "sync_log",
+        "sync_sessions",
+        "topics",
+        "world_book_entries",
+        "world_books",
     },
     "media": {
         "Media",
@@ -124,6 +186,22 @@ VALID_COLUMNS = {
         "deleted_at",
         "client_id",
     },
+    # TASK-864: real caller is ChaChaNotes_DB.update_keyword_collection() /
+    # soft_delete_keyword_collection() via _update_generic_item /
+    # _soft_delete_generic_item, both passing pk_col_name="id". Columns
+    # verified against ``PRAGMA table_info(keyword_collections)`` on a live
+    # migrated DB -- note there is deliberately no ``uuid``/``deleted_at``
+    # here, unlike the sibling tables above.
+    "keyword_collections": {
+        "id",
+        "name",
+        "parent_id",
+        "created_at",
+        "last_modified",
+        "deleted",
+        "client_id",
+        "version",
+    },
     # Media DB
     "Media": {
         "id",
@@ -157,6 +235,76 @@ VALID_COLUMNS = {
         "deleted_at",
         "client_id",
     },
+    # TASK-864: these four are Media's soft-delete/undelete cascade child
+    # tables (Client_Media_DB_v2.py, ``child_tables`` cascade loops in
+    # ``soft_delete_media``/``undelete_media``), which always validate
+    # ``fk_col="media_id"``/``uuid_col="uuid"``. Columns verified against
+    # each table's own ``CREATE TABLE`` in Client_Media_DB_v2.py.
+    "Transcripts": {
+        "id",
+        "media_id",
+        "whisper_model",
+        "transcription",
+        "created_at",
+        "uuid",
+        "last_modified",
+        "version",
+        "client_id",
+        "deleted",
+        "prev_version",
+        "merge_parent_uuid",
+    },
+    "MediaChunks": {
+        "id",
+        "media_id",
+        "chunk_text",
+        "start_index",
+        "end_index",
+        "chunk_id",
+        "uuid",
+        "last_modified",
+        "version",
+        "client_id",
+        "deleted",
+        "prev_version",
+        "merge_parent_uuid",
+    },
+    "UnvectorizedMediaChunks": {
+        "id",
+        "media_id",
+        "chunk_text",
+        "chunk_index",
+        "start_char",
+        "end_char",
+        "chunk_type",
+        "creation_date",
+        "last_modified_orig",
+        "is_processed",
+        "metadata",
+        "uuid",
+        "last_modified",
+        "version",
+        "client_id",
+        "deleted",
+        "prev_version",
+        "merge_parent_uuid",
+    },
+    "DocumentVersions": {
+        "id",
+        "media_id",
+        "version_number",
+        "prompt",
+        "analysis_content",
+        "content",
+        "created_at",
+        "uuid",
+        "last_modified",
+        "version",
+        "client_id",
+        "deleted",
+        "prev_version",
+        "merge_parent_uuid",
+    },
     # Prompts DB
     "Prompts": {
         "id",
@@ -170,6 +318,27 @@ VALID_COLUMNS = {
         "version",
         "deleted_at",
         "client_id",
+    },
+    # TASK-864: real caller is Sync_Interop/sync_state_repository.py's
+    # ``_ensure_sync_v2_profile_columns``, immediately before an
+    # ``ALTER TABLE ... ADD COLUMN`` f-string. Columns verified against that
+    # module's own ``CREATE TABLE IF NOT EXISTS sync_profile_state`` (not a
+    # ChaChaNotes/Media/Prompts DB table, but sharing this module's
+    # allow-list is simplest -- ``validate_column_name`` takes no db_type).
+    "sync_profile_state": {
+        "source_authority",
+        "server_profile_id",
+        "authenticated_principal_id",
+        "workspace_scope",
+        "profile_mode",
+        "device_id",
+        "dataset_id",
+        "dataset_cursors",
+        "capabilities",
+        "dry_run_metadata",
+        "last_error",
+        "last_mirror_report_id",
+        "updated_at",
     },
 }
 
@@ -294,6 +463,26 @@ def validate_column_name(column_name: str, table_name: Optional[str] = None) -> 
     """
     Validates a column name, optionally against a specific table's schema.
 
+    TASK-864: when ``table_name`` is given, this fails CLOSED for a table
+    that has no entry in ``VALID_COLUMNS`` -- it used to silently no-op
+    (returning whatever ``validate_identifier`` alone decided) for any
+    table not among that dict's keys, so a caller documenting "validated
+    against this table's schema" wasn't actually getting that check for
+    ``sync_profile_state`` or the Media cascade child tables (Transcripts,
+    MediaChunks, UnvectorizedMediaChunks, DocumentVersions) -- not
+    exploitable at the time (every real caller passed in-file literals),
+    but the promised validation wasn't being delivered. Every real caller
+    that passes a concrete ``table_name`` now has a matching
+    ``VALID_COLUMNS`` entry (see the table-specific comments above), so
+    this tightening does not change behavior for any of them; a future
+    caller that introduces a new table must add its columns here first,
+    the same way ``validate_table_name`` already requires a
+    ``VALID_TABLES`` entry.
+
+    Passing ``table_name=None`` (the "no schema context" case, e.g.
+    generic identifier checks with no specific table in scope) is
+    unaffected and still skips the per-table check entirely.
+
     Args:
         column_name: The column name to validate
         table_name: Optional table name to validate against specific schema
@@ -304,10 +493,14 @@ def validate_column_name(column_name: str, table_name: Optional[str] = None) -> 
     if not validate_identifier(column_name, "column name"):
         return False
 
-    # If table name provided and we have schema info, validate against it
-    if table_name and table_name in VALID_COLUMNS:
-        valid_columns = VALID_COLUMNS[table_name]
-        if column_name not in valid_columns:
+    if table_name:
+        if table_name not in VALID_COLUMNS:
+            logger.warning(
+                f"No column allow-list registered for table '{table_name}'; "
+                f"rejecting column '{column_name}' (fail-closed)"
+            )
+            return False
+        if column_name not in VALID_COLUMNS[table_name]:
             logger.warning(
                 f"Column '{column_name}' not in schema for table '{table_name}'"
             )

--- a/tldw_chatbook/Utils/sensitive_paths.py
+++ b/tldw_chatbook/Utils/sensitive_paths.py
@@ -576,6 +576,107 @@ def is_sensitive_path(
     return False
 
 
+def find_root_binding_conflict(
+    root: Path, context: SensitivePathContext | None = None
+) -> Path | None:
+    """Whether granting recursive access under ``root`` would reach a protected path.
+
+    TASK-857: consulted by ``Workspaces.registry_service.add_folder_binding``,
+    the gate that decides whether a folder root may be bound as an
+    additional file-tool access root (``Tools/workspace_file_roots.py``
+    layers every bound folder on top of the sandbox root, and the file
+    tools then trust any path under any of them, subject only to the
+    the per-path checks below). That is a fundamentally different question
+    from ``is_sensitive_path``'s: that function asks whether one candidate
+    READ/WRITE target falls inside a denied area; this asks whether an
+    entire subtree about to be granted blanket, recursive reachability
+    conflicts with one, which matters in BOTH directions:
+
+    1. ``root`` itself resolves to, or under, one of the fixed sensitive
+       directories (``~/.ssh``, ``~/.aws``, ..., the skill-trust subtree)
+       or one of this app's own state-container directories
+       (``get_user_data_dir()``, the effective config directory, the
+       ChromaDB persist directory, the RAG-profile directory). Binding a
+       root already inside one of these would make everything else in
+       there reachable too -- including subdirectories
+       ``is_sensitive_path``'s direct-child-file rule deliberately leaves
+       alone for per-path reads (e.g. ``tool_sandbox`` nested under
+       ``get_user_data_dir()``), because that rule was designed to catch
+       stray loose files in an otherwise-normal directory, not to make an
+       entire application-state directory safe to use as a binding root.
+       Nothing legitimate needs to bind these directly: the sandbox root
+       is already included automatically by
+       ``Tools.workspace_file_roots.allowed_file_roots`` without ever
+       going through this gate.
+    2. ``root`` is coarse enough to CONTAIN one of those same directories
+       or one of this app's sensitive single files/database paths -- e.g.
+       binding ``~/.local/share`` (which contains ``get_user_data_dir()``
+       on a typical Linux install) or ``~/.config`` (which contains
+       ``~/.config/tldw_cli``). ``root`` need not itself look sensitive
+       for this direction to matter.
+
+    Args:
+        root: The already-resolved candidate folder-binding root.
+        context: Optional pre-resolved ``SensitivePathContext``; see
+            ``resolve_sensitive_context``.
+
+    Returns:
+        The protected path ``root`` conflicts with, or ``None`` if it
+        conflicts with nothing this module tracks. The returned path is
+        meant to be named directly in the caller's rejection message, so
+        the user can see exactly what stood in the way. When more than one
+        protected path would match, the most specific/direct relationship
+        wins, in this priority order: (1) ``root`` IS the protected path
+        itself, (2) ``root`` is nested INSIDE a protected directory --
+        ties broken toward the DEEPEST (closest, most specific) enclosing
+        directory, (3) ``root`` CONTAINS a protected directory or file --
+        ties broken toward the SHALLOWEST (closest, most immediate)
+        contained path. E.g. binding ``get_user_data_dir()`` itself is
+        reported as case (1) even though it also technically contains the
+        skill-trust subtree several levels down (case (3)); binding
+        ``get_user_data_dir()``'s own PARENT is reported as containing
+        ``get_user_data_dir()`` itself (the nearest contained protected
+        directory), not the more deeply nested skill-trust subtree beneath
+        it -- naming the closest conflict is more actionable than naming
+        an obscure one several levels further away.
+    """
+    ctx = context if context is not None else resolve_sensitive_context()
+
+    protected_dirs = ctx.dirs + ctx.direct_child_denied_dirs
+    protected_files: list[Path] = list(ctx.files)
+    for db_path in ctx.db_paths:
+        protected_files.append(db_path)
+        protected_files.extend(_db_sidecar_paths(db_path))
+
+    # (1) `root` IS a protected path itself -- the most direct, most
+    # actionable case, checked before either containment direction so it
+    # always wins when several apply at once.
+    for protected in tuple(protected_dirs) + tuple(protected_files):
+        if root == protected:
+            return protected
+
+    # (2) `root` is nested INSIDE a protected directory. Several enclosing
+    # directories can match at once (e.g. the skill-trust subtree nested
+    # inside `get_user_data_dir()`); the one with the MOST path parts is
+    # the deepest/closest enclosing directory, hence the most specific.
+    nested_inside = [protected for protected in protected_dirs if protected in root.parents]
+    if nested_inside:
+        return max(nested_inside, key=lambda candidate: len(candidate.parts))
+
+    # (3) `root` is coarse enough to CONTAIN a protected directory or
+    # file. Several contained paths can match at once (e.g. an ancestor of
+    # `get_user_data_dir()` also contains the skill-trust subtree nested
+    # inside it); the one with the FEWEST path parts is the shallowest/
+    # nearest contained path, hence the most immediate, least obscure one
+    # to report.
+    contains = [protected for protected in protected_dirs if root in protected.parents]
+    contains.extend(protected for protected in protected_files if root in protected.parents)
+    if contains:
+        return min(contains, key=lambda candidate: len(candidate.parts))
+
+    return None
+
+
 def refuses_new_directory_chain(
     target_dir: Path, context: SensitivePathContext | None = None
 ) -> bool:

--- a/tldw_chatbook/Workspaces/registry_service.py
+++ b/tldw_chatbook/Workspaces/registry_service.py
@@ -12,6 +12,7 @@ from loguru import logger
 
 from tldw_chatbook.Chat.rag_scope import RagScope, parse_scope, serialize_scope
 from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+from tldw_chatbook.Utils.sensitive_paths import find_root_binding_conflict
 
 from .models import (
     DEFAULT_WORKSPACE_DESCRIPTION,
@@ -665,10 +666,11 @@ class LocalWorkspaceRegistryService:
         """Bind a folder as a file-tool access root (spec §2).
 
         Read-only by default; canonical (resolved) locator; denies the
-        filesystem root, the home directory itself, non-directories, and
-        duplicate/nested roots within the same workspace. Default-workspace
-        and unknown-workspace rejection is delegated to
-        ``save_runtime_binding``.
+        filesystem root, the home directory itself, non-directories,
+        duplicate/nested roots within the same workspace, and any root
+        that is or contains a path ``Utils.sensitive_paths`` protects
+        (TASK-857). Default-workspace and unknown-workspace rejection is
+        delegated to ``save_runtime_binding``.
         """
         candidate = Path(path).expanduser()
         try:
@@ -689,6 +691,22 @@ class LocalWorkspaceRegistryService:
             raise WorkspaceRegistryServiceError(
                 "Your home directory itself cannot be bound; choose a "
                 "project folder inside it."
+            )
+        # TASK-857: the sensitive-path denylist used to only be consulted
+        # at file-tool READ/WRITE time, never here at the binding gate --
+        # so binding e.g. ~/.config/tldw_cli (this app's own config,
+        # API keys included), get_user_data_dir() (every app database), or
+        # ~/.ssh as a workspace folder root all passed this check, widening
+        # what the agent file tools can reach up to the edge of whatever
+        # the denylist enumerates. See ``find_root_binding_conflict`` for
+        # the exact "is, or contains, or is contained by" rule.
+        conflict = find_root_binding_conflict(resolved)
+        if conflict is not None:
+            raise WorkspaceRegistryServiceError(
+                f"'{resolved}' cannot be bound: it is, or contains, the "
+                f"protected path '{conflict}'. Choose a folder that does "
+                f"not overlap this application's own data, configuration, "
+                f"or credential directories."
             )
         for existing in self.list_folder_bindings(workspace_id):
             existing_path = Path(existing.locator)


### PR DESCRIPTION
Closes TASK-864, TASK-857. Continuation of the path-naming audit (#964, #985, #996). Both are checks that could not do their job.

## TASK-864 — a live, unconditional feature break

`sql_validation.VALID_TABLES` did not contain `keyword_collections`, a table the schema genuinely defines, so `update_keyword_collection` raised `ValueError: Invalid table name` **every time it was called**. That feature could not work at all.

Reconciling the allow-list against a live migrated database found **38 missing tables**, not the ~25 the audit estimated — schema v27 has added `rag_*` tables since the audit ran. `VALID_TABLES['chachanotes']` now lists all 47 real tables.

Kept hand-maintained rather than derived at runtime: deriving would require building a migrated database inside a shared low-level validator, pulling a heavyweight dependency and a circular import into the one module everything else validates through. Instead there is now a **test that compares the list against the real schema and fails on drift in either direction**, so the next omission surfaces as a red test rather than as a user hitting an unconditional `ValueError`.

`validate_column_name` now **fails closed** for tables absent from `VALID_COLUMNS` — but only after backfilling every real caller's table first (`keyword_collections`, `sync_profile_state`, four Media cascade tables). Doing only half of that would either repeat 864's bug or leave the validator a silent no-op.

## TASK-857 — the reachability gate for a denylist that already existed

`Workspaces.add_folder_binding` accepted any folder root without consulting `Utils.sensitive_paths`. Agent file tools honour workspace folder roots, so binding the wrong folder made credential files and this application's own state reachable *through* the very denylist built to refuse them.

Before: binding `get_user_data_dir()`, `~/.config/tldw_cli`, or `~/.ssh` all succeeded. After: all rejected, with a message naming the exact protected path so the user can act on it. Ordinary project folders still bind.

New `find_root_binding_conflict()` checks both directions — a root that **is**, is nested inside, or **contains** a protected path. The containing case is the dangerous one and was the gap. The rule is deliberately coarser than `is_sensitive_path`'s own per-path exemptions (it refuses the container directories too, e.g. `tool_sandbox`), because nothing legitimate needs to bind those directly.

Existing bindings are untouched at read time; this is the binding gate only. If any already-bound folder is unsafe, that is visible rather than silently migrated.

## Testing

**1512 passed** across `Tests/DB`, `Tests/Utils`, `Tests/Workspaces`, `Tests/ChaChaNotesDB`, `Tests/Tools`, `Tests/Sync_Interop`.

Two failures on this branch are **pre-existing on dev** — verified by running the same two files on a pristine `origin/dev` worktree, which produces the identical pair (`test_private_sqlite_inventory` census drift and `test_add_folder_binding_rejects_duplicates_and_nesting`, which fails with `PrivatePathError: missing_directory` from dev's own recent private-paths hardening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align SQL validation with the live schema and block unsafe workspace folder bindings to restore keyword collection updates and enforce the sensitive-path denylist. Addresses TASK-864 and TASK-857.

- **Bug Fixes**
  - Reconciled `VALID_TABLES['chachanotes']` to all 47 real tables and added `VALID_COLUMNS` entries; `validate_column_name` now fails closed for unregistered tables. Fixes `update_keyword_collection` raising on `keyword_collections` (TASK-864).
  - `Workspaces.add_folder_binding` now uses `Utils/sensitive_paths.find_root_binding_conflict` to reject roots that are, inside, or contain protected paths (e.g. app data dir, `~/.config/tldw_cli`, `~/.ssh`). Error names the conflicting path (TASK-857).

- **Tests**
  - Added a schema-drift guard comparing `VALID_TABLES['chachanotes']` to live `sqlite_master` to catch future mismatches.
  - Added unit/integration tests for the binding gate and keyword collection add/update/soft-delete flows.

<sup>Written for commit d37fb23dcbf8c357cff07121293a95813ecf0f73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

