### PR TITLE
docs(backlog): close TASK-1011 with the analysis that settles it

### DIFF
--- a/backlog/tasks/task-1011 - MCP-risk-tags-are-self-declared-by-the-server-being-gated.md
+++ b/backlog/tasks/task-1011 - MCP-risk-tags-are-self-declared-by-the-server-being-gated.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-1011
 title: MCP risk tags are self-declared by the server being gated
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-27 20:27'
+updated_date: '2026-07-27 20:42'
 labels:
   - mcp
   - security
@@ -21,3 +22,21 @@ A remote MCP tool's risk tags are derived from that server's own payload -- its 
 <!-- AC:BEGIN -->
 - [ ] #1 It is decided and documented whether a server-supplied tag may lower a tool's risk classification,A tool whose server declares no tags is floored according to a policy we control rather than defaulting to unfloored,A test covers a server payload that omits mutates for a tool that clearly mutates,The decision is recorded at the definition site alongside the existing tag-set rationale
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Closed as not-worth-the-complexity after analysing the actual resolution path. Recording the analysis so this is not re-discovered.
+
+The concern as filed was that a remote MCP server supplies its own risk tags (MCP.hub_tool_catalog._extra_tags derives them from the server's risk_class field and its free-form capabilities list), so a server could avoid the risk floor for its own tools by declaring nothing. That is true but much narrower than it sounds, for two reasons found by reading resolve_effective_state:
+
+1. DEFAULT_GLOBAL is 'ask'. Out of the box every unconfigured MCP tool prompts regardless of its tags, so the floor is not what protects a default install -- the default state is.
+
+2. The floor only applies when origin != 'tool_override'. An explicit per-tool allow is deliberately never floored, on the documented reasoning that the operator opted in with knowledge of that specific tool.
+
+So the exposure is limited to a user who has broadened permissions -- set global_default: allow, or a server_default: allow -- and is then relying on a safety net woven by the server itself to re-tighten individual tools. That user has already extended trust to the server at the server level; a tag they cannot verify is a weak addition to a decision they made deliberately.
+
+Fixing it properly would mean either treating absent tags as unknown-rather-than-safe (which floors everything for allow-configured servers, defeating the point of choosing allow) or classifying arbitrary remote tools ourselves from name and schema, which is a hard problem with a poor accuracy ceiling and its own false-positive cost.
+
+Related and unaffected: TASK-845 resolved that 'network' stays in BUILTIN_HIGH_RISK_TAGS rather than the shared set, precisely because MCP tags are server-supplied. That decision stands on the same provenance fact and does not depend on this one.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
Closes TASK-1011 as not-worth-the-complexity. Backlog-only; no code touched.

I filed 1011 believing MCP risk tags being server-supplied was a gating weakness. Reading `resolve_effective_state` properly narrows it substantially, and the analysis is worth keeping so nobody re-derives it:

- **`DEFAULT_GLOBAL` is `ask`.** Out of the box every unconfigured MCP tool prompts regardless of its tags. The floor is not what protects a default install — the default state is.
- **The floor only applies when `origin != "tool_override"`.** An explicit per-tool `allow` is deliberately never floored, on the documented reasoning that the operator opted in knowing that specific tool.

So the exposure is limited to a user who has broadened permissions — `global_default: allow`, or a `server_default: allow` — and is then relying on a safety net woven by the server itself to re-tighten individual tools. That user has already extended trust to the server *at the server level*; an unverifiable tag is a weak addition to a decision they made deliberately.

Fixing it properly would mean either treating absent tags as unknown-rather-than-safe, which floors everything for allow-configured servers and defeats the point of choosing allow, or classifying arbitrary remote tools ourselves from name and schema — a hard problem with a poor accuracy ceiling and real false-positive cost.

**TASK-845 is unaffected and still stands.** It resolved that `network` stays in `BUILTIN_HIGH_RISK_TAGS` rather than the shared set precisely *because* MCP tags are server-supplied. That decision rests on the same provenance fact and does not depend on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes TASK-1011 by documenting that server-supplied MCP risk tags don’t warrant changes; default 'ask' and floor behavior already limit exposure. Docs-only update to the backlog note; no code or behavior changes, and TASK-845 remains unaffected.

<sup>Written for commit 787ac9708aaa762246be14dbab83ceaf40c332e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

