### PR TITLE
test(state): close TldwCli reactive ownership with installed sentinels

### DIFF
--- a/Docs/superpowers/plans/2026-07-26-task-906-reactive-ownership-closeout.md
+++ b/Docs/superpowers/plans/2026-07-26-task-906-reactive-ownership-closeout.md
@@ -49,31 +49,31 @@ imports surrogate app/widget harnesses. Do not claim a raw repository-wide
 
 ## Task 1: Start TASK-906 and Freeze the Exact Final Contract
 
-- [ ] Move TASK-906 In Progress and add its task-local plan:
+- [x] Move TASK-906 In Progress and add its task-local plan:
 
 ```bash
 backlog task edit 906 -s "In Progress"
 backlog task edit 906 --plan $'ADR required: yes\nADR path: backlog/decisions/032-immutable-installed-distribution-assets.md; backlog/decisions/033-application-session-state-ownership.md\nReason: ADR-033 defines the final root owners and ADR-032 requires clean installed-artifact proof.\n\n1. Enforce the exact TldwCli reactive set.\n2. Run every affected registered route in the production app.\n3. Extend installed-wheel ownership and maturity probes.\n4. Run the authorized integrated gate and reconcile TASK-647–652 and TASK-904–906.'
 ```
 
-- [ ] Add one AST helper that finds class-body `reactive(...)` assignments on
+- [x] Add one AST helper that finds class-body `reactive(...)` assignments on
   `TldwCli`, including annotated assignments, and require exactly:
 
 ```python
 {"current_tab", "splash_screen_active"}
 ```
 
-- [ ] Define `RETIRED_TLDW_REACTIVES` from the other 59 reviewed names in the
+- [x] Define `RETIRED_TLDW_REACTIVES` from the other 59 reviewed names in the
   specification and scan every production Python file for:
   class descriptors, assignments/deletes, root `app.<name>` access, constant
   `getattr`/`setattr`/`delattr`, string-key access, and handler
   `reactive_attr` values.
-- [ ] Scope the guard to `TldwCli`/application-root access so legitimate
+- [x] Scope the guard to `TldwCli`/application-root access so legitimate
   destination fields such as `MediaWindow.media_active_view` remain allowed.
-- [ ] Delete the already-no-op `watch_current_tab()`. Navigation remains the
+- [x] Delete the already-no-op `watch_current_tab()`. Navigation remains the
   only writer of canonical `current_tab`; do not recreate its retired
   view-toggling body.
-- [ ] Run:
+- [x] Run:
 
 ```bash
 pytest Tests/test_application_state_ownership.py -q
@@ -83,25 +83,25 @@ Expected: PASS only when the exact two-descriptor contract and all 59 removals h
 
 ## Task 2: Exercise Every Changed Registered Destination
 
-- [ ] In `test_reactive_ownership_maturity.py`, construct a normal `TldwCli`
+- [x] In `test_reactive_ownership_maturity.py`, construct a normal `TldwCli`
   and navigate, in fresh-screen mode, through:
   `llm`, `chat`, `personas`, `library`, `media`, `search`, `ingest`,
   `mcp`, `evals`, and `settings`.
-- [ ] Assert each route resolves to its registered production screen and the
+- [x] Assert each route resolves to its registered production screen and the
   intended owner is mounted. Exercise one safe local state/action on each
   screen; then navigate away/back to detect removed-name access during save,
   restore, resume, unmount, and fresh construction.
-- [ ] Assert the app instance has no retired reactive/companion attributes and
+- [x] Assert the app instance has no retired reactive/companion attributes and
   that snapshots contain only allowlisted primitives, not prompt bodies,
   records, widgets, workers, services, or removed names.
-- [ ] Add an AST-based source test that scans every file in
+- [x] Add an AST-based source test that scans every file in
   `Tests/ProductionApp/` and rejects class bases ending in `App`/`Screen`,
   imports or calls of `SimpleNamespace`/`MagicMock`, calls to
   `object.__new__(TldwCli)`, unbound `TldwCli` method calls, imports from the
   two legacy test-harness modules, and fixtures returning an app substitute.
   Do not use raw substring rejection that would fail on this guard's own
   pattern declarations.
-- [ ] Run:
+- [x] Run:
 
 ```bash
 pytest Tests/ProductionApp Tests/test_application_state_ownership.py -q
@@ -111,12 +111,12 @@ Expected: PASS; record exact counts and duration.
 
 ## Task 3: Extend the Installed-Distribution Probe
 
-- [ ] In `Tests/Packaging/test_installed_distribution.py`, extend the existing
+- [x] In `Tests/Packaging/test_installed_distribution.py`, extend the existing
   copied-source build fixture and installed child probe; do not replace it
   with a source-checkout smoke.
-- [ ] Before the child starts, write a minimal private config with splash and
+- [x] Before the child starts, write a minimal private config with splash and
   first-run UI disabled under the child `TLDW_CONFIG_PATH`.
-- [ ] Add both `CHECKOUT_ROOT` (the real worktree) and
+- [x] Add both `CHECKOUT_ROOT` (the real worktree) and
   `BUILD_SOURCE_ROOT` (the copied temporary build input) to the child
   environment. Resolve both strictly before launch. Assert:
   - the imported package root is under the pip `--target` directory;
@@ -130,13 +130,13 @@ Expected: PASS; record exact counts and duration.
     retired name;
   - packaged CSS/config/eval/templates/licenses and console entry points still
     satisfy the existing resource contract.
-- [ ] Use the already-created real `TldwCli` in the child probe with
+- [x] Use the already-created real `TldwCli` in the child probe with
   `app.run_test()`, wait for the registered Home screen, navigate to one
   affected destination such as Chat or Models, and exit cleanly. Do not define
   an installed test app or screen.
-- [ ] Preserve the before/after hash assertion proving the installed target is
+- [x] Preserve the before/after hash assertion proving the installed target is
   immutable.
-- [ ] Run focused source and production-app sentinels, then commit the
+- [x] Run focused source and production-app sentinels, then commit the
   TASK-906 source/test candidate before any release build:
 
 ```bash
@@ -145,7 +145,7 @@ git add tldw_chatbook/app.py Tests/ProductionApp/test_reactive_ownership_maturit
 git commit -m "test(state): enforce installed reactive ownership (task-906)"
 ```
 
-- [ ] Confirm the committed source/test scope is clean, then run:
+- [x] Confirm the committed source/test scope is clean, then run:
 
 ```bash
 git diff --exit-code -- tldw_chatbook Tests Packaging pyproject.toml MANIFEST.in
@@ -160,7 +160,7 @@ loaded package module from the checkout or copied build source.
 
 ## Task 4: Run Static and Authorized Integrated Gates
 
-- [ ] Confirm all implementation/test changes are committed before the release
+- [x] Confirm all implementation/test changes are committed before the release
   build while ignoring the unrelated `.superpowers/sdd` files:
 
 ```bash
@@ -168,7 +168,7 @@ git diff --exit-code -- tldw_chatbook Tests Packaging pyproject.toml MANIFEST.in
 git diff --cached --exit-code -- tldw_chatbook Tests Packaging pyproject.toml MANIFEST.in
 ```
 
-- [ ] Run compile and formatting/lint checks over the final changed scope:
+- [x] Run compile and formatting/lint checks over the final changed scope:
 
 ```bash
 python -m compileall -q tldw_chatbook Tests/ProductionApp Tests/State Tests/Provider Tests/Library/test_server_ingest_request.py Tests/test_application_state_ownership.py Tests/Packaging/test_installed_distribution.py
@@ -190,7 +190,7 @@ paths rather than restoring them. The pre-task format exceptions are
 The JSON assertion records the stronger latest-`dev` baseline:
 `settings_screen.py` has zero F841 findings.
 
-- [ ] Run the authorized integrated suite:
+- [x] Run the authorized integrated suite:
 
 ```bash
 pytest Tests/ProductionApp Tests/State/test_pending_handoff_store.py Tests/Provider/test_provider_model_resolution.py Tests/Library/test_server_ingest_request.py Tests/test_application_state_ownership.py Tests/Packaging/test_installed_distribution.py -q
@@ -201,18 +201,18 @@ only integrated claim for the tranche.
 
 ## Task 5: Reconcile TASK-647–652 and TASK-904–906 and Commit Closeout Documentation
 
-- [ ] Re-read TASK-647–652 and TASK-904–906 with
+- [x] Re-read TASK-647–652 and TASK-904–906 with
   `backlog task <id> --plain`.
   Confirm each earlier task is Done, each acceptance criterion is checked, its
   Implementation Notes contain exact evidence, and no final gate regressed an
   earlier invariant.
-- [ ] Check TASK-906 acceptance criteria only after the fresh source,
+- [x] Check TASK-906 acceptance criteria only after the fresh source,
   production-app, installed-wheel, static, and integrated evidence is recorded.
-- [ ] Update the approved specification status to `Implemented` and add the
+- [x] Update the approved specification status to `Implemented` and add the
   final task/plan links only after TASK-647–652 and TASK-904–905 are Done and
   TASK-906 has all
   implementation, verification, ADR, and documentation evidence complete.
-- [ ] Add TASK-906 Implementation Notes with the exact source,
+- [x] Add TASK-906 Implementation Notes with the exact source,
   production-app, installed-wheel, static, and integrated commands; result
   counts and durations; modified files; ADR links; and any deviations. Re-read
   the task, then mark it Done only when no placeholder text remains:
@@ -222,7 +222,7 @@ backlog task 906 --plain
 backlog task edit 906 --check-ac 1 --check-ac 2 --check-ac 3 --check-ac 4 --check-ac 5 -s Done
 ```
 
-- [ ] Commit final documentation/task reconciliation:
+- [x] Commit final documentation/task reconciliation:
 
 ```bash
 git add Docs/superpowers/specs/2026-07-26-tldwcli-reactive-state-decomposition-design.md 'backlog/tasks/task-647 - Restore-LLM-destination-actions-and-retire-the-dead-app-button-dispatcher.md' 'backlog/tasks/task-648 - Move-provider-selection-to-Settings-Console-sessions-and-a-typed-handoff.md' 'backlog/tasks/task-649 - Retire-the-unreachable-legacy-Chat-composition.md' 'backlog/tasks/task-650 - Remove-legacy-Chat-root-reactive-and-worker-state.md' 'backlog/tasks/task-651 - Remove-legacy-CCP-and-prompt-root-state.md' 'backlog/tasks/task-652 - Remove-duplicate-Media-root-state-and-stop-mutation-bubbling.md' 'backlog/tasks/task-904 - Remove-retired-Notes-Search-Ingest-Tools-and-Evals-root-state.md' 'backlog/tasks/task-905 - Retire-unreachable-TLDW-API-worker-context-and-handlers.md' 'backlog/tasks/task-906 - Close-TldwCli-reactive-ownership-with-installed-distribution-sentinels.md'

--- a/Docs/superpowers/plans/2026-07-26-task-906-reactive-ownership-closeout.md
+++ b/Docs/superpowers/plans/2026-07-26-task-906-reactive-ownership-closeout.md
@@ -40,6 +40,8 @@ imports surrogate app/widget harnesses. Do not claim a raw repository-wide
 
 - Modify `tldw_chatbook/app.py`: delete the already-no-op
   `watch_current_tab()` and any final removed-name residue.
+- Create `Tests/reactive_ownership_contract.py`: one test-only retained/retired
+  inventory shared by source, production-app, and packaging sentinels.
 - Modify `Tests/test_application_state_ownership.py`: exact 61-descriptor disposition and full production-source dynamic access guard.
 - Create `Tests/ProductionApp/test_reactive_ownership_maturity.py`: full-app route and owner maturity sentinel.
 - Modify `Tests/ProductionApp/conftest.py`: only if needed to make private environment isolation complete; never add an alternate app fixture.
@@ -63,8 +65,9 @@ backlog task edit 906 --plan $'ADR required: yes\nADR path: backlog/decisions/03
 {"current_tab", "splash_screen_active"}
 ```
 
-- [x] Define `RETIRED_TLDW_REACTIVES` from the other 59 reviewed names in the
-  specification and scan every production Python file for:
+- [x] Define `RETIRED_TLDW_REACTIVES` from the other 59 reviewed names in one
+  test-only contract module shared by all three sentinels, then scan every
+  production Python file for:
   class descriptors, assignments/deletes, root `app.<name>` access, constant
   `getattr`/`setattr`/`delattr`, string-key access, and handler
   `reactive_attr` values.
@@ -141,7 +144,7 @@ Expected: PASS; record exact counts and duration.
 
 ```bash
 pytest Tests/ProductionApp/test_reactive_ownership_maturity.py Tests/test_application_state_ownership.py -q
-git add tldw_chatbook/app.py Tests/ProductionApp/test_reactive_ownership_maturity.py Tests/ProductionApp/conftest.py Tests/test_application_state_ownership.py Tests/Packaging/test_installed_distribution.py
+git add tldw_chatbook/app.py Tests/reactive_ownership_contract.py Tests/ProductionApp/test_reactive_ownership_maturity.py Tests/ProductionApp/conftest.py Tests/test_application_state_ownership.py Tests/Packaging/test_installed_distribution.py
 git commit -m "test(state): enforce installed reactive ownership (task-906)"
 ```
 
