### PR TITLE
qa: first Watchlists UAT since the rebuild — the new-user path is blocked (995-998)

### DIFF
--- a/Docs/superpowers/qa/watchlists-uat-2026-07-27/notes.md
+++ b/Docs/superpowers/qa/watchlists-uat-2026-07-27/notes.md
@@ -1,0 +1,86 @@
+# Watchlists UAT — 2026-07-27
+
+First UAT of the Watchlists screen since the Phase A/B/C rebuild. Run against
+`origin/dev` at `dbbb7de84`, in a **clean profile** (`users_name = "uat_wl_clean"`,
+data directory created from scratch and deleted afterwards), 235x52, driven
+through tmux with SGR mouse clicks.
+
+Prior QA for this screen was `task-14.6 "Screen QA: Watchlists"`, a screenshot
+pass dated **2026-05-09** — before the rebuild — whose evidence archive was
+deleted on 2026-06-11 (`6461279e6`). This is the first time the shipped screen
+has been walked end to end.
+
+## New-user journey
+
+Land on Watchlists with nothing configured, create a watchlist, add a source.
+
+**It stops at step three.**
+
+1. The empty screen offers two entry points: `New` in the rail (a watchlist) and
+   `Create source` in the centre. Reasonable, though it asks the user to grasp
+   the watchlist-vs-source distinction immediately.
+2. `New` opens a "New watchlist" dialog. Typing a name and pressing Enter works:
+   the tree gains `Morning AI Brief  0` and the centre heading follows to
+   `Feeds in Morning AI Brief (0)`. **Scope-follows-creation works as designed.**
+3. `Create source` switches the centre to Sources — and that toolbar renders with
+   **no visible controls at all**:
+
+```
+  Sources
+
+  ▊▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+      Preview        Check now      Import OPML     Export OPML
+  Name  Type  Status  Last scraped  Active
+```
+
+That single `▊▔▔▔` row is the strip holding the search input, the type / status /
+active filters, **`New Source`**, and `Filters` (`sources_pane.py:132-158`). Only
+its top border renders. A user who has just created a watchlist has no visible
+way to add a source to it.
+
+## Cause, isolated during the run
+
+`.destination-filter-strip` is `height: 1` (`css/layout/_panes.tcss:31-36`). A
+bordered `Input`/`Select` is three rows, so only the top border survives.
+
+The Rules section, whose strip holds only `Button`s, renders correctly
+(`Refresh  New Rule` both visible) — isolating this to strips containing Inputs
+or Selects rather than to the strip class as a whole.
+
+This is the **third** occurrence of the one-row-container / three-row-children
+pattern here, after `WatchlistsTabStrip` and `LabModeStrip`.
+
+## Other findings
+
+- **Tab strip hit regions do not match label positions.** Clicking the column
+  where `Items` is drawn activates `Runs`; repeated attempts never reached
+  `Items`. Consistent with three-row tab buttons inside a one-row strip.
+- **The watchlist row draws its expand chevron on its own line**, indented, above
+  the name rather than beside it:
+
+```
+│ Unassigned  0            │
+│       ▸                  │
+│ Morning AI Brief  0      │
+```
+
+- **Overview is seven empty bordered cards** — the largest region on a new user's
+  first screen, containing nothing.
+- **The Inspector's empty state is a dead end for a new user**: "Select a source,
+  run, item, rule, or notification to see actions." when by definition none exist.
+- **The dialog's `Create` button did not respond to a click** at its rendered
+  coordinates (row 29, col 228); `Enter` submitted correctly. Possibly the same
+  hit-region issue as the tab strip, possibly harness coordinate error — recorded
+  as needs-verification rather than asserted.
+
+## What worked
+
+Watchlist creation, scope following creation, tree and heading staying in sync,
+section switching, the Rules and Runs toolbars, and the region chrome (one border
+and one heading each) all behaved correctly.
+
+## Not covered
+
+The experienced-user journey — many sources, tag filtering, scope switching
+across watchlists, Console staging, rename/delete — was not reached, because
+adding a source is blocked. It should be re-run once the toolbar is fixed.

