### PR TITLE
chore(backlog): resolve the 982 id collision

### DIFF
--- a/backlog/tasks/task-984 - Reconcile-the-Chatbook-export-directory-default-across-the-four-windows.md
+++ b/backlog/tasks/task-984 - Reconcile-the-Chatbook-export-directory-default-across-the-four-windows.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-982
+id: TASK-984
 title: Reconcile the Chatbook export directory default across the four windows
 status: To Do
 assignee: []


### PR DESCRIPTION
A File-Notes task took id 982 on dev between PR #1011's duplicate scan and its merge, leaving 982 duplicated. The File-Notes task landed first, so the Chatbook export-directory task filed in #1011 moves to 984.

Backlog-only; no code touched. Duplicate scan clean.

Cause worth recording: #1011's merge command ran the duplicate scan and the merge in a single invocation rather than gating the merge on the scan result. The scan correctly reported `982 taken on dev` and the merge proceeded anyway. The check is only worth having if it can stop the thing it checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolved backlog ID collision by moving the Chatbook export-directory task from 982 to 984 so task IDs remain unique. Updated the backlog task file only; no code changes.

<sup>Written for commit c6aefd14576af6a7775abfab3ecaf376199e3a06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

