### PR TITLE
docs: file TASK-981 — audit the two @work(thread=True) async workers

### DIFF
--- a/backlog/tasks/task-981 - Audit-the-two-work-thread-True-async-workers-for-cross-event-loop-hazards.md
+++ b/backlog/tasks/task-981 - Audit-the-two-work-thread-True-async-workers-for-cross-event-loop-hazards.md
@@ -1,0 +1,43 @@
+---
+id: TASK-981
+title: >-
+  Audit the two @work(thread=True) async workers for cross-event-loop hazards
+status: To Do
+assignee: []
+created_date: '2026-07-27 12:00'
+labels:
+  - ui
+  - concurrency
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Noticed while sweeping `self.call_from_thread` misuse for TASK-929. Two workers combine `@work(thread=True)` with `async def`:
+
+- `Widgets/Media_Creation/swarmui_widget.py:354` — `@work(exclusive=True, thread=True)` on `async def generate_image`
+- `Widgets/multi_item_review_window.py:377` — `@work(thread=True)` on `async def _generate_analyses_worker`
+
+**This is not a bug, and the task is not to "fix" it.** Textual supports the combination explicitly. `Worker._run_threaded` (`textual/worker.py:284-323`) checks `inspect.iscoroutinefunction(self._work)` and, when true, routes through `run_coroutine` → `run_awaitable` → `asyncio.run(do_work())`. The decorator only rejects the opposite mistake — a non-async function *without* `thread=True`.
+
+**What it actually means, and why it is worth auditing.** The coroutine does not run on the application's event loop. It runs on a **brand-new event loop created by `asyncio.run()` inside the worker thread**. That is a sharp edge, because anything bound to the app's loop is now being touched from a different one:
+
+- `asyncio` primitives created on the app loop — `Lock`, `Event`, `Queue`, `Semaphore` — are bound to that loop and misbehave when awaited from another.
+- Long-lived library objects created on the app loop, notably an `httpx.AsyncClient`, carry loop-bound state; reusing one inside these workers is a genuine hazard.
+- Any UI touch must go through `self.app.call_from_thread(...)` because this is a real thread. TASK-929 fixed exactly that in both of these files, which is what surfaced them.
+- `asyncio.run()` also *closes* its loop on completion, so anything cached on it does not survive between invocations.
+
+Audit both workers for those four patterns. If each only awaits objects it creates itself inside the worker, the combination is fine and should be left alone with a short comment recording why. If either shares a loop-bound object with the app, that is a real defect to fix — most cheaply by making the worker a plain `def` that owns its own `asyncio.run`, or by moving it off the thread pool entirely.
+
+Worth checking whether any other `@work(thread=True)` in the tree decorates an `async def`; these two were found incidentally, not by an exhaustive search.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] Both workers are audited for awaiting app-loop-bound asyncio primitives or clients
+- [ ] Any genuine cross-loop sharing is fixed; anything safe is left alone with a comment recording why
+- [ ] The tree is searched for other `@work(thread=True)` on `async def` and each is judged the same way
+<!-- AC:END -->


### PR DESCRIPTION
Filed from the TASK-929 sweep.

Two workers combine `@work(thread=True)` with `async def` — `swarmui_widget.generate_image` and `multi_item_review_window._generate_analyses_worker`.

**Deliberately not filed as a bug.** I checked Textual's source rather than assuming: `Worker._run_threaded` (`textual/worker.py:284-323`) explicitly detects `iscoroutinefunction` and routes through `run_coroutine` → `run_awaitable` → `asyncio.run(do_work())`. The decorator only rejects the opposite mistake — a non-async function *without* `thread=True`.

**What it does mean** is that the coroutine runs on a brand-new event loop inside the worker thread, not the app's. That makes four things hazardous if shared: app-loop-bound `asyncio` primitives (`Lock`/`Event`/`Queue`/`Semaphore`), loop-bound clients such as `httpx.AsyncClient`, any UI touch not routed through `self.app.call_from_thread` (which is what TASK-929 just fixed in both files, and how these surfaced), and anything expected to survive between invocations — `asyncio.run` closes its loop on completion.

The task is to audit for those patterns: fix genuine cross-loop sharing, and leave anything safe alone with a comment recording why. It also asks for a search for other instances, since these two were found incidentally rather than exhaustively.

Documentation only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds backlog doc for `TASK-981` to audit two `@work(thread=True)` async workers that run on their own event loops: `swarmui_widget.generate_image` and `multi_item_review_window._generate_analyses_worker`. The doc clarifies this pattern is supported (run via `asyncio.run()`), lists cross-loop hazards to check, adds a search for other instances, sets acceptance criteria, and links to `TASK-929`.

<sup>Written for commit 746ce91c7bd7f282981ecf47af1af3361f185df0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

