### PR TITLE
fix(chatbooks): reconcile export directory default across the four windows

### DIFF
--- a/.superpowers/sdd/task-984-report.md
+++ b/.superpowers/sdd/task-984-report.md
@@ -1,0 +1,69 @@
+# task-984 report
+
+## Review findings
+
+Addressed three automated-reviewer findings on PR #1026 (fix/chatbook-export-default).
+
+1. **Real bug — server-mode preview touched the filesystem (ACCEPTED, fixed).**
+   `PreviewConfirmStep._update_preview()` in `tldw_chatbook/UI/Wizards/ChatbookCreationWizard.py`
+   called `get_private_chatbooks_dir()` (which hardens and *creates* the directory via
+   `secure_private_directory(..., create=True, application_owned=True)`) before checking
+   `execution_mode`, then discarded the result for server-mode exports. Reordered so
+   `execution_mode` is read first and the local path (timestamp/filename/`get_private_chatbooks_dir()`)
+   is only resolved in the non-server branch.
+
+   Added `test_wizard_preview_confirm_server_mode_never_touches_local_directory` in
+   `Tests/Chatbooks/test_chatbook_export_directory_default.py`. TDD-verified: wrote the test
+   against the pre-fix code, confirmed it failed (`get_private_chatbooks_dir()` called twice —
+   once from the initial `on_show()`, once from the explicit call — asserted 0), applied the
+   fix, confirmed it passed. The test also asserts the fake `user_data_dir` root never gets
+   created on disk, and that `wizard_data["export_path"]` stays `""` with the server-mode text
+   rendered.
+
+2. **`ChatbooksWindowImproved.__init__` missing a docstring (ACCEPTED, added).**
+   Added a minimal Google-style docstring (`Store the owning app and resolve the default
+   export directory.` + `Args: app_instance`). Note: this is not strictly the prevailing
+   convention in this codebase — a grep of `tldw_chatbook/UI/*.py` shows `__init__` methods
+   are undocumented far more often than documented (including the sibling
+   `ChatbookExportManagementWindow.__init__`, which has the identical shape/comment and was
+   not flagged). Added anyway since it's cheap and harmless.
+
+3. **New test docstrings "not Google-style" (DECLINED).**
+   Reviewed every docstring in `Tests/Chatbooks/test_chatbook_export_directory_default.py`
+   against the repo's actual convention rather than an abstract ideal:
+   - One-line summaries and multi-line summary+blank-line+body docstrings are the exact
+     pattern used throughout `Tests/Chatbooks/` (e.g. `test_chatbook_creator.py`'s
+     `test_the_temp_dir_fallback_survives_a_symlinked_system_temp_root`,
+     `test_chatbook_importer.py`'s `stub_citation_composition`) and in the production module
+     under test itself (`tldw_chatbook/Chatbooks/database_paths.py`'s `get_private_chatbooks_dir`,
+     `secure_chatbook_directory` — one-liners, no `Args:`).
+   - `Args:` sections are added elsewhere in this test tree only when a fixture's role is
+     non-obvious (the symlink test, the key-casing stub); plain `tmp_path`/`monkeypatch` usage
+     is left undocumented repo-wide, including in `test_chatbook_database_paths.py`'s tests
+     which have *no* docstring at all.
+   - The module-level header (`# filename.py` comment block + `"""Title\n----\n\n...` docstring)
+     matches `Tests/textual_test_utils.py` and `Tests/Evals/test_eval_orchestrator.py` verbatim.
+
+   Every docstring already ends in a period, starts capitalized, and separates summary from
+   body correctly. Concluded the finding's premise is incorrect for this repo and left the
+   test docstrings unmodified rather than padding them against a rule the codebase doesn't
+   actually follow.
+
+### Rebase
+
+Rebased onto `origin/dev` (39 commits behind at merge-base `155574902`). No commits on dev
+touched any of the four Chatbook files or the new test file between the merge-base and dev tip,
+so the rebase applied cleanly with zero conflicts. Force-pushed with `--force-with-lease`.
+
+### Verification
+
+- `Tests/Chatbooks/`: 170 passed, 1 skipped (was 169 passed pre-fix; +1 new test).
+- `Tests/UI/test_chatbook_action_recovery_tooltips.py`,
+  `test_chatbook_management_server_jobs.py`, `test_chatbooks_screen_server_actions.py`,
+  `test_file_picker_action_tooltips.py`, `test_server_chatbook_service_lease.py`: 27 passed.
+- `pyflakes` clean on all three touched files.
+- Confirmed server-mode preview no longer creates the local chatbooks directory
+  (call-count + filesystem-existence assertions in the new test).
+
+Commits: `e07cdb1ce` → rebased to `1faf2cd98` (default fix), `878afa396` (docs close-out),
+`88bb8156b` (this fix + docstring + test, HEAD after rebase and force-push).

--- a/Tests/Chatbooks/test_chatbook_database_paths.py
+++ b/Tests/Chatbooks/test_chatbook_database_paths.py
@@ -89,3 +89,27 @@ def test_chatbook_surfaces_do_not_embed_database_defaults(
     assert "chachanotes_db_path" not in source
     assert "prompts_db_path" not in source
     assert "media_db_path" not in source
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "tldw_chatbook/UI/Wizards/ChatbookCreationWizard.py",
+        "tldw_chatbook/UI/ChatbookExportManagementWindow.py",
+        "tldw_chatbook/UI/Chatbooks_Window_Improved.py",
+        "tldw_chatbook/UI/ChatbookCreationWindow.py",
+    ],
+)
+def test_chatbook_export_directory_surfaces_use_private_chatbooks_dir_accessor(
+    relative_path: str,
+) -> None:
+    """The four Chatbook windows default the export dir via the accessor.
+
+    Regression guard for task-984: reconciles the export directory default
+    across all four windows onto ``get_private_chatbooks_dir()`` instead of
+    the hardcoded ``~/Documents/Chatbooks`` literal.
+    """
+    source = (Path(__file__).parents[2] / relative_path).read_text(encoding="utf-8")
+
+    assert "get_private_chatbooks_dir" in source
+    assert '"Documents" / "Chatbooks"' not in source

