### PR TITLE
Fix File Notes moved-path recovery identity [TASK-982]

### DIFF
--- a/Tests/Notes/test_file_notes_replica.py
+++ b/Tests/Notes/test_file_notes_replica.py
@@ -315,6 +315,26 @@ def test_mark_deleted_retains_bytes_and_clear_tombstone_restores_search(
     assert not replica.clear_tombstone(root, "folder/gone.md")
 
 
+def test_discard_file_removes_current_projection_without_tombstone(
+    replica: FileNotesReplica,
+) -> None:
+    root = "/notes"
+    _upsert(replica, root, "moved-from.md", b"searchable move bytes")
+
+    assert replica.discard_file(root, "moved-from.md")
+    assert replica.list_active_files(root) == []
+    assert replica.search(root, "searchable") == []
+    assert replica.get_bytes(root, "moved-from.md") is None
+    assert replica.list_deleted(root) == []
+    assert not replica.discard_file(root, "moved-from.md")
+
+    _upsert(replica, root, "real-delete.md", b"recoverable bytes")
+    assert replica.mark_deleted(root, "real-delete.md")
+    assert not replica.discard_file(root, "real-delete.md")
+    assert replica.get_restore_bytes(root, "real-delete.md") == b"recoverable bytes"
+    assert replica.list_deleted(root) == ["real-delete.md"]
+
+
 def test_protection_matches_exact_files_and_component_bounded_prefixes(
     replica: FileNotesReplica,
 ) -> None:

--- a/Tests/Notes/test_file_notes_replica.py
+++ b/Tests/Notes/test_file_notes_replica.py
@@ -315,24 +315,84 @@ def test_mark_deleted_retains_bytes_and_clear_tombstone_restores_search(
     assert not replica.clear_tombstone(root, "folder/gone.md")
 
 
-def test_discard_file_removes_current_projection_without_tombstone(
+def test_move_file_replaces_current_projection_without_tombstone(
     replica: FileNotesReplica,
 ) -> None:
     root = "/notes"
     _upsert(replica, root, "moved-from.md", b"searchable move bytes")
+    moved_bytes = b"searchable move bytes"
 
-    assert replica.discard_file(root, "moved-from.md")
-    assert replica.list_active_files(root) == []
-    assert replica.search(root, "searchable") == []
+    assert replica.move_file(
+        root,
+        "moved-from.md",
+        "folder/moved-to.md",
+        moved_bytes,
+        content_hash=_digest(moved_bytes),
+        decoded_text=moved_bytes.decode("utf-8"),
+        size=len(moved_bytes),
+        mtime_ns=2,
+    )
+    assert [
+        item.relative_path for item in replica.list_active_files(root)
+    ] == ["folder/moved-to.md"]
+    assert replica.search(root, "searchable") == ["folder/moved-to.md"]
     assert replica.get_bytes(root, "moved-from.md") is None
     assert replica.list_deleted(root) == []
-    assert not replica.discard_file(root, "moved-from.md")
 
     _upsert(replica, root, "real-delete.md", b"recoverable bytes")
     assert replica.mark_deleted(root, "real-delete.md")
-    assert not replica.discard_file(root, "real-delete.md")
+    assert not replica.move_file(
+        root,
+        "real-delete.md",
+        "copied-from-tombstone.md",
+        b"current bytes",
+        content_hash=_digest(b"current bytes"),
+        decoded_text="current bytes",
+        size=len(b"current bytes"),
+        mtime_ns=3,
+    )
     assert replica.get_restore_bytes(root, "real-delete.md") == b"recoverable bytes"
     assert replica.list_deleted(root) == ["real-delete.md"]
+
+
+def test_move_file_rolls_back_destination_when_source_cleanup_fails(
+    replica: FileNotesReplica,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = "/notes"
+    source_bytes = b"source recovery bytes"
+    destination_bytes = b"destination bytes"
+    _upsert(replica, root, "source.md", source_bytes)
+    real_delete_fts = replica._delete_fts
+
+    def fail_source_cleanup(
+        cursor: sqlite3.Cursor,
+        selected_root: str,
+        relative_path: str,
+    ) -> None:
+        if relative_path == "source.md":
+            raise sqlite3.OperationalError("forced source cleanup failure")
+        real_delete_fts(cursor, selected_root, relative_path)
+
+    monkeypatch.setattr(replica, "_delete_fts", fail_source_cleanup)
+
+    with pytest.raises(sqlite3.OperationalError, match="forced source cleanup"):
+        replica.move_file(
+            root,
+            "source.md",
+            "destination.md",
+            destination_bytes,
+            content_hash=_digest(destination_bytes),
+            decoded_text=destination_bytes.decode("utf-8"),
+            size=len(destination_bytes),
+            mtime_ns=2,
+        )
+
+    assert replica.get_bytes(root, "source.md") == source_bytes
+    assert replica.get_bytes(root, "destination.md") is None
+    assert replica.search(root, "source recovery") == ["source.md"]
+    assert replica.search(root, "destination") == []
+    assert replica.list_deleted(root) == []
 
 
 def test_protection_matches_exact_files_and_component_bounded_prefixes(

--- a/Tests/Notes/test_file_notes_service.py
+++ b/Tests/Notes/test_file_notes_service.py
@@ -508,6 +508,67 @@ def test_create_is_exclusive_and_move_is_no_clobber_with_rollback(
     assert not (root / "folder" / "moved.md").exists()
 
 
+def test_move_replaces_replica_path_without_tombstoning_source(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+) -> None:
+    root = tmp_path / "notes"
+    (root / "folder").mkdir(parents=True)
+    (root / "source.md").write_text("unique move content", encoding="utf-8")
+    service = FileNotesService(root, replica)
+    service.scan()
+
+    result = service.move_file("source.md", "folder/moved.md")
+
+    assert result.status == "ok"
+    assert result.replica_warning is None
+    assert not (root / "source.md").exists()
+    assert (root / "folder" / "moved.md").read_text(encoding="utf-8") == (
+        "unique move content"
+    )
+    assert [
+        item.relative_path
+        for item in replica.list_active_files(str(root.resolve()))
+    ] == ["folder/moved.md"]
+    assert replica.search(str(root.resolve()), "unique move") == [
+        "folder/moved.md"
+    ]
+    assert replica.list_deleted(str(root.resolve())) == []
+    assert len(service.session_changes) == 1
+    change = service.session_changes[0]
+    assert change.action == "moved"
+    assert change.relative_path == "source.md"
+    assert change.destination_path == "folder/moved.md"
+
+
+def test_move_retains_source_replica_when_destination_refresh_fails(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    source = root / "source.md"
+    source.write_bytes(b"last recovery copy")
+    service = FileNotesService(root, replica)
+    service.scan()
+
+    def fail_upsert(*args: object, **kwargs: object) -> None:
+        raise sqlite3.OperationalError("forced replica failure")
+
+    monkeypatch.setattr(replica, "upsert_file", fail_upsert)
+    result = service.move_file("source.md", "moved.md")
+
+    assert result.status == "ok"
+    assert result.replica_warning is not None
+    assert not source.exists()
+    assert (root / "moved.md").read_bytes() == b"last recovery copy"
+    root_key = str(root.resolve())
+    assert replica.get_bytes(root_key, "source.md") == b"last recovery copy"
+    assert replica.get_bytes(root_key, "moved.md") is None
+    assert replica.list_deleted(root_key) == []
+
+
 def test_delete_rechecks_after_tombstone_and_restore_requires_absent_destination(
     tmp_path: Path,
     replica: FileNotesReplica,

--- a/Tests/Notes/test_file_notes_service.py
+++ b/Tests/Notes/test_file_notes_service.py
@@ -541,6 +541,30 @@ def test_move_replaces_replica_path_without_tombstoning_source(
     assert change.destination_path == "folder/moved.md"
 
 
+def test_recreated_source_path_is_tombstoned_after_a_later_external_delete(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    original = b"original move content"
+    (root / "source.md").write_bytes(original)
+    service = FileNotesService(root, replica)
+    service.scan()
+
+    assert service.move_file("source.md", "moved.md").status == "ok"
+    assert service.create_file("source.md", "replacement").status == "ok"
+    (root / "source.md").unlink()
+
+    result = service.reconcile()
+
+    root_key = str(root.resolve())
+    assert result.deleted == ("source.md",)
+    assert replica.list_deleted(root_key) == ["source.md"]
+    assert replica.get_restore_bytes(root_key, "source.md") == b"replacement"
+    assert replica.get_bytes(root_key, "moved.md") == original
+
+
 def test_move_retains_source_replica_when_destination_refresh_fails(
     tmp_path: Path,
     replica: FileNotesReplica,
@@ -552,11 +576,12 @@ def test_move_retains_source_replica_when_destination_refresh_fails(
     source.write_bytes(b"last recovery copy")
     service = FileNotesService(root, replica)
     service.scan()
+    real_move = replica.move_file
 
-    def fail_upsert(*args: object, **kwargs: object) -> None:
+    def fail_move(*args: object, **kwargs: object) -> None:
         raise sqlite3.OperationalError("forced replica failure")
 
-    monkeypatch.setattr(replica, "upsert_file", fail_upsert)
+    monkeypatch.setattr(replica, "move_file", fail_move)
     result = service.move_file("source.md", "moved.md")
 
     assert result.status == "ok"
@@ -567,6 +592,80 @@ def test_move_retains_source_replica_when_destination_refresh_fails(
     assert replica.get_bytes(root_key, "source.md") == b"last recovery copy"
     assert replica.get_bytes(root_key, "moved.md") is None
     assert replica.list_deleted(root_key) == []
+
+    failed_retry = service.reconcile()
+    assert failed_retry.deleted == ()
+    assert failed_retry.replica_warning is not None
+    assert replica.list_deleted(root_key) == []
+    assert replica.get_bytes(root_key, "source.md") == b"last recovery copy"
+
+    monkeypatch.setattr(replica, "move_file", real_move)
+    completed_retry = service.reconcile()
+    assert completed_retry.created == ()
+    assert completed_retry.deleted == ()
+    assert replica.get_bytes(root_key, "source.md") is None
+    assert replica.get_bytes(root_key, "moved.md") == b"last recovery copy"
+    assert replica.list_deleted(root_key) == []
+
+
+def test_reusing_source_after_failed_move_preserves_later_deletion(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "source.md").write_bytes(b"original")
+    service = FileNotesService(root, replica)
+    service.scan()
+    real_move = replica.move_file
+
+    def fail_move(*args: object, **kwargs: object) -> None:
+        raise sqlite3.OperationalError("forced replica failure")
+
+    monkeypatch.setattr(replica, "move_file", fail_move)
+    assert service.move_file("source.md", "moved.md").status == "ok"
+    assert service.create_file("source.md", "replacement").status == "ok"
+    (root / "source.md").unlink()
+    monkeypatch.setattr(replica, "move_file", real_move)
+
+    result = service.reconcile()
+
+    root_key = str(root.resolve())
+    assert result.deleted == ("source.md",)
+    assert replica.list_deleted(root_key) == ["source.md"]
+    assert replica.get_restore_bytes(root_key, "source.md") == b"replacement"
+    assert replica.get_bytes(root_key, "moved.md") == b"original"
+
+
+def test_deleted_destination_after_failed_move_uses_destination_tombstone(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    original = b"destination recovery bytes"
+    (root / "source.md").write_bytes(original)
+    service = FileNotesService(root, replica)
+    service.scan()
+    real_move = replica.move_file
+
+    def fail_move(*args: object, **kwargs: object) -> None:
+        raise sqlite3.OperationalError("forced replica failure")
+
+    monkeypatch.setattr(replica, "move_file", fail_move)
+    assert service.move_file("source.md", "moved.md").status == "ok"
+    monkeypatch.setattr(replica, "move_file", real_move)
+    (root / "moved.md").unlink()
+
+    result = service.reconcile()
+
+    root_key = str(root.resolve())
+    assert result.deleted == ("moved.md",)
+    assert replica.list_deleted(root_key) == ["moved.md"]
+    assert replica.get_bytes(root_key, "source.md") is None
+    assert replica.get_restore_bytes(root_key, "moved.md") == original
 
 
 def test_delete_rechecks_after_tombstone_and_restore_requires_absent_destination(

--- a/Tests/Notes/test_file_notes_service.py
+++ b/Tests/Notes/test_file_notes_service.py
@@ -625,9 +625,9 @@ def test_reusing_source_after_failed_move_preserves_later_deletion(
 
     monkeypatch.setattr(replica, "move_file", fail_move)
     assert service.move_file("source.md", "moved.md").status == "ok"
+    monkeypatch.setattr(replica, "move_file", real_move)
     assert service.create_file("source.md", "replacement").status == "ok"
     (root / "source.md").unlink()
-    monkeypatch.setattr(replica, "move_file", real_move)
 
     result = service.reconcile()
 
@@ -636,6 +636,38 @@ def test_reusing_source_after_failed_move_preserves_later_deletion(
     assert replica.list_deleted(root_key) == ["source.md"]
     assert replica.get_restore_bytes(root_key, "source.md") == b"replacement"
     assert replica.get_bytes(root_key, "moved.md") == b"original"
+
+
+def test_reusing_source_materializes_destination_before_it_can_be_deleted(
+    tmp_path: Path,
+    replica: FileNotesReplica,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "source.md").write_bytes(b"original")
+    service = FileNotesService(root, replica)
+    service.scan()
+    real_move = replica.move_file
+
+    def fail_move(*args: object, **kwargs: object) -> None:
+        raise sqlite3.OperationalError("forced replica failure")
+
+    monkeypatch.setattr(replica, "move_file", fail_move)
+    assert service.move_file("source.md", "moved.md").status == "ok"
+    monkeypatch.setattr(replica, "move_file", real_move)
+    created = service.create_file("source.md", "replacement")
+    assert created.status == "ok"
+    assert created.replica_warning is None
+    (root / "moved.md").unlink()
+
+    result = service.reconcile()
+
+    root_key = str(root.resolve())
+    assert result.deleted == ("moved.md",)
+    assert replica.list_deleted(root_key) == ["moved.md"]
+    assert replica.get_restore_bytes(root_key, "moved.md") == b"original"
+    assert replica.get_bytes(root_key, "source.md") == b"replacement"
 
 
 def test_deleted_destination_after_failed_move_uses_destination_tombstone(

--- a/Tests/UI/test_library_file_notes_workspace.py
+++ b/Tests/UI/test_library_file_notes_workspace.py
@@ -384,6 +384,10 @@ async def test_create_move_delete_protect_and_restore_use_real_service(
         )
         assert not (root / "created.md").exists()
         assert (root / "moved.md").exists()
+        assert replica.list_deleted(str(root.resolve())) == []
+        assert "Recently deleted" not in _tree_labels(
+            workspace.query_one("#file-notes-tree", Tree)
+        )
 
         workspace.query_one("#file-notes-delete", Button).press()
         await _wait_until(

--- a/backlog/tasks/task-982 - Do-not-retain-moved-from-File-Notes-paths-as-restorable-deletions.md
+++ b/backlog/tasks/task-982 - Do-not-retain-moved-from-File-Notes-paths-as-restorable-deletions.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-27 18:50'
-updated_date: '2026-07-27 18:52'
+updated_date: '2026-07-27 18:58'
 labels:
   - bug
   - notes
@@ -31,8 +31,8 @@ A Chatbook-initiated File Notes move currently tombstones the source path after 
 
 <!-- SECTION:PLAN:BEGIN -->
 1. Add focused failing replica, service, and mounted-workspace regressions showing a successful Chatbook move does not create a source tombstone while the destination remains active/searchable and the session action remains `moved`.
-2. Add one transactional replica operation that removes a moved-from current row and FTS projection without touching revisions or recording a tombstone.
-3. Call that operation only after the moved destination has been successfully published to the replica; preserve the existing warning and recovery behavior when replica refresh fails.
+2. Add one atomic replica operation that publishes the destination row/FTS and removes only the active moved-from row/FTS in the same transaction, without touching revisions or genuine tombstones.
+3. Route the service move through that single operation so a replica failure rolls back destination publication and preserves the source recovery copy.
 4. Run the focused File Notes replica, service, and mounted-workspace tests plus targeted Ruff and diff checks, then self-review.
 
 ADR required: no

--- a/backlog/tasks/task-982 - Do-not-retain-moved-from-File-Notes-paths-as-restorable-deletions.md
+++ b/backlog/tasks/task-982 - Do-not-retain-moved-from-File-Notes-paths-as-restorable-deletions.md
@@ -1,0 +1,41 @@
+---
+id: TASK-982
+title: Do not retain moved-from File Notes paths as restorable deletions
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-07-27 18:50'
+updated_date: '2026-07-27 18:52'
+labels:
+  - bug
+  - notes
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A Chatbook-initiated File Notes move currently tombstones the source path after publishing the destination. That makes the old path appear under Recently deleted and allows Restore to recreate a stale duplicate. Because Chatbook knows this operation is a move, the source replica projection should be removed without recording a deletion; genuine Chatbook deletes and externally detected missing files must remain recoverable.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A successful Chatbook move leaves only the destination active and searchable in the replica
+- [ ] #2 The moved-from source is absent from list_deleted() and the Recently deleted UI
+- [ ] #3 Actual Chatbook deletions and externally detected missing files remain tombstoned and restorable
+- [ ] #4 Disk and session reporting continue to record the operation as moved source to destination
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused failing replica, service, and mounted-workspace regressions showing a successful Chatbook move does not create a source tombstone while the destination remains active/searchable and the session action remains `moved`.
+2. Add one transactional replica operation that removes a moved-from current row and FTS projection without touching revisions or recording a tombstone.
+3. Call that operation only after the moved destination has been successfully published to the replica; preserve the existing warning and recovery behavior when replica refresh fails.
+4. Run the focused File Notes replica, service, and mounted-workspace tests plus targeted Ruff and diff checks, then self-review.
+
+ADR required: no
+ADR path: backlog/decisions/029-file-notes-disk-authority.md (existing)
+Reason: This corrects move behavior to match the accepted distinction between moves and deletion tombstones; it changes no schema, authority rule, or cross-module interface.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-982 - Do-not-retain-moved-from-File-Notes-paths-as-restorable-deletions.md
+++ b/backlog/tasks/task-982 - Do-not-retain-moved-from-File-Notes-paths-as-restorable-deletions.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-982
 title: Do not retain moved-from File Notes paths as restorable deletions
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-27 18:50'
-updated_date: '2026-07-27 18:58'
+updated_date: '2026-07-27 19:17'
 labels:
   - bug
   - notes
@@ -21,10 +21,10 @@ A Chatbook-initiated File Notes move currently tombstones the source path after 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A successful Chatbook move leaves only the destination active and searchable in the replica
-- [ ] #2 The moved-from source is absent from list_deleted() and the Recently deleted UI
-- [ ] #3 Actual Chatbook deletions and externally detected missing files remain tombstoned and restorable
-- [ ] #4 Disk and session reporting continue to record the operation as moved source to destination
+- [x] #1 A successful Chatbook move leaves only the destination active and searchable in the replica
+- [x] #2 The moved-from source is absent from list_deleted() and the Recently deleted UI
+- [x] #3 Actual Chatbook deletions and externally detected missing files remain tombstoned and restorable
+- [x] #4 Disk and session reporting continue to record the operation as moved source to destination
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -39,3 +39,9 @@ ADR required: no
 ADR path: backlog/decisions/029-file-notes-disk-authority.md (existing)
 Reason: This corrects move behavior to match the accepted distinction between moves and deletion tombstones; it changes no schema, authority rule, or cross-module interface.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented an atomic replica move that publishes destination bytes and removes only the active source projection without creating a source tombstone. Added session-local retry handling for transient replica failures, including safe source-path reuse and destination deletion so retained bytes keep the correct recovery identity. Updated the mounted workspace regression to verify the moved-from path never appears under Recently deleted while genuine deletions remain restorable. ADR: existing backlog/decisions/029-file-notes-disk-authority.md applies; no new ADR was required. Verification after rebasing on current dev: 48 focused replica/service tests passed, the mounted create/move/delete/protect/restore UI test passed, targeted Ruff passed, production modules compiled, and git diff --check passed. Modified File Notes replica, service, focused tests, mounted workspace test, and this task record.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Notes/file_notes_replica.py
+++ b/tldw_chatbook/Notes/file_notes_replica.py
@@ -227,6 +227,30 @@ class FileNotesReplica:
             self._delete_fts(cursor, root, relative_path)
         return True
 
+    def discard_file(self, root: str, relative_path: str) -> bool:
+        """Remove one active replica projection without creating a tombstone.
+
+        Args:
+            root: Canonical notes-root identifier.
+            relative_path: File path relative to ``root``.
+
+        Returns:
+            ``True`` when an active replica row was removed.
+        """
+        with self._transaction() as cursor:
+            self._delete_fts(cursor, root, relative_path)
+            cursor.execute(
+                """
+                DELETE FROM files
+                WHERE root = ?
+                  AND relative_path = ?
+                  AND deleted_at IS NULL
+                """,
+                (root, relative_path),
+            )
+            removed = cursor.rowcount > 0
+        return removed
+
     def clear_tombstone(self, root: str, relative_path: str) -> bool:
         """Clear a deletion marker and restore searchable current content.
 

--- a/tldw_chatbook/Notes/file_notes_replica.py
+++ b/tldw_chatbook/Notes/file_notes_replica.py
@@ -76,38 +76,16 @@ class FileNotesReplica:
             mtime_ns: File modification time in nanoseconds.
         """
         with self._transaction() as cursor:
-            cursor.execute(
-                """
-                INSERT INTO files (
-                    root,
-                    relative_path,
-                    raw_bytes,
-                    content_hash,
-                    decoded_text,
-                    size,
-                    mtime_ns,
-                    deleted_at
-                )
-                VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
-                ON CONFLICT(root, relative_path) DO UPDATE SET
-                    raw_bytes = excluded.raw_bytes,
-                    content_hash = excluded.content_hash,
-                    decoded_text = excluded.decoded_text,
-                    size = excluded.size,
-                    mtime_ns = excluded.mtime_ns,
-                    deleted_at = NULL
-                """,
-                (
-                    root,
-                    relative_path,
-                    raw_bytes,
-                    content_hash,
-                    decoded_text,
-                    size,
-                    mtime_ns,
-                ),
+            self._upsert_file(
+                cursor,
+                root,
+                relative_path,
+                raw_bytes,
+                content_hash=content_hash,
+                decoded_text=decoded_text,
+                size=size,
+                mtime_ns=mtime_ns,
             )
-            self._replace_fts(cursor, root, relative_path, decoded_text)
 
     def get_bytes(self, root: str, relative_path: str) -> bytes | None:
         """Return exact current or tombstoned bytes for a path.
@@ -227,18 +205,46 @@ class FileNotesReplica:
             self._delete_fts(cursor, root, relative_path)
         return True
 
-    def discard_file(self, root: str, relative_path: str) -> bool:
-        """Remove one active replica projection without creating a tombstone.
+    def move_file(
+        self,
+        root: str,
+        source_path: str,
+        destination_path: str,
+        raw_bytes: bytes,
+        *,
+        content_hash: str,
+        decoded_text: str | None,
+        size: int,
+        mtime_ns: int,
+    ) -> bool:
+        """Publish a moved file and discard its active source atomically.
 
         Args:
             root: Canonical notes-root identifier.
-            relative_path: File path relative to ``root``.
+            source_path: Moved-from path relative to ``root``.
+            destination_path: Moved-to path relative to ``root``.
+            raw_bytes: Exact destination bytes read from disk.
+            content_hash: Digest of ``raw_bytes``.
+            decoded_text: Searchable text, or ``None`` for non-text content.
+            size: Destination file size in bytes.
+            mtime_ns: Destination modification time in nanoseconds.
 
         Returns:
-            ``True`` when an active replica row was removed.
+            ``True`` when an active source row was removed. A genuine source
+            tombstone is retained.
         """
         with self._transaction() as cursor:
-            self._delete_fts(cursor, root, relative_path)
+            self._upsert_file(
+                cursor,
+                root,
+                destination_path,
+                raw_bytes,
+                content_hash=content_hash,
+                decoded_text=decoded_text,
+                size=size,
+                mtime_ns=mtime_ns,
+            )
+            self._delete_fts(cursor, root, source_path)
             cursor.execute(
                 """
                 DELETE FROM files
@@ -246,7 +252,7 @@ class FileNotesReplica:
                   AND relative_path = ?
                   AND deleted_at IS NULL
                 """,
-                (root, relative_path),
+                (root, source_path),
             )
             removed = cursor.rowcount > 0
         return removed
@@ -602,6 +608,52 @@ class FileNotesReplica:
                 raise
             finally:
                 cursor.close()
+
+    @classmethod
+    def _upsert_file(
+        cls,
+        cursor: sqlite3.Cursor,
+        root: str,
+        relative_path: str,
+        raw_bytes: bytes,
+        *,
+        content_hash: str,
+        decoded_text: str | None,
+        size: int,
+        mtime_ns: int,
+    ) -> None:
+        cursor.execute(
+            """
+            INSERT INTO files (
+                root,
+                relative_path,
+                raw_bytes,
+                content_hash,
+                decoded_text,
+                size,
+                mtime_ns,
+                deleted_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
+            ON CONFLICT(root, relative_path) DO UPDATE SET
+                raw_bytes = excluded.raw_bytes,
+                content_hash = excluded.content_hash,
+                decoded_text = excluded.decoded_text,
+                size = excluded.size,
+                mtime_ns = excluded.mtime_ns,
+                deleted_at = NULL
+            """,
+            (
+                root,
+                relative_path,
+                raw_bytes,
+                content_hash,
+                decoded_text,
+                size,
+                mtime_ns,
+            ),
+        )
+        cls._replace_fts(cursor, root, relative_path, decoded_text)
 
     @staticmethod
     def _delete_fts(

--- a/tldw_chatbook/Notes/file_notes_service.py
+++ b/tldw_chatbook/Notes/file_notes_service.py
@@ -596,16 +596,19 @@ class FileNotesService:
             )
 
         warning: str | None = None
+        destination_replicated = False
         try:
             moved = self._load_file(destination_path)
             warning = self._upsert_opened(moved)
+            destination_replicated = warning is None
         except (OSError, ValueError) as error:
             warning = f"Replica refresh failed: {error}"
         if self._replica is not None:
-            try:
-                self._replica.mark_deleted(self.root_key, relative_path)
-            except Exception as error:
-                warning = _merge_warnings(warning, _replica_warning(error))
+            if destination_replicated:
+                try:
+                    self._replica.discard_file(self.root_key, relative_path)
+                except Exception as error:
+                    warning = _merge_warnings(warning, _replica_warning(error))
         else:
             warning = _merge_warnings(warning, "Replica unavailable")
         self._session_changes.append(

--- a/tldw_chatbook/Notes/file_notes_service.py
+++ b/tldw_chatbook/Notes/file_notes_service.py
@@ -825,46 +825,32 @@ class FileNotesService:
             for source_path, destination_path in tuple(
                 self._pending_replica_moves.items()
             ):
-                if source_path not in old_files or source_path in observed:
+                if source_path not in old_files:
                     self._pending_replica_moves.pop(source_path, None)
+                    continue
+                source_info = old_files[source_path]
+                if source_path in observed:
+                    moved_info, move_warning = self._materialize_pending_move(
+                        source_path,
+                        fallback_mtime_ns=source_info.mtime_ns,
+                    )
+                    warning = _merge_warnings(warning, move_warning)
+                    if moved_info is not None:
+                        old_files[moved_info.relative_path] = moved_info
                     continue
                 if destination_path not in observed:
                     if had_walk_error:
                         continue
-                    source_info = old_files[source_path]
-                    try:
-                        retained_bytes = self._replica.get_bytes(
-                            self.root_key,
-                            source_path,
-                        )
-                        if retained_bytes is None:
-                            raise KeyError(source_path)
-                        retained_hash = _digest(retained_bytes)
-                        self._replica.move_file(
-                            self.root_key,
-                            source_path,
-                            destination_path,
-                            retained_bytes,
-                            content_hash=retained_hash,
-                            decoded_text=_decode_for_replica(retained_bytes),
-                            size=len(retained_bytes),
-                            mtime_ns=source_info.mtime_ns,
-                        )
-                    except Exception as error:
-                        warning = _merge_warnings(
-                            warning,
-                            _replica_warning(error),
-                        )
+                    moved_info, move_warning = self._materialize_pending_move(
+                        source_path,
+                        fallback_mtime_ns=source_info.mtime_ns,
+                    )
+                    warning = _merge_warnings(warning, move_warning)
+                    if moved_info is None:
                         pending_move_sources.add(source_path)
                         continue
-                    self._pending_replica_moves.pop(source_path, None)
                     old_files.pop(source_path, None)
-                    old_files[destination_path] = ReplicaFileInfo(
-                        relative_path=destination_path,
-                        content_hash=retained_hash,
-                        size=len(retained_bytes),
-                        mtime_ns=source_info.mtime_ns,
-                    )
+                    old_files[moved_info.relative_path] = moved_info
                     continue
                 try:
                     moved = self._load_file(destination_path)
@@ -1225,6 +1211,66 @@ class FileNotesService:
             return _replica_warning(error)
         return None
 
+    def _materialize_pending_move(
+        self,
+        source_path: str,
+        *,
+        fallback_mtime_ns: int,
+    ) -> tuple[ReplicaFileInfo | None, str | None]:
+        destination_path = self._pending_replica_moves.get(source_path)
+        if destination_path is None:
+            return None, None
+        if self._replica is None:
+            return None, "Replica unavailable"
+
+        try:
+            moved = self._load_file(destination_path)
+        except FileNotFoundError:
+            try:
+                retained_bytes = self._replica.get_bytes(
+                    self.root_key,
+                    source_path,
+                )
+                if retained_bytes is None:
+                    return (
+                        None,
+                        "Replica update deferred: retained move source is unavailable",
+                    )
+                retained_hash = _digest(retained_bytes)
+                self._replica.move_file(
+                    self.root_key,
+                    source_path,
+                    destination_path,
+                    retained_bytes,
+                    content_hash=retained_hash,
+                    decoded_text=_decode_for_replica(retained_bytes),
+                    size=len(retained_bytes),
+                    mtime_ns=fallback_mtime_ns,
+                )
+            except Exception as error:
+                return None, _replica_warning(error)
+            moved_info = ReplicaFileInfo(
+                relative_path=destination_path,
+                content_hash=retained_hash,
+                size=len(retained_bytes),
+                mtime_ns=fallback_mtime_ns,
+            )
+        except (OSError, ValueError) as error:
+            return None, f"Replica update deferred: {error}"
+        else:
+            warning = self._move_opened(source_path, moved)
+            if warning is not None:
+                return None, warning
+            moved_info = ReplicaFileInfo(
+                relative_path=destination_path,
+                content_hash=moved.content_hash,
+                size=moved.size,
+                mtime_ns=moved.mtime_ns,
+            )
+
+        self._pending_replica_moves.pop(source_path, None)
+        return moved_info, None
+
     def _upsert_bytes(
         self,
         relative_path: str,
@@ -1241,6 +1287,12 @@ class FileNotesService:
         )
         if observed_mtime_ns is None:
             raise ValueError("mtime_ns is required for replica upsert")
+        _, pending_warning = self._materialize_pending_move(
+            relative_path,
+            fallback_mtime_ns=observed_mtime_ns,
+        )
+        if pending_warning is not None:
+            return pending_warning
         try:
             self._replica.upsert_file(
                 self.root_key,
@@ -1253,7 +1305,6 @@ class FileNotesService:
             )
         except Exception as error:
             return _replica_warning(error)
-        self._pending_replica_moves.pop(relative_path, None)
         return None
 
     def _clear_tombstone(self, relative_path: str) -> str | None:

--- a/tldw_chatbook/Notes/file_notes_service.py
+++ b/tldw_chatbook/Notes/file_notes_service.py
@@ -163,6 +163,7 @@ class FileNotesService:
         self._operation_lock = operation_lock or RLock()
         self._session_changes: list[SessionChange] = []
         self._entry_cache: dict[str, FileNoteEntry] = {}
+        self._pending_replica_moves: dict[str, str] = {}
 
     @property
     @_serialized
@@ -596,21 +597,22 @@ class FileNotesService:
             )
 
         warning: str | None = None
-        destination_replicated = False
         try:
             moved = self._load_file(destination_path)
-            warning = self._upsert_opened(moved)
-            destination_replicated = warning is None
         except (OSError, ValueError) as error:
             warning = f"Replica refresh failed: {error}"
-        if self._replica is not None:
-            if destination_replicated:
-                try:
-                    self._replica.discard_file(self.root_key, relative_path)
-                except Exception as error:
-                    warning = _merge_warnings(warning, _replica_warning(error))
         else:
-            warning = _merge_warnings(warning, "Replica unavailable")
+            warning = self._move_opened(relative_path, moved)
+        self._pending_replica_moves.pop(destination_path, None)
+        for pending_source, pending_destination in tuple(
+            self._pending_replica_moves.items()
+        ):
+            if pending_destination == relative_path:
+                self._pending_replica_moves[pending_source] = destination_path
+        if warning is None:
+            self._pending_replica_moves.pop(relative_path, None)
+        else:
+            self._pending_replica_moves[relative_path] = destination_path
         self._session_changes.append(
             SessionChange("moved", relative_path, destination_path)
         )
@@ -817,10 +819,81 @@ class FileNotesService:
             warning = "Replica unavailable"
 
         observed, uncertain_paths, had_walk_error = self._walk_candidates()
+        pending_move_entries: dict[str, OpenedFileNote] = {}
+        pending_move_sources: set[str] = set()
+        if old_files is not None and self._replica is not None:
+            for source_path, destination_path in tuple(
+                self._pending_replica_moves.items()
+            ):
+                if source_path not in old_files or source_path in observed:
+                    self._pending_replica_moves.pop(source_path, None)
+                    continue
+                if destination_path not in observed:
+                    if had_walk_error:
+                        continue
+                    source_info = old_files[source_path]
+                    try:
+                        retained_bytes = self._replica.get_bytes(
+                            self.root_key,
+                            source_path,
+                        )
+                        if retained_bytes is None:
+                            raise KeyError(source_path)
+                        retained_hash = _digest(retained_bytes)
+                        self._replica.move_file(
+                            self.root_key,
+                            source_path,
+                            destination_path,
+                            retained_bytes,
+                            content_hash=retained_hash,
+                            decoded_text=_decode_for_replica(retained_bytes),
+                            size=len(retained_bytes),
+                            mtime_ns=source_info.mtime_ns,
+                        )
+                    except Exception as error:
+                        warning = _merge_warnings(
+                            warning,
+                            _replica_warning(error),
+                        )
+                        pending_move_sources.add(source_path)
+                        continue
+                    self._pending_replica_moves.pop(source_path, None)
+                    old_files.pop(source_path, None)
+                    old_files[destination_path] = ReplicaFileInfo(
+                        relative_path=destination_path,
+                        content_hash=retained_hash,
+                        size=len(retained_bytes),
+                        mtime_ns=source_info.mtime_ns,
+                    )
+                    continue
+                try:
+                    moved = self._load_file(destination_path)
+                except (OSError, ValueError):
+                    pending_move_sources.add(source_path)
+                    continue
+                move_warning = self._move_opened(source_path, moved)
+                if move_warning is not None:
+                    warning = _merge_warnings(warning, move_warning)
+                    pending_move_sources.add(source_path)
+                    pending_move_entries[destination_path] = moved
+                    continue
+                self._pending_replica_moves.pop(source_path, None)
+                old_files.pop(source_path, None)
+                old_files[destination_path] = ReplicaFileInfo(
+                    relative_path=destination_path,
+                    content_hash=moved.content_hash,
+                    size=moved.size,
+                    mtime_ns=moved.mtime_ns,
+                )
+
         entries: list[FileNoteEntry] = []
         created: list[str] = []
         modified: list[str] = []
         for relative_path, observed_file in observed.items():
+            pending_move = pending_move_entries.get(relative_path)
+            if pending_move is not None:
+                entries.append(_entry_from_opened(pending_move))
+                continue
             previous = None if old_files is None else old_files.get(relative_path)
             cached = self._entry_cache.get(relative_path)
             replica_matches = (
@@ -885,7 +958,10 @@ class FileNotesService:
         deleted: list[str] = []
         if old_files is not None and not had_walk_error:
             deleted = sorted(
-                set(old_files) - set(observed) - uncertain_paths
+                set(old_files)
+                - set(observed)
+                - uncertain_paths
+                - pending_move_sources
             )
             for relative_path in deleted:
                 try:
@@ -1127,6 +1203,28 @@ class FileNotesService:
             mtime_ns=opened.mtime_ns,
         )
 
+    def _move_opened(
+        self,
+        source_path: str,
+        opened: OpenedFileNote,
+    ) -> str | None:
+        if self._replica is None:
+            return "Replica unavailable"
+        try:
+            self._replica.move_file(
+                self.root_key,
+                source_path,
+                opened.relative_path,
+                opened.raw_bytes,
+                content_hash=opened.content_hash,
+                decoded_text=_decode_for_replica(opened.raw_bytes),
+                size=opened.size,
+                mtime_ns=opened.mtime_ns,
+            )
+        except Exception as error:
+            return _replica_warning(error)
+        return None
+
     def _upsert_bytes(
         self,
         relative_path: str,
@@ -1155,6 +1253,7 @@ class FileNotesService:
             )
         except Exception as error:
             return _replica_warning(error)
+        self._pending_replica_moves.pop(relative_path, None)
         return None
 
     def _clear_tombstone(self, relative_path: str) -> str | None:


### PR DESCRIPTION
## Summary
- replace a moved File Notes replica projection atomically, without tombstoning the source path
- retry transient replica failures while preserving exact recovery bytes and destination identity
- keep reused source paths and later genuine deletions independently recoverable
- prevent moved-from paths from appearing under Recently deleted

## Focused verification
- 48 File Notes replica/service tests passed
- mounted create/move/delete/protect/restore workspace test passed
- targeted Ruff, py_compile, and git diff --check passed

ADR: existing backlog/decisions/029-file-notes-disk-authority.md applies; no new ADR required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes File Notes moves to update the replica atomically and avoid tombstoning the source, so moved-from paths no longer appear under Recently deleted while real deletions remain restorable. Implements resilient retries that keep exact recovery bytes and the correct destination identity on transient replica failures. Satisfies TASK-982.

- **Bug Fixes**
  - Replica: added `move_file` to upsert the destination and remove only the active source in one transaction; updates FTS and retains genuine tombstones.
  - Service: routes moves through the atomic replica op; tracks pending moves and retries on `reconcile`, restoring from retained source bytes if needed; preserves later deletions and destination identity.
  - UI: moved-from paths do not appear in Recently deleted.
  - Tests: added focused replica/service cases and a mounted workspace check for create/move/delete/protect/restore flows.

<sup>Written for commit 56e7536aef8dcde7120a09553345f0c37c2e8eb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

