### PR TITLE
docs: record the optional-dep boot trap and the --ac quirk; file task-1261

### DIFF
--- a/backlog/docs/lessons-backlog-hygiene.md
+++ b/backlog/docs/lessons-backlog-hygiene.md
@@ -37,6 +37,26 @@ illustration of why these entries carry their evidence.
 
 ---
 
+## `--ac` does not split on commas — you get one run-on criterion
+
+**What happened.** 2026-07-28, filing task-1261: four acceptance criteria were passed
+as `--ac "first,second,third,fourth"`, exactly the shape CLAUDE.md documents
+(`--ac "Must work,Must be tested"`). The CLI (v1.44.0) wrote **a single** criterion
+whose text was the whole comma-joined string. Confirmed on a trivial control:
+`--ac "alpha,beta,gamma"` produces `- [ ] #1 alpha,beta,gamma`, not three items.
+
+A single run-on AC is not a cosmetic problem: it cannot be checked off
+independently, so the Definition of Done ("all `- [ ]` changed to `- [x]`") becomes
+all-or-nothing and the task stops describing what is actually left.
+
+**What to do.** Pass `--ac` **once per criterion** if the flag repeats, or write the
+`## Acceptance Criteria` block into the task file directly and verify with
+`backlog task <id> --plain` before moving on. Whichever route, read the rendered AC
+list back — the CLI accepted the comma form silently rather than erroring, so nothing
+warns you.
+
+---
+
 ## `git ls-tree` octal-escapes non-ASCII filenames
 
 **What happened.** Several task titles contain an em-dash. `git ls-tree` emits those

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -177,6 +177,60 @@ And when a test asserts a configuration default, make it state *why* that value
 is right, not just what it is. `assert enabled is False` is unfalsifiable
 documentation of whatever was there when it was written.
 
+## A green suite says nothing about installs that are not yours
+
+**The trap.** The suite runs where every optional extra is already installed. It
+therefore cannot see a dependency that is *declared* optional but has become
+*mandatory to boot* — the one environment it never tests is the plain install.
+
+**What happened.** 2026-07-27: the app died on start with
+`RuntimeError: Unable to resolve default chat screen`. `aiohttp` is optional —
+declared only in the `[websearch]`/`[all-tools]` extras, and registered
+`"aiohttp": False` in `Utils/optional_deps.py` — but the `/generate-image`
+console feature had quietly wired it onto the **default** screen's import chain:
+
+```
+UI/Screens/chat_screen.py
+  -> Chat/console_generate_image.py        (ImageGenerationService)
+    -> Media_Creation/image_generation_service.py
+      -> Media_Creation/swarmui_client.py  -> import aiohttp   (module scope)
+```
+
+Nothing was red. No test asserted that the default route resolves *without* the
+extras, so the suite was structurally blind to a total boot failure.
+
+Two multipliers made it worse:
+
+- **The masking cost more time than the bug.** `ScreenRoute.load_screen_class()`
+  catches `ImportError` and returns `None`, by design, so one broken optional
+  screen cannot break navigation. For the *default* screen that turned a precise
+  `ModuleNotFoundError: No module named 'aiohttp'` into a message naming neither
+  the module nor the file that imported it.
+- **The obvious suspect was innocent.** The only dirty file in the tree was a
+  `.tcss` whose diff was a regenerated timestamp comment. Reproducing first and
+  reading the traceback cost one command; guessing from `git status` would have
+  cost the session.
+
+**What to do.** When a feature adds an import to a screen module, check whether
+the new chain reaches an optional dependency — the import that breaks boot is
+rarely the one you wrote, it is three hops down. Guard boot-critical routes with
+a test that simulates absence, and run it in a **subprocess**: `sys.modules` is
+process-global, so an unrelated earlier test that imported the package gives a
+false pass.
+
+```python
+class _BlockAiohttp:                       # meta-path finder, installed first
+    def find_spec(self, name, path=None, target=None):
+        if name == "aiohttp" or name.startswith("aiohttp."):
+            raise ImportError("simulated missing aiohttp")
+        return None
+```
+
+See `Tests/Utils/test_optional_import_deferral.py` (the aiohttp section) and
+`Tests/UI/test_screen_navigation.py` (`screen_load_error`). And when a resolver
+degrades a failure to `None` on purpose, give callers for whom it is *fatal* a
+way to ask why — a graceful contract should not also be a silent one.
+
 ---
 
 ## Related

