### PR TITLE
fix(tests): make the NLTK unusable-tokenizer test independent of extras [TASK-1261]

### DIFF
--- a/Tests/Utils/test_startup_polish_regressions.py
+++ b/Tests/Utils/test_startup_polish_regressions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import builtins
 import importlib
 import sys
+import types
 from types import SimpleNamespace
 
 import pytest
@@ -242,6 +243,24 @@ def test_nltk_download_false_is_not_logged_as_success(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from tldw_chatbook.Chunking import Chunk_Lib
+
+    # `nltk` is an OPTIONAL extra (chunker/websearch). Forcing NLTK_AVAILABLE
+    # below is not enough on its own: `_ensure_nltk()` still does a real
+    # `import nltk`, so without the package it returns early and never reaches
+    # the warning under test -- which surfaces as "no WARNING was logged" and
+    # reads exactly like the production warning having been deleted. It cost a
+    # wrong root-cause once (task-1261); stub the module so this test asserts
+    # our logic, not which extras happen to be installed.
+    #
+    # The stub only has to satisfy the import: `_probe_sent_tokenize` is
+    # stubbed to False below, so this tokenizer is never actually called.
+    fake_nltk = types.ModuleType("nltk")
+    fake_tokenize = types.ModuleType("nltk.tokenize")
+    fake_tokenize.sent_tokenize = lambda text, **kwargs: [text]
+    fake_nltk.tokenize = fake_tokenize
+    fake_nltk.download = lambda *args, **kwargs: False
+    monkeypatch.setitem(sys.modules, "nltk", fake_nltk)
+    monkeypatch.setitem(sys.modules, "nltk.tokenize", fake_tokenize)
 
     messages: list[tuple[str, str]] = []
     sink_id = logger.add(

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -270,6 +270,47 @@ conclusion about `subscription_events` from the other direction months earlier
 (`handle_add_subscription` has zero dispatchers). A prior investigation's notes
 are cheaper than re-deriving the graph.
 
+## A missing extra fakes a code regression — check the env before blaming the code
+
+**The trap.** The mirror image of the entry above. There, everything was installed
+and the suite went blind. Here, an optional extra is *absent* and a test fails with a
+message describing a defect that does not exist. The failure text names production
+behaviour, so it reads as a regression, and you go fix code that was never broken.
+
+**What happened.** 2026-07-28, task-1261. `test_nltk_download_false_is_not_logged_as_success`
+was failing on dev with "no WARNING/ERROR mentioning punkt was logged". That is
+precisely what a deleted `logger.warning` looks like. It was filed as one — *"the
+warning was lost in a refactor"* — with `git log -L` even producing a plausible
+culprit commit that had genuinely rewritten that function, and an orphaned
+over-indented comment left behind as the apparent fingerprint.
+
+All of it was wrong. `nltk` is an optional extra, and it was not installed. The test
+sets `NLTK_AVAILABLE = True` to simulate presence, but `_ensure_nltk()` still runs a
+real `import nltk`, so it returned early and never reached the warning. Installing
+`nltk` turned the test green with no code change at all. The confirming probe written
+to "verify" the diagnosis had been run in the same interpreter, so it hit the same
+early return and agreed — a second wrong answer from the same cause reads as
+corroboration.
+
+**What to do.** When a test asserts that a log/branch/side effect is missing, check
+whether the code path can even be *reached* in your environment before concluding the
+behaviour was removed. One command settles it:
+
+```bash
+python -c "import importlib.util as u; print(u.find_spec('nltk') is not None)"
+```
+
+And a test that forces an availability flag must also stub the import that flag
+stands for — otherwise it silently depends on which extras you installed:
+
+```python
+monkeypatch.setattr(Chunk_Lib, "NLTK_AVAILABLE", True)   # not sufficient alone
+monkeypatch.setitem(sys.modules, "nltk", fake_nltk)      # _ensure_nltk() still imports
+```
+
+Corollary: a probe re-run in the same broken environment is not independent evidence.
+Vary the thing you suspect — here, install the package — and see if the symptom moves.
+
 ---
 
 ## Related

--- a/backlog/tasks/task-1261 - Restore-the-lost-warning-when-NLTK-tokenizer-data-is-unusable.md
+++ b/backlog/tasks/task-1261 - Restore-the-lost-warning-when-NLTK-tokenizer-data-is-unusable.md
@@ -1,12 +1,13 @@
 ---
 id: TASK-1261
-title: Restore the lost warning when NLTK tokenizer data is unusable
-status: To Do
-assignee: []
+title: Make the NLTK unusable-tokenizer test independent of the installed extras
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-28 18:51'
 labels:
   - bug
-  - logging
+  - testing
   - chunking
 dependencies: []
 priority: medium
@@ -15,13 +16,50 @@ priority: medium
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-ensure_nltk_data() degrades silently when NLTK is installed but its sentence-tokenizer data cannot tokenize. The readiness flag is set correctly, but nothing is logged, so a user whose chunking has silently fallen back to the non-NLTK path gets no signal anywhere. Tests/Utils/test_startup_polish_regressions.py::test_nltk_download_false_is_not_logged_as_success has been failing on dev because of this; the test is correct and the code lost its warning during a refactor.
+`Tests/Utils/test_startup_polish_regressions.py::test_nltk_download_false_is_not_logged_as_success` fails on any machine where the optional `nltk` package is not installed, and the way it fails points at the wrong thing.
+
+The test simulates "nltk is installed but its tokenizer data is unusable" by setting `Chunk_Lib.NLTK_AVAILABLE = True` and stubbing the probe and download helpers. But `_ensure_nltk()` still performs a real `import nltk` (Chunk_Lib.py:139). Without the package that import raises, and the function returns at line 142 — before reaching the warning at lines 153-158. The test then reports "no WARNING/ERROR mentioning punkt was logged", which reads exactly like the production warning has been lost.
+
+It has not been lost: with `nltk` installed the test passes and the warning fires correctly. The defect is that the test silently depends on an optional extra (`chunker`/`websearch`) while claiming to exercise logic independent of it, and emits a misleading failure signal when that extra is absent.
+
+Note: this task was originally filed on the opposite, incorrect diagnosis — "the warning was lost in a refactor". That conclusion came from probing in the same nltk-less environment, which hits the same early return. Corrected 2026-07-28.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `ensure_nltk_data()` emits a WARNING or ERROR naming the missing punkt/punkt_tab corpus when the tokenizer probe fails
-- [ ] #2 No "downloaded successfully" message is logged on the failure path
-- [ ] #3 `Tests/Utils/test_startup_polish_regressions.py::test_nltk_download_false_is_not_logged_as_success` passes
-- [ ] #4 The orphaned, over-indented comment block left at `Chunk_Lib.py:267-268` by the refactor is removed
+- [x] #1 `test_nltk_download_false_is_not_logged_as_success` passes whether or not `nltk` is installed
+- [x] #2 The test still fails if the production warning in `_ensure_nltk()` is removed, i.e. the fix does not make it vacuous
+- [x] #3 The orphaned, over-indented comment block left at `Chunk_Lib.py:267-268` by the task-842 refactor is removed
+- [x] #4 No production behaviour changes: `Chunk_Lib`'s logging and readiness semantics are untouched
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inject a stub `nltk` / `nltk.tokenize` pair into `sys.modules` for the duration of the test so `_ensure_nltk()`'s import succeeds regardless of environment. The existing stubs on `_probe_sent_tokenize` and `_download_nltk_tokenizer_corpora` already prevent the fake tokenizer from being called, so the stub only has to satisfy the import.
+2. Verify the test passes both with `nltk` installed and with it genuinely uninstalled. (Deviation from the first draft of this plan, which proposed a `sys.meta_path` blocker: actually removing the package tests the real condition rather than a simulation of it, and the install/uninstall is cheap.)
+3. Mutation-check the guard per `lessons-testing-evidence.md`: temporarily delete the production warning and confirm the test fails.
+4. Delete the dead comment block at `Chunk_Lib.py:267-268`.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The production warning was never missing. The task's original premise was wrong and is corrected in the Description above; what shipped is a test fix plus a dead-comment cleanup.
+
+**Approach.** `test_nltk_download_false_is_not_logged_as_success` now injects a stub `nltk`/`nltk.tokenize` pair into `sys.modules` via `monkeypatch.setitem`, so `_ensure_nltk()`'s real `import nltk` succeeds regardless of which extras are installed. The stub only satisfies the import: `_probe_sent_tokenize` is already stubbed to return False, so the fake tokenizer is never called. Setting `NLTK_AVAILABLE = True` alone was never sufficient, and that gap is now called out in a comment at the test so it is not reintroduced.
+
+**Verified.**
+- Passes with `nltk` installed, and with it uninstalled (both run explicitly, not inferred).
+- Mutation-checked per `lessons-testing-evidence.md`: deleting the `logger.warning` in `_ensure_nltk()` makes the test fail; restoring it makes it pass. The guard is not vacuous.
+- `Tests/Utils/test_startup_polish_regressions.py` + `Tests/Chunking`: 106 passed, 1 skipped.
+
+**Trade-off.** A stub was chosen over `pytest.importorskip("nltk")`. Skipping would also stop the misleading failure, but it would silently drop coverage on exactly the minimal installs where the fallback path matters most. The logic under test is ours, not nltk's, so it should not require the package.
+
+**Production change is comment-only:** the orphaned, over-indented two-line comment at `Chunk_Lib.py:267-268` — dead text left when task-842 replaced the download block — was removed. No logging or readiness semantics were touched.
+
+**Modified files.**
+- `Tests/Utils/test_startup_polish_regressions.py` — stub injection, `types` import, explanatory comment
+- `tldw_chatbook/Chunking/Chunk_Lib.py` — dead comment removed
+- `backlog/docs/lessons-testing-evidence.md` — new entry "A missing extra fakes a code regression", recording the wrong root-cause this produced
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chunking/Chunk_Lib.py
+++ b/tldw_chatbook/Chunking/Chunk_Lib.py
@@ -264,8 +264,6 @@ def ensure_nltk_data() -> None:
     # LookupError. Probing the behaviour instead of naming a resource is what
     # keeps that from depending on the installed nltk version (task-842).
     _nltk_data_ready = _ensure_nltk() is not None
-            # Depending on how critical this is, you might raise an error or just warn
-            # For now, we'll let it proceed, and sent_tokenize will fail later if needed.
 
 
 ### REWRITTEN SECTION: New Configuration Loading ###


### PR DESCRIPTION
Closes TASK-1261.

## Correction first

I filed TASK-1261 claiming the production warning had been lost in a refactor. **That was wrong**, and the task's Description now records the correction. No production logging was ever missing.

## What was actually wrong

`test_nltk_download_false_is_not_logged_as_success` fails on any machine without the optional `nltk` package — and fails in a way that points at the wrong thing:

```
assert any(level in {"WARNING","ERROR"} and "punkt" in message ...)
```

"No WARNING/ERROR mentioning punkt was logged" is exactly what a deleted `logger.warning` looks like. It isn't one. The test forces `NLTK_AVAILABLE = True` to simulate nltk being present, but `_ensure_nltk()` still runs a real `import nltk` (`Chunk_Lib.py:139`); without the package that raises and the function returns at line 142 — before ever reaching the warning at 153-158.

Installing `nltk` turns the test green with **zero** code changes. The defect is that the test silently depends on the `chunker`/`websearch` extra while claiming to exercise logic independent of it.

## The fix

The test injects a stub `nltk`/`nltk.tokenize` pair into `sys.modules`, so the import succeeds regardless of installed extras. The stub only has to satisfy the import — `_probe_sent_tokenize` is already stubbed to `False`, so the fake tokenizer is never called.

**Stub over `pytest.importorskip("nltk")`**: skipping would also stop the misleading failure, but would silently drop coverage on exactly the minimal installs where the fallback path matters most. The logic under test is ours, not nltk's.

## Verification

| Check | Result |
|---|---|
| `nltk` installed | pass |
| `nltk` **uninstalled** | pass |
| Mutation: production `logger.warning` deleted | **fail** (guard is not vacuous) |
| Mutation reverted | pass |
| `Tests/Utils/test_startup_polish_regressions.py` + `Tests/Chunking` | 106 passed, 1 skipped |

Both environment states were run explicitly rather than inferred, and the mutation check follows `lessons-testing-evidence.md`'s "mutation-test every guard you add".

## Production change is comment-only

```diff
     _nltk_data_ready = _ensure_nltk() is not None
-            # Depending on how critical this is, you might raise an error or just warn
-            # For now, we'll let it proceed, and sent_tokenize will fail later if needed.
```

Dead, over-indented text left behind when task-842 replaced the download block. No logging or readiness semantics touched.

## Lesson recorded

`lessons-testing-evidence.md` gains "A missing extra fakes a code regression" — the mirror of the entry added in #1064. It records the full failure mode including the part that made it stick: the probe written to *confirm* the diagnosis was run in the same nltk-less interpreter, so it hit the same early return and agreed. A second wrong answer from the same cause reads as corroboration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the NLTK unusable-tokenizer test independent of installed extras by stubbing `nltk`, so it passes with or without the package and still catches missing warnings. Addresses TASK-1261; production behavior is unchanged (dead comment removed only).

- **Bug Fixes**
  - Injects stub `nltk`/`nltk.tokenize` into `sys.modules` in `test_nltk_download_false_is_not_logged_as_success` to bypass real import and test our logic.
  - Keeps the test failing if the production warning is removed (mutation check), ensuring the guard is effective.

- **Refactors**
  - Removes an orphaned comment in `Chunk_Lib.py`; no logging or readiness semantics changed.

<sup>Written for commit afdfbe26555804b833f7a4d78f544698a757add8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