--- a/Tests/Chatbooks/test_chatbook_export_directory_default.py
+++ b/Tests/Chatbooks/test_chatbook_export_directory_default.py
@@ -1,0 +1,196 @@
+# test_chatbook_export_directory_default.py
+# Description: Regression tests for task-984 -- reconciling the Chatbook
+# export directory default across the four windows.
+#
+"""
+Chatbook Export Directory Default
+----------------------------------
+
+Covers the runtime behavior half of task-984: ``ChatbookExportManagementWindow``,
+``ChatbooksWindowImproved`` and the ``ChatbookCreationWizard`` preview step now
+default the visible export directory to ``get_private_chatbooks_dir()`` (the
+same accessor ``ChatbookCreationWindow`` already used) instead of the
+hardcoded ``~/Documents/Chatbooks`` literal.
+
+Every expected value below is derived by calling the real accessor with its
+dependency monkeypatched, never by re-spelling a path literal -- a test that
+repeats the literal goes vacuous in lockstep with the next drift instead of
+catching it.
+"""
+
+from pathlib import Path
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+
+from tldw_chatbook.Chatbooks import database_paths
+from tldw_chatbook.UI.ChatbookExportManagementWindow import (
+    ChatbookExportManagementWindow,
+)
+from tldw_chatbook.UI.Chatbooks_Window_Improved import ChatbooksWindowImproved
+from tldw_chatbook.UI.Wizards.BaseWizard import WizardStepConfig
+from tldw_chatbook.UI.Wizards.ChatbookCreationWizard import PreviewConfirmStep
+
+
+class _FakeAppInstance:
+    """Minimal stand-in for TldwCli; the windows under test only store it."""
+
+
+class _FakeWizard:
+    """Minimal stand-in for WizardContainer; only `.wizard_data` is read."""
+
+    def __init__(self) -> None:
+        self.wizard_data: dict = {}
+
+
+def test_export_management_window_default_uses_private_chatbooks_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The management window's default storage dir is get_private_chatbooks_dir()."""
+    user_data_dir = tmp_path / "runtime-data"
+    monkeypatch.setattr(
+        database_paths.config, "get_user_data_dir", lambda: user_data_dir
+    )
+
+    window = ChatbookExportManagementWindow(_FakeAppInstance())
+
+    assert window.chatbooks_dir == database_paths.get_private_chatbooks_dir()
+
+
+def test_chatbooks_window_improved_default_uses_private_chatbooks_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The landing page's default scan dir is get_private_chatbooks_dir()."""
+    user_data_dir = tmp_path / "runtime-data"
+    monkeypatch.setattr(
+        database_paths.config, "get_user_data_dir", lambda: user_data_dir
+    )
+
+    window = ChatbooksWindowImproved(_FakeAppInstance())
+
+    assert window._export_path == database_paths.get_private_chatbooks_dir()
+
+
+@pytest.mark.asyncio
+async def test_wizard_preview_confirm_default_export_path_uses_private_chatbooks_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The creation wizard's previewed export path sits under the private dir.
+
+    Also proves the UI keeps showing the resolved directory rather than
+    implying a fixed location: `#export-path` renders the same directory the
+    wizard will actually write to.
+    """
+    user_data_dir = tmp_path / "runtime-data"
+    monkeypatch.setattr(
+        database_paths.config, "get_user_data_dir", lambda: user_data_dir
+    )
+
+    fake_wizard = _FakeWizard()
+    step = PreviewConfirmStep(
+        wizard=fake_wizard,
+        config=WizardStepConfig(
+            id="preview-confirm",
+            title="Preview & Confirm",
+            description="Review your chatbook",
+            step_number=4,
+        ),
+    )
+
+    class WizardStepApp(App):
+        def compose(self) -> ComposeResult:
+            yield step
+
+    app = WizardStepApp()
+    async with app.run_test():
+        step._update_preview()
+        rendered_path = str(step.query_one("#export-path", Static).content)
+
+    expected_dir = database_paths.get_private_chatbooks_dir()
+    export_path = Path(fake_wizard.wizard_data["export_path"])
+
+    assert export_path.parent == expected_dir
+    assert str(expected_dir) in rendered_path
+
+
+@pytest.mark.parametrize(
+    "window_factory",
+    [
+        lambda: ChatbookExportManagementWindow(_FakeAppInstance()).chatbooks_dir,
+        lambda: ChatbooksWindowImproved(_FakeAppInstance())._export_path,
+    ],
+    ids=["export-management-window", "chatbooks-window-improved"],
+)
+def test_explicit_data_dir_override_relocates_export_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    window_factory,
+) -> None:
+    """A user-configured data directory still wins over the default root.
+
+    Neither window has its own export-directory config key; the only lever a
+    user has to relocate exports today is the general ``[paths] data_dir``
+    setting that ``get_private_chatbooks_dir()`` already resolves through
+    ``get_user_data_dir()``. This proves the windows follow wherever that
+    resolves rather than a value baked in at construction time.
+    """
+    first_root = tmp_path / "root-one"
+    monkeypatch.setattr(database_paths.config, "get_user_data_dir", lambda: first_root)
+    first_resolved = window_factory()
+    first_expected = database_paths.get_private_chatbooks_dir()
+    assert first_resolved == first_expected
+
+    second_root = tmp_path / "root-two"
+    monkeypatch.setattr(
+        database_paths.config, "get_user_data_dir", lambda: second_root
+    )
+    second_resolved = window_factory()
+    second_expected = database_paths.get_private_chatbooks_dir()
+    assert second_resolved == second_expected
+
+    assert first_expected != second_expected
+
+
+def test_existing_export_at_old_documents_location_is_left_untouched(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Constructing a window under the new default must not touch old exports.
+
+    Regression guard for task-984's default-only constraint: this change only
+    affects what the export directory defaults to. A user who already has
+    exports under the pre-existing ``~/Documents/Chatbooks`` literal keeps
+    them exactly where they are -- nothing is moved, copied, or deleted.
+    """
+    # `Path.home()` resolves the per-test isolated HOME set by the autouse
+    # `isolate_test_environment` fixture in Tests/conftest.py, never the
+    # real user's home directory.
+    old_export_dir = Path.home() / "Documents" / "Chatbooks"
+    old_export_dir.mkdir(parents=True, mode=0o755)
+    marker = old_export_dir / "existing_export.zip"
+    marker.write_bytes(b"pre-existing chatbook export")
+    marker_mtime_before = marker.stat().st_mtime_ns
+
+    user_data_dir = tmp_path / "runtime-data"
+    monkeypatch.setattr(
+        database_paths.config, "get_user_data_dir", lambda: user_data_dir
+    )
+
+    management_window = ChatbookExportManagementWindow(_FakeAppInstance())
+    landing_window = ChatbooksWindowImproved(_FakeAppInstance())
+
+    resolved = database_paths.get_private_chatbooks_dir()
+    assert management_window.chatbooks_dir == resolved
+    assert landing_window._export_path == resolved
+    assert resolved != old_export_dir
+
+    # The old location and its pre-existing contents are exactly as they
+    # were -- not read into a listing, not deleted, not written to.
+    assert old_export_dir.exists()
+    assert [p.name for p in old_export_dir.iterdir()] == ["existing_export.zip"]
+    assert marker.read_bytes() == b"pre-existing chatbook export"
+    assert marker.stat().st_mtime_ns == marker_mtime_before

