### PR TITLE
test(ui): remove stale initial-tab test

### DIFF
--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -285,17 +285,6 @@ def test_first_run_initial_route_defaults_to_home():
     assert app._resolve_initial_shell_route() == "home"
 
 
-@pytest.mark.asyncio
-async def test_deferred_initial_tab_uses_first_run_home_route():
-    app = _build_test_app()
-    app.app_config["_first_run"] = True
-    app._initial_tab_value = "chat"
-
-    await app._set_initial_tab()
-
-    assert app.current_tab == "home"
-
-
 @pytest.mark.parametrize("configured_route", ["home", "library", "settings", "notes"])
 def test_returning_user_initial_route_preserves_configured_default(configured_route):
     app = _build_test_app()

--- a/backlog/tasks/task-1078 - Remove-stale-deferred-initial-tab-test-after-startup-refactor.md
+++ b/backlog/tasks/task-1078 - Remove-stale-deferred-initial-tab-test-after-startup-refactor.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-1078
 title: Remove stale deferred initial-tab test after startup refactor
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2026-07-27 22:01'
+updated_date: '2026-07-27 22:50'
 labels:
   - ui
   - tests
@@ -25,7 +27,30 @@ The scoped TASK-944 baseline run found `test_deferred_initial_tab_uses_first_run
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The navigation suite no longer calls the removed `_set_initial_tab` method
-- [ ] #2 Current first-run Home routing remains covered through the supported startup or resolver path
-- [ ] #3 The focused navigation test file passes without production runtime changes
+- [x] #1 The navigation suite no longer calls the removed `_set_initial_tab` method
+- [x] #2 Current first-run Home routing remains covered through the supported startup or resolver path
+- [x] #3 The focused navigation test file passes without production runtime changes
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the stale `_set_initial_tab` failure with its exact test node.
+2. Compare adjacent first-run routing coverage and remove the obsolete test if the supported resolver path already pins the same outcome; otherwise rewrite only that test against the current startup path.
+3. Run only `Tests/UI/test_screen_navigation.py`, then Ruff on that test file and `git diff --check`.
+4. Review the minimal diff, document verification, complete the acceptance criteria, and mark TASK-1078 Done.
+
+ADR required: no
+ADR path: N/A
+Reason: Test-only cleanup after an existing startup refactor; no application behavior or architecture changes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Removed the single obsolete `test_deferred_initial_tab_uses_first_run_home_route` test. It duplicated the adjacent resolver-level first-run Home assertion while calling `_set_initial_tab`, a production method removed by commit 1df0c4cb4. No replacement test or production compatibility shim was added because `test_first_run_initial_route_defaults_to_home` already covers the supported routing contract.
+
+TDD evidence: the exact stale node first failed with `AttributeError: TldwCli has no attribute _set_initial_tab`; after deletion, the focused navigation file passed 55 tests. Ruff check and format-check passed for the one touched test file, no `_set_initial_tab` reference remains there, and `git diff --check` passed. The run emitted only existing RequestsDependencyWarning and train-journey SyntaxWarnings.
+
+ADR required: no. ADR path: N/A. Test-only cleanup with no production or architectural change.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary
- remove the obsolete navigation test that calls the deleted `_set_initial_tab` method
- retain first-run Home routing coverage through the supported resolver and existing mounted startup test
- complete TASK-1078 without production runtime changes

## Verification
- `pytest Tests/UI/test_screen_navigation.py -q` — 55 passed
- `ruff check Tests/UI/test_screen_navigation.py`
- `ruff format --check Tests/UI/test_screen_navigation.py`
- `git diff --check`
- independent review: no findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the stale UI navigation test that called the deleted `_set_initial_tab`, while keeping first-run Home routing covered via the supported resolver path. Completes TASK-1078 with no production changes.

<sup>Written for commit f0bcc8bafbf7540db32a5b4d24b117b434088449. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

