### PR TITLE
fix(mcp): rewire search_conversations and get_rag_chunk_resource to real DB APIs (TASK-985)

### DIFF
--- a/.superpowers/sdd/task-985-report.md
+++ b/.superpowers/sdd/task-985-report.md
@@ -1,0 +1,77 @@
+# TASK-985 report
+
+Worktree: `/Users/macbook-dev/Documents/GitHub/wt-985`, branch `fix/mcp-search-and-rag-resource`.
+
+## Review findings
+
+Four automated-reviewer findings on PR #1024. Investigated each against repo convention before acting;
+two were declined with evidence rather than implemented.
+
+### 1. "F-string SQL in `get_chunk_by_uuid`" — accepted (cosmetic only), security framing declined
+
+The finding's SQL-injection framing is wrong: `target_table` was a hardcoded local literal
+(`"UnvectorizedMediaChunks"`), the only user-supplied value (`chunk_uuid`) was already parameterized with
+`?`, and the immediately preceding sibling `get_chunk_text` builds its query with the exact same
+`f"...{target_table}..."` shape. There was no vulnerability.
+
+What the f-string *did* do pointlessly was interpolate a constant, which is what trips scanners that flag
+any f-string touching a `SELECT`. Fixed by inlining the literal table name and converting the query to a
+plain (non-f) string, keeping the parameterized `?` for `chunk_uuid` untouched. Left the sibling
+`get_chunk_text` alone — matching it would not have been a one-line change (it interpolates the table name
+differently, on a single line) and the task said not to touch it unless the change was trivially safe.
+
+### 2. "`get_chunk_by_uuid` lacks `transaction()`" — declined
+
+This is a read, and every read helper in `Client_Media_DB_v2.py` — including the direct sibling
+`get_chunk_text`, plus `get_specific_transcript`, `get_latest_transcription`, `get_specific_analysis`,
+`get_media_prompts`, `get_unprocessed_media` — calls `db_instance.execute_query(...)` directly with no
+`transaction()` wrapper. `transaction()` in this module is reserved for multi-statement writes needing
+atomicity/rollback, not single-statement reads. `get_chunk_by_uuid` matches the established convention
+exactly. No change made.
+
+### 3. "`_seed_chunk` bypasses `transaction()`" (Tests/MCP/test_tools_resources_prompts_real_methods.py) — declined
+
+Matches the sibling `_seed_transcript` helper in the same test file (same file, same pattern: direct
+`media_db.execute_query(INSERT ..., commit=True)`, both with a docstring explaining that no public writer
+API exists to seed a row with a caller-known UUID). It also matches the broader convention in
+`Tests/Media_DB/test_media_db_v2.py`, which uses plain `execute_query(..., commit=True)` for fixture-row
+inserts throughout and reserves `db.transaction()` specifically for tests asserting atomicity/rollback
+behavior (e.g. its `Keywords` count-after-rollback test). No change made.
+
+### 4. "`search_conversations` inputs unvalidated" (tldw_chatbook/MCP/tools.py) — accepted
+
+`search_conversations` took a free-text `query` and integer `limit` straight from the MCP boundary with
+zero validation, then handed `limit` directly into `search_conversations_by_content`'s `LIMIT ?` — a
+negative value there is not just "no results," it's SQLite's `LIMIT -1` meaning *unbounded*, returning
+every matching row.
+
+Checked repo convention first: no MCP tool in `tools.py` (`chat_with_character`, `perform_rag_search`,
+`get_conversation_history`, `export_conversation`) validates its inputs via `Utils/input_validation.py`
+today, so this is a real, if scoped, gap rather than an established pattern this file already follows. But
+the *same shape* of input — free-text search query plus a numeric result limit — is already validated
+elsewhere in the codebase: `Library/library_rag_state.py`'s Library RAG search entry point uses
+`validate_text_input` (bounded length, `allow_html=False`) on the query and `validate_number_range` on the
+`top_k` limit. Brought `search_conversations` in line with that existing convention rather than closing the
+whole file's gap: added `validate_text_input`/`validate_number_range` checks (query: non-empty, plain text,
+≤2000 chars; limit: 1–100), returning the same `[{"error": ...}]` shape the function already used for
+downstream exceptions. Deliberately left `perform_rag_search` (the sibling with the identical gap)
+untouched — noted here rather than silently expanding scope; it did not use validation before this task,
+and still doesn't. A follow-up task should be filed if that gap should also be closed.
+
+## What changed
+
+- `tldw_chatbook/DB/Client_Media_DB_v2.py` — `get_chunk_by_uuid`: dropped the pointless f-string, table name
+  now inlined into a plain string.
+- `tldw_chatbook/MCP/tools.py` — `search_conversations`: added `query`/`limit` validation via
+  `Utils/input_validation.validate_text_input`/`validate_number_range`, new module-level
+  `MAX_SEARCH_QUERY_LENGTH` (2000) / `MAX_SEARCH_RESULTS_LIMIT` (100) constants.
+
+## Verification
+
+- `Tests/MCP/` — 381 passed.
+- `Tests/Media_DB/test_media_db_v2.py` — 38 passed.
+- Rebased onto `origin/dev` (`1f00c19ea`) cleanly — no conflicts; upstream had not touched any of the
+  files this branch modifies.
+
+Commits: `fd5a5102d` (rewire, pre-existing), `a495d8045` (docs, pre-existing), `19548a1a6` (this review-fix
+commit, post-rebase SHA).