--- a/Tests/Chatbooks/test_chatbook_export_directory_default.py
+++ b/Tests/Chatbooks/test_chatbook_export_directory_default.py
@@ -117,6 +117,68 @@ async def test_wizard_preview_confirm_default_export_path_uses_private_chatbooks
     assert str(expected_dir) in rendered_path
 
 
+@pytest.mark.asyncio
+async def test_wizard_preview_confirm_server_mode_never_touches_local_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Server-mode preview must not resolve or create the local chatbooks dir.
+
+    Regression guard: `_update_preview()` used to call
+    `get_private_chatbooks_dir()` -- which hardens and *creates* the
+    directory -- before checking `execution_mode`, then discarded the
+    result for server-mode exports. That made merely opening the preview
+    step mutate the filesystem (and able to raise) even though server mode
+    never needs a local directory.
+    """
+    from tldw_chatbook.UI.Wizards import ChatbookCreationWizard as wizard_module
+
+    user_data_dir = tmp_path / "runtime-data"
+    monkeypatch.setattr(
+        database_paths.config, "get_user_data_dir", lambda: user_data_dir
+    )
+
+    call_count = 0
+    real_get_private_chatbooks_dir = wizard_module.get_private_chatbooks_dir
+
+    def _counting_get_private_chatbooks_dir():
+        nonlocal call_count
+        call_count += 1
+        return real_get_private_chatbooks_dir()
+
+    monkeypatch.setattr(
+        wizard_module, "get_private_chatbooks_dir", _counting_get_private_chatbooks_dir
+    )
+
+    fake_wizard = _FakeWizard()
+    fake_wizard.wizard_data["export-options"] = {"execution_mode": "server"}
+    step = PreviewConfirmStep(
+        wizard=fake_wizard,
+        config=WizardStepConfig(
+            id="preview-confirm",
+            title="Preview & Confirm",
+            description="Review your chatbook",
+            step_number=4,
+        ),
+    )
+
+    class WizardStepApp(App):
+        def compose(self) -> ComposeResult:
+            yield step
+
+    app = WizardStepApp()
+    async with app.run_test():
+        step._update_preview()
+        rendered_path = str(step.query_one("#export-path", Static).content)
+
+    assert call_count == 0, "server mode must not resolve the local directory at all"
+    assert not user_data_dir.exists(), (
+        "server mode must not create the local chatbooks directory as a side effect"
+    )
+    assert fake_wizard.wizard_data["export_path"] == ""
+    assert "Server-side export" in rendered_path
+
+
 @pytest.mark.parametrize(
     "window_factory",
     [

--- a/backlog/tasks/task-984 - Reconcile-the-Chatbook-export-directory-default-across-the-four-windows.md
+++ b/backlog/tasks/task-984 - Reconcile-the-Chatbook-export-directory-default-across-the-four-windows.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-984
 title: Reconcile the Chatbook export directory default across the four windows
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-27 19:33'
+updated_date: '2026-07-27 21:02'
 labels:
   - chatbooks
   - config
@@ -19,5 +21,34 @@ Three live Chatbook files default the visible export directory to ~/Documents/Ch
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The export directory default is the same in all four Chatbook windows,It is decided and written down whether pre-existing exports are migrated or deliberately left,No file composes the path by literal where an accessor exists,A test derives the expected default the way the app does
+- [x] #1 The export directory default is the same in all four Chatbook windows,It is decided and written down whether pre-existing exports are migrated or deliberately left,No file composes the path by literal where an accessor exists,A test derives the expected default the way the app does
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Grep the whole tree (not just the task's named files) for the ~/Documents/Chatbooks literal to confirm the full set of live windows involved.
+2. Read task-967's Implementation Notes for the prior owner's context on why this was deliberately deferred.
+3. For each of the three live files (ChatbookExportManagementWindow.py, Chatbooks_Window_Improved.py, Wizards/ChatbookCreationWizard.py), verify there is no existing user-facing override (config key or directory picker) for the export path before swapping the literal for get_private_chatbooks_dir().
+4. Replace each Path.home()/"Documents"/"Chatbooks" default with get_private_chatbooks_dir(), removing now-unused imports (secure_private_directory, Path where applicable).
+5. Confirm each window still surfaces the resolved directory in its existing UI (status bar / preview Static) without inventing a new affordance.
+6. Add regression tests deriving the expected path via the real accessor (get_private_chatbooks_dir()) rather than a literal: default resolution per window/wizard, a data_dir config override relocating the default, and a non-destructive check that pre-existing exports at the old ~/Documents/Chatbooks location are left untouched.
+7. Add a parametrized source-scan test guarding against the literal reappearing in any of the four files.
+8. Run Tests/Chatbooks/ and the UI tests covering the three windows.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Standardized all four Chatbook windows on get_private_chatbooks_dir() (tldw_chatbook/Chatbooks/database_paths.py), the app's private, hardened per-user data directory, matching the project owner's decision already recorded in the task body. This is a default-only change: no migration code was added or needed, and existing exports at ~/Documents/Chatbooks are left exactly where they are (verified by a dedicated regression test).
+
+Found four windows, not three: ChatbookCreationWindow.py already used the accessor (per task-967). The three that still hardcoded Path.home()/"Documents"/"Chatbooks" were ChatbookExportManagementWindow.py, Chatbooks_Window_Improved.py, and Wizards/ChatbookCreationWizard.py -- exactly the set task-967's notes flagged and deliberately left alone. All three already called secure_private_directory/secure_chatbook_directory (create=True, application_owned=True) on the old literal, so no bare mkdir needed hardening; the fix is a one-line swap of the input path plus import cleanup (dropped the now-unused secure_private_directory import in ChatbookExportManagementWindow.py and the now-unused Path import in Chatbooks_Window_Improved.py).
+
+None of the three files has its own export-directory config key or a working directory picker today (ChatbookCreationWizard.py's "Change Location" button on the preview step has zero handler wired to it -- pre-existing dead UI, out of scope for this task and not touched). The only lever a user has to relocate the default is the general [paths] data_dir config setting, which get_private_chatbooks_dir() already resolves through get_user_data_dir() -- a dedicated test proves that override still wins. Each window already displays the resolved directory through its existing affordance (ChatbookExportManagementWindow's status bar "Storage: {dir}", the wizard preview step's #export-path Static), so no new UI was invented.
+
+Tests added: Tests/Chatbooks/test_chatbook_export_directory_default.py (default resolution per window/wizard step, config-override relocation, and a non-destructive regression test that plants a marker file at the old ~/Documents/Chatbooks location and asserts it is untouched after construction). Extended Tests/Chatbooks/test_chatbook_database_paths.py with a parametrized source-scan guarding all four files against the literal reappearing. Every expected path in these tests is computed by calling get_private_chatbooks_dir() itself (with get_user_data_dir monkeypatched), never re-spelled as a literal.
+
+Verified: Tests/Chatbooks/ (169 passed, 1 skipped), plus Tests/UI/test_chatbook_action_recovery_tooltips.py, test_chatbook_management_server_jobs.py, test_chatbooks_screen_server_actions.py, test_file_picker_action_tooltips.py, test_server_chatbook_service_lease.py (27 passed). ruff/pyflakes clean on all touched files.
+
+Files: tldw_chatbook/UI/ChatbookExportManagementWindow.py, tldw_chatbook/UI/Chatbooks_Window_Improved.py, tldw_chatbook/UI/Wizards/ChatbookCreationWizard.py, Tests/Chatbooks/test_chatbook_export_directory_default.py (new), Tests/Chatbooks/test_chatbook_database_paths.py.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/ChatbookExportManagementWindow.py
+++ b/tldw_chatbook/UI/ChatbookExportManagementWindow.py
@@ -24,9 +24,11 @@ from textual.widgets import Static, Button, DataTable, OptionList, Footer
 from textual.reactive import reactive
 from loguru import logger
 
-from ..Utils.private_paths import secure_private_directory
 from ..Chatbooks.chatbook_importer import ChatbookImporter
-from ..Chatbooks.database_paths import get_chatbook_database_paths
+from ..Chatbooks.database_paths import (
+    get_chatbook_database_paths,
+    get_private_chatbooks_dir,
+)
 from ..Chatbooks.chatbook_models import ChatbookManifest
 from ..Chatbooks.server_chatbook_service import (
     get_server_job_records,
@@ -314,11 +316,10 @@ class ChatbookExportManagementWindow(ModalScreen):
     def __init__(self, app_instance: "TldwCli", **kwargs):
         super().__init__(**kwargs)
         self.app_instance = app_instance
-        self.chatbooks_dir = secure_private_directory(
-            Path.home() / "Documents" / "Chatbooks",
-            create=True,
-            application_owned=True,
-        ).lexical_path
+        # Default to the app's private, hardened data directory rather than
+        # the hardcoded ~/Documents/Chatbooks literal (task-984). Pre-existing
+        # exports at the old location are not moved by this change.
+        self.chatbooks_dir = get_private_chatbooks_dir()
         self.chatbook_files: List[Dict[str, Any]] = []
         self.current_manifest: Optional[ChatbookManifest] = None
         self.server_job_records: List[Dict[str, Any]] = []

--- a/tldw_chatbook/UI/Chatbooks_Window_Improved.py
+++ b/tldw_chatbook/UI/Chatbooks_Window_Improved.py
@@ -382,6 +382,11 @@ class ChatbooksWindowImproved(RecomposeCaptureGuard, Screen):
     search_query = reactive("")
 
     def __init__(self, app_instance: "TldwCli", **kwargs):
+        """Store the owning app and resolve the default export directory.
+
+        Args:
+            app_instance: The running TldwCli app instance.
+        """
         super().__init__(**kwargs)
         self.app_instance = app_instance
         # Default to the app's private, hardened data directory rather than

--- a/tldw_chatbook/UI/Chatbooks_Window_Improved.py
+++ b/tldw_chatbook/UI/Chatbooks_Window_Improved.py
@@ -10,7 +10,6 @@ more features, and enhanced user experience.
 """
 
 from typing import List, Dict, Any, TYPE_CHECKING