--- a/backlog/tasks/task-1261 - Restore-the-lost-warning-when-NLTK-tokenizer-data-is-unusable.md
+++ b/backlog/tasks/task-1261 - Restore-the-lost-warning-when-NLTK-tokenizer-data-is-unusable.md
@@ -1,0 +1,27 @@
+---
+id: TASK-1261
+title: Restore the lost warning when NLTK tokenizer data is unusable
+status: To Do
+assignee: []
+created_date: '2026-07-28 18:51'
+labels:
+  - bug
+  - logging
+  - chunking
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+ensure_nltk_data() degrades silently when NLTK is installed but its sentence-tokenizer data cannot tokenize. The readiness flag is set correctly, but nothing is logged, so a user whose chunking has silently fallen back to the non-NLTK path gets no signal anywhere. Tests/Utils/test_startup_polish_regressions.py::test_nltk_download_false_is_not_logged_as_success has been failing on dev because of this; the test is correct and the code lost its warning during a refactor.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 `ensure_nltk_data()` emits a WARNING or ERROR naming the missing punkt/punkt_tab corpus when the tokenizer probe fails
+- [ ] #2 No "downloaded successfully" message is logged on the failure path
+- [ ] #3 `Tests/Utils/test_startup_polish_regressions.py::test_nltk_download_false_is_not_logged_as_success` passes
+- [ ] #4 The orphaned, over-indented comment block left at `Chunk_Lib.py:267-268` by the refactor is removed
+<!-- AC:END -->


### PR DESCRIPTION
Follow-ups from the aiohttp startup crash (#1051). Docs and one new backlog task — no source changes.

## 1. `lessons-testing-evidence.md` — "A green suite says nothing about installs that are not yours"

The suite runs where every optional extra is already installed, so it was structurally blind to a **total boot failure**: `aiohttp` is optional by declaration (`[websearch]`/`[all-tools]` only, registered `"aiohttp": False` in `optional_deps.py`) but the `/generate-image` feature had wired it onto the **default** screen's import chain. Nothing was red.

The entry records the two multipliers, because both cost real time:

- **The masking cost more than the bug.** `ScreenRoute.load_screen_class()` catches `ImportError` and returns `None` *by design*, so one broken optional screen can't break navigation. For the default screen that turned `ModuleNotFoundError: No module named 'aiohttp'` into a message naming neither the module nor the importing file.
- **The obvious suspect was innocent.** The only dirty file was a `.tcss` whose entire diff was a regenerated timestamp comment. Reproducing first cost one command; guessing from `git status` would have cost the session.

Includes the subprocess + `sys.meta_path` recipe for simulating an absent dependency, and why it must be a subprocess (`sys.modules` is process-global, so an unrelated earlier import gives a false pass).

## 2. `lessons-backlog-hygiene.md` — `--ac` does not split on commas

Filing task-1261 with the form CLAUDE.md documents (`--ac "Must work,Must be tested"`) produced **one** run-on criterion. Confirmed on a trivial control with CLI v1.44.0: `--ac "alpha,beta,gamma"` → `- [ ] #1 alpha,beta,gamma`.

This matters beyond cosmetics — a run-on AC can't be checked off independently, so the DoD's "all `- [ ]` changed to `- [x]`" becomes all-or-nothing and the task stops describing what's left. The CLI accepts the comma form silently rather than erroring.

## 3. `task-1261` — NLTK tokenizer degrades silently

Found while separating pre-existing failures from my own changes. `ensure_nltk_data()` sets its readiness flag correctly but logs **nothing** when NLTK is installed and its tokenizer data can't tokenize — users get a silent fallback with no signal. The warning was lost in a refactor; the orphaned, over-indented comment left at `Chunk_Lib.py:267-268` is its fingerprint.

`Tests/Utils/test_startup_polish_regressions.py::test_nltk_download_false_is_not_logged_as_success` has been failing on `dev` because of this. **The test is correct; the code regressed.**

> Note: the other pre-existing failure I reported on #1051, `test_fd_protection::test_all_call_sites_share_the_same_function_object`, now **passes** — it was fixed by one of the commits that landed on dev in the interim. Only the nltk one remains, hence a single task.

## Task ID hygiene

Swept all remote refs per `lessons-backlog-hygiene.md` (true max **1260**) rather than trusting the CLI's auto-assignment, which offered **1235** — precisely the trap that doc records. Filed as 1261, updated in both namespaces the guard checks (filename prefix and frontmatter `id:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the `aiohttp` optional-dependency boot trap (default screen imported it transitively) and the CLI `--ac` comma-splitting quirk, and added backlog task-1261 to restore the lost `nltk` tokenizer warning. Includes a subprocess + `sys.meta_path` recipe to simulate a missing dependency; no source changes.

<sup>Written for commit 4f13f5fab8902a4d4b789615ffd35ca442e55b1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

