### PR TITLE
fix(stt): defer optional MLX runtime imports

### DIFF
--- a/Docs/superpowers/plans/2026-07-27-lazy-mlx-import-boundary.md
+++ b/Docs/superpowers/plans/2026-07-27-lazy-mlx-import-boundary.md
@@ -1,0 +1,348 @@
+# TASK-839 Lazy MLX Import Boundary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep Parakeet MLX and Lightning Whisper MLX out of unrelated application imports and test collection while preserving installed-provider discovery and first-use behavior.
+
+**Architecture:** `transcription_service.py` will retain cheap `find_spec` discovery but replace module-level native imports with two cached lazy loaders. Existing file, buffer, and streaming paths will call a loader only when they actually need to construct a model, preserving input validation and cached-model behavior.
+
+**Tech Stack:** Python 3.11+, `importlib`, pytest subprocess tests, Ruff
+
+---
+
+## Files
+
+- Create: `Tests/Local_Ingestion/test_transcription_service_lazy_mlx.py`
+- Modify: `tldw_chatbook/Local_Ingestion/transcription_service.py`
+- Modify: `Tests/ProductionApp/test_chat_composition_retirement.py`
+- Modify: `Tests/ProductionApp/test_chat_root_state_removal.py`
+- Modify: `Tests/ProductionApp/test_provider_selection_ownership.py`
+- Verify unchanged: `Tests/test_config_stt_provider_probe.py`
+- Modify for closeout:
+  `backlog/tasks/task-839 - Prevent-optional-MLX-imports-from-aborting-test-collection.md`
+
+ADR required: no
+
+ADR path: N/A
+
+Reason: This defers existing optional imports without changing provider
+ownership, dependencies, storage, schema, or service contracts.
+
+### Task 1: Implement the complete lazy import boundary with TDD
+
+**Files:**
+
+- Create: `Tests/Local_Ingestion/test_transcription_service_lazy_mlx.py`
+- Modify: `tldw_chatbook/Local_Ingestion/transcription_service.py`
+
+- [ ] **Step 1: Write a failing subprocess import test**
+
+Use the isolated environment helper pattern from
+`Tests/test_config_stt_provider_probe.py`. The child process must:
+
+```python
+import builtins
+import importlib.machinery
+import importlib.util
+import json
+import sys
+
+guarded = {"parakeet_mlx", "lightning_whisper_mlx"}
+original_find_spec = importlib.util.find_spec
+original_import = builtins.__import__
+
+
+def find_spec(name, package=None):
+    if name in guarded:
+        return importlib.machinery.ModuleSpec(name, loader=None)
+    return original_find_spec(name, package)
+
+
+def reject_runtime_import(name, *args, **kwargs):
+    if name.split(".", 1)[0] in guarded:
+        raise AssertionError(f"optional runtime imported: {name}")
+    return original_import(name, *args, **kwargs)
+
+
+importlib.util.find_spec = find_spec
+builtins.__import__ = reject_runtime_import
+sys.platform = "darwin"
+
+from tldw_chatbook.Local_Ingestion import transcription_service
+
+print(
+    json.dumps(
+        {
+            "parakeet_available":
+                transcription_service.PARAKEET_MLX_AVAILABLE,
+            "lightning_available":
+                transcription_service.LIGHTNING_WHISPER_AVAILABLE,
+            "parakeet_loaded":
+                transcription_service.parakeet_from_pretrained is not None,
+            "lightning_loaded":
+                transcription_service.LightningWhisperMLX is not None,
+        }
+    )
+)
+```
+
+Assert a zero return code, both availability flags true, and both symbols
+unset. Set `PYTHONPATH` only to the project root—never to a stub directory.
+
+- [ ] **Step 2: Write failing loader lifecycle tests**
+
+Parameterize the two loaders. Reset each flag to true and symbol to `None`,
+patch `importlib.import_module`, then assert the loader imports once and returns
+the cached symbol on its second call:
+
+```python
+assert ensure_import() is expected_symbol
+assert ensure_import() is expected_symbol
+assert imported_modules == [expected_module]
+```
+
+Add an import-failure case using `RuntimeError("unsafe mlx")`. Assert:
+
+- the first call raises `TranscriptionError`;
+- the original exception is `__cause__`;
+- the availability flag becomes false;
+- the backend symbol stays `None`;
+- a second call does not retry `import_module`.
+
+- [ ] **Step 3: Write failing execution-path tests**
+
+Construct a `TranscriptionService` with `get_cli_setting` returning supplied
+defaults. Patch each ensure function to raise a test-only sentinel and drive
+these fresh-model paths:
+
+- Lightning file transcription;
+- Parakeet file transcription with `soundfile` reads mocked;
+- Parakeet direct-buffer transcription with a valid two-byte sample;
+- Parakeet streaming-transcriber creation.
+
+Each call must reach the sentinel immediately before model construction. It
+must not require a real MLX import. Do not require the loader to run before
+normal input validation or when a matching model is already cached.
+
+- [ ] **Step 4: Run the new file and confirm RED**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/pytest \
+  Tests/Local_Ingestion/test_transcription_service_lazy_mlx.py -q
+```
+
+Expected: the subprocess rejects the current eager import and the lazy-loader
+tests fail because the ensure functions do not exist.
+
+- [ ] **Step 5: Replace module-level imports with discovery and loaders**
+
+At module scope:
+
+```python
+def _optional_module_available(module_name: str) -> bool:
+    try:
+        return (
+            sys.platform == "darwin"
+            and importlib.util.find_spec(module_name) is not None
+        )
+    except (AttributeError, ImportError, ValueError):
+        return False
+
+
+LIGHTNING_WHISPER_AVAILABLE = _optional_module_available(
+    "lightning_whisper_mlx"
+)
+PARAKEET_MLX_AVAILABLE = _optional_module_available("parakeet_mlx")
+LightningWhisperMLX = None
+parakeet_from_pretrained = None
+```
+
+After `TranscriptionError` is defined, add two explicit functions:
+
+```python
+def _ensure_lightning_whisper_mlx_import():
+    global LIGHTNING_WHISPER_AVAILABLE, LightningWhisperMLX
+    if LightningWhisperMLX is not None:
+        return LightningWhisperMLX
+    if not LIGHTNING_WHISPER_AVAILABLE:
+        raise TranscriptionError("lightning-whisper-mlx is not installed")
+    try:
+        module = importlib.import_module("lightning_whisper_mlx")
+        LightningWhisperMLX = module.LightningWhisperMLX
+    except Exception as exc:
+        LIGHTNING_WHISPER_AVAILABLE = False
+        raise TranscriptionError(
+            "lightning-whisper-mlx could not be loaded"
+        ) from exc
+    return LightningWhisperMLX
+
+
+def _ensure_parakeet_mlx_import():
+    global PARAKEET_MLX_AVAILABLE, parakeet_from_pretrained
+    if parakeet_from_pretrained is not None:
+        return parakeet_from_pretrained
+    if not PARAKEET_MLX_AVAILABLE:
+        raise TranscriptionError("parakeet-mlx is not installed")
+    try:
+        module = importlib.import_module("parakeet_mlx")
+        parakeet_from_pretrained = module.from_pretrained
+    except Exception as exc:
+        PARAKEET_MLX_AVAILABLE = False
+        raise TranscriptionError("parakeet-mlx could not be loaded") from exc
+    return parakeet_from_pretrained
+```
+
+Do not catch `BaseException`, retry a failed import, add a loader lock, or add a
+dependency registry.
+
+- [ ] **Step 6: Wire only actual model construction**
+
+Inside each existing model-cache miss:
+
+```python
+lightning_whisper_cls = _ensure_lightning_whisper_mlx_import()
+lightning_model = lightning_whisper_cls(...)
+```
+
+and:
+
+```python
+parakeet_loader = _ensure_parakeet_mlx_import()
+self._parakeet_mlx_model = parakeet_loader(...)
+```
+
+Apply the Parakeet form to file, buffer, and streaming model loads. Preserve
+all existing input validation, model locks, cached-model fast paths, error copy,
+and the streaming method's `None` fallback.
+
+- [ ] **Step 7: Run focused GREEN tests**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/pytest \
+  Tests/Local_Ingestion/test_transcription_service_lazy_mlx.py \
+  Tests/Transcription/test_mlx_parakeet_transcription.py \
+  Tests/Transcription/test_mlx_whisper_transcription.py \
+  -k "lazy or model_loading or model_caching or not_available" -q
+```
+
+Expected: all selected tests pass without importing an actual MLX backend.
+
+- [ ] **Step 8: Confirm raw symbols are no longer invoked**
+
+```bash
+rg -n "LightningWhisperMLX\\(|parakeet_from_pretrained\\(" \
+  tldw_chatbook/Local_Ingestion/transcription_service.py
+```
+
+Expected: no direct model-construction call remains.
+
+- [ ] **Step 9: Commit the atomic implementation**
+
+```bash
+git add \
+  tldw_chatbook/Local_Ingestion/transcription_service.py \
+  Tests/Local_Ingestion/test_transcription_service_lazy_mlx.py
+git commit -m "fix(stt): defer optional MLX runtime imports"
+```
+
+### Task 2: Remove obsolete ProductionApp stubs
+
+**Files:**
+
+- Modify: `Tests/ProductionApp/test_chat_composition_retirement.py`
+- Modify: `Tests/ProductionApp/test_chat_root_state_removal.py`
+- Modify: `Tests/ProductionApp/test_provider_selection_ownership.py`
+
+- [ ] **Step 1: Remove only import scaffolding**
+
+Delete the `_MISSING_MODULE` sentinels, `sys.modules["parakeet_mlx"] = None`,
+and the surrounding restore blocks. Keep the same application/test imports as
+ordinary module-level imports. Remove `import sys` and `# ruff: noqa: E402`
+only where they become unused. Do not change product assertions or add
+replacement stubs.
+
+- [ ] **Step 2: Run the three affected modules**
+
+```bash
+HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/pytest \
+  Tests/ProductionApp/test_chat_composition_retirement.py \
+  Tests/ProductionApp/test_chat_root_state_removal.py \
+  Tests/ProductionApp/test_provider_selection_ownership.py -q
+```
+
+Expected: all tests collect and pass without importing or stubbing MLX.
+
+- [ ] **Step 3: Commit the test cleanup**
+
+```bash
+git add \
+  Tests/ProductionApp/test_chat_composition_retirement.py \
+  Tests/ProductionApp/test_chat_root_state_removal.py \
+  Tests/ProductionApp/test_provider_selection_ownership.py
+git commit -m "test: remove obsolete MLX collection stubs"
+```
+
+### Task 3: Scoped verification and closeout
+
+**Files:**
+
+- Modify:
+  `backlog/tasks/task-839 - Prevent-optional-MLX-imports-from-aborting-test-collection.md`
+
+- [ ] **Step 1: Run the exact scoped tests**
+
+```bash
+HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/pytest \
+  Tests/Local_Ingestion/test_transcription_service_lazy_mlx.py \
+  Tests/test_config_stt_provider_probe.py \
+  Tests/ProductionApp/test_chat_composition_retirement.py \
+  Tests/ProductionApp/test_chat_root_state_removal.py \
+  Tests/ProductionApp/test_provider_selection_ownership.py -q
+
+HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/pytest \
+  Tests/Transcription/test_mlx_parakeet_transcription.py \
+  Tests/Transcription/test_mlx_whisper_transcription.py \
+  -k "model_loading or model_caching or not_available" -q
+```
+
+Do not run the repository-wide suite.
+
+- [ ] **Step 2: Run touched-file checks**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/ruff check \
+  tldw_chatbook/Local_Ingestion/transcription_service.py \
+  Tests/Local_Ingestion/test_transcription_service_lazy_mlx.py \
+  Tests/ProductionApp/test_chat_composition_retirement.py \
+  Tests/ProductionApp/test_chat_root_state_removal.py \
+  Tests/ProductionApp/test_provider_selection_ownership.py
+
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/ruff format --check \
+  tldw_chatbook/Local_Ingestion/transcription_service.py \
+  Tests/Local_Ingestion/test_transcription_service_lazy_mlx.py \
+  Tests/ProductionApp/test_chat_composition_retirement.py \
+  Tests/ProductionApp/test_chat_root_state_removal.py \
+  Tests/ProductionApp/test_provider_selection_ownership.py
+
+git diff --check origin/dev...HEAD
+```
+
+- [ ] **Step 3: Review scope**
+
+Confirm no citation files, provider defaults, routing, schema, dependencies, or
+runtime ownership changed. Confirm only explicit MLX model construction invokes
+the loaders and no ProductionApp MLX stubs remain.
+
+- [ ] **Step 4: Complete TASK-839 and commit**
+
+Check all acceptance criteria, add concise implementation notes with RED/GREEN
+evidence and the no-ADR decision, set the task Done with Backlog CLI, then:
+
+```bash
+git add \
+  'backlog/tasks/task-839 - Prevent-optional-MLX-imports-from-aborting-test-collection.md'
+git commit -m "docs: close TASK-839"
+```

--- a/Docs/superpowers/specs/2026-07-27-lazy-mlx-import-boundary-design.md
+++ b/Docs/superpowers/specs/2026-07-27-lazy-mlx-import-boundary-design.md
@@ -34,19 +34,24 @@ At first provider use:
 - Load the selected backend through one explicit loader per backend.
 - Cache the imported class/function in the existing module-level reference.
 - Reuse the cached reference on later calls.
-- If Python raises while importing the optional backend, mark that backend
-  unavailable and raise the existing bounded `TranscriptionError`.
+- Have every path that dereferences a backend symbol obtain it from the loader
+  first. For Parakeet this includes file, buffer, and streaming model loads.
+- If Python raises `Exception` while importing the optional backend, keep its
+  symbol unset, mark that backend unavailable for the process, and raise the
+  existing bounded `TranscriptionError` with the original exception chained.
 
 Only paths that actually execute Parakeet MLX or Lightning Whisper MLX call
 these loaders. Provider discovery, configuration loading, app startup, and
-unrelated tests never do.
+unrelated tests never do. Python's import lock and idempotent module cache are
+sufficient here; this task does not add another loader lock.
 
 ## Error Behavior
 
 Missing packages continue to appear unavailable through the existing flags.
 An installed package that raises a normal Python exception during its lazy
 import becomes unavailable for the process and produces a transcription error
-instead of leaking the backend exception through the application.
+instead of leaking the backend exception through the application. Later calls
+fail through the same availability boundary rather than retrying the import.
 
 This change does not add a subprocess runtime, retry policy, new dependency
 registry, or new provider abstraction. A native library that terminates the
@@ -58,14 +63,18 @@ from unrelated imports and test collection.
 
 Test-driven verification will:
 
-1. Prove in a subprocess that importing the production app does not import
+1. Prove in a subprocess that importing `transcription_service` does not import
    either MLX module even when both are discoverable.
-2. Prove each backend imports on first actual use and reuses its cached symbol.
-3. Prove ordinary lazy-import failures become bounded transcription errors.
-4. Remove the three ProductionApp `sys.modules` stubs and run those affected
-   modules without replacement stubs.
-5. Run the existing config provider-probe test plus touched-file Ruff and
-   `git diff --check`.
+2. Run the existing config provider probe to preserve installed-provider
+   selection without native imports.
+3. Prove each backend imports on first actual use, every direct model-load path
+   uses the loader, and later calls reuse the cached symbol.
+4. Prove ordinary lazy-import failures become bounded transcription errors and
+   disable later retries for that process.
+5. Remove the three ProductionApp `sys.modules` stubs and run those affected
+   modules without replacement stubs; these are the full app-import proof, so
+   no redundant app subprocess test is added.
+6. Run touched-file Ruff and `git diff --check`.
 
 No full repository test suite is part of this task.
 

--- a/Docs/superpowers/specs/2026-07-27-lazy-mlx-import-boundary-design.md
+++ b/Docs/superpowers/specs/2026-07-27-lazy-mlx-import-boundary-design.md
@@ -1,0 +1,98 @@
+# Lazy MLX Import Boundary Design
+
+## Goal
+
+Keep unrelated application imports and test collection from initializing the
+optional Parakeet MLX or Lightning Whisper MLX runtimes. Installed providers
+remain discoverable, but their native Python modules load only when a user
+actually invokes that provider.
+
+## Current Problem
+
+`tldw_chatbook.Local_Ingestion.transcription_service` imports both MLX
+backends at module scope on macOS. Importing the production application reaches
+that module through the local-ingestion chain, so an installed MLX package can
+abort Python before non-STT tests collect or the application mounts. Three
+ProductionApp tests currently work around the problem by temporarily assigning
+`None` to `sys.modules["parakeet_mlx"]`.
+
+Configuration discovery already uses `importlib.util.find_spec` without
+importing either runtime. The transcription service should follow the same
+boundary until actual provider use.
+
+## Approved Design
+
+At module import:
+
+- Probe `parakeet_mlx` and `lightning_whisper_mlx` with `find_spec`.
+- Preserve the existing availability flags and provider-selection behavior.
+- Keep the backend class/function references unset.
+- Do not import either optional native runtime.
+
+At first provider use:
+
+- Load the selected backend through one explicit loader per backend.
+- Cache the imported class/function in the existing module-level reference.
+- Reuse the cached reference on later calls.
+- If Python raises while importing the optional backend, mark that backend
+  unavailable and raise the existing bounded `TranscriptionError`.
+
+Only paths that actually execute Parakeet MLX or Lightning Whisper MLX call
+these loaders. Provider discovery, configuration loading, app startup, and
+unrelated tests never do.
+
+## Error Behavior
+
+Missing packages continue to appear unavailable through the existing flags.
+An installed package that raises a normal Python exception during its lazy
+import becomes unavailable for the process and produces a transcription error
+instead of leaking the backend exception through the application.
+
+This change does not add a subprocess runtime, retry policy, new dependency
+registry, or new provider abstraction. A native library that terminates the
+process during an explicitly requested MLX transcription remains the native
+backend's responsibility; the approved scope is preventing that initialization
+from unrelated imports and test collection.
+
+## Verification
+
+Test-driven verification will:
+
+1. Prove in a subprocess that importing the production app does not import
+   either MLX module even when both are discoverable.
+2. Prove each backend imports on first actual use and reuses its cached symbol.
+3. Prove ordinary lazy-import failures become bounded transcription errors.
+4. Remove the three ProductionApp `sys.modules` stubs and run those affected
+   modules without replacement stubs.
+5. Run the existing config provider-probe test plus touched-file Ruff and
+   `git diff --check`.
+
+No full repository test suite is part of this task.
+
+## Scope
+
+In scope:
+
+- The MLX import boundary in `transcription_service.py`.
+- Focused import/lazy-loader regression tests.
+- Removal of the three obsolete ProductionApp collection stubs.
+- TASK-839 documentation and closeout.
+
+Out of scope:
+
+- Citation behavior.
+- STT provider routing or defaults.
+- Installing, removing, or replacing MLX backends.
+- Subprocess-isolated transcription.
+- Schema, configuration format, or dependency changes.
+- Unrelated test baseline repair.
+
+## ADR Check
+
+ADR required: no
+
+ADR path: N/A
+
+Reason: This defers existing optional imports to their point of use without
+changing provider ownership, runtime contracts, dependencies, storage, or
+security policy.

--- a/Tests/Local_Ingestion/test_transcription_service_lazy_mlx.py
+++ b/Tests/Local_Ingestion/test_transcription_service_lazy_mlx.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+import importlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+from types import ModuleType, SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SERVICE_MODULE = "tldw_chatbook.Local_Ingestion.transcription_service"
+LOADER_CASES = (
+    pytest.param(
+        "_ensure_lightning_whisper_mlx_import",
+        "LIGHTNING_WHISPER_AVAILABLE",
+        "LightningWhisperMLX",
+        "lightning_whisper_mlx",
+        "LightningWhisperMLX",
+        id="lightning-whisper",
+    ),
+    pytest.param(
+        "_ensure_parakeet_mlx_import",
+        "PARAKEET_MLX_AVAILABLE",
+        "parakeet_from_pretrained",
+        "parakeet_mlx",
+        "from_pretrained",
+        id="parakeet",
+    ),
+)
+
+
+@pytest.fixture(scope="module")
+def service_module():
+    """Import safely while preserving the pre-fix RED test path."""
+    if SERVICE_MODULE in sys.modules:
+        return sys.modules[SERVICE_MODULE]
+    lightning_module = ModuleType("lightning_whisper_mlx")
+    lightning_module.LightningWhisperMLX = object()
+    parakeet_module = ModuleType("parakeet_mlx")
+    parakeet_module.from_pretrained = object()
+    with patch.dict(
+        sys.modules,
+        {
+            "lightning_whisper_mlx": lightning_module,
+            "parakeet_mlx": parakeet_module,
+        },
+    ):
+        return importlib.import_module(SERVICE_MODULE)
+
+
+def _isolated_env(tmp_path: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    private_home = tmp_path / "home"
+    private_data = tmp_path / "data"
+    private_config = tmp_path / "config"
+    private_temp = tmp_path / "tmp"
+    for directory in (private_home, private_data, private_config, private_temp):
+        directory.mkdir(parents=True, mode=0o700)
+    env.update(
+        {
+            "HOME": str(private_home),
+            "USERPROFILE": str(private_home),
+            "XDG_DATA_HOME": str(private_data),
+            "XDG_CONFIG_HOME": str(private_config),
+            "TLDW_CONFIG_PATH": str(private_config / "config.toml"),
+            "TMPDIR": str(private_temp),
+            "PYTHONPATH": str(PROJECT_ROOT),
+        }
+    )
+    return env
+
+
+def _service(service_module, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        service_module, "get_cli_setting", lambda _key, default=None: default
+    )
+    return service_module.TranscriptionService()
+
+
+def _install_fake_mlx(monkeypatch: pytest.MonkeyPatch) -> None:
+    mlx_module = ModuleType("mlx")
+    core_module = ModuleType("mlx.core")
+    core_module.float32 = object()
+    core_module.float16 = object()
+    core_module.bfloat16 = object()
+    mlx_module.core = core_module
+    monkeypatch.setitem(sys.modules, "mlx", mlx_module)
+    monkeypatch.setitem(sys.modules, "mlx.core", core_module)
+
+
+def test_service_import_discovers_mlx_without_importing_it(tmp_path: Path) -> None:
+    script = textwrap.dedent(
+        """
+        import builtins
+        import importlib.machinery
+        import importlib.util
+        import json
+        import sys
+
+        guarded = {"parakeet_mlx", "lightning_whisper_mlx"}
+        original_find_spec = importlib.util.find_spec
+        original_import = builtins.__import__
+
+        def find_spec(name, package=None):
+            if name in guarded:
+                return importlib.machinery.ModuleSpec(name, loader=None)
+            return original_find_spec(name, package)
+
+        def reject_runtime_import(name, *args, **kwargs):
+            if name.split(".", 1)[0] in guarded:
+                raise AssertionError(f"optional runtime imported: {name}")
+            return original_import(name, *args, **kwargs)
+
+        importlib.util.find_spec = find_spec
+        builtins.__import__ = reject_runtime_import
+        sys.platform = "darwin"
+
+        from tldw_chatbook.Local_Ingestion import transcription_service
+
+        print(
+            json.dumps(
+                {
+                    "parakeet_available":
+                        transcription_service.PARAKEET_MLX_AVAILABLE,
+                    "lightning_available":
+                        transcription_service.LIGHTNING_WHISPER_AVAILABLE,
+                    "parakeet_loaded":
+                        transcription_service.parakeet_from_pretrained is not None,
+                    "lightning_loaded":
+                        transcription_service.LightningWhisperMLX is not None,
+                }
+            )
+        )
+        """
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=PROJECT_ROOT,
+        env=_isolated_env(tmp_path),
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert json.loads(completed.stdout.strip().splitlines()[-1]) == {
+        "parakeet_available": True,
+        "lightning_available": True,
+        "parakeet_loaded": False,
+        "lightning_loaded": False,
+    }
+
+
+@pytest.mark.parametrize(
+    (
+        "loader_name",
+        "available_name",
+        "symbol_name",
+        "module_name",
+        "export_name",
+    ),
+    LOADER_CASES,
+)
+def test_mlx_loader_imports_once_and_caches_symbol(
+    service_module,
+    monkeypatch: pytest.MonkeyPatch,
+    loader_name: str,
+    available_name: str,
+    symbol_name: str,
+    module_name: str,
+    export_name: str,
+) -> None:
+    expected_symbol = object()
+    imported_modules: list[str] = []
+
+    def import_module(name: str):
+        imported_modules.append(name)
+        return SimpleNamespace(**{export_name: expected_symbol})
+
+    monkeypatch.setattr(service_module, available_name, True)
+    monkeypatch.setattr(service_module, symbol_name, None)
+    monkeypatch.setattr(service_module.importlib, "import_module", import_module)
+    ensure_import = getattr(service_module, loader_name)
+
+    assert ensure_import() is expected_symbol
+    assert ensure_import() is expected_symbol
+    assert imported_modules == [module_name]
+
+
+@pytest.mark.parametrize(
+    (
+        "loader_name",
+        "available_name",
+        "symbol_name",
+        "module_name",
+        "_export_name",
+    ),
+    LOADER_CASES,
+)
+def test_mlx_loader_failure_is_cached(
+    service_module,
+    monkeypatch: pytest.MonkeyPatch,
+    loader_name: str,
+    available_name: str,
+    symbol_name: str,
+    module_name: str,
+    _export_name: str,
+) -> None:
+    imported_modules: list[str] = []
+    unsafe_runtime = RuntimeError("unsafe mlx")
+
+    def import_module(name: str):
+        imported_modules.append(name)
+        raise unsafe_runtime
+
+    monkeypatch.setattr(service_module, available_name, True)
+    monkeypatch.setattr(service_module, symbol_name, None)
+    monkeypatch.setattr(service_module.importlib, "import_module", import_module)
+    ensure_import = getattr(service_module, loader_name)
+
+    with pytest.raises(service_module.TranscriptionError) as first_error:
+        ensure_import()
+    with pytest.raises(service_module.TranscriptionError) as second_error:
+        ensure_import()
+
+    assert first_error.value.__cause__ is unsafe_runtime
+    assert second_error.value.__cause__ is None
+    assert getattr(service_module, available_name) is False
+    assert getattr(service_module, symbol_name) is None
+    assert imported_modules == [module_name]
+
+
+def test_lightning_file_model_construction_uses_loader(
+    service_module, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service = _service(service_module, monkeypatch)
+    sentinel = RuntimeError("lightning loader reached")
+    ensure_import = Mock(side_effect=sentinel)
+    monkeypatch.setattr(service_module, "LIGHTNING_WHISPER_AVAILABLE", True)
+    monkeypatch.setattr(
+        service_module, "_ensure_lightning_whisper_mlx_import", ensure_import
+    )
+
+    with pytest.raises(service_module.TranscriptionError) as error:
+        service._transcribe_with_lightning_whisper_mlx("audio.wav")
+
+    assert error.value.__cause__ is sentinel
+    ensure_import.assert_called_once_with()
+
+
+def test_parakeet_file_model_construction_uses_loader(
+    service_module, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service = _service(service_module, monkeypatch)
+    sentinel = RuntimeError("parakeet loader reached")
+    ensure_import = Mock(side_effect=sentinel)
+    soundfile = Mock()
+    soundfile.read.return_value = (service_module.np.zeros(1), 16000)
+    soundfile.info.return_value = SimpleNamespace(duration=0.0)
+    _install_fake_mlx(monkeypatch)
+    monkeypatch.setattr(service_module, "PARAKEET_MLX_AVAILABLE", True)
+    monkeypatch.setattr(service_module, "sf", soundfile)
+    monkeypatch.setattr(service_module, "_ensure_parakeet_mlx_import", ensure_import)
+
+    with pytest.raises(service_module.TranscriptionError) as error:
+        service._transcribe_with_parakeet_mlx("audio.wav")
+
+    assert error.value.__cause__ is sentinel
+    ensure_import.assert_called_once_with()
+
+
+def test_parakeet_buffer_model_construction_uses_loader(
+    service_module, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service = _service(service_module, monkeypatch)
+    sentinel = RuntimeError("parakeet loader reached")
+    ensure_import = Mock(side_effect=sentinel)
+    _install_fake_mlx(monkeypatch)
+    monkeypatch.setattr(service_module, "PARAKEET_MLX_AVAILABLE", True)
+    monkeypatch.setattr(service_module, "_ensure_parakeet_mlx_import", ensure_import)
+
+    with pytest.raises(service_module.TranscriptionError) as error:
+        service._transcribe_buffer_with_parakeet_mlx(
+            b"\x00\x00",
+            sample_rate=16000,
+            channels=1,
+            sample_width=2,
+            model=None,
+            language=None,
+        )
+
+    assert error.value.__cause__ is sentinel
+    ensure_import.assert_called_once_with()
+
+
+def test_parakeet_streaming_model_construction_uses_loader(
+    service_module, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service = _service(service_module, monkeypatch)
+    ensure_import = Mock(side_effect=RuntimeError("parakeet loader reached"))
+    _install_fake_mlx(monkeypatch)
+    monkeypatch.setattr(service_module, "PARAKEET_MLX_AVAILABLE", True)
+    monkeypatch.setattr(service_module, "_ensure_parakeet_mlx_import", ensure_import)
+
+    assert service.create_streaming_transcriber(provider="parakeet-mlx") is None
+    ensure_import.assert_called_once_with()

--- a/Tests/Local_Ingestion/test_transcription_service_lazy_mlx.py
+++ b/Tests/Local_Ingestion/test_transcription_service_lazy_mlx.py
@@ -179,20 +179,26 @@ def test_mlx_loader_imports_once_and_caches_symbol(
     export_name: str,
 ) -> None:
     expected_symbol = object()
-    imported_modules: list[str] = []
+    required_modules: list[str] = []
+    optional_deps = importlib.import_module("tldw_chatbook.Utils.optional_deps")
 
-    def import_module(name: str):
-        imported_modules.append(name)
+    def require_dependency(name: str):
+        required_modules.append(name)
         return SimpleNamespace(**{export_name: expected_symbol})
 
     monkeypatch.setattr(service_module, available_name, True)
     monkeypatch.setattr(service_module, symbol_name, None)
-    monkeypatch.setattr(service_module.importlib, "import_module", import_module)
+    monkeypatch.setattr(optional_deps, "require_dependency", require_dependency)
+    monkeypatch.setattr(
+        service_module.importlib,
+        "import_module",
+        Mock(side_effect=AssertionError("optional_deps helper bypassed")),
+    )
     ensure_import = getattr(service_module, loader_name)
 
     assert ensure_import() is expected_symbol
     assert ensure_import() is expected_symbol
-    assert imported_modules == [module_name]
+    assert required_modules == [module_name]
 
 
 @pytest.mark.parametrize(
@@ -214,16 +220,22 @@ def test_mlx_loader_failure_is_cached(
     module_name: str,
     _export_name: str,
 ) -> None:
-    imported_modules: list[str] = []
+    required_modules: list[str] = []
     unsafe_runtime = RuntimeError("unsafe mlx")
+    optional_deps = importlib.import_module("tldw_chatbook.Utils.optional_deps")
 
-    def import_module(name: str):
-        imported_modules.append(name)
+    def require_dependency(name: str):
+        required_modules.append(name)
         raise unsafe_runtime
 
     monkeypatch.setattr(service_module, available_name, True)
     monkeypatch.setattr(service_module, symbol_name, None)
-    monkeypatch.setattr(service_module.importlib, "import_module", import_module)
+    monkeypatch.setattr(optional_deps, "require_dependency", require_dependency)
+    monkeypatch.setattr(
+        service_module.importlib,
+        "import_module",
+        Mock(side_effect=AssertionError("optional_deps helper bypassed")),
+    )
     ensure_import = getattr(service_module, loader_name)
 
     with pytest.raises(service_module.TranscriptionError) as first_error:
@@ -235,7 +247,7 @@ def test_mlx_loader_failure_is_cached(
     assert second_error.value.__cause__ is None
     assert getattr(service_module, available_name) is False
     assert getattr(service_module, symbol_name) is None
-    assert imported_modules == [module_name]
+    assert required_modules == [module_name]
 
 
 def test_lightning_file_model_construction_uses_loader(
@@ -259,6 +271,12 @@ def test_lightning_file_model_construction_uses_loader(
 def test_parakeet_file_model_construction_uses_loader(
     service_module, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    debug_messages: list[str] = []
+    monkeypatch.setattr(
+        service_module.logger,
+        "debug",
+        lambda message, *args, **kwargs: debug_messages.append(str(message)),
+    )
     service = _service(service_module, monkeypatch)
     sentinel = RuntimeError("parakeet loader reached")
     ensure_import = Mock(side_effect=sentinel)
@@ -275,6 +293,9 @@ def test_parakeet_file_model_construction_uses_loader(
 
     assert error.value.__cause__ is sentinel
     ensure_import.assert_called_once_with()
+    assert not any(
+        "parakeet_from_pretrained function:" in message for message in debug_messages
+    )
 
 
 def test_parakeet_buffer_model_construction_uses_loader(

--- a/Tests/ProductionApp/test_chat_composition_retirement.py
+++ b/Tests/ProductionApp/test_chat_composition_retirement.py
@@ -1,42 +1,24 @@
-# ruff: noqa: E402
-
 from __future__ import annotations
 
 import asyncio
 import logging
-import sys
 
 import pytest
 from textual.css.query import NoMatches
 from textual.widgets import Input
 
-# Exercise the full production app in its supported "optional transcription
-# backend absent" configuration. The installed parakeet-mlx wheel aborts the
-# interpreter while importing MLX in this test runner, before Textual can mount.
-_MISSING_MODULE = object()
-_previous_parakeet_mlx = sys.modules.get("parakeet_mlx", _MISSING_MODULE)
-sys.modules["parakeet_mlx"] = None
-
-try:
-    import tldw_chatbook.app as app_module
-    from tldw_chatbook.app import TldwCli
-    from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload
-    from tldw_chatbook.config import load_settings
-    from tldw_chatbook.Constants import TAB_CHAT
-    from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
-    from tldw_chatbook.UI.Navigation.pending_handoff_store import HandoffChannel
-    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
-    from tldw_chatbook.UI.Screens.settings_config_adapter import SettingsConfigAdapter
-    from tldw_chatbook.UI.Screens.settings_screen import SettingsScreen
-    from tldw_chatbook.Widgets.Console.console_composer_bar import ConsoleComposerBar
-    from tldw_chatbook.Widgets.Console.console_session_surface import (
-        ConsoleSessionSurface,
-    )
-finally:
-    if _previous_parakeet_mlx is _MISSING_MODULE:
-        sys.modules.pop("parakeet_mlx", None)
-    else:
-        sys.modules["parakeet_mlx"] = _previous_parakeet_mlx
+import tldw_chatbook.app as app_module
+from tldw_chatbook.app import TldwCli
+from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload
+from tldw_chatbook.config import load_settings
+from tldw_chatbook.Constants import TAB_CHAT
+from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
+from tldw_chatbook.UI.Navigation.pending_handoff_store import HandoffChannel
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from tldw_chatbook.UI.Screens.settings_config_adapter import SettingsConfigAdapter
+from tldw_chatbook.UI.Screens.settings_screen import SettingsScreen
+from tldw_chatbook.Widgets.Console.console_composer_bar import ConsoleComposerBar
+from tldw_chatbook.Widgets.Console.console_session_surface import ConsoleSessionSurface
 
 
 def _disable_splash(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -260,7 +242,9 @@ async def test_native_console_prompt_handoff_releases_transient_and_acknowledges
         async with app.run_test(size=(140, 48)) as pilot:
             chat = await _wait_for_screen(app, pilot, ChatScreen)
 
-            monkeypatch.setattr(chat, "_console_setup_blocked_reason", lambda: "blocked")
+            monkeypatch.setattr(
+                chat, "_console_setup_blocked_reason", lambda: "blocked"
+            )
             app.pending_handoffs.stage(
                 HandoffChannel.CONSOLE_PROMPT_INSERT,
                 "terminal prompt",
@@ -270,8 +254,7 @@ async def test_native_console_prompt_handoff_releases_transient_and_acknowledges
                 HandoffChannel.CONSOLE_PROMPT_INSERT
             )
             assert (
-                app.pending_handoffs.claim(HandoffChannel.CONSOLE_PROMPT_INSERT)
-                is None
+                app.pending_handoffs.claim(HandoffChannel.CONSOLE_PROMPT_INSERT) is None
             )
 
             monkeypatch.setattr(chat, "_console_setup_blocked_reason", lambda: "")

--- a/Tests/ProductionApp/test_chat_root_state_removal.py
+++ b/Tests/ProductionApp/test_chat_root_state_removal.py
@@ -1,45 +1,27 @@
-# ruff: noqa: E402
-
 from __future__ import annotations
 
 import asyncio
 import logging
-import sys
 from typing import Any
 
 import pytest
 from textual.widgets import Button
 
-# Exercise the full production app in its supported "optional transcription
-# backend absent" configuration. The installed parakeet-mlx wheel aborts the
-# interpreter while importing MLX in this test runner, before Textual can mount.
-_MISSING_MODULE = object()
-_previous_parakeet_mlx = sys.modules.get("parakeet_mlx", _MISSING_MODULE)
-sys.modules["parakeet_mlx"] = None
-
-try:
-    import tldw_chatbook.app as app_module
-    from tldw_chatbook.app import TldwCli
-    from tldw_chatbook.Chat.console_chat_models import (
-        ConsoleMessageRole,
-        ConsoleRunStatus,
-    )
-    from tldw_chatbook.Chat.console_provider_gateway import (
-        ConsoleProviderResolution,
-    )
-    from tldw_chatbook.config import load_settings
-    from tldw_chatbook.Constants import TAB_CHAT
-    from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
-    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
-    from tldw_chatbook.UI.Screens.chat_screen_state import TaskResumeState
-    from tldw_chatbook.UI.Screens.settings_config_adapter import SettingsConfigAdapter
-    from tldw_chatbook.UI.Screens.settings_screen import SettingsScreen
-    from tldw_chatbook.Widgets.Console.console_composer_bar import ConsoleComposerBar
-finally:
-    if _previous_parakeet_mlx is _MISSING_MODULE:
-        sys.modules.pop("parakeet_mlx", None)
-    else:
-        sys.modules["parakeet_mlx"] = _previous_parakeet_mlx
+import tldw_chatbook.app as app_module
+from tldw_chatbook.app import TldwCli
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleMessageRole,
+    ConsoleRunStatus,
+)
+from tldw_chatbook.Chat.console_provider_gateway import ConsoleProviderResolution
+from tldw_chatbook.config import load_settings
+from tldw_chatbook.Constants import TAB_CHAT
+from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from tldw_chatbook.UI.Screens.chat_screen_state import TaskResumeState
+from tldw_chatbook.UI.Screens.settings_config_adapter import SettingsConfigAdapter
+from tldw_chatbook.UI.Screens.settings_screen import SettingsScreen
+from tldw_chatbook.Widgets.Console.console_composer_bar import ConsoleComposerBar
 
 
 REMOVED_CHAT_ROOT_NAMES = (

--- a/Tests/ProductionApp/test_provider_selection_ownership.py
+++ b/Tests/ProductionApp/test_provider_selection_ownership.py
@@ -1,44 +1,28 @@
-# ruff: noqa: E402
-
 from __future__ import annotations
 
 from dataclasses import replace
 import logging
-import sys
 
 import pytest
 from textual.css.query import NoMatches
 from textual.widget import Widget
 from textual.widgets import Input, OptionList, Select
 
-# Exercise the full production app in its supported "optional transcription
-# backend absent" configuration. The installed parakeet-mlx wheel aborts the
-# interpreter while importing MLX in this test runner, before Textual can mount.
-_MISSING_MODULE = object()
-_previous_parakeet_mlx = sys.modules.get("parakeet_mlx", _MISSING_MODULE)
-sys.modules["parakeet_mlx"] = None
-
-try:
-    import tldw_chatbook.app as app_module
-    from tldw_chatbook.app import LLMProviderProvider, TldwCli
-    from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
-    from tldw_chatbook.config import load_settings
-    from tldw_chatbook.Constants import TAB_CHAT
-    from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
-    from tldw_chatbook.UI.Navigation.pending_handoff_store import (
-        ConsoleProviderIntent,
-        HandoffChannel,
-    )
-    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
-    from tldw_chatbook.UI.Screens.settings_config_adapter import SettingsConfigAdapter
-    from tldw_chatbook.UI.Screens.settings_config_models import SettingsCategoryId
-    from tldw_chatbook.UI.Screens.settings_screen import SettingsScreen
-    from tldw_chatbook.Widgets.Console.console_model_popover import ConsoleModelPopover
-finally:
-    if _previous_parakeet_mlx is _MISSING_MODULE:
-        sys.modules.pop("parakeet_mlx", None)
-    else:
-        sys.modules["parakeet_mlx"] = _previous_parakeet_mlx
+import tldw_chatbook.app as app_module
+from tldw_chatbook.app import LLMProviderProvider, TldwCli
+from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
+from tldw_chatbook.config import load_settings
+from tldw_chatbook.Constants import TAB_CHAT
+from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
+from tldw_chatbook.UI.Navigation.pending_handoff_store import (
+    ConsoleProviderIntent,
+    HandoffChannel,
+)
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from tldw_chatbook.UI.Screens.settings_config_adapter import SettingsConfigAdapter
+from tldw_chatbook.UI.Screens.settings_config_models import SettingsCategoryId
+from tldw_chatbook.UI.Screens.settings_screen import SettingsScreen
+from tldw_chatbook.Widgets.Console.console_model_popover import ConsoleModelPopover
 
 
 PROVIDERS_MODELS = {

--- a/backlog/tasks/task-839 - Prevent-optional-MLX-imports-from-aborting-test-collection.md
+++ b/backlog/tasks/task-839 - Prevent-optional-MLX-imports-from-aborting-test-collection.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-839
 title: Prevent optional MLX imports from aborting test collection
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-27 02:06'
-updated_date: '2026-07-27 20:25'
+updated_date: '2026-07-27 21:04'
 labels:
   - testing
   - optional-deps
@@ -25,10 +25,10 @@ Keep optional Parakeet and Lightning MLX backends from aborting Python during un
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Unrelated test modules collect without importing or initializing optional MLX backends
-- [ ] #2 Unavailable or unsafe MLX backends resolve through a bounded optional-dependency failure instead of aborting Python
-- [ ] #3 Focused regression coverage reproduces the current config import path without temporary PYTHONPATH stubs
-- [ ] #4 TASK-553.15 verification no longer needs parakeet_mlx or lightning_whisper_mlx stubs
+- [x] #1 Unrelated test modules collect without importing or initializing optional MLX backends
+- [x] #2 Unavailable or unsafe MLX backends resolve through a bounded optional-dependency failure instead of aborting Python
+- [x] #3 Focused regression coverage reproduces the current config import path without temporary PYTHONPATH stubs
+- [x] #4 TASK-553.15 verification no longer needs parakeet_mlx or lightning_whisper_mlx stubs
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -53,3 +53,13 @@ Reason: This defers existing optional imports to their point of use without
 changing provider ownership, dependencies, storage, schema, or service
 contracts.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented cheap MLX package discovery with two cached first-use loaders in transcription_service.py. Lightning file transcription and Parakeet file, buffer, and streaming model creation now load native runtimes only when explicitly used; import failures are chained as TranscriptionError and disable same-process retries.
+
+Added subprocess and loader lifecycle/path regression coverage, then removed the three ProductionApp sys.modules stubs. Scoped verification passed: 20 import/config/ProductionApp tests, 6 exact legacy MLX availability/loading/cache tests, Ruff check/format for all five touched code/test files, and git diff --check. The planned broad -k not_available selector was narrowed to exact node IDs because it also selected an unrelated soundfile test that initializes the unsafe native runtime. Repository-wide tests were intentionally not run per user direction.
+
+ADR required: no. No provider ownership, citation behavior, routing/defaults, schema, dependency, security, or license boundary changed.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-839 - Prevent-optional-MLX-imports-from-aborting-test-collection.md
+++ b/backlog/tasks/task-839 - Prevent-optional-MLX-imports-from-aborting-test-collection.md
@@ -1,15 +1,18 @@
 ---
 id: TASK-839
 title: Prevent optional MLX imports from aborting test collection
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2026-07-27 02:06'
-updated_date: '2026-07-27 02:06'
+updated_date: '2026-07-27 20:25'
 labels:
   - testing
   - optional-deps
   - stt
 dependencies: []
+references:
+  - Docs/superpowers/specs/2026-07-27-lazy-mlx-import-boundary-design.md
 priority: medium
 ---
 

--- a/backlog/tasks/task-839 - Prevent-optional-MLX-imports-from-aborting-test-collection.md
+++ b/backlog/tasks/task-839 - Prevent-optional-MLX-imports-from-aborting-test-collection.md
@@ -13,6 +13,7 @@ labels:
 dependencies: []
 references:
   - Docs/superpowers/specs/2026-07-27-lazy-mlx-import-boundary-design.md
+  - Docs/superpowers/plans/2026-07-27-lazy-mlx-import-boundary.md
 priority: medium
 ---
 
@@ -29,3 +30,26 @@ Keep optional Parakeet and Lightning MLX backends from aborting Python during un
 - [ ] #3 Focused regression coverage reproduces the current config import path without temporary PYTHONPATH stubs
 - [ ] #4 TASK-553.15 verification no longer needs parakeet_mlx or lightning_whisper_mlx stubs
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Detailed plan:
+`Docs/superpowers/plans/2026-07-27-lazy-mlx-import-boundary.md`
+
+1. Add failing subprocess and loader-lifecycle regressions for non-importing
+   MLX discovery, first-use caching, and bounded import failure.
+2. Replace module-level native imports with `find_spec` flags and two explicit
+   lazy loaders.
+3. Route Lightning file transcription and Parakeet file, buffer, and streaming
+   model loads through those loaders.
+4. Remove the three ProductionApp `sys.modules` stubs and run only the
+   affected import, provider, MLX-loader, and app tests.
+5. Run touched-file Ruff and diff checks, review scope, and close the task.
+
+ADR required: no
+ADR path: N/A
+Reason: This defers existing optional imports to their point of use without
+changing provider ownership, dependencies, storage, schema, or service
+contracts.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-839 - Prevent-optional-MLX-imports-from-aborting-test-collection.md
+++ b/backlog/tasks/task-839 - Prevent-optional-MLX-imports-from-aborting-test-collection.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-27 02:06'
-updated_date: '2026-07-27 21:04'
+updated_date: '2026-07-27 21:33'
 labels:
   - testing
   - optional-deps
@@ -62,4 +62,6 @@ Implemented cheap MLX package discovery with two cached first-use loaders in tra
 Added subprocess and loader lifecycle/path regression coverage, then removed the three ProductionApp sys.modules stubs. Scoped verification passed: 20 import/config/ProductionApp tests, 6 exact legacy MLX availability/loading/cache tests, Ruff check/format for all five touched code/test files, and git diff --check. The planned broad -k not_available selector was narrowed to exact node IDs because it also selected an unrelated soundfile test that initializes the unsafe native runtime. Repository-wide tests were intentionally not run per user direction.
 
 ADR required: no. No provider ownership, citation behavior, routing/defaults, schema, dependency, security, or license boundary changed.
+
+PR review follow-up: rebased onto the latest dev, routed first-use MLX imports through Utils.optional_deps.require_dependency() while keeping that helper import local to preserve startup laziness, and removed the misleading pre-load callable debug log. The dedicated regressions now fail on direct importlib bypasses and guard against restoring that stale log.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Local_Ingestion/transcription_service.py
+++ b/tldw_chatbook/Local_Ingestion/transcription_service.py
@@ -243,7 +243,9 @@ def _ensure_lightning_whisper_mlx_import():
     if not LIGHTNING_WHISPER_AVAILABLE:
         raise TranscriptionError("lightning-whisper-mlx is not installed")
     try:
-        module = importlib.import_module("lightning_whisper_mlx")
+        from ..Utils.optional_deps import require_dependency
+
+        module = require_dependency("lightning_whisper_mlx")
         LightningWhisperMLX = module.LightningWhisperMLX
     except Exception as exc:
         LIGHTNING_WHISPER_AVAILABLE = False
@@ -258,7 +260,9 @@ def _ensure_parakeet_mlx_import():
     if not PARAKEET_MLX_AVAILABLE:
         raise TranscriptionError("parakeet-mlx is not installed")
     try:
-        module = importlib.import_module("parakeet_mlx")
+        from ..Utils.optional_deps import require_dependency
+
+        module = require_dependency("parakeet_mlx")
         parakeet_from_pretrained = module.from_pretrained
     except Exception as exc:
         PARAKEET_MLX_AVAILABLE = False
@@ -2525,9 +2529,6 @@ class TranscriptionService:
                     # Add detailed logging before the problematic call
                     logger.debug(f"Current working directory: {os.getcwd()}")
                     logger.debug(f"PARAKEET_MLX_AVAILABLE: {PARAKEET_MLX_AVAILABLE}")
-                    logger.debug(
-                        f"parakeet_from_pretrained function: {parakeet_from_pretrained}"
-                    )
 
                     logger.info("[PARAKEET] About to call parakeet_from_pretrained...")
                     logger.info(f"[PARAKEET] Model name: '{model}'")

--- a/tldw_chatbook/Local_Ingestion/transcription_service.py
+++ b/tldw_chatbook/Local_Ingestion/transcription_service.py
@@ -101,42 +101,21 @@ try:
 except (ImportError, ValueError, ModuleNotFoundError):
     ONNX_ASR_AVAILABLE = False
 
-try:
-    if sys.platform == "darwin":
-        from lightning_whisper_mlx import LightningWhisperMLX
 
-        LIGHTNING_WHISPER_AVAILABLE = True
-    else:
-        LIGHTNING_WHISPER_AVAILABLE = False
-except ImportError:
-    LightningWhisperMLX = None
-    LIGHTNING_WHISPER_AVAILABLE = False
-    if sys.platform == "darwin":
-        logger.warning(
-            "lightning-whisper-mlx not available. Install with: pip install lightning-whisper-mlx"
+def _optional_module_available(module_name: str) -> bool:
+    try:
+        return (
+            sys.platform == "darwin"
+            and importlib.util.find_spec(module_name) is not None
         )
-else:
-    if sys.platform != "darwin":
-        LightningWhisperMLX = None
+    except (AttributeError, ImportError, ValueError):
+        return False
 
-try:
-    if sys.platform == "darwin":
-        from parakeet_mlx import from_pretrained as parakeet_from_pretrained
 
-        PARAKEET_MLX_AVAILABLE = True
-        logger.info("parakeet-mlx is available for real-time ASR on Apple Silicon")
-    else:
-        PARAKEET_MLX_AVAILABLE = False
-except ImportError:
-    parakeet_from_pretrained = None
-    PARAKEET_MLX_AVAILABLE = False
-    if sys.platform == "darwin":
-        logger.warning(
-            "parakeet-mlx not available. Install with: pip install parakeet-mlx"
-        )
-else:
-    if sys.platform != "darwin":
-        parakeet_from_pretrained = None
+LIGHTNING_WHISPER_AVAILABLE = _optional_module_available("lightning_whisper_mlx")
+PARAKEET_MLX_AVAILABLE = _optional_module_available("parakeet_mlx")
+LightningWhisperMLX = None
+parakeet_from_pretrained = None
 
 # torch/transformers are heavy optional dependencies (torch alone pulls in
 # ~500 transitive modules). Probe availability cheaply via find_spec instead
@@ -255,6 +234,36 @@ class TranscriptionError(Exception):
     """Base exception for transcription errors."""
 
     pass
+
+
+def _ensure_lightning_whisper_mlx_import():
+    global LIGHTNING_WHISPER_AVAILABLE, LightningWhisperMLX
+    if LightningWhisperMLX is not None:
+        return LightningWhisperMLX
+    if not LIGHTNING_WHISPER_AVAILABLE:
+        raise TranscriptionError("lightning-whisper-mlx is not installed")
+    try:
+        module = importlib.import_module("lightning_whisper_mlx")
+        LightningWhisperMLX = module.LightningWhisperMLX
+    except Exception as exc:
+        LIGHTNING_WHISPER_AVAILABLE = False
+        raise TranscriptionError("lightning-whisper-mlx could not be loaded") from exc
+    return LightningWhisperMLX
+
+
+def _ensure_parakeet_mlx_import():
+    global PARAKEET_MLX_AVAILABLE, parakeet_from_pretrained
+    if parakeet_from_pretrained is not None:
+        return parakeet_from_pretrained
+    if not PARAKEET_MLX_AVAILABLE:
+        raise TranscriptionError("parakeet-mlx is not installed")
+    try:
+        module = importlib.import_module("parakeet_mlx")
+        parakeet_from_pretrained = module.from_pretrained
+    except Exception as exc:
+        PARAKEET_MLX_AVAILABLE = False
+        raise TranscriptionError("parakeet-mlx could not be loaded") from exc
+    return parakeet_from_pretrained
 
 
 class ConversionError(TranscriptionError):
@@ -2200,7 +2209,8 @@ class TranscriptionService:
                     model_load_start = time.time()
 
                     try:
-                        lightning_model = LightningWhisperMLX(
+                        lightning_whisper_cls = _ensure_lightning_whisper_mlx_import()
+                        lightning_model = lightning_whisper_cls(
                             model=model, batch_size=batch_size, quant=quant
                         )
                         # Store config for cache comparison
@@ -2545,9 +2555,8 @@ class TranscriptionService:
 
                     # Note: We cannot use signal-based timeout in worker threads
                     # The model loading will either succeed or fail on its own
-                    self._parakeet_mlx_model = parakeet_from_pretrained(
-                        model, dtype=dtype
-                    )
+                    parakeet_loader = _ensure_parakeet_mlx_import()
+                    self._parakeet_mlx_model = parakeet_loader(model, dtype=dtype)
                     logger.info(
                         "[PARAKEET] parakeet_from_pretrained completed successfully"
                     )
@@ -3683,9 +3692,8 @@ class TranscriptionService:
                     precision = self._parakeet_mlx_config["precision"]
                     dtype = dtype_map.get(precision, mx.bfloat16)
 
-                    self._parakeet_mlx_model = parakeet_from_pretrained(
-                        model_name, dtype=dtype
-                    )
+                    parakeet_loader = _ensure_parakeet_mlx_import()
+                    self._parakeet_mlx_model = parakeet_loader(model_name, dtype=dtype)
                     self._parakeet_mlx_model._model_name = model_name
                     logger.info(f"Loaded Parakeet MLX model: {model_name}")
 
@@ -3878,9 +3886,8 @@ class TranscriptionService:
                     }
                     dtype = dtype_map.get(precision, mx.bfloat16)
 
-                    self._parakeet_mlx_model = parakeet_from_pretrained(
-                        model, dtype=dtype
-                    )
+                    parakeet_loader = _ensure_parakeet_mlx_import()
+                    self._parakeet_mlx_model = parakeet_loader(model, dtype=dtype)
                     self._parakeet_mlx_model._model_name = model
                     logger.info("Model loaded successfully")
                 except Exception as e:


### PR DESCRIPTION
## Summary
- discover optional Parakeet and Lightning MLX packages without importing their native runtimes
- load each backend only at explicit model construction and cache bounded import failures
- add import/lifecycle/path regressions and remove obsolete ProductionApp `sys.modules` stubs

## Verification
- `20 passed` — lazy-import, config probe, and three affected ProductionApp modules
- `6 passed` — exact legacy MLX availability/loading/cache tests
- Ruff check and format checks passed for all five touched code/test files
- `git diff --check` passed

Repository-wide tests were intentionally not run per the scoped-test requirement. Existing dependency/pytest-marker warnings and the headless Metal atexit message remain baseline-only.

Backlog: TASK-839

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers optional MLX runtime imports in the transcription service so `parakeet_mlx` and `lightning_whisper_mlx` are discovered but only imported on first use. Prevents crashes during app import and test collection on macOS and satisfies TASK-839.

- **Bug Fixes**
  - Replaced eager MLX imports with `find_spec` checks and two cached loaders: `_ensure_lightning_whisper_mlx_import` and `_ensure_parakeet_mlx_import`.
  - Load backends via `tldw_chatbook.Utils.optional_deps.require_dependency`; on failure, mark the backend unavailable and raise `TranscriptionError` with the original exception chained (no retry).
  - Routed Lightning file and Parakeet file/buffer/streaming paths through the loaders; preserved validation and existing model caching.
  - Removed ProductionApp `sys.modules` stubs; added subprocess and loader lifecycle/path tests to prove discovery without import; removed a misleading pre-load debug log.

<sup>Written for commit a24b9f83e2e04e4a56f9d90c25e7ceceb4329083. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