-from pathlib import Path
 from datetime import datetime
 
 from textual.app import ComposeResult
@@ -20,7 +19,10 @@ from textual.widgets import Static, Button, Input, ListView, ListItem
 from textual.reactive import reactive
 from loguru import logger
 
-from ..Chatbooks.database_paths import secure_chatbook_directory
+from ..Chatbooks.database_paths import (
+    get_private_chatbooks_dir,
+    secure_chatbook_directory,
+)
 from ..Widgets.recompose_capture_guard import RecomposeCaptureGuard
 
 if TYPE_CHECKING:
@@ -382,9 +384,10 @@ class ChatbooksWindowImproved(RecomposeCaptureGuard, Screen):
     def __init__(self, app_instance: "TldwCli", **kwargs):
         super().__init__(**kwargs)
         self.app_instance = app_instance
-        self._export_path = secure_chatbook_directory(
-            Path.home() / "Documents" / "Chatbooks"
-        )
+        # Default to the app's private, hardened data directory rather than
+        # the hardcoded ~/Documents/Chatbooks literal (task-984). Pre-existing
+        # exports at the old location are not moved by this change.
+        self._export_path = get_private_chatbooks_dir()
 
     def compose(self) -> ComposeResult:
         # Header

--- a/tldw_chatbook/UI/Wizards/ChatbookCreationWizard.py
+++ b/tldw_chatbook/UI/Wizards/ChatbookCreationWizard.py
@@ -615,22 +615,26 @@ class PreviewConfirmStep(WizardStep):
                 notes_node.add("...")
 
         # Update export path
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        safe_name = "".join(c for c in title if c.isalnum() or c in " -_").strip()
-        export_format = export_options.get("format", "zip")
-        filename = f"{safe_name}_{timestamp}.{export_format}"
-        # Default to the app's private, hardened data directory rather than
-        # the hardcoded ~/Documents/Chatbooks literal (task-984); existing
-        # exports at the old location are left in place.
-        export_path = get_private_chatbooks_dir() / filename
         execution_mode = export_options.get("execution_mode", "local")
 
         if execution_mode == "server":
