### PR TITLE
feat(stt): add gated Parakeet v3 batch routing

### DIFF
--- a/Docs/Features/TRANSCRIPTION.md
+++ b/Docs/Features/TRANSCRIPTION.md
@@ -91,10 +91,13 @@ selected code, `effective_language=auto`, `detected_language=null`, and the
 or was forced to the requested language.
 
 Batch transcription never downloads a model in an ingestion worker. Exact
-Parakeet requires the matching existing local bundle. Selecting v3 with a
-known verified v2 receipt is rejected; a receipt does not verify an arbitrary
-v3 directory. faster-whisper is also loaded with `local_files_only=True`, so a
-missing cache fails clearly instead of starting a worker download.
+Parakeet uses a user-selected existing local directory and checks that the
+required config, vocabulary, encoder, and decoder filenames are present. The
+runtime may read at most 64 KiB from a non-symlink receipt; when its repository
+and revision metadata identify v2 while v3 is selected, the directory is
+rejected. This receipt is not authenticated and does not verify file contents
+or v3 eligibility. faster-whisper is also loaded with `local_files_only=True`,
+so a missing cache fails clearly instead of starting a worker download.
 
 This Parakeet ONNX batch path is distinct from the legacy NeMo `parakeet`
 provider and the macOS-only `parakeet-mlx` provider described below. Full
@@ -247,7 +250,8 @@ The Local Ingestion window supports batch processing:
 - Ensure you've installed the required dependencies
 - For Library batch transcription, install or cache the model before ingesting;
   the worker will not download it
-- For exact Parakeet ONNX, select the local bundle for the routed v2 or v3 model
+- For exact Parakeet ONNX, select an existing local directory containing the
+  required filenames; this check does not validate their contents
 - For faster-whisper, confirm the selected model is already in the local cache
 
 **"CUDA out of memory"**

--- a/Docs/Features/TRANSCRIPTION.md
+++ b/Docs/Features/TRANSCRIPTION.md
@@ -67,8 +67,9 @@ chunk_length_seconds = 40.0         # For Canary long audio processing
 For local audio and video ingestion, the Library's **Transcription provider**
 menu exposes `default`, `parakeet-onnx`, and `faster-whisper`. The visible
 `default` value is a semantic default, not an alias for Parakeet. While the
-Parakeet promotion gate is closed, it resolves to faster-whisper for every
-request. `en` remains the default requested language.
+Parakeet promotion gate is closed, compatible requests resolve to
+faster-whisper; translation targets other than `en` fail. `en` remains the
+default requested language.
 
 | Selected provider | Request | Current batch result |
 |---|---|---|

--- a/Docs/Features/TRANSCRIPTION.md
+++ b/Docs/Features/TRANSCRIPTION.md
@@ -17,9 +17,22 @@ tldw_chatbook provides a unified transcription service that supports multiple ba
 
 ## Installation
 
-### Basic Audio Support
+### Library Audio and Video
+
+The `audio` and `video` extras each install faster-whisper:
+
 ```bash
 pip install -e ".[audio]"
+pip install -e ".[video]"
+```
+
+Add the Parakeet ONNX runtime when you want to select exact
+`parakeet-onnx`:
+
+```bash
+pip install -e ".[audio,transcription_parakeet_onnx]"
+# Or, for video:
+pip install -e ".[video,transcription_parakeet_onnx]"
 ```
 
 ### Console Microphone Dictation
@@ -27,10 +40,11 @@ pip install -e ".[audio]"
 pip install -e ".[speech_recording,transcription_parakeet_onnx]"
 ```
 
-Install the verified **Parakeet v2 INT8** bundle from **Library → Models**
-before using the Console microphone. The Mic action never downloads a model.
+In the Library audio/video options, select exact `parakeet-onnx`, keep language
+`en`, and use **Install verified Parakeet v2 INT8** before using the Console
+microphone. The Mic action never downloads a model.
 
-### NVIDIA Models (Parakeet & Canary)
+### Legacy NeMo Models (`parakeet` and `canary`)
 ```bash
 pip install -e ".[nemo]"
 ```
@@ -71,6 +85,10 @@ Parakeet promotion gate is closed, compatible requests resolve to
 faster-whisper; translation targets other than `en` fail. `en` remains the
 default requested language.
 
+The current Library audio/video form has no translation-target control. The
+translation rows below describe stored or programmatic job options, not
+controls offered by the form.
+
 | Selected provider | Request | Current batch result |
 |---|---|---|
 | `default` | Transcription, `auto`, unsupported language, or translation to `en` | faster-whisper INT8 while the promotion gate is closed |
@@ -80,6 +98,10 @@ default requested language.
 | `parakeet-onnx` | `auto`, an unsupported language, or any translation | Fails with `Retry with faster-whisper` guidance |
 | `faster-whisper` | Transcription, or translation with target `en` | faster-whisper INT8 |
 | `faster-whisper` | Translation to any target other than `en` | Fails; faster-whisper translates only to English |
+
+The Parakeet model values in this table are selected route/model labels. They
+do not attest that a user-selected directory contains that model or verified
+model contents.
 
 The exact supported non-English Parakeet v3 codes are `bg`, `hr`, `cs`, `da`,
 `nl`, `et`, `fi`, `fr`, `de`, `el`, `hu`, `it`, `lv`, `lt`, `mt`, `pl`, `pt`,
@@ -104,6 +126,30 @@ This Parakeet ONNX batch path is distinct from the legacy NeMo `parakeet`
 provider and the macOS-only `parakeet-mlx` provider described below. Full
 managed v3 artifacts and the interactive **Retry with faster-whisper** action
 remain deferred.
+
+### Prepare Models Before Starting Ingest
+
+Library ingestion workers are local-only and never download a transcription
+model.
+
+- For exact faster-whisper, select the model in the Library form and cache that
+  exact model before choosing **Start ingest**. For example, to cache `base`:
+
+  ```bash
+  python -c "from faster_whisper import WhisperModel; WhisperModel('base', device='cpu', compute_type='int8')"
+  ```
+
+  Replace `base` with the exact model selected in the form.
+- For exact English Parakeet, select `parakeet-onnx`, keep language `en`, and
+  use **Install verified Parakeet v2 INT8**. The installer fills the local
+  model folder with the curated v2 installation.
+- There is no supported in-app Parakeet v3 acquisition yet. Exact supported
+  non-English Parakeet requires a manually obtained existing local directory
+  with the required filenames. If you do not already have such a directory,
+  select `faster-whisper` for non-English transcription.
+
+Direct or non-batch transcription calls may retain their existing download
+behavior. That does not permit a Library ingestion worker to download.
 
 ## Available Models
 
@@ -162,29 +208,23 @@ transcription failures leave the draft unchanged and display an error.
 
 ### Basic Transcription
 
-1. Navigate to **Library**
-2. Select **Local Audio** or **Local Video**
+1. Navigate to **Library**.
+2. Select **Local Audio** or **Local Video**.
 3. Choose your transcription settings:
-   - **Provider**: Keep the semantic default or select an exact provider
-   - **Model**: Choose model size/variant
-   - **Language**: `en` by default; use `auto` only with faster-whisper
-4. Select your audio/video files
-5. Click **Process Files**
+   - **Provider**: Keep the semantic default or select an exact provider.
+   - **Model**: Available only when exact `faster-whisper` is selected.
+   - **Local Parakeet model folder** and **Install verified Parakeet v2
+     INT8**: Available only when exact `parakeet-onnx` is selected.
+   - **Language**: `en` by default; use `auto` only with faster-whisper.
+4. Select your audio/video files.
+5. Choose **Start ingest**.
 
-### Translation
+### Programmatic Translation
 
-Translation is available when using supported providers:
-
-#### Faster-Whisper (English Translation Only)
-1. Select a non-English audio file
-2. Set the translation target to `en`
-3. Process the file for transcription and translation to English
-
-#### Canary (Multilingual Translation)
-1. Select **canary** as the provider
-2. Set the **Source Language** (en, de, es, or fr)
-3. Set the **Target Language** (en, de, es, or fr)
-4. Process the file for transcription + translation
+The current Library audio/video form does not expose a translation-target
+control. Stored or programmatic faster-whisper jobs may request translation
+with target `en`; other targets fail. Canary translation remains a legacy
+provider capability and is not a current Library workflow.
 
 ## Language Codes
 
@@ -208,7 +248,7 @@ Use "auto" for automatic language detection (Faster-Whisper only).
 ## Performance Tips
 
 ### Model Selection
-- **For speed**: Use smaller models (tiny, base) or Parakeet
+- **For speed**: Use smaller faster-whisper models or Legacy NeMo `parakeet`
 - **For accuracy**: Use larger models (large-v3) or Canary
 - **For non-English**: Use Faster-Whisper or Canary
 
@@ -249,11 +289,12 @@ The Local Ingestion window supports batch processing:
 
 **"Model not found"**
 - Ensure you've installed the required dependencies
-- For Library batch transcription, install or cache the model before ingesting;
-  the worker will not download it
-- For exact Parakeet ONNX, select an existing local directory containing the
-  required filenames; this check does not validate their contents
-- For faster-whisper, confirm the selected model is already in the local cache
+- Follow [Prepare Models Before Starting Ingest](#prepare-models-before-starting-ingest);
+  the Library worker will not download a missing model
+- For exact Parakeet ONNX, remember that a manual directory is checked only for
+  required filenames; the check does not validate their contents
+- For faster-whisper, cache the exact model selected in the Library form before
+  choosing **Start ingest**
 
 **"CUDA out of memory"**
 - Use a smaller model

--- a/Docs/Features/TRANSCRIPTION.md
+++ b/Docs/Features/TRANSCRIPTION.md
@@ -132,14 +132,22 @@ remain deferred.
 Library ingestion workers are local-only and never download a transcription
 model.
 
-- For exact faster-whisper, select the model in the Library form and cache that
-  exact model before choosing **Start ingest**. For example, to cache `base`:
+- For semantic `default`, the closed promotion gate selects local-only
+  faster-whisper. The model picker stays disabled, so cache the model configured
+  as `[transcription].default_model` (normally `base`) before choosing
+  **Start ingest**.
+- For exact `faster-whisper`, cache the exact model selected in the Library
+  model picker before choosing **Start ingest**.
 
-  ```bash
-  python -c "from faster_whisper import WhisperModel; WhisperModel('base', device='cpu', compute_type='int8')"
-  ```
+For example, this prepares semantic `default` when `default_model = "base"`:
 
-  Replace `base` with the exact model selected in the form.
+```bash
+python -c "from faster_whisper import WhisperModel; WhisperModel('base', device='cpu', compute_type='int8')"
+```
+
+Replace `base` with the configured `default_model` for semantic `default`, or
+with the exact model selected for exact `faster-whisper`.
+
 - For exact English Parakeet, select `parakeet-onnx`, keep language `en`, and
   use **Install verified Parakeet v2 INT8**. The installer fills the local
   model folder with the curated v2 installation.
@@ -293,8 +301,10 @@ The Local Ingestion window supports batch processing:
   the Library worker will not download a missing model
 - For exact Parakeet ONNX, remember that a manual directory is checked only for
   required filenames; the check does not validate their contents
-- For faster-whisper, cache the exact model selected in the Library form before
-  choosing **Start ingest**
+- For semantic `default`, cache `[transcription].default_model` even though the
+  model picker is disabled
+- For exact `faster-whisper`, cache the exact model selected in the Library
+  form before choosing **Start ingest**
 
 **"CUDA out of memory"**
 - Use a smaller model

--- a/Docs/Features/TRANSCRIPTION.md
+++ b/Docs/Features/TRANSCRIPTION.md
@@ -7,9 +7,12 @@ This document describes the transcription capabilities available in tldw_chatboo
 tldw_chatbook provides a unified transcription service that supports multiple backend providers, each with their own strengths:
 
 - **Faster-Whisper**: Fast, accurate transcription with support for many languages
-- **Parakeet ONNX**: Cross-platform local Parakeet v2 INT8 for explicit English
+- **Parakeet ONNX**: Installed, local-only Parakeet v2/v3 INT8 for Library batch
+  transcription
 - **Qwen2Audio**: Advanced multimodal understanding
-- **Parakeet**: NVIDIA's optimized models for real-time transcription
+- **Parakeet (legacy NeMo)**: NVIDIA's older optimized provider for real-time
+  transcription
+- **Parakeet-MLX**: The separate Apple Silicon real-time provider
 - **Canary**: NVIDIA's multilingual model with translation capabilities
 
 ## Installation
@@ -59,7 +62,53 @@ use_vad_by_default = false          # Voice Activity Detection
 chunk_length_seconds = 40.0         # For Canary long audio processing
 ```
 
+## Library Batch Routing
+
+For local audio and video ingestion, the Library's **Transcription provider**
+menu exposes `default`, `parakeet-onnx`, and `faster-whisper`. The visible
+`default` value is a semantic default, not an alias for Parakeet. While the
+Parakeet promotion gate is closed, it resolves to faster-whisper for every
+request. `en` remains the default requested language.
+
+| Selected provider | Request | Current batch result |
+|---|---|---|
+| `default` | Transcription, `auto`, unsupported language, or translation to `en` | faster-whisper INT8 while the promotion gate is closed |
+| `default` | Translation to any target other than `en` | Fails; faster-whisper translates only to English |
+| `parakeet-onnx` | Missing language or `en` | `nemo-parakeet-tdt-0.6b-v2`, INT8 |
+| `parakeet-onnx` | Supported non-English code | `nemo-parakeet-tdt-0.6b-v3`, INT8 |
+| `parakeet-onnx` | `auto`, an unsupported language, or any translation | Fails with `Retry with faster-whisper` guidance |
+| `faster-whisper` | Transcription, or translation with target `en` | faster-whisper INT8 |
+| `faster-whisper` | Translation to any target other than `en` | Fails; faster-whisper translates only to English |
+
+The exact supported non-English Parakeet v3 codes are `bg`, `hr`, `cs`, `da`,
+`nl`, `et`, `fi`, `fr`, `de`, `el`, `hu`, `it`, `lv`, `lt`, `mt`, `pl`, `pt`,
+`ro`, `sk`, `sl`, `es`, `sv`, `ru`, and `uk`.
+
+For v3, the requested language selects the route only; it is not passed to the
+decoder as a constraint. Results therefore report `requested_language` as the
+selected code, `effective_language=auto`, `detected_language=null`, and the
+`requested_language_not_enforced` warning. They do not claim that v3 detected
+or was forced to the requested language.
+
+Batch transcription never downloads a model in an ingestion worker. Exact
+Parakeet requires the matching existing local bundle. Selecting v3 with a
+known verified v2 receipt is rejected; a receipt does not verify an arbitrary
+v3 directory. faster-whisper is also loaded with `local_files_only=True`, so a
+missing cache fails clearly instead of starting a worker download.
+
+This Parakeet ONNX batch path is distinct from the legacy NeMo `parakeet`
+provider and the macOS-only `parakeet-mlx` provider described below. Full
+managed v3 artifacts and the interactive **Retry with faster-whisper** action
+remain deferred.
+
 ## Available Models
+
+### Parakeet ONNX
+- **English model**: `nemo-parakeet-tdt-0.6b-v2` (INT8)
+- **Supported non-English model**: `nemo-parakeet-tdt-0.6b-v3` (INT8)
+- **Runtime**: `onnx-asr[cpu]==0.12.0`
+- **Translation**: Not supported
+- **Best for**: Explicit, installed/local Library batch transcription
 
 ### Faster-Whisper
 - **Models**: tiny, base, small, medium, large-v1, large-v2, large-v3, distil-large-v3
@@ -73,7 +122,7 @@ chunk_length_seconds = 40.0         # For Canary long audio processing
 - **Translation**: Not supported
 - **Best for**: Advanced audio understanding and context
 
-### Parakeet
+### Parakeet (Legacy NeMo Provider)
 - **Models**: 
   - nvidia/parakeet-tdt-1.1b (Transducer)
   - nvidia/parakeet-rnnt-1.1b (RNN-Transducer)
@@ -109,12 +158,12 @@ transcription failures leave the draft unchanged and display an error.
 
 ### Basic Transcription
 
-1. Navigate to the **Ingest** tab
+1. Navigate to **Library**
 2. Select **Local Audio** or **Local Video**
 3. Choose your transcription settings:
-   - **Provider**: Select from available providers
+   - **Provider**: Keep the semantic default or select an exact provider
    - **Model**: Choose model size/variant
-   - **Language**: Set source language (or "auto" for detection)
+   - **Language**: `en` by default; use `auto` only with faster-whisper
 4. Select your audio/video files
 5. Click **Process Files**
 
@@ -124,7 +173,8 @@ Translation is available when using supported providers:
 
 #### Faster-Whisper (English Translation Only)
 1. Select a non-English audio file
-2. The system will automatically translate to English during transcription
+2. Set the translation target to `en`
+3. Process the file for transcription and translation to English
 
 #### Canary (Multilingual Translation)
 1. Select **canary** as the provider
@@ -195,8 +245,10 @@ The Local Ingestion window supports batch processing:
 
 **"Model not found"**
 - Ensure you've installed the required dependencies
-- First run may take time to download models
-- Check internet connection for model downloads
+- For Library batch transcription, install or cache the model before ingesting;
+  the worker will not download it
+- For exact Parakeet ONNX, select the local bundle for the routed v2 or v3 model
+- For faster-whisper, confirm the selected model is already in the local cache
 
 **"CUDA out of memory"**
 - Use a smaller model

--- a/Docs/Features/TRANSCRIPTION_PROVIDERS.md
+++ b/Docs/Features/TRANSCRIPTION_PROVIDERS.md
@@ -6,8 +6,8 @@ This guide helps you choose the right transcription provider for your use case.
 
 The Library audio/video form exposes a visible semantic `default` plus the exact
 `parakeet-onnx` and `faster-whisper` providers. While the Parakeet promotion
-gate is closed, `default` remains faster-whisper; `en` remains the default
-requested language.
+gate is closed, compatible `default` requests use faster-whisper; translation
+targets other than `en` fail. `en` remains the default requested language.
 
 | Selected provider | Request | Model/runtime behavior |
 |---|---|---|

--- a/Docs/Features/TRANSCRIPTION_PROVIDERS.md
+++ b/Docs/Features/TRANSCRIPTION_PROVIDERS.md
@@ -24,10 +24,13 @@ constraint. Results report the request, `effective_language=auto`,
 `detected_language=null`, and `requested_language_not_enforced`.
 
 All successful Library batch routes are INT8 and installed/local-only. Exact
-Parakeet requires the correct existing local bundle; a known verified v2
-receipt is rejected when v3 is selected. faster-whisper requires its model to
-already be cached. Missing files fail clearly and never trigger a download in
-an ingestion worker.
+Parakeet uses a user-selected existing local directory and checks for the
+required config, vocabulary, encoder, and decoder filenames. The runtime may
+read at most 64 KiB from a non-symlink receipt; repository and revision
+metadata that identify v2 are rejected when v3 is selected. The receipt is not
+authenticated and does not verify file contents or v3 eligibility.
+faster-whisper requires its model to already be cached. Missing files fail
+clearly and never trigger a download in an ingestion worker.
 
 Parakeet ONNX is not the legacy NeMo `parakeet` provider or the macOS-only
 `parakeet-mlx` provider covered below. Full managed v3 artifacts and the

--- a/Docs/Features/TRANSCRIPTION_PROVIDERS.md
+++ b/Docs/Features/TRANSCRIPTION_PROVIDERS.md
@@ -4,44 +4,24 @@ This guide helps you choose the right transcription provider for your use case.
 
 ## Current Library Batch Route
 
