### PR TITLE
docs(backlog): file the perform_rag_search input-validation gap

### DIFF
--- a/backlog/tasks/task-1077 - Validate-perform_rag_search-inputs-like-its-sibling-MCP-tools.md
+++ b/backlog/tasks/task-1077 - Validate-perform_rag_search-inputs-like-its-sibling-MCP-tools.md
@@ -1,0 +1,23 @@
+---
+id: TASK-1077
+title: Validate perform_rag_search inputs like its sibling MCP tools
+status: To Do
+assignee: []
+created_date: '2026-07-27 21:47'
+labels:
+  - mcp
+  - security
+  - validation
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+perform_rag_search in tldw_chatbook/MCP/tools.py accepts a query string and a limit from an MCP caller and passes both straight through to the search backends without validation. It is the only tool in that file that takes a query string and does not validate it -- verified by parsing every async def in the module and checking each body for validate_text_input. Its sibling search_conversations was brought in line during TASK-985 (PR #1024), which established the pattern and the import; this one was deliberately left alone at the time rather than silently extending a convention change beyond that task's scope. CLAUDE.md states inputs are validated at boundaries, and an MCP tool handler is a boundary: the caller is a model, and on a hub-connected setup the values can originate outside the user's own machine.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 perform_rag_search validates its query and limit using Utils/input_validation.py the way search_conversations does,Invalid input returns the tool's normal error dict rather than raising or reaching the backend,A test covers a rejected query and a rejected limit,No other tool in tldw_chatbook/MCP/tools.py accepts an unvalidated query string
+<!-- AC:END -->


### PR DESCRIPTION
Backlog-only; no code touched. Files **TASK-1077**.

`perform_rag_search` in `tldw_chatbook/MCP/tools.py` takes a query string and a limit from an MCP caller and passes both straight to the search backends without validation.

Its sibling `search_conversations` was brought in line during TASK-985 (#1024), which established the pattern and added the `Utils/input_validation.py` import. `perform_rag_search` was deliberately left alone at the time rather than silently extending a convention change beyond that task's scope — filing it rather than leaving it as a loose end.

**Scope verified rather than assumed.** Parsing every `async def` in the module and checking each body for `validate_text_input` shows `perform_rag_search` is the *only* tool taking a query string that does not validate it. So this is one gap, not the first of many.

Worth fixing because an MCP tool handler is a boundary in the sense CLAUDE.md means: the caller is a model, and on a hub-connected setup the values can originate outside the user's own machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backlog-only: added TASK-1077 to address missing input validation in `perform_rag_search` (`tldw_chatbook/MCP/tools.py`) and align it with `search_conversations`. Documents that it’s the only unvalidated query path in the module and that both query and limit should be validated via `Utils/input_validation.py`.

<sup>Written for commit a62aa796b4dcdd13fef07c9a25584becb5904077. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