+            # Server-mode exports never touch a local directory, so don't
+            # resolve one -- get_private_chatbooks_dir() hardens and *creates*
+            # the directory as a side effect, which would otherwise make
+            # merely previewing a server-mode export mutate the filesystem.
             self.query_one("#export-path", Static).update(
                 "Server-side export via configured TLDW API"
             )
             self.wizard.wizard_data["export_path"] = ""
         else:
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            safe_name = "".join(c for c in title if c.isalnum() or c in " -_").strip()
+            export_format = export_options.get("format", "zip")
+            filename = f"{safe_name}_{timestamp}.{export_format}"
+            # Default to the app's private, hardened data directory rather than
+            # the hardcoded ~/Documents/Chatbooks literal (task-984); existing
+            # exports at the old location are left in place.
+            export_path = get_private_chatbooks_dir() / filename
             self.query_one("#export-path", Static).update(str(export_path))
             self.wizard.wizard_data["export_path"] = str(export_path)
 

--- a/tldw_chatbook/UI/Wizards/ChatbookCreationWizard.py
+++ b/tldw_chatbook/UI/Wizards/ChatbookCreationWizard.py
@@ -45,7 +45,10 @@ from ..Widgets.SmartContentTree import (
     ContentSelectionChanged,
 )
 from ...Chatbooks.chatbook_creator import ChatbookCreator
