### PR TITLE
docs: register the issues identified but not fixed this session

### DIFF
--- a/backlog/tasks/task-1064 - Register-of-issues-identified-but-not-fixed-during-the-Evals-session.md
+++ b/backlog/tasks/task-1064 - Register-of-issues-identified-but-not-fixed-during-the-Evals-session.md
@@ -1,0 +1,58 @@
+---
+id: TASK-1064
+title: >-
+  Register of issues identified but not fixed during the Evals/settings session
+status: To Do
+assignee: []
+created_date: '2026-07-27 17:00'
+labels:
+  - tech-debt
+  - follow-up
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Everything surfaced during the Evals rebuild and its follow-up work that was verified but deliberately left unfixed. Each item below is independently actionable and can be split into its own task; they are collected here so none is lost.
+
+Findings that already have their own tasks are not repeated: TASK-1022 (ADR-019 rollback), TASK-1034/1035/1036 (Evals UAT).
+
+---
+
+### 1. `ConsoleProviderGateway` has the single-slot client-loop race that TASK-981 fixed elsewhere — **highest value here**
+
+`Chat/console_provider_gateway.py::_active_http_client` keeps **one** `http_client` plus one `_client_loop`, and on a loop mismatch it swaps in a new client and schedules `aclose()` on the loop it replaced.
+
+That is structurally the same defect Qodo found in `GitHubAPIClient` during PR #1009, where it was fixed by moving to a per-loop `WeakKeyDictionary` cache. The gateway is in better shape than that code was — the read-check-swap is atomic under `_client_lock` (PR #629), and the close future carries a done-callback — but the underlying hazard remains: **closing a client that another live loop may still be using.**
+
+Its own docstrings state the exposure. `_active_http_client` says the gateway is shared between "readiness probes (awaited on the app's own event loop)" and "agent-runtime generation calls (bridged from a worker thread via a fresh `asyncio.run()` per turn)", and `_schedule_stale_client_close` concedes the previous loop "may still be running elsewhere (the app's main loop)". Those two can overlap, which is exactly the race condition.
+
+The fix is the one already proven in `GitHubAPIClient`: key the cache by running loop so no loop ever closes another's client, prune closed loops to bound growth, and keep the existing lock and done-callback.
+
+### 2. `Tests/UI/test_console_native_chat_flow.py` is red on `dev` — 18 failures
+
+Observed repeatedly across several agents in this session and dismissed each time as "pre-existing and unrelated", which was true but meant nobody wrote it down. Measured on `origin/dev`: **18 failed, 192 passed** in ~5m24s.
+
+At least two distinct causes:
+- `AssertionError: assert 'llama_cpp' == 'local_llamacpp'` — a provider-name mismatch between test expectation and current behaviour.
+- `AttributeError: 'ChatScreen' object has no attribute '_task_resume_state'` — reported by agents during the `call_from_thread` sweep.
+
+Worth establishing whether the tests are stale (provider naming changed under them) or the product regressed. The file also takes over five minutes, which is why it is rarely run and why the rot went unnoticed.
+
+### 3. Repository hygiene: 2,536 unreachable loose objects and a stale `gc.log`
+
+`git count-objects -v` reports **2,536 loose objects, ~35 MB**, and `.git/gc.log` carries "There are too many unreachable loose objects; run 'git prune'". Automatic gc will not run again until that file is removed.
+
+Deliberately not acted on during the session: this checkout hosts many concurrent worktrees and other sessions' in-flight work, and `git prune` removes unreachable objects — which is precisely what an agent's detached or uncommitted work may look like. It should be done when the repo is quiet and no other sessions are active, not opportunistically.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] `ConsoleProviderGateway` uses a per-loop client cache; a test proves two live loops never close each other's client
+- [ ] The 18 failures in `test_console_native_chat_flow.py` are each classified as stale-test or product regression, and resolved
+- [ ] Repo gc/prune is run at a quiet moment and `.git/gc.log` cleared
+- [ ] Any item split into its own task is linked from here
+<!-- AC:END -->

--- a/backlog/tasks/task-1064 - Register-of-issues-identified-but-not-fixed-during-the-Evals-session.md
+++ b/backlog/tasks/task-1064 - Register-of-issues-identified-but-not-fixed-during-the-Evals-session.md
@@ -17,7 +17,7 @@ priority: medium
 <!-- SECTION:DESCRIPTION:BEGIN -->
 Everything surfaced during the Evals rebuild and its follow-up work that was verified but deliberately left unfixed. Each item below is independently actionable and can be split into its own task; they are collected here so none is lost.
 
-Findings that already have their own tasks are not repeated: TASK-1022 (ADR-019 rollback), TASK-1034/1035/1036 (Evals UAT).
+Findings that already have their own tasks are not repeated: TASK-1022 (ADR-019 rollback), and TASK-1034 / TASK-1076 / TASK-1036 (Evals UAT). All four are on `dev`. The UAT trio was filed as 1034/1035/1036; 1035 was renumbered to 1076 after colliding with another session's Done task of that id, so the reference above names the surviving ids.
 
 ---
 


### PR DESCRIPTION
Collects everything surfaced during the Evals rebuild and its follow-ups that was verified but left unfixed, so none of it is lost. Items that already have tasks are not repeated (TASK-1022, TASK-1034/1035/1036).

**1. `ConsoleProviderGateway` has the single-slot client-loop race that #1009 fixed elsewhere** — the highest-value item. `_active_http_client` keeps one client plus one `_client_loop` and, on mismatch, swaps and schedules `aclose()` on the loop it replaced. Structurally the same defect Qodo found in `GitHubAPIClient`, fixed there with a per-loop `WeakKeyDictionary`. The gateway is in better shape — atomic swap under `_client_lock`, done-callback on the close future — but it can still close a client another live loop is using. Its own docstrings describe the exposure: the gateway is shared between app-loop readiness probes and worker-thread generation calls, and `_schedule_stale_client_close` concedes the previous loop "may still be running elsewhere".

**2. `Tests/UI/test_console_native_chat_flow.py` is red on `dev`** — 18 failed, 192 passed, ~5m24s. Agents hit this repeatedly this session and each correctly called it pre-existing and unrelated; nobody wrote it down. At least two causes: `assert 'llama_cpp' == 'local_llamacpp'` and `AttributeError: 'ChatScreen' object has no attribute '_task_resume_state'`. Needs classifying as stale tests vs product regression — the five-minute runtime is likely why the rot went unnoticed.

**3. Repo hygiene** — 2,536 unreachable loose objects (~35 MB) and a stale `.git/gc.log` blocking automatic gc. Deliberately not acted on during the session: `git prune` removes unreachable objects, which is exactly what another session's detached or uncommitted work can look like in a checkout hosting this many concurrent worktrees. Should be done when the repo is quiet.

Documentation only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add TASK-1064 to record verified-but-unfixed findings from the Evals/settings session. Lists the `ConsoleProviderGateway` client/loop race, 18 failures in `Tests/UI/test_console_native_chat_flow.py`, and repo GC cleanup (`git prune`, stale `.git/gc.log`); includes follow-up acceptance criteria; no code changes.

<sup>Written for commit ce1685dc5f7d692c011c222b0b9a8c936d7463d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