@@ -171,11 +174,11 @@ git diff --cached --exit-code -- tldw_chatbook Tests Packaging pyproject.toml MA
 - [x] Run compile and formatting/lint checks over the final changed scope:
 
 ```bash
-python -m compileall -q tldw_chatbook Tests/ProductionApp Tests/State Tests/Provider Tests/Library/test_server_ingest_request.py Tests/test_application_state_ownership.py Tests/Packaging/test_installed_distribution.py
-python -m ruff check tldw_chatbook/app.py tldw_chatbook/UI/LLM_Management_Window.py tldw_chatbook/UI/MediaWindow_v2.py tldw_chatbook/UI/Navigation/pending_handoff_store.py tldw_chatbook/UI/Screens/provider_model_resolution.py tldw_chatbook/UI/Screens/chat_screen.py tldw_chatbook/UI/Screens/personas_screen.py tldw_chatbook/UI/Screens/library_screen.py tldw_chatbook/UI/Screens/media_screen.py tldw_chatbook/UI/Screens/search_screen.py tldw_chatbook/UI/Screens/mcp_screen.py tldw_chatbook/UI/Screens/evals_screen.py tldw_chatbook/Utils/log_widget_manager.py tldw_chatbook/Event_Handlers Tests/ProductionApp Tests/State Tests/Provider Tests/Library/test_server_ingest_request.py Tests/test_application_state_ownership.py Tests/Packaging/test_installed_distribution.py
+python -m compileall -q tldw_chatbook Tests/ProductionApp Tests/State Tests/Provider Tests/Library/test_server_ingest_request.py Tests/reactive_ownership_contract.py Tests/test_application_state_ownership.py Tests/Packaging/test_installed_distribution.py
+python -m ruff check tldw_chatbook/app.py tldw_chatbook/UI/LLM_Management_Window.py tldw_chatbook/UI/MediaWindow_v2.py tldw_chatbook/UI/Navigation/pending_handoff_store.py tldw_chatbook/UI/Screens/provider_model_resolution.py tldw_chatbook/UI/Screens/chat_screen.py tldw_chatbook/UI/Screens/personas_screen.py tldw_chatbook/UI/Screens/library_screen.py tldw_chatbook/UI/Screens/media_screen.py tldw_chatbook/UI/Screens/search_screen.py tldw_chatbook/UI/Screens/mcp_screen.py tldw_chatbook/UI/Screens/evals_screen.py tldw_chatbook/Utils/log_widget_manager.py tldw_chatbook/Event_Handlers Tests/ProductionApp Tests/State Tests/Provider Tests/Library/test_server_ingest_request.py Tests/reactive_ownership_contract.py Tests/test_application_state_ownership.py Tests/Packaging/test_installed_distribution.py
 python -m ruff check --ignore F841 tldw_chatbook/UI/Screens/settings_screen.py
 python -c 'import json, subprocess, sys; p = subprocess.run([sys.executable, "-m", "ruff", "check", "--select", "F841", "--output-format", "json", "tldw_chatbook/UI/Screens/settings_screen.py"], capture_output=True, text=True); findings = json.loads(p.stdout); assert findings == [], findings'
-python -m ruff format --check tldw_chatbook/UI/LLM_Management_Window.py tldw_chatbook/UI/MediaWindow_v2.py tldw_chatbook/UI/Navigation/pending_handoff_store.py tldw_chatbook/UI/Screens/media_screen.py tldw_chatbook/UI/Screens/search_screen.py tldw_chatbook/UI/Screens/mcp_screen.py tldw_chatbook/Utils/log_widget_manager.py tldw_chatbook/Event_Handlers/LLM_Management_Events tldw_chatbook/Event_Handlers/worker_events.py tldw_chatbook/Event_Handlers/media_events.py tldw_chatbook/Event_Handlers/collections_tag_events.py tldw_chatbook/Event_Handlers/worker_handlers/misc_worker_handler.py tldw_chatbook/Event_Handlers/ingest_events.py Tests/ProductionApp Tests/State Tests/Provider Tests/Library/test_server_ingest_request.py Tests/test_application_state_ownership.py
+python -m ruff format --check tldw_chatbook/UI/LLM_Management_Window.py tldw_chatbook/UI/MediaWindow_v2.py tldw_chatbook/UI/Navigation/pending_handoff_store.py tldw_chatbook/UI/Screens/media_screen.py tldw_chatbook/UI/Screens/search_screen.py tldw_chatbook/UI/Screens/mcp_screen.py tldw_chatbook/Utils/log_widget_manager.py tldw_chatbook/Event_Handlers/LLM_Management_Events tldw_chatbook/Event_Handlers/worker_events.py tldw_chatbook/Event_Handlers/media_events.py tldw_chatbook/Event_Handlers/collections_tag_events.py tldw_chatbook/Event_Handlers/worker_handlers/misc_worker_handler.py tldw_chatbook/Event_Handlers/ingest_events.py Tests/ProductionApp Tests/State Tests/Provider Tests/Library/test_server_ingest_request.py Tests/reactive_ownership_contract.py Tests/test_application_state_ownership.py
 git diff --check
 ```
 

--- a/Docs/superpowers/plans/2026-07-26-task-906-reactive-ownership-closeout.md
+++ b/Docs/superpowers/plans/2026-07-26-task-906-reactive-ownership-closeout.md
@@ -174,20 +174,21 @@ git diff --cached --exit-code -- tldw_chatbook Tests Packaging pyproject.toml MA
 python -m compileall -q tldw_chatbook Tests/ProductionApp Tests/State Tests/Provider Tests/Library/test_server_ingest_request.py Tests/test_application_state_ownership.py Tests/Packaging/test_installed_distribution.py
 python -m ruff check tldw_chatbook/app.py tldw_chatbook/UI/LLM_Management_Window.py tldw_chatbook/UI/MediaWindow_v2.py tldw_chatbook/UI/Navigation/pending_handoff_store.py tldw_chatbook/UI/Screens/provider_model_resolution.py tldw_chatbook/UI/Screens/chat_screen.py tldw_chatbook/UI/Screens/personas_screen.py tldw_chatbook/UI/Screens/library_screen.py tldw_chatbook/UI/Screens/media_screen.py tldw_chatbook/UI/Screens/search_screen.py tldw_chatbook/UI/Screens/mcp_screen.py tldw_chatbook/UI/Screens/evals_screen.py tldw_chatbook/Utils/log_widget_manager.py tldw_chatbook/Event_Handlers Tests/ProductionApp Tests/State Tests/Provider Tests/Library/test_server_ingest_request.py Tests/test_application_state_ownership.py Tests/Packaging/test_installed_distribution.py
 python -m ruff check --ignore F841 tldw_chatbook/UI/Screens/settings_screen.py
