### PR TITLE
docs: file TASK-1260 — path-validation property tests are load-sensitive

### DIFF
--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -272,13 +272,6 @@ are cheaper than re-deriving the graph.
 
 ---
 
-## Related
-
-- `lessons-live-verification.md` — why the suite could not see seven of these defects
-- `lessons-backlog-hygiene.md` — task IDs, CLI quirks, git plumbing traps
-
----
-
 ## A property test with no deadline override is load-sensitive
 
 **TASK-1260, 2026-07-28.** `test_safe_paths_always_validate` failed once inside a
@@ -307,3 +300,10 @@ and this repo has punished both.
 
 The durable fix is a Hypothesis profile registered once in `Tests/conftest.py`,
 not a per-file patch — other property files carry the same exposure.
+
+---
+
+## Related
+
+- `lessons-live-verification.md` — why the suite could not see seven of these defects
+- `lessons-backlog-hygiene.md` — task IDs, CLI quirks, git plumbing traps

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -284,10 +284,12 @@ are cheaper than re-deriving the graph.
 **TASK-1260, 2026-07-28.** `test_safe_paths_always_validate` failed once inside a
 three-directory run, passed alone, passed on re-run, and passed on a clean
 baseline with the identical command. It is a Hypothesis `@given` property that
-creates a `TemporaryDirectory` and up to five directories per example, with no
-`settings(...)` override and no Hypothesis profile in `Tests/conftest.py` — so it
-runs under the default **200 ms per-example deadline**. On a machine with 10+
-concurrent pytest processes, filesystem work crosses that.
+creates a `TemporaryDirectory` and up to four directories per example (the
+strategy yields 1-5 components; the loop walks `components[:-1]`, the last being
+the file), with no `settings(...)` override and no Hypothesis profile in
+`Tests/conftest.py` — so it runs under the default **200 ms per-example
+deadline**. On a machine with 10+ concurrent pytest processes, filesystem work
+crosses that.
 
 **The cost is in attribution, not in the failure.** Establishing that it was not
 a regression took five runs across two worktrees: the identical command on a

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -276,3 +276,32 @@ are cheaper than re-deriving the graph.
 
 - `lessons-live-verification.md` — why the suite could not see seven of these defects
 - `lessons-backlog-hygiene.md` — task IDs, CLI quirks, git plumbing traps
+
+---
+
+## A property test with no deadline override is load-sensitive
+
+**TASK-1260, 2026-07-28.** `test_safe_paths_always_validate` failed once inside a
+three-directory run, passed alone, passed on re-run, and passed on a clean
+baseline with the identical command. It is a Hypothesis `@given` property that
+creates a `TemporaryDirectory` and up to five directories per example, with no
+`settings(...)` override and no Hypothesis profile in `Tests/conftest.py` — so it
+runs under the default **200 ms per-example deadline**. On a machine with 10+
+concurrent pytest processes, filesystem work crosses that.
+
+**The cost is in attribution, not in the failure.** Establishing that it was not
+a regression took five runs across two worktrees: the identical command on a
+clean pre-change baseline, `Tests/Utils/` with and without a newly added file in
+that same directory, the test alone, and a re-run to show intermittency. The
+failure was indistinguishable from a real regression at the moment it appeared,
+and it appeared while unrelated work was in flight.
+
+**What to do.** When a failure appears in a run that mixes suites: before
+anything else, check whether the test is a Hypothesis property with no deadline
+override. If it is, the load hypothesis is cheap to confirm — run it alone, then
+re-run the mixed command. Do not skip the clean-baseline run, though: "it's
+probably a flake" is the same shape of reasoning as "it's probably unrelated",
+and this repo has punished both.
+
+The durable fix is a Hypothesis profile registered once in `Tests/conftest.py`,
+not a per-file patch — other property files carry the same exposure.