-from ...Chatbooks.database_paths import get_chatbook_database_paths
+from ...Chatbooks.database_paths import (
+    get_chatbook_database_paths,
+    get_private_chatbooks_dir,
+)
 from ...Chatbooks.chatbook_models import ContentType
 from ...Chatbooks.server_chatbook_service import (
     build_server_job_record,
@@ -616,7 +619,10 @@ class PreviewConfirmStep(WizardStep):
         safe_name = "".join(c for c in title if c.isalnum() or c in " -_").strip()
         export_format = export_options.get("format", "zip")
         filename = f"{safe_name}_{timestamp}.{export_format}"
-        export_path = Path.home() / "Documents" / "Chatbooks" / filename
+        # Default to the app's private, hardened data directory rather than
+        # the hardcoded ~/Documents/Chatbooks literal (task-984); existing
+        # exports at the old location are left in place.
+        export_path = get_private_chatbooks_dir() / filename
         execution_mode = export_options.get("execution_mode", "local")
 
         if execution_mode == "server":


### PR DESCRIPTION
## Summary

- Standardizes the Chatbook export directory default across all four windows on `get_private_chatbooks_dir()` (the app's private, hardened per-user data directory), per the project decision recorded in task-984.
- Found four windows, not three: `ChatbookCreationWindow.py` already used the accessor (per task-967). `ChatbookExportManagementWindow.py`, `Chatbooks_Window_Improved.py`, and `Wizards/ChatbookCreationWizard.py` still hardcoded `Path.home() / "Documents" / "Chatbooks"`.
- **This is a default-only change.** No migration code was added or is needed. **Existing exports at `~/Documents/Chatbooks` are not moved, copied, or deleted — they remain exactly where they are.** A dedicated regression test plants a marker file at the old location and asserts it is untouched after the windows are constructed under the new default.
- Each affected window already surfaces the resolved directory through its existing affordance (`ChatbookExportManagementWindow`'s status bar `"Storage: {dir}"`, the wizard preview step's `#export-path` Static) — no new UI was invented.
- Noted but out of scope: the wizard's "Change Location" button on the preview step has zero handler wired to it (pre-existing dead UI, unrelated to this task).

## Why `get_private_chatbooks_dir()`

`~/Documents/Chatbooks` is a hardcoded literal sitting outside the app's data directory, so it inherited none of the private-path guards (ownership checks, no shared-writable ancestor, no untrusted symlink) that the rest of the app's data now passes through via `secure_private_directory`. Chatbooks can contain conversations, notes, and character cards, so that matters.

## Test plan

- [x] `Tests/Chatbooks/` — 169 passed, 1 skipped
- [x] `Tests/UI/test_chatbook_action_recovery_tooltips.py`, `test_chatbook_management_server_jobs.py`, `test_chatbooks_screen_server_actions.py`, `test_file_picker_action_tooltips.py`, `test_server_chatbook_service_lease.py` — 27 passed
- [x] New tests derive every expected path by calling `get_private_chatbooks_dir()` itself (with `get_user_data_dir` monkeypatched), never by re-spelling a literal
- [x] New test proves a `[paths] data_dir` config override still relocates the default
- [x] New test proves pre-existing exports at the old `~/Documents/Chatbooks` location are left untouched
- [x] `ruff`/`pyflakes` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized the Chatbook export directory default across all four windows to `get_private_chatbooks_dir()` and fixed the wizard’s server‑mode preview to avoid creating a local directory. Aligns with TASK-984; existing exports under `~/Documents/Chatbooks` are left as-is.

- **Bug Fixes**
  - Set defaults in `ChatbookExportManagementWindow`, `Chatbooks_Window_Improved`, and the wizard preview step to `get_private_chatbooks_dir()` (creation window was already correct); UI still shows the resolved path.
  - Server-mode preview now checks `execution_mode` first and skips resolving/creating a local directory; only builds a path in non-server mode.
  - Added tests for the new default, `[paths] data_dir` overrides, preserving old exports, and server-mode preview not touching the filesystem; added a source-scan guard to prevent reintroducing the `~/Documents/Chatbooks` literal.
  - Minor cleanups and an `__init__` docstring for `ChatbooksWindowImproved`.

<sup>Written for commit d6cd6bb6a80f0568020409d150092ebfdcb17a29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

