### PR TITLE
fix(notes): secure File Notes replica SQLite owner [TASK-975]

### DIFF
--- a/Tests/DB/test_private_sqlite_inventory.py
+++ b/Tests/DB/test_private_sqlite_inventory.py
@@ -570,12 +570,11 @@ def test_inventory_has_stable_unique_connection_and_backup_ids() -> None:
     backup_rows = _inventory_rows("B")
 
     assert [row["id"] for row in connection_rows] == [
-        # C36 added for `ensure_site_configs_schema`: it opens the
-        # subscriptions database to declare one table without constructing the
-        # whole `SubscriptionsDB`. Extending this range is the deliberate step
-        # the inventory exists to force -- a new connection site must be
-        # documented and owner-registered, not merely written.
-        f"C{number:02d}" for number in range(1, 37)
+        # Extending this range is the deliberate step the inventory exists to
+        # force -- a new connection site must be documented and
+        # owner-registered, not merely written. C37 is the File Notes recovery
+        # replica, which stores exact private note bytes.
+        f"C{number:02d}" for number in range(1, 38)
     ]
     assert [row["id"] for row in backup_rows] == [
         f"B{number:02d}" for number in range(1, 17)

--- a/Tests/Notes/test_file_notes_replica.py
+++ b/Tests/Notes/test_file_notes_replica.py
@@ -13,6 +13,8 @@ import pytest
 # Avoid importing the unrelated optional MLX stack during focused Notes tests.
 sys.modules.setdefault("parakeet_mlx", types.ModuleType("parakeet_mlx"))
 
+from tldw_chatbook.DB.private_sqlite import connect_private_sqlite  # noqa: E402
+import tldw_chatbook.Notes.file_notes_replica as file_notes_replica  # noqa: E402
 from tldw_chatbook.Notes.file_notes_replica import FileNotesReplica  # noqa: E402
 from tldw_chatbook.Notes.file_notes_replica import ReplicaFileInfo  # noqa: E402
 
@@ -48,6 +50,45 @@ def replica() -> FileNotesReplica:
     value = FileNotesReplica(":memory:")
     yield value
     value.close()
+
+
+def test_connections_use_registered_private_sqlite_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, str, dict[str, object]]] = []
+
+    def recording_connect(
+        owner_id: str,
+        database: str | Path,
+        **kwargs: object,
+    ) -> sqlite3.Connection:
+        calls.append((owner_id, str(database), kwargs))
+        return connect_private_sqlite(owner_id, database, **kwargs)
+
+    monkeypatch.setattr(
+        file_notes_replica,
+        "connect_private_sqlite",
+        recording_connect,
+    )
+    file_path = tmp_path / "file_notes.sqlite"
+    memory_replica = FileNotesReplica(":memory:")
+    file_replica = FileNotesReplica(file_path)
+    memory_replica.close()
+    file_replica.close()
+
+    assert calls == [
+        (
+            "notes.file_notes_replica",
+            ":memory:",
+            {"isolation_level": None, "check_same_thread": False},
+        ),
+        (
+            "notes.file_notes_replica",
+            str(file_path),
+            {"isolation_level": None, "check_same_thread": False},
+        ),
+    ]
 
 
 def test_connection_operations_are_serialized_across_worker_threads(

--- a/backlog/docs/sqlite-private-owner-inventory.md
+++ b/backlog/docs/sqlite-private-owner-inventory.md
@@ -55,6 +55,7 @@ Classifications have these meanings:
 | C34 | tldw_chatbook/TTS/profile_repository | TTSProfileRepository._worker_backup_to | tts.profile_backup | private_file | backup destination | Migrated via `connect_private_sqlite`. Open the already-created private temporary destination through the checked writable seam before online backup. |
 | C35 | tldw_chatbook/TTS/profile_repository | TTSProfileRepository._worker_validate_standalone_snapshot | tts.profile_snapshot | read_only_uri | immutable integrity read | Migrated via `connect_private_sqlite`. Run full integrity checks through a validated immutable read-only handle. |
 | C36 | tldw_chatbook/DB/Subscriptions_DB | ensure_site_configs_schema | db.subscriptions.site_configs | private_file | declare one table | Migrated via `connect_private_sqlite`. Declares `site_configs` on a caller-supplied path without opening the whole `SubscriptionsDB`, so the one table `SiteConfigManager` needs exists without imposing ~15 unrelated tables on that file. |
+| C37 | tldw_chatbook/Notes/file_notes_replica | FileNotesReplica.__init__ | notes.file_notes_replica | private_file, memory | read/write recovery replica | Migrated via `connect_private_sqlite`. The independent File Notes replica stores exact private note bytes, so file targets use the checked private boundary while preserving the exact in-memory test target. |
 
 ## SQLite backup and restore inventory
 
@@ -143,7 +144,7 @@ a checked `P` row when it is introduced.
 | X03 | tldw_chatbook/DB/Client_Media_DB_v2 | create_automated_backup | No-op placeholder; it creates no backup artifact. |
 | X04 | production tree | aiosqlite.connect | No production `aiosqlite.connect` owner exists. |
 
-The migrated boundary retains the 35 classified connection owners and fifteen
+The migrated boundary retains 37 classified connection sites and sixteen
 classified backup/restore operations. Production has one raw
 `sqlite3.connect` site and one direct `Connection.backup()` site, both inside
 `DB/private_sqlite.py`; Settings has no SQLite database `shutil.copy2()` site.

--- a/backlog/tasks/task-975 - FileNotesReplica-opens-a-raw-sqlite-connection-that-is-neither-registered-nor-documented.md
+++ b/backlog/tasks/task-975 - FileNotesReplica-opens-a-raw-sqlite-connection-that-is-neither-registered-nor-documented.md
@@ -3,15 +3,17 @@ id: TASK-975
 title: >-
   FileNotesReplica opens a raw sqlite connection that is neither registered nor
   documented
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2026-07-27 20:00'
+updated_date: '2026-07-27 18:43'
 labels:
   - bug
   - db
   - security
-priority: high
 dependencies: []
+priority: high
 ---
 
 ## Description
@@ -44,3 +46,16 @@ What is not an option is leaving the census red, because the next person to add 
 - [ ] #4 If excluded: the `X`-row states why this database is outside the private-path contract
 - [ ] #5 File-notes replica behaviour is unchanged — existing replica tests pass
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Confirm the raw-connection inventory failure on current dev and add a focused regression proving FileNotesReplica uses the registered private seam for both memory and file targets.
+2. Register a File Notes replica owner for private-file and memory targets, then route FileNotesReplica.__init__ through connect_private_sqlite without changing its SQLite options or schema.
+3. Add inventory row C37 and extend the stable connection-ID assertion.
+4. Run the focused private-SQLite inventory and File Notes replica tests, then self-review the diff.
+
+ADR required: no
+ADR path: backlog/decisions/029-local-private-data-boundary.md (existing) and backlog/decisions/029-file-notes-disk-authority.md (existing)
+Reason: This directly applies the accepted private-database boundary to the dedicated recovery replica; it introduces no new storage or ownership decision.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-975 - FileNotesReplica-opens-a-raw-sqlite-connection-that-is-neither-registered-nor-documented.md
+++ b/backlog/tasks/task-975 - FileNotesReplica-opens-a-raw-sqlite-connection-that-is-neither-registered-nor-documented.md
@@ -3,11 +3,11 @@ id: TASK-975
 title: >-
   FileNotesReplica opens a raw sqlite connection that is neither registered nor
   documented
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-27 20:00'
-updated_date: '2026-07-27 18:43'
+updated_date: '2026-07-27 18:48'
 labels:
   - bug
   - db
@@ -40,11 +40,11 @@ What is not an option is leaving the census red, because the next person to add 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A decision is recorded — route through `connect_private_sqlite`, or document as an exclusion — with the reasoning stated
-- [ ] #2 `Tests/DB/test_private_sqlite_inventory.py` passes on a clean `dev` checkout
-- [ ] #3 If routed: an owner is registered and the inventory carries a `C`-row, with the ID range assertion extended
-- [ ] #4 If excluded: the `X`-row states why this database is outside the private-path contract
-- [ ] #5 File-notes replica behaviour is unchanged — existing replica tests pass
+- [x] #1 A decision is recorded — route through `connect_private_sqlite`, or document as an exclusion — with the reasoning stated
+- [x] #2 `Tests/DB/test_private_sqlite_inventory.py` passes on a clean `dev` checkout
+- [x] #3 If routed: an owner is registered and the inventory carries a `C`-row, with the ID range assertion extended
+- [x] #4 If excluded: the `X`-row states why this database is outside the private-path contract
+- [x] #5 File-notes replica behaviour is unchanged — existing replica tests pass
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -59,3 +59,11 @@ ADR required: no
 ADR path: backlog/decisions/029-local-private-data-boundary.md (existing) and backlog/decisions/029-file-notes-disk-authority.md (existing)
 Reason: This directly applies the accepted private-database boundary to the dedicated recovery replica; it introduces no new storage or ownership decision.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Routed FileNotesReplica through the registered private-SQLite boundary as owner `notes.file_notes_replica` for private-file and exact in-memory targets. The decision applies the existing local-private-data ADR because the replica stores exact current, revision, and recovery note bytes; no new ADR or schema change was needed. Added inventory row C37, extended the stable ID guard, corrected the inventory totals, and added a focused regression preserving the existing autocommit and cross-thread connection options.
+
+Focused verification after rebasing on current `origin/dev`: 21 private-SQLite inventory tests passed; 14 File Notes replica tests passed; the two new-owner target-kind cases passed; targeted Ruff and `git diff --check` passed. Self-review and an independent focused review found no actionable issues.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/DB/private_sqlite.py
+++ b/tldw_chatbook/DB/private_sqlite.py
@@ -200,6 +200,12 @@ _SQLITE_OWNER_POLICIES = {
         _PRIVATE_OR_MEMORY,
         "Local Kanban supports private files and exact in-memory targets.",
     ),
+    "notes.file_notes_replica": SQLiteOwnerPolicy(
+        "tldw_chatbook/Notes/file_notes_replica",
+        _PRIVATE_OR_MEMORY,
+        "The File Notes recovery replica contains private note bytes and "
+        "supports private files or an exact in-memory test target.",
+    ),
     "notes.library_parent": SQLiteOwnerPolicy(
         "tldw_chatbook/Notes/Notes_Library",
         _PRIVATE_FILE,

--- a/tldw_chatbook/Notes/file_notes_replica.py
+++ b/tldw_chatbook/Notes/file_notes_replica.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from threading import RLock
 from typing import NamedTuple
 
+from tldw_chatbook.DB.private_sqlite import connect_private_sqlite
+
 
 class ReplicaFileInfo(NamedTuple):
     """Metadata needed to reconcile one active disk file with its replica."""
@@ -37,7 +39,8 @@ class FileNotesReplica:
             Path(path).parent.mkdir(parents=True, exist_ok=True)
         self._lock = RLock()
         with self._lock:
-            self._connection = sqlite3.connect(
+            self._connection = connect_private_sqlite(
+                "notes.file_notes_replica",
                 path,
                 isolation_level=None,
                 check_same_thread=False,


### PR DESCRIPTION
## Summary
- route `FileNotesReplica` through the registered private-SQLite boundary
- register the file/memory owner and document inventory row C37
- preserve existing connection options and replica behavior

## Verification
- `Tests/DB/test_private_sqlite_inventory.py`: 21 passed
- `Tests/Notes/test_file_notes_replica.py`: 14 passed
- new-owner target-kind matrix: 2 passed
- targeted Ruff and `git diff --check`: passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secure the File Notes replica by routing its SQLite connections through `connect_private_sqlite` with owner `notes.file_notes_replica`. Adds inventory entry C37 and keeps the same connection options and behavior. Satisfies TASK-975.

- **Bug Fixes**
  - Route `FileNotesReplica` to `connect_private_sqlite("notes.file_notes_replica", ...)` for file paths and `:memory:`, preserving `isolation_level=None` and `check_same_thread=False`.
  - Register owner policy in `tldw_chatbook/DB/private_sqlite.py` (private file or memory).
  - Update inventory docs and stable ID assertions (add C37) and add a regression test to confirm the registered owner is used; related tests pass.

<sup>Written for commit ec314fd166dc5f986812dc5bab1eed09345a3e46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