-The Library audio/video form exposes a visible semantic `default` plus the exact
-`parakeet-onnx` and `faster-whisper` providers. While the Parakeet promotion
-gate is closed, compatible `default` requests use faster-whisper; translation
-targets other than `en` fail. `en` remains the default requested language.
+See the canonical [Library Batch Routing](TRANSCRIPTION.md#library-batch-routing)
+policy for the exact routing table, supported Parakeet ONNX v3 languages,
+installation, cache recovery, and artifact limitations.
 
-| Selected provider | Request | Model/runtime behavior |
-|---|---|---|
-| `default` | Transcription, `auto`, unsupported language, or translation to `en` | faster-whisper INT8 while the promotion gate is closed |
-| `default` | Translation to another target | Fails; faster-whisper translates only to English |
-| `parakeet-onnx` | Missing language or `en` | `nemo-parakeet-tdt-0.6b-v2` INT8 |
-| `parakeet-onnx` | `bg`, `hr`, `cs`, `da`, `nl`, `et`, `fi`, `fr`, `de`, `el`, `hu`, `it`, `lv`, `lt`, `mt`, `pl`, `pt`, `ro`, `sk`, `sl`, `es`, `sv`, `ru`, or `uk` | `nemo-parakeet-tdt-0.6b-v3` INT8 |
-| `parakeet-onnx` | `auto`, unsupported language, or translation | Fails with `Retry with faster-whisper` guidance |
-| `faster-whisper` | Translation with target `en` | Translates to English |
-| `faster-whisper` | Translation to another target | Fails; non-English targets are unsupported |
-
-For Parakeet v3, the selected language is routing-only and is not a decoder
-constraint. Results report the request, `effective_language=auto`,
-`detected_language=null`, and `requested_language_not_enforced`.
-
-All successful Library batch routes are INT8 and installed/local-only. Exact
-Parakeet uses a user-selected existing local directory and checks for the
-required config, vocabulary, encoder, and decoder filenames. The runtime may
-read at most 64 KiB from a non-symlink receipt; repository and revision
-metadata that identify v2 are rejected when v3 is selected. The receipt is not
-authenticated and does not verify file contents or v3 eligibility.
-faster-whisper requires its model to already be cached. Missing files fail
-clearly and never trigger a download in an ingestion worker.
-
-Parakeet ONNX is not the legacy NeMo `parakeet` provider or the macOS-only
-`parakeet-mlx` provider covered below. Full managed v3 artifacts and the
-interactive **Retry with faster-whisper** action remain deferred.
+The current form exposes semantic `default`, exact `parakeet-onnx`, and exact
+`faster-whisper`. Exact faster-whisper supports ordinary transcription,
+including explicit languages or `auto`, and is the only selection that enables
+the model picker. The form has no translation-target control; the
+translation-to-English contract applies only to stored or programmatic
+options. Parakeet ONNX is distinct from Parakeet-MLX and Legacy NeMo Parakeet
+(`parakeet`).
 
 ## Quick Comparison Table
 
-The comparison below covers the older general and real-time providers; the
-current Parakeet ONNX Library batch route is documented separately above.
+The comparison below covers the older general and real-time providers; use the
+canonical routing link above for the current Parakeet ONNX Library batch path.
 
-| Feature | Parakeet-MLX | Lightning-Whisper-MLX | Faster-Whisper | Qwen2Audio | Parakeet | Canary |
+| Feature | Parakeet-MLX | Lightning-Whisper-MLX | Faster-Whisper | Qwen2Audio | Legacy NeMo Parakeet | Canary |
 |---------|--------------|----------------------|----------------|------------|----------|---------|
 | **Speed** | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐ |
 | **Accuracy** | ⭐⭐⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐⭐⭐ |
@@ -173,7 +153,7 @@ current Parakeet ONNX Library batch route is documented separately above.
 - Research applications
 - When context understanding is critical
 
-### Parakeet (Legacy NeMo Provider)
+### Legacy NeMo Parakeet (`parakeet`)
 
 **Best for:** Real-time English transcription
 
@@ -205,6 +185,9 @@ current Parakeet ONNX Library batch route is documented separately above.
 ### Canary
 
 **Best for:** Multilingual transcription and translation
+
+This is a legacy provider capability, not a workflow exposed by the current
+Library audio/video form.
 
 **Strengths:**
 - Supports 4 languages (en, de, es, fr)
@@ -239,7 +222,7 @@ current Parakeet ONNX Library batch route is documented separately above.
 
 **Real-time/Streaming:**
 - First choice: Parakeet-MLX (macOS)
-- Alternative: Parakeet (tdt models)
+- Alternative: Legacy NeMo Parakeet (TDT models)
 - Fallback: Canary with small chunks
 
 **Multilingual Content:**
@@ -248,7 +231,7 @@ current Parakeet ONNX Library batch route is documented separately above.
 
 **Quick Drafts:**
 - Faster-Whisper (tiny or base)
-- Parakeet (0.6b models)
+- Legacy NeMo Parakeet (0.6b models)
 
 **Best Quality:**
 - Faster-Whisper (large-v3)
@@ -265,12 +248,12 @@ current Parakeet ONNX Library batch route is documented separately above.
 
 **CPU Only:**
 - Faster-Whisper with int8 compute
-- Small Parakeet models
+- Small Legacy NeMo Parakeet models
 - Avoid Qwen2Audio
 
 **Limited GPU (4-8GB):**
 - Faster-Whisper (all models)
-- Parakeet (all models)
+- Legacy NeMo Parakeet (all models)
 - Canary (may need reduced batch size)
 
 **Powerful GPU (16GB+):**
@@ -281,7 +264,7 @@ current Parakeet ONNX Library batch route is documented separately above.
 ### By Language
 
 **English Only:**
-- Parakeet for speed
+- Legacy NeMo Parakeet for speed
 - Faster-Whisper for accuracy
 
 **European Languages:**
@@ -302,7 +285,7 @@ current Parakeet ONNX Library batch route is documented separately above.
 2. Enable GPU acceleration if available
 3. Use int8 compute type for CPU
 4. Disable VAD if not needed
-5. Use Parakeet for English-only content
+5. Use Legacy NeMo Parakeet for English-only content
 
 ### for Accuracy
 1. Use larger models (large-v3, 1.1b variants)
@@ -342,7 +325,7 @@ current Parakeet ONNX Library batch route is documented separately above.
 - Settings: GPU acceleration
 
 ### "Real-time English"
-- Provider: Parakeet
+- Provider: `parakeet` (Legacy NeMo Parakeet)
 - Model: parakeet-tdt-0.6b-v2
 - Settings: GPU if available
 
@@ -356,7 +339,7 @@ current Parakeet ONNX Library batch route is documented separately above.
 ### "Transcription is too slow"
 - Switch to smaller model
 - Enable GPU acceleration
-- Use Parakeet for English
+- Use Legacy NeMo Parakeet for English
 - Check CPU/GPU usage
 
 ### "Poor accuracy"

--- a/Docs/Features/TRANSCRIPTION_PROVIDERS.md
+++ b/Docs/Features/TRANSCRIPTION_PROVIDERS.md
@@ -2,7 +2,41 @@
 
 This guide helps you choose the right transcription provider for your use case.
 
+## Current Library Batch Route
+
+The Library audio/video form exposes a visible semantic `default` plus the exact
+`parakeet-onnx` and `faster-whisper` providers. While the Parakeet promotion
+gate is closed, `default` remains faster-whisper; `en` remains the default
+requested language.
+
+| Selected provider | Request | Model/runtime behavior |
+|---|---|---|
+| `default` | Transcription, `auto`, unsupported language, or translation to `en` | faster-whisper INT8 while the promotion gate is closed |
+| `default` | Translation to another target | Fails; faster-whisper translates only to English |
+| `parakeet-onnx` | Missing language or `en` | `nemo-parakeet-tdt-0.6b-v2` INT8 |
+| `parakeet-onnx` | `bg`, `hr`, `cs`, `da`, `nl`, `et`, `fi`, `fr`, `de`, `el`, `hu`, `it`, `lv`, `lt`, `mt`, `pl`, `pt`, `ro`, `sk`, `sl`, `es`, `sv`, `ru`, or `uk` | `nemo-parakeet-tdt-0.6b-v3` INT8 |
+| `parakeet-onnx` | `auto`, unsupported language, or translation | Fails with `Retry with faster-whisper` guidance |
+| `faster-whisper` | Translation with target `en` | Translates to English |
+| `faster-whisper` | Translation to another target | Fails; non-English targets are unsupported |
+
+For Parakeet v3, the selected language is routing-only and is not a decoder
+constraint. Results report the request, `effective_language=auto`,
+`detected_language=null`, and `requested_language_not_enforced`.
+
+All successful Library batch routes are INT8 and installed/local-only. Exact
+Parakeet requires the correct existing local bundle; a known verified v2
+receipt is rejected when v3 is selected. faster-whisper requires its model to
+already be cached. Missing files fail clearly and never trigger a download in
+an ingestion worker.
+
+Parakeet ONNX is not the legacy NeMo `parakeet` provider or the macOS-only
+`parakeet-mlx` provider covered below. Full managed v3 artifacts and the
+interactive **Retry with faster-whisper** action remain deferred.
+
 ## Quick Comparison Table
+
+The comparison below covers the older general and real-time providers; the
+current Parakeet ONNX Library batch route is documented separately above.
 
 | Feature | Parakeet-MLX | Lightning-Whisper-MLX | Faster-Whisper | Qwen2Audio | Parakeet | Canary |
 |---------|--------------|----------------------|----------------|------------|----------|---------|
@@ -136,7 +170,7 @@ This guide helps you choose the right transcription provider for your use case.
 - Research applications
 - When context understanding is critical
 
-### Parakeet
+### Parakeet (Legacy NeMo Provider)
 
 **Best for:** Real-time English transcription
 

--- a/Docs/superpowers/plans/2026-07-27-gated-parakeet-v3-batch-routing.md
+++ b/Docs/superpowers/plans/2026-07-27-gated-parakeet-v3-batch-routing.md
@@ -1,0 +1,355 @@
+# Gated Parakeet v3 Batch Routing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add explicit Parakeet v3 INT8 batch transcription and deterministic STT request routing without enabling unqualified Parakeet semantic defaults.
+
+**Architecture:** A small dependency-free routing module resolves a batch request before inference. `provider=default` remains on faster-whisper while the promotion gate is closed; exact `parakeet-onnx` requests select v2 for English or v3 for supported non-English and fail clearly for incompatible requests. The existing `TranscriptionService` remains the narrow execution seam and gains only the v3 model/result differences needed by the working batch path.
+
+**Tech Stack:** Python 3.11+, pytest, Textual ingestion option contracts, `onnx-asr[cpu]==0.12.0`.
+
+**ADR required:** yes
+
+**ADR path:** `backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md`
+
+**Reason:** ADR-025 already governs semantic STT routing, v3's routing-only language behavior, INT8 selection, explicit faster-whisper recovery, and the promotion gate. This child task implements a bounded subset without changing those decisions.
+
+---
+
+### Task 1: Add the gated batch routing policy
+
+**Files:**
+- Create: `tldw_chatbook/Local_Ingestion/stt_batch_routing.py`
+- Create: `Tests/Transcription/test_stt_batch_routing.py`
+
+- [ ] **Step 1: Write failing routing tests**
+
+Cover these independent outcomes:
+
+```python
+def test_default_stays_on_faster_whisper_while_promotion_gate_is_closed():
+    route = resolve_batch_stt_route(provider="default", language="en")
+    assert route.provider == "faster-whisper"
+    assert route.reason == "parakeet_promotion_gate_closed"
+    assert route.precision == "int8"
+    assert route.local_files_only is True
+
+
+@pytest.mark.parametrize(
+    ("language", "target_language", "provider", "model"),
+    [
+        ("en", None, "parakeet-onnx", PARAKEET_V2_MODEL),
+        ("de", None, "parakeet-onnx", PARAKEET_V3_MODEL),
+        ("auto", None, "faster-whisper", None),
+        ("ja", None, "faster-whisper", None),
+        ("en", "fr", "faster-whisper", None),
+    ],
+)
+def test_enabled_default_policy_covers_every_routing_row(
+    language, target_language, provider, model
+):
+    route = resolve_batch_stt_route(
+        provider="default",
+        language=language,
+        target_language=target_language,
+        parakeet_defaults_enabled=True,
+    )
+    assert (route.provider, route.model) == (provider, model)
+
+
+@pytest.mark.parametrize("language", [None, "", "en", "EN"])
+def test_explicit_parakeet_english_selects_v2(language):
+    route = resolve_batch_stt_route(provider="parakeet-onnx", language=language)
+    assert route.model == PARAKEET_V2_MODEL
+    assert route.requested_language == "en"
+
+
+@pytest.mark.parametrize("language", ["de", "es", "fr", "uk"])
+def test_explicit_supported_non_english_selects_v3(language):
+    route = resolve_batch_stt_route(provider="parakeet-onnx", language=language)
+    assert route.model == PARAKEET_V3_MODEL
+    assert route.requested_language == language
+
+
+@pytest.mark.parametrize(
+    ("language", "target_language"),
+    [("auto", None), ("ja", None), ("en", "fr")],
+)
+def test_explicit_parakeet_rejects_incompatible_requests_with_retry_guidance(
+    language, target_language
+):
+    with pytest.raises(BatchSTTRoutingError, match="Retry with faster-whisper"):
+        resolve_batch_stt_route(
+            provider="parakeet-onnx",
+            language=language,
+            target_language=target_language,
+        )
+```
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest Tests/Transcription/test_stt_batch_routing.py -q
+```
+
+Expected: collection fails because `stt_batch_routing` does not exist.
+
+- [ ] **Step 3: Implement the minimal routing module**
+
+Add immutable constants for the v2/v3 model IDs and upstream v3 language set, a frozen `BatchSTTRoute`, a `BatchSTTRoutingError`, and:
+
+```python
+def resolve_batch_stt_route(
+    *,
+    provider: str | None,
+    language: str | None,
+    target_language: str | None = None,
+    parakeet_defaults_enabled: bool = False,
+) -> BatchSTTRoute:
+    ...
+```
+
+Rules:
+
+- Normalize missing language to `en` and lowercase explicit codes.
+- `default` resolves to faster-whisper while `parakeet_defaults_enabled` is false.
+- With the gate enabled, `default` follows ADR-025: English/v2, supported non-English/v3, and auto/unsupported/translation/faster-whisper.
+- Exact `parakeet-onnx` selects v2/v3 only for compatible explicit languages and raises with the literal recovery action for auto, unsupported languages, or translation.
+- Exact `faster-whisper` remains exact and retains the requested language/task.
+- Every batch route records `precision="int8"` and `local_files_only=True`; routing never authorizes a worker download.
+- Reject unknown providers; do not prefix-match or silently substitute.
+
+- [ ] **Step 4: Run the routing tests and verify GREEN**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest Tests/Transcription/test_stt_batch_routing.py -q
+```
+
+Expected: all routing tests pass.
+
+- [ ] **Step 5: Commit the routing policy**
+
+```bash
+git add tldw_chatbook/Local_Ingestion/stt_batch_routing.py Tests/Transcription/test_stt_batch_routing.py
+git commit -m "feat(stt): add gated batch routing policy"
+```
+
+### Task 2: Add Parakeet v3 execution and transparent language semantics
+
+**Files:**
+- Modify: `tldw_chatbook/Local_Ingestion/transcription_service.py`
+- Modify: `Tests/Transcription/test_parakeet_onnx_vertical_slice.py`
+
+- [ ] **Step 1: Write failing service tests**
+
+Add tests proving:
+
+- Explicit `de` plus the v3 model and local INT8 bundle loads `nemo-parakeet-tdt-0.6b-v3`.
+- `load_model()` receives no language/decoder constraint.
+- The normalized v3 result contains:
+
+```python
+{
+    "language": None,
+    "requested_language": "de",
+    "effective_language": "auto",
+    "detected_language": None,
+    "warnings": ["requested_language_not_enforced"],
+}
+```
+
+- English v2 additionally reports `requested_language=en`, `effective_language=en`, and no warning while preserving existing legacy result keys.
+- Auto, unsupported explicit languages, translation, and mismatched model/language pairs fail before `onnx_asr.load_model()` and contain “Retry with faster-whisper”.
+
+- [ ] **Step 2: Run the focused service tests and verify RED**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest Tests/Transcription/test_parakeet_onnx_vertical_slice.py -q
+```
+
+Expected: v3/result-contract assertions fail because the service is v2-only.
+
+- [ ] **Step 3: Implement minimal v2/v3 model validation and result shaping**
+
+Use the routing constants rather than duplicating model strings. Change `_load_parakeet_onnx_model()` to validate the exact model/language pairing, keep `quantization="int8"` and `CPUExecutionProvider`, and continue requiring an existing complete local bundle. Do not pass language to `onnx_asr.load_model()`.
+
+Change `_parakeet_onnx_result()` to receive `requested_language` and distinguish:
+
+- v2: effective English, no detected language, no warnings.
+- v3: nullable legacy language, effective auto, no fabricated detection, stable warning.
+
+Keep the existing text and segment keys so current ingestion callers remain compatible.
+
+- [ ] **Step 4: Run the focused service tests and verify GREEN**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest Tests/Transcription/test_parakeet_onnx_vertical_slice.py -q
+```
+
+Expected: all focused Parakeet ONNX tests pass.
+
+- [ ] **Step 5: Commit v3 execution support**
+
+```bash
+git add tldw_chatbook/Local_Ingestion/transcription_service.py Tests/Transcription/test_parakeet_onnx_vertical_slice.py
+git commit -m "feat(stt): add explicit Parakeet v3 batch inference"
+```
+
+### Task 3: Resolve and preserve routes through audio and video ingestion
+
+**Files:**
+- Modify: `tldw_chatbook/app.py`
+- Modify: `tldw_chatbook/Local_Ingestion/audio_processing.py`
+- Modify: `tldw_chatbook/Local_Ingestion/transcription_service.py`
+- Modify: `tldw_chatbook/Local_Ingestion/local_file_ingestion.py`
+- Modify: `Tests/App/test_submit_library_ingest_job.py`
+- Modify: `Tests/Local_Ingestion/test_local_file_ingestion.py`
+- Modify: `Tests/Local_Ingestion/test_audio_model_dir_routing.py`
+- Modify: `Tests/Transcription/test_faster_whisper_transcription.py`
+
+- [ ] **Step 1: Write failing app and ingestion seam tests**
+
+Add cases proving:
+
+- A Library audio/video job with exact Parakeet plus `de` stores the v3 model, normalized language, and selected local model directory.
+- An exact Parakeet English job stores v2.
+- A semantic `default` job resolves to faster-whisper while the gate is closed and drops a stale Parakeet directory.
+- Audio and video processor calls receive the same resolved provider/model/language/model directory, `precision="int8"`, and `local_files_only=True`.
+- Faster-whisper batch model construction receives `local_files_only=True` and `compute_type="int8"` even when service config says `float16`; direct non-batch calls without routed overrides retain the configured compute type.
+- Incompatible exact Parakeet requests are caught after the job is claimed and marked failed with sanitized “Retry with faster-whisper” guidance before pool creation or submission. A queue regression test places a valid job behind the invalid job and proves the invalid job never reaches the pool while the valid job is still dispatched in the same top-up pass.
+
+- [ ] **Step 2: Run seam tests and verify RED**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/App/test_submit_library_ingest_job.py \
+  Tests/Local_Ingestion/test_local_file_ingestion.py \
+  Tests/Local_Ingestion/test_audio_model_dir_routing.py \
+  Tests/Transcription/test_faster_whisper_transcription.py -q
+```
+
+Expected: v3/default-routing assertions fail against the hard-coded v2 app seam.
+
+- [ ] **Step 3: Resolve once at the app option boundary**
+
+In `_ingest_job_options()` call `resolve_batch_stt_route()` for audio/video options, then store the resolved provider, model, normalized requested language, precision, and local-only policy. Retain a model directory only for resolved Parakeet.
+
+In `_top_up_ingest_parse_pool()`, wrap `_ingest_job_options(claimed)` before pool creation. On `BatchSTTRoutingError`, sanitize the message, mark the claimed job failed and retryable, decrement the local `parsing_count` and (for audio/video) `heavy_parsing_count` that were incremented for the claim, then `continue` scanning the queue. This prevents a stuck `PARSING` row without stranding valid jobs behind it.
+
+Keep `local_file_ingestion.py` mechanical: forward the already-resolved fields unchanged to audio and video processors. In `audio_processing.py`, pass precision and the local-only flag into `TranscriptionService`. In the faster-whisper loader, select `effective_compute_type = kwargs.get("compute_type") or self.config["compute_type"]`, use it in both the cache key and `WhisperModel(compute_type=...)`, and pass `local_files_only=True` when requested. Direct callers that omit the override retain configured behavior. Do not download, inspect bundles, or reroute in a worker.
+
+- [ ] **Step 4: Run seam tests and verify GREEN**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/App/test_submit_library_ingest_job.py \
+  Tests/Local_Ingestion/test_local_file_ingestion.py \
+  Tests/Local_Ingestion/test_audio_model_dir_routing.py \
+  Tests/Transcription/test_faster_whisper_transcription.py -q
+```
+
+Expected: all focused seam tests pass.
+
+- [ ] **Step 5: Commit batch integration**
+
+```bash
+git add \
+  tldw_chatbook/app.py \
+  tldw_chatbook/Local_Ingestion/audio_processing.py \
+  tldw_chatbook/Local_Ingestion/transcription_service.py \
+  tldw_chatbook/Local_Ingestion/local_file_ingestion.py \
+  Tests/App/test_submit_library_ingest_job.py \
+  Tests/Local_Ingestion/test_local_file_ingestion.py \
+  Tests/Local_Ingestion/test_audio_model_dir_routing.py \
+  Tests/Transcription/test_faster_whisper_transcription.py
+git commit -m "feat(ingestion): resolve gated Parakeet batch routes"
+```
+
+### Task 4: Verify, document, and close only the child task
+
+**Files:**
+- Modify: `Docs/Features/TRANSCRIPTION.md`
+- Modify: `Docs/Features/TRANSCRIPTION_PROVIDERS.md`
+- Modify: `backlog/tasks/task-602.1 - Stage-gated-Parakeet-v3-batch-routing.md`
+
+- [ ] **Step 1: Update user-facing routing documentation**
+
+Document:
+
+- `en` remains the default requested language.
+- Exact Parakeet English uses v2 INT8.
+- Exact supported non-English uses v3 INT8 and does not enforce the selected language in the decoder.
+- Semantic Parakeet defaults remain gated; auto, unsupported languages, and translation use faster-whisper under the approved policy.
+- Batch transcription uses installed/local models only; Parakeet requires its explicit bundle and faster-whisper uses `local_files_only=True`, so a missing model fails clearly instead of downloading in a worker.
+
+- [ ] **Step 2: Run fresh focused verification**
+
+Run outside the macOS sandbox because the installed optional MLX probe requires Metal:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/Transcription/test_stt_batch_routing.py \
+  Tests/Transcription/test_parakeet_onnx_vertical_slice.py \
+  Tests/App/test_submit_library_ingest_job.py \
+  Tests/Local_Ingestion/test_local_file_ingestion.py \
+  Tests/Local_Ingestion/test_audio_model_dir_routing.py \
+  Tests/Transcription/test_faster_whisper_transcription.py \
+  Tests/Library/test_ingest_capabilities.py -q
+```
+
+Run static checks:
+
+```bash
+../../.venv/bin/python -m ruff check \
+  tldw_chatbook/Local_Ingestion/stt_batch_routing.py \
+  tldw_chatbook/Local_Ingestion/transcription_service.py \
+  tldw_chatbook/Local_Ingestion/audio_processing.py \
+  tldw_chatbook/app.py \
+  tldw_chatbook/Local_Ingestion/local_file_ingestion.py \
+  Tests/Transcription/test_stt_batch_routing.py \
+  Tests/Transcription/test_parakeet_onnx_vertical_slice.py \
+  Tests/App/test_submit_library_ingest_job.py \
+  Tests/Local_Ingestion/test_local_file_ingestion.py \
+  Tests/Local_Ingestion/test_audio_model_dir_routing.py \
+  Tests/Transcription/test_faster_whisper_transcription.py
+git diff --check
+```
+
+Expected: tests and static checks exit zero.
+
+- [ ] **Step 3: Review acceptance criteria and record limits**
+
+Check every TASK-602.1 criterion. Explicitly record that parent TASK-602 remains open for:
+
+- promoted/managed artifact eligibility,
+- app-owned `LocalSTTExecutor`,
+- durable normalized provenance/retry lineage,
+- managed long-form VAD and cancellation,
+- the interactive retry action,
+- Windows/Linux/platform matrix evidence.
+
+- [ ] **Step 4: Complete TASK-602.1 only after evidence**
+
+Add concise implementation notes, check every child criterion, and set TASK-602.1 to Done. Do not mark TASK-602 Done.
+
+- [ ] **Step 5: Commit documentation and task completion**
+
+```bash
+git add \
+  Docs/Features/TRANSCRIPTION.md \
+  Docs/Features/TRANSCRIPTION_PROVIDERS.md \
+  backlog/tasks/task-602.1\ -\ Stage-gated-Parakeet-v3-batch-routing.md
+git commit -m "docs(stt): record gated v3 batch routing"
+```

--- a/Docs/superpowers/plans/2026-07-27-gated-parakeet-v3-batch-routing.md
+++ b/Docs/superpowers/plans/2026-07-27-gated-parakeet-v3-batch-routing.md
@@ -177,11 +177,12 @@ Expected: v3/result-contract assertions fail because the service is v2-only.
 
 - [ ] **Step 3: Implement minimal v2/v3 model validation and result shaping**
 
-Use the routing constants rather than duplicating model strings. Change `_load_parakeet_onnx_model()` to validate the exact model/language pairing, keep `quantization="int8"` and `CPUExecutionProvider`, and continue requiring an existing complete local bundle. Do not pass language to `onnx_asr.load_model()`.
+Use the routing constants rather than duplicating model strings. Change `_load_parakeet_onnx_model()` to validate the exact model/language pairing, keep `quantization="int8"` and `CPUExecutionProvider`, and continue requiring a user-selected existing local directory with the required filenames. Do not pass language to `onnx_asr.load_model()`.
 
-A narrow verification-receipt identity read of at most 64 KiB is allowed only
-to reject a known v2 receipt when v3 is selected. It does not establish v3
-eligibility or inspect model contents; malformed, oversized, or otherwise
+A narrow, non-symlink verification-receipt metadata read of at most 64 KiB is
+allowed only to identify repository and revision metadata as v2 and reject that
+directory when v3 is selected. The receipt is not authenticated and does not
+verify file contents or v3 eligibility; malformed, oversized, or otherwise
 untrusted receipts are ignored. Do not download artifacts or parse ONNX graphs.
 
 Change `_parakeet_onnx_result()` to receive `requested_language` and distinguish:
@@ -251,7 +252,7 @@ In `_ingest_job_options()` call `resolve_batch_stt_route()` for audio/video opti
 
 In `_top_up_ingest_parse_pool()`, wrap `_ingest_job_options(claimed)` before pool creation. On `BatchSTTRoutingError`, sanitize the message, mark the claimed job failed and retryable, decrement the local `parsing_count` and (for audio/video) `heavy_parsing_count` that were incremented for the claim, then `continue` scanning the queue. This prevents a stuck `PARSING` row without stranding valid jobs behind it.
 
-Keep `local_file_ingestion.py` mechanical: forward the already-resolved fields unchanged to audio and video processors. In `audio_processing.py`, pass precision and the local-only flag into `TranscriptionService`. In the faster-whisper loader, select `effective_compute_type = kwargs.get("compute_type") or self.config["compute_type"]`, use it in both the cache key and `WhisperModel(compute_type=...)`, and pass `local_files_only=True` when requested. Direct callers that omit the override retain configured behavior. Do not download, parse graphs, or reroute in a worker; the service's bounded receipt read described in Task 2 is allowed only to reject a known v2/v3 identity mismatch.
+Keep `local_file_ingestion.py` mechanical: forward the already-resolved fields unchanged to audio and video processors. In `audio_processing.py`, pass precision and the local-only flag into `TranscriptionService`. In the faster-whisper loader, select `effective_compute_type = kwargs.get("compute_type") or self.config["compute_type"]`, use it in both the cache key and `WhisperModel(compute_type=...)`, and pass `local_files_only=True` when requested. Direct callers that omit the override retain configured behavior. Do not download, parse graphs, or reroute in a worker; the service's bounded receipt read described in Task 2 is allowed only to reject repository/revision metadata that identify v2 when v3 is selected.
 
 - [ ] **Step 4: Run seam tests and verify GREEN**
 
@@ -297,7 +298,7 @@ Document:
 - Exact Parakeet English uses v2 INT8.
 - Exact supported non-English uses v3 INT8 and does not enforce the selected language in the decoder.
 - Semantic Parakeet defaults remain gated; auto, unsupported languages, and translation use faster-whisper under the approved policy.
-- Batch transcription uses installed/local models only; Parakeet requires its explicit bundle and faster-whisper uses `local_files_only=True`, so a missing model fails clearly instead of downloading in a worker.
+- Batch transcription uses installed/local models only; Parakeet requires a user-selected existing local directory with the required filenames, and faster-whisper uses `local_files_only=True`, so a missing model fails clearly instead of downloading in a worker. The bounded receipt metadata check can reject a v2/v3 mismatch but does not authenticate or verify model contents.
 
 - [ ] **Step 2: Run fresh focused verification**
 
@@ -311,7 +312,10 @@ Run outside the macOS sandbox because the installed optional MLX probe requires 
   Tests/Local_Ingestion/test_local_file_ingestion.py \
   Tests/Local_Ingestion/test_audio_model_dir_routing.py \
   Tests/Transcription/test_faster_whisper_transcription.py \
-  Tests/Library/test_ingest_capabilities.py -q
+  Tests/Library/test_ingest_capabilities.py \
+  Tests/UI/test_library_ingest_canvas.py \
+  Tests/Audio/test_console_dictation.py \
+  Tests/UI/test_console_dictation.py -q
 ```
 
 Run static checks:

--- a/Docs/superpowers/plans/2026-07-27-gated-parakeet-v3-batch-routing.md
+++ b/Docs/superpowers/plans/2026-07-27-gated-parakeet-v3-batch-routing.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add explicit Parakeet v3 INT8 batch transcription and deterministic STT request routing without enabling unqualified Parakeet semantic defaults.
 
-**Architecture:** A small dependency-free routing module resolves a batch request before inference. `provider=default` remains on faster-whisper while the promotion gate is closed; exact `parakeet-onnx` requests select v2 for English or v3 for supported non-English and fail clearly for incompatible requests. The existing `TranscriptionService` remains the narrow execution seam and gains only the v3 model/result differences needed by the working batch path.
+**Architecture:** A small dependency-free routing module resolves a batch request before inference. Compatible `provider=default` requests remain on faster-whisper while the promotion gate is closed, and non-English translation targets fail; exact `parakeet-onnx` requests select v2 for English or v3 for supported non-English and fail clearly for incompatible requests. The existing `TranscriptionService` remains the narrow execution seam and gains only the v3 model/result differences needed by the working batch path.
 
 **Tech Stack:** Python 3.11+, pytest, Textual ingestion option contracts, `onnx-asr[cpu]==0.12.0`.
 
@@ -114,8 +114,11 @@ def resolve_batch_stt_route(
 Rules:
 
 - Normalize missing language to `en` and lowercase explicit codes.
-- `default` resolves to faster-whisper while `parakeet_defaults_enabled` is false.
-- With the gate enabled, `default` follows ADR-025: English/v2, supported non-English/v3, and auto/unsupported/translation/faster-whisper.
+- While `parakeet_defaults_enabled` is false, compatible `default` requests
+  resolve to faster-whisper and non-English translation targets fail.
+- With the gate enabled, `default` follows ADR-025: English/v2, supported
+  non-English/v3, auto or unsupported languages/faster-whisper, and
+  translation-to-English/faster-whisper; other translation targets fail.
 - Exact `parakeet-onnx` selects v2/v3 only for compatible explicit languages and raises with the literal recovery action for auto, unsupported languages, or translation.
 - Exact `faster-whisper` remains exact and retains the requested language/task.
 - Every batch route records `precision="int8"` and `local_files_only=True`; routing never authorizes a worker download.
@@ -227,7 +230,8 @@ Add cases proving:
 
 - A Library audio/video job with exact Parakeet plus `de` stores the v3 model, normalized language, and selected local model directory.
 - An exact Parakeet English job stores v2.
-- A semantic `default` job resolves to faster-whisper while the gate is closed and drops a stale Parakeet directory.
+- A compatible semantic `default` transcription job resolves to faster-whisper
+  while the gate is closed and drops a stale Parakeet directory.
 - Audio and video processor calls receive the same resolved provider/model/language/model directory, `precision="int8"`, and `local_files_only=True`.
 - Faster-whisper batch model construction receives `local_files_only=True` and `compute_type="int8"` even when service config says `float16`; direct non-batch calls without routed overrides retain the configured compute type.
 - Incompatible exact Parakeet requests are caught after the job is claimed and marked failed with sanitized “Retry with faster-whisper” guidance before pool creation or submission. A queue regression test places a valid job behind the invalid job and proves the invalid job never reaches the pool while the valid job is still dispatched in the same top-up pass.
@@ -297,7 +301,9 @@ Document:
 - `en` remains the default requested language.
 - Exact Parakeet English uses v2 INT8.
 - Exact supported non-English uses v3 INT8 and does not enforce the selected language in the decoder.
-- Semantic Parakeet defaults remain gated; auto, unsupported languages, and translation use faster-whisper under the approved policy.
+- Semantic Parakeet defaults remain gated; auto, unsupported languages, and
+  translation-to-English use faster-whisper under the approved policy, while
+  other translation targets fail.
 - Batch transcription uses installed/local models only; Parakeet requires a user-selected existing local directory with the required filenames, and faster-whisper uses `local_files_only=True`, so a missing model fails clearly instead of downloading in a worker. The bounded receipt metadata check can reject a v2/v3 mismatch but does not authenticate or verify model contents.
 
 - [ ] **Step 2: Run fresh focused verification**

--- a/Docs/superpowers/plans/2026-07-27-gated-parakeet-v3-batch-routing.md
+++ b/Docs/superpowers/plans/2026-07-27-gated-parakeet-v3-batch-routing.md
@@ -22,7 +22,7 @@
 - Create: `tldw_chatbook/Local_Ingestion/stt_batch_routing.py`
 - Create: `Tests/Transcription/test_stt_batch_routing.py`
 
-- [ ] **Step 1: Write failing routing tests**
+- [x] **Step 1: Write failing routing tests**
 
 Cover these independent outcomes:
 
@@ -86,7 +86,7 @@ def test_explicit_parakeet_rejects_incompatible_requests_with_retry_guidance(
         )
 ```
 
-- [ ] **Step 2: Run the tests and verify RED**
+- [x] **Step 2: Run the tests and verify RED**
 
 Run:
 
@@ -96,7 +96,7 @@ Run:
 
 Expected: collection fails because `stt_batch_routing` does not exist.
 
-- [ ] **Step 3: Implement the minimal routing module**
+- [x] **Step 3: Implement the minimal routing module**
 
 Add immutable constants for the v2/v3 model IDs and upstream v3 language set, a frozen `BatchSTTRoute`, a `BatchSTTRoutingError`, and:
 
@@ -124,7 +124,7 @@ Rules:
 - Every batch route records `precision="int8"` and `local_files_only=True`; routing never authorizes a worker download.
 - Reject unknown providers; do not prefix-match or silently substitute.
 
-- [ ] **Step 4: Run the routing tests and verify GREEN**
+- [x] **Step 4: Run the routing tests and verify GREEN**
 
 Run:
 
@@ -134,7 +134,7 @@ Run:
 
 Expected: all routing tests pass.
 
-- [ ] **Step 5: Commit the routing policy**
+- [x] **Step 5: Commit the routing policy**
 
 ```bash
 git add tldw_chatbook/Local_Ingestion/stt_batch_routing.py Tests/Transcription/test_stt_batch_routing.py
@@ -147,7 +147,7 @@ git commit -m "feat(stt): add gated batch routing policy"
 - Modify: `tldw_chatbook/Local_Ingestion/transcription_service.py`
 - Modify: `Tests/Transcription/test_parakeet_onnx_vertical_slice.py`
 
-- [ ] **Step 1: Write failing service tests**
+- [x] **Step 1: Write failing service tests**
 
 Add tests proving:
 
@@ -168,7 +168,7 @@ Add tests proving:
 - English v2 additionally reports `requested_language=en`, `effective_language=en`, and no warning while preserving existing legacy result keys.
 - Auto, unsupported explicit languages, translation, and mismatched model/language pairs fail before `onnx_asr.load_model()` and contain “Retry with faster-whisper”.
 
-- [ ] **Step 2: Run the focused service tests and verify RED**
+- [x] **Step 2: Run the focused service tests and verify RED**
 
 Run:
 
@@ -178,7 +178,7 @@ Run:
 
 Expected: v3/result-contract assertions fail because the service is v2-only.
 
-- [ ] **Step 3: Implement minimal v2/v3 model validation and result shaping**
+- [x] **Step 3: Implement minimal v2/v3 model validation and result shaping**
 
 Use the routing constants rather than duplicating model strings. Change `_load_parakeet_onnx_model()` to validate the exact model/language pairing, keep `quantization="int8"` and `CPUExecutionProvider`, and continue requiring a user-selected existing local directory with the required filenames. Do not pass language to `onnx_asr.load_model()`.
 
@@ -195,7 +195,7 @@ Change `_parakeet_onnx_result()` to receive `requested_language` and distinguish
 
 Keep the existing text and segment keys so current ingestion callers remain compatible.
 
-- [ ] **Step 4: Run the focused service tests and verify GREEN**
+- [x] **Step 4: Run the focused service tests and verify GREEN**
 
 Run:
 
@@ -205,7 +205,7 @@ Run:
 
 Expected: all focused Parakeet ONNX tests pass.
 
-- [ ] **Step 5: Commit v3 execution support**
+- [x] **Step 5: Commit v3 execution support**
 
 ```bash
 git add tldw_chatbook/Local_Ingestion/transcription_service.py Tests/Transcription/test_parakeet_onnx_vertical_slice.py
@@ -224,7 +224,7 @@ git commit -m "feat(stt): add explicit Parakeet v3 batch inference"
 - Modify: `Tests/Local_Ingestion/test_audio_model_dir_routing.py`
 - Modify: `Tests/Transcription/test_faster_whisper_transcription.py`
 
-- [ ] **Step 1: Write failing app and ingestion seam tests**
+- [x] **Step 1: Write failing app and ingestion seam tests**
 
 Add cases proving:
 
@@ -236,7 +236,7 @@ Add cases proving:
 - Faster-whisper batch model construction receives `local_files_only=True` and `compute_type="int8"` even when service config says `float16`; direct non-batch calls without routed overrides retain the configured compute type.
 - Incompatible exact Parakeet requests are caught after the job is claimed and marked failed with sanitized “Retry with faster-whisper” guidance before pool creation or submission. A queue regression test places a valid job behind the invalid job and proves the invalid job never reaches the pool while the valid job is still dispatched in the same top-up pass.
 
-- [ ] **Step 2: Run seam tests and verify RED**
+- [x] **Step 2: Run seam tests and verify RED**
 
 Run:
 
@@ -250,7 +250,7 @@ Run:
 
 Expected: v3/default-routing assertions fail against the hard-coded v2 app seam.
 
-- [ ] **Step 3: Resolve once at the app option boundary**
+- [x] **Step 3: Resolve once at the app option boundary**
 
 In `_ingest_job_options()` call `resolve_batch_stt_route()` for audio/video options, then store the resolved provider, model, normalized requested language, precision, and local-only policy. Retain a model directory only for resolved Parakeet.
 
@@ -258,7 +258,7 @@ In `_top_up_ingest_parse_pool()`, wrap `_ingest_job_options(claimed)` before poo
 
 Keep `local_file_ingestion.py` mechanical: forward the already-resolved fields unchanged to audio and video processors. In `audio_processing.py`, pass precision and the local-only flag into `TranscriptionService`. In the faster-whisper loader, select `effective_compute_type = kwargs.get("compute_type") or self.config["compute_type"]`, use it in both the cache key and `WhisperModel(compute_type=...)`, and pass `local_files_only=True` when requested. Direct callers that omit the override retain configured behavior. Do not download, parse graphs, or reroute in a worker; the service's bounded receipt read described in Task 2 is allowed only to reject repository/revision metadata that identify v2 when v3 is selected.
 
-- [ ] **Step 4: Run seam tests and verify GREEN**
+- [x] **Step 4: Run seam tests and verify GREEN**
 
 Run:
 
@@ -272,7 +272,7 @@ Run:
 
 Expected: all focused seam tests pass.
 
-- [ ] **Step 5: Commit batch integration**
+- [x] **Step 5: Commit batch integration**
 
 ```bash
 git add \
@@ -294,7 +294,7 @@ git commit -m "feat(ingestion): resolve gated Parakeet batch routes"
 - Modify: `Docs/Features/TRANSCRIPTION_PROVIDERS.md`
 - Modify: `backlog/tasks/task-602.1 - Stage-gated-Parakeet-v3-batch-routing.md`
 
-- [ ] **Step 1: Update user-facing routing documentation**
+- [x] **Step 1: Update user-facing routing documentation**
 
 Document:
 
@@ -304,9 +304,11 @@ Document:
 - Semantic Parakeet defaults remain gated; auto, unsupported languages, and
   translation-to-English use faster-whisper under the approved policy, while
   other translation targets fail.
+- The current Library form has no translation-target control; translation
+  routing applies only to stored or programmatic options.
 - Batch transcription uses installed/local models only; Parakeet requires a user-selected existing local directory with the required filenames, and faster-whisper uses `local_files_only=True`, so a missing model fails clearly instead of downloading in a worker. The bounded receipt metadata check can reject a v2/v3 mismatch but does not authenticate or verify model contents.
 
-- [ ] **Step 2: Run fresh focused verification**
+- [x] **Step 2: Run fresh focused verification**
 
 Run outside the macOS sandbox because the installed optional MLX probe requires Metal:
 
@@ -328,6 +330,7 @@ Run static checks:
 
 ```bash
 ../../.venv/bin/python -m ruff check \
+  tldw_chatbook/Library/ingest_capabilities.py \
   tldw_chatbook/Local_Ingestion/stt_batch_routing.py \
   tldw_chatbook/Local_Ingestion/transcription_service.py \
   tldw_chatbook/Local_Ingestion/audio_processing.py \
@@ -336,15 +339,26 @@ Run static checks:
   Tests/Transcription/test_stt_batch_routing.py \
   Tests/Transcription/test_parakeet_onnx_vertical_slice.py \
   Tests/App/test_submit_library_ingest_job.py \
+  Tests/Library/test_ingest_capabilities.py \
   Tests/Local_Ingestion/test_local_file_ingestion.py \
   Tests/Local_Ingestion/test_audio_model_dir_routing.py \
-  Tests/Transcription/test_faster_whisper_transcription.py
+  Tests/Transcription/test_faster_whisper_transcription.py \
+  Tests/UI/test_library_ingest_canvas.py
+../../.venv/bin/python -m compileall -q \
+  tldw_chatbook/Library/ingest_capabilities.py \
+  tldw_chatbook/Local_Ingestion/stt_batch_routing.py \
+  tldw_chatbook/Local_Ingestion/transcription_service.py \
+  tldw_chatbook/Local_Ingestion/audio_processing.py \
+  tldw_chatbook/app.py \
+  tldw_chatbook/Local_Ingestion/local_file_ingestion.py
+../../.venv/bin/python -m mypy \
+  tldw_chatbook/Local_Ingestion/stt_batch_routing.py
 git diff --check
 ```
 
 Expected: tests and static checks exit zero.
 
-- [ ] **Step 3: Review acceptance criteria and record limits**
+- [x] **Step 3: Review acceptance criteria and record limits**
 
 Check every TASK-602.1 criterion. Explicitly record that parent TASK-602 remains open for:
 
@@ -355,11 +369,11 @@ Check every TASK-602.1 criterion. Explicitly record that parent TASK-602 remains
 - the interactive retry action,
 - Windows/Linux/platform matrix evidence.
 
-- [ ] **Step 4: Complete TASK-602.1 only after evidence**
+- [x] **Step 4: Complete TASK-602.1 only after evidence**
 
 Add concise implementation notes, check every child criterion, and set TASK-602.1 to Done. Do not mark TASK-602 Done.
 
-- [ ] **Step 5: Commit documentation and task completion**
+- [x] **Step 5: Commit documentation and task completion**
 
 ```bash
 git add \

--- a/Docs/superpowers/plans/2026-07-27-gated-parakeet-v3-batch-routing.md
+++ b/Docs/superpowers/plans/2026-07-27-gated-parakeet-v3-batch-routing.md
@@ -42,7 +42,7 @@ def test_default_stays_on_faster_whisper_while_promotion_gate_is_closed():
         ("de", None, "parakeet-onnx", PARAKEET_V3_MODEL),
         ("auto", None, "faster-whisper", None),
         ("ja", None, "faster-whisper", None),
-        ("en", "fr", "faster-whisper", None),
+        ("de", "en", "faster-whisper", None),
     ],
 )
 def test_enabled_default_policy_covers_every_routing_row(
@@ -73,7 +73,7 @@ def test_explicit_supported_non_english_selects_v3(language):
 
 @pytest.mark.parametrize(
     ("language", "target_language"),
-    [("auto", None), ("ja", None), ("en", "fr")],
+    [("auto", None), ("ja", None), ("de", "en")],
 )
 def test_explicit_parakeet_rejects_incompatible_requests_with_retry_guidance(
     language, target_language
@@ -179,6 +179,11 @@ Expected: v3/result-contract assertions fail because the service is v2-only.
 
 Use the routing constants rather than duplicating model strings. Change `_load_parakeet_onnx_model()` to validate the exact model/language pairing, keep `quantization="int8"` and `CPUExecutionProvider`, and continue requiring an existing complete local bundle. Do not pass language to `onnx_asr.load_model()`.
 
+A narrow verification-receipt identity read of at most 64 KiB is allowed only
+to reject a known v2 receipt when v3 is selected. It does not establish v3
+eligibility or inspect model contents; malformed, oversized, or otherwise
+untrusted receipts are ignored. Do not download artifacts or parse ONNX graphs.
+
 Change `_parakeet_onnx_result()` to receive `requested_language` and distinguish:
 
 - v2: effective English, no detected language, no warnings.
@@ -246,7 +251,7 @@ In `_ingest_job_options()` call `resolve_batch_stt_route()` for audio/video opti
 
 In `_top_up_ingest_parse_pool()`, wrap `_ingest_job_options(claimed)` before pool creation. On `BatchSTTRoutingError`, sanitize the message, mark the claimed job failed and retryable, decrement the local `parsing_count` and (for audio/video) `heavy_parsing_count` that were incremented for the claim, then `continue` scanning the queue. This prevents a stuck `PARSING` row without stranding valid jobs behind it.
 
-Keep `local_file_ingestion.py` mechanical: forward the already-resolved fields unchanged to audio and video processors. In `audio_processing.py`, pass precision and the local-only flag into `TranscriptionService`. In the faster-whisper loader, select `effective_compute_type = kwargs.get("compute_type") or self.config["compute_type"]`, use it in both the cache key and `WhisperModel(compute_type=...)`, and pass `local_files_only=True` when requested. Direct callers that omit the override retain configured behavior. Do not download, inspect bundles, or reroute in a worker.
+Keep `local_file_ingestion.py` mechanical: forward the already-resolved fields unchanged to audio and video processors. In `audio_processing.py`, pass precision and the local-only flag into `TranscriptionService`. In the faster-whisper loader, select `effective_compute_type = kwargs.get("compute_type") or self.config["compute_type"]`, use it in both the cache key and `WhisperModel(compute_type=...)`, and pass `local_files_only=True` when requested. Direct callers that omit the override retain configured behavior. Do not download, parse graphs, or reroute in a worker; the service's bounded receipt read described in Task 2 is allowed only to reject a known v2/v3 identity mismatch.
 
 - [ ] **Step 4: Run seam tests and verify GREEN**
 

--- a/Tests/App/test_submit_library_ingest_job.py
+++ b/Tests/App/test_submit_library_ingest_job.py
@@ -156,6 +156,7 @@ class TestIngestJobOptions:
         assert options["language"] == "en"
         assert options["transcription_precision"] == "int8"
         assert options["transcription_local_files_only"] is True
+        assert options["transcription_batch_route_resolved"] is True
         assert options["timestamps"] is False
         assert options["diarization"] is True
 
@@ -180,6 +181,7 @@ class TestIngestJobOptions:
         assert options["language"] == "de"
         assert options["transcription_precision"] == "int8"
         assert options["transcription_local_files_only"] is True
+        assert options["transcription_batch_route_resolved"] is True
 
     def test_parakeet_onnx_defaults_language_to_english(self) -> None:
         app = _minimal_app()
@@ -246,6 +248,27 @@ class TestIngestJobOptions:
         assert options["transcription_model"] == "small"
         assert options["language"] == "ja"
         assert options["translation_target_language"] == "en"
+
+    def test_untouched_exact_faster_whisper_model_uses_visible_base_default(
+        self,
+    ) -> None:
+        screen = object.__new__(LibraryScreen)
+        screen._library_ingest_form = LibraryIngestFormState()
+        screen._library_ingest_form.type_options["audio_video"] = {
+            "transcription_provider": "faster-whisper",
+        }
+        snapshot = screen._build_ingest_options_snapshot()
+
+        app = _minimal_app()
+        job = _make_job(
+            source_path="/tmp/test.mp3",
+            ingest_options=snapshot,
+        )
+
+        options = app._ingest_job_options(job)
+
+        assert options["transcription_provider"] == "faster-whisper"
+        assert options["transcription_model"] == "base"
 
     def test_explicit_empty_translation_target_does_not_fall_back_to_alias(
         self,

--- a/Tests/App/test_submit_library_ingest_job.py
+++ b/Tests/App/test_submit_library_ingest_job.py
@@ -8,6 +8,7 @@ import pytest
 
 from tldw_chatbook.Library.library_ingest_jobs import (
     DEFAULT_CHUNK_SIZE,
+    IngestJobState,
     LibraryIngestJob,
     LibraryIngestJobRegistry,
 )
@@ -152,8 +153,32 @@ class TestIngestJobOptions:
         )
         assert options["transcription_model"] == "nemo-parakeet-tdt-0.6b-v2"
         assert options["language"] == "en"
+        assert options["transcription_precision"] == "int8"
+        assert options["transcription_local_files_only"] is True
         assert options["timestamps"] is False
         assert options["diarization"] is True
+
+    def test_supported_non_english_parakeet_route_uses_v3(self) -> None:
+        app = _minimal_app()
+        job = _make_job(
+            source_path="/tmp/test.mp4",
+            ingest_options={
+                "audio_video": {
+                    "transcription_provider": "parakeet-onnx",
+                    "transcription_model_dir": "/models/parakeet-v3-int8",
+                    "language": " DE ",
+                },
+            },
+        )
+
+        options = app._ingest_job_options(job)
+
+        assert options["transcription_provider"] == "parakeet-onnx"
+        assert options["transcription_model"] == "nemo-parakeet-tdt-0.6b-v3"
+        assert options["transcription_model_dir"] == "/models/parakeet-v3-int8"
+        assert options["language"] == "de"
+        assert options["transcription_precision"] == "int8"
+        assert options["transcription_local_files_only"] is True
 
     def test_parakeet_onnx_defaults_language_to_english(self) -> None:
         app = _minimal_app()
@@ -171,22 +196,47 @@ class TestIngestJobOptions:
         assert options["language"] == "en"
         assert options["transcription_model_dir"] is None
 
-    def test_faster_whisper_ignores_stale_parakeet_model_directory(self) -> None:
+    def test_semantic_default_stays_on_faster_whisper_and_drops_stale_directory(
+        self,
+    ) -> None:
         app = _minimal_app()
         job = _make_job(
             source_path="/tmp/test.mp3",
             ingest_options={
                 "audio_video": {
-                    "transcription_provider": "faster-whisper",
                     "transcription_model_dir": "/models/parakeet-v2-int8",
                     "transcription_model": "small",
+                    "language": " FR ",
                 },
             },
         )
 
         options = app._ingest_job_options(job)
 
+        assert options["transcription_provider"] == "faster-whisper"
+        assert options["transcription_model"] == "small"
         assert options["transcription_model_dir"] is None
+        assert options["language"] == "fr"
+        assert options["transcription_precision"] == "int8"
+        assert options["transcription_local_files_only"] is True
+
+    def test_faster_whisper_preserves_normalized_translation_target(self) -> None:
+        app = _minimal_app()
+        job = _make_job(
+            source_path="/tmp/test.mp3",
+            ingest_options={
+                "audio_video": {
+                    "transcription_provider": "faster-whisper",
+                    "language": " JA ",
+                    "target_language": " EN ",
+                },
+            },
+        )
+
+        options = app._ingest_job_options(job)
+
+        assert options["language"] == "ja"
+        assert options["translation_target_language"] == "en"
 
     def test_ebook_group_options(self) -> None:
         app = _minimal_app()
@@ -307,3 +357,70 @@ def test_ingest_job_options_detects_type_group(
         assert "pdf_engine" not in options
         assert "transcription_model" not in options
         assert "extraction_method" not in options
+
+
+def test_invalid_parakeet_allows_next_job_to_dispatch() -> None:
+    app = object.__new__(TldwCli)
+    app.library_ingest_jobs = LibraryIngestJobRegistry()
+    app._ingest_shutdown = False
+    app._ingest_parse_worker_count = lambda: 1  # type: ignore[method-assign]
+    app._ingest_heavy_lane_max_workers = lambda: 1  # type: ignore[method-assign]
+    app._ingest_parse_pool_generation = 1
+    app._ingest_parse_jobs_by_generation = {1: set()}
+
+    invalid = app.library_ingest_jobs.submit(
+        source_path="/tmp/invalid.mp3",
+        detected_type="audio",
+        ingest_options={
+            "audio_video": {
+                "transcription_provider": "parakeet-onnx",
+                "language": "auto",
+            }
+        },
+    )
+    valid = app.library_ingest_jobs.submit(
+        source_path="/tmp/valid.mp3",
+        detected_type="audio",
+        ingest_options={
+            "audio_video": {
+                "transcription_provider": "faster-whisper",
+                "transcription_model": "small",
+                "language": "en",
+            }
+        },
+    )
+
+    class _Pool:
+        def __init__(self) -> None:
+            self.calls: list[tuple[Any, ...]] = []
+
+        def apply_async(self, function, args, callback, error_callback) -> None:
+            self.calls.append((function, args, callback, error_callback))
+
+    pool = _Pool()
+    pool_creation_calls = 0
+
+    def ensure_pool() -> _Pool:
+        nonlocal pool_creation_calls
+        pool_creation_calls += 1
+        return pool
+
+    app._ensure_ingest_parse_pool = ensure_pool  # type: ignore[method-assign]
+
+    app._top_up_ingest_parse_pool()
+
+    jobs_by_id = {job.job_id: job for job in app.library_ingest_jobs.jobs()}
+    invalid_job = jobs_by_id[invalid.job_id]
+    valid_job = jobs_by_id[valid.job_id]
+    assert invalid_job.state is IngestJobState.FAILED
+    assert invalid_job.permanent is False
+    assert invalid_job.error is not None
+    assert "Retry with faster-whisper" in invalid_job.error
+    assert "\n" not in invalid_job.error
+    assert len(invalid_job.error) <= 200
+    assert valid_job.state is IngestJobState.PARSING
+    assert pool_creation_calls == 1
+    assert len(pool.calls) == 1
+    _, (source_path, options), _, _ = pool.calls[0]
+    assert source_path == valid.source_path
+    assert options["transcription_provider"] == "faster-whisper"

--- a/Tests/App/test_submit_library_ingest_job.py
+++ b/Tests/App/test_submit_library_ingest_job.py
@@ -239,6 +239,26 @@ class TestIngestJobOptions:
         assert options["language"] == "ja"
         assert options["translation_target_language"] == "en"
 
+    def test_explicit_empty_translation_target_does_not_fall_back_to_alias(
+        self,
+    ) -> None:
+        app = _minimal_app()
+        job = _make_job(
+            source_path="/tmp/test.mp3",
+            ingest_options={
+                "audio_video": {
+                    "transcription_provider": "faster-whisper",
+                    "language": "ja",
+                    "translation_target_language": "",
+                    "target_language": "fr",
+                },
+            },
+        )
+
+        options = app._ingest_job_options(job)
+
+        assert options["translation_target_language"] is None
+
     def test_untouched_audio_form_snapshot_resolves_closed_gate_default(self) -> None:
         provider_field = next(
             field
@@ -410,6 +430,43 @@ def test_ingest_job_options_detects_type_group(
                 "language": 7,
             },
             "language",
+        ),
+        (
+            {
+                "transcription_provider": 0,
+                "language": "en",
+            },
+            "provider",
+        ),
+        (
+            {
+                "transcription_provider": False,
+                "language": "en",
+            },
+            "provider",
+        ),
+        (
+            {
+                "transcription_provider": "",
+                "language": "en",
+            },
+            "Unsupported batch STT provider",
+        ),
+        (
+            {
+                "transcription_provider": "faster-whisper",
+                "language": "en",
+                "translation_target_language": 0,
+            },
+            "target_language",
+        ),
+        (
+            {
+                "transcription_provider": "faster-whisper",
+                "language": "en",
+                "target_language": False,
+            },
+            "target_language",
         ),
     ],
 )

--- a/Tests/App/test_submit_library_ingest_job.py
+++ b/Tests/App/test_submit_library_ingest_job.py
@@ -504,6 +504,7 @@ def test_ingest_job_options_detects_type_group(
 def test_invalid_audio_request_allows_next_job_to_dispatch(
     invalid_audio_options: dict[str, Any],
     error_fragment: str,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     app = object.__new__(TldwCli)
     app.library_ingest_jobs = LibraryIngestJobRegistry()
@@ -512,6 +513,11 @@ def test_invalid_audio_request_allows_next_job_to_dispatch(
     app._ingest_heavy_lane_max_workers = lambda: 1  # type: ignore[method-assign]
     app._ingest_parse_pool_generation = 1
     app._ingest_parse_jobs_by_generation = {1: set()}
+    warning_messages: list[str] = []
+    monkeypatch.setattr(
+        "tldw_chatbook.app.logger.warning",
+        lambda message: warning_messages.append(str(message)),
+    )
 
     invalid = app.library_ingest_jobs.submit(
         source_path="/tmp/invalid.mp3",
@@ -564,3 +570,12 @@ def test_invalid_audio_request_allows_next_job_to_dispatch(
     _, (source_path, options), _, _ = pool.calls[0]
     assert source_path == valid.source_path
     assert options["transcription_provider"] == "faster-whisper"
+    routing_warnings = [
+        message
+        for message in warning_messages
+        if "batch STT routing failed" in message
+    ]
+    assert len(routing_warnings) == 1
+    assert invalid.job_id in routing_warnings[0]
+    assert "detected_type=audio" in routing_warnings[0]
+    assert error_fragment in routing_warnings[0]

--- a/Tests/App/test_submit_library_ingest_job.py
+++ b/Tests/App/test_submit_library_ingest_job.py
@@ -151,9 +151,7 @@ class TestIngestJobOptions:
         options = app._ingest_job_options(job)
 
         assert options["transcription_provider"] == "parakeet-onnx"
-        assert (
-            options["transcription_model_dir"] == "/models/parakeet-v2-int8"
-        )
+        assert options["transcription_model_dir"] == "/models/parakeet-v2-int8"
         assert options["transcription_model"] == "nemo-parakeet-tdt-0.6b-v2"
         assert options["language"] == "en"
         assert options["transcription_precision"] == "int8"
@@ -332,7 +330,10 @@ class TestSubmitLibraryIngestJob:
 
     def test_submit_passes_ingest_options_to_registry(self) -> None:
         app = _minimal_app(media_db="present")
-        ingest_options = {"generic": {"analyze": True}, "pdf": {"pdf_engine": "docling"}}
+        ingest_options = {
+            "generic": {"analyze": True},
+            "pdf": {"pdf_engine": "docling"},
+        }
         job = app.submit_library_ingest_job(
             source_path="/tmp/test.pdf",
             ingest_options=ingest_options,
@@ -393,7 +394,29 @@ def test_ingest_job_options_detects_type_group(
         assert "extraction_method" not in options
 
 
-def test_invalid_parakeet_allows_next_job_to_dispatch() -> None:
+@pytest.mark.parametrize(
+    ("invalid_audio_options", "error_fragment"),
+    [
+        (
+            {
+                "transcription_provider": "parakeet-onnx",
+                "language": "auto",
+            },
+            "Retry with faster-whisper",
+        ),
+        (
+            {
+                "transcription_provider": "parakeet-onnx",
+                "language": 7,
+            },
+            "language",
+        ),
+    ],
+)
+def test_invalid_audio_request_allows_next_job_to_dispatch(
+    invalid_audio_options: dict[str, Any],
+    error_fragment: str,
+) -> None:
     app = object.__new__(TldwCli)
     app.library_ingest_jobs = LibraryIngestJobRegistry()
     app._ingest_shutdown = False
@@ -405,12 +428,7 @@ def test_invalid_parakeet_allows_next_job_to_dispatch() -> None:
     invalid = app.library_ingest_jobs.submit(
         source_path="/tmp/invalid.mp3",
         detected_type="audio",
-        ingest_options={
-            "audio_video": {
-                "transcription_provider": "parakeet-onnx",
-                "language": "auto",
-            }
-        },
+        ingest_options={"audio_video": invalid_audio_options},
     )
     valid = app.library_ingest_jobs.submit(
         source_path="/tmp/valid.mp3",
@@ -449,7 +467,7 @@ def test_invalid_parakeet_allows_next_job_to_dispatch() -> None:
     assert invalid_job.state is IngestJobState.FAILED
     assert invalid_job.permanent is False
     assert invalid_job.error is not None
-    assert "Retry with faster-whisper" in invalid_job.error
+    assert error_fragment in invalid_job.error
     assert "\n" not in invalid_job.error
     assert len(invalid_job.error) <= 200
     assert valid_job.state is IngestJobState.PARSING

--- a/Tests/App/test_submit_library_ingest_job.py
+++ b/Tests/App/test_submit_library_ingest_job.py
@@ -197,25 +197,31 @@ class TestIngestJobOptions:
         assert options["language"] == "en"
         assert options["transcription_model_dir"] is None
 
-    def test_semantic_default_stays_on_faster_whisper_and_drops_stale_directory(
-        self,
+    @pytest.mark.parametrize(
+        "provider",
+        [None, "default"],
+        ids=["absent-provider", "explicit-default"],
+    )
+    def test_semantic_default_stays_on_faster_whisper_and_drops_stale_model(
+        self, provider: str | None
     ) -> None:
         app = _minimal_app()
+        audio_options = {
+            "transcription_model_dir": "/models/parakeet-v2-int8",
+            "transcription_model": "small",
+            "language": " FR ",
+        }
+        if provider is not None:
+            audio_options["transcription_provider"] = provider
         job = _make_job(
             source_path="/tmp/test.mp3",
-            ingest_options={
-                "audio_video": {
-                    "transcription_model_dir": "/models/parakeet-v2-int8",
-                    "transcription_model": "small",
-                    "language": " FR ",
-                },
-            },
+            ingest_options={"audio_video": audio_options},
         )
 
         options = app._ingest_job_options(job)
 
         assert options["transcription_provider"] == "faster-whisper"
-        assert options["transcription_model"] == "small"
+        assert options["transcription_model"] is None
         assert options["transcription_model_dir"] is None
         assert options["language"] == "fr"
         assert options["transcription_precision"] == "int8"
@@ -228,6 +234,7 @@ class TestIngestJobOptions:
             ingest_options={
                 "audio_video": {
                     "transcription_provider": "faster-whisper",
+                    "transcription_model": "small",
                     "language": " JA ",
                     "target_language": " EN ",
                 },
@@ -236,6 +243,7 @@ class TestIngestJobOptions:
 
         options = app._ingest_job_options(job)
 
+        assert options["transcription_model"] == "small"
         assert options["language"] == "ja"
         assert options["translation_target_language"] == "en"
 

--- a/Tests/App/test_submit_library_ingest_job.py
+++ b/Tests/App/test_submit_library_ingest_job.py
@@ -6,12 +6,15 @@ from typing import Any
 
 import pytest
 
+from tldw_chatbook.Library.ingest_capabilities import get_capabilities
 from tldw_chatbook.Library.library_ingest_jobs import (
     DEFAULT_CHUNK_SIZE,
     IngestJobState,
     LibraryIngestJob,
     LibraryIngestJobRegistry,
 )
+from tldw_chatbook.Library.library_ingest_state import LibraryIngestFormState
+from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
 from tldw_chatbook.app import TldwCli
 
 
@@ -237,6 +240,37 @@ class TestIngestJobOptions:
 
         assert options["language"] == "ja"
         assert options["translation_target_language"] == "en"
+
+    def test_untouched_audio_form_snapshot_resolves_closed_gate_default(self) -> None:
+        provider_field = next(
+            field
+            for field in get_capabilities("audio_video").fields
+            if field.name == "transcription_provider"
+        )
+        screen = object.__new__(LibraryScreen)
+        screen._library_ingest_form = LibraryIngestFormState()
+        snapshot = screen._build_ingest_options_snapshot()
+        submitted_audio_options = snapshot.get("audio_video", {})
+
+        assert provider_field.default == "default"
+        assert submitted_audio_options.get("transcription_provider") not in {
+            "parakeet-onnx",
+            "faster-whisper",
+        }
+
+        app = _minimal_app()
+        job = _make_job(
+            source_path="/tmp/test.mp3",
+            ingest_options=snapshot,
+        )
+
+        options = app._ingest_job_options(job)
+
+        assert options["transcription_provider"] == "faster-whisper"
+        assert options["transcription_model_dir"] is None
+        assert options["language"] == "en"
+        assert options["transcription_precision"] == "int8"
+        assert options["transcription_local_files_only"] is True
 
     def test_ebook_group_options(self) -> None:
         app = _minimal_app()

--- a/Tests/Library/test_ingest_capabilities.py
+++ b/Tests/Library/test_ingest_capabilities.py
@@ -147,11 +147,13 @@ def test_get_capabilities_audio_video() -> None:
         "diarization",
     )
 
-    provider_field = next(
-        f for f in caps.fields if f.name == "transcription_provider"
+    provider_field = next(f for f in caps.fields if f.name == "transcription_provider")
+    assert provider_field.options == (
+        "default",
+        "parakeet-onnx",
+        "faster-whisper",
     )
-    assert provider_field.options == ("parakeet-onnx", "faster-whisper")
-    assert provider_field.default == "parakeet-onnx"
+    assert provider_field.default == "default"
 
     model_dir_field = next(
         f for f in caps.fields if f.name == "transcription_model_dir"

--- a/Tests/Local_Ingestion/test_audio_model_dir_routing.py
+++ b/Tests/Local_Ingestion/test_audio_model_dir_routing.py
@@ -26,6 +26,8 @@ def test_audio_processor_passes_model_directory_to_transcription(
         transcription_model="nemo-parakeet-tdt-0.6b-v2",
         transcription_model_dir="/models/parakeet-v2-int8",
         transcription_language="en",
+        transcription_precision="int8",
+        transcription_local_files_only=True,
         perform_chunking=False,
         perform_analysis=False,
     )
@@ -41,6 +43,8 @@ def test_audio_processor_passes_model_directory_to_transcription(
             "vad_filter": False,
             "diarize": False,
             "model_dir": "/models/parakeet-v2-int8",
+            "compute_type": "int8",
+            "local_files_only": True,
             "progress_callback": None,
         }
     ]

--- a/Tests/Local_Ingestion/test_audio_model_dir_routing.py
+++ b/Tests/Local_Ingestion/test_audio_model_dir_routing.py
@@ -28,6 +28,7 @@ def test_audio_processor_passes_model_directory_to_transcription(
         transcription_language="en",
         transcription_precision="int8",
         transcription_local_files_only=True,
+        transcription_batch_route_resolved=True,
         perform_chunking=False,
         perform_analysis=False,
     )
@@ -45,6 +46,38 @@ def test_audio_processor_passes_model_directory_to_transcription(
             "model_dir": "/models/parakeet-v2-int8",
             "compute_type": "int8",
             "local_files_only": True,
+            "batch_route_resolved": True,
             "progress_callback": None,
         }
     ]
+
+
+def test_audio_processor_preserves_legacy_positional_perform_chunking(
+    tmp_path: Path, monkeypatch
+) -> None:
+    audio_path = tmp_path / "speech.wav"
+    audio_path.write_bytes(b"not-read-by-stub")
+    calls: list[dict] = []
+    processor = LocalAudioProcessor(media_db=None)
+
+    def fake_process(**kwargs):
+        calls.append(kwargs)
+        return {"status": "Success"}
+
+    monkeypatch.setattr(processor, "_process_single_audio", fake_process)
+
+    result = processor.process_audio_files(
+        [str(audio_path)],
+        "faster-whisper",
+        "base",
+        None,
+        "en",
+        None,
+        False,
+    )
+
+    assert result["processed_count"] == 1
+    assert calls[0]["perform_chunking"] is False
+    assert calls[0]["transcription_precision"] is None
+    assert calls[0]["transcription_local_files_only"] is False
+    assert calls[0]["transcription_batch_route_resolved"] is False

--- a/Tests/Local_Ingestion/test_local_file_ingestion.py
+++ b/Tests/Local_Ingestion/test_local_file_ingestion.py
@@ -188,6 +188,7 @@ def test_audio_options_are_routed_to_processor(tmp_path: Path, monkeypatch) -> N
             "language": "en",
             "transcription_precision": "int8",
             "transcription_local_files_only": True,
+            "transcription_batch_route_resolved": True,
             "timestamps": False,
             "diarization": True,
         },
@@ -201,6 +202,7 @@ def test_audio_options_are_routed_to_processor(tmp_path: Path, monkeypatch) -> N
     assert call["transcription_language"] == "en"
     assert call["transcription_precision"] == "int8"
     assert call["transcription_local_files_only"] is True
+    assert call["transcription_batch_route_resolved"] is True
     assert call["timestamp_option"] is False
     assert call["diarize"] is True
 
@@ -244,6 +246,7 @@ def test_video_options_are_routed_to_processor(tmp_path: Path, monkeypatch) -> N
             "translation_target_language": "en",
             "transcription_precision": "int8",
             "transcription_local_files_only": True,
+            "transcription_batch_route_resolved": True,
             "timestamps": True,
             "diarization": False,
         },
@@ -258,6 +261,7 @@ def test_video_options_are_routed_to_processor(tmp_path: Path, monkeypatch) -> N
     assert call["translation_target_language"] == "en"
     assert call["transcription_precision"] == "int8"
     assert call["transcription_local_files_only"] is True
+    assert call["transcription_batch_route_resolved"] is True
     assert call["timestamp_option"] is True
     assert call["diarize"] is False
 

--- a/Tests/Local_Ingestion/test_local_file_ingestion.py
+++ b/Tests/Local_Ingestion/test_local_file_ingestion.py
@@ -186,6 +186,8 @@ def test_audio_options_are_routed_to_processor(tmp_path: Path, monkeypatch) -> N
             "transcription_model_dir": "/models/parakeet-v2-int8",
             "transcription_model": "nemo-parakeet-tdt-0.6b-v2",
             "language": "en",
+            "transcription_precision": "int8",
+            "transcription_local_files_only": True,
             "timestamps": False,
             "diarization": True,
         },
@@ -197,6 +199,8 @@ def test_audio_options_are_routed_to_processor(tmp_path: Path, monkeypatch) -> N
     assert call["transcription_model_dir"] == "/models/parakeet-v2-int8"
     assert call["transcription_model"] == "nemo-parakeet-tdt-0.6b-v2"
     assert call["transcription_language"] == "en"
+    assert call["transcription_precision"] == "int8"
+    assert call["transcription_local_files_only"] is True
     assert call["timestamp_option"] is False
     assert call["diarize"] is True
 
@@ -237,6 +241,9 @@ def test_video_options_are_routed_to_processor(tmp_path: Path, monkeypatch) -> N
             "transcription_model_dir": None,
             "transcription_model": "medium",
             "language": "fr",
+            "translation_target_language": "en",
+            "transcription_precision": "int8",
+            "transcription_local_files_only": True,
             "timestamps": True,
             "diarization": False,
         },
@@ -248,6 +255,9 @@ def test_video_options_are_routed_to_processor(tmp_path: Path, monkeypatch) -> N
     assert call["transcription_model_dir"] is None
     assert call["transcription_model"] == "medium"
     assert call["transcription_language"] == "fr"
+    assert call["translation_target_language"] == "en"
+    assert call["transcription_precision"] == "int8"
+    assert call["transcription_local_files_only"] is True
     assert call["timestamp_option"] is True
     assert call["diarize"] is False
 

--- a/Tests/Transcription/test_faster_whisper_edge_cases.py
+++ b/Tests/Transcription/test_faster_whisper_edge_cases.py
@@ -187,7 +187,7 @@ class TestFasterWhisperEdgeCases:
                 mock_service.config["compute_type"] = compute_type
 
                 # Clear this specific cache entry
-                cache_key = (model, device, compute_type)
+                cache_key = (model, device, compute_type, False)
                 if cache_key in mock_service._model_cache:
                     del mock_service._model_cache[cache_key]
 
@@ -503,14 +503,8 @@ class TestFasterWhisperEdgeCases:
                 ("es", "en", "translate"),  # Spanish to English
                 ("fr", "en", "translate"),  # French to English
                 ("en", "en", "transcribe"),  # English to English (no translation)
-                ("es", "es", "transcribe"),  # Spanish to Spanish (no translation)
-                (
-                    "es",
-                    "fr",
-                    "transcribe",
-                ),  # Spanish to French (not supported, transcribe only)
-                (None, "en", "transcribe"),  # Auto-detect to English
-                ("auto", "en", "transcribe"),  # Auto to English
+                (None, "en", "translate"),  # Auto-detect to English
+                ("auto", "en", "translate"),  # Auto to English
             ]
 
             for source_lang, target_lang, expected_task in test_cases:

--- a/Tests/Transcription/test_faster_whisper_transcription.py
+++ b/Tests/Transcription/test_faster_whisper_transcription.py
@@ -392,6 +392,84 @@ class TestFasterWhisperUnit:
         assert result["target_language"] == "en"
         assert "translation" in result
 
+    def test_auto_translation_to_english_uses_translate_task(
+        self, transcription_service, mock_whisper_model, sample_audio_file
+    ):
+        """Automatic language detection still requests faster-whisper translation."""
+        _, mock_instance = mock_whisper_model
+        info = MockTranscriptionInfo(
+            language="es", language_probability=0.99, duration=7.5
+        )
+        mock_instance.transcribe.side_effect = lambda *args, **kwargs: (
+            iter([MockSegment(0.0, 1.0, "Translated.")]),
+            info,
+        )
+
+        result = transcription_service._transcribe_with_faster_whisper(
+            audio_path=sample_audio_file,
+            model="base",
+            language="auto",
+            vad_filter=True,
+            source_lang="auto",
+            target_lang="en",
+        )
+
+        call_args = mock_instance.transcribe.call_args
+        assert call_args.kwargs["task"] == "translate"
+        assert call_args.kwargs["language"] is None
+        assert result["task"] == "translation"
+        assert result["source_language"] == "es"
+        assert result["target_language"] == "en"
+
+    def test_resolved_batch_route_ignores_global_language_defaults(
+        self, transcription_service, monkeypatch, sample_audio_file
+    ):
+        """Resolved batch source/target values must survive service configuration."""
+        transcription_service.config["default_source_language"] = "en"
+        transcription_service.config["default_target_language"] = "en"
+        captured = {}
+
+        def fake_transcribe(
+            audio_path,
+            model,
+            language,
+            vad_filter,
+            source_lang,
+            target_lang,
+            **kwargs,
+        ):
+            captured.update(
+                {
+                    "audio_path": audio_path,
+                    "model": model,
+                    "language": language,
+                    "vad_filter": vad_filter,
+                    "source_lang": source_lang,
+                    "target_lang": target_lang,
+                    **kwargs,
+                }
+            )
+            return {"text": "Bonjour", "segments": []}
+
+        monkeypatch.setattr(
+            transcription_service,
+            "_transcribe_with_faster_whisper",
+            fake_transcribe,
+        )
+
+        transcription_service.transcribe(
+            sample_audio_file,
+            provider="faster-whisper",
+            model="base",
+            language="fr",
+            target_lang=None,
+            batch_route_resolved=True,
+        )
+
+        assert captured["language"] == "fr"
+        assert captured["source_lang"] == "fr"
+        assert captured["target_lang"] is None
+
     def test_non_english_translation_target_rejected_before_model_construction(
         self, transcription_service, mock_whisper_model, sample_audio_file
     ):

--- a/Tests/Transcription/test_faster_whisper_transcription.py
+++ b/Tests/Transcription/test_faster_whisper_transcription.py
@@ -392,6 +392,24 @@ class TestFasterWhisperUnit:
         assert result["target_language"] == "en"
         assert "translation" in result
 
+    def test_non_english_translation_target_rejected_before_model_construction(
+        self, transcription_service, mock_whisper_model, sample_audio_file
+    ):
+        """Reject unsupported translation targets before loading a model."""
+        mock_class, _ = mock_whisper_model
+
+        with pytest.raises(TranscriptionError, match="target en"):
+            transcription_service._transcribe_with_faster_whisper(
+                audio_path=sample_audio_file,
+                model="base",
+                language="es",
+                vad_filter=True,
+                source_lang="es",
+                target_lang="fr",
+            )
+
+        mock_class.assert_not_called()
+
     def test_vad_filter_options(
         self, transcription_service, mock_whisper_model, sample_audio_file
     ):

--- a/Tests/Transcription/test_faster_whisper_transcription.py
+++ b/Tests/Transcription/test_faster_whisper_transcription.py
@@ -201,7 +201,7 @@ class TestFasterWhisperUnit:
         assert result["provider"] == "faster-whisper"
 
         # Verify model is cached
-        cache_key = ("base", "cpu", "int8")
+        cache_key = ("base", "cpu", "int8", False)
         assert cache_key in transcription_service._model_cache
 
     def test_model_cache_reuse(
@@ -230,7 +230,7 @@ class TestFasterWhisperUnit:
         mock_class.assert_not_called()
 
         # The cached model should be used - verify cache is populated
-        cache_key = ("base", "cpu", "int8")
+        cache_key = ("base", "cpu", "int8", False)
         assert cache_key in transcription_service._model_cache
         cached_model = transcription_service._model_cache[cache_key]
         # Both calls should use the same model instance
@@ -258,7 +258,7 @@ class TestFasterWhisperUnit:
             transcription_service.config["compute_type"] = compute_type
 
             # Clear specific cache entry if it exists
-            cache_key = (model, device, compute_type)
+            cache_key = (model, device, compute_type, False)
             if cache_key in transcription_service._model_cache:
                 del transcription_service._model_cache[cache_key]
 
@@ -273,6 +273,78 @@ class TestFasterWhisperUnit:
             # Should create new model for this configuration
             mock_class.assert_called_once()
             assert cache_key in transcription_service._model_cache
+
+    def test_batch_overrides_force_local_int8_model_loading(
+        self, transcription_service, mock_whisper_model, sample_audio_file
+    ):
+        """Routed batch settings override config at the model-loading boundary."""
+        mock_class, _ = mock_whisper_model
+        transcription_service.config["compute_type"] = "float16"
+
+        transcription_service._transcribe_with_faster_whisper(
+            audio_path=sample_audio_file,
+            model="base",
+            language="en",
+            vad_filter=True,
+            compute_type="int8",
+            local_files_only=True,
+        )
+
+        mock_class.assert_called_once_with(
+            "base",
+            device="cpu",
+            compute_type="int8",
+            download_root=None,
+            local_files_only=True,
+        )
+        assert ("base", "cpu", "int8", True) in transcription_service._model_cache
+
+    def test_direct_call_without_overrides_keeps_configured_loading_behavior(
+        self, transcription_service, mock_whisper_model, sample_audio_file
+    ):
+        """Non-batch callers retain configured compute type and downloads."""
+        mock_class, _ = mock_whisper_model
+        transcription_service.config["compute_type"] = "float16"
+
+        transcription_service._transcribe_with_faster_whisper(
+            audio_path=sample_audio_file,
+            model="base",
+            language="en",
+            vad_filter=True,
+        )
+
+        mock_class.assert_called_once_with(
+            "base",
+            device="cpu",
+            compute_type="float16",
+            download_root=None,
+            local_files_only=False,
+        )
+        assert ("base", "cpu", "float16", False) in transcription_service._model_cache
+
+    def test_local_only_state_participates_in_model_cache_identity(
+        self, transcription_service, mock_whisper_model, sample_audio_file
+    ):
+        """Local-only and download-enabled calls never share a cached model."""
+        mock_class, _ = mock_whisper_model
+
+        transcription_service._transcribe_with_faster_whisper(
+            audio_path=sample_audio_file,
+            model="base",
+            language="en",
+            vad_filter=True,
+            local_files_only=True,
+        )
+        transcription_service._transcribe_with_faster_whisper(
+            audio_path=sample_audio_file,
+            model="base",
+            language="en",
+            vad_filter=True,
+        )
+
+        assert mock_class.call_count == 2
+        assert ("base", "cpu", "int8", True) in transcription_service._model_cache
+        assert ("base", "cpu", "int8", False) in transcription_service._model_cache
 
     def test_language_detection(
         self, transcription_service, mock_whisper_model, sample_audio_file

--- a/Tests/Transcription/test_parakeet_onnx_vertical_slice.py
+++ b/Tests/Transcription/test_parakeet_onnx_vertical_slice.py
@@ -202,8 +202,11 @@ def test_parakeet_onnx_rejects_known_v2_bundle_when_v3_is_selected(
             model_dir=str(model_dir),
         )
 
-    assert "Choose a Parakeet v3 folder" in str(exc_info.value)
-    assert "Retry with faster-whisper" in str(exc_info.value)
+    error_text = str(exc_info.value)
+    assert "identified as Parakeet v2 by receipt metadata" in error_text
+    assert "verified" not in error_text.lower()
+    assert "Choose a Parakeet v3 folder" in error_text
+    assert "Retry with faster-whisper" in error_text
     assert load_calls == []
 
 

--- a/Tests/Transcription/test_parakeet_onnx_vertical_slice.py
+++ b/Tests/Transcription/test_parakeet_onnx_vertical_slice.py
@@ -1,5 +1,6 @@
 """Focused coverage for the runnable Parakeet ONNX batch path."""
 
+import json
 import sys
 import wave
 from types import SimpleNamespace
@@ -8,6 +9,11 @@ import numpy as np
 import pytest
 
 from tldw_chatbook.Local_Ingestion import transcription_service as service_module
+from tldw_chatbook.Local_Ingestion.parakeet_v2_installer import (
+    PARAKEET_V2_REPOSITORY,
+    PARAKEET_V2_REVISION,
+    VERIFICATION_RECEIPT,
+)
 from tldw_chatbook.Local_Ingestion.stt_batch_routing import (
     PARAKEET_V2_MODEL,
     PARAKEET_V3_MODEL,
@@ -35,6 +41,14 @@ def _write_model_bundle(path) -> None:
         "decoder_joint-model.int8.onnx",
     ):
         (path / filename).touch()
+
+
+def _known_v2_receipt() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "repository": PARAKEET_V2_REPOSITORY,
+        "revision": PARAKEET_V2_REVISION,
+    }
 
 
 def test_parakeet_onnx_transcribes_with_local_v2_int8_model(
@@ -155,6 +169,86 @@ def test_parakeet_onnx_non_english_selects_v3_without_decoder_language(
     assert result["effective_language"] == "auto"
     assert result["detected_language"] is None
     assert result["warnings"] == ["requested_language_not_enforced"]
+    assert result["model"] == PARAKEET_V3_MODEL
+
+
+def test_parakeet_onnx_rejects_known_v2_bundle_when_v3_is_selected(
+    tmp_path, monkeypatch
+) -> None:
+    audio_path = tmp_path / "speech.wav"
+    model_dir = tmp_path / "model"
+    _write_model_bundle(model_dir)
+    _write_silent_wav(audio_path)
+    (model_dir / VERIFICATION_RECEIPT).write_text(
+        json.dumps(_known_v2_receipt()),
+        encoding="utf-8",
+    )
+    load_calls = []
+
+    def unexpected_load(*args, **kwargs):
+        load_calls.append((args, kwargs))
+        raise AssertionError("load_model must not run for a known v2/v3 mismatch")
+
+    monkeypatch.setattr(service_module, "ONNX_ASR_AVAILABLE", True, raising=False)
+    monkeypatch.setitem(
+        sys.modules, "onnx_asr", SimpleNamespace(load_model=unexpected_load)
+    )
+
+    with pytest.raises(TranscriptionError) as exc_info:
+        TranscriptionService().transcribe(
+            str(audio_path),
+            provider="parakeet-onnx",
+            language="de",
+            model_dir=str(model_dir),
+        )
+
+    assert "Choose a Parakeet v3 folder" in str(exc_info.value)
+    assert "Retry with faster-whisper" in str(exc_info.value)
+    assert load_calls == []
+
+
+@pytest.mark.parametrize(
+    "receipt_text",
+    [
+        pytest.param("{", id="malformed"),
+        pytest.param(("[" * 30_000) + ("]" * 30_000), id="excessively-nested"),
+        pytest.param(
+            json.dumps(_known_v2_receipt()) + (" " * (1024 * 1024)),
+            id="oversized-valid-known-v2",
+        ),
+    ],
+)
+def test_parakeet_onnx_manual_v3_directory_ignores_untrusted_receipts(
+    tmp_path, monkeypatch, receipt_text
+) -> None:
+    audio_path = tmp_path / "speech.wav"
+    model_dir = tmp_path / "model"
+    _write_model_bundle(model_dir)
+    _write_silent_wav(audio_path)
+    (model_dir / VERIFICATION_RECEIPT).write_text(receipt_text, encoding="utf-8")
+    load_calls = []
+
+    class FakeModel:
+        def recognize(self, path):
+            return "Eine lokale Transkription."
+
+    def fake_load_model(name, **kwargs):
+        load_calls.append((name, kwargs))
+        return FakeModel()
+
+    monkeypatch.setattr(service_module, "ONNX_ASR_AVAILABLE", True, raising=False)
+    monkeypatch.setitem(
+        sys.modules, "onnx_asr", SimpleNamespace(load_model=fake_load_model)
+    )
+
+    result = TranscriptionService().transcribe(
+        str(audio_path),
+        provider="parakeet-onnx",
+        language="de",
+        model_dir=str(model_dir),
+    )
+
+    assert load_calls[0][0] == PARAKEET_V3_MODEL
     assert result["model"] == PARAKEET_V3_MODEL
 
 

--- a/Tests/Transcription/test_parakeet_onnx_vertical_slice.py
+++ b/Tests/Transcription/test_parakeet_onnx_vertical_slice.py
@@ -159,6 +159,148 @@ def test_parakeet_onnx_non_english_selects_v3_without_decoder_language(
 
 
 @pytest.mark.parametrize(
+    ("source_lang", "language", "expected_model", "expected_language"),
+    [
+        pytest.param(
+            None,
+            "de",
+            PARAKEET_V3_MODEL,
+            "de",
+            id="explicit-language",
+        ),
+        pytest.param(
+            "de",
+            "en",
+            PARAKEET_V3_MODEL,
+            "de",
+            id="explicit-source-language",
+        ),
+        pytest.param(
+            None,
+            None,
+            PARAKEET_V2_MODEL,
+            "en",
+            id="missing-language-defaults-to-english",
+        ),
+    ],
+)
+def test_parakeet_onnx_request_ignores_configured_language_defaults(
+    tmp_path,
+    monkeypatch,
+    source_lang,
+    language,
+    expected_model,
+    expected_language,
+) -> None:
+    audio_path = tmp_path / "speech.wav"
+    model_dir = tmp_path / "model"
+    _write_model_bundle(model_dir)
+    _write_silent_wav(audio_path)
+    load_calls = []
+
+    class FakeModel:
+        def recognize(self, path):
+            assert path == str(audio_path)
+            return "Eine lokale Transkription."
+
+    def fake_load_model(name, **kwargs):
+        load_calls.append((name, kwargs))
+        return FakeModel()
+
+    monkeypatch.setattr(service_module, "ONNX_ASR_AVAILABLE", True, raising=False)
+    monkeypatch.setitem(
+        sys.modules, "onnx_asr", SimpleNamespace(load_model=fake_load_model)
+    )
+    service = TranscriptionService()
+    service.config["default_source_language"] = "fr"
+    service.config["default_target_language"] = "es"
+
+    result = service.transcribe(
+        str(audio_path),
+        provider="parakeet-onnx",
+        source_lang=source_lang,
+        language=language,
+        model_dir=str(model_dir),
+    )
+
+    assert load_calls[0][0] == expected_model
+    assert "language" not in load_calls[0][1]
+    assert result["requested_language"] == expected_language
+    if expected_model == PARAKEET_V3_MODEL:
+        assert result["effective_language"] == "auto"
+        assert result["warnings"] == ["requested_language_not_enforced"]
+    else:
+        assert result["effective_language"] == "en"
+        assert result["warnings"] == []
+
+
+def test_parakeet_onnx_file_target_language_alias_rejects_before_model_load(
+    tmp_path, monkeypatch
+) -> None:
+    audio_path = tmp_path / "speech.wav"
+    model_dir = tmp_path / "model"
+    _write_model_bundle(model_dir)
+    _write_silent_wav(audio_path)
+    load_calls = []
+
+    def unexpected_load(*args, **kwargs):
+        load_calls.append((args, kwargs))
+        raise AssertionError("load_model must not run for a translation request")
+
+    monkeypatch.setattr(service_module, "ONNX_ASR_AVAILABLE", True, raising=False)
+    monkeypatch.setitem(
+        sys.modules, "onnx_asr", SimpleNamespace(load_model=unexpected_load)
+    )
+
+    with pytest.raises(TranscriptionError, match="Retry with faster-whisper"):
+        TranscriptionService().transcribe(
+            str(audio_path),
+            provider="parakeet-onnx",
+            language="en",
+            target_language="fr",
+            model_dir=str(model_dir),
+        )
+
+    assert load_calls == []
+
+
+def test_parakeet_onnx_target_lang_argument_wins_over_alias(
+    tmp_path, monkeypatch
+) -> None:
+    audio_path = tmp_path / "speech.wav"
+    model_dir = tmp_path / "model"
+    _write_model_bundle(model_dir)
+    _write_silent_wav(audio_path)
+    load_calls = []
+
+    class FakeModel:
+        def recognize(self, path):
+            assert path == str(audio_path)
+            return "English transcription."
+
+    def fake_load_model(name, **kwargs):
+        load_calls.append((name, kwargs))
+        return FakeModel()
+
+    monkeypatch.setattr(service_module, "ONNX_ASR_AVAILABLE", True, raising=False)
+    monkeypatch.setitem(
+        sys.modules, "onnx_asr", SimpleNamespace(load_model=fake_load_model)
+    )
+
+    result = TranscriptionService().transcribe(
+        str(audio_path),
+        provider="parakeet-onnx",
+        language="en",
+        target_lang="",
+        target_language="fr",
+        model_dir=str(model_dir),
+    )
+
+    assert load_calls[0][0] == PARAKEET_V2_MODEL
+    assert result["requested_language"] == "en"
+
+
+@pytest.mark.parametrize(
     ("language", "target_lang", "model"),
     [
         pytest.param("auto", None, PARAKEET_V3_MODEL, id="auto"),
@@ -269,3 +411,60 @@ def test_parakeet_onnx_transcribes_pcm_buffer_without_staging_a_file(
     )
     assert result["text"] == "Memory only."
     assert result["segments"][0]["end"] == pytest.approx(4 / 8_000)
+
+
+def test_parakeet_onnx_v3_transcribes_pcm_buffer_with_transparent_language_result(
+    tmp_path, monkeypatch
+) -> None:
+    model_dir = tmp_path / "model"
+    _write_model_bundle(model_dir)
+    load_calls = []
+
+    class FakeModel:
+        def recognize(self, waveform, *, sample_rate):
+            assert waveform.dtype == np.float32
+            assert sample_rate == 16_000
+            return " Deutsche Aufnahme. "
+
+    def fake_load_model(name, **kwargs):
+        load_calls.append((name, kwargs))
+        return FakeModel()
+
+    monkeypatch.setattr(service_module, "ONNX_ASR_AVAILABLE", True, raising=False)
+    monkeypatch.setitem(
+        sys.modules, "onnx_asr", SimpleNamespace(load_model=fake_load_model)
+    )
+
+    result = TranscriptionService().transcribe_buffer(
+        np.array([0, 16384], dtype=np.int16).tobytes(),
+        sample_rate=16_000,
+        channels=1,
+        sample_width=2,
+        provider="parakeet-onnx",
+        language="de",
+        model_dir=str(model_dir),
+    )
+
+    assert load_calls == [
+        (
+            PARAKEET_V3_MODEL,
+            {
+                "path": str(model_dir),
+                "quantization": "int8",
+                "providers": ["CPUExecutionProvider"],
+                "preprocessor_config": {
+                    "use_numpy_preprocessors": True,
+                    "max_concurrent_workers": 1,
+                },
+            },
+        )
+    ]
+    assert result["text"] == "Deutsche Aufnahme."
+    assert result["language"] is None
+    assert result["requested_language"] == "de"
+    assert result["effective_language"] == "auto"
+    assert result["detected_language"] is None
+    assert result["warnings"] == ["requested_language_not_enforced"]
+    assert result["model"] == PARAKEET_V3_MODEL
+    assert result["segments"][0]["text"] == "Deutsche Aufnahme."
+    assert result["segments"][0]["end"] == pytest.approx(2 / 16_000)

--- a/Tests/Transcription/test_parakeet_onnx_vertical_slice.py
+++ b/Tests/Transcription/test_parakeet_onnx_vertical_slice.py
@@ -213,6 +213,10 @@ def test_parakeet_onnx_rejects_known_v2_bundle_when_v3_is_selected(
         pytest.param("{", id="malformed"),
         pytest.param(("[" * 30_000) + ("]" * 30_000), id="excessively-nested"),
         pytest.param(
+            '{"repository": ' + ("1" * 5_000) + "}",
+            id="oversized-integer-token",
+        ),
+        pytest.param(
             json.dumps(_known_v2_receipt()) + (" " * (1024 * 1024)),
             id="oversized-valid-known-v2",
         ),

--- a/Tests/Transcription/test_parakeet_onnx_vertical_slice.py
+++ b/Tests/Transcription/test_parakeet_onnx_vertical_slice.py
@@ -8,6 +8,10 @@ import numpy as np
 import pytest
 
 from tldw_chatbook.Local_Ingestion import transcription_service as service_module
+from tldw_chatbook.Local_Ingestion.stt_batch_routing import (
+    PARAKEET_V2_MODEL,
+    PARAKEET_V3_MODEL,
+)
 from tldw_chatbook.Local_Ingestion.transcription_service import (
     TranscriptionError,
     TranscriptionService,
@@ -22,19 +26,23 @@ def _write_silent_wav(path) -> None:
         wav_file.writeframes(b"\0\0" * 1_600)
 
 
-def test_parakeet_onnx_transcribes_with_local_v2_int8_model(
-    tmp_path, monkeypatch
-) -> None:
-    audio_path = tmp_path / "speech.wav"
-    model_dir = tmp_path / "model"
-    model_dir.mkdir()
+def _write_model_bundle(path) -> None:
+    path.mkdir()
     for filename in (
         "config.json",
         "vocab.txt",
         "encoder-model.int8.onnx",
         "decoder_joint-model.int8.onnx",
     ):
-        (model_dir / filename).touch()
+        (path / filename).touch()
+
+
+def test_parakeet_onnx_transcribes_with_local_v2_int8_model(
+    tmp_path, monkeypatch
+) -> None:
+    audio_path = tmp_path / "speech.wav"
+    model_dir = tmp_path / "model"
+    _write_model_bundle(model_dir)
     _write_silent_wav(audio_path)
 
     load_calls = []
@@ -62,7 +70,7 @@ def test_parakeet_onnx_transcribes_with_local_v2_int8_model(
 
     assert load_calls == [
         (
-            "nemo-parakeet-tdt-0.6b-v2",
+            PARAKEET_V2_MODEL,
             {
                 "path": str(model_dir),
                 "quantization": "int8",
@@ -87,9 +95,108 @@ def test_parakeet_onnx_transcribes_with_local_v2_int8_model(
             }
         ],
         "language": "en",
+        "requested_language": "en",
+        "effective_language": "en",
+        "detected_language": None,
+        "warnings": [],
         "provider": "parakeet-onnx",
-        "model": "nemo-parakeet-tdt-0.6b-v2",
+        "model": PARAKEET_V2_MODEL,
     }
+
+
+def test_parakeet_onnx_non_english_selects_v3_without_decoder_language(
+    tmp_path, monkeypatch
+) -> None:
+    audio_path = tmp_path / "speech.wav"
+    model_dir = tmp_path / "model"
+    _write_model_bundle(model_dir)
+    _write_silent_wav(audio_path)
+    load_calls = []
+
+    class FakeModel:
+        def recognize(self, path):
+            assert path == str(audio_path)
+            return " Eine lokale Transkription. "
+
+    def fake_load_model(name, **kwargs):
+        load_calls.append((name, kwargs))
+        return FakeModel()
+
+    monkeypatch.setattr(service_module, "ONNX_ASR_AVAILABLE", True, raising=False)
+    monkeypatch.setitem(
+        sys.modules, "onnx_asr", SimpleNamespace(load_model=fake_load_model)
+    )
+
+    result = TranscriptionService().transcribe(
+        str(audio_path),
+        provider="parakeet-onnx",
+        language="de",
+        model_dir=str(model_dir),
+    )
+
+    assert load_calls == [
+        (
+            PARAKEET_V3_MODEL,
+            {
+                "path": str(model_dir),
+                "quantization": "int8",
+                "providers": ["CPUExecutionProvider"],
+                "preprocessor_config": {
+                    "use_numpy_preprocessors": True,
+                    "max_concurrent_workers": 1,
+                },
+            },
+        )
+    ]
+    assert result["text"] == "Eine lokale Transkription."
+    assert result["segments"][0]["text"] == "Eine lokale Transkription."
+    assert result["language"] is None
+    assert result["requested_language"] == "de"
+    assert result["effective_language"] == "auto"
+    assert result["detected_language"] is None
+    assert result["warnings"] == ["requested_language_not_enforced"]
+    assert result["model"] == PARAKEET_V3_MODEL
+
+
+@pytest.mark.parametrize(
+    ("language", "target_lang", "model"),
+    [
+        pytest.param("auto", None, PARAKEET_V3_MODEL, id="auto"),
+        pytest.param("ja", None, PARAKEET_V3_MODEL, id="unsupported-language"),
+        pytest.param("en", "fr", PARAKEET_V2_MODEL, id="translation"),
+        pytest.param("de", None, PARAKEET_V2_MODEL, id="v2-non-english-mismatch"),
+        pytest.param("en", None, PARAKEET_V3_MODEL, id="v3-english-mismatch"),
+    ],
+)
+def test_parakeet_onnx_rejects_incompatible_requests_before_model_load(
+    tmp_path, monkeypatch, language, target_lang, model
+) -> None:
+    audio_path = tmp_path / "speech.wav"
+    model_dir = tmp_path / "model"
+    _write_model_bundle(model_dir)
+    _write_silent_wav(audio_path)
+    load_calls = []
+
+    def unexpected_load(*args, **kwargs):
+        load_calls.append((args, kwargs))
+        raise AssertionError("load_model must not run for an incompatible request")
+
+    monkeypatch.setattr(service_module, "ONNX_ASR_AVAILABLE", True, raising=False)
+    monkeypatch.setitem(
+        sys.modules, "onnx_asr", SimpleNamespace(load_model=unexpected_load)
+    )
+
+    with pytest.raises(TranscriptionError, match="Retry with faster-whisper"):
+        TranscriptionService().transcribe(
+            str(audio_path),
+            provider="parakeet-onnx",
+            model=model,
+            language=language,
+            target_lang=target_lang,
+            model_dir=str(model_dir),
+        )
+
+    assert load_calls == []
 
 
 def test_parakeet_onnx_rejects_incomplete_model_directory_before_loading(
@@ -120,14 +227,7 @@ def test_parakeet_onnx_transcribes_pcm_buffer_without_staging_a_file(
     tmp_path, monkeypatch
 ) -> None:
     model_dir = tmp_path / "model"
-    model_dir.mkdir()
-    for filename in (
-        "config.json",
-        "vocab.txt",
-        "encoder-model.int8.onnx",
-        "decoder_joint-model.int8.onnx",
-    ):
-        (model_dir / filename).touch()
+    _write_model_bundle(model_dir)
 
     recognized = []
 
@@ -155,7 +255,7 @@ def test_parakeet_onnx_transcribes_pcm_buffer_without_staging_a_file(
         channels=1,
         sample_width=2,
         provider="parakeet-onnx",
-        model="nemo-parakeet-tdt-0.6b-v2",
+        model=PARAKEET_V2_MODEL,
         language="en",
         model_dir=str(model_dir),
     )

--- a/Tests/Transcription/test_parakeet_onnx_vertical_slice.py
+++ b/Tests/Transcription/test_parakeet_onnx_vertical_slice.py
@@ -466,6 +466,36 @@ def test_parakeet_onnx_rejects_incomplete_model_directory_before_loading(
         )
 
 
+def test_parakeet_onnx_rejects_model_directory_that_fails_central_path_validation(
+    tmp_path, monkeypatch
+) -> None:
+    audio_path = tmp_path / "speech.wav"
+    model_dir = tmp_path / "model$(unsafe)"
+    _write_model_bundle(model_dir)
+    _write_silent_wav(audio_path)
+    load_calls = []
+
+    def unexpected_load(*args, **kwargs):
+        load_calls.append((args, kwargs))
+        raise AssertionError("load_model must not run for an invalid model path")
+
+    monkeypatch.setattr(service_module, "ONNX_ASR_AVAILABLE", True, raising=False)
+    monkeypatch.setitem(
+        sys.modules, "onnx_asr", SimpleNamespace(load_model=unexpected_load)
+    )
+
+    with pytest.raises(TranscriptionError, match="invalid local model directory"):
+        TranscriptionService().transcribe(
+            str(audio_path),
+            provider="parakeet-onnx",
+            model=PARAKEET_V2_MODEL,
+            language="en",
+            model_dir=str(model_dir),
+        )
+
+    assert load_calls == []
+
+
 def test_parakeet_onnx_transcribes_pcm_buffer_without_staging_a_file(
     tmp_path, monkeypatch
 ) -> None:

--- a/Tests/Transcription/test_parakeet_onnx_vertical_slice.py
+++ b/Tests/Transcription/test_parakeet_onnx_vertical_slice.py
@@ -514,6 +514,43 @@ def test_parakeet_onnx_transcribes_pcm_buffer_without_staging_a_file(
     assert result["segments"][0]["end"] == pytest.approx(4 / 8_000)
 
 
+def test_parakeet_onnx_buffer_target_lang_wins_over_alias(
+    tmp_path, monkeypatch
+) -> None:
+    model_dir = tmp_path / "model"
+    _write_model_bundle(model_dir)
+    load_calls = []
+
+    class FakeModel:
+        def recognize(self, waveform, *, sample_rate):
+            return "Memory only."
+
+    def fake_load_model(name, **kwargs):
+        load_calls.append((name, kwargs))
+        return FakeModel()
+
+    monkeypatch.setattr(service_module, "ONNX_ASR_AVAILABLE", True, raising=False)
+    monkeypatch.setitem(
+        sys.modules, "onnx_asr", SimpleNamespace(load_model=fake_load_model)
+    )
+
+    result = TranscriptionService().transcribe_buffer(
+        np.array([0, 16384], dtype=np.int16).tobytes(),
+        sample_rate=16_000,
+        channels=1,
+        sample_width=2,
+        provider="parakeet-onnx",
+        model=PARAKEET_V2_MODEL,
+        language="en",
+        target_lang="",
+        target_language="fr",
+        model_dir=str(model_dir),
+    )
+
+    assert load_calls[0][0] == PARAKEET_V2_MODEL
+    assert result["requested_language"] == "en"
+
+
 def test_parakeet_onnx_v3_transcribes_pcm_buffer_with_transparent_language_result(
     tmp_path, monkeypatch
 ) -> None:

--- a/Tests/Transcription/test_stt_batch_routing.py
+++ b/Tests/Transcription/test_stt_batch_routing.py
@@ -97,6 +97,7 @@ def test_exact_faster_whisper_retains_requested_language_and_task() -> None:
         "parakeet",
         "faster",
         "faster-whisper-large",
+        "",
         " PARAKEET-ONNX ",
         "Faster-Whisper",
     ],

--- a/Tests/Transcription/test_stt_batch_routing.py
+++ b/Tests/Transcription/test_stt_batch_routing.py
@@ -28,7 +28,7 @@ def test_default_english_uses_faster_whisper_while_promotion_gate_is_closed() ->
         ("de", None, "parakeet-onnx", PARAKEET_V3_MODEL),
         ("auto", None, "faster-whisper", None),
         ("ja", None, "faster-whisper", None),
-        ("en", "fr", "faster-whisper", None),
+        ("en", "en", "faster-whisper", None),
     ],
 )
 def test_enabled_default_routes_by_language_and_task(
@@ -67,7 +67,7 @@ def test_exact_parakeet_routes_supported_non_english_to_v3(language: str) -> Non
 
 @pytest.mark.parametrize(
     ("language", "target_language"),
-    [("auto", None), ("ja", None), ("en", "fr")],
+    [("auto", None), ("ja", None)],
 )
 def test_exact_parakeet_rejects_unsupported_or_translation_requests(
     language: str,
@@ -81,6 +81,18 @@ def test_exact_parakeet_rejects_unsupported_or_translation_requests(
         )
 
 
+def test_exact_parakeet_non_english_translation_error_explains_retry_limit() -> None:
+    with pytest.raises(BatchSTTRoutingError) as exc_info:
+        resolve_batch_stt_route(
+            provider="parakeet-onnx",
+            language="en",
+            target_language="fr",
+        )
+
+    assert "Retry with faster-whisper" in str(exc_info.value)
+    assert "target en" in str(exc_info.value)
+
+
 def test_exact_faster_whisper_retains_requested_language_and_task() -> None:
     route = resolve_batch_stt_route(
         provider="faster-whisper",
@@ -91,6 +103,50 @@ def test_exact_faster_whisper_retains_requested_language_and_task() -> None:
     assert route.provider == "faster-whisper"
     assert route.requested_language == "ja"
     assert route.target_language == "en"
+
+
+@pytest.mark.parametrize(
+    ("provider", "parakeet_defaults_enabled"),
+    [
+        ("default", False),
+        ("default", True),
+        ("faster-whisper", False),
+    ],
+)
+def test_faster_whisper_routes_reject_non_english_translation_targets(
+    provider: str,
+    parakeet_defaults_enabled: bool,
+) -> None:
+    with pytest.raises(BatchSTTRoutingError, match="target en"):
+        resolve_batch_stt_route(
+            provider=provider,
+            language="de",
+            target_language="fr",
+            parakeet_defaults_enabled=parakeet_defaults_enabled,
+        )
+
+
+@pytest.mark.parametrize(
+    ("arguments", "field"),
+    [
+        ({"provider": 7, "language": "en"}, "provider"),
+        ({"provider": "default", "language": ["en"]}, "language"),
+        (
+            {
+                "provider": "faster-whisper",
+                "language": "en",
+                "target_language": {"code": "en"},
+            },
+            "target_language",
+        ),
+    ],
+)
+def test_malformed_persisted_route_fields_raise_routing_error(
+    arguments: dict[str, object],
+    field: str,
+) -> None:
+    with pytest.raises(BatchSTTRoutingError, match=field):
+        resolve_batch_stt_route(**arguments)  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize(
@@ -109,7 +165,9 @@ def test_unknown_providers_are_rejected_without_prefix_matching(provider: str) -
         resolve_batch_stt_route(provider=provider, language="en")
 
 
-def test_language_codes_are_normalized_and_missing_language_defaults_to_english() -> None:
+def test_language_codes_are_normalized_and_missing_language_defaults_to_english() -> (
+    None
+):
     route = resolve_batch_stt_route(
         provider="parakeet-onnx",
         language=" DE ",
@@ -127,7 +185,7 @@ def test_language_codes_are_normalized_and_missing_language_defaults_to_english(
         ("default", "en", None, True),
         ("default", "de", None, True),
         ("default", "auto", None, True),
-        ("default", "en", "fr", True),
+        ("default", "en", "en", True),
         ("parakeet-onnx", "en", None, False),
         ("parakeet-onnx", "de", None, False),
         ("faster-whisper", "ja", "en", False),

--- a/Tests/Transcription/test_stt_batch_routing.py
+++ b/Tests/Transcription/test_stt_batch_routing.py
@@ -1,0 +1,108 @@
+"""Tests for the dependency-free batch speech-to-text routing policy."""
+
+import pytest
+
+from tldw_chatbook.Local_Ingestion.stt_batch_routing import (
+    PARAKEET_V2_MODEL,
+    PARAKEET_V3_MODEL,
+    BatchSTTRoutingError,
+    resolve_batch_stt_route,
+)
+
+
+def test_default_english_uses_faster_whisper_while_promotion_gate_is_closed() -> None:
+    route = resolve_batch_stt_route(provider="default", language="en")
+
+    assert route.provider == "faster-whisper"
+    assert route.reason == "parakeet_promotion_gate_closed"
+    assert route.precision == "int8"
+    assert route.local_files_only is True
+
+
+@pytest.mark.parametrize(
+    ("language", "target_language", "provider", "model"),
+    [
+        ("en", None, "parakeet-onnx", PARAKEET_V2_MODEL),
+        ("de", None, "parakeet-onnx", PARAKEET_V3_MODEL),
+        ("auto", None, "faster-whisper", None),
+        ("ja", None, "faster-whisper", None),
+        ("en", "fr", "faster-whisper", None),
+    ],
+)
+def test_enabled_default_routes_by_language_and_task(
+    language: str,
+    target_language: str | None,
+    provider: str,
+    model: str | None,
+) -> None:
+    route = resolve_batch_stt_route(
+        provider="default",
+        language=language,
+        target_language=target_language,
+        parakeet_defaults_enabled=True,
+    )
+
+    assert route.provider == provider
+    assert route.model == model
+
+
+@pytest.mark.parametrize("language", [None, "", "en", "EN"])
+def test_exact_parakeet_defaults_english_inputs_to_v2(language: str | None) -> None:
+    route = resolve_batch_stt_route(provider="parakeet-onnx", language=language)
+
+    assert route.provider == "parakeet-onnx"
+    assert route.model == PARAKEET_V2_MODEL
+    assert route.requested_language == "en"
+
+
+@pytest.mark.parametrize("language", ["de", "es", "fr", "uk"])
+def test_exact_parakeet_routes_supported_non_english_to_v3(language: str) -> None:
+    route = resolve_batch_stt_route(provider="parakeet-onnx", language=language)
+
+    assert route.model == PARAKEET_V3_MODEL
+    assert route.requested_language == language
+
+
+@pytest.mark.parametrize(
+    ("language", "target_language"),
+    [("auto", None), ("ja", None), ("en", "fr")],
+)
+def test_exact_parakeet_rejects_unsupported_or_translation_requests(
+    language: str,
+    target_language: str | None,
+) -> None:
+    with pytest.raises(BatchSTTRoutingError, match="Retry with faster-whisper"):
+        resolve_batch_stt_route(
+            provider="parakeet-onnx",
+            language=language,
+            target_language=target_language,
+        )
+
+
+def test_exact_faster_whisper_retains_requested_language_and_task() -> None:
+    route = resolve_batch_stt_route(
+        provider="faster-whisper",
+        language="ja",
+        target_language="en",
+    )
+
+    assert route.provider == "faster-whisper"
+    assert route.requested_language == "ja"
+    assert route.target_language == "en"
+
+
+@pytest.mark.parametrize("provider", ["parakeet", "faster", "faster-whisper-large"])
+def test_unknown_providers_are_rejected_without_prefix_matching(provider: str) -> None:
+    with pytest.raises(BatchSTTRoutingError):
+        resolve_batch_stt_route(provider=provider, language="en")
+
+
+def test_language_codes_are_normalized_and_missing_language_defaults_to_english() -> None:
+    route = resolve_batch_stt_route(
+        provider="parakeet-onnx",
+        language=" DE ",
+    )
+    missing = resolve_batch_stt_route(provider="faster-whisper", language=None)
+
+    assert route.requested_language == "de"
+    assert missing.requested_language == "en"

--- a/Tests/Transcription/test_stt_batch_routing.py
+++ b/Tests/Transcription/test_stt_batch_routing.py
@@ -91,7 +91,16 @@ def test_exact_faster_whisper_retains_requested_language_and_task() -> None:
     assert route.target_language == "en"
 
 
-@pytest.mark.parametrize("provider", ["parakeet", "faster", "faster-whisper-large"])
+@pytest.mark.parametrize(
+    "provider",
+    [
+        "parakeet",
+        "faster",
+        "faster-whisper-large",
+        " PARAKEET-ONNX ",
+        "Faster-Whisper",
+    ],
+)
 def test_unknown_providers_are_rejected_without_prefix_matching(provider: str) -> None:
     with pytest.raises(BatchSTTRoutingError):
         resolve_batch_stt_route(provider=provider, language="en")

--- a/Tests/Transcription/test_stt_batch_routing.py
+++ b/Tests/Transcription/test_stt_batch_routing.py
@@ -1,5 +1,7 @@
 """Tests for the dependency-free batch speech-to-text routing policy."""
 
+from dataclasses import FrozenInstanceError
+
 import pytest
 
 from tldw_chatbook.Local_Ingestion.stt_batch_routing import (
@@ -116,3 +118,40 @@ def test_language_codes_are_normalized_and_missing_language_defaults_to_english(
 
     assert route.requested_language == "de"
     assert missing.requested_language == "en"
+
+
+@pytest.mark.parametrize(
+    ("provider", "language", "target_language", "parakeet_defaults_enabled"),
+    [
+        ("default", "en", None, False),
+        ("default", "en", None, True),
+        ("default", "de", None, True),
+        ("default", "auto", None, True),
+        ("default", "en", "fr", True),
+        ("parakeet-onnx", "en", None, False),
+        ("parakeet-onnx", "de", None, False),
+        ("faster-whisper", "ja", "en", False),
+    ],
+)
+def test_successful_routes_are_local_int8(
+    provider: str,
+    language: str,
+    target_language: str | None,
+    parakeet_defaults_enabled: bool,
+) -> None:
+    route = resolve_batch_stt_route(
+        provider=provider,
+        language=language,
+        target_language=target_language,
+        parakeet_defaults_enabled=parakeet_defaults_enabled,
+    )
+
+    assert route.precision == "int8"
+    assert route.local_files_only is True
+
+
+def test_routes_are_immutable() -> None:
+    route = resolve_batch_stt_route(provider="faster-whisper", language="en")
+
+    with pytest.raises(FrozenInstanceError):
+        setattr(route, "provider", "parakeet-onnx")

--- a/Tests/UI/test_library_ingest_canvas.py
+++ b/Tests/UI/test_library_ingest_canvas.py
@@ -797,7 +797,7 @@ async def test_mounting_option_panels_posts_no_option_changes():
 
 
 @pytest.mark.asyncio
-async def test_audio_video_defaults_to_parakeet_onnx_without_whisper_models():
+async def test_audio_video_defaults_to_semantic_provider_with_exact_controls_disabled():
     form = _default_form()
     form.expanded_type_groups.add("audio_video")
     state = build_library_ingest_state(
@@ -821,23 +821,114 @@ async def test_audio_video_defaults_to_parakeet_onnx_without_whisper_models():
             provider = pilot.app.query_one(
                 "#opt-audio_video-transcription_provider", Select
             )
-            model = pilot.app.query_one(
-                "#opt-audio_video-transcription_model", Select
-            )
+            model = pilot.app.query_one("#opt-audio_video-transcription_model", Select)
             model_dir = pilot.app.query_one(
                 "#opt-audio_video-transcription_model_dir", Input
             )
-            assert provider.value == "parakeet-onnx"
+            assert provider.value == "default"
             assert model.disabled is True
-            assert model_dir.disabled is False
+            assert model_dir.disabled is True
             assert model_dir.value == ""
             install = pilot.app.query_one(
                 "#opt-audio_video-install-parakeet-v2", Button
             )
             assert "Install verified Parakeet v2 INT8" in str(install.label)
+            assert install.disabled is True
+            install.press()
+            await pilot.pause()
+            assert app.parakeet_install_requests == 0
+
+
+@pytest.mark.asyncio
+async def test_explicit_parakeet_enables_model_dir_and_verified_installer():
+    form = _default_form()
+    form.expanded_type_groups.add("audio_video")
+    form.type_options = {"audio_video": {"transcription_provider": "parakeet-onnx"}}
+    state = build_library_ingest_state(
+        (),
+        form=form,
+        preflight=PreflightResult(
+            type_groups={"audio_video": ["/tmp/a.mp3"]},
+            warnings=[],
+            errors=[],
+            total_size=0,
+            truncated=False,
+            total_files=1,
+        ),
+    )
+    app = _MessageRecordingHost(state)
+    with patch(
+        "tldw_chatbook.Widgets.Library.library_ingest_canvas._is_installed",
+        return_value=True,
+    ):
+        async with app.run_test() as pilot:
+            provider = pilot.app.query_one(
+                "#opt-audio_video-transcription_provider", Select
+            )
+            model = pilot.app.query_one("#opt-audio_video-transcription_model", Select)
+            model_dir = pilot.app.query_one(
+                "#opt-audio_video-transcription_model_dir", Input
+            )
+            install = pilot.app.query_one(
+                "#opt-audio_video-install-parakeet-v2", Button
+            )
+
+            assert provider.value == "parakeet-onnx"
+            assert model.disabled is True
+            assert model_dir.disabled is False
+            assert install.disabled is False
             install.press()
             await pilot.pause()
             assert app.parakeet_install_requests == 1
+
+
+@pytest.mark.asyncio
+async def test_explicit_faster_whisper_enables_only_whisper_model_control():
+    form = _default_form()
+    form.expanded_type_groups.add("audio_video")
+    form.type_options = {"audio_video": {"transcription_provider": "faster-whisper"}}
+    state = build_library_ingest_state(
+        (),
+        form=form,
+        preflight=PreflightResult(
+            type_groups={"audio_video": ["/tmp/a.mp3"]},
+            warnings=[],
+            errors=[],
+            total_size=0,
+            truncated=False,
+            total_files=1,
+        ),
+    )
+    app = _CanvasHost(state)
+    with patch(
+        "tldw_chatbook.Widgets.Library.library_ingest_canvas._is_installed",
+        return_value=True,
+    ):
+        async with app.run_test() as pilot:
+            assert (
+                pilot.app.query_one(
+                    "#opt-audio_video-transcription_provider", Select
+                ).value
+                == "faster-whisper"
+            )
+            assert (
+                pilot.app.query_one(
+                    "#opt-audio_video-transcription_model", Select
+                ).disabled
+                is False
+            )
+            assert (
+                pilot.app.query_one(
+                    "#opt-audio_video-transcription_model_dir", Input
+                ).disabled
+                is True
+            )
+            assert (
+                pilot.app.query_one(
+                    "#opt-audio_video-install-parakeet-v2", Button
+                ).disabled
+                is True
+            )
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-602.1 - Stage-gated-Parakeet-v3-batch-routing.md
+++ b/backlog/tasks/task-602.1 - Stage-gated-Parakeet-v3-batch-routing.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-602.1
 title: Stage gated Parakeet v3 batch routing
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-27 17:47'
-updated_date: '2026-07-27 19:54'
+updated_date: '2026-07-27 20:05'
 labels:
   - stt
   - onnx
@@ -70,7 +70,7 @@ Reason: ADR-025 already governs routing, v3 language transparency, INT8, explici
   UI and Console dictation test modules. User documentation is in
   `Docs/Features/TRANSCRIPTION.md` and
   `Docs/Features/TRANSCRIPTION_PROVIDERS.md`.
-- Fresh post-rebase expanded verification command: 227 passed, 11 skipped, and
+- Fresh post-rebase expanded verification command: 253 passed, 11 skipped, and
   3 warnings.
   Ruff lint passed on all cumulative changed runtime/test files; compileall
   passed on changed runtime modules; routing mypy reported no issues;
@@ -87,4 +87,9 @@ Reason: ADR-025 already governs routing, v3 language transparency, INT8, explici
   installer but no supported in-app v3 acquisition; manually selected
   directories receive required-filename checks and the bounded receipt
   metadata mismatch check only.
+- Final review fixes preserve resolved batch source/target values over global
+  defaults, execute the visible `base` model for an untouched exact
+  faster-whisper picker, translate `auto` source requests to English with
+  detection metadata, keep canonical Parakeet buffer alias precedence, and
+  retain the legacy positional `process_audio_files` API.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-602.1 - Stage-gated-Parakeet-v3-batch-routing.md
+++ b/backlog/tasks/task-602.1 - Stage-gated-Parakeet-v3-batch-routing.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-602.1
 title: Stage gated Parakeet v3 batch routing
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-27 17:47'
-updated_date: '2026-07-27 17:48'
+updated_date: '2026-07-27 19:14'
 labels:
   - stt
   - onnx
@@ -27,11 +27,11 @@ Extend the working batch transcription path with explicit Parakeet v3 support an
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Explicit parakeet-onnx plus en uses the local v2 INT8 bundle; explicit supported non-English uses the local v3 INT8 bundle; explicit auto, unsupported languages, and translation fail clearly with Retry with faster-whisper guidance.
-- [ ] #2 Semantic provider=default resolves to faster-whisper until the Parakeet promotion gate is enabled; the approved en/v2, supported non-English/v3, and auto-or-unsupported/faster-whisper policy is implemented without silently crossing engines.
-- [ ] #3 Parakeet v3 never receives a decoder language constraint and returns requested_language, effective_language=auto, detected_language=null, and requested_language_not_enforced.
-- [ ] #4 Batch audio and video preserve the resolved provider, model, language, model directory, and INT8 precision without downloading inside transcription workers.
-- [ ] #5 Focused routing, service, audio, video, and app-option tests pass; parent TASK-602 remains open for managed executor, provenance, VAD, retry-action, and platform gates.
+- [x] #1 Explicit parakeet-onnx plus en uses the local v2 INT8 bundle; explicit supported non-English uses the local v3 INT8 bundle; explicit auto, unsupported languages, and translation fail clearly with Retry with faster-whisper guidance.
+- [x] #2 Semantic provider=default resolves to faster-whisper until the Parakeet promotion gate is enabled; the approved en/v2, supported non-English/v3, and auto-or-unsupported/faster-whisper policy is implemented without silently crossing engines.
+- [x] #3 Parakeet v3 never receives a decoder language constraint and returns requested_language, effective_language=auto, detected_language=null, and requested_language_not_enforced.
+- [x] #4 Batch audio and video preserve the resolved provider, model, language, model directory, and INT8 precision without downloading inside transcription workers.
+- [x] #5 Focused routing, service, audio, video, and app-option tests pass; parent TASK-602 remains open for managed executor, provenance, VAD, retry-action, and platform gates.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -48,3 +48,33 @@ ADR required: yes
 ADR path: backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md
 Reason: ADR-025 already governs routing, v3 language transparency, INT8, explicit recovery, and the promotion gate; no new decision is introduced.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added deterministic local INT8 batch routing, explicit Parakeet ONNX v2/v3
+  execution, transparent v3 language metadata, and end-to-end audio/video
+  option preservation. Updated the Library-facing routing documentation and
+  kept semantic `default` on faster-whisper while the promotion gate is closed.
+- Corrected the plan's invalid faster-whisper `en` to `fr` example to a
+  translation-to-English request. Runtime validation rejects all non-English
+  faster-whisper targets. Also allowed a bounded, non-symlink receipt identity
+  read of at most 64 KiB solely to reject a known v2 receipt selected for v3;
+  it performs no download, graph parsing, or v3 eligibility claim.
+- Runtime changes are in the Library capability/app boundary and
+  `Local_Ingestion` routing, service, audio, and local-file seams. Focused
+  coverage is in the App, Library, Local_Ingestion, Transcription, and Library
+  UI test modules. User documentation is in `Docs/Features/TRANSCRIPTION.md`
+  and `Docs/Features/TRANSCRIPTION_PROVIDERS.md`.
+- Fresh verification: 226 passed, 11 skipped, and 3 warnings. Ruff lint passed
+  on all cumulative changed runtime/test files; compileall passed on changed
+  runtime modules; routing mypy reported no issues; `git diff --check` passed.
+  The known whole-file `app.py` Ruff-format baseline was not reformatted or
+  rewritten.
+- ADR-025 remains the governing decision. Parent TASK-602 remains open for
+  promoted/managed artifact eligibility, the app-owned `LocalSTTExecutor`,
+  durable normalized provenance and retry lineage, managed long-form VAD and
+  cancellation, the interactive retry action, and Windows/Linux/platform
+  matrix evidence. Full managed v3 artifacts and retry UI are not part of this
+  child task.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-602.1 - Stage-gated-Parakeet-v3-batch-routing.md
+++ b/backlog/tasks/task-602.1 - Stage-gated-Parakeet-v3-batch-routing.md
@@ -70,7 +70,8 @@ Reason: ADR-025 already governs routing, v3 language transparency, INT8, explici
   UI and Console dictation test modules. User documentation is in
   `Docs/Features/TRANSCRIPTION.md` and
   `Docs/Features/TRANSCRIPTION_PROVIDERS.md`.
-- Fresh expanded verification command: 226 passed, 11 skipped, and 3 warnings.
+- Fresh post-rebase expanded verification command: 227 passed, 11 skipped, and
+  3 warnings.
   Ruff lint passed on all cumulative changed runtime/test files; compileall
   passed on changed runtime modules; routing mypy reported no issues;
   `git diff --check` passed. The known whole-file `app.py` Ruff-format baseline

--- a/backlog/tasks/task-602.1 - Stage-gated-Parakeet-v3-batch-routing.md
+++ b/backlog/tasks/task-602.1 - Stage-gated-Parakeet-v3-batch-routing.md
@@ -58,19 +58,22 @@ Reason: ADR-025 already governs routing, v3 language transparency, INT8, explici
   kept semantic `default` on faster-whisper while the promotion gate is closed.
 - Corrected the plan's invalid faster-whisper `en` to `fr` example to a
   translation-to-English request. Runtime validation rejects all non-English
-  faster-whisper targets. Also allowed a bounded, non-symlink receipt identity
-  read of at most 64 KiB solely to reject a known v2 receipt selected for v3;
-  it performs no download, graph parsing, or v3 eligibility claim.
+  faster-whisper targets. Also allowed a bounded, non-symlink receipt metadata
+  read of at most 64 KiB solely to reject repository and revision metadata that
+  identify v2 when v3 is selected. The receipt is not authenticated and does
+  not verify file contents or v3 eligibility; no download or graph parsing is
+  performed.
 - Runtime changes are in the Library capability/app boundary and
   `Local_Ingestion` routing, service, audio, and local-file seams. Focused
   coverage is in the App, Library, Local_Ingestion, Transcription, and Library
-  UI test modules. User documentation is in `Docs/Features/TRANSCRIPTION.md`
-  and `Docs/Features/TRANSCRIPTION_PROVIDERS.md`.
-- Fresh verification: 226 passed, 11 skipped, and 3 warnings. Ruff lint passed
-  on all cumulative changed runtime/test files; compileall passed on changed
-  runtime modules; routing mypy reported no issues; `git diff --check` passed.
-  The known whole-file `app.py` Ruff-format baseline was not reformatted or
-  rewritten.
+  UI and Console dictation test modules. User documentation is in
+  `Docs/Features/TRANSCRIPTION.md` and
+  `Docs/Features/TRANSCRIPTION_PROVIDERS.md`.
+- Fresh expanded verification command: 226 passed, 11 skipped, and 3 warnings.
+  Ruff lint passed on all cumulative changed runtime/test files; compileall
+  passed on changed runtime modules; routing mypy reported no issues;
+  `git diff --check` passed. The known whole-file `app.py` Ruff-format baseline
+  was not reformatted or rewritten.
 - ADR-025 remains the governing decision. Parent TASK-602 remains open for
   promoted/managed artifact eligibility, the app-owned `LocalSTTExecutor`,
   durable normalized provenance and retry lineage, managed long-form VAD and

--- a/backlog/tasks/task-602.1 - Stage-gated-Parakeet-v3-batch-routing.md
+++ b/backlog/tasks/task-602.1 - Stage-gated-Parakeet-v3-batch-routing.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-602.1
 title: Stage gated Parakeet v3 batch routing
-status: Done
+status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-27 17:47'
-updated_date: '2026-07-27 19:14'
+updated_date: '2026-07-27 19:54'
 labels:
   - stt
   - onnx

--- a/backlog/tasks/task-602.1 - Stage-gated-Parakeet-v3-batch-routing.md
+++ b/backlog/tasks/task-602.1 - Stage-gated-Parakeet-v3-batch-routing.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-27 17:47'
-updated_date: '2026-07-27 20:05'
+updated_date: '2026-07-27 20:25'
 labels:
   - stt
   - onnx
@@ -70,7 +70,7 @@ Reason: ADR-025 already governs routing, v3 language transparency, INT8, explici
   UI and Console dictation test modules. User documentation is in
   `Docs/Features/TRANSCRIPTION.md` and
   `Docs/Features/TRANSCRIPTION_PROVIDERS.md`.
-- Fresh post-rebase expanded verification command: 253 passed, 11 skipped, and
+- Fresh post-rebase expanded verification command: 254 passed, 11 skipped, and
   3 warnings.
   Ruff lint passed on all cumulative changed runtime/test files; compileall
   passed on changed runtime modules; routing mypy reported no issues;
@@ -92,4 +92,8 @@ Reason: ADR-025 already governs routing, v3 language transparency, INT8, explici
   faster-whisper picker, translate `auto` source requests to English with
   detection metadata, keep canonical Parakeet buffer alias precedence, and
   retain the legacy positional `process_audio_files` API.
+- PR review follow-up validates user-selected Parakeet model paths through the
+  central path validator before filesystem access and logs sanitized batch
+  routing failures with job/type context. Exact provider matching and the
+  dependency-free routing core remain intentional contract requirements.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-602.1 - Stage-gated-Parakeet-v3-batch-routing.md
+++ b/backlog/tasks/task-602.1 - Stage-gated-Parakeet-v3-batch-routing.md
@@ -1,0 +1,50 @@
+---
+id: TASK-602.1
+title: Stage gated Parakeet v3 batch routing
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-07-27 17:47'
+updated_date: '2026-07-27 17:48'
+labels:
+  - stt
+  - onnx
+  - ingestion
+dependencies: []
+references:
+  - backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md
+documentation:
+  - Docs/superpowers/specs/2026-07-23-stt-parakeet-onnx-transcribe-cpp-design.md
+parent_task_id: TASK-602
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Extend the working batch transcription path with explicit Parakeet v3 support and deterministic language routing while preserving the artifact/default-promotion gate.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Explicit parakeet-onnx plus en uses the local v2 INT8 bundle; explicit supported non-English uses the local v3 INT8 bundle; explicit auto, unsupported languages, and translation fail clearly with Retry with faster-whisper guidance.
+- [ ] #2 Semantic provider=default resolves to faster-whisper until the Parakeet promotion gate is enabled; the approved en/v2, supported non-English/v3, and auto-or-unsupported/faster-whisper policy is implemented without silently crossing engines.
+- [ ] #3 Parakeet v3 never receives a decoder language constraint and returns requested_language, effective_language=auto, detected_language=null, and requested_language_not_enforced.
+- [ ] #4 Batch audio and video preserve the resolved provider, model, language, model directory, and INT8 precision without downloading inside transcription workers.
+- [ ] #5 Focused routing, service, audio, video, and app-option tests pass; parent TASK-602 remains open for managed executor, provenance, VAD, retry-action, and platform gates.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a dependency-free, test-first batch STT routing policy that keeps semantic defaults on faster-whisper while the promotion gate is closed and resolves exact Parakeet v2/v3 requests deterministically.
+2. Extend the existing Parakeet ONNX service seam for explicit v3 INT8 inference without passing a decoder language constraint, and normalize requested/effective/detected language plus warnings.
+3. Resolve audio/video routes once at the app option boundary and preserve provider/model/language/model_dir through workers without downloads.
+4. Run focused tests and static checks, update routing documentation, record remaining parent gates, and complete only TASK-602.1.
+
+Detailed plan: Docs/superpowers/plans/2026-07-27-gated-parakeet-v3-batch-routing.md
+
+ADR required: yes
+ADR path: backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md
+Reason: ADR-025 already governs routing, v3 language transparency, INT8, explicit recovery, and the promotion gate; no new decision is introduced.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-602.1 - Stage-gated-Parakeet-v3-batch-routing.md
+++ b/backlog/tasks/task-602.1 - Stage-gated-Parakeet-v3-batch-routing.md
@@ -27,8 +27,8 @@ Extend the working batch transcription path with explicit Parakeet v3 support an
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [x] #1 Explicit parakeet-onnx plus en uses the local v2 INT8 bundle; explicit supported non-English uses the local v3 INT8 bundle; explicit auto, unsupported languages, and translation fail clearly with Retry with faster-whisper guidance.
-- [x] #2 Semantic provider=default resolves to faster-whisper until the Parakeet promotion gate is enabled; the approved en/v2, supported non-English/v3, and auto-or-unsupported/faster-whisper policy is implemented without silently crossing engines.
+- [x] #1 Explicit parakeet-onnx plus en selects `nemo-parakeet-tdt-0.6b-v2`; explicit supported non-English selects `nemo-parakeet-tdt-0.6b-v3`; both require a user-selected existing local directory with the required filenames; explicit auto, unsupported languages, and translation fail clearly with Retry with faster-whisper guidance.
+- [x] #2 Compatible semantic provider=default requests resolve to faster-whisper until the Parakeet promotion gate is enabled, while non-English translation targets fail; the approved en/v2, supported non-English/v3, and auto-or-unsupported/faster-whisper policy is implemented without silently crossing engines.
 - [x] #3 Parakeet v3 never receives a decoder language constraint and returns requested_language, effective_language=auto, detected_language=null, and requested_language_not_enforced.
 - [x] #4 Batch audio and video preserve the resolved provider, model, language, model directory, and INT8 precision without downloading inside transcription workers.
 - [x] #5 Focused routing, service, audio, video, and app-option tests pass; parent TASK-602 remains open for managed executor, provenance, VAD, retry-action, and platform gates.
@@ -55,7 +55,8 @@ Reason: ADR-025 already governs routing, v3 language transparency, INT8, explici
 - Added deterministic local INT8 batch routing, explicit Parakeet ONNX v2/v3
   execution, transparent v3 language metadata, and end-to-end audio/video
   option preservation. Updated the Library-facing routing documentation and
-  kept semantic `default` on faster-whisper while the promotion gate is closed.
+  kept compatible semantic `default` requests on faster-whisper while the
+  promotion gate is closed.
 - Corrected the plan's invalid faster-whisper `en` to `fr` example to a
   translation-to-English request. Runtime validation rejects all non-English
   faster-whisper targets. Also allowed a bounded, non-symlink receipt metadata
@@ -80,4 +81,9 @@ Reason: ADR-025 already governs routing, v3 language transparency, INT8, explici
   cancellation, the interactive retry action, and Windows/Linux/platform
   matrix evidence. Full managed v3 artifacts and retry UI are not part of this
   child task.
+- Current route/model values are selection labels, not attestation of a local
+  directory's identity or contents. The Library offers the verified v2
+  installer but no supported in-app v3 acquisition; manually selected
+  directories receive required-filename checks and the bounded receipt
+  metadata mismatch check only.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Library/ingest_capabilities.py
+++ b/tldw_chatbook/Library/ingest_capabilities.py
@@ -344,8 +344,8 @@ _TYPE_GROUPS: dict[str, TypeGroupCapabilities] = {
                 name="transcription_provider",
                 label="Transcription provider",
                 type="select",
-                default="parakeet-onnx",
-                options=("parakeet-onnx", "faster-whisper"),
+                default="default",
+                options=("default", "parakeet-onnx", "faster-whisper"),
                 depends_on="audio_processing",
             ),
             OptionField(

--- a/tldw_chatbook/Local_Ingestion/audio_processing.py
+++ b/tldw_chatbook/Local_Ingestion/audio_processing.py
@@ -287,6 +287,8 @@ class LocalAudioProcessor:
         transcription_model_dir: Optional[str] = None,
         transcription_language: Optional[str] = "en",
         translation_target_language: Optional[str] = None,
+        transcription_precision: Optional[str] = None,
+        transcription_local_files_only: bool = False,
         perform_chunking: bool = True,
         chunk_method: Optional[str] = None,
         max_chunk_size: int = 500,
@@ -348,6 +350,8 @@ class LocalAudioProcessor:
                         transcription_model_dir=transcription_model_dir,
                         transcription_language=transcription_language,
                         translation_target_language=translation_target_language,
+                        transcription_precision=transcription_precision,
+                        transcription_local_files_only=transcription_local_files_only,
                         perform_chunking=perform_chunking,
                         chunk_method=chunk_method,
                         max_chunk_size=max_chunk_size,
@@ -498,6 +502,10 @@ class LocalAudioProcessor:
                     language=language,
                     model_dir=kwargs.get("transcription_model_dir"),
                     target_lang=kwargs.get("translation_target_language"),
+                    compute_type=kwargs.get("transcription_precision"),
+                    local_files_only=kwargs.get(
+                        "transcription_local_files_only", False
+                    ),
                     vad_filter=kwargs.get("vad_use", False),
                     diarize=kwargs.get("diarize", False),
                     progress_callback=transcription_progress_callback,

--- a/tldw_chatbook/Local_Ingestion/audio_processing.py
+++ b/tldw_chatbook/Local_Ingestion/audio_processing.py
@@ -287,8 +287,6 @@ class LocalAudioProcessor:
         transcription_model_dir: Optional[str] = None,
         transcription_language: Optional[str] = "en",
         translation_target_language: Optional[str] = None,
-        transcription_precision: Optional[str] = None,
-        transcription_local_files_only: bool = False,
         perform_chunking: bool = True,
         chunk_method: Optional[str] = None,
         max_chunk_size: int = 500,
@@ -316,6 +314,9 @@ class LocalAudioProcessor:
         transcription_progress_callback: Optional[
             Callable[[float, str, Optional[Dict]], None]
         ] = None,
+        transcription_precision: Optional[str] = None,
+        transcription_local_files_only: bool = False,
+        transcription_batch_route_resolved: bool = False,
     ) -> Dict[str, Any]:
         """
         Process multiple audio inputs (URLs or local files).
@@ -352,6 +353,7 @@ class LocalAudioProcessor:
                         translation_target_language=translation_target_language,
                         transcription_precision=transcription_precision,
                         transcription_local_files_only=transcription_local_files_only,
+                        transcription_batch_route_resolved=transcription_batch_route_resolved,
                         perform_chunking=perform_chunking,
                         chunk_method=chunk_method,
                         max_chunk_size=max_chunk_size,
@@ -505,6 +507,9 @@ class LocalAudioProcessor:
                     compute_type=kwargs.get("transcription_precision"),
                     local_files_only=kwargs.get(
                         "transcription_local_files_only", False
+                    ),
+                    batch_route_resolved=kwargs.get(
+                        "transcription_batch_route_resolved", False
                     ),
                     vad_filter=kwargs.get("vad_use", False),
                     diarize=kwargs.get("diarize", False),

--- a/tldw_chatbook/Local_Ingestion/local_file_ingestion.py
+++ b/tldw_chatbook/Local_Ingestion/local_file_ingestion.py
@@ -606,6 +606,9 @@ def parse_local_file_for_ingest(
                 transcription_local_files_only=options.get(
                     "transcription_local_files_only", False
                 ),
+                transcription_batch_route_resolved=options.get(
+                    "transcription_batch_route_resolved", False
+                ),
                 perform_chunking=True,
                 chunk_method=chunk_options.get('method', 'sentences'),
                 max_chunk_size=chunk_options.get('size', 500),
@@ -673,6 +676,9 @@ def parse_local_file_for_ingest(
                 transcription_precision=options.get("transcription_precision"),
                 transcription_local_files_only=options.get(
                     "transcription_local_files_only", False
+                ),
+                transcription_batch_route_resolved=options.get(
+                    "transcription_batch_route_resolved", False
                 ),
                 perform_chunking=True,
                 chunk_method=chunk_options.get('method', 'sentences'),

--- a/tldw_chatbook/Local_Ingestion/local_file_ingestion.py
+++ b/tldw_chatbook/Local_Ingestion/local_file_ingestion.py
@@ -593,8 +593,19 @@ def parse_local_file_for_ingest(
                     "transcription_provider", "faster-whisper"
                 ),
                 transcription_model_dir=options.get("transcription_model_dir"),
-                transcription_model=options.get('transcription_model', chunk_options.get('transcription_model', 'base')),
-                transcription_language=options.get('language', chunk_options.get('transcription_language', 'en')),
+                transcription_model=options.get(
+                    "transcription_model",
+                    chunk_options.get("transcription_model", "base"),
+                ),
+                transcription_language=options.get(
+                    "language",
+                    chunk_options.get("transcription_language", "en"),
+                ),
+                translation_target_language=options.get("translation_target_language"),
+                transcription_precision=options.get("transcription_precision"),
+                transcription_local_files_only=options.get(
+                    "transcription_local_files_only", False
+                ),
                 perform_chunking=True,
                 chunk_method=chunk_options.get('method', 'sentences'),
                 max_chunk_size=chunk_options.get('size', 500),
@@ -650,8 +661,19 @@ def parse_local_file_for_ingest(
                     "transcription_provider", "faster-whisper"
                 ),
                 transcription_model_dir=options.get("transcription_model_dir"),
-                transcription_model=options.get('transcription_model', chunk_options.get('transcription_model', 'base')),
-                transcription_language=options.get('language', chunk_options.get('transcription_language', 'en')),
+                transcription_model=options.get(
+                    "transcription_model",
+                    chunk_options.get("transcription_model", "base"),
+                ),
+                transcription_language=options.get(
+                    "language",
+                    chunk_options.get("transcription_language", "en"),
+                ),
+                translation_target_language=options.get("translation_target_language"),
+                transcription_precision=options.get("transcription_precision"),
+                transcription_local_files_only=options.get(
+                    "transcription_local_files_only", False
+                ),
                 perform_chunking=True,
                 chunk_method=chunk_options.get('method', 'sentences'),
                 max_chunk_size=chunk_options.get('size', 500),

--- a/tldw_chatbook/Local_Ingestion/stt_batch_routing.py
+++ b/tldw_chatbook/Local_Ingestion/stt_batch_routing.py
@@ -129,7 +129,7 @@ def resolve_batch_stt_route(
 
 
 def _normalize_provider(provider: str | None) -> str:
-    return _DEFAULT_PROVIDER if provider is None else provider.strip().lower()
+    return _DEFAULT_PROVIDER if provider is None or provider == "" else provider
 
 
 def _normalize_language(language: str | None, *, default: str | None) -> str | None:

--- a/tldw_chatbook/Local_Ingestion/stt_batch_routing.py
+++ b/tldw_chatbook/Local_Ingestion/stt_batch_routing.py
@@ -61,9 +61,9 @@ class BatchSTTRoute:
 
 def resolve_batch_stt_route(
     *,
-    provider: str | None,
-    language: str | None,
-    target_language: str | None = None,
+    provider: object | None,
+    language: object | None,
+    target_language: object | None = None,
     parakeet_defaults_enabled: bool = False,
 ) -> BatchSTTRoute:
     """Resolve a batch STT request to its permitted local implementation.
@@ -101,7 +101,9 @@ def resolve_batch_stt_route(
         )
 
     if requested_provider != _DEFAULT_PROVIDER:
-        raise BatchSTTRoutingError(f"Unsupported batch STT provider: {requested_provider}")
+        raise BatchSTTRoutingError(
+            f"Unsupported batch STT provider: {requested_provider}"
+        )
 
     if not parakeet_defaults_enabled:
         return _faster_whisper_route(
@@ -118,7 +120,10 @@ def resolve_batch_stt_route(
             normalized_target,
             "translation_requires_faster_whisper",
         )
-    if requested_language == _AUTO_LANGUAGE or requested_language not in _PARAKEET_V3_LANGUAGES:
+    if (
+        requested_language == _AUTO_LANGUAGE
+        or requested_language not in _PARAKEET_V3_LANGUAGES
+    ):
         return _faster_whisper_route(
             requested_provider,
             requested_language,
@@ -128,22 +133,31 @@ def resolve_batch_stt_route(
     return _parakeet_route(requested_provider, requested_language, normalized_target)
 
 
-def _normalize_provider(provider: str | None) -> str:
-    return _DEFAULT_PROVIDER if provider is None else provider
+def _normalize_provider(provider: object | None) -> str:
+    if provider is None:
+        return _DEFAULT_PROVIDER
+    if not isinstance(provider, str):
+        raise BatchSTTRoutingError("Batch STT provider must be a string.")
+    return provider
 
 
-def _normalize_source_language(language: str | None) -> str:
+def _normalize_source_language(language: object | None) -> str:
     """Normalize a source language, defaulting omitted values to English."""
-    if language is None or not language.strip():
+    if language is None:
         return "en"
-    return language.strip().lower()
+    if not isinstance(language, str):
+        raise BatchSTTRoutingError("Batch STT language must be a string.")
+    normalized = language.strip().lower()
+    return normalized or "en"
 
 
-def _normalize_target_language(language: str | None) -> str | None:
+def _normalize_target_language(language: object | None) -> str | None:
     """Normalize an optional target language."""
-    if language is None or not language.strip():
+    if language is None:
         return None
-    return language.strip().lower()
+    if not isinstance(language, str):
+        raise BatchSTTRoutingError("Batch STT target_language must be a string.")
+    return language.strip().lower() or None
 
 
 def _parakeet_route(
@@ -153,9 +167,13 @@ def _parakeet_route(
 ) -> BatchSTTRoute:
     if target_language is not None:
         raise BatchSTTRoutingError(
-            "Parakeet does not support translation. Retry with faster-whisper."
+            "Parakeet does not support translation. Retry with faster-whisper "
+            "only for target en."
         )
-    if requested_language == _AUTO_LANGUAGE or requested_language not in _PARAKEET_V3_LANGUAGES:
+    if (
+        requested_language == _AUTO_LANGUAGE
+        or requested_language not in _PARAKEET_V3_LANGUAGES
+    ):
         raise BatchSTTRoutingError(
             "Parakeet does not support this language. Retry with faster-whisper."
         )
@@ -169,7 +187,9 @@ def _parakeet_route(
         target_language=target_language,
         precision="int8",
         local_files_only=True,
-        reason="parakeet_v2_english" if model == PARAKEET_V2_MODEL else "parakeet_v3_language",
+        reason="parakeet_v2_english"
+        if model == PARAKEET_V2_MODEL
+        else "parakeet_v3_language",
     )
 
 
@@ -179,6 +199,10 @@ def _faster_whisper_route(
     target_language: str | None,
     reason: str,
 ) -> BatchSTTRoute:
+    if target_language is not None and target_language != "en":
+        raise BatchSTTRoutingError(
+            "faster-whisper translation only supports target en."
+        )
     return BatchSTTRoute(
         requested_provider=requested_provider,
         provider=_FASTER_WHISPER_PROVIDER,

--- a/tldw_chatbook/Local_Ingestion/stt_batch_routing.py
+++ b/tldw_chatbook/Local_Ingestion/stt_batch_routing.py
@@ -82,8 +82,8 @@ def resolve_batch_stt_route(
             request cannot be fulfilled.
     """
     requested_provider = _normalize_provider(provider)
-    requested_language = _normalize_language(language, default="en")
-    normalized_target = _normalize_language(target_language, default=None)
+    requested_language = _normalize_source_language(language)
+    normalized_target = _normalize_target_language(target_language)
 
     if requested_provider == _FASTER_WHISPER_PROVIDER:
         return _faster_whisper_route(
@@ -132,9 +132,17 @@ def _normalize_provider(provider: str | None) -> str:
     return _DEFAULT_PROVIDER if provider is None else provider
 
 
-def _normalize_language(language: str | None, *, default: str | None) -> str | None:
+def _normalize_source_language(language: str | None) -> str:
+    """Normalize a source language, defaulting omitted values to English."""
     if language is None or not language.strip():
-        return default
+        return "en"
+    return language.strip().lower()
+
+
+def _normalize_target_language(language: str | None) -> str | None:
+    """Normalize an optional target language."""
+    if language is None or not language.strip():
+        return None
     return language.strip().lower()
 
 

--- a/tldw_chatbook/Local_Ingestion/stt_batch_routing.py
+++ b/tldw_chatbook/Local_Ingestion/stt_batch_routing.py
@@ -129,7 +129,7 @@ def resolve_batch_stt_route(
 
 
 def _normalize_provider(provider: str | None) -> str:
-    return _DEFAULT_PROVIDER if provider is None or provider == "" else provider
+    return _DEFAULT_PROVIDER if provider is None else provider
 
 
 def _normalize_language(language: str | None, *, default: str | None) -> str | None:

--- a/tldw_chatbook/Local_Ingestion/stt_batch_routing.py
+++ b/tldw_chatbook/Local_Ingestion/stt_batch_routing.py
@@ -1,0 +1,183 @@
+"""Dependency-free routing policy for batch speech-to-text requests."""
+
+from dataclasses import dataclass
+
+
+PARAKEET_V2_MODEL = "nemo-parakeet-tdt-0.6b-v2"
+PARAKEET_V3_MODEL = "nemo-parakeet-tdt-0.6b-v3"
+
+_DEFAULT_PROVIDER = "default"
+_FASTER_WHISPER_PROVIDER = "faster-whisper"
+_PARAKEET_PROVIDER = "parakeet-onnx"
+_AUTO_LANGUAGE = "auto"
+_PARAKEET_V3_LANGUAGES = frozenset(
+    {
+        "bg",
+        "hr",
+        "cs",
+        "da",
+        "nl",
+        "en",
+        "et",
+        "fi",
+        "fr",
+        "de",
+        "el",
+        "hu",
+        "it",
+        "lv",
+        "lt",
+        "mt",
+        "pl",
+        "pt",
+        "ro",
+        "sk",
+        "sl",
+        "es",
+        "sv",
+        "ru",
+        "uk",
+    }
+)
+
+
+class BatchSTTRoutingError(ValueError):
+    """Raised when a requested batch STT provider cannot serve a request."""
+
+
+@dataclass(frozen=True)
+class BatchSTTRoute:
+    """Resolved batch STT provider settings."""
+
+    requested_provider: str
+    provider: str
+    model: str | None
+    requested_language: str
+    target_language: str | None
+    precision: str
+    local_files_only: bool
+    reason: str
+
+
+def resolve_batch_stt_route(
+    *,
+    provider: str | None,
+    language: str | None,
+    target_language: str | None = None,
+    parakeet_defaults_enabled: bool = False,
+) -> BatchSTTRoute:
+    """Resolve a batch STT request to its permitted local implementation.
+
+    Args:
+        provider: Requested provider, or ``None`` for the semantic default.
+        language: Requested source language, or ``None`` for English.
+        target_language: Translation target, when requested.
+        parakeet_defaults_enabled: Whether the Parakeet default promotion gate is open.
+
+    Returns:
+        The immutable routing decision.
+
+    Raises:
+        BatchSTTRoutingError: If the provider is unknown or an explicit Parakeet
+            request cannot be fulfilled.
+    """
+    requested_provider = _normalize_provider(provider)
+    requested_language = _normalize_language(language, default="en")
+    normalized_target = _normalize_language(target_language, default=None)
+
+    if requested_provider == _FASTER_WHISPER_PROVIDER:
+        return _faster_whisper_route(
+            requested_provider,
+            requested_language,
+            normalized_target,
+            "explicit_faster_whisper",
+        )
+
+    if requested_provider == _PARAKEET_PROVIDER:
+        return _parakeet_route(
+            requested_provider,
+            requested_language,
+            normalized_target,
+        )
+
+    if requested_provider != _DEFAULT_PROVIDER:
+        raise BatchSTTRoutingError(f"Unsupported batch STT provider: {requested_provider}")
+
+    if not parakeet_defaults_enabled:
+        return _faster_whisper_route(
+            requested_provider,
+            requested_language,
+            normalized_target,
+            "parakeet_promotion_gate_closed",
+        )
+
+    if normalized_target is not None:
+        return _faster_whisper_route(
+            requested_provider,
+            requested_language,
+            normalized_target,
+            "translation_requires_faster_whisper",
+        )
+    if requested_language == _AUTO_LANGUAGE or requested_language not in _PARAKEET_V3_LANGUAGES:
+        return _faster_whisper_route(
+            requested_provider,
+            requested_language,
+            normalized_target,
+            "language_requires_faster_whisper",
+        )
+    return _parakeet_route(requested_provider, requested_language, normalized_target)
+
+
+def _normalize_provider(provider: str | None) -> str:
+    return _DEFAULT_PROVIDER if provider is None else provider.strip().lower()
+
+
+def _normalize_language(language: str | None, *, default: str | None) -> str | None:
+    if language is None or not language.strip():
+        return default
+    return language.strip().lower()
+
+
+def _parakeet_route(
+    requested_provider: str,
+    requested_language: str,
+    target_language: str | None,
+) -> BatchSTTRoute:
+    if target_language is not None:
+        raise BatchSTTRoutingError(
+            "Parakeet does not support translation. Retry with faster-whisper."
+        )
+    if requested_language == _AUTO_LANGUAGE or requested_language not in _PARAKEET_V3_LANGUAGES:
+        raise BatchSTTRoutingError(
+            "Parakeet does not support this language. Retry with faster-whisper."
+        )
+
+    model = PARAKEET_V2_MODEL if requested_language == "en" else PARAKEET_V3_MODEL
+    return BatchSTTRoute(
+        requested_provider=requested_provider,
+        provider=_PARAKEET_PROVIDER,
+        model=model,
+        requested_language=requested_language,
+        target_language=target_language,
+        precision="int8",
+        local_files_only=True,
+        reason="parakeet_v2_english" if model == PARAKEET_V2_MODEL else "parakeet_v3_language",
+    )
+
+
+def _faster_whisper_route(
+    requested_provider: str,
+    requested_language: str,
+    target_language: str | None,
+    reason: str,
+) -> BatchSTTRoute:
+    return BatchSTTRoute(
+        requested_provider=requested_provider,
+        provider=_FASTER_WHISPER_PROVIDER,
+        model=None,
+        requested_language=requested_language,
+        target_language=target_language,
+        precision="int8",
+        local_files_only=True,
+        reason=reason,
+    )

--- a/tldw_chatbook/Local_Ingestion/transcription_service.py
+++ b/tldw_chatbook/Local_Ingestion/transcription_service.py
@@ -432,15 +432,22 @@ class TranscriptionService:
                 model = "Qwen2-Audio-7B-Instruct"
             else:
                 model = self.config["default_model"]
-        # Handle source language - prefer explicit source_lang over language param
-        source_lang = (
-            source_lang
-            or self.config["default_source_language"]
-            or language
-            or self.config["default_language"]
-        )
-        # Handle target language
-        target_lang = target_lang or self.config["default_target_language"] or None
+        if provider == "parakeet-onnx":
+            target_language_alias = kwargs.pop("target_language", None)
+            source_lang = source_lang or language or "en"
+            target_lang = (
+                target_lang if target_lang is not None else target_language_alias
+            )
+        else:
+            # Handle source language - prefer explicit source_lang over language param
+            source_lang = (
+                source_lang
+                or self.config["default_source_language"]
+                or language
+                or self.config["default_language"]
+            )
+            # Handle target language
+            target_lang = target_lang or self.config["default_target_language"] or None
         # For backward compatibility, set language to source_lang if not specified
         language = language or source_lang
 

--- a/tldw_chatbook/Local_Ingestion/transcription_service.py
+++ b/tldw_chatbook/Local_Ingestion/transcription_service.py
@@ -38,6 +38,7 @@ except ImportError:
 
 # Local imports
 from ..config import get_cli_setting
+from ..Utils.path_validation import validate_path_simple
 from .parakeet_v2_installer import (
     PARAKEET_V2_REPOSITORY,
     PARAKEET_V2_REVISION,
@@ -54,8 +55,11 @@ _VERIFICATION_RECEIPT_MAX_BYTES = 64 * 1024
 
 def _has_known_parakeet_v2_receipt(model_dir: Path) -> bool:
     """Return whether bounded receipt metadata claims the curated v2 identity."""
-    receipt_path = model_dir / VERIFICATION_RECEIPT
     try:
+        receipt_path = validate_path_simple(
+            model_dir / VERIFICATION_RECEIPT,
+            probe_existing=False,
+        )
         if receipt_path.is_symlink() or not receipt_path.is_file():
             return False
         if receipt_path.stat().st_size > _VERIFICATION_RECEIPT_MAX_BYTES:
@@ -781,13 +785,25 @@ class TranscriptionService:
             )
 
         model_dir = model_dir or self.config["parakeet_onnx_model_dir"]
-        if not model_dir or not Path(model_dir).is_dir():
+        if not model_dir:
             raise TranscriptionError(
                 "parakeet-onnx requires an explicit existing local model directory "
                 "via model_dir or transcription.parakeet_onnx_model_dir; "
                 "no model will be downloaded automatically."
             )
-        model_root = Path(model_dir)
+        try:
+            model_root = validate_path_simple(model_dir, require_exists=True)
+        except ValueError as exc:
+            raise TranscriptionError(
+                "parakeet-onnx invalid local model directory; choose an existing "
+                "local model folder. No model will be downloaded automatically."
+            ) from exc
+        if not model_root.is_dir():
+            raise TranscriptionError(
+                "parakeet-onnx requires an explicit existing local model directory "
+                "via model_dir or transcription.parakeet_onnx_model_dir; "
+                "no model will be downloaded automatically."
+            )
         if selected_model == PARAKEET_V3_MODEL and _has_known_parakeet_v2_receipt(
             model_root
         ):
@@ -813,7 +829,7 @@ class TranscriptionService:
                 + ", ".join(missing_files)
             )
 
-        cache_key = ("parakeet-onnx", selected_model, str(model_dir), "int8")
+        cache_key = ("parakeet-onnx", selected_model, str(model_root), "int8")
         with self._model_cache_lock:
             parakeet_model = self._model_cache.get(cache_key)
             if parakeet_model is None:
@@ -821,7 +837,7 @@ class TranscriptionService:
 
                 parakeet_model = load_model(
                     selected_model,
-                    path=str(model_dir),
+                    path=str(model_root),
                     quantization="int8",
                     providers=["CPUExecutionProvider"],
                     preprocessor_config={

--- a/tldw_chatbook/Local_Ingestion/transcription_service.py
+++ b/tldw_chatbook/Local_Ingestion/transcription_service.py
@@ -53,7 +53,7 @@ _VERIFICATION_RECEIPT_MAX_BYTES = 64 * 1024
 
 
 def _has_known_parakeet_v2_receipt(model_dir: Path) -> bool:
-    """Return whether a small trusted receipt identifies the curated v2 bundle."""
+    """Return whether bounded receipt metadata claims the curated v2 identity."""
     receipt_path = model_dir / VERIFICATION_RECEIPT
     try:
         if receipt_path.is_symlink() or not receipt_path.is_file():
@@ -787,7 +787,8 @@ class TranscriptionService:
             model_root
         ):
             raise TranscriptionError(
-                "Selected Parakeet v3 cannot use this verified Parakeet v2 bundle. "
+                "Selected Parakeet v3 cannot use a directory identified as "
+                "Parakeet v2 by receipt metadata. "
                 "Choose a Parakeet v3 folder or Retry with faster-whisper."
             )
         required_files = {

--- a/tldw_chatbook/Local_Ingestion/transcription_service.py
+++ b/tldw_chatbook/Local_Ingestion/transcription_service.py
@@ -440,6 +440,7 @@ class TranscriptionService:
         progress_callback: Optional[
             Callable[[float, str, Optional[Dict]], None]
         ] = None,
+        batch_route_resolved: bool = False,
         **kwargs,
     ) -> Dict[str, Any]:
         """
@@ -452,6 +453,8 @@ class TranscriptionService:
             language: Language code (for backward compatibility)
             source_lang: Explicit source language for transcription
             target_lang: Target language for translation (if supported)
+            batch_route_resolved: Preserve the already-normalized batch language
+                and target instead of applying configured language defaults.
             vad_filter: Apply voice activity detection
             diarize: Perform speaker diarization to identify different speakers
             progress_callback: Optional callback for progress updates (progress: 0-100, status: str, data: dict)
@@ -475,6 +478,8 @@ class TranscriptionService:
             target_lang = (
                 target_lang if target_lang is not None else target_language_alias
             )
+        elif batch_route_resolved:
+            source_lang = source_lang or language or "en"
         else:
             # Handle source language - prefer explicit source_lang over language param
             source_lang = (
@@ -889,8 +894,11 @@ class TranscriptionService:
             self._load_parakeet_onnx_model(
                 model=model,
                 language=language,
-                target_language=kwargs.get("target_lang")
-                or kwargs.get("target_language"),
+                target_language=(
+                    kwargs.get("target_lang")
+                    if "target_lang" in kwargs
+                    else kwargs.get("target_language")
+                ),
                 model_dir=kwargs.get("model_dir"),
             )
         )
@@ -1336,16 +1344,12 @@ class TranscriptionService:
         # Use source_lang if provided, otherwise fall back to language
         transcribe_language = source_lang or language
 
-        # Determine task - translate if target language is English and source is non-English
-        # For auto-detection cases (None or 'auto'), we need to detect language first
-        if target_lang and target_lang == "en":
-            if transcribe_language and transcribe_language not in ["en", "auto", None]:
-                task = "translate"
-            else:
-                # For auto-detection, we'll decide after language detection
-                task = "transcribe"
-        else:
-            task = "transcribe"
+        # faster-whisper can translate to English while auto-detecting the source.
+        task = (
+            "translate"
+            if target_lang == "en" and transcribe_language != "en"
+            else "transcribe"
+        )
 
         logger.info(f"Transcription task: {task}, language: {transcribe_language}")
 
@@ -1559,7 +1563,11 @@ class TranscriptionService:
             # Add translation info if applicable
             if task == "translate":
                 result["task"] = "translation"
-                result["source_language"] = transcribe_language or info.language
+                result["source_language"] = (
+                    info.language
+                    if transcribe_language in (None, "auto")
+                    else transcribe_language
+                )
                 result["target_language"] = "en"
                 result["translation"] = result["text"]
 

--- a/tldw_chatbook/Local_Ingestion/transcription_service.py
+++ b/tldw_chatbook/Local_Ingestion/transcription_service.py
@@ -37,6 +37,11 @@ except ImportError:
 
 # Local imports
 from ..config import get_cli_setting
+from .stt_batch_routing import (
+    BatchSTTRoutingError,
+    PARAKEET_V3_MODEL,
+    resolve_batch_stt_route,
+)
 
 # Optional imports with graceful degradation
 try:
@@ -420,10 +425,8 @@ class TranscriptionService:
         provider = provider or self.config["default_provider"]
 
         # Handle provider-specific default models
-        if not model:
-            if provider == "parakeet-onnx":
-                model = "nemo-parakeet-tdt-0.6b-v2"
-            elif provider == "parakeet-mlx":
+        if not model and provider != "parakeet-onnx":
+            if provider == "parakeet-mlx":
                 model = "mlx-community/parakeet-tdt-0.6b-v2"
             elif provider == "qwen2audio":
                 model = "Qwen2-Audio-7B-Instruct"
@@ -464,6 +467,7 @@ class TranscriptionService:
                     wav_path,
                     model,
                     source_lang,
+                    target_language=target_lang,
                     progress_callback=progress_callback,
                     **kwargs,
                 )
@@ -523,7 +527,7 @@ class TranscriptionService:
                     )
                 result = self._transcribe_with_faster_whisper(
                     wav_path,
-                    model,
+                    model or self.config["default_model"],
                     language,
                     vad_filter,
                     source_lang,
@@ -658,18 +662,22 @@ class TranscriptionService:
     def _transcribe_with_parakeet_onnx(
         self,
         audio_path: str,
-        model: str,
+        model: str | None,
         language: str,
+        target_language: str | None = None,
         progress_callback: Optional[
             Callable[[float, str, Optional[Dict]], None]
         ] = None,
         **kwargs,
     ) -> Dict[str, Any]:
-        """Transcribe English audio with a local Parakeet v2 INT8 model."""
-        parakeet_model = self._load_parakeet_onnx_model(
-            model=model,
-            language=language,
-            model_dir=kwargs.get("model_dir"),
+        """Transcribe audio with a compatible local Parakeet INT8 model."""
+        parakeet_model, selected_model, requested_language = (
+            self._load_parakeet_onnx_model(
+                model=model,
+                language=language,
+                target_language=target_language,
+                model_dir=kwargs.get("model_dir"),
+            )
         )
 
         if progress_callback:
@@ -682,25 +690,45 @@ class TranscriptionService:
         if progress_callback:
             progress_callback(100, "Transcription complete", None)
 
-        return self._parakeet_onnx_result(text, duration=duration, model=model)
+        return self._parakeet_onnx_result(
+            text,
+            duration=duration,
+            model=selected_model,
+            requested_language=requested_language,
+        )
 
     def _load_parakeet_onnx_model(
         self,
         *,
-        model: str,
+        model: str | None,
         language: str,
+        target_language: str | None,
         model_dir: str | Path | None,
-    ) -> Any:
-        """Validate and load the configured local Parakeet v2 INT8 model."""
+    ) -> tuple[Any, str, str]:
+        """Validate and load a compatible local Parakeet INT8 model."""
+        try:
+            route = resolve_batch_stt_route(
+                provider="parakeet-onnx",
+                language=language,
+                target_language=target_language,
+            )
+        except BatchSTTRoutingError as exc:
+            raise TranscriptionError(str(exc)) from exc
+
+        expected_model = route.model
+        assert expected_model is not None
+        selected_model = model or expected_model
+        if selected_model != expected_model:
+            raise TranscriptionError(
+                f"Parakeet model {selected_model!r} is incompatible with requested "
+                f"language {route.requested_language!r}; expected {expected_model!r}. "
+                "Retry with faster-whisper."
+            )
+
         if not ONNX_ASR_AVAILABLE:
             raise TranscriptionError(
                 "parakeet-onnx is not installed. Install with: "
                 "pip install 'onnx-asr[cpu]==0.12.0'"
-            )
-        if language != "en":
-            raise TranscriptionError(
-                "parakeet-onnx v2 supports explicit English only. "
-                "Retry with faster-whisper for automatic or non-English transcription."
             )
 
         model_dir = model_dir or self.config["parakeet_onnx_model_dir"]
@@ -727,14 +755,14 @@ class TranscriptionService:
                 + ", ".join(missing_files)
             )
 
-        cache_key = ("parakeet-onnx", model, str(model_dir), "int8")
+        cache_key = ("parakeet-onnx", selected_model, str(model_dir), "int8")
         with self._model_cache_lock:
             parakeet_model = self._model_cache.get(cache_key)
             if parakeet_model is None:
                 from onnx_asr import load_model
 
                 parakeet_model = load_model(
-                    model,
+                    selected_model,
                     path=str(model_dir),
                     quantization="int8",
                     providers=["CPUExecutionProvider"],
@@ -744,13 +772,14 @@ class TranscriptionService:
                     },
                 )
                 self._model_cache[cache_key] = parakeet_model
-        return parakeet_model
+        return parakeet_model, selected_model, route.requested_language
 
     @staticmethod
     def _parakeet_onnx_result(
-        text: str, *, duration: float, model: str
+        text: str, *, duration: float, model: str, requested_language: str
     ) -> Dict[str, Any]:
         """Build the common Parakeet ONNX transcription result."""
+        is_v3 = model == PARAKEET_V3_MODEL
         return {
             "text": text,
             "segments": [
@@ -765,7 +794,11 @@ class TranscriptionService:
             ]
             if text
             else [],
-            "language": "en",
+            "language": None if is_v3 else "en",
+            "requested_language": requested_language,
+            "effective_language": "auto" if is_v3 else "en",
+            "detected_language": None,
+            "warnings": ["requested_language_not_enforced"] if is_v3 else [],
             "provider": "parakeet-onnx",
             "model": model,
         }
@@ -776,7 +809,7 @@ class TranscriptionService:
         sample_rate: int,
         channels: int,
         sample_width: int,
-        model: str,
+        model: str | None,
         language: str,
         **kwargs,
     ) -> Dict[str, Any]:
@@ -799,17 +832,26 @@ class TranscriptionService:
         if channels > 1:
             waveform = waveform.reshape(-1, channels).mean(axis=1)
         waveform = waveform.astype(np.float32) / 32768.0
-        parakeet_model = self._load_parakeet_onnx_model(
-            model=model,
-            language=language,
-            model_dir=kwargs.get("model_dir"),
+        parakeet_model, selected_model, requested_language = (
+            self._load_parakeet_onnx_model(
+                model=model,
+                language=language,
+                target_language=kwargs.get("target_lang")
+                or kwargs.get("target_language"),
+                model_dir=kwargs.get("model_dir"),
+            )
         )
         text = parakeet_model.recognize(
             waveform,
             sample_rate=sample_rate,
         ).strip()
         duration = (len(audio_data) // frame_bytes) / sample_rate
-        return self._parakeet_onnx_result(text, duration=duration, model=model)
+        return self._parakeet_onnx_result(
+            text,
+            duration=duration,
+            model=selected_model,
+            requested_language=requested_language,
+        )
 
     def transcribe_buffer(
         self,
@@ -858,7 +900,7 @@ class TranscriptionService:
                 sample_rate,
                 channels,
                 sample_width,
-                model or "nemo-parakeet-tdt-0.6b-v2",
+                model,
                 language or "en",
                 **kwargs,
             )

--- a/tldw_chatbook/Local_Ingestion/transcription_service.py
+++ b/tldw_chatbook/Local_Ingestion/transcription_service.py
@@ -70,7 +70,7 @@ def _has_known_parakeet_v2_receipt(model_dir: Path) -> bool:
         RecursionError,
         TypeError,
         UnicodeDecodeError,
-        json.JSONDecodeError,
+        ValueError,
     ):
         return False
     return (

--- a/tldw_chatbook/Local_Ingestion/transcription_service.py
+++ b/tldw_chatbook/Local_Ingestion/transcription_service.py
@@ -5,6 +5,7 @@ Supports multiple transcription backends including faster-whisper, Qwen2Audio, e
 """
 
 import importlib.util
+import json
 import os
 import subprocess
 import tempfile
@@ -37,11 +38,47 @@ except ImportError:
 
 # Local imports
 from ..config import get_cli_setting
+from .parakeet_v2_installer import (
+    PARAKEET_V2_REPOSITORY,
+    PARAKEET_V2_REVISION,
+    VERIFICATION_RECEIPT,
+)
 from .stt_batch_routing import (
     BatchSTTRoutingError,
     PARAKEET_V3_MODEL,
     resolve_batch_stt_route,
 )
+
+_VERIFICATION_RECEIPT_MAX_BYTES = 64 * 1024
+
+
+def _has_known_parakeet_v2_receipt(model_dir: Path) -> bool:
+    """Return whether a small trusted receipt identifies the curated v2 bundle."""
+    receipt_path = model_dir / VERIFICATION_RECEIPT
+    try:
+        if receipt_path.is_symlink() or not receipt_path.is_file():
+            return False
+        if receipt_path.stat().st_size > _VERIFICATION_RECEIPT_MAX_BYTES:
+            return False
+        with receipt_path.open("rb") as receipt_file:
+            payload = receipt_file.read(_VERIFICATION_RECEIPT_MAX_BYTES + 1)
+        if len(payload) > _VERIFICATION_RECEIPT_MAX_BYTES:
+            return False
+        receipt = json.loads(payload.decode("utf-8"))
+    except (
+        OSError,
+        RecursionError,
+        TypeError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+    ):
+        return False
+    return (
+        isinstance(receipt, dict)
+        and receipt.get("repository") == PARAKEET_V2_REPOSITORY
+        and receipt.get("revision") == PARAKEET_V2_REVISION
+    )
+
 
 # Optional imports with graceful degradation
 try:
@@ -745,6 +782,14 @@ class TranscriptionService:
                 "via model_dir or transcription.parakeet_onnx_model_dir; "
                 "no model will be downloaded automatically."
             )
+        model_root = Path(model_dir)
+        if selected_model == PARAKEET_V3_MODEL and _has_known_parakeet_v2_receipt(
+            model_root
+        ):
+            raise TranscriptionError(
+                "Selected Parakeet v3 cannot use this verified Parakeet v2 bundle. "
+                "Choose a Parakeet v3 folder or Retry with faster-whisper."
+            )
         required_files = {
             "config.json",
             "vocab.txt",
@@ -754,7 +799,7 @@ class TranscriptionService:
         missing_files = sorted(
             filename
             for filename in required_files
-            if not (Path(model_dir) / filename).is_file()
+            if not (model_root / filename).is_file()
         )
         if missing_files:
             raise TranscriptionError(
@@ -1089,6 +1134,18 @@ class TranscriptionService:
         **kwargs,
     ) -> Dict[str, Any]:
         """Transcribe using faster-whisper."""
+
+        if target_lang is not None:
+            if not isinstance(target_lang, str):
+                raise TranscriptionError(
+                    "faster-whisper translation target must be target en."
+                )
+            normalized_target = target_lang.strip().lower()
+            if normalized_target and normalized_target != "en":
+                raise TranscriptionError(
+                    "faster-whisper translation only supports target en."
+                )
+            target_lang = normalized_target or None
 
         if not FASTER_WHISPER_AVAILABLE:
             logger.error("faster-whisper is not installed")

--- a/tldw_chatbook/Local_Ingestion/transcription_service.py
+++ b/tldw_chatbook/Local_Ingestion/transcription_service.py
@@ -1127,13 +1127,27 @@ class TranscriptionService:
             except Exception as e:
                 _handle_progress_callback_error(e)
 
-        # Get or create model instance with thread safety
-        cache_key = (model, self.config["device"], self.config["compute_type"])
+        # Get or create model instance with thread safety. Routed batch calls
+        # can narrow execution to local INT8 without changing direct callers'
+        # configured compute type or existing download behavior.
+        effective_compute_type = (
+            kwargs.get("compute_type") or self.config["compute_type"]
+        )
+        effective_local_files_only = bool(kwargs.get("local_files_only", False))
+        cache_key = (
+            model,
+            self.config["device"],
+            effective_compute_type,
+            effective_local_files_only,
+        )
 
         with self._model_cache_lock:
             if cache_key not in self._model_cache:
                 logger.info(
-                    f"Loading Whisper model: {model} (device: {self.config['device']}, compute_type: {self.config['compute_type']})"
+                    f"Loading Whisper model: {model} "
+                    f"(device: {self.config['device']}, "
+                    f"compute_type: {effective_compute_type}, "
+                    f"local_files_only: {effective_local_files_only})"
                 )
 
                 # Report model loading progress
@@ -1141,7 +1155,7 @@ class TranscriptionService:
                     try:
                         # Check if this is likely a first-time download
                         is_huggingface_model = "/" in model
-                        if is_huggingface_model:
+                        if is_huggingface_model and not effective_local_files_only:
                             progress_callback(
                                 0,
                                 f"Downloading model '{model}' from HuggingFace (this may take several minutes on first use)...",
@@ -1173,9 +1187,9 @@ class TranscriptionService:
                         self._model_cache[cache_key] = WhisperModel(
                             model,
                             device=self.config["device"],
-                            compute_type=self.config["compute_type"],
+                            compute_type=effective_compute_type,
                             download_root=None,  # Use default cache directory
-                            local_files_only=False,  # Allow downloading if needed
+                            local_files_only=effective_local_files_only,
                         )
                     model_load_time = time.time() - model_load_start
                     logger.info(
@@ -1300,7 +1314,7 @@ class TranscriptionService:
                         f"Starting transcription with {model}{device_info}...",
                         {
                             "device": self.config["device"],
-                            "compute_type": self.config["compute_type"],
+                            "compute_type": effective_compute_type,
                             "model": model,
                             "provider": "faster-whisper",
                         },

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -2303,11 +2303,14 @@ class LibraryIngestQueueMixin:
             )
             options["extract_images"] = flat_opts.get("extract_images", False)
         elif group == "audio_video":
-            target_language = flat_opts.get(
-                "translation_target_language"
-            ) or flat_opts.get("target_language")
+            provider = flat_opts.get("transcription_provider")
+            if provider is None:
+                provider = "default"
+            target_language = flat_opts.get("translation_target_language")
+            if target_language is None:
+                target_language = flat_opts.get("target_language")
             route = resolve_batch_stt_route(
-                provider=flat_opts.get("transcription_provider") or "default",
+                provider=provider,
                 language=flat_opts.get("language"),
                 target_language=target_language,
             )

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -2326,11 +2326,14 @@ class LibraryIngestQueueMixin:
                 selected_model = flat_opts.get("model") or flat_opts.get(
                     "transcription_model"
                 )
+                if route.requested_provider == "faster-whisper" and not selected_model:
+                    selected_model = "base"
             options["transcription_model"] = selected_model
             options["language"] = route.requested_language
             options["translation_target_language"] = route.target_language
             options["transcription_precision"] = route.precision
             options["transcription_local_files_only"] = route.local_files_only
+            options["transcription_batch_route_resolved"] = True
             options["timestamps"] = flat_opts.get("timestamps", True)
             options["diarization"] = flat_opts.get("diarization", False)
         elif group == "ebook":

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -2435,9 +2435,16 @@ class LibraryIngestQueueMixin:
                 options = self._ingest_job_options(claimed)
             except BatchSTTRoutingError as exc:
                 error_text = _sanitize_library_ingest_error_text(str(exc))
+                failure_text = error_text or "Batch transcription routing failed."
+                logger.warning(
+                    "Library ingest batch STT routing failed "
+                    f"(job_id={claimed.job_id}, "
+                    f"detected_type={claimed.detected_type}, "
+                    f"error={failure_text})."
+                )
                 self.library_ingest_jobs.mark_failed(
                     claimed.job_id,
-                    error=error_text or "Batch transcription routing failed.",
+                    error=failure_text,
                     permanent=False,
                 )
                 parsing_count -= 1

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -2321,11 +2321,12 @@ class LibraryIngestQueueMixin:
                 else ""
             )
             options["transcription_model_dir"] = selected_model_dir or None
-            options["transcription_model"] = (
-                route.model
-                or flat_opts.get("model")
-                or flat_opts.get("transcription_model")
-            )
+            selected_model = route.model
+            if selected_model is None and route.requested_provider != "default":
+                selected_model = flat_opts.get("model") or flat_opts.get(
+                    "transcription_model"
+                )
+            options["transcription_model"] = selected_model
             options["language"] = route.requested_language
             options["translation_target_language"] = route.target_language
             options["transcription_precision"] = route.precision

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -188,6 +188,10 @@ from tldw_chatbook.Local_Ingestion.local_file_ingestion import (
     classify_ingest_source,
     persist_parsed_media,
 )
+from tldw_chatbook.Local_Ingestion.stt_batch_routing import (
+    BatchSTTRoutingError,
+    resolve_batch_stt_route,
+)
 from tldw_chatbook.Home.active_work_adapter import (
     HomeControlAction,
     HomeControlResult,
@@ -2299,23 +2303,30 @@ class LibraryIngestQueueMixin:
             )
             options["extract_images"] = flat_opts.get("extract_images", False)
         elif group == "audio_video":
-            transcription_provider = (
-                flat_opts.get("transcription_provider") or "parakeet-onnx"
+            target_language = flat_opts.get(
+                "translation_target_language"
+            ) or flat_opts.get("target_language")
+            route = resolve_batch_stt_route(
+                provider=flat_opts.get("transcription_provider") or "default",
+                language=flat_opts.get("language"),
+                target_language=target_language,
             )
-            options["transcription_provider"] = transcription_provider
+            options["transcription_provider"] = route.provider
             selected_model_dir = (
                 str(flat_opts.get("transcription_model_dir") or "").strip()
-                if transcription_provider == "parakeet-onnx"
+                if route.provider == "parakeet-onnx"
                 else ""
             )
             options["transcription_model_dir"] = selected_model_dir or None
             options["transcription_model"] = (
-                "nemo-parakeet-tdt-0.6b-v2"
-                if transcription_provider == "parakeet-onnx"
-                else flat_opts.get("model")
+                route.model
+                or flat_opts.get("model")
                 or flat_opts.get("transcription_model")
             )
-            options["language"] = flat_opts.get("language", "en")
+            options["language"] = route.requested_language
+            options["translation_target_language"] = route.target_language
+            options["transcription_precision"] = route.precision
+            options["transcription_local_files_only"] = route.local_files_only
             options["timestamps"] = flat_opts.get("timestamps", True)
             options["diarization"] = flat_opts.get("diarization", False)
         elif group == "ebook":
@@ -2413,7 +2424,19 @@ class LibraryIngestQueueMixin:
             parsing_count += 1
             if job.detected_type in _INGEST_HEAVY_TYPES:
                 heavy_parsing_count += 1
-            options = self._ingest_job_options(claimed)
+            try:
+                options = self._ingest_job_options(claimed)
+            except BatchSTTRoutingError as exc:
+                error_text = _sanitize_library_ingest_error_text(str(exc))
+                self.library_ingest_jobs.mark_failed(
+                    claimed.job_id,
+                    error=error_text or "Batch transcription routing failed.",
+                    permanent=False,
+                )
+                parsing_count -= 1
+                if claimed.detected_type in _INGEST_HEAVY_TYPES:
+                    heavy_parsing_count -= 1
+                continue
             job_id = claimed.job_id
             source_path = claimed.source_path
             try:


### PR DESCRIPTION
## Summary

- add deterministic local INT8 batch STT routing with the Parakeet promotion gate preserved
- support explicit Parakeet ONNX v2 for English and v3 for supported non-English requests, with faster-whisper fallback policy and clear retry guidance
- preserve resolved provider, model, language, target, model directory, precision, and local-only behavior through audio/video ingestion
- keep exact faster-whisper model selection and auto-to-English translation behavior truthful
- renovate Library transcription controls and user documentation for local model preparation

## Verification

- 253 passed, 11 skipped in the focused STT, ingestion, Library UI, and console dictation suite
- Ruff lint passed on all cumulative changed Python files
- compileall passed on changed runtime modules
- mypy passed for the dependency-free routing module and tests
- git diff --check passed
- final cumulative code review: no Critical, Important, or Minor findings

## Scope gates preserved

TASK-602 remains open for promoted/managed Parakeet v3 artifact eligibility, the app-owned LocalSTTExecutor, durable provenance/retry lineage, managed VAD/cancellation, interactive retry action, and Windows/Linux validation. This PR completes atomic child TASK-602.1 only.

ADR: backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds deterministic local INT8 batch STT routing with a promotion gate for Parakeet v3 and a semantic `default` provider. Completes TASK‑602.1 by mapping `default` to `faster-whisper` and routing explicit `parakeet-onnx` to v2 for English and v3 for supported non‑English with strict validation and clear errors.

- **New Features**
  - Dependency‑free batch resolver; only `default`, `parakeet-onnx`, or `faster-whisper` are allowed; empty/invalid providers fail closed with guidance.
  - Local‑only Parakeet v3 batch inference (INT8); v2 bundle verified via bounded on‑disk receipt; enforced language/translation rules with actionable errors.
  - Audio/video ingestion routes via the resolver and preserves provider, model, language, target, and model dir; sets `transcription_precision`, `transcription_local_files_only=True`, `transcription_batch_route_resolved=True`.
  - Library UI exposes semantic `default`; model picker enabled only for `faster-whisper`. Docs include routing policy, v3 language list, install steps, cache recovery, and bundle identity notes.
  - Faster‑whisper model caching now keys on the local‑files‑only dimension.

- **Migration**
  - For local Parakeet, select `parakeet-onnx` and point to existing model dirs: v2 for English, v3 for supported non‑English.
  - Keep `default` for current `faster-whisper` behavior; select `faster-whisper` to enable the model picker.
  - If you see provider errors, choose one of: `default`, `parakeet-onnx`, `faster-whisper`.

<sup>Written for commit f69fe450cfd2e33684681171c9deb7ef2655caa3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