--- a/Tests/MCP/test_tools_resources_prompts_real_methods.py
+++ b/Tests/MCP/test_tools_resources_prompts_real_methods.py
@@ -41,6 +41,27 @@ value); ``tags``/``template`` on notes and ``message_count`` on characters
 are a different, non-mechanical case (no such column/aggregation exists at
 all) and are called out in TASK-983's Implementation Notes rather than
 guessed at here.
+
+TASK-985 fixes two further call sites of the same overall shape, deliberately
+left for a follow-up because the fix needed a design decision rather than a
+mechanical rename:
+
+- ``MCPTools.search_conversations`` called ``search_all_content``, which does
+  not exist on ``CharactersRAGDB`` at all. The real accessor,
+  ``search_conversations_by_content``, returns conversation rows with no
+  content column to preview from, so ``preview`` is now sourced from a
+  second, real query per matching conversation:
+  ``search_messages_by_content(conversation_id=...)``, the actual matching
+  message text.
+- ``MCPResources.get_rag_chunk_resource`` called ``get_chunk_by_id``, which
+  does not exist on ``MediaDatabase``. The nearest real accessor,
+  ``get_chunk_text``, keys on a UUID rather than an int id and returns only
+  bare text with no metadata at all, so a sibling accessor,
+  ``get_chunk_by_uuid`` (added alongside this fix), is used instead --
+  UUID-keyed, returning the chunk's real ``media_id``/``start_char``/
+  ``end_char``/``chunk_index``/``chunk_type`` columns. There is no
+  ``embedding_id`` column on ``UnvectorizedMediaChunks`` at all, so it is
+  dropped rather than guessed at.
 """
 
 from __future__ import annotations
@@ -74,6 +95,34 @@ def _seed_transcript(media_db: MediaDatabase, media_id: int, text: str) -> None:
                 'test_client', 0)
         """,
         (media_id, text, f"transcript-uuid-{media_id}"),
+        commit=True,
+    )
+
+
+def _seed_chunk(
+    media_db: MediaDatabase,
+    media_id: int,
+    chunk_uuid: str,
+    chunk_text: str,
+    chunk_index: int = 0,
+    start_char: int = 0,
+    end_char: int = 0,
+) -> None:
+    """Insert an UnvectorizedMediaChunks row directly with a known uuid.
+
+    ``process_unvectorized_chunks`` (the public writer for this table)
+    generates its own UUID internally and never returns it, so there is no
+    public way to seed a chunk with a UUID the test can assert against
+    afterwards -- same rationale as `_seed_transcript` above.
+    """
+    media_db.execute_query(
+        """
+        INSERT INTO UnvectorizedMediaChunks
+            (media_id, chunk_text, chunk_index, start_char, end_char,
+             chunk_type, uuid, last_modified, version, client_id, deleted)
+        VALUES (?, ?, ?, ?, ?, 'text', ?, datetime('now'), 1, 'test_client', 0)
+        """,
+        (media_id, chunk_text, chunk_index, start_char, end_char, chunk_uuid),
         commit=True,
     )
 
@@ -243,3 +292,106 @@ def test_generate_document_prompt_executes_against_real_db(tmp_path):
     assert len(result) == 1
     assert "get_conversation_messages" not in result[0]["content"]
     assert "Hello there" in result[0]["content"]
