### PR TITLE
fix(mcp): wire the notes tools to the real service and sweep the module for the same defect class

### DIFF
--- a/.superpowers/sdd/task-962-983-report.md
+++ b/.superpowers/sdd/task-962-983-report.md
@@ -1,0 +1,197 @@
+# TASK-962 / TASK-983 — implementation report
+
+Worktree: `/Users/macbook-dev/Documents/GitHub/wt-983-930`, branch `fix/mcp-server-pass-and-raw-toml`.
+
+## TASK-962 — Tools_Settings_Window raw-TOML save path
+
+**Finding: already fixed on current `dev`. No source change made.**
+
+`UI/Tools_Settings_Window.py::_save_raw_toml_config` no longer does the
+described `open(DEFAULT_CONFIG_PATH, 'w') + toml.dump`. It calls
+`config.replace_cli_config(config_data)`, which:
+
+- resolves the target file via `get_cli_config_path()` (== the profile-aware
+  `_get_effective_config_path()`, honoring `TLDW_CONFIG_PATH`), and
+- persists via `_write_raw_cli_config_unlocked()` → `atomic_private_write_text()`
+  (temp-file-plus-rename write, hardened file mode).
+
+This was already true on `dev` before this session started (per task-962's
+own Implementation Notes, the old code path was removed in a prior
+dev-reconciliation commit, `1df0c4cb4`). Confirmed by reading the current
+source and by running the three existing regression tests in
+`Tests/UI/test_tools_settings_window.py`
+(`test_save_raw_toml_config_writes_effective_path_not_default_decoy`,
+`test_save_raw_toml_config_is_atomic_on_serialization_failure`,
+`test_save_raw_toml_config_roundtrips_with_no_profile_override`) — all 3 pass.
+
+### Before / after repro
+
+No "before" exists to reproduce against on this branch (the bug was already
+gone). To verify the *current* behavior end to end, a manual repro script
+was run under a fully redirected `HOME` (never touching the real user
+profile):
+
+- `TLDW_CONFIG_PATH` → a temp profile file seeded with
+  `plaintext_sentinel = "ORIGINAL_SENTINEL_VALUE"`.
+- `config.DEFAULT_CONFIG_PATH` monkeypatched to a separate temp decoy file
+  seeded with `plaintext_sentinel = "DECOY_SHOULD_NOT_CHANGE"` (simulating
+  the old hardcoded-wrong-path target).
+- Called `config.replace_cli_config({"plaintext_sentinel": "UPDATED_SENTINEL_VALUE", ...})`
+  (the same call `_save_raw_toml_config` makes).
+
+**Result — which file actually changed:**
+
+| File | Before | After |
+|---|---|---|
+| Profile file (`_get_effective_config_path()`'s result) | `ORIGINAL_SENTINEL_VALUE`, mode `0o600` | `UPDATED_SENTINEL_VALUE`, mode `0o600` (unchanged) |
+| Decoy `DEFAULT_CONFIG_PATH` | `DECOY_SHOULD_NOT_CHANGE` | `DECOY_SHOULD_NOT_CHANGE` (untouched) |
+
+The write landed exclusively in the effective/profile path, the decoy was
+never touched, the file mode was preserved (not widened), and the returned
+in-memory config round-tripped every configured value/type correctly
+(verified in the repro's captured output).
+
+No files modified for this task.
+
+---
+
+## TASK-983 — MCP notes tools called a nonexistent API
+
+### The core fix
+
+`TldwMCPServer._init_databases()` constructed
+`NotesInteropService(self.chachanotes_db)` — one positional argument (a
+`CharactersRAGDB`) bound to the real class's first parameter,
+`base_db_directory: Union[str, Path]`. Every construction failed before the
+server could open a single connection.
+
+**Decision: wire it correctly, don't remove it.** A fully working
+implementation of the same feature already exists in this codebase
+(`Tools/note_management_tools.py`'s `CreateNoteTool`/`SearchNotesTool`, and
+`app.py`'s own `NotesInteropService` construction), proving the feature is
+finished and intentional — only this one call site was wired wrong. Fixed
+to match that established pattern exactly:
+
+```python
+self.notes_service = NotesInteropService(
+    base_db_directory=get_chachanotes_db_path().parent,
+    api_client_id=CLI_APP_CLIENT_ID,
+    global_db_to_use=self.chachanotes_db,
+)
+```
+
+`create_note` and `search_notes` were then rewired to the real API:
+
+- `create_note(title, content)` → `notes_service.add_note(user_id=, title=, content=)`.
+  Dropped `tags`/`template` from the tool's own parameter schema entirely:
+  neither `NotesInteropService` nor the `notes` table has any such concept
+  (no tags column, no template system) — they were never real, just assumed.
+- `search_notes(query, limit)` → `notes_service.search_notes(user_id=, search_term=, limit=)`.
+  The old call passed `query=`/`limit=` with no `user_id` (a `TypeError` on
+  the real signature) and then read results via attribute access
+  (`note.id`, `note.updated_at`) — the real method returns plain **dicts**
+  keyed by the real `notes` table columns, which has `last_modified`, not
+  `updated_at`.
+
+`user_id` is resolved via a new `_resolve_notes_user_id()` helper mirroring
+`Tools/note_management_tools.py::_resolve_user_id` (`load_settings()["USERS_NAME"]`
+or `"default_user"` — an attribution value, not a visibility partition).
+
+Proved end to end (not just import) in `Tests/MCP/test_server_notes_service.py`:
+bypasses `__init__` via `__new__` (same technique the existing
+TASK-854/968 tests use, since the optional `mcp` package isn't installed in
+this venv), runs the real `_init_databases()`, swaps a recording fake in for
+`FastMCP` so the actual `create_note`/`search_notes` closures can be
+captured and called directly, and creates + full-text-searches a note
+against a temp on-disk database with `HOME`/`TLDW_CONFIG_PATH` redirected to
+a temp profile (never touching the real user config/DB). 3/3 pass. The
+service now constructs without needing the `_PermissiveFakeService` stub
+the TASK-854/968 tests had to use — their docstrings were updated to note
+this (stub left in place there anyway, to keep those files' own scope
+narrow).
+
+### Whole-module pass
+
+Per the mandate to check "every service construction, config lookup,
+import, and tool handler," `MCP/server.py` and the three collaborator
+modules its tool/resource/prompt handlers delegate to (`tools.py`,
+`resources.py`, `prompts.py`) were read in full and every call checked
+against the real class it targets.
+
+**Fixed (unambiguous — a real method/column exists with the obviously
+intended value, no design call needed):**
+
+| Site | Was | Now |
+|---|---|---|
+| `tools.py::chat_with_character` | `get_cli_setting("API", f"{provider}_api_key", "")` | `get_api_key(provider)` (same defect TASK-968 already fixed at the sibling call site in `server.py::chat_with_llm`) |
+| `resources.py::list_recent_conversations` | `chachanotes_db.get_recent_conversations(limit=)` (doesn't exist) | `chachanotes_db.list_all_active_conversations(limit=)` (already ordered by recency) |
+| `resources.py::list_recent_notes` | `chachanotes_db.get_recent_notes(limit=)` (doesn't exist) | `chachanotes_db.list_notes(limit=)` (already ordered by recency) |
+| `resources.py::get_media_resource`, `prompts.py::analyze_media_prompt` | `media_db.get_media_transcript(media_id)` (never existed as an instance method) | module-level `get_media_transcripts(db, media_id)`, most recent transcript taken |
+| `prompts.py::summarize_conversation_prompt`, `generate_document_prompt` | `chachanotes_db.get_conversation_messages(id)` (never existed) | `chachanotes_db.get_messages_for_conversation(str(id))` (already fixed at the identical shape elsewhere in this same module) |
+
+**Also found — wrong dict-key access (not missing methods, wrong column
+names), surfaced because they broke the new regression tests against real
+seeded rows, then fixed the same way:**
+
+- `media['media_type']` / `media['created_at']` (`resources.py`, `prompts.py`) —
+  the `Media` table's real columns are `type` and `ingestion_date`.
+- `char.get('greeting')` / `char.get('example_dialogue')` / `char.get('updated_at')`
+  (`resources.py::get_character_resource`) — `character_cards`' real columns
+  are `first_message`, `message_example`, `last_modified`.
+- `conv.get('updated_at')` / `note.get('updated_at')` (`resources.py`) — both
+  tables have `last_modified`, not `updated_at`.
+
+All covered by 8 new tests in `Tests/MCP/test_tools_resources_prompts_real_methods.py`.
+
+**Filed rather than guessed (genuine design decisions) — TASK-985:**
+
+- `tools.py::search_conversations` calls `chachanotes_db.search_all_content(...)`,
+  which does not exist anywhere in the codebase at all. The real analog,
+  `search_conversations_by_content(search_query, limit)`, returns
+  conversation rows with **no inline content column**, so the tool's
+  `preview` formatting (`result["content"][:200]`) can't be ported as-is —
+  what a preview should be sourced from instead is a product decision.
+- `resources.py::get_rag_chunk_resource` calls
+  `media_db.get_chunk_by_id(int(chunk_id))`, which also does not exist. The
+  real accessor, `get_chunk_text(db, chunk_uuid)`, takes a **UUID string**,
+  not an int id, and returns **bare text only** — no `media_id`/
+  `start_char`/`end_char`/`embedding_id` (that table has no `embedding_id`
+  column at all). The resource's whole id scheme and metadata contract need
+  reconciling with what the DB can actually provide, not guessing.
+
+**Noted, not fixed — harmless dead metadata (a feature never built, not a
+crash; always-empty via defensive `.get()`):**
+
+- Notes have no `tags`/`template` columns (`get_note_resource`'s tags/template
+  metadata is always empty; keyword *linking* is a separate real API,
+  `link_note_to_keyword`, this resource never calls).
+- `character_cards` has no `message_count` (`list_available_characters` /
+  `get_character_resource` always report `0`; would need a join/count query).
+- `Media` has no `duration` column (`get_media_resource`'s duration metadata
+  is always empty).
+
+### Tests / files
+
+- Added: `Tests/MCP/test_server_notes_service.py` (3 tests),
+  `Tests/MCP/test_tools_resources_prompts_real_methods.py` (8 tests).
+- Modified: `tldw_chatbook/MCP/server.py`, `tools.py`, `resources.py`,
+  `prompts.py`.
+- Updated stale scope-disclaimer docstrings in
+  `Tests/MCP/test_server_media_db_path.py` and
+  `Tests/MCP/test_server_character_service.py` (they used to explain a
+  `NotesInteropService` stub was needed because of "an unrelated,
+  pre-existing defect out of this task's scope" — that defect is now fixed
+  for real; the stub is kept in those files anyway to keep their own scope
+  narrow).
+- Filed `backlog/tasks/task-985` for the two defects that need a design
+  decision (id scanned against local `backlog/tasks/` max, 984, and
+  `origin/dev`'s tree max, 1010 — 985–1009 were free on both; re-scanned
+  after filing, still no collision).
+
+### Test results (foreground, this session)
+
+- `Tests/MCP/`: 377 passed.
+- `Tests/UI/test_tools_settings_window.py`: 49 passed, 16 skipped
+  (pre-existing `AppTest not available in this version of Textual` /
+  one intentionally-hard-to-mock case — unrelated to this change).
+- `Tests/Utils/`: 562 passed.

--- a/Tests/MCP/test_server_character_service.py
+++ b/Tests/MCP/test_server_character_service.py
@@ -30,9 +30,12 @@ import pytest
 
 
 class _PermissiveFakeService:
-    """Stand-in for NotesInteropService, whose own call-signature mismatch
-    is a separate, pre-existing defect out of this task's scope (see
-    test_server_media_db_path.py and this task's Implementation Notes)."""
+    """Stand-in for NotesInteropService. At the time this test was written,
+    its own call-signature mismatch was a separate, pre-existing defect out
+    of this task's scope (see test_server_media_db_path.py and this task's
+    Implementation Notes); TASK-983 has since fixed that construction for
+    real (see test_server_notes_service.py). Kept here anyway so this
+    file's scope stays the character-service-removal fix alone."""
 
     def __init__(self, *args, **kwargs) -> None:
         pass

--- a/Tests/MCP/test_server_media_db_path.py
+++ b/Tests/MCP/test_server_media_db_path.py
@@ -15,14 +15,18 @@ not a CWD-relative file.
 that does not exist anywhere in the codebase at all -- that dead reference
 was removed by TASK-968 (it was never consumed by anything else in the MCP
 package either; character-related tools already read ``chachanotes_db``
-directly). ``NotesInteropService`` is still constructed with a call
-signature that doesn't match the real class -- an unrelated, pre-existing
-defect out of this task's scope (see TASK-968's Implementation Notes) --
-so the tests below still stub it (a permissive fake swapped in at its
-*source* module, so ``_init_databases``'s own local import picks it up)
-to drive the real, unmodified method far enough to construct
-``self.media_db`` -- proving the fix through the actual code path rather
-than by re-implementing its logic in the test.
+directly). At the time this test was written, ``NotesInteropService`` was
+still constructed with a call signature that didn't match the real class --
+an unrelated, pre-existing defect out of this task's scope (see TASK-968's
+Implementation Notes) -- so the tests below stub it (a permissive fake
+swapped in at its *source* module, so ``_init_databases``'s own local
+import picks it up) to drive the real, unmodified method far enough to
+construct ``self.media_db`` -- proving the fix through the actual code
+path rather than by re-implementing its logic in the test. TASK-983 has
+since fixed that construction for real (see
+``test_server_notes_service.py``); the stub is kept here anyway so this
+file's scope stays the media-DB-path fix alone, not a second dependency on
+notes-service construction succeeding.
 """
 
 from __future__ import annotations

--- a/Tests/MCP/test_server_notes_service.py
+++ b/Tests/MCP/test_server_notes_service.py
@@ -1,0 +1,155 @@
+"""TASK-983: MCP notes tools must call a real ``NotesInteropService`` API.
+
+``TldwMCPServer._init_databases()`` used to construct
+``NotesInteropService(self.chachanotes_db)`` -- one positional argument, a
+``CharactersRAGDB`` instance, bound to the real class's first parameter
+(``base_db_directory: Union[str, Path]``). Every construction raised (either
+immediately, or once ``verify_trusted_directory`` rejected the bogus "path"),
+so the MCP server could never even finish initializing, let alone run a
+notes tool.
+
+The ``create_note`` and ``search_notes`` tool bodies then called a method
+that doesn't exist at all (``notes_service.create_note(tags=, template=)``)
+and one that exists but with the wrong keyword names and no ``user_id``
+(``notes_service.search_notes(query=, limit=)`` instead of
+``search_notes(user_id=, search_term=, limit=)``), then read the results as
+attribute access (``note.id``, ``note.updated_at``) when
+``NotesInteropService.search_notes`` returns plain dicts keyed by the real
+``notes`` table columns (which has ``last_modified``, not ``updated_at``).
+
+This test drives the real, unmodified ``_init_databases()`` and the real
+tool closures ``_register_tools()`` defines, against a temp on-disk
+database -- proving the fix works end to end rather than only importing the
+module. ``HOME``/``TLDW_CONFIG_PATH`` are redirected to a temp profile so
+this never touches a real user config or database.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict
+
+import pytest
+
+
+class _RecordingFastMCP:
+    """Stand-in for ``mcp.server.fastmcp.FastMCP``.
+
+    Captures every ``@self.mcp.tool()``-decorated function by name so the
+    test can call the exact closures ``_register_tools()`` defines, without
+    requiring the optional ``mcp`` package to be installed (it is not,
+    in this environment).
+    """
+
+    def __init__(self) -> None:
+        self.tools: Dict[str, Callable[..., Any]] = {}
+
+    def tool(self):
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            self.tools[func.__name__] = func
+            return func
+
+        return decorator
+
+
+@pytest.fixture
+def _isolated_profile(tmp_path, monkeypatch):
+    """Redirect HOME and TLDW_CONFIG_PATH to a temp profile.
+
+    Never touches the real user config/databases -- a fresh, nonexistent
+    config path under ``tmp_path`` bootstraps its own defaults on first
+    access, and every ``*_db_path`` accessor server.py calls resolves
+    underneath the redirected HOME.
+    """
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(tmp_path / "profile_config.toml"))
+    monkeypatch.delenv("USERS_NAME", raising=False)
+    return tmp_path
+
+
+def _build_server_with_real_notes_tools(monkeypatch):
+    """Construct a bare ``TldwMCPServer`` with real notes tools registered.
+
+    Bypasses ``__init__`` (which requires the optional ``mcp`` package) via
+    ``__new__``, runs the real, unmodified ``_init_databases()``, then
+    registers tools using ``_RecordingFastMCP`` in place of ``FastMCP`` so
+    the real ``create_note``/``search_notes`` closures can be captured and
+    called directly.
+    """
+    from tldw_chatbook.MCP import server as mcp_server_module
+
+    instance = mcp_server_module.TldwMCPServer.__new__(mcp_server_module.TldwMCPServer)
+    instance._init_databases()
+
+    fake_mcp = _RecordingFastMCP()
+    instance.mcp = fake_mcp
+    instance._register_tools()
+
+    return instance, fake_mcp
+
+
+@pytest.mark.asyncio
+async def test_create_note_and_search_notes_work_end_to_end(
+    _isolated_profile, monkeypatch
+):
+    """AC: create_note and search_notes work end to end against a temp DB."""
+    instance, fake_mcp = _build_server_with_real_notes_tools(monkeypatch)
+
+    create_note = fake_mcp.tools["create_note"]
+    search_notes = fake_mcp.tools["search_notes"]
+
+    created = await create_note(
+        title="Grocery List", content="Buy oat milk and coffee beans"
+    )
+    assert "error" not in created
+    assert created["title"] == "Grocery List"
+    assert created["id"]
+
+    results = await search_notes(query="oat milk", limit=10)
+    assert results, f"expected a match, got: {results}"
+    assert not any("error" in r for r in results)
+
+    match = next(r for r in results if r["id"] == created["id"])
+    assert match["title"] == "Grocery List"
+    assert "Buy oat milk" in match["preview"]
+    assert match["created"] is not None
+    assert match["modified"] is not None
+
+
+@pytest.mark.asyncio
+async def test_create_note_tool_no_longer_accepts_tags_or_template(
+    _isolated_profile, monkeypatch
+):
+    """Regression guard: ``tags``/``template`` are gone from the tool schema.
+
+    Neither parameter maps to anything ``NotesInteropService.add_note`` (or
+    the ``notes`` table) actually supports -- passing them used to be
+    silently accepted syntax that still failed at the (nonexistent)
+    ``create_note`` method call.
+    """
+    import inspect
+
+    instance, fake_mcp = _build_server_with_real_notes_tools(monkeypatch)
+
+    create_note = fake_mcp.tools["create_note"]
+    parameters = set(inspect.signature(create_note).parameters)
+
+    assert parameters == {"title", "content"}
+
+
+def test_notes_service_is_constructed_with_the_real_signature(
+    _isolated_profile, monkeypatch
+):
+    """Regression guard for the exact bug: the service must construct
+    without needing a permissive fake (unlike the pre-fix tests in
+    ``test_server_media_db_path.py`` / ``test_server_character_service.py``,
+    which had to stub ``NotesInteropService`` out entirely because the real
+    class rejected the old call shape).
+    """
+    from tldw_chatbook.Notes.Notes_Library import NotesInteropService
+
+    instance, _fake_mcp = _build_server_with_real_notes_tools(monkeypatch)
+
+    assert isinstance(instance.notes_service, NotesInteropService)
+    assert instance.notes_service.unified_db_template is instance.chachanotes_db

--- a/Tests/MCP/test_tools_resources_prompts_real_methods.py
+++ b/Tests/MCP/test_tools_resources_prompts_real_methods.py
@@ -1,0 +1,245 @@
+"""TASK-983 module-pass follow-ups: sibling defects of the same shape found
+while auditing MCP/server.py's notes tools, in the collaborator modules its
+tool handlers delegate to (MCP/tools.py, MCP/resources.py, MCP/prompts.py).
+
+Each of these called a method or config key that does not exist, exactly
+the pattern TASK-854/968/983 already fixed elsewhere in this package:
+
+- ``MCPTools.chat_with_character`` read the API key via a direct
+  ``get_cli_setting("API", f"{provider}_api_key", "")`` call instead of the
+  declared ``config.get_api_key()`` accessor (the same defect TASK-968 fixed
+  in ``server.py``'s ``chat_with_llm``, in a different call site).
+- ``MCPResources.list_recent_conversations`` / ``.list_recent_notes`` called
+  ``get_recent_conversations`` / ``get_recent_notes``, neither of which
+  exists on ``CharactersRAGDB``.
+- ``MCPResources.get_media_resource`` and ``MCPPrompts.analyze_media_prompt``
+  called ``media_db.get_media_transcript(media_id)`` (singular), which never
+  existed as an instance method -- the real accessor is the module-level
+  ``get_media_transcripts`` (plural).
+- ``MCPPrompts.summarize_conversation_prompt`` / ``.generate_document_prompt``
+  called ``get_conversation_messages``, which never existed on
+  ``CharactersRAGDB`` (the real method is ``get_messages_for_conversation``,
+  already fixed at the identical call shape in ``tools.py``/``resources.py``).
+
+A related, wider defect surfaced while fixing the above and writing these
+tests: ``MCPResources``/``MCPPrompts`` read several dict keys that do not
+match the real row shape at all (not missing methods -- wrong column
+names), each silently returning ``KeyError`` or (via ``.get()``) a
+permanently empty value:
+
+- ``media['media_type']`` / ``media['created_at']`` -- the ``Media`` table's
+  real columns are ``type`` and ``ingestion_date``.
+- ``char.get('greeting')`` / ``char.get('example_dialogue')`` /
+  ``char.get('updated_at')`` -- ``character_cards``' real columns are
+  ``first_message``, ``message_example``, and ``last_modified``.
+- ``conv.get('updated_at')`` / ``note.get('updated_at')`` -- both tables
+  have ``last_modified``, not ``updated_at``.
+
+All fixed alongside the notes-tool fix since they're the identical
+unambiguous shape (a real column exists with the obviously-intended
+value); ``tags``/``template`` on notes and ``message_count`` on characters
+are a different, non-mechanical case (no such column/aggregation exists at
+all) and are called out in TASK-983's Implementation Notes rather than
+guessed at here.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+from pathlib import Path
+
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
+
+
+def _real_dbs(tmp_path: Path) -> tuple[CharactersRAGDB, MediaDatabase]:
+    chachanotes_db = CharactersRAGDB(
+        str(tmp_path / "chachanotes.sqlite"), "test_client"
+    )
+    media_db = MediaDatabase(str(tmp_path / "media.sqlite"), "test_client")
+    return chachanotes_db, media_db
+
+
+def _seed_transcript(media_db: MediaDatabase, media_id: int, text: str) -> None:
+    """Insert a Transcripts row directly -- no public "add transcript"
+    method exists on MediaDatabase; ingestion normally writes this table
+    through the transcription pipeline, out of scope here."""
+    media_db.execute_query(
+        """
+        INSERT INTO Transcripts
+            (media_id, whisper_model, transcription, created_at, uuid,
+             last_modified, version, client_id, deleted)
+        VALUES (?, 'test-model', ?, datetime('now'), ?, datetime('now'), 1,
+                'test_client', 0)
+        """,
+        (media_id, text, f"transcript-uuid-{media_id}"),
+        commit=True,
+    )
+
+
+def test_chat_with_character_uses_the_declared_api_key_accessor():
+    """AST check mirroring test_server_character_service.py's identical
+    check for server.py's chat_with_llm: this sibling call site in
+    MCP/tools.py must go through get_api_key(), not get_cli_setting()."""
+    import tldw_chatbook.MCP.tools as tools_module
+
+    source = Path(tools_module.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    called_names = {
+        getattr(node.func, "attr", None) or getattr(node.func, "id", None)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+    }
+    assert "get_api_key" in called_names
+    assert "get_cli_setting" not in called_names
+
+    imported_names = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        for alias in node.names
+    }
+    assert "get_api_key" in imported_names
+    assert "get_cli_setting" not in imported_names
+
+
+def test_list_recent_conversations_executes_against_real_db(tmp_path):
+    from tldw_chatbook.MCP.resources import MCPResources
+
+    chachanotes_db, media_db = _real_dbs(tmp_path)
+    resources = MCPResources(chachanotes_db, media_db)
+
+    chachanotes_db.add_conversation({"title": "Recent Conversation"})
+
+    result = asyncio.run(resources.list_recent_conversations(limit=5))
+
+    assert result, "expected the seeded conversation to be listed"
+    assert result[0]["name"] == "Recent Conversation"
+    assert result[0]["uri"].startswith("conversation://")
+
+
+def test_list_recent_notes_executes_against_real_db(tmp_path):
+    from tldw_chatbook.MCP.resources import MCPResources
+
+    chachanotes_db, media_db = _real_dbs(tmp_path)
+    resources = MCPResources(chachanotes_db, media_db)
+
+    chachanotes_db.add_note(title="Recent Note", content="Some content")
+
+    result = asyncio.run(resources.list_recent_notes(limit=5))
+
+    assert result, "expected the seeded note to be listed"
+    assert result[0]["name"] == "Recent Note"
+    assert result[0]["uri"].startswith("note://")
+
+
+def test_get_character_resource_uses_the_real_character_card_columns(tmp_path):
+    """Regression guard for the wrong-column-name defects found alongside
+    the notes-tool fix: `greeting`/`example_dialogue`/`updated_at` never
+    matched `character_cards`' real `first_message`/`message_example`/
+    `last_modified` columns."""
+    from tldw_chatbook.MCP.resources import MCPResources
+
+    chachanotes_db, media_db = _real_dbs(tmp_path)
+    resources = MCPResources(chachanotes_db, media_db)
+
+    character_id = chachanotes_db.add_character_card(
+        {
+            "name": "Test Character",
+            "first_message": "Hello, traveler!",
+            "message_example": "<START>\n{{user}}: Hi\n{{char}}: Hello!",
+        }
+    )
+
+    result = asyncio.run(resources.get_character_resource(str(character_id)))
+
+    assert result["name"] != "Error"
+    assert "Hello, traveler!" in result["content"]
+    assert "<START>" in result["content"]
+    assert result["metadata"]["updated"] is not None
+
+
+def test_get_media_resource_surfaces_the_most_recent_transcript(tmp_path):
+    from tldw_chatbook.MCP.resources import MCPResources
+
+    chachanotes_db, media_db = _real_dbs(tmp_path)
+    resources = MCPResources(chachanotes_db, media_db)
+
+    media_id, _uuid, _msg = media_db.add_media_with_keywords(
+        title="Test Media", media_type="video", content="fallback content"
+    )
+    _seed_transcript(media_db, media_id, "This is the real transcript text.")
+
+    result = asyncio.run(resources.get_media_resource(str(media_id)))
+
+    assert result["name"] != "Error"
+    assert "This is the real transcript text." in result["content"]
+
+
+def test_analyze_media_prompt_surfaces_the_most_recent_transcript(tmp_path):
+    from tldw_chatbook.MCP.prompts import MCPPrompts
+
+    chachanotes_db, media_db = _real_dbs(tmp_path)
+    prompts = MCPPrompts(chachanotes_db, media_db)
+
+    media_id, _uuid, _msg = media_db.add_media_with_keywords(
+        title="Test Media", media_type="video", content="fallback content"
+    )
+    _seed_transcript(media_db, media_id, "This is the real transcript text.")
+
+    result = asyncio.run(prompts.analyze_media_prompt(media_id))
+
+    assert len(result) == 1
+    assert "This is the real transcript text." in result[0]["content"]
+
+
+def test_summarize_conversation_prompt_executes_against_real_db(tmp_path):
+    from tldw_chatbook.MCP.prompts import MCPPrompts
+
+    chachanotes_db, media_db = _real_dbs(tmp_path)
+    prompts = MCPPrompts(chachanotes_db, media_db)
+
+    conversation_id = chachanotes_db.add_conversation({"title": "Test Conversation"})
+    chachanotes_db.add_message(
+        {
+            "conversation_id": conversation_id,
+            "sender": "user",
+            "content": "Hello there",
+            "role": "user",
+        }
+    )
+
+    result = asyncio.run(
+        prompts.summarize_conversation_prompt(conversation_id, style="concise")
+    )
+
+    assert len(result) == 1
+    assert "get_conversation_messages" not in result[0]["content"]
+    assert "Hello there" in result[0]["content"]
+
+
+def test_generate_document_prompt_executes_against_real_db(tmp_path):
+    from tldw_chatbook.MCP.prompts import MCPPrompts
+
+    chachanotes_db, media_db = _real_dbs(tmp_path)
+    prompts = MCPPrompts(chachanotes_db, media_db)
+
+    conversation_id = chachanotes_db.add_conversation({"title": "Test Conversation"})
+    chachanotes_db.add_message(
+        {
+            "conversation_id": conversation_id,
+            "sender": "user",
+            "content": "Hello there",
+            "role": "user",
+        }
+    )
+
+    result = asyncio.run(
+        prompts.generate_document_prompt(conversation_id, doc_type="summary")
+    )
+
+    assert len(result) == 1
+    assert "get_conversation_messages" not in result[0]["content"]
+    assert "Hello there" in result[0]["content"]

--- a/backlog/tasks/task-983 - Fix-the-MCP-notes-tools-calling-a-service-API-that-does-not-exist.md
+++ b/backlog/tasks/task-983 - Fix-the-MCP-notes-tools-calling-a-service-API-that-does-not-exist.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-983
 title: Fix the MCP notes tools calling a service API that does not exist
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-27 19:33'
+updated_date: '2026-07-27 20:09'
 labels:
   - mcp
   - notes
@@ -19,5 +21,38 @@ MCP/server.py constructs NotesInteropService(self.chachanotes_db) with the wrong
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 MCP notes tools call a real NotesInteropService API with correct arguments,create_note and search_notes work end to end against a temp database,A test exercises both tools rather than only importing the module,The module has no remaining reference to a service or method that does not exist
+- [x] #1 MCP notes tools call a real NotesInteropService API with correct arguments,create_note and search_notes work end to end against a temp database,A test exercises both tools rather than only importing the module,The module has no remaining reference to a service or method that does not exist
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Read the real NotesInteropService (Notes/Notes_Library.py) and the already-working construction pattern in Tools/note_management_tools.py and app.py.
+2. Fix TldwMCPServer._init_databases()'s NotesInteropService construction to the real (base_db_directory, api_client_id, global_db_to_use) signature.
+3. Rewrite create_note/search_notes tool bodies to call add_note/search_notes with the real keyword arguments and dict-based results, dropping the unsupported tags/template parameters.
+4. Add an end-to-end regression test (Tests/MCP/test_server_notes_service.py) against a temp on-disk DB, bypassing __init__ via __new__ the way the TASK-854/968 tests do.
+5. Do a deliberate pass over the rest of MCP/server.py and its collaborator modules (tools.py, resources.py, prompts.py) for the same defect shape; fix what is unambiguous, file what needs a design decision.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed TldwMCPServer._init_databases() constructing NotesInteropService(self.chachanotes_db) -- one positional arg bound to the real class's base_db_directory parameter -- to the real (base_db_directory, api_client_id, global_db_to_use) signature, matching the already-working construction in Tools/note_management_tools.py/app.py: base_db_directory=get_chachanotes_db_path().parent, api_client_id=CLI_APP_CLIENT_ID, global_db_to_use=self.chachanotes_db (reuses this process's own DB handle instead of opening a second one).
+
+Rewrote the create_note and search_notes tool bodies: create_note now calls notes_service.add_note(user_id=, title=, content=) -- the real method; create_note does not exist on the class. Dropped the tags/template parameters entirely: neither NotesInteropService nor the notes table has any such concept (tags/template were never real, just assumed). search_notes now calls notes_service.search_notes(user_id=, search_term=, limit=) -- the old call passed query=/limit= with no user_id (a TypeError on the real signature) -- and reads results as dicts (note.get("id")/note.get("last_modified")) instead of attribute access (note.id/note.updated_at, an AttributeError either way; the real column is last_modified, not updated_at). user_id is resolved via a new _resolve_notes_user_id() helper mirroring Tools/note_management_tools.py's _resolve_user_id (load_settings()["USERS_NAME"] or "default_user" -- an attribution value, not a visibility partition).
+
+Proved it end to end (not just import) in Tests/MCP/test_server_notes_service.py: bypasses __init__ via __new__ (same technique test_server_media_db_path.py/test_server_character_service.py use), runs the real _init_databases(), swaps a recording fake in for FastMCP so the actual create_note/search_notes closures can be captured and called, and creates+searches a note against a temp on-disk DB with HOME/TLDW_CONFIG_PATH redirected to a temp profile. 3/3 pass; the notes-service construction no longer needs the _PermissiveFakeService stub the TASK-854/968 tests used (their own docstrings updated to note this, stub kept there anyway to keep those files' scope narrow).
+
+Whole-module pass (as asked, not just server.py's notes tools) turned up more of the identical defect shape in server.py's collaborator modules and fixed what was unambiguous (a real column/method exists with the obviously-intended value/semantics, no design call needed):
+- tools.py::chat_with_character: get_cli_setting("API", f"{provider}_api_key", "") -> get_api_key(provider) (same defect TASK-968 fixed in server.py's chat_with_llm, sibling call site missed).
+- resources.py::list_recent_conversations/list_recent_notes: get_recent_conversations/get_recent_notes (neither exists on CharactersRAGDB) -> list_all_active_conversations(limit=)/list_notes(limit=) (both already ordered by recency).
+- resources.py::get_media_resource + prompts.py::analyze_media_prompt: media_db.get_media_transcript(media_id) (never existed) -> the module-level get_media_transcripts(db, media_id), most-recent transcript taken.
+- prompts.py::summarize_conversation_prompt/generate_document_prompt: get_conversation_messages (never existed) -> get_messages_for_conversation(str(id)) (same fix already applied at the identical call shape in tools.py/resources.py).
+- Wrong-dict-key defects (not missing methods -- wrong column names), found because they made my own new tests fail: media['media_type']/media['created_at'] (Media's real columns are type/ingestion_date) in both resources.py and prompts.py; char.get('greeting')/char.get('example_dialogue')/char.get('updated_at') (character_cards' real columns are first_message/message_example/last_modified) and conv.get('updated_at')/note.get('updated_at') (both last_modified, not updated_at) in resources.py. All fixed; covered by new tests in Tests/MCP/test_tools_resources_prompts_real_methods.py (8 tests).
+
+Left un-fixed, needs a design decision, filed as TASK-985: tools.py::search_conversations calls chachanotes_db.search_all_content(...), which does not exist anywhere in the codebase; the real equivalent (search_conversations_by_content) returns conversation rows with no inline "content" column, so the tool's preview formatting can't be ported without deciding what a preview should show instead. resources.py::get_rag_chunk_resource calls media_db.get_chunk_by_id(int(chunk_id)), which also does not exist; the real accessor (get_chunk_text) takes a UUID string not an int id and returns bare text with no media_id/start_char/end_char/embedding_id (UnvectorizedMediaChunks has no embedding_id column at all) -- the resource's whole id scheme and metadata contract need reconciling, not guessing.
+
+Noted but not fixed (harmless, always-empty via .get() defaults, no crash, a feature that was never built rather than a bug): notes have no tags/template columns (resources.py::get_note_resource's tags/template metadata always empty); character_cards has no message_count (tools.py::list_available_characters / resources.py::get_character_resource always report 0); Media has no duration column (resources.py::get_media_resource's duration metadata always empty).
+
+Modified: tldw_chatbook/MCP/server.py, tldw_chatbook/MCP/tools.py, tldw_chatbook/MCP/resources.py, tldw_chatbook/MCP/prompts.py. Added: Tests/MCP/test_server_notes_service.py, Tests/MCP/test_tools_resources_prompts_real_methods.py. Updated stale scope-disclaimer comments in Tests/MCP/test_server_media_db_path.py and test_server_character_service.py now that the NotesInteropService construction they used to have to stub around is fixed for real. Filed TASK-985 for the two remaining defects that need a design call. Full Tests/MCP/ suite: 377 passed.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-985 - MCP-search_conversations-and-RAG-chunk-resource-call-APIs-that-do-not-exist.md
+++ b/backlog/tasks/task-985 - MCP-search_conversations-and-RAG-chunk-resource-call-APIs-that-do-not-exist.md
@@ -1,0 +1,26 @@
+---
+id: TASK-985
+title: MCP search_conversations and RAG chunk resource call APIs that do not exist
+status: To Do
+assignee: []
+created_date: '2026-07-27 20:05'
+labels:
+  - mcp
+  - bug
+  - notes-followup
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-983's whole-module pass over MCP/server.py's collaborator modules (tools.py, resources.py, prompts.py) found two more call sites of the same shape as TASK-854/968/983, deliberately left unfixed because resolving them needs a design call rather than a mechanical rename. MCPTools.search_conversations (backing server.py's search_conversations tool) calls self.chachanotes_db.search_all_content(search_query=, content_type=, limit=), a method that does not exist anywhere in the codebase at all, so the tool cannot work. The nearest real equivalent, CharactersRAGDB.search_conversations_by_content(search_query, limit), returns conversation rows with no inline content column, so the tool's current preview formatting (result["content"][:200]) cannot be ported as-is -- what the preview should be sourced from instead is a product decision. MCPResources.get_rag_chunk_resource (backing the rag-chunk://{chunk_id} MCP resource) calls self.media_db.get_chunk_by_id(int(chunk_id)), a method that also does not exist; the nearest real accessor, the module-level get_chunk_text(db_instance, chunk_uuid), takes a UUID string rather than an integer id and returns only bare chunk text, with no media_id/start_char/end_char/embedding_id metadata (UnvectorizedMediaChunks has no embedding_id column at all) -- so both the resource's id scheme and its promised metadata need to be reconciled with what the database can actually provide, not guessed at.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 MCPTools.search_conversations calls a real CharactersRAGDB method with arguments that actually exist and its formatted preview field is sourced from real data per a deliberate decision (not guessed)
+- [ ] #2 MCPResources.get_rag_chunk_resource calls a real MediaDatabase accessor with an identifier scheme and returned metadata fields that are reconciled with what the database can actually provide
+- [ ] #3 A test exercises both fixed tool/resource paths end to end against a temp database rather than only importing the module
+<!-- AC:END -->

--- a/tldw_chatbook/MCP/prompts.py
+++ b/tldw_chatbook/MCP/prompts.py
@@ -10,7 +10,7 @@ from loguru import logger
 
 # Import tldw_chatbook components
 from ..DB.ChaChaNotes_DB import CharactersRAGDB
-from ..DB.Client_Media_DB_v2 import MediaDatabase
+from ..DB.Client_Media_DB_v2 import MediaDatabase, get_media_transcripts
 
 # `get_character_by_id` was never a standalone function in
 # Character_Chat_Lib.py; `CharactersRAGDB.get_character_card_by_id()` is
@@ -50,8 +50,15 @@ class MCPPrompts:
                     }
                 ]
 
-            # Get messages
-            messages = self.chachanotes_db.get_conversation_messages(conversation_id)
+            # Get messages. `get_conversation_messages` never existed on
+            # CharactersRAGDB; the real method is
+            # `get_messages_for_conversation`, which takes a string
+            # conversation id and already excludes soft-deleted
+            # messages/conversations (same fix already applied to the
+            # identical call shape in tools.py/resources.py).
+            messages = self.chachanotes_db.get_messages_for_conversation(
+                str(conversation_id)
+            )
 
             # Build conversation text
             conversation_text = f"Title: {conv['title']}\n\n"
@@ -114,8 +121,11 @@ class MCPPrompts:
                     }
                 ]
 
-            # Get messages
-            messages = self.chachanotes_db.get_conversation_messages(conversation_id)
+            # Get messages (see summarize_conversation_prompt for why this
+            # is get_messages_for_conversation, not get_conversation_messages).
+            messages = self.chachanotes_db.get_messages_for_conversation(
+                str(conversation_id)
+            )
 
             # Build conversation text
             conversation_text = ""
@@ -170,13 +180,22 @@ class MCPPrompts:
                     {"role": "user", "content": f"Error: Media {media_id} not found"}
                 ]
 
-            # Get transcript or content
-            content = self.media_db.get_media_transcript(media_id) or media.get(
-                "content", ""
-            )
+            # Get transcript or content. `get_media_transcript` (singular)
+            # never existed as an instance method on MediaDatabase; the real
+            # accessor is the module-level `get_media_transcripts` (plural),
+            # returning every active transcript ordered newest first --
+            # take the most recent, matching this call site's original
+            # single-value assumption (see MCPResources.get_media_resource
+            # for the identical fix).
+            transcripts = get_media_transcripts(self.media_db, media_id)
+            content = (
+                transcripts[0]["transcription"] if transcripts else None
+            ) or media.get("content", "")
 
-            # Build prompt based on analysis type
-            prompt = f"Please analyze the following {media['media_type']} content"
+            # Build prompt based on analysis type. The Media table's own
+            # column is `type`, not `media_type` -- `media['media_type']`
+            # raised KeyError on every real row.
+            prompt = f"Please analyze the following {media['type']} content"
 
             if analysis_type == "summary":
                 prompt += " and provide a summary"

--- a/tldw_chatbook/MCP/resources.py
+++ b/tldw_chatbook/MCP/resources.py
@@ -10,7 +10,7 @@ from loguru import logger
 
 # Import tldw_chatbook components
 from ..DB.ChaChaNotes_DB import CharactersRAGDB
-from ..DB.Client_Media_DB_v2 import MediaDatabase
+from ..DB.Client_Media_DB_v2 import MediaDatabase, get_media_transcripts
 
 # `get_note_by_id` (tldw_chatbook.Notes.Notes_Library) and
 # `get_character_by_id` (tldw_chatbook.Character_Chat.Character_Chat_Lib)
@@ -84,7 +84,9 @@ class MCPResources:
                 "content": content,
                 "metadata": {
                     "created": conv["created_at"],
-                    "updated": conv.get("updated_at"),
+                    # conversations has `last_modified`, not `updated_at`
+                    # -- `.get("updated_at")` always returned None.
+                    "updated": conv.get("last_modified"),
                     "character_id": conv.get("character_id"),
                     "message_count": len(messages),
                 },
@@ -126,8 +128,11 @@ class MCPResources:
                 content += f"*Tags: {tags}*\n\n"
 
             content += f"*Created: {note['created_at']}*\n"
-            if note.get("updated_at"):
-                content += f"*Updated: {note['updated_at']}*\n"
+            # notes has `last_modified`, not `updated_at` -- the old
+            # `.get("updated_at")` always returned None/falsy, so the
+            # "Updated" line never rendered for any real note.
+            if note.get("last_modified"):
+                content += f"*Updated: {note['last_modified']}*\n"
 
             content += "\n---\n\n"
             content += note["content"]
@@ -139,7 +144,15 @@ class MCPResources:
                 "content": content,
                 "metadata": {
                     "created": note["created_at"],
-                    "updated": note.get("updated_at"),
+                    "updated": note.get("last_modified"),
+                    # `tags`/`template`: the `notes` table has neither
+                    # column -- notes have no tagging or template concept
+                    # in this schema (keyword/tag *linking* is a separate,
+                    # unrelated API, `link_note_to_keyword`, this resource
+                    # never called). Left as always-empty defaults rather
+                    # than removed outright: whether to surface linked
+                    # keywords here instead is a product decision, not a
+                    # bug fix (see TASK-983's Implementation Notes).
                     "tags": note.get("tags", []),
                     "template": note.get("template"),
                 },
@@ -185,11 +198,14 @@ class MCPResources:
             if char.get("scenario"):
                 content += f"## Scenario\n\n{char['scenario']}\n\n"
 
-            if char.get("greeting"):
-                content += f"## Greeting\n\n{char['greeting']}\n\n"
+            # character_cards' real columns are `first_message` and
+            # `message_example` -- `char.get("greeting")` /
+            # `char.get("example_dialogue")` never matched anything.
+            if char.get("first_message"):
+                content += f"## Greeting\n\n{char['first_message']}\n\n"
 
-            if char.get("example_dialogue"):
-                content += f"## Example Dialogue\n\n{char['example_dialogue']}\n\n"
+            if char.get("message_example"):
+                content += f"## Example Dialogue\n\n{char['message_example']}\n\n"
 
             # Add metadata
             content += "\n---\n\n"
@@ -202,7 +218,8 @@ class MCPResources:
                 "content": content,
                 "metadata": {
                     "created": char["created_at"],
-                    "updated": char.get("updated_at"),
+                    # character_cards has `last_modified`, not `updated_at`.
+                    "updated": char.get("last_modified"),
                     "message_count": char.get("message_count", 0),
                 },
             }
@@ -236,13 +253,25 @@ class MCPResources:
                     "content": "Media not found",
                 }
 
-            # Get transcript/content
-            transcript = self.media_db.get_media_transcript(int(media_id))
+            # Get transcript/content. `get_media_transcript` (singular)
+            # never existed as an instance method on MediaDatabase; the real
+            # accessor is the module-level `get_media_transcripts` (plural),
+            # which returns every active transcript row ordered newest
+            # first -- take the most recent one, matching this call site's
+            # original single-value assumption.
+            transcripts = get_media_transcripts(self.media_db, int(media_id))
+            transcript = transcripts[0]["transcription"] if transcripts else None
 
-            # Format content
+            # Format content. The Media table's own column is `type`, not
+            # `media_type` -- `media['media_type']` raised KeyError on
+            # every real row (the "media_type" name is this tool's own
+            # output-field naming, applied below, not the DB column).
+            # The Media table's own column is `ingestion_date` -- there is
+            # no `created_at` column at all -- `media['created_at']`
+            # raised KeyError on every real row.
             content = f"# {media['title']}\n\n"
-            content += f"*Type: {media['media_type']}*\n"
-            content += f"*Created: {media['created_at']}*\n\n"
+            content += f"*Type: {media['type']}*\n"
+            content += f"*Created: {media['ingestion_date']}*\n\n"
 
             if media.get("url"):
                 content += f"**Source**: {media['url']}\n\n"
@@ -262,9 +291,9 @@ class MCPResources:
                 "mimeType": "text/markdown",
                 "content": content,
                 "metadata": {
-                    "media_type": media["media_type"],
+                    "media_type": media["type"],
                     "url": media.get("url"),
-                    "created": media["created_at"],
+                    "created": media["ingestion_date"],
                     "duration": media.get("duration"),
                     "author": media.get("author"),
                 },
@@ -342,7 +371,14 @@ class MCPResources:
             List of resource references
         """
         try:
-            conversations = self.chachanotes_db.get_recent_conversations(limit=limit)
+            # `get_recent_conversations` never existed on CharactersRAGDB.
+            # `list_all_active_conversations` is the real, already-ordered
+            # equivalent ("more recently active or created conversations
+            # appear first", per its own docstring) -- same `limit` kwarg,
+            # same id/title/created_at fields used below.
+            conversations = self.chachanotes_db.list_all_active_conversations(
+                limit=limit
+            )
 
             resources = []
             for conv in conversations:
@@ -371,7 +407,11 @@ class MCPResources:
             List of resource references
         """
         try:
-            notes = self.chachanotes_db.get_recent_notes(limit=limit)
+            # `get_recent_notes` never existed on CharactersRAGDB.
+            # `list_notes` is the real, already-ordered equivalent (`last_modified
+            # DESC`, per its own index/query) -- same `limit` kwarg, same
+            # id/title/created_at fields used below.
+            notes = self.chachanotes_db.list_notes(limit=limit)
 
             resources = []
             for note in notes:

--- a/tldw_chatbook/MCP/server.py
+++ b/tldw_chatbook/MCP/server.py
@@ -27,6 +27,37 @@ except ImportError:
 from loguru import logger  # noqa: E402
 
 
+#: Matches ``Tools/note_management_tools.py``'s ``_DEFAULT_USER_ID`` /
+#: ``config.py``'s ``default_users_name_fallback``, so an unconfigured user
+#: sees the same attribution the rest of the app uses.
+_DEFAULT_NOTES_USER_ID = "default_user"
+
+
+def _resolve_notes_user_id() -> str:
+    """Return the id notes created/searched via MCP should be attributed to.
+
+    This is an ATTRIBUTION value, not a visibility partition: the ``notes``
+    table has no user column, and ``NotesInteropService`` documents that the
+    ``user_id`` it's given is used as the underlying ``CharactersRAGDB``
+    instance's ``client_id`` -- the column sync and conflict resolution key
+    off, not a per-user filter. Mirrors
+    ``Tools/note_management_tools.py::_resolve_user_id`` (same source, same
+    fallback), duplicated locally rather than imported so this module keeps
+    no reach-through into an unrelated tool-catalog module for one helper.
+
+    Returns:
+        The configured user id, or ``"default_user"`` if settings cannot be
+        read.
+    """
+    from ..config import load_settings
+
+    try:
+        return load_settings().get("USERS_NAME") or _DEFAULT_NOTES_USER_ID
+    except Exception as e:  # noqa: BLE001 - a tool must not crash on config
+        logger.warning(f"Could not resolve USERS_NAME, using default: {e}")
+        return _DEFAULT_NOTES_USER_ID
+
+
 def _first_doc_line(value: str | None) -> str:
     if not value:
         return ""
@@ -172,7 +203,25 @@ class TldwMCPServer:
             # (``get_character_card_by_id`` / ``list_character_cards``) --
             # so the dead reference was removed rather than resolved to a
             # real service.
-            self.notes_service = NotesInteropService(self.chachanotes_db)
+            # ``NotesInteropService.__init__`` takes (base_db_directory,
+            # api_client_id, global_db_to_use=None) -- it used to be
+            # constructed here with a single positional arg
+            # (``self.chachanotes_db``, a ``CharactersRAGDB``, bound to the
+            # ``base_db_directory: Union[str, Path]`` parameter), so every
+            # construction raised before the server could open a single
+            # database connection (TASK-983). Mirrors the already-working
+            # construction in ``Tools/note_management_tools.py`` and
+            # ``app.py``: the *parent directory* of the unified DB file as
+            # ``base_db_directory`` (used only to verify the directory is
+            # trusted), this server's own app-wide client id as
+            # ``api_client_id``, and the already-open ``self.chachanotes_db``
+            # handle as ``global_db_to_use`` so the service reuses this
+            # process's connection instead of opening a second one.
+            self.notes_service = NotesInteropService(
+                base_db_directory=get_chachanotes_db_path().parent,
+                api_client_id=CLI_APP_CLIENT_ID,
+                global_db_to_use=self.chachanotes_db,
+            )
 
             logger.info("Databases initialized successfully")
         except Exception as e:
@@ -286,17 +335,23 @@ class TldwMCPServer:
         async def create_note(
             title: str,
             content: str,
-            tags: Optional[List[str]] = None,
-            template: Optional[str] = None,
         ) -> Dict[str, Any]:
-            """Create a new note."""
+            """Create a new note.
+
+            ``tags`` and ``template`` were dropped from this tool's
+            signature (TASK-983): ``NotesInteropService.add_note`` -- the
+            real method, ``create_note`` does not exist on the class -- has
+            no such parameters, and the ``notes`` table it wraps has no
+            tags column and no template concept at all. Keyword/tag linking
+            is a separate, unrelated API (``link_note_to_keyword``) this
+            tool never actually called even before the fix.
+            """
             try:
                 note_id = await asyncio.to_thread(
-                    self.notes_service.create_note,
+                    self.notes_service.add_note,
+                    user_id=_resolve_notes_user_id(),
                     title=title,
                     content=content,
-                    tags=tags or [],
-                    template=template,
                 )
                 return {
                     "id": note_id,
@@ -312,18 +367,31 @@ class TldwMCPServer:
         async def search_notes(query: str, limit: int = 10) -> List[Dict[str, Any]]:
             """Search notes by content or title."""
             try:
+                # NotesInteropService.search_notes(user_id, search_term, limit)
+                # returns a list of plain dicts (the notes table's own
+                # columns: id/title/content/created_at/last_modified), not
+                # objects with attribute access -- this used to call
+                # ``query=``/``limit=`` with no ``user_id`` at all (a
+                # TypeError on the real signature) and then read
+                # ``note.id``/``note.updated_at`` off the result, an
+                # AttributeError on a dict either way. ``last_modified`` is
+                # the real column name; the notes table has no
+                # ``updated_at`` column (TASK-983).
                 results = await asyncio.to_thread(
-                    self.notes_service.search_notes, query=query, limit=limit
+                    self.notes_service.search_notes,
+                    user_id=_resolve_notes_user_id(),
+                    search_term=query,
+                    limit=limit,
                 )
                 return [
                     {
-                        "id": note.id,
-                        "title": note.title,
-                        "preview": note.content[:200] + "..."
-                        if len(note.content) > 200
-                        else note.content,
-                        "created": note.created_at,
-                        "modified": note.updated_at,
+                        "id": note.get("id"),
+                        "title": note.get("title"),
+                        "preview": note.get("content", "")[:200] + "..."
+                        if len(note.get("content", "")) > 200
+                        else note.get("content", ""),
+                        "created": note.get("created_at"),
+                        "modified": note.get("last_modified"),
                     }
                     for note in results
                 ]

--- a/tldw_chatbook/MCP/tools.py
+++ b/tldw_chatbook/MCP/tools.py
@@ -12,7 +12,7 @@ import json
 from loguru import logger
 
 # Import tldw_chatbook components
-from ..config import get_cli_setting
+from ..config import get_api_key
 from ..DB.ChaChaNotes_DB import CharactersRAGDB
 from ..DB.Client_Media_DB_v2 import MediaDatabase
 from ..RAG_Search.simplified.search_service import SimplifiedRAGSearchService
@@ -85,8 +85,15 @@ class MCPTools:
             if not character:
                 return {"error": f"Character {character_id} not found"}
 
-            # Get API key
-            api_key = get_cli_setting("API", f"{provider.lower()}_api_key", "")
+            # Get API key. `get_api_key()` is the declared accessor: it
+            # checks the newer api_settings.<provider> structure, then the
+            # legacy [API] section, then a bare env var -- a direct
+            # get_cli_setting("API", ...) lookup only covered the middle
+            # tier and silently missed a key configured either of the other
+            # two ways (same defect TASK-968 fixed in server.py's
+            # chat_with_llm; this sibling call site in the same MCP module
+            # had the identical shape).
+            api_key = get_api_key(provider)
             if not api_key:
                 return {"error": f"No API key configured for {provider}"}
 


### PR DESCRIPTION
Closes TASK-983. Closes TASK-962 as already-fixed. Final loose ends of the path-naming audit series (#985, #996, #999, #1000, #1005, #1011).

## TASK-983 — wire, don't remove

`MCP/server.py` constructed `NotesInteropService` with the wrong argument count and type, and its `create_note`/`search_notes` tools called methods and keyword arguments the real class does not define, so those tools could not work.

**Decision: wire.** `Tools/note_management_tools.py` already contains a working `NotesInteropService` implementation of this exact feature — the feature is finished, it was just wired wrong here. Fixed the constructor call and repointed the tools at the real `add_note`/`search_notes` with genuine kwargs and dict-based results, dropping fictional `tags`/`template` parameters that were never supported. Proved end to end against a temp database rather than by importing the module.

## The module pass — the point of the task

This was the **third** defect of one shape in this module. The other two: a config key `media_db` that does not exist, so it silently opened `./media_library.db` relative to the current working directory instead of the real media database (TASK-854); and a `CharacterInteropService` that was never implemented anywhere (TASK-968). Three of a kind meant the module deserved a deliberate pass, not another one-at-a-time fix.

Found and fixed, all the same shape — code that reads as working and cannot run:
- `chat_with_character`'s stale API-key lookup, bypassing the declared accessor
- `list_recent_conversations` and `list_recent_notes` calling methods that do not exist
- `get_media_transcript` (singular — never existed) in two places
- `get_conversation_messages` (never existed) in two places
- Several wrong dict-key accesses — `media['media_type']`/`created_at`, character `greeting`/`example_dialogue`/`updated_at`, conversation and note `updated_at` — which only surfaced once tests ran against real seeded rows rather than mocks

That last group is worth noting: they were invisible until something exercised the code with real data. Import-only tests would have stayed green.

**Filed TASK-985** for two that need a design decision rather than a guess: `search_conversations`'s `search_all_content` (the replacement has no content column to preview from) and `get_rag_chunk_resource`'s `get_chunk_by_id` (the replacement keys on UUID, not an int id, and no `embedding_id` column exists).

## TASK-962 — already fixed on dev

`_save_raw_toml_config` now routes through `replace_cli_config()` → `get_cli_config_path()` + `atomic_private_write_text()`. Verified by reproduction under a redirected `HOME` and `TLDW_CONFIG_PATH`: the write landed only in the profile file with mode `0o600` preserved, and the decoy `DEFAULT_CONFIG_PATH` was untouched. Recorded as already-fixed rather than reshaped into work.

## Testing

`Tests/MCP/` 377 passed · `Tests/Utils/` 562 passed · `Tests/UI/test_tools_settings_window.py` 49 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired MCP notes tools to the real `NotesInteropService` so note creation and search work end to end, and cleaned up related dead calls/field names across the `MCP` module. Satisfies TASK-983; TASK-962 was already fixed on `dev`; filed TASK-985 for two follow-ups.

- **Bug Fixes**
  - Constructed `NotesInteropService` with `base_db_directory`, `api_client_id`, and `global_db_to_use=self.chachanotes_db`.
  - Rewired `create_note` to `add_note(user_id, title, content)` and removed `tags`/`template` from the tool schema.
  - Rewired `search_notes` to use `user_id` and `search_term`, and read dict results (`created_at`/`last_modified`).
  - `tools.chat_with_character`: use `get_api_key()` instead of `get_cli_setting()`.
  - `resources`: replace nonexistent calls with real ones and fix field names:
    - Conversations/notes: `list_all_active_conversations()` / `list_notes()`, use `last_modified`.
    - Media: use `get_media_transcripts(...)`, and `type`/`ingestion_date` instead of `media_type`/`created_at`.
    - Characters: use `first_message`/`message_example` and `last_modified`.
  - `prompts`: use `get_messages_for_conversation(str(id))` and `get_media_transcripts(...)`.
  - Filed TASK-985 for `search_conversations` preview and `rag-chunk` resource id/metadata (APIs don’t exist as called).

- **Migration**
  - Update any callers of the MCP `create_note` tool to remove `tags` and `template` parameters.

<sup>Written for commit 532784b95f606afb9e40c4bfe614f0a83d86fefd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