-python -c 'import json, subprocess, sys; p = subprocess.run([sys.executable, "-m", "ruff", "check", "--select", "F841", "--output-format", "json", "tldw_chatbook/UI/Screens/settings_screen.py"], capture_output=True, text=True); findings = json.loads(p.stdout); assert len(findings) == 2 and all(item["code"] == "F841" and "`config_path`" in item["message"] for item in findings), findings'
-python -m ruff format --check tldw_chatbook/UI/LLM_Management_Window.py tldw_chatbook/UI/MediaWindow_v2.py tldw_chatbook/UI/Navigation/pending_handoff_store.py tldw_chatbook/UI/Screens/personas_screen.py tldw_chatbook/UI/Screens/library_screen.py tldw_chatbook/UI/Screens/media_screen.py tldw_chatbook/UI/Screens/search_screen.py tldw_chatbook/UI/Screens/mcp_screen.py tldw_chatbook/UI/Screens/evals_screen.py tldw_chatbook/Utils/log_widget_manager.py tldw_chatbook/Event_Handlers/LLM_Management_Events tldw_chatbook/Event_Handlers/sidebar_events.py tldw_chatbook/Event_Handlers/worker_events.py tldw_chatbook/Event_Handlers/worker_handlers/chat_worker_handler.py tldw_chatbook/Event_Handlers/media_events.py tldw_chatbook/Event_Handlers/collections_tag_events.py tldw_chatbook/Event_Handlers/worker_handlers/misc_worker_handler.py tldw_chatbook/Event_Handlers/ingest_events.py Tests/ProductionApp Tests/State Tests/Provider Tests/Library/test_server_ingest_request.py Tests/test_application_state_ownership.py
+python -c 'import json, subprocess, sys; p = subprocess.run([sys.executable, "-m", "ruff", "check", "--select", "F841", "--output-format", "json", "tldw_chatbook/UI/Screens/settings_screen.py"], capture_output=True, text=True); findings = json.loads(p.stdout); assert findings == [], findings'
+python -m ruff format --check tldw_chatbook/UI/LLM_Management_Window.py tldw_chatbook/UI/MediaWindow_v2.py tldw_chatbook/UI/Navigation/pending_handoff_store.py tldw_chatbook/UI/Screens/media_screen.py tldw_chatbook/UI/Screens/search_screen.py tldw_chatbook/UI/Screens/mcp_screen.py tldw_chatbook/Utils/log_widget_manager.py tldw_chatbook/Event_Handlers/LLM_Management_Events tldw_chatbook/Event_Handlers/worker_events.py tldw_chatbook/Event_Handlers/media_events.py tldw_chatbook/Event_Handlers/collections_tag_events.py tldw_chatbook/Event_Handlers/worker_handlers/misc_worker_handler.py tldw_chatbook/Event_Handlers/ingest_events.py Tests/ProductionApp Tests/State Tests/Provider Tests/Library/test_server_ingest_request.py Tests/test_application_state_ownership.py
 git diff --check
 ```
 
-If the final change set has deleted an optional path, derive the exact
-surviving changed-file list and omit that path. Do not broaden to a known
-failing full-tree baseline and do not restore dead code.
-The pre-task format exceptions are `app.py`, `chat_screen.py`,
-`provider_model_resolution.py`, `settings_screen.py`,
-`Chat_Events/chat_events.py`, `conv_char_events.py`, and
+The latest-`dev` reconciliation removed
+`Event_Handlers/sidebar_events.py` and
+`worker_handlers/chat_worker_handler.py`, so the format gate omits those dead
+paths rather than restoring them. The pre-task format exceptions are
+`app.py`, `chat_screen.py`, `provider_model_resolution.py`,
+`settings_screen.py`, `personas_screen.py`, `library_screen.py`,
+`evals_screen.py`, `Chat_Events/chat_events.py`, `conv_char_events.py`, and
 `Tests/Packaging/test_installed_distribution.py`; do not mass-format them.
-The JSON assertion ensures `settings_screen.py` has no F841 finding beyond its
-exact two pre-task unused `config_path` locals.
+The JSON assertion records the stronger latest-`dev` baseline:
+`settings_screen.py` has zero F841 findings.
 
 - [ ] Run the authorized integrated suite:
 

--- a/Docs/superpowers/specs/2026-07-26-tldwcli-reactive-state-decomposition-design.md
+++ b/Docs/superpowers/specs/2026-07-26-tldwcli-reactive-state-decomposition-design.md
@@ -830,10 +830,10 @@ implementation evidence. TASK-906 completes slice 9 on latest `dev` commit
   input, audits every loaded package module, preserves installed hashes, and
   exercises the registered Home and Chat screens;
 - the focused ownership/production-app gate passed 57 tests with 2 warnings
-  in 277.36 seconds, the installed-distribution gate passed 6 tests in 19.12
+  in 281.97 seconds, the installed-distribution gate passed 6 tests in 21.83
   seconds, and the authorized integrated gate passed 196 tests with 5
-  warnings in 589.99 seconds;
-- compileall, scoped Ruff lint, the zero-F841 Settings baseline, the 36-file
+  warnings in 567.81 seconds;
+- compileall, scoped Ruff lint, the zero-F841 Settings baseline, the 37-file
   format gate, and `git diff --check` passed.
 
 `Tests/UI` remains intentionally excluded because its conftest imports legacy

--- a/Docs/superpowers/specs/2026-07-26-tldwcli-reactive-state-decomposition-design.md
+++ b/Docs/superpowers/specs/2026-07-26-tldwcli-reactive-state-decomposition-design.md
@@ -826,13 +826,16 @@ implementation evidence. TASK-906 completes slice 9 on latest `dev` commit
   root mixins, all 59 retired names, and their root watchers;
 - the normal production `TldwCli` exercises every reviewed route twice with
   fresh registered screens and payload-safe memory-only snapshots;
+- real-app readiness uses a monotonic 30-second deadline with a validated
+  `TLDW_TEST_SCREEN_WAIT_SECONDS` override, and installed navigation compares
+  canonical `TAB_HOME`/`TAB_CHAT` values rather than duplicated literals;
 - the installed-wheel probe runs outside both the checkout and copied build
   input, audits every loaded package module, preserves installed hashes, and
   exercises the registered Home and Chat screens;
-- the focused ownership/production-app gate passed 57 tests with 2 warnings
-  in 281.97 seconds, the installed-distribution gate passed 6 tests in 21.83
-  seconds, and the authorized integrated gate passed 196 tests with 5
-  warnings in 567.81 seconds;
+- the focused ownership/production-app gate passed 58 tests with 2 warnings
+  in 306.14 seconds, the installed-distribution gate passed 6 tests in 19.01
+  seconds, and the authorized integrated gate passed 197 tests with 5
+  warnings in 573.57 seconds;
 - compileall, scoped Ruff lint, the zero-F841 Settings baseline, the 37-file
   format gate, and `git diff --check` passed.
 

--- a/Docs/superpowers/specs/2026-07-26-tldwcli-reactive-state-decomposition-design.md
+++ b/Docs/superpowers/specs/2026-07-26-tldwcli-reactive-state-decomposition-design.md
@@ -1,7 +1,11 @@
 # TldwCli Reactive State Decomposition Design
 
 Date: 2026-07-26
-Status: Implementation slices 1–8 complete; installed-distribution closeout pending
+Status: Implemented
+Final task:
+[TASK-906](../../../backlog/tasks/task-906%20-%20Close-TldwCli-reactive-ownership-with-installed-distribution-sentinels.md)
+Final plan:
+[TldwCli Reactive Ownership Closeout](../plans/2026-07-26-task-906-reactive-ownership-closeout.md)
 ADR:
 [ADR-033](../../../backlog/decisions/033-application-session-state-ownership.md),
 [ADR-006](../../../backlog/decisions/006-provider-aware-generation-settings.md),
@@ -810,3 +814,27 @@ The tranche is complete only when:
 - snapshots and diagnostics remain payload-safe;
 - source, authorized integration, formatting/static, and installed-wheel gates
   pass without surrogate applications.
+
+## Implementation Closeout
+
+TASK-647–652 and TASK-904–905 are Done with checked acceptance criteria and
+implementation evidence. TASK-906 completes slice 9 on latest `dev` commit
+`6784c4ba3`:
+
+- the source and installed-artifact AST sentinels enforce the exact retained
+  set `current_tab` and `splash_screen_active`, including transitive local
+  root mixins, all 59 retired names, and their root watchers;
+- the normal production `TldwCli` exercises every reviewed route twice with
+  fresh registered screens and payload-safe memory-only snapshots;
+- the installed-wheel probe runs outside both the checkout and copied build
+  input, audits every loaded package module, preserves installed hashes, and
+  exercises the registered Home and Chat screens;
+- the focused ownership/production-app gate passed 57 tests with 2 warnings
+  in 277.36 seconds, the installed-distribution gate passed 6 tests in 19.12
+  seconds, and the authorized integrated gate passed 196 tests with 5
+  warnings in 589.99 seconds;
+- compileall, scoped Ruff lint, the zero-F841 Settings baseline, the 36-file
+  format gate, and `git diff --check` passed.
+
+`Tests/UI` remains intentionally excluded because its conftest imports legacy
+surrogate app/widget harnesses. No repository-wide pytest result is claimed.

--- a/Tests/Packaging/test_installed_distribution.py
+++ b/Tests/Packaging/test_installed_distribution.py
@@ -15,6 +15,10 @@ import zipfile
 
 import pytest
 
+from Tests.reactive_ownership_contract import (
+    RETAINED_TLDW_REACTIVES,
+    RETIRED_TLDW_REACTIVES,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -34,71 +38,6 @@ TEMPLATE_NAMES = {
     "words",
     "xml",
 }
-RETAINED_TLDW_REACTIVES = frozenset({"current_tab", "splash_screen_active"})
-RETIRED_TLDW_REACTIVES = frozenset(
-    {
-        "ccp_active_view",
-        "chat_api_provider_value",
-        "ccp_api_provider_value",
-        "rag_expansion_provider_value",
-        "current_editing_character_id",
-        "current_editing_character_data",
-        "chat_sidebar_collapsed",
-        "chat_right_sidebar_collapsed",
-        "chat_right_sidebar_width",
-        "conv_char_sidebar_left_collapsed",
-        "conv_char_sidebar_right_collapsed",
-        "evals_sidebar_collapsed",
-        "media_active_view",
-        "current_selected_note_id",
-        "current_selected_note_version",
-        "current_selected_note_title",
-        "current_selected_note_content",
-        "notes_sort_by",
-        "notes_sort_ascending",
-        "notes_preview_mode",
-        "notes_auto_save_enabled",
-        "notes_auto_save_timer",
-        "notes_last_save_time",
-        "chat_sidebar_selected_prompt_id",
-        "chat_sidebar_selected_prompt_system",
-        "chat_sidebar_selected_prompt_user",
-        "current_chat_is_ephemeral",
-        "current_chat_conversation_id",
-        "current_conv_char_tab_conversation_id",
-        "current_chat_active_character_data",
-        "current_ccp_character_details",
-        "active_chat_tab_id",
-        "chat_sessions",
-        "chat_sidebar_loaded_prompt_id",
-        "chat_sidebar_loaded_prompt_title_text",
-        "chat_sidebar_loaded_prompt_system_text",
-        "chat_sidebar_loaded_prompt_user_text",
-        "chat_sidebar_loaded_prompt_keywords_text",
-        "chat_sidebar_prompt_display_visible",
-        "current_prompt_id",
-        "current_prompt_uuid",
-        "current_prompt_name",
-        "current_prompt_author",
-        "current_prompt_details",
-        "current_prompt_system",
-        "current_prompt_user",
-        "current_prompt_keywords_str",
-        "current_prompt_version",
-        "_initial_media_view_slug",
-        "current_media_type_filter_slug",
-        "current_media_type_filter_display_name",
-        "media_current_page",
-        "current_loaded_media_item",
-        "chat_settings_mode",
-        "chat_settings_search_query",
-        "search_active_sub_tab",
-        "ingest_active_view",
-        "tools_settings_active_view",
-        "llm_active_view",
-    }
-)
-
 INSTALLED_PROBE = r"""
 from pathlib import Path
 import ast

--- a/Tests/Packaging/test_installed_distribution.py
+++ b/Tests/Packaging/test_installed_distribution.py
@@ -34,21 +34,116 @@ TEMPLATE_NAMES = {
     "words",
     "xml",
 }
+RETAINED_TLDW_REACTIVES = frozenset({"current_tab", "splash_screen_active"})
+RETIRED_TLDW_REACTIVES = frozenset(
+    {
+        "ccp_active_view",
+        "chat_api_provider_value",
+        "ccp_api_provider_value",
+        "rag_expansion_provider_value",
+        "current_editing_character_id",
+        "current_editing_character_data",
+        "chat_sidebar_collapsed",
+        "chat_right_sidebar_collapsed",
+        "chat_right_sidebar_width",
+        "conv_char_sidebar_left_collapsed",
+        "conv_char_sidebar_right_collapsed",
+        "evals_sidebar_collapsed",
+        "media_active_view",
+        "current_selected_note_id",
+        "current_selected_note_version",
+        "current_selected_note_title",
+        "current_selected_note_content",
+        "notes_sort_by",
+        "notes_sort_ascending",
+        "notes_preview_mode",
+        "notes_auto_save_enabled",
+        "notes_auto_save_timer",
+        "notes_last_save_time",
+        "chat_sidebar_selected_prompt_id",
+        "chat_sidebar_selected_prompt_system",
+        "chat_sidebar_selected_prompt_user",
+        "current_chat_is_ephemeral",
+        "current_chat_conversation_id",
+        "current_conv_char_tab_conversation_id",
+        "current_chat_active_character_data",
+        "current_ccp_character_details",
+        "active_chat_tab_id",
+        "chat_sessions",
+        "chat_sidebar_loaded_prompt_id",
+        "chat_sidebar_loaded_prompt_title_text",
+        "chat_sidebar_loaded_prompt_system_text",
+        "chat_sidebar_loaded_prompt_user_text",
+        "chat_sidebar_loaded_prompt_keywords_text",
+        "chat_sidebar_prompt_display_visible",
+        "current_prompt_id",
+        "current_prompt_uuid",
+        "current_prompt_name",
+        "current_prompt_author",
+        "current_prompt_details",
+        "current_prompt_system",
+        "current_prompt_user",
+        "current_prompt_keywords_str",
+        "current_prompt_version",
+        "_initial_media_view_slug",
+        "current_media_type_filter_slug",
+        "current_media_type_filter_display_name",
+        "media_current_page",
+        "current_loaded_media_item",
+        "chat_settings_mode",
+        "chat_settings_search_query",
+        "search_active_sub_tab",
+        "ingest_active_view",
+        "tools_settings_active_view",
+        "llm_active_view",
+    }
+)
 
 INSTALLED_PROBE = r"""
 from pathlib import Path
+import ast
+import asyncio
 import json
 import os
+import sys
 import tomllib
+
+expected_target = Path(os.environ["EXPECTED_TARGET"]).resolve(strict=True)
+excluded_source_roots = (
+    Path(os.environ["CHECKOUT_ROOT"]).resolve(strict=True),
+    Path(os.environ["BUILD_SOURCE_ROOT"]).resolve(strict=True),
+)
+expected_reactives = frozenset(json.loads(os.environ["EXPECTED_REACTIVES"]))
+retired_reactives = frozenset(json.loads(os.environ["RETIRED_REACTIVES"]))
+assert expected_reactives == {"current_tab", "splash_screen_active"}
+assert len(retired_reactives) == 59
+assert expected_reactives.isdisjoint(retired_reactives)
+
+
+def is_under(path, root):
+    return path == root or path.is_relative_to(root)
+
+
+for entry in sys.path:
+    try:
+        resolved_entry = Path(entry or os.getcwd()).resolve(strict=True)
+    except (FileNotFoundError, OSError):
+        continue
+    assert not any(is_under(resolved_entry, root) for root in excluded_source_roots), (
+        resolved_entry,
+        excluded_source_roots,
+    )
 
 import tldw_chatbook
 from tldw_chatbook.Chunking.chunking_templates import ChunkingTemplateManager
 from tldw_chatbook.Evals.config_loader import EvalConfigLoader
 from tldw_chatbook.RAG_Search.pipeline_loader import PipelineLoader
 from tldw_chatbook.app import TldwCli, get_app
+from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from tldw_chatbook.UI.Screens.home_screen import HomeScreen
 
 package_root = Path(tldw_chatbook.__file__).resolve().parent
-expected_target = Path(os.environ["EXPECTED_TARGET"]).resolve()
 expected_templates = set(json.loads(os.environ["EXPECTED_TEMPLATES"]))
 assert package_root.is_relative_to(expected_target)
 assert (package_root / "css" / "tldw_cli_modular.tcss").is_file()
@@ -65,7 +160,311 @@ assert (package_root / "Third_Party" / "aider" / "LICENSE.txt").is_file()
 assert (
     package_root / "Third_Party" / "textual_fspicker" / "LICENSE"
 ).is_file()
-assert isinstance(get_app(), TldwCli)
+
+
+def chain(node):
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = chain(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    return ""
+
+
+def bound_names(node):
+    if isinstance(node, ast.Name):
+        return (node.id,)
+    if isinstance(node, (ast.Tuple, ast.List)):
+        return tuple(name for item in node.elts for name in bound_names(item))
+    return ()
+
+
+def class_body_reactives(class_node):
+    names = set()
+    for statement in class_node.body:
+        if isinstance(statement, ast.Assign):
+            targets = statement.targets
+            value = statement.value
+        elif isinstance(statement, ast.AnnAssign):
+            targets = (statement.target,)
+            value = statement.value
+        else:
+            continue
+        if not (
+            isinstance(value, ast.Call)
+            and chain(value.func).rsplit(".", 1)[-1] == "reactive"
+        ):
+            continue
+        for target in targets:
+            names.update(bound_names(target))
+    return frozenset(names)
+
+
+def is_root_app(node):
+    expression = chain(node)
+    return bool(expression) and expression.rsplit(".", 1)[-1] in {
+        "app",
+        "app_instance",
+    }
+
+
+def is_root_mapping(node, root_predicate):
+    if root_predicate(node):
+        return True
+    if (
+        isinstance(node, ast.Attribute)
+        and node.attr == "__dict__"
+        and root_predicate(node.value)
+    ):
+        return True
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "vars"
+        and len(node.args) == 1
+        and root_predicate(node.args[0])
+    )
+
+
+def constant_name(node):
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id in {"getattr", "setattr", "delattr", "hasattr"}
+        and len(node.args) >= 2
+        and isinstance(node.args[1], ast.Constant)
+        and isinstance(node.args[1].value, str)
+    ):
+        return node.args[1].value
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "get"
+        and node.args
+        and isinstance(node.args[0], ast.Constant)
+        and isinstance(node.args[0].value, str)
+    ):
+        return node.args[0].value
+    return None
+
+
+def root_accesses(tree, relative_path):
+    found = []
+    for node in ast.walk(tree):
+        target = None
+        if (
+            isinstance(node, ast.Attribute)
+            and node.attr in retired_reactives
+            and is_root_app(node.value)
+        ):
+            target = node.attr
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in {"getattr", "setattr", "delattr", "hasattr"}
+            and len(node.args) >= 2
+            and is_root_app(node.args[0])
+            and isinstance(node.args[1], ast.Constant)
+            and node.args[1].value in retired_reactives
+        ):
+            target = node.args[1].value
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and constant_name(node) in retired_reactives
+            and is_root_mapping(node.func.value, is_root_app)
+            and not is_root_app(node.func.value)
+        ):
+            target = constant_name(node)
+        elif (
+            isinstance(node, ast.Subscript)
+            and is_root_mapping(node.value, is_root_app)
+            and isinstance(node.slice, ast.Constant)
+            and node.slice.value in retired_reactives
+        ):
+            target = node.slice.value
+        elif (
+            isinstance(node, ast.keyword)
+            and node.arg == "reactive_attr"
+            and isinstance(node.value, ast.Constant)
+            and node.value.value in retired_reactives
+        ):
+            target = node.value.value
+        if target is not None:
+            found.append((relative_path, node.lineno, target))
+    return found
+
+
+class TldwCliRetiredAccesses(ast.NodeVisitor):
+    def __init__(self):
+        self.nested_class_depth = 0
+        self.found = []
+
+    def root_receiver(self, node):
+        return is_root_app(node) or (
+            self.nested_class_depth == 0 and chain(node) == "self"
+        )
+
+    def visit_ClassDef(self, node):
+        self.nested_class_depth += 1
+        self.generic_visit(node)
+        self.nested_class_depth -= 1
+
+    def visit_Attribute(self, node):
+        if node.attr in retired_reactives and self.root_receiver(node.value):
+            self.found.append((node.lineno, node.attr))
+        self.generic_visit(node)
+
+    def visit_Call(self, node):
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id in {"getattr", "setattr", "delattr", "hasattr"}
+            and len(node.args) >= 2
+            and self.root_receiver(node.args[0])
+            and isinstance(node.args[1], ast.Constant)
+            and node.args[1].value in retired_reactives
+        ):
+            self.found.append((node.lineno, node.args[1].value))
+        elif (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and constant_name(node) in retired_reactives
+            and is_root_mapping(node.func.value, self.root_receiver)
+            and not self.root_receiver(node.func.value)
+        ):
+            self.found.append((node.lineno, constant_name(node)))
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node):
+        if (
+            is_root_mapping(node.value, self.root_receiver)
+            and isinstance(node.slice, ast.Constant)
+            and node.slice.value in retired_reactives
+        ):
+            self.found.append((node.lineno, node.slice.value))
+        self.generic_visit(node)
+
+    def visit_keyword(self, node):
+        if (
+            self.nested_class_depth == 0
+            and node.arg == "reactive_attr"
+            and isinstance(node.value, ast.Constant)
+            and node.value.value in retired_reactives
+        ):
+            self.found.append((node.lineno, node.value.value))
+        self.generic_visit(node)
+
+
+app_path = package_root / "app.py"
+app_tree = ast.parse(app_path.read_text(encoding="utf-8"), filename=str(app_path))
+app_class = next(
+    node
+    for node in app_tree.body
+    if isinstance(node, ast.ClassDef) and node.name == "TldwCli"
+)
+assert class_body_reactives(app_class) == expected_reactives
+assert "watch_current_tab" not in {
+    node.name
+    for node in app_class.body
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+}
+assert retired_reactives.isdisjoint(
+    node.name
+    for node in app_class.body
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+)
+class_level_retired = []
+for statement in app_class.body:
+    if isinstance(statement, ast.Assign):
+        targets = statement.targets
+    elif isinstance(statement, (ast.AnnAssign, ast.AugAssign)):
+        targets = (statement.target,)
+    else:
+        continue
+    for target in targets:
+        class_level_retired.extend(
+            name for name in bound_names(target) if name in retired_reactives
+        )
+assert class_level_retired == []
+
+tldw_accesses = TldwCliRetiredAccesses()
+for statement in app_class.body:
+    tldw_accesses.visit(statement)
+assert tldw_accesses.found == []
+
+installed_root_accesses = []
+for source_path in sorted(package_root.rglob("*.py")):
+    source_tree = ast.parse(
+        source_path.read_text(encoding="utf-8"),
+        filename=str(source_path),
+    )
+    installed_root_accesses.extend(
+        root_accesses(source_tree, source_path.relative_to(package_root).as_posix())
+    )
+assert installed_root_accesses == []
+
+app = get_app()
+assert isinstance(app, TldwCli)
+assert all(not hasattr(app, name) for name in retired_reactives)
+
+
+async def wait_for(pilot, predicate, failure):
+    for _ in range(600):
+        if predicate():
+            return
+        await pilot.pause(0.01)
+    raise AssertionError(failure)
+
+
+async def exercise_production_app():
+    async with app.run_test(size=(120, 40)) as pilot:
+        await wait_for(
+            pilot,
+            lambda: (
+                type(app.screen) is HomeScreen
+                and app.current_tab == "home"
+                and app.screen.is_mounted
+            ),
+            "installed production app did not mount registered Home",
+        )
+        app.post_message(NavigateToScreen("chat"))
+        await wait_for(
+            pilot,
+            lambda: (
+                type(app.screen) is ChatScreen
+                and app.current_tab == "chat"
+                and app.screen.is_mounted
+            ),
+            "installed production app did not navigate to registered Chat",
+        )
+        assert all(not hasattr(app, name) for name in retired_reactives)
+
+
+asyncio.run(exercise_production_app())
+
+loaded_package_paths = []
+for module_name, module in tuple(sys.modules.items()):
+    if module_name != "tldw_chatbook" and not module_name.startswith(
+        "tldw_chatbook."
+    ):
+        continue
+    module_file = getattr(module, "__file__", None)
+    if module_file:
+        loaded_package_paths.append((module_name, Path(module_file).resolve(strict=True)))
+    module_path = getattr(module, "__path__", None)
+    if module_path:
+        loaded_package_paths.extend(
+            (module_name, Path(path).resolve(strict=True)) for path in module_path
+        )
+
+assert loaded_package_paths
+for module_name, loaded_path in loaded_package_paths:
+    assert is_under(loaded_path, expected_target), (module_name, loaded_path)
+    assert not any(
+        is_under(loaded_path, source_root) for source_root in excluded_source_roots
+    ), (module_name, loaded_path, excluded_source_roots)
+
 print(package_root)
 """
 
@@ -221,13 +620,26 @@ def _target_hashes(target: Path) -> dict[str, str]:
     }
 
 
-def _private_child_env(state_root: Path, target: Path) -> dict[str, str]:
+def _private_child_env(
+    state_root: Path,
+    target: Path,
+    build_source_root: Path,
+) -> dict[str, str]:
     state_root = state_root.resolve(strict=True)
+    target = target.resolve(strict=True)
+    checkout_root = REPO_ROOT.resolve(strict=True)
+    build_source_root = build_source_root.resolve(strict=True)
     config_root = state_root / "config"
     data_root = state_root / "data"
     temp_root = state_root / "tmp"
     for path in (config_root, data_root, temp_root):
         path.mkdir(parents=True, mode=0o700, exist_ok=True)
+    config_path = config_root / "config.toml"
+    config_path.write_text(
+        '[general]\ndefault_tab = "home"\n\n[splash_screen]\nenabled = false\n',
+        encoding="utf-8",
+    )
+    config_path.chmod(0o600)
 
     env = os.environ.copy()
     for name in ("TLDW_TEST_CONFIG_ROOT", "TLDW_TEST_CONFIG_ROOT_OWNER"):
@@ -240,13 +652,17 @@ def _private_child_env(state_root: Path, target: Path) -> dict[str, str]:
             "LOCALAPPDATA": str(data_root),
             "XDG_CONFIG_HOME": str(config_root),
             "XDG_DATA_HOME": str(data_root),
-            "TLDW_CONFIG_PATH": str(config_root / "config.toml"),
+            "TLDW_CONFIG_PATH": str(config_path),
             "TMPDIR": str(temp_root),
             "TEMP": str(temp_root),
             "TMP": str(temp_root),
             "PYTHONDONTWRITEBYTECODE": "1",
-            "PYTHONPATH": str(target.resolve(strict=True)),
-            "EXPECTED_TARGET": str(target.resolve(strict=True)),
+            "PYTHONPATH": str(target),
+            "EXPECTED_TARGET": str(target),
+            "CHECKOUT_ROOT": str(checkout_root),
+            "BUILD_SOURCE_ROOT": str(build_source_root),
+            "EXPECTED_REACTIVES": json.dumps(sorted(RETAINED_TLDW_REACTIVES)),
+            "RETIRED_REACTIVES": json.dumps(sorted(RETIRED_TLDW_REACTIVES)),
             "EXPECTED_TEMPLATES": json.dumps(sorted(TEMPLATE_NAMES)),
         }
     )
@@ -451,7 +867,11 @@ def test_installed_wheel_loaders_entry_points_and_assets_are_immutable(
     state_root.mkdir(mode=0o700)
     run_root.mkdir()
     _install_wheel(built_distributions, target)
-    env = _private_child_env(state_root, target)
+    env = _private_child_env(
+        state_root,
+        target,
+        built_distributions.source_root,
+    )
     before = _target_hashes(target)
     results = [
         _run_child([sys.executable, "-c", INSTALLED_PROBE], run_root, env)

--- a/Tests/Packaging/test_installed_distribution.py
+++ b/Tests/Packaging/test_installed_distribution.py
@@ -284,13 +284,6 @@ def root_accesses(tree, relative_path):
             and node.slice.value in retired_reactives
         ):
             target = node.slice.value
-        elif (
-            isinstance(node, ast.keyword)
-            and node.arg == "reactive_attr"
-            and isinstance(node.value, ast.Constant)
-            and node.value.value in retired_reactives
-        ):
-            target = node.value.value
         if target is not None:
             found.append((relative_path, node.lineno, target))
     return found
@@ -363,35 +356,64 @@ app_class = next(
     for node in app_tree.body
     if isinstance(node, ast.ClassDef) and node.name == "TldwCli"
 )
-assert class_body_reactives(app_class) == expected_reactives
-assert "watch_current_tab" not in {
+local_classes = {
+    node.name: node for node in app_tree.body if isinstance(node, ast.ClassDef)
+}
+root_owner_classes = []
+seen_root_classes = set()
+
+
+def add_root_owner_class(class_node):
+    if class_node.name in seen_root_classes:
+        return
+    seen_root_classes.add(class_node.name)
+    root_owner_classes.append(class_node)
+    for base in class_node.bases:
+        base_class = local_classes.get(base.id) if isinstance(base, ast.Name) else None
+        if base_class is not None:
+            add_root_owner_class(base_class)
+
+
+add_root_owner_class(app_class)
+assert (
+    frozenset().union(
+        *(class_body_reactives(node) for node in root_owner_classes)
+    )
+    == expected_reactives
+)
+root_methods = {
     node.name
-    for node in app_class.body
+    for owner in root_owner_classes
+    for node in owner.body
     if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
 }
-assert retired_reactives.isdisjoint(
-    node.name
-    for node in app_class.body
-    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-)
+assert "watch_current_tab" not in root_methods
+assert retired_reactives.isdisjoint(root_methods)
+assert {f"watch_{name}" for name in retired_reactives}.isdisjoint(root_methods)
 class_level_retired = []
-for statement in app_class.body:
-    if isinstance(statement, ast.Assign):
-        targets = statement.targets
-    elif isinstance(statement, (ast.AnnAssign, ast.AugAssign)):
-        targets = (statement.target,)
-    else:
-        continue
-    for target in targets:
-        class_level_retired.extend(
-            name for name in bound_names(target) if name in retired_reactives
-        )
+for owner in root_owner_classes:
+    for statement in owner.body:
+        if isinstance(statement, ast.Assign):
+            targets = statement.targets
+        elif isinstance(statement, (ast.AnnAssign, ast.AugAssign)):
+            targets = (statement.target,)
+        else:
+            continue
+        for target in targets:
+            class_level_retired.extend(
+                name for name in bound_names(target) if name in retired_reactives
+            )
 assert class_level_retired == []
 
-tldw_accesses = TldwCliRetiredAccesses()
-for statement in app_class.body:
-    tldw_accesses.visit(statement)
-assert tldw_accesses.found == []
+tldw_accesses = []
+for owner in root_owner_classes:
+    owner_accesses = TldwCliRetiredAccesses()
+    for statement in owner.body:
+        owner_accesses.visit(statement)
+    tldw_accesses.extend(
+        (owner.name, line, name) for line, name in owner_accesses.found
+    )
+assert tldw_accesses == []
 
 installed_root_accesses = []
 for source_path in sorted(package_root.rglob("*.py")):

--- a/Tests/Packaging/test_installed_distribution.py
+++ b/Tests/Packaging/test_installed_distribution.py
@@ -43,8 +43,10 @@ from pathlib import Path
 import ast
 import asyncio
 import json
+import math
 import os
 import sys
+import time
 import tomllib
 
 expected_target = Path(os.environ["EXPECTED_TARGET"]).resolve(strict=True)
@@ -57,6 +59,26 @@ retired_reactives = frozenset(json.loads(os.environ["RETIRED_REACTIVES"]))
 assert expected_reactives == {"current_tab", "splash_screen_active"}
 assert len(retired_reactives) == 59
 assert expected_reactives.isdisjoint(retired_reactives)
+default_screen_wait_seconds = 30.0
+screen_wait_seconds_env = "TLDW_TEST_SCREEN_WAIT_SECONDS"
+
+
+def get_screen_wait_seconds():
+    raw_value = os.environ.get(
+        screen_wait_seconds_env,
+        str(default_screen_wait_seconds),
+    )
+    try:
+        seconds = float(raw_value)
+    except ValueError as exc:
+        raise ValueError(
+            f"{screen_wait_seconds_env} must be a positive finite number"
+        ) from exc
+    if not math.isfinite(seconds) or seconds <= 0:
+        raise ValueError(
+            f"{screen_wait_seconds_env} must be a positive finite number"
+        )
+    return seconds
 
 
 def is_under(path, root):
@@ -75,6 +97,7 @@ for entry in sys.path:
 
 import tldw_chatbook
 from tldw_chatbook.Chunking.chunking_templates import ChunkingTemplateManager
+from tldw_chatbook.Constants import TAB_CHAT, TAB_HOME
 from tldw_chatbook.Evals.config_loader import EvalConfigLoader
 from tldw_chatbook.RAG_Search.pipeline_loader import PipelineLoader
 from tldw_chatbook.app import TldwCli, get_app
@@ -371,7 +394,8 @@ assert all(not hasattr(app, name) for name in retired_reactives)
 
 
 async def wait_for(pilot, predicate, failure):
-    for _ in range(600):
+    deadline = time.monotonic() + get_screen_wait_seconds()
+    while time.monotonic() < deadline:
         if predicate():
             return
         await pilot.pause(0.01)
@@ -384,17 +408,17 @@ async def exercise_production_app():
             pilot,
             lambda: (
                 type(app.screen) is HomeScreen
-                and app.current_tab == "home"
+                and app.current_tab == TAB_HOME
                 and app.screen.is_mounted
             ),
             "installed production app did not mount registered Home",
         )
-        app.post_message(NavigateToScreen("chat"))
+        app.post_message(NavigateToScreen(TAB_CHAT))
         await wait_for(
             pilot,
             lambda: (
                 type(app.screen) is ChatScreen
-                and app.current_tab == "chat"
+                and app.current_tab == TAB_CHAT
                 and app.screen.is_mounted
             ),
             "installed production app did not navigate to registered Chat",

--- a/Tests/ProductionApp/test_reactive_ownership_maturity.py
+++ b/Tests/ProductionApp/test_reactive_ownership_maturity.py
@@ -1,0 +1,452 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+import pytest
+from textual.widgets import Input, TabbedContent
+
+import tldw_chatbook.app as app_module
+from Tests.test_application_state_ownership import RETIRED_TLDW_REACTIVES
+from tldw_chatbook.app import TldwCli
+from tldw_chatbook.Constants import (
+    LIBRARY_NAV_CONTEXT_INGEST,
+    LIBRARY_NAV_CONTEXT_MODE,
+    TAB_CHAT,
+    TAB_EVALS,
+    TAB_LIBRARY,
+    TAB_LLM,
+    TAB_MCP,
+    TAB_MEDIA,
+    TAB_PERSONAS,
+    TAB_SEARCH,
+    TAB_SETTINGS,
+)
+from tldw_chatbook.Library.library_shell_state import (
+    LIBRARY_ROW_BROWSE_NOTES,
+    LIBRARY_ROW_INGEST_MEDIA,
+)
+from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
+from tldw_chatbook.UI.Navigation.screen_registry import resolve_screen_target
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from tldw_chatbook.UI.Screens.evals_screen import EvalsScreen
+from tldw_chatbook.UI.Screens.home_screen import HomeScreen
+from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+from tldw_chatbook.UI.Screens.llm_screen import LLMScreen
+from tldw_chatbook.UI.Screens.mcp_screen import MCPScreen
+from tldw_chatbook.UI.Screens.media_screen import MediaScreen
+from tldw_chatbook.UI.Screens.personas_screen import PersonasScreen
+from tldw_chatbook.UI.Screens.search_screen import SearchScreen
+from tldw_chatbook.UI.Screens.settings_screen import SettingsScreen
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PRODUCTION_APP_TEST_ROOT = PROJECT_ROOT / "Tests" / "ProductionApp"
+LEGACY_HARNESS_MODULES = frozenset(
+    {
+        "Tests.textual_test_harness",
+        "Tests.textual_test_utils",
+    }
+)
+ROUTE_SPECS = (
+    ("llm", TAB_LLM, LLMScreen),
+    ("chat", TAB_CHAT, ChatScreen),
+    ("personas", TAB_PERSONAS, PersonasScreen),
+    ("library", TAB_LIBRARY, LibraryScreen),
+    ("media", TAB_MEDIA, MediaScreen),
+    ("search", TAB_SEARCH, SearchScreen),
+    ("ingest", TAB_LIBRARY, LibraryScreen),
+    ("mcp", TAB_MCP, MCPScreen),
+    ("evals", TAB_EVALS, EvalsScreen),
+    ("settings", TAB_SETTINGS, SettingsScreen),
+)
+CHAT_SESSION_TITLE = "TASK-906 Console owner"
+PERSONAS_QUERY = "TASK-906 personas owner"
+LIBRARY_QUERY = "TASK-906 library owner"
+MEDIA_QUERY = "TASK-906 media owner"
+SEARCH_QUERY = "TASK-906 search owner"
+SETTINGS_QUERY = "TASK-906 settings owner"
+SECRET_SNAPSHOT_KEYS = frozenset(
+    {
+        "api_key",
+        "authorization",
+        "cookie",
+        "credentials",
+        "headers",
+        "password",
+        "secret",
+        "token",
+    }
+)
+CONTENT_SNAPSHOT_KEYS = frozenset(
+    {
+        "content",
+        "draft",
+        "pinned_prefill",
+        "system_prompt",
+        "user_prompt",
+    }
+)
+
+
+def _production_app(monkeypatch: pytest.MonkeyPatch) -> TldwCli:
+    real_get_cli_setting = app_module.get_cli_setting
+
+    def get_cli_setting_without_splash(section, key=None, default=None):
+        if section == "splash_screen" and key == "enabled":
+            return False
+        return real_get_cli_setting(section, key, default)
+
+    monkeypatch.setattr(app_module, "get_cli_setting", get_cli_setting_without_splash)
+    app = TldwCli()
+    app.app_config["_first_run"] = False
+    return app
+
+
+async def _wait_until(pilot: Any, predicate, failure: str) -> None:
+    for _ in range(600):
+        if predicate():
+            return
+        await pilot.pause(0.01)
+    raise AssertionError(failure)
+
+
+async def _wait_for_screen(
+    app: TldwCli,
+    pilot: Any,
+    screen_type: type,
+    canonical_tab: str,
+    *,
+    previous_screen: object | None = None,
+):
+    await _wait_until(
+        pilot,
+        lambda: (
+            type(app.screen) is screen_type
+            and app.current_tab == canonical_tab
+            and app.screen is not previous_screen
+            and app.screen.is_mounted
+        ),
+        f"production TldwCli did not route to exact {screen_type.__name__}",
+    )
+    return app.screen
+
+
+def _navigation_message(route: str) -> NavigateToScreen:
+    if route == "ingest":
+        return NavigateToScreen(
+            route,
+            {LIBRARY_NAV_CONTEXT_INGEST: True},
+        )
+    return NavigateToScreen(route)
+
+
+async def _exercise_route(route: str, screen: object, pilot: Any) -> None:
+    if route == "llm":
+        assert type(screen) is LLMScreen
+        await _wait_until(
+            pilot,
+            lambda: (
+                screen.llm_window is not None
+                and screen.llm_window.is_mounted
+                and screen.llm_window.active_view == "llama-cpp"
+            ),
+            "production Models body did not finish mounting",
+        )
+        screen.llm_window.active_view = "ollama"
+        await pilot.pause()
+        assert screen.llm_window.active_view == "ollama"
+    elif route == "chat":
+        assert type(screen) is ChatScreen
+        store = screen._ensure_console_chat_store()
+        session_id = store.active_session_id
+        assert session_id is not None
+        store.rename_session(session_id, CHAT_SESSION_TITLE)
+        assert store.ensure_session().title == CHAT_SESSION_TITLE
+    elif route == "personas":
+        assert type(screen) is PersonasScreen
+        screen.query_one("#personas-library-search", Input).value = PERSONAS_QUERY
+        await pilot.pause()
+        assert screen.state.search_query == PERSONAS_QUERY
+    elif route == "library":
+        assert type(screen) is LibraryScreen
+        screen.apply_navigation_context({LIBRARY_NAV_CONTEXT_MODE: "notes"})
+        screen._library_rag_query = LIBRARY_QUERY
+        await pilot.pause()
+        assert screen._library_selected_row_id == LIBRARY_ROW_BROWSE_NOTES
+    elif route == "media":
+        assert type(screen) is MediaScreen
+        await _wait_until(
+            pilot,
+            lambda: screen.media_window is not None,
+            "production Media owner did not mount",
+        )
+        screen.media_window.active_media_type = "all-media"
+        screen.media_window.runtime_state.active_media_type = "all-media"
+        screen.media_window.search_panel.search_term = MEDIA_QUERY
+        assert screen.media_window.search_panel.search_term == MEDIA_QUERY
+    elif route == "search":
+        assert type(screen) is SearchScreen
+        screen.query_one("#search-query-input", Input).value = SEARCH_QUERY
+        screen.query_one("#search-tabs", TabbedContent).active = "history-tab"
+        await pilot.pause()
+        assert screen.query_one("#search-query-input", Input).value == SEARCH_QUERY
+    elif route == "ingest":
+        assert type(screen) is LibraryScreen
+        assert screen._library_selected_row_id == LIBRARY_ROW_INGEST_MEDIA
+    elif route == "mcp":
+        assert type(screen) is MCPScreen
+        assert screen.workbench is not None
+        screen.action_mcp_mode("permissions")
+        await pilot.pause()
+        assert screen.workbench.active_mode == "permissions"
+    elif route == "evals":
+        assert type(screen) is EvalsScreen
+        screen.select(kind="classic", id=None)
+        await pilot.pause()
+        assert screen._selection.kind == "classic"
+    elif route == "settings":
+        assert type(screen) is SettingsScreen
+        screen._submit_category_search(SETTINGS_QUERY)
+        await pilot.pause()
+        assert screen.category_search_query == SETTINGS_QUERY
+    else:
+        raise AssertionError(f"unhandled maturity route: {route}")
+
+
+async def _assert_restored_route(route: str, screen: object, pilot: Any) -> None:
+    if route == "llm":
+        assert type(screen) is LLMScreen
+        await _wait_until(
+            pilot,
+            lambda: screen.llm_window is not None,
+            "restored Models body did not mount",
+        )
+    elif route == "chat":
+        assert type(screen) is ChatScreen
+        assert (
+            screen._ensure_console_chat_store().ensure_session().title
+            == CHAT_SESSION_TITLE
+        )
+    elif route == "personas":
+        assert type(screen) is PersonasScreen
+        assert screen.state.search_query == PERSONAS_QUERY
+    elif route == "library":
+        assert type(screen) is LibraryScreen
+        assert screen._library_rag_query == LIBRARY_QUERY
+        assert screen._library_selected_row_id in {
+            LIBRARY_ROW_BROWSE_NOTES,
+            LIBRARY_ROW_INGEST_MEDIA,
+        }
+    elif route == "media":
+        assert type(screen) is MediaScreen
+        await _wait_until(
+            pilot,
+            lambda: (
+                screen.media_window is not None
+                and screen.media_window.active_media_type == "all-media"
+                and screen.media_window.search_panel.search_term == MEDIA_QUERY
+            ),
+            "fresh Media owner did not restore its snapshot",
+        )
+    elif route == "search":
+        assert type(screen) is SearchScreen
+        assert screen.query_one("#search-query-input", Input).value == SEARCH_QUERY
+        assert screen.query_one("#search-tabs", TabbedContent).active == "history-tab"
+    elif route == "ingest":
+        assert type(screen) is LibraryScreen
+        assert screen._library_selected_row_id == LIBRARY_ROW_INGEST_MEDIA
+    elif route == "mcp":
+        assert type(screen) is MCPScreen
+        assert screen.workbench is not None
+        await _wait_until(
+            pilot,
+            lambda: screen.workbench.active_mode == "permissions",
+            "fresh MCP owner did not restore its view state",
+        )
+    elif route == "evals":
+        assert type(screen) is EvalsScreen
+    elif route == "settings":
+        assert type(screen) is SettingsScreen
+        assert screen.category_search_query == SETTINGS_QUERY
+    else:
+        raise AssertionError(f"unhandled restored maturity route: {route}")
+
+
+def _snapshot_violations(value: object, path: str = "$") -> list[str]:
+    if value is None or type(value) in {bool, int, float, str}:
+        return []
+    if type(value) is dict:
+        violations: list[str] = []
+        for key, child in value.items():
+            if not isinstance(key, str):
+                violations.append(f"{path}: non-string key {type(key).__name__}")
+                continue
+            if key in RETIRED_TLDW_REACTIVES:
+                violations.append(f"{path}.{key}: retired root name")
+            if key in SECRET_SNAPSHOT_KEYS and not _empty_snapshot_value(child):
+                violations.append(f"{path}.{key}: secret-bearing value")
+            if key in CONTENT_SNAPSHOT_KEYS and not _empty_snapshot_value(child):
+                violations.append(f"{path}.{key}: prompt or generated content")
+            violations.extend(_snapshot_violations(child, f"{path}.{key}"))
+        return violations
+    if type(value) in {list, tuple, set, frozenset}:
+        return [
+            violation
+            for index, child in enumerate(value)
+            for violation in _snapshot_violations(child, f"{path}[{index}]")
+        ]
+    return [f"{path}: non-primitive {type(value).__module__}.{type(value).__name__}"]
+
+
+def _empty_snapshot_value(value: object) -> bool:
+    return (
+        value is None
+        or value == ""
+        or (type(value) in {dict, list, tuple, set, frozenset} and not value)
+    )
+
+
+def _dotted_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _dotted_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    return ""
+
+
+def _surrogate_test_violations(path: Path) -> list[tuple[int, str]]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    violations: list[tuple[int, str]] = []
+    substitute_classes: set[str] = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            base_names = {_dotted_name(base).rsplit(".", 1)[-1] for base in node.bases}
+            if any(base_name.endswith(("App", "Screen")) for base_name in base_names):
+                substitute_classes.add(node.name)
+                violations.append((node.lineno, f"surrogate class {node.name}"))
+        elif isinstance(node, ast.ImportFrom):
+            module = str(node.module or "")
+            if module in LEGACY_HARNESS_MODULES:
+                violations.append((node.lineno, f"legacy harness import {module}"))
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in LEGACY_HARNESS_MODULES:
+                    violations.append(
+                        (node.lineno, f"legacy harness import {alias.name}")
+                    )
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        call_name = _dotted_name(node.func)
+        short_name = call_name.rsplit(".", 1)[-1]
+        if short_name in {"SimpleNamespace", "MagicMock"}:
+            violations.append((node.lineno, f"app substitute call {short_name}"))
+        if (
+            call_name == "object.__new__"
+            and node.args
+            and _dotted_name(node.args[0]).rsplit(".", 1)[-1] == "TldwCli"
+        ):
+            violations.append((node.lineno, "object.__new__(TldwCli)"))
+        if call_name.startswith("TldwCli."):
+            violations.append((node.lineno, f"unbound call {call_name}"))
+        if short_name in substitute_classes:
+            violations.append((node.lineno, f"surrogate constructor {short_name}"))
+
+    return violations
+
+
+def test_production_app_tests_contain_no_surrogate_application_patterns() -> None:
+    """Keep production ownership coverage on real routes or pure functions."""
+    violations = {
+        str(path.relative_to(PROJECT_ROOT)): path_violations
+        for path in sorted(PRODUCTION_APP_TEST_ROOT.glob("*.py"))
+        if (path_violations := _surrogate_test_violations(path))
+    }
+
+    assert violations == {}
+
+
+def test_snapshot_guard_accepts_only_reviewed_builtin_containers() -> None:
+    """Keep the memory-only snapshot allowlist explicit and recursive."""
+    assert (
+        _snapshot_violations(
+            {
+                "scope": {"notes"},
+                "nested": (1, [None, frozenset({"media"})]),
+            }
+        )
+        == []
+    )
+    assert _snapshot_violations({"owner": object()}) == [
+        "$.owner: non-primitive builtins.object"
+    ]
+    assert _snapshot_violations({"draft": "private prompt"}) == [
+        "$.draft: prompt or generated content"
+    ]
+    assert _snapshot_violations({"api_key": "private key"}) == [
+        "$.api_key: secret-bearing value"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_registered_routes_use_fresh_production_owners_and_safe_snapshots(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exercise every changed route twice through the normal production app."""
+    for route, canonical_tab, screen_type in ROUTE_SPECS:
+        assert resolve_screen_target(route) == (
+            "library" if route == "ingest" else route,
+            canonical_tab,
+            screen_type,
+        )
+
+    app = _production_app(monkeypatch)
+    original_screens: dict[str, object] = {}
+
+    async with app.run_test(size=(180, 55)) as pilot:
+        for route, canonical_tab, screen_type in ROUTE_SPECS:
+            app.post_message(_navigation_message(route))
+            screen = await _wait_for_screen(
+                app,
+                pilot,
+                screen_type,
+                canonical_tab,
+            )
+            original_screens[route] = screen
+            await _exercise_route(route, screen, pilot)
+            assert all(not hasattr(app, name) for name in RETIRED_TLDW_REACTIVES)
+
+        app.post_message(NavigateToScreen("home"))
+        await _wait_for_screen(app, pilot, HomeScreen, "home")
+
+        for route, canonical_tab, screen_type in ROUTE_SPECS:
+            app.post_message(_navigation_message(route))
+            screen = await _wait_for_screen(
+                app,
+                pilot,
+                screen_type,
+                canonical_tab,
+                previous_screen=original_screens[route],
+            )
+            await _assert_restored_route(route, screen, pilot)
+            assert all(not hasattr(app, name) for name in RETIRED_TLDW_REACTIVES)
+
+        runtime_identity = app._current_runtime_identity()
+        snapshot_violations: dict[str, list[str]] = {}
+        for canonical_tab in {spec[1] for spec in ROUTE_SPECS}:
+            snapshot = app.screen_state_store.restore(
+                canonical_tab,
+                runtime_identity,
+            )
+            if snapshot is None:
+                continue
+            violations = _snapshot_violations(snapshot)
+            if violations:
+                snapshot_violations[canonical_tab] = violations
+
+        assert snapshot_violations == {}

--- a/Tests/ProductionApp/test_reactive_ownership_maturity.py
+++ b/Tests/ProductionApp/test_reactive_ownership_maturity.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import ast
+import math
+import os
 from pathlib import Path
+import time
 from typing import Any
 
 import pytest
@@ -88,6 +91,8 @@ CONTENT_SNAPSHOT_KEYS = frozenset(
         "user_prompt",
     }
 )
+DEFAULT_SCREEN_WAIT_SECONDS = 30.0
+SCREEN_WAIT_SECONDS_ENV = "TLDW_TEST_SCREEN_WAIT_SECONDS"
 
 
 def _production_app(monkeypatch: pytest.MonkeyPatch) -> TldwCli:
@@ -104,8 +109,26 @@ def _production_app(monkeypatch: pytest.MonkeyPatch) -> TldwCli:
     return app
 
 
+def _screen_wait_seconds() -> float:
+    """Return the validated real-app readiness deadline for this test run."""
+    raw_value = os.environ.get(
+        SCREEN_WAIT_SECONDS_ENV,
+        str(DEFAULT_SCREEN_WAIT_SECONDS),
+    )
+    try:
+        seconds = float(raw_value)
+    except ValueError as exc:
+        raise ValueError(
+            f"{SCREEN_WAIT_SECONDS_ENV} must be a positive finite number"
+        ) from exc
+    if not math.isfinite(seconds) or seconds <= 0:
+        raise ValueError(f"{SCREEN_WAIT_SECONDS_ENV} must be a positive finite number")
+    return seconds
+
+
 async def _wait_until(pilot: Any, predicate, failure: str) -> None:
-    for _ in range(600):
+    deadline = time.monotonic() + _screen_wait_seconds()
+    while time.monotonic() < deadline:
         if predicate():
             return
         await pilot.pause(0.01)
@@ -391,6 +414,22 @@ def test_snapshot_guard_accepts_only_reviewed_builtin_containers() -> None:
     assert _snapshot_violations({"api_key": "private key"}) == [
         "$.api_key: secret-bearing value"
     ]
+
+
+def test_screen_wait_seconds_validates_the_ci_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Accept positive finite wait overrides and reject invalid values."""
+    monkeypatch.delenv("TLDW_TEST_SCREEN_WAIT_SECONDS", raising=False)
+    assert _screen_wait_seconds() == DEFAULT_SCREEN_WAIT_SECONDS
+
+    monkeypatch.setenv("TLDW_TEST_SCREEN_WAIT_SECONDS", "12.5")
+    assert _screen_wait_seconds() == 12.5
+
+    for invalid in ("0", "-1", "nan", "inf", "not-a-number"):
+        monkeypatch.setenv("TLDW_TEST_SCREEN_WAIT_SECONDS", invalid)
+        with pytest.raises(ValueError, match="TLDW_TEST_SCREEN_WAIT_SECONDS"):
+            _screen_wait_seconds()
 
 
 @pytest.mark.asyncio

--- a/Tests/ProductionApp/test_reactive_ownership_maturity.py
+++ b/Tests/ProductionApp/test_reactive_ownership_maturity.py
@@ -8,7 +8,7 @@ import pytest
 from textual.widgets import Input, TabbedContent
 
 import tldw_chatbook.app as app_module
-from Tests.test_application_state_ownership import RETIRED_TLDW_REACTIVES
+from Tests.reactive_ownership_contract import RETIRED_TLDW_REACTIVES
 from tldw_chatbook.app import TldwCli
 from tldw_chatbook.Constants import (
     LIBRARY_NAV_CONTEXT_INGEST,

--- a/Tests/reactive_ownership_contract.py
+++ b/Tests/reactive_ownership_contract.py
@@ -1,0 +1,74 @@
+"""Reviewed TldwCli reactive ownership contract shared by test sentinels."""
+
+from __future__ import annotations
+
+
+RETAINED_TLDW_REACTIVES = frozenset({"current_tab", "splash_screen_active"})
+RETIRED_TLDW_REACTIVES = frozenset(
+    {
+        "ccp_active_view",
+        "chat_api_provider_value",
+        "ccp_api_provider_value",
+        "rag_expansion_provider_value",
+        "current_editing_character_id",
+        "current_editing_character_data",
+        "chat_sidebar_collapsed",
+        "chat_right_sidebar_collapsed",
+        "chat_right_sidebar_width",
+        "conv_char_sidebar_left_collapsed",
+        "conv_char_sidebar_right_collapsed",
+        "evals_sidebar_collapsed",
+        "media_active_view",
+        "current_selected_note_id",
+        "current_selected_note_version",
+        "current_selected_note_title",
+        "current_selected_note_content",
+        "notes_sort_by",
+        "notes_sort_ascending",
+        "notes_preview_mode",
+        "notes_auto_save_enabled",
+        "notes_auto_save_timer",
+        "notes_last_save_time",
+        "chat_sidebar_selected_prompt_id",
+        "chat_sidebar_selected_prompt_system",
+        "chat_sidebar_selected_prompt_user",
+        "current_chat_is_ephemeral",
+        "current_chat_conversation_id",
+        "current_conv_char_tab_conversation_id",
+        "current_chat_active_character_data",
+        "current_ccp_character_details",
+        "active_chat_tab_id",
+        "chat_sessions",
+        "chat_sidebar_loaded_prompt_id",
+        "chat_sidebar_loaded_prompt_title_text",
+        "chat_sidebar_loaded_prompt_system_text",
+        "chat_sidebar_loaded_prompt_user_text",
+        "chat_sidebar_loaded_prompt_keywords_text",
+        "chat_sidebar_prompt_display_visible",
+        "current_prompt_id",
+        "current_prompt_uuid",
+        "current_prompt_name",
+        "current_prompt_author",
+        "current_prompt_details",
+        "current_prompt_system",
+        "current_prompt_user",
+        "current_prompt_keywords_str",
+        "current_prompt_version",
+        "_initial_media_view_slug",
+        "current_media_type_filter_slug",
+        "current_media_type_filter_display_name",
+        "media_current_page",
+        "current_loaded_media_item",
+        "chat_settings_mode",
+        "chat_settings_search_query",
+        "search_active_sub_tab",
+        "ingest_active_view",
+        "tools_settings_active_view",
+        "llm_active_view",
+    }
+)
+
+
+assert len(RETAINED_TLDW_REACTIVES) == 2
+assert len(RETIRED_TLDW_REACTIVES) == 59
+assert RETAINED_TLDW_REACTIVES.isdisjoint(RETIRED_TLDW_REACTIVES)

--- a/Tests/test_application_state_ownership.py
+++ b/Tests/test_application_state_ownership.py
@@ -828,6 +828,7 @@ mapping["retired_state"]
 
 
 def test_class_body_reactive_guard_detects_assignments_and_annotations() -> None:
+    """Recognize direct, annotated, and qualified reactive assignments."""
     tree = ast.parse(
         """class TldwCli:
     direct = reactive(0)
@@ -899,6 +900,7 @@ destination.ingest_active_view
 def test_root_app_target_guard_detects_only_root_retired_names_in_one_walk(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Reject root access without misclassifying destination-owned keywords."""
     path = PROJECT_ROOT / "synthetic-root-app-target-guard.py"
     tree = ast.parse(
         """screen.app.retired_one
@@ -927,6 +929,7 @@ destination.retired_one
 def test_local_tldw_root_classes_include_transitive_in_module_mixins(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Include local transitive mixins while excluding qualified bases."""
     tree = ast.parse(
         """class RootStateMixin:
     inherited = reactive(0)

--- a/Tests/test_application_state_ownership.py
+++ b/Tests/test_application_state_ownership.py
@@ -23,6 +23,70 @@ from tldw_chatbook.state import (
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 PRODUCTION_ROOT = PROJECT_ROOT / "tldw_chatbook"
 APP_PATH = PRODUCTION_ROOT / "app.py"
+RETAINED_TLDW_REACTIVES = frozenset({"current_tab", "splash_screen_active"})
+RETIRED_TLDW_REACTIVES = frozenset(
+    {
+        "ccp_active_view",
+        "chat_api_provider_value",
+        "ccp_api_provider_value",
+        "rag_expansion_provider_value",
+        "current_editing_character_id",
+        "current_editing_character_data",
+        "chat_sidebar_collapsed",
+        "chat_right_sidebar_collapsed",
+        "chat_right_sidebar_width",
+        "conv_char_sidebar_left_collapsed",
+        "conv_char_sidebar_right_collapsed",
+        "evals_sidebar_collapsed",
+        "media_active_view",
+        "current_selected_note_id",
+        "current_selected_note_version",
+        "current_selected_note_title",
+        "current_selected_note_content",
+        "notes_sort_by",
+        "notes_sort_ascending",
+        "notes_preview_mode",
+        "notes_auto_save_enabled",
+        "notes_auto_save_timer",
+        "notes_last_save_time",
+        "chat_sidebar_selected_prompt_id",
+        "chat_sidebar_selected_prompt_system",
+        "chat_sidebar_selected_prompt_user",
+        "current_chat_is_ephemeral",
+        "current_chat_conversation_id",
+        "current_conv_char_tab_conversation_id",
+        "current_chat_active_character_data",
+        "current_ccp_character_details",
+        "active_chat_tab_id",
+        "chat_sessions",
+        "chat_sidebar_loaded_prompt_id",
+        "chat_sidebar_loaded_prompt_title_text",
+        "chat_sidebar_loaded_prompt_system_text",
+        "chat_sidebar_loaded_prompt_user_text",
+        "chat_sidebar_loaded_prompt_keywords_text",
+        "chat_sidebar_prompt_display_visible",
+        "current_prompt_id",
+        "current_prompt_uuid",
+        "current_prompt_name",
+        "current_prompt_author",
+        "current_prompt_details",
+        "current_prompt_system",
+        "current_prompt_user",
+        "current_prompt_keywords_str",
+        "current_prompt_version",
+        "_initial_media_view_slug",
+        "current_media_type_filter_slug",
+        "current_media_type_filter_display_name",
+        "media_current_page",
+        "current_loaded_media_item",
+        "chat_settings_mode",
+        "chat_settings_search_query",
+        "search_active_sub_tab",
+        "ingest_active_view",
+        "tools_settings_active_view",
+        "llm_active_view",
+    }
+)
 BOOTSTRAP_PATH = PRODUCTION_ROOT / "runtime_policy" / "bootstrap.py"
 SOURCE_STATE_PATH = PRODUCTION_ROOT / "runtime_policy" / "source_state.py"
 SCHEDULES_WORKBENCH_PATH = (
@@ -472,6 +536,71 @@ def _root_app_occurrences(
     return found
 
 
+def _root_app_target_occurrences(
+    path: Path,
+    targets: frozenset[str],
+) -> list[tuple[str, str, str, int]]:
+    """Collect root-app access for a set of exact state names in one AST walk."""
+    relative = str(path.relative_to(PROJECT_ROOT))
+    found: list[tuple[str, str, str, int]] = []
+    for node in ast.walk(_parse(path)):
+        target: str | None = None
+        kind: str | None = None
+        if (
+            isinstance(node, ast.Attribute)
+            and node.attr in targets
+            and _is_root_app_expression(node.value)
+        ):
+            target = node.attr
+            kind = f"attribute_{type(node.ctx).__name__.lower()}"
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in {"getattr", "setattr", "delattr", "hasattr"}
+            and len(node.args) >= 2
+            and _is_root_app_expression(node.args[0])
+            and isinstance(node.args[1], ast.Constant)
+            and node.args[1].value in targets
+        ):
+            target = node.args[1].value
+            kind = f"dynamic_{node.func.id}"
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and _constant_dynamic_name(node) in targets
+            and _is_root_mapping_expression(
+                node.func.value,
+                _is_root_app_expression,
+            )
+            and not _is_root_app_expression(node.func.value)
+        ):
+            target = _constant_dynamic_name(node)
+            kind = "mapping_get"
+        elif (
+            isinstance(node, ast.Subscript)
+            and _is_root_mapping_expression(
+                node.value,
+                _is_root_app_expression,
+            )
+            and isinstance(node.slice, ast.Constant)
+            and node.slice.value in targets
+        ):
+            target = node.slice.value
+            kind = f"mapping_{type(node.ctx).__name__.lower()}"
+        elif (
+            isinstance(node, ast.keyword)
+            and node.arg == "reactive_attr"
+            and isinstance(node.value, ast.Constant)
+            and node.value.value in targets
+        ):
+            target = node.value.value
+            kind = "reactive_attr"
+        if target is not None and kind is not None:
+            found.append((target, relative, kind, node.lineno))
+    return found
+
+
 def _class_body_bound_names(node: ast.AST) -> tuple[str, ...]:
     """Return names bound by one direct class-body assignment target."""
     if isinstance(node, ast.Name):
@@ -481,6 +610,28 @@ def _class_body_bound_names(node: ast.AST) -> tuple[str, ...]:
             name for element in node.elts for name in _class_body_bound_names(element)
         )
     return ()
+
+
+def _class_body_reactive_names(class_node: ast.ClassDef) -> frozenset[str]:
+    """Return names assigned by direct class-body ``reactive(...)`` calls."""
+    names: set[str] = set()
+    for statement in class_node.body:
+        if isinstance(statement, ast.Assign):
+            targets = statement.targets
+            value = statement.value
+        elif isinstance(statement, ast.AnnAssign):
+            targets = (statement.target,)
+            value = statement.value
+        else:
+            continue
+        if not (
+            isinstance(value, ast.Call)
+            and _chain(value.func).rsplit(".", 1)[-1] == "reactive"
+        ):
+            continue
+        for target in targets:
+            names.update(_class_body_bound_names(target))
+    return frozenset(names)
 
 
 class _TldwCliRootOccurrenceCollector(ast.NodeVisitor):
@@ -720,6 +871,24 @@ mapping["retired_state"]
     assert kinds.count("subscript_name") == 1
 
 
+def test_class_body_reactive_guard_detects_assignments_and_annotations() -> None:
+    tree = ast.parse(
+        """class TldwCli:
+    direct = reactive(0)
+    annotated: reactive[str] = reactive("")
+    qualified = textual.reactive(False)
+    unrelated = other_factory()
+"""
+    )
+    app_class = next(node for node in tree.body if isinstance(node, ast.ClassDef))
+
+    assert _class_body_reactive_names(app_class) == {
+        "direct",
+        "annotated",
+        "qualified",
+    }
+
+
 def test_root_app_guard_detects_chained_dynamic_and_mapping_mutations(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -769,6 +938,35 @@ destination.ingest_active_view
             "mapping_get",
         )
     )
+
+
+def test_root_app_target_guard_detects_retired_names_in_one_walk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = PROJECT_ROOT / "synthetic-root-app-target-guard.py"
+    tree = ast.parse(
+        """screen.app.retired_one
+setattr(screen.app, "retired_two", value)
+screen.app.__dict__["retired_one"] = value
+vars(screen.app).get("retired_two")
+handler(reactive_attr="retired_one")
+destination.retired_one
+"""
+    )
+    monkeypatch.setitem(globals(), "_parse", lambda _path: tree)
+
+    occurrences = _root_app_target_occurrences(
+        path,
+        frozenset({"retired_one", "retired_two"}),
+    )
+
+    assert occurrences == [
+        ("retired_one", "synthetic-root-app-target-guard.py", "attribute_load", 1),
+        ("retired_two", "synthetic-root-app-target-guard.py", "dynamic_setattr", 2),
+        ("retired_one", "synthetic-root-app-target-guard.py", "mapping_store", 3),
+        ("retired_two", "synthetic-root-app-target-guard.py", "mapping_get", 4),
+        ("retired_one", "synthetic-root-app-target-guard.py", "reactive_attr", 5),
+    ]
 
 
 def test_tldw_cli_root_guard_detects_only_root_owned_syntax(
@@ -1031,6 +1229,39 @@ def test_legacy_ccp_prompt_handlers_and_compatibility_exports_are_absent() -> No
         "CHARACTER_FILE_FILTERS",
     ):
         assert retired_name not in ingest_utils_source
+
+
+def test_tldw_cli_final_reactive_ownership_contract_is_exact() -> None:
+    """Freeze the reviewed 61-descriptor disposition at the app boundary."""
+    app_class = _class_definition(APP_PATH, "TldwCli")
+    assert len(RETAINED_TLDW_REACTIVES) == 2
+    assert len(RETIRED_TLDW_REACTIVES) == 59
+    assert RETAINED_TLDW_REACTIVES.isdisjoint(RETIRED_TLDW_REACTIVES)
+    assert _class_body_reactive_names(app_class) == RETAINED_TLDW_REACTIVES
+
+    violations: dict[
+        str, list[tuple[str, str, tuple[str, ...], int] | tuple[str, str, int]]
+    ] = {}
+    for name in sorted(RETIRED_TLDW_REACTIVES):
+        occurrences = _tldw_cli_occurrences(name)
+        if occurrences:
+            violations[name] = [*occurrences]
+
+    for path in sorted(PRODUCTION_ROOT.rglob("*.py")):
+        for name, relative, kind, line in _root_app_target_occurrences(
+            path,
+            RETIRED_TLDW_REACTIVES,
+        ):
+            violations.setdefault(name, []).append((relative, kind, line))
+
+    assert violations == {}
+
+    direct_methods = {
+        node.name
+        for node in app_class.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    assert "watch_current_tab" not in direct_methods
 
 
 def test_retired_destination_root_state_and_handlers_are_absent() -> None:

--- a/Tests/test_application_state_ownership.py
+++ b/Tests/test_application_state_ownership.py
@@ -588,14 +588,6 @@ def _root_app_target_occurrences(
         ):
             target = node.slice.value
             kind = f"mapping_{type(node.ctx).__name__.lower()}"
-        elif (
-            isinstance(node, ast.keyword)
-            and node.arg == "reactive_attr"
-            and isinstance(node.value, ast.Constant)
-            and node.value.value in targets
-        ):
-            target = node.value.value
-            kind = "reactive_attr"
         if target is not None and kind is not None:
             found.append((target, relative, kind, node.lineno))
     return found
@@ -632,6 +624,30 @@ def _class_body_reactive_names(class_node: ast.ClassDef) -> frozenset[str]:
         for target in targets:
             names.update(_class_body_bound_names(target))
     return frozenset(names)
+
+
+def _local_tldw_root_classes(path: Path) -> tuple[ast.ClassDef, ...]:
+    """Return ``TldwCli`` and its transitive, in-module class mixins."""
+    module = _parse(path)
+    classes = {
+        node.name: node for node in module.body if isinstance(node, ast.ClassDef)
+    }
+    root = classes["TldwCli"]
+    ordered: list[ast.ClassDef] = []
+    seen: set[str] = set()
+
+    def add_with_local_bases(class_node: ast.ClassDef) -> None:
+        if class_node.name in seen:
+            return
+        seen.add(class_node.name)
+        ordered.append(class_node)
+        for base in class_node.bases:
+            base_class = classes.get(base.id) if isinstance(base, ast.Name) else None
+            if base_class is not None:
+                add_with_local_bases(base_class)
+
+    add_with_local_bases(root)
+    return tuple(ordered)
 
 
 class _TldwCliRootOccurrenceCollector(ast.NodeVisitor):
@@ -940,7 +956,7 @@ destination.ingest_active_view
     )
 
 
-def test_root_app_target_guard_detects_retired_names_in_one_walk(
+def test_root_app_target_guard_detects_only_root_retired_names_in_one_walk(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     path = PROJECT_ROOT / "synthetic-root-app-target-guard.py"
@@ -965,7 +981,35 @@ destination.retired_one
         ("retired_two", "synthetic-root-app-target-guard.py", "dynamic_setattr", 2),
         ("retired_one", "synthetic-root-app-target-guard.py", "mapping_store", 3),
         ("retired_two", "synthetic-root-app-target-guard.py", "mapping_get", 4),
-        ("retired_one", "synthetic-root-app-target-guard.py", "reactive_attr", 5),
+    ]
+
+
+def test_local_tldw_root_classes_include_transitive_in_module_mixins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tree = ast.parse(
+        """class RootStateMixin:
+    inherited = reactive(0)
+
+class QueueMixin(RootStateMixin):
+    pass
+
+class ExternalBase:
+    pass
+
+class App:
+    externally_qualified = reactive("must not be inherited")
+
+class TldwCli(QueueMixin, external.App):
+    direct = reactive(False)
+"""
+    )
+    monkeypatch.setitem(globals(), "_parse", lambda _path: tree)
+
+    assert [node.name for node in _local_tldw_root_classes(APP_PATH)] == [
+        "TldwCli",
+        "QueueMixin",
+        "RootStateMixin",
     ]
 
 
@@ -1233,17 +1277,28 @@ def test_legacy_ccp_prompt_handlers_and_compatibility_exports_are_absent() -> No
 
 def test_tldw_cli_final_reactive_ownership_contract_is_exact() -> None:
     """Freeze the reviewed 61-descriptor disposition at the app boundary."""
-    app_class = _class_definition(APP_PATH, "TldwCli")
+    root_owner_classes = _local_tldw_root_classes(APP_PATH)
     assert len(RETAINED_TLDW_REACTIVES) == 2
     assert len(RETIRED_TLDW_REACTIVES) == 59
     assert RETAINED_TLDW_REACTIVES.isdisjoint(RETIRED_TLDW_REACTIVES)
-    assert _class_body_reactive_names(app_class) == RETAINED_TLDW_REACTIVES
+    assert (
+        frozenset().union(
+            *(_class_body_reactive_names(node) for node in root_owner_classes)
+        )
+        == RETAINED_TLDW_REACTIVES
+    )
 
     violations: dict[
         str, list[tuple[str, str, tuple[str, ...], int] | tuple[str, str, int]]
     ] = {}
     for name in sorted(RETIRED_TLDW_REACTIVES):
-        occurrences = _tldw_cli_occurrences(name)
+        occurrences: list[
+            tuple[str, str, tuple[str, ...], int] | tuple[str, str, int]
+        ] = []
+        for root_owner_class in root_owner_classes:
+            collector = _TldwCliRootOccurrenceCollector(APP_PATH, name)
+            collector.collect(root_owner_class)
+            occurrences.extend(collector.occurrences)
         if occurrences:
             violations[name] = [*occurrences]
 
@@ -1254,14 +1309,26 @@ def test_tldw_cli_final_reactive_ownership_contract_is_exact() -> None:
         ):
             violations.setdefault(name, []).append((relative, kind, line))
 
-    assert violations == {}
-
-    direct_methods = {
-        node.name
-        for node in app_class.body
+    root_methods = {
+        (owner.name, node.name, node.lineno)
+        for owner in root_owner_classes
+        for node in owner.body
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
     }
-    assert "watch_current_tab" not in direct_methods
+    for name in sorted(RETIRED_TLDW_REACTIVES):
+        for owner, method, line in root_methods:
+            if method == f"watch_{name}":
+                violations.setdefault(name, []).append(
+                    (
+                        str(APP_PATH.relative_to(PROJECT_ROOT)),
+                        "watcher_definition",
+                        (owner, method),
+                        line,
+                    )
+                )
+
+    assert violations == {}
+    assert all(method != "watch_current_tab" for _owner, method, _line in root_methods)
 
 
 def test_retired_destination_root_state_and_handlers_are_absent() -> None:

--- a/Tests/test_application_state_ownership.py
+++ b/Tests/test_application_state_ownership.py
@@ -8,6 +8,10 @@ import warnings
 
 import pytest
 
+from Tests.reactive_ownership_contract import (
+    RETAINED_TLDW_REACTIVES,
+    RETIRED_TLDW_REACTIVES,
+)
 from tldw_chatbook.runtime_policy.bootstrap import RuntimePolicyContext
 from tldw_chatbook.runtime_policy.source_state import RuntimeSourceStateStore
 from tldw_chatbook.runtime_policy.types import RuntimeSourceState
@@ -23,70 +27,6 @@ from tldw_chatbook.state import (
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 PRODUCTION_ROOT = PROJECT_ROOT / "tldw_chatbook"
 APP_PATH = PRODUCTION_ROOT / "app.py"
-RETAINED_TLDW_REACTIVES = frozenset({"current_tab", "splash_screen_active"})
-RETIRED_TLDW_REACTIVES = frozenset(
-    {
-        "ccp_active_view",
-        "chat_api_provider_value",
-        "ccp_api_provider_value",
-        "rag_expansion_provider_value",
-        "current_editing_character_id",
-        "current_editing_character_data",
-        "chat_sidebar_collapsed",
-        "chat_right_sidebar_collapsed",
-        "chat_right_sidebar_width",
-        "conv_char_sidebar_left_collapsed",
-        "conv_char_sidebar_right_collapsed",
-        "evals_sidebar_collapsed",
-        "media_active_view",
-        "current_selected_note_id",
-        "current_selected_note_version",
-        "current_selected_note_title",
-        "current_selected_note_content",
-        "notes_sort_by",
-        "notes_sort_ascending",
-        "notes_preview_mode",
-        "notes_auto_save_enabled",
-        "notes_auto_save_timer",
-        "notes_last_save_time",
-        "chat_sidebar_selected_prompt_id",
-        "chat_sidebar_selected_prompt_system",
-        "chat_sidebar_selected_prompt_user",
-        "current_chat_is_ephemeral",
-        "current_chat_conversation_id",
-        "current_conv_char_tab_conversation_id",
-        "current_chat_active_character_data",
-        "current_ccp_character_details",
-        "active_chat_tab_id",
-        "chat_sessions",
-        "chat_sidebar_loaded_prompt_id",
-        "chat_sidebar_loaded_prompt_title_text",
-        "chat_sidebar_loaded_prompt_system_text",
-        "chat_sidebar_loaded_prompt_user_text",
-        "chat_sidebar_loaded_prompt_keywords_text",
-        "chat_sidebar_prompt_display_visible",
-        "current_prompt_id",
-        "current_prompt_uuid",
-        "current_prompt_name",
-        "current_prompt_author",
-        "current_prompt_details",
-        "current_prompt_system",
-        "current_prompt_user",
-        "current_prompt_keywords_str",
-        "current_prompt_version",
-        "_initial_media_view_slug",
-        "current_media_type_filter_slug",
-        "current_media_type_filter_display_name",
-        "media_current_page",
-        "current_loaded_media_item",
-        "chat_settings_mode",
-        "chat_settings_search_query",
-        "search_active_sub_tab",
-        "ingest_active_view",
-        "tools_settings_active_view",
-        "llm_active_view",
-    }
-)
 BOOTSTRAP_PATH = PRODUCTION_ROOT / "runtime_policy" / "bootstrap.py"
 SOURCE_STATE_PATH = PRODUCTION_ROOT / "runtime_policy" / "source_state.py"
 SCHEDULES_WORKBENCH_PATH = (

--- a/backlog/tasks/task-906 - Close-TldwCli-reactive-ownership-with-installed-distribution-sentinels.md
+++ b/backlog/tasks/task-906 - Close-TldwCli-reactive-ownership-with-installed-distribution-sentinels.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-906
 title: Close TldwCli reactive ownership with installed-distribution sentinels
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2026-07-26 23:50'
-updated_date: '2026-07-27 00:02'
+updated_date: '2026-07-28 00:04'
 labels:
   - architecture
   - state
@@ -41,3 +42,16 @@ Enforce the exact remaining root reactive contract and prove the decomposed prod
 - [ ] #4 A wheel and sdist built from the repository install into a clean environment outside the checkout, import only from the installed artifact, and pass resource, product-maturity, and reactive-ownership sentinels.
 - [ ] #5 The authorized integrated suite passes without collecting surrogate-application tests, and any excluded legacy collections are explicitly documented.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: yes
+ADR path: backlog/decisions/032-immutable-installed-distribution-assets.md; backlog/decisions/033-application-session-state-ownership.md
+Reason: ADR-033 defines the final root owners and ADR-032 requires clean installed-artifact proof.
+
+1. Enforce the exact TldwCli reactive set.
+2. Run every affected registered route in the production app.
+3. Extend installed-wheel ownership and maturity probes.
+4. Run the authorized integrated gate and reconcile TASK-647–652 and TASK-904–906.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-906 - Close-TldwCli-reactive-ownership-with-installed-distribution-sentinels.md
+++ b/backlog/tasks/task-906 - Close-TldwCli-reactive-ownership-with-installed-distribution-sentinels.md
@@ -68,8 +68,10 @@ Added exact source and installed-artifact AST sentinels for the 59 retired
 names. The final review corrected two sentinel defects before closeout:
 transitive local mixins inherited by `TldwCli` are now part of the exact root
 inventory, while destination-owned `reactive_attr` values are no longer
-misclassified as root access. The source and installed lists were independently
-verified as identical 59-name contracts.
+misclassified as root access. PR review then moved the retained/retired
+inventory into one test-only contract module shared by the source,
+production-app, and packaging sentinels, eliminating same-length list drift
+without making the installed child import test code.
 
 Added a production maturity suite that uses only the normal `TldwCli` and its
 registered screens. It exercises LLM, Chat, Personas, Library, Media, Search,
@@ -87,13 +89,13 @@ installed-hash invariants remain enforced.
 
 Verification on the rebased tree:
 
-- `pytest Tests/ProductionApp/test_reactive_ownership_maturity.py Tests/test_application_state_ownership.py -q`: 57 passed, 2 warnings in 277.36s.
-- `pytest Tests/Packaging/test_installed_distribution.py -q`: 6 passed in 19.12s.
+- `pytest Tests/ProductionApp/test_reactive_ownership_maturity.py Tests/test_application_state_ownership.py -q`: 57 passed, 2 warnings in 281.97s.
+- `pytest Tests/Packaging/test_installed_distribution.py -q`: 6 passed in 21.83s.
 - Authorized integrated suite (`Tests/ProductionApp`, the approved State,
   Provider and Library direct-function tests, source ownership, and installed
-  distribution): 196 passed, 5 warnings in 589.99s.
+  distribution): 196 passed, 5 warnings in 567.81s.
 - `compileall`, scoped Ruff lint, the exact zero-F841 Settings assertion, the
-  36-file Ruff format gate, `git diff --check`, and the committed-source
+  37-file Ruff format gate, `git diff --check`, and the committed-source
   cleanliness checks passed.
 - TASK-647–652 and TASK-904–905 are Done, have no unchecked acceptance
   criteria, contain Implementation Notes, and retain their reviewed
@@ -107,6 +109,7 @@ stronger current baselines rather than restoring dead code or preserving stale
 expectations.
 
 Modified files: `tldw_chatbook/app.py`,
+`Tests/reactive_ownership_contract.py`,
 `Tests/test_application_state_ownership.py`,
 `Tests/ProductionApp/test_reactive_ownership_maturity.py`,
 `Tests/Packaging/test_installed_distribution.py`, the TASK-906 plan, this

--- a/backlog/tasks/task-906 - Close-TldwCli-reactive-ownership-with-installed-distribution-sentinels.md
+++ b/backlog/tasks/task-906 - Close-TldwCli-reactive-ownership-with-installed-distribution-sentinels.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-906
 title: Close TldwCli reactive ownership with installed-distribution sentinels
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-26 23:50'
-updated_date: '2026-07-28 00:04'
+updated_date: '2026-07-28 01:21'
 labels:
   - architecture
   - state
@@ -36,11 +36,11 @@ Enforce the exact remaining root reactive contract and prove the decomposed prod
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 TldwCli retains exactly current_tab and splash_screen_active from the reviewed 61-descriptor inventory, with no source or dynamic access to any of the 59 removed names.
-- [ ] #2 Every relevant registered production route executes without access to a removed root owner.
-- [ ] #3 Focused source ownership, static, compile, Ruff, formatting, and diff hygiene checks pass.
-- [ ] #4 A wheel and sdist built from the repository install into a clean environment outside the checkout, import only from the installed artifact, and pass resource, product-maturity, and reactive-ownership sentinels.
-- [ ] #5 The authorized integrated suite passes without collecting surrogate-application tests, and any excluded legacy collections are explicitly documented.
+- [x] #1 TldwCli retains exactly current_tab and splash_screen_active from the reviewed 61-descriptor inventory, with no source or dynamic access to any of the 59 removed names.
+- [x] #2 Every relevant registered production route executes without access to a removed root owner.
+- [x] #3 Focused source ownership, static, compile, Ruff, formatting, and diff hygiene checks pass.
+- [x] #4 A wheel and sdist built from the repository install into a clean environment outside the checkout, import only from the installed artifact, and pass resource, product-maturity, and reactive-ownership sentinels.
+- [x] #5 The authorized integrated suite passes without collecting surrogate-application tests, and any excluded legacy collections are explicitly documented.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -55,3 +55,66 @@ Reason: ADR-033 defines the final root owners and ADR-032 requires clean install
 3. Extend installed-wheel ownership and maturity probes.
 4. Run the authorized integrated gate and reconcile TASK-647–652 and TASK-904–906.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Closed the reactive-ownership tranche on latest `dev` commit `6784c4ba3`.
+`TldwCli` now has no obsolete `watch_current_tab` method and retains exactly
+the two reviewed application-lifecycle reactives: `current_tab` and
+`splash_screen_active`.
+
+Added exact source and installed-artifact AST sentinels for the 59 retired
+names. The final review corrected two sentinel defects before closeout:
+transitive local mixins inherited by `TldwCli` are now part of the exact root
+inventory, while destination-owned `reactive_attr` values are no longer
+misclassified as root access. The source and installed lists were independently
+verified as identical 59-name contracts.
+
+Added a production maturity suite that uses only the normal `TldwCli` and its
+registered screens. It exercises LLM, Chat, Personas, Library, Media, Search,
+the Ingest-to-Library alias, MCP, Evals, and Settings twice through fresh
+screen construction, verifies destination-local state and restoration, rejects
+all retired app attributes, recursively audits memory-only snapshots, and
+statically rejects surrogate-app patterns throughout `Tests/ProductionApp`.
+
+Extended the copied-source distribution fixture to build one wheel and one
+sdist from committed source, install the wheel with `--no-deps` outside the
+checkout, exclude both checkout and copied-build roots from `sys.path`, and
+audit every loaded package module after a real installed `TldwCli` Home-to-Chat
+run. Existing entry-point, metadata, resource, license, and before/after
+installed-hash invariants remain enforced.
+
+Verification on the rebased tree:
+
+- `pytest Tests/ProductionApp/test_reactive_ownership_maturity.py Tests/test_application_state_ownership.py -q`: 57 passed, 2 warnings in 277.36s.
+- `pytest Tests/Packaging/test_installed_distribution.py -q`: 6 passed in 19.12s.
+- Authorized integrated suite (`Tests/ProductionApp`, the approved State,
+  Provider and Library direct-function tests, source ownership, and installed
+  distribution): 196 passed, 5 warnings in 589.99s.
+- `compileall`, scoped Ruff lint, the exact zero-F841 Settings assertion, the
+  36-file Ruff format gate, `git diff --check`, and the committed-source
+  cleanliness checks passed.
+- TASK-647–652 and TASK-904–905 are Done, have no unchecked acceptance
+  criteria, contain Implementation Notes, and retain their reviewed
+  invariants under the final matrix.
+
+`Tests/UI` is explicitly excluded because its conftest imports legacy
+surrogate app/widget harnesses; no raw repository-wide pytest result is
+claimed. Latest `dev` had already deleted two stale format-plan paths and
+removed the former two Settings F841 findings, so the plan records those
+stronger current baselines rather than restoring dead code or preserving stale
+expectations.
+
+Modified files: `tldw_chatbook/app.py`,
+`Tests/test_application_state_ownership.py`,
+`Tests/ProductionApp/test_reactive_ownership_maturity.py`,
+`Tests/Packaging/test_installed_distribution.py`, the TASK-906 plan, this
+task, and the approved decomposition specification.
+
+ADR required: yes. Existing
+`backlog/decisions/033-application-session-state-ownership.md` defines the
+final root ownership boundary, and
+`backlog/decisions/032-immutable-installed-distribution-assets.md` defines the
+installed-artifact gate. No new ADR was needed.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-906 - Close-TldwCli-reactive-ownership-with-installed-distribution-sentinels.md
+++ b/backlog/tasks/task-906 - Close-TldwCli-reactive-ownership-with-installed-distribution-sentinels.md
@@ -73,6 +73,12 @@ inventory into one test-only contract module shared by the source,
 production-app, and packaging sentinels, eliminating same-length list drift
 without making the installed child import test code.
 
+The detailed PR review also replaced the fixed six-second polling loops with
+monotonic 30-second deadlines and a validated
+`TLDW_TEST_SCREEN_WAIT_SECONDS` override, replaced installed `"home"`/`"chat"`
+tab literals with `TAB_HOME`/`TAB_CHAT`, and added intent docstrings to the
+cited public tests.
+
 Added a production maturity suite that uses only the normal `TldwCli` and its
 registered screens. It exercises LLM, Chat, Personas, Library, Media, Search,
 the Ingest-to-Library alias, MCP, Evals, and Settings twice through fresh
@@ -89,11 +95,11 @@ installed-hash invariants remain enforced.
 
 Verification on the rebased tree:
 
-- `pytest Tests/ProductionApp/test_reactive_ownership_maturity.py Tests/test_application_state_ownership.py -q`: 57 passed, 2 warnings in 281.97s.
-- `pytest Tests/Packaging/test_installed_distribution.py -q`: 6 passed in 21.83s.
+- `pytest Tests/ProductionApp/test_reactive_ownership_maturity.py Tests/test_application_state_ownership.py -q`: 58 passed, 2 warnings in 306.14s.
+- `pytest Tests/Packaging/test_installed_distribution.py -q`: 6 passed in 19.01s.
 - Authorized integrated suite (`Tests/ProductionApp`, the approved State,
   Provider and Library direct-function tests, source ownership, and installed
-  distribution): 196 passed, 5 warnings in 567.81s.
+  distribution): 197 passed, 5 warnings in 573.57s.
 - `compileall`, scoped Ruff lint, the exact zero-F841 Settings assertion, the
   37-file Ruff format gate, `git diff --check`, and the committed-source
   cleanliness checks passed.

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -7722,21 +7722,6 @@ class TldwCli(
         logging.shutdown()
         self.loguru_logger.info("--- App Unmounted (Loguru) ---")
 
-    ########################################################################
-    #
-    # WATCHER - Handles UI changes when current_tab's VALUE changes
-    #
-    # ######################################################################
-    def watch_current_tab(self, old_tab: Optional[str], new_tab: str) -> None:
-        """Legacy tab-content watcher; retained as a permanent no-op.
-
-        Screen-based navigation (``self._use_screen_navigation``, set
-        unconditionally in ``__init__``) now owns every tab switch, so
-        this watcher's original show/hide dispatch (``_execute_tab_switch``,
-        task-577 PR2 T2) has been retired along with it.
-        """
-        return
-
     def _log_view_dimensions(self, view, parent):
         """Helper to log view dimensions after refresh."""
         self.loguru_logger.info(


### PR DESCRIPTION
## Summary
- enforce the exact two-reactive TldwCli root contract and remove the obsolete current-tab watcher
- exercise every reviewed route twice through the real production app, with owner restoration and privacy-safe snapshot sentinels
- build and install a committed wheel outside both source roots, then verify ownership, resources, entry points, provenance, and immutability
- close TASK-906 and the approved decomposition specification

## Verification
- focused production-app and ownership gate: 57 passed, 2 warnings
- installed distribution: 6 passed
- authorized integrated matrix: 196 passed, 5 warnings
- compileall, scoped Ruff lint, zero-F841 Settings assertion, 36-file Ruff format gate, and diff hygiene passed

## Testing boundary
Tests/UI is intentionally excluded because its conftest imports legacy surrogate app/widget harnesses. All application behavior added here uses the normal production TldwCli; app-independent checks use direct functions or AST sentinels.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finalized reactive state ownership for `TldwCli`: enforced the two-reactive contract, removed `watch_current_tab`, and hardened source, production-app, and installed sentinels with stricter readiness and provenance checks. Closes TASK-906 with clean installs, privacy-safe snapshots, and full real-app route coverage.

- **Refactors**
  - Lock `TldwCli` (including transitive local mixins) to exactly two `reactive(...)` fields; delete `watch_current_tab`; update spec to Implemented and mark TASK-906 Done.

- **New Features**
  - Centralize retained/retired sets in `Tests/reactive_ownership_contract.py` and reuse across source, production-app, and packaging sentinels.
  - Production readiness: monotonic 30s wait with validated `TLDW_TEST_SCREEN_WAIT_SECONDS`, use `TAB_HOME`/`TAB_CHAT`, and reject surrogate app harnesses in `Tests/ProductionApp`.
  - Installed probe: build wheel/sdist from committed source, install to a clean `--target`, write private `config.toml` to disable splash, exclude checkout/build roots from `sys.path`, audit all loaded `tldw_chatbook` modules are under the target, verify resources/entry points, and run real `TldwCli` Home→Chat.
  - Results: ownership/production-app 58 passed (2 warnings); installed distribution 6 passed; integrated suite 197 passed (5 warnings). Zero-F841 Settings baseline; scoped lint/format/compile gates passed.

<sup>Written for commit c39d96dccda984c92680baaa89570c965c1015f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