--- a/backlog/tasks/task-995 - Sources-toolbar-controls-are-invisible-blocking-the-new-user-path.md
+++ b/backlog/tasks/task-995 - Sources-toolbar-controls-are-invisible-blocking-the-new-user-path.md
@@ -1,0 +1,48 @@
+---
+id: TASK-995
+title: >-
+  The Sources toolbar renders no controls, so a new user cannot add a source
+status: To Do
+assignee: []
+created_date: '2026-07-27 22:00'
+labels:
+  - watchlists
+  - bug
+  - ui
+  - uat
+priority: critical
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+On the Sources section, the toolbar's first filter strip renders as a single bare bar with **no visible controls**. It holds the search input, the type / status / active filters, the **`New Source`** button and `Filters` (`sources_pane.py:132-158`) — only its top border row is drawn.
+
+Captured live at 235x52 on `origin/dev` `dbbb7de84`, clean profile:
+
+```
+  Sources
+
+  ▊▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+      Preview        Check now      Import OPML     Export OPML
+  Name  Type  Status  Last scraped  Active
+```
+
+**This blocks the primary new-user path.** A user who lands on Watchlists, creates a watchlist, and clicks `Create source` arrives here with no visible way to add one. Watchlists cannot be populated through the UI at all.
+
+**Cause, isolated during the UAT.** `.destination-filter-strip` is `height: 1` (`css/layout/_panes.tcss:31-36`), but a bordered `Input`/`Select` is three rows, so only the top border survives. The Rules section's strip, which contains only `Button`s, renders correctly (`Refresh  New Rule` both visible) — so this is specific to strips carrying Inputs or Selects, not to the class itself.
+
+Third occurrence of the one-row-container / three-row-children pattern on this project, after `WatchlistsTabStrip` and `LabModeStrip` (task-875). Note `.destination-filter-strip` is shared chrome — check which other screens put Inputs or Selects in one before changing the class itself, and prefer a scoped rule if the blast radius is wide.
+
+Evidence: `Docs/superpowers/qa/watchlists-uat-2026-07-27/notes.md`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The search input, all three filters, `New Source` and `Filters` are visible and usable on the Sources section
+- [ ] #2 A new user can create a source from a clean profile without using OPML import
+- [ ] #3 Every other screen using `.destination-filter-strip` is checked for the same clipping, and any found are listed here or fixed
+- [ ] #4 A test asserts the controls are actually rendered — against the production stylesheet in the full shell, and proven to fail against current code
+- [ ] #5 The Sources table keeps the row space it gained in task-897
+<!-- AC:END -->

--- a/backlog/tasks/task-996 - Watchlists-tab-strip-hit-regions-do-not-match-its-labels.md
+++ b/backlog/tasks/task-996 - Watchlists-tab-strip-hit-regions-do-not-match-its-labels.md
@@ -1,0 +1,37 @@
+---
+id: TASK-996
+title: >-
+  Watchlists tab strip activates the wrong section for a given click column
+status: To Do
+assignee: []
+created_date: '2026-07-27 22:00'
+labels:
+  - watchlists
+  - bug
+  - ui
+  - uat
+priority: high
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Clicking the column where `Items` is drawn in the section tab strip activates `Runs` instead. Reproduced repeatedly at 235x52 on `origin/dev` `dbbb7de84`: computing the click column from `index($0, "Items")` and from `index($0, "    Items")+6` both landed on `Runs`, and `Items` was never reached by mouse.
+
+So the tabs are mislabelled from the user's point of view — the thing you click is not the thing you get.
+
+Very likely the same root as task-875's fix: `WatchlistsTabStrip` pins itself to `height: 1` while its `Button`s want three rows, so their layout boxes — and therefore their hit regions — do not line up with where their labels are painted. The label fix in `features/_watchlists.tcss` made the text visible; it may not have corrected the geometry.
+
+The dialog `Create` button showing the same symptom (see `Docs/superpowers/qa/watchlists-uat-2026-07-27/notes.md`) suggests checking whether this is broader than the tab strip.
+
+Evidence: `Docs/superpowers/qa/watchlists-uat-2026-07-27/notes.md`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Clicking any tab activates the section whose label is under the pointer
+- [ ] #2 A test drives a real click at each tab's rendered label column and asserts the resulting `active_section`, proven to fail against current code
+- [ ] #3 The active tab stays visually distinguishable and the strip stays one row
+- [ ] #4 It is established whether the dialog `Create` button shares this cause, and the answer recorded here
+<!-- AC:END -->

