### PR TITLE
fix(tests,db): clear the standing dev-baseline test failures (963-966)

### DIFF
--- a/.superpowers/sdd/task-963-966-report.md
+++ b/.superpowers/sdd/task-963-966-report.md
@@ -1,0 +1,121 @@
+# TASK-963..966 -- dev baseline test-failure fixes
+
+Worktree: `/Users/macbook-dev/Documents/GitHub/wt-baseline`, branch `fix/dev-baseline-test-failures`,
+fast-forwarded from a stale 19-behind snapshot to `origin/dev@a73b9b46f` before starting (branch had
+no local commits, so the fast-forward was safe and matches the "cut from current origin/dev" intent).
+
+## TASK-963 -- raw-connection census test
+
+**Root cause.** Two production sites bypassed the `connect_private_sqlite` seam with a raw
+`sqlite3.connect(...)`:
+- `tldw_chatbook/DB/Subscriptions_DB.py::ensure_site_configs_schema` (the exact site named in the task).
+- `tldw_chatbook/Notes/file_notes_replica.py::FileNotesReplica.__init__` -- a **second** site the census
+  also flagged, introduced by the File Notes feature that merged into `dev` after this task was triaged
+  (picked up by the fast-forward). Not in the task's original description; found by re-running the
+  census on current dev rather than assuming only one site was outstanding.
+
+**Fix: production code**, both sites. Each genuinely bypassed the private-path boundary the seam exists
+to enforce -- qualifying was the correct answer, not silencing the census.
+- Added `db.subscriptions.site_configs` (`private_file`) and `notes.file_replica`
+  (`private_file` + `memory`) owner policies to `SQLITE_OWNER_REGISTRY` in
+  `tldw_chatbook/DB/private_sqlite.py`.
+- Both call sites now route through `connect_private_sqlite(owner_id, ...)`.
+- Added inventory rows C36/C37 to `backlog/docs/sqlite-private-owner-inventory.md`.
+- Updated `Tests/DB/test_private_sqlite_inventory.py`'s id-range assertion from C01..C35 to C01..C37
+  (a legitimate shape change now that two new documented sites exist, not a relaxed assertion).
+
+**Before/after:** `Tests/DB/test_private_sqlite_inventory.py`: 1 failed / 20 passed -> 21 passed.
+Also verified clean: `Tests/DB/test_subscriptions_db_site_configs.py` (20 passed),
+`Tests/Notes/test_file_notes_replica.py`, `Tests/DB/` (600 passed, 1 skipped),
+`Tests/Subscriptions/` + `Tests/Notes/` (296 passed, 1 skipped).
+
+## TASK-964 -- workspace folder-binding test
+
+**Root cause.** The full traceback (not just the exception type) shows the `PrivatePathError` does
+**not** come from `add_folder_binding`'s own root-validation logic. `add_folder_binding` already
+requires the candidate folder to exist (`resolved.is_dir()`, else a domain `WorkspaceRegistryServiceError`)
+-- production already treats binding a not-yet-existing root as **not legitimate**, unconditionally.
+
+The actual raise happens in the test's own `build_registry()` helper: it constructs a second,
+independent `WorkspaceDB` under `tmp_path / "second-db"`, a directory the test never created. The
+private-paths hardening removed `BaseDB.__init__`'s old auto-`mkdir` of its own parent directory
+(inventory row P06, now "migrated"), so opening a database whose containing directory doesn't exist
+now raises instead of silently creating it. Real callers never hit this because `WorkspaceDB` is
+always constructed under `get_user_data_dir()`, which is guaranteed to exist first.
+
+**Fix: test code only.** `build_registry()` in `Tests/Workspaces/test_workspace_folder_bindings.py`
+now does `tmp_path.mkdir(parents=True, exist_ok=True)` before constructing `WorkspaceDB`, mirroring
+what a real caller's directory is guaranteed to have. No production change -- both the hardening and
+`add_folder_binding`'s existing rejection of nonexistent folders are correct as-is.
+
+**Before/after:** `test_workspace_folder_bindings.py`: 1 failed / 10 passed -> 11 passed.
+`Tests/Workspaces/` overall: 138 passed, no regressions.
+
+## TASK-965 -- 33 failing Skills tests
+
+**Already fixed on current `origin/dev`; no code change made.** `Tests/Skills/` ran clean twice in a
+row on this worktree: 379 passed, 0 failed both times (re-run specifically to rule out flakiness given
+the task's claimed 33-failed baseline).
+
+This worktree started 26 commits behind `origin/dev` and was fast-forwarded to catch up. Among the
+commits picked up, `ee49881d2` ("test: make sensitive-path and skills-fixture tests re-derive paths",
+TASK-866, landed the same day, after this task's triage) rewrote `Tests/conftest.py`'s
+`make_trust_service` fixture and `Tests/Skills/test_skills_library_flow.py`'s trust-service builders,
+and as a side effect of deriving `trust_dir` from the real accessor, added
+`trust_dir.mkdir(parents=True, exist_ok=True)` before constructing the trust store. That is exactly
+root cause #3 (a test not pre-creating a config parent directory) -- fixed incidentally by an unrelated
+hygiene task before this one started.
+
+Root causes #1 (`current_runtime_backend` read-only property) and #2 (`provider_model_resolution`'s
+`persisted_defaults must be a mapping`) do **not** appear anywhere in `Tests/Skills/` or the production
+code it exercises -- grepped `Skills_Interop/`, the Skills UI screen, and `Tests/Skills/` for both
+symbols with zero hits; no `TldwCli(...)` construction and no `resolve_effective_provider_model` call
+anywhere in that directory. Both symptoms are real, but they reproduce in `Tests/UI/` (this same batch's
+TASK-966 file sets `current_runtime_backend` on a stub `App`, and several other `Tests/UI/*` files
+construct a real `TldwCli` or call `resolve_effective_provider_model` directly) -- not in `Tests/Skills`.
+Likely explanation: the original triage ran a larger/combined failure set and misfiled two UI-suite
+causes under the Skills task.
+
+No test relaxed; nothing needed changing in `Tests/Skills/` itself.
+
+**Before/after:** claimed 33 failed / 342 passed -> confirmed 379 passed / 0 failed (x2 runs) on current dev.
+
+## TASK-966 -- six chat-API-key tests, `KeyError: 'openai'`
+
+**Root cause**, confirmed via full traceback + captured logs (not the `KeyError` alone):
+`mount_settings_window()`'s `mock_config_path` fixture monkeypatches
+`tldw_chatbook.config.DEFAULT_CONFIG_PATH` to `temp_config_path`. But every code path these six tests
+exercise (`get_provider_readiness`, `save_setting_to_cli_config` -> `apply_settings_mutation_to_cli_config`,
+`load_cli_config_and_ensure_existence`) resolves its path via `_get_effective_config_path()`, which
+checks the `TLDW_CONFIG_PATH` **environment variable first** and only falls back to
+`DEFAULT_CONFIG_PATH` when unset. `Tests/conftest.py`'s autouse `isolate_test_environment` fixture
+always sets `TLDW_CONFIG_PATH` (to a sandbox path under a *different* per-test directory) for every
+test in the whole suite -- so the `DEFAULT_CONFIG_PATH` patch was silently a no-op for these tests: they
+read/wrote a config file the test never touched, while asserting against `temp_config_path`, which was
+never written by app code.
+
+**Fix: test code only.** `mock_config_path` (autouse, applies to the whole file) now also does
+`monkeypatch.setenv("TLDW_CONFIG_PATH", str(temp_config_path))`, so it actually controls the path every
+real code path resolves. No production change -- the env-var-over-module-constant precedence is
+intentional and load-bearing (it's exactly what `Tests/conftest.py`'s own sandboxing depends on).
+
+**Before/after:** `Tests/UI/test_tools_settings_window.py`: 6 failed / 40 passed / 16 skipped ->
+46 passed / 16 skipped (unrelated, pre-existing "AppTest not available in this version of Textual"
+skips), 0 failed.
+
+## Left failing
+
+Nothing. All four tasks are green on this worktree; TASK-965 required no code change (already fixed
+upstream). Known, pre-accepted environment gaps (`pytest-mock`/`numpy` absent) were not touched and are
+out of scope per the task instructions.
+
+## Files touched
+
+- `tldw_chatbook/DB/private_sqlite.py` (production: two new owner-registry entries)
+- `tldw_chatbook/DB/Subscriptions_DB.py` (production: qualify `ensure_site_configs_schema`)
+- `tldw_chatbook/Notes/file_notes_replica.py` (production: qualify `FileNotesReplica.__init__`)
+- `backlog/docs/sqlite-private-owner-inventory.md` (docs: C36/C37 rows)
+- `Tests/DB/test_private_sqlite_inventory.py` (test: id-range assertion widened to match new rows)
+- `Tests/Workspaces/test_workspace_folder_bindings.py` (test: `build_registry` creates its own dir)
+- `Tests/UI/test_tools_settings_window.py` (test: `mock_config_path` also pins `TLDW_CONFIG_PATH`)
+- Four task files under `backlog/tasks/` updated with Implementation Notes and status Done.

--- a/Tests/UI/test_tools_settings_window.py
+++ b/Tests/UI/test_tools_settings_window.py
@@ -104,10 +104,18 @@ def mock_config_path(monkeypatch, temp_config_path: Path):
 
     monkeypatch.setattr(tldw_chatbook.config, 'DEFAULT_CONFIG_PATH', temp_config_path)
 
-    # If load_cli_config_and_ensure_existence has its own reference to the original path (e.g. via default arg)
-    # it might need to be mocked or reloaded. However, direct setattr should be effective for module-level constants.
-    # For this setup, we assume that when ToolsSettingsWindow calls load_cli_config_and_ensure_existence,
-    # it will see the monkeypatched DEFAULT_CONFIG_PATH.
+    # `_get_effective_config_path()` (the function every read/write path in
+    # this module actually calls -- `load_cli_config_and_ensure_existence`,
+    # `get_provider_readiness`, `save_setting_to_cli_config`, etc.) checks the
+    # `TLDW_CONFIG_PATH` environment variable FIRST and only falls back to
+    # `DEFAULT_CONFIG_PATH` when it is unset. Tests/conftest.py's autouse
+    # `isolate_test_environment` fixture always sets `TLDW_CONFIG_PATH` (to a
+    # sandbox path under a DIFFERENT `tmp_path`-derived directory) for every
+    # test in the suite, so the `DEFAULT_CONFIG_PATH` patch above is silently
+    # ineffective for any code that resolves its path through that function --
+    # it keeps reading/writing the global sandbox file, never `temp_config_path`.
+    # Re-pointing the env var here is what actually redirects those calls.
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(temp_config_path))
 
 
 @pytest.fixture