+
+
+def test_search_conversations_uses_a_real_content_search_accessor(tmp_path):
+    """TASK-985: `search_all_content` never existed on `CharactersRAGDB`.
+    The real accessor, `search_conversations_by_content`, returns
+    conversation rows with no content column, so `preview` must be sourced
+    from the best-matching *message* in that conversation instead (a
+    second, real query), not fabricated from the title."""
+    from tldw_chatbook.MCP.tools import MCPTools
+
+    chachanotes_db, media_db = _real_dbs(tmp_path)
+    tools = MCPTools(chachanotes_db, media_db)
+
+    conversation_id = chachanotes_db.add_conversation({"title": "Trip Planning"})
+    chachanotes_db.add_message(
+        {
+            "conversation_id": conversation_id,
+            "sender": "user",
+            "content": "Let's book the flight to Kyoto next spring.",
+            "role": "user",
+        }
+    )
+
+    results = asyncio.run(tools.search_conversations(query="Kyoto", limit=5))
+
+    assert results and "error" not in results[0]
+    assert results[0]["id"] == conversation_id
+    assert results[0]["title"] == "Trip Planning"
+    assert "Kyoto" in results[0]["preview"]
+    assert results[0]["message_count"] == 1
+
+
+def test_search_conversations_filters_by_character_id(tmp_path):
+    """The character_id filter reads `result.get("character_id")` off the
+    conversation row returned by `search_conversations_by_content` -- a
+    real `conversations.character_id` column -- so a non-matching filter
+    must exclude the conversation instead of raising."""
+    from tldw_chatbook.MCP.tools import MCPTools
+
+    chachanotes_db, media_db = _real_dbs(tmp_path)
+    tools = MCPTools(chachanotes_db, media_db)
+
+    conversation_id = chachanotes_db.add_conversation({"title": "Trip Planning"})
+    chachanotes_db.add_message(
+        {
+            "conversation_id": conversation_id,
+            "sender": "user",
+            "content": "Let's book the flight to Kyoto next spring.",
+            "role": "user",
+        }
+    )
+
+    results = asyncio.run(
+        tools.search_conversations(query="Kyoto", limit=5, character_id=999)
+    )
+
+    assert results == []
+
+
+def test_get_rag_chunk_resource_uses_a_real_media_db_accessor(tmp_path):
+    """TASK-985: `get_chunk_by_id` never existed on `MediaDatabase`, and the
+    id scheme was an integer -- the real accessor (`get_chunk_by_uuid`,
+    added alongside this fix) keys on the chunk's UUID and has no
+    `embedding_id` to report (the column doesn't exist on
+    `UnvectorizedMediaChunks`)."""
+    from tldw_chatbook.MCP.resources import MCPResources
+
+    chachanotes_db, media_db = _real_dbs(tmp_path)
+    resources = MCPResources(chachanotes_db, media_db)
+
+    media_id, _uuid, _msg = media_db.add_media_with_keywords(
+        title="Kyoto Guide", media_type="document", content="fallback content"
+    )
+    chunk_uuid = "chunk-uuid-1234"
+    _seed_chunk(
+        media_db,
+        media_id,
+        chunk_uuid,
+        "Kinkaku-ji is a Zen Buddhist temple in Kyoto.",
+        start_char=0,
+        end_char=46,
+    )
+
+    result = asyncio.run(resources.get_rag_chunk_resource(chunk_uuid))
+
+    assert result["name"] not in ("Error", "Not Found")
+    assert "Kinkaku-ji is a Zen Buddhist temple in Kyoto." in result["content"]
+    assert "Kyoto Guide" in result["content"]
+    assert result["metadata"]["media_id"] == media_id
+    assert result["metadata"]["start_char"] == 0
+    assert result["metadata"]["end_char"] == 46
+    assert "embedding_id" not in result["metadata"]
+
+
+def test_get_rag_chunk_resource_reports_not_found_for_unknown_uuid(tmp_path):
+    from tldw_chatbook.MCP.resources import MCPResources
+
+    chachanotes_db, media_db = _real_dbs(tmp_path)
+    resources = MCPResources(chachanotes_db, media_db)
+
+    result = asyncio.run(resources.get_rag_chunk_resource("does-not-exist"))
+
+    assert result["name"] == "Not Found"

--- a/backlog/tasks/task-985 - MCP-search_conversations-and-RAG-chunk-resource-call-APIs-that-do-not-exist.md
+++ b/backlog/tasks/task-985 - MCP-search_conversations-and-RAG-chunk-resource-call-APIs-that-do-not-exist.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-985
 title: MCP search_conversations and RAG chunk resource call APIs that do not exist
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-27 20:05'
 labels:
   - mcp
