### PR TITLE
docs(mcp): resolve the network-tag scope question on evidence (TASK-845)

### DIFF
--- a/backlog/tasks/task-1011 - MCP-risk-tags-are-self-declared-by-the-server-being-gated.md
+++ b/backlog/tasks/task-1011 - MCP-risk-tags-are-self-declared-by-the-server-being-gated.md
@@ -1,0 +1,23 @@
+---
+id: TASK-1011
+title: MCP risk tags are self-declared by the server being gated
+status: To Do
+assignee: []
+created_date: '2026-07-27 20:27'
+labels:
+  - mcp
+  - security
+  - design
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A remote MCP tool's risk tags are derived from that server's own payload -- its risk_class field plus a free-form capabilities list, lowercased (MCP.hub_tool_catalog._extra_tags). Those tags are what resolve_effective_state uses to floor an inherited allow to ask. So a server can avoid the risk floor for its own tools simply by not declaring mutates, and can trip the floor for unrelated reasons by listing an ordinary word. The floor is a default rather than the only control -- users still set per-tool allow/ask/deny and a definition-hash guard catches later redefinition -- but the floor exists precisely to protect tools a user has not explicitly configured, which is exactly the case where the server's self-declaration is the only input. Surfaced while resolving TASK-845, which asked whether the network tag should move to the shared HIGH_RISK_TAGS and resolved no for this reason.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 It is decided and documented whether a server-supplied tag may lower a tool's risk classification,A tool whose server declares no tags is floored according to a policy we control rather than defaulting to unfloored,A test covers a server payload that omits mutates for a tool that clearly mutates,The decision is recorded at the definition site alongside the existing tag-set rationale
+<!-- AC:END -->

--- a/backlog/tasks/task-845 - Decide-whether-the-network-risk-tag-belongs-in-the-shared-HIGH_RISK_TAGS.md
+++ b/backlog/tasks/task-845 - Decide-whether-the-network-risk-tag-belongs-in-the-shared-HIGH_RISK_TAGS.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-845
 title: Decide whether the network risk tag belongs in the shared HIGH_RISK_TAGS
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-27 03:46'
+updated_date: '2026-07-27 20:27'
 labels:
   - tools
   - security
@@ -22,3 +23,9 @@ PR #953 added the `network` risk tag to `BUILTIN_HIGH_RISK_TAGS` rather than the
 <!-- AC:BEGIN -->
 - [ ] #1 The intended scope of the network tag is decided and written down,The tag sits in whichever set that decision names,A comment at the definition site states why that set and not the other
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Resolved NO on evidence: network stays in BUILTIN_HIGH_RISK_TAGS and does not move to the shared HIGH_RISK_TAGS. An MCP tool's tags are not ours -- they are derived from the remote server's own risk_class and free-form capabilities list, lowercased (MCP.hub_tool_catalog._extra_tags). 'network' is an ordinary word for a server to list among its capabilities, so widening the shared set would not be the no-op it appears to be; it would start prompting on real servers because of a string chosen for unrelated reasons. The built-in set is a vocabulary we control and can reason about; the shared set is partly server-supplied and should stay narrow. Rationale recorded at the definition site. This reverses the earlier preference for widening the shared set, and supersedes it with the provenance evidence that was not available when that preference was expressed. The investigation also surfaced a larger concern -- that MCP risk tags are self-declared by the very server being gated -- filed separately.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/MCP/permission_store.py
+++ b/tldw_chatbook/MCP/permission_store.py
@@ -73,9 +73,16 @@ HIGH_RISK_TAGS = frozenset({"mutates", "process"})
 #: arbitrary sandbox files is a disclosure risk even though it mutates
 #: nothing, and treat network egress as prompt-worthy too, because egress
 #: is the exfiltration leg of a prompt-injection chain. MCP deliberately
-#: keeps ``HIGH_RISK_TAGS`` -- widening the shared set would make remote
-#: tools carrying ``"reads"`` or ``"network"`` start prompting, which is
-#: not this phase's call to make.
+#: keeps ``HIGH_RISK_TAGS``. TASK-845 asked whether ``network`` should move
+#: to the shared set and resolved NO, on evidence rather than preference:
+#: an MCP tool's tags are not ours, they are derived from the remote
+#: server's own payload -- ``risk_class`` plus a free-form ``capabilities``
+#: list, lowercased (``MCP.hub_tool_catalog._extra_tags``). "network" is an
+#: ordinary word for a server to list among its capabilities, so widening
+#: the shared set would not be the no-op it looks like: it would start
+#: prompting on real servers because of a string they chose for unrelated
+#: reasons. The built-in set is a vocabulary WE control and can reason
+#: about; the shared set is partly server-supplied and should stay narrow.
 BUILTIN_HIGH_RISK_TAGS = HIGH_RISK_TAGS | frozenset({"reads", "network"})
 
 _DEFAULT_PROFILE_ID = "default"


### PR DESCRIPTION
Closes TASK-845. Files TASK-1011.

**Outcome: `network` stays in `BUILTIN_HIGH_RISK_TAGS` and does not move to the shared `HIGH_RISK_TAGS`.** No behaviour change; the deliverable is a decision on record with the evidence that settles it.

## Why this reverses the earlier preference

The task existed because I put `network` in the built-in-only set, reversing an earlier instruction to widen the shared set. Both positions were argued from principle. The provenance evidence settles it factually:

An MCP tool's risk tags **are not ours**. They are derived from the remote server's own payload — its `risk_class` field plus a free-form `capabilities` list, lowercased (`MCP.hub_tool_catalog._extra_tags`).

"network" is an ordinary word for a server to list among its capabilities. So widening the shared set is **not the no-op it appears to be** — it would start prompting on real servers because of a string they chose for unrelated reasons, with no defect on their side.

The built-in set is a vocabulary we control and can reason about. The shared set is partly server-supplied and should stay narrow. Rationale recorded at the definition site so the next reader does not have to re-derive it.

## What the investigation surfaced — filed as TASK-1011

The same fact has a sharper edge than the question that uncovered it: **MCP risk tags are self-declared by the very server being gated.**

A server can avoid the risk floor for its own tools simply by not declaring `mutates`, and can trip it for unrelated reasons by listing an ordinary word. The floor is a default rather than the only control — users still set per-tool allow/ask/deny, and a definition-hash guard catches later redefinition — but the floor exists precisely to protect tools a user has **not** explicitly configured, which is exactly the case where the server's self-declaration is the only input.

That needs a design decision about whether a server-supplied tag may lower a tool's risk classification, so it is filed rather than guessed at.

## Testing

`Tests/MCP/` + `Tests/Agents/test_builtin_tool_gate.py` → **401 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record and explain the decision for TASK-845: keep `network` in `BUILTIN_HIGH_RISK_TAGS` (not shared `HIGH_RISK_TAGS`) to avoid prompting based on server-supplied capability words. Adds inline rationale in `permission_store.py` and files TASK-1011 to track the design question on server-declared MCP risk tags; no behavior change.

<sup>Written for commit aa177dff9533e7878f97a2405f93a4623b1175c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

