### PR TITLE
docs: file Evals UAT findings from a live walkthrough

### DIFF
--- a/backlog/tasks/task-1034 - Results-grid-intermittently-drops-its-column-header-and-warned-canary-.md
+++ b/backlog/tasks/task-1034 - Results-grid-intermittently-drops-its-column-header-and-warned-canary-.md
@@ -1,0 +1,43 @@
+---
+id: TASK-1034
+title: >-
+  Results grid intermittently drops its column header and [warned] canary marker
+status: To Do
+assignee: []
+created_date: '2026-07-27 16:00'
+labels:
+  - evals
+  - bug
+  - ux
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found during UAT of the Evals screen on `origin/dev` (155574902), driven live against llama.cpp.
+
+The results table renders in **two structurally different ways within the same view**, and which one you get is not under the user's control:
+
+- **Boxed, no header.** Rows render inside a drawn box with no column header at all, e.g. `│The protestors were [neutral]  "mente"  49%`. The target column is unlabelled and the `[warned]` canary marker is absent.
+- **Unboxed, with header.** The same grid renders `Snippet | Sample target (llama.cpp) f0fded1f [warned]` above the rows.
+
+Reproduced repeatedly. Immediately after "Create sample bench" completes the grid appears in the boxed/headerless form; at one point during lens interaction it switched to the headed form; a later systematic pass over all five lenses showed `header=0` on every one, including Entropy which had shown a header minutes earlier. Clicking a cell did not restore it. So it is **not lens-dependent** — it is some other state we did not isolate.
+
+Two things are lost in the headerless state, and both matter:
+
+1. **Column identity.** With one target the reader can infer it; with several the numbers become unattributable, which is the whole point of the grid.
+2. **The `[warned]` canary marker.** This is the column-level signal that the target preflighted with a degenerate canary. Losing it silently removes the interpretive guardrail the design added on purpose.
+
+Worth investigating whether the boxed form is a different widget (an error/placeholder container) rather than the `DataTable` with `show_header` off — the row prefixes differ (`│ │The…` boxed vs `│  The…` headed), which suggests two render paths rather than one widget in two states.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] The results grid always renders its column header, in every lens and every entry path
+- [ ] The `[warned]` marker is present whenever the run's canary is degenerate
+- [ ] The two render paths are reconciled to one, or the second is explained and made deliberate
+- [ ] A test fails if the header is absent after a fresh mount
+<!-- AC:END -->

--- a/backlog/tasks/task-1035 - Evals-the-primary-action-is-a-silent-no-op-and-the-empty-state-has-no-.md
+++ b/backlog/tasks/task-1035 - Evals-the-primary-action-is-a-silent-no-op-and-the-empty-state-has-no-.md
@@ -1,0 +1,39 @@
+---
+id: TASK-1035
+title: >-
+  Evals: the primary action is a silent no-op and the empty state has no ordering
+status: To Do
+assignee: []
+created_date: '2026-07-27 16:00'
+labels:
+  - evals
+  - ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found during UAT of the Evals screen, walking it as a first-time user.
+
+**The primary action does nothing, silently.** With no bench selected, the Inspector still presents a **Run Bench** button. Clicking it produces no toast, no inline error, no state change — nothing. The user cannot distinguish "I did something wrong", "the app is busy", and "the app is broken". Either disable it with a reason, or have it explain what is missing.
+
+**The empty state offers three competing actions with no primacy.** On first open the rail shows `Benches (0)` / `Datasets (0)` / `Runs (0)` simultaneously, each with its own affordance — `Create sample bench`, `+ New dataset`, `Import…`. Nothing signals that the sample bench is the intended first step, nor that a bench depends on a dataset. A newcomer has to reverse-engineer the model from three equal-looking options.
+
+**The Detail pane's empty text is unactionable at exactly the moment it is shown.** It reads "Select a bench, dataset, or run in the library rail to see its detail here" — while the rail is empty and there is nothing to select. It should acknowledge the zero-data case and point at the one action that helps.
+
+**Unexplained jargon on first contact.** The run header reads `loaded-nouns (sample) 4465779b · raw · K 20 · 4 cells · 0 failed`. For a first-time reader `raw`, `K 20` and `cells` are all undefined, and the screen's own subtitle — "Run and review evaluation jobs" — never says what an eval or a bench is or why one would want either.
+
+**Layout.** At 200 columns the Inspector is roughly 25 characters wide, so its content wraps mid-phrase ("K requested 20 · K returned" / "canary degenerate"). Three panes at that width leaves the rightmost one too narrow for the text it carries.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] `Run Bench` is disabled with a stated reason, or explains what is missing when pressed
+- [ ] The empty state establishes one obvious first step
+- [ ] The Detail pane's zero-data text is actionable
+- [ ] First-contact jargon is defined somewhere reachable from the screen
+- [ ] The Inspector has enough width for its content at common terminal sizes
+<!-- AC:END -->