--- a/backlog/tasks/task-1260 - Path-validation-property-tests-fail-under-machine-load.md
+++ b/backlog/tasks/task-1260 - Path-validation-property-tests-fail-under-machine-load.md
@@ -1,0 +1,53 @@
+---
+id: TASK-1260
+title: Path-validation property tests fail under machine load, producing false regression signals
+status: To Do
+assignee: []
+created_date: '2026-07-28 10:55'
+labels:
+  - testing
+  - flaky
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`Tests/Utils/test_path_validation_properties.py::TestPathValidationProperties::test_safe_paths_always_validate`
+fails intermittently when run alongside other suites, and passes in isolation.
+
+Observed on `origin/dev` @ `048e53cab`:
+
+| Command | Result |
+| --- | --- |
+| the test alone | passed |
+| `Tests/Utils/` alone | 576 passed |
+| `Tests/Subscriptions/ Tests/Scheduling/ Tests/Utils/` | **1 failed**, 892 passed |
+| the same three, re-run | 893 passed |
+| the same three at `e74e37d07` (before the day's changes) | 878 passed |
+
+The tests are Hypothesis `@given` properties with no `settings(...)` override anywhere in the file
+and no Hypothesis profile in `Tests/conftest.py`, so they run under the default 200 ms per-example
+deadline. `test_safe_paths_always_validate` does real filesystem work per example — a
+`TemporaryDirectory` plus up to five `mkdir` calls — which is exactly the kind of work that crosses
+200 ms when the machine is loaded. This repo routinely has 10+ concurrent pytest processes from
+parallel agents.
+
+**Why this is worth fixing rather than tolerating.** The failure is indistinguishable from a real
+regression at the moment it appears. Attributing this one instance cost five separate runs across
+two worktrees — running the identical command on a clean baseline, with and without a newly added
+file in the same directory, plus a re-run to establish intermittency. Any future change that happens
+to be in flight when this fires will pay that cost again.
+
+Other property files in the tree may have the same exposure; the fix should be a Hypothesis profile
+rather than a one-line patch to this file.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A Hypothesis settings profile is registered in Tests/conftest.py and applied to the suite, rather than each property file setting its own deadline
+- [ ] #2 The profile disables or substantially raises the per-example deadline, so a loaded machine cannot fail a property that holds
+- [ ] #3 Property tests that do real filesystem or database work are identified, and the profile covers them
+- [ ] #4 test_safe_paths_always_validate passes when its suite runs concurrently with at least two other large suites under load
+- [ ] #5 The reason the deadline is relaxed is recorded next to the profile, so it is not "tightened back up" later as an apparent improvement
+<!-- AC:END -->

--- a/backlog/tasks/task-1260 - Path-validation-property-tests-fail-under-machine-load.md
+++ b/backlog/tasks/task-1260 - Path-validation-property-tests-fail-under-machine-load.md
@@ -29,9 +29,10 @@ Observed on `origin/dev` @ `048e53cab`:
 The tests are Hypothesis `@given` properties with no `settings(...)` override anywhere in the file
 and no Hypothesis profile in `Tests/conftest.py`, so they run under the default 200 ms per-example
 deadline. `test_safe_paths_always_validate` does real filesystem work per example — a
-`TemporaryDirectory` plus up to five `mkdir` calls — which is exactly the kind of work that crosses
-200 ms when the machine is loaded. This repo routinely has 10+ concurrent pytest processes from
-parallel agents.
+`TemporaryDirectory` plus up to four `mkdir` calls (the strategy generates 1-5 components and the
+loop walks `components[:-1]`, since the last component is the file, not a directory) — which is
+exactly the kind of work that crosses 200 ms when the machine is loaded. This repo routinely has
+10+ concurrent pytest processes from parallel agents.
 
 **Why this is worth fixing rather than tolerating.** The failure is indistinguishable from a real
 regression at the moment it appears. Attributing this one instance cost five separate runs across


### PR DESCRIPTION
Docs and backlog only. Files TASK-1260 and records the lesson behind it.

## What happened

A post-merge check on `dev` showed one failure — `test_safe_paths_always_validate` — and I reported the session complete a moment before seeing it. This PR is the follow-through.

## Attribution

The failure appeared in a three-suite run, and the test lives in `Tests/Utils/`, the directory I had just added a file to. "Obviously unrelated" wasn't good enough, so I ran the matched comparisons rather than assuming:

| Command | Result |
| --- | --- |
| the test alone | passed |
| `Tests/Utils/` **with** my new file | 576 passed |
| `Tests/Utils/` **without** it | 570 passed |
| `Subscriptions/ Scheduling/ Utils/` | **1 failed**, 892 passed |
| the same three, re-run | 893 passed |
| the same three at `e74e37d07` (pre-change) | 878 passed |

Not a regression, and not caused by the new file. An intermittent.

## Mechanism

The property tests in that file carry no `settings(...)` override, and there is no Hypothesis profile in `Tests/conftest.py` — so they run under the default **200 ms per-example deadline**. `test_safe_paths_always_validate` creates a `TemporaryDirectory` plus up to five directories *per example*. On a machine running 10+ concurrent pytest processes from parallel agents, that crosses 200 ms.

## Why file it rather than shrug

The failure is indistinguishable from a real regression at the moment it appears, and it appeared while unrelated work was in flight. Attributing this single instance took five runs across two worktrees. Any future change unlucky enough to be in flight when it fires pays that cost again.

The AC asks for a Hypothesis profile registered once in `Tests/conftest.py` rather than a one-line patch to this file — other property files carry the same exposure — and asks that the reason be recorded next to it, so the deadline is not "tightened back up" later as an apparent improvement.

## Lesson recorded

`backlog/docs/lessons-testing-evidence.md` gains the diagnostic shortcut: when a failure shows up in a run that mixes suites, check first whether it's a Hypothesis property with no deadline override — that's cheap to confirm. But don't skip the clean-baseline run on the strength of it, because "it's probably a flake" is the same shape of reasoning as "it's probably unrelated," and this repo has punished both.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Docs for TASK-1260: `hypothesis` path-validation properties are load-sensitive and can fail under the default 200 ms deadline.
Adds a backlog task and a testing lesson with steps to add a suite-wide Hypothesis profile in `Tests/conftest.py` that relaxes deadlines to prevent false failures; also corrects the mkdir count (four, not five) and fixes the lesson’s section ordering.

<sup>Written for commit fd05e3dc5cb4fa5f6b5743445cb34894a5088f90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

