### PR TITLE
test(console): make missing RAG service recovery offline

### DIFF
--- a/Docs/superpowers/plans/2026-07-27-console-rag-no-service-offline.md
+++ b/Docs/superpowers/plans/2026-07-27-console-rag-no-service-offline.md
@@ -1,0 +1,23 @@
+# TASK-762 Console RAG no-service offline repair
+
+## Goal
+
+Make the existing Console no-service regression exercise the actual missing-service
+boundary and complete deterministically without constructing an embedding runtime or
+accessing the network.
+
+## Implementation
+
+1. Explicitly remove the app-owned Library RAG search service in the no-service test.
+2. Install a recording sentinel at the shared RAG factory boundary and assert it is
+   not reached.
+3. Wait for the final blocked UI state instead of an intermediate live-work card.
+4. Keep the configured-service regression unchanged as the compatibility guard.
+5. Run only the exact regression and focused Console RAG checks.
+
+ADR required: no
+
+ADR path: N/A
+
+Reason: This is a stale-fixture correction against an existing service boundary. It
+does not change application architecture, ownership, storage, or service contracts.

--- a/Tests/UI/test_console_internals_decomposition.py
+++ b/Tests/UI/test_console_internals_decomposition.py
@@ -34,6 +34,7 @@ from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
 from tldw_chatbook.Chat.console_glyphs import GLYPH_CLOSE
 from tldw_chatbook.Chat.console_live_work import ConsoleLiveWorkLaunch
 from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
+from tldw_chatbook.Library import library_local_rag_search_service
 from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
 from tldw_chatbook.UI.Screens.chat_screen import (
     CONSOLE_PROVIDER_CONFIGURE_API_KEY_LABEL,
@@ -3905,8 +3906,22 @@ async def test_console_rag_query_validation_blocks_unsafe_markup():
 
 
 @pytest.mark.asyncio
-async def test_console_rag_action_without_service_stages_recoverable_blocker():
+async def test_console_rag_action_without_service_stages_recoverable_blocker(
+    monkeypatch,
+):
     app = _build_test_app()
+    app.library_rag_search_service = None
+    rag_factory_calls = []
+
+    def record_rag_factory_call():
+        rag_factory_calls.append(True)
+        return None
+
+    monkeypatch.setattr(
+        library_local_rag_search_service,
+        "get_shared_rag_service",
+        record_rag_factory_call,
+    )
     host = ConsoleHarness(app)
 
     async with host.run_test(size=(196, 48)) as pilot:
@@ -3917,9 +3932,13 @@ async def test_console_rag_action_without_service_stages_recoverable_blocker():
         console.query_one(
             "#console-library-rag-query-input", Input
         ).value = "What changed?"
-        await pilot.pause(0.1)
+        await _wait_for_console_library_rag_button_state(
+            console,
+            pilot,
+            disabled=False,
+        )
         console.query_one("#console-run-library-rag", Button).press()
-        await _wait_for_selector(console, pilot, "#console-live-work-status")
+        await _wait_for_visible_text(console, pilot, "Status: blocked")
 
         text = _visible_text(console)
         assert "Status: blocked" in text
@@ -3927,6 +3946,7 @@ async def test_console_rag_action_without_service_stages_recoverable_blocker():
         assert "RAG/source:" not in text
         assert "Unavailable: Library Search/RAG retrieval." in text
         assert "Owner: Library retrieval service." in text
+        assert rag_factory_calls == []
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-762 - Make-Console-RAG-no-service-recovery-deterministic-offline.md
+++ b/backlog/tasks/task-762 - Make-Console-RAG-no-service-recovery-deterministic-offline.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-762
 title: Make Console RAG no-service recovery deterministic offline
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2026-07-26 17:57'
+updated_date: '2026-07-27 19:38'
 labels:
   - console
   - rag
@@ -21,5 +23,40 @@ Make the Console Library RAG no-service path stage its recoverable blocked state
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 No-service Console RAG action stages a blocked recoverable result,The no-service path performs no embedding download or network access,Existing configured-service RAG staging remains unchanged,The exact no-service regression and focused Console RAG tests pass offline
+- [x] #1 No-service Console RAG action stages a blocked recoverable result.
+- [x] #2 The no-service path performs no embedding download or network access.
+- [x] #3 Existing configured-service RAG staging remains unchanged.
+- [x] #4 The exact no-service regression and focused Console RAG tests pass offline.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Correct the Console no-service regression setup so the app has no Library RAG search service and assert the shared RAG factory is never reached.
+2. Preserve the existing configured-service test as the compatibility guard; make no production-code changes unless the corrected regression exposes a real behavior defect.
+3. Run the exact no-service regression, the configured-service Console RAG regression, and the focused Console RAG subset offline; run Ruff on the touched test and git diff --check.
+4. Complete task acceptance criteria, implementation notes, self-review, and Backlog status.
+
+ADR required: no
+ADR path: N/A
+Reason: Routine correction of a stale test fixture that exercises an existing service boundary; no storage, ownership, service-contract, security, or architectural decision changes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Corrected the stale Console no-service regression so it explicitly removes the
+app-owned Library RAG search service, records that the shared RAG factory is never
+reached, and waits for the final blocked state instead of an intermediate card. No
+production code changed; the existing configured-service staging test remains the
+compatibility guard.
+
+ADR required: no. ADR path: N/A. This is a test-fixture correction at an existing
+service boundary.
+
+Verification was intentionally scoped to touched Console RAG behavior: the exact
+regression passed; five `console_rag` tests in the touched file passed with
+`HF_HUB_OFFLINE=1` and `TRANSFORMERS_OFFLINE=1`; the underlying Library RAG
+no-service adapter test passed offline; Ruff check and format check passed for the
+touched test file; and `git diff --check` passed.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary
- make the Console RAG no-service regression explicitly remove the default Library RAG service
- prove the no-service path never reaches the shared embedding/RAG factory
- wait for the final recoverable blocked state while preserving configured-service staging

## Verification
- `HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 python -m pytest Tests/UI/test_console_internals_decomposition.py -q -k console_rag` (5 passed)
- `HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 python -m pytest Tests/Library/test_library_rag_service.py::test_run_library_rag_search_returns_unavailable_recovery_without_service -q` (1 passed)
- `ruff check Tests/UI/test_console_internals_decomposition.py`
- `ruff format --check Tests/UI/test_console_internals_decomposition.py`
- `git diff --check origin/dev...HEAD`

## Scope
- test and task documentation only; no production code changes
- ADR required: no (routine stale-fixture correction at an existing service boundary)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Console RAG “no-service” recovery deterministic and offline by fixing the test to remove the Library RAG service and asserting the shared RAG factory is never called. Keeps the configured-service path unchanged and completes TASK-762.

- **Bug Fixes**
  - Unset `app.library_rag_search_service`, assert no calls to `get_shared_rag_service`, and wait for the final “Status: blocked” state.
  - Runs offline; targeted `console_rag` and library adapter tests pass; no production code changes.
  - Added short plan doc and updated TASK-762 acceptance criteria.

<sup>Written for commit 7c378372a25734dd0121e267ab0c9f28cc47132b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