--- a/backlog/tasks/task-997 - Watchlist-tree-row-draws-its-chevron-on-a-separate-line.md
+++ b/backlog/tasks/task-997 - Watchlist-tree-row-draws-its-chevron-on-a-separate-line.md
@@ -1,0 +1,41 @@
+---
+id: TASK-997
+title: >-
+  Watchlist tree row draws its expand chevron on its own line above the name
+status: To Do
+assignee: []
+created_date: '2026-07-27 22:00'
+labels:
+  - watchlists
+  - bug
+  - ui
+  - uat
+priority: medium
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A watchlist row in the tree renders its expand chevron on a separate, indented line above the name instead of beside it. Captured live at 235x52 on `origin/dev` `dbbb7de84` after creating one watchlist from a clean profile:
+
+```
+│ Unassigned  0            │
+│       ▸                  │
+│ Morning AI Brief  0      │
+```
+
+Expected: `▸ Morning AI Brief  0` on one row.
+
+It costs a rail row per watchlist and reads as a stray glyph, which matters more as the tree fills up — the rail is 26 columns and the tree is the screen's primary navigation.
+
+Evidence: `Docs/superpowers/qa/watchlists-uat-2026-07-27/notes.md`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The chevron and the watchlist name render on the same row
+- [ ] #2 One watchlist occupies one row in the collapsed state
+- [ ] #3 A test asserts the rendered row text against the production stylesheet, proven to fail against current code
+- [ ] #4 Expanding still shows the watchlist's sources indented beneath it
+<!-- AC:END -->

--- a/backlog/tasks/task-998 - Watchlists-first-run-shows-empty-cards-and-dead-end-guidance.md
+++ b/backlog/tasks/task-998 - Watchlists-first-run-shows-empty-cards-and-dead-end-guidance.md
@@ -1,0 +1,38 @@
+---
+id: TASK-998
+title: >-
+  Watchlists first run shows seven empty cards and dead-end Inspector guidance
+status: To Do
+assignee: []
+created_date: '2026-07-27 22:00'
+labels:
+  - watchlists
+  - ux
+  - uat
+priority: medium
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Two first-run problems seen together in the clean-profile UAT (`origin/dev` `dbbb7de84`, 235x52).
+
+**The Overview region is seven empty bordered cards.** It is the largest region on the screen and the first thing a new user sees, and it contains nothing. This was recorded during the original design work as one of the screen's defects and has never been addressed.
+
+**The Inspector's empty state is a dead end.** It reads "Select a source, run, item, rule, or notification to see actions." — but on first run none of those exist, so the guidance names five things the user cannot do. The right-hand rail is a third of the screen and spends it telling a new user to do something impossible.
+
+Together these mean a first-time user's screen is mostly empty boxes and instructions that do not apply. The tree's `New` and the centre's `Create source` are the only real affordances, and neither is where the eye goes.
+
+Worth treating as one piece of work: it is the same question — what should this screen say when there is nothing in it yet.
+
+Evidence: `Docs/superpowers/qa/watchlists-uat-2026-07-27/notes.md`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The Overview region shows real content, or is not shown, on a profile with no watchlists and no sources
+- [ ] #2 The Inspector's first-run text points at an action the user can actually take
+- [ ] #3 A first-run capture from a clean profile is attached, showing no empty bordered cards
+- [ ] #4 The populated states of both regions are unchanged
+<!-- AC:END -->


