### PR TITLE
style(console): normalize citation path formatting

### DIFF
--- a/Docs/superpowers/plans/2026-07-27-console-citation-format-normalization.md
+++ b/Docs/superpowers/plans/2026-07-27-console-citation-format-normalization.md
@@ -1,0 +1,21 @@
+# TASK-840 Console citation format normalization
+
+## Goal
+
+Normalize inherited Ruff formatting drift in the four Console files identified
+by TASK-553.15 without changing behavior.
+
+## Implementation
+
+1. Reproduce the exact eleven-file Ruff format check from TASK-553.15.
+2. Run Ruff format on only the four recorded failing files.
+3. Review the complete diff for formatter-only changes.
+4. Run the exact eleven-file format gate, Ruff check on the touched files,
+   focused Console citation/UI tests, and `git diff --check`.
+
+ADR required: no
+
+ADR path: N/A
+
+Reason: This is mechanical formatting normalization with no change to behavior,
+interfaces, ownership, persistence, security, or architecture.

--- a/backlog/tasks/task-840 - Normalize-inherited-Ruff-format-drift-in-Console-citation-files.md
+++ b/backlog/tasks/task-840 - Normalize-inherited-Ruff-format-drift-in-Console-citation-files.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-840
 title: Normalize inherited Ruff format drift in Console citation files
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2026-07-27 04:02'
+updated_date: '2026-07-27 19:54'
 labels:
   - maintenance
   - formatting
@@ -27,8 +29,39 @@ The same four files fail the formatter check on `origin/dev`, so this work is tr
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The exact TASK-553.15 eleven-file Ruff format check exits zero
-- [ ] #2 Formatting changes are mechanical and behavior-preserving
-- [ ] #3 Scoped Console citation and UI tests pass after formatting
-- [ ] #4 `git diff --check` passes and formatter-only scope is independently reviewed
+- [x] #1 The exact TASK-553.15 eleven-file Ruff format check exits zero
+- [x] #2 Formatting changes are mechanical and behavior-preserving
+- [x] #3 Scoped Console citation and UI tests pass after formatting
+- [x] #4 `git diff --check` passes and formatter-only scope is independently reviewed
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the exact TASK-553.15 eleven-file Ruff format check and confirm only the four recorded Console files fail.
+2. Run Ruff format on exactly those four files; do not hand-edit or change behavior.
+3. Review the complete diff as formatter-only and run the exact eleven-file formatter gate, Ruff check on the four touched files, focused Console citation/UI tests, and git diff --check.
+4. Record verification and self-review, complete all acceptance criteria, and mark TASK-840 Done.
+
+ADR required: no
+ADR path: N/A
+Reason: Mechanical formatter normalization only; no behavior, interface, ownership, storage, security, or architectural decision changes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Ran Ruff format on exactly the four inherited-drift files recorded by
+TASK-553.15. No production logic or tests were hand-edited. A complete
+zero-context diff review plus parsed-AST and comment-token comparisons against
+`dev` confirmed that executable structure and comment text are unchanged.
+
+ADR required: no. ADR path: N/A. This is mechanical formatter normalization
+with no architectural or behavioral change.
+
+Verification: the exact eleven-file Ruff format check reports all eleven files
+formatted; Ruff check passes on the four touched production files; 95 focused
+controller/agent citation tests and 20 transcript/native-flow citation tests
+pass with offline model flags; and `git diff --check` passes. The UI group
+emits one existing RequestsDependencyWarning.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -612,9 +612,7 @@ class _StreamingModelAdapter:
         # stable no matter when the override changed.
         resolved = get_internal_prompt("agents.subagent_system")
         _KNOWN_SUBAGENT_PREFIXES.add(resolved)
-        return any(
-            content.startswith(prefix) for prefix in _KNOWN_SUBAGENT_PREFIXES
-        )
+        return any(content.startswith(prefix) for prefix in _KNOWN_SUBAGENT_PREFIXES)
 
 
 def _eligible_skill_entries(context: Mapping[str, Any]) -> list[Mapping[str, Any]]:
@@ -1093,14 +1091,17 @@ class ConsoleAgentBridge:
             except Exception as exc:  # pragma: no cover - defensive only
                 logger.warning(
                     "Failed to load schema for {tool_id}: {exc}",
-                    tool_id=entry.id, exc=exc,
+                    tool_id=entry.id,
+                    exc=exc,
                 )
                 continue
-            schemas.append({
-                "name": schema.name,
-                "description": schema.description,
-                "parameters": schema.parameters,
-            })
+            schemas.append(
+                {
+                    "name": schema.name,
+                    "description": schema.description,
+                    "parameters": schema.parameters,
+                }
+            )
         return schemas
 
     # -- run ------------------------------------------------------------
@@ -1280,7 +1281,10 @@ class ConsoleAgentBridge:
         # raises a bare ValueError("local_skill_exists:...") on collision, so
         # the install catch is broad.
         install_skill_tool = None
-        if self._skills_service is not None and request_skill_install_confirm is not None:
+        if (
+            self._skills_service is not None
+            and request_skill_install_confirm is not None
+        ):
             scope = self._skills_service
 
             def install_skill_tool(url: str) -> ToolResult:
@@ -1453,7 +1457,9 @@ class ConsoleAgentBridge:
                         f"{item['name']} ({item['size']} bytes)"
                         for item in outcome.output_files
                     )
-                    lines.append(f"produced {len(outcome.output_files)} file(s): {listed}")
+                    lines.append(
+                        f"produced {len(outcome.output_files)} file(s): {listed}"
+                    )
                     lines.append(f"output directory: {outcome.output_dir}")
                 return ToolResult(ok=True, content="\n".join(lines))
 
@@ -1618,9 +1624,8 @@ class ConsoleAgentBridge:
             for index in range(len(agent_messages) - 1, -1, -1):
                 message = agent_messages[index]
                 content = message.get("content")
