### PR TITLE
qa: reading path walked with real content — it ends at Items (task-1120)

### DIFF
--- a/Docs/superpowers/qa/watchlists-uat-2026-07-27/reading-path.md
+++ b/Docs/superpowers/qa/watchlists-uat-2026-07-27/reading-path.md
@@ -1,0 +1,47 @@
+# Watchlists reading path — walked with real content, 2026-07-28
+
+`origin/dev` `79152bbb6`, clean profile, 235x52. First walk with genuine
+scraped content, now that `Check now` works (task-1100).
+
+Fetched `https://summitroute.com/blog/feed.xml`: **10 items**, with real article
+bodies stored — 6,194 and 12,193 bytes for the first two.
+
+## Feeds → Items: works
+
+The Items table lists all ten with title, source, status `new` and created date:
+
+```
+Title                                                                Source        Status
+Lightsail object storage concerns - Part 2                           Summit Route  new
+Lightsail object storage concerns - Part 1                           Summit Route  new
+S3 backups and other strategies for ensuring data durability ...     Summit Route  new
+```
+
+Clicking an item selects it and the Inspector names it correctly.
+
+## Items → Content: there is no reader
+
+The Content region is still the Phase D placeholder:
+
+```
+Content
+Reader arrives in the next slice.
+```
+
+So the path ends at the list. Ten articles with full bodies are sitting in
+`subscription_items.content` and nothing in the app can display them.
+
+## Found
+
+**task-1120 (high)** — a selected item is classified as a source. The Inspector
+reports `Type: source` and offers `Preview` / `Check now`; the item actions
+(`Mark reviewed`, `Ingest`, `Ignore`) never appear, so an item cannot be acted
+on at all.
+
+## Where this leaves Phase D
+
+Phase D is the reader, and it now has real content to build against rather than
+placeholders — which is the first time that has been true. Two things should be
+fixed before or as part of it: task-1120 above, and task-1105 (clicking a row
+other than the first does not move the selection), since both sit directly on
+the path a reader user takes.

--- a/backlog/tasks/task-1120 - Selecting-an-item-shows-source-actions-and-Type-source.md
+++ b/backlog/tasks/task-1120 - Selecting-an-item-shows-source-actions-and-Type-source.md
@@ -1,0 +1,43 @@
+---
+id: TASK-1120
+title: >-
+  Selecting an item shows "Type: source" and offers source actions
+status: To Do
+assignee: []
+created_date: '2026-07-28 10:30'
+labels:
+  - watchlists
+  - bug
+  - ui
+  - uat
+priority: high
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Clicking a row in the **Items** table selects it, and the Inspector names it correctly — but classifies it as a source:
+
+```
+Selected: Lightsail object storage concerns - Part 2
+Type: source
+           Preview
+          Check now
+```
+
+`Preview` and `Check now` are *source* actions. The item actions the Inspector is built to offer — `Mark reviewed`, `Ingest`, `Ignore` — never appear, so an item cannot be acted on at all.
+
+Observed with real scraped content on `origin/dev` `79152bbb6`: 10 items fetched from `https://summitroute.com/blog/feed.xml`, clean profile.
+
+`InspectorPane._entity_type` decides this, and the entity reaching it evidently carries the shape of a source rather than an item. Worth checking what `ItemSelected` puts on the wire versus what `SourceSelected` does, and whether the Items table's rows are being routed through the sources selection path — the Sources table's own selection defect (task-1105) suggests these tables share more wiring than is obvious.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Selecting an item reports `Type: item`
+- [ ] #2 The Inspector offers `Mark reviewed`, `Ingest` and `Ignore` for a selected item
+- [ ] #3 Those actions change the item's status, verified against the database
+- [ ] #4 Source, run, rule and notification selections still report their own types
+- [ ] #5 A test selects an item and asserts the reported type and offered actions, proven to fail against current code
+<!-- AC:END -->


### PR DESCRIPTION
First walk of the Feeds → Items → Content path with **genuine scraped content**, now that `Check now` works. Docs and backlog only.

Fetched `https://summitroute.com/blog/feed.xml` on a clean profile: **10 items**, with real article bodies stored — 6,194 and 12,193 bytes for the first two.

## Feeds → Items: works

All ten listed with title, source, status `new` and created date. Clicking an item selects it and the Inspector names it correctly.

## Items → Content: there is no reader

```
Content
Reader arrives in the next slice.
```

Still the Phase D placeholder. Ten full articles are sitting in `subscription_items.content` with nothing in the app able to display them. Expected — Phase D is unbuilt — but worth recording that the data is now genuinely there and unreachable, rather than assumed absent.

## Found

**task-1120 (high)** — a selected item is classified as a **source**:

```
Selected: Lightsail object storage concerns - Part 2
Type: source
           Preview
          Check now
```

`Preview` and `Check now` are source actions. The item actions the Inspector is built to offer — `Mark reviewed`, `Ingest`, `Ignore` — never appear, so **an item cannot be acted on at all**.

## Where this leaves Phase D

Phase D is the reader, and for the first time it has real content to build against instead of `example.com` placeholders. Two defects sit directly on the path a reader user takes and should be fixed before or as part of it:

- **task-1120** — items mis-typed as sources, so no item action works
- **task-1105** — clicking any row other than the first does not move the selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the Feeds → Items → Content path with real scraped content; Feeds → Items works, but the path currently ends at Content because the reader isn’t built. Added QA doc and a backlog entry for task-1120 with acceptance criteria (items mis-typed as sources, blocking item actions), and flagged task-1105 about row selection not moving beyond the first row.

<sup>Written for commit 89ac786e300a68d8397a619592c3ebd975c1d727. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

