### PR TITLE
fix(console): gateway closed a client that another live event loop was using

### DIFF
--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -1795,19 +1795,74 @@ def test_injected_http_client_is_never_swapped_across_loops():
     asyncio.run(client.aclose())
 
 
-def test_active_http_client_swap_is_mutually_exclusive_across_threads():
-    """PR #629 Fix 1(a) (Gemini HIGH x2 + Qodo-8): the check-and-swap of
-    ``http_client``/``_client_loop`` must be a single atomic critical
-    section guarded by one lock, not two independently-racy reads/writes --
-    otherwise a concurrent caller from another thread/loop can interleave
-    with an in-flight swap and desync the client/loop pair (see the
-    interleaving hammer test below for the crash this produces in
-    practice). Proven deterministically here (no reliance on GIL
-    scheduling luck): thread A is parked *inside* the swap via a
-    monkeypatched, blocking ``_new_owned_http_client``, and thread B's
-    concurrent call must provably fail to complete while A is still in
-    flight -- only completing once A releases and the lock is free."""
+def test_active_http_client_first_touch_adopts_the_unclaimed_init_client(monkeypatch):
+    """TASK-1064 item 1: the client built in ``__init__`` is not yet bound to
+    (has not made a request on) any event loop, so the FIRST loop to call
+    ``_active_http_client()`` adopts it directly into the per-loop cache
+    instead of discarding it and building a fresh one -- construction should
+    not waste a connection, and there is nothing to close since no loop has
+    touched it yet. Directly supersedes the old single-slot design's
+    behavior (PR #629 Fix 1(b)), where the first touch unconditionally
+    swapped in a brand-new client and scheduled a close of the original."""
     gateway = ConsoleProviderGateway()
+    original_client = gateway.http_client
+    scheduled: list[tuple[int, object]] = []
+
+    def fake_schedule(client, loop):
+        scheduled.append((id(client), loop))
+
+    monkeypatch.setattr(
+        ConsoleProviderGateway,
+        "_schedule_stale_client_close",
+        staticmethod(fake_schedule),
+    )
+
+    async def touch() -> httpx.AsyncClient:
+        return gateway._active_http_client()
+
+    adopted = asyncio.run(touch())
+
+    assert adopted is original_client, (
+        "the first loop to touch the gateway must adopt the unclaimed "
+        "init-time client rather than discarding it for a fresh one"
+    )
+    assert scheduled == [], (
+        "adopting an unclaimed client must not schedule a close of it -- "
+        "nothing was ever using it"
+    )
+
+
+def test_active_http_client_creation_is_mutually_exclusive_across_threads():
+    """PR #629 Fix 1(a) (Gemini HIGH x2 + Qodo-8), preserved across the move
+    to a per-loop cache (TASK-1064 item 1): building a NEW per-loop cache
+    entry must be a single atomic critical section guarded by one lock, not
+    two independently-racy reads/writes -- otherwise two concurrent callers
+    on different not-yet-cached loops could each decide the cache is empty
+    and both build+insert, or interleave with the cache's other bookkeeping.
+    Proven deterministically here (no reliance on GIL scheduling luck):
+    thread A is parked *inside* client construction via a monkeypatched,
+    blocking ``_new_owned_http_client``, and thread B's concurrent call for
+    a DIFFERENT loop must provably fail to complete while A is still in
+    flight -- only completing once A releases and the lock is free.
+
+    The gateway is primed with one throwaway touch first so that both
+    threads' loops are genuinely new to the cache and both take the
+    ``_new_owned_http_client`` creation path -- the very first touch ever is
+    now an adopt-in-place of the unclaimed ``__init__`` client (see
+    ``test_active_http_client_first_touch_adopts_the_unclaimed_init_client``)
+    and would not exercise this path.
+    """
+    gateway = ConsoleProviderGateway()
+    priming_loop = asyncio.new_event_loop()
+    try:
+
+        async def prime() -> None:
+            gateway._active_http_client()
+
+        priming_loop.run_until_complete(prime())
+    finally:
+        priming_loop.close()
+
     original_new_client = ConsoleProviderGateway._new_owned_http_client
     entered = threading.Event()
     release = threading.Event()
@@ -1816,7 +1871,7 @@ def test_active_http_client_swap_is_mutually_exclusive_across_threads():
         # Only the FIRST call (thread A's) blocks -- a concurrent second
         # call (thread B's) that is *not* actually serialized by a lock
         # would sail straight through this on its own turn and finish its
-        # swap well before thread A ever releases, which is exactly the
+        # creation well before thread A ever releases, which is exactly the
         # unlocked-race behavior this test must catch.
         if not entered.is_set():
             entered.set()
@@ -1839,7 +1894,7 @@ def test_active_http_client_swap_is_mutually_exclusive_across_threads():
 
         thread_a = threading.Thread(target=call_a)
         thread_a.start()
-        assert entered.wait(timeout=5), "thread A must have entered the swap"
+        assert entered.wait(timeout=5), "thread A must have entered creation"
 
         def call_b() -> None:
             async def go() -> None:
