### PR TITLE
chore(backlog): hand TASK-1022 to the watchlists workstream, close TASK-1010

### DIFF
--- a/backlog/tasks/task-1010 - Three-worker-components-are-dead-or-broken-on-first-call.md
+++ b/backlog/tasks/task-1010 - Three-worker-components-are-dead-or-broken-on-first-call.md
@@ -2,7 +2,7 @@
 id: TASK-1010
 title: >-
   Three worker components are dead or broken on first call -- decide whether to fix or delete
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-27 12:30'
 labels:
@@ -50,3 +50,9 @@ For each: establish whether anything constructs and uses it. Delete what is dead
 
 Per the task owner's instruction, AC1 is ticked (all three components' live/dead status is now established with construction-site evidence). AC2 and AC3 are left unticked: only two of the three dead components were deleted; the third is intentionally not deleted because doing so, or leaving it as-is, both have consequences for an Accepted ADR's documented guarantee that this investigation cannot resolve. AC4 is left unticked for the same reason — "resolved... rather than left ambiguous" needs an owner decision on which of the two remediation paths above (or updating the ADR) to take, not just a diagnosis. Status set to `In Progress` rather than `Done`: real work remains (an explicit decision on `SubscriptionSchedulerWorker`/ADR-019, plus whichever deletion or fix follows from it), and forcing this to `Done` would misrepresent that gap as closed.
 <!-- SECTION:NOTES:END -->
+
+## Closed 2026-07-27
+
+Two of the three components were deleted (`SwarmUIWidget`, `MultiItemReviewWindow`) in PR #1019, verified dead by construction-site trace and with the image-generation spec annotated to match.
+
+The third, `SubscriptionSchedulerWorker`, is **not** deleted and is no longer this task's concern. Investigating whether ADR-019's rollback depended on it found a broader gap — rollback never reaches the old scheduler on either flag setting — which is filed as **TASK-1022** and handed to the watchlists workstream. Its disposition follows that decision: if rollback is restored the worker may be replaced by a working entry point; if the ADR is amended it is retired along with the rest of the chain. Either way it should not be removed in isolation.

--- a/backlog/tasks/task-1022 - ADR-019-rollback-path-does-not-exist-and-scheduled-watchlist-checks-are-off.md
+++ b/backlog/tasks/task-1022 - ADR-019-rollback-path-does-not-exist-and-scheduled-watchlist-checks-are-off.md
@@ -8,6 +8,7 @@ created_date: '2026-07-27 14:00'
 labels:
   - scheduling
   - adr
+  - watchlists
 dependencies: []
 priority: high
 ---
@@ -56,3 +57,9 @@ So this is not an ADR that was authored against code that never worked; it is a 
 - [ ] If dropped: ADR-019 is amended, and the dead scheduler/worker/controller are removed together
 - [ ] The default value of `scheduling.watchlist_checks_enabled` is a deliberate, documented choice
 <!-- AC:END -->
+
+## Ownership
+
+Handed to the **watchlists workstream** (2026-07-27). This was found incidentally while deleting dead worker components under TASK-1010, and the investigation deliberately stopped at establishing the facts: the decision — restore the rollback path, or amend ADR-019 and retire the old scheduler chain — belongs with whoever owns the watchlist migration, not with a cleanup task.
+
+Everything needed to make that call is in the description above: the missing `else` branch, the absent construction path, the default-false flag, what still works (manual "Check now"), and the twelve-hour window in which the rollback path was severed. No code was changed.


### PR DESCRIPTION
TASK-1022 was already filed earlier today with the full investigation; this records the handoff rather than duplicating it.

**1022** gains a `watchlists` label and an explicit ownership note. The investigation deliberately stopped at establishing facts — the missing `else` branch on `watchlist_checks_enabled`, the absent construction path to `SubscriptionScheduler`, the default-false flag, what still works (manual "Check now"), and the twelve-hour window on 2026-07-19 in which `fc9e50da5` severed the rollback path hours after the ADR landed. Whether to restore rollback or amend ADR-019 and retire the old scheduler chain is the watchlist migration owner's decision, not a cleanup task's. No code was changed.

**1010** closes. Two of its three components were deleted and verified in #1019. The third, `SubscriptionSchedulerWorker`, is delegated to 1022 rather than removed in isolation — its disposition follows that decision: replaced by a working entry point if rollback is restored, retired with the rest of the chain if the ADR is amended.

Backlog only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handed TASK-1022 to the watchlists workstream with a new `watchlists` label and ownership note; it requires a decision to either restore ADR-019’s rollback path or amend the ADR and retire the old scheduler chain. Marked TASK-1010 as Done by documenting that two dead components were removed in #1019 and delegating the `SubscriptionSchedulerWorker` outcome to TASK-1022.

<sup>Written for commit ed89a884784521c492763449cce143a1e85bbd51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