--- a/Tests/Workspaces/test_workspace_folder_bindings.py
+++ b/Tests/Workspaces/test_workspace_folder_bindings.py
@@ -17,6 +17,19 @@ from tldw_chatbook.Workspaces.registry_service import (
 
 
 def build_registry(tmp_path: Path) -> LocalWorkspaceRegistryService:
+    """Build a registry backed by a fresh ``WorkspaceDB`` under ``tmp_path``.
+
+    Real callers always place ``WorkspaceDB`` under ``get_user_data_dir()``,
+    which is created as a side effect before the path is ever used. The
+    private-paths hardening removed ``BaseDB``'s own parent-directory
+    auto-creation (see ``P06`` in the SQLite private-owner inventory), so
+    opening a database whose containing directory does not yet exist now
+    raises ``PrivatePathError`` instead of silently creating it. Callers of
+    this helper may pass a subdirectory that has not been created yet (e.g.
+    a second, isolated registry root), so create it here the same way a real
+    caller's directory is guaranteed to exist.
+    """
+    tmp_path.mkdir(parents=True, exist_ok=True)
     return LocalWorkspaceRegistryService(
         WorkspaceDB(tmp_path / "workspaces.sqlite", client_id="folder-tests")
     )

--- a/backlog/tasks/task-964 - Fix-workspace-folder-binding-test-broken-by-the-private-paths-hardening.md
+++ b/backlog/tasks/task-964 - Fix-workspace-folder-binding-test-broken-by-the-private-paths-hardening.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-964
 title: Fix workspace folder-binding test broken by the private-paths hardening
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-27 18:06'
+updated_date: '2026-07-27 18:42'
 labels:
   - workspaces
   - tests
@@ -19,5 +21,27 @@ Tests/Workspaces/test_workspace_folder_bindings.py::test_add_folder_binding_reje
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The test passes on a clean checkout,It is decided and documented whether binding a not-yet-existing root is legitimate,If it is legitimate the binding path handles it rather than raising
+- [x] #1 The test passes on a clean checkout,It is decided and documented whether binding a not-yet-existing root is legitimate,If it is legitimate the binding path handles it rather than raising
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce test_add_folder_binding_rejects_duplicates_and_nesting on the worktree and get the full traceback (not just the exception type) to find exactly which call raises PrivatePathError.
+2. Determine whether the raise originates in add_folder_binding's own root validation or elsewhere.
+3. Decide whether binding a not-yet-existing root is legitimate production behavior, using add_folder_binding's existing is_dir() gate as evidence.
+4. Fix at the correct layer (test vs production) based on that decision.
+5. Re-run Tests/Workspaces/test_workspace_folder_bindings.py and the broader Tests/Workspaces/ suite.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The full traceback (not just the exception type quoted in the task) shows the PrivatePathError does NOT come from add_folder_binding's own root-validation logic at all. add_folder_binding already requires the candidate folder to exist (resolved.is_dir() check, raising a domain-specific WorkspaceRegistryServiceError otherwise) and always has -- so binding a not-yet-existing root is already, deliberately, NOT legitimate in production, and that gate needed no change.
+
+The actual raise happens in the test's own build_registry() helper: 'other = build_registry(tmp_path / "second-db")' constructs a brand-new WorkspaceDB whose OWN sqlite file lives under a directory (second-db) the test never created. BaseDB.__init__ used to auto-mkdir its parent (see inventory row P06, now 'migrated' -- disposition secure_default) but the private-paths hardening removed that, so opening a database whose containing directory doesn't yet exist now raises PrivatePathError instead of silently creating it. Real production callers never hit this because WorkspaceDB is always constructed under get_user_data_dir(), which is created as a side effect before its path is ever used.
+
+Fix landed in the test only: build_registry() now creates tmp_path (mkdir(parents=True, exist_ok=True)) before constructing WorkspaceDB, mirroring what a real caller's directory is guaranteed to have. No production change -- the hardening is correct and add_folder_binding's existing non-existent-folder rejection is the right, unchanged behavior.
+
+Before: 1 failed / 10 passed (test_workspace_folder_bindings.py). After: 11 passed. Tests/Workspaces/ overall: 138 passed, no regressions.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-965 - Fix-the-33-failing-Skills-tests-on-dev.md
+++ b/backlog/tasks/task-965 - Fix-the-33-failing-Skills-tests-on-dev.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-965
 title: Fix the 33 failing Skills tests on dev
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-27 18:06'
+updated_date: '2026-07-27 18:42'
 labels:
   - skills
   - tests
@@ -19,5 +21,28 @@ Tests/Skills/ reports 33 failures on pristine origin/dev (33 failed / 342 passed
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Tests/Skills passes on a clean checkout,Each of the three root causes is fixed rather than worked around in the test,No test is relaxed merely to make it pass
+- [x] #1 Tests/Skills passes on a clean checkout,Each of the three root causes is fixed rather than worked around in the test,No test is relaxed merely to make it pass
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Run Tests/Skills/ on the fast-forwarded worktree to get current failure counts before assuming the three triaged root causes still apply.
+2. If failures reproduce, verify each of the three suspected causes (current_runtime_backend read-only property, provider_model_resolution mapping TypeError, missing config parent directory) against the actual tracebacks rather than assuming.
+3. Fix each confirmed cause at its source; do not relax any assertion.
+4. Re-run Tests/Skills/ to confirm.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Already fixed on current origin/dev -- no code change made here. Tests/Skills/ ran clean twice in a row on this worktree (379 passed, 0 failed, both runs; re-run for determinism since the task's own baseline of 33 failed/342 passed implied this suite was not previously green).
+
+This worktree's branch started 26 commits behind origin/dev at task-assignment time and was fast-forwarded to catch up (per the task instructions, work must target current origin/dev). Among the commits picked up, ee49881d2 ('test: make sensitive-path and skills-fixture tests re-derive paths', TASK-866, landed same day after this task's triage) rewrote Tests/conftest.py's make_trust_service fixture and Tests/Skills/test_skills_library_flow.py's two trust-service builders to derive skills_dir/trust_dir from the real accessors and, as a necessary side effect of that rewrite, added trust_dir.mkdir(parents=True, exist_ok=True) before constructing the trust store. That is precisely root cause #3 (a test not pre-creating a config parent directory) -- fixed incidentally by an unrelated hygiene task before this one started.
+
+Root causes #1 (current_runtime_backend read-only property) and #2 (provider_model_resolution's persisted_defaults-must-be-a-mapping) do NOT appear anywhere in Tests/Skills/ or in the production code it exercises -- grepped Skills_Interop/, the Skills UI screen, and Tests/Skills/ for both symbols with zero hits. Tests/Skills/ has no TldwCli(...) construction and no resolve_effective_provider_model call. Those two symptoms are real and DO reproduce, but in Tests/UI/test_tools_settings_window.py (TASK-966, this same batch) and other Tests/UI files (test_console_session_settings.py, test_study_*.py, test_runtime_policy_full_app.py) that construct a real TldwCli or call resolve_effective_provider_model directly -- not in Tests/Skills. Most likely explanation: the original triage ran a combined/larger batch of failures and misfiled two UI-suite causes under the Skills task.
+
+No test relaxed, no assertion weakened -- nothing needed changing in Tests/Skills/ itself. Recommend closing TASK-944 (Console runtime-backend fixture repair, still To Do) as the right home for root cause #1 if it resurfaces elsewhere; root cause #2 was not independently reproduced in this pass and is not otherwise tracked.
+
+Before: task claimed 33 failed / 342 passed. After (current dev, this worktree, x2 runs): 379 passed, 0 failed.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-966 - Fix-the-six-failing-chat-API-key-tests-on-dev.md
+++ b/backlog/tasks/task-966 - Fix-the-six-failing-chat-API-key-tests-on-dev.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-966
 title: Fix the six failing chat API key tests on dev
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-27 18:06'
+updated_date: '2026-07-27 18:42'
 labels:
   - ui
   - tests
@@ -19,5 +21,27 @@ Tests/UI/test_tools_settings_window.py's six test_chat_api_key_* tests fail on p
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The six tests pass on a clean checkout,The KeyError root cause is fixed rather than the assertion relaxed,The file has no remaining expected failures
+- [x] #1 The six tests pass on a clean checkout,The KeyError root cause is fixed rather than the assertion relaxed,The file has no remaining expected failures
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the six test_chat_api_key_* failures and read full tracebacks + captured logs, not just the KeyError.
+2. Trace where the config path actually resolves at runtime (get_provider_readiness / save_setting_to_cli_config / load_cli_config_and_ensure_existence all go through _get_effective_config_path()) versus what the test's mock_config_path fixture patches (DEFAULT_CONFIG_PATH).
+3. Check whether Tests/conftest.py's autouse environment-isolation fixture sets an environment variable that outranks the module-attribute patch.
+4. Fix at the correct layer once the precedence is confirmed.
+5. Re-run the six tests plus the whole file for regressions.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause confirmed via full traceback + captured stderr logs, not the KeyError alone: the six tests use mount_settings_window(), which monkeypatches tldw_chatbook.config.DEFAULT_CONFIG_PATH to temp_config_path. But every code path these tests exercise (get_provider_readiness, save_setting_to_cli_config -> apply_settings_mutation_to_cli_config, load_cli_config_and_ensure_existence) resolves its path via _get_effective_config_path(), which checks the TLDW_CONFIG_PATH environment variable FIRST and only falls back to DEFAULT_CONFIG_PATH when that env var is unset. Tests/conftest.py's autouse isolate_test_environment fixture (applies to every test in the whole suite) always sets TLDW_CONFIG_PATH to a sandbox path under a DIFFERENT tmp_path-derived directory -- so the DEFAULT_CONFIG_PATH patch was silently a no-op for this module's newer async-pilot tests: they were reading/writing a config file the test never touched, while asserting against temp_config_path, which never got written. That produced both symptoms: '' where a configured key was expected (never loaded), and KeyError: 'openai' after save (temp_config_path's on-disk api_settings stayed exactly as the test wrote it -- {} -- because save also went to the sandbox path, not temp_config_path).
+
+This is a test bug, not a production bug: the TLDW_CONFIG_PATH-over-DEFAULT_CONFIG_PATH precedence is intentional and load-bearing elsewhere (it's exactly the mechanism Tests/conftest.py's own sandboxing relies on to keep every test off the user's real config). The older AppTest-based tests in this same file that exercise the raw config-text-area save/reload path are all skipped in this environment (Textual's AppTest is unavailable), so they never surfaced this.
+
+Fixed by making the file's own autouse mock_config_path fixture also monkeypatch.setenv('TLDW_CONFIG_PATH', str(temp_config_path)), so it actually controls the path every real code path resolves, instead of a module attribute nothing reads once the env var is set. No production code changed.
+
+Before: 6 failed / 40 passed / 16 skipped (Tests/UI/test_tools_settings_window.py). After: 46 passed / 16 skipped (unrelated AppTest-unavailable skips, unchanged), 0 failed.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
Closes TASK-963, TASK-964, TASK-966. Closes TASK-965 as already-fixed.

Four sets of tests were failing on pristine `origin/dev`. Four consecutive PRs in the path-naming audit series each had to be separately baselined against a clean dev worktree to prove their own red output was not their fault. Standing baseline failures are corrosive beyond the tests themselves: they train reviewers to skim red output, which is exactly how a real regression slips through.

**`Tests/DB` + `Tests/Workspaces` + `Tests/Skills` + `Tests/UI/test_tools_settings_window.py` → 1167 passed, 0 failed.**

Only one of the four matched its filed description. The rest are recorded honestly rather than reshaped to fit.

## TASK-963 — a real production bug, and dev fixed half of it concurrently

The census caught **two** unqualified raw `sqlite3.connect` sites, not the one filed: `Subscriptions_DB.ensure_site_configs_schema` (as reported) and `FileNotesReplica.__init__`, introduced by a File-Notes commit that landed after triage. Both now route through `connect_private_sqlite`.

Dev independently qualified the Subscriptions site while this branch was in flight, so the rebase conflicted; dev's version was kept (its comment is fuller). That silently dropped the registry entry for the *second* site while keeping its code change — and the census immediately failed on an owner present in production but absent from the inventory. Fixed by adding the C37 row and extending the expected id range, which the test's own comment calls "the deliberate step the inventory exists to force."

Nice counterpoint to the rest of this audit series: this check caught a real gap introduced by a conflict resolution, within seconds.

## TASK-964 — the task's premise was wrong

I filed this asking whether binding a not-yet-existing root should be legitimate. It already is not, and correctly so — `add_folder_binding` requires the folder to exist. The actual failure was the **test's** `build_registry()` helper opening a second `WorkspaceDB` in a directory it never created. Test-only fix; no production change was warranted.

## TASK-965 — already fixed; my triage was partly wrong

`Tests/Skills` passes on current dev (379 passed, reproduced twice). Of the three root causes I attributed when filing, two — `current_runtime_backend` and `persisted_defaults must be a mapping` — **do not exist anywhere in `Tests/Skills`** and were misattributed from `Tests/UI`. The third was fixed incidentally by TASK-866. Closed as already-fixed with no code change.

## TASK-966 — the same defect class this whole audit is about

`mock_config_path` patched `DEFAULT_CONFIG_PATH`, but `_get_effective_config_path()` prefers the `TLDW_CONFIG_PATH` environment variable, which conftest's autouse sandbox always sets — **silently nullifying the patch**. A fixture that looked like it redirected config and did not, which is the same shape as a denylist naming a path the app never writes. Fixed by pinning the environment variable in the fixture too.

## Note

No assertion was relaxed to make anything pass. The two fixes that landed in tests rather than production are called out above with why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the standing baseline test failures by repairing two test fixtures; the Skills suite was already green. Addresses TASK-964 and TASK-966, and confirms TASK-965 as already fixed; targeted suites now pass on current `dev`.

- **Tests**
  - Workspaces (TASK-964): `build_registry` now creates its storage dir to avoid a false `PrivatePathError`.
  - UI settings (TASK-966): `mock_config_path` also sets `TLDW_CONFIG_PATH` so reads/writes hit the test file.
  - Skills (TASK-965): no changes; suite already passes.

<sup>Written for commit 6c2514fb77746dccf8d57350fb9a2a521f4115b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