-                if (
-                    message.get("role") == ConsoleMessageRole.USER.value
-                    and isinstance(content, str)
+                if message.get("role") == ConsoleMessageRole.USER.value and isinstance(
+                    content, str
                 ):
                     run_messages = list(agent_messages)
                     run_messages[index] = {

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -458,9 +458,7 @@ def build_tool_review_hook(
         decisions = request_approvals(all_pending)
         if mcp_provider is not None:
             mcp_decisions = {
-                name: decisions[name]
-                for name in mcp_claimed_names
-                if name in decisions
+                name: decisions[name] for name in mcp_claimed_names if name in decisions
             }
             mcp_provider.apply_batch_decisions(mcp_decisions)
         for row in builtin_pending:
@@ -717,7 +715,9 @@ class ConsoleChatController:
         # way as the two maps above -- keyed by the run's OWNING session id,
         # so a background session's in-flight repair can never be read/
         # cleared by another session's close/stop/teardown path.
-        self._active_citation_repair_sessions: dict[str, ConsoleCitationRepairSession] = {}
+        self._active_citation_repair_sessions: dict[
+            str, ConsoleCitationRepairSession
+        ] = {}
         self._original_attempts: OrderedDict[str, str] = OrderedDict()
         #: Per-run cancellation flag for the agent bridge's background
         #: thread (see ``_run_agent_reply``), keyed by owning session id
@@ -1040,9 +1040,7 @@ class ConsoleChatController:
         with self._approval_state_lock:
             pending_snapshot = set(self._pending_approvals)
         other_pending = {
-            sid
-            for sid in pending_snapshot
-            if sid in live_ids and sid != active
+            sid for sid in pending_snapshot if sid in live_ids and sid != active
         }
         other_busy = {sid for sid in self._live_busy_session_ids() if sid != active}
         return len(other_busy - other_pending), len(other_pending)
@@ -1129,9 +1127,7 @@ class ConsoleChatController:
             The session's list of recorded ``ConsoleRunStatus`` values,
             initialized to ``[ConsoleRunStatus.IDLE]`` when absent.
         """
-        return self._run_state_histories.setdefault(
-            session_id, [ConsoleRunStatus.IDLE]
-        )
+        return self._run_state_histories.setdefault(session_id, [ConsoleRunStatus.IDLE])
 
     async def submit_draft(
         self, draft: str, *, session_id: str | None = None
@@ -1451,7 +1447,9 @@ class ConsoleChatController:
             return
         derived = derive_console_session_title(draft)
         if derived:
-            self.store.rename_session(session.id, derived)  # (session, persisted) — auto-title best-effort
+            self.store.rename_session(
+                session.id, derived
+            )  # (session, persisted) — auto-title best-effort
 
     def update_provider_selection(self, selection: ConsoleProviderSelection) -> None:
         """Sync controller provider settings from a Console selection."""
@@ -1779,7 +1777,9 @@ class ConsoleChatController:
         the shared, lifecycle-reset ``_stop_requested`` flag with the
         never-reset ``_shutdown_requested`` in that same fallback branch.
         """
-        cancel_event = self._active_cancel_events.get(self.store.active_session_id or "")
+        cancel_event = self._active_cancel_events.get(
+            self.store.active_session_id or ""
+        )
         return cancel_event is not None and cancel_event.is_set()
 
     def _is_session_cancelled(self, session_id: str | None) -> bool:
@@ -1925,8 +1925,10 @@ class ConsoleChatController:
         # ever resolved by -- mirrors `_pending_skill_script_rounds`'
         # identical `request_id`-keyed defense.
         round_id = str(uuid4())
-        owning_session_id = session_id if session_id is not None else (
-            self.store.active_session_id or ""
+        owning_session_id = (
+            session_id
+            if session_id is not None
+            else (self.store.active_session_id or "")
         )
         # F2b fix (Qodo wave): guard the round registration -- the UI
         # thread's `resolve_pending_approval`/legacy fallback and the
@@ -1962,9 +1964,8 @@ class ConsoleChatController:
         # DIFFERENT, background session -- `session_id is None` (a legacy
         # caller with no session context) always mounts, matching every
         # pre-Task-9 call site.
-        is_parked = (
-            session_id is not None
-            and session_id != (self.store.active_session_id or "")
+        is_parked = session_id is not None and session_id != (
+            self.store.active_session_id or ""
         )
         if session_id is not None:
             # Set the badge flag directly here (worker thread, plain-dict/
@@ -2334,11 +2335,7 @@ class ConsoleChatController:
             with self._approval_state_lock:
                 round_states = list(self._pending_approval_rounds.values())
             round_state = next(
-                (
-                    state
-                    for state in round_states
-                    if state.get("session_id") == active
-                ),
+                (state for state in round_states if state.get("session_id") == active),
                 None,
             )
         if round_state is None:
@@ -2807,9 +2804,7 @@ class ConsoleChatController:
         provider_messages = await self._apply_chat_dictionaries(
             provider_messages, session_id
         )
-        provider_messages = await self._apply_world_info(
-            provider_messages, session_id
-        )
+        provider_messages = await self._apply_world_info(provider_messages, session_id)
         prefill = self._pinned_prefill_for_session(session_id)
         return await self._stream_assistant_response(
             resolution=resolution,
@@ -2880,9 +2875,7 @@ class ConsoleChatController:
         provider_messages = await self._apply_chat_dictionaries(
             provider_messages, session_id
         )
-        provider_messages = await self._apply_world_info(
-            provider_messages, session_id
-        )
+        provider_messages = await self._apply_world_info(provider_messages, session_id)
         assistant = self.store.append_message(
             session_id,
             role=ConsoleMessageRole.ASSISTANT,
@@ -2988,9 +2981,7 @@ class ConsoleChatController:
         provider_messages = await self._apply_chat_dictionaries(
             provider_messages, session_id
         )
-        provider_messages = await self._apply_world_info(
-            provider_messages, session_id
-        )
+        provider_messages = await self._apply_world_info(provider_messages, session_id)
         prefill = self._pinned_prefill_for_session(session_id)
         self.clear_original_attempt(message_id)
         new_message = self.store.create_sibling(
@@ -3194,14 +3185,20 @@ class ConsoleChatController:
             ]
             transcript_text = "\n".join(lines)
             if prior_summary:
-                return f"[Previous summary]\n{prior_summary}\n\n{transcript_text}".rstrip()
+                return (
+                    f"[Previous summary]\n{prior_summary}\n\n{transcript_text}".rstrip()
+                )
             return transcript_text
 
         rows = list(span)
         body = assemble(rows)
-        while len(rows) > 1 and count_console_messages_tokens(
-            [{"role": "user", "content": body}], model
-        ) > self._SUMMARY_SPAN_TOKEN_BUDGET:
+        while (
+            len(rows) > 1
+            and count_console_messages_tokens(
+                [{"role": "user", "content": body}], model
+            )
+            > self._SUMMARY_SPAN_TOKEN_BUDGET
+        ):
             rows = rows[1:]
             body = assemble(rows)
         return body
@@ -3393,9 +3390,7 @@ class ConsoleChatController:
         provider_messages = await self._apply_chat_dictionaries(
             provider_messages, session_id
         )
-        provider_messages = await self._apply_world_info(
-            provider_messages, session_id
-        )
+        provider_messages = await self._apply_world_info(provider_messages, session_id)
         prefill = self._pinned_prefill_for_session(session_id)
 
         # Every transform succeeded: now (and only now) fork the edited USER
@@ -3493,7 +3488,9 @@ class ConsoleChatController:
             )
 
             # Chat dictionaries are safe to apply (string replacements only).
-            provider_messages = await self._apply_chat_dictionaries(provider_messages, session_id)
+            provider_messages = await self._apply_chat_dictionaries(
+                provider_messages, session_id
+            )
 
             # task-548: mirror the dispatch choke point's boundary-summary
             # compaction so the preview matches what is actually sent when a
@@ -3528,7 +3525,9 @@ class ConsoleChatController:
                 ]
 
             # Replace image data with placeholders for the preview, including historical images.
-            provider_messages = self._replace_image_data_with_placeholders(provider_messages)
+            provider_messages = self._replace_image_data_with_placeholders(
+                provider_messages
+            )
 
             # Gather native tool schemas and MCP note.
             tools_info = self._build_tools_info_for_snapshot()
@@ -3616,7 +3615,9 @@ class ConsoleChatController:
             )
 
     @staticmethod
-    def _replace_image_data_with_placeholders(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def _replace_image_data_with_placeholders(
+        messages: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
         result = copy.deepcopy(messages)
 
         def _is_data_url(value: Any) -> bool:
@@ -3648,7 +3649,9 @@ class ConsoleChatController:
                     if not isinstance(part, dict):
                         continue
                     if part.get("type") == "image_url":
-                        part["image_url"] = _redact_image_url_value(part.get("image_url"))
+                        part["image_url"] = _redact_image_url_value(
+                            part.get("image_url")
+                        )
                     if part.get("type") == "image":
                         # Anthropic-style image parts use a ``source`` dict with
                         # base64 data; preserve the surrounding structure.
@@ -3718,9 +3721,7 @@ class ConsoleChatController:
             tools = self._agent_bridge.native_tool_schemas()
         mcp_note: str | None = None
         if self._mcp_provider:
-            mcp_note = (
-                "MCP tools are configured but live catalog composition is not shown in this preview."
-            )
+            mcp_note = "MCP tools are configured but live catalog composition is not shown in this preview."
         if tools:
             preview_note = (
                 "This preview shows only builtin native tools. "
@@ -3734,15 +3735,20 @@ class ConsoleChatController:
             "preview_note": preview_note,
         }
 
-    _SECRET_REDACTION_KEYS = {"api_key", "apikey", "token", "password", "secret", "bearer"}
+    _SECRET_REDACTION_KEYS = {
+        "api_key",
+        "apikey",
+        "token",
+        "password",
+        "secret",
+        "bearer",
+    }
     _SECRET_REDACTION_KEYS_NORMALIZED = {
         k.replace("-", "").replace("_", "") for k in _SECRET_REDACTION_KEYS
     }
     _SECRET_REDACTION_PATTERN = re.compile(
         r"(?P<open_quote>[\"']?)"
-        r"(?P<key>"
-        + "|".join(re.escape(k) for k in _SECRET_REDACTION_KEYS)
-        + r")"
+        r"(?P<key>" + "|".join(re.escape(k) for k in _SECRET_REDACTION_KEYS) + r")"
         r"(?P=open_quote)"
         r"(?P<sep>\s*[:=]\s*)"
         r"(?P<value>"
@@ -3777,7 +3783,9 @@ class ConsoleChatController:
                 sep = match.group("sep")
                 return f"{open_quote}{key}{open_quote}{sep}{redacted_value}"
 
-            return ConsoleChatController._SECRET_REDACTION_PATTERN.sub(_replace_value, value)
+            return ConsoleChatController._SECRET_REDACTION_PATTERN.sub(
+                _replace_value, value
+            )
 
         def _matches_secret_key(key: str) -> bool:
             """Return True when ``key`` matches or ends with a secret word.
@@ -3913,9 +3921,7 @@ class ConsoleChatController:
 
     async def _apply_skill_substitution(
         self, provider_messages: list[dict[str, Any]]
-    ) -> tuple[
-        list[dict[str, Any]], str | None, tuple[str, ...], tuple[str, ...], str
-    ]:
+    ) -> tuple[list[dict[str, Any]], str | None, tuple[str, ...], tuple[str, ...], str]:
         """Render-fresh the triggering turn's skill mention(s) at payload build time.
 
         Spec: "Invocation semantics" §5 (the substitution rule) -- one rule
@@ -4146,9 +4152,7 @@ class ConsoleChatController:
                 result.get("execution_mode") if isinstance(result, Mapping) else None
             )
             rendered = (
-                result.get("rendered_prompt", "")
-                if isinstance(result, Mapping)
-                else ""
+                result.get("rendered_prompt", "") if isinstance(result, Mapping) else ""
             )
             # Fork (or anything non-inline) cannot splice in place: leave
             # the mention literal, no note (this is not a trust failure).
@@ -4573,8 +4577,7 @@ class ConsoleChatController:
             (
                 index
                 for index in range(len(provider_messages) - 1, -1, -1)
-                if provider_messages[index].get("role")
-                == ConsoleMessageRole.USER.value
+                if provider_messages[index].get("role") == ConsoleMessageRole.USER.value
             ),
             None,
         )
@@ -4823,7 +4826,10 @@ class ConsoleChatController:
                 self._active_stream_tasks.pop(owner_id, None)
                 self._active_assistant_message_ids.pop(owner_id, None)
                 self._stop_requested = False
-                if self._active_citation_repair_sessions.get(owner_id) is citation_repair_session:
+                if (
+                    self._active_citation_repair_sessions.get(owner_id)
+                    is citation_repair_session
+                ):
                     self._active_citation_repair_sessions.pop(owner_id, None)
                 # Task 3b (agent path): `_run_agent_reply`'s own finally
                 # deliberately leaves its cancel_event live past its own
@@ -5573,11 +5579,9 @@ class ConsoleChatController:
             # preserves whatever partial content already streamed
             # otherwise).
             visible_copy = f"Agent run failed: {describe_stream_failure(exc)}"
-            if (
-                getattr(getattr(exc, "response", None), "status_code", None)
-                is not None
-                and self._session_history_carries_images(session_id)
-            ):
+            if getattr(
+                getattr(exc, "response", None), "status_code", None
+            ) is not None and self._session_history_carries_images(session_id):
                 visible_copy += self._IMAGE_REJECTION_RECOVERY_HINT
             try:
                 self.store.mark_message_failed(assistant_message_id)
@@ -5670,9 +5674,8 @@ class ConsoleChatController:
         # prior status for a regenerate, "stopped" for a plain send) and
         # the variant base (already popped), so this is a benign no-op
         # read-back, never an error, in either case.
-        stopped_now = (
-            (current is not None and current.status == "stopped")
-            or (cancel_event is not None and cancel_event.is_set())
+        stopped_now = (current is not None and current.status == "stopped") or (
+            cancel_event is not None and cancel_event.is_set()
         )
         if stopped_now:
             # The stopped message was already persisted by
@@ -5688,20 +5691,31 @@ class ConsoleChatController:
                 ConsoleRunState(ConsoleRunStatus.STOPPED, "Response stopped."),
                 session_id=session_id,
             )
-            return ConsoleSubmitResult(True, True, current.content if current is not None else "")
+            return ConsoleSubmitResult(
+                True, True, current.content if current is not None else ""
+            )
 
         if outcome.status == RUN_CANCELLED:
             return self._finalize_agent_cancelled(
-                assistant_message_id, session_id, variant_mode=variant_mode,
-                run_id=run_id)
+                assistant_message_id,
+                session_id,
+                variant_mode=variant_mode,
+                run_id=run_id,
+            )
 
         if outcome.status != RUN_DONE:
             return self._finalize_agent_failure(
-                assistant_message_id, session_id, outcome, variant_mode=variant_mode,
-                run_id=run_id)
+                assistant_message_id,
+                session_id,
+                outcome,
+                variant_mode=variant_mode,
+                run_id=run_id,
+            )
 
         return await self._finalize_agent_success(
-            assistant_message_id, session_id, outcome,
+            assistant_message_id,
+            session_id,
+            outcome,
             variant_mode=variant_mode,
             run_id=run_id,
             citation_repair_session=citation_repair_session,
@@ -5709,7 +5723,9 @@ class ConsoleChatController:
         )
 
     def _ensure_assistant_placeholder(
-        self, assistant_message_id: str, session_id: str,
+        self,
+        assistant_message_id: str,
+        session_id: str,
     ) -> ConsoleChatMessage | None:
         """Return the assistant placeholder message if it still exists.
 
@@ -5723,7 +5739,8 @@ class ConsoleChatController:
             return None
 
     def _find_runtime_written_assistant(
-        self, session_id: str,
+        self,
+        session_id: str,
     ) -> ConsoleChatMessage | None:
         """Return the most recent assistant message in ``session_id``, if any."""
         try:
@@ -5736,7 +5753,10 @@ class ConsoleChatController:
         return None
 
     def _complete_agent_message(
-        self, assistant_message_id: str, variant_mode: bool, outcome: Any,
+        self,
+        assistant_message_id: str,
+        variant_mode: bool,
+        outcome: Any,
     ) -> ConsoleChatMessage:
         """Finalize a placeholder, applying the empty-final-text fallback.
 
@@ -5754,7 +5774,11 @@ class ConsoleChatController:
         return self.store.mark_message_complete(assistant_message_id)
 
     def _finalize_agent_cancelled(
-        self, assistant_message_id: str, session_id: str, *, variant_mode: bool,
+        self,
+        assistant_message_id: str,
+        session_id: str,
+        *,
+        variant_mode: bool,
         run_id: str | None = None,
     ) -> ConsoleSubmitResult:
         """Handle a ``RUN_CANCELLED`` outcome: the placeholder becomes ``failed``.
@@ -5768,7 +5792,9 @@ class ConsoleChatController:
         ordinal fallback -- see ``_record_run_assistant_message``).
         """
         visible_copy = "Response stopped/cancelled."
-        placeholder = self._ensure_assistant_placeholder(assistant_message_id, session_id)
+        placeholder = self._ensure_assistant_placeholder(
+            assistant_message_id, session_id
+        )
         if placeholder is not None:
             failed = self.store.mark_message_failed(assistant_message_id)
         else:
@@ -5781,8 +5807,13 @@ class ConsoleChatController:
         return ConsoleSubmitResult(True, True, failed.content)
 
     def _finalize_agent_failure(
-        self, assistant_message_id: str, session_id: str, outcome: Any,
-        *, variant_mode: bool, run_id: str | None = None,
+        self,
+        assistant_message_id: str,
+        session_id: str,
+        outcome: Any,
+        *,
+        variant_mode: bool,
+        run_id: str | None = None,
     ) -> ConsoleSubmitResult:
         """Handle ``RUN_ERROR``, ``RUN_STUCK``, or any unknown non-done outcome.
 
@@ -5803,7 +5834,9 @@ class ConsoleChatController:
             self._session_history_carries_images(session_id)
         ):
             visible_copy += self._IMAGE_REJECTION_RECOVERY_HINT
-        placeholder = self._ensure_assistant_placeholder(assistant_message_id, session_id)
+        placeholder = self._ensure_assistant_placeholder(
+            assistant_message_id, session_id
+        )
         if placeholder is not None:
             failed = self.store.mark_message_failed(assistant_message_id)
             self._record_run_assistant_message(run_id, failed)
@@ -5815,7 +5848,10 @@ class ConsoleChatController:
             return ConsoleSubmitResult(True, True, failed.content)
 
         runtime_written = self._find_runtime_written_assistant(session_id)
-        if runtime_written is not None and runtime_written.status in {"pending", "streaming"}:
+        if runtime_written is not None and runtime_written.status in {
+            "pending",
+            "streaming",
+        }:
             self.store.append_stream_chunk(runtime_written.id, f"\n\n{visible_copy}")
             failed = self.store.mark_message_failed(runtime_written.id)
         else:
@@ -5828,7 +5864,10 @@ class ConsoleChatController:
         return ConsoleSubmitResult(True, True, failed.content)
 
     async def _finalize_agent_success(
-        self, assistant_message_id: str, session_id: str, outcome: Any,
+        self,
+        assistant_message_id: str,
+        session_id: str,
+        outcome: Any,
         *,
         variant_mode: bool,
         run_id: str | None = None,
@@ -5847,7 +5886,9 @@ class ConsoleChatController:
         ``_record_run_assistant_message`` -- the load-bearing correction of
         the native id ``create_run`` recorded, which resume anchors markers by.
         """
-        placeholder = self._ensure_assistant_placeholder(assistant_message_id, session_id)
+        placeholder = self._ensure_assistant_placeholder(
+            assistant_message_id, session_id
+        )
         if placeholder is not None:
             if (
                 citation_repair_session is not None
@@ -5883,7 +5924,9 @@ class ConsoleChatController:
                         True,
                         selection.selected_body,
                     )
-            completed = self._complete_agent_message(assistant_message_id, variant_mode, outcome)
+            completed = self._complete_agent_message(
+                assistant_message_id, variant_mode, outcome
+            )
             self._record_run_assistant_message(run_id, completed)
             self._set_run_state(
                 ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete."),
@@ -5892,8 +5935,13 @@ class ConsoleChatController:
             return ConsoleSubmitResult(True, True, completed.content)
 
         runtime_written = self._find_runtime_written_assistant(session_id)
-        if runtime_written is not None and runtime_written.status in {"pending", "streaming"}:
-            completed = self._complete_agent_message(runtime_written.id, variant_mode=False, outcome=outcome)
+        if runtime_written is not None and runtime_written.status in {
+            "pending",
+            "streaming",
+        }:
+            completed = self._complete_agent_message(
+                runtime_written.id, variant_mode=False, outcome=outcome
+            )
             self._record_run_assistant_message(run_id, completed)
             self._set_run_state(
                 ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete."),
@@ -5903,7 +5951,8 @@ class ConsoleChatController:
 
         final_text = getattr(outcome, "final_text", "") or "No response was generated."
         completed = self.store.append_message(
-            session_id, role=ConsoleMessageRole.ASSISTANT, content=final_text)
+            session_id, role=ConsoleMessageRole.ASSISTANT, content=final_text
+        )
         self._record_run_assistant_message(run_id, completed)
         self._set_run_state(
             ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete."),
@@ -5912,7 +5961,9 @@ class ConsoleChatController:
         return ConsoleSubmitResult(True, True, completed.content)
 
     def _record_run_assistant_message(
-        self, run_id: str | None, completed: ConsoleChatMessage,
+        self,
+        run_id: str | None,
+        completed: ConsoleChatMessage,
     ) -> None:
         """Write the completed reply's PERSISTED id onto the agent run.
 
@@ -5954,9 +6005,7 @@ class ConsoleChatController:
         if self._agent_bridge is None:
             return None
         try:
-            return self._agent_bridge.latest_unanchored_primary_run_id(
-                conversation_id
-            )
+            return self._agent_bridge.latest_unanchored_primary_run_id(conversation_id)
         except Exception:  # noqa: BLE001 -- bookkeeping must never fail the stop
             logger.opt(exception=True).warning(
                 "failed to look up unanchored primary run for stop recording",
@@ -5965,7 +6014,9 @@ class ConsoleChatController:
             return None
 
     def _append_failed_assistant(
-        self, session_id: str, visible_copy: str,
+        self,
+        session_id: str,
+        visible_copy: str,
     ) -> ConsoleChatMessage:
         """Append a failed assistant message carrying ``visible_copy``.
 
@@ -5974,7 +6025,8 @@ class ConsoleChatController:
         streamed in, and then it is marked failed.
         """
         message = self.store.append_message(
-            session_id, role=ConsoleMessageRole.ASSISTANT, content="")
+            session_id, role=ConsoleMessageRole.ASSISTANT, content=""
+        )
         self.store.append_stream_chunk(message.id, visible_copy)
         return self.store.mark_message_failed(message.id)
 
@@ -6133,7 +6185,9 @@ class ConsoleChatController:
             if message.id == message_id:
                 break
         return self._leading_system_message() + self._provider_message_payloads(
-            collected, skip_failed=False, use_variant_content=True,
+            collected,
+            skip_failed=False,
+            use_variant_content=True,
             annotate_ids=annotate_ids,
         )
 
@@ -6321,8 +6375,10 @@ class ConsoleChatController:
         active one once a background run outlives a session switch) pass it
         explicitly.
         """
-        target = session_id if session_id is not None else (
-            self.store.active_session_id or ""
+        target = (
+            session_id
+            if session_id is not None
+            else (self.store.active_session_id or "")
         )
         # Task 10 (background completion toasts): captured BEFORE the
         # overwrite below so the once-guard downstream can tell a genuine
@@ -6378,7 +6434,8 @@ class ConsoleChatController:
             # the same COMPLETED/FAILED status again (e.g. a defensive
             # re-stamp) does not re-toast.
             if (
-                run_state.status in (ConsoleRunStatus.COMPLETED, ConsoleRunStatus.FAILED)
+                run_state.status
+                in (ConsoleRunStatus.COMPLETED, ConsoleRunStatus.FAILED)
                 and previous_status
                 not in {
                     ConsoleRunStatus.BLOCKED,
@@ -6398,8 +6455,10 @@ class ConsoleChatController:
         background run in progress on another session is untouched when the
         viewed session changes.
         """
-        target = session_id if session_id is not None else (
-            self.store.active_session_id or ""
+        target = (
+            session_id
+            if session_id is not None
+            else (self.store.active_session_id or "")
         )
         if self.run_state_for(target).status in {
             ConsoleRunStatus.BLOCKED,

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -48,6 +48,7 @@ from ...Event_Handlers.Chat_Events.chat_events_console_dictionaries import (
     handle_console_dictionary_attach,
     handle_console_dictionary_detach,
 )
+
 # Reused rather than duplicated (task-6): the same conversation-scope
 # resolution the native-Console chat entry point uses (task-5) -- session
 # identity via `persisted_conversation_id`, `SessionScopeHolder` for
@@ -780,9 +781,7 @@ class ChatScreen(BaseAppScreen):
         ),
         Binding("ctrl+k", "open_console_session_switcher", "Switch session", show=True),
         Binding("alt+m", "open_console_model_popover", "Model", show=True),
-        Binding(
-            "alt+w", "open_console_workspace_switcher", "Workspace", show=True
-        ),
+        Binding("alt+w", "open_console_workspace_switcher", "Workspace", show=True),
         Binding("alt+v", "paste_clipboard_image", "Paste image", show=True),
         Binding("ctrl+shift+p", "view_chat_context", "View context", show=True),
         Binding(
@@ -1443,9 +1442,7 @@ class ChatScreen(BaseAppScreen):
                 )
                 for index, pending_attachment in enumerate(pending)
             )
-            current_staged_sources = (
-                controller.store.workspace_context.allowed_sources
-            )
+            current_staged_sources = controller.store.workspace_context.allowed_sources
 
             return await controller.build_context_snapshot(
                 draft=current_draft,
@@ -1712,9 +1709,7 @@ class ChatScreen(BaseAppScreen):
                 self.app_instance.notify(str(exc), severity="warning")
                 return
             except Exception:
-                logger.opt(exception=True).warning(
-                    "Unable to rename Console workspace"
-                )
+                logger.opt(exception=True).warning("Unable to rename Console workspace")
                 self.app_instance.notify(
                     "Workspace could not be renamed.", severity="error"
                 )
@@ -1778,11 +1773,7 @@ class ChatScreen(BaseAppScreen):
                 exclusive=True,
                 group="console-sync",
             )
-            suffix = (
-                " Console switched to the Default workspace."
-                if was_active
-                else ""
-            )
+            suffix = " Console switched to the Default workspace." if was_active else ""
             self.app_instance.notify(
                 f"Archived {record.name}. Its conversations stay saved in "
                 f"Library.{suffix}",
@@ -1996,9 +1987,7 @@ class ChatScreen(BaseAppScreen):
             logger.opt(exception=True).warning(
                 "Failed to write workspace scope for {}", workspace_id
             )
-            self.app_instance.notify(
-                "Couldn't save workspace scope.", severity="error"
-            )
+            self.app_instance.notify("Couldn't save workspace scope.", severity="error")
             return
         session = self._active_native_console_session()
         if session is not None:
@@ -2159,9 +2148,7 @@ class ChatScreen(BaseAppScreen):
         self._console_citation_resolved_signatures: dict[
             str, tuple[str, str, str, str]
         ] = {}
-        self._console_citation_repository_token: tuple[str, int, int, int] | None = (
-            None
-        )
+        self._console_citation_repository_token: tuple[str, int, int, int] | None = None
         self._console_citation_input_signature: (
             tuple[str | None, tuple[tuple[str, str, str, str], ...]] | None
         ) = None
@@ -2738,8 +2725,7 @@ class ChatScreen(BaseAppScreen):
                 return False
         except Exception as exc:
             logger.warning(
-                "Console provider handoff is not ready "
-                "(exception_category={})",
+                "Console provider handoff is not ready (exception_category={})",
                 type(exc).__name__,
             )
             return False
@@ -3911,8 +3897,7 @@ class ChatScreen(BaseAppScreen):
 
     async def _start_console_dictation(self) -> None:
         session = (
-            self._console_dictation_session
-            or self._create_console_dictation_session()
+            self._console_dictation_session or self._create_console_dictation_session()
         )
         self._console_dictation_session = session
         try:
@@ -4167,9 +4152,7 @@ class ChatScreen(BaseAppScreen):
         typed_suffix = ""
         if snapshot is not None and snapshot[0] == visible_session_id:
             snap_text, snap_serial = snapshot[1], snapshot[2]
-            if composer.edit_serial != snap_serial and live_text.startswith(
-                snap_text
-            ):
+            if composer.edit_serial != snap_serial and live_text.startswith(snap_text):
                 # User typed during the settle window: the old session keeps
                 # what it actually had at the keypress; the new typing rides
                 # into the new session below. (Non-append edits — e.g.
@@ -4331,18 +4314,16 @@ class ChatScreen(BaseAppScreen):
         """
         resolution = await resolve_scope_for_session(self.app_instance, session)
         if session.persisted_conversation_id is not None:
-            self._console_retrieval_scope_cache[
-                session.persisted_conversation_id
-            ] = resolution.conv_scope
+            self._console_retrieval_scope_cache[session.persisted_conversation_id] = (
+                resolution.conv_scope
+            )
         conv_item_count = (
             len(resolution.conv_scope.items)
             if resolution.conv_scope is not None
             else None
         )
         ws_item_count = (
-            len(resolution.ws_scope.items)
-            if resolution.ws_scope is not None
-            else None
+            len(resolution.ws_scope.items) if resolution.ws_scope is not None else None
         )
         state = ConsoleRetrievalScopeState.from_effective(
             resolution.effective,
@@ -4407,7 +4388,9 @@ class ChatScreen(BaseAppScreen):
             )
 
     @staticmethod
-    async def _read_console_retrieval_scope(db: Any, conversation_id: str) -> Optional[RagScope]:
+    async def _read_console_retrieval_scope(
+        db: Any, conversation_id: str
+    ) -> Optional[RagScope]:
         """Read a conversation's stored scope, off-loop for file-backed DBs.
 
         In-memory SQLite connections are thread-local -- the same trap
@@ -4433,7 +4416,9 @@ class ChatScreen(BaseAppScreen):
         if getattr(db, "is_memory_db", False):
             write_conversation_scope(db, conversation_id, scope)
         else:
-            await asyncio.to_thread(write_conversation_scope, db, conversation_id, scope)
+            await asyncio.to_thread(
+                write_conversation_scope, db, conversation_id, scope
+            )
 
     @staticmethod
     async def _read_console_workspace_scope(
@@ -4658,12 +4643,16 @@ class ChatScreen(BaseAppScreen):
         await self._refresh_console_effective_scope_and_sync(session)
 
     @on(Button.Pressed, ".console-retrieval-scope-open-btn")
-    async def _console_retrieval_scope_open_pressed(self, event: Button.Pressed) -> None:
+    async def _console_retrieval_scope_open_pressed(
+        self, event: Button.Pressed
+    ) -> None:
         event.stop()
         await self._open_console_retrieval_scope_picker()
 
     @on(Button.Pressed, ".console-retrieval-scope-clear-btn")
-    async def _console_retrieval_scope_clear_pressed(self, event: Button.Pressed) -> None:
+    async def _console_retrieval_scope_clear_pressed(
+        self, event: Button.Pressed
+    ) -> None:
         event.stop()
         await self._clear_console_retrieval_scope()
 
@@ -4760,7 +4749,9 @@ class ChatScreen(BaseAppScreen):
             logger.opt(exception=True).debug("avatar: character fetch failed")
             return None
 
-    def _fetch_expression_image_bytes(self, character_id: int, state: str) -> bytes | None:
+    def _fetch_expression_image_bytes(
+        self, character_id: int, state: str
+    ) -> bytes | None:
         """Return the image bytes for (character, state): the expression-table
         image for a non-idle state, else the character's idle avatar. Runs
         off-thread (called via asyncio.to_thread). Never raises -> None on any error."""
@@ -4774,7 +4765,11 @@ class ChatScreen(BaseAppScreen):
                     return img
             card = self._fetch_character_card_for_avatar(character_id)  # idle fallback
             image = (card or {}).get("image")
-            return bytes(image) if isinstance(image, (bytes, bytearray)) and image else None
+            return (
+                bytes(image)
+                if isinstance(image, (bytes, bytearray)) and image
+                else None
+            )
         except Exception:
             logger.opt(exception=True).debug("avatar: expression fetch failed")
             return None
@@ -4806,11 +4801,15 @@ class ChatScreen(BaseAppScreen):
         character_id = self._current_console_rail_character_id()
         controller = getattr(self, "_console_chat_controller", None)
         store = getattr(controller, "store", None) if controller is not None else None
-        active_session_id = getattr(store, "active_session_id", None) if store is not None else None
+        active_session_id = (
+            getattr(store, "active_session_id", None) if store is not None else None
+        )
         react = resolve_react_character_expressions(
             getattr(getattr(self, "app_instance", None), "app_config", {}) or {}
         )
-        state = resolve_console_expression_state(store, active_session_id, react_enabled=react)
+        state = resolve_console_expression_state(
+            store, active_session_id, react_enabled=react
+        )
         scope = (character_id, state)
         if scope == self._last_console_avatar_scope:
             return
@@ -4831,10 +4830,18 @@ class ChatScreen(BaseAppScreen):
         _, cache = self._ensure_console_image_view()
         mode = getattr(self, "_console_image_default_mode", "pixels")
         key = f"character:{character_id}:{state}"
-        spec = {"character_id": character_id, "state": state, "name": name,
-                "mode": mode, "pil": None, "pixels": None}
+        spec = {
+            "character_id": character_id,
+            "state": state,
+            "name": name,
+            "mode": mode,
+            "pil": None,
+            "pixels": None,
+        }
         try:
-            image = await asyncio.to_thread(self._fetch_expression_image_bytes, character_id, state)
+            image = await asyncio.to_thread(
+                self._fetch_expression_image_bytes, character_id, state
+            )
             if image:
                 ok = await asyncio.to_thread(cache.prepare, key, image)
                 if ok:
@@ -4854,16 +4861,25 @@ class ChatScreen(BaseAppScreen):
         # it live -- both the session id and the state -- rather than reusing
         # the `active_session_id` captured before the await, so two tabs
         # sharing one character can't paint a stale render.
-        current_session_id = getattr(store, "active_session_id", None) if store is not None else None
-        current_state = resolve_console_expression_state(store, current_session_id, react_enabled=react)
-        if (self._current_console_rail_character_id(), current_state) != scope or not self.is_mounted:
+        current_session_id = (
+            getattr(store, "active_session_id", None) if store is not None else None
+        )
+        current_state = resolve_console_expression_state(
+            store, current_session_id, react_enabled=react
+        )
+        if (
+            self._current_console_rail_character_id(),
+            current_state,
+        ) != scope or not self.is_mounted:
             return
         self._console_expression_spec_cache[(character_id, state)] = spec
         # Bound the cache: evict oldest insertion-ordered entries (dicts
         # preserve insertion order) so a long session visiting many
         # characters/states doesn't retain unbounded PIL image references.
         while len(self._console_expression_spec_cache) > _EXPRESSION_SPEC_CACHE_MAX:
-            del self._console_expression_spec_cache[next(iter(self._console_expression_spec_cache))]
+            del self._console_expression_spec_cache[
+                next(iter(self._console_expression_spec_cache))
+            ]
         self._active_character_avatar = spec
         await self._render_character_avatar_into_section()
 
@@ -4882,7 +4898,9 @@ class ChatScreen(BaseAppScreen):
             return  # section not composed (config off / not mounted)
         try:
             await holder.remove_children()
-            await holder.mount(self._build_character_avatar_widget(self._active_character_avatar))
+            await holder.mount(
+                self._build_character_avatar_widget(self._active_character_avatar)
+            )
             try:
                 self.query_one("#console-character-name", Static).update(
                     self._active_character_avatar_name or "No character in this chat"
@@ -4917,12 +4935,19 @@ class ChatScreen(BaseAppScreen):
         no-image case.
         """
         if not spec or (spec.get("pil") is None and spec.get("pixels") is None):
-            hint = "no avatar" if (spec and spec.get("character_id") is not None) else "No character in this chat"
+            hint = (
+                "no avatar"
+                if (spec and spec.get("character_id") is not None)
+                else "No character in this chat"
+            )
             return Static(hint, id="console-character-avatar-empty")
         if spec.get("mode") == "graphics" and spec.get("pil") is not None:
             try:
                 from textual_image.widget import Image as _GraphicsImage
-                widget = _GraphicsImage(spec["pil"], id="console-character-avatar-image")
+
+                widget = _GraphicsImage(
+                    spec["pil"], id="console-character-avatar-image"
+                )
                 # Explicit fitted cell size, not just max-width/max-height --
                 # see `console_transcript._image_row_widget`'s identical
                 # guard: textual_image's "auto" sizing resolves its render
@@ -4930,8 +4955,12 @@ class ChatScreen(BaseAppScreen):
                 # tick before that settles can ask the renderer to scale
                 # into a transient 0-width/height region, which PIL's
                 # resize() raises on.
-                w, h = fit_image_cell_size(spec["pil"].width, spec["pil"].height,
-                                           CHARACTER_AVATAR_COLS, CHARACTER_AVATAR_LINES)
+                w, h = fit_image_cell_size(
+                    spec["pil"].width,
+                    spec["pil"].height,
+                    CHARACTER_AVATAR_COLS,
+                    CHARACTER_AVATAR_LINES,
+                )
                 widget.styles.width = w
                 widget.styles.height = h
                 return widget
@@ -4944,8 +4973,12 @@ class ChatScreen(BaseAppScreen):
                     spec["pil"], CHARACTER_AVATAR_COLS, CHARACTER_AVATAR_LINES
                 )
                 from rich_pixels import Pixels
+
                 pixels = Pixels.from_image(scaled)
-            widget = Static(pixels if pixels is not None else "", id="console-character-avatar-image")
+            widget = Static(
+                pixels if pixels is not None else "",
+                id="console-character-avatar-image",
+            )
             widget.styles.max_width = CHARACTER_AVATAR_COLS
             widget.styles.max_height = CHARACTER_AVATAR_LINES
             return widget
@@ -5638,9 +5671,7 @@ class ChatScreen(BaseAppScreen):
                 # row is usually scrolled out of view at that moment, so the
                 # side effect needs an explicit announcement.
                 switched = registry_service.get_active_workspace()
-                switched_name = (
-                    switched.name if switched is not None else workspace_id
-                )
+                switched_name = switched.name if switched is not None else workspace_id
                 self.app_instance.notify(
                     f"Switched Console to {switched_name}.",
                     severity="information",
@@ -5827,9 +5858,7 @@ class ChatScreen(BaseAppScreen):
             # like TASK-717 threaded `openable` (input row -> normalize ->
             # display row -> row label).
             run_marker = (
-                CONSOLE_RUN_MARKER_GLYPHS.get(
-                    controller.run_marker_for(session.id), ""
-                )
+                CONSOLE_RUN_MARKER_GLYPHS.get(controller.run_marker_for(session.id), "")
                 if controller is not None
                 else ""
             )
@@ -8371,7 +8400,9 @@ class ChatScreen(BaseAppScreen):
                 return
             try:
                 picked = await self.app_instance.push_screen_wait(
-                    WorldBookPicker(rows, title="Detach world book", confirm_label="Detach")
+                    WorldBookPicker(
+                        rows, title="Detach world book", confirm_label="Detach"
+                    )
                 )
             except Exception:
                 logger.opt(exception=True).warning(
@@ -9435,9 +9466,10 @@ class ChatScreen(BaseAppScreen):
     async def _execute_console_library_rag_search(
         self, request: LibraryRagSearchRequest
     ) -> None:
-        scoped_request, short_circuit_outcome = (
-            await self._resolve_console_library_rag_scope(request)
-        )
+        (
+            scoped_request,
+            short_circuit_outcome,
+        ) = await self._resolve_console_library_rag_scope(request)
         outcome = short_circuit_outcome or await run_library_rag_search(
             self.app_instance, scoped_request
         )
@@ -9907,7 +9939,10 @@ class ChatScreen(BaseAppScreen):
 
                         # Section 5: Character (avatar of the active character).
                         if resolve_show_character_avatar(
-                            getattr(getattr(self, "app_instance", None), "app_config", {}) or {}
+                            getattr(
+                                getattr(self, "app_instance", None), "app_config", {}
+                            )
+                            or {}
                         ):
                             yield ConsoleRailSectionHeader(
                                 "Character",
@@ -10719,11 +10754,9 @@ class ChatScreen(BaseAppScreen):
             self._restore_native_console_state(native_console_state)
         self.sync_task_resume_state()
 
-
-
-
-
-    async def _start_character_console_session(self, payload: ChatHandoffPayload) -> bool:
+    async def _start_character_console_session(
+        self, payload: ChatHandoffPayload
+    ) -> bool:
         """Build a dedicated character conversation from a Start-Chat handoff.
 
         Args:
@@ -10775,7 +10808,9 @@ class ChatScreen(BaseAppScreen):
         active_user_name = await resolve_active_user_profile_name_async(
             getattr(self.app_instance, "character_persona_scope_service", None),
             mode=resolve_runtime_backend_mode(self.app_instance),
-            local_service=getattr(self.app_instance, "local_character_persona_service", None),
+            local_service=getattr(
+                self.app_instance, "local_character_persona_service", None
+            ),
         )
         greeting = replace_placeholders(
             str(card.get("first_message") or ""), name, active_user_name or "User"
@@ -10827,6 +10862,7 @@ class ChatScreen(BaseAppScreen):
                 "considered consumed."
             )
         return True
+
     async def _consume_pending_chat_handoff(self) -> None:
         """Claim one Chat handoff and stage it directly in native Console."""
         if self._handoff_consumption_in_progress:
@@ -11020,8 +11056,7 @@ class ChatScreen(BaseAppScreen):
         return (
             getattr(message, "role", None) is ConsoleMessageRole.ASSISTANT
             and getattr(message, "status", None) == "complete"
-            and getattr(message, "persisted_message_id", None)
-            == persisted_message_id
+            and getattr(message, "persisted_message_id", None) == persisted_message_id
             and self._console_citation_message_body(message) == current_body
         )
 
@@ -11050,9 +11085,7 @@ class ChatScreen(BaseAppScreen):
         ):
             return
         current_body = self._console_citation_message_body(message)
-        repository_token, repository = (
-            self._console_citation_repository_readiness()
-        )
+        repository_token, repository = self._console_citation_repository_readiness()
         if repository is None:
             return
         modal = ConsoleCitationSourcesModal(
@@ -11060,14 +11093,12 @@ class ChatScreen(BaseAppScreen):
             persisted_message_id=persisted_message_id,
             current_body=current_body,
             repository=repository,
-            request_is_current=lambda: (
-                self._console_citation_modal_request_is_current(
-                    native_message_id=native_message_id,
-                    persisted_message_id=persisted_message_id,
-                    current_body=current_body,
-                    repository=repository,
-                    repository_token=repository_token,
-                )
+            request_is_current=lambda: self._console_citation_modal_request_is_current(
+                native_message_id=native_message_id,
+                persisted_message_id=persisted_message_id,
+                current_body=current_body,
+                repository=repository,
+                repository_token=repository_token,
             ),
         )
 
@@ -11171,12 +11202,8 @@ class ChatScreen(BaseAppScreen):
     def _sync_console_citation_count_discovery(self, messages: list[Any]) -> None:
         """Dispatch one count lookup worker when eligible inputs change."""
         signature = self._console_citation_signature(messages)
-        repository_token, repository = (
-            self._console_citation_repository_readiness()
-        )
-        repository_changed = (
-            repository_token != self._console_citation_repository_token
-        )
+        repository_token, repository = self._console_citation_repository_readiness()
+        repository_changed = repository_token != self._console_citation_repository_token
         if repository_changed:
             self._console_citation_repository_token = repository_token
             self._console_citation_input_signature = signature
@@ -11211,8 +11238,7 @@ class ChatScreen(BaseAppScreen):
 
         previous_signature = self._console_citation_input_signature
         same_session = (
-            previous_signature is not None
-            and previous_signature[0] == signature[0]
+            previous_signature is not None and previous_signature[0] == signature[0]
         )
         current_entries = {item[0]: item for item in signature[1]}
         if not same_session:
@@ -11223,10 +11249,9 @@ class ChatScreen(BaseAppScreen):
                 self._console_citation_resolved_signatures
             )
             for native_message_id in cached_ids:
-                if (
-                    self._console_citation_resolved_signatures.get(native_message_id)
-                    != current_entries.get(native_message_id)
-                ):
+                if self._console_citation_resolved_signatures.get(
+                    native_message_id
+                ) != current_entries.get(native_message_id):
                     self._console_citation_counts.pop(native_message_id, None)
                     self._console_citation_resolved_signatures.pop(
                         native_message_id,
@@ -11423,9 +11448,7 @@ class ChatScreen(BaseAppScreen):
             # applies it at ingest time once the landed sibling's id is in
             # the pushed set (see ConsoleTranscript.pending_selection_id).
             if self._pending_console_swipe_selection is not None:
-                transcript.pending_selection_id = (
-                    self._pending_console_swipe_selection
-                )
+                transcript.pending_selection_id = self._pending_console_swipe_selection
                 self._pending_console_swipe_selection = None
             transcript.set_messages(messages)
             visible_citation_counts = {
@@ -11520,7 +11543,6 @@ class ChatScreen(BaseAppScreen):
                 self._last_native_transcript_refresh_key = refresh_key
             self._sync_console_transcript_guidance()
             return
-
 
     def _clear_native_console_message_selection(self) -> None:
         """Dismiss contextual message actions when an action changes the transcript flow."""
@@ -11845,7 +11867,11 @@ class ChatScreen(BaseAppScreen):
             # cleared at the keypress, so hand the draft back (ahead of any
             # keystrokes typed since).
             composer.restore_stashed_draft(stash)
-        if result.should_clear_draft and composer_reflects_session and inflight_stash is None:
+        if (
+            result.should_clear_draft
+            and composer_reflects_session
+            and inflight_stash is None
+        ):
             # Stashed sends were cleared at the keypress — clearing again
             # here would eat keystrokes typed after Enter (the next draft).
             composer.clear_draft()
@@ -11888,9 +11914,7 @@ class ChatScreen(BaseAppScreen):
             composer = None
         task = asyncio.current_task()
         session_id = (
-            self._console_submit_session_by_task.get(task)
-            if task is not None
-            else None
+            self._console_submit_session_by_task.get(task) if task is not None else None
         )
         active_session_id = self._ensure_console_chat_store().active_session_id or ""
         if session_id is None:
@@ -12154,9 +12178,7 @@ class ChatScreen(BaseAppScreen):
         cross-session data to leak or clobber.
         """
         try:
-            transcript = self.query_one(
-                "#console-native-transcript", ConsoleTranscript
-            )
+            transcript = self.query_one("#console-native-transcript", ConsoleTranscript)
         except QueryError:
             return
         transcript.note_follow_intent()
@@ -12583,13 +12605,10 @@ class ChatScreen(BaseAppScreen):
             lines = []
             if one_shot:
                 lines.append(
-                    "Prefill (next send only): "
-                    f"'{describe_prefill_preview(one_shot)}'"
+                    f"Prefill (next send only): '{describe_prefill_preview(one_shot)}'"
                 )
             if pinned:
-                lines.append(
-                    f"Prefill (pinned): '{describe_prefill_preview(pinned)}'"
-                )
+                lines.append(f"Prefill (pinned): '{describe_prefill_preview(pinned)}'")
             if not lines:
                 lines.append("No prefill armed.")
             # Clear before the message-append await: `_append_native_console_
@@ -12692,7 +12711,9 @@ class ChatScreen(BaseAppScreen):
                 message.content,
             )
             for message in store.messages_for_session(session_id)
-            if message.status == "complete" and message.content and message.content.strip()
+            if message.status == "complete"
+            and message.content
+            and message.content.strip()
         ]
 
     async def _console_generate_image_llm_context_options(
@@ -12847,9 +12868,7 @@ class ChatScreen(BaseAppScreen):
             )
             return
         catalog = list_image_models_for_catalog()
-        entry = next(
-            (item for item in catalog if item.get("name") == backend), None
-        )
+        entry = next((item for item in catalog if item.get("name") == backend), None)
         if entry is None or not entry.get("is_configured"):
             await self._append_native_console_system_message(
                 f"Image backend '{backend}' is not enabled/configured. "
@@ -13010,6 +13029,7 @@ class ChatScreen(BaseAppScreen):
             await self._sync_native_console_chat_ui()
         finally:
             inflight.discard(message_id)
+
     # Preview length used to build `/rewind` menu rows -- collapses the
     # prompt to one line and truncates it (with a trailing ellipsis) via the
     # same helper session titles use.
@@ -14809,9 +14829,7 @@ class ChatScreen(BaseAppScreen):
                 self.app_instance.notify(refusal, severity="warning")
                 return
             self.run_worker(
-                self._edit_resend_console_message(
-                    controller, message_id, result.text
-                ),
+                self._edit_resend_console_message(controller, message_id, result.text),
                 exclusive=True,
                 group=f"console-run-{target_session_id}",
             )
@@ -15266,7 +15284,6 @@ class ChatScreen(BaseAppScreen):
             total=MAX_PENDING_ATTACHMENTS,
         )
 
-
     def _focus_console_composer_if_needed(self, *, force: bool = False) -> None:
         """Focus the native Console composer when no other control owns focus."""
         if self._console_composer_collapsed:
@@ -15284,7 +15301,6 @@ class ChatScreen(BaseAppScreen):
         ):
             return
         composer.focus()
-
 
     @staticmethod
     def _is_descendant_or_self(widget: object | None, ancestor: object) -> bool:
@@ -15841,9 +15857,7 @@ class ChatScreen(BaseAppScreen):
             controller, session_id
         )
         verb = "finished" if status is ConsoleRunStatus.COMPLETED else "failed"
-        self.app_instance.notify(
-            f"Agent in {session_title} ({workspace_name}) {verb}."
-        )
+        self.app_instance.notify(f"Agent in {session_title} ({workspace_name}) {verb}.")
 
     def _set_console_pending_skill_install(
         self, payload: Dict[str, Any] | None
@@ -15858,9 +15872,7 @@ class ChatScreen(BaseAppScreen):
         current = self._task_resume_state
         self.set_task_resume_state(replace(current, pending_skill_install=payload))
 
-    def _set_console_pending_skill_script(
-        self, payload: Dict[str, Any] | None
-    ) -> None:
+    def _set_console_pending_skill_script(self, payload: Dict[str, Any] | None) -> None:
         """Set/clear the pending skill-script confirm, then sync the task cards.
 
         UI-thread bridge target for ``ConsoleChatController.
@@ -16069,9 +16081,11 @@ class ChatScreen(BaseAppScreen):
                 return
             # TASK-357: confirm the toggle so a star/unstar is not a silent state
             # change (the review saw an accidental star go unnoticed).
-            title = str(
-                getattr(event.button, "conversation_title", "") or ""
-            ).splitlines()[0].strip()
+            title = (
+                str(getattr(event.button, "conversation_title", "") or "")
+                .splitlines()[0]
+                .strip()
+            )
             # notify() interprets Rich markup, so escape the stored title before
             # interpolating it (a title like "[red]x[/red]" would otherwise inject
             # styling into the toast) — matches the escape_markup convention used

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -114,10 +114,11 @@ def _message_body(message: ConsoleChatMessage) -> str:
         # has no content; show a visible generating state instead of an empty
         # row (local models can take 30-90s to first token).
         return CONSOLE_GENERATING_PLACEHOLDER
-    if (
-        message.role is not ConsoleMessageRole.USER
-        and message.status in {"streaming", "stopped", "failed"}
-    ):
+    if message.role is not ConsoleMessageRole.USER and message.status in {
+        "streaming",
+        "stopped",
+        "failed",
+    }:
         # streaming/stopped/failed are assistant-response states; a USER row only
         # carries "failed" via the TASK-457(a) send-blocked echo, where the
         # SYSTEM block-row already explains it — so keep the user's text clean.
@@ -287,7 +288,9 @@ def _message_render_text(message: ConsoleChatMessage, *, selected: bool) -> Cont
     """
     role_label = _message_role_label(message)
     if message.sibling_count > 1:
-        role_label = f"{role_label} ({message.sibling_index + 1}/{message.sibling_count})"
+        role_label = (
+            f"{role_label} ({message.sibling_index + 1}/{message.sibling_count})"
+        )
     body = _message_body(message)
     chips = _message_attachment_chips(message)
     if chips:
@@ -553,22 +556,24 @@ class ConsoleTranscript(VerticalScroll):
         ("r", "invoke_selected_action('regenerate')", "Regenerate"),
     ]
 
-    PROTECTED_CLICK_CLASSES: frozenset[str] = frozenset({
-        "console-transcript-action-row",
-        "console-transcript-action-guide",
-        "console-transcript-empty-panel",
-        "console-transcript-empty-body",
-        "console-transcript-empty-state",
-        "console-transcript-rule",
-        "console-transcript-summary-banner",
-        "console-transcript-citation-sources",
-        # Textual scrollbars carry the generic system-widget class; ignore them
-        # defensively if a scrollbar click ever bubbles up to the transcript.
-        "-textual-system",
-        "vertical-scrollbar",
-        "horizontal-scrollbar",
-        "scrollbar",
-    })
+    PROTECTED_CLICK_CLASSES: frozenset[str] = frozenset(
+        {
+            "console-transcript-action-row",
+            "console-transcript-action-guide",
+            "console-transcript-empty-panel",
+            "console-transcript-empty-body",
+            "console-transcript-empty-state",
+            "console-transcript-rule",
+            "console-transcript-summary-banner",
+            "console-transcript-citation-sources",
+            # Textual scrollbars carry the generic system-widget class; ignore them
+            # defensively if a scrollbar click ever bubbles up to the transcript.
+            "-textual-system",
+            "vertical-scrollbar",
+            "horizontal-scrollbar",
+            "scrollbar",
+        }
+    )
     """Widget classes that must keep the current selection active when clicked."""
 
     def __init__(self, **kwargs) -> None:
@@ -993,11 +998,13 @@ class ConsoleTranscript(VerticalScroll):
         timing is the point) but the file append is deferred off the caller's
         critical section via ``call_later``."""
         import os
+
         path = os.environ.get("TLDW_TRANSCRIPT_PAINT_LOG")
         if not path:
             return
         try:
             import time
+
             rows = list(self.query(".console-transcript-action-row"))
             lines = [
                 f"{time.strftime('%H:%M:%S')} {label}: selected={self.selected_message_id!r} "
@@ -1088,8 +1095,7 @@ class ConsoleTranscript(VerticalScroll):
         """
         control = event.control
         if control is not None and any(
-            control.has_class(class_name)
-            for class_name in self.PROTECTED_CLICK_CLASSES
+            control.has_class(class_name) for class_name in self.PROTECTED_CLICK_CLASSES
         ):
             event.stop()
             return


### PR DESCRIPTION
## Summary
- normalize inherited Ruff formatting drift in the four Console files recorded by TASK-553.15
- keep the change strictly mechanical; parsed ASTs and comment-token streams are identical to current dev
- close TASK-840 with the exact eleven-file formatter gate and focused citation verification

## Verification
- exact TASK-553.15 eleven-file `ruff format --check` (11 files already formatted)
- `ruff check` on the four touched Console files
- focused controller/agent citation gate (95 passed)
- focused transcript/native-flow citation gate (20 passed)
- parsed AST and comment-token identity against `origin/dev`
- `git diff --check origin/dev...HEAD`

## Scope
- Ruff formatting plus task/plan documentation only
- no production behavior, interface, ownership, persistence, security, or architecture changes
- ADR required: no

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalized `ruff` formatting in the Console citation path to remove inherited drift with no behavior changes. Satisfies TASK-840 by reproducing the TASK-553.15 eleven-file formatter gate while keeping citation checks stable.

- **Refactors**
  - Ran `ruff format` only on: `tldw_chatbook/Chat/console_agent_bridge.py`, `tldw_chatbook/Chat/console_chat_controller.py`, `tldw_chatbook/UI/Screens/chat_screen.py`, `tldw_chatbook/Widgets/Console/console_transcript.py`.
  - Added plan doc: `Docs/superpowers/plans/2026-07-27-console-citation-format-normalization.md`; marked TASK-840 Done in backlog.
  - Gates: eleven-file `ruff format --check` zero; `ruff check` clean on touched files; focused citation/UI tests pass; `git diff --check` clean.

<sup>Written for commit c31d4985f55e969b2234de827b2c09329a30dcee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

