### PR TITLE
fix(evals): benches saved before the duplicate-id validation were un-openable

### DIFF
--- a/Tests/Evals/word_bench/test_models.py
+++ b/Tests/Evals/word_bench/test_models.py
@@ -70,6 +70,53 @@ def test_bench_config_rejects_duplicate_target_ids():
         )
 
 
+# ---------------------------------------------------------------------------
+# task-1132 follow-up (Qodo review, finding 2): target_ids element-type
+# validation. This is a SEPARATE, pre-existing gap from the uniqueness check
+# above -- `strict` never gated anything but uniqueness, and no element-type
+# check existed on read or write before or after task-1132. It matters now
+# because `load_bench`'s read-leniency means a corrupted stored `target_ids`
+# entry (an int, a nested list, an empty string) would otherwise load
+# without complaint and only fail much later, deep inside
+# `db.get_model(target_id)`, as an opaque sqlite parameter-binding error.
+# ---------------------------------------------------------------------------
+
+
+def test_bench_config_rejects_a_non_string_target_id():
+    """A malformed element (an int here, standing in for corrupted stored
+    data) must be rejected at construction with a message naming both the
+    offending value and its type, not surface later as an opaque sqlite
+    parameter-binding error out of db.get_model."""
+    with pytest.raises(ValueError, match=r"target_ids.*123.*int"):
+        BenchConfig(
+            name="b", prompt_mode="raw", top_k=20, dataset_id="d",
+            target_ids=("t1", 123),
+        )
+
+
+def test_bench_config_rejects_a_non_string_target_id_even_when_lenient():
+    """The element-type check is NOT gated by `strict`, unlike the
+    uniqueness check above -- `storage.load_bench` always constructs with
+    `strict=False`, so a check that only ran when `strict` is True would
+    never protect the read path this validation exists for."""
+    with pytest.raises(ValueError, match=r"target_ids.*123.*int"):
+        BenchConfig(
+            name="b", prompt_mode="raw", top_k=20, dataset_id="d",
+            target_ids=("t1", 123), strict=False,
+        )
+
+
+def test_bench_config_rejects_target_ids_that_is_not_a_list_or_tuple():
+    """Covers the other half of the malformed-data surface: target_ids
+    itself has the wrong shape entirely (e.g. a bare string, which Python
+    would otherwise happily iterate character-by-character)."""
+    with pytest.raises(ValueError, match="target_ids must be a list or tuple"):
+        BenchConfig(
+            name="b", prompt_mode="raw", top_k=20, dataset_id="d",
+            target_ids="t1",  # type: ignore[arg-type]
+        )
+
+
 def test_cell_capture_computes_truncated_mass():
     cap = CellCapture(
         prompt_mode="raw",

--- a/Tests/Evals/word_bench/test_storage.py
+++ b/Tests/Evals/word_bench/test_storage.py
@@ -14,6 +14,7 @@ from tldw_chatbook.Evals.word_bench.models import (
     TokenProb,
 )
 from tldw_chatbook.Evals.word_bench.storage import (
+    BENCH_TYPE,
     create_run_group,
     load_bench,
     load_grid,
@@ -93,6 +94,79 @@ def test_create_run_group_rejects_duplicate_target_ids(db, config, snippets):
     assert len(db.list_runs(limit=10_000)) == runs_before, (
         "rejection must happen before any eval_runs row is created"
     )
+
+
+# ---------------------------------------------------------------------------
+# task-1132: BenchConfig.__post_init__'s target-id-uniqueness check (added
+# by b73de3564 to fix the silent-column-collapse bug) also ran on
+# storage.load_bench's read path, so a bench saved BEFORE that validation
+# existed -- one whose stored config_data.target_ids already carries a
+# duplicate -- could no longer be opened at all. The fix keeps every write
+# path strict (BenchConfig's default strict=True, save_bench, and
+# create_run_group, all unchanged in behavior) and makes only load_bench
+# lenient (BenchConfig(..., strict=False)), so a legacy duplicate is read
+# back and displayed rather than raising.
+# ---------------------------------------------------------------------------
+
+
+def test_load_bench_tolerates_and_preserves_a_legacy_duplicate_target_id(db, dataset):
+    """Writes an eval_tasks row directly against EvalsDB.create_task --
+    bypassing BenchConfig and save_bench entirely, exactly as a bench saved
+    before target-id-uniqueness validation existed would have been written
+    -- with config_data.target_ids naming the same id twice, then asserts
+    load_bench reads it back without raising and preserves BOTH entries
+    rather than deduplicating them. Deduplicating here would be the
+    original silent-column-collapse bug wearing a different hat: the user
+    would no longer be able to see the duplicate in order to remove it."""
+    target_id = db.create_model(name="legacy-target", provider="llama_cpp", model_id="m")
+    task_id = db.create_task(
+        name="pre-validation bench",
+        task_type="logprob",
+        config_format="custom",
+        config_data={
+            "bench_type": BENCH_TYPE,
+            "prompt_mode": "raw",
+            "top_k": 20,
+            "probes": [],
+            "target_ids": [target_id, target_id],
+            "concurrency": 1,
+        },
+        dataset_id=dataset,
+    )
+
+    loaded = load_bench(db, task_id)
+
+    assert loaded.target_ids == (target_id, target_id)
+    assert len(loaded.target_ids) == 2
+
+
+def test_bench_config_construction_still_rejects_duplicates_by_default(dataset):
+    """User-facing bench creation goes through BenchConfig's plain
+    constructor (strict=True is the default -- nothing has to opt in), and
+    that must still reject a duplicate unconditionally. This is the same
+    assertion as test_models.test_bench_config_rejects_duplicate_target_ids;
+    repeated here, next to the new load_bench leniency test above, so the
+    write/read split this file exercises is visible in one place."""
+    with pytest.raises(ValueError, match="target_ids must be unique"):
+        BenchConfig(
+            name="new bench", prompt_mode="raw", top_k=20, dataset_id=dataset,
+            target_ids=("dup", "dup"),
+        )
+
+
+def test_save_bench_rejects_duplicates_even_for_a_leniently_loaded_config(db, dataset):
+    """save_bench must not let a legacy duplicate round-trip back into
+    storage un-flagged just because it arrived through load_bench's lenient
+    (strict=False) read. Builds the same shape load_bench would produce for
+    a legacy row -- BenchConfig(..., strict=False), which itself does not
+    raise -- and asserts save_bench still refuses to persist it."""
+    target_id = db.create_model(name="legacy-target", provider="llama_cpp", model_id="m")
+    leniently_loaded = BenchConfig(
+        name="pre-validation bench", prompt_mode="raw", top_k=20, dataset_id=dataset,
+        target_ids=(target_id, target_id), strict=False,
+    )
+    with pytest.raises(ValueError, match="target_ids must be unique"):
+        save_bench(db, leniently_loaded)
 
 
 def test_run_snapshot_carries_snippet_text_not_only_ids(db, config, targets, snippets):

--- a/Tests/Evals/word_bench/test_storage.py
+++ b/Tests/Evals/word_bench/test_storage.py
@@ -106,6 +106,17 @@ def test_create_run_group_rejects_duplicate_target_ids(db, config, snippets):
 # create_run_group, all unchanged in behavior) and makes only load_bench
 # lenient (BenchConfig(..., strict=False)), so a legacy duplicate is read
 # back and displayed rather than raising.
+#
+# Qodo review follow-up, finding 2: that read-leniency means BenchConfig now
+# deliberately accepts more from stored data than it used to, but nothing
+# ever validated target_ids' ELEMENT shape -- not before task-1132, not
+# after. That is a pre-existing gap, not a regression this PR introduced,
+# but it is worth closing here since a corrupted config_data.target_ids
+# entry (an int, a nested list) would otherwise load silently and only fail
+# later, deep inside db.get_model(target_id), as an opaque sqlite
+# parameter-binding error. The check lives in BenchConfig.__post_init__,
+# UNGATED (unlike the uniqueness check above), so it runs on every path
+# including this file's lenient load_bench.
 # ---------------------------------------------------------------------------
 
 
@@ -117,7 +128,14 @@ def test_load_bench_tolerates_and_preserves_a_legacy_duplicate_target_id(db, dat
     load_bench reads it back without raising and preserves BOTH entries
     rather than deduplicating them. Deduplicating here would be the
     original silent-column-collapse bug wearing a different hat: the user
-    would no longer be able to see the duplicate in order to remove it."""
+    would no longer be able to see the duplicate in order to remove it.
+
+    Args:
+        db: In-memory EvalsDB fixture (see conftest.py), used to write the
+            legacy row directly against create_task/create_model.
+        dataset: A real eval_datasets row id fixture, required because
+            eval_tasks.dataset_id carries a FOREIGN KEY to eval_datasets(id).
+    """
     target_id = db.create_model(name="legacy-target", provider="llama_cpp", model_id="m")
     task_id = db.create_task(
         name="pre-validation bench",
@@ -140,13 +158,55 @@ def test_load_bench_tolerates_and_preserves_a_legacy_duplicate_target_id(db, dat
     assert len(loaded.target_ids) == 2
 
 
+def test_load_bench_rejects_a_malformed_stored_target_id(db, dataset):
+    """Companion to the legacy-duplicate test above, for the OTHER kind of
+    malformed target_ids entry: not a duplicate (still tolerated), but an
+    element of the wrong type entirely -- here an int standing in for
+    corrupted stored data. Unlike the uniqueness check, element-type
+    validation is unconditional in BenchConfig.__post_init__, so load_bench
+    (which always constructs with strict=False) still raises a diagnosable
+    ValueError naming the offending value and its type, instead of loading
+    silently and failing much later inside db.get_model(target_id) as an
+    opaque sqlite parameter-binding error (eval_models.id is TEXT).
+
+    Args:
+        db: In-memory EvalsDB fixture (see conftest.py), used to write the
+            corrupted row directly against create_task/create_model.
+        dataset: A real eval_datasets row id fixture, required because
+            eval_tasks.dataset_id carries a FOREIGN KEY to eval_datasets(id).
+    """
+    target_id = db.create_model(name="legacy-target", provider="llama_cpp", model_id="m")
+    task_id = db.create_task(
+        name="corrupted bench",
+        task_type="logprob",
+        config_format="custom",
+        config_data={
+            "bench_type": BENCH_TYPE,
+            "prompt_mode": "raw",
+            "top_k": 20,
+            "probes": [],
+            "target_ids": [target_id, 123],
+            "concurrency": 1,
+        },
+        dataset_id=dataset,
+    )
+
+    with pytest.raises(ValueError, match=r"target_ids.*123.*int"):
+        load_bench(db, task_id)
+
+
 def test_bench_config_construction_still_rejects_duplicates_by_default(dataset):
     """User-facing bench creation goes through BenchConfig's plain
     constructor (strict=True is the default -- nothing has to opt in), and
     that must still reject a duplicate unconditionally. This is the same
     assertion as test_models.test_bench_config_rejects_duplicate_target_ids;
     repeated here, next to the new load_bench leniency test above, so the
-    write/read split this file exercises is visible in one place."""
+    write/read split this file exercises is visible in one place.
+
+    Args:
+        dataset: A real eval_datasets row id fixture, required because
+            eval_tasks.dataset_id carries a FOREIGN KEY to eval_datasets(id).
+    """
     with pytest.raises(ValueError, match="target_ids must be unique"):
         BenchConfig(
             name="new bench", prompt_mode="raw", top_k=20, dataset_id=dataset,
@@ -159,7 +219,13 @@ def test_save_bench_rejects_duplicates_even_for_a_leniently_loaded_config(db, da
     storage un-flagged just because it arrived through load_bench's lenient
     (strict=False) read. Builds the same shape load_bench would produce for
     a legacy row -- BenchConfig(..., strict=False), which itself does not
-    raise -- and asserts save_bench still refuses to persist it."""
+    raise -- and asserts save_bench still refuses to persist it.
+
+    Args:
+        db: In-memory EvalsDB fixture (see conftest.py).
+        dataset: A real eval_datasets row id fixture, required because
+            eval_tasks.dataset_id carries a FOREIGN KEY to eval_datasets(id).
+    """
     target_id = db.create_model(name="legacy-target", provider="llama_cpp", model_id="m")
     leniently_loaded = BenchConfig(
         name="pre-validation bench", prompt_mode="raw", top_k=20, dataset_id=dataset,

--- a/Tests/UI/test_evals_bench_editor.py
+++ b/Tests/UI/test_evals_bench_editor.py
@@ -26,7 +26,7 @@ from textual.app import App
 import tldw_chatbook
 from tldw_chatbook.DB.Evals_DB import EvalsDB
 from tldw_chatbook.Evals.word_bench.models import BenchConfig, PreflightResult, Snippet, Target
-from tldw_chatbook.Evals.word_bench.storage import create_run_group, save_bench
+from tldw_chatbook.Evals.word_bench.storage import BENCH_TYPE, create_run_group, save_bench
 from tldw_chatbook.UI.Evals import bench_editor as bench_editor_module
 from tldw_chatbook.UI.Evals import inspector as inspector_module
 from tldw_chatbook.UI.Evals.bench_editor import CLASSIC_TASK_DEFERRAL_SENTENCE
@@ -658,14 +658,25 @@ async def test_classic_task_selection_has_no_run_control(evals_app, classic_task
 
 @pytest.fixture
 def bench_with_duplicate_target_id(evals_db: EvalsDB) -> str:
-    """A `BenchConfig` whose `target_ids` names the SAME id twice.
+    """An `eval_tasks` row whose `config_data.target_ids` names the SAME id
+    twice -- a legacy bench saved before `BenchConfig.__post_init__` (or
+    `create_run_group`) rejected that shape (task-1132's ancestor,
+    `git rev` b73de3564).
 
-    Nothing in `BenchConfig.__post_init__`, `save_bench`, or `load_bench`
-    enforces target-id uniqueness -- a word bench's target list is plain,
-    editable data -- so this is a realistic shape a UI edit (or a hand-
-    edited config_data blob) can produce, not a contrived one. Before the
-    fix, `bench_editor.py`'s target table and `inspector.py`'s readiness
-    list each derived a widget id straight from `target_id`
+    Written directly against `EvalsDB.create_task`, NOT through
+    `BenchConfig`/`save_bench`: both now reject a duplicate unconditionally
+    on the write path (`BenchConfig`'s default `strict=True`, and
+    `save_bench`'s own independent check -- see task-1132), so a bench
+    actually carrying this shape can now only arise from data written
+    before that validation existed. `storage.load_bench` constructs its
+    `BenchConfig` with `strict=False` specifically so this legacy shape can
+    still be read back rather than becoming permanently unopenable (see
+    that function's own docstring) -- this fixture exercises exactly that
+    read path.
+
+    Before the id-collision fix (Qodo #941 finding 2, unrelated to
+    task-1132), `bench_editor.py`'s target table and `inspector.py`'s
+    readiness list each derived a widget id straight from `target_id`
     (`evals-bench-target-<id>`, `evals-inspector-target-<id>`), so a
     duplicate collided at mount time and failed to compose the whole pane
     -- not just the duplicated row.
@@ -677,14 +688,20 @@ def bench_with_duplicate_target_id(evals_db: EvalsDB) -> str:
         source_path="inline:dup-target-set",
         metadata={"sample_count": 4},
     )
-    config = BenchConfig(
+    return evals_db.create_task(
         name="duplicate-target bench",
-        prompt_mode="raw",
-        top_k=20,
+        task_type="logprob",
+        config_format="custom",
+        config_data={
+            "bench_type": BENCH_TYPE,
+            "prompt_mode": "raw",
+            "top_k": 20,
+            "probes": [],
+            "target_ids": [target_id, target_id],
+            "concurrency": 1,
+        },
         dataset_id=dataset_id,
-        target_ids=(target_id, target_id),
     )
-    return save_bench(evals_db, config)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_evals_bench_editor.py
+++ b/Tests/UI/test_evals_bench_editor.py
@@ -680,6 +680,15 @@ def bench_with_duplicate_target_id(evals_db: EvalsDB) -> str:
     (`evals-bench-target-<id>`, `evals-inspector-target-<id>`), so a
     duplicate collided at mount time and failed to compose the whole pane
     -- not just the duplicated row.
+
+    Args:
+        evals_db: In-memory EvalsDB fixture, written to directly (bypassing
+            BenchConfig/save_bench) so it can carry a shape neither will
+            construct anymore.
+
+    Returns:
+        The `eval_tasks` row id (`task_id`) of the bench carrying the
+        duplicate `target_ids`.
     """
     target_id = _make_model(evals_db, "repeated-target")
     dataset_id = evals_db.create_dataset(
@@ -711,7 +720,13 @@ async def test_bench_with_duplicate_target_id_composes_without_raising(
     """Composes the real workbench (not just the id-derivation helper) with
     a bench carrying a genuine duplicate target id, and asserts both the
     detail pane's target table and the inspector's readiness list render
-    every row rather than raising out of compose()."""
+    every row rather than raising out of compose().
+
+    Args:
+        evals_app: The Evals screen's app-under-test fixture.
+        bench_with_duplicate_target_id: The `task_id` of the legacy bench
+            fixture above, carrying a genuine duplicate `target_id`.
+    """
     async with evals_app.run_test() as pilot:
         await pilot.pause()
         evals_app.screen.select(kind="bench", id=bench_with_duplicate_target_id)

--- a/backlog/tasks/task-1132 - Word-bench-target-id-uniqueness-check-ran-on-the-read-path-too.md
+++ b/backlog/tasks/task-1132 - Word-bench-target-id-uniqueness-check-ran-on-the-read-path-too.md
@@ -1,0 +1,176 @@
+---
+id: TASK-1132
+title: >-
+  Word bench target-id-uniqueness check ran on the read path too, making
+  legacy benches unopenable
+status: Done
+assignee: []
+created_date: '2026-07-28 10:00'
+labels:
+  - evals
+  - bug
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+PR #962 (`b73de3564`) added a check to `BenchConfig.__post_init__`
+(`tldw_chatbook/Evals/word_bench/models.py`) rejecting duplicate
+`target_ids`: every per-target map downstream (`WordBenchRunner`'s
+`clients`, its preflight/canary dicts, `storage.create_run_group`'s
+`run_ids`) is keyed by target id, so a duplicate silently collapsed two
+grid columns into one shared `eval_run`. That fix is correct on the WRITE
+path.
+
+`storage.load_bench` also constructs a `BenchConfig` — from whatever is
+already sitting in a stored `eval_tasks.config_data` row — so the same
+validation ran on the READ path too. A bench saved before this check
+existed, whose stored `target_ids` already carried a duplicate, could no
+longer be opened at all: `load_bench` raised `ValueError`, and both
+`tldw_chatbook/UI/Evals/bench_editor.py` and `tldw_chatbook/UI/Evals/
+inspector.py` swallow that in a bare `except Exception` and render an
+error placeholder instead of the bench.
+
+Verified directly: writing an `eval_tasks` row with
+`config_data.target_ids = [mid, mid]` via `EvalsDB.create_task` (bypassing
+`BenchConfig`, as a pre-validation save would have produced) and then
+calling `load_bench` raised
+`ValueError: target_ids must be unique, got duplicates: [...]`.
+
+There was also an existing, already-failing test stating the intended
+behavior plainly:
+`Tests/UI/test_evals_bench_editor.py::test_bench_with_duplicate_target_id_composes_without_raising`
+— asserting both the detail pane's target table and the inspector's
+readiness list render every row (not just N-1) for a bench carrying a
+duplicate target id. It had been failing since #962 because its own
+fixture called `BenchConfig(...)` directly with a duplicate, which #962
+made raise even at fixture setup.
+
+The fix is not to dedupe on read: silently collapsing two columns into one
+on display is the original #962 bug wearing a different hat, and it would
+hide the problem from the user who needs to fix it. The correct split is
+write-strict, read-lenient:
+
+- WRITE (`BenchConfig` construction from user action, `save_bench`,
+  `create_run_group`, `WordBenchRunner.run`): keep rejecting duplicates
+  unconditionally. A user must not be able to create or run one.
+- READ (`load_bench`, and anything the editor/inspector use to display a
+  stored bench): tolerate a duplicate, preserve it exactly as stored, and
+  render every row, so the user can see it and remove it.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [x] #1 A bench whose stored `config_data.target_ids` contains a duplicate can be opened: `load_bench` returns a `BenchConfig` instead of raising, preserving both duplicate entries (not deduplicated)
+- [x] #2 `BenchConfig` constructed the normal way (user-facing creation, no special argument) still rejects a duplicate `target_ids` unconditionally
+- [x] #3 `storage.create_run_group` and `WordBenchRunner.run` still reject a duplicate target list before any `eval_runs` row is created
+- [x] #4 `storage.save_bench` rejects a duplicate even when handed a leniently-loaded `BenchConfig`, so a legacy duplicate can never round-trip back into storage un-flagged
+- [x] #5 `test_bench_with_duplicate_target_id_composes_without_raising` passes: both the bench editor's target table and the inspector's readiness list render every row for a duplicate-carrying bench
+- [x] #6 A test covers a legacy stored bench (written directly against `EvalsDB.create_task`, bypassing `BenchConfig`) loading and preserving both ids
+- [x] #7 A test covers that user-facing creation and `create_run_group` still reject duplicates
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a `strict: InitVar[bool] = True` to `BenchConfig`, gating only the
+   `target_ids`-uniqueness check in `__post_init__`. Default `True` keeps
+   every existing call site (including the plain-constructor write-path
+   test) unchanged.
+2. `storage.load_bench` constructs with `strict=False` so a legacy
+   duplicate is preserved rather than rejected.
+3. `storage.save_bench` gets its own independent duplicate check (mirroring
+   `create_run_group`'s existing one) so a leniently-loaded config can
+   never be persisted with a duplicate still in it — defense in depth,
+   since `save_bench` cannot assume the `BenchConfig` handed to it was
+   built strictly.
+4. Update the pre-existing `bench_with_duplicate_target_id` fixture in
+   `Tests/UI/test_evals_bench_editor.py` to write directly against
+   `EvalsDB.create_task`, since `BenchConfig(...)` (now correctly strict by
+   default) can no longer be used to construct that fixture's legacy shape.
+5. Add new tests: legacy load-and-preserve (storage-level), and write-path
+   rejection for both plain `BenchConfig` construction and `save_bench`
+   given a leniently-loaded config.
+6. Revert-check: temporarily restore pre-fix `models.py`/`storage.py` and
+   confirm exactly the targeted tests fail, with the expected error text.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Approach.** `BenchConfig` gained a `strict: dataclasses.InitVar[bool] =
+True` parameter. `InitVar` is accepted by the generated `__init__` and
+passed to `__post_init__`, but is not a real dataclass field — it never
+appears in equality, `repr`, or `asdict`, so it adds no persistent surface
+to the type. `__post_init__` now only runs the `target_ids`-uniqueness
+check `if strict`; the other invariants (`prompt_mode`, `top_k`,
+`concurrency`) are unaffected and still always enforced — they predate #962
+and are not a read-path concern. Every existing call site is unchanged
+(default `True`); only `storage.load_bench` passes `strict=False`.
+
+`storage.save_bench` gained its own explicit duplicate check (same shape as
+`create_run_group`'s pre-existing one), because it cannot assume the
+`BenchConfig` handed to it was built strictly — a caller could pass through
+a leniently-loaded legacy config unmodified. This is defense in depth for a
+path nothing currently exercises (no UI edit-and-resave flow exists yet in
+this PR slice; `save_bench`'s only production caller,
+`sample_bench.create_and_run_sample_bench`, always builds a single-target,
+strictly-validated `BenchConfig`), but it is one of the write call sites
+the task explicitly named, and closing it now means a future edit form
+cannot silently persist a duplicate it inherited from a lenient read.
+
+`create_run_group` and `WordBenchRunner.run` needed no change: the former
+already validates its `targets` argument independently of `BenchConfig`
+(documented in its own docstring as deliberate, since it is callable
+directly, bypassing `BenchConfig`); the latter relies on that same check
+before any cell capture begins.
+
+**What the user sees.** Opening a legacy bench with a duplicate target id
+now renders normally instead of an error placeholder: the target table and
+readiness list both show the target twice (index-derived widget ids, from
+the pre-existing Qodo #941 fix, already handle the duplicate without
+colliding). Seeing the same target listed twice IS the visibility the user
+needs to notice and remove it — no new UI affordance was added. The
+`#evals-primary-action` "Run" button is unconditionally disabled in this PR
+slice regardless of bench validity (`evals_screen.py`'s
+`_primary_action_state`, "wiring lands in a later PR"), so there is no
+separate run-blocking state to wire for a duplicate specifically yet; the
+write-side guard (`create_run_group`) is what will stop an actual run once
+that wiring lands.
+
+**Revert-check.** Temporarily restored pre-fix `models.py`/`storage.py`
+(new tests and the updated fixture left in place) and reran the target
+scope: exactly 3 failures, nothing else.
+- `test_bench_with_duplicate_target_id_composes_without_raising` →
+  `AssertionError: both duplicate-id target rows should compose` (the
+  `ValueError` from `load_bench` is caught by `bench_editor.py`/
+  `inspector.py`'s own `except Exception`, so it surfaces as zero rendered
+  target rows, not a raised exception in the test itself).
+- `test_load_bench_tolerates_and_preserves_a_legacy_duplicate_target_id` →
+  `ValueError: target_ids must be unique, got duplicates: [...]` raised
+  directly out of `load_bench`.
+- `test_save_bench_rejects_duplicates_even_for_a_leniently_loaded_config` →
+  `TypeError: BenchConfig.__init__() got an unexpected keyword argument
+  'strict'` (the pre-fix dataclass has no such parameter at all).
+Restored the fix afterward and reconfirmed all 182 tests in scope pass.
+
+**Files modified:**
+- `tldw_chatbook/Evals/word_bench/models.py` — `BenchConfig.strict`
+  `InitVar`, gated duplicate check.
+- `tldw_chatbook/Evals/word_bench/storage.py` — `load_bench` constructs
+  with `strict=False`; `save_bench` gained its own duplicate check.
+- `Tests/UI/test_evals_bench_editor.py` — `bench_with_duplicate_target_id`
+  fixture now writes directly via `EvalsDB.create_task`, bypassing
+  `BenchConfig`.
+- `Tests/Evals/word_bench/test_storage.py` — three new tests: legacy
+  load-and-preserve, plain-construction still rejects, `save_bench` still
+  rejects a leniently-loaded duplicate.
+
+**Test result:** `pytest Tests/UI/test_evals_bench_editor.py
+Tests/Evals/word_bench Tests/UI/test_evals_results_grid.py -q` → 182
+passed (178 baseline + 4 new; the previously-erroring fixture now passes
+instead of erroring).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-1132 - Word-bench-target-id-uniqueness-check-ran-on-the-read-path-too.md
+++ b/backlog/tasks/task-1132 - Word-bench-target-id-uniqueness-check-ran-on-the-read-path-too.md
@@ -173,4 +173,68 @@ Restored the fix afterward and reconfirmed all 182 tests in scope pass.
 Tests/Evals/word_bench Tests/UI/test_evals_results_grid.py -q` → 182
 passed (178 baseline + 4 new; the previously-erroring fixture now passes
 instead of erroring).
+
+**Follow-up (Qodo review, finding 2): `target_ids` element-type
+validation.** The review characterized `strict=False` as bypassing "the
+only validation that would catch malformed `target_ids`". That causation
+is wrong: `strict` in `BenchConfig.__post_init__` has only ever gated the
+*uniqueness* check above — `prompt_mode`, `top_k`, and `concurrency`
+validate unconditionally, and no check has EVER validated `target_ids`'
+element shape, on read or write, before or after this task's original fix.
+This was a **pre-existing gap**, not something this PR introduced.
+
+It was still worth closing here, because this PR's read-leniency means
+`BenchConfig` now deliberately accepts more from stored data than it used
+to: a corrupted `config_data.target_ids` entry (an int, a nested list, an
+empty string) loaded without complaint and only failed much later inside
+`db.get_model(target_id)` as an opaque sqlite parameter-binding error far
+from the cause (`eval_models.id` is `TEXT`).
+
+Added to `BenchConfig.__post_init__`, **ungated** (unlike the uniqueness
+check, which stays `strict`-gated exactly as before): `target_ids` must be
+a `list`/`tuple`, and every element must be a non-empty `str`, on every
+construction path including `load_bench`'s lenient one. Placed before the
+uniqueness check's `set(self.target_ids)` call specifically so an
+unhashable element (e.g. a nested list) fails with this check's
+diagnosable `ValueError` (naming the offending value and its type) rather
+than an opaque `TypeError` out of `set()`.
+
+Tests added: `test_bench_config_rejects_a_non_string_target_id`,
+`test_bench_config_rejects_a_non_string_target_id_even_when_lenient` (the
+key one — proves the check is NOT gated by `strict`), and
+`test_bench_config_rejects_target_ids_that_is_not_a_list_or_tuple` in
+`Tests/Evals/word_bench/test_models.py`; `test_load_bench_rejects_a_malformed_stored_target_id`
+in `Tests/Evals/word_bench/test_storage.py` (storage-level: a corrupted
+`eval_tasks.config_data.target_ids` fails at `load_bench` instead of
+loading silently). The pre-existing legacy-duplicate test and the plain
+round-trip test already covered "a legacy duplicate still loads" and "a
+valid bench is unaffected" respectively, so no new test was needed for
+those two.
+
+Revert-check: reverted only `models.py` to its pre-follow-up state (new
+tests left in place), reran the same scope — exactly 4 failures, all
+`Failed: DID NOT RAISE <class 'ValueError'>`, nothing else. Restored the
+fix and reconfirmed 150 passed. Fixed-code error text confirmed directly:
+`target_ids elements must be non-empty strings, got 123 (type: int)` and
+`target_ids must be a list or tuple, got 't1' (type: str)`.
+
+Also added Google-style `Args:`/`Returns:` sections to the
+`bench_with_duplicate_target_id` fixture and its consuming test in
+`Tests/UI/test_evals_bench_editor.py`, and to the three tests in
+`Tests/Evals/word_bench/test_storage.py`'s legacy-duplicate section
+(~112-170), per a separate Qodo docstring finding — prose preserved,
+structure added around it.
+
+**Files modified (this follow-up):**
+- `tldw_chatbook/Evals/word_bench/models.py` — ungated `target_ids`
+  element-type check in `__post_init__`; class docstring updated.
+- `Tests/Evals/word_bench/test_models.py` — 3 new tests.
+- `Tests/Evals/word_bench/test_storage.py` — 1 new test; Google-style
+  docstrings added to 3 existing tests.
+- `Tests/UI/test_evals_bench_editor.py` — Google-style docstrings added to
+  the `bench_with_duplicate_target_id` fixture and its consuming test.
+
+**Test result (this follow-up):** `pytest
+Tests/UI/test_evals_bench_editor.py Tests/Evals/word_bench -q` → 150
+passed (146 baseline in this narrower scope + 4 new).
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Evals/word_bench/models.py
+++ b/tldw_chatbook/Evals/word_bench/models.py
@@ -112,6 +112,20 @@ class BenchConfig:
     inspector render every row (see their own duplicate-safe, index-keyed
     widget ids), and the run control stays blocked until the write path
     (which still validates unconditionally) accepts an edited config.
+
+    ``target_ids`` element-type validation (a list/tuple of non-empty
+    ``str``) is a SEPARATE check from the uniqueness one above and always
+    runs, regardless of ``strict`` -- task-1132 only ever gated the
+    uniqueness check; ``target_ids`` element shape was never validated
+    anywhere, on read or write, before or after that fix. It is worth
+    closing now because ``load_bench``'s read-leniency means this class
+    deliberately accepts more from stored data than it used to: a
+    corrupted ``config_data.target_ids`` entry (e.g. an int, or a nested
+    list) previously loaded without complaint and only failed later, deep
+    inside ``db.get_model(target_id)``, as an opaque sqlite
+    parameter-binding error far from the actual cause (``eval_models.id``
+    is ``TEXT``). Validating the shape here, unconditionally, turns that
+    into a clear failure at the boundary instead.
     """
 
     name: str
@@ -133,6 +147,24 @@ class BenchConfig:
             raise ValueError(f"top_k must be >= 1, got {self.top_k}")
         if self.concurrency < 1:
             raise ValueError(f"concurrency must be >= 1, got {self.concurrency}")
+        # Element-type validation, unlike the uniqueness check below, is NOT
+        # gated by `strict`: it must catch genuinely malformed data on every
+        # path, including the lenient `load_bench` read. It also has to run
+        # BEFORE the `set(self.target_ids)` call below -- an unhashable
+        # element (e.g. a nested list) would otherwise blow up that line
+        # with an opaque TypeError instead of the diagnosable ValueError
+        # this check produces.
+        if not isinstance(self.target_ids, (list, tuple)):
+            raise ValueError(
+                f"target_ids must be a list or tuple, got {self.target_ids!r} "
+                f"(type: {type(self.target_ids).__name__})"
+            )
+        for target_id in self.target_ids:
+            if not isinstance(target_id, str) or not target_id:
+                raise ValueError(
+                    f"target_ids elements must be non-empty strings, got "
+                    f"{target_id!r} (type: {type(target_id).__name__})"
+                )
         if strict and len(set(self.target_ids)) != len(self.target_ids):
             # Every per-target map downstream (WordBenchRunner's `clients`,
             # its preflight/canary dicts, storage.create_run_group's

--- a/tldw_chatbook/Evals/word_bench/models.py
+++ b/tldw_chatbook/Evals/word_bench/models.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import math
-from dataclasses import dataclass
+from dataclasses import InitVar, dataclass
 from typing import Literal, Optional
 
 PromptMode = Literal["raw", "chat"]
@@ -85,7 +85,34 @@ class Target:
 
 @dataclass(frozen=True)
 class BenchConfig:
-    """A word bench definition."""
+    """A word bench definition.
+
+    ``strict`` (default ``True``) gates only the ``target_ids``-uniqueness
+    check below, and is an ``InitVar`` -- accepted by ``__init__`` but not
+    stored as a field, so it never appears in equality, ``repr``, or
+    ``dataclasses.asdict``.
+
+    Every WRITE call site (user-facing bench creation/edit, ``save_bench``,
+    ``create_run_group``, ``WordBenchRunner.run``) must go through a
+    ``strict=True`` construction (the default -- nothing needs to opt in)
+    so a duplicate can never be created or run: every per-target map
+    downstream (``WordBenchRunner``'s ``clients``, its preflight/canary
+    dicts, ``storage.create_run_group``'s ``run_ids``) is keyed by target
+    id, and a duplicate would otherwise silently collapse two targets into
+    one with no error.
+
+    ``storage.load_bench`` is the ONE exception, constructing with
+    ``strict=False``: it rebuilds a ``BenchConfig`` from whatever is
+    already sitting in ``eval_tasks.config_data``, including a bench saved
+    before this validation existed (task-1132). Rejecting on READ would
+    make that legacy bench permanently unopenable instead of merely
+    unrunnable -- worse than the bug this validation fixes, since the user
+    could no longer even see the duplicate to remove it. A lenient load
+    preserves both ids exactly as stored so the bench editor and readiness
+    inspector render every row (see their own duplicate-safe, index-keyed
+    widget ids), and the run control stays blocked until the write path
+    (which still validates unconditionally) accepts an edited config.
+    """
 
     name: str
     prompt_mode: PromptMode
@@ -95,8 +122,9 @@ class BenchConfig:
     probes: tuple[str, ...] = ()
     description: str = ""
     concurrency: int = 1
+    strict: InitVar[bool] = True
 
-    def __post_init__(self) -> None:
+    def __post_init__(self, strict: bool) -> None:
         if self.prompt_mode not in ("raw", "chat"):
             raise ValueError(
                 f"prompt_mode must be 'raw' or 'chat', got {self.prompt_mode!r}"
@@ -105,7 +133,7 @@ class BenchConfig:
             raise ValueError(f"top_k must be >= 1, got {self.top_k}")
         if self.concurrency < 1:
             raise ValueError(f"concurrency must be >= 1, got {self.concurrency}")
-        if len(set(self.target_ids)) != len(self.target_ids):
+        if strict and len(set(self.target_ids)) != len(self.target_ids):
             # Every per-target map downstream (WordBenchRunner's `clients`,
             # its preflight/canary dicts, storage.create_run_group's
             # `run_ids`) is keyed by target id. A duplicate silently

--- a/tldw_chatbook/Evals/word_bench/storage.py
+++ b/tldw_chatbook/Evals/word_bench/storage.py
@@ -50,7 +50,23 @@ def save_bench(db: EvalsDB, config: BenchConfig, task_id: Optional[str] = None) 
     dataset_id values, and passing those through raised sqlite3's FOREIGN
     KEY constraint failed. A documented restriction is preferable to a
     surface that breaks existing callers this way.
+
+    Raises:
+        ValueError: If ``config.target_ids`` contains a duplicate. A
+            ``BenchConfig`` built the normal way (``strict=True``, the
+            default) already rejects this at construction time, but
+            ``config`` here could instead be one ``load_bench`` built
+            leniently from a legacy row (task-1132) -- re-checking here
+            means a duplicate read off a pre-existing bench can never
+            round-trip back into storage un-flagged just because it arrived
+            through a lenient read; it must be resolved before a save
+            succeeds, same as a brand-new bench.
     """
+    target_ids = list(config.target_ids)
+    if len(set(target_ids)) != len(target_ids):
+        duplicates = sorted({tid for tid in target_ids if target_ids.count(tid) > 1})
+        raise ValueError(f"target_ids must be unique, got duplicates: {duplicates!r}")
+
     config_data = {
         "bench_type": BENCH_TYPE,
         "prompt_mode": config.prompt_mode,
@@ -83,12 +99,27 @@ def save_bench(db: EvalsDB, config: BenchConfig, task_id: Optional[str] = None) 
 def load_bench(db: EvalsDB, task_id: str) -> BenchConfig:
     """Load a bench definition back out of its eval_tasks row.
 
+    Constructs with ``strict=False`` (see ``BenchConfig``'s own docstring)
+    -- this is the read path, not the write path ``BenchConfig`` guards by
+    default. A bench saved before target-id-uniqueness validation existed
+    (task-1132) still has to be readable: rejecting here would make it
+    permanently unopenable rather than merely unrunnable, and would hide
+    the very duplicate the user needs to see in order to fix it. Any
+    duplicate present in ``config_data.target_ids`` is preserved exactly as
+    stored, not deduplicated -- deduplicating would silently collapse two
+    columns into one, which is the original bug (task-1132's ancestor) in
+    a different guise.
+
     Args:
         db: Database handle.
         task_id: The eval_tasks row id returned by save_bench.
 
     Returns:
-        The bench's current (live, editable) definition.
+        The bench's current (live, editable) definition. ``target_ids`` may
+        contain a duplicate if the stored row does; nothing downstream of
+        this function may assume uniqueness -- the write path
+        (``save_bench``, ``create_run_group``, ``WordBenchRunner.run``)
+        still rejects a duplicate before it can be persisted or run.
 
     Raises:
         TypeError: If task_id does not name an existing, non-deleted task
@@ -105,6 +136,7 @@ def load_bench(db: EvalsDB, task_id: str) -> BenchConfig:
         target_ids=tuple(data.get("target_ids", ())),
         probes=tuple(data.get("probes", ())),
         concurrency=int(data.get("concurrency", 1)),
+        strict=False,
     )
 
 


### PR DESCRIPTION
Fixes a regression I introduced in PR #962, filed here as TASK-1132.

#962 added duplicate-`target_ids` rejection to `BenchConfig.__post_init__`, correctly: duplicates
silently collapsed, because the runner and storage key per-target state by `target.id`, so two grid
columns shared one `eval_run`.

But `storage.load_bench()` builds a `BenchConfig` from stored rows, so that validation ran on the
**read** path too — and a bench saved *before* the validation existed became permanently un-openable.
Verified by writing a task row with `target_ids: [mid, mid]` directly (as a pre-validation save would
have) and calling `load_bench`: `ValueError: target_ids must be unique`.

An existing test had been saying so since #962 and was dismissed four times in one session as
"pre-existing, unrelated": `test_bench_with_duplicate_target_id_composes_without_raising`.

**The obvious fix would have been wrong.** Deduping on read collapses two columns into one — the
original bug wearing a different hat — and hides the problem from the person who has to fix it. That
test asserts *both* rows should render, and it is right.

So: **write stays strict, read becomes lenient.** `BenchConfig` gained `strict: InitVar[bool] = True`
gating only the uniqueness check — an `InitVar` is not a real field, so it stays out of equality,
repr and `asdict`, adding no persistent surface. Every write call site keeps the default; only
`load_bench` passes `strict=False`. `save_bench` gained its own independent check, since it cannot
assume a config handed to it was built strictly. `create_run_group` and the runner needed no change —
they were already independently guarded, which is what actually prevents the collapse.

Verified end to end on a legacy bench:
```
READ  : opens, both duplicate ids preserved
WRITE : still rejected  -- target_ids must be unique
RUN   : still rejected  -- targets must have unique ids
```

So a legacy bench opens, shows the duplicate target twice — that repetition *is* the visibility — and
refuses to run until corrected. Unreachable data becomes visible-but-blocked.

One thing the revert-check surfaced, worth recording: the `ValueError` was being swallowed by
`bench_editor.py`/`inspector.py`'s broad `except Exception`, so the user saw **zero rendered rows**
rather than an error. The bench did not appear broken; it appeared empty.

182 tests pass (178 baseline plus 4 new; the previously-erroring fixture now passes instead of failing
at setup).

Known and stated: `save_bench`'s new guard is not yet exercised in production — there is no edit-resave
flow, and `sample_bench.py` always passes a single target. It is defence-in-depth covered by unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes duplicate-target validation write-strict and read-lenient so legacy word benches open, while saves and runs still reject duplicates. Also adds ungated type checks for `target_ids` to catch corrupted stored data early. Fixes TASK-1132.

- Bug Fixes
  - `BenchConfig` adds `strict: InitVar[bool] = True` gating only the duplicate `target_ids` check.
  - `BenchConfig.__post_init__` now always validates `target_ids` is a list/tuple of non-empty strings; malformed entries (e.g., ints, nested lists) raise a clear `ValueError`.
  - `load_bench` builds with `strict=False` and preserves duplicate `target_ids` (no deduping).
  - `save_bench` independently rejects duplicate `target_ids`, even for leniently loaded configs.
  - Write-time guards remain in `create_run_group` and `WordBenchRunner.run`.
  - Tests updated/added for legacy read, malformed types, write-time rejection, and UI composition.

<sup>Written for commit e503575932a372d8c2786a39f10f913160bd729a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