--- a/backlog/tasks/task-1036 - Degenerate-canary-warning-is-not-surfaced-where-results-are-read.md
+++ b/backlog/tasks/task-1036 - Degenerate-canary-warning-is-not-surfaced-where-results-are-read.md
@@ -1,0 +1,39 @@
+---
+id: TASK-1036
+title: >-
+  Degenerate-canary warning is not surfaced where results are read
+status: To Do
+assignee: []
+created_date: '2026-07-27 16:00'
+labels:
+  - evals
+  - ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found during UAT of the Evals screen.
+
+The word bench has a real interpretive hazard: raw mode against an instruct-tuned model is out-of-distribution, so the numbers can be well-formed and meaningless. The design added a **distribution sanity canary** precisely for this, and on the **bench** view it is presented well — a recovery callout naming the target and explaining the consequence: *"a large divergence in its column may reflect that, not the prompt."*
+
+On the **run** view, where the user actually reads results, that explanation is absent.
+
+Walked live: after "Create sample bench" the grid showed `The protestors were [neutral] → "mente" 49%`. `"mente"` is a nonsense continuation — the canary was degenerate — but nothing on screen said so. Searching the whole rendered view for "canary", "degenerate", "warn" or "out-of-distribution" matched **zero** times.
+
+The signal does exist, but only two clicks deep and only as raw jargon: focusing a cell populates the Inspector with `canary degenerate` on a metadata line, alongside `K requested 20 · K returned …` and `truncated mass: 10.4%`. There is no sentence saying what that means or how it should change the reading.
+
+So a first-time user runs the sample bench, sees a nonsense token with a confident-looking 49%, and has nothing telling them the setup is out-of-distribution. That is the exact misreading the canary was introduced to prevent, and the fix is placement and wording rather than new machinery — the verdict is already computed and already stamped on every cell.
+
+See also the sibling defect where the `[warned]` column marker disappears entirely in one of the grid's two render paths.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] A degenerate canary is visible on the run view without requiring a cell click
+- [ ] The wording explains the consequence, not just the state
+- [ ] The bench view and run view agree on how prominently it is presented
+<!-- AC:END -->

--- a/backlog/tasks/task-1076 - Evals-the-primary-action-is-a-silent-no-op-and-the-empty-state-has-no-.md
+++ b/backlog/tasks/task-1076 - Evals-the-primary-action-is-a-silent-no-op-and-the-empty-state-has-no-.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-1035
+id: TASK-1076
 title: >-
   Evals: the primary action is a silent no-op and the empty state has no ordering
 status: To Do


### PR DESCRIPTION
Walked the Evals screen live on `origin/dev` (155574902) against a real llama.cpp, in an isolated profile — first as a new user, then as an experienced one, then re-reading it against interaction-design heuristics.

**Three findings filed:**

- **TASK-1034 (high)** — the results grid renders **two structurally different ways in the same view**: boxed with no column header and no `[warned]` marker, or unboxed with both. Not lens-dependent; a systematic pass showed `header=0` on all five lenses minutes after Entropy had shown one. The headerless form loses column identity and the canary marker — the interpretive guardrail the design added deliberately.
- **TASK-1035 (medium)** — `Run Bench` with nothing selected is a **silent no-op**: no toast, no error, no state change, so the user cannot tell whether they erred or the app broke. Plus an empty state offering three equal-weight actions with no first step, a Detail pane whose "select a bench…" text is unactionable while nothing exists to select, and undefined first-contact jargon (`raw · K 20 · 4 cells`).
- **TASK-1036 (medium)** — the degenerate-canary explanation is presented well on the **bench** view but reduced on the **run** view to the bare phrase `canary degenerate`, two clicks deep. Searching the rendered results view for "canary", "degenerate", "warn" or "out-of-distribution" matched **zero** times, while the grid showed `"mente" 49%` for "The protestors were" — the exact misreading the canary exists to prevent.

**What held up well**, and is worth not regressing: the sample-bench path is fast (~3–4s) with immediate "Creating sample bench…" feedback and auto-navigation to results rather than a dead end; the `l`/`b`/`s`/`e` shortcuts work reliably and are advertised in the footer; the Probe lens degrades honestly to `Lens: Probe (no probes configured)` with `n/a` rather than blanks; and zero ERROR lines were logged across the whole session.

It also confirmed **TASK-860 in practice** — the run persisted to `uat_fresh/evals.db`, the isolated profile, leaving `default_user` untouched. That was the bug that wrote into real user data earlier in this programme.

Documentation only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents Evals UAT findings and adds three backlog task entries with acceptance criteria. Captures the results grid header/canary marker inconsistency (TASK-1034), the silent Run Bench behavior and unclear empty state (TASK-1076, renumbered), and the missing canary warning on the run view where results are read (TASK-1036).

<sup>Written for commit 53704e24efd38f5923d2bd696ae94ad642881fb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