@@ -20,7 +21,75 @@ TASK-983's whole-module pass over MCP/server.py's collaborator modules (tools.py
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 MCPTools.search_conversations calls a real CharactersRAGDB method with arguments that actually exist and its formatted preview field is sourced from real data per a deliberate decision (not guessed)
-- [ ] #2 MCPResources.get_rag_chunk_resource calls a real MediaDatabase accessor with an identifier scheme and returned metadata fields that are reconciled with what the database can actually provide
-- [ ] #3 A test exercises both fixed tool/resource paths end to end against a temp database rather than only importing the module
+- [x] #1 MCPTools.search_conversations calls a real CharactersRAGDB method with arguments that actually exist and its formatted preview field is sourced from real data per a deliberate decision (not guessed)
+- [x] #2 MCPResources.get_rag_chunk_resource calls a real MediaDatabase accessor with an identifier scheme and returned metadata fields that are reconciled with what the database can actually provide
+- [x] #3 A test exercises both fixed tool/resource paths end to end against a temp database rather than only importing the module
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Read `MCPTools.search_conversations` (tools.py), `MCPResources.get_rag_chunk_resource`
+   (resources.py), and the real DB APIs (`CharactersRAGDB.search_conversations_by_content`,
+   `.search_messages_by_content`, `Client_Media_DB_v2.get_chunk_text`, and the
+   `UnvectorizedMediaChunks`/`conversations`/`messages` table schemas) to see exactly what
+   columns/arguments genuinely exist.
+2. Decide, per call site, whether to adapt (rewire to real data with an honest schema) or
+   remove (if nothing useful can be returned).
+3. Implement the fix, updating docstrings/schemas so the tool never promises a field it
+   cannot supply.
+4. Add end-to-end tests against a real temp on-disk SQLite database (no mocks), seeding rows
+   directly for tables with no public writer that returns a known id/uuid.
+5. Run `Tests/MCP/` plus the touched data-layer module's own test suite.
+
+## Implementation Notes
+
+**search_conversations (adapt).** `search_all_content` never existed on `CharactersRAGDB`.
+Rewired to `search_conversations_by_content(search_query=, limit=)`, the real FTS accessor,
+which returns `conversations` rows (real columns: `id`, `title`, `created_at`, `character_id`,
+plus an aggregated `message_count`) but no content column at all — there is nothing on the
+conversation row itself to preview. Rather than fabricate a preview from the title, `preview`
+is now sourced from a second, deliberate query per matching conversation:
+`search_messages_by_content(content_query=query, conversation_id=..., limit=1)` — the actual
+best-matching *message* text in that conversation, against the same FTS index the
+conversation-level search already matched on. This is real seeded data, not a guess, and
+keeps the same truncate-to-200-chars convention `search_notes` already uses elsewhere in this
+module. Caller-visible contract: `search_conversations` still returns
+id/title/preview/created/character_id/message_count; `preview` is now "the matching message
+text" rather than "conversation content" (there is no such thing), documented in both
+`MCPTools.search_conversations`'s docstring and the `server.py` tool's docstring.
+
+**get_rag_chunk_resource (adapt).** `get_chunk_by_id` never existed on `MediaDatabase`. The
+nearest real accessor, `get_chunk_text(db_instance, chunk_uuid)`, keys on a UUID (not an int
+id) but returns only the bare `chunk_text` string — no `media_id`/`start_char`/`end_char`, and
+`UnvectorizedMediaChunks` has no `embedding_id` column at all (chunks are correlated to the
+vector store by this same UUID, not a separate id). Rather than either invent an `embedding_id`
+or throw away the position/media metadata the resource used to promise, added a small sibling
+accessor, `get_chunk_by_uuid(db_instance, chunk_uuid)` (`Client_Media_DB_v2.py`, next to
+`get_chunk_text`), that selects the chunk's real columns
+(`id`/`uuid`/`media_id`/`chunk_text`/`chunk_index`/`start_char`/`end_char`/`chunk_type`) by
+UUID with the same active-chunk/active-media join `get_chunk_text` already uses. Reworked
+`get_rag_chunk_resource` (and the `rag-chunk://{chunk_uuid}` MCP resource route in `server.py`)
+to take `chunk_uuid` instead of an int `chunk_id`, matching how chunks are actually addressed
+elsewhere in the app. `embedding_id` is dropped from the returned metadata (documented as
+nonexistent); `chunk_index`/`chunk_type` are added since they are real, previously-unreported
+columns.
+
+**Tests.** Added 4 tests to `Tests/MCP/test_tools_resources_prompts_real_methods.py`
+(TASK-983's sibling-defect test module) against real on-disk SQLite databases, no mocks:
+`test_search_conversations_uses_a_real_content_search_accessor`,
+`test_search_conversations_filters_by_character_id`,
+`test_get_rag_chunk_resource_uses_a_real_media_db_accessor`, and
+`test_get_rag_chunk_resource_reports_not_found_for_unknown_uuid`. A `_seed_chunk` helper
+inserts an `UnvectorizedMediaChunks` row directly with a known UUID, mirroring the existing
+`_seed_transcript` helper's rationale: `process_unvectorized_chunks` (the public writer)
+generates its own UUID internally and never returns it, so there is no public way to seed a
+chunk with a UUID a test can assert against afterwards.
+
+**Verification:** `Tests/MCP/` (381 passed), `Tests/Media_DB/test_media_db_v2.py` +
+`Tests/DB/test_search_conversations_fts.py` (54 passed, covering the touched
+`Client_Media_DB_v2.py` module and the pre-existing `search_conversations_by_content` DB
+method this fix now calls from MCP).
+
+**Files changed:** `tldw_chatbook/MCP/tools.py`, `tldw_chatbook/MCP/resources.py`,
+`tldw_chatbook/MCP/server.py`, `tldw_chatbook/DB/Client_Media_DB_v2.py` (new
+`get_chunk_by_uuid` function, additive), `Tests/MCP/test_tools_resources_prompts_real_methods.py`.

--- a/tldw_chatbook/DB/Client_Media_DB_v2.py
+++ b/tldw_chatbook/DB/Client_Media_DB_v2.py
@@ -8309,6 +8309,56 @@ def get_chunk_text(db_instance: MediaDatabase, chunk_uuid: str) -> Optional[str]
         raise DatabaseError(f"Failed get chunk text {chunk_uuid}") from e
 
 
+def get_chunk_by_uuid(
+    db_instance: MediaDatabase, chunk_uuid: str
+) -> Optional[Dict[str, Any]]:
+    """Retrieves a chunk's row data (not just its text) by UUID.
+
+    Companion to `get_chunk_text`: that helper returns only the bare
+    `chunk_text` string, with no way to tell which media item a chunk
+    belongs to or where it falls in the source document. This returns the
+    columns `UnvectorizedMediaChunks` actually has for a single-chunk
+    lookup: `id`, `uuid`, `media_id`, `chunk_text`, `chunk_index`,
+    `start_char`, `end_char`, and `chunk_type`. There is no `embedding_id`
+    column on this table at all -- chunks are correlated with vector-store
+    entries by this same UUID, not a separate id -- so callers must not
+    expect one.
+
+    Currently queries `UnvectorizedMediaChunks`. Ensures both the chunk and
+    its parent Media item are active (`deleted=0`).
+
+    Args:
+        db_instance (MediaDatabase): An initialized Database instance.
+        chunk_uuid (str): The UUID of the chunk (`UnvectorizedMediaChunks.uuid`).
+
+    Returns:
+        Optional[Dict[str, Any]]: The chunk's row data if found and active,
+        otherwise None.
+
+    Raises:
+        TypeError: If `db_instance` is not a Database object.
+        DatabaseError: For database query errors.
+    """
+    if not isinstance(db_instance, MediaDatabase):
+        raise TypeError("db_instance required.")
+    target_table = "UnvectorizedMediaChunks"
+    try:
+        query = (
+            f"SELECT c.id, c.uuid, c.media_id, c.chunk_text, c.chunk_index, "
+            f"c.start_char, c.end_char, c.chunk_type "
+            f"FROM {target_table} c JOIN Media m ON c.media_id = m.id "
+            f"WHERE c.uuid = ? AND c.deleted = 0 AND m.deleted = 0"
+        )
+        cursor = db_instance.execute_query(query, (chunk_uuid,))
+        result = cursor.fetchone()
+        return dict(result) if result else None
+    except (DatabaseError, sqlite3.Error) as e:
+        logger.error(
+            f"Error getting chunk by UUID {chunk_uuid} '{db_instance.db_path_str}': {e}"
+        )
+        raise DatabaseError(f"Failed to get chunk by UUID {chunk_uuid}") from e
+
+
 def get_all_content_from_database(db_instance: MediaDatabase) -> List[Dict[str, Any]]:
     """
     Retrieves basic identifying information for all active, non-trashed media items.

--- a/tldw_chatbook/DB/Client_Media_DB_v2.py
+++ b/tldw_chatbook/DB/Client_Media_DB_v2.py
@@ -8341,13 +8341,12 @@ def get_chunk_by_uuid(
     """
     if not isinstance(db_instance, MediaDatabase):
         raise TypeError("db_instance required.")
-    target_table = "UnvectorizedMediaChunks"
     try:
         query = (
-            f"SELECT c.id, c.uuid, c.media_id, c.chunk_text, c.chunk_index, "
-            f"c.start_char, c.end_char, c.chunk_type "
-            f"FROM {target_table} c JOIN Media m ON c.media_id = m.id "
-            f"WHERE c.uuid = ? AND c.deleted = 0 AND m.deleted = 0"
+            "SELECT c.id, c.uuid, c.media_id, c.chunk_text, c.chunk_index, "
+            "c.start_char, c.end_char, c.chunk_type "
+            "FROM UnvectorizedMediaChunks c JOIN Media m ON c.media_id = m.id "
+            "WHERE c.uuid = ? AND c.deleted = 0 AND m.deleted = 0"
         )
         cursor = db_instance.execute_query(query, (chunk_uuid,))
         result = cursor.fetchone()

--- a/tldw_chatbook/MCP/resources.py
+++ b/tldw_chatbook/MCP/resources.py
@@ -10,7 +10,11 @@ from loguru import logger
 
 # Import tldw_chatbook components
 from ..DB.ChaChaNotes_DB import CharactersRAGDB
-from ..DB.Client_Media_DB_v2 import MediaDatabase, get_media_transcripts
+from ..DB.Client_Media_DB_v2 import (
+    MediaDatabase,
+    get_media_transcripts,
+    get_chunk_by_uuid,
+)
 
 # `get_note_by_id` (tldw_chatbook.Notes.Notes_Library) and
 # `get_character_by_id` (tldw_chatbook.Character_Chat.Character_Chat_Lib)
@@ -308,21 +312,33 @@ class MCPResources:
                 "content": f"Error loading media: {str(e)}",
             }
 
-    async def get_rag_chunk_resource(self, chunk_id: str) -> Dict[str, Any]:
+    async def get_rag_chunk_resource(self, chunk_uuid: str) -> Dict[str, Any]:
         """Get a RAG chunk as a resource.
 
         Args:
-            chunk_id: ID of the chunk
+            chunk_uuid: UUID of the chunk (`UnvectorizedMediaChunks.uuid`).
+
+                This used to be an integer id (`int(chunk_id)`) passed to
+                `self.media_db.get_chunk_by_id(...)`, a method that has
+                never existed on `MediaDatabase` (TASK-985). The real
+                accessor for a single chunk's row, `get_chunk_by_uuid`
+                (added alongside this fix, a sibling of the pre-existing
+                `get_chunk_text`), keys on the chunk's UUID rather than an
+                int id -- matching how chunks are addressed everywhere else
+                in the app (vector-store lookups use this same UUID). There
+                is no `embedding_id` column on `UnvectorizedMediaChunks` at
+                all, so it is dropped from the metadata below rather than
+                guessed at.
 
         Returns:
-            Resource dict with content and metadata
+            Resource dict with content and metadata.
         """
         try:
             # Get chunk from media database
-            chunk = self.media_db.get_chunk_by_id(int(chunk_id))
+            chunk = get_chunk_by_uuid(self.media_db, chunk_uuid)
             if not chunk:
                 return {
-                    "uri": f"rag-chunk://{chunk_id}",
+                    "uri": f"rag-chunk://{chunk_uuid}",
                     "name": "Not Found",
                     "mimeType": "text/plain",
                     "content": "Chunk not found",
@@ -332,15 +348,15 @@ class MCPResources:
             media = self.media_db.get_media_by_id(chunk["media_id"])
 
             # Format content
-            content = f"# RAG Chunk {chunk_id}\n\n"
+            content = f"# RAG Chunk {chunk_uuid}\n\n"
             if media:
                 content += f"**From**: {media['title']}\n"
-            content += f"**Position**: {chunk.get('start_char', 0)} - {chunk.get('end_char', 0)}\n\n"
+            content += f"**Position**: {chunk.get('start_char') or 0} - {chunk.get('end_char') or 0}\n\n"
             content += "---\n\n"
-            content += chunk["text"]
+            content += chunk["chunk_text"]
 
             return {
-                "uri": f"rag-chunk://{chunk_id}",
+                "uri": f"rag-chunk://{chunk_uuid}",
                 "name": f"Chunk from {media['title'] if media else 'Unknown'}",
                 "mimeType": "text/plain",
                 "content": content,
@@ -348,14 +364,15 @@ class MCPResources:
                     "media_id": chunk["media_id"],
                     "start_char": chunk.get("start_char"),
                     "end_char": chunk.get("end_char"),
-                    "embedding_id": chunk.get("embedding_id"),
+                    "chunk_index": chunk.get("chunk_index"),
+                    "chunk_type": chunk.get("chunk_type"),
                 },
             }
 
         except Exception as e:
             logger.error(f"Error getting RAG chunk resource: {e}")
             return {
-                "uri": f"rag-chunk://{chunk_id}",
+                "uri": f"rag-chunk://{chunk_uuid}",
                 "name": "Error",
                 "mimeType": "text/plain",
                 "content": f"Error loading chunk: {str(e)}",

--- a/tldw_chatbook/MCP/server.py
+++ b/tldw_chatbook/MCP/server.py
@@ -325,7 +325,14 @@ class TldwMCPServer:
         async def search_conversations(
             query: str, limit: int = 10, character_id: Optional[int] = None
         ) -> List[Dict[str, Any]]:
-            """Search conversations by content."""
+            """Search conversations by message content.
+
+            Each result's ``preview`` is the best-matching message's text in
+            that conversation (there is no conversation-level content field
+            to preview from), truncated to 200 characters -- see
+            ``MCPTools.search_conversations`` for the full rationale
+            (TASK-985).
+            """
             return await self.tools.search_conversations(
                 query=query, limit=limit, character_id=character_id
             )
@@ -472,10 +479,15 @@ class TldwMCPServer:
             """Get media content by ID."""
             return await self.resources.get_media_resource(media_id)
 
-        @self.mcp.resource("rag-chunk://{chunk_id}")
-        async def get_rag_chunk(chunk_id: str) -> Dict[str, Any]:
-            """Get a RAG chunk by ID."""
-            return await self.resources.get_rag_chunk_resource(chunk_id)
+        @self.mcp.resource("rag-chunk://{chunk_uuid}")
+        async def get_rag_chunk(chunk_uuid: str) -> Dict[str, Any]:
+            """Get a RAG chunk by UUID.
+
+            Keyed on the chunk's UUID (`UnvectorizedMediaChunks.uuid`), not
+            an integer id -- see `MCPResources.get_rag_chunk_resource` for
+            why (TASK-985).
+            """
+            return await self.resources.get_rag_chunk_resource(chunk_uuid)
 
         # List resources
         @self.mcp.list_resources()

--- a/tldw_chatbook/MCP/tools.py
+++ b/tldw_chatbook/MCP/tools.py
@@ -16,6 +16,18 @@ from ..config import get_api_key
 from ..DB.ChaChaNotes_DB import CharactersRAGDB
 from ..DB.Client_Media_DB_v2 import MediaDatabase
 from ..RAG_Search.simplified.search_service import SimplifiedRAGSearchService
+from ..Utils.input_validation import validate_number_range, validate_text_input
+
+# Bounds for `search_conversations`' free-text `query` / integer `limit`
+# inputs, mirroring the same query+limit validation shape already used for
+# the Library RAG search entry point (`Library/library_rag_state.py`'s
+# `LIBRARY_RAG_QUERY_MAX_LENGTH` / `LIBRARY_RAG_TOP_K_MAX`) rather than
+# inventing new bounds. An unvalidated `limit` reaches SQLite's `LIMIT ?`
+# directly (`ChaChaNotes_DB.search_conversations_by_content`); a negative
+# value there returns every matching row unbounded (SQLite's `LIMIT -1`
+# means "no limit").
+MAX_SEARCH_QUERY_LENGTH = 2000
+MAX_SEARCH_RESULTS_LIMIT = 100
 
 # `save_conversation_from_messages` (tldw_chatbook.Chat.Chat_Functions) and
 # `chat_with_provider` (tldw_chatbook.LLM_Calls.LLM_API_Calls) were both
@@ -169,7 +181,9 @@ class MCPTools:
 
         Returns:
             List of matching conversations, each with id/title/preview/
-            created/character_id/message_count.
+            created/character_id/message_count. A single-item list with an
+            ``error`` key if ``query``/``limit`` fail validation or the
+            search itself raises.
 
         Note:
             This used to call ``self.chachanotes_db.search_all_content``,
@@ -188,6 +202,31 @@ class MCPTools:
             conversation match ``query`` -- not fabricated from an
             unrelated field.
         """
+        if not isinstance(query, str) or not query.strip():
+            return [{"error": "query must be a non-empty string"}]
+        if not validate_text_input(
+            query, max_length=MAX_SEARCH_QUERY_LENGTH, allow_html=False
+        ):
+            return [
+                {
+                    "error": (
+                        "query must be plain text of at most "
+                        f"{MAX_SEARCH_QUERY_LENGTH} characters"
+                    )
+                }
+            ]
+        if not validate_number_range(
+            limit, min_val=1, max_val=MAX_SEARCH_RESULTS_LIMIT
+        ):
+            return [
+                {
+                    "error": (
+                        f"limit must be between 1 and {MAX_SEARCH_RESULTS_LIMIT}"
+                    )
+                }
+            ]
+        limit = int(limit)
+
         try:
             results = await asyncio.to_thread(
                 self.chachanotes_db.search_conversations_by_content,

--- a/tldw_chatbook/MCP/tools.py
+++ b/tldw_chatbook/MCP/tools.py
@@ -160,21 +160,38 @@ class MCPTools:
     async def search_conversations(
         self, query: str, limit: int = 10, character_id: Optional[int] = None
     ) -> List[Dict[str, Any]]:
-        """Search conversations by content.
+        """Search conversations by message content.
 
         Args:
-            query: Search query
-            limit: Maximum number of results
-            character_id: Optional character ID to filter by
+            query: Search query (FTS5 syntax, matched against message text).
+            limit: Maximum number of conversations to return.
+            character_id: Optional character ID to filter results by.
 
         Returns:
-            List of matching conversations
+            List of matching conversations, each with id/title/preview/
+            created/character_id/message_count.
+
+        Note:
+            This used to call ``self.chachanotes_db.search_all_content``,
+            which does not exist anywhere on ``CharactersRAGDB`` (TASK-985).
+            The real accessor, ``search_conversations_by_content(search_query,
+            limit)``, returns conversation rows (``conversations`` table
+            columns plus an aggregated ``message_count``) with no inline
+            message content to preview -- the ``conversations`` table has no
+            content column at all. Rather than guess at a substitute (e.g.
+            truncating the title), ``preview`` is sourced from a second,
+            deliberate query per matching conversation:
+            ``search_messages_by_content(content_query=query,
+            conversation_id=..., limit=1)``, the best-matching *message* in
+            that conversation against the same FTS index. That is real
+            seeded data -- the actual message text that made the
+            conversation match ``query`` -- not fabricated from an
+            unrelated field.
         """
         try:
             results = await asyncio.to_thread(
-                self.chachanotes_db.search_all_content,
+                self.chachanotes_db.search_conversations_by_content,
                 search_query=query,
-                content_type="conversation",
                 limit=limit,
             )
 
@@ -183,13 +200,26 @@ class MCPTools:
                 if character_id and result.get("character_id") != character_id:
                     continue
 
+                preview = ""
+                matching_messages = await asyncio.to_thread(
+                    self.chachanotes_db.search_messages_by_content,
+                    content_query=query,
+                    conversation_id=result["id"],
+                    limit=1,
+                )
+                if matching_messages:
+                    message_content = matching_messages[0].get("content") or ""
+                    preview = (
+                        message_content[:200] + "..."
+                        if len(message_content) > 200
+                        else message_content
+                    )
+
                 conversations.append(
                     {
                         "id": result["id"],
                         "title": result["title"],
-                        "preview": result["content"][:200] + "..."
-                        if len(result["content"]) > 200
-                        else result["content"],
+                        "preview": preview,
                         "created": result["created_at"],
                         "character_id": result.get("character_id"),
                         "message_count": result.get("message_count", 0),


### PR DESCRIPTION
## Summary

TASK-983's module pass over `MCP/server.py`'s collaborator modules found two call sites of the same "calls a nonexistent method" shape that were deliberately left unfixed because the fix needed a design decision instead of a mechanical rename. This PR makes those two decisions.

### 1. `MCPTools.search_conversations`

- **Before**: called `self.chachanotes_db.search_all_content(search_query=, content_type=, limit=)` — this method does not exist anywhere in the codebase.
- **What the real API offers**: `CharactersRAGDB.search_conversations_by_content(search_query, limit)` — a real FTS accessor that returns `conversations` table rows (id/title/created_at/character_id) plus an aggregated `message_count`. There is **no content column** on the conversation row to preview from.
- **Decision: adapt.** Rewired to `search_conversations_by_content`. For the `preview` field the tool has always promised, added a second, deliberate query per matching conversation — `search_messages_by_content(content_query=query, conversation_id=..., limit=1)` — which returns the actual best-matching *message* text in that conversation, against the same FTS index the conversation-level search already matched on. This is real seeded data, not a guess or a truncated title.
- **What a caller can now expect**: the same shape as before (id/title/preview/created/character_id/message_count), but `preview` is now documented as "the matching message's text" rather than implying conversation-level content, since no such thing exists.

### 2. `MCPResources.get_rag_chunk_resource`

- **Before**: called `self.media_db.get_chunk_by_id(int(chunk_id))` — this method does not exist. The resource was keyed on an integer id and promised `media_id`/`start_char`/`end_char`/`embedding_id` metadata.
- **What the real API offers**: the nearest existing accessor, `get_chunk_text(db_instance, chunk_uuid)`, keys on a UUID (not an int id) and returns *only* the bare chunk text — no other metadata. `UnvectorizedMediaChunks` (the backing table) has **no `embedding_id` column at all**, but it does have real `media_id`/`chunk_index`/`start_char`/`end_char`/`chunk_type` columns that no existing accessor surfaces.
- **Decision: adapt.** Added a small sibling accessor, `get_chunk_by_uuid` (`Client_Media_DB_v2.py`, next to `get_chunk_text`), that selects those real columns by UUID with the same active-chunk/active-media join `get_chunk_text` already uses. Reworked the resource (and the `rag-chunk://{chunk_uuid}` MCP route) to take a UUID instead of an int id — matching how chunks are addressed everywhere else in the app (vector-store lookups use this same UUID).
- **What a caller can now expect**: `rag-chunk://{chunk_uuid}` (UUID, not an int id) returns chunk text plus real `media_id`/`start_char`/`end_char`/`chunk_index`/`chunk_type` metadata. `embedding_id` is gone from the response — it never existed as data, so it's no longer promised.

## Test plan

- [x] `Tests/MCP/` — 381 passed (includes 4 new end-to-end tests against a real temp on-disk SQLite database, no mocks, seeding rows directly for `search_conversations`/`get_rag_chunk_resource`)
- [x] `Tests/Media_DB/test_media_db_v2.py` + `Tests/DB/test_search_conversations_fts.py` — 54 passed (covers the touched `Client_Media_DB_v2.py` module and the pre-existing `search_conversations_by_content` DB method this fix now calls)
- [x] Backlog task-985 updated with Implementation Notes, all 3 ACs checked off

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewired MCP conversation search and the RAG chunk resource to real DB APIs and added strict input validation (TASK-985). Search previews now use the best‑matching message; RAG chunks are fetched by UUID with accurate metadata.

- **Bug Fixes**
  - Search: switched to `CharactersRAGDB.search_conversations_by_content`; `preview` comes from `search_messages_by_content` (best‑matching message), not fabricated.
  - Validation: added `validate_text_input`/`validate_number_range` for `search_conversations` (plain‑text query ≤2000 chars; limit 1–100); consistent `[{"error": "..."}]` on invalid input.
  - RAG chunk: replaced nonexistent `get_chunk_by_id` with `get_chunk_by_uuid` (in `Client_Media_DB_v2.py`); returns text + `media_id`, `start_char`, `end_char`, `chunk_index`, `chunk_type`; removed `embedding_id`; query built as a plain string with bound params.
  - Server/tests: resource path is `rag-chunk://{chunk_uuid}`; added E2E SQLite tests for both paths, including not‑found.

- **Migration**
  - Use `rag-chunk://{chunk_uuid}`; stop passing int IDs.
  - Stop expecting `embedding_id` in chunk metadata.
  - `search_conversations` now validates inputs (plain‑text query ≤2000; limit 1–100) and returns `[{"error": "..."}]` on invalid input.
  - `search_conversations.preview` is the matching message text (shape unchanged).

<sup>Written for commit 416fd47082761517b0e2ed48ce6e1ea370a44abd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