### PR DESCRIPTION
First UAT of the Watchlists screen since the Phase A/B/C rebuild. Docs and backlog only — no code changes.

## Why this was overdue

The only prior QA for this screen was `task-14.6 "Screen QA: Watchlists"`, a **screenshot** pass dated **2026-05-09** — before the rebuild — whose evidence archive was deleted on 2026-06-11 (`6461279e6`). Phases A, B and C landed 07-25 → 07-27. There is no `Docs/superpowers/qa/` entry for Watchlists at all, while Console, Library ingest, Roleplay and ATHF all have one.

So the tree, tabs, breadcrumbs, scope-driven feeds, scope-driven Console staging and the CRUD that landed in #989 had never been walked by a human from a clean start.

## The finding that matters

**The new-user path is blocked.** Clean profile, land on Watchlists, create a watchlist — that works, and the scope correctly follows the new watchlist. Then click `Create source`, and the Sources toolbar renders with **no visible controls**:

```
  Sources

  ▊▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
      Preview        Check now      Import OPML     Export OPML
  Name  Type  Status  Last scraped  Active
```

That one `▊▔▔▔` row holds the search input, the type/status/active filters, **`New Source`** and `Filters`. Only its top border draws. **Watchlists cannot be populated through the UI at all.**

**Cause isolated during the run:** `.destination-filter-strip` is `height: 1` (`layout/_panes.tcss:31-36`) and a bordered `Input`/`Select` is three rows. The Rules strip, which holds only `Button`s, renders correctly — pinning this to strips carrying Inputs or Selects rather than the class itself. Third occurrence of the one-row-container / three-row-children pattern, after `WatchlistsTabStrip` and `LabModeStrip`.

## Filed

- **995 (critical)** — Sources toolbar controls invisible; blocks the new-user path
- **996 (high)** — tab strip hit regions activate the wrong section: clicking `Items` gives `Runs`
- **997 (medium)** — watchlist tree draws its chevron on its own line above the name
- **998 (medium)** — first run is seven empty Overview cards plus Inspector guidance naming five things a new user cannot do

## What worked

Watchlist creation, the scope following creation, tree and heading staying in sync, section switching, the Rules and Runs toolbars, and the region chrome — one border and one heading per region — all behaved correctly. Phase C's structural work holds up; what fails is the surface a new user has to touch first.

## Not covered

The experienced-user journey — many sources, tag filtering, scope switching across watchlists, Console staging, rename/delete — was **not reached**, because adding a source is blocked. It needs re-running once 995 is fixed, and I'd treat this UAT as half-done until then.

## Method

`origin/dev` at `dbbb7de84`, clean profile (`users_name = "uat_wl_clean"`, data directory created from scratch and deleted after), 235x52, tmux with SGR mouse clicks. Your real config and data directory were untouched — verified byte-identical afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
First UAT of the rebuilt Watchlists screen. Found a blocker: the Sources toolbar controls are invisible, so a new user cannot add a source. Adds QA notes and files tasks 995–998; no code changes.

- **Docs and Backlog**
  - Added UAT notes: Docs/superpowers/qa/watchlists-uat-2026-07-27/notes.md
  - Filed 995 (critical): Sources toolbar controls invisible; new-user path blocked. Root cause: `.destination-filter-strip` is 1 row while `Input`/`Select` need 3.
  - Filed 996 (high): Tab strip hit regions don’t match labels (clicking Items opens Runs).
  - Filed 997 (medium): Watchlist tree chevron renders on a separate line above the name.
  - Filed 998 (medium): First run shows empty Overview cards and dead-end Inspector guidance.
  - Next: Re-run the new-user journey after 995 is fixed.

<sup>Written for commit 697050a842e380cfb18855c41a4f5348f9203b68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