@@ -1851,13 +1906,14 @@ def test_active_http_client_swap_is_mutually_exclusive_across_threads():
         thread_b = threading.Thread(target=call_b)
         thread_b.start()
 
-        # Thread A is still parked inside its swap -- give thread B ample
-        # opportunity to race ahead if the swap were not actually
+        # Thread A is still parked inside its creation -- give thread B
+        # ample opportunity to race ahead if creation were not actually
         # serialized by a lock.
         premature = second_done.wait(timeout=0.5)
         assert premature is False, (
-            "a concurrent swap completed while another thread's swap was "
-            "still in flight -- the check-and-swap is not atomic"
+            "a concurrent cache-entry creation completed while another "
+            "thread's creation was still in flight -- the critical section "
+            "is not atomic"
         )
         assert second_done.wait(timeout=5)
     finally:
@@ -1882,35 +1938,51 @@ def test_active_http_client_swap_is_mutually_exclusive_across_threads():
         loop_b.close()
 
 
-def test_first_swap_still_schedules_close_of_the_original_owned_client(monkeypatch):
-    """PR #629 Fix 1(b) (Gemini HIGH + Qodo-8): the very first swap has
-    ``_client_loop`` still ``None`` (there is no previous loop to close the
-    replaced client on), and the old code's ``if stale_loop is not None:``
-    guard skipped scheduling a close entirely in that case -- silently
-    leaking the client created in ``__init__``. The replaced client must
-    always be closed best-effort, even on the first swap."""
+def test_aclose_closes_current_loop_client_and_schedules_others(monkeypatch):
+    """The per-loop cache can hold multiple live clients at once (one per
+    loop that has touched the gateway); ``aclose()`` must close the calling
+    loop's own client directly and hand off every OTHER cached loop's client
+    to ``_schedule_stale_client_close`` -- never await, and never directly
+    close, a client bound to a loop it is not currently running on. This is
+    the non-leaking-close guarantee (PR #629 Fix 1(b)) restated for a cache
+    that can hold more than one entry."""
     gateway = ConsoleProviderGateway()
-    original_client = gateway.http_client
-    scheduled: list[tuple[int, object]] = []
+    other_loop = asyncio.new_event_loop()
+    try:
 
-    def fake_schedule(client, loop):
-        scheduled.append((id(client), loop))
+        async def touch() -> None:
+            gateway._active_http_client()
 
-    monkeypatch.setattr(
-        ConsoleProviderGateway,
-        "_schedule_stale_client_close",
-        staticmethod(fake_schedule),
-    )
+        other_loop.run_until_complete(touch())
+        other_client = gateway._loop_clients[other_loop]
+        assert other_client.is_closed is False
 
-    async def touch() -> None:
-        gateway._active_http_client()
+        scheduled: list[tuple[int, object]] = []
 
-    asyncio.run(touch())
+        def fake_schedule(client, loop):
+            scheduled.append((id(client), loop))
 
