### PR TITLE
docs: audit the briefing subsystem — watchlists never check on a schedule

### DIFF
--- a/Docs/superpowers/research/2026-07-27-briefing-subsystem-revive-or-retire.md
+++ b/Docs/superpowers/research/2026-07-27-briefing-subsystem-revive-or-retire.md
@@ -1,0 +1,152 @@
+# Briefing subsystem: revive-or-retire audit
+
+**Date:** 2026-07-27
+**Baseline:** `origin/dev` @ `9a9e9fea5`
+**Question:** Watchlists spec #2 (briefings + 2-speaker podcasts + scheduled delivery) assumed
+it would build on the existing briefing machinery in `Subscriptions/`. Is that machinery live,
+and can it be revived?
+
+**Answer: retire it.** The briefing machinery is bolted to a *retired scheduler*, not to the one
+that actually runs. Reviving the briefing path would mean reviving the dead scheduler with it.
+
+## Method
+
+Static greps were run first and gave a misleading answer twice, so the conclusion here rests on a
+runtime import trace: import `tldw_chatbook.app` under a throwaway `TLDW_CONFIG_PATH` profile and
+inspect `sys.modules`. That distinguishes *a module that is imported* from *a class that is
+constructed* — the distinction the greps kept blurring.
+
+Two of this programme's own prior claims were wrong and are corrected below.
+
+## Findings
+
+### 1. There are two parallel watchlist-checking implementations
+
+| | Retired | Live |
+|---|---|---|
+| Entry point | `Subscriptions/textual_scheduler_worker.py` | `Scheduling/scheduler/handlers/watchlist_check_handler.py` |
+| Size | 492 LOC | 159 LOC |
+| Monitors via | `Subscriptions/website_monitor.py` | `Subscriptions/monitoring_engine.py` (`FeedMonitor`, `URLMonitor`) |
+| In `sys.modules` after `import tldw_chatbook.app` | **no** | **yes** |
+| Briefing step | yes | **none** |
+| Shadow mode | no | yes |
+
+The live handler is stateless, shadow-mode aware, and delegates to `monitoring_engine`. It has no
+briefing or aggregation step at all. The briefing machinery hangs entirely off the retired side.
+
+### 2. `BriefingGenerator` is imported but never constructed
+
+`Subscriptions/briefing_generator` **is** in `sys.modules` at startup — but only because
+`Subscriptions/__init__.py:65` eagerly imports it inside a `try:` block. That is a module-level
+side effect, not a call path: it costs import time on every launch and executes nothing.
+
+The class has exactly one construction site, `textual_scheduler_worker.py:101`:
+
+```python
+self.briefing_generator = BriefingGenerator(db) if BRIEFING_AVAILABLE else None
+```
+
+`textual_scheduler_worker` is **not** in `sys.modules` after a full app import. So
+`BriefingGenerator` is never instantiated in production, and `generate_briefing` is never called.
+
+### 3. The UI controllers that would drive it target a class that no longer exists
+
+`UI/Subscription_Modules/` has **zero** production importers — the only importer anywhere is
+`Tests/Subscriptions/test_notifications_inbox_controller.py`. The package is absent from
+`sys.modules` after app import.
+
+`SubscriptionBackendController` (the only thing that imports `textual_scheduler_worker`) drives
+`self.window`, a `SubscriptionWindow`. **`class SubscriptionWindow` does not exist anywhere in the
+codebase.** The window was deleted; its controllers were not.
+
+### 4. Reachability of each module
+
+Sizes are the retirement estimate.
+
+| Module | LOC | Reached by | Status |
+|---|---|---|---|
+| `briefing_templates.py` | 813 | nothing | dead |
+| `briefing_generator.py` | 838 | `Subscriptions/__init__` (import only), `textual_scheduler_worker` | dead |
+| `recursive_summarizer.py` | 635 | `aggregation_engine` only | dead (transitive) |
+| `aggregation_engine.py` | 612 | `briefing_templates` (dead), `textual_scheduler_worker` (dead) | dead |
+| `rss_feed_generator.py` | 605 | `website_monitor` only | dead (transitive) |
+| `export_manager.py` | 591 | nothing | dead |
+| `distribution_manager.py` | 536 | nothing | dead |
+| `textual_scheduler_worker.py` | 492 | `subscription_backend_controller` (dead) | dead |
+| `website_monitor.py` | — | `textual_scheduler_worker` only | dead (transitive) |
+
+`monitoring_engine.py` is **live** and stays — it is what the working scheduler calls.
+
+Only one test touches any of this: `Tests/Subscriptions/test_scheduler_deprecation.py`, which
+asserts the deprecation warning fires. Nothing tests the behaviour.
+
+### 5. ADR-019's dual-run safety net does not exist in the shipped app
+
+ADR-019 (Accepted, 2026-07-19) describes a shadow-mode dual-run: the old scheduler stays "the
+execution authority by default", the new handler shadows it, and a runtime toggle allows "instant
+rollback to the old scheduler". None of that is true of the code on `origin/dev`:
+
+- The old scheduler is **unreachable** (finding 3), so it cannot be the execution authority and the
+  documented rollback — "set the flag false and `SubscriptionScheduler` resumes authoritative
+  execution" — cannot happen. Setting the flag false leaves *no* executor.
+- `[scheduling] watchlist_checks_enabled` ships **`false`** (`config.py:2296`, and the `app.py:4666`
+  default). With it false, `app.py:4674` never constructs the handler, `"watchlist_job"` is never
+  registered in the `handlers` dict, and `watchlist_projection` is passed to `SchedulerLoop` as
+  `None`. The new path is off entirely — not even shadowing.
+- `watchlist_checks_shadow` ships **`true`**. So even after enabling checks, the handler fetches
+  and then discards: `record_check_result` is skipped and `URLMonitor` is built with
+  `persist_snapshots=False` (`watchlist_check_handler.py:55-59, 107`).
+
+**Net effect: nothing checks watchlists on a schedule.** Getting working scheduled checks requires
+setting *both* flags, and neither is reachable from the Watchlists UI. Manual "Check now" works —
+that is the `launch_run` path fixed on 2026-07-27 — but there is no automatic checking at all.
+
+To be precise about scope: the Watchlists UI does not currently expose `check_frequency` either
+(it appears only in `local_watchlists_service.py:665`), so no user is setting a schedule that
+silently fails. The accurate statement is that **automatic checking is unimplemented end to end**,
+not that it is broken.
+
+This matters for spec #2 more than the briefing question does. Spec #2's headline is *scheduled*
+delivery; there is no working schedule to deliver on yet.
+
+## Corrections to earlier claims
+
+- **"~4,600 LOC with zero importers outside the package"** — wrong on the mechanism. There *are*
+  importers; they form a closed cycle (`textual_scheduler_worker` ↔ `subscription_backend_controller`)
+  with no external entry. A naive grep sees four importers and concludes the code is live. That is
+  presumably how it survived this long.
+- **"`watchlists_collections_screen.py:38` imports `notifications_inbox_controller`"** — wrong.
+  The Watchlists screen does not import from `Subscription_Modules` at all.
+
+## Consequence for spec #2
+
+The spec has a prerequisite it did not know about. Ordering:
+
+1. **Make scheduled checks actually run** (finding 5) — promote the handler out of shadow, decide
+   the default, and give the UI a way to set a check frequency. Without this there is nothing to
+   attach a briefing to.
+2. **Retire the island** (findings 1-4) so the briefing work is not built beside a second, dead
+   implementation of the same thing.
+3. **Then** build briefing/podcast generation as a new handler alongside `watchlist_check_handler`
+   in `Scheduling/scheduler/handlers/`, on the live seam.
+
+Two things make step 3 cheaper than it looks:
+
+- The scrape/fetch pipeline underneath actually works as of 2026-07-27 (PR #989 line), so a
+  briefing generator would be fed real content for the first time.
+- `TTS/audiobook_generator.py` already does `multi_voice` with per-character voices and segment
+  concatenation — most of the 2-speaker podcast path exists and is live.
+
+## Reproducing
+
+```bash
+SCRATCH=$(mktemp -d)
+printf '[general]\nusers_name = "audit_probe"\n' > "$SCRATCH/config.toml"
+TLDW_CONFIG_PATH="$SCRATCH/config.toml" .venv/bin/python -c "
+import sys, tldw_chatbook.app
+print(sorted(m for m in sys.modules if 'briefing' in m or 'scheduler' in m or 'Subscription_Modules' in m))"
+rm -rf ~/.local/share/tldw_cli/audit_probe "$SCRATCH"
+```
+
+Expected: `briefing_generator` present, `textual_scheduler_worker` absent,
+`Subscription_Modules` absent, `Scheduling.scheduler.handlers.watchlist_check_handler` present.

--- a/backlog/decisions/019-watchlist-scheduler-migration.md
+++ b/backlog/decisions/019-watchlist-scheduler-migration.md
@@ -1,9 +1,32 @@
 # ADR-019: Migrate watchlist checks to the unified Scheduling scheduler
 
-Status: Accepted
+Status: Accepted — **partially implemented; see the status note below before relying on this**
 Date: 2026-07-19
 Related Task: TASK-299
 Supersedes: N/A
+
+## Status note (2026-07-27)
+
+A runtime import-trace audit found that the dual-run safety net described below **does not exist in
+the shipped app**. Two clauses of this ADR are not true of the code:
+
+- *"Old scheduler remains the execution authority by default"* — the old `SubscriptionScheduler`
+  and `SubscriptionSchedulerWorker` are **unreachable**. Their only construction site is
+  `UI/Subscription_Modules/subscription_backend_controller.py`, which serves a `SubscriptionWindow`
+  class that no longer exists; neither module is in `sys.modules` after a full app import.
+- *"Rollback plan: set `watchlist_checks_enabled = false` and the old `SubscriptionScheduler`
+  resumes authoritative execution"* — setting that flag false leaves **no** executor at all, since
+  the new handler is then never constructed and the old one cannot run.
+
+Because the flag ships `false` (and `watchlist_checks_shadow` ships `true`, which fetches and
+discards results), the practical effect is that **nothing checks watchlists on a schedule**. Manual
+"Check now" works; automatic checking is unimplemented end to end.
+
+Tracked by TASK-1210 (make scheduled checks run) and TASK-1211 (retire the unreachable scheduler,
+the removal this ADR deferred). This note will be replaced by an amended decision when 1210 lands.
+
+Full analysis and reproduction:
+`Docs/superpowers/research/2026-07-27-briefing-subsystem-revive-or-retire.md`
 
 ## Decision
 

--- a/backlog/tasks/task-1210 - Watchlists-never-check-on-a-schedule.md
+++ b/backlog/tasks/task-1210 - Watchlists-never-check-on-a-schedule.md
@@ -1,0 +1,47 @@
+---
+id: TASK-1210
+title: Watchlists never check on a schedule - promote the unified handler out of shadow mode
+status: To Do
+assignee: []
+created_date: '2026-07-27 22:15'
+labels:
+  - watchlists
+  - scheduling
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Automatic watchlist checking is unimplemented end to end, so a watchlist only ever updates when a
+user presses "Check now".
+
+The unified `WatchlistCheckHandler` ships disabled: `[scheduling] watchlist_checks_enabled` is
+`false`, so `app.py` never constructs the handler, never registers a `watchlist_job` entry in the
+scheduler's handler map, and passes `watchlist_projection=None` to `SchedulerLoop`. When the flag
+is enabled, `watchlist_checks_shadow` still ships `true`, which fetches feeds and then discards
+the results — `record_check_result` is skipped and `URLMonitor` is constructed with
+`persist_snapshots=False`.
+
+ADR-019 designates the legacy `SubscriptionScheduler` as the execution authority that the flag
+falls back to, but that scheduler is unreachable in the shipped app (its only construction site
+serves a `SubscriptionWindow` class that no longer exists). So the documented rollback lever is
+dead: setting the flag false leaves no executor at all rather than restoring the old one.
+
+This blocks the scheduled-delivery half of the Watchlists briefing spec — there is no working
+schedule for a briefing to attach to.
+
+Audit: `Docs/superpowers/research/2026-07-27-briefing-subsystem-revive-or-retire.md`
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A watchlist source with a check frequency is executed automatically by SchedulerLoop under default configuration, with no config.toml edit required
+- [ ] #2 Results of an automatic check are persisted to Subscriptions_DB - record_check_result runs and URLMonitor persists snapshots
+- [ ] #3 The Watchlists UI exposes a check frequency and round-trips it to Subscriptions_DB
+- [ ] #4 Shadow mode remains available as an explicit opt-in for diagnostics, and its discard-results behaviour is documented where the flag is defined
+- [ ] #5 A regression test asserts a due watchlist task dispatches to the handler and mutates the DB under default configuration
+- [ ] #6 A test covers the case where neither scheduling flag is present in config.toml
+- [ ] #7 ADR-019 is amended or superseded to record that the dual-run fallback it describes does not exist
+<!-- AC:END -->

--- a/backlog/tasks/task-1211 - Retire-the-unreachable-subscription-scheduler-and-briefing-island.md
+++ b/backlog/tasks/task-1211 - Retire-the-unreachable-subscription-scheduler-and-briefing-island.md
@@ -1,0 +1,49 @@
+---
+id: TASK-1211
+title: Retire the unreachable subscription scheduler and briefing island
+status: To Do
+assignee: []
+created_date: '2026-07-27 22:15'
+labels:
+  - watchlists
+  - cleanup
+dependencies:
+  - TASK-1210
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+About 5,100 LOC of subscription scheduling and briefing code is unreachable in the shipped app and
+duplicates a live implementation. A runtime import trace (`import tldw_chatbook.app`, then inspect
+`sys.modules`) confirms `textual_scheduler_worker` and `UI/Subscription_Modules` are never loaded,
+and that `BriefingGenerator` — whose sole construction site is `textual_scheduler_worker.py:101` —
+is never instantiated.
+
+The modules form a closed import cycle (`textual_scheduler_worker` <-> `subscription_backend_controller`)
+with no external entry point, which is why grep-based checks have repeatedly read them as live.
+`SubscriptionBackendController` drives a `SubscriptionWindow` class that no longer exists anywhere
+in the codebase.
+
+Watchlist checking is now done by `Scheduling/scheduler/handlers/watchlist_check_handler.py`
+delegating to `Subscriptions/monitoring_engine.py`. ADR-019 already accepted this migration and
+deferred removal of the old scheduler to a follow-up; this is that follow-up.
+
+Retiring this before building briefing generation avoids growing a second implementation of the
+same feature beside a dead one.
+
+Audit: `Docs/superpowers/research/2026-07-27-briefing-subsystem-revive-or-retire.md`
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The unreachable modules are removed - briefing_generator, briefing_templates, recursive_summarizer, aggregation_engine, rss_feed_generator, export_manager, distribution_manager, textual_scheduler_worker, website_monitor, and Subscriptions/scheduler.py
+- [ ] #2 UI/Subscription_Modules/subscription_backend_controller.py is removed and dropped from the package __init__ exports
+- [ ] #3 monitoring_engine.py is retained unchanged - it is live and used by WatchlistCheckHandler
+- [ ] #4 The eager try-import of briefing_generator in Subscriptions/__init__.py is removed, along with the lazy re-exports of the retired symbols
+- [ ] #5 Tests/Subscriptions/test_scheduler_deprecation.py is removed or rewritten, since the modules it warns about no longer exist
+- [ ] #6 App startup imports no retired module - asserted by a test that inspects sys.modules after importing the app
+- [ ] #7 ADR-019 is updated to record the removal as complete
+- [ ] #8 Full test suite shows no new failures against the pre-change baseline
+<!-- AC:END -->


### PR DESCRIPTION
## What

Settles the revive-or-retire question for the briefing subsystem that Watchlists spec #2 was going to build on, and records what the audit turned up. Docs and backlog only — no code changes.

## Method

Greps gave a misleading answer twice, so the conclusion rests on a runtime import trace: import `tldw_chatbook.app` under a throwaway `TLDW_CONFIG_PATH` profile and inspect `sys.modules`. That separates *a module that is imported* from *a class that is constructed* — the distinction the greps kept blurring. Reproduction steps are in the audit doc.

## Findings

**1. The briefing machinery is attached to a retired scheduler, not the live one.**

There are two parallel watchlist-checking implementations. `Scheduling/scheduler/handlers/watchlist_check_handler.py` (159 LOC, stateless, delegates to `monitoring_engine`) is present in `sys.modules` after app import. `Subscriptions/textual_scheduler_worker.py` (492 LOC) is not — and it is the only thing that constructs `BriefingGenerator`, `AggregationEngine`, and `WebsiteMonitor`. Reviving briefings would mean reviving the dead scheduler with them.

**2. `BriefingGenerator` is imported but never constructed.** It reaches `sys.modules` only via an eager `try:` import at `Subscriptions/__init__.py:65` — a module-level side effect that costs import time on every launch and executes nothing.

**3. The controllers that would drive it target a deleted class.** `UI/Subscription_Modules/` has zero production importers, and `SubscriptionBackendController` drives a `SubscriptionWindow` that does not exist anywhere in the codebase.

**4. The modules form a closed import cycle** (`textual_scheduler_worker` ↔ `subscription_backend_controller`) with no external entry. A naive grep sees four importers and concludes the code is live — presumably how ~5,100 LOC survived this long.

**5. ADR-019's dual-run safety net does not exist in the shipped app**, and this one is bigger than the briefing question. The ADR designates the old scheduler as "the execution authority by default" with the new handler shadowing it and a runtime toggle for "instant rollback". But the old scheduler is unreachable, so the documented rollback — set the flag false, old scheduler resumes — leaves *no* executor rather than restoring one.

**Net effect: nothing checks watchlists on a schedule.** `watchlist_checks_enabled` ships `false`, so `app.py:4674` never builds the handler and never registers `watchlist_job`. When enabled, `watchlist_checks_shadow` ships `true`, which fetches and discards — `record_check_result` skipped, `URLMonitor(persist_snapshots=False)`. Working scheduled checks need both flags set, and neither is reachable from the UI.

Scope stated precisely: the Watchlists UI does not expose `check_frequency` either, so no user is setting a schedule that silently fails. Automatic checking is unimplemented end to end, not broken.

## Corrections to my own earlier claims

- "~4,600 LOC with zero importers outside the package" — wrong on the mechanism. There are importers; they just form a cycle.
- "`watchlists_collections_screen.py:38` imports `notifications_inbox_controller`" — wrong. The Watchlists screen does not import from `Subscription_Modules` at all.

## Tasks filed

- **task-1210** (high) — make scheduled watchlist checks actually run. Prerequisite for the scheduled-delivery half of spec #2.
- **task-1211** (medium, depends on 1210) — retire the island. ADR-019 already accepted this migration and deferred removal to a follow-up; this is that follow-up.

Note the backlog CLI numbered the first task 1181 from this worktree alone, which collided with an existing 1181 elsewhere. Renumbered to 1210/1211 after a global scan across 90 worktrees (global max 1191).

## Test plan

Docs and backlog only; no code paths touched. The audit's claims are reproducible via the snippet in the doc.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Audited the briefing subsystem and confirmed automatic watchlist checks never run because the briefing path hangs off a retired scheduler. Added a research doc, updated ADR-019 with a status note that the dual-run fallback is not implemented, and filed TASK-1210 to enable the live `Scheduling/scheduler/handlers/watchlist_check_handler.py` path plus TASK-1211 to retire the unreachable scheduling/briefing island.

<sup>Written for commit 432bc6440d21b0a91c8ffd1cdd982e99cd4b8278. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

