### PR TITLE
fix(mcp,chatbooks): remove a service that never existed; route the last path literals

### DIFF
--- a/.superpowers/sdd/task-967-968-report.md
+++ b/.superpowers/sdd/task-967-968-report.md
@@ -1,0 +1,171 @@
+# TASK-967 / TASK-968 report
+
+Worktree: `/Users/macbook-dev/Documents/GitHub/wt-967-968`, branch `fix/chatbook-accessors-and-mcp-service`, cut from `origin/dev`.
+
+## TASK-967 — Route Chatbook window and wizard files through the path accessors
+
+### What I found
+
+Task-865's Implementation Notes named the *exact* deferred finding this task was filed to capture:
+`ChatbookCreationWindow.py`, `ChatbookExportManagementWindow.py`, `ChatbookCreationWizard.py` and
+`ChatbookImportWizard.py` each built an ad-hoc `db_paths` dict from
+`self.app.config_data.get('database', {})` with hardcoded fallback literals like
+`'~/.local/share/tldw_cli/tldw_prompts_db.db'`, and `ChatbookCreationWindow.py`'s output dir was a bare
+`Path.home() / '.local' / 'share' / 'tldw_cli' / 'chatbooks'` with a bare `.mkdir()`.
+
+**That specific defect was already fixed on current dev before this task started** — all four files now
+call the real accessors (`get_chatbook_database_paths()`, `get_private_chatbooks_dir()`), and zero literal
+`~/.config/tldw_cli` or `~/.local/share/tldw_cli` string remains in any Chatbook window/wizard file
+(verified by grep across all 10 candidate files, and by the existing, passing
+`Tests/Chatbooks/test_chatbook_database_paths.py::test_chatbook_surfaces_do_not_embed_database_defaults`,
+parametrized across all four files).
+
+### A related-but-out-of-AC-scope finding, reported not silently fixed
+
+Three live files — `ChatbookExportManagementWindow.py`, `Chatbooks_Window_Improved.py`,
+`Wizards/ChatbookCreationWizard.py` — default the *visible* chatbooks export/scan directory to
+`Path.home() / "Documents" / "Chatbooks"` (already correctly hardened via
+`secure_private_directory`/`secure_chatbook_directory` in all three). This is not the AC's named literal
+class (it's not `~/.config/tldw_cli` or `~/.local/share/tldw_cli`), and it diverges from
+`get_private_chatbooks_dir()` (`~/.local/share/tldw_cli/<user>/chatbooks`), which
+`ChatbookCreationWindow.py` + `Tools_Settings_Window.py`'s modal-based creation flow already use for the
+same conceptual directory. Switching the three wizard/window files to `get_private_chatbooks_dir()` would
+silently stop the management window from finding chatbooks a user already exported via the wizard flow —
+the exact live-data-relocation risk the task's constraints told me to stop and report on rather than act
+on. **Filed as a cross-window inconsistency worth its own follow-up**, not resolved here.
+
+### What I fixed
+
+- `tldw_chatbook/UI/Chatbooks_Window.py` (confirmed dead code — not imported anywhere in the live app
+  except a `.skip`'d integration test) still built its export path from raw `config.get()` +
+  `.expanduser()` + a bare `.mkdir()`. Routed it through `Chatbooks/database_paths.secure_chatbook_directory`
+  (the same helper `Chatbooks_Window_Improved.py` already uses), matching the `chatbook_importer.py`
+  hardening pattern the task pointed at.
+- Deleted `Tests/Chatbooks/conftest.py`'s unused `mock_app_config` fixture and `MockWizardApp` class: dead
+  test scaffolding referenced by zero tests, re-spelling the exact stale db-path/export-directory literals
+  the earlier production fix already replaced — left in place it would have been misleading debris of the
+  "test repeats a literal instead of deriving it" shape the task warns about.
+
+### Verification
+
+- `Tests/Chatbooks/` — 159 passed, 1 skipped.
+- `Tests/UI/test_chatbook_action_recovery_tooltips.py`, `test_chatbook_management_server_jobs.py`,
+  `test_chatbooks_screen_server_actions.py`, `test_file_picker_action_tooltips.py` — 22 passed.
+
+### Status
+
+Backlog task-967 marked **Done**, AC #1 checked.
+
+---
+
+## TASK-968 — Fix the missing `CharacterInteropService` referenced by MCP server
+
+### Decision: remove, not resolve
+
+`Character_Chat/Character_Chat_Lib.py` is a free-function module — it has never had a single class in it
+(confirmed by listing every top-level `class`/`def`). `CharacterInteropService` was never renamed or moved;
+it was never implemented at all. `self.character_service` (built from it in `_init_databases()`) was never
+read anywhere else in `MCP/server.py` or the rest of the `MCP/` package. The character-related tools that
+*are* wired up — `chat_with_character`, `list_characters` — go through `self.tools` (`MCPTools`), which
+already reads character rows directly off `self.chachanotes_db` via `get_character_card_by_id()` /
+`list_character_cards()`. There was no unfinished feature behind the reference to wire up — only a
+guaranteed `ImportError` on every call to `_init_databases()`. **Removed** the import and the
+`self.character_service = ...` line, with an explanatory comment in place.
+
+### Before / after reproduction
+
+Technique: bypass `TldwMCPServer.__init__` (which requires the optional `mcp` package, not installed in
+this venv) via `__new__`, then call the real, unmodified `_init_databases()` directly — the same technique
+`Tests/MCP/test_server_media_db_path.py` already used for TASK-854. `NotesInteropService` is stubbed with a
+permissive fake because its own call-signature mismatch (see "broader look" below) is a separate,
+pre-existing defect that would otherwise mask the specific thing being reproduced.
+
+Commands (run from the worktree, `HOME`/`TLDW_CONFIG_PATH` redirected to a scratch dir so nothing touches
+real config/databases; `PYTHONPATH` pinned to the worktree so `tldw_chatbook.__file__` resolves there, not
+the main checkout):
+
+```bash
+SCRATCH=<scratchpad>
+# BEFORE: git HEAD's server.py (pre-fix) copied temporarily into place
+cp <scratchpad>/server_before.py tldw_chatbook/MCP/server.py
+HOME="$SCRATCH/home968" TLDW_CONFIG_PATH="$SCRATCH/home968/.config/tldw_cli/config.toml" \
+  PYTHONPATH=/Users/macbook-dev/Documents/GitHub/wt-967-968 \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python <scratchpad>/repro_968.py
+# -> _init_databases() RAISED: ImportError: cannot import name 'CharacterInteropService' from
+#    'tldw_chatbook.Character_Chat.Character_Chat_Lib'   (exit 1)
+
+# AFTER: restore the fixed server.py
+cp <scratchpad>/server_current_fixed.py tldw_chatbook/MCP/server.py
+HOME="$SCRATCH/home968" TLDW_CONFIG_PATH="$SCRATCH/home968/.config/tldw_cli/config.toml" \
+  PYTHONPATH=/Users/macbook-dev/Documents/GitHub/wt-967-968 \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python <scratchpad>/repro_968.py
+# -> _init_databases() SUCCEEDED; has character_service attribute = False   (exit 0)
+```
+
+`repro_968.py` (in the session scratchpad) just monkeypatches `NotesInteropService` to a permissive fake at
+its source module, constructs `TldwMCPServer.__new__(...)`, calls `._init_databases()`, and prints
+success/failure plus whether `character_service` exists. The same assertions are now pytest-enforced in
+`Tests/MCP/test_server_character_service.py` (no scratch files needed to re-run them).
+
+### Broader look at `MCP/server.py` (as asked — checked, not everything fixed)
+
+- **Fixed** (in scope, low-risk, single call site): `chat_with_llm`'s API-key lookup called
+  `get_cli_setting("API", f"{provider}_api_key", "")` directly instead of `config.get_api_key(provider)`,
+  the declared accessor. `get_api_key()` checks three tiers — the newer `api_settings.<provider>` structure
+  (with its own env-var-name indirection), then the legacy `[API]` section (the *only* tier the direct call
+  covered), then a bare `{PROVIDER}_API_KEY` env var. The direct call silently missed a key configured via
+  either of the other two tiers, returning `"No API key configured"` even when a real one existed.
+  Repointed to `get_api_key(provider)`; the now-unused `get_cli_setting` import was removed.
+- **Reported, not fixed** (own design decision, out of this task's scope): `self.notes_service =
+  NotesInteropService(self.chachanotes_db)` is *also* broken, independently of the character bug.
+  `NotesInteropService.__init__` requires `(base_db_directory: str|Path, api_client_id: str,
+  global_db_to_use=None)` — the call passes only one positional arg (a `CharactersRAGDB` instance) where a
+  directory path is required, and omits the required `api_client_id` entirely. (This is exactly why
+  `test_server_media_db_path.py` has to stub `NotesInteropService` with a permissive fake just to get past
+  `_init_databases()` at all.) Even a corrected construction wouldn't help downstream: the `create_note`
+  tool calls `self.notes_service.create_note(title=, content=, tags=, template=)`, but the real class has
+  no `create_note` method (only `add_note(user_id, title, content, note_id=None)` — no `tags`/`template`
+  params, and a required `user_id` the tool call never supplies); `search_notes` calls
+  `self.notes_service.search_notes(query=, limit=)`, but the real signature is
+  `search_notes(user_id, search_term, limit=10, fts_match_query=None, *, id_allowlist=None)` — wrong kwarg
+  name (`query` vs `search_term`) and again a missing required `user_id`. Fixing this needs a real design
+  decision (where does an MCP-context `user_id` come from?) that's beyond this task's scope — recommend
+  filing separately.
+- **Verified clean**: `MCPResources` and `MCPPrompts` constructors, and every method `server.py` calls on
+  `self.resources`/`self.prompts` (`get_conversation_resource`, `get_note_resource`,
+  `get_character_resource`, `get_media_resource`, `get_rag_chunk_resource`, `list_recent_conversations`,
+  `list_recent_notes`, `summarize_conversation_prompt`, `generate_document_prompt`, `analyze_media_prompt`,
+  `search_and_synthesize_prompt`, `character_writing_prompt`) all exist with matching signatures.
+  `MCPTools`'s other methods used by `server.py` (`search_conversations`, `get_conversation_history`,
+  `export_conversation`, `perform_rag_search`) also verified present with matching signatures.
+  `get_chachanotes_db_path()`/`get_media_db_path()` (TASK-854's fix) remain correct. `ingest_media` is an
+  explicit `TODO`/placeholder, not a silent-failure case.
+
+### Files changed
+
+- `tldw_chatbook/MCP/server.py` — removed the dead `CharacterInteropService` import + assignment (with
+  explanatory comment); repointed `chat_with_llm`'s API-key lookup to `get_api_key`.
+- `Tests/MCP/test_server_media_db_path.py` — dropped the now-unnecessary `CharacterInteropService` stub,
+  updated the module docstring to reflect the fix.
+- `Tests/MCP/test_server_character_service.py` (new) — 4 tests: no `CharacterInteropService`
+  import/reference remains (AST-based, so it doesn't false-flag the explanatory comment),
+  `_init_databases()` succeeds without the old stub and has no `character_service` attribute,
+  `Character_Chat_Lib` still has no such class (sanity check on the remove-vs-resolve decision), and
+  `chat_with_llm` calls `get_api_key` rather than `get_cli_setting` (AST-based).
+
+### Verification
+
+- `Tests/MCP/test_server_character_service.py` + `test_server_media_db_path.py` +
+  `test_server_chat_repoint.py` — 10 passed.
+- `Tests/MCP/` (full directory) — 366 passed.
+- `Tests/Utils/` (full directory) — 562 passed.
+
+### Status
+
+Backlog task-968 marked **Done**, AC #1 checked.
+
+---
+
+## Commits
+
+See git log on `fix/chatbook-accessors-and-mcp-service` for the SHAs (not pushed).

--- a/Tests/Chatbooks/conftest.py
+++ b/Tests/Chatbooks/conftest.py
@@ -331,32 +331,3 @@ This is a test note for the chatbook."""
         )
 
     return chatbook_path
-
-
-@pytest.fixture
-def mock_app_config():
-    """Create a mock app configuration."""
-    return {
-        "database": {
-            "chachanotes_db_path": "~/.local/share/tldw_cli/tldw_chatbook_ChaChaNotes.db",
-            "prompts_db_path": "~/.local/share/tldw_cli/tldw_prompts.db",
-            "media_db_path": "~/.local/share/tldw_cli/media_db_v2.db",
-        },
-        "chatbooks": {
-            "export_directory": "~/Documents/Chatbooks",
-            "auto_include_dependencies": True,
-            "default_media_quality": "thumbnail",
-        },
-    }
-
-
-class MockWizardApp:
-    """Mock wizard app for UI testing."""
-
-    def __init__(self, config_data):
-        self.config_data = config_data
-        self.notifications = []
-
-    def notify(self, message, severity="info"):
-        """Mock notify method."""
-        self.notifications.append({"message": message, "severity": severity})

--- a/Tests/MCP/test_server_character_service.py
+++ b/Tests/MCP/test_server_character_service.py
@@ -1,0 +1,137 @@
+"""TASK-968: MCP server no longer references a nonexistent CharacterInteropService.
+
+``TldwMCPServer._init_databases()`` used to construct a
+``CharacterInteropService`` -- a class that does not exist anywhere in the
+codebase (``Character_Chat_Lib.py`` is a free-function module, not a
+service class). Because the import ran unconditionally inside
+``_init_databases()``, constructing a ``TldwMCPServer`` always raised
+``ImportError`` before it could open a single database connection. The
+resulting ``self.character_service`` attribute was never read anywhere
+else in the MCP package either: the character-related tools
+(``MCPTools.chat_with_character`` / ``list_available_characters``) already
+read character rows directly off ``self.chachanotes_db``
+(``get_character_card_by_id`` / ``list_character_cards``). The dead
+reference has been removed rather than resolved to a real service, since
+there was no unfinished feature behind it to wire up.
+
+Also covers the adjacent finding from this task's "look at the module more
+broadly" mandate: ``chat_with_llm``'s API key lookup used to call
+``get_cli_setting("API", f"{provider}_api_key", "")`` directly instead of
+the declared accessor ``config.get_api_key()``, silently missing a key
+configured via the newer ``api_settings.<provider>`` structure or a bare
+environment variable (both of which ``get_api_key()`` checks first/last).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+class _PermissiveFakeService:
+    """Stand-in for NotesInteropService, whose own call-signature mismatch
+    is a separate, pre-existing defect out of this task's scope (see
+    test_server_media_db_path.py and this task's Implementation Notes)."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+
+def _server_source() -> str:
+    import tldw_chatbook.MCP.server as srv
+
+    return Path(srv.__file__).read_text(encoding="utf-8")
+
+
+def test_no_character_interop_service_reference_remains():
+    """No reference to the nonexistent service remains in the module.
+
+    Walks the AST rather than grepping raw text: an explanatory comment on
+    the removal legitimately names the class it removed (see the source),
+    which a text search would false-flag.
+    """
+    import ast
+
+    tree = ast.parse(_server_source())
+
+    imported_names = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        for alias in node.names
+    }
+    assert "CharacterInteropService" not in imported_names
+
+    referenced_names = {
+        node.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute)
+    } | {
+        node.id for node in ast.walk(tree) if isinstance(node, ast.Name)
+    }
+    assert "character_service" not in referenced_names
+    assert "CharacterInteropService" not in referenced_names
+
+
+def test_init_databases_no_longer_needs_a_character_service_stub(monkeypatch):
+    """Regression guard for the exact bug: before the fix, driving
+    ``_init_databases()`` far enough to construct required stubbing a
+    ``CharacterInteropService`` into ``Character_Chat_Lib`` (a class that
+    doesn't exist there) just so the import wouldn't raise. That stub
+    should no longer be necessary at all -- and the constructed instance
+    should have no ``character_service`` attribute.
+    """
+    import tldw_chatbook.Notes.Notes_Library as notes_library_module
+    from tldw_chatbook.MCP import server as mcp_server_module
+
+    monkeypatch.setattr(
+        notes_library_module, "NotesInteropService", _PermissiveFakeService
+    )
+
+    instance = mcp_server_module.TldwMCPServer.__new__(mcp_server_module.TldwMCPServer)
+    instance._init_databases()
+
+    assert not hasattr(instance, "character_service")
+
+
+def test_character_chat_lib_still_has_no_interop_service_class():
+    """Sanity check on the decision itself: confirms the removal (not a
+    rename-and-rewire) was correct by asserting the source module this bug
+    imported from still has no such class -- if one is ever added, this
+    test should be revisited alongside the removal in server.py.
+    """
+    import tldw_chatbook.Character_Chat.Character_Chat_Lib as character_chat_lib_module
+
+    assert not hasattr(character_chat_lib_module, "CharacterInteropService")
+
+
+def test_chat_with_llm_uses_the_declared_api_key_accessor():
+    """The broader-look finding: the API key lookup must go through
+    ``config.get_api_key()`` (checks api_settings.<provider>, the legacy
+    [API] section, and a bare env var) rather than a direct
+    ``get_cli_setting("API", ...)`` call that only covers the middle tier.
+
+    Walks the AST rather than grepping raw text: explanatory comments in
+    the module legitimately mention ``get_cli_setting`` by name (this is
+    exactly what used to be called), so a text search would false-flag.
+    """
+    import ast
+
+    tree = ast.parse(_server_source())
+    called_names = {
+        getattr(node.func, "attr", None) or getattr(node.func, "id", None)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+    }
+    assert "get_api_key" in called_names
+    assert "get_cli_setting" not in called_names
+
+    imported_names = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        for alias in node.names
+    }
+    assert "get_api_key" in imported_names
+    assert "get_cli_setting" not in imported_names

--- a/Tests/MCP/test_server_media_db_path.py
+++ b/Tests/MCP/test_server_media_db_path.py
@@ -11,15 +11,16 @@ per-profile data directory -- and outside ``Utils.sensitive_paths``'
 denylist coverage, since that denylists ``get_media_db_path()``'s result,
 not a CWD-relative file.
 
-``_init_databases()`` also constructs ``NotesInteropService`` and
-``CharacterInteropService`` with call signatures that don't match either
-class (``CharacterInteropService`` does not exist anywhere in the
-codebase at all -- see ``test_no_other_undeclared_database_config_keys``'s
-module docstring reference and this task's Implementation Notes for the
-grep). Both are unrelated, pre-existing defects out of this task's scope;
-the tests below stub just enough of them (permissive fakes swapped in at
-their *source* modules, so ``_init_databases``'s own local imports pick
-them up) to drive the real, unmodified method far enough to construct
+``_init_databases()`` also used to construct a ``CharacterInteropService``
+that does not exist anywhere in the codebase at all -- that dead reference
+was removed by TASK-968 (it was never consumed by anything else in the MCP
+package either; character-related tools already read ``chachanotes_db``
+directly). ``NotesInteropService`` is still constructed with a call
+signature that doesn't match the real class -- an unrelated, pre-existing
+defect out of this task's scope (see TASK-968's Implementation Notes) --
+so the tests below still stub it (a permissive fake swapped in at its
+*source* module, so ``_init_databases``'s own local import picks it up)
+to drive the real, unmodified method far enough to construct
 ``self.media_db`` -- proving the fix through the actual code path rather
 than by re-implementing its logic in the test.
 """
@@ -47,20 +48,10 @@ def _build_server_with_databases(monkeypatch):
     directly -- exercising the actual fixed code path.
     """
     import tldw_chatbook.Notes.Notes_Library as notes_library_module
-    import tldw_chatbook.Character_Chat.Character_Chat_Lib as character_chat_lib_module
     from tldw_chatbook.MCP import server as mcp_server_module
 
     monkeypatch.setattr(
         notes_library_module, "NotesInteropService", _PermissiveFakeService
-    )
-    # CharacterInteropService does not exist in this module at all (see
-    # docstring) -- raising=False allows creating the attribute rather than
-    # requiring one already be there.
-    monkeypatch.setattr(
-        character_chat_lib_module,
-        "CharacterInteropService",
-        _PermissiveFakeService,
-        raising=False,
     )
 
     instance = mcp_server_module.TldwMCPServer.__new__(mcp_server_module.TldwMCPServer)

--- a/backlog/tasks/task-967 - Route-Chatbook-window-and-wizard-files-through-the-path-accessors.md
+++ b/backlog/tasks/task-967 - Route-Chatbook-window-and-wizard-files-through-the-path-accessors.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-967
 title: Route Chatbook window and wizard files through the path accessors
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-27 18:06'
+updated_date: '2026-07-27 19:28'
 labels:
   - config
   - chatbooks
@@ -19,5 +21,27 @@ While completing TASK-865's sweep, the Chatbook window and wizard files were fou
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Chatbook window and wizard files derive their paths from the accessors,No hardcoded ~/.config/tldw_cli or ~/.local/share/tldw_cli literal remains in those files,A test derives its expected path the same way the app does rather than re-spelling a literal
+- [x] #1 Chatbook window and wizard files derive their paths from the accessors,No hardcoded ~/.config/tldw_cli or ~/.local/share/tldw_cli literal remains in those files,A test derives its expected path the same way the app does rather than re-spelling a literal
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Enumerate every Chatbook window/wizard file (ChatbookCreationWindow.py, ChatbookExportManagementWindow.py, ChatbookTemplatesWindow.py, Chatbooks_Window_Improved.py, Chatbooks_Window.py, Wizards/ChatbookCreationWizard.py, Wizards/ChatbookImportWizard.py, Wizards/BaseWizard.py, Screens/chatbooks_screen.py, server_chatbook_service_lease.py) for direct ~/.config/tldw_cli or ~/.local/share/tldw_cli composition.
+2. Check task-865's Implementation Notes for the exact deferred finding (the ad-hoc db_paths dict + output_dir literal) and verify current state against it.
+3. Fix any remaining bare-mkdir/un-hardened directory creation using secure_private_directory, following the chatbook_importer.py pattern.
+4. Clean up any test fixtures that re-spell a literal the production code no longer uses.
+5. Run Tests/Chatbooks/ and the relevant Tests/UI/test_chatbook*.py files.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The specific defect this task was filed for was already fixed on dev before this task started. Task-865's Implementation Notes named the exact deferred finding: ChatbookCreationWindow.py, ChatbookExportManagementWindow.py, ChatbookCreationWizard.py and ChatbookImportWizard.py each built an ad-hoc db_paths dict from self.app.config_data.get('database', {}) with hardcoded fallback literals like '~/.local/share/tldw_cli/tldw_prompts_db.db', and ChatbookCreationWindow.py's output_dir was a bare Path.home()/'.local'/'share'/'tldw_cli'/'chatbooks' with a bare mkdir. Verified all four files now call the real accessors (get_chatbook_database_paths(), get_private_chatbooks_dir()) with zero literal '~/.config/tldw_cli' or '~/.local/share/tldw_cli' remaining, confirmed by the existing Tests/Chatbooks/test_chatbook_database_paths.py (7/7 passing, including a parametrized source-text check across all four files) and Tests/UI/test_tools_settings_window.py's accessor-parity tests.
+
+A distinct, narrower literal survives in three live files -- ChatbookExportManagementWindow.py, Chatbooks_Window_Improved.py and Wizards/ChatbookCreationWizard.py all default the visible chatbooks export/scan directory to Path.home()/'Documents'/'Chatbooks' (already correctly hardened via secure_private_directory/secure_chatbook_directory in all three, just not derived from get_private_chatbooks_dir()). This is NOT the AC's named literal class and switching it to get_private_chatbooks_dir() (~/.local/share/tldw_cli/<user>/chatbooks, already the location ChatbookCreationWindow.py + Tools_Settings_Window.py use for the modal-based creation flow) would silently stop the management window from finding chatbooks a user already exported via the wizard flow -- exactly the live-data-relocation risk this task's constraints say to stop and report on rather than act on. Reporting it here as a real cross-window inconsistency (two live UI flows disagree on where local chatbook exports live) worth its own follow-up task, not silently reconciled by this one.
+
+Fixed the one remaining no-risk item: Chatbooks_Window.py (dead code -- not imported anywhere in the live app except a `.skip`'d integration test) still built its export path from raw config.get() + bare .mkdir(). Routed it through Chatbooks/database_paths.secure_chatbook_directory (the same helper Chatbooks_Window_Improved.py already uses), matching the chatbook_importer.py hardening pattern the task pointed at. Also deleted Tests/Chatbooks/conftest.py's unused mock_app_config fixture and MockWizardApp class: dead test scaffolding, referenced by zero tests, that re-spelled the exact stale db-path/export-directory literals the production fix above already replaced -- left in place it would have been misleading debris of the same "test repeats a literal instead of deriving it" shape the task warns about.
+
+Files: tldw_chatbook/UI/Chatbooks_Window.py, Tests/Chatbooks/conftest.py. Verified via Tests/Chatbooks/ (159 passed, 1 skipped) and Tests/UI/test_chatbook_action_recovery_tooltips.py, test_chatbook_management_server_jobs.py, test_chatbooks_screen_server_actions.py, test_file_picker_action_tooltips.py (22 passed).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-968 - Fix-the-missing-CharacterInteropService-referenced-by-MCP-server.md
+++ b/backlog/tasks/task-968 - Fix-the-missing-CharacterInteropService-referenced-by-MCP-server.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-968
 title: Fix the missing CharacterInteropService referenced by MCP server
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-27 18:06'
+updated_date: '2026-07-27 19:28'
 labels:
   - mcp
   - bug
@@ -18,5 +20,34 @@ While fixing TASK-854's media DB lookup, MCP/server.py was found referencing a C
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 MCP/server.py's character code path either resolves a real service or is removed,No reference to a nonexistent service remains in that module,The module's other config lookups are checked against the declared accessors
+- [x] #1 MCP/server.py's character code path either resolves a real service or is removed,No reference to a nonexistent service remains in that module,The module's other config lookups are checked against the declared accessors
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Read MCP/server.py in full; confirm CharacterInteropService does not exist anywhere in the codebase (grep for the class definition).
+2. Determine intent: check whether self.character_service is consumed anywhere in the MCP package, and whether MCPTools' character-related tools (chat_with_character, list_available_characters) already get character data another way.
+3. Decide resolve-vs-remove based on that, then apply the fix and update tests that stub around the old bug (test_server_media_db_path.py's helper).
+4. Broader look: check every other service construction, config lookup (get_cli_setting), and import in the module against its target's real signature/declared accessor; report mismatches found even if not fixed.
+5. Write a before/after reproduction bypassing __init__ (which needs the optional mcp package) via __new__, calling the real _init_databases() directly, mirroring the existing test's technique.
+6. Add regression tests; run Tests/MCP/, Tests/Utils/.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Decision: removed the dead code path rather than resolving it to a real service. Character_Chat_Lib.py is a free-function module -- it has never had any class in it (confirmed by listing every top-level class/def in the file), so CharacterInteropService was never renamed or moved, just never implemented. self.character_service (built from it) was never read anywhere else in MCP/server.py or the rest of the MCP package: the character-related tools that ARE wired up (chat_with_character, list_characters) go through self.tools (MCPTools), which already reads character rows directly off self.chachanotes_db via get_character_card_by_id()/list_character_cards(). There was no unfinished feature behind the reference to wire up, only a guaranteed ImportError on every call to _init_databases().
+
+Reproduction (both commands run from the worktree, HOME/TLDW_CONFIG_PATH redirected to a scratch dir, __new__ used to bypass __init__'s optional-mcp-package guard so _init_databases() -- the real, unmodified method -- can be driven directly, same technique as the pre-existing Tests/MCP/test_server_media_db_path.py):
+  Before (git show HEAD:tldw_chatbook/MCP/server.py copied into place): `_init_databases()` raised `ImportError: cannot import name 'CharacterInteropService' from 'tldw_chatbook.Character_Chat.Character_Chat_Lib'` (exit 1).
+  After (this task's fix): `_init_databases()` succeeds; the constructed instance has no `character_service` attribute at all (exit 0).
+Full script and both raw outputs are in this task's report file; the same assertions are now pytest-enforced in Tests/MCP/test_server_character_service.py.
+
+Broader look at MCP/server.py, as asked (checked, not all fixed):
+- FIXED (in scope, low-risk, single call site): chat_with_llm's API-key lookup called get_cli_setting("API", f"{provider}_api_key", "") directly instead of config.get_api_key(provider), the declared accessor. get_api_key() checks three tiers (newer api_settings.<provider> structure with its own env-var-name indirection, then the legacy [API] section -- the one tier the direct call covered -- then a bare {PROVIDER}_API_KEY env var); the direct call silently missed a key configured via either of the other two, returning "No API key configured" even when one existed. Repointed to get_api_key(provider); get_cli_setting import removed (no other use in the file).
+- REPORTED, NOT FIXED (own design decision, out of this task's scope): self.notes_service = NotesInteropService(self.chachanotes_db) is ALSO broken, independently of the character bug. NotesInteropService.__init__ requires (base_db_directory: str|Path, api_client_id: str, global_db_to_use=None) -- the call passes only one positional arg (a CharactersRAGDB instance) where a directory path is required, and omits the required api_client_id entirely (this is exactly why test_server_media_db_path.py has to stub NotesInteropService with a permissive fake to get past _init_databases() at all -- documented in that test's docstring, updated by this task). Even a corrected construction wouldn't help: the create_note tool calls self.notes_service.create_note(title=, content=, tags=, template=) but the real class has no create_note method (only add_note(user_id, title, content, note_id=None), no tags/template params, and a required user_id neither tool call supplies); search_notes calls self.notes_service.search_notes(query=, limit=) but the real signature is search_notes(user_id, search_term, limit=10, fts_match_query=None, *, id_allowlist=None) -- wrong kwarg name (query vs search_term) and again a missing required user_id. Fixing this needs a real design decision (where does an MCP-context user_id come from?) that's beyond this task; recommend filing separately.
+- Verified clean: MCPResources and MCPPrompts constructors, and every method server.py calls on self.resources/self.prompts (get_conversation_resource, get_note_resource, get_character_resource, get_media_resource, get_rag_chunk_resource, list_recent_conversations, list_recent_notes, summarize_conversation_prompt, generate_document_prompt, analyze_media_prompt, search_and_synthesize_prompt, character_writing_prompt) -- all exist with matching signatures. MCPTools' other methods used by server.py (search_conversations, get_conversation_history, export_conversation, perform_rag_search) also verified present. get_chachanotes_db_path()/get_media_db_path() (TASK-854's fix) still correct. ingest_media is an explicit TODO/placeholder, not a silent-failure case.
+
+Files: tldw_chatbook/MCP/server.py (removed the import + self.character_service line with an explanatory comment; repointed chat_with_llm to get_api_key), Tests/MCP/test_server_media_db_path.py (dropped the now-unnecessary CharacterInteropService stub, updated docstring), Tests/MCP/test_server_character_service.py (new -- 4 tests covering the removal and the get_api_key repoint via AST-based source checks plus an executable _init_databases() regression guard). Verified via Tests/MCP/ (366 passed) and Tests/Utils/ (562 passed).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-982 - Reconcile-the-Chatbook-export-directory-default-across-the-four-windows.md
+++ b/backlog/tasks/task-982 - Reconcile-the-Chatbook-export-directory-default-across-the-four-windows.md
@@ -1,0 +1,23 @@
+---
+id: TASK-982
+title: Reconcile the Chatbook export directory default across the four windows
+status: To Do
+assignee: []
+created_date: '2026-07-27 19:33'
+labels:
+  - chatbooks
+  - config
+  - ux
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Three live Chatbook files default the visible export directory to ~/Documents/Chatbooks while ChatbookCreationWindow.py uses get_private_chatbooks_dir(). Found completing TASK-967 and deliberately not acted on: reconciling in either direction risks orphaning exports a user already has on disk, so the decision needs an owner rather than a sweep. Whichever default wins, the other location needs either a migration or a documented statement that pre-existing exports stay where they are.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The export directory default is the same in all four Chatbook windows,It is decided and written down whether pre-existing exports are migrated or deliberately left,No file composes the path by literal where an accessor exists,A test derives the expected default the way the app does
+<!-- AC:END -->

--- a/backlog/tasks/task-983 - Fix-the-MCP-notes-tools-calling-a-service-API-that-does-not-exist.md
+++ b/backlog/tasks/task-983 - Fix-the-MCP-notes-tools-calling-a-service-API-that-does-not-exist.md
@@ -1,0 +1,23 @@
+---
+id: TASK-983
+title: Fix the MCP notes tools calling a service API that does not exist
+status: To Do
+assignee: []
+created_date: '2026-07-27 19:33'
+labels:
+  - mcp
+  - notes
+  - bug
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+MCP/server.py constructs NotesInteropService(self.chachanotes_db) with the wrong argument count and type, and its create_note and search_notes tools call methods and keyword arguments the real class does not define, so those tools cannot work. Found while removing the nonexistent CharacterInteropService from the same module (TASK-968) and reported rather than fixed because resolving it needs a design call about what the notes tools should expose. This is the third defect of the same shape in this one module -- the others were a config key that did not exist so a database opened in the working directory (TASK-854), and a service that was never implemented (TASK-968).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 MCP notes tools call a real NotesInteropService API with correct arguments,create_note and search_notes work end to end against a temp database,A test exercises both tools rather than only importing the module,The module has no remaining reference to a service or method that does not exist
+<!-- AC:END -->

--- a/tldw_chatbook/MCP/server.py
+++ b/tldw_chatbook/MCP/server.py
@@ -143,7 +143,6 @@ class TldwMCPServer:
             from ..DB.ChaChaNotes_DB import CharactersRAGDB
             from ..DB.Client_Media_DB_v2 import MediaDatabase
             from ..Notes.Notes_Library import NotesInteropService
-            from ..Character_Chat.Character_Chat_Lib import CharacterInteropService
 
             # Initialize character/chat/notes database
             self.chachanotes_db = CharactersRAGDB(
@@ -160,9 +159,20 @@ class TldwMCPServer:
                 db_path=media_db_path, client_id=CLI_APP_CLIENT_ID
             )
 
-            # Initialize services
+            # Initialize services. There is deliberately no
+            # ``self.character_service`` here: this used to construct a
+            # ``CharacterInteropService`` that does not exist anywhere in the
+            # codebase (Character_Chat_Lib.py is a free-function module, not
+            # a service class), so the server could never actually be
+            # constructed (see TASK-968). The attribute was never read by
+            # anything else in this module either -- the character-related
+            # tools below (``chat_with_character``, ``list_characters``)
+            # already go through ``self.tools``, which reads character rows
+            # directly off ``self.chachanotes_db``
+            # (``get_character_card_by_id`` / ``list_character_cards``) --
+            # so the dead reference was removed rather than resolved to a
+            # real service.
             self.notes_service = NotesInteropService(self.chachanotes_db)
-            self.character_service = CharacterInteropService(self.chachanotes_db)
 
             logger.info("Databases initialized successfully")
         except Exception as e:
@@ -171,7 +181,7 @@ class TldwMCPServer:
 
     def _register_tools(self):
         """Register MCP tools."""
-        from ..config import get_cli_setting
+        from ..config import get_api_key
         from ..Chat.Chat_Functions import chat_api_call, extract_response_content
 
         # Basic chat tool
@@ -188,7 +198,13 @@ class TldwMCPServer:
             """Send a message to an LLM and get a response."""
             # For basic chat, we'll implement directly here
             try:
-                api_key = get_cli_setting("API", f"{provider.lower()}_api_key", "")
+                # get_api_key() is the declared accessor: it checks the
+                # newer api_settings.<provider> structure, then the legacy
+                # [API] section, then a bare env var -- a direct
+                # get_cli_setting("API", ...) lookup only covers the middle
+                # tier and silently misses a key configured either of the
+                # other two ways.
+                api_key = get_api_key(provider)
                 if not api_key:
                     return {"error": f"No API key configured for {provider}"}
 

--- a/tldw_chatbook/UI/Chatbooks_Window.py
+++ b/tldw_chatbook/UI/Chatbooks_Window.py
@@ -24,6 +24,8 @@ from textual.reactive import reactive
 from textual.widget import Widget
 from loguru import logger
 
+from ..Chatbooks.database_paths import secure_chatbook_directory
+
 if TYPE_CHECKING:
     from ..app import TldwCli
 
@@ -65,10 +67,10 @@ class ChatbooksWindow(Widget):
 
         # Get export path from config or use default
         config = self.app_instance.app_config.get("chatbooks", {})
-        self._export_path = Path(
+        configured_export_path = Path(
             config.get("export_directory", "~/Documents/Chatbooks")
         ).expanduser()
-        self._export_path.mkdir(parents=True, exist_ok=True)
+        self._export_path = secure_chatbook_directory(configured_export_path)
 
         logger.info("ChatbooksWindow.__init__: Created")
 
@@ -222,8 +224,7 @@ class ChatbooksWindow(Widget):
         """Load chatbooks from export directory."""
         logger.info(f"_refresh_chatbooks: Starting, export_path={self._export_path}")
         try:
-            if not self._export_path.exists():
-                self._export_path.mkdir(parents=True, exist_ok=True)
+            self._export_path = secure_chatbook_directory(self._export_path)
 
             chatbooks = []
 


### PR DESCRIPTION
Closes TASK-967, TASK-968. Final tasks from the path-naming audit series (#964, #985, #996, #999, #1005).

**`Tests/MCP/` + `Tests/Chatbooks/` → 525 passed, 0 failed.**

## TASK-968 — a service that was never implemented

`MCP/server.py` constructed a `CharacterInteropService` that does not exist anywhere in the codebase, so `_init_databases()` raised `ImportError` and that path could never run. `self.character_service` was never read either — the character tools already use `chachanotes_db` directly.

**Removed rather than resolved.** There is no real equivalent under another name; it was never finished. Leaving a reference that reads as working code is worse than deleting it, so the removal carries a comment explaining what was there and why it went.

## The broader look at that module found a third defect of the same shape

TASK-854 previously found this file reading a config key `media_db` that does not exist, so it silently opened `./media_library.db` relative to the current working directory instead of the real, denylisted media database. Two independent defects of the same shape in one module was a signal worth following.

Fixed here: `chat_with_llm` called `get_cli_setting("API", ...)` directly instead of the declared `get_api_key()` accessor, missing two of its three lookup tiers.

Found and **deliberately not fixed**, because both need an owner's decision — filed as **982** and **983**:
- `NotesInteropService(self.chachanotes_db)` is constructed with the wrong argument count and type, and the `create_note`/`search_notes` tools call methods and keyword arguments the real class does not define. Those tools cannot work.
- Three live Chatbook files default the visible export directory to `~/Documents/Chatbooks` while `ChatbookCreationWindow` uses `get_private_chatbooks_dir()`. Reconciling in either direction risks orphaning exports users already have on disk.

That is now three defects of one shape in this module. Task 983 records that it warrants a deliberate pass rather than more one-at-a-time fixes.

## TASK-967 — mostly already fixed on dev

The literal defect TASK-865 deferred (an ad-hoc `db_paths` dict and a `~/.local/share/tldw_cli` output directory across four Chatbook files) has since been fixed on dev. What remained was a residual gap in dead, unwired code in `Chatbooks_Window.py` — now hardened via `secure_chatbook_directory`, following the `secure_private_directory(..., application_owned=True)` pattern dev adopted for `chatbook_importer` — plus an unused test fixture re-spelling stale literals, deleted.

Recorded as already-fixed rather than reshaped into work to match the task description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the nonexistent `CharacterInteropService` from `MCP/server.py` and fixes LLM API key resolution; also hardens the Chatbooks export path. Addresses TASK-967 and TASK-968, with follow-ups filed for remaining notes/tooling issues.

- Bug Fixes
  - MCP: Removed dead `CharacterInteropService` import and `self.character_service`; character tools already read `chachanotes_db` directly.
  - MCP: `chat_with_llm` now uses `config.get_api_key(provider)` (covers all tiers) instead of `get_cli_setting`.
  - Chatbooks: `tldw_chatbook/UI/Chatbooks_Window.py` now uses `secure_chatbook_directory` for the export path; removed an unused test fixture.
  - Tests: Added `Tests/MCP/test_server_character_service.py`; updated `Tests/MCP/test_server_media_db_path.py` to drop the old stub.

<sup>Written for commit 57958f2ddbdf2fe7898f12d2ecffeb4b0ce6d5a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