-    assert scheduled, (
-        "the original owned client must be scheduled for close on the first swap too"
-    )
-    assert scheduled[0][0] == id(original_client)
+        monkeypatch.setattr(
+            ConsoleProviderGateway,
+            "_schedule_stale_client_close",
+            staticmethod(fake_schedule),
+        )
+
+        async def close_from_new_loop() -> None:
+            await gateway.aclose()
+
+        asyncio.run(close_from_new_loop())
+
+        assert scheduled == [(id(other_client), other_loop)], (
+            "aclose() must hand off every other cached loop's client to "
+            "_schedule_stale_client_close, keyed to its own loop"
+        )
+        # `fake_schedule` never actually closed it -- confirms aclose() did
+        # not itself await/close a client bound to a different loop.
+        assert other_client.is_closed is False
+    finally:
+        other_loop.run_until_complete(other_client.aclose())
+        other_loop.close()
 
 
 def test_active_http_client_concurrent_swap_never_leaves_client_bound_to_wrong_loop(
@@ -2008,6 +2080,73 @@ def test_active_http_client_concurrent_swap_never_leaves_client_bound_to_wrong_l
         thread.join(timeout=2)
 
     assert errors == []
+
+
+def test_concurrent_live_loops_never_close_each_others_client():
+    """TASK-1064 item 1 -- genuine concurrency, NOT sequential ``asyncio.run()``
+    calls. A sequential two-loop probe does not discriminate: the first loop
+    is already closed by the time the second one runs, so both the fixed and
+    the unfixed single-slot code pass it. Two real OS threads each run their
+    own ``asyncio.run()`` loop and are barrier-synchronized so both loops are
+    genuinely alive at the same wall-clock moment while each resolves
+    ``_active_http_client()`` on the SAME shared gateway instance -- exactly
+    the overlap the gateway's own docstrings describe: a readiness probe
+    awaited on the app's own event loop racing an agent-runtime generation
+    call bridged from a worker thread's fresh ``asyncio.run()``. Under the
+    old single-slot ``http_client``/``_client_loop`` cache, the second
+    thread's touch treats the first thread's still-in-flight client as
+    "stale" and schedules ``aclose()`` of it on the first thread's own
+    (still-running) loop -- which actually executes it, closing a client the
+    first thread is still using.
+    """
+    gateway = ConsoleProviderGateway()
+    barrier = threading.Barrier(2)
+    obtained: dict[str, httpx.AsyncClient] = {}
+    errors: list[BaseException] = []
+    errors_lock = threading.Lock()
+
+    def run(name: str) -> None:
+        async def go() -> None:
+            client = gateway._active_http_client()
+            obtained[name] = client
+            barrier.wait(timeout=5)
+            # Keep this loop alive and pumping so a cross-loop `aclose()`
+            # scheduled onto it via `run_coroutine_threadsafe` (the bug)
+            # actually gets a chance to execute, exactly like a real
+            # in-flight request would still be holding the client open.
+            for _ in range(50):
+                await asyncio.sleep(0.01)
+                if client.is_closed:
+                    break
+
+        try:
+            asyncio.run(go())
+        except BaseException as exc:  # noqa: BLE001 -- collected, asserted below
+            with errors_lock:
+                errors.append(exc)
+
+    thread_a = threading.Thread(target=run, args=("a",))
+    thread_b = threading.Thread(target=run, args=("b",))
+    thread_a.start()
+    thread_b.start()
+    thread_a.join(timeout=10)
+    thread_b.join(timeout=10)
+
+    assert errors == [], f"unexpected errors from worker threads: {errors!r}"
+    assert "a" in obtained and "b" in obtained, "both loops must obtain a client"
+    assert obtained["a"] is not obtained["b"], (
+        "two live loops must never share the same owned http client"
+    )
+    assert obtained["a"].is_closed is False, (
+        "loop A's client was closed while loop B was concurrently alive and "
+        "touching the shared gateway -- a live loop must never close "
+        "another live loop's client"
+    )
+    assert obtained["b"].is_closed is False, (
+        "loop B's client was closed while loop A was concurrently alive and "
+        "touching the shared gateway -- a live loop must never close "
+        "another live loop's client"
+    )
 
 
 def _sse(payload):

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -1602,6 +1602,63 @@ async def test_gateway_does_not_close_injected_http_client():
     await client.aclose()
 
 
+def test_aclose_does_not_let_a_later_loop_adopt_a_previously_claimed_client():
+    """Review finding: `aclose()` clears `_loop_clients` and resets
+    `_client_loop` to `None`, but never touched `self.http_client` itself,
+    so the "unclaimed init client" escape hatch in `_active_http_client()`
+    -- which used to key off `self._client_loop is None` -- could not tell
+    "never claimed by any loop" apart from "was claimed and released by a
+    loop that is now gone". Force the reliable version of the hazard: loop
+    A claims a client via a plain ``asyncio.run()`` call, which closes loop
+    A the instant it returns (mirrors a `console_agent_bridge` per-turn
+    loop that finished on its own, with `aclose()` never having run on it).
+    When `aclose()` later runs on an unrelated loop B, A's client can't even
+    be scheduled for closing (its owning loop is already gone), so it is
+    left with `is_closed is False`. A subsequent loop C must never adopt
+    that leftover client -- doing so reuses a client whose httpx/httpcore
+    connection-pool primitives are already bound to loop A, reintroducing
+    the cross-loop binding failure this per-loop cache exists to eliminate.
+
+    Uses three separate ``asyncio.run()`` calls (each spins up and tears
+    down its own loop) rather than ``@pytest.mark.asyncio`` -- a loop
+    cannot run another loop nested inside it, and the whole point here is
+    three DISTINCT loops, the first already closed before the second ever
+    starts.
+    """
+    gateway = ConsoleProviderGateway()
+
+    async def claim() -> tuple[httpx.AsyncClient, asyncio.AbstractEventLoop]:
+        return gateway._active_http_client(), asyncio.get_running_loop()
+
+    client_a, loop_a = asyncio.run(claim())
+
+    # Sanity: loop A really did claim the client, and `asyncio.run()` has
+    # already closed loop A by the time control returns here.
+    assert gateway._client_loop is loop_a
+    assert gateway.http_client is client_a
+    assert loop_a.is_closed()
+
+    # `aclose()` now runs on loop B -- unrelated to loop A, and gone by the
+    # time it returns too. It cannot schedule a close of A's client (A is
+    # already closed), so A's client is left open; that alone is fine (its
+    # own finalizer reclaims the sockets). What must NOT happen is a later
+    # loop adopting it.
+    asyncio.run(gateway.aclose())
+    assert client_a.is_closed is False
+
+    async def reclaim() -> httpx.AsyncClient:
+        return gateway._active_http_client()
+
+    new_client = asyncio.run(reclaim())
+
+    assert new_client is not client_a, (
+        "a client already bound to loop A's (now-closed) httpx/httpcore "
+        "internals must never be adopted for a different loop"
+    )
+
+    asyncio.run(gateway.aclose())
+
+
 @pytest.mark.asyncio
 async def test_owned_http_client_uses_generous_generation_read_timeout():
     """The owned client must not cap slow local generations at the old 30s."""

--- a/backlog/tasks/task-1064 - Register-of-issues-identified-but-not-fixed-during-the-Evals-settings-session.md
+++ b/backlog/tasks/task-1064 - Register-of-issues-identified-but-not-fixed-during-the-Evals-settings-session.md
@@ -50,7 +50,7 @@ Deliberately not acted on during the session: this checkout hosts many concurren
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `ConsoleProviderGateway` uses a per-loop client cache; a test proves two live loops never close each other's client
+- [x] #1 `ConsoleProviderGateway` uses a per-loop client cache; a test proves two live loops never close each other's client
 - [x] #2 The 18 failures in `test_console_native_chat_flow.py` are each classified as stale-test or product regression, and resolved
 - [ ] #3 Repo gc/prune is run at a quiet moment and `.git/gc.log` cleared
 - [ ] #4 Any item split into its own task is linked from here
@@ -59,6 +59,23 @@ Deliberately not acted on during the session: this checkout hosts many concurren
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
+Item 1 (ConsoleProviderGateway loop-cache race) fixed; items 2 and 3 remain open and are tracked separately.
+
+Approach: replaced `Chat/console_provider_gateway.py`'s single-slot `http_client`/`_client_loop` swap with a per-loop cache (`_loop_clients: WeakKeyDictionary[loop, AsyncClient]`), following the pattern already proven in `Utils/github_api_client.py` under TASK-981/PR #1009 rather than inventing a new approach.
+
+- Keyed by the running event loop itself (WeakKeyDictionary), so entries are reclaimable once a loop is GC'd; `_prune_closed_loops()` (called under the lock on every `_active_http_client()`/`aclose()` access) proactively drops entries for loops that have already closed, bounding growth from the many short-lived per-turn `asyncio.run()` loops the agent bridge creates.
+- Kept the existing `_client_lock` guarding the whole check-cache/create-and-insert critical section (PR #629 Fix 1(a)) and the `_owns_http_client` ownership flag (injected clients still bypass the cache entirely, untouched).
+- Kept `_schedule_stale_client_close` (PR #629 Fix 1(b) non-leaking-close), but its role moved: it's no longer invoked from every cross-loop touch (there is no more "stale" client to discard on a get -- each live loop keeps its own cache entry), it's now used by `aclose()` to hand off every OTHER cached loop's client for closing on its own loop while the caller's own loop's client is awaited/closed directly. Its done-callback now actually logs failures via `logger.opt(exception=exc).warning(...)` instead of silently discarding them.
+- Added an "unclaimed client" escape hatch: the client eagerly built in `__init__` (before any loop has touched it) is adopted by the first loop that calls `_active_http_client()`, rather than being discarded and closed -- avoids wasting a connection and mirrors `GitHubAPIClient.client`'s unknown-loop escape hatch.
+
+Decisive test: `test_concurrent_live_loops_never_close_each_others_client` runs two real OS threads, each with its own `asyncio.run()` loop, barrier-synchronized so both loops are genuinely alive at the same wall-clock moment while each resolves `_active_http_client()` on the same shared gateway. Verified this test FAILS against the pre-fix single-slot code (confirming it discriminates, unlike a sequential probe): `AssertionError: loop A's client was closed while loop B was concurrently alive and touching the shared gateway -- a live loop must never close another live loop's client / assert True is False / + where True = <httpx.AsyncClient object at 0x107fb63c0>.is_closed`. Passes reliably post-fix (5/5 local reruns).
+
+Two existing tests exercised the OLD single-slot swap mechanics specifically and were rewritten to match the new architecture's invariants rather than the removed swap-and-close-on-every-touch behavior: `test_active_http_client_swap_is_mutually_exclusive_across_threads` -> `test_active_http_client_creation_is_mutually_exclusive_across_threads` (primes the cache first so both racing threads exercise the actual `_new_owned_http_client()` creation path, since the very first touch is now an adopt, not a create); `test_first_swap_still_schedules_close_of_the_original_owned_client` -> split into `test_active_http_client_first_touch_adopts_the_unclaimed_init_client` (no swap/close on first touch) and `test_aclose_closes_current_loop_client_and_schedules_others` (non-leaking close re-proven for a cache that can hold multiple live entries).
+
+Testing: `Tests/Chat/test_console_provider_gateway.py` 85 passed (was 82 passed + 2 pre-existing-design tests replaced, +3 new tests); `Tests/Utils/test_github_api_client.py` 38 passed (reference implementation undisturbed); combined with agent-bridge/agent-swap/native-tools/generation-actions/citation-boundary/run-state gateway-adjacent suites, 496 passed. Did not touch or attempt to fix `Tests/UI/test_console_native_chat_flow.py` (already red on dev, tracked as item 2) or run the full suite, per scope.
+
+Modified files: tldw_chatbook/Chat/console_provider_gateway.py, Tests/Chat/test_console_provider_gateway.py.
+
 Triaged all 18 red tests in `Tests/UI/test_console_native_chat_flow.py`. All 18 are stale tests; no product regressions found. Full file: 210 passed in 4m32s (was 18 failed/192 passed in ~5m24s on dev).
 
 Root causes (3 distinct, all test-only):

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -497,6 +497,19 @@ class ConsoleProviderGateway:
         # `http_client`/`_client_loop` directly before any loop has touched
         # the gateway.
         self._client_loop: asyncio.AbstractEventLoop | None = None
+        # Whether the client built above (or injected) has ever been
+        # resolved through `_active_http_client`/`aclose`'s "unclaimed
+        # client" escape hatches. `_client_loop is None` is NOT a safe proxy
+        # for "never claimed": `aclose()` resets it to `None` on every
+        # teardown, including after a real loop already claimed and
+        # released a client, so re-deriving "unclaimed" from it would let a
+        # SECOND loop adopt a client a FIRST loop already bound internally
+        # (httpx/httpcore lazily bind connection-pool locks to whichever
+        # loop first touches them) -- silently reintroducing the very
+        # cross-loop binding failure this per-loop cache exists to
+        # eliminate. This flag is set exactly once, on the first-ever
+        # resolution, and `aclose()` never restores it.
+        self._client_ever_claimed = False
         # Guards every read-check-create of `_loop_clients` (and the mirror
         # fields above) as a single atomic critical section (PR #629 Fix
         # 1(a), preserved across the move to a per-loop cache below):
@@ -534,9 +547,6 @@ class ConsoleProviderGateway:
     async def aclose(self) -> None:
         """Close the HTTP client(s) owned by this instance.
 
-        Returns:
-            ``None``. Injected HTTP clients are left open for their owner.
-
         The client bound to the caller's current running loop (if any) is
         closed directly -- safe, since we are already running on that loop.
         Every other cached per-loop client -- e.g. one built earlier by the
@@ -545,6 +555,9 @@ class ConsoleProviderGateway:
         ``_schedule_stale_client_close`` on its own loop; this never awaits,
         and never closes, a client bound to a loop it is not currently
         running on.
+
+        Returns:
+            ``None``. Injected HTTP clients are left open for their owner.
         """
         if not self._owns_http_client:
             return
@@ -558,14 +571,20 @@ class ConsoleProviderGateway:
             current_client: httpx.AsyncClient | None = None
             if loop is not None:
                 current_client = self._loop_clients.pop(loop, None)
-                if current_client is None and self._client_loop is None:
+                if current_client is None and not self._client_ever_claimed:
                     # Never claimed by any loop yet -- e.g. `aclose()` is
                     # called right after construction, before
                     # `_active_http_client()` was ever touched. Treat the
                     # client built in `__init__` as belonging to the loop
                     # calling `aclose()` now (mirrors the escape hatch in
-                    # `_active_http_client`).
+                    # `_active_http_client`). `_client_ever_claimed` -- not
+                    # `_client_loop is None` -- is the correct test here: it
+                    # is set exactly once, on first-ever resolution, and is
+                    # never restored by a prior teardown, so a client a
+                    # loop already bound and released can never be
+                    # re-treated as "unclaimed" by this branch.
                     current_client = self.http_client
+                    self._client_ever_claimed = True
             others = [
                 (other_loop, other_client)
                 for other_loop, other_client in self._loop_clients.items()
@@ -652,23 +671,35 @@ class ConsoleProviderGateway:
                 self.http_client, self._client_loop = cached, loop
                 return cached
             if (
-                self._client_loop is None
+                not self._client_ever_claimed
                 and self.http_client is not None
                 and not self.http_client.is_closed
             ):
                 # Unclaimed-client escape hatch: the client built in
-                # `__init__` (or otherwise not yet resolved through this
-                # method by any loop) hasn't been adopted by a loop yet --
-                # claim it for the loop touching it now instead of
-                # discarding + scheduling a close of a client nothing has
-                # even used, exactly mirroring `GitHubAPIClient.client`'s
-                # unknown-loop escape hatch.
+                # `__init__` hasn't been adopted by ANY loop yet -- claim it
+                # for the loop touching it now instead of discarding +
+                # scheduling a close of a client nothing has even used,
+                # exactly mirroring `GitHubAPIClient.client`'s unknown-loop
+                # escape hatch. Gated on `_client_ever_claimed`, not
+                # `self._client_loop is None`: `aclose()` resets
+                # `_client_loop` to `None` on every teardown, including
+                # after a real loop already claimed and released a client,
+                # so re-deriving "unclaimed" from it would let a later loop
+                # adopt a client a prior loop already bound -- httpx/httpcore
+                # lazily bind connection-pool locks to whichever loop first
+                # touches them, so reusing that client from a second loop
+                # reintroduces the cross-loop binding failure this per-loop
+                # cache exists to eliminate. `_client_ever_claimed` is set
+                # exactly once, on the first-ever resolution, and is never
+                # restored by a subsequent `aclose()`.
                 self._loop_clients[loop] = self.http_client
                 self._client_loop = loop
+                self._client_ever_claimed = True
                 return self.http_client
             new_client = self._new_owned_http_client()
             self._loop_clients[loop] = new_client
             self.http_client, self._client_loop = new_client, loop
+            self._client_ever_claimed = True
             return new_client
 
     @staticmethod

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import json
 import threading
+import weakref
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass, field, replace
 from types import GeneratorType
@@ -13,6 +14,7 @@ from typing import Any, AsyncIterator, Callable
 from urllib.parse import urlparse, urlunparse
 
 import httpx
+from loguru import logger
 
 from tldw_chatbook.Chat.Chat_Deps import (
     ChatAuthenticationError,
@@ -489,28 +491,94 @@ class ConsoleProviderGateway:
     ) -> None:
         self._owns_http_client = http_client is None
         self.http_client = http_client or self._new_owned_http_client()
+        # Mirrors whichever entry in `_loop_clients` was most recently
+        # resolved by `_active_http_client` -- kept for the "unclaimed
+        # client" escape hatch below and for callers/tests that read
+        # `http_client`/`_client_loop` directly before any loop has touched
+        # the gateway.
         self._client_loop: asyncio.AbstractEventLoop | None = None
-        # Guards the check-and-swap in `_active_http_client` as a single
-        # atomic critical section (PR #629 Fix 1(a)): concurrent callers on
-        # different loops/threads -- e.g. the app loop's readiness probe
-        # racing the agent worker thread's per-turn loop -- must never
-        # interleave the read-then-write, which could otherwise desync
-        # `http_client` from `_client_loop` (a client bound to one loop
-        # while the recorded loop is a different one).
+        # Guards every read-check-create of `_loop_clients` (and the mirror
+        # fields above) as a single atomic critical section (PR #629 Fix
+        # 1(a), preserved across the move to a per-loop cache below):
+        # concurrent callers on different loops/threads -- e.g. the app
+        # loop's readiness probe racing the agent worker thread's per-turn
+        # loop -- must never interleave a read with another caller's write,
+        # which could otherwise desync `http_client`/`_client_loop` from
+        # `_loop_clients`, or race two callers into each building their own
+        # client for what should be the same cache slot.
         self._client_lock = threading.Lock()
+        # Per-loop client cache (TASK-1064 item 1, same shape as the fix
+        # applied to `GitHubAPIClient` under TASK-981 / PR #1009): every
+        # event loop that is *currently alive* and has touched
+        # `_active_http_client()` gets its own owned `httpx.AsyncClient`, so
+        # two loops alive at the same time -- the app's own event loop
+        # awaiting a readiness probe while an agent-runtime generation call
+        # is bridged in from a worker thread's fresh per-turn
+        # ``asyncio.run()`` -- never fight over, or close, each other's
+        # client. A single-slot cache (the previous design) discarded and
+        # scheduled `aclose()` of whatever the *other*, still-live loop was
+        # using on every cross-loop touch -- closing a client mid-flight.
+        # Keyed by the loop object itself via a `WeakKeyDictionary` so an
+        # entry can be reclaimed as soon as nothing else references that
+        # loop; pruned proactively in `_prune_closed_loops` so a long-running
+        # process that bridges many short-lived per-turn loops over time
+        # doesn't accumulate dead entries waiting on GC alone.
+        self._loop_clients: "weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, httpx.AsyncClient]" = (
+            weakref.WeakKeyDictionary()
+        )
         self._config_provider = config_provider or (lambda: {})
         self._environ = environ
         self._chat_api_call_fn = chat_api_call_fn
         self._safe_error_copy = safe_error_copy or safe_provider_error_copy
 
     async def aclose(self) -> None:
-        """Close the owned HTTP client.
+        """Close the HTTP client(s) owned by this instance.
 
         Returns:
             ``None``. Injected HTTP clients are left open for their owner.
+
+        The client bound to the caller's current running loop (if any) is
+        closed directly -- safe, since we are already running on that loop.
+        Every other cached per-loop client -- e.g. one built earlier by the
+        app's long-lived loop, still alive while a shorter-lived per-turn
+        loop is the one calling ``aclose()`` -- is closed best-effort via
+        ``_schedule_stale_client_close`` on its own loop; this never awaits,
+        and never closes, a client bound to a loop it is not currently
+        running on.
         """
-        if self._owns_http_client:
-            await self.http_client.aclose()
+        if not self._owns_http_client:
+            return
+        try:
+            loop: asyncio.AbstractEventLoop | None = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        with self._client_lock:
+            self._prune_closed_loops()
+            current_client: httpx.AsyncClient | None = None
+            if loop is not None:
+                current_client = self._loop_clients.pop(loop, None)
+                if current_client is None and self._client_loop is None:
+                    # Never claimed by any loop yet -- e.g. `aclose()` is
+                    # called right after construction, before
+                    # `_active_http_client()` was ever touched. Treat the
+                    # client built in `__init__` as belonging to the loop
+                    # calling `aclose()` now (mirrors the escape hatch in
+                    # `_active_http_client`).
+                    current_client = self.http_client
+            others = [
+                (other_loop, other_client)
+                for other_loop, other_client in self._loop_clients.items()
+                if other_client is not current_client
+            ]
+            self._loop_clients.clear()
+            self._client_loop = None
+
+        for other_loop, other_client in others:
+            self._schedule_stale_client_close(other_client, other_loop)
+
+        if current_client is not None:
+            await current_client.aclose()
 
     @staticmethod
     def _new_owned_http_client() -> httpx.AsyncClient:
@@ -522,6 +590,23 @@ class ConsoleProviderGateway:
                 pool=GENERATION_READ_TIMEOUT_SECONDS,
             )
         )
+
+    def _prune_closed_loops(self) -> None:
+        """Drop ``_loop_clients`` entries whose owning loop has closed.
+
+        Must be called with ``_client_lock`` held. A ``WeakKeyDictionary``
+        alone would eventually reclaim these once the loop object itself is
+        garbage collected, but asyncio loops can take a while to be
+        collected (reference cycles via internal callbacks), and there is
+        nothing left to gracefully close on an already-closed loop -- its
+        client's own finalizer releases the underlying sockets. Pruning
+        proactively on every cache access bounds ``_loop_clients``'s size
+        even under many short-lived per-turn loops (see
+        ``console_agent_bridge``, which builds a fresh ``asyncio.run()``
+        loop per agent turn).
+        """
+        for stale_loop in [lp for lp in self._loop_clients if lp.is_closed()]:
+            del self._loop_clients[stale_loop]
 
     def _active_http_client(self) -> httpx.AsyncClient:
         """Return an HTTP client bound to the CURRENTLY running event loop.
@@ -537,22 +622,22 @@ class ConsoleProviderGateway:
         the first loop has since closed, ``RuntimeError: Event loop is
         closed``) on every request -- observed live as every agent send
         failing with "Agent run failed: ... is bound to a different event
-        loop." Recreate the owned client whenever the running loop changes
-        so each loop gets its own client; injected clients (tests) are
-        trusted to manage their own loop lifecycle and are left untouched.
+        loop." Give each running loop its own owned client via a per-loop
+        cache (``_loop_clients``) so no live loop ever has its client
+        replaced -- let alone closed -- by another loop's touch; injected
+        clients (tests) are trusted to manage their own loop lifecycle and
+        are left untouched.
 
-        The read-check-swap below is guarded by ``_client_lock`` (PR #629
-        Fix 1(a)): without it, two concurrent callers on different
+        The whole check-and-maybe-create below is guarded by
+        ``_client_lock`` (PR #629 Fix 1(a), preserved from the single-slot
+        design): without it, two concurrent callers on different
         loops/threads (the app loop's readiness probe racing the agent
-        worker thread's per-turn loop) can each read the same stale
-        ``(http_client, _client_loop)`` pair before either writes, then
-        both swap -- whichever writer's ``self.http_client`` assignment
-        loses the race ends up paired with the *other* writer's
-        ``self._client_loop`` assignment, leaving the recorded loop and the
-        actual client bound to different loops. The very next probe on the
-        recorded loop then reuses a client bound elsewhere and crashes.
-        Holding the lock across the whole check, creation, and both
-        assignments makes the swap a single atomic step.
+        worker thread's per-turn loop) could race each other while building
+        a client for the SAME not-yet-cached loop, or interleave with
+        ``aclose()``'s cache teardown. Holding the lock across the prune,
+        lookup, and any creation makes the whole operation a single atomic
+        step; unlike the old single-slot swap, nothing here ever discards or
+        schedules a close of another loop's still-cached client.
         """
         if not self._owns_http_client:
             return self.http_client
@@ -561,40 +646,67 @@ class ConsoleProviderGateway:
         except RuntimeError:
             return self.http_client
         with self._client_lock:
-            if self._client_loop is loop:
+            self._prune_closed_loops()
+            cached = self._loop_clients.get(loop)
+            if cached is not None:
+                self.http_client, self._client_loop = cached, loop
+                return cached
+            if (
+                self._client_loop is None
+                and self.http_client is not None
+                and not self.http_client.is_closed
+            ):
+                # Unclaimed-client escape hatch: the client built in
+                # `__init__` (or otherwise not yet resolved through this
+                # method by any loop) hasn't been adopted by a loop yet --
+                # claim it for the loop touching it now instead of
+                # discarding + scheduling a close of a client nothing has
+                # even used, exactly mirroring `GitHubAPIClient.client`'s
+                # unknown-loop escape hatch.
+                self._loop_clients[loop] = self.http_client
+                self._client_loop = loop
                 return self.http_client
-            stale_client, stale_loop = self.http_client, self._client_loop
-            self.http_client = self._new_owned_http_client()
-            self._client_loop = loop
-            active_client = self.http_client
-        # Best-effort close of whatever this swap replaced -- including the
-        # very first swap, where `stale_loop` is still `None` (there is no
-        # previous loop to close it on). A dropped owned client must never
-        # simply leak (PR #629 Fix 1(b)): fall back to closing it on the
-        # loop that just replaced it, which is safe since we are executing
-        # inside that running loop right now. Scheduling the close outside
-        # the lock keeps the critical section itself minimal.
-        self._schedule_stale_client_close(
-            stale_client, stale_loop if stale_loop is not None else loop
-        )
-        return active_client
+            new_client = self._new_owned_http_client()
+            self._loop_clients[loop] = new_client
+            self.http_client, self._client_loop = new_client, loop
+            return new_client
 
     @staticmethod
     def _schedule_stale_client_close(
         client: httpx.AsyncClient, loop: asyncio.AbstractEventLoop
     ) -> None:
-        """Best-effort close of a client left behind by a loop swap.
+        """Best-effort close of a client left behind on another loop.
 
-        The previous loop may already be closed (a completed per-turn
-        ``asyncio.run()``) or may still be running elsewhere (the app's
-        main loop) -- either way this must never raise into the caller
-        that triggered the swap.
+        Used by ``aclose()`` to hand off a still-cached OTHER loop's client
+        for closing on its own loop, never on the caller's. That loop may
+        already be closed (a completed per-turn ``asyncio.run()``) or may
+        still be running elsewhere (the app's main loop) -- either way this
+        must never raise into the caller. The returned ``Future`` is
+        retained with a done-callback so a failed close on another loop is
+        logged rather than silently swallowed.
         """
+        if loop.is_closed():
+            return
         try:
             future = asyncio.run_coroutine_threadsafe(client.aclose(), loop)
         except RuntimeError:
             return
-        future.add_done_callback(lambda f: f.exception())
+
+        def _log_close_failure(fut: "asyncio.Future") -> None:
+            try:
+                exc = fut.exception()
+            except Exception:
+                # Cancelled, or otherwise unable to retrieve the exception --
+                # nothing more we can do here.
+                return
+            if exc is not None:
+                logger.opt(exception=exc).warning(
+                    "Failed to close a stale Console provider HTTP client on "
+                    "its owning loop: {}",
+                    exc,
+                )
+
+        future.add_done_callback(_log_close_failure)
 
     async def resolve_llamacpp(
         self, config: LlamaCppProviderConfig


### PR DESCRIPTION
Closes item 1 of TASK-1064 — the highest-value item in that register.

`ConsoleProviderGateway._active_http_client` kept a **single slot**: one `http_client` plus one
`_client_loop`. On a loop mismatch it swapped in a new client and scheduled `aclose()` on the loop it
replaced — closing a client another **live** loop might still be using.

The gateway's own docstrings describe exactly the overlap that makes this reachable: it is shared
between "readiness probes (awaited on the app's own event loop)" and "agent-runtime generation calls
(bridged from a worker thread via a fresh `asyncio.run()` per turn)", and
`_schedule_stale_client_close` concedes the previous loop "may still be running elsewhere (the app's
main loop)".

**This is the same defect that PR #1009 fixed in `GitHubAPIClient`**, so it takes the same shape of
fix rather than a second invented approach: a per-loop `WeakKeyDictionary` cache keyed by the running
loop, pruning of entries whose loop is closed, and an escape hatch that adopts the constructor-built
client into the first loop to touch it.

**What was already better here is preserved.** The read-check-swap stays atomic under `_client_lock`
(PR #629 Fix 1(a), which fixed a real torn-state race), `_owns_http_client` is untouched, and the
non-leaking close is kept — and improved: its done-callback now actually logs via
`logger.opt(exception=…)` instead of silently discarding the exception.

**Verified with a probe that discriminates.** Two real threads, barrier-synchronised so both loops are
alive simultaneously, each claiming a client and holding it in flight:

```
unfixed dev : loopA closed_in_flight=True   -> a live loop's client was closed
this branch : neither closed, distinct clients
```

That distinction matters. On #1009 I first wrote a *sequential* two-loop probe, saw distinct clients
and called it verified — then ran the identical probe against the unfixed code and it passed there
too, because the first loop is already closed by the time the second runs. A sequential test cannot
detect this class of bug. The branch's own new test (`test_concurrent_live_loops_never_close_each_others_client`)
was likewise checked against the pre-fix code first, failing with
`AssertionError: loop A's client was closed while loop B was concurrently alive…`, and passes 5/5 on rerun.

Tests: `test_console_provider_gateway.py` 85 passed (two single-slot-era tests rewritten for the new
architecture, three added), `test_github_api_client.py` 38 passed unchanged, 496 across the
agent-bridge/swap/native-tools suites. Unrelated pre-existing UI failures were checked by restoring
HEAD and re-running samples — none HTTP-client-related.

Items 2 and 3 of TASK-1064 are handled separately; their criteria are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the single-slot HTTP client in `ConsoleProviderGateway` with a per-event-loop cache so one loop can’t close another’s in-use client, and fixed teardown so a later loop can’t adopt a stale client. Adds safer close handling and targeted tests; addresses TASK-1064 item 1.

- **Bug Fixes**
  - Per-loop `WeakKeyDictionary` of `httpx.AsyncClient`, guarded by `_client_lock`, with pruning of closed loops.
  - Correct “unclaimed init client” handling via `_client_ever_claimed` to prevent adopting a client previously bound to another loop; added a regression test.
  - `aclose()` closes the caller loop’s client and schedules others via `_schedule_stale_client_close`, with failure logging.
  - Added a two-thread concurrency test to ensure live loops never close or share each other’s client; updated/added tests for first-touch adoption and `aclose()` behavior.

<sup>Written for commit 5c8bf396e5b640d921c1d8d6ed3a54495b116616. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

