### PR TITLE
feat(agents): programmatic run memory — lossless run log + search_run_log

### DIFF
--- a/Docs/superpowers/plans/2026-07-27-agent-run-log-phase-1.md
+++ b/Docs/superpowers/plans/2026-07-27-agent-run-log-phase-1.md
@@ -1,0 +1,2031 @@
+# Agent Run Log (Phase 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Append every model turn, tool call, and tool result of an agent run losslessly to a segmented, searchable log file, and give the primary agent a `search_run_log` tool to query it.
+
+**Architecture:** A pure codec (`run_log_format.py`) encodes/parses a line-anchored record format. A writer (`run_log.py`) owns path resolution, segmentation, and durability. The pure loop gains one injected callable, `LoopDeps.on_record`, called at the two points where full-fidelity values exist. `AgentService` constructs the writer once per run tree and wires it. `search_run_log` is registered as a runtime tool exactly like `install_skill`.
+
+**Tech Stack:** Python 3.11+, stdlib only (`dataclasses`, `pathlib`, `threading`, `re`), pytest.
+
+**Spec:** `Docs/superpowers/specs/2026-07-27-agent-programmatic-run-memory-design.md`
+
+## Global Constraints
+
+- **Phase 1 is additive.** `run_agent_loop`'s `messages` list is NOT modified. Existing runs must behave byte-identically when logging is disabled or unwired.
+- **Every new `LoopDeps` field defaults to `None`/no-op**, matching `review_tool_calls`, `read_skill_file`, `install_skill`, `run_skill_script`.
+- **`agent_runtime.py` stays pure**: no I/O, no DB, no Textual imports. It may only call injected callables.
+- **A failing log write must never abort a run.** Wrap `on_record` in catch-and-continue, as `add()` already does for `on_step`.
+- **Path resolution goes through `allowed_file_roots(write=True, sandbox_root=_tool_sandbox_root())`** → `is_within` → `is_sensitive_path`. Never construct or validate paths independently.
+- **Record anchor is `#@#`** (never `###` — markdown H3 collides).
+- **`bytes=N` is UTF-8 bytes of content, excluding the terminating newline.** Log files are read and written in **binary**.
+- **Tests run from the venv:** `python -m pytest` with the project venv active. The `timeout` command is unavailable in this environment.
+- Docstrings are Google style with Args/Returns/Raises. Type hints on public APIs.
+
+---
+
+### Task 1: Record codec
+
+Pure encode/parse. No filesystem, no runtime imports.
+
+**Files:**
+- Create: `tldw_chatbook/Agents/run_log_format.py`
+- Test: `Tests/Agents/test_run_log_format.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `RECORD_ANCHOR: str = "#@#"`
+  - `@dataclass(frozen=True) RunLogRecord(number: int, run_id: str, kind: str, type: str, ts: str, content: str, tool: str = "", status: str = "", call_id: str = "", truncated_from: int = 0)`
+  - `encode_record(record: RunLogRecord) -> bytes`
+  - `iter_records(data: bytes) -> Iterator[RunLogRecord]`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/Agents/test_run_log_format.py`:
+
+```python
+# Tests/Agents/test_run_log_format.py
+"""Pure record codec: round-trip, adversarial content, partial tails."""
+
+from tldw_chatbook.Agents.run_log_format import (
+    RECORD_ANCHOR,
+    RunLogRecord,
+    encode_record,
+    iter_records,
+)
+
+
+def rec(number=1, content="hello", **kw):
+    base = dict(
+        number=number,
+        run_id="a3f9c1",
+        kind="primary",
+        type="tool_result",
+        ts="2026-07-27T18:22:31.004Z",
+        content=content,
+    )
+    base.update(kw)
+    return RunLogRecord(**base)
+
+
+def test_round_trip_preserves_content_exactly():
+    original = rec(content="line one\nline two\n")
+    (parsed,) = list(iter_records(encode_record(original)))
+    assert parsed.content == original.content
+    assert parsed.number == 1
+    assert parsed.run_id == "a3f9c1"
+
+
+def test_header_is_one_physical_line():
+    blob = encode_record(rec(tool="grep_files", status="ok", call_id="call_7"))
+    header = blob.split(b"\n", 1)[0].decode()
+    assert header.startswith(RECORD_ANCHOR + " ")
+    assert "tool=grep_files" in header
+    assert "bytes=5" in header
+
+
+def test_content_containing_the_anchor_does_not_corrupt_parsing():
+    # The whole point of bytes=N: content is sliced by length, never scanned.
+    evil = f"{RECORD_ANCHOR} 999999 run=x kind=primary type=model ts=z bytes=0\nnope"
+    blob = encode_record(rec(number=1, content=evil)) + encode_record(rec(number=2))
+    parsed = list(iter_records(blob))
+    assert len(parsed) == 2
+    assert parsed[0].content == evil
+    assert parsed[1].number == 2
+
+
+def test_multibyte_content_counts_bytes_not_characters():
+    original = rec(content="héllo — ✅")
+    blob = encode_record(original)
+    assert f"bytes={len(original.content.encode('utf-8'))}".encode() in blob
+    (parsed,) = list(iter_records(blob))
+    assert parsed.content == original.content
+
+
+def test_partial_trailing_record_is_ignored():
+    blob = encode_record(rec(number=1)) + encode_record(rec(number=2, content="abcdef"))
+    truncated = blob[:-3]  # content cut mid-write
+    parsed = list(iter_records(truncated))
+    assert [p.number for p in parsed] == [1]
+
+
+def test_record_missing_only_its_terminator_is_ignored():
+    blob = encode_record(rec(number=1))
+    parsed = list(iter_records(blob[:-1]))
+    assert parsed == []
+
+
+def test_truncated_field_round_trips_and_is_absent_otherwise():
+    assert b"truncated=" not in encode_record(rec())
+    blob = encode_record(rec(content="cut", truncated_from=9000))
+    assert b"truncated=9000" in blob
+    (parsed,) = list(iter_records(blob))
+    assert parsed.truncated_from == 9000
+
+
+def test_whitespace_in_header_values_is_sanitised():
+    # A header field containing a space or newline would break single-line parsing.
+    (parsed,) = list(iter_records(encode_record(rec(tool="bad name\nx"))))
+    assert " " not in parsed.tool and "\n" not in parsed.tool
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest Tests/Agents/test_run_log_format.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'tldw_chatbook.Agents.run_log_format'`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `tldw_chatbook/Agents/run_log_format.py`:
+
+```python
+# tldw_chatbook/Agents/run_log_format.py
+"""Line-anchored, byte-exact record codec for the agent run log.
+
+Pure module: no filesystem, no runtime imports. See the design spec
+(Docs/superpowers/specs/2026-07-27-agent-programmatic-run-memory-design.md §4).
+
+Format, one record:
+
+    #@# 000412 run=a3f9c1 kind=primary type=tool_result tool=grep_files \
+status=ok call=call_7 ts=2026-07-27T18:22:31.004Z bytes=1834
+    <exactly 1834 UTF-8 bytes of content>
+
+The header is always ONE physical line: a wrapped header would break
+``^#@# `` matching and detach fields onto a continuation line. ``bytes=``
+lets a parser slice content by length instead of scanning for the next
+anchor, so content containing a literal ``#@#`` cannot corrupt parsing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterator
+
+#: Never occurs naturally. ``###`` was rejected: it is a markdown H3, so
+#: every heading in generated or fetched content would false-positive.
+RECORD_ANCHOR = "#@#"
+
+_ANCHOR_BYTES = RECORD_ANCHOR.encode("utf-8") + b" "
+_PLACEHOLDER = "-"
+
+
+def _sanitise(value: str) -> str:
+    """Collapse whitespace so a value can never break the single-line header.
+
+    Args:
+        value: Raw field value (a tool name, run id, status, or call id).
+
+    Returns:
+        ``value`` with every whitespace run replaced by ``_``, or ``"-"``
+        when empty.
+    """
+    cleaned = "_".join(str(value).split())
+    return cleaned or _PLACEHOLDER
+
+
+@dataclass(frozen=True)
+class RunLogRecord:
+    """One appended record: a model turn, tool call, tool result, or spawn."""
+
+    number: int
+    run_id: str
+    kind: str
+    type: str
+    ts: str
+    content: str
+    tool: str = ""
+    status: str = ""
+    call_id: str = ""
+    truncated_from: int = 0
+
+
+def encode_record(record: RunLogRecord) -> bytes:
+    """Serialise one record to its on-disk bytes.
+
+    Args:
+        record: The record to encode.
+
+    Returns:
+        The header line, a newline, the UTF-8 content, and a terminating
+        newline. ``bytes=`` counts the content only, never the terminator.
+    """
+    body = record.content.encode("utf-8")
+    header = (
+        f"{RECORD_ANCHOR} {record.number:06d}"
+        f" run={_sanitise(record.run_id)}"
+        f" kind={_sanitise(record.kind)}"
+        f" type={_sanitise(record.type)}"
+        f" tool={_sanitise(record.tool)}"
+        f" status={_sanitise(record.status)}"
+        f" call={_sanitise(record.call_id)}"
+        f" ts={_sanitise(record.ts)}"
+        f" bytes={len(body)}"
+    )
+    if record.truncated_from:
+        header += f" truncated={record.truncated_from}"
+    return header.encode("utf-8") + b"\n" + body + b"\n"
+
+
+def _parse_header(line: str) -> dict[str, str] | None:
+    parts = line.split(" ")
+    if len(parts) < 3 or parts[0] != RECORD_ANCHOR:
+        return None
+    fields: dict[str, str] = {"number": parts[1]}
+    for token in parts[2:]:
+        key, _, value = token.partition("=")
+        if value:
+            fields[key] = value
+    return fields
+
+
+def iter_records(data: bytes) -> Iterator[RunLogRecord]:
+    """Parse every COMPLETE record in ``data``, in file order.
+
+    A trailing record whose declared content (plus its terminating newline)
+    is not fully present is skipped: the agent searches its own log while
+    the writer is still appending to it, so a half-written tail is normal
+    rather than corruption.
+
+    Args:
+        data: Raw bytes of one log segment.
+
+    Yields:
+        Each fully-present ``RunLogRecord``.
+    """
+    position = 0
+    length = len(data)
+    while position < length:
+        if not data.startswith(_ANCHOR_BYTES, position):
+            # Not at a record boundary; find the next anchor at a line start.
+            nxt = data.find(b"\n" + _ANCHOR_BYTES, position)
+            if nxt == -1:
+                return
+            position = nxt + 1
+            continue
+        newline = data.find(b"\n", position)
+        if newline == -1:
+            return
+        fields = _parse_header(data[position:newline].decode("utf-8", "replace"))
+        if fields is None:
+            return
+        try:
+            size = int(fields.get("bytes", "0"))
+            number = int(fields["number"])
+        except (KeyError, ValueError):
+            return
+        start = newline + 1
+        end = start + size
+        # end + 1 covers the terminating newline: only fully-terminated
+        # records are yielded, so a record still being written is skipped.
+        if size < 0 or end + 1 > length:
+            return
+        yield RunLogRecord(
+            number=number,
+            run_id=fields.get("run", _PLACEHOLDER),
+            kind=fields.get("kind", _PLACEHOLDER),
+            type=fields.get("type", _PLACEHOLDER),
+            ts=fields.get("ts", _PLACEHOLDER),
+            content=data[start:end].decode("utf-8", "replace"),
+            tool=fields.get("tool", _PLACEHOLDER),
+            status=fields.get("status", _PLACEHOLDER),
+            call_id=fields.get("call", _PLACEHOLDER),
+            truncated_from=int(fields.get("truncated", "0") or 0),
+        )
+        position = end + 1
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest Tests/Agents/test_run_log_format.py -v`
+Expected: PASS (8 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Agents/run_log_format.py Tests/Agents/test_run_log_format.py
+git commit -m "feat(agents): byte-exact record codec for the agent run log"
+```
+
+---
+
+### Task 2: RunLogWriter
+
+Path resolution, two-phase binding, segmentation, durability, config.
+
+**Files:**
+- Create: `tldw_chatbook/Agents/run_log.py`
+- Test: `Tests/Agents/test_run_log_writer.py`
+
+**Interfaces:**
+- Consumes: `RunLogRecord`, `encode_record` from Task 1.
+- Produces:
+  - `class RunLogWriter(*, dir_name=None, segment_bytes=None, max_record_bytes=None)` — `None` resolves from `[agents]` config
+  - `RunLogWriter.bind(run_id: str) -> None` — idempotent; creates the directory
+  - `RunLogWriter.append(*, run_id: str, kind: str, type: str, content: str, tool: str = "", status: str = "", call_id: str = "") -> int | None` — returns the assigned record number, or `None` when inactive/failed
+  - `RunLogWriter.write_manifest(metadata: dict) -> None` — never raises
+  - `RunLogWriter.close() -> None` — final fsync; idempotent
+  - `RunLogWriter.is_active -> bool`, `RunLogWriter.log_dir -> Path | None`
+  - `resolve_log_root() -> Path | None`
+  - `_setting(key: str, default)` — `[agents]` config accessor and test seam
+  - Config keys (spec §8): `run_log_enabled` (default `True`), `run_log_dir_name` (`agent-runs`), `run_log_segment_bytes` (`4_000_000`), `run_log_max_record_bytes` (`1_000_000`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/Agents/test_run_log_writer.py`:
+
+```python
+# Tests/Agents/test_run_log_writer.py
+"""Writer: binding, segmentation, durability, degradation."""
+
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Agents import run_log as run_log_module
+from tldw_chatbook.Agents.run_log import RunLogWriter
+from tldw_chatbook.Agents.run_log_format import iter_records
+
+
+@pytest.fixture
+def root(tmp_path, monkeypatch):
+    """Pin the writer's resolved root to a temp dir."""
+    monkeypatch.setattr(run_log_module, "resolve_log_root", lambda: tmp_path)
+    return tmp_path
+
+
+def make(root_dir, **kw):
+    writer = RunLogWriter(**kw)
+    writer.bind("run-abc")
+    return writer
+
+
+def test_unbound_writer_writes_nothing(root):
+    writer = RunLogWriter()
+    assert writer.append(run_id="r", kind="primary", type="model", content="x") is None
+    assert list(root.iterdir()) == []
+
+
+def test_bind_creates_the_run_directory_and_gitignore(root):
+    make(root)
+    assert (root / "agent-runs" / "run-abc").is_dir()
+    assert (root / "agent-runs" / ".gitignore").read_text() == "*\n"
+
+
+def test_existing_gitignore_is_never_overwritten(root):
+    (root / "agent-runs").mkdir()
+    (root / "agent-runs" / ".gitignore").write_text("keep me\n")
+    make(root)
+    assert (root / "agent-runs" / ".gitignore").read_text() == "keep me\n"
+
+
+def test_records_are_numbered_monotonically_from_one(root):
+    writer = make(root)
+    numbers = [
+        writer.append(run_id="r", kind="primary", type="model", content=str(i))
+        for i in range(3)
+    ]
+    assert numbers == [1, 2, 3]
+
+
+def test_a_child_run_shares_the_parent_counter(root):
+    writer = make(root)
+    writer.append(run_id="parent", kind="primary", type="model", content="a")
+    writer.append(run_id="child", kind="subagent", type="model", content="b")
+    data = (root / "agent-runs" / "run-abc" / "logs.0001.txt").read_bytes()
+    parsed = list(iter_records(data))
+    assert [(p.number, p.run_id) for p in parsed] == [(1, "parent"), (2, "child")]
+
+
+def test_second_bind_is_ignored(root):
+    writer = make(root)
+    writer.bind("run-other")
+    assert writer.log_dir.name == "run-abc"
+
+
+def test_segment_rolls_and_no_record_spans_a_boundary(root):
+    writer = make(root, segment_bytes=400)
+    for _ in range(6):
+        writer.append(run_id="r", kind="primary", type="model", content="x" * 100)
+    run_dir = root / "agent-runs" / "run-abc"
+    segments = sorted(run_dir.glob("logs.*.txt"))
+    assert len(segments) > 1
+    # Every segment parses standalone: no record straddles a boundary.
+    total = 0
+    for segment in segments:
+        parsed = list(iter_records(segment.read_bytes()))
+        assert parsed, f"{segment.name} parsed to nothing"
+        total += len(parsed)
+    assert total == 6
+
+
+def test_oversized_record_is_capped_and_marked(root):
+    writer = make(root, max_record_bytes=50)
+    writer.append(run_id="r", kind="primary", type="tool_result", content="y" * 500)
+    data = (root / "agent-runs" / "run-abc" / "logs.0001.txt").read_bytes()
+    (parsed,) = list(iter_records(data))
+    assert len(parsed.content.encode()) <= 50
+    assert parsed.truncated_from == 500
+
+
+def test_unresolvable_root_deactivates_the_writer(monkeypatch):
+    monkeypatch.setattr(run_log_module, "resolve_log_root", lambda: None)
+    writer = RunLogWriter()
+    writer.bind("run-abc")
+    assert writer.is_active is False
+    assert writer.append(run_id="r", kind="primary", type="model", content="x") is None
+
+
+def test_write_failure_deactivates_rather_than_raising(root, monkeypatch):
+    writer = make(root)
+    assert writer.append(run_id="r", kind="primary", type="model", content="a") == 1
+
+    def boom(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(writer, "_write_bytes", boom)
+    assert writer.append(run_id="r", kind="primary", type="model", content="b") is None
+    assert writer.is_active is False
+
+
+def test_config_can_disable_logging_entirely(root, monkeypatch):
+    monkeypatch.setattr(
+        run_log_module, "_setting", lambda key, default: False if key == "run_log_enabled" else default
+    )
+    writer = RunLogWriter()
+    writer.bind("run-abc")
+    assert writer.is_active is False
+    assert not (root / "agent-runs").exists()
+
+
+def test_config_overrides_the_directory_name(root, monkeypatch):
+    monkeypatch.setattr(
+        run_log_module,
+        "_setting",
+        lambda key, default: "my-logs" if key == "run_log_dir_name" else default,
+    )
+    writer = RunLogWriter()
+    writer.bind("run-abc")
+    assert (root / "my-logs" / "run-abc").is_dir()
+
+
+def test_write_manifest_emits_readable_json(root):
+    writer = make(root)
+    writer.write_manifest({"run_id": "run-abc", "status": "done"})
+    import json
+
+    manifest = json.loads((root / "agent-runs" / "run-abc" / "MANIFEST").read_text())
+    assert manifest["status"] == "done"
+    assert manifest["segments"] == []  # nothing appended yet
+
+
+def test_manifest_records_segments_after_appends(root):
+    writer = make(root, segment_bytes=400)
+    for _ in range(6):
+        writer.append(run_id="r", kind="primary", type="model", content="x" * 100)
+    writer.write_manifest({"status": "done"})
+    import json
+
+    manifest = json.loads((root / "agent-runs" / "run-abc" / "MANIFEST").read_text())
+    assert len(manifest["segments"]) > 1
+    assert manifest["record_count"] == 6
+
+
+def test_manifest_failure_never_raises(root, monkeypatch):
+    writer = make(root)
+    monkeypatch.setattr(writer, "_write_bytes", lambda *a, **k: (_ for _ in ()).throw(OSError))
+    writer.write_manifest({"status": "done"})  # must not raise
+
+
+def test_close_is_safe_to_call_twice_and_on_an_inactive_writer(root):
+    writer = make(root)
+    writer.close()
+    writer.close()
+    RunLogWriter().close()
+
+
+def test_concurrent_appends_produce_unique_numbers_and_no_corruption(root):
+    import threading
+
+    writer = make(root)
+
+    def worker(index):
+        for _ in range(20):
+            writer.append(
+                run_id=f"r{index}", kind="primary", type="model", content=f"payload-{index}"
+            )
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    records = []
+    for segment in sorted((root / "agent-runs" / "run-abc").glob("logs.*.txt")):
+        records.extend(iter_records(segment.read_bytes()))
+    numbers = sorted(r.number for r in records)
+    assert numbers == list(range(1, 81))
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest Tests/Agents/test_run_log_writer.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'tldw_chatbook.Agents.run_log'`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `tldw_chatbook/Agents/run_log.py`:
+
+```python
+# tldw_chatbook/Agents/run_log.py
+"""Segmented, append-only run log writer.
+
+Impure by design (filesystem + config). Path resolution reuses the file
+tools' own chain -- ``allowed_file_roots`` -> ``is_within`` ->
+``is_sensitive_path`` -- so this writer can never become a path-validation
+bypass. See the design spec §3.3, §7, §8, §9.2.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+from loguru import logger
+
+from .run_log_format import RunLogRecord, encode_record
+
+#: Directory created inside the resolved root. Deliberately UNDOTTED: a
+#: dotted directory is excluded by `_is_hidden_within`, which would hide
+#: the log from the very tools meant to read it.
+DEFAULT_DIR_NAME = "agent-runs"
+DEFAULT_SEGMENT_BYTES = 4_000_000
+DEFAULT_MAX_RECORD_BYTES = 1_000_000
+MANIFEST_NAME = "MANIFEST"
+
+
+def _setting(key: str, default):
+    """Read one ``[agents]`` config key. Test seam: monkeypatched wholesale.
+
+    Args:
+        key: Key name within the ``[agents]`` section.
+        default: Value returned when unset or unreadable.
+
+    Returns:
+        The configured value, or ``default``.
+    """
+    try:
+        from tldw_chatbook.config import get_cli_setting
+
+        value = get_cli_setting("agents", key, default)
+    except Exception:
+        return default
+    return default if value is None else value
+
+
+def resolve_log_root() -> Path | None:
+    """Return the directory the log tree is created under, or ``None``.
+
+    Prefers the run's first read-write workspace folder root so the log is
+    a user-visible artifact; falls back to the tool sandbox root when no
+    such folder is bound. Any failure resolves to ``None`` (logging off)
+    rather than to a wider or unvalidated location.
+
+    Returns:
+        The chosen root directory, or ``None`` when none is usable.
+    """
+    try:
+        from tldw_chatbook.Tools.file_operation_tools import _tool_sandbox_root
+        from tldw_chatbook.Tools.workspace_file_roots import allowed_file_roots
+
+        sandbox = _tool_sandbox_root()
+        roots = allowed_file_roots(write=True, sandbox_root=sandbox)
+    except Exception:
+        logger.opt(exception=True).warning("run log: cannot resolve any root")
+        return None
+    if not roots:
+        return None
+    # allowed_file_roots returns (sandbox, *workspace_folders); prefer a
+    # bound workspace folder, fall back to the sandbox.
+    for candidate in roots[1:]:
+        return candidate
+    return roots[0]
+
+
+class RunLogWriter:
+    """Appends records for ONE run tree to a segmented log.
+
+    Constructed unbound (the run id does not exist until ``_run_one`` calls
+    ``create_run``), then bound once by the primary run. Child runs share
+    the instance, and therefore the record counter, so parent and child
+    record numbers can never collide.
+    """
+
+    def __init__(
+        self,
+        *,
+        dir_name: str | None = None,
+        segment_bytes: int | None = None,
+        max_record_bytes: int | None = None,
+    ) -> None:
+        """Build an UNBOUND writer. Explicit args override ``[agents]`` config.
+
+        Args:
+            dir_name: Directory name; defaults to ``[agents] run_log_dir_name``.
+            segment_bytes: Roll threshold; defaults to
+                ``[agents] run_log_segment_bytes``.
+            max_record_bytes: Per-record ceiling; defaults to
+                ``[agents] run_log_max_record_bytes``.
+        """
+        self._dir_name = dir_name or str(_setting("run_log_dir_name", DEFAULT_DIR_NAME))
+        self._segment_bytes = int(
+            segment_bytes
+            if segment_bytes is not None
+            else _setting("run_log_segment_bytes", DEFAULT_SEGMENT_BYTES)
+        )
+        self._max_record_bytes = int(
+            max_record_bytes
+            if max_record_bytes is not None
+            else _setting("run_log_max_record_bytes", DEFAULT_MAX_RECORD_BYTES)
+        )
+        self._lock = threading.Lock()
+        self._counter = 0
+        self._segment_index = 1
+        self._segment_size = 0
+        self._active = False
+        self.log_dir: Path | None = None
+
+    @property
+    def is_active(self) -> bool:
+        """Whether records are currently being written."""
+        return self._active
+
+    def bind(self, run_id: str) -> None:
+        """Bind to ``run_id`` and create its directory. Idempotent.
+
+        Args:
+            run_id: The PRIMARY run's id. Later calls are ignored so a
+                child run never rebinds its parent's writer.
+        """
+        if self.log_dir is not None:
+            return
+        if not _setting("run_log_enabled", True):
+            self._active = False
+            return
+        root = resolve_log_root()
+        if root is None:
+            self._active = False
+            return
+        try:
+            base = root / self._dir_name
+            base.mkdir(parents=True, exist_ok=True)
+            gitignore = base / ".gitignore"
+            if not gitignore.exists():
+                # Created only if absent: writing into a user's repository
+                # is itself a mutation.
+                gitignore.write_text("*\n", encoding="utf-8")
+            run_dir = base / run_id
+            run_dir.mkdir(parents=True, exist_ok=True)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "run log: cannot create log directory; logging disabled"
+            )
+            self._active = False
+            return
+        self.log_dir = run_dir
+        self._active = True
+
+    def _segment_path(self) -> Path:
+        assert self.log_dir is not None
+        return self.log_dir / f"logs.{self._segment_index:04d}.txt"
+
+    def _write_bytes(self, path: Path, payload: bytes, *, sync: bool = False) -> None:
+        """Append ``payload`` to ``path``.
+
+        ``flush()`` on every record survives a process crash. ``fsync`` is
+        reserved for segment rolls and run end (``sync=True``): calling it
+        per record into a user's project directory is wasteful.
+
+        Args:
+            path: Target file, opened in append-binary mode.
+            payload: Bytes to append.
+            sync: Whether to force an ``fsync`` after flushing.
+        """
+        import os
+
+        with open(path, "ab") as handle:
+            handle.write(payload)
+            handle.flush()
+            if sync:
+                os.fsync(handle.fileno())
+
+    def append(
+        self,
+        *,
+        run_id: str,
+        kind: str,
+        type: str,
+        content: str,
+        tool: str = "",
+        status: str = "",
+        call_id: str = "",
+    ) -> int | None:
+        """Append one record and return its number.
+
+        Args:
+            run_id: Id of the run this record belongs to (parent or child).
+            kind: ``primary`` or ``subagent``.
+            type: ``model``, ``tool_call``, ``tool_result``, or ``spawn``.
+            content: Full, untruncated text.
+            tool: Tool name, when applicable.
+            status: ``ok`` / ``error``, when applicable.
+            call_id: Provider ``tool_call_id``, when applicable.
+
+        Returns:
+            The assigned record number, or ``None`` when the writer is
+            inactive or the write failed. Never raises.
+        """
+        if not self._active or self.log_dir is None:
+            return None
+        with self._lock:
+            truncated_from = 0
+            body = content.encode("utf-8")
+            if len(body) > self._max_record_bytes:
+                truncated_from = len(body)
+                # Cut on a character boundary, then re-encode.
+                body = body[: self._max_record_bytes]
+                content = body.decode("utf-8", "ignore")
+            self._counter += 1
+            record = RunLogRecord(
+                number=self._counter,
+                run_id=run_id,
+                kind=kind,
+                type=type,
+                ts=_now_iso(),
+                content=content,
+                tool=tool,
+                status=status,
+                call_id=call_id,
+                truncated_from=truncated_from,
+            )
+            payload = encode_record(record)
+            # Roll BEFORE writing: a record must never span segments, or
+            # bytes=-exact parsing (which assumes one file) breaks.
+            if self._segment_size and self._segment_size + len(payload) > (
+                self._segment_bytes
+            ):
+                try:
+                    # fsync the segment being retired; it will not be
+                    # appended to again.
+                    self._write_bytes(self._segment_path(), b"", sync=True)
+                except Exception:  # noqa: BLE001 — durability is best-effort
+                    logger.opt(exception=True).warning("run log: segment fsync failed")
+                self._segment_index += 1
+                self._segment_size = 0
+            try:
+                self._write_bytes(self._segment_path(), payload)
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "run log: append failed; logging disabled for this run"
+                )
+                self._active = False
+                return None
+            self._segment_size += len(payload)
+            return record.number
+
+    def write_manifest(self, metadata: dict) -> None:
+        """Write run-level convenience metadata. Never raises.
+
+        The manifest is deliberately NOT load-bearing: segment discovery is
+        glob + sort (``run_log_search.load_records``), so a crashed run that
+        never reaches this call is still fully readable.
+
+        Args:
+            metadata: Run-level fields (model, budget, status, supersession).
+        """
+        if self.log_dir is None:
+            return
+        import json
+
+        payload = dict(metadata)
+        try:
+            payload["segments"] = [p.name for p in sorted(self.log_dir.glob("logs.*.txt"))]
+            payload["record_count"] = self._counter
+            self._write_bytes(
+                self.log_dir / MANIFEST_NAME,
+                json.dumps(payload, indent=2, default=str).encode("utf-8"),
+                sync=True,
+            )
+        except Exception:  # noqa: BLE001 — convenience metadata only
+            logger.opt(exception=True).warning("run log: manifest write failed")
+
+    def close(self) -> None:
+        """Flush the final segment to disk. Idempotent and always safe."""
+        if not self._active or self.log_dir is None:
+            return
+        try:
+            self._write_bytes(self._segment_path(), b"", sync=True)
+        except Exception:  # noqa: BLE001 — best-effort durability
+            logger.opt(exception=True).warning("run log: final fsync failed")
+
+
+def _now_iso() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest Tests/Agents/test_run_log_writer.py -v`
+Expected: PASS (17 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Agents/run_log.py Tests/Agents/test_run_log_writer.py
+git commit -m "feat(agents): segmented run-log writer with two-phase binding"
+```
+
+---
+
+### Task 3: `on_record` hook in the pure loop
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/agent_runtime.py` (`LoopDeps`, ~line 256; model turn site ~line 424; content assembly ~line 642)
+- Test: `Tests/Agents/test_run_log_on_record.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks (the hook is a bare callable).
+- Produces: `LoopDeps.on_record: Callable[[str, dict], None] | None = None`, called as `on_record(record_type, payload)` where `record_type` is `"model"`, `"tool_call"`, or `"tool_result"`, and `payload` carries `content`, `tool`, `status`, `call_id`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/Agents/test_run_log_on_record.py`:
+
+```python
+# Tests/Agents/test_run_log_on_record.py
+"""on_record captures FULL fidelity at both loop call sites."""
+
+from tldw_chatbook.Agents.agent_models import (
+    AgentConfig,
+    ModelTurn,
+    RunBudget,
+    ToolCall,
+    ToolResult,
+)
+from tldw_chatbook.Agents.agent_runtime import LoopDeps, run_agent_loop
+
+from Tests.Agents.test_agent_runtime import make_deps
+
+
+def collect():
+    seen = []
+    return seen, lambda kind, payload: seen.append((kind, payload))
+
+
+def run(turns, *, invoke=None, budget=None):
+    seen, hook = collect()
+    deps = make_deps(turns, invoke=invoke)
+    deps.on_record = hook
+    config = AgentConfig(
+        model="m",
+        system_prompt="s",
+        allowed_tools=("calculator",),
+        budget=budget or RunBudget(max_steps=8, max_model_turns=8),
+    )
+    outcome = run_agent_loop(config, [{"role": "user", "content": "go"}], [], deps)
+    return seen, outcome
+
+
+def test_model_record_carries_full_text_not_the_200_char_summary():
+    long_text = "z" * 5000
+    seen, _ = run([ModelTurn(text=long_text)])
+    model_records = [p for kind, p in seen if kind == "model"]
+    assert model_records and model_records[0]["content"] == long_text
+
+
+def test_tool_result_record_carries_content_before_truncation():
+    big = "q" * 40_000
+    turns = [
+        ModelTurn(
+            text="",
+            tool_calls=(ToolCall(name="calculator", args={}, call_id="c1"),),
+            assistant_message={"role": "assistant", "content": ""},
+        ),
+        ModelTurn(text="done"),
+    ]
+    seen, _ = run(
+        turns,
+        invoke=lambda c: ToolResult(ok=True, content=big),
+        budget=RunBudget(max_steps=8, max_model_turns=8, max_tool_result_chars=100),
+    )
+    results = [p for kind, p in seen if kind == "tool_result"]
+    assert results and results[0]["content"] == big
+    assert results[0]["call_id"] == "c1"
+
+
+def test_tool_call_record_carries_full_args():
+    turns = [
+        ModelTurn(
+            text="",
+            tool_calls=(
+                ToolCall(name="calculator", args={"expr": "1+1"}, call_id="c1"),
+            ),
+            assistant_message={"role": "assistant", "content": ""},
+        ),
+        ModelTurn(text="done"),
+    ]
+    seen, _ = run(turns)
+    calls = [p for kind, p in seen if kind == "tool_call"]
+    assert calls and "1+1" in calls[0]["content"]
+
+
+def test_runtime_tool_results_are_captured_too():
+    # find_tools never reaches deps.invoke_tool -- a service-side wrapper
+    # would have missed it entirely.
+    turns = [
+        ModelTurn(
+            text="",
+            tool_calls=(ToolCall(name="find_tools", args={"query": "x"}, call_id="c1"),),
+            assistant_message={"role": "assistant", "content": ""},
+        ),
+        ModelTurn(text="done"),
+    ]
+    seen, _ = run(turns)
+    tools = [p["tool"] for kind, p in seen if kind == "tool_result"]
+    assert "find_tools" in tools
+
+
+def test_failing_hook_never_aborts_the_run():
+    def boom(kind, payload):
+        raise RuntimeError("log is on fire")
+
+    deps = make_deps([ModelTurn(text="fine")])
+    deps.on_record = boom
+    config = AgentConfig(model="m", system_prompt="s", budget=RunBudget())
+    outcome = run_agent_loop(config, [{"role": "user", "content": "go"}], [], deps)
+    assert outcome.final_text == "fine"
+
+
+def test_absent_hook_is_a_no_op():
+    deps = make_deps([ModelTurn(text="fine")])
+    config = AgentConfig(model="m", system_prompt="s", budget=RunBudget())
+    outcome = run_agent_loop(config, [{"role": "user", "content": "go"}], [], deps)
+    assert outcome.final_text == "fine"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest Tests/Agents/test_run_log_on_record.py -v`
+Expected: FAIL — `AttributeError` / `TypeError` on `deps.on_record`
+
+- [ ] **Step 3: Add the field and both call sites**
+
+In `tldw_chatbook/Agents/agent_runtime.py`, append to `LoopDeps` (after `run_skill_script`):
+
+```python
+    # on_record: full-fidelity capture for the run log (run_log.py). Called
+    # with (record_type, payload) at the two points where the COMPLETE value
+    # exists -- which the step log does not carry, since `add()` truncates
+    # model turns to 200 chars and tool results to 2000. Captured in the
+    # loop rather than in service wrappers because the loop assembles
+    # `content` for EVERY dispatch branch at one point: a wrapper around
+    # deps.invoke_tool would silently miss find_tools, load_tools,
+    # spawn_subagent, skill_file, install_skill and run_skill_script.
+    # `None` (the default) is a no-op: behavior is byte-identical to
+    # pre-run-log runs.
+    on_record: Callable[[str, dict], None] | None = None
+```
+
+Add a module-level helper beside `_catalog_lines`:
+
+```python
+def _emit_record(deps: "LoopDeps", record_type: str, **payload) -> int | None:
+    """Best-effort run-log capture; a failing writer never aborts a run.
+
+    Args:
+        deps: The run's injected dependencies.
+        record_type: ``model``, ``tool_call``, or ``tool_result``.
+        **payload: ``content``, ``tool``, ``status``, ``call_id``.
+
+    Returns:
+        The assigned record number, or ``None`` when logging is off or the
+        write failed. Task 7 threads this into the truncation trailer.
+    """
+    if deps.on_record is None:
+        return None
+    try:
+        return deps.on_record(record_type, payload)
+    except Exception:  # noqa: BLE001 — logging is never load-bearing
+        logger.opt(exception=True).warning(
+            f"on_record hook raised for a {record_type} record; continuing"
+        )
+        return None
+```
+
+At the model-turn site, immediately after `add(STEP_MODEL, summary=turn.text[:200])`:
+
+```python
+        _emit_record(
+            deps,
+            "model",
+            content=turn.text,
+            tool="",
+            status="",
+            call_id="",
+        )
+```
+
+At the dispatch site, replace:
+
+```python
+                content = result.content if result.ok else f"ERROR: {result.error}"
+```
+
+with:
+
+```python
+                content = result.content if result.ok else f"ERROR: {result.error}"
+
+            # Capture BEFORE _truncate_tool_result below: the log is the
+            # lossless record, history is the capped view of it. This single
+            # point covers every dispatch branch above -- builtin, MCP,
+            # skill, runtime tools -- and the review-hook refusal path.
+            _emit_record(
+                deps,
+                "tool_call",
+                content=json.dumps(call.args, sort_keys=True, default=str),
+                tool=call.name,
+                status="",
+                call_id=call.call_id,
+            )
+            _emit_record(
+                deps,
+                "tool_result",
+                content=content,
+                tool=call.name,
+                status="ok" if verdict == "proceed" else "refused",
+                call_id=call.call_id,
+            )
+```
+
+Note the dedent: both `_emit_record` calls sit at the `for call in calls:` body level, so they run for the refusal path too (where `content` is the verdict string).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest Tests/Agents/test_run_log_on_record.py Tests/Agents/test_agent_runtime.py -v`
+Expected: PASS — new tests pass and every existing runtime test still passes (the hook defaults to `None`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Agents/agent_runtime.py Tests/Agents/test_run_log_on_record.py
+git commit -m "feat(agents): on_record capture hook at the loop's full-fidelity points"
+```
+
+---
+
+### Task 4: Wire the writer into AgentService
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/agent_service.py` (`__init__`, `run_turn` ~line 766, `_run_one` ~line 423, `LoopDeps(...)` construction)
+- Test: `Tests/Agents/test_run_log_service_wiring.py`
+
+**Interfaces:**
+- Consumes: `RunLogWriter` (Task 2), `LoopDeps.on_record` (Task 3).
+- Produces: `AgentService(run_log_writer: RunLogWriter | None = None)`; `AgentService.run_log_writer` attribute readable by Task 6.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/Agents/test_run_log_service_wiring.py`:
+
+```python
+# Tests/Agents/test_run_log_service_wiring.py
+"""The service owns the writer: one counter per run tree, every caller logged."""
+
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Agents import run_log as run_log_module
+from tldw_chatbook.Agents.agent_models import AgentConfig, RunBudget
+from tldw_chatbook.Agents.agent_service import AgentService
+from tldw_chatbook.Agents.run_log import RunLogWriter
+from tldw_chatbook.Agents.run_log_format import iter_records
+from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider, ToolCatalogRegistry
+from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+
+@pytest.fixture
+def wired(tmp_path, monkeypatch):
+    monkeypatch.setattr(run_log_module, "resolve_log_root", lambda: tmp_path)
+    db = AgentRunsDB(tmp_path / "runs.db")
+    registry = ToolCatalogRegistry()
+    registry.register_provider(BuiltinToolProvider())
+    return db, registry, tmp_path
+
+
+def chat_call_returning(text):
+    def call(**kwargs):
+        return {"choices": [{"message": {"content": text}}]}
+
+    return call
+
+
+def read_all(root: Path):
+    run_dirs = list((root / "agent-runs").iterdir())
+    run_dirs = [d for d in run_dirs if d.is_dir()]
+    assert len(run_dirs) == 1
+    records = []
+    for segment in sorted(run_dirs[0].glob("logs.*.txt")):
+        records.extend(iter_records(segment.read_bytes()))
+    return records
+
+
+def test_a_plain_run_writes_records_without_the_caller_wiring_anything(wired):
+    db, registry, root = wired
+    service = AgentService(db, registry, chat_call=chat_call_returning("hello"))
+    service.run_turn(
+        conversation_id="conv1",
+        messages=[{"role": "user", "content": "hi"}],
+        config=AgentConfig(model="m", system_prompt="s", budget=RunBudget()),
+        api_endpoint="openai",
+    )
+    records = read_all(root)
+    assert [r.type for r in records] == ["model"]
+    assert records[0].content == "hello"
+    assert records[0].kind == "primary"
+
+
+def test_record_numbers_are_unique_across_the_whole_run_tree(wired):
+    db, registry, root = wired
+    writer = RunLogWriter()
+    service = AgentService(
+        db, registry, chat_call=chat_call_returning("x"), run_log_writer=writer
+    )
+    service.run_turn(
+        conversation_id="conv1",
+        messages=[{"role": "user", "content": "hi"}],
+        config=AgentConfig(model="m", system_prompt="s", budget=RunBudget()),
+        api_endpoint="openai",
+    )
+    # Simulate a child appending through the same shared writer.
+    writer.append(run_id="child", kind="subagent", type="model", content="child work")
+    numbers = [r.number for r in read_all(root)]
+    assert numbers == sorted(set(numbers))
+
+
+def test_disabled_writer_leaves_the_run_untouched(wired, monkeypatch):
+    db, registry, root = wired
+    monkeypatch.setattr(run_log_module, "resolve_log_root", lambda: None)
+    service = AgentService(db, registry, chat_call=chat_call_returning("hello"))
+    _run_id, outcome = service.run_turn(
+        conversation_id="conv1",
+        messages=[{"role": "user", "content": "hi"}],
+        config=AgentConfig(model="m", system_prompt="s", budget=RunBudget()),
+        api_endpoint="openai",
+    )
+    assert outcome.final_text == "hello"
+    assert not (root / "agent-runs").exists()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest Tests/Agents/test_run_log_service_wiring.py -v`
+Expected: FAIL — `TypeError: AgentService.__init__() got an unexpected keyword argument 'run_log_writer'`
+
+- [ ] **Step 3: Wire it**
+
+In `agent_service.py` `__init__`, add the parameter and store it:
+
+```python
+        run_log_writer: "RunLogWriter | None" = None,
+```
+```python
+        # Constructed here (or by the caller) so EVERY caller gets a log --
+        # on_step is passed in by the Console bridge, so anything riding
+        # that hook would silently log nothing for other callers.
+        from .run_log import RunLogWriter as _RunLogWriter
+
+        self.run_log_writer = run_log_writer or _RunLogWriter()
+```
+
+In `_run_one`, immediately after `run_id = self.db.create_run(...)`:
+
+```python
+        # Two-phase: the writer was constructed before any run id existed.
+        # Only the PRIMARY run binds; a child finds it already bound.
+        if agent_kind == AGENT_KIND_PRIMARY:
+            self.run_log_writer.bind(run_id)
+```
+
+Define the per-run adapter beside the other closures in `_run_one`:
+
+```python
+        def on_record(record_type: str, payload: dict) -> int | None:
+            # MUST return the record number: Task 7 threads it into the
+            # truncation trailer so a cut result points at its full copy.
+            return self.run_log_writer.append(
+                run_id=run_id,
+                kind=agent_kind,
+                type=record_type,
+                content=str(payload.get("content", "")),
+                tool=str(payload.get("tool", "")),
+                status=str(payload.get("status", "")),
+                call_id=str(payload.get("call_id", "")),
+            )
+```
+
+Write the manifest once the run tree finishes, at the end of `run_turn` (it
+needs run-level metadata the writer does not have, including supersession):
+
+```python
+        self.run_log_writer.write_manifest(
+            {
+                "run_id": run_id,
+                "model": config.model,
+                "api_endpoint": api_endpoint,
+                "allowed_tools": list(config.allowed_tools),
+                "budget": dataclasses.asdict(config.budget),
+                "status": outcome.status,
+                "superseded_run_id": supersede_run_id or "",
+                "total_tokens": outcome.total_tokens,
+            }
+        )
+        self.run_log_writer.close()
+```
+
+And pass it in the `LoopDeps(...)` construction:
+
+```python
+            on_record=on_record,
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest Tests/Agents/test_run_log_service_wiring.py Tests/Agents/test_agent_service.py -v`
+Expected: PASS — new tests plus the existing service suite.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Agents/agent_service.py Tests/Agents/test_run_log_service_wiring.py
+git commit -m "feat(agents): own the run-log writer in AgentService"
+```
+
+---
+
+### Task 5: Log search (pure)
+
+**Files:**
+- Create: `tldw_chatbook/Agents/run_log_search.py`
+- Test: `Tests/Agents/test_run_log_search.py`
+
+**Interfaces:**
+- Consumes: `RunLogRecord`, `iter_records` (Task 1).
+- Produces:
+  - `search_records(records: list[RunLogRecord], *, contains: str = "", pattern: str = "", tool: str = "", type: str = "", status: str = "", kind: str = "", from_record: int = 0, to_record: int = 0, context: int = 0, limit: int = 50) -> list[RunLogRecord]`
+  - `load_records(log_dir: Path) -> list[RunLogRecord]`
+  - `format_results(records: list[RunLogRecord], *, max_chars: int = 400) -> str`
+  - `MAX_REGEX_SCAN_CHARS: int = 500`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/Agents/test_run_log_search.py`:
+
+```python
+# Tests/Agents/test_run_log_search.py
+"""Search: literal by default, structured filters, bounded regex."""
+
+from tldw_chatbook.Agents.run_log_format import RunLogRecord
+from tldw_chatbook.Agents.run_log_search import (
+    MAX_REGEX_SCAN_CHARS,
+    format_results,
+    search_records,
+)
+
+
+def rec(number, content, **kw):
+    base = dict(
+        number=number,
+        run_id="r",
+        kind="primary",
+        type="tool_result",
+        ts="t",
+        content=content,
+    )
+    base.update(kw)
+    return RunLogRecord(**base)
+
+
+CORPUS = [
+    rec(1, "opened the config file", tool="read_file", status="ok"),
+    rec(2, "connection refused", tool="web_search", status="error"),
+    rec(3, "thinking about it", type="model"),
+    rec(4, "wrote the config file", tool="write_file", status="ok"),
+]
+
+
+def test_literal_contains_is_the_default_and_is_not_a_regex():
+    assert [r.number for r in search_records(CORPUS, contains="config file")] == [1, 4]
+    # A regex metacharacter is matched literally, never compiled.
+    assert search_records(CORPUS, contains="config.file") == []
+
+
+def test_literal_search_is_unbounded_by_line_length():
+    long_record = [rec(9, "x" * 5000 + "NEEDLE")]
+    assert len(search_records(long_record, contains="NEEDLE")) == 1
+
+
+def test_structured_filters_compose():
+    hits = search_records(CORPUS, status="error")
+    assert [r.number for r in hits] == [2]
+    assert [r.number for r in search_records(CORPUS, type="model")] == [3]
+    assert [r.number for r in search_records(CORPUS, tool="write_file")] == [4]
+
+
+def test_record_range_slices():
+    assert [r.number for r in search_records(CORPUS, from_record=3)] == [3, 4]
+    assert [r.number for r in search_records(CORPUS, to_record=2)] == [1, 2]
+
+
+def test_context_returns_neighbours_in_order_without_duplicates():
+    hits = search_records(CORPUS, contains="refused", context=1)
+    assert [r.number for r in hits] == [1, 2, 3]
+
+
+def test_regex_mode_is_opt_in_and_scan_bounded():
+    assert [r.number for r in search_records(CORPUS, pattern=r"conn\w+")] == [2]
+    # Beyond the scan window the pattern cannot match, by design.
+    far = [rec(9, "y" * (MAX_REGEX_SCAN_CHARS + 50) + "NEEDLE")]
+    assert search_records(far, pattern="NEEDLE") == []
+    assert len(search_records(far, contains="NEEDLE")) == 1
+
+
+def test_invalid_regex_returns_no_hits_rather_than_raising():
+    assert search_records(CORPUS, pattern="(unclosed") == []
+
+
+def test_limit_caps_results():
+    assert len(search_records(CORPUS, limit=2)) == 2
+
+
+def test_format_results_is_readable_and_truncates_long_content():
+    text = format_results([rec(7, "z" * 900, tool="read_file")], max_chars=50)
+    assert "record 000007" in text
+    assert "read_file" in text
+    assert len(text) < 300
+
+
+def test_format_results_reports_no_matches():
+    assert "no matching records" in format_results([]).lower()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest Tests/Agents/test_run_log_search.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'tldw_chatbook.Agents.run_log_search'`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `tldw_chatbook/Agents/run_log_search.py`:
+
+```python
+# tldw_chatbook/Agents/run_log_search.py
+"""Query the run log: literal by default, structured filters, bounded regex.
+
+Pure module. Literal substring search is the DEFAULT and carries no
+line-length cap: `str.__contains__` is linear and cannot backtrack. Regex
+is opt-in and scan-bounded, because Python's `re` has no match timeout and
+`agent_service._call_with_timeout` abandons rather than kills its worker
+thread -- the same reasoning behind `grep_files`' own 500-char window.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .run_log_format import RunLogRecord, iter_records
+
+#: Per-record scan window for opt-in regex mode; mirrors
+#: `file_operation_tools._MAX_GREP_LINE_SEARCH_CHARS`.
+MAX_REGEX_SCAN_CHARS = 500
+
+
+def load_records(log_dir: Path) -> list[RunLogRecord]:
+    """Load every complete record from every segment, in order.
+
+    Segment discovery is glob + sort, never the MANIFEST: a crashed run
+    writes no manifest, and those are exactly the runs worth inspecting.
+
+    Args:
+        log_dir: The run's log directory.
+
+    Returns:
+        All records in record-number order; empty when unreadable.
+    """
+    records: list[RunLogRecord] = []
+    try:
+        for segment in sorted(log_dir.glob("logs.*.txt")):
+            records.extend(iter_records(segment.read_bytes()))
+    except OSError:
+        return records
+    return sorted(records, key=lambda r: r.number)
+
+
+def search_records(
+    records: list[RunLogRecord],
+    *,
+    contains: str = "",
+    pattern: str = "",
+    tool: str = "",
+    type: str = "",
+    status: str = "",
+    kind: str = "",
+    from_record: int = 0,
+    to_record: int = 0,
+    context: int = 0,
+    limit: int = 50,
+) -> list[RunLogRecord]:
+    """Filter ``records``; return hits plus optional neighbouring context.
+
+    Args:
+        records: All loaded records, in order.
+        contains: Literal substring (case-insensitive). Never compiled.
+        pattern: Opt-in regex, searched only over the first
+            ``MAX_REGEX_SCAN_CHARS`` characters of each record.
+        tool: Exact tool-name filter.
+        type: Exact record-type filter.
+        status: Exact status filter.
+        kind: Exact agent-kind filter.
+        from_record: Inclusive lower bound on record number.
+        to_record: Inclusive upper bound on record number.
+        context: Include this many records either side of each hit.
+        limit: Maximum records returned.
+
+    Returns:
+        Matching records in record order, deduplicated, capped at ``limit``.
+    """
+    compiled = None
+    if pattern:
+        try:
+            compiled = re.compile(pattern, re.IGNORECASE)
+        except re.error:
+            return []
+    needle = contains.lower()
+    hit_indexes: list[int] = []
+    for index, record in enumerate(records):
+        if from_record and record.number < from_record:
+            continue
+        if to_record and record.number > to_record:
+            continue
+        if tool and record.tool != tool:
+            continue
+        if type and record.type != type:
+            continue
+        if status and record.status != status:
+            continue
+        if kind and record.kind != kind:
+            continue
+        if needle and needle not in record.content.lower():
+            continue
+        if compiled is not None and not compiled.search(
+            record.content[:MAX_REGEX_SCAN_CHARS]
+        ):
+            continue
+        hit_indexes.append(index)
+    selected: set[int] = set()
+    for index in hit_indexes:
+        low = max(0, index - context)
+        high = min(len(records) - 1, index + context)
+        selected.update(range(low, high + 1))
+    return [records[i] for i in sorted(selected)][:limit]
+
+
+def format_results(records: list[RunLogRecord], *, max_chars: int = 400) -> str:
+    """Render results for the model.
+
+    Args:
+        records: Records to render.
+        max_chars: Per-record content ceiling in the rendering.
+
+    Returns:
+        One block per record, or a plain no-matches line.
+    """
+    if not records:
+        return "No matching records."
+    blocks = []
+    for record in records:
+        body = record.content
+        if len(body) > max_chars:
+            body = body[:max_chars] + f"… (+{len(record.content) - max_chars} chars)"
+        blocks.append(
+            f"record {record.number:06d} [{record.type}"
+            f"{'/' + record.tool if record.tool and record.tool != '-' else ''}"
+            f"{'/' + record.status if record.status and record.status != '-' else ''}]"
+            f"\n{body}"
+        )
+    return "\n\n".join(blocks)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest Tests/Agents/test_run_log_search.py -v`
+Expected: PASS (10 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Agents/run_log_search.py Tests/Agents/test_run_log_search.py
+git commit -m "feat(agents): literal-first run-log search with bounded regex mode"
+```
+
+---
+
+### Task 6: `search_run_log` runtime tool
+
+Mirrors `install_skill` exactly: schema in `tool_catalog`, `LoopDeps` field, dispatch branch, `AGENT_KIND_PRIMARY`-gated wiring.
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/agent_models.py` (name constant + `RUNTIME_TOOL_NAMES`)
+- Modify: `tldw_chatbook/Agents/tool_catalog.py` (schema)
+- Modify: `tldw_chatbook/Agents/agent_runtime.py` (`LoopDeps` field + dispatch branch)
+- Modify: `tldw_chatbook/Agents/agent_service.py` (runtime_schemas gate + closure)
+- Test: `Tests/Agents/test_search_run_log_runtime_tool.py`
+
+**Interfaces:**
+- Consumes: `load_records`, `search_records`, `format_results` (Task 5); `AgentService.run_log_writer` (Task 4).
+- Produces: `SEARCH_RUN_LOG_TOOL_NAME = "search_run_log"`, `SEARCH_RUN_LOG_TOOL_SCHEMA`, `LoopDeps.search_run_log: Callable[[dict], ToolResult] | None`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/Agents/test_search_run_log_runtime_tool.py`:
+
+```python
+# Tests/Agents/test_search_run_log_runtime_tool.py
+"""search_run_log: primary-only, no catalog slot, dispatched by the loop."""
+
+import pytest
+
+from tldw_chatbook.Agents.agent_models import (
+    AGENT_KIND_PRIMARY,
+    AGENT_KIND_SUBAGENT,
+    RUNTIME_TOOL_NAMES,
+    SEARCH_RUN_LOG_TOOL_NAME,
+    AgentConfig,
+    ModelTurn,
+    RunBudget,
+    ToolCall,
+    ToolResult,
+)
+from tldw_chatbook.Agents.agent_runtime import run_agent_loop
+from tldw_chatbook.Agents.tool_catalog import SEARCH_RUN_LOG_TOOL_SCHEMA
+
+from Tests.Agents.test_agent_runtime import make_deps
+
+
+def test_name_is_registered_as_a_runtime_tool():
+    assert SEARCH_RUN_LOG_TOOL_NAME in RUNTIME_TOOL_NAMES
+    assert SEARCH_RUN_LOG_TOOL_SCHEMA.name == SEARCH_RUN_LOG_TOOL_NAME
+    props = SEARCH_RUN_LOG_TOOL_SCHEMA.parameters["properties"]
+    assert "contains" in props and "pattern" in props and "from_record" in props
+
+
+def test_loop_dispatches_to_the_injected_callable():
+    seen = {}
+
+    def handler(args):
+        seen.update(args)
+        return ToolResult(ok=True, content="record 000412 [model]")
+
+    turns = [
+        ModelTurn(
+            text="",
+            tool_calls=(
+                ToolCall(
+                    name=SEARCH_RUN_LOG_TOOL_NAME,
+                    args={"contains": "refused"},
+                    call_id="c1",
+                ),
+            ),
+            assistant_message={"role": "assistant", "content": ""},
+        ),
+        ModelTurn(text="answered"),
+    ]
+    deps = make_deps(turns)
+    deps.search_run_log = handler
+    config = AgentConfig(
+        model="m", system_prompt="s", budget=RunBudget(max_steps=8, max_model_turns=8)
+    )
+    outcome = run_agent_loop(config, [{"role": "user", "content": "go"}], [], deps)
+    assert seen == {"contains": "refused"}
+    assert outcome.final_text == "answered"
+
+
+def test_unwired_name_falls_through_to_the_permission_gate():
+    # deps.search_run_log is None -> the else branch -> deps.invoke_tool.
+    invoked = []
+
+    def invoke(call):
+        invoked.append(call.name)
+        return ToolResult(ok=False, error=f"Tool not permitted: {call.name}")
+
+    turns = [
+        ModelTurn(
+            text="",
+            tool_calls=(
+                ToolCall(name=SEARCH_RUN_LOG_TOOL_NAME, args={}, call_id="c1"),
+            ),
+            assistant_message={"role": "assistant", "content": ""},
+        ),
+        ModelTurn(text="done"),
+    ]
+    deps = make_deps(turns, invoke=invoke)
+    config = AgentConfig(
+        model="m", system_prompt="s", budget=RunBudget(max_steps=8, max_model_turns=8)
+    )
+    run_agent_loop(config, [{"role": "user", "content": "go"}], [], deps)
+    assert invoked == [SEARCH_RUN_LOG_TOOL_NAME]
+```
+
+Append to `Tests/Agents/test_run_log_service_wiring.py`:
+
+```python
+def test_tool_is_offered_to_the_primary_agent_only(wired, monkeypatch):
+    from tldw_chatbook.Agents.agent_models import SEARCH_RUN_LOG_TOOL_NAME
+
+    db, registry, root = wired
+    offered = []
+
+    def capture(**kwargs):
+        names = [t["function"]["name"] for t in kwargs.get("tools", [])]
+        offered.append(names)
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    service = AgentService(db, registry, chat_call=capture)
+    service.run_turn(
+        conversation_id="conv1",
+        messages=[{"role": "user", "content": "hi"}],
+        config=AgentConfig(
+            model="m",
+            system_prompt="s",
+            budget=RunBudget(max_subagents=0),
+        ),
+        api_endpoint="openai",
+    )
+    assert any(SEARCH_RUN_LOG_TOOL_NAME in names for names in offered)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest Tests/Agents/test_search_run_log_runtime_tool.py -v`
+Expected: FAIL — `ImportError: cannot import name 'SEARCH_RUN_LOG_TOOL_NAME'`
+
+- [ ] **Step 3: Implement across the four modules**
+
+In `agent_models.py`, beside the other runtime-tool names:
+
+```python
+SEARCH_RUN_LOG_TOOL_NAME = "search_run_log"
+```
+and add `SEARCH_RUN_LOG_TOOL_NAME` to the `RUNTIME_TOOL_NAMES` frozenset.
+
+In `tool_catalog.py`, beside `RUN_SKILL_SCRIPT_TOOL_SCHEMA`:
+
+```python
+SEARCH_RUN_LOG_TOOL_SCHEMA = ToolSchema(
+    id="runtime:search_run_log",
+    name=SEARCH_RUN_LOG_TOOL_NAME,
+    description=(
+        "Search this run's own complete log. Your context holds a truncated "
+        "view; the log holds every model turn, tool call, and tool result in "
+        "full. Use it to recover a truncated result or recall an earlier step "
+        "instead of re-running work. Prefer 'contains' (literal substring, "
+        "searches the whole record); 'pattern' is a regular expression and "
+        "only examines each record's first 500 characters."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "contains": {
+                "type": "string",
+                "description": "Literal substring to find (case-insensitive).",
+            },
+            "pattern": {
+                "type": "string",
+                "description": "Regular expression; first 500 chars per record.",
+            },
+            "tool": {"type": "string", "description": "Filter by tool name."},
+            "type": {
+                "type": "string",
+                "description": "Filter by record type: model, tool_call, tool_result.",
+            },
+            "status": {"type": "string", "description": "Filter: ok or error."},
+            "from_record": {"type": "integer", "description": "Lowest record number."},
+            "to_record": {"type": "integer", "description": "Highest record number."},
+            "context": {
+                "type": "integer",
+                "description": "Records to include either side of each hit.",
+            },
+        },
+        "required": [],
+    },
+)
+```
+
+In `agent_runtime.py`, add the `LoopDeps` field:
+
+```python
+    # search_run_log: the seventh runtime tool (run-log query). Wired ONLY
+    # for the top-level agent (agent_kind == primary), like install_skill:
+    # a depth-1 child has max_subagents clamped to 0, so its "subtree" is
+    # itself and its short history is already in its context -- the tool
+    # would buy it nothing while widening what it can see. `None` (the
+    # default) means the run is not wired for it and a call by that name
+    # falls through to the generic deps.invoke_tool path.
+    search_run_log: Callable[[dict], ToolResult] | None = None
+```
+
+and the dispatch branch, immediately before the final `else:`:
+
+```python
+                elif (
+                    call.name == SEARCH_RUN_LOG_TOOL_NAME
+                    and deps.search_run_log is not None
+                ):
+                    add(STEP_TOOL_CALL, tool_name=call.name, args=dict(call.args))
+                    result = deps.search_run_log(dict(call.args))
+```
+
+(import `SEARCH_RUN_LOG_TOOL_NAME` from `.agent_models` at the top.)
+
+In `agent_service.py` `_run_one`, gate the schema beside the `install_skill` gate:
+
+```python
+        if (
+            agent_kind == AGENT_KIND_PRIMARY
+            and self.run_log_writer.is_active
+        ):
+            runtime_schemas.append(SEARCH_RUN_LOG_TOOL_SCHEMA)
+```
+
+and define the closure:
+
+```python
+        def search_run_log(args: dict) -> ToolResult:
+            """Query THIS run's log. Reads only what this agent produced."""
+            from .run_log_search import format_results, load_records, search_records
+
+            log_dir = self.run_log_writer.log_dir
+            if log_dir is None:
+                return ToolResult(ok=False, error="No run log is available.")
+            try:
+                records = load_records(log_dir)
+                hits = search_records(
+                    records,
+                    contains=str(args.get("contains", "")),
+                    pattern=str(args.get("pattern", "")),
+                    tool=str(args.get("tool", "")),
+                    type=str(args.get("type", "")),
+                    status=str(args.get("status", "")),
+                    from_record=int(args.get("from_record") or 0),
+                    to_record=int(args.get("to_record") or 0),
+                    context=int(args.get("context") or 0),
+                )
+            except (TypeError, ValueError) as exc:
+                return ToolResult(ok=False, error=f"Invalid search arguments: {exc}")
+            return ToolResult(ok=True, content=format_results(hits))
+```
+
+Pass `search_run_log=search_run_log if agent_kind == AGENT_KIND_PRIMARY else None` in the `LoopDeps(...)` construction.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest Tests/Agents/test_search_run_log_runtime_tool.py Tests/Agents/test_run_log_service_wiring.py Tests/Agents/test_tool_catalog.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Agents/ Tests/Agents/
+git commit -m "feat(agents): search_run_log runtime tool, primary agent only"
+```
+
+---
+
+### Task 7: Prompt integration
+
+The connective tissue that makes an additive Phase 1 pay off: truncation trailers point at records, and the model is told the log exists — only when it really does.
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/agent_runtime.py` (`_truncate_tool_result`)
+- Modify: `tldw_chatbook/Agents/agent_service.py` (system-prompt section)
+- Test: `Tests/Agents/test_run_log_prompt_integration.py`
+
+**Interfaces:**
+- Consumes: `search_run_log` wiring (Task 6).
+- Produces: `RUN_LOG_PROMPT_SECTION: str` in `agent_service.py`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/Agents/test_run_log_prompt_integration.py`:
+
+```python
+# Tests/Agents/test_run_log_prompt_integration.py
+"""Truncation points at the log; the prompt mentions it only when real."""
+
+import pytest
+
+from tldw_chatbook.Agents import run_log as run_log_module
+from tldw_chatbook.Agents.agent_models import AgentConfig, RunBudget
+from tldw_chatbook.Agents.agent_runtime import _truncate_tool_result
+from tldw_chatbook.Agents.agent_service import AgentService
+from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider, ToolCatalogRegistry
+from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+
+def test_trailer_points_at_the_record_when_one_exists():
+    out = _truncate_tool_result("z" * 100, 10, "grep_files", record_number=412)
+    assert "search_run_log" in out
+    assert "412" in out
+
+
+def test_trailer_keeps_the_old_wording_when_there_is_no_record():
+    out = _truncate_tool_result("z" * 100, 10, "grep_files", record_number=None)
+    assert "search_run_log" not in out
+    assert "narrower query" in out
+
+
+def test_untruncated_content_is_returned_unchanged():
+    assert _truncate_tool_result("short", 100, "t", record_number=7) == "short"
+
+
+def _service(tmp_path, capture):
+    db = AgentRunsDB(tmp_path / "runs.db")
+    registry = ToolCatalogRegistry()
+    registry.register_provider(BuiltinToolProvider())
+    return AgentService(db, registry, chat_call=capture)
+
+
+def _run(service):
+    service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "hi"}],
+        config=AgentConfig(model="m", system_prompt="BASE", budget=RunBudget()),
+        api_endpoint="openai",
+    )
+
+
+def test_prompt_mentions_the_log_when_logging_is_active(tmp_path, monkeypatch):
+    monkeypatch.setattr(run_log_module, "resolve_log_root", lambda: tmp_path)
+    prompts = []
+
+    def capture(**kwargs):
+        prompts.append(kwargs["messages_payload"][0]["content"])
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    _run(_service(tmp_path, capture))
+    assert any("search_run_log" in p for p in prompts)
+    assert all(p.startswith("BASE") for p in prompts)
+
+
+def test_prompt_is_silent_about_the_log_when_it_is_unavailable(tmp_path, monkeypatch):
+    monkeypatch.setattr(run_log_module, "resolve_log_root", lambda: None)
+    prompts = []
+
+    def capture(**kwargs):
+        prompts.append(kwargs["messages_payload"][0]["content"])
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    _run(_service(tmp_path, capture))
+    assert all("search_run_log" not in p for p in prompts)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest Tests/Agents/test_run_log_prompt_integration.py -v`
+Expected: FAIL — `TypeError: _truncate_tool_result() got an unexpected keyword argument 'record_number'`
+
+- [ ] **Step 3: Implement**
+
+In `agent_runtime.py`, change the signature and trailer:
+
+```python
+def _truncate_tool_result(
+    content: str, max_chars: int, tool_name: str, record_number: int | None = None
+) -> str:
+```
+
+and replace the return with:
+
+```python
+    if record_number is not None:
+        recovery = (
+            f" The full result is recorded at record {record_number:06d} — "
+            f"search_run_log(from_record={record_number}, to_record={record_number})."
+        )
+    else:
+        recovery = (
+            " Re-issue the call with a narrower query, or use the tool's "
+            "offset/limit arguments to read the rest."
+        )
+    return (
+        content[:max_chars]
+        + f"\n\n[truncated: {tool_name} returned {len(content)} characters; "
+        f"showing the first {max_chars}.{recovery}]"
+    )
+```
+
+At the call site, thread through the number `on_record` returned. Change `_emit_record` to return the writer's value, capture it for the `tool_result` record, and pass it:
+
+```python
+            record_number = _emit_record(deps, "tool_result", ...)
+            ...
+            content = _truncate_tool_result(
+                content,
+                budget.max_tool_result_chars,
+                call.name,
+                record_number=record_number,
+            )
+```
+
+`_emit_record` returns `deps.on_record(...)`'s value (the record number) or `None`; `agent_service`'s `on_record` closure must `return self.run_log_writer.append(...)`.
+
+In `agent_service.py`, add the section constant:
+
+```python
+RUN_LOG_PROMPT_SECTION = (
+    "Run log: every model turn, tool call, and tool result of this run is "
+    "recorded in full to a log file. Your context holds a truncated view of "
+    "it. When a result was truncated, or you need something from earlier in "
+    "this run, call search_run_log to read the complete record instead of "
+    "re-running the work or guessing. Prefer the 'contains' argument (a "
+    "literal substring, searched over the whole record) over 'pattern'. "
+    "Search for specific content you know you need rather than browsing."
+)
+```
+
+and in `_make_call_model`, append it to `config.system_prompt` when — and only when — this run wired the tool:
+
+```python
+            system_content = config.system_prompt
+            if log_active:
+                system_content = f"{system_content}\n\n{RUN_LOG_PROMPT_SECTION}"
+```
+
+where `_make_call_model` gains a `log_active: bool` parameter, passed from `_run_one` as `agent_kind == AGENT_KIND_PRIMARY and self.run_log_writer.is_active` — the same condition that gates `SEARCH_RUN_LOG_TOOL_SCHEMA`, so the prompt can never advertise a tool the run does not have.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest Tests/Agents/ -v`
+Expected: PASS — the whole Agents suite, including every pre-existing test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Agents/ Tests/Agents/
+git commit -m "feat(agents): point truncation trailers at the run log and prompt for it"
+```
+
+---
+
+### Task 8: Full-suite verification and live run
+
+**Files:**
+- Test: no new files; runs the existing suites.
+
+- [ ] **Step 1: Run the full agent and chat suites**
+
+Run: `python -m pytest Tests/Agents/ Tests/Chat/ -q`
+Expected: PASS with **zero novel regressions** against an `origin/dev` baseline. Capture the baseline first if unsure:
+`git stash && python -m pytest Tests/Agents/ Tests/Chat/ -q | tail -5 && git stash pop`
+
+- [ ] **Step 2: Verify the additive guarantee**
+
+Run: `python -m pytest Tests/Agents/test_agent_runtime.py Tests/Agents/test_agent_service.py -q`
+Expected: PASS. These predate this work and exercise the loop with `on_record=None`; they must not have needed edits. If any required a change, the additive guarantee was broken — stop and reassess.
+
+- [ ] **Step 3: Live run against a real provider**
+
+Per the repository's live-verification rule (tests alone have repeatedly missed defects here), and using `.claude/skills/verify` to drive the TUI:
+
+1. Set `TLDW_CONFIG_PATH` to a scratch config so the live DB is untouched.
+2. Enable a file tool so a run produces a large result: `[tools] read_file_enabled = true`.
+3. Bind a scratch workspace folder with `rw` access.
+4. Send a Console message that makes the agent read a large file, so a result exceeds `max_tool_result_chars`.
+5. Confirm on disk: `<workspace>/agent-runs/<run_id>/logs.0001.txt` exists, contains `#@#`-anchored records, and holds the **full** result while the transcript shows the truncated one.
+6. Confirm `<workspace>/agent-runs/.gitignore` contains `*`.
+7. Ask the agent a question answerable only from the truncated remainder, and confirm it calls `search_run_log` and recovers it.
+
+- [ ] **Step 4: Record the evidence**
+
+Write the observed record count, file sizes, and the recovered-content exchange into the task's Implementation Notes. Live evidence, not test output, is what closes this.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit --allow-empty -m "test(agents): full-suite and live verification of the run log"
+```

--- a/Docs/superpowers/specs/2026-07-27-agent-programmatic-run-memory-design.md
+++ b/Docs/superpowers/specs/2026-07-27-agent-programmatic-run-memory-design.md
@@ -562,7 +562,7 @@ reviewers can check the reasoning rather than rediscover it.
   full-content access. The Console currently shows 160–200 characters of a result
   the model received at up to 16,000. The log is what makes "read the full
   content" answerable.
-- **task-895** — `glob_files`/`grep_files` ignore workspace folder roots that
+- **task-1265** — `glob_files`/`grep_files` ignore workspace folder roots that
   `read_file` honours (§9.4). Filed rather than fixed here.
 - **task-326 / task-327** — token budget and durability hardening; already merged
   into the substrate this builds on.

--- a/Docs/superpowers/specs/2026-07-27-agent-programmatic-run-memory-design.md
+++ b/Docs/superpowers/specs/2026-07-27-agent-programmatic-run-memory-design.md
@@ -1,0 +1,453 @@
+# Programmatic run memory for the agent runtime
+
+**Date:** 2026-07-27
+**Status:** Design approved; not implemented
+**Baseline:** `origin/dev` @ `c2e6483c4`
+**Prior art:** PRO-LONG (arXiv 2607.20064v2; `github.com/alexisfox7/PRO-LONG`)
+
+## 1. Problem
+
+The agent runtime's memory *is* its message list. Every tool result, every model
+turn, and every sub-agent result accumulates in `run_agent_loop`'s `messages`,
+and the whole list is re-sent on every provider call. Nothing ever evicts, and
+nothing outside that list is queryable while a run is in flight.
+
+That was survivable when runs were short. They are not short any more. The
+Console budget on `origin/dev` is:
+
+```python
+CONSOLE_MAX_MODEL_TURNS = 30
+CONSOLE_MAX_STEPS       = 96
+CONSOLE_MAX_WALL_SECONDS = 1800.0
+CONSOLE_MAX_TOTAL_TOKENS = 1_000_000
+```
+
+Thirty tool-calling rounds over thirty minutes, with each tool result admitted
+into history at up to `max_tool_result_chars = 16_000`. A run that actually uses
+that budget can push well past 100k tokens of prompt by its final rounds. A
+200k-context cloud model tolerates it expensively; a 32k local model does not
+reach round ten.
+
+**The budgets were raised for long-horizon work. The memory architecture was
+never changed to match.** This design changes it.
+
+Three further consequences of the same root cause:
+
+- **Nothing survives a crash.** `agent_service._persist` writes `agent_runs.steps`
+  as a single JSON blob *after* the loop terminates. A run killed at round 28 of
+  30 leaves no record of the first 27.
+- **Truncation is lossy, permanently.** When `_truncate_tool_result` cuts a
+  result to 16,000 characters, the remainder is gone. The trailer tells the model
+  to "re-issue the call with a narrower query" — re-doing work whose answer was
+  already computed.
+- **Sub-agent work is discarded.** A parent sees `max_subagent_result_chars =
+  4000` of its child's entire run. Everything else the child learned is lost at
+  the `spawn` boundary.
+
+## 2. Approach
+
+PRO-LONG's finding is that an agent does not need its history *in context*; it
+needs history to be *reachable*. Append every action and observation losslessly
+to a structured log, and give the agent a way to search it. The paper's ablation
+(GPT-5.5, pass@1) shows how much the read side matters: read-only 23.1%, plus
+grep 27.2%, plus model-authored Python 38.3%, plus write/edit 41.2%.
+
+Applied here, in one sentence: **the log becomes the lossless record, and the
+message list becomes a cache of it.**
+
+Phase 1 is deliberately *additive* — the log is written and made searchable, but
+`messages` is not touched, so existing runs behave byte-identically. The format
+and seams are designed so that a later phase can evict from context (§10), which
+is where goals 1 and 2 are fully realised.
+
+### 2.1 Goals
+
+1. Long-horizon runs that are not bounded by the context window.
+2. Small-context local models running the same workloads as large cloud models.
+3. Queryable, crash-durable run history for the user and the UI.
+4. A later 1:1 PRO-LONG mode (full accessed/accessible split) reachable as a
+   configuration change, not a rewrite.
+
+### 2.2 Non-goals
+
+- Model-authored code execution over the log. Deferred; see §11.
+- Semantic/embedding retrieval over history. PRO-LONG's central claim is that
+  programmatic search beats it, and the app's RAG stack is a separate concern.
+- Changing `grep_files` / `glob_files`. See §9.4.
+- Replacing `agent_runs` DB persistence. The log is a second, independent record.
+
+### 2.3 What `origin/dev` already provides
+
+| Capability | State |
+| --- | --- |
+| Sandboxed file read/write/list | `read_file`, `write_file`, `list_directory` — consult `allowed_file_roots`, so they reach workspace folders |
+| Sandboxed search | `glob_files`, `grep_files` — **sandbox root only** (see §9.4) |
+| Constrained script execution | `run_skill_script` — trusted-skill bundles only, scrubbed env, rlimits |
+| Long budgets | 30 model turns / 96 steps / 1800s / 1M tokens |
+| Per-result history cap | `max_tool_result_chars = 16_000` |
+| Run lineage + supersession | `AgentRunsDB`, `supersede_run_tree` |
+| Append-only lossless log | **Missing — this design** |
+| Context eviction | **Missing — deferred to Phase 3** |
+
+## 3. Architecture
+
+### 3.1 Writer ownership
+
+```
+run_turn()                            RunLogWriter constructed ONCE here
+  └─ _run_one(primary)                writer passed down
+       └─ spawn() → _run_one(child)   SAME writer instance
+```
+
+The writer is constructed in `AgentService.run_turn` and threaded through the
+`_run_one` recursion. Two requirements make this mandatory rather than stylistic:
+
+- **One monotonic record counter per run *tree*.** `AgentStep.index` is
+  `len(steps)` — per-run. Sub-agents run inline via `spawn` → `_run_one`, so a
+  per-run writer would give parent and child each their own counter and produce
+  duplicate record numbers in a shared log.
+- **Every caller gets logging.** `on_step` is passed *into* `AgentService` by the
+  Console bridge. Anything built on the hook would silently produce no log for
+  any non-Console caller.
+
+### 3.2 Capture points
+
+Full fidelity is only available in `agent_service`'s own closures. The step
+record is not a viable source: `agent_runtime.py` truncates model turns to 200
+characters (`summary=turn.text[:200]`) and tool results to 2,000
+(`result=content[:2000]`) — strictly *less* than history retains.
+
+| Record type | Captured at | Carries |
+| --- | --- | --- |
+| `model` | wrapper around `_make_call_model`'s `call_model` | full `ModelTurn.text`, `tokens` |
+| `tool_call` | `invoke_tool` wrapper, pre-dispatch | **full args** — `write_file` args are file contents |
+| `tool_result` | `invoke_tool` wrapper, post-dispatch | full `ToolResult.content` / `error` |
+| `spawn` | `spawn` closure | full task text **and the child's untruncated result**, captured before `max_subagent_result_chars` |
+| `error` | `on_step` | budget exhaustion, cycle detection |
+
+**Anti-duplication rule.** The wrappers own `model`, `tool_call`, `tool_result`,
+and `spawn`. `on_step` owns *only* `STEP_ERROR`. `on_step` also fires
+`STEP_TOOL_CALL` before dispatch; that firing is ignored, because the wrapper
+holds the complete version.
+
+`agent_runtime.py` is not modified. `agent_service` remains, per its own module
+docstring, the only impure module in `Agents/`.
+
+### 3.3 Location
+
+```
+<workspace>/agent-runs/            undotted — dotted dirs are excluded by _is_hidden_within
+  .gitignore                       contains "*"; created only if absent
+  <run_id>/
+    MANIFEST                       convenience metadata only (§4.3)
+    logs.0001.txt
+    logs.0002.txt
+```
+
+The log is written into the run's bound workspace folder, making it a
+user-visible artifact they can open, diff, and keep. Path resolution goes through
+the same chain the file tools use — `allowed_file_roots(write=True,
+sandbox_root=_tool_sandbox_root())` → `is_within` → `is_sensitive_path` — and
+never through bespoke path logic, so the writer cannot become a validation
+bypass.
+
+When no read-write workspace folder is bound, `allowed_file_roots` degrades to
+sandbox-only; the writer follows it and logs under the sandbox root. The log is
+always written somewhere.
+
+## 4. Log format
+
+### 4.1 Record structure
+
+```
+#@# 000412 run=a3f9c1 kind=primary type=tool_result tool=grep_files status=ok call=call_7 ts=2026-07-27T18:22:31.004Z bytes=1834
+<content verbatim — exactly 1834 UTF-8 bytes, excluding the newline that ends it>
+#@# 000413 run=b7e2d4 kind=subagent type=model tool=- status=- call=- ts=2026-07-27T18:22:48.221Z bytes=94
+<content verbatim>
+```
+
+| Element | Rationale |
+| --- | --- |
+| `#@#` anchor | Never occurs naturally. `###` was rejected: it is a markdown H3, so every heading in fetched or generated content would false-positive. |
+| **One physical line** per header | A wrapped header breaks `^#@# ` matching and detaches fields onto a continuation line no search can associate. ~130 chars — inside grep's 500-char window. |
+| Zero-padded monotonic `000412` | Unique across the whole run tree; sortable; stable to reference from a truncation trailer. |
+| `run=` / `kind=` | Sub-agent records are distinguishable in a shared log — a parent can search its child's *entire* trace rather than the 4,000-char summary it receives. |
+| `call=<tool_call_id>` | Lets Phase 3 reconstruct valid assistant-echo/`role="tool"` pairs (§10). |
+| `bytes=N` | **UTF-8 bytes of content, excluding the terminating newline. Files are parsed in binary.** Exact slicing means content containing a literal `#@#` cannot corrupt parsing. |
+| `truncated=<original_bytes>` | Present **only** on a record cut by the per-record ceiling (§8.1); absent otherwise. |
+| Content verbatim, unwrapped | Losslessness requires no transformation to reverse. |
+
+### 4.2 The one accepted trade-off
+
+Content is not wrapped, so a long content line is searchable by `grep_files` only
+in its first 500 characters (`_MAX_GREP_LINE_SEARCH_CHARS`). This is accepted
+because `search_run_log` (§5) is the primary read path and has no such limit.
+Header lines — which carry every structured field — are short and fully
+searchable by any tool.
+
+### 4.3 Segmentation
+
+Segments roll at 4 MB (`logs.0002.txt`, …), under `grep_files`'
+`_MAX_GREP_FILE_BYTES` ceiling of 5 MB.
+
+**Segment discovery is glob + sort, not `MANIFEST`.** A crashed run never writes
+a manifest; making it load-bearing would render exactly the runs that most need
+inspection unreadable. `MANIFEST` carries convenience metadata only: run header
+(model, budget, allowed tools, workspace), segment ranges, final status, and
+supersession.
+
+## 5. `search_run_log`
+
+### 5.1 Registration
+
+Registered as a **runtime tool**, handled in the service alongside `find_tools`,
+`load_tools`, and `spawn_subagent` — not as a catalog tool. Three consequences,
+each resolving a specific problem:
+
+- **Consumes no `max_active_tools` slot.** That ceiling is a one-way ratchet
+  (`load_tools` refuses past it, nothing unloads). A memory tool should not
+  compete with real capabilities for it.
+- **No config gate and no approval prompt.** `grep_files` carries the `"reads"`
+  risk tag, which floors it to `ask`; an autonomous run would stall on its first
+  log search. The exemption is justified rather than assumed: `search_run_log`
+  reads only the current run's own log — content this agent already produced or
+  received. The disclosure risk the `"reads"` tag guards against is absent.
+- **Offered only when logging is active** and the log is confirmed writable
+  (§7).
+
+### 5.2 Sub-agent scoping
+
+A sub-agent's `search_run_log` is scoped to its own subtree's records by default.
+`spawn_subagent`'s contract is *"It sees only the task text you pass"*; granting
+a child its parent's entire history as an unremarked side effect would break that
+isolation. Widening it is a deliberate future decision, not a default.
+
+### 5.3 Interface
+
+```
+search_run_log(
+    contains,                  literal substring — DEFAULT search mode
+    tool, kind, type, status,  structured filters
+    from_record, to_record,    range slice
+    context,                   N records either side of each hit
+    pattern,                   OPT-IN regex, bounded (§5.4)
+)
+```
+
+Literal-first is a safety property, not a convenience. Python's `re` has no match
+timeout, and `agent_service._call_with_timeout` abandons rather than kills its
+worker thread, so a catastrophic-backtracking pattern keeps burning CPU past its
+deadline — the documented reason `grep_files` searches only 500 characters per
+line. Literal substring search is linear and cannot backtrack, so the default
+mode needs no line-length cap and searches the log without limit.
+
+### 5.4 Regex mode
+
+`pattern=` is opt-in and carries the same 500-character-per-line guard as
+`grep_files`, for the same reason. Its limitation is stated in the tool
+description so the model can choose `contains=` when it needs unbounded reach.
+
+## 6. Prompt integration
+
+### 6.1 Truncation trailer
+
+`_truncate_tool_result`'s trailer currently reads:
+
+> `[truncated: {tool} returned {n} characters; showing the first {max}. Re-issue
+> the call with a narrower query, or use the tool's offset/limit arguments to
+> read the rest.]`
+
+It gains a pointer to the exact record:
+
+> `… The full result is recorded at record 000412 — search_run_log(from_record=412).`
+
+This is the single change that makes an additive Phase 1 pay off immediately:
+every truncation in the run becomes a pointer to a lossless copy, instead of an
+instruction to redo the work.
+
+### 6.2 System prompt section
+
+A short section (~8 lines) appended when and only when logging is active and the
+log is writable: the log's location, the record format in one line, the tool
+name, and the operative instruction — *history in your context is truncated but
+the log is complete; search it rather than guessing or re-running work.*
+
+## 7. Failure and degradation
+
+| Condition | Behaviour |
+| --- | --- |
+| Write failure (any cause) | Log once at warning; **suppress the prompt section and withdraw the tool**. The model is never told to search a log that does not exist. |
+| No `rw` workspace folder bound | Fall back to the sandbox root. |
+| `agent-runs/` unwritable | As write failure. |
+| Concurrent access | Lock plus `O_APPEND`. Tool calls run under `_call_with_timeout` on a worker thread, so the writer is reachable from more than one thread. |
+| Durability | `flush()` per record (survives process crash); `fsync` at segment roll and run end (survives power loss). Per-record `fsync` into a user's project directory is rejected as wasteful. |
+
+`agent_runtime.add()` swallows hook exceptions by design, so a broken log can
+never abort a run. That safety property is exactly why silent absence must be
+made loud at the prompt/tool level instead.
+
+## 8. Configuration
+
+`[agents]`:
+
+| Key | Default | Meaning |
+| --- | --- | --- |
+| `run_log_enabled` | `true` | Master switch |
+| `run_log_dir_name` | `agent-runs` | Directory name within the workspace |
+| `run_log_max_record_bytes` | `1_000_000` | Per-record ceiling (§8.1) |
+| `run_log_segment_bytes` | `4_000_000` | Segment roll threshold |
+
+**Retention: never auto-delete.** Silently pruning files from a user's project
+directory is the wrong default. The Console surfaces total size and offers
+explicit cleanup instead.
+
+### 8.1 The one bounded exception to losslessness
+
+`run_log_max_record_bytes` is a deliberate exception to §4's losslessness
+guarantee, and the only one. A single record exceeding it is written truncated,
+and:
+
+- `bytes=` reports the **bytes actually written**, never the original — so
+  parsing stays exact and a truncated record cannot desynchronise the file.
+- The record header gains `truncated=<original_bytes>` so both a human and
+  `search_run_log` can see that content was dropped and how much.
+
+Without a per-record ceiling, a single pathological tool result (a multi-gigabyte
+file read) could fill a user's disk inside one run. The default of 1 MB is far
+above `max_tool_result_chars` (16,000), so in normal operation no record is ever
+truncated and the log remains fully lossless.
+
+## 9. Security
+
+### 9.1 Content sensitivity
+
+The log contains full, untruncated tool results — `read_file` contents, web
+fetches, MCP responses. Today that material lives only in memory and in a
+2,000-character DB field. Writing it into a workspace folder, which is very
+likely a git repository, is a new disclosure path. Mitigations:
+
+- `agent-runs/.gitignore` containing `*`, created **only if absent**, never
+  overwritten — creating files in a user's repository is itself a mutation.
+- The directory is **undotted** deliberately: dotted directories are excluded by
+  `_is_hidden_within`, which would make the log invisible to the very tools meant
+  to read it.
+- Sensitive paths remain refused at the writer via `is_sensitive_path`.
+
+### 9.2 Path validation
+
+The writer resolves through `allowed_file_roots` → `is_within` →
+`is_sensitive_path`. It never constructs or validates paths itself.
+
+### 9.3 Regex exposure
+
+Covered in §5.3–5.4: literal default, bounded opt-in regex.
+
+### 9.4 Out of scope: `grep_files` / `glob_files`
+
+Both glob and containment-check against `_tool_sandbox_root()` alone and never
+consult `allowed_file_roots`, unlike `read_file`. A workspace-folder log is
+therefore readable by exact path but **not searchable** by them. This asymmetry
+is arguably a defect in those tools, but correcting it widens two shared,
+security-reviewed tools for every caller and belongs in its own task with its own
+review. This design routes around it via `search_run_log` instead.
+
+Likewise, adopting ripgrep as a search backend was considered and rejected for
+now: it would remove every cap listed in §5.3, but it introduces an external
+binary dependency that the repository has no precedent for, and its discovery
+would conflict with the established rule that binaries are never resolved via
+ambient `PATH` (`resolve_interpreter` searches only `SCRUBBED_PATH`).
+
+## 10. Phasing
+
+| Phase | Contents |
+| --- | --- |
+| **1 — this spec** | Writer, format, `search_run_log`, prompt section, truncation trailer. Additive: `messages` untouched, existing runs byte-identical. |
+| **2** | `run_log_stats` / `run_log_slice` aggregation tools; TASK-870's Console reader. |
+| **3 — 1:1 PRO-LONG** | Eviction at the history-assembly seam: keep recent rounds, replace older ones with a pointer. |
+
+Phase 3 is cheap by construction because the log is authoritative by then and
+`call=` preserves pairing. **The hazard it must respect, recorded now because it
+is expensive to retrofit:** the native protocol pairs an assistant `tool_calls`
+echo with its `role="tool"` replies by `tool_call_id`. Eviction that orphans
+either half produces a request strict providers reject. Any eviction policy must
+operate on whole call/result groups.
+
+## 11. Deferred
+
+- **Model-authored code over the log.** The paper's largest single gain
+  (+10.1pp). `skill_script_runner` provides most of the hardening already
+  (scrubbed `PATH`, `RLIMIT_CPU/NOFILE/FSIZE/AS`, process-group kill, capped
+  sinks, throwaway `HOME`, `shell=False`), but it is resource-confined, not
+  filesystem-confined, and its trust model assumes a *trusted skill bundle* —
+  model-authored code is neither. Needs its own confinement design.
+- **Ripgrep backend** (§9.4).
+- **Extending `glob_files`/`grep_files` to workspace roots** (§9.4).
+- **Cross-run search.** The log is per-run; searching *across* runs is a natural
+  Phase 2+ extension.
+
+## 12. Testing
+
+- **Format round-trip:** write → parse → byte-identical content, including
+  content containing a literal `#@#` and multi-byte UTF-8 at a `bytes=` boundary.
+- **Counter monotonicity** across a parent plus two sub-agents; no duplicate
+  record numbers.
+- **Segmentation:** roll at threshold; search spanning segments; a run with a
+  missing `MANIFEST` remains fully searchable.
+- **Capture fidelity:** a 50,000-character tool result appears in full in the log
+  while history shows the 16,000-character truncation plus a record pointer.
+- **Degradation:** no workspace bound; unwritable directory; write failure
+  mid-run — each suppresses the prompt section and withdraws the tool.
+- **Sub-agent scoping:** a child cannot retrieve parent-only records.
+- **Concurrency:** simultaneous runs do not interleave or corrupt records.
+- **Live verification:** a real provider run per the repository's
+  live-verification rule — tests alone have repeatedly missed defects here.
+
+## 13. Review findings register
+
+Twenty issues were found across two review passes before this document was
+written — the first over the architecture, the second over the record format.
+Each is addressed above; they are recorded here so reviewers can check the
+reasoning rather than rediscover it.
+
+**First pass — architecture.**
+
+| # | Finding | Resolution |
+| --- | --- | --- |
+| 1 | `on_step` truncates to 200/2000 chars — cannot carry a lossless log | Capture in service closures (§3.2) |
+| 2 | `grep_files` searches only 500 chars per line | `search_run_log` is the primary path; headers stay short (§4.2) |
+| 3 | Grep caps (5 MB/file, 200k lines, 200 matches) degrade on long runs | Segmentation; `search_run_log` is uncapped (§4.3, §5.3) |
+| 4 | `grep_files` is `ask`-floored on every call | `search_run_log` is a runtime tool, justified exemption (§5.1) |
+| 5 | Wiring on the caller's `on_step` misses non-Console callers | Writer built inside `AgentService` (§3.1) |
+| 6 | Step indices collide across the run tree | Tree-scoped monotonic counter (§3.1, §4.1) |
+| 7 | Secrets reach a user's git repository | `.gitignore`, undotted dir, sensitive-path refusal (§9.1) |
+| 8 | Silent log failure while the prompt advertises the log | Suppress prompt section and withdraw tool (§7) |
+| 9 | Phase 3 eviction can orphan `tool_call_id` pairs | `call=` recorded now; whole-group eviction required (§10) |
+| 10 | Writer could bypass path validation | Reuses the file tools' chain (§9.2) |
+| 11 | Unbounded disk growth | Per-record cap, segmentation, never auto-delete (§8, §8.1) |
+| 12 | Supersession invisible in the log | Recorded in `MANIFEST` (§4.3) |
+
+**Second pass — record format.**
+
+| # | Finding | Resolution |
+| --- | --- | --- |
+| 13 | **Blocker:** a workspace-folder log is unsearchable by `grep_files`, which globs the sandbox root alone and never consults `allowed_file_roots` — unlike `read_file` | The workspace location stands; `search_run_log` replaces grep as the Phase 1 read path (§5, §9.4) |
+| 14 | Dropping ripgrep re-arms catastrophic backtracking in `search_run_log` | Literal-substring default; regex opt-in and bounded (§5.3–5.4) |
+| 15 | `###` anchor collides with markdown H3 in generated and fetched content | `#@#` (§4.1) |
+| 16 | A header wrapped across two lines breaks `^#@# ` matching and detaches fields | One physical line, mandatory (§4.1) |
+| 17 | `bytes=N` ambiguous — UTF-8 bytes or characters, newline included or not | Defined exactly: UTF-8 bytes, excluding the terminating newline, parsed in binary (§4.1) |
+| 18 | `MANIFEST` as a correctness dependency makes crashed runs unreadable | Discovery is glob + sort; manifest is metadata only (§4.3) |
+| 19 | Writer reachable from multiple threads via `_call_with_timeout`; fsync policy unstated | Lock + `O_APPEND`; flush per record, fsync at roll and run end (§7) |
+| 20 | `tool_call` args were unspecified — `write_file` args *are* file contents | Full args logged (§3.2) |
+
+## 14. Related work in this repository
+
+- **TASK-870** — Console tool-result display caps: Settings control and
+  full-content access. The Console currently shows 160–200 characters of a result
+  the model received at up to 16,000. The log is what makes "read the full
+  content" answerable.
+- **task-322** — *Bound Console conversation history by tokens before dispatch*
+  proposes lossy truncation for the adjacent problem. Phase 3 here is the
+  offload-rather-than-discard alternative; the two want reconciling before either
+  ships.
+- **task-326 / task-327** — token budget and durability hardening; already merged
+  into the substrate this builds on.

--- a/Docs/superpowers/specs/2026-07-27-agent-programmatic-run-memory-design.md
+++ b/Docs/superpowers/specs/2026-07-27-agent-programmatic-run-memory-design.md
@@ -94,9 +94,9 @@ is where goals 1 and 2 are fully realised.
 ### 3.1 Writer ownership
 
 ```
-run_turn()                            RunLogWriter constructed ONCE here
-  └─ _run_one(primary)                writer passed down
-       └─ spawn() → _run_one(child)   SAME writer instance
+run_turn()                            RunLogWriter constructed ONCE here, UNBOUND
+  └─ _run_one(primary)                bind(run_id) — directory created here
+       └─ spawn() → _run_one(child)   SAME writer, already bound
 ```
 
 The writer is constructed in `AgentService.run_turn` and threaded through the
@@ -110,28 +110,62 @@ The writer is constructed in `AgentService.run_turn` and threaded through the
   Console bridge. Anything built on the hook would silently produce no log for
   any non-Console caller.
 
+**Construction is two-phase, and must be.** The run id does not exist when
+`run_turn` runs — `run_id = self.db.create_run(...)` is the first statement of
+`_run_one`, so the writer cannot name its `<run_id>/` directory at construction
+time. The writer is therefore constructed *unbound* in `run_turn` (fixing the
+counter to the tree) and `bind(run_id)` is called by the **primary** `_run_one`,
+which creates the directory. Child `_run_one` calls find the writer already
+bound and never rebind it.
+
 ### 3.2 Capture points
 
-Full fidelity is only available in `agent_service`'s own closures. The step
-record is not a viable source: `agent_runtime.py` truncates model turns to 200
-characters (`summary=turn.text[:200]`) and tool results to 2,000
-(`result=content[:2000]`) — strictly *less* than history retains.
+The step record is not a viable source: `agent_runtime.py` truncates model turns
+to 200 characters (`summary=turn.text[:200]`) and tool results to 2,000
+(`result=content[:2000]`) — strictly *less* than history retains. So capture must
+happen somewhere the full value exists.
 
-| Record type | Captured at | Carries |
+Capture is a **single new injected callable, `LoopDeps.on_record`**, called at
+exactly two points inside `run_agent_loop`:
+
+| Call site | Record types | Carries |
 | --- | --- | --- |
-| `model` | wrapper around `_make_call_model`'s `call_model` | full `ModelTurn.text`, `tokens` |
-| `tool_call` | `invoke_tool` wrapper, pre-dispatch | **full args** — `write_file` args are file contents |
-| `tool_result` | `invoke_tool` wrapper, post-dispatch | full `ToolResult.content` / `error` |
-| `spawn` | `spawn` closure | full task text **and the child's untruncated result**, captured before `max_subagent_result_chars` |
-| `error` | `on_step` | budget exhaustion, cycle detection |
+| Immediately after `turn = deps.call_model(...)`, before `add(STEP_MODEL, …)` | `model` | full `turn.text`, `turn.tokens`, and any `tool_calls` with their `call_id`s |
+| At the point `content` is assembled for a dispatched call, **before** `_truncate_tool_result` is applied | `tool_call`, `tool_result` | full args; full result or error text |
+| `on_step` (existing hook) | `error` | budget exhaustion, cycle detection |
 
-**Anti-duplication rule.** The wrappers own `model`, `tool_call`, `tool_result`,
-and `spawn`. `on_step` owns *only* `STEP_ERROR`. `on_step` also fires
-`STEP_TOOL_CALL` before dispatch; that firing is ignored, because the wrapper
-holds the complete version.
+**Why one hook in the loop rather than wrappers in the service.** An earlier
+draft wrapped `call_model`, `invoke_tool`, and `spawn` individually in
+`agent_service`. That is both more code and *incomplete*: the loop dispatches
+`find_tools`, `load_tools`, `spawn_subagent`, `skill_file`, `install_skill`, and
+`run_skill_script` through their own branches, never through `deps.invoke_tool`,
+so none of their results would have been logged — `run_skill_script`'s script
+output least excusably of all. The loop assembles `content` for **every** branch
+at one point, immediately before truncation. Capturing there is uniform by
+construction: builtin, MCP, skill, and runtime tools are all covered, and so is
+the `review_tool_calls` refusal path.
 
-`agent_runtime.py` is not modified. `agent_service` remains, per its own module
-docstring, the only impure module in `Agents/`.
+It also removes the need for a special `spawn` capture. A child's own model and
+tool records are already written by the same hook during its own loop, so the
+child's untruncated final answer is in the log as its last `model` record —
+independently of the `max_subagent_result_chars = 4000` cut applied to what the
+*parent* receives. The parent's `spawn` record needs only the task text and the
+returned summary.
+
+**This does modify `agent_runtime.py`**, and an earlier draft of this document
+wrongly claimed otherwise. The modification follows the module's established
+pattern exactly: `on_record` is an optional injected callable on `LoopDeps`,
+defaulting to a no-op, in the same shape as the existing `on_step` and
+`review_tool_calls`. The loop stays pure — it calls an injected function and
+owns no I/O. `agent_service` remains the only impure module in `Agents/`.
+
+**Anti-duplication rule.** `on_record` owns `model`, `tool_call`, `tool_result`,
+and `spawn`. `on_step` owns *only* `STEP_ERROR`; its `STEP_TOOL_CALL` and
+`STEP_MODEL` firings are ignored because `on_record` holds the complete versions.
+
+**Failure isolation.** `on_record` must be wrapped in the same
+catch-and-continue that `add()` already applies to `on_step`: a failing log write
+can never abort a run.
 
 ### 3.3 Location
 
@@ -190,6 +224,18 @@ searchable by any tool.
 Segments roll at 4 MB (`logs.0002.txt`, …), under `grep_files`'
 `_MAX_GREP_FILE_BYTES` ceiling of 5 MB.
 
+**A record never spans segments.** The roll decision is made *before* writing a
+record that would carry the current segment past the threshold, not after
+exceeding it. A split record would break the `bytes=`-exact parsing model, which
+assumes a record's content lies wholly within one file. Because
+`run_log_max_record_bytes` (1 MB) is well under the segment threshold (4 MB), a
+single record always fits.
+
+**Readers must tolerate a partially written trailing record.** The agent searches
+its own log *while the writer is appending to it*. `search_run_log` therefore
+parses up to the last record whose declared `bytes=` is fully present on disk and
+ignores any trailing remainder.
+
 **Segment discovery is glob + sort, not `MANIFEST`.** A crashed run never writes
 a manifest; making it load-bearing would render exactly the runs that most need
 inspection unreadable. `MANIFEST` carries convenience metadata only: run header
@@ -200,9 +246,18 @@ supersession.
 
 ### 5.1 Registration
 
-Registered as a **runtime tool**, handled in the service alongside `find_tools`,
-`load_tools`, and `spawn_subagent` — not as a catalog tool. Three consequences,
-each resolving a specific problem:
+Registered as a **runtime tool**, alongside `find_tools`, `load_tools`,
+`spawn_subagent`, `skill_file`, `install_skill`, and `run_skill_script` — not as
+a catalog tool.
+
+Registration follows the pattern those six already establish: a schema in
+`tool_catalog`, an optional callable on `LoopDeps`, and a dispatch branch in
+`run_agent_loop` guarded by `deps.<name> is not None`, appended to the existing
+`elif` chain. An unrecognised name still falls through to the chain's `else`,
+reaching `deps.invoke_tool` and its permission gate — so a stray call when the
+tool is not offered is refused normally rather than mishandled.
+
+Three consequences, each resolving a specific problem:
 
 - **Consumes no `max_active_tools` slot.** That ceiling is a one-way ratchet
   (`load_tools` refuses past it, nothing unloads). A memory tool should not
@@ -215,12 +270,24 @@ each resolving a specific problem:
 - **Offered only when logging is active** and the log is confirmed writable
   (§7).
 
-### 5.2 Sub-agent scoping
+### 5.2 Sub-agents do not get the tool
 
-A sub-agent's `search_run_log` is scoped to its own subtree's records by default.
-`spawn_subagent`'s contract is *"It sees only the task text you pass"*; granting
-a child its parent's entire history as an unremarked side effect would break that
-isolation. Widening it is a deliberate future decision, not a default.
+In Phase 1, `search_run_log` is offered to the **primary agent only**.
+
+The isolation argument is the first reason: `spawn_subagent`'s contract is *"It
+sees only the task text you pass"*, and granting a child its parent's entire
+history as an unremarked side effect would break that.
+
+But scoping a child to its *own* records — the obvious middle path, and what an
+earlier draft specified — turns out to be pointless. `clamp_child_budget` sets
+`max_subagents=0`, so a child's subtree is only itself; children are short; and a
+short run's entire history is already in its context. The tool would add surface
+area and a scoping rule to buy a child nothing. Not offering it is simpler and
+strictly safer.
+
+Giving children scoped or full access is a deliberate future decision, and one
+worth revisiting only once Phase 3 eviction makes a child's own history capable
+of exceeding its window.
 
 ### 5.3 Interface
 
@@ -372,6 +439,34 @@ echo with its `role="tool"` replies by `tool_call_id`. Eviction that orphans
 either half produces a request strict providers reject. Any eviction policy must
 operate on whole call/result groups.
 
+### 10.1 Which goals each phase actually delivers
+
+| Goal (§2.1) | Phase 1 | Phase 2 | Phase 3 |
+| --- | --- | --- | --- |
+| 1. Long-horizon runs unbounded by context | — | — | **Yes** |
+| 2. Small-context local models | — | — | **Yes** |
+| 3. Queryable, crash-durable run history | **Durability + per-run search** | Console reader, aggregation, cross-run search | — |
+| 4. 1:1 PRO-LONG reachable as config | Format and seams built for it | — | **Delivered** |
+
+Stated plainly so nobody mistakes Phase 1 for the whole thing: **Phase 1 does not
+reduce context usage.** It makes truncated content *recoverable* and run history
+*durable*. Goals 1 and 2 are delivered by Phase 3.
+
+### 10.2 A known Phase 1 failure mode
+
+Because Phase 1 evicts nothing, a `search_run_log` result enters history like any
+other tool result — capped at `max_tool_result_chars`, counted against
+`max_total_tokens`. An agent that searches its log heavily therefore *grows* its
+context faster than one that does not, and in the worst case can thrash: search →
+large result → context pressure → truncation → search again.
+
+Three things bound this rather than solve it: search results are capped at 16,000
+characters like every other result; the `context=` parameter defaults low so hits
+return records rather than whole regions; and the system-prompt section (§6.2)
+directs the model to search for *specific* content it knows it needs, not to
+browse. It is genuinely resolved only by Phase 3, and that is a further argument
+for not treating Phase 1 as the finished feature.
+
 ## 11. Deferred
 
 - **Model-authored code over the log.** The paper's largest single gain
@@ -392,7 +487,16 @@ operate on whole call/result groups.
 - **Counter monotonicity** across a parent plus two sub-agents; no duplicate
   record numbers.
 - **Segmentation:** roll at threshold; search spanning segments; a run with a
-  missing `MANIFEST` remains fully searchable.
+  missing `MANIFEST` remains fully searchable; **no record ever spans a segment
+  boundary**, including one written when the segment is just under threshold.
+- **Concurrent read during write:** a search issued while a record is
+  half-written returns every complete record and ignores the remainder.
+- **Capture completeness:** results from `find_tools`, `load_tools`,
+  `run_skill_script`, an MCP tool, a skill tool, and a `review_tool_calls`
+  refusal each appear in the log — the branches a service-side wrapper would have
+  missed.
+- **Primary-only offer:** a sub-agent is not given `search_run_log`, and a stray
+  call to it from a child is refused through the normal permission path.
 - **Capture fidelity:** a 50,000-character tool result appears in full in the log
   while history shows the 16,000-character truncation plus a record pointer.
 - **Degradation:** no workspace bound; unwritable directory; write failure
@@ -404,10 +508,10 @@ operate on whole call/result groups.
 
 ## 13. Review findings register
 
-Twenty issues were found across two review passes before this document was
-written — the first over the architecture, the second over the record format.
-Each is addressed above; they are recorded here so reviewers can check the
-reasoning rather than rediscover it.
+Twenty-seven issues were found across three review passes — the first over the
+architecture, the second over the record format, the third over this document
+after it was written. Each is addressed above; they are recorded here so
+reviewers can check the reasoning rather than rediscover it.
 
 **First pass — architecture.**
 
@@ -438,6 +542,18 @@ reasoning rather than rediscover it.
 | 18 | `MANIFEST` as a correctness dependency makes crashed runs unreadable | Discovery is glob + sort; manifest is metadata only (§4.3) |
 | 19 | Writer reachable from multiple threads via `_call_with_timeout`; fsync policy unstated | Lock + `O_APPEND`; flush per record, fsync at roll and run end (§7) |
 | 20 | `tool_call` args were unspecified — `write_file` args *are* file contents | Full args logged (§3.2) |
+
+**Third pass — this document.**
+
+| # | Finding | Resolution |
+| --- | --- | --- |
+| 21 | **Contradiction:** §3.2 claimed `agent_runtime.py` is unmodified while §5.1 registered a runtime tool, which requires a `LoopDeps` field and a dispatch branch in the loop | Claim corrected; the modification is stated and shown to follow the pattern the six existing runtime tools already establish (§3.2, §5.1) |
+| 22 | **Incomplete capture:** service-side wrappers miss every runtime-tool result — `find_tools`, `load_tools`, `skill_file`, `install_skill`, `run_skill_script` — because the loop dispatches those outside `deps.invoke_tool` | Replaced three wrappers with one `on_record` hook at the loop's single `content`-assembly point, which is uniform across all branches (§3.2) |
+| 23 | **Ordering bug:** the writer cannot name its `<run_id>/` directory in `run_turn`; `create_run` is the first statement of `_run_one` | Two-phase construction: unbound in `run_turn`, `bind(run_id)` by the primary `_run_one` (§3.1) |
+| 24 | Sub-agent scoping was specified but buys a child nothing — `max_subagents=0` makes its subtree just itself, and its short history is already in context | Tool is offered to the primary agent only in Phase 1 (§5.2) |
+| 25 | A record could span a segment boundary, breaking `bytes=`-exact parsing | Roll decided *before* writing; a 1 MB record cap under a 4 MB threshold guarantees fit (§4.3) |
+| 26 | Readers would hit a partially written trailing record — the agent searches the log while the writer appends | Parse to the last complete record; ignore the remainder (§4.3) |
+| 27 | The document did not say which goals each phase delivers, and never stated that Phase 1 can *increase* context pressure | Goal/phase matrix and the thrash failure mode both documented (§10.1, §10.2) |
 
 ## 14. Related work in this repository
 

--- a/Docs/superpowers/specs/2026-07-27-agent-programmatic-run-memory-design.md
+++ b/Docs/superpowers/specs/2026-07-27-agent-programmatic-run-memory-design.md
@@ -508,7 +508,7 @@ for not treating Phase 1 as the finished feature.
 
 ## 13. Review findings register
 
-Twenty-seven issues were found across three review passes — the first over the
+Twenty-eight issues were found across three review passes — the first over the
 architecture, the second over the record format, the third over this document
 after it was written. Each is addressed above; they are recorded here so
 reviewers can check the reasoning rather than rediscover it.
@@ -554,6 +554,7 @@ reviewers can check the reasoning rather than rediscover it.
 | 25 | A record could span a segment boundary, breaking `bytes=`-exact parsing | Roll decided *before* writing; a 1 MB record cap under a 4 MB threshold guarantees fit (§4.3) |
 | 26 | Readers would hit a partially written trailing record — the agent searches the log while the writer appends | Parse to the last complete record; ignore the remainder (§4.3) |
 | 27 | The document did not say which goals each phase delivers, and never stated that Phase 1 can *increase* context pressure | Goal/phase matrix and the thrash failure mode both documented (§10.1, §10.2) |
+| 28 | task-322 was described as an unshipped, competing proposal. It shipped 2026-07-22 as `console_history_budget.py`, already bounds the agent run's *starting* history, and is the primitive Phase 3 should reuse — but its `_group_turns` splits on `role == "user"`, which the fence protocol uses for tool results | §14.1 rewritten with the reuse requirement and the fence-protocol grouping trap |
 
 ## 14. Related work in this repository
 
@@ -561,9 +562,43 @@ reviewers can check the reasoning rather than rediscover it.
   full-content access. The Console currently shows 160–200 characters of a result
   the model received at up to 16,000. The log is what makes "read the full
   content" answerable.
-- **task-322** — *Bound Console conversation history by tokens before dispatch*
-  proposes lossy truncation for the adjacent problem. Phase 3 here is the
-  offload-rather-than-discard alternative; the two want reconciling before either
-  ships.
+- **task-895** — `glob_files`/`grep_files` ignore workspace folder roots that
+  `read_file` honours (§9.4). Filed rather than fixed here.
 - **task-326 / task-327** — token budget and durability hardening; already merged
   into the substrate this builds on.
+
+### 14.1 task-322 is Done, and Phase 3 must build on it
+
+**task-322 shipped on 2026-07-22**, adding `Chat/console_history_budget.py`
+(`count_console_messages_tokens`, `_group_turns`, `bound_messages_to_window`).
+An earlier draft of this document described it as an unshipped proposal for lossy
+truncation and an alternative to Phase 3. Both halves were wrong.
+
+What it means in practice:
+
+- **The entry point is already bounded.** `console_chat_controller.py:4395` does
+  `agent_messages = list(provider_messages)`, so the history an agent run *starts*
+  from is already trimmed to the model window. The remaining unbounded quantity
+  is growth *during* a run — which sharpens this design's problem statement
+  rather than competing with it.
+- **Phase 3 must reuse `bound_messages_to_window`, not reimplement it.** Window
+  lookup, safety margin, reply reservation, and system-prefix preservation are
+  all solved there and should not be written twice.
+
+**The trap, recorded now because it will not be obvious later.** `_group_turns`
+splits history on `role == "user"` boundaries, and its docstring notes that
+dropping a whole group never splits a tool_call/tool_result pair *"were tool rows
+ever present in the payload"* — they never are, on the Console send path it was
+built for. In an agent run they are, and the two tool-call protocols encode them
+differently (`agent_runtime._append_tool_result`):
+
+- **Native protocol** appends `{"role": "tool", "tool_call_id": …}`. `_group_turns`
+  keeps that inside the current group. Correct as-is.
+- **Fence protocol** appends `{"role": "user", "content": "Tool result for …"}`.
+  `_group_turns` reads that as **the start of a new turn**, splitting an
+  assistant turn from the tool result that answers it.
+
+So reuse is safe for native-protocol runs and **incorrect for fence-protocol
+runs** until grouping understands the fence convention. Phase 3 must either teach
+`_group_turns` about it or group on the run's own record structure, where `call=`
+already pairs them unambiguously (§4.1).

--- a/Tests/Agents/test_agent_models.py
+++ b/Tests/Agents/test_agent_models.py
@@ -14,6 +14,7 @@ from tldw_chatbook.Agents.agent_models import (
     RUN_STUCK,
     RUN_SUPERSEDED,
     RUNTIME_TOOL_NAMES,
+    SEARCH_RUN_LOG_TOOL_NAME,
     SPAWN_TOOL_NAME,
     TERMINAL_RUN_STATUSES,
     AgentConfig,
@@ -57,6 +58,7 @@ def test_runtime_tool_names():
         "skill_file",
         INSTALL_SKILL_TOOL_NAME,
         RUN_SKILL_SCRIPT_TOOL_NAME,
+        SEARCH_RUN_LOG_TOOL_NAME,
     }
     assert DIRECT_DISCLOSE_THRESHOLD == 16 and LOOP_DETECTION_N == 3
 

--- a/Tests/Agents/test_install_skill_runtime_tool.py
+++ b/Tests/Agents/test_install_skill_runtime_tool.py
@@ -12,6 +12,7 @@ from tldw_chatbook.Agents.agent_models import (
     INSTALL_SKILL_TOOL_NAME,
     RUNTIME_TOOL_NAMES,
     RUN_SKILL_SCRIPT_TOOL_NAME,
+    SEARCH_RUN_LOG_TOOL_NAME,
     SPAWN_TOOL_NAME,
     FIND_TOOLS_NAME,
     LOAD_TOOLS_NAME,
@@ -37,6 +38,7 @@ def test_install_skill_name_in_runtime_tool_names():
         SKILL_FILE_TOOL_NAME,
         INSTALL_SKILL_TOOL_NAME,
         RUN_SKILL_SCRIPT_TOOL_NAME,
+        SEARCH_RUN_LOG_TOOL_NAME,
     }
 
 

--- a/Tests/Agents/test_run_log_format.py
+++ b/Tests/Agents/test_run_log_format.py
@@ -80,3 +80,55 @@ def test_whitespace_in_header_values_is_sanitised():
     # A header field containing a space or newline would break single-line parsing.
     (parsed,) = list(iter_records(encode_record(rec(tool="bad name\nx"))))
     assert " " not in parsed.tool and "\n" not in parsed.tool
+
+
+def test_empty_optional_fields_round_trip():
+    # CRITICAL 1: Empty optional fields must round-trip as empty, not as "-".
+    # A model record has tool="", status="", call_id="" by default.
+    original = rec(number=1, tool="", status="", call_id="")
+    (parsed,) = list(iter_records(encode_record(original)))
+    assert parsed.tool == ""
+    assert parsed.status == ""
+    assert parsed.call_id == ""
+    # Required fields should still be present.
+    assert parsed.run_id == "a3f9c1"
+    assert parsed.kind == "primary"
+
+
+def test_malformed_bytes_field_does_not_discard_following_records():
+    # CRITICAL 2a: Malformed header should resync, not return and lose all.
+    # Good record 1, bad bytes field, good record 2.
+    good1 = encode_record(rec(number=1, content="first"))
+    bad = b"#@# 000002 run=a3f9c1 kind=primary type=model ts=z bytes=notanumber\nno-parse\n"
+    good2 = encode_record(rec(number=3, content="third"))
+    blob = good1 + bad + good2
+    parsed = list(iter_records(blob))
+    # Should yield only records 1 and 3, skipping the malformed record 2.
+    assert len(parsed) == 2
+    assert parsed[0].number == 1
+    assert parsed[0].content == "first"
+    assert parsed[1].number == 3
+    assert parsed[1].content == "third"
+
+
+def test_torn_record_does_not_stitch_following_record():
+    # CRITICAL 2b: Torn record with overrun byte count must not yield stitched content.
+    # Record 1: normal
+    good1 = encode_record(rec(number=1, content="SHORT"))
+    # Record 2: declares content is 100 bytes but only writes 10, then Record 3
+    # This simulates a torn write: the parser would stitch record 3's start into record 2's content.
+    # Manually craft record 2 with overrun declaration.
+    # Content "123456789X" is 10 bytes, but declare bytes=100.
+    torn_header = b"#@# 000002 run=a3f9c1 kind=primary type=tool_result tool=- status=- call=- ts=- bytes=100\n"
+    torn_content = b"123456789X"  # Only 10 bytes, not 100
+    # Add record 3 after torn content; resync will find it via "\n#@# "
+    good3 = encode_record(rec(number=3, content="legitimate"))
+    blob = good1 + torn_header + torn_content + b"\n" + good3
+    parsed = list(iter_records(blob))
+    # Record 1 should parse fine.
+    # Record 2 is torn: declared 100 bytes, but at position end (10 bytes), we don't see '\n', so resync.
+    # Record 3 should be recovered after resync.
+    assert len(parsed) == 2
+    assert parsed[0].number == 1
+    assert parsed[1].number == 3
+    assert parsed[1].content == "legitimate"

--- a/Tests/Agents/test_run_log_format.py
+++ b/Tests/Agents/test_run_log_format.py
@@ -1,0 +1,82 @@
+"""Pure record codec: round-trip, adversarial content, partial tails."""
+
+from tldw_chatbook.Agents.run_log_format import (
+    RECORD_ANCHOR,
+    RunLogRecord,
+    encode_record,
+    iter_records,
+)
+
+
+def rec(number=1, content="hello", **kw):
+    base = dict(
+        number=number,
+        run_id="a3f9c1",
+        kind="primary",
+        type="tool_result",
+        ts="2026-07-27T18:22:31.004Z",
+        content=content,
+    )
+    base.update(kw)
+    return RunLogRecord(**base)
+
+
+def test_round_trip_preserves_content_exactly():
+    original = rec(content="line one\nline two\n")
+    (parsed,) = list(iter_records(encode_record(original)))
+    assert parsed.content == original.content
+    assert parsed.number == 1
+    assert parsed.run_id == "a3f9c1"
+
+
+def test_header_is_one_physical_line():
+    blob = encode_record(rec(tool="grep_files", status="ok", call_id="call_7"))
+    header = blob.split(b"\n", 1)[0].decode()
+    assert header.startswith(RECORD_ANCHOR + " ")
+    assert "tool=grep_files" in header
+    assert "bytes=5" in header
+
+
+def test_content_containing_the_anchor_does_not_corrupt_parsing():
+    # The whole point of bytes=N: content is sliced by length, never scanned.
+    evil = f"{RECORD_ANCHOR} 999999 run=x kind=primary type=model ts=z bytes=0\nnope"
+    blob = encode_record(rec(number=1, content=evil)) + encode_record(rec(number=2))
+    parsed = list(iter_records(blob))
+    assert len(parsed) == 2
+    assert parsed[0].content == evil
+    assert parsed[1].number == 2
+
+
+def test_multibyte_content_counts_bytes_not_characters():
+    original = rec(content="héllo — ✅")
+    blob = encode_record(original)
+    assert f"bytes={len(original.content.encode('utf-8'))}".encode() in blob
+    (parsed,) = list(iter_records(blob))
+    assert parsed.content == original.content
+
+
+def test_partial_trailing_record_is_ignored():
+    blob = encode_record(rec(number=1)) + encode_record(rec(number=2, content="abcdef"))
+    truncated = blob[:-3]  # content cut mid-write
+    parsed = list(iter_records(truncated))
+    assert [p.number for p in parsed] == [1]
+
+
+def test_record_missing_only_its_terminator_is_ignored():
+    blob = encode_record(rec(number=1))
+    parsed = list(iter_records(blob[:-1]))
+    assert parsed == []
+
+
+def test_truncated_field_round_trips_and_is_absent_otherwise():
+    assert b"truncated=" not in encode_record(rec())
+    blob = encode_record(rec(content="cut", truncated_from=9000))
+    assert b"truncated=9000" in blob
+    (parsed,) = list(iter_records(blob))
+    assert parsed.truncated_from == 9000
+
+
+def test_whitespace_in_header_values_is_sanitised():
+    # A header field containing a space or newline would break single-line parsing.
+    (parsed,) = list(iter_records(encode_record(rec(tool="bad name\nx"))))
+    assert " " not in parsed.tool and "\n" not in parsed.tool

--- a/Tests/Agents/test_run_log_format.py
+++ b/Tests/Agents/test_run_log_format.py
@@ -132,3 +132,19 @@ def test_torn_record_does_not_stitch_following_record():
     assert parsed[0].number == 1
     assert parsed[1].number == 3
     assert parsed[1].content == "legitimate"
+
+
+def test_negative_bytes_field_does_not_discard_following_records():
+    # CRITICAL 2a (continued): Negative size is malformed header, must resync not return.
+    # Good record 1, record with bytes=-1, good record 2.
+    good1 = encode_record(rec(number=1, content="first"))
+    bad = b"#@# 000002 run=a3f9c1 kind=primary type=model ts=z bytes=-1\nno-parse\n"
+    good2 = encode_record(rec(number=3, content="third"))
+    blob = good1 + bad + good2
+    parsed = list(iter_records(blob))
+    # Should yield only records 1 and 3, skipping the malformed record 2.
+    assert len(parsed) == 2
+    assert parsed[0].number == 1
+    assert parsed[0].content == "first"
+    assert parsed[1].number == 3
+    assert parsed[1].content == "third"

--- a/Tests/Agents/test_run_log_on_record.py
+++ b/Tests/Agents/test_run_log_on_record.py
@@ -91,6 +91,52 @@ def test_runtime_tool_results_are_captured_too():
     assert "find_tools" in tools
 
 
+def test_refused_tool_call_still_emits_tool_call_and_tool_result_records():
+    # Pins the placement of both _emit_record calls at the dispatch site:
+    # they must sit at the `for call in calls:` body level, OUTSIDE the
+    # `if verdict != "proceed": ... else: ...` pair, so a review_tool_calls
+    # refusal (the same seam MCP approval refusals ride) is captured too.
+    # A mutation that nests both calls one level deeper -- into the `else:`
+    # branch that only runs on a "proceed" verdict -- silently stops
+    # logging every refused call, and no other test in this suite catches
+    # that: this one must fail if that happens.
+    turns = [
+        ModelTurn(
+            text="",
+            tool_calls=(
+                ToolCall(name="calculator", args={"expr": "1+1"}, call_id="c1"),
+            ),
+            assistant_message={"role": "assistant", "content": ""},
+        ),
+        ModelTurn(text="done"),
+    ]
+    seen, hook = collect()
+    deps = make_deps(turns)
+    deps.on_record = hook
+    deps.review_tool_calls = lambda calls: {"calculator": "blocked by policy"}
+    config = AgentConfig(
+        model="m",
+        system_prompt="s",
+        allowed_tools=("calculator",),
+        budget=RunBudget(max_steps=8, max_model_turns=8),
+    )
+    run_agent_loop(config, [{"role": "user", "content": "go"}], [], deps)
+
+    tool_calls = [p for kind, p in seen if kind == "tool_call"]
+    tool_results = [p for kind, p in seen if kind == "tool_result"]
+
+    assert tool_calls, "refused call must still emit a tool_call record"
+    assert tool_calls[0]["tool"] == "calculator"
+    assert tool_calls[0]["call_id"] == "c1"
+
+    assert tool_results, "refused call must still emit a tool_result record"
+    refused = tool_results[0]
+    assert refused["status"] == "refused"
+    assert refused["content"] == "blocked by policy"
+    assert refused["tool"] == "calculator"
+    assert refused["call_id"] == "c1"
+
+
 def test_failing_hook_never_aborts_the_run():
     def boom(kind, payload):
         raise RuntimeError("log is on fire")

--- a/Tests/Agents/test_run_log_on_record.py
+++ b/Tests/Agents/test_run_log_on_record.py
@@ -137,6 +137,71 @@ def test_refused_tool_call_still_emits_tool_call_and_tool_result_records():
     assert refused["call_id"] == "c1"
 
 
+def test_successful_dispatched_call_is_still_status_ok():
+    # Regression guard for the fix below: a genuine success must not
+    # collapse to "error" just because the status computation now looks at
+    # `result.ok` instead of the verdict alone.
+    turns = [
+        ModelTurn(
+            text="",
+            tool_calls=(
+                ToolCall(name="calculator", args={"expr": "1+1"}, call_id="c1"),
+            ),
+            assistant_message={"role": "assistant", "content": ""},
+        ),
+        ModelTurn(text="done"),
+    ]
+    seen, _ = run(turns, invoke=lambda c: ToolResult(ok=True, content="2"))
+    results = [p for kind, p in seen if kind == "tool_result"]
+    assert results and results[0]["status"] == "ok"
+
+
+def test_failing_tool_call_emits_and_is_searchable_as_error_status():
+    """tool_catalog.py documents `status` as filterable by "ok or error", but
+    the loop only ever wrote "ok" (any "proceed" verdict, even a dispatch
+    that actually failed -- see `content = ... f"ERROR: {result.error}"` in
+    agent_runtime.py) or "refused" -- "error" was never reachable, so an
+    agent filtering for its own failed calls got zero hits forever. This
+    pins both ends: the loop must emit status="error" for a genuine dispatch
+    failure, and search_records(..., status="error") must actually find it.
+    """
+    from tldw_chatbook.Agents.run_log_format import RunLogRecord
+    from tldw_chatbook.Agents.run_log_search import search_records
+
+    turns = [
+        ModelTurn(
+            text="",
+            tool_calls=(
+                ToolCall(name="calculator", args={"expr": "1/0"}, call_id="c1"),
+            ),
+            assistant_message={"role": "assistant", "content": ""},
+        ),
+        ModelTurn(text="done"),
+    ]
+    seen, _ = run(
+        turns, invoke=lambda c: ToolResult(ok=False, error="division by zero")
+    )
+    results = [p for kind, p in seen if kind == "tool_result"]
+    assert results, "a dispatched failure must still emit a tool_result record"
+    failed = results[0]
+    assert failed["status"] == "error"
+    assert failed["content"] == "ERROR: division by zero"
+
+    record = RunLogRecord(
+        number=1,
+        run_id="r",
+        kind="primary",
+        type="tool_result",
+        ts="t",
+        content=failed["content"],
+        tool=failed["tool"],
+        status=failed["status"],
+        call_id=failed["call_id"],
+    )
+    hits = search_records([record], status="error")
+    assert [r.number for r in hits] == [1]
+
+
 def test_failing_hook_never_aborts_the_run():
     def boom(kind, payload):
         raise RuntimeError("log is on fire")

--- a/Tests/Agents/test_run_log_on_record.py
+++ b/Tests/Agents/test_run_log_on_record.py
@@ -1,0 +1,109 @@
+# Tests/Agents/test_run_log_on_record.py
+"""on_record captures FULL fidelity at both loop call sites."""
+
+from tldw_chatbook.Agents.agent_models import (
+    AgentConfig,
+    ModelTurn,
+    RunBudget,
+    ToolCall,
+    ToolResult,
+)
+from tldw_chatbook.Agents.agent_runtime import LoopDeps, run_agent_loop
+
+from Tests.Agents.test_agent_runtime import make_deps
+
+
+def collect():
+    seen = []
+    return seen, lambda kind, payload: seen.append((kind, payload))
+
+
+def run(turns, *, invoke=None, budget=None):
+    seen, hook = collect()
+    deps = make_deps(turns, invoke=invoke)
+    deps.on_record = hook
+    config = AgentConfig(
+        model="m",
+        system_prompt="s",
+        allowed_tools=("calculator",),
+        budget=budget or RunBudget(max_steps=8, max_model_turns=8),
+    )
+    outcome = run_agent_loop(config, [{"role": "user", "content": "go"}], [], deps)
+    return seen, outcome
+
+
+def test_model_record_carries_full_text_not_the_200_char_summary():
+    long_text = "z" * 5000
+    seen, _ = run([ModelTurn(text=long_text)])
+    model_records = [p for kind, p in seen if kind == "model"]
+    assert model_records and model_records[0]["content"] == long_text
+
+
+def test_tool_result_record_carries_content_before_truncation():
+    big = "q" * 40_000
+    turns = [
+        ModelTurn(
+            text="",
+            tool_calls=(ToolCall(name="calculator", args={}, call_id="c1"),),
+            assistant_message={"role": "assistant", "content": ""},
+        ),
+        ModelTurn(text="done"),
+    ]
+    seen, _ = run(
+        turns,
+        invoke=lambda c: ToolResult(ok=True, content=big),
+        budget=RunBudget(max_steps=8, max_model_turns=8, max_tool_result_chars=100),
+    )
+    results = [p for kind, p in seen if kind == "tool_result"]
+    assert results and results[0]["content"] == big
+    assert results[0]["call_id"] == "c1"
+
+
+def test_tool_call_record_carries_full_args():
+    turns = [
+        ModelTurn(
+            text="",
+            tool_calls=(
+                ToolCall(name="calculator", args={"expr": "1+1"}, call_id="c1"),
+            ),
+            assistant_message={"role": "assistant", "content": ""},
+        ),
+        ModelTurn(text="done"),
+    ]
+    seen, _ = run(turns)
+    calls = [p for kind, p in seen if kind == "tool_call"]
+    assert calls and "1+1" in calls[0]["content"]
+
+
+def test_runtime_tool_results_are_captured_too():
+    # find_tools never reaches deps.invoke_tool -- a service-side wrapper
+    # would have missed it entirely.
+    turns = [
+        ModelTurn(
+            text="",
+            tool_calls=(ToolCall(name="find_tools", args={"query": "x"}, call_id="c1"),),
+            assistant_message={"role": "assistant", "content": ""},
+        ),
+        ModelTurn(text="done"),
+    ]
+    seen, _ = run(turns)
+    tools = [p["tool"] for kind, p in seen if kind == "tool_result"]
+    assert "find_tools" in tools
+
+
+def test_failing_hook_never_aborts_the_run():
+    def boom(kind, payload):
+        raise RuntimeError("log is on fire")
+
+    deps = make_deps([ModelTurn(text="fine")])
+    deps.on_record = boom
+    config = AgentConfig(model="m", system_prompt="s", budget=RunBudget())
+    outcome = run_agent_loop(config, [{"role": "user", "content": "go"}], [], deps)
+    assert outcome.final_text == "fine"
+
+
+def test_absent_hook_is_a_no_op():
+    deps = make_deps([ModelTurn(text="fine")])
+    config = AgentConfig(model="m", system_prompt="s", budget=RunBudget())
+    outcome = run_agent_loop(config, [{"role": "user", "content": "go"}], [], deps)
+    assert outcome.final_text == "fine"

--- a/Tests/Agents/test_run_log_on_record.py
+++ b/Tests/Agents/test_run_log_on_record.py
@@ -1,6 +1,8 @@
 # Tests/Agents/test_run_log_on_record.py
 """on_record captures FULL fidelity at both loop call sites."""
 
+import pytest
+
 from tldw_chatbook.Agents.agent_models import (
     AgentConfig,
     ModelTurn,
@@ -218,3 +220,157 @@ def test_absent_hook_is_a_no_op():
     config = AgentConfig(model="m", system_prompt="s", budget=RunBudget())
     outcome = run_agent_loop(config, [{"role": "user", "content": "go"}], [], deps)
     assert outcome.final_text == "fine"
+
+
+# -- F5 (Qodo #5, PR #1066 review): tool_call must be durable BEFORE dispatch
+
+
+def test_tool_call_record_exists_even_when_the_tool_raises():
+    """A crash mid-dispatch must not erase the record that the call was
+    ever attempted -- that is the whole point of a crash-durable log. The
+    old placement (both _emit_record calls at the content-assembly point,
+    AFTER dispatch) meant a tool that raised left NO durable record at all.
+    This drives a tool whose invoke_tool raises, confirms the exception
+    still propagates (this test does not change that -- only capture
+    placement), and confirms the tool_call record was ALREADY written
+    (present in `seen`, standing in for "already flushed to disk") before
+    that exception ever happened.
+    """
+
+    def boom(call):
+        raise RuntimeError("the tool call hung and the worker was killed")
+
+    turns = [
+        ModelTurn(
+            text="",
+            tool_calls=(
+                ToolCall(name="calculator", args={"expr": "1+1"}, call_id="c1"),
+            ),
+            assistant_message={"role": "assistant", "content": ""},
+        ),
+    ]
+    seen, hook = collect()
+    deps = make_deps(turns, invoke=boom)
+    deps.on_record = hook
+    config = AgentConfig(
+        model="m",
+        system_prompt="s",
+        allowed_tools=("calculator",),
+        budget=RunBudget(max_steps=8, max_model_turns=8),
+    )
+    with pytest.raises(RuntimeError, match="worker was killed"):
+        run_agent_loop(config, [{"role": "user", "content": "go"}], [], deps)
+
+    tool_calls = [p for kind, p in seen if kind == "tool_call"]
+    assert tool_calls, "the tool_call record must exist despite the crash"
+    assert tool_calls[0]["tool"] == "calculator"
+    assert tool_calls[0]["call_id"] == "c1"
+    assert "1+1" in tool_calls[0]["content"]
+    # The tool never returned, so no tool_result record can exist -- this
+    # confirms the ordering (tool_call written, THEN dispatch attempted),
+    # not merely that a tool_call record exists somewhere.
+    assert not [p for kind, p in seen if kind == "tool_result"]
+
+
+def test_tool_call_record_exists_even_when_the_tool_never_returns():
+    """Same durability property, phrased for the "hangs forever" case named
+    in the finding rather than "raises": a tool whose invoke_tool blocks
+    indefinitely (simulated here as never being called at all, since the
+    loop itself is synchronous and a real hang cannot be driven in a unit
+    test) must still have left its tool_call record. This is really the
+    same assertion as the "raises" test from the log's point of view: the
+    record exists before dispatch resolves, by whatever means it resolves.
+    """
+    seen, hook = collect()
+
+    def never_returns(call):
+        raise TimeoutError("simulated: this call never returned")
+
+    turns = [
+        ModelTurn(
+            text="",
+            tool_calls=(
+                ToolCall(name="calculator", args={"expr": "2+2"}, call_id="c9"),
+            ),
+            assistant_message={"role": "assistant", "content": ""},
+        ),
+    ]
+    deps = make_deps(turns, invoke=never_returns)
+    deps.on_record = hook
+    config = AgentConfig(
+        model="m",
+        system_prompt="s",
+        allowed_tools=("calculator",),
+        budget=RunBudget(max_steps=8, max_model_turns=8),
+    )
+    with pytest.raises(TimeoutError):
+        run_agent_loop(config, [{"role": "user", "content": "go"}], [], deps)
+
+    tool_calls = [p for kind, p in seen if kind == "tool_call"]
+    assert tool_calls and tool_calls[0]["call_id"] == "c9"
+
+
+def test_spawn_tool_call_record_is_emitted_before_the_spawn_dispatch_runs():
+    """Pure-loop counterpart of the service-level ordering test in
+    test_run_log_service_wiring.py (which drives a REAL nested spawn through
+    RunLogWriter). Here `deps.spawn` itself appends records through the SAME
+    shared hook while it runs -- simulating a child's own on_record calls
+    happening DURING the parent's spawn dispatch, exactly as a real
+    spawn_subagent does (it runs the child's entire loop inline, BEFORE the
+    parent's own spawn_subagent tool_call/tool_result pair around it
+    finishes assembling). Before the F5 fix, the parent's tool_call record
+    for spawn_subagent was emitted AFTER `deps.spawn()` returned, so it
+    would have appeared AFTER these simulated child records below --
+    backwards. After the fix, it must appear FIRST.
+    """
+    from tldw_chatbook.Agents.agent_models import SPAWN_TOOL_NAME
+
+    seen, hook = collect()
+
+    def fake_spawn(task):
+        # Simulate a child writing its own records mid-dispatch, exactly
+        # as a real nested _run_one does through the shared writer.
+        hook("model", {"content": "child turn 1", "tool": "", "status": "", "call_id": ""})
+        hook(
+            "tool_call",
+            {"content": "{}", "tool": "child_tool", "status": "", "call_id": ""},
+        )
+        return ToolResult(ok=True, content="child done")
+
+    turns = [
+        ModelTurn(
+            text="",
+            tool_calls=(
+                ToolCall(
+                    name=SPAWN_TOOL_NAME, args={"task": "go investigate"}, call_id="s1"
+                ),
+            ),
+            assistant_message={"role": "assistant", "content": ""},
+        ),
+        ModelTurn(text="parent done"),
+    ]
+    deps = make_deps(turns, spawn=fake_spawn)
+    deps.on_record = hook
+    config = AgentConfig(
+        model="m",
+        system_prompt="s",
+        allowed_tools=(SPAWN_TOOL_NAME,),
+        budget=RunBudget(max_steps=8, max_model_turns=8, max_subagents=1),
+    )
+    outcome = run_agent_loop(config, [{"role": "user", "content": "go"}], [], deps)
+    assert outcome.final_text == "parent done"
+
+    kinds_in_order = [kind for kind, _ in seen]
+    parent_spawn_call_index = next(
+        i
+        for i, (kind, p) in enumerate(seen)
+        if kind == "tool_call" and p.get("tool") == SPAWN_TOOL_NAME
+    )
+    child_first_index = next(
+        i for i, (kind, p) in enumerate(seen) if p.get("tool") == "child_tool"
+    )
+    assert parent_spawn_call_index < child_first_index, (
+        "the parent's spawn_subagent tool_call record must be written "
+        "BEFORE the child's own records, not after -- got order "
+        f"{kinds_in_order}"
+    )

--- a/Tests/Agents/test_run_log_prompt_integration.py
+++ b/Tests/Agents/test_run_log_prompt_integration.py
@@ -1,0 +1,68 @@
+# Tests/Agents/test_run_log_prompt_integration.py
+"""Truncation points at the log; the prompt mentions it only when real."""
+
+import pytest
+
+from tldw_chatbook.Agents import run_log as run_log_module
+from tldw_chatbook.Agents.agent_models import AgentConfig, RunBudget
+from tldw_chatbook.Agents.agent_runtime import _truncate_tool_result
+from tldw_chatbook.Agents.agent_service import AgentService
+from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider, ToolCatalogRegistry
+from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+
+def test_trailer_points_at_the_record_when_one_exists():
+    out = _truncate_tool_result("z" * 100, 10, "grep_files", record_number=412)
+    assert "search_run_log" in out
+    assert "412" in out
+
+
+def test_trailer_keeps_the_old_wording_when_there_is_no_record():
+    out = _truncate_tool_result("z" * 100, 10, "grep_files", record_number=None)
+    assert "search_run_log" not in out
+    assert "narrower query" in out
+
+
+def test_untruncated_content_is_returned_unchanged():
+    assert _truncate_tool_result("short", 100, "t", record_number=7) == "short"
+
+
+def _service(tmp_path, capture):
+    db = AgentRunsDB(tmp_path / "runs.db")
+    registry = ToolCatalogRegistry()
+    registry.register_provider(BuiltinToolProvider())
+    return AgentService(db, registry, chat_call=capture)
+
+
+def _run(service):
+    service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "hi"}],
+        config=AgentConfig(model="m", system_prompt="BASE", budget=RunBudget()),
+        api_endpoint="openai",
+    )
+
+
+def test_prompt_mentions_the_log_when_logging_is_active(tmp_path, monkeypatch):
+    monkeypatch.setattr(run_log_module, "resolve_log_root", lambda: tmp_path)
+    prompts = []
+
+    def capture(**kwargs):
+        prompts.append(kwargs["messages_payload"][0]["content"])
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    _run(_service(tmp_path, capture))
+    assert any("search_run_log" in p for p in prompts)
+    assert all(p.startswith("BASE") for p in prompts)
+
+
+def test_prompt_is_silent_about_the_log_when_it_is_unavailable(tmp_path, monkeypatch):
+    monkeypatch.setattr(run_log_module, "resolve_log_root", lambda: None)
+    prompts = []
+
+    def capture(**kwargs):
+        prompts.append(kwargs["messages_payload"][0]["content"])
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    _run(_service(tmp_path, capture))
+    assert all("search_run_log" not in p for p in prompts)

--- a/Tests/Agents/test_run_log_prompt_integration.py
+++ b/Tests/Agents/test_run_log_prompt_integration.py
@@ -1,14 +1,20 @@
 # Tests/Agents/test_run_log_prompt_integration.py
 """Truncation points at the log; the prompt mentions it only when real."""
 
-import pytest
-
 from tldw_chatbook.Agents import run_log as run_log_module
-from tldw_chatbook.Agents.agent_models import AgentConfig, RunBudget
-from tldw_chatbook.Agents.agent_runtime import _truncate_tool_result
-from tldw_chatbook.Agents.agent_service import AgentService
+from tldw_chatbook.Agents.agent_models import (
+    AgentConfig,
+    ModelTurn,
+    RunBudget,
+    STEP_TOOL_RESULT,
+    ToolResult,
+)
+from tldw_chatbook.Agents.agent_runtime import _truncate_tool_result, run_agent_loop
+from tldw_chatbook.Agents.agent_service import RUN_LOG_PROMPT_SECTION, AgentService
 from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider, ToolCatalogRegistry
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+from Tests.Agents.test_agent_runtime import CALC, fence, make_deps
 
 
 def test_trailer_points_at_the_record_when_one_exists():
@@ -66,3 +72,65 @@ def test_prompt_is_silent_about_the_log_when_it_is_unavailable(tmp_path, monkeyp
 
     _run(_service(tmp_path, capture))
     assert all("search_run_log" not in p for p in prompts)
+
+
+def test_truncation_trailer_names_the_tool_result_record_not_the_tool_call_record():
+    """Both `tool_call` and `tool_result` are captured at the same dispatch
+    site (see _emit_record's two calls in run_agent_loop); the trailer must
+    point at the SECOND one's record number -- the record holding the full,
+    untruncated content -- not the first. A wrong pointer is worse than no
+    pointer: the model follows it and confidently retrieves someone else's
+    content. Distinct sentinel numbers per record kind make an off-by-one
+    (capturing the tool_call number instead) fail loudly here."""
+    huge = "y" * 5000
+
+    def on_record(record_type, payload):
+        return {"tool_call": 111, "tool_result": 999}.get(record_type)
+
+    cfg = AgentConfig(
+        model="m",
+        system_prompt="s",
+        allowed_tools=("calculator",),
+        budget=RunBudget(max_tool_result_chars=100),
+    )
+    deps = make_deps(
+        [ModelTurn(text=fence("calculator", {"expression": "1"})), ModelTurn(text="done")],
+        invoke=lambda c: ToolResult(ok=True, content=huge),
+    )
+    deps.on_record = on_record
+    out = run_agent_loop(cfg, [{"role": "user", "content": "hi"}], [CALC], deps)
+
+    result_steps = [s for s in out.steps if s.kind == STEP_TOOL_RESULT]
+    assert result_steps, "expected a truncated tool_result step"
+    trailer = result_steps[0].result
+    assert "record 000999" in trailer
+    assert "000111" not in trailer
+
+
+def test_prompt_mentions_the_log_on_a_non_native_fence_protocol_endpoint(
+    tmp_path, monkeypatch
+):
+    """test_prompt_mentions_the_log_when_logging_is_active above drives
+    api_endpoint="openai", a NATIVE-tools provider -- _make_call_model's
+    non-native `else` branch (where system_content gets reassigned from
+    config.system_prompt to append the rendered fence protocol, the exact
+    seam the brief's literal RUN_LOG_PROMPT_SECTION placement would have
+    been clobbered by) never executes there, so that test alone does not
+    prove the fix. This drives a genuine fence-protocol provider."""
+    monkeypatch.setattr(run_log_module, "resolve_log_root", lambda: tmp_path)
+    prompts = []
+
+    def capture(**kwargs):
+        prompts.append(kwargs["messages_payload"][0]["content"])
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    service = _service(tmp_path, capture)
+    service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "hi"}],
+        config=AgentConfig(model="m", system_prompt="BASE", budget=RunBudget()),
+        api_endpoint="llama_cpp",
+    )
+    assert prompts, "expected at least one call_model turn"
+    assert any(RUN_LOG_PROMPT_SECTION in p for p in prompts)
+    assert all(p.startswith("BASE") for p in prompts)

--- a/Tests/Agents/test_run_log_prompt_integration.py
+++ b/Tests/Agents/test_run_log_prompt_integration.py
@@ -33,6 +33,61 @@ def test_untruncated_content_is_returned_unchanged():
     assert _truncate_tool_result("short", 100, "t", record_number=7) == "short"
 
 
+def test_trailer_does_not_claim_full_recovery_when_the_log_itself_capped_the_record():
+    """F7 (Qodo #7): a plain int (every pre-existing caller, and every test
+    above) is treated as "not capped" -- but a `RunLogRecordNumber` whose
+    `.truncated` is True (see run_log.py) must flip the trailer's wording so
+    it never promises "the full result" for a record the log itself had to
+    cut. Constructed directly here (not through a real RunLogWriter) to
+    pin the CONTRACT `_truncate_tool_result` reads via `getattr(...,
+    "truncated", False)`, independent of run_log.py's own tests.
+    """
+    from tldw_chatbook.Agents.run_log import RunLogRecordNumber
+
+    capped = RunLogRecordNumber(412, truncated=True)
+    out = _truncate_tool_result("z" * 100, 10, "grep_files", record_number=capped)
+    assert "search_run_log" in out
+    assert "412" in out
+    assert "cannot be recovered" in out
+    assert "The full result is recorded" not in out
+
+
+def test_trailer_keeps_full_recovery_wording_for_a_plain_int_record_number():
+    """Regression guard for the fix above: an ordinary (non-capped) record
+    number -- a plain int, exactly like every pre-existing test in this
+    file uses -- must keep the unconditional "full result" wording."""
+    out = _truncate_tool_result("z" * 100, 10, "grep_files", record_number=412)
+    assert "The full result is recorded" in out
+    assert "cannot be recovered" not in out
+
+
+def test_end_to_end_a_really_capped_record_produces_an_honest_trailer(
+    tmp_path, monkeypatch
+):
+    """F7 (Qodo #7): the whole chain, not just one piece in isolation --
+    a REAL RunLogWriter (tiny max_record_bytes, over which a real result
+    exceeds), appended exactly the way agent_service.on_record does, its
+    REAL returned record number fed into the REAL _truncate_tool_result.
+    Before this fix, a record over the writer's own storage cap still got
+    the "The full result is recorded" trailer -- an unrecoverable tail the
+    agent was never told about.
+    """
+    monkeypatch.setattr(run_log_module, "resolve_log_root", lambda: tmp_path)
+    writer = run_log_module.RunLogWriter(max_record_bytes=50)
+    writer.bind("run-1")
+
+    huge = "z" * 5000
+    number = writer.append(
+        run_id="run-1", kind="primary", type="tool_result", content=huge
+    )
+    assert number.truncated is True, "the writer itself must have capped this record"
+
+    trailer = _truncate_tool_result(huge, 100, "read_file", record_number=number)
+    assert "cannot be recovered" in trailer
+    assert "The full result is recorded" not in trailer
+    assert "search_run_log" in trailer
+
+
 def _service(tmp_path, capture):
     db = AgentRunsDB(tmp_path / "runs.db")
     registry = ToolCatalogRegistry()

--- a/Tests/Agents/test_run_log_sandbox_isolation.py
+++ b/Tests/Agents/test_run_log_sandbox_isolation.py
@@ -126,6 +126,69 @@ def test_sandbox_fallback_directory_is_dotted_and_hidden_from_grep(
     )
 
 
+def test_workspace_folder_inside_the_sandbox_is_dotted_and_hidden_from_grep(
+    tmp_path, monkeypatch
+):
+    """task-1251 / F8 (Qodo #8, PR #1066 review): the edge case the
+    fallback-branch-only dotting decision missed -- a bound READ-WRITE
+    workspace folder whose resolved path lies INSIDE the sandbox root (a
+    deliberate but unusual binding; `add_folder_binding` has no guard
+    against it). `resolve_log_root()` takes the "workspace" branch here
+    (NOT the sandbox-fallback branch), so the pre-fix flag-only decision
+    would have kept the undotted name -- reproducing the exact
+    `PARENT_SECRET_API_KEY` disclosure `test_sandbox_fallback_directory_is_
+    dotted_and_hidden_from_grep` above guards against, just reached through
+    the other branch. Mirrors that test's plant-a-secret-and-grep shape
+    (task-1251 AC #3) but through a WORKSPACE folder binding, not the
+    no-workspace fallback.
+    """
+    import tldw_chatbook.Tools.file_operation_tools as file_tools
+    import tldw_chatbook.Tools.workspace_file_roots as ws_roots
+
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    workspace = sandbox / "bound-workspace"  # INSIDE the sandbox root
+    workspace.mkdir()
+    monkeypatch.setattr(file_tools, "_tool_sandbox_root", lambda: sandbox)
+    monkeypatch.setattr(
+        ws_roots,
+        "allowed_file_roots",
+        lambda write=False, sandbox_root=None: (sandbox, workspace),
+    )
+
+    # Positive control: grep_files genuinely scans the sandbox (which is
+    # what GrepFiles roots at, per §9.4 -- it never consults
+    # allowed_file_roots and so has no idea a workspace folder is bound at
+    # all), including this nested workspace directory.
+    (workspace / "control.txt").write_text("CONTROL_MARKER_2b7e\n", encoding="utf-8")
+    assert _grep("CONTROL_MARKER_2b7e"), (
+        "positive control failed: grep_files must find visible content "
+        "nested under the sandbox root"
+    )
+
+    writer = RunLogWriter()
+    writer.bind("run-secret")
+    assert writer.is_active, "writer must still activate for this binding"
+    assert writer.log_dir is not None
+    assert writer.log_dir.parent.name == ".agent-runs", (
+        f"a workspace folder resolving inside the sandbox root must still "
+        f"get the DOTTED name; got {writer.log_dir.parent.name!r}"
+    )
+    assert writer.log_dir.parent.parent == workspace
+
+    writer.append(
+        run_id="run-secret",
+        kind="primary",
+        type="model",
+        content="PARENT_SECRET_API_KEY=sk-live-xyz789",
+    )
+
+    assert _grep("PARENT_SECRET_API_KEY") == [], (
+        "grep_files must not be able to read the run log through a "
+        "workspace folder bound inside the sandbox root"
+    )
+
+
 def test_bound_workspace_folder_keeps_the_undotted_name(tmp_path, monkeypatch):
     """Sibling case: when `resolve_log_root()` reports a bound workspace
     folder (not the fallback), the directory must stay undotted -- it is

--- a/Tests/Agents/test_run_log_sandbox_isolation.py
+++ b/Tests/Agents/test_run_log_sandbox_isolation.py
@@ -1,0 +1,233 @@
+# Tests/Agents/test_run_log_sandbox_isolation.py
+"""Final-review CRITICAL 2: the sandbox-fallback log must stay invisible to
+the generic file tools.
+
+When no read-write workspace folder is bound -- confirmed the REAL default
+by a live probe (see Task 8's live-probe finding in the SDD progress log) --
+`resolve_log_root()` falls back to `_tool_sandbox_root()`, which is EXACTLY
+the root `glob_files`/`grep_files` are rooted at (spec §9.4: those two tools
+glob/grep the sandbox root directly and never consult `allowed_file_roots`,
+unlike `read_file`). Because §9.1 deliberately made the log directory name
+undotted (`agent-runs`) so it reads as a user-visible artifact inside a
+BOUND WORKSPACE folder, `_is_hidden_within` does not exclude it -- and that
+same undotted name, reached via the sandbox fallback instead, is a plain
+directory those two tools happily enumerate and read. A spawned sub-agent
+inherits its parent's tool allow-list (`spawn`'s default in
+agent_service.py), so a child running `grep_files` could read its PARENT's
+entire log, directly contradicting `spawn_subagent`'s promise ("It sees
+only the task text you pass") and bypassing `search_run_log`'s own
+primary-only gate (Task 6) entirely -- through a completely different pair
+of tools.
+
+Fix: `bind()` dots the directory name (`.agent-runs`) specifically in the
+sandbox-fallback case, reported by `resolve_log_root()` itself via a
+thread-local side channel (see `run_log._root_kind`) rather than guessed by
+inspecting the resolved path's name. Dotting does not break
+`search_run_log`'s own reader (`run_log_search.load_records` globs the
+directory directly, never through `validate_path`/`_is_hidden_within`) --
+it only removes the directory from what `glob_files`/`grep_files`/
+`read_file` can see, which in the app-internal sandbox case is exactly the
+intent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from tldw_chatbook.Agents.agent_models import (
+    RUN_DONE,
+    SPAWN_TOOL_NAME,
+    AgentConfig,
+    RunBudget,
+)
+from tldw_chatbook.Agents.agent_service import AgentService
+from tldw_chatbook.Agents.run_log import RunLogWriter
+from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider, ToolCatalogRegistry
+from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+from tldw_chatbook.Tools.file_operation_tools import GrepFiles
+
+
+class _AllowGate:
+    """Bypasses BuiltinToolProvider's approval machinery for these tests.
+
+    `grep_files` carries the "reads" risk tag, which floors it to `ask`
+    under the real gate. These tests care about path-level containment
+    (can `grep_files` even SEE the log directory), not the approval round
+    trip, so the provider is handed a gate that always allows.
+    """
+
+    def check(self, tool):
+        return None
+
+
+def _fallback_seams(monkeypatch, sandbox: Path):
+    """Simulate the REAL default configuration: no rw workspace folder bound.
+
+    Both `resolve_log_root()` (via its own local imports) and
+    `GrepFiles.execute` (a bare module-level reference) resolve
+    `_tool_sandbox_root` dynamically from `file_operation_tools` at call
+    time, so patching the one module attribute redirects both consumers to
+    the SAME sandbox directory -- exactly the real-world condition this
+    finding depends on.
+    """
+    import tldw_chatbook.Tools.file_operation_tools as file_tools
+    import tldw_chatbook.Tools.workspace_file_roots as ws_roots
+
+    sandbox.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(file_tools, "_tool_sandbox_root", lambda: sandbox)
+    monkeypatch.setattr(
+        ws_roots,
+        "allowed_file_roots",
+        lambda write=False, sandbox_root=None: (sandbox,),
+    )
+
+
+def _grep(pattern: str) -> list[dict]:
+    result = asyncio.run(GrepFiles().execute(pattern=pattern))
+    return result.get("matches", [])
+
+
+def test_sandbox_fallback_directory_is_dotted_and_hidden_from_grep(
+    tmp_path, monkeypatch
+):
+    sandbox = tmp_path / "sandbox"
+    _fallback_seams(monkeypatch, sandbox)
+
+    # Positive control FIRST: prove grep_files genuinely scans this sandbox
+    # before trusting a "no matches" result below for the log directory --
+    # a plain, non-hidden file's content IS found.
+    (sandbox / "control.txt").write_text("CONTROL_MARKER_9f1c\n", encoding="utf-8")
+    assert _grep("CONTROL_MARKER_9f1c"), (
+        "positive control failed: grep_files must find visible sandbox content"
+    )
+
+    # The real writer, default dir_name, REAL bind() naming logic -- no
+    # dir_name override, so this exercises exactly what a production run
+    # does under the sandbox fallback.
+    writer = RunLogWriter()
+    writer.bind("run-secret")
+    assert writer.is_active, "writer must still activate under the fallback"
+    assert writer.log_dir is not None
+    assert writer.log_dir.parent.name == ".agent-runs", (
+        f"expected the dotted fallback directory name, got "
+        f"{writer.log_dir.parent.name!r}"
+    )
+    writer.append(
+        run_id="run-secret",
+        kind="primary",
+        type="model",
+        content="PARENT_SECRET_API_KEY=sk-live-abc123",
+    )
+
+    assert _grep("PARENT_SECRET_API_KEY") == [], (
+        "grep_files must not be able to read the sandbox-fallback run log"
+    )
+
+
+def test_bound_workspace_folder_keeps_the_undotted_name(tmp_path, monkeypatch):
+    """Sibling case: when `resolve_log_root()` reports a bound workspace
+    folder (not the fallback), the directory must stay undotted -- it is
+    meant to be a user-visible artifact there (spec §3.3), and the fix must
+    not regress that by dotting unconditionally.
+    """
+    import tldw_chatbook.Tools.file_operation_tools as file_tools
+    import tldw_chatbook.Tools.workspace_file_roots as ws_roots
+
+    sandbox = tmp_path / "sandbox"
+    workspace = tmp_path / "workspace"
+    sandbox.mkdir()
+    workspace.mkdir()
+    monkeypatch.setattr(file_tools, "_tool_sandbox_root", lambda: sandbox)
+    monkeypatch.setattr(
+        ws_roots,
+        "allowed_file_roots",
+        lambda write=False, sandbox_root=None: (sandbox, workspace),
+    )
+
+    writer = RunLogWriter()
+    writer.bind("run-1")
+    assert writer.is_active
+    assert writer.log_dir.parent.name == "agent-runs"
+    assert writer.log_dir.parent.parent == workspace
+
+
+def _fence(name, args):
+    return f"```tool_call\n{json.dumps({'name': name, 'arguments': args})}\n```"
+
+
+def _svc_fence(name, args):
+    return {"choices": [{"message": {"content": _fence(name, args)}}]}
+
+
+def test_spawned_subagent_cannot_read_parents_log_via_grep_files(tmp_path, monkeypatch):
+    """Reproduces the reviewer's finding directly through a live run: the
+    PARENT's own turn embeds a secret (captured verbatim into its "model"
+    log record before any tool dispatch), it spawns a child, and the child
+    tries to read the secret back out through `grep_files` -- a tool it
+    inherits through the ordinary allow-list, completely independent of
+    `search_run_log`'s own primary-only gate.
+    """
+    sandbox = tmp_path / "sandbox"
+    _fallback_seams(monkeypatch, sandbox)
+
+    import tldw_chatbook.config as config_module
+
+    def fake_get_cli_setting(section, key=None, default=None):
+        if section == "tools" and key == "grep_files_enabled":
+            return True
+        return default
+
+    monkeypatch.setattr(config_module, "get_cli_setting", fake_get_cli_setting)
+
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    reg = ToolCatalogRegistry()
+    reg.register_provider(BuiltinToolProvider(gate=_AllowGate()))
+
+    secret = "PARENT_SECRET_API_KEY=sk-live-abc123"
+    task = "search the sandbox for anything interesting"
+    script = [
+        {
+            "choices": [
+                {
+                    "message": {
+                        "content": (
+                            f"Noting {secret} before delegating.\n"
+                            + _fence(SPAWN_TOOL_NAME, {"task": task})
+                        )
+                    }
+                }
+            ]
+        },
+        _svc_fence("grep_files", {"pattern": "PARENT_SECRET"}),  # child tries
+        {"choices": [{"message": {"content": "found nothing"}}]},  # child's answer
+        {"choices": [{"message": {"content": "done"}}]},  # parent's answer
+    ]
+
+    def chat(**kwargs):
+        return script.pop(0)
+
+    service = AgentService(db, reg, chat_call=chat)
+    _rid, outcome = service.run_turn(
+        conversation_id="c1",
+        messages=[{"role": "user", "content": "go"}],
+        config=AgentConfig(
+            model="m",
+            system_prompt="s",
+            allowed_tools=("calculator", SPAWN_TOOL_NAME, "grep_files"),
+            budget=RunBudget(),
+        ),
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+
+    # The child's own persisted tool_result for its grep_files call must
+    # never contain the parent's secret.
+    child_runs = [r for r in db.list_runs("c1") if r["agent_kind"] == "subagent"]
+    assert len(child_runs) == 1
+    tool_results = [
+        s["result"] for s in child_runs[0]["steps"] if s["kind"] == "tool_result"
+    ]
+    assert tool_results, "expected the child's grep_files tool_result step"
+    assert not any(secret in r or "PARENT_SECRET" in r for r in tool_results)

--- a/Tests/Agents/test_run_log_search.py
+++ b/Tests/Agents/test_run_log_search.py
@@ -1,0 +1,85 @@
+# Tests/Agents/test_run_log_search.py
+"""Search: literal by default, structured filters, bounded regex."""
+
+from tldw_chatbook.Agents.run_log_format import RunLogRecord
+from tldw_chatbook.Agents.run_log_search import (
+    MAX_REGEX_SCAN_CHARS,
+    format_results,
+    search_records,
+)
+
+
+def rec(number, content, **kw):
+    base = dict(
+        number=number,
+        run_id="r",
+        kind="primary",
+        type="tool_result",
+        ts="t",
+        content=content,
+    )
+    base.update(kw)
+    return RunLogRecord(**base)
+
+
+CORPUS = [
+    rec(1, "opened the config file", tool="read_file", status="ok"),
+    rec(2, "connection refused", tool="web_search", status="error"),
+    rec(3, "thinking about it", type="model"),
+    rec(4, "wrote the config file", tool="write_file", status="ok"),
+]
+
+
+def test_literal_contains_is_the_default_and_is_not_a_regex():
+    assert [r.number for r in search_records(CORPUS, contains="config file")] == [1, 4]
+    # A regex metacharacter is matched literally, never compiled.
+    assert search_records(CORPUS, contains="config.file") == []
+
+
+def test_literal_search_is_unbounded_by_line_length():
+    long_record = [rec(9, "x" * 5000 + "NEEDLE")]
+    assert len(search_records(long_record, contains="NEEDLE")) == 1
+
+
+def test_structured_filters_compose():
+    hits = search_records(CORPUS, status="error")
+    assert [r.number for r in hits] == [2]
+    assert [r.number for r in search_records(CORPUS, type="model")] == [3]
+    assert [r.number for r in search_records(CORPUS, tool="write_file")] == [4]
+
+
+def test_record_range_slices():
+    assert [r.number for r in search_records(CORPUS, from_record=3)] == [3, 4]
+    assert [r.number for r in search_records(CORPUS, to_record=2)] == [1, 2]
+
+
+def test_context_returns_neighbours_in_order_without_duplicates():
+    hits = search_records(CORPUS, contains="refused", context=1)
+    assert [r.number for r in hits] == [1, 2, 3]
+
+
+def test_regex_mode_is_opt_in_and_scan_bounded():
+    assert [r.number for r in search_records(CORPUS, pattern=r"conn\w+")] == [2]
+    # Beyond the scan window the pattern cannot match, by design.
+    far = [rec(9, "y" * (MAX_REGEX_SCAN_CHARS + 50) + "NEEDLE")]
+    assert search_records(far, pattern="NEEDLE") == []
+    assert len(search_records(far, contains="NEEDLE")) == 1
+
+
+def test_invalid_regex_returns_no_hits_rather_than_raising():
+    assert search_records(CORPUS, pattern="(unclosed") == []
+
+
+def test_limit_caps_results():
+    assert len(search_records(CORPUS, limit=2)) == 2
+
+
+def test_format_results_is_readable_and_truncates_long_content():
+    text = format_results([rec(7, "z" * 900, tool="read_file")], max_chars=50)
+    assert "record 000007" in text
+    assert "read_file" in text
+    assert len(text) < 300
+
+
+def test_format_results_reports_no_matches():
+    assert "no matching records" in format_results([]).lower()

--- a/Tests/Agents/test_run_log_search.py
+++ b/Tests/Agents/test_run_log_search.py
@@ -83,3 +83,27 @@ def test_format_results_is_readable_and_truncates_long_content():
 
 def test_format_results_reports_no_matches():
     assert "no matching records" in format_results([]).lower()
+
+
+def test_limit_applies_to_hits_before_context_expansion():
+    # Reproducer from reviewer: 11-record corpus with only one match at record 6,
+    # context=3, limit=3. The match must be in the result.
+    corpus = [
+        rec(1, "a"),
+        rec(2, "b"),
+        rec(3, "c"),
+        rec(4, "d"),
+        rec(5, "e"),
+        rec(6, "NEEDLE"),
+        rec(7, "f"),
+        rec(8, "g"),
+        rec(9, "h"),
+        rec(10, "i"),
+        rec(11, "j"),
+    ]
+    result = search_records(corpus, contains="NEEDLE", context=3, limit=3)
+    # The one matching record (6) must be present.
+    assert 6 in [r.number for r in result]
+    # Context should include records 3-9 (3 before and after record 6),
+    # which is 7 records total (exceeding limit because context is additional).
+    assert [r.number for r in result] == [3, 4, 5, 6, 7, 8, 9]

--- a/Tests/Agents/test_run_log_search.py
+++ b/Tests/Agents/test_run_log_search.py
@@ -95,6 +95,95 @@ def test_format_results_reports_no_matches():
     assert "no matching records" in format_results([]).lower()
 
 
+def test_match_beyond_max_chars_is_rendered_not_silently_dropped():
+    """TASK-1250 live reproduction.
+
+    Observed against a real llama.cpp model with max_tool_result_chars=500
+    and a 2,925-character tool result whose answer sat at character 2,646:
+    `format_results` always rendered `content[:max_chars]` from offset 0 --
+    the same ceiling that truncated the result in history in the first
+    place -- so a record far larger than that ceiling rendered byte-
+    identical to the truncated view the model already saw. Worse,
+    `contains=` could legitimately MATCH the record (search_records has no
+    scan bound for literal search) and then render a body that did not
+    contain the match: the agent was told the record matched and shown
+    text that contradicted it. The model followed the trailer, searched by
+    content, and produced an EMPTY final answer -- it had the information
+    in its log and could not reach it.
+
+    Before the fix: format_results had no `contains` parameter at all, so
+    this call fails outright. After the fix: the render must be centred on
+    the match, so the marker -- 2,146 characters past the render ceiling --
+    must be visible in the rendered text.
+    """
+    marker = "ZEBRA_9931"
+    content = "x" * 2646 + marker + "y" * 269
+    assert len(content) == 2925  # pins the live evidence's exact shape
+    record = rec(3, content)
+
+    # The record DOES match -- search_records has no scan bound for
+    # literal `contains`, so this half of the bug was never in question.
+    hits = search_records([record], contains=marker)
+    assert [r.number for r in hits] == [3]
+
+    # The RENDER must contain what the search says matched.
+    rendered = format_results(hits, max_chars=500, contains=marker)
+    assert marker in rendered
+
+
+def test_offset_pages_through_a_large_record_to_its_end():
+    # A record several times max_chars, with a marker reachable only by
+    # following the render's own "Use offset=N to continue" pointer.
+    tail = "TAIL_MARKER_END"
+    content = "m" * 1985 + tail
+    assert len(content) == 2000
+    record = rec(5, content)
+
+    first = format_results([record], max_chars=500)
+    assert tail not in first
+    assert "Use offset=500 to continue" in first
+
+    second = format_results([record], max_chars=500, offset=500)
+    assert tail not in second
+    assert "Use offset=1000 to continue" in second
+
+    third = format_results([record], max_chars=500, offset=1000)
+    assert tail not in third
+    assert "Use offset=1500 to continue" in third
+
+    fourth = format_results([record], max_chars=500, offset=1500)
+    assert tail in fourth
+    # The final page reaches the record's true end: no further pointer.
+    assert "Use offset=" not in fourth
+
+
+def test_offset_negative_or_past_end_is_clamped_not_empty():
+    content = "n" * 2000
+    record = rec(6, content)
+
+    # A negative offset (a model guessing at search_run_log's args could
+    # send one) must behave like offset=0, never raise, never render an
+    # empty window.
+    negative = format_results([record], max_chars=500, offset=-999)
+    body = negative.split("\n", 1)[1]
+    assert body.startswith("n" * 500)
+
+    # An offset past the record's end must still render its final window
+    # rather than nothing.
+    past_end = format_results([record], max_chars=500, offset=999_999)
+    body = past_end.split("\n", 1)[1]
+    assert body.strip() != ""
+    assert "chars 1500-2000 of 2000" in past_end
+
+
+def test_no_query_render_still_starts_at_offset_zero():
+    content = "p" * 2000
+    record = rec(9, content)
+    rendered = format_results([record], max_chars=500)
+    body = rendered.split("\n", 1)[1]
+    assert body.startswith("p" * 500)
+
+
 def test_limit_applies_to_hits_before_context_expansion():
     # Reproducer from reviewer: 11-record corpus with only one match at record 6,
     # context=3, limit=3. The match must be in the result.

--- a/Tests/Agents/test_run_log_search.py
+++ b/Tests/Agents/test_run_log_search.py
@@ -58,6 +58,16 @@ def test_context_returns_neighbours_in_order_without_duplicates():
     assert [r.number for r in hits] == [1, 2, 3]
 
 
+def test_negative_context_is_clamped_and_still_returns_the_hit():
+    # Reviewer finding: a negative context made low > high, so
+    # range(low, high + 1) came back empty and even the matching record
+    # itself was silently dropped -- "No matching records." even though a
+    # match exists. context must clamp to 0, not widen the window the
+    # wrong direction.
+    hits = search_records(CORPUS, contains="refused", context=-5)
+    assert [r.number for r in hits] == [2]
+
+
 def test_regex_mode_is_opt_in_and_scan_bounded():
     assert [r.number for r in search_records(CORPUS, pattern=r"conn\w+")] == [2]
     # Beyond the scan window the pattern cannot match, by design.

--- a/Tests/Agents/test_run_log_search.py
+++ b/Tests/Agents/test_run_log_search.py
@@ -1,9 +1,15 @@
 # Tests/Agents/test_run_log_search.py
 """Search: literal by default, structured filters, bounded regex."""
 
+import time
+
+import pytest
+
 from tldw_chatbook.Agents.run_log_format import RunLogRecord
 from tldw_chatbook.Agents.run_log_search import (
     MAX_REGEX_SCAN_CHARS,
+    RunLogSearchPatternRejected,
+    RunLogSearchTimeout,
     format_results,
     search_records,
 )
@@ -206,3 +212,88 @@ def test_limit_applies_to_hits_before_context_expansion():
     # Context should include records 3-9 (3 before and after record 6),
     # which is 7 records total (exceeding limit because context is additional).
     assert [r.number for r in result] == [3, 4, 5, 6, 7, 8, 9]
+
+
+# -- F6 (Qodo #6): a model-controlled regex must never hang the worker -------
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        "(a+)+",
+        "(a*)*",
+        "(a+)*",
+        "(a*)+",
+        "(a+?)+",  # lazy variant, same shape
+        "((a+)+)+",  # nested twice
+        "prefix(a+)+suffix",  # not anchored at the pattern's start
+    ],
+)
+def test_catastrophic_pattern_shapes_are_rejected_quickly(pattern):
+    """Each of these is the textbook nested-quantifier shape named in the
+    finding. The screen must reject BEFORE compiling/executing -- this
+    itself proves nothing hung (a real hang would time the test out), and
+    the message must point the model at `contains=` instead.
+    """
+    started = time.monotonic()
+    with pytest.raises(RunLogSearchPatternRejected, match="contains"):
+        search_records(CORPUS, pattern=pattern)
+    # "quickly" -- a generous ceiling far below what an actual catastrophic
+    # match against even a short string would take (fractions of a second
+    # vs. an unreachable amount of time).
+    assert time.monotonic() - started < 1.0
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        r"\d{3}-\d{4}",
+        "(abc)+",
+        "a+b*",
+        "(foo|bar)+",
+        "[a-z]+",
+        "(ab)+c*",
+        "config.*file",
+        r"(a+)(b+)",  # two quantified groups, but NOT nested -- must not trip
+    ],
+)
+def test_ordinary_patterns_are_not_rejected(pattern):
+    """The screen is conservative by design -- it must never flag a normal
+    pattern, even ones with multiple quantified groups, as long as they are
+    not the specific nested shape."""
+    # Must not raise; whether it matches anything is irrelevant here.
+    search_records(CORPUS, pattern=pattern)
+
+
+def test_search_records_raises_a_clear_timeout_past_its_deadline():
+    """F6 layer 1: a wall-clock deadline checked between records. Uses a
+    near-zero deadline against a small corpus so the very first
+    between-record check trips it deterministically -- this does not (and
+    cannot, from pure Python) prove protection against a single hung regex
+    evaluation; see the module docstring for that limitation.
+    """
+    with pytest.raises(RunLogSearchTimeout, match="wall-clock"):
+        search_records(CORPUS, contains="config", deadline_seconds=0.0)
+
+
+def test_search_records_completes_well_within_a_generous_deadline():
+    # Regression guard: the deadline check itself must not be so aggressive
+    # it breaks an ordinary, fast search.
+    result = search_records(CORPUS, contains="config file", deadline_seconds=5.0)
+    assert [r.number for r in result] == [1, 4]
+
+
+# -- F7 (Qodo #7): a capped record must say so, not claim completeness -------
+
+
+def test_format_results_flags_a_record_the_writer_itself_capped():
+    record = rec(1, "y" * 50, truncated_from=1_000_000)
+    out = format_results([record])
+    assert "cannot be recovered" in out
+    assert "1000000" in out
+
+
+def test_format_results_says_nothing_extra_for_an_uncapped_record():
+    record = rec(1, "ordinary content")
+    out = format_results([record])
+    assert "cannot be recovered" not in out

--- a/Tests/Agents/test_run_log_service_wiring.py
+++ b/Tests/Agents/test_run_log_service_wiring.py
@@ -233,3 +233,82 @@ def test_run_turn_called_twice_on_one_service_gets_two_separate_logs(wired):
             "numbering must restart per tree, not continue across "
             f"run_turn calls; got {numbers}"
         )
+
+
+def test_tool_is_offered_to_the_primary_agent_only(wired, monkeypatch):
+    """Primary + at least one other disclosable schema (here: the builtin
+    ``calculator``, allow-listed so it lands in ``active``) -> offered.
+
+    Controller ruling (post-review of the original spec): search_run_log is
+    additionally gated on the run having at least one OTHER disclosable
+    schema (``runtime_schemas or active`` non-empty), mirroring every other
+    runtime tool's own gate (spawn_subagent on max_subagents>0, find_tools/
+    load_tools on offer_find_load, skill_file on a non-empty authorized
+    set). This test now allow-lists ``calculator`` so ``active`` is
+    non-empty and the assertion is exercising "primary vs subagent",
+    exactly as it did before that ruling -- not the separate "nothing else
+    disclosed" case, which ``test_tool_is_not_offered_when_nothing_else_is_disclosed``
+    below covers.
+    """
+    from tldw_chatbook.Agents.agent_models import SEARCH_RUN_LOG_TOOL_NAME
+
+    db, registry, root = wired
+    offered = []
+
+    def capture(**kwargs):
+        names = [t["function"]["name"] for t in kwargs.get("tools", [])]
+        offered.append(names)
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    service = AgentService(db, registry, chat_call=capture)
+    service.run_turn(
+        conversation_id="conv1",
+        messages=[{"role": "user", "content": "hi"}],
+        config=AgentConfig(
+            model="m",
+            system_prompt="s",
+            allowed_tools=("calculator",),
+            budget=RunBudget(max_subagents=0),
+        ),
+        api_endpoint="openai",
+    )
+    assert any(SEARCH_RUN_LOG_TOOL_NAME in names for names in offered)
+
+
+def test_tool_is_not_offered_when_nothing_else_is_disclosed(wired, monkeypatch):
+    """Controller ruling: an otherwise-tool-less primary run (empty
+    allow-list, max_subagents=0, no skills/install/run-script wiring) must
+    NOT be offered search_run_log even though the writer is active.
+
+    Such a run can only ever produce model-turn log records -- it has no
+    tool results, so nothing was ever truncated and there is nothing to
+    recover -- so the tool would buy it nothing while changing the
+    provider payload of a deliberately tool-less run (task-243 minor m3:
+    a native-capable endpoint with no disclosable schemas must send no
+    ``tools=`` kwarg at all).
+    """
+    from tldw_chatbook.Agents.agent_models import SEARCH_RUN_LOG_TOOL_NAME
+
+    db, registry, root = wired
+    offered = []
+
+    def capture(**kwargs):
+        offered.append(kwargs)
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    service = AgentService(db, registry, chat_call=capture)
+    service.run_turn(
+        conversation_id="conv1",
+        messages=[{"role": "user", "content": "hi"}],
+        config=AgentConfig(
+            model="m",
+            system_prompt="s",
+            budget=RunBudget(max_subagents=0),
+        ),
+        api_endpoint="openai",
+    )
+    assert len(offered) == 1
+    assert "tools" not in offered[0], (
+        "a deliberately tool-less run must never gain search_run_log as its "
+        f"sole disclosed tool; got kwargs {offered[0]!r}"
+    )

--- a/Tests/Agents/test_run_log_service_wiring.py
+++ b/Tests/Agents/test_run_log_service_wiring.py
@@ -162,6 +162,60 @@ def test_a_real_spawn_shares_the_parent_log_directory_and_counter(wired):
     )
 
 
+def test_parent_spawn_tool_call_record_precedes_the_childs_own_records(wired):
+    """F5 (Qodo #5, PR #1066 review): end-to-end counterpart of the pure-loop
+    test in test_run_log_on_record.py, driven through a REAL nested spawn
+    and the REAL RunLogWriter. `deps.spawn()` runs the child's ENTIRE loop
+    inline before returning to the parent's dispatch of spawn_subagent, so
+    before the F5 fix (both _emit_record calls at the content-assembly
+    point, AFTER dispatch) the child's own model/tool_call/tool_result
+    records -- written during that still-in-progress parent dispatch --
+    landed in the log BEFORE the parent's own tool_call record that caused
+    the spawn at all: backwards chronological order. After the fix, the
+    parent's tool_call record for spawn_subagent (its record number is
+    assigned BEFORE `deps.spawn()` runs) must precede every one of the
+    child's records.
+    """
+    db, registry, root = wired
+    replies = [
+        fence(SPAWN_TOOL_NAME, {"task": "child task"}),  # parent turn 1: spawns
+        "child says hi",  # CHILD turn 1
+        "parent final",  # parent turn 2
+    ]
+    service = AgentService(db, registry, chat_call=scripted_chat(replies))
+    config = AgentConfig(
+        model="m",
+        system_prompt="s",
+        allowed_tools=(SPAWN_TOOL_NAME,),
+        budget=RunBudget(),
+    )
+    _run_id, outcome = service.run_turn(
+        conversation_id="conv1",
+        messages=[{"role": "user", "content": "delegate this"}],
+        config=config,
+        api_endpoint="llama_cpp",  # non-native: dispatches spawn via the fence
+    )
+    assert outcome.status == RUN_DONE and outcome.subagents_spawned == 1
+
+    run_dirs = [d for d in (root / "agent-runs").iterdir() if d.is_dir()]
+    assert len(run_dirs) == 1
+    records = all_records(run_dirs[0])
+
+    parent_spawn_call = next(
+        r
+        for r in records
+        if r.kind == "primary" and r.type == "tool_call" and r.tool == SPAWN_TOOL_NAME
+    )
+    child_first = min(
+        (r for r in records if r.kind == "subagent"), key=lambda r: r.number
+    )
+    assert parent_spawn_call.number < child_first.number, (
+        "the parent's spawn_subagent tool_call record must be the FIRST "
+        f"record of this spawn, not appear after the child's own records; "
+        f"got parent={parent_spawn_call.number}, child first={child_first.number}"
+    )
+
+
 def test_on_record_returns_the_assigned_record_number(wired, monkeypatch):
     """Round-1 review fix: a mutation that calls ``append(...)`` and then
     ``return None`` instead of returning its result still passed all 51

--- a/Tests/Agents/test_run_log_service_wiring.py
+++ b/Tests/Agents/test_run_log_service_wiring.py
@@ -1,0 +1,87 @@
+# Tests/Agents/test_run_log_service_wiring.py
+"""The service owns the writer: one counter per run tree, every caller logged."""
+
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Agents import run_log as run_log_module
+from tldw_chatbook.Agents.agent_models import AgentConfig, RunBudget
+from tldw_chatbook.Agents.agent_service import AgentService
+from tldw_chatbook.Agents.run_log import RunLogWriter
+from tldw_chatbook.Agents.run_log_format import iter_records
+from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider, ToolCatalogRegistry
+from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+
+@pytest.fixture
+def wired(tmp_path, monkeypatch):
+    monkeypatch.setattr(run_log_module, "resolve_log_root", lambda: tmp_path)
+    db = AgentRunsDB(tmp_path / "runs.db")
+    registry = ToolCatalogRegistry()
+    registry.register_provider(BuiltinToolProvider())
+    return db, registry, tmp_path
+
+
+def chat_call_returning(text):
+    def call(**kwargs):
+        return {"choices": [{"message": {"content": text}}]}
+
+    return call
+
+
+def read_all(root: Path):
+    run_dirs = list((root / "agent-runs").iterdir())
+    run_dirs = [d for d in run_dirs if d.is_dir()]
+    assert len(run_dirs) == 1
+    records = []
+    for segment in sorted(run_dirs[0].glob("logs.*.txt")):
+        records.extend(iter_records(segment.read_bytes()))
+    return records
+
+
+def test_a_plain_run_writes_records_without_the_caller_wiring_anything(wired):
+    db, registry, root = wired
+    service = AgentService(db, registry, chat_call=chat_call_returning("hello"))
+    service.run_turn(
+        conversation_id="conv1",
+        messages=[{"role": "user", "content": "hi"}],
+        config=AgentConfig(model="m", system_prompt="s", budget=RunBudget()),
+        api_endpoint="openai",
+    )
+    records = read_all(root)
+    assert [r.type for r in records] == ["model"]
+    assert records[0].content == "hello"
+    assert records[0].kind == "primary"
+
+
+def test_record_numbers_are_unique_across_the_whole_run_tree(wired):
+    db, registry, root = wired
+    writer = RunLogWriter()
+    service = AgentService(
+        db, registry, chat_call=chat_call_returning("x"), run_log_writer=writer
+    )
+    service.run_turn(
+        conversation_id="conv1",
+        messages=[{"role": "user", "content": "hi"}],
+        config=AgentConfig(model="m", system_prompt="s", budget=RunBudget()),
+        api_endpoint="openai",
+    )
+    # Simulate a child appending through the same shared writer.
+    writer.append(run_id="child", kind="subagent", type="model", content="child work")
+    numbers = [r.number for r in read_all(root)]
+    assert numbers == sorted(set(numbers))
+
+
+def test_disabled_writer_leaves_the_run_untouched(wired, monkeypatch):
+    db, registry, root = wired
+    monkeypatch.setattr(run_log_module, "resolve_log_root", lambda: None)
+    service = AgentService(db, registry, chat_call=chat_call_returning("hello"))
+    _run_id, outcome = service.run_turn(
+        conversation_id="conv1",
+        messages=[{"role": "user", "content": "hi"}],
+        config=AgentConfig(model="m", system_prompt="s", budget=RunBudget()),
+        api_endpoint="openai",
+    )
+    assert outcome.final_text == "hello"
+    assert not (root / "agent-runs").exists()

--- a/Tests/Agents/test_run_log_service_wiring.py
+++ b/Tests/Agents/test_run_log_service_wiring.py
@@ -1,12 +1,19 @@
 # Tests/Agents/test_run_log_service_wiring.py
 """The service owns the writer: one counter per run tree, every caller logged."""
 
+import json
 from pathlib import Path
 
 import pytest
 
+from tldw_chatbook.Agents import agent_service as agent_service_module
 from tldw_chatbook.Agents import run_log as run_log_module
-from tldw_chatbook.Agents.agent_models import AgentConfig, RunBudget
+from tldw_chatbook.Agents.agent_models import (
+    RUN_DONE,
+    SPAWN_TOOL_NAME,
+    AgentConfig,
+    RunBudget,
+)
 from tldw_chatbook.Agents.agent_service import AgentService
 from tldw_chatbook.Agents.run_log import RunLogWriter
 from tldw_chatbook.Agents.run_log_format import iter_records
@@ -28,6 +35,27 @@ def chat_call_returning(text):
         return {"choices": [{"message": {"content": text}}]}
 
     return call
+
+
+def fence(name, args):
+    return f"```tool_call\n{json.dumps({'name': name, 'arguments': args})}\n```"
+
+
+def scripted_chat(replies):
+    """Returns each reply from ``replies`` in order across successive calls."""
+    remaining = list(replies)
+
+    def call(**kwargs):
+        return {"choices": [{"message": {"content": remaining.pop(0)}}]}
+
+    return call
+
+
+def all_records(run_dir: Path):
+    records = []
+    for segment in sorted(run_dir.glob("logs.*.txt")):
+        records.extend(iter_records(segment.read_bytes()))
+    return records
 
 
 def read_all(root: Path):
@@ -85,3 +113,123 @@ def test_disabled_writer_leaves_the_run_untouched(wired, monkeypatch):
     )
     assert outcome.final_text == "hello"
     assert not (root / "agent-runs").exists()
+
+
+def test_a_real_spawn_shares_the_parent_log_directory_and_counter(wired):
+    """Round-1 review fix: the prior version of this suite only ever proved
+    sharing by manually calling ``writer.append`` on the object the test
+    already held -- a real ``spawn()`` never ran. A mutation giving
+    non-primary runs their own fresh writer instance (see this file's git
+    history / the fix report) still passed all 51 pre-fix tests. This test
+    drives an ACTUAL sub-agent spawn through the fence tool-call protocol
+    and checks the parent's and child's records land in one directory with
+    one strictly-increasing, gap-free, duplicate-free number sequence.
+    """
+    db, registry, root = wired
+    replies = [
+        fence(SPAWN_TOOL_NAME, {"task": "child task"}),  # parent turn 1: spawns
+        "child says hi",  # CHILD turn 1
+        "parent final",  # parent turn 2
+    ]
+    service = AgentService(db, registry, chat_call=scripted_chat(replies))
+    config = AgentConfig(
+        model="m",
+        system_prompt="s",
+        allowed_tools=(SPAWN_TOOL_NAME,),
+        budget=RunBudget(),
+    )
+    _run_id, outcome = service.run_turn(
+        conversation_id="conv1",
+        messages=[{"role": "user", "content": "delegate this"}],
+        config=config,
+        api_endpoint="llama_cpp",  # non-native: dispatches spawn via the fence
+    )
+    assert outcome.status == RUN_DONE and outcome.subagents_spawned == 1
+
+    run_dirs = [d for d in (root / "agent-runs").iterdir() if d.is_dir()]
+    assert len(run_dirs) == 1, "parent and child must share ONE log directory"
+    records = all_records(run_dirs[0])
+
+    numbers = [r.number for r in records]
+    assert numbers == list(range(1, len(numbers) + 1)), (
+        "record numbers must be gap-free, duplicate-free, and strictly "
+        f"increasing across the whole tree; got {numbers}"
+    )
+    kinds = {r.kind for r in records}
+    assert kinds == {"primary", "subagent"}, (
+        "both the parent's and the child's records must actually be present "
+        f"-- got kinds {kinds}"
+    )
+
+
+def test_on_record_returns_the_assigned_record_number(wired, monkeypatch):
+    """Round-1 review fix: a mutation that calls ``append(...)`` and then
+    ``return None`` instead of returning its result still passed all 51
+    pre-fix tests -- nothing pinned the return value. A later task threads
+    this number into a truncation trailer, so dropping it silently breaks
+    that. This test captures the actual ``LoopDeps`` the service builds and
+    calls its ``on_record`` directly, asserting the return is the writer's
+    assigned (non-``None``) record number.
+    """
+    db, registry, root = wired
+    captured: dict = {}
+    real_run_agent_loop = agent_service_module.run_agent_loop
+
+    def spy_run_agent_loop(config, messages, active, deps):
+        captured["deps"] = deps
+        return real_run_agent_loop(config, messages, active, deps)
+
+    monkeypatch.setattr(agent_service_module, "run_agent_loop", spy_run_agent_loop)
+
+    service = AgentService(db, registry, chat_call=chat_call_returning("hello"))
+    service.run_turn(
+        conversation_id="conv1",
+        messages=[{"role": "user", "content": "hi"}],
+        config=AgentConfig(model="m", system_prompt="s", budget=RunBudget()),
+        api_endpoint="openai",
+    )
+    deps = captured["deps"]
+    assert deps.on_record is not None
+    result = deps.on_record("model", {"content": "probe"})
+    assert isinstance(result, int) and result > 0, (
+        f"on_record must return the writer's assigned record number, got {result!r}"
+    )
+
+
+def test_run_turn_called_twice_on_one_service_gets_two_separate_logs(wired):
+    """Round-1 review fix (item 3): ``bind()`` latches permanently, so a
+    writer built once in ``__init__`` and reused across two ``run_turn``
+    calls on the same ``AgentService`` would silently append the second
+    tree's records into the first tree's (already-bound) directory and
+    overwrite its manifest. The writer must be constructed fresh per
+    ``run_turn`` call (per spec §3.1) unless one was explicitly injected via
+    the constructor.
+    """
+    db, registry, root = wired
+    service = AgentService(db, registry, chat_call=chat_call_returning("hello"))
+    config = AgentConfig(model="m", system_prompt="s", budget=RunBudget())
+    service.run_turn(
+        conversation_id="conv1",
+        messages=[{"role": "user", "content": "first"}],
+        config=config,
+        api_endpoint="openai",
+    )
+    service.run_turn(
+        conversation_id="conv1",
+        messages=[{"role": "user", "content": "second"}],
+        config=config,
+        api_endpoint="openai",
+    )
+    run_dirs = [d for d in (root / "agent-runs").iterdir() if d.is_dir()]
+    assert len(run_dirs) == 2, "each run_turn call must get its own log directory"
+    for run_dir in run_dirs:
+        manifest = json.loads((run_dir / "MANIFEST").read_text())
+        assert manifest["record_count"] == 1, (
+            "the second tree's manifest must not include the first tree's "
+            f"records; got {manifest}"
+        )
+        numbers = [r.number for r in all_records(run_dir)]
+        assert numbers == [1], (
+            "numbering must restart per tree, not continue across "
+            f"run_turn calls; got {numbers}"
+        )

--- a/Tests/Agents/test_run_log_writer.py
+++ b/Tests/Agents/test_run_log_writer.py
@@ -246,10 +246,52 @@ def test_path_traversal_with_dotdot_is_rejected(root, monkeypatch):
     assert not (root / "agent-runs").exists()
 
 
+def test_non_numeric_segment_bytes_explicit_arg_uses_default():
+    """Test explicit segment_bytes="not-a-number" uses default."""
+    writer = RunLogWriter(segment_bytes="not-a-number")
+    assert writer._segment_bytes == 4_000_000  # default
+
+
+def test_zero_segment_bytes_explicit_arg_uses_default():
+    """Test explicit segment_bytes=0 uses default."""
+    writer = RunLogWriter(segment_bytes=0)
+    assert writer._segment_bytes == 4_000_000  # default
+
+
+def test_negative_segment_bytes_explicit_arg_uses_default():
+    """Test explicit segment_bytes=-999 uses default."""
+    writer = RunLogWriter(segment_bytes=-999)
+    assert writer._segment_bytes == 4_000_000  # default
+
+
+def test_non_numeric_max_record_bytes_explicit_arg_uses_default():
+    """Test explicit max_record_bytes="not-a-number" uses default."""
+    writer = RunLogWriter(max_record_bytes="not-a-number")
+    assert writer._max_record_bytes == 1_000_000  # default
+
+
+def test_zero_max_record_bytes_explicit_arg_uses_default():
+    """Test explicit max_record_bytes=0 uses default."""
+    writer = RunLogWriter(max_record_bytes=0)
+    assert writer._max_record_bytes == 1_000_000  # default
+
+
+def test_negative_max_record_bytes_explicit_arg_uses_default():
+    """Test explicit max_record_bytes=-5 uses default."""
+    writer = RunLogWriter(max_record_bytes=-5)
+    assert writer._max_record_bytes == 1_000_000  # default
+
+
+def test_legitimate_explicit_args_still_work():
+    """Test that valid explicit args (e.g., 400, 50) continue to work."""
+    writer = RunLogWriter(segment_bytes=400, max_record_bytes=50)
+    assert writer._segment_bytes == 400
+    assert writer._max_record_bytes == 50
+
+
 def test_real_resolve_log_root_prefers_workspace_over_sandbox(monkeypatch):
-    """Test real resolve_log_root() prefers workspace folder over sandbox root."""
+    """Test real resolve_log_root() calls and prefers workspace folder over sandbox root."""
     from pathlib import Path
-    from unittest.mock import MagicMock
 
     tmp_sandbox = Path("/tmp/sandbox")
     tmp_workspace = Path("/tmp/workspace")
@@ -261,25 +303,62 @@ def test_real_resolve_log_root_prefers_workspace_over_sandbox(monkeypatch):
         # Return (sandbox, workspace) tuple; resolve_log_root should prefer workspace
         return [tmp_sandbox, tmp_workspace]
 
-    # Stub the imports at the point resolve_log_root uses them
+    # Stub the underlying imports that resolve_log_root uses
     import tldw_chatbook.Tools.file_operation_tools as file_tools
-
-    monkeypatch.setattr(file_tools, "_tool_sandbox_root", mock_tool_sandbox_root)
-
     import tldw_chatbook.Tools.workspace_file_roots as ws_roots
 
+    monkeypatch.setattr(file_tools, "_tool_sandbox_root", mock_tool_sandbox_root)
     monkeypatch.setattr(ws_roots, "allowed_file_roots", mock_allowed_file_roots)
 
+    # Call the REAL resolve_log_root() with stubbed seams
     result = run_log_module.resolve_log_root()
     assert result == tmp_workspace  # Prefers workspace over sandbox
 
 
-def test_resolve_log_root_returns_none_on_exception(monkeypatch):
-    """Test that resolve_log_root returns None (logging off) when resolution raises."""
-    monkeypatch.setattr(
-        run_log_module, "resolve_log_root", lambda: None
-    )
-    writer = RunLogWriter()
-    writer.bind("run-abc")
-    assert writer.is_active is False
-    assert writer.log_dir is None
+def test_real_resolve_log_root_falls_back_to_sandbox_when_no_workspace(monkeypatch):
+    """Test real resolve_log_root() falls back to sandbox root when no workspace folder bound."""
+    from pathlib import Path
+
+    tmp_sandbox = Path("/tmp/sandbox")
+
+    def mock_tool_sandbox_root():
+        return tmp_sandbox
+
+    def mock_allowed_file_roots(write=False, sandbox_root=None):
+        # Return only sandbox; no workspace folders bound
+        return [tmp_sandbox]
+
+    # Stub the underlying imports
+    import tldw_chatbook.Tools.file_operation_tools as file_tools
+    import tldw_chatbook.Tools.workspace_file_roots as ws_roots
+
+    monkeypatch.setattr(file_tools, "_tool_sandbox_root", mock_tool_sandbox_root)
+    monkeypatch.setattr(ws_roots, "allowed_file_roots", mock_allowed_file_roots)
+
+    # Call the REAL resolve_log_root()
+    result = run_log_module.resolve_log_root()
+    assert result == tmp_sandbox  # Falls back to sandbox
+
+
+def test_real_resolve_log_root_returns_none_on_exception(monkeypatch):
+    """Test real resolve_log_root() returns None when underlying call raises."""
+    from pathlib import Path
+
+    tmp_sandbox = Path("/tmp/sandbox")
+
+    def mock_tool_sandbox_root():
+        return tmp_sandbox
+
+    def mock_allowed_file_roots_raises(write=False, sandbox_root=None):
+        raise RuntimeError("cannot access workspace roots")
+
+    # Stub the underlying imports
+    import tldw_chatbook.Tools.file_operation_tools as file_tools
+    import tldw_chatbook.Tools.workspace_file_roots as ws_roots
+
+    monkeypatch.setattr(file_tools, "_tool_sandbox_root", mock_tool_sandbox_root)
+    monkeypatch.setattr(ws_roots, "allowed_file_roots", mock_allowed_file_roots_raises)
+
+    # Call the REAL resolve_log_root(); it catches and logs, returns None
+    result = run_log_module.resolve_log_root()
+    assert result is None  # Returns None (logging off) on exception

--- a/Tests/Agents/test_run_log_writer.py
+++ b/Tests/Agents/test_run_log_writer.py
@@ -1,0 +1,189 @@
+"""Writer: binding, segmentation, durability, degradation."""
+
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Agents import run_log as run_log_module
+from tldw_chatbook.Agents.run_log import RunLogWriter
+from tldw_chatbook.Agents.run_log_format import iter_records
+
+
+@pytest.fixture
+def root(tmp_path, monkeypatch):
+    """Pin the writer's resolved root to a temp dir."""
+    monkeypatch.setattr(run_log_module, "resolve_log_root", lambda: tmp_path)
+    return tmp_path
+
+
+def make(root_dir, **kw):
+    writer = RunLogWriter(**kw)
+    writer.bind("run-abc")
+    return writer
+
+
+def test_unbound_writer_writes_nothing(root):
+    writer = RunLogWriter()
+    assert writer.append(run_id="r", kind="primary", type="model", content="x") is None
+    assert list(root.iterdir()) == []
+
+
+def test_bind_creates_the_run_directory_and_gitignore(root):
+    make(root)
+    assert (root / "agent-runs" / "run-abc").is_dir()
+    assert (root / "agent-runs" / ".gitignore").read_text() == "*\n"
+
+
+def test_existing_gitignore_is_never_overwritten(root):
+    (root / "agent-runs").mkdir()
+    (root / "agent-runs" / ".gitignore").write_text("keep me\n")
+    make(root)
+    assert (root / "agent-runs" / ".gitignore").read_text() == "keep me\n"
+
+
+def test_records_are_numbered_monotonically_from_one(root):
+    writer = make(root)
+    numbers = [
+        writer.append(run_id="r", kind="primary", type="model", content=str(i))
+        for i in range(3)
+    ]
+    assert numbers == [1, 2, 3]
+
+
+def test_a_child_run_shares_the_parent_counter(root):
+    writer = make(root)
+    writer.append(run_id="parent", kind="primary", type="model", content="a")
+    writer.append(run_id="child", kind="subagent", type="model", content="b")
+    data = (root / "agent-runs" / "run-abc" / "logs.0001.txt").read_bytes()
+    parsed = list(iter_records(data))
+    assert [(p.number, p.run_id) for p in parsed] == [(1, "parent"), (2, "child")]
+
+
+def test_second_bind_is_ignored(root):
+    writer = make(root)
+    writer.bind("run-other")
+    assert writer.log_dir.name == "run-abc"
+
+
+def test_segment_rolls_and_no_record_spans_a_boundary(root):
+    writer = make(root, segment_bytes=400)
+    for _ in range(6):
+        writer.append(run_id="r", kind="primary", type="model", content="x" * 100)
+    run_dir = root / "agent-runs" / "run-abc"
+    segments = sorted(run_dir.glob("logs.*.txt"))
+    assert len(segments) > 1
+    # Every segment parses standalone: no record straddles a boundary.
+    total = 0
+    for segment in segments:
+        parsed = list(iter_records(segment.read_bytes()))
+        assert parsed, f"{segment.name} parsed to nothing"
+        total += len(parsed)
+    assert total == 6
+
+
+def test_oversized_record_is_capped_and_marked(root):
+    writer = make(root, max_record_bytes=50)
+    writer.append(run_id="r", kind="primary", type="tool_result", content="y" * 500)
+    data = (root / "agent-runs" / "run-abc" / "logs.0001.txt").read_bytes()
+    (parsed,) = list(iter_records(data))
+    assert len(parsed.content.encode()) <= 50
+    assert parsed.truncated_from == 500
+
+
+def test_unresolvable_root_deactivates_the_writer(monkeypatch):
+    monkeypatch.setattr(run_log_module, "resolve_log_root", lambda: None)
+    writer = RunLogWriter()
+    writer.bind("run-abc")
+    assert writer.is_active is False
+    assert writer.append(run_id="r", kind="primary", type="model", content="x") is None
+
+
+def test_write_failure_deactivates_rather_than_raising(root, monkeypatch):
+    writer = make(root)
+    assert writer.append(run_id="r", kind="primary", type="model", content="a") == 1
+
+    def boom(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(writer, "_write_bytes", boom)
+    assert writer.append(run_id="r", kind="primary", type="model", content="b") is None
+    assert writer.is_active is False
+
+
+def test_config_can_disable_logging_entirely(root, monkeypatch):
+    monkeypatch.setattr(
+        run_log_module, "_setting", lambda key, default: False if key == "run_log_enabled" else default
+    )
+    writer = RunLogWriter()
+    writer.bind("run-abc")
+    assert writer.is_active is False
+    assert not (root / "agent-runs").exists()
+
+
+def test_config_overrides_the_directory_name(root, monkeypatch):
+    monkeypatch.setattr(
+        run_log_module,
+        "_setting",
+        lambda key, default: "my-logs" if key == "run_log_dir_name" else default,
+    )
+    writer = RunLogWriter()
+    writer.bind("run-abc")
+    assert (root / "my-logs" / "run-abc").is_dir()
+
+
+def test_write_manifest_emits_readable_json(root):
+    writer = make(root)
+    writer.write_manifest({"run_id": "run-abc", "status": "done"})
+    import json
+
+    manifest = json.loads((root / "agent-runs" / "run-abc" / "MANIFEST").read_text())
+    assert manifest["status"] == "done"
+    assert manifest["segments"] == []  # nothing appended yet
+
+
+def test_manifest_records_segments_after_appends(root):
+    writer = make(root, segment_bytes=400)
+    for _ in range(6):
+        writer.append(run_id="r", kind="primary", type="model", content="x" * 100)
+    writer.write_manifest({"status": "done"})
+    import json
+
+    manifest = json.loads((root / "agent-runs" / "run-abc" / "MANIFEST").read_text())
+    assert len(manifest["segments"]) > 1
+    assert manifest["record_count"] == 6
+
+
+def test_manifest_failure_never_raises(root, monkeypatch):
+    writer = make(root)
+    monkeypatch.setattr(writer, "_write_bytes", lambda *a, **k: (_ for _ in ()).throw(OSError))
+    writer.write_manifest({"status": "done"})  # must not raise
+
+
+def test_close_is_safe_to_call_twice_and_on_an_inactive_writer(root):
+    writer = make(root)
+    writer.close()
+    writer.close()
+    RunLogWriter().close()
+
+
+def test_concurrent_appends_produce_unique_numbers_and_no_corruption(root):
+    import threading
+
+    writer = make(root)
+
+    def worker(index):
+        for _ in range(20):
+            writer.append(
+                run_id=f"r{index}", kind="primary", type="model", content=f"payload-{index}"
+            )
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    records = []
+    for segment in sorted((root / "agent-runs" / "run-abc").glob("logs.*.txt")):
+        records.extend(iter_records(segment.read_bytes()))
+    numbers = sorted(r.number for r in records)
+    assert numbers == list(range(1, 81))

--- a/Tests/Agents/test_run_log_writer.py
+++ b/Tests/Agents/test_run_log_writer.py
@@ -187,3 +187,99 @@ def test_concurrent_appends_produce_unique_numbers_and_no_corruption(root):
         records.extend(iter_records(segment.read_bytes()))
     numbers = sorted(r.number for r in records)
     assert numbers == list(range(1, 81))
+
+
+def test_non_numeric_segment_bytes_uses_default(root, monkeypatch):
+    monkeypatch.setattr(
+        run_log_module,
+        "_setting",
+        lambda key, default: "not-a-number" if key == "run_log_segment_bytes" else default,
+    )
+    writer = RunLogWriter()
+    writer.bind("run-abc")
+    assert writer.is_active is True
+    assert writer._segment_bytes == 4_000_000  # default
+
+
+def test_negative_max_record_bytes_uses_default(root, monkeypatch):
+    monkeypatch.setattr(
+        run_log_module,
+        "_setting",
+        lambda key, default: -999 if key == "run_log_max_record_bytes" else default,
+    )
+    writer = RunLogWriter()
+    writer.bind("run-abc")
+    assert writer.is_active is True
+    assert writer._max_record_bytes == 1_000_000  # default
+
+
+def test_bind_idempotent_after_failed_first_bind(root, monkeypatch):
+    monkeypatch.setattr(
+        run_log_module, "_setting", lambda key, default: False if key == "run_log_enabled" else default
+    )
+    writer = RunLogWriter()
+    writer.bind("run-abc")
+    assert writer.is_active is False
+    assert writer.log_dir is None
+
+    # Second bind with different run_id must not activate or create directory
+    monkeypatch.setattr(
+        run_log_module, "_setting", lambda key, default: True if key == "run_log_enabled" else default
+    )
+    writer.bind("run-other")
+    assert writer.is_active is False
+    assert writer.log_dir is None
+    assert not (root / "agent-runs" / "run-other").exists()
+
+
+def test_path_traversal_with_dotdot_is_rejected(root, monkeypatch):
+    monkeypatch.setattr(
+        run_log_module,
+        "_setting",
+        lambda key, default: "../escape" if key == "run_log_dir_name" else default,
+    )
+    writer = RunLogWriter()
+    writer.bind("run-abc")
+    assert writer.is_active is False
+    assert writer.log_dir is None
+    assert not (root / "escape").exists()
+    assert not (root / "agent-runs").exists()
+
+
+def test_real_resolve_log_root_prefers_workspace_over_sandbox(monkeypatch):
+    """Test real resolve_log_root() prefers workspace folder over sandbox root."""
+    from pathlib import Path
+    from unittest.mock import MagicMock
+
+    tmp_sandbox = Path("/tmp/sandbox")
+    tmp_workspace = Path("/tmp/workspace")
+
+    def mock_tool_sandbox_root():
+        return tmp_sandbox
+
+    def mock_allowed_file_roots(write=False, sandbox_root=None):
+        # Return (sandbox, workspace) tuple; resolve_log_root should prefer workspace
+        return [tmp_sandbox, tmp_workspace]
+
+    # Stub the imports at the point resolve_log_root uses them
+    import tldw_chatbook.Tools.file_operation_tools as file_tools
+
+    monkeypatch.setattr(file_tools, "_tool_sandbox_root", mock_tool_sandbox_root)
+
+    import tldw_chatbook.Tools.workspace_file_roots as ws_roots
+
+    monkeypatch.setattr(ws_roots, "allowed_file_roots", mock_allowed_file_roots)
+
+    result = run_log_module.resolve_log_root()
+    assert result == tmp_workspace  # Prefers workspace over sandbox
+
+
+def test_resolve_log_root_returns_none_on_exception(monkeypatch):
+    """Test that resolve_log_root returns None (logging off) when resolution raises."""
+    monkeypatch.setattr(
+        run_log_module, "resolve_log_root", lambda: None
+    )
+    writer = RunLogWriter()
+    writer.bind("run-abc")
+    assert writer.is_active is False
+    assert writer.log_dir is None

--- a/Tests/Agents/test_run_log_writer.py
+++ b/Tests/Agents/test_run_log_writer.py
@@ -232,7 +232,21 @@ def test_bind_idempotent_after_failed_first_bind(root, monkeypatch):
     assert not (root / "agent-runs" / "run-other").exists()
 
 
-def test_path_traversal_with_dotdot_is_rejected(root, monkeypatch):
+def test_path_traversal_with_dotdot_falls_back_to_the_default_dir_name(root, monkeypatch):
+    """F1 (Qodo #1, PR #1066 review ruling): CHANGED BEHAVIOR, deliberately.
+
+    Before this fix, a `..`-bearing dir_name reached `bind()` unvalidated
+    and was only caught by the SECOND-LAYER `is_within` containment check,
+    which disabled logging entirely (is_active stayed False) -- this test
+    used to pin exactly that. The ruling on Qodo finding #1 requires
+    validating the dir_name COMPONENT itself up front and falling back to
+    the safe default (logged at warning) instead: a bad *config* value
+    should not be able to silently kill a crash-durability feature. The
+    security property this test guards -- `..` can NEVER walk the log
+    outside its root -- still holds; only the AVAILABILITY outcome changed,
+    from "logging disabled" to "logging continues under 'agent-runs'".
+    `bind()`'s `is_within` check remains as defense in depth underneath.
+    """
     monkeypatch.setattr(
         run_log_module,
         "_setting",
@@ -240,10 +254,91 @@ def test_path_traversal_with_dotdot_is_rejected(root, monkeypatch):
     )
     writer = RunLogWriter()
     writer.bind("run-abc")
-    assert writer.is_active is False
-    assert writer.log_dir is None
+    assert writer.is_active is True
+    assert writer.log_dir == root / "agent-runs" / "run-abc"
     assert not (root / "escape").exists()
-    assert not (root / "agent-runs").exists()
+    assert not (root.parent / "escape").exists()
+
+
+def test_dir_name_with_a_separator_falls_back_to_the_default(root, monkeypatch):
+    """F1: a dir_name containing a separator (but no literal `..`) must be
+    rejected too -- it is still an untrusted value joined into a path, and
+    a nested path could otherwise create unexpected intermediate
+    directories even when it stays within root."""
+    monkeypatch.setattr(
+        run_log_module,
+        "_setting",
+        lambda key, default: "sub/dir" if key == "run_log_dir_name" else default,
+    )
+    writer = RunLogWriter()
+    writer.bind("run-abc")
+    assert writer.is_active is True
+    assert writer.log_dir == root / "agent-runs" / "run-abc"
+    assert not (root / "sub").exists()
+
+
+def test_dir_name_absolute_falls_back_to_the_default(root, monkeypatch):
+    """F1: pathlib's `/` operator REPLACES the whole path when the
+    right-hand side is absolute (`Path("/root") / "/etc" == Path("/etc")`),
+    so an absolute dir_name is uniquely dangerous -- it does not merely
+    nest somewhere unexpected, it can retarget the log tree entirely."""
+    monkeypatch.setattr(
+        run_log_module,
+        "_setting",
+        lambda key, default: "/etc/evil" if key == "run_log_dir_name" else default,
+    )
+    writer = RunLogWriter()
+    writer.bind("run-abc")
+    assert writer.is_active is True
+    assert writer.log_dir == root / "agent-runs" / "run-abc"
+
+
+def test_dir_name_whitespace_only_falls_back_to_the_default(root, monkeypatch):
+    monkeypatch.setattr(
+        run_log_module,
+        "_setting",
+        lambda key, default: "   " if key == "run_log_dir_name" else default,
+    )
+    writer = RunLogWriter()
+    writer.bind("run-abc")
+    assert writer.is_active is True
+    assert writer.log_dir == root / "agent-runs" / "run-abc"
+
+
+def test_dir_name_bare_dotdot_falls_back_to_the_default(root, monkeypatch):
+    monkeypatch.setattr(
+        run_log_module,
+        "_setting",
+        lambda key, default: ".." if key == "run_log_dir_name" else default,
+    )
+    writer = RunLogWriter()
+    writer.bind("run-abc")
+    assert writer.is_active is True
+    assert writer.log_dir == root / "agent-runs" / "run-abc"
+
+
+def test_dir_name_explicit_constructor_arg_is_validated_too(root):
+    """F1: the SAME validation applies to an explicit constructor arg, not
+    only the config-sourced value -- both go through `_coerce_dir_name`."""
+    writer = RunLogWriter(dir_name="../escape")
+    writer.bind("run-abc")
+    assert writer.is_active is True
+    assert writer.log_dir == root / "agent-runs" / "run-abc"
+
+
+def test_legitimate_custom_dir_name_is_not_rejected(root, monkeypatch):
+    """A safe, single-component custom name (no separators, no traversal,
+    not absolute) must pass through unchanged -- the validation must not
+    be so aggressive it breaks the existing `run_log_dir_name` override."""
+    monkeypatch.setattr(
+        run_log_module,
+        "_setting",
+        lambda key, default: "my-logs" if key == "run_log_dir_name" else default,
+    )
+    writer = RunLogWriter()
+    writer.bind("run-abc")
+    assert writer.is_active is True
+    assert writer.log_dir == root / "my-logs" / "run-abc"
 
 
 def test_non_numeric_segment_bytes_explicit_arg_uses_default():
@@ -362,3 +457,207 @@ def test_real_resolve_log_root_returns_none_on_exception(monkeypatch):
     # Call the REAL resolve_log_root(); it catches and logs, returns None
     result = run_log_module.resolve_log_root()
     assert result is None  # Returns None (logging off) on exception
+
+
+# -- F3 (Qodo #3): env vars -> config.toml -> defaults -----------------------
+
+
+def test_setting_env_var_overrides_a_conflicting_toml_value(monkeypatch):
+    """CLAUDE.md's documented priority is "env vars -> config.toml ->
+    defaults"; `_setting` previously never consulted the environment at all,
+    silently skipping the highest-priority tier. `TLDW_AGENTS_<KEY>` (this
+    repo's existing per-setting override convention -- see
+    `TLDW_CONSOLE_LLAMA_CPP_BASE_URL` in UI/Screens/chat_screen.py) must win
+    over a conflicting TOML-backed value.
+    """
+    import tldw_chatbook.config as config_module
+
+    monkeypatch.setattr(config_module, "get_cli_setting", lambda *a, **k: "toml-value")
+    monkeypatch.setenv("TLDW_AGENTS_RUN_LOG_DIR_NAME", "env-value")
+    assert run_log_module._setting("run_log_dir_name", "default-value") == "env-value"
+
+
+def test_setting_falls_back_to_toml_when_env_unset(monkeypatch):
+    import tldw_chatbook.config as config_module
+
+    monkeypatch.delenv("TLDW_AGENTS_RUN_LOG_DIR_NAME", raising=False)
+    monkeypatch.setattr(config_module, "get_cli_setting", lambda *a, **k: "toml-value")
+    assert run_log_module._setting("run_log_dir_name", "default-value") == "toml-value"
+
+
+def test_setting_env_var_blank_string_does_not_count_as_set(monkeypatch):
+    """An env var present but empty must not shadow a real TOML value --
+    same as unset, not "set to empty"."""
+    import tldw_chatbook.config as config_module
+
+    monkeypatch.setenv("TLDW_AGENTS_RUN_LOG_DIR_NAME", "")
+    monkeypatch.setattr(config_module, "get_cli_setting", lambda *a, **k: "toml-value")
+    assert run_log_module._setting("run_log_dir_name", "default-value") == "toml-value"
+
+
+def test_setting_boolean_env_var_is_parsed_not_just_truthy(monkeypatch):
+    """`run_log_enabled`'s default is a Python bool; the raw env STRING
+    "false" is truthy in Python (`bool("false") is True`), so a naive
+    `_setting(...)` return would have silently failed to disable logging.
+    """
+    import tldw_chatbook.config as config_module
+
+    monkeypatch.setattr(config_module, "get_cli_setting", lambda *a, **k: True)
+    monkeypatch.setenv("TLDW_AGENTS_RUN_LOG_ENABLED", "false")
+    assert run_log_module._setting("run_log_enabled", True) is False
+
+    monkeypatch.setenv("TLDW_AGENTS_RUN_LOG_ENABLED", "1")
+    assert run_log_module._setting("run_log_enabled", True) is True
+
+
+def test_setting_boolean_env_var_unrecognized_value_uses_default(monkeypatch):
+    import tldw_chatbook.config as config_module
+
+    monkeypatch.setattr(config_module, "get_cli_setting", lambda *a, **k: True)
+    monkeypatch.setenv("TLDW_AGENTS_RUN_LOG_ENABLED", "maybe")
+    assert run_log_module._setting("run_log_enabled", True) is True
+
+
+def test_env_var_disables_logging_end_to_end(root, monkeypatch):
+    """Integration check: the env override actually reaches `bind()`, not
+    just the unit-level `_setting` function."""
+    monkeypatch.setenv("TLDW_AGENTS_RUN_LOG_ENABLED", "false")
+    writer = RunLogWriter()
+    writer.bind("run-abc")
+    assert writer.is_active is False
+    assert not (root / "agent-runs").exists()
+
+
+def test_explicit_constructor_arg_still_wins_over_env_var(monkeypatch):
+    """Explicit constructor args remain the highest-priority override --
+    ABOVE both the env var and TOML tiers `_setting` resolves between."""
+    monkeypatch.setenv("TLDW_AGENTS_RUN_LOG_DIR_NAME", "env-value")
+    writer = RunLogWriter(dir_name="explicit-value")
+    assert writer._dir_name == "explicit-value"
+
+
+# -- F7 (Qodo #7): a capped record must say so, not claim completeness -------
+
+
+def test_append_reports_truncated_on_the_returned_record_number(root):
+    writer = make(root, max_record_bytes=50)
+    number = writer.append(run_id="r", kind="primary", type="tool_result", content="y" * 500)
+    assert number.truncated is True
+    assert int(number) == 1  # still a plain int for every ordinary purpose
+
+
+def test_append_reports_not_truncated_when_under_the_cap(root):
+    writer = make(root)
+    number = writer.append(run_id="r", kind="primary", type="model", content="short")
+    assert number.truncated is False
+    assert int(number) == 1
+
+
+def test_record_number_behaves_like_a_plain_int_everywhere(root):
+    """RunLogRecordNumber must be indistinguishable from int for every
+    existing consumer -- formatting, equality, hashing/set membership --
+    since `test_on_record_returns_the_assigned_record_number` (and every
+    caller before this fix) only ever expects a plain int."""
+    writer = make(root)
+    number = writer.append(run_id="r", kind="primary", type="model", content="x")
+    assert isinstance(number, int)
+    assert number == 1
+    assert f"{number:06d}" == "000001"
+    assert {number, 1} == {1}
+
+
+# -- F8 (Qodo #8, task-1251): a workspace folder inside the sandbox must ----
+# -- still get the dotted name -----------------------------------------------
+
+
+def test_workspace_folder_resolving_inside_the_sandbox_still_gets_dotted_name(
+    tmp_path, monkeypatch
+):
+    """The fallback FLAG alone only reports which BRANCH resolve_log_root()
+    took -- but a bound WORKSPACE folder can itself resolve inside (or
+    equal to) the sandbox root, in which case the "workspace" branch fires,
+    the flag stays False, and (pre-fix) the log would get the undotted
+    name while still being fully reachable via grep_files/glob_files
+    (which root at the sandbox and never consult allowed_file_roots,
+    §9.4) -- exactly the sub-agent log-disclosure bug the dotted name
+    exists to prevent. This drives the REAL resolve_log_root()/bind() (no
+    monkeypatching either of those directly) with a workspace folder
+    planted INSIDE a fake sandbox root, and asserts the dotted name is
+    still chosen.
+    """
+    import tldw_chatbook.Tools.file_operation_tools as file_tools
+    import tldw_chatbook.Tools.workspace_file_roots as ws_roots
+
+    sandbox_root = tmp_path / "sandbox"
+    sandbox_root.mkdir()
+    workspace_folder = sandbox_root / "bound-workspace"
+    workspace_folder.mkdir()
+
+    monkeypatch.setattr(file_tools, "_tool_sandbox_root", lambda: sandbox_root)
+    monkeypatch.setattr(
+        ws_roots,
+        "allowed_file_roots",
+        lambda write=False, sandbox_root=None: (sandbox_root, workspace_folder),
+    )
+
+    writer = RunLogWriter()
+    writer.bind("run-abc")
+
+    assert writer.is_active is True
+    assert writer.log_dir == workspace_folder / ".agent-runs" / "run-abc"
+    # The undotted name must never have been created at all.
+    assert not (workspace_folder / "agent-runs").exists()
+
+
+def test_workspace_folder_equal_to_the_sandbox_root_gets_dotted_name(
+    tmp_path, monkeypatch
+):
+    """Same as above for the degenerate case: the bound workspace folder
+    IS the sandbox root, not merely nested inside it."""
+    import tldw_chatbook.Tools.file_operation_tools as file_tools
+    import tldw_chatbook.Tools.workspace_file_roots as ws_roots
+
+    sandbox_root = tmp_path / "sandbox"
+    sandbox_root.mkdir()
+
+    monkeypatch.setattr(file_tools, "_tool_sandbox_root", lambda: sandbox_root)
+    monkeypatch.setattr(
+        ws_roots,
+        "allowed_file_roots",
+        lambda write=False, sandbox_root=None: (sandbox_root, sandbox_root),
+    )
+
+    writer = RunLogWriter()
+    writer.bind("run-abc")
+
+    assert writer.is_active is True
+    assert writer.log_dir == sandbox_root / ".agent-runs" / "run-abc"
+
+
+def test_workspace_folder_outside_the_sandbox_keeps_the_undotted_name(
+    tmp_path, monkeypatch
+):
+    """Regression guard for the fix above: a GENUINE workspace folder
+    (outside the sandbox entirely) must still get the user-visible,
+    undotted name -- the F8 fix narrows the dotting decision, it must not
+    widen it to dot every workspace folder."""
+    import tldw_chatbook.Tools.file_operation_tools as file_tools
+    import tldw_chatbook.Tools.workspace_file_roots as ws_roots
+
+    sandbox_root = tmp_path / "sandbox"
+    sandbox_root.mkdir()
+    workspace_folder = tmp_path / "genuine-workspace"
+    workspace_folder.mkdir()
+
+    monkeypatch.setattr(file_tools, "_tool_sandbox_root", lambda: sandbox_root)
+    monkeypatch.setattr(
+        ws_roots,
+        "allowed_file_roots",
+        lambda write=False, sandbox_root=None: (sandbox_root, workspace_folder),
+    )
+
+    writer = RunLogWriter()
+    writer.bind("run-abc")
+
+    assert writer.is_active is True
+    assert writer.log_dir == workspace_folder / "agent-runs" / "run-abc"

--- a/Tests/Agents/test_run_log_writer.py
+++ b/Tests/Agents/test_run_log_writer.py
@@ -25,7 +25,7 @@ def make(root_dir, **kw):
 def test_unbound_writer_writes_nothing(root):
     writer = RunLogWriter()
     assert writer.append(run_id="r", kind="primary", type="model", content="x") is None
-    assert list(root.iterdir()) == []
+    assert not (root / "agent-runs").exists()
 
 
 def test_bind_creates_the_run_directory_and_gitignore(root):

--- a/Tests/Agents/test_search_run_log_runtime_tool.py
+++ b/Tests/Agents/test_search_run_log_runtime_tool.py
@@ -425,3 +425,149 @@ def test_real_closure_never_raises_on_a_junk_offset(tmp_path, monkeypatch):
     ]
     assert tool_results, "expected a search_run_log tool_result step"
     assert any("Invalid search arguments" in r for r in tool_results)
+
+
+# -- F2 (Qodo #2, PR #1066 review -- DECLINED, confirmed by test) ------------
+#
+# Qodo wanted these raw dict args routed through a Pydantic model before use.
+# Declined: every OTHER runtime tool this service wires (install_skill,
+# run_skill_script, skill_file) takes the same raw-dict-plus-defensive-cast
+# shape, and every argument here is ALREADY coerced defensively -- a bad
+# value returns a clean ToolResult error rather than raising. This section
+# drives the REAL closure (captured off a REAL AgentService the same way
+# test_on_record_returns_the_assigned_record_number does) with a string
+# where an int is expected, null, a nested object, and a list, for BOTH the
+# string-typed metadata filters and the int-typed range/paging arguments --
+# confirming none of them raise. If any gap had been found, it would have
+# been fixed here rather than merely asserted away.
+
+
+@pytest.fixture
+def wired(tmp_path, monkeypatch):
+    from tldw_chatbook.Agents import run_log as run_log_module
+
+    monkeypatch.setattr(run_log_module, "resolve_log_root", lambda: tmp_path)
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    reg = ToolCatalogRegistry()
+    reg.register_provider(BuiltinToolProvider())
+    return db, reg, tmp_path
+
+
+@pytest.fixture
+def real_search_run_log(wired, monkeypatch):
+    """The ACTUAL search_run_log closure a real AgentService wires into
+    LoopDeps, captured via a run_agent_loop spy -- mirrors
+    test_run_log_service_wiring.py::test_on_record_returns_the_assigned_record_number.
+    """
+    from tldw_chatbook.Agents import agent_service as agent_service_module
+
+    db, registry, _root = wired
+    captured: dict = {}
+    real_run_agent_loop = agent_service_module.run_agent_loop
+
+    def spy_run_agent_loop(config, messages, active, deps):
+        captured["deps"] = deps
+        return real_run_agent_loop(config, messages, active, deps)
+
+    monkeypatch.setattr(agent_service_module, "run_agent_loop", spy_run_agent_loop)
+
+    service = AgentService(
+        db, registry, chat_call=lambda **kw: {"choices": [{"message": {"content": "ok"}}]}
+    )
+    service.run_turn(
+        conversation_id="c1",
+        messages=[{"role": "user", "content": "hi"}],
+        config=AgentConfig(model="m", system_prompt="s", budget=RunBudget()),
+        api_endpoint="openai",
+    )
+    deps = captured["deps"]
+    assert deps.search_run_log is not None
+    return deps.search_run_log
+
+
+@pytest.mark.parametrize(
+    "bad_args",
+    [
+        {"from_record": "not-a-number"},
+        {"to_record": "not-a-number"},
+        {"context": "not-a-number"},
+        {"offset": "not-a-number"},
+        {"from_record": {"nested": "object"}},
+        {"to_record": {"nested": "object"}},
+        {"context": {"nested": "object"}},
+        {"offset": {"nested": "object"}},
+        {"from_record": [1, 2, 3]},
+        {"to_record": [1, 2, 3]},
+        {"context": [1, 2, 3]},
+        {"offset": [1, 2, 3]},
+        {"from_record": float("nan")},
+    ],
+)
+def test_unparseable_numeric_args_return_a_clean_error_never_raise(
+    real_search_run_log, bad_args
+):
+    result = real_search_run_log(bad_args)
+    assert result.ok is False
+    assert "Invalid search arguments" in result.error
+
+
+@pytest.mark.parametrize(
+    "null_args",
+    [
+        {"from_record": None},
+        {"to_record": None},
+        {"context": None},
+        {"offset": None},
+    ],
+)
+def test_null_numeric_args_are_coerced_to_zero_not_an_error(
+    real_search_run_log, null_args
+):
+    # `args.get(key) or 0` treats an explicit `null`/None the same as a
+    # missing key -- a deliberate, already-safe coercion (not a gap): the
+    # model sent nothing usable, so "no filter/no offset" is the correct
+    # reading, distinct from a genuinely malformed value like a string or a
+    # nested object above, which DOES surface as an error.
+    result = real_search_run_log(null_args)
+    assert result.ok is True
+
+
+@pytest.mark.parametrize(
+    "bad_args",
+    [
+        {"contains": 123},
+        {"contains": None},
+        {"contains": {"nested": "object"}},
+        {"contains": [1, 2, 3]},
+        {"pattern": 123},
+        {"pattern": None},
+        {"pattern": {"nested": "object"}},
+        {"tool": 123},
+        {"tool": None},
+        {"tool": {"nested": "object"}},
+        {"tool": [1, 2, 3]},
+        {"type": None},
+        {"status": None},
+        {"kind": None},
+    ],
+)
+def test_string_typed_args_are_defensively_coerced_never_raise(
+    real_search_run_log, bad_args
+):
+    result = real_search_run_log(bad_args)
+    # str(...) on any of these never raises, so these must reach a normal
+    # (possibly empty) result -- never an exception.
+    assert result.ok is True
+
+
+def test_missing_args_dict_entirely_does_not_raise(real_search_run_log):
+    # An empty dict -- every key falls back to its documented default.
+    result = real_search_run_log({})
+    assert result.ok is True
+
+
+def test_args_is_not_even_a_dict_of_the_expected_shape(real_search_run_log):
+    # A model could plausibly hand back a flat, oddly-shaped dict (extra
+    # unrecognised keys) -- ignored, never raises.
+    result = real_search_run_log({"unexpected_key": "whatever", "contains": "x"})
+    assert result.ok is True

--- a/Tests/Agents/test_search_run_log_runtime_tool.py
+++ b/Tests/Agents/test_search_run_log_runtime_tool.py
@@ -1,13 +1,17 @@
 # Tests/Agents/test_search_run_log_runtime_tool.py
 """search_run_log: primary-only, no catalog slot, dispatched by the loop."""
 
+import json
+
 import pytest
 
 from tldw_chatbook.Agents.agent_models import (
     AGENT_KIND_PRIMARY,
     AGENT_KIND_SUBAGENT,
+    RUN_DONE,
     RUNTIME_TOOL_NAMES,
     SEARCH_RUN_LOG_TOOL_NAME,
+    SPAWN_TOOL_NAME,
     AgentConfig,
     ModelTurn,
     RunBudget,
@@ -15,7 +19,13 @@ from tldw_chatbook.Agents.agent_models import (
     ToolResult,
 )
 from tldw_chatbook.Agents.agent_runtime import run_agent_loop
-from tldw_chatbook.Agents.tool_catalog import SEARCH_RUN_LOG_TOOL_SCHEMA
+from tldw_chatbook.Agents.agent_service import AgentService
+from tldw_chatbook.Agents.tool_catalog import (
+    SEARCH_RUN_LOG_TOOL_SCHEMA,
+    BuiltinToolProvider,
+    ToolCatalogRegistry,
+)
+from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 
 from Tests.Agents.test_agent_runtime import make_deps
 
@@ -82,3 +92,98 @@ def test_unwired_name_falls_through_to_the_permission_gate():
     )
     run_agent_loop(config, [{"role": "user", "content": "go"}], [], deps)
     assert invoked == [SEARCH_RUN_LOG_TOOL_NAME]
+
+
+# -- Sub-agent isolation, gated to the top-level agent -----------------------
+#
+# Mirrors Tests/Agents/test_install_skill_runtime_tool.py::
+# test_subagent_cannot_call_install_skill -- this task's own header says
+# search_run_log mirrors install_skill exactly, so its isolation test does
+# too. The AGENT_KIND_PRIMARY gate exists in TWO independent places in
+# agent_service.py's _run_one: the schema pin (the runtime_schemas.append
+# under the `agent_kind == AGENT_KIND_PRIMARY and ...` condition) and the
+# LoopDeps wiring (`search_run_log=(search_run_log if agent_kind ==
+# AGENT_KIND_PRIMARY else None)`). Either can regress independently, so
+# this test pins BOTH halves rather than just the end-to-end outcome:
+#   (a) the schema must never be disclosed to a child at all -- a
+#       fence-protocol child's own rendered system prompt (which embeds
+#       every schema it was given, by name) must not mention
+#       "search_run_log";
+#   (b) a child that calls the name anyway (scripted here regardless of
+#       (a), the same way test_subagent_cannot_call_install_skill forces
+#       the call) must be refused through the ordinary permission path
+#       (deps.invoke_tool's "Tool not permitted" message) rather than
+#       executing -- proven from the child run's own persisted
+#       tool_result steps, not merely the parent's final answer.
+#
+# A child sharing the parent's log_dir through the two-phase bind is what
+# makes this matter: without BOTH gates, a sub-agent handed this tool could
+# read its PARENT's entire run history, directly contradicting what
+# spawn_subagent promises its children ("It sees only the task text you
+# pass").
+
+
+def _fence(name, args):
+    return f"```tool_call\n{json.dumps({'name': name, 'arguments': args})}\n```"
+
+
+def _svc_fence(name, args):
+    return {"choices": [{"message": {"content": _fence(name, args)}}]}
+
+
+def test_subagent_cannot_call_search_run_log(tmp_path, monkeypatch):
+    from tldw_chatbook.Agents import run_log as run_log_module
+
+    # Deterministic, hermetic writer: the run log resolves under tmp_path
+    # instead of the real (developer-machine) sandbox root, so `is_active`
+    # is controlled by this test, not by whatever happens to be writable
+    # on whatever machine runs the suite.
+    monkeypatch.setattr(run_log_module, "resolve_log_root", lambda: tmp_path)
+
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    reg = ToolCatalogRegistry()
+    reg.register_provider(BuiltinToolProvider())
+
+    calls = []
+    script = [
+        _svc_fence(SPAWN_TOOL_NAME, {"task": "native task"}),  # parent spawns
+        _svc_fence(SEARCH_RUN_LOG_TOOL_NAME, {"contains": "x"}),  # child tries
+        {"choices": [{"message": {"content": "child gave up"}}]},
+        {"choices": [{"message": {"content": "final"}}]},
+    ]
+
+    def chat(**kwargs):
+        calls.append(kwargs)
+        return script.pop(0)
+
+    service = AgentService(db, reg, chat_call=chat)
+    _rid, outcome = service.run_turn(
+        conversation_id="c1",
+        messages=[{"role": "user", "content": "go"}],
+        config=AgentConfig(
+            model="m",
+            system_prompt="s",
+            allowed_tools=("calculator", SPAWN_TOOL_NAME),
+            budget=RunBudget(),
+        ),
+        api_endpoint="llama_cpp",  # non-native: fence protocol, schemas render into the system prompt
+    )
+    assert outcome.status == RUN_DONE
+
+    # (a) schema gate: the child's OWN call (calls[1] -- the parent's spawn
+    # dispatch runs the child's whole loop inline before dispatch returns,
+    # so this is the second chat_call invocation overall) must never have
+    # been offered search_run_log at all.
+    child_system_prompt = calls[1]["messages_payload"][0]["content"]
+    assert SEARCH_RUN_LOG_TOOL_NAME not in child_system_prompt
+
+    # (b) dispatch gate: the child's call, made regardless of (a), must be
+    # refused through the ordinary permission path, never executed.
+    child_runs = [r for r in db.list_runs("c1") if r["agent_kind"] == "subagent"]
+    assert len(child_runs) == 1
+    tool_results = [
+        s["result"] for s in child_runs[0]["steps"] if s["kind"] == "tool_result"
+    ]
+    assert any(
+        f"Tool not permitted: {SEARCH_RUN_LOG_TOOL_NAME}" in r for r in tool_results
+    )

--- a/Tests/Agents/test_search_run_log_runtime_tool.py
+++ b/Tests/Agents/test_search_run_log_runtime_tool.py
@@ -1,0 +1,84 @@
+# Tests/Agents/test_search_run_log_runtime_tool.py
+"""search_run_log: primary-only, no catalog slot, dispatched by the loop."""
+
+import pytest
+
+from tldw_chatbook.Agents.agent_models import (
+    AGENT_KIND_PRIMARY,
+    AGENT_KIND_SUBAGENT,
+    RUNTIME_TOOL_NAMES,
+    SEARCH_RUN_LOG_TOOL_NAME,
+    AgentConfig,
+    ModelTurn,
+    RunBudget,
+    ToolCall,
+    ToolResult,
+)
+from tldw_chatbook.Agents.agent_runtime import run_agent_loop
+from tldw_chatbook.Agents.tool_catalog import SEARCH_RUN_LOG_TOOL_SCHEMA
+
+from Tests.Agents.test_agent_runtime import make_deps
+
+
+def test_name_is_registered_as_a_runtime_tool():
+    assert SEARCH_RUN_LOG_TOOL_NAME in RUNTIME_TOOL_NAMES
+    assert SEARCH_RUN_LOG_TOOL_SCHEMA.name == SEARCH_RUN_LOG_TOOL_NAME
+    props = SEARCH_RUN_LOG_TOOL_SCHEMA.parameters["properties"]
+    assert "contains" in props and "pattern" in props and "from_record" in props
+
+
+def test_loop_dispatches_to_the_injected_callable():
+    seen = {}
+
+    def handler(args):
+        seen.update(args)
+        return ToolResult(ok=True, content="record 000412 [model]")
+
+    turns = [
+        ModelTurn(
+            text="",
+            tool_calls=(
+                ToolCall(
+                    name=SEARCH_RUN_LOG_TOOL_NAME,
+                    args={"contains": "refused"},
+                    call_id="c1",
+                ),
+            ),
+            assistant_message={"role": "assistant", "content": ""},
+        ),
+        ModelTurn(text="answered"),
+    ]
+    deps = make_deps(turns)
+    deps.search_run_log = handler
+    config = AgentConfig(
+        model="m", system_prompt="s", budget=RunBudget(max_steps=8, max_model_turns=8)
+    )
+    outcome = run_agent_loop(config, [{"role": "user", "content": "go"}], [], deps)
+    assert seen == {"contains": "refused"}
+    assert outcome.final_text == "answered"
+
+
+def test_unwired_name_falls_through_to_the_permission_gate():
+    # deps.search_run_log is None -> the else branch -> deps.invoke_tool.
+    invoked = []
+
+    def invoke(call):
+        invoked.append(call.name)
+        return ToolResult(ok=False, error=f"Tool not permitted: {call.name}")
+
+    turns = [
+        ModelTurn(
+            text="",
+            tool_calls=(
+                ToolCall(name=SEARCH_RUN_LOG_TOOL_NAME, args={}, call_id="c1"),
+            ),
+            assistant_message={"role": "assistant", "content": ""},
+        ),
+        ModelTurn(text="done"),
+    ]
+    deps = make_deps(turns, invoke=invoke)
+    config = AgentConfig(
+        model="m", system_prompt="s", budget=RunBudget(max_steps=8, max_model_turns=8)
+    )
+    run_agent_loop(config, [{"role": "user", "content": "go"}], [], deps)
+    assert invoked == [SEARCH_RUN_LOG_TOOL_NAME]

--- a/Tests/Agents/test_search_run_log_runtime_tool.py
+++ b/Tests/Agents/test_search_run_log_runtime_tool.py
@@ -36,6 +36,9 @@ def test_name_is_registered_as_a_runtime_tool():
     assert SEARCH_RUN_LOG_TOOL_SCHEMA.name == SEARCH_RUN_LOG_TOOL_NAME
     props = SEARCH_RUN_LOG_TOOL_SCHEMA.parameters["properties"]
     assert "contains" in props and "pattern" in props and "from_record" in props
+    # TASK-1250: offset is the schema-level knob that lets a model page
+    # deterministically through a record larger than the render ceiling.
+    assert "offset" in props
 
 
 def test_loop_dispatches_to_the_injected_callable():
@@ -373,3 +376,52 @@ def test_parent_can_filter_its_log_to_subagent_records_via_kind(tmp_path, monkey
     ]
     assert search_results, "expected a search_run_log tool_result step"
     assert any(child_marker in r for r in search_results)
+
+
+def test_real_closure_never_raises_on_a_junk_offset(tmp_path, monkeypatch):
+    """TASK-1250: `offset` must be coerced defensively, the same way the
+    closure already coerces from_record/to_record/context -- a model
+    sending a non-numeric value must come back as an ordinary error
+    ToolResult, never an exception that aborts the run.
+    """
+    from tldw_chatbook.Agents import run_log as run_log_module
+
+    monkeypatch.setattr(run_log_module, "resolve_log_root", lambda: tmp_path)
+
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    reg = ToolCatalogRegistry()
+    reg.register_provider(BuiltinToolProvider())
+
+    script = [
+        _svc_fence(
+            SEARCH_RUN_LOG_TOOL_NAME, {"contains": "x", "offset": "not-a-number"}
+        ),
+        {"choices": [{"message": {"content": "done"}}]},
+    ]
+
+    def chat(**kwargs):
+        return script.pop(0)
+
+    service = AgentService(db, reg, chat_call=chat)
+    _rid, outcome = service.run_turn(
+        conversation_id="c1",
+        messages=[{"role": "user", "content": "go"}],
+        config=AgentConfig(
+            model="m",
+            system_prompt="s",
+            allowed_tools=("calculator",),
+            budget=RunBudget(),
+        ),
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+
+    parent_runs = [r for r in db.list_runs("c1") if r["agent_kind"] == "primary"]
+    assert len(parent_runs) == 1
+    tool_results = [
+        s["result"]
+        for s in parent_runs[0]["steps"]
+        if s["kind"] == "tool_result" and s.get("tool_name") == SEARCH_RUN_LOG_TOOL_NAME
+    ]
+    assert tool_results, "expected a search_run_log tool_result step"
+    assert any("Invalid search arguments" in r for r in tool_results)

--- a/Tests/Agents/test_search_run_log_runtime_tool.py
+++ b/Tests/Agents/test_search_run_log_runtime_tool.py
@@ -2,6 +2,7 @@
 """search_run_log: primary-only, no catalog slot, dispatched by the loop."""
 
 import json
+import re
 
 import pytest
 
@@ -187,3 +188,188 @@ def test_subagent_cannot_call_search_run_log(tmp_path, monkeypatch):
     assert any(
         f"Tool not permitted: {SEARCH_RUN_LOG_TOOL_NAME}" in r for r in tool_results
     )
+
+
+# -- Final-review CRITICAL 1 / IMPORTANT 6: exercise the REAL closure --------
+#
+# Every test above either injects a fake deps.search_run_log or asserts on
+# the schema; none drives agent_service.py's REAL closure. That gap is why
+# the closure's 400-char rendering ceiling (format_results' own default,
+# never overridden by the closure) survived seven reviews: following a
+# truncation trailer returned LESS content than the truncation it was
+# supposed to repair -- defeating spec §6.1, the single change that makes an
+# additive Phase 1 pay off at all.
+
+
+class _AllowGate:
+    """Bypasses BuiltinToolProvider's approval machinery for these tests.
+
+    `read_file`/`grep_files` carry the "reads" risk tag, which floors them
+    to `ask` under the REAL gate (`BuiltinToolProvider()`'s lazily-built
+    default) -- see test_builtin_gate_live_tools.py. These tests care about
+    the run-log closure and the file tools' own containment, not the
+    approval round trip, so they hand the provider a gate that always
+    allows.
+    """
+
+    def check(self, tool):
+        return None
+
+
+def test_real_closure_recovers_full_content_beyond_both_caps(tmp_path, monkeypatch):
+    """CRITICAL 1's regression test: drive a real tool result large enough
+    to be truncated in history, follow the trailer's own record pointer
+    through the REAL search_run_log closure, and confirm the recovered
+    content reaches a marker placed well beyond format_results' OLD
+    400-char rendering default.
+
+    Note on "beyond 16,000 chars" (the run's tool-result ceiling): this is
+    NOT independently achievable and is not attempted here. The recovered
+    render is deliberately capped at THIS SAME ceiling
+    (`config.budget.max_tool_result_chars`) that the ORIGINAL append-time
+    truncation used, and the search_run_log call's own result is re-capped
+    at the identical ceiling when IT is appended to history (the loop's
+    ordinary `_truncate_tool_result`, applied uniformly to every tool
+    result). So nothing the model ever reads in a message can exceed that
+    ceiling, by design ("this cannot blow the context" -- see the finding).
+    The marker is instead placed comfortably ABOVE 400 and comfortably
+    BELOW the ceiling: exactly the band the old bug made unreachable and
+    the fix restores.
+    """
+    from tldw_chatbook.Agents import run_log as run_log_module
+    import tldw_chatbook.Tools.file_operation_tools as file_tools
+    import tldw_chatbook.config as config_module
+
+    monkeypatch.setattr(run_log_module, "resolve_log_root", lambda: tmp_path)
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    monkeypatch.setattr(file_tools, "_resolve_sandbox_config", lambda: str(sandbox))
+
+    def fake_get_cli_setting(section, key=None, default=None):
+        if section == "tools" and key == "read_file_enabled":
+            return True
+        return default
+
+    monkeypatch.setattr(config_module, "get_cli_setting", fake_get_cli_setting)
+
+    # Marker sits at ~char 10,000: well past the old 400-char rendering
+    # bug, safely inside the run's 16,000-char ceiling so it is genuinely
+    # recoverable, while the trailing filler pushes the WHOLE result past
+    # 16,000 so a real append-time truncation (and a real format_results
+    # truncation on the recovery side) both actually fire.
+    marker = "END_MARKER_7f3a9c"
+    big_content = "A" * 10_000 + marker + "C" * 40_000
+    (sandbox / "big.txt").write_text(big_content, encoding="utf-8")
+
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    reg = ToolCatalogRegistry()
+    reg.register_provider(BuiltinToolProvider(gate=_AllowGate()))
+
+    calls = []
+
+    def chat(**kwargs):
+        calls.append(kwargs)
+        round_idx = len(calls)
+        if round_idx == 1:
+            return _svc_fence("read_file", {"file_path": "big.txt"})
+        if round_idx == 2:
+            # Follow the trailer's OWN pointer, extracted from the ACTUAL
+            # truncated tool-result message the loop appended -- not a
+            # hardcoded record number -- so this test tracks the real
+            # capture order rather than assuming it.
+            last_msg = kwargs["messages_payload"][-1]["content"]
+            match = re.search(r"from_record=(\d+)", last_msg)
+            assert match, f"trailer did not name a record: {last_msg!r}"
+            record_number = int(match.group(1))
+            return _svc_fence(
+                SEARCH_RUN_LOG_TOOL_NAME,
+                {"from_record": record_number, "to_record": record_number},
+            )
+        return {"choices": [{"message": {"content": "done"}}]}
+
+    service = AgentService(db, reg, chat_call=chat)
+    _rid, outcome = service.run_turn(
+        conversation_id="c1",
+        messages=[{"role": "user", "content": "read the file"}],
+        config=AgentConfig(
+            model="m",
+            system_prompt="s",
+            allowed_tools=("read_file",),
+            budget=RunBudget(),
+        ),
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+
+    # Round 2's payload carries the history-truncated result: confirm a
+    # genuine truncation happened (there is more content than the ceiling
+    # allows), and that it names a recovery record.
+    truncated_msg = calls[1]["messages_payload"][-1]["content"]
+    assert "truncated" in truncated_msg
+    assert "search_run_log" in truncated_msg
+
+    # Round 3's payload carries search_run_log's rendered result: the
+    # marker -- at ~char 10,000, 25x past format_results' OLD 400-char
+    # default -- must be PRESENT, proving the closure now renders at the
+    # run's real ceiling rather than the old hardcoded default.
+    recovered_msg = calls[2]["messages_payload"][-1]["content"]
+    assert marker in recovered_msg
+    assert len(recovered_msg) > 400, (
+        "recovered message must be far larger than the old 400-char bug"
+    )
+
+
+def test_parent_can_filter_its_log_to_subagent_records_via_kind(tmp_path, monkeypatch):
+    """IMPORTANT 5's regression test: `kind` is implemented in
+    `search_records` and justified by spec §4.1 ("a parent can search its
+    child's entire trace"), but the schema omitted it and the closure never
+    passed it through -- so it was unreachable end to end. Drives a real
+    spawn, then has the PARENT (never the child -- search_run_log stays
+    primary-only) filter its own log to `kind=subagent` and confirms it
+    finds the child's own record.
+    """
+    from tldw_chatbook.Agents import run_log as run_log_module
+
+    monkeypatch.setattr(run_log_module, "resolve_log_root", lambda: tmp_path)
+
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    reg = ToolCatalogRegistry()
+    reg.register_provider(BuiltinToolProvider())
+
+    child_marker = "CHILD_ONLY_MARKER_4b8e"
+    script = [
+        _svc_fence(SPAWN_TOOL_NAME, {"task": "investigate"}),  # parent spawns
+        {"choices": [{"message": {"content": child_marker}}]},  # child's final answer
+        _svc_fence(SEARCH_RUN_LOG_TOOL_NAME, {"kind": "subagent"}),  # parent searches
+        {"choices": [{"message": {"content": "done"}}]},  # parent's final answer
+    ]
+
+    def chat(**kwargs):
+        return script.pop(0)
+
+    service = AgentService(db, reg, chat_call=chat)
+    _rid, outcome = service.run_turn(
+        conversation_id="c1",
+        messages=[{"role": "user", "content": "go"}],
+        config=AgentConfig(
+            model="m",
+            system_prompt="s",
+            allowed_tools=("calculator", SPAWN_TOOL_NAME),
+            budget=RunBudget(),
+        ),
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+
+    # Verify against the persisted run tree, not just the scripted flow:
+    # the PARENT's own tool_result for its search_run_log call must
+    # contain the CHILD's marker text.
+    parent_runs = [r for r in db.list_runs("c1") if r["agent_kind"] == "primary"]
+    assert len(parent_runs) == 1
+    search_results = [
+        s["result"]
+        for s in parent_runs[0]["steps"]
+        if s["kind"] == "tool_result" and s.get("tool_name") == SEARCH_RUN_LOG_TOOL_NAME
+    ]
+    assert search_results, "expected a search_run_log tool_result step"
+    assert any(child_marker in r for r in search_results)

--- a/backlog/tasks/task-1250 - Run-log-recovery-cannot-return-content-past-max_tool_result_chars.md
+++ b/backlog/tasks/task-1250 - Run-log-recovery-cannot-return-content-past-max_tool_result_chars.md
@@ -1,0 +1,59 @@
+---
+id: TASK-1250
+title: Run-log recovery cannot return content past max_tool_result_chars
+status: To Do
+assignee: []
+created_date: '2026-07-28 00:00'
+labels: [agents, run-log, correctness]
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+When an agent's tool result is truncated in history, `_truncate_tool_result` now
+appends a trailer naming the run-log record holding the full copy:
+
+> The full result is recorded at record 000412 — `search_run_log(from_record=412, to_record=412)`.
+
+Following that pointer cannot return anything the model has not already seen.
+`run_log_search.format_results` renders `content[:max_chars]` from **offset 0**,
+and the service closure sets `max_chars` to the run's
+`budget.max_tool_result_chars` (16,000 by default) — the same ceiling that
+truncated the result in history in the first place. So for any result larger than
+that ceiling, the "recovered" render is byte-identical to the truncated view the
+model already had.
+
+Two consequences:
+
+1. **The trailer overpromises.** It says the full result is recoverable. For the
+   results most worth recovering — the large ones — it is not.
+2. **A match can render a body without the match.** Because rendering always
+   starts at offset 0, `contains="THE_ANSWER"` can legitimately *match* a record
+   whose match sits at character 40,000, and then render characters 0–16,000,
+   which do not contain it. The agent is told the record matches and shown text
+   that contradicts that. This is the same silent-wrong-answer class as the
+   `limit`/`context` and negative-`context` defects fixed earlier in this branch.
+
+This is a scope boundary rather than a regression — the Phase 1 fix it came from
+removed a much worse 400-character cap, and the design spec defers slicing and
+aggregation tools to Phase 2. But the trailer's wording asserts a capability that
+does not exist yet, and the match-without-showing behaviour is actively
+misleading.
+
+Discovered by the final whole-branch re-review of the run-log Phase 1 branch
+(`feat/agent-run-log-spec`); see
+`Docs/superpowers/specs/2026-07-27-agent-programmatic-run-memory-design.md` §6.1
+and §11.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 An agent can retrieve content from a logged record beyond `max_tool_result_chars` — e.g. via an offset/length parameter, a windowed render centred on the match, or a dedicated slice tool
+- [ ] #2 When a record matches a `contains=`/`pattern=` query, the rendered body contains the match, or states explicitly that the match lies outside the rendered window and how to reach it
+- [ ] #3 The truncation trailer's wording matches what following it can actually deliver
+- [ ] #4 Retrieval remains bounded so a single call cannot blow the context window
+- [ ] #5 Tests cover a result substantially larger than `max_tool_result_chars`, asserting that content near its END is retrievable and that a match beyond the ceiling is either shown or explicitly located
+<!-- AC:END -->

--- a/backlog/tasks/task-1250 - Run-log-recovery-cannot-return-content-past-max_tool_result_chars.md
+++ b/backlog/tasks/task-1250 - Run-log-recovery-cannot-return-content-past-max_tool_result_chars.md
@@ -1,10 +1,15 @@
 ---
 id: TASK-1250
 title: Run-log recovery cannot return content past max_tool_result_chars
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-28 00:00'
-labels: [agents, run-log, correctness]
+updated_date: '2026-07-28 18:57'
+labels:
+  - agents
+  - run-log
+  - correctness
 dependencies: []
 priority: high
 ---
@@ -49,11 +54,88 @@ and §11.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
-- [ ] #1 An agent can retrieve content from a logged record beyond `max_tool_result_chars` — e.g. via an offset/length parameter, a windowed render centred on the match, or a dedicated slice tool
-- [ ] #2 When a record matches a `contains=`/`pattern=` query, the rendered body contains the match, or states explicitly that the match lies outside the rendered window and how to reach it
-- [ ] #3 The truncation trailer's wording matches what following it can actually deliver
-- [ ] #4 Retrieval remains bounded so a single call cannot blow the context window
-- [ ] #5 Tests cover a result substantially larger than `max_tool_result_chars`, asserting that content near its END is retrievable and that a match beyond the ceiling is either shown or explicitly located
+- [x] #1 An agent can retrieve content from a logged record beyond `max_tool_result_chars` — e.g. via an offset/length parameter, a windowed render centred on the match, or a dedicated slice tool
+- [x] #2 When a record matches a `contains=`/`pattern=` query, the rendered body contains the match, or states explicitly that the match lies outside the rendered window and how to reach it
+- [x] #3 The truncation trailer's wording matches what following it can actually deliver
+- [x] #4 Retrieval remains bounded so a single call cannot blow the context window
+- [x] #5 Tests cover a result substantially larger than `max_tool_result_chars`, asserting that content near its END is retrievable and that a match beyond the ceiling is either shown or explicitly located
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add match-centred rendering to run_log_search.format_results: new keyword-only
+   contains/pattern/offset params; a helper locates each record's first match
+   (contains unbounded, pattern bounded to MAX_REGEX_SCAN_CHARS, matching
+   search_records' own decision) and another picks the window start (explicit
+   offset > 0 wins; else centre on the match; else 0), clamped into bounds.
+2. Make elision visible: when the rendered window doesn't cover the whole
+   record, append the shown character range, total size, and the offset to
+   pass next.
+3. Add "offset" to the search_run_log tool schema (tool_catalog.py) and thread
+   it from args through agent_service.py's search_run_log closure into
+   format_results, coerced the same defensively-numeric way as
+   from_record/to_record/context.
+4. Reword _truncate_tool_result's trailer (agent_runtime.py) so it no longer
+   implies a bare from_record/to_record call recovers everything -- it now
+   names contains=/offset= as how to actually reach content past the ceiling.
+5. Add tests: the live-failure reproduction (2,925-char record, marker at
+   2,646, max_chars=500), offset paging to a record's end, negative/past-end
+   offset clamping, junk offset via the real closure, and a no-query control.
+   Verify the reproduction test fails pre-fix (TypeError: unexpected keyword
+   argument 'contains') and passes post-fix.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed by adding match-centred rendering, an explicit `offset` paging
+parameter, and visible/actionable elision to run_log_search.format_results,
+threaded end to end through the search_run_log tool.
+
+Approach: format_results gained keyword-only contains/pattern/offset params
+(existing max_chars=400 default untouched, existing tests unmodified). Per
+record, a window start is chosen: explicit offset>0 always wins (deterministic
+paging); otherwise a match position (contains searched unbounded, pattern
+bounded to MAX_REGEX_SCAN_CHARS, mirroring search_records' own match
+decision) centres the window; otherwise it starts at 0 as before. Centring
+math is proven (see _window_start's docstring) to always keep the match
+inside the window once found. When the window doesn't cover a record's whole
+content, the block states the shown range, total size, and the `offset` to
+continue with -- this is what lets an agent actually page past the render
+ceiling across multiple calls, since the ceiling itself did not change (AC #4:
+retrieval stays bounded per call).
+
+`offset` was added to SEARCH_RUN_LOG_TOOL_SCHEMA and threaded through
+agent_service.py's search_run_log closure with the same defensive
+int(args.get(...) or 0) coercion already used for from_record/to_record/
+context -- a non-numeric value returns an error ToolResult, never raises.
+
+_truncate_tool_result's trailer (agent_runtime.py) was reworded: it no
+longer implies a bare `search_run_log(from_record=X, to_record=X)` call
+recovers everything (it renders at the same ceiling that did the original
+cut) -- it now names `contains=`/`offset=` as how to actually reach content
+beyond that cut. The record-number threading itself is unchanged.
+
+Tests added (Tests/Agents/test_run_log_search.py,
+test_search_run_log_runtime_tool.py):
+- test_match_beyond_max_chars_is_rendered_not_silently_dropped: reproduces
+  the live failure exactly (2,925-char record, marker at char 2,646,
+  max_chars=500). Verified failing pre-fix (TypeError: format_results() got
+  an unexpected keyword argument 'contains') and passing post-fix.
+- test_offset_pages_through_a_large_record_to_its_end
+- test_offset_negative_or_past_end_is_clamped_not_empty
+- test_no_query_render_still_starts_at_offset_zero
+- test_name_is_registered_as_a_runtime_tool: extended to assert "offset" in
+  the schema
+- test_real_closure_never_raises_on_a_junk_offset: full AgentService.run_turn
+  flow proving a non-numeric offset never raises into the run
+
+Full suite: Tests/Agents/ 447 passed, 0 failed (442 baseline + 5 new tests).
+
+Modified: tldw_chatbook/Agents/run_log_search.py,
+tldw_chatbook/Agents/agent_service.py, tldw_chatbook/Agents/agent_runtime.py,
+tldw_chatbook/Agents/tool_catalog.py, Tests/Agents/test_run_log_search.py,
+Tests/Agents/test_search_run_log_runtime_tool.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-1251 - Workspace-folder-bound-to-the-sandbox-root-re-exposes-the-run-log.md
+++ b/backlog/tasks/task-1251 - Workspace-folder-bound-to-the-sandbox-root-re-exposes-the-run-log.md
@@ -1,10 +1,15 @@
 ---
 id: TASK-1251
 title: Workspace folder bound to the sandbox root re-exposes the run log
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-28 00:00'
-labels: [agents, run-log, security]
+updated_date: '2026-07-28 19:42'
+labels:
+  - agents
+  - run-log
+  - security
 dependencies: []
 priority: medium
 ---
@@ -43,11 +48,30 @@ blocker, but it silently defeats a security control and should not stay open.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
-- [ ] #1 A workspace folder whose resolved path is the sandbox root (or lies inside it) cannot cause the run log to be written under an undotted, glob/grep-reachable name
-- [ ] #2 The chosen remedy is stated and justified — either refusing/warning on such a binding at `add_folder_binding`, or having the writer detect the overlap and fall back to the dotted name
-- [ ] #3 A sub-agent cannot reach the parent's run log via `glob_files` or `grep_files` in this configuration; the test plants a distinctive secret and asserts it is not recoverable
-- [ ] #4 The normal cases are unaffected: a genuine workspace folder outside the sandbox still gets the visible undotted `agent-runs`, and the no-workspace fallback still gets the dotted name
-- [ ] #5 The app's own reader (`search_run_log` / `load_records`) still reads the log in every case, since it deliberately does not route through `validate_path`
+- [x] #1 A workspace folder whose resolved path is the sandbox root (or lies inside it) cannot cause the run log to be written under an undotted, glob/grep-reachable name
+- [x] #2 The chosen remedy is stated and justified — either refusing/warning on such a binding at `add_folder_binding`, or having the writer detect the overlap and fall back to the dotted name
+- [x] #3 A sub-agent cannot reach the parent's run log via `glob_files` or `grep_files` in this configuration; the test plants a distinctive secret and asserts it is not recoverable
+- [x] #4 The normal cases are unaffected: a genuine workspace folder outside the sandbox still gets the visible undotted `agent-runs`, and the no-workspace fallback still gets the dotted name
+- [x] #5 The app's own reader (`search_run_log` / `load_records`) still reads the log in every case, since it deliberately does not route through `validate_path`
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. In RunLogWriter.bind(), after resolving `root`, compute containment against `_tool_sandbox_root()` directly (resolved-path comparison), independent of the `is_sandbox_fallback` branch flag resolve_log_root() reports.
+2. OR the chosen root: dot the directory name whenever the flag says fallback OR the containment check says the resolved root is the sandbox root or nested inside it.
+3. Fail closed (treat as sandboxed/dot) if the containment check itself raises.
+4. Add tests: workspace folder nested inside the sandbox root, workspace folder equal to the sandbox root, and a regression guard that a genuine outside-sandbox workspace folder keeps the undotted name.
+5. Add an end-to-end grep_files test mirroring the existing sandbox-fallback disclosure test, planting a secret and confirming it is unreachable through this workspace-inside-sandbox binding too (AC #3).
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented in tldw_chatbook/Agents/run_log.py: RunLogWriter.bind() now decides the dotted-vs-undotted name on ACTUAL containment (resolved root == or under `_tool_sandbox_root()`), not merely on which branch resolve_log_root() took. The check is skipped (cheap short-circuit) when the fallback flag already says True, and runs otherwise; any exception during the check fails closed (dots the name) rather than risking disclosure. This also covers callers that monkeypatch resolve_log_root() wholesale, since the check reads the already-resolved `root` value directly rather than the side-channel flag.
+
+Tests added: Tests/Agents/test_run_log_writer.py (nested-inside-sandbox, equal-to-sandbox, and outside-sandbox-stays-undotted regression guard) and Tests/Agents/test_run_log_sandbox_isolation.py::test_workspace_folder_inside_the_sandbox_is_dotted_and_hidden_from_grep, which mirrors the existing PARENT_SECRET_API_KEY disclosure test but through a workspace-folder binding nested inside the sandbox root, driving the real GrepFiles tool and confirming the secret is unrecoverable (AC #3). search_run_log/load_records' own reader is unaffected since it globs log_dir directly and never routes through validate_path/_is_hidden_within (AC #5), unchanged by this fix.
+
+Addressed as part of the PR #1066 Qodo review pass (finding F8) rather than as a separate follow-up PR, per reviewer instruction to fix everything before merge.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-1251 - Workspace-folder-bound-to-the-sandbox-root-re-exposes-the-run-log.md
+++ b/backlog/tasks/task-1251 - Workspace-folder-bound-to-the-sandbox-root-re-exposes-the-run-log.md
@@ -1,0 +1,53 @@
+---
+id: TASK-1251
+title: Workspace folder bound to the sandbox root re-exposes the run log
+status: To Do
+assignee: []
+created_date: '2026-07-28 00:00'
+labels: [agents, run-log, security]
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The agent run log is written under a bound read-write workspace folder when one
+exists, and under the tool sandbox root otherwise. Those two cases deliberately
+use different directory names:
+
+- **workspace folder** → `agent-runs` (undotted, so the log is a visible artifact
+  in the user's own project)
+- **sandbox fallback** → `.agent-runs` (dotted, so `_is_hidden_within` excludes it
+  from `glob_files`/`grep_files`)
+
+The dotting exists for a security reason. The sandbox root is exactly the root
+`glob_files` and `grep_files` are rooted at, and sub-agents inherit the parent's
+allow-list — so with an undotted name a spawned child could `grep_files` its
+parent's entire run log, contradicting `spawn_subagent`'s contract that a child
+"sees only the task text you pass". That was reproduced during review by
+extracting a planted `PARENT_SECRET_API_KEY` from a parent's log, and is fixed
+for the default configuration.
+
+The choice is made from which branch `resolve_log_root` took, deliberately not by
+comparing path strings. That leaves one edge case open: **nothing prevents a user
+from binding a workspace folder whose resolved path IS the sandbox root**
+(`Workspaces/registry_service.py` `add_folder_binding` has no such guard). When
+that happens `resolve_log_root` takes the workspace branch, the writer picks the
+undotted `agent-runs` name, and the log lands undotted *inside the sandbox root* —
+reproducing exactly the disclosure the dotting prevents.
+
+Reproduced during the final re-review of `feat/agent-run-log-spec`. It requires a
+deliberate and unusual binding, which is why it was not treated as a merge
+blocker, but it silently defeats a security control and should not stay open.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 A workspace folder whose resolved path is the sandbox root (or lies inside it) cannot cause the run log to be written under an undotted, glob/grep-reachable name
+- [ ] #2 The chosen remedy is stated and justified — either refusing/warning on such a binding at `add_folder_binding`, or having the writer detect the overlap and fall back to the dotted name
+- [ ] #3 A sub-agent cannot reach the parent's run log via `glob_files` or `grep_files` in this configuration; the test plants a distinctive secret and asserts it is not recoverable
+- [ ] #4 The normal cases are unaffected: a genuine workspace folder outside the sandbox still gets the visible undotted `agent-runs`, and the no-workspace fallback still gets the dotted name
+- [ ] #5 The app's own reader (`search_run_log` / `load_records`) still reads the log in every case, since it deliberately does not route through `validate_path`
+<!-- AC:END -->

--- a/backlog/tasks/task-1265 - glob_files-grep_files-ignore-workspace-folder-roots-that-read_file-honors.md
+++ b/backlog/tasks/task-1265 - glob_files-grep_files-ignore-workspace-folder-roots-that-read_file-honors.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-895
+id: TASK-1265
 title: glob_files/grep_files ignore workspace folder roots that read_file honors
 status: To Do
 assignee: []

--- a/backlog/tasks/task-870 - Console-tool-result-display-caps-Settings-control-and-full-content-access.md
+++ b/backlog/tasks/task-870 - Console-tool-result-display-caps-Settings-control-and-full-content-access.md
@@ -1,0 +1,60 @@
+---
+id: TASK-870
+title: Console tool-result display caps — Settings control and full-content access
+status: To Do
+assignee: []
+created_date: '2026-07-27 00:00'
+labels: [console, agents, settings, ux]
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+What the Console shows of an agent tool result is governed by a cascade of
+hardcoded constants, none of them user-adjustable, and the final display cap is
+roughly 1% of what the model itself received. A tool result that reached the
+model at up to 16,000 characters is rendered to the user as 160-200.
+
+The cascade, on `origin/dev`:
+
+| Stage | Cap | Site |
+| --- | --- | --- |
+| Tool returns | unbounded | provider / tool |
+| Enters model history | 16,000 | `RunBudget.max_tool_result_chars` |
+| Recorded on the step | 2,000 | `agent_runtime.py:652` `result=content[:2000]` |
+| Live step summary | **200** | `console_agent_bridge._STEP_SUMMARY_LIMIT` |
+| Transcript marker | **160** | `console_agent_bridge._STEP_MARKER_RESULT_LIMIT` |
+| Resumed / persisted step | **200** | `console_agent_bridge._summarize_persisted_step` |
+| Tool widget fields | 97 / 77 / 197, first 3 items | `Widgets/tool_message_widgets.py` |
+
+Two consequences. First, a user debugging an agent run cannot see what the agent
+actually saw, and has no control over the trade-off between transcript
+readability and detail. Second, the paths are inconsistent: the live path uses
+`_truncate_step_text`, which cuts on a word boundary and appends an explicit
+`(+N chars)` affordance (TASK-350), while `_summarize_persisted_step` does a bare
+`str(raw)[:200]` — so a resumed or historical run shows a silent mid-word clip,
+which is exactly the defect TASK-350 fixed for live steps.
+
+Separately, the run-log work (see the PRO-LONG programmatic run-memory design)
+writes the full, untruncated result to a file on disk. Where such a file exists
+for a run, the Console should be able to open the full record rather than only
+ever showing a preview — raising the cap and linking to the source are two halves
+of the same fix, and the second is what makes a conservative default cap
+acceptable.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 The Console tool-result display cap is a single configurable setting, surfaced on the Settings page, not a set of scattered module constants
+- [ ] #2 The setting has a documented default that preserves today's transcript readability, and a documented maximum
+- [ ] #3 Changing the setting takes effect on newly rendered steps without an app restart
+- [ ] #4 Live, transcript-marker, and resumed/persisted step rendering all honour the same setting; no path retains an independent hardcoded cap
+- [ ] #5 `_summarize_persisted_step` uses the same word-boundary + `(+N chars)` affordance as the live path, so a resumed run never shows a silent mid-word clip
+- [ ] #6 When a run log file exists for the run, the Console offers a way to read the full, untruncated result from it
+- [ ] #7 When no run log file exists, the affordance is absent rather than dangling or erroring
+- [ ] #8 The Settings control explains the relationship between the display cap and `max_tool_result_chars` (what the model saw), so the two are not confused
+- [ ] #9 Tests cover the cap being read from config, applied identically across all three rendering paths, and the present/absent log-file branches of #6 and #7
+<!-- AC:END -->

--- a/backlog/tasks/task-895 - glob_files-grep_files-ignore-workspace-folder-roots-that-read_file-honors.md
+++ b/backlog/tasks/task-895 - glob_files-grep_files-ignore-workspace-folder-roots-that-read_file-honors.md
@@ -1,0 +1,65 @@
+---
+id: TASK-895
+title: glob_files/grep_files ignore workspace folder roots that read_file honors
+status: To Do
+assignee: []
+created_date: '2026-07-27 00:00'
+labels: [agents, tools, security, tech-debt]
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The sandboxed file tools disagree about what "the sandbox" means. `read_file`,
+`write_file` and `list_directory` resolve against the sandbox root **plus the
+run's bound workspace folder roots**:
+
+```python
+validate_path_multi(
+    file_path,
+    allowed_file_roots(write=False, sandbox_root=_tool_sandbox_root()),
+)
+```
+
+`glob_files` and `grep_files` never call `allowed_file_roots` at all. Both glob
+and containment-check against the sandbox root alone:
+
+```python
+root = _tool_sandbox_root()
+candidates = root.glob(pattern)
+...
+if not path.is_file() or not is_within(path, root, context=sensitive_ctx):
+```
+
+So a file in a bound workspace folder is readable by exact path but cannot be
+found or searched. An agent that can read a workspace file has no way to discover
+it, and a user who binds a project folder reasonably expects the search tools to
+see it — the asymmetry is silent and surprising in both directions.
+
+This was found while designing programmatic run memory
+(`Docs/superpowers/specs/2026-07-27-agent-programmatic-run-memory-design.md`
+§9.4), which routes around it rather than fixing it: correcting the asymmetry
+widens two shared tools' reach for **every** caller, which is a security-relevant
+change that deserves its own review rather than being folded into a feature spec.
+
+Whichever way it is resolved, the two behaviours should agree. Note that
+narrowing is also a legitimate outcome: if search tools are deliberately meant to
+stay sandbox-only, that intent belongs in the tool descriptions and docstrings,
+which currently say only "inside the tool sandbox" without acknowledging that
+sibling tools reach further.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 A decision is recorded (ADR or task notes) on whether search tools reach workspace folder roots, with the security reasoning stated
+- [ ] #2 `glob_files` and `grep_files` behave consistently with `read_file`/`list_directory` per that decision — either both reach workspace roots, or the sandbox-only scope is documented as deliberate in each tool's description
+- [ ] #3 If widened: containment is checked against every allowed root, not just the sandbox root, and a path outside all of them is still refused
+- [ ] #4 If widened: the existing hidden-component rule (`_is_hidden_within`) and sensitive-path denylist apply to workspace roots exactly as they do to the sandbox root
+- [ ] #5 If widened: `_MAX_CANDIDATES` and the other traversal bounds are re-evaluated against the larger search space, since a bound workspace folder can be far larger than the sandbox
+- [ ] #6 If widened: the `"reads"` risk tag and its `ask` permission floor are re-confirmed as still appropriate for the wider reach
+- [ ] #7 Symlink and mount drift on workspace roots is re-checked per call, matching `allowed_file_roots`' existing ADR-028 behaviour
+- [ ] #8 Tests cover a file in a bound workspace folder being found or refused per the decision, and a file outside all roots always being refused
+<!-- AC:END -->

--- a/tldw_chatbook/Agents/agent_models.py
+++ b/tldw_chatbook/Agents/agent_models.py
@@ -34,6 +34,7 @@ LOAD_TOOLS_NAME = "load_tools"
 SKILL_FILE_TOOL_NAME = "skill_file"
 INSTALL_SKILL_TOOL_NAME = "install_skill"
 RUN_SKILL_SCRIPT_TOOL_NAME = "run_skill_script"
+SEARCH_RUN_LOG_TOOL_NAME = "search_run_log"
 RUNTIME_TOOL_NAMES = frozenset(
     {
         SPAWN_TOOL_NAME,
@@ -42,6 +43,7 @@ RUNTIME_TOOL_NAMES = frozenset(
         SKILL_FILE_TOOL_NAME,
         INSTALL_SKILL_TOOL_NAME,
         RUN_SKILL_SCRIPT_TOOL_NAME,
+        SEARCH_RUN_LOG_TOOL_NAME,
     }
 )
 

--- a/tldw_chatbook/Agents/agent_runtime.py
+++ b/tldw_chatbook/Agents/agent_runtime.py
@@ -725,12 +725,25 @@ def run_agent_loop(
                 status="",
                 call_id=call.call_id,
             )
+            # Final-review IMPORTANT 3: tool_catalog.py documents `status` as
+            # "ok or error", but this used to write only "ok" (any
+            # "proceed" verdict, even a dispatch that actually failed -- see
+            # `content = ... f"ERROR: {result.error}"` above) or "refused"
+            # -- "error" was never reachable. `result` is only safe to read
+            # here when verdict == "proceed": that is the sole branch above
+            # that assigns it in THIS iteration (a non-"proceed" verdict
+            # skips dispatch entirely, so `result` -- if it exists at all --
+            # would be a stale value from a different call in this batch).
+            if verdict == "proceed":
+                record_status = "ok" if result.ok else "error"
+            else:
+                record_status = "refused"
             record_number = _emit_record(
                 deps,
                 "tool_result",
                 content=content,
                 tool=call.name,
-                status="ok" if verdict == "proceed" else "refused",
+                status=record_status,
                 call_id=call.call_id,
             )
 

--- a/tldw_chatbook/Agents/agent_runtime.py
+++ b/tldw_chatbook/Agents/agent_runtime.py
@@ -333,9 +333,18 @@ def _truncate_tool_result(
     if max_chars <= 0 or len(content) <= max_chars:
         return content
     if record_number is not None:
+        # TASK-1250: a bare from_record/to_record call renders the SAME
+        # first `max_chars` this trailer already cut -- format_results
+        # windows at this run's own tool-result ceiling, so it cannot show
+        # more in one call. Naming `contains=`/`offset=` here is what makes
+        # the pointer actually deliver content beyond this cut, instead of
+        # promising recovery a bare call can't provide.
         recovery = (
             f" The full result is recorded at record {record_number:06d} — "
-            f"search_run_log(from_record={record_number}, to_record={record_number})."
+            f"search_run_log(from_record={record_number}, to_record={record_number}) "
+            f"renders it windowed at this same limit, so add contains=<term> to "
+            f"jump straight to a match, or offset=<n> to page past it (the "
+            f"rendered output states the next offset)."
         )
     else:
         recovery = (

--- a/tldw_chatbook/Agents/agent_runtime.py
+++ b/tldw_chatbook/Agents/agent_runtime.py
@@ -254,12 +254,46 @@ class LoopDeps:
     # `None` (the default) means the run is not wired for it and a call by
     # that name falls through to the generic deps.invoke_tool path.
     run_skill_script: Callable[[str, str, list[str]], ToolResult] | None = None
+    # on_record: full-fidelity capture for the run log (run_log.py). Called
+    # with (record_type, payload) at the two points where the COMPLETE value
+    # exists -- which the step log does not carry, since `add()` truncates
+    # model turns to 200 chars and tool results to 2000. Captured in the
+    # loop rather than in service wrappers because the loop assembles
+    # `content` for EVERY dispatch branch at one point: a wrapper around
+    # deps.invoke_tool would silently miss find_tools, load_tools,
+    # spawn_subagent, skill_file, install_skill and run_skill_script.
+    # `None` (the default) is a no-op: behavior is byte-identical to
+    # pre-run-log runs.
+    on_record: Callable[[str, dict], None] | None = None
 
 
 def _catalog_lines(entries: list) -> str:
     if not entries:
         return "No matching tools."
     return "\n".join(f"{e.id} — {e.name}: {e.one_line_description}" for e in entries)
+
+
+def _emit_record(deps: "LoopDeps", record_type: str, **payload) -> int | None:
+    """Best-effort run-log capture; a failing writer never aborts a run.
+
+    Args:
+        deps: The run's injected dependencies.
+        record_type: ``model``, ``tool_call``, or ``tool_result``.
+        **payload: ``content``, ``tool``, ``status``, ``call_id``.
+
+    Returns:
+        The assigned record number, or ``None`` when logging is off or the
+        write failed. Task 7 threads this into the truncation trailer.
+    """
+    if deps.on_record is None:
+        return None
+    try:
+        return deps.on_record(record_type, payload)
+    except Exception:  # noqa: BLE001 — logging is never load-bearing
+        logger.opt(exception=True).warning(
+            f"on_record hook raised for a {record_type} record; continuing"
+        )
+        return None
 
 
 def _truncate_tool_result(content: str, max_chars: int, tool_name: str) -> str:
@@ -423,6 +457,14 @@ def run_agent_loop(
         model_turns += 1
         total_tokens += turn.tokens
         add(STEP_MODEL, summary=turn.text[:200])
+        _emit_record(
+            deps,
+            "model",
+            content=turn.text,
+            tool="",
+            status="",
+            call_id="",
+        )
 
         calls = list(turn.tool_calls)
         if not calls:
@@ -640,6 +682,27 @@ def run_agent_loop(
                     result = deps.invoke_tool(call)
 
                 content = result.content if result.ok else f"ERROR: {result.error}"
+
+            # Capture BEFORE _truncate_tool_result below: the log is the
+            # lossless record, history is the capped view of it. This single
+            # point covers every dispatch branch above -- builtin, MCP,
+            # skill, runtime tools -- and the review-hook refusal path.
+            _emit_record(
+                deps,
+                "tool_call",
+                content=json.dumps(call.args, sort_keys=True, default=str),
+                tool=call.name,
+                status="",
+                call_id=call.call_id,
+            )
+            _emit_record(
+                deps,
+                "tool_result",
+                content=content,
+                tool=call.name,
+                status="ok" if verdict == "proceed" else "refused",
+                call_id=call.call_id,
+            )
 
             # Truncate once, unconditionally, regardless of which branch set
             # `content` above -- the review-hook refusal string (verdict !=

--- a/tldw_chatbook/Agents/agent_runtime.py
+++ b/tldw_chatbook/Agents/agent_runtime.py
@@ -305,7 +305,9 @@ def _emit_record(deps: "LoopDeps", record_type: str, **payload) -> int | None:
         return None
 
 
-def _truncate_tool_result(content: str, max_chars: int, tool_name: str) -> str:
+def _truncate_tool_result(
+    content: str, max_chars: int, tool_name: str, record_number: int | None = None
+) -> str:
     """Bound one tool result before it enters history.
 
     Applied at the append seam rather than inside each tool so a tool that
@@ -318,6 +320,10 @@ def _truncate_tool_result(content: str, max_chars: int, tool_name: str) -> str:
             negative means unlimited.
         tool_name: Named in the trailer so the model knows which call was
             cut and can re-issue it more narrowly.
+        record_number: The run-log record number the untruncated result was
+            captured under, or ``None`` when logging is off or the capture
+            failed. When given, the trailer points at it via
+            ``search_run_log`` instead of suggesting a re-issue.
 
     Returns:
         ``content`` unchanged when under the cap or when unlimited;
@@ -326,11 +332,20 @@ def _truncate_tool_result(content: str, max_chars: int, tool_name: str) -> str:
     """
     if max_chars <= 0 or len(content) <= max_chars:
         return content
+    if record_number is not None:
+        recovery = (
+            f" The full result is recorded at record {record_number:06d} — "
+            f"search_run_log(from_record={record_number}, to_record={record_number})."
+        )
+    else:
+        recovery = (
+            " Re-issue the call with a narrower query, or use the tool's "
+            "offset/limit arguments to read the rest."
+        )
     return (
         content[:max_chars]
         + f"\n\n[truncated: {tool_name} returned {len(content)} characters; "
-        f"showing the first {max_chars}. Re-issue the call with a narrower "
-        f"query, or use the tool's offset/limit arguments to read the rest.]"
+        f"showing the first {max_chars}.{recovery}]"
     )
 
 
@@ -710,7 +725,7 @@ def run_agent_loop(
                 status="",
                 call_id=call.call_id,
             )
-            _emit_record(
+            record_number = _emit_record(
                 deps,
                 "tool_result",
                 content=content,
@@ -722,9 +737,15 @@ def run_agent_loop(
             # Truncate once, unconditionally, regardless of which branch set
             # `content` above -- the review-hook refusal string (verdict !=
             # "proceed") and every dispatched-tool result share the same cap
-            # so neither path can enter history unbounded.
+            # so neither path can enter history unbounded. `record_number`
+            # (Task 7) is the number the tool_result record above was just
+            # captured under -- threading it through lets a truncated result
+            # point at its own full copy in the run log.
             content = _truncate_tool_result(
-                content, budget.max_tool_result_chars, call.name
+                content,
+                budget.max_tool_result_chars,
+                call.name,
+                record_number=record_number,
             )
 
             add(STEP_TOOL_RESULT, tool_name=call.name, result=content[:2000])

--- a/tldw_chatbook/Agents/agent_runtime.py
+++ b/tldw_chatbook/Agents/agent_runtime.py
@@ -273,7 +273,7 @@ class LoopDeps:
     # spawn_subagent, skill_file, install_skill and run_skill_script.
     # `None` (the default) is a no-op: behavior is byte-identical to
     # pre-run-log runs.
-    on_record: Callable[[str, dict], None] | None = None
+    on_record: Callable[[str, dict], int | None] | None = None
 
 
 def _catalog_lines(entries: list) -> str:
@@ -323,7 +323,14 @@ def _truncate_tool_result(
         record_number: The run-log record number the untruncated result was
             captured under, or ``None`` when logging is off or the capture
             failed. When given, the trailer points at it via
-            ``search_run_log`` instead of suggesting a re-issue.
+            ``search_run_log`` instead of suggesting a re-issue. F7 (Qodo
+            #7): may carry a truthy ``.truncated`` attribute (see
+            ``run_log.RunLogRecordNumber``) reporting that the LOG ITSELF
+            capped that record at ``run_log_max_record_bytes`` -- a plain
+            ``int`` (every pre-existing caller, including every test that
+            fabricates a bare record number) is read via ``getattr(...,
+            "truncated", False)`` and always treated as "not capped", so
+            this stays backward compatible.
 
     Returns:
         ``content`` unchanged when under the cap or when unlimited;
@@ -333,19 +340,35 @@ def _truncate_tool_result(
     if max_chars <= 0 or len(content) <= max_chars:
         return content
     if record_number is not None:
-        # TASK-1250: a bare from_record/to_record call renders the SAME
-        # first `max_chars` this trailer already cut -- format_results
-        # windows at this run's own tool-result ceiling, so it cannot show
-        # more in one call. Naming `contains=`/`offset=` here is what makes
-        # the pointer actually deliver content beyond this cut, instead of
-        # promising recovery a bare call can't provide.
-        recovery = (
-            f" The full result is recorded at record {record_number:06d} — "
-            f"search_run_log(from_record={record_number}, to_record={record_number}) "
-            f"renders it windowed at this same limit, so add contains=<term> to "
-            f"jump straight to a match, or offset=<n> to page past it (the "
-            f"rendered output states the next offset)."
-        )
+        # F7 (Qodo #7): a record the WRITER itself had to cap (content over
+        # run_log_max_record_bytes, 1MB default) has an unrecoverable tail
+        # of its own -- pointing at it as "the full result" would be a
+        # second, compounding false promise on top of this history cut.
+        # `getattr` defaults to False so a plain int (every record number
+        # before this fix, and every record that was NOT capped) takes the
+        # unconditional-recovery wording unchanged.
+        if getattr(record_number, "truncated", False):
+            recovery = (
+                f" Record {record_number:06d} holds as much as this run's "
+                f"log could store under its own per-record cap -- the "
+                f"remainder was never written and cannot be recovered. "
+                f"search_run_log(from_record={record_number}, "
+                f"to_record={record_number}) shows exactly how much was kept."
+            )
+        else:
+            # TASK-1250: a bare from_record/to_record call renders the SAME
+            # first `max_chars` this trailer already cut -- format_results
+            # windows at this run's own tool-result ceiling, so it cannot
+            # show more in one call. Naming `contains=`/`offset=` here is
+            # what makes the pointer actually deliver content beyond this
+            # cut, instead of promising recovery a bare call can't provide.
+            recovery = (
+                f" The full result is recorded at record {record_number:06d} — "
+                f"search_run_log(from_record={record_number}, to_record={record_number}) "
+                f"renders it windowed at this same limit, so add contains=<term> to "
+                f"jump straight to a match, or offset=<n> to page past it (the "
+                f"rendered output states the next offset)."
+            )
     else:
         recovery = (
             " Re-issue the call with a narrower query, or use the tool's "
@@ -541,6 +564,29 @@ def run_agent_loop(
                 verdicts = {}
 
         for call in calls:
+            # F5 (Qodo #5, PR #1066 review): emit the tool_call record BEFORE
+            # the dispatch chain below, not after. `call.name`/`call.args`
+            # are already known here, so nothing is gained by waiting -- and
+            # waiting is exactly the bug: the old placement sat at the
+            # content-assembly point, which runs AFTER the tool has already
+            # executed (including, for SPAWN_TOOL_NAME, after `deps.spawn`
+            # has run the ENTIRE child loop inline). A crash, a kill, or an
+            # indefinitely blocked tool left no durable record the call was
+            # ever attempted, and a child's own records -- written during
+            # the parent's still-in-progress spawn dispatch -- landed in the
+            # log BEFORE the parent's own record that caused them.
+            # MUST stay at this `for call in calls:` body level, OUTSIDE the
+            # `if verdict != "proceed": ... else: ...` pair below: that is
+            # what captures the review-hook refusal path too, and it is
+            # pinned by test_run_log_on_record.py.
+            _emit_record(
+                deps,
+                "tool_call",
+                content=json.dumps(call.args, sort_keys=True, default=str),
+                tool=call.name,
+                status="",
+                call_id=call.call_id,
+            )
             if deps.should_cancel():
                 return _outcome(RUN_CANCELLED)
             recent_calls.append((call.name, json.dumps(call.args, sort_keys=True)))
@@ -722,18 +768,14 @@ def run_agent_loop(
 
                 content = result.content if result.ok else f"ERROR: {result.error}"
 
+            # tool_result capture stays HERE, after dispatch: this is the
+            # first point the full result/error text exists. (The tool_call
+            # record for this same call was already emitted above, BEFORE
+            # dispatch -- see the comment at the top of this `for` body.)
             # Capture BEFORE _truncate_tool_result below: the log is the
             # lossless record, history is the capped view of it. This single
             # point covers every dispatch branch above -- builtin, MCP,
             # skill, runtime tools -- and the review-hook refusal path.
-            _emit_record(
-                deps,
-                "tool_call",
-                content=json.dumps(call.args, sort_keys=True, default=str),
-                tool=call.name,
-                status="",
-                call_id=call.call_id,
-            )
             # Final-review IMPORTANT 3: tool_catalog.py documents `status` as
             # "ok or error", but this used to write only "ok" (any
             # "proceed" verdict, even a dispatch that actually failed -- see

--- a/tldw_chatbook/Agents/agent_runtime.py
+++ b/tldw_chatbook/Agents/agent_runtime.py
@@ -22,6 +22,7 @@ from .agent_models import (
     RUN_DONE,
     RUN_SKILL_SCRIPT_TOOL_NAME,
     RUN_STUCK,
+    SEARCH_RUN_LOG_TOOL_NAME,
     SKILL_FILE_TOOL_NAME,
     SPAWN_TOOL_NAME,
     STEP_ERROR,
@@ -254,6 +255,14 @@ class LoopDeps:
     # `None` (the default) means the run is not wired for it and a call by
     # that name falls through to the generic deps.invoke_tool path.
     run_skill_script: Callable[[str, str, list[str]], ToolResult] | None = None
+    # search_run_log: the seventh runtime tool (run-log query). Wired ONLY
+    # for the top-level agent (agent_kind == primary), like install_skill:
+    # a depth-1 child has max_subagents clamped to 0, so its "subtree" is
+    # itself and its short history is already in its context -- the tool
+    # would buy it nothing while widening what it can see. `None` (the
+    # default) means the run is not wired for it and a call by that name
+    # falls through to the generic deps.invoke_tool path.
+    search_run_log: Callable[[dict], ToolResult] | None = None
     # on_record: full-fidelity capture for the run log (run_log.py). Called
     # with (record_type, payload) at the two points where the COMPLETE value
     # exists -- which the step log does not carry, since `add()` truncates
@@ -677,6 +686,12 @@ def run_agent_loop(
                         str(call.args.get("script_path", "")),
                         [str(item) for item in raw_args],
                     )
+                elif (
+                    call.name == SEARCH_RUN_LOG_TOOL_NAME
+                    and deps.search_run_log is not None
+                ):
+                    add(STEP_TOOL_CALL, tool_name=call.name, args=dict(call.args))
+                    result = deps.search_run_log(dict(call.args))
                 else:
                     add(STEP_TOOL_CALL, tool_name=call.name, args=dict(call.args))
                     result = deps.invoke_tool(call)

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -63,6 +63,20 @@ SUBAGENT_SYSTEM_PROMPT = CATALOG["agents.subagent_system"].default
 
 TRUNCATION_NOTICE = "\n[truncated]"
 
+# Task 7: appended to config.system_prompt only when THIS run wired the
+# search_run_log tool (see the `log_active` gate in _run_one, reused
+# verbatim by _make_call_model) -- so the model is never told a log exists
+# when it can't actually search it.
+RUN_LOG_PROMPT_SECTION = (
+    "Run log: every model turn, tool call, and tool result of this run is "
+    "recorded in full to a log file. Your context holds a truncated view of "
+    "it. When a result was truncated, or you need something from earlier in "
+    "this run, call search_run_log to read the complete record instead of "
+    "re-running the work or guessing. Prefer the 'contains' argument (a "
+    "literal substring, searched over the whole record) over 'pattern'. "
+    "Search for specific content you know you need rather than browsing."
+)
+
 
 class SkillRunner(Protocol):
     """Executes a skill-tool call as a budget-counted, spawn-wired sub-agent.
@@ -315,7 +329,11 @@ class AgentService:
     # -- internals -------------------------------------------------------
 
     def _make_call_model(
-        self, config: AgentConfig, api_endpoint: str, runtime_schemas: list
+        self,
+        config: AgentConfig,
+        api_endpoint: str,
+        runtime_schemas: list,
+        log_active: bool = False,
     ):
         native = config.native_tools and provider_supports_native_tools(api_endpoint)
         # task-245: one render per active-set change, not per turn. Keyed by
@@ -346,6 +364,8 @@ class AgentService:
                     protocol_key = key
                 if protocol_text:
                     system_content = f"{config.system_prompt}\n\n{protocol_text}"
+            if log_active:
+                system_content = f"{system_content}\n\n{RUN_LOG_PROMPT_SECTION}"
             payload = [{"role": "system", "content": system_content}]
             payload.extend(messages)
             resp = self.chat_call(
@@ -511,11 +531,15 @@ class AgentService:
         # `tools=` kwarg) of a deliberately tool-less run. See task-243
         # minor m3: a native-capable endpoint with no disclosable schemas
         # must send no `tools=` kwarg at all.
-        if (
+        # Task 7: reused verbatim (not re-derived) as the gate on whether the
+        # system prompt's RUN_LOG_PROMPT_SECTION gets appended below, so the
+        # prompt can never mention a tool this run didn't actually disclose.
+        log_active = (
             agent_kind == AGENT_KIND_PRIMARY
             and self.run_log_writer.is_active
             and (runtime_schemas or active)
-        ):
+        )
+        if log_active:
             runtime_schemas.append(SEARCH_RUN_LOG_TOOL_SCHEMA)
 
         def find_tools(query: str):
@@ -793,7 +817,9 @@ class AgentService:
             )
 
         deps = LoopDeps(
-            call_model=self._make_call_model(config, api_endpoint, runtime_schemas),
+            call_model=self._make_call_model(
+                config, api_endpoint, runtime_schemas, log_active
+            ),
             invoke_tool=invoke_tool,
             spawn=spawn,
             find_tools=find_tools,

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -297,12 +297,19 @@ class AgentService:
         # see the schema-pin comment in _run_one for the rationale. `None`
         # (the default) means the run is not wired for it.
         self._run_skill_script_tool = run_skill_script_tool
-        # Constructed here (or by the caller) so EVERY caller gets a log --
-        # on_step is passed in by the Console bridge, so anything riding
-        # that hook would silently log nothing for other callers.
-        from .run_log import RunLogWriter as _RunLogWriter
-
-        self.run_log_writer = run_log_writer or _RunLogWriter()
+        # Round-1 review fix (spec §3.1): the writer is per RUN TREE, not
+        # per service instance -- `bind()` latches permanently (see its own
+        # docstring), so a writer built here in __init__ and reused across
+        # two `run_turn` calls on the same `AgentService` would silently
+        # append the second tree's records into the first tree's
+        # already-bound directory and overwrite its manifest. `run_turn`
+        # builds a fresh, UNBOUND writer per call from this attribute being
+        # `None` -- see its own docstring/body. An explicitly injected
+        # writer (tests, primarily) is the one exception: it is honored
+        # as-is for the life of the service, on the assumption a caller
+        # supplying its own writer also owns that writer's lifecycle.
+        self._injected_run_log_writer = run_log_writer
+        self.run_log_writer = run_log_writer
 
     # -- internals -------------------------------------------------------
 
@@ -834,9 +841,31 @@ class AgentService:
             A ``(run_id, outcome)`` tuple: the new primary run's id and its
             terminal ``RunOutcome``. The run record (and any sub-agent run
             records) are persisted before this returns.
+
+        Run-log contract:
+            The run-log writer is scoped to ONE run tree, not to this
+            service instance. Unless a writer was explicitly injected via
+            the constructor (tests, primarily — that one is reused as-is
+            for the life of the service), each call to ``run_turn`` builds
+            a fresh, unbound ``RunLogWriter``. ``bind()`` latches
+            permanently for that writer's whole life (see its own
+            docstring), so reusing one writer across two ``run_turn`` calls
+            would append the second tree's records into the first tree's
+            already-bound directory and overwrite its manifest.
         """
         if supersede_run_id:
             self.db.supersede_run_tree(supersede_run_id)
+        # Per run tree, not per service instance -- see "Run-log contract"
+        # above. `_injected_run_log_writer` is `None` for every caller that
+        # didn't pass one to the constructor (i.e. every production caller
+        # today), so this builds a new, unbound writer each call; an
+        # injected writer is honored unchanged.
+        if self._injected_run_log_writer is not None:
+            self.run_log_writer = self._injected_run_log_writer
+        else:
+            from .run_log import RunLogWriter as _RunLogWriter
+
+            self.run_log_writer = _RunLogWriter()
         # Per-run scope for the registry's owner-map cache (tool_catalog's
         # _owner_and_id): reset here, once, at the top of the run tree —
         # covers the primary turn AND any sub-agents it spawns via

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import contextlib
 import dataclasses
+import sys
 import threading
 import time
 from collections.abc import Mapping
@@ -73,7 +74,9 @@ RUN_LOG_PROMPT_SECTION = (
     "it. When a result was truncated, or you need something from earlier in "
     "this run, call search_run_log to read the complete record instead of "
     "re-running the work or guessing. Prefer the 'contains' argument (a "
-    "literal substring, searched over the whole record) over 'pattern'. "
+    "literal substring) over 'pattern' -- but note 'contains' and 'pattern' "
+    "both match a record's CONTENT ONLY, never its metadata; use the "
+    "'tool', 'type', 'status', and 'kind' arguments to filter by metadata. "
     "Search for specific content you know you need rather than browsing."
 )
 
@@ -795,13 +798,35 @@ class AgentService:
                     tool=str(args.get("tool", "")),
                     type=str(args.get("type", "")),
                     status=str(args.get("status", "")),
+                    kind=str(args.get("kind", "")),
                     from_record=int(args.get("from_record") or 0),
                     to_record=int(args.get("to_record") or 0),
                     context=int(args.get("context") or 0),
                 )
             except (TypeError, ValueError) as exc:
                 return ToolResult(ok=False, error=f"Invalid search arguments: {exc}")
-            return ToolResult(ok=True, content=format_results(hits))
+            # Final-review CRITICAL 1: render recovered records at THIS run's
+            # own tool-result ceiling, not format_results' 400-char rendering
+            # default. §6.1's whole point is that a truncation trailer points
+            # at a lossless copy -- if the copy renders at 400 chars while
+            # the truncation it repairs cut at 16,000, following the trailer
+            # returns LESS than the thing it was supposed to fix. Keep
+            # format_results' own default untouched (its existing tests pin
+            # 400) and instead pass the run's actual ceiling from here.
+            # 0 (or negative) is the documented "unlimited" value for
+            # RunBudget.max_tool_result_chars / _truncate_tool_result;
+            # format_results has no such sentinel (max_chars=0 would render
+            # nothing), so translate it into a ceiling that never trips
+            # format_results' own truncation branch. The rendered search
+            # RESULT still passes back through the loop's ordinary
+            # _truncate_tool_result at the history-append seam, so this
+            # cannot blow the run's context budget -- it only stops the
+            # recovery path from being strictly worse than what it repairs.
+            ceiling = config.budget.max_tool_result_chars
+            render_max_chars = ceiling if ceiling > 0 else sys.maxsize
+            return ToolResult(
+                ok=True, content=format_results(hits, max_chars=render_max_chars)
+            )
 
         def on_record(record_type: str, payload: dict) -> int | None:
             # MUST return the record number: Task 7 threads it into the

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -247,6 +247,7 @@ class AgentService:
         install_skill_tool: Callable[[str], ToolResult] | None = None,
         run_skill_script_tool: Callable[[str, str, list[str]], ToolResult]
         | None = None,
+        run_log_writer: "RunLogWriter | None" = None,
     ) -> None:
         self.db = db
         self.registry = registry
@@ -296,6 +297,12 @@ class AgentService:
         # see the schema-pin comment in _run_one for the rationale. `None`
         # (the default) means the run is not wired for it.
         self._run_skill_script_tool = run_skill_script_tool
+        # Constructed here (or by the caller) so EVERY caller gets a log --
+        # on_step is passed in by the Console bridge, so anything riding
+        # that hook would silently log nothing for other callers.
+        from .run_log import RunLogWriter as _RunLogWriter
+
+        self.run_log_writer = run_log_writer or _RunLogWriter()
 
     # -- internals -------------------------------------------------------
 
@@ -441,6 +448,10 @@ class AgentService:
             budget=dataclasses.asdict(config.budget),
             assistant_message_id=assistant_message_id,
         )
+        # Two-phase: the writer was constructed before any run id existed.
+        # Only the PRIMARY run binds; a child finds it already bound.
+        if agent_kind == AGENT_KIND_PRIMARY:
+            self.run_log_writer.bind(run_id)
         started = self.clock()
 
         active, offer_find_load = initial_disclosure(self.registry, config.budget)
@@ -706,6 +717,19 @@ class AgentService:
                 return ToolResult(ok=False, error=f"skill_file: {exc}")
             return ToolResult(ok=True, content=str(content))
 
+        def on_record(record_type: str, payload: dict) -> int | None:
+            # MUST return the record number: Task 7 threads it into the
+            # truncation trailer so a cut result points at its full copy.
+            return self.run_log_writer.append(
+                run_id=run_id,
+                kind=agent_kind,
+                type=record_type,
+                content=str(payload.get("content", "")),
+                tool=str(payload.get("tool", "")),
+                status=str(payload.get("status", "")),
+                call_id=str(payload.get("call_id", "")),
+            )
+
         deps = LoopDeps(
             call_model=self._make_call_model(config, api_endpoint, runtime_schemas),
             invoke_tool=invoke_tool,
@@ -739,6 +763,7 @@ class AgentService:
                 else None
             ),
             run_skill_script=self._run_skill_script_tool,
+            on_record=on_record,
         )
         try:
             outcome = run_agent_loop(config, messages, active, deps)
@@ -819,7 +844,7 @@ class AgentService:
         # is listed fresh at this point, so skill CRUD since the last run
         # is always picked up with no separate invalidation signal needed.
         self.registry.reset_catalog_cache()
-        return self._run_one(
+        run_id, outcome = self._run_one(
             conversation_id=conversation_id,
             messages=messages,
             config=config,
@@ -830,3 +855,20 @@ class AgentService:
             parent_run_id=None,
             assistant_message_id=assistant_message_id,
         )
+        # Manifest needs run-level metadata the writer itself does not have
+        # (including supersession), so it is written once the whole run
+        # tree finishes, here rather than inside _run_one.
+        self.run_log_writer.write_manifest(
+            {
+                "run_id": run_id,
+                "model": config.model,
+                "api_endpoint": api_endpoint,
+                "allowed_tools": list(config.allowed_tools),
+                "budget": dataclasses.asdict(config.budget),
+                "status": outcome.status,
+                "superseded_run_id": supersede_run_id or "",
+                "total_tokens": outcome.total_tokens,
+            }
+        )
+        self.run_log_writer.close()
+        return run_id, outcome

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -49,6 +49,7 @@ from .tool_catalog import (
     INSTALL_SKILL_TOOL_SCHEMA,
     LOAD_TOOLS_SCHEMA,
     RUN_SKILL_SCRIPT_TOOL_SCHEMA,
+    SEARCH_RUN_LOG_TOOL_SCHEMA,
     SKILL_FILE_TOOL_SCHEMA,
     SPAWN_TOOL_SCHEMA,
     ToolCatalogRegistry,
@@ -486,6 +487,36 @@ class AgentService:
         # applied in the bridge closure and the service, not here.
         if self._run_skill_script_tool is not None:
             runtime_schemas.append(RUN_SKILL_SCRIPT_TOOL_SCHEMA)
+        # search_run_log (7th runtime tool): primary agent only, like
+        # install_skill above -- a depth-1 child's max_subagents is always
+        # clamped to 0, so its "subtree" is only itself and its short
+        # history is already in its context; letting it search would only
+        # widen what it can see, into its parent's whole run tree, breaking
+        # the isolation spawn_subagent promises. Also gated on the writer
+        # actually being active: an inactive writer means no log directory
+        # was ever created, so there is nothing to search.
+        #
+        # Placed LAST, after every other runtime_schemas append above, and
+        # additionally requires `runtime_schemas or active` to be non-empty
+        # (controller ruling, post-review of the original spec): unlike
+        # every OTHER runtime tool -- spawn_subagent gated on
+        # `max_subagents > 0`, find_tools/load_tools on `offer_find_load`,
+        # skill_file on a non-empty authorized set -- an unconditional
+        # `is_active` gate would offer this tool even to a run with
+        # nothing else disclosed at all (empty allow-list, no sub-agents,
+        # no skills). Such a run can only ever produce model-turn log
+        # records -- it has no tool results, so nothing was ever
+        # truncated and there is nothing to recover -- so the tool would
+        # buy it nothing while changing the provider payload (adding a
+        # `tools=` kwarg) of a deliberately tool-less run. See task-243
+        # minor m3: a native-capable endpoint with no disclosable schemas
+        # must send no `tools=` kwarg at all.
+        if (
+            agent_kind == AGENT_KIND_PRIMARY
+            and self.run_log_writer.is_active
+            and (runtime_schemas or active)
+        ):
+            runtime_schemas.append(SEARCH_RUN_LOG_TOOL_SCHEMA)
 
         def find_tools(query: str):
             # Q7(b): never surface a disallowed tool through find_tools,
@@ -724,6 +755,30 @@ class AgentService:
                 return ToolResult(ok=False, error=f"skill_file: {exc}")
             return ToolResult(ok=True, content=str(content))
 
+        def search_run_log(args: dict) -> ToolResult:
+            """Query THIS run's log. Reads only what this agent produced."""
+            from .run_log_search import format_results, load_records, search_records
+
+            log_dir = self.run_log_writer.log_dir
+            if log_dir is None:
+                return ToolResult(ok=False, error="No run log is available.")
+            try:
+                records = load_records(log_dir)
+                hits = search_records(
+                    records,
+                    contains=str(args.get("contains", "")),
+                    pattern=str(args.get("pattern", "")),
+                    tool=str(args.get("tool", "")),
+                    type=str(args.get("type", "")),
+                    status=str(args.get("status", "")),
+                    from_record=int(args.get("from_record") or 0),
+                    to_record=int(args.get("to_record") or 0),
+                    context=int(args.get("context") or 0),
+                )
+            except (TypeError, ValueError) as exc:
+                return ToolResult(ok=False, error=f"Invalid search arguments: {exc}")
+            return ToolResult(ok=True, content=format_results(hits))
+
         def on_record(record_type: str, payload: dict) -> int | None:
             # MUST return the record number: Task 7 threads it into the
             # truncation trailer so a cut result points at its full copy.
@@ -770,6 +825,9 @@ class AgentService:
                 else None
             ),
             run_skill_script=self._run_skill_script_tool,
+            search_run_log=(
+                search_run_log if agent_kind == AGENT_KIND_PRIMARY else None
+            ),
             on_record=on_record,
         )
         try:

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -783,8 +783,49 @@ class AgentService:
             return ToolResult(ok=True, content=str(content))
 
         def search_run_log(args: dict) -> ToolResult:
-            """Query THIS run's log. Reads only what this agent produced."""
-            from .run_log_search import format_results, load_records, search_records
+            """Query THIS run's log. Reads only what this agent produced.
+
+            F2 (Qodo #2, PR #1066 review -- DECLINED): Qodo's finding wanted
+            these raw ``dict`` args routed through a Pydantic model before
+            use. Declined: every OTHER runtime tool this service wires
+            (``install_skill``, ``run_skill_script``, ``skill_file``) takes
+            the exact same raw-dict-plus-defensive-cast shape, and every
+            argument here is ALREADY coerced defensively (``str(...)`` for
+            the metadata filters below; ``int(... or 0)`` inside a single
+            ``try/except (TypeError, ValueError)`` for the numeric ones) --
+            a bad value already returns a clean ``ToolResult`` error rather
+            than raising, which is the property Pydantic would add. Giving
+            this one tool a model would make it the odd one out in this
+            module without changing behavior. See
+            ``Tests/Agents/test_search_run_log_runtime_tool.py`` for the
+            coverage confirming every argument is safely coerced (string
+            where an int is expected, null, a nested object, a list).
+
+            Args:
+                args: The model-supplied call arguments, straight off
+                    ``ToolCall.args`` (always a ``dict`` -- both parsing
+                    paths in ``native_tools.py``/``agent_runtime.py``
+                    guarantee that, never validated by a schema here).
+                    Recognised keys mirror ``search_records``'/
+                    ``format_results``' own parameters: ``contains``,
+                    ``pattern``, ``tool``, ``type``, ``status``, ``kind``,
+                    ``from_record``, ``to_record``, ``context``, ``offset``.
+
+            Returns:
+                ``ToolResult(ok=True, content=...)`` with the rendered hits
+                (or "No matching records."), or ``ok=False`` with a
+                human-readable error -- for a missing log, malformed
+                numeric arguments, a rejected catastrophic-looking
+                ``pattern``, or a search that exceeded its wall-clock
+                budget (F6). Never raises.
+            """
+            from .run_log_search import (
+                RunLogSearchPatternRejected,
+                RunLogSearchTimeout,
+                format_results,
+                load_records,
+                search_records,
+            )
 
             log_dir = self.run_log_writer.log_dir
             if log_dir is None:
@@ -814,6 +855,14 @@ class AgentService:
                 offset = int(args.get("offset") or 0)
             except (TypeError, ValueError) as exc:
                 return ToolResult(ok=False, error=f"Invalid search arguments: {exc}")
+            except (RunLogSearchPatternRejected, RunLogSearchTimeout) as exc:
+                # F6 (Qodo #6): a model-supplied `pattern=` that looks
+                # catastrophic, or a search that ran past its wall-clock
+                # budget -- both must degrade to a normal tool error, never
+                # raise into (and abort) this run. See run_log_search.py's
+                # module docstring for why neither defense is complete
+                # alone.
+                return ToolResult(ok=False, error=str(exc))
             # Final-review CRITICAL 1: render recovered records at THIS run's
             # own tool-result ceiling, not format_results' 400-char rendering
             # default. §6.1's whole point is that a truncation trailer points
@@ -856,8 +905,32 @@ class AgentService:
             )
 
         def on_record(record_type: str, payload: dict) -> int | None:
-            # MUST return the record number: Task 7 threads it into the
-            # truncation trailer so a cut result points at its full copy.
+            """Append one full-fidelity record to THIS run tree's log.
+
+            The ``LoopDeps.on_record`` callable: called by
+            ``agent_runtime.run_agent_loop`` (via its ``_emit_record``
+            helper) at the two points the COMPLETE value exists, before any
+            truncation. Wraps ``self.run_log_writer.append`` with this
+            run's identity (``run_id``, ``agent_kind``) and defensively
+            stringifies every payload field, so a malformed payload can
+            never raise here either.
+
+            Args:
+                record_type: ``"model"``, ``"tool_call"``, or
+                    ``"tool_result"`` (``_emit_record``'s own vocabulary;
+                    ``"spawn"`` is not currently emitted -- a spawn's
+                    dispatch is captured as an ordinary ``tool_call``/
+                    ``tool_result`` pair like any other tool).
+                payload: ``content``/``tool``/``status``/``call_id``, as
+                    built by ``_emit_record``'s ``**payload`` kwargs.
+
+            Returns:
+                The record number MUST be returned here, not swallowed:
+                Task 7 threads it into the truncation trailer so a cut
+                result points at its own full copy in the log (see
+                ``_truncate_tool_result``). ``None`` when the writer is
+                inactive or the underlying write failed -- never raises.
+            """
             return self.run_log_writer.append(
                 run_id=run_id,
                 kind=agent_kind,

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -789,12 +789,14 @@ class AgentService:
             log_dir = self.run_log_writer.log_dir
             if log_dir is None:
                 return ToolResult(ok=False, error="No run log is available.")
+            contains = str(args.get("contains", ""))
+            pattern = str(args.get("pattern", ""))
             try:
                 records = load_records(log_dir)
                 hits = search_records(
                     records,
-                    contains=str(args.get("contains", "")),
-                    pattern=str(args.get("pattern", "")),
+                    contains=contains,
+                    pattern=pattern,
                     tool=str(args.get("tool", "")),
                     type=str(args.get("type", "")),
                     status=str(args.get("status", "")),
@@ -803,6 +805,13 @@ class AgentService:
                     to_record=int(args.get("to_record") or 0),
                     context=int(args.get("context") or 0),
                 )
+                # TASK-1250: offset, coerced the same defensively-numeric way
+                # as from_record/to_record/context above -- a model sending
+                # junk (a non-numeric string) is caught below like any other
+                # bad numeric arg, never raised into the run. Negative and
+                # past-the-end clamping happens in format_results itself
+                # (single point of truth, mirroring `context`'s own clamp).
+                offset = int(args.get("offset") or 0)
             except (TypeError, ValueError) as exc:
                 return ToolResult(ok=False, error=f"Invalid search arguments: {exc}")
             # Final-review CRITICAL 1: render recovered records at THIS run's
@@ -822,10 +831,28 @@ class AgentService:
             # _truncate_tool_result at the history-append seam, so this
             # cannot blow the run's context budget -- it only stops the
             # recovery path from being strictly worse than what it repairs.
+            #
+            # TASK-1250: that alone was not enough. format_results always
+            # rendered from character 0 of each record, which is the SAME
+            # ceiling that truncated the result in the first place -- so a
+            # record larger than render_max_chars still rendered byte-
+            # identical to what history already showed, and a `contains=`
+            # match past that ceiling could render a body that did not
+            # contain it. Passing `contains`/`pattern` lets format_results
+            # centre the window on the actual match; passing `offset` lets
+            # the model page past render_max_chars deterministically once a
+            # render tells it the next offset to use.
             ceiling = config.budget.max_tool_result_chars
             render_max_chars = ceiling if ceiling > 0 else sys.maxsize
             return ToolResult(
-                ok=True, content=format_results(hits, max_chars=render_max_chars)
+                ok=True,
+                content=format_results(
+                    hits,
+                    max_chars=render_max_chars,
+                    contains=contains,
+                    pattern=pattern,
+                    offset=offset,
+                ),
             )
 
         def on_record(record_type: str, payload: dict) -> int | None:

--- a/tldw_chatbook/Agents/run_log.py
+++ b/tldw_chatbook/Agents/run_log.py
@@ -1,0 +1,295 @@
+"""Segmented, append-only run log writer.
+
+Impure by design (filesystem + config). Path resolution reuses the file
+tools' own chain -- ``allowed_file_roots`` -> ``is_within`` ->
+``is_sensitive_path`` -- so this writer can never become a path-validation
+bypass. See the design spec §3.3, §7, §8, §9.2.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+from loguru import logger
+
+from .run_log_format import RunLogRecord, encode_record
+
+#: Directory created inside the resolved root. Deliberately UNDOTTED: a
+#: dotted directory is excluded by `_is_hidden_within`, which would hide
+#: the log from the very tools meant to read it.
+DEFAULT_DIR_NAME = "agent-runs"
+DEFAULT_SEGMENT_BYTES = 4_000_000
+DEFAULT_MAX_RECORD_BYTES = 1_000_000
+MANIFEST_NAME = "MANIFEST"
+
+
+def _setting(key: str, default):
+    """Read one ``[agents]`` config key. Test seam: monkeypatched wholesale.
+
+    Args:
+        key: Key name within the ``[agents]`` section.
+        default: Value returned when unset or unreadable.
+
+    Returns:
+        The configured value, or ``default``.
+    """
+    try:
+        from tldw_chatbook.config import get_cli_setting
+
+        value = get_cli_setting("agents", key, default)
+    except Exception:
+        return default
+    return default if value is None else value
+
+
+def resolve_log_root() -> Path | None:
+    """Return the directory the log tree is created under, or ``None``.
+
+    Prefers the run's first read-write workspace folder root so the log is
+    a user-visible artifact; falls back to the tool sandbox root when no
+    such folder is bound. Any failure resolves to ``None`` (logging off)
+    rather than to a wider or unvalidated location.
+
+    Returns:
+        The chosen root directory, or ``None`` when none is usable.
+    """
+    try:
+        from tldw_chatbook.Tools.file_operation_tools import _tool_sandbox_root
+        from tldw_chatbook.Tools.workspace_file_roots import allowed_file_roots
+
+        sandbox = _tool_sandbox_root()
+        roots = allowed_file_roots(write=True, sandbox_root=sandbox)
+    except Exception:
+        logger.opt(exception=True).warning("run log: cannot resolve any root")
+        return None
+    if not roots:
+        return None
+    # allowed_file_roots returns (sandbox, *workspace_folders); prefer a
+    # bound workspace folder, fall back to the sandbox.
+    for candidate in roots[1:]:
+        return candidate
+    return roots[0]
+
+
+class RunLogWriter:
+    """Appends records for ONE run tree to a segmented log.
+
+    Constructed unbound (the run id does not exist until ``_run_one`` calls
+    ``create_run``), then bound once by the primary run. Child runs share
+    the instance, and therefore the record counter, so parent and child
+    record numbers can never collide.
+    """
+
+    def __init__(
+        self,
+        *,
+        dir_name: str | None = None,
+        segment_bytes: int | None = None,
+        max_record_bytes: int | None = None,
+    ) -> None:
+        """Build an UNBOUND writer. Explicit args override ``[agents]`` config.
+
+        Args:
+            dir_name: Directory name; defaults to ``[agents] run_log_dir_name``.
+            segment_bytes: Roll threshold; defaults to
+                ``[agents] run_log_segment_bytes``.
+            max_record_bytes: Per-record ceiling; defaults to
+                ``[agents] run_log_max_record_bytes``.
+        """
+        self._dir_name = dir_name or str(_setting("run_log_dir_name", DEFAULT_DIR_NAME))
+        self._segment_bytes = int(
+            segment_bytes
+            if segment_bytes is not None
+            else _setting("run_log_segment_bytes", DEFAULT_SEGMENT_BYTES)
+        )
+        self._max_record_bytes = int(
+            max_record_bytes
+            if max_record_bytes is not None
+            else _setting("run_log_max_record_bytes", DEFAULT_MAX_RECORD_BYTES)
+        )
+        self._lock = threading.Lock()
+        self._counter = 0
+        self._segment_index = 1
+        self._segment_size = 0
+        self._active = False
+        self.log_dir: Path | None = None
+
+    @property
+    def is_active(self) -> bool:
+        """Whether records are currently being written."""
+        return self._active
+
+    def bind(self, run_id: str) -> None:
+        """Bind to ``run_id`` and create its directory. Idempotent.
+
+        Args:
+            run_id: The PRIMARY run's id. Later calls are ignored so a
+                child run never rebinds its parent's writer.
+        """
+        if self.log_dir is not None:
+            return
+        if not _setting("run_log_enabled", True):
+            self._active = False
+            return
+        root = resolve_log_root()
+        if root is None:
+            self._active = False
+            return
+        try:
+            base = root / self._dir_name
+            base.mkdir(parents=True, exist_ok=True)
+            gitignore = base / ".gitignore"
+            if not gitignore.exists():
+                # Created only if absent: writing into a user's repository
+                # is itself a mutation.
+                gitignore.write_text("*\n", encoding="utf-8")
+            run_dir = base / run_id
+            run_dir.mkdir(parents=True, exist_ok=True)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "run log: cannot create log directory; logging disabled"
+            )
+            self._active = False
+            return
+        self.log_dir = run_dir
+        self._active = True
+
+    def _segment_path(self) -> Path:
+        assert self.log_dir is not None
+        return self.log_dir / f"logs.{self._segment_index:04d}.txt"
+
+    def _write_bytes(self, path: Path, payload: bytes, *, sync: bool = False) -> None:
+        """Append ``payload`` to ``path``.
+
+        ``flush()`` on every record survives a process crash. ``fsync`` is
+        reserved for segment rolls and run end (``sync=True``): calling it
+        per record into a user's project directory is wasteful.
+
+        Args:
+            path: Target file, opened in append-binary mode.
+            payload: Bytes to append.
+            sync: Whether to force an ``fsync`` after flushing.
+        """
+        import os
+
+        with open(path, "ab") as handle:
+            handle.write(payload)
+            handle.flush()
+            if sync:
+                os.fsync(handle.fileno())
+
+    def append(
+        self,
+        *,
+        run_id: str,
+        kind: str,
+        type: str,
+        content: str,
+        tool: str = "",
+        status: str = "",
+        call_id: str = "",
+    ) -> int | None:
+        """Append one record and return its number.
+
+        Args:
+            run_id: Id of the run this record belongs to (parent or child).
+            kind: ``primary`` or ``subagent``.
+            type: ``model``, ``tool_call``, ``tool_result``, or ``spawn``.
+            content: Full, untruncated text.
+            tool: Tool name, when applicable.
+            status: ``ok`` / ``error``, when applicable.
+            call_id: Provider ``tool_call_id``, when applicable.
+
+        Returns:
+            The assigned record number, or ``None`` when the writer is
+            inactive or the write failed. Never raises.
+        """
+        if not self._active or self.log_dir is None:
+            return None
+        with self._lock:
+            truncated_from = 0
+            body = content.encode("utf-8")
+            if len(body) > self._max_record_bytes:
+                truncated_from = len(body)
+                # Cut on a character boundary, then re-encode.
+                body = body[: self._max_record_bytes]
+                content = body.decode("utf-8", "ignore")
+            self._counter += 1
+            record = RunLogRecord(
+                number=self._counter,
+                run_id=run_id,
+                kind=kind,
+                type=type,
+                ts=_now_iso(),
+                content=content,
+                tool=tool,
+                status=status,
+                call_id=call_id,
+                truncated_from=truncated_from,
+            )
+            payload = encode_record(record)
+            # Roll BEFORE writing: a record must never span segments, or
+            # bytes=-exact parsing (which assumes one file) breaks.
+            if self._segment_size and self._segment_size + len(payload) > (
+                self._segment_bytes
+            ):
+                try:
+                    # fsync the segment being retired; it will not be
+                    # appended to again.
+                    self._write_bytes(self._segment_path(), b"", sync=True)
+                except Exception:  # noqa: BLE001 — durability is best-effort
+                    logger.opt(exception=True).warning("run log: segment fsync failed")
+                self._segment_index += 1
+                self._segment_size = 0
+            try:
+                self._write_bytes(self._segment_path(), payload)
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "run log: append failed; logging disabled for this run"
+                )
+                self._active = False
+                return None
+            self._segment_size += len(payload)
+            return record.number
+
+    def write_manifest(self, metadata: dict) -> None:
+        """Write run-level convenience metadata. Never raises.
+
+        The manifest is deliberately NOT load-bearing: segment discovery is
+        glob + sort (``run_log_search.load_records``), so a crashed run that
+        never reaches this call is still fully readable.
+
+        Args:
+            metadata: Run-level fields (model, budget, status, supersession).
+        """
+        if self.log_dir is None:
+            return
+        import json
+
+        payload = dict(metadata)
+        try:
+            payload["segments"] = [p.name for p in sorted(self.log_dir.glob("logs.*.txt"))]
+            payload["record_count"] = self._counter
+            self._write_bytes(
+                self.log_dir / MANIFEST_NAME,
+                json.dumps(payload, indent=2, default=str).encode("utf-8"),
+                sync=True,
+            )
+        except Exception:  # noqa: BLE001 — convenience metadata only
+            logger.opt(exception=True).warning("run log: manifest write failed")
+
+    def close(self) -> None:
+        """Flush the final segment to disk. Idempotent and always safe."""
+        if not self._active or self.log_dir is None:
+            return
+        try:
+            self._write_bytes(self._segment_path(), b"", sync=True)
+        except Exception:  # noqa: BLE001 — best-effort durability
+            logger.opt(exception=True).warning("run log: final fsync failed")
+
+
+def _now_iso() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")

--- a/tldw_chatbook/Agents/run_log.py
+++ b/tldw_chatbook/Agents/run_log.py
@@ -8,12 +8,24 @@ bypass. See the design spec §3.3, §7, §8, §9.2.
 
 from __future__ import annotations
 
+import os
 import threading
 from pathlib import Path
 
 from loguru import logger
 
 from .run_log_format import RunLogRecord, encode_record
+
+#: F3 (Qodo #3): CLAUDE.md mandates "env vars -> config.toml -> defaults",
+#: but `_setting` below previously never consulted the environment at all.
+#: Named ``TLDW_AGENTS_<KEY>`` to match this repo's existing per-setting
+#: override convention -- e.g. ``TLDW_CONSOLE_LLAMA_CPP_BASE_URL`` in
+#: UI/Screens/chat_screen.py is ``TLDW_`` + the config SECTION
+#: (``console``) + the key. The ``[agents]`` section name gives the middle
+#: segment here.
+_ENV_PREFIX = "TLDW_AGENTS_"
+_ENV_TRUE = {"1", "true", "yes", "on"}
+_ENV_FALSE = {"0", "false", "no", "off"}
 
 #: Directory created inside the resolved root. Deliberately UNDOTTED when the
 #: run's log lands in a bound workspace folder: a dotted directory is
@@ -47,16 +59,74 @@ MANIFEST_NAME = "MANIFEST"
 _root_kind = threading.local()
 
 
+def _env_override(key: str) -> str | None:
+    """Read ``TLDW_AGENTS_<KEY>`` from the environment, or ``None`` if unset.
+
+    F3 (Qodo #3): the highest-priority tier below an explicit constructor
+    argument (CLAUDE.md: "env vars -> config.toml -> defaults"). Only a
+    non-empty string counts as "set" -- an env var present but blank falls
+    through to the TOML/default tiers, same as an unset one.
+
+    Args:
+        key: Key name within the ``[agents]`` section (e.g. ``run_log_dir_name``).
+
+    Returns:
+        The raw environment string, or ``None`` when not set to a
+        non-empty value.
+    """
+    value = os.environ.get(f"{_ENV_PREFIX}{key.upper()}")
+    return value if value not in (None, "") else None
+
+
+def _parse_env_bool(raw: str, key: str, default: bool) -> bool:
+    """Parse an env-var override for a boolean ``[agents]`` setting.
+
+    Args:
+        raw: The raw environment string (already confirmed non-empty).
+        key: Setting key, named in the warning on an unrecognised value.
+        default: Value returned when ``raw`` cannot be parsed as a boolean.
+
+    Returns:
+        ``True``/``False`` for a recognised token (case-insensitive
+        ``1``/``true``/``yes``/``on`` or ``0``/``false``/``no``/``off``),
+        else ``default``.
+    """
+    lowered = raw.strip().lower()
+    if lowered in _ENV_TRUE:
+        return True
+    if lowered in _ENV_FALSE:
+        return False
+    logger.warning(
+        f"run log: TLDW_AGENTS_{key.upper()}={raw!r} is not a recognised "
+        f"boolean; using default"
+    )
+    return default
+
+
 def _setting(key: str, default):
-    """Read one ``[agents]`` config key. Test seam: monkeypatched wholesale.
+    """Read one ``[agents]`` config key: env var, then TOML, then default.
+
+    F3 (Qodo #3): CLAUDE.md's documented priority is "env vars ->
+    config.toml -> defaults", but this previously skipped the env tier
+    entirely. An explicit constructor argument on ``RunLogWriter`` (see
+    ``__init__``) short-circuits this function altogether and is therefore
+    still the highest-priority override overall -- this only fixes the
+    ordering of the two tiers BELOW that.
 
     Args:
         key: Key name within the ``[agents]`` section.
         default: Value returned when unset or unreadable.
 
     Returns:
-        The configured value, or ``default``.
+        The env override (boolean-parsed when ``default`` is a ``bool``,
+        else the raw string) when set; otherwise the configured TOML value;
+        otherwise ``default``.
     """
+    env_value = _env_override(key)
+    if env_value is not None:
+        if isinstance(default, bool):
+            return _parse_env_bool(env_value, key, default)
+        return env_value
     try:
         from tldw_chatbook.config import get_cli_setting
 
@@ -67,23 +137,56 @@ def _setting(key: str, default):
 
 
 def _coerce_dir_name(value, default: str) -> str:
-    """Coerce dir_name defensively: non-string or empty falls back to default.
+    """Coerce dir_name defensively into a single, safe path COMPONENT.
+
+    F1 (Qodo #1, PR #1066 review ruling): ``dir_name`` is configurable
+    (``[agents] run_log_dir_name`` or an explicit constructor argument) and
+    therefore untrusted like any config value, and it is joined directly
+    onto the resolved log root (``root / dir_name`` in ``bind()``) --
+    pathlib's ``/`` operator REPLACES the whole path outright when the
+    right-hand side is absolute, so an unvalidated value could silently
+    redirect the log tree entirely rather than merely fail the later
+    containment check. This rejects a separator, ``.``/``..``, an absolute
+    form, or an empty/whitespace-only value UP FRONT and falls back to
+    ``default`` (logged at warning) so a bad config value degrades to
+    "log under the default name" rather than "logging silently disabled" --
+    a config typo should not be able to kill a crash-durability feature.
+    ``bind()``'s existing ``allowed_file_roots`` -> ``is_within``
+    containment check on the ASSEMBLED path remains as defense in depth
+    (it is what actually matters for ``run_id``, which is not vetted here).
+
+    Deliberately NOT routed through ``Utils/path_validation.validate_path``:
+    that function raises "Access to hidden files/directories is not
+    allowed" on any hidden (dotted) path component, and ``bind()``
+    intentionally dots this directory under the sandbox fallback -- a real,
+    reviewed fix for a sub-agent log-disclosure bug (a child could
+    ``grep_files`` its parent's log and extract secrets; see ``bind()``'s
+    own "Final-review CRITICAL 2" comment and the F8 sandbox-containment
+    check below it). Routing through ``validate_path`` would reject
+    ``.agent-runs`` outright and disable logging in the DEFAULT
+    configuration -- do not "fix" this by reaching for that function.
 
     Args:
         value: Value to coerce (from explicit arg or config).
         default: Default value if coercion fails.
 
     Returns:
-        A valid string directory name, or ``default``.
+        A safe, single-path-component directory name, or ``default``.
     """
     try:
-        s = str(value)
+        s = str(value).strip()
         if not s:
             raise ValueError("empty dir_name")
-        return s
+        if "/" in s or "\\" in s:
+            raise ValueError(f"dir_name contains a path separator: {s!r}")
+        if s in (".", ".."):
+            raise ValueError(f"dir_name is a path-traversal segment: {s!r}")
+        if Path(s).is_absolute():
+            raise ValueError(f"dir_name is absolute: {s!r}")
     except Exception:
         logger.opt(exception=True).warning("run log: invalid dir_name, using default")
         return default
+    return s
 
 
 def _coerce_positive_int(value, default: int, name: str) -> int:
@@ -147,6 +250,32 @@ def resolve_log_root() -> Path | None:
         return candidate
     _root_kind.is_sandbox_fallback = True
     return roots[0]
+
+
+class RunLogRecordNumber(int):
+    """A record number that also reports whether the LOG capped this record.
+
+    F7 (Qodo #7): a caller following a truncation trailer's pointer needs to
+    know whether the pointed-at record is itself complete -- ``append()``
+    already knows this (it is the same comparison that decides whether to
+    set ``truncated_from`` on the record), but plumbing it back to
+    ``agent_runtime._truncate_tool_result`` without this class would mean
+    either changing ``append()``'s / ``LoopDeps.on_record``'s return shape
+    (which ``test_on_record_returns_the_assigned_record_number`` pins as a
+    plain ``int``) or adding a whole new ``LoopDeps`` callable for one
+    boolean. Subclassing ``int`` instead means every existing caller --
+    equality, comparison, ``%06d`` formatting, ``isinstance(x, int)``,
+    hashing/set membership -- sees no difference at all, while a caller that
+    knows to look can read ``.truncated``. Callers that don't know about
+    this class read it exactly like a plain ``int`` and are unaffected.
+    """
+
+    truncated: bool
+
+    def __new__(cls, value: int, *, truncated: bool) -> "RunLogRecordNumber":
+        obj = super().__new__(cls, value)
+        obj.truncated = truncated
+        return obj
 
 
 class RunLogWriter:
@@ -213,7 +342,15 @@ class RunLogWriter:
 
     @property
     def is_active(self) -> bool:
-        """Whether records are currently being written."""
+        """Whether records are currently being written.
+
+        Returns:
+            ``True`` once ``bind()`` has successfully activated the writer
+            (root resolved, directory created); ``False`` before ``bind()``
+            is called, after a failed bind (disabled config, unresolvable
+            root, or a directory-creation failure), or once a later write
+            failure has deactivated it (see ``append()``).
+        """
         return self._active
 
     def bind(self, run_id: str) -> None:
@@ -242,6 +379,44 @@ class RunLogWriter:
             self._active = False
             return
         is_sandbox_fallback = getattr(_root_kind, "is_sandbox_fallback", False)
+        # F8 (Qodo #8, task-1251): the fallback FLAG only reports which
+        # BRANCH resolve_log_root() took internally -- but what the dotted
+        # name actually protects against is reachability from the
+        # sandbox-rooted file tools (grep_files/glob_files glob
+        # `_tool_sandbox_root()` directly and never consult
+        # `allowed_file_roots`, §9.4). A bound WORKSPACE folder can itself
+        # resolve inside (or equal to) the sandbox root -- e.g. a user (or a
+        # test/misconfiguration) binds a folder that lives under the tool
+        # sandbox -- in which case resolve_log_root() takes the "workspace"
+        # branch, `is_sandbox_fallback` stays False, and the log would get
+        # the undotted name while still being fully reachable by a
+        # sub-agent's grep_files/glob_files: exactly the disclosure the
+        # dotting exists to prevent. Checking actual containment against
+        # the sandbox root here, independent of which branch produced
+        # `root`, closes that gap -- and also covers a caller that
+        # monkeypatches `resolve_log_root` wholesale (many existing test
+        # fixtures do), which never touches the side-channel flag at all.
+        if not is_sandbox_fallback:
+            try:
+                from tldw_chatbook.Tools.file_operation_tools import (
+                    _tool_sandbox_root,
+                )
+
+                sandbox_root = _tool_sandbox_root().resolve()
+                resolved_root = root.resolve()
+                is_sandbox_fallback = (
+                    resolved_root == sandbox_root
+                    or sandbox_root in resolved_root.parents
+                )
+            except Exception:
+                # Cannot verify containment -- fail CLOSED (dot the name)
+                # rather than risk a workspace-folder root silently
+                # aliasing the sandbox and re-exposing the log.
+                logger.opt(exception=True).warning(
+                    "run log: cannot verify sandbox containment; dotting "
+                    "the log directory defensively"
+                )
+                is_sandbox_fallback = True
         dir_name = self._dir_name
         if is_sandbox_fallback and not dir_name.startswith("."):
             # Final-review CRITICAL 2: the undotted name exists so the log
@@ -344,8 +519,12 @@ class RunLogWriter:
             call_id: Provider ``tool_call_id``, when applicable.
 
         Returns:
-            The assigned record number, or ``None`` when the writer is
-            inactive or the write failed. Never raises.
+            The assigned record number as a ``RunLogRecordNumber`` (a plain
+            ``int`` for every purpose -- equality, formatting, hashing --
+            plus a ``.truncated`` attribute reporting whether THIS record's
+            content exceeded ``run_log_max_record_bytes`` and was cut), or
+            ``None`` when the writer is inactive or the write failed. Never
+            raises.
         """
         if not self._active or self.log_dir is None:
             return None
@@ -393,7 +572,7 @@ class RunLogWriter:
                 self._active = False
                 return None
             self._segment_size += len(payload)
-            return record.number
+            return RunLogRecordNumber(record.number, truncated=bool(truncated_from))
 
     def write_manifest(self, metadata: dict) -> None:
         """Write run-level convenience metadata. Never raises.

--- a/tldw_chatbook/Agents/run_log.py
+++ b/tldw_chatbook/Agents/run_log.py
@@ -15,13 +15,36 @@ from loguru import logger
 
 from .run_log_format import RunLogRecord, encode_record
 
-#: Directory created inside the resolved root. Deliberately UNDOTTED: a
-#: dotted directory is excluded by `_is_hidden_within`, which would hide
-#: the log from the very tools meant to read it.
+#: Directory created inside the resolved root. Deliberately UNDOTTED when the
+#: run's log lands in a bound workspace folder: a dotted directory is
+#: excluded by `_is_hidden_within`, which would hide the log from the very
+#: tools meant to read it there. `bind()` dots this name instead when the
+#: root came from the SANDBOX FALLBACK -- see its own comment (final-review
+#: CRITICAL 2).
 DEFAULT_DIR_NAME = "agent-runs"
 DEFAULT_SEGMENT_BYTES = 4_000_000
 DEFAULT_MAX_RECORD_BYTES = 1_000_000
 MANIFEST_NAME = "MANIFEST"
+
+#: Side channel from `resolve_log_root()` to `bind()`: whether the last
+#: real call resolved via the sandbox fallback (no read-write workspace
+#: folder bound) rather than a bound workspace folder. Thread-local so
+#: concurrent binds on different writers/threads can never cross-contaminate
+#: each other's naming choice.
+#:
+#: This exists ONLY because `resolve_log_root()`'s return value itself must
+#: stay a bare `Path | None` -- it is pinned by
+#: `test_real_resolve_log_root_prefers_workspace_over_sandbox` and its
+#: sandbox-fallback sibling in Tests/Agents/test_run_log_writer.py, which
+#: assert plain `Path` equality against the real function's result -- and
+#: because many pre-existing tests across several files monkeypatch
+#: `resolve_log_root` wholesale with a bare `lambda: some_path`, which never
+#: touches this side channel. `bind()` resets it to `False` immediately
+#: before calling `resolve_log_root()`, so those doubles (and any stale
+#: value from an earlier call in this thread) always read back as "not the
+#: sandbox fallback" -- the safe, pre-existing-behaviour-preserving default.
+#: Only the REAL `resolve_log_root()` ever sets it to `True`.
+_root_kind = threading.local()
 
 
 def _setting(key: str, default):
@@ -94,9 +117,17 @@ def resolve_log_root() -> Path | None:
     such folder is bound. Any failure resolves to ``None`` (logging off)
     rather than to a wider or unvalidated location.
 
+    As a side effect, records into the thread-local ``_root_kind`` whether
+    THIS call resolved via the sandbox fallback rather than a bound
+    workspace folder -- ``bind()`` reads it back to choose the log
+    directory's name (see CRITICAL 2, final review). The return value
+    itself is unchanged by this: still a bare ``Path | None``, exactly as
+    before.
+
     Returns:
         The chosen root directory, or ``None`` when none is usable.
     """
+    _root_kind.is_sandbox_fallback = False
     try:
         from tldw_chatbook.Tools.file_operation_tools import _tool_sandbox_root
         from tldw_chatbook.Tools.workspace_file_roots import allowed_file_roots
@@ -109,9 +140,12 @@ def resolve_log_root() -> Path | None:
     if not roots:
         return None
     # allowed_file_roots returns (sandbox, *workspace_folders); prefer a
-    # bound workspace folder, fall back to the sandbox.
+    # bound workspace folder, fall back to the sandbox. Which branch fires
+    # IS the fallback signal, reported structurally via the flag above --
+    # never guessed afterward by inspecting the resolved path's name.
     for candidate in roots[1:]:
         return candidate
+    _root_kind.is_sandbox_fallback = True
     return roots[0]
 
 
@@ -196,14 +230,42 @@ class RunLogWriter:
         if not _setting("run_log_enabled", True):
             self._active = False
             return
+        # Reset the side channel immediately before calling resolve_log_root()
+        # -- see `_root_kind`'s own docstring. Only a call to the REAL
+        # function can flip it back to True; a monkeypatched double (many
+        # pre-existing test fixtures) or a stale value from an earlier bind
+        # in this thread both read back as False, which is the
+        # backward-compatible, previously-shipped naming choice (undotted).
+        _root_kind.is_sandbox_fallback = False
         root = resolve_log_root()
         if root is None:
             self._active = False
             return
+        is_sandbox_fallback = getattr(_root_kind, "is_sandbox_fallback", False)
+        dir_name = self._dir_name
+        if is_sandbox_fallback and not dir_name.startswith("."):
+            # Final-review CRITICAL 2: the undotted name exists so the log
+            # is a user-visible artifact inside the user's OWN workspace
+            # folder -- that rationale holds only when the log actually
+            # lands there. Under the sandbox fallback (confirmed the real
+            # default: no rw workspace folder bound), `_tool_sandbox_root()`
+            # is EXACTLY the root `glob_files`/`grep_files` are rooted at,
+            # and those tools never consult `allowed_file_roots` (§9.4) --
+            # so an undotted "agent-runs" there is a live directory a
+            # sub-agent (which inherits the parent's allow-list) can read
+            # via grep_files/glob_files, handing it its PARENT's entire log
+            # and breaking spawn_subagent's "sees only the task text"
+            # promise. Dotting it here does NOT break OUR OWN reader --
+            # `search_run_log` -> `run_log_search.load_records` globs this
+            # directory directly and never routes through
+            # `validate_path`/`_is_hidden_within` -- it only removes the
+            # directory from what glob_files/grep_files/read_file can see,
+            # which in the app-internal sandbox case is exactly the intent.
+            dir_name = f".{dir_name}"
         try:
             from tldw_chatbook.Tools.file_operation_tools import is_within
 
-            base = root / self._dir_name
+            base = root / dir_name
             # Verify containment before creating any directories.
             if not is_within(base, root):
                 logger.warning(

--- a/tldw_chatbook/Agents/run_log.py
+++ b/tldw_chatbook/Agents/run_log.py
@@ -43,6 +43,49 @@ def _setting(key: str, default):
     return default if value is None else value
 
 
+def _coerce_dir_name(value, default: str) -> str:
+    """Coerce dir_name defensively: non-string or empty falls back to default.
+
+    Args:
+        value: Value to coerce (from explicit arg or config).
+        default: Default value if coercion fails.
+
+    Returns:
+        A valid string directory name, or ``default``.
+    """
+    try:
+        s = str(value)
+        if not s:
+            raise ValueError("empty dir_name")
+        return s
+    except Exception:
+        logger.opt(exception=True).warning("run log: invalid dir_name, using default")
+        return default
+
+
+def _coerce_positive_int(value, default: int, name: str) -> int:
+    """Coerce to positive int defensively: non-numeric, zero, or negative falls back to default.
+
+    Args:
+        value: Value to coerce (from explicit arg or config).
+        default: Default value if coercion fails.
+        name: Parameter name for logging (e.g., "segment_bytes").
+
+    Returns:
+        A positive integer, or ``default``.
+    """
+    try:
+        val = int(value)
+        if val <= 0:
+            raise ValueError(f"non-positive {name}")
+        return val
+    except Exception:
+        logger.opt(exception=True).warning(
+            f"run log: invalid {name}, using default"
+        )
+        return default
+
+
 def resolve_log_root() -> Path | None:
     """Return the directory the log tree is created under, or ``None``.
 
@@ -97,52 +140,34 @@ class RunLogWriter:
             max_record_bytes: Per-record ceiling; defaults to
                 ``[agents] run_log_max_record_bytes``.
         """
-        # Coerce dir_name defensively; non-string or empty falls back to default.
-        if dir_name:
-            self._dir_name = str(dir_name)
+        # Coerce dir_name defensively using shared helper.
+        if dir_name is not None:
+            self._dir_name = _coerce_dir_name(dir_name, DEFAULT_DIR_NAME)
         else:
             configured = _setting("run_log_dir_name", DEFAULT_DIR_NAME)
-            try:
-                self._dir_name = str(configured)
-                if not self._dir_name:
-                    raise ValueError("empty dir_name")
-            except Exception:
-                logger.opt(exception=True).warning(
-                    "run log: invalid dir_name config, using default"
-                )
-                self._dir_name = DEFAULT_DIR_NAME
+            self._dir_name = _coerce_dir_name(configured, DEFAULT_DIR_NAME)
 
-        # Coerce segment_bytes defensively; non-numeric or invalid falls back to default.
+        # Coerce segment_bytes defensively using shared helper.
         if segment_bytes is not None:
-            self._segment_bytes = int(segment_bytes)
+            self._segment_bytes = _coerce_positive_int(
+                segment_bytes, DEFAULT_SEGMENT_BYTES, "segment_bytes"
+            )
         else:
             configured = _setting("run_log_segment_bytes", DEFAULT_SEGMENT_BYTES)
-            try:
-                val = int(configured)
-                if val <= 0:
-                    raise ValueError("non-positive segment_bytes")
-                self._segment_bytes = val
-            except Exception:
-                logger.opt(exception=True).warning(
-                    "run log: invalid segment_bytes config, using default"
-                )
-                self._segment_bytes = DEFAULT_SEGMENT_BYTES
+            self._segment_bytes = _coerce_positive_int(
+                configured, DEFAULT_SEGMENT_BYTES, "segment_bytes"
+            )
 
-        # Coerce max_record_bytes defensively; non-numeric or invalid falls back to default.
+        # Coerce max_record_bytes defensively using shared helper.
         if max_record_bytes is not None:
-            self._max_record_bytes = int(max_record_bytes)
+            self._max_record_bytes = _coerce_positive_int(
+                max_record_bytes, DEFAULT_MAX_RECORD_BYTES, "max_record_bytes"
+            )
         else:
             configured = _setting("run_log_max_record_bytes", DEFAULT_MAX_RECORD_BYTES)
-            try:
-                val = int(configured)
-                if val <= 0:
-                    raise ValueError("non-positive max_record_bytes")
-                self._max_record_bytes = val
-            except Exception:
-                logger.opt(exception=True).warning(
-                    "run log: invalid max_record_bytes config, using default"
-                )
-                self._max_record_bytes = DEFAULT_MAX_RECORD_BYTES
+            self._max_record_bytes = _coerce_positive_int(
+                configured, DEFAULT_MAX_RECORD_BYTES, "max_record_bytes"
+            )
 
         self._lock = threading.Lock()
         self._counter = 0

--- a/tldw_chatbook/Agents/run_log.py
+++ b/tldw_chatbook/Agents/run_log.py
@@ -97,22 +97,59 @@ class RunLogWriter:
             max_record_bytes: Per-record ceiling; defaults to
                 ``[agents] run_log_max_record_bytes``.
         """
-        self._dir_name = dir_name or str(_setting("run_log_dir_name", DEFAULT_DIR_NAME))
-        self._segment_bytes = int(
-            segment_bytes
-            if segment_bytes is not None
-            else _setting("run_log_segment_bytes", DEFAULT_SEGMENT_BYTES)
-        )
-        self._max_record_bytes = int(
-            max_record_bytes
-            if max_record_bytes is not None
-            else _setting("run_log_max_record_bytes", DEFAULT_MAX_RECORD_BYTES)
-        )
+        # Coerce dir_name defensively; non-string or empty falls back to default.
+        if dir_name:
+            self._dir_name = str(dir_name)
+        else:
+            configured = _setting("run_log_dir_name", DEFAULT_DIR_NAME)
+            try:
+                self._dir_name = str(configured)
+                if not self._dir_name:
+                    raise ValueError("empty dir_name")
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "run log: invalid dir_name config, using default"
+                )
+                self._dir_name = DEFAULT_DIR_NAME
+
+        # Coerce segment_bytes defensively; non-numeric or invalid falls back to default.
+        if segment_bytes is not None:
+            self._segment_bytes = int(segment_bytes)
+        else:
+            configured = _setting("run_log_segment_bytes", DEFAULT_SEGMENT_BYTES)
+            try:
+                val = int(configured)
+                if val <= 0:
+                    raise ValueError("non-positive segment_bytes")
+                self._segment_bytes = val
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "run log: invalid segment_bytes config, using default"
+                )
+                self._segment_bytes = DEFAULT_SEGMENT_BYTES
+
+        # Coerce max_record_bytes defensively; non-numeric or invalid falls back to default.
+        if max_record_bytes is not None:
+            self._max_record_bytes = int(max_record_bytes)
+        else:
+            configured = _setting("run_log_max_record_bytes", DEFAULT_MAX_RECORD_BYTES)
+            try:
+                val = int(configured)
+                if val <= 0:
+                    raise ValueError("non-positive max_record_bytes")
+                self._max_record_bytes = val
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "run log: invalid max_record_bytes config, using default"
+                )
+                self._max_record_bytes = DEFAULT_MAX_RECORD_BYTES
+
         self._lock = threading.Lock()
         self._counter = 0
         self._segment_index = 1
         self._segment_size = 0
         self._active = False
+        self._bind_attempted = False  # Track whether bind() was called, success or failure
         self.log_dir: Path | None = None
 
     @property
@@ -127,8 +164,10 @@ class RunLogWriter:
             run_id: The PRIMARY run's id. Later calls are ignored so a
                 child run never rebinds its parent's writer.
         """
-        if self.log_dir is not None:
+        if self._bind_attempted:
             return
+        self._bind_attempted = True
+
         if not _setting("run_log_enabled", True):
             self._active = False
             return
@@ -137,7 +176,16 @@ class RunLogWriter:
             self._active = False
             return
         try:
+            from tldw_chatbook.Tools.file_operation_tools import is_within
+
             base = root / self._dir_name
+            # Verify containment before creating any directories.
+            if not is_within(base, root):
+                logger.warning(
+                    "run log: base directory escapes root; logging disabled"
+                )
+                self._active = False
+                return
             base.mkdir(parents=True, exist_ok=True)
             gitignore = base / ".gitignore"
             if not gitignore.exists():
@@ -145,6 +193,13 @@ class RunLogWriter:
                 # is itself a mutation.
                 gitignore.write_text("*\n", encoding="utf-8")
             run_dir = base / run_id
+            # Verify containment of run_dir before creating it.
+            if not is_within(run_dir, root):
+                logger.warning(
+                    "run log: run directory escapes root; logging disabled"
+                )
+                self._active = False
+                return
             run_dir.mkdir(parents=True, exist_ok=True)
         except Exception:
             logger.opt(exception=True).warning(

--- a/tldw_chatbook/Agents/run_log_format.py
+++ b/tldw_chatbook/Agents/run_log_format.py
@@ -154,11 +154,19 @@ def iter_records(data: bytes) -> Iterator[RunLogRecord]:
                 return
             position = nxt + 1
             continue
+        # Negative size is a malformed header: resync instead of discarding all.
+        if size < 0:
+            nxt = data.find(b"\n" + _ANCHOR_BYTES, position + 1)
+            if nxt == -1:
+                return
+            position = nxt + 1
+            continue
         start = newline + 1
         end = start + size
         # end + 1 covers the terminating newline: only fully-terminated
         # records are yielded, so a record still being written is skipped.
-        if size < 0 or end + 1 > length:
+        # This is a genuinely partial trailing record (normal for logs being appended).
+        if end + 1 > length:
             return
         # Integrity check: the byte at the slice end MUST be the terminating newline.
         # If not, this record is torn (declared byte count overran real content);

--- a/tldw_chatbook/Agents/run_log_format.py
+++ b/tldw_chatbook/Agents/run_log_format.py
@@ -42,6 +42,18 @@ def _sanitise(value: str) -> str:
     return cleaned or _PLACEHOLDER
 
 
+def _placeholder_to_empty(value: str) -> str:
+    """Map the wire placeholder back to empty string for optional fields.
+
+    Args:
+        value: Field value from the wire (e.g., "-").
+
+    Returns:
+        Empty string if ``value`` is the placeholder, else ``value``.
+    """
+    return "" if value == _PLACEHOLDER else value
+
+
 @dataclass(frozen=True)
 class RunLogRecord:
     """One appended record: a model turn, tool call, tool result, or spawn."""
@@ -126,18 +138,37 @@ def iter_records(data: bytes) -> Iterator[RunLogRecord]:
             return
         fields = _parse_header(data[position:newline].decode("utf-8", "replace"))
         if fields is None:
-            return
+            # Malformed header: resync to next anchor instead of discarding all.
+            nxt = data.find(b"\n" + _ANCHOR_BYTES, position + 1)
+            if nxt == -1:
+                return
+            position = nxt + 1
+            continue
         try:
             size = int(fields.get("bytes", "0"))
             number = int(fields["number"])
         except (KeyError, ValueError):
-            return
+            # Unparseable bytes or number: resync instead of losing all records.
+            nxt = data.find(b"\n" + _ANCHOR_BYTES, position + 1)
+            if nxt == -1:
+                return
+            position = nxt + 1
+            continue
         start = newline + 1
         end = start + size
         # end + 1 covers the terminating newline: only fully-terminated
         # records are yielded, so a record still being written is skipped.
         if size < 0 or end + 1 > length:
             return
+        # Integrity check: the byte at the slice end MUST be the terminating newline.
+        # If not, this record is torn (declared byte count overran real content);
+        # resync instead of yielding stitched content.
+        if data[end:end + 1] != b"\n":
+            nxt = data.find(b"\n" + _ANCHOR_BYTES, position + 1)
+            if nxt == -1:
+                return
+            position = nxt + 1
+            continue
         yield RunLogRecord(
             number=number,
             run_id=fields.get("run", _PLACEHOLDER),
@@ -145,9 +176,9 @@ def iter_records(data: bytes) -> Iterator[RunLogRecord]:
             type=fields.get("type", _PLACEHOLDER),
             ts=fields.get("ts", _PLACEHOLDER),
             content=data[start:end].decode("utf-8", "replace"),
-            tool=fields.get("tool", _PLACEHOLDER),
-            status=fields.get("status", _PLACEHOLDER),
-            call_id=fields.get("call", _PLACEHOLDER),
+            tool=_placeholder_to_empty(fields.get("tool", _PLACEHOLDER)),
+            status=_placeholder_to_empty(fields.get("status", _PLACEHOLDER)),
+            call_id=_placeholder_to_empty(fields.get("call", _PLACEHOLDER)),
             truncated_from=int(fields.get("truncated", "0") or 0),
         )
         position = end + 1

--- a/tldw_chatbook/Agents/run_log_format.py
+++ b/tldw_chatbook/Agents/run_log_format.py
@@ -1,0 +1,153 @@
+"""Line-anchored, byte-exact record codec for the agent run log.
+
+Pure module: no filesystem, no runtime imports. See the design spec
+(Docs/superpowers/specs/2026-07-27-agent-programmatic-run-memory-design.md §4).
+
+Format, one record:
+
+    #@# 000412 run=a3f9c1 kind=primary type=tool_result tool=grep_files \
+status=ok call=call_7 ts=2026-07-27T18:22:31.004Z bytes=1834
+    <exactly 1834 UTF-8 bytes of content>
+
+The header is always ONE physical line: a wrapped header would break
+``^#@# `` matching and detach fields onto a continuation line. ``bytes=``
+lets a parser slice content by length instead of scanning for the next
+anchor, so content containing a literal ``#@#`` cannot corrupt parsing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterator
+
+#: Never occurs naturally. ``###`` was rejected: it is a markdown H3, so
+#: every heading in generated or fetched content would false-positive.
+RECORD_ANCHOR = "#@#"
+
+_ANCHOR_BYTES = RECORD_ANCHOR.encode("utf-8") + b" "
+_PLACEHOLDER = "-"
+
+
+def _sanitise(value: str) -> str:
+    """Collapse whitespace so a value can never break the single-line header.
+
+    Args:
+        value: Raw field value (a tool name, run id, status, or call id).
+
+    Returns:
+        ``value`` with every whitespace run replaced by ``_``, or ``"-"``
+        when empty.
+    """
+    cleaned = "_".join(str(value).split())
+    return cleaned or _PLACEHOLDER
+
+
+@dataclass(frozen=True)
+class RunLogRecord:
+    """One appended record: a model turn, tool call, tool result, or spawn."""
+
+    number: int
+    run_id: str
+    kind: str
+    type: str
+    ts: str
+    content: str
+    tool: str = ""
+    status: str = ""
+    call_id: str = ""
+    truncated_from: int = 0
+
+
+def encode_record(record: RunLogRecord) -> bytes:
+    """Serialise one record to its on-disk bytes.
+
+    Args:
+        record: The record to encode.
+
+    Returns:
+        The header line, a newline, the UTF-8 content, and a terminating
+        newline. ``bytes=`` counts the content only, never the terminator.
+    """
+    body = record.content.encode("utf-8")
+    header = (
+        f"{RECORD_ANCHOR} {record.number:06d}"
+        f" run={_sanitise(record.run_id)}"
+        f" kind={_sanitise(record.kind)}"
+        f" type={_sanitise(record.type)}"
+        f" tool={_sanitise(record.tool)}"
+        f" status={_sanitise(record.status)}"
+        f" call={_sanitise(record.call_id)}"
+        f" ts={_sanitise(record.ts)}"
+        f" bytes={len(body)}"
+    )
+    if record.truncated_from:
+        header += f" truncated={record.truncated_from}"
+    return header.encode("utf-8") + b"\n" + body + b"\n"
+
+
+def _parse_header(line: str) -> dict[str, str] | None:
+    parts = line.split(" ")
+    if len(parts) < 3 or parts[0] != RECORD_ANCHOR:
+        return None
+    fields: dict[str, str] = {"number": parts[1]}
+    for token in parts[2:]:
+        key, _, value = token.partition("=")
+        if value:
+            fields[key] = value
+    return fields
+
+
+def iter_records(data: bytes) -> Iterator[RunLogRecord]:
+    """Parse every COMPLETE record in ``data``, in file order.
+
+    A trailing record whose declared content (plus its terminating newline)
+    is not fully present is skipped: the agent searches its own log while
+    the writer is still appending to it, so a half-written tail is normal
+    rather than corruption.
+
+    Args:
+        data: Raw bytes of one log segment.
+
+    Yields:
+        Each fully-present ``RunLogRecord``.
+    """
+    position = 0
+    length = len(data)
+    while position < length:
+        if not data.startswith(_ANCHOR_BYTES, position):
+            # Not at a record boundary; find the next anchor at a line start.
+            nxt = data.find(b"\n" + _ANCHOR_BYTES, position)
+            if nxt == -1:
+                return
+            position = nxt + 1
+            continue
+        newline = data.find(b"\n", position)
+        if newline == -1:
+            return
+        fields = _parse_header(data[position:newline].decode("utf-8", "replace"))
+        if fields is None:
+            return
+        try:
+            size = int(fields.get("bytes", "0"))
+            number = int(fields["number"])
+        except (KeyError, ValueError):
+            return
+        start = newline + 1
+        end = start + size
+        # end + 1 covers the terminating newline: only fully-terminated
+        # records are yielded, so a record still being written is skipped.
+        if size < 0 or end + 1 > length:
+            return
+        yield RunLogRecord(
+            number=number,
+            run_id=fields.get("run", _PLACEHOLDER),
+            kind=fields.get("kind", _PLACEHOLDER),
+            type=fields.get("type", _PLACEHOLDER),
+            ts=fields.get("ts", _PLACEHOLDER),
+            content=data[start:end].decode("utf-8", "replace"),
+            tool=fields.get("tool", _PLACEHOLDER),
+            status=fields.get("status", _PLACEHOLDER),
+            call_id=fields.get("call", _PLACEHOLDER),
+            truncated_from=int(fields.get("truncated", "0") or 0),
+        )
+        position = end + 1

--- a/tldw_chatbook/Agents/run_log_search.py
+++ b/tldw_chatbook/Agents/run_log_search.py
@@ -114,6 +114,12 @@ def search_records(
     # Context records are returned in addition to the limit.
     limited_hit_indexes = hit_indexes[:limit]
     selected: set[int] = set()
+    # A negative context would make low > high below, so range(low, high+1)
+    # comes back empty and even the hit itself is dropped -- a caller (or a
+    # model guessing at search_run_log's args) passing context=-5 would be
+    # told "No matching records." even though a match exists, which is
+    # worse than an error. Clamp here, at the point of use.
+    context = max(0, context)
     for index in limited_hit_indexes:
         low = max(0, index - context)
         high = min(len(records) - 1, index + context)

--- a/tldw_chatbook/Agents/run_log_search.py
+++ b/tldw_chatbook/Agents/run_log_search.py
@@ -10,11 +10,43 @@ expensive within the window. Python's `re` has no match timeout, and
 thread -- bounding the scan to the first 500 characters avoids runaway
 execution, not catastrophe within the bound. See also
 `file_operation_tools._MAX_GREP_LINE_SEARCH_CHARS`.
+
+F6 (Qodo #6, PR #1066 review): because `search_run_log` is a RUNTIME tool
+(agent_runtime.py dispatches it directly via `deps.search_run_log`, never
+through `deps.invoke_tool`), it also bypasses the ordinary per-tool timeout
+wrapper (`agent_service._call_with_timeout`) that every catalog tool gets.
+The 500-char scan window above bounds the INPUT to one regex evaluation but
+does not bound its WORST-CASE TIME -- a single catastrophic-backtracking
+match against even 500 characters can still run for a very long time. Two
+additional, independently-cheap layers narrow that, and NEITHER is a
+complete fix on its own:
+
+  1. A wall-clock deadline (`MAX_SEARCH_SECONDS`) checked between records in
+     `search_records`. This bounds the CUMULATIVE cost of scanning many
+     records, each individually fast. It CANNOT interrupt a single record
+     whose regex evaluation itself hangs -- `re.Pattern.search` is not
+     interruptible from pure Python without threads/signals, and this
+     module stays synchronous and dependency-free on purpose.
+  2. A pattern screen (`_looks_catastrophic`) that rejects the textbook
+     nested-quantifier shape (`(a+)+`, `(a*)*`, `(a+)*`, ...) BEFORE
+     compiling. This catches the common case that would hang on layer 1's
+     very first record, but it is a conservative STRING scan for one known
+     dangerous shape, not a general safety proof -- other constructs (e.g.
+     alternation-based blowups) can still be slow and are not screened.
+
+Together these make a catastrophic pattern's cost bounded in the common
+case and finite in the worst case a wall clock can observe -- they do not
+make it fast, and a sufficiently adversarial single-record pattern can
+still exceed both bounds before the deadline check next runs. `contains=`
+remains the only mode with no such caveat: it is linear and cannot
+backtrack by construction, and the tool description tells the model to
+prefer it.
 """
 
 from __future__ import annotations
 
 import re
+import time
 from pathlib import Path
 
 from .run_log_format import RunLogRecord, iter_records
@@ -24,6 +56,71 @@ from .run_log_format import RunLogRecord, iter_records
 #: makes such a pattern fast — only bounded. Mirrors
 #: `file_operation_tools._MAX_GREP_LINE_SEARCH_CHARS`.
 MAX_REGEX_SCAN_CHARS = 500
+
+#: F6: wall-clock ceiling on one `search_records` call, checked between
+#: records. Deliberately small -- this is meant to be a CHEAP, in-process
+#: log search over local files, not a bounded-but-still-slow operation.
+MAX_SEARCH_SECONDS = 5.0
+
+#: F6: characters that make a quantified group "already quantified" for the
+#: nested-quantifier screen below (`+`/`*`; `?` after either is a lazy
+#: variant of the same shape, handled separately).
+_QUANTIFIER_CHARS = ("+", "*")
+
+
+class RunLogSearchTimeout(Exception):
+    """A `search_records` call exceeded `MAX_SEARCH_SECONDS`. See F6."""
+
+
+class RunLogSearchPatternRejected(Exception):
+    """`pattern=` matched a known catastrophic-backtracking shape. See F6."""
+
+
+def _looks_catastrophic(pattern: str) -> bool:
+    """Cheap, conservative screen for the classic nested-quantifier shape.
+
+    Detects a parenthesised group whose content ends in a quantifier
+    (``+``/``*``, optionally followed by a lazy ``?``) immediately followed
+    by another quantifier outside the group -- e.g. ``(a+)+``, ``(a*)*``,
+    ``(a+)*``, ``(a*)+``, ``(a+){2,}``. This is THE textbook
+    catastrophic-backtracking signature. Deliberately a balanced-paren
+    STRING scan, not a regex: a regex screen for dangerous regexes would
+    itself need to be immune to the same class of attack. Conservative by
+    design -- it can miss more exotic catastrophic shapes (alternation-based
+    blowups, deeply nested cross-group cases) but is built to never flag an
+    ordinary pattern like ``(abc)+``, ``a+b*``, or ``(foo|bar)+``.
+
+    Args:
+        pattern: The model-supplied regex source, unmodified.
+
+    Returns:
+        ``True`` when the nested-quantifier shape is found, else ``False``.
+    """
+    stack: list[int] = []
+    n = len(pattern)
+    i = 0
+    while i < n:
+        ch = pattern[i]
+        if ch == "\\":
+            i += 2
+            continue
+        if ch == "(":
+            stack.append(i)
+        elif ch == ")" and stack:
+            start = stack.pop()
+            inner_end = i - 1
+            if inner_end > start:
+                trailing = pattern[inner_end]
+                # A lazy quantifier (`+?`/`*?`) is the same dangerous shape
+                # one character further back.
+                if trailing == "?" and inner_end - 1 > start:
+                    trailing = pattern[inner_end - 1]
+                if trailing in _QUANTIFIER_CHARS:
+                    j = i + 1
+                    if j < n and (pattern[j] in _QUANTIFIER_CHARS or pattern[j] == "{"):
+                        return True
+        i += 1
+    return False
 
 
 def load_records(log_dir: Path) -> list[RunLogRecord]:
@@ -60,6 +157,7 @@ def search_records(
     to_record: int = 0,
     context: int = 0,
     limit: int = 50,
+    deadline_seconds: float = MAX_SEARCH_SECONDS,
 ) -> list[RunLogRecord]:
     """Filter ``records``; return hits plus optional neighbouring context.
 
@@ -67,7 +165,11 @@ def search_records(
         records: All loaded records, in order.
         contains: Literal substring (case-insensitive). Never compiled.
         pattern: Opt-in regex, searched only over the first
-            ``MAX_REGEX_SCAN_CHARS`` characters of each record.
+            ``MAX_REGEX_SCAN_CHARS`` characters of each record. Rejected
+            up front (``RunLogSearchPatternRejected``) when it matches the
+            classic nested-quantifier catastrophic-backtracking shape; see
+            the module docstring for why this is a partial, not complete,
+            defense.
         tool: Exact tool-name filter.
         type: Exact record-type filter.
         status: Exact status filter.
@@ -77,20 +179,44 @@ def search_records(
         context: Include this many records either side of each hit.
         limit: Maximum number of matching records returned; context records
             are returned in addition to this limit.
+        deadline_seconds: Wall-clock ceiling for this call, checked between
+            records (F6). Cannot interrupt a single record's regex
+            evaluation if THAT hangs; see the module docstring.
 
     Returns:
         Matching records in record order, deduplicated, with context records
         included (result may exceed ``limit`` when context is used).
+
+    Raises:
+        RunLogSearchPatternRejected: ``pattern`` matches a known
+            catastrophic-backtracking shape.
+        RunLogSearchTimeout: the scan exceeded ``deadline_seconds``.
     """
     compiled = None
     if pattern:
+        if _looks_catastrophic(pattern):
+            raise RunLogSearchPatternRejected(
+                f"pattern {pattern!r} looks like it could backtrack "
+                f"catastrophically (a quantifier applied to an "
+                f"already-quantified group, e.g. (a+)+, (a*)*, (a+)*). "
+                f"Use contains=<literal substring> instead -- it is "
+                f"unbounded and cannot backtrack."
+            )
         try:
             compiled = re.compile(pattern, re.IGNORECASE)
         except re.error:
             return []
     needle = contains.lower()
     hit_indexes: list[int] = []
+    started = time.monotonic()
     for index, record in enumerate(records):
+        if time.monotonic() - started > deadline_seconds:
+            raise RunLogSearchTimeout(
+                f"search exceeded its {deadline_seconds:g}s wall-clock "
+                f"budget after scanning {index} of {len(records)} records. "
+                f"Narrow the query -- add 'contains', or filter by 'tool', "
+                f"'type', 'from_record'/'to_record' -- and try again."
+            )
         if from_record and record.number < from_record:
             continue
         if to_record and record.number > to_record:
@@ -156,6 +282,12 @@ def format_results(
     to pass to continue reading. Before this, a partial render was silent,
     which is what let a model conclude matched content did not exist.
 
+    F7 (Qodo #7): when a record's ``truncated_from`` is set (the WRITER
+    itself capped it at ``run_log_max_record_bytes``), the block also says
+    so explicitly -- that content beyond the per-record storage cap was
+    never written and cannot be recovered, distinct from the windowing note
+    above (which is about what THIS render shows, not what the log stored).
+
     Args:
         records: Records to render.
         max_chars: Per-record content ceiling in the rendering.
@@ -207,6 +339,25 @@ def format_results(
         if start > 0 or end < total:
             continuation = f" Use offset={end} to continue." if end < total else ""
             body = f"{body}\n[showing chars {start}-{end} of {total} total.{continuation}]"
+        if record.truncated_from:
+            # F7 (Qodo #7): the writer caps any record over
+            # `run_log_max_record_bytes` and records the ORIGINAL size in
+            # `truncated_from` -- but this field was never rendered here, so
+            # a model recovering a capped record via search_run_log had no
+            # way to learn its tail was unrecoverable and could easily
+            # mistake the stored length for the whole result. Byte-accurate
+            # (not `total`, which is character length): `truncated_from` is
+            # UTF-8 bytes (run_log_format.py's own unit), and the two only
+            # coincide for pure-ASCII content.
+            stored_bytes = len(record.content.encode("utf-8"))
+            body = (
+                f"{body}\n[NOTE: this run's log could only store "
+                f"{stored_bytes} of this record's original "
+                f"{record.truncated_from} bytes (the per-record storage "
+                f"cap) -- the remaining "
+                f"{record.truncated_from - stored_bytes} bytes were never "
+                f"written and cannot be recovered from this run's log.]"
+            )
         blocks.append(f"{header}\n{body}")
     return "\n\n".join(blocks)
 

--- a/tldw_chatbook/Agents/run_log_search.py
+++ b/tldw_chatbook/Agents/run_log_search.py
@@ -1,0 +1,136 @@
+# tldw_chatbook/Agents/run_log_search.py
+"""Query the run log: literal by default, structured filters, bounded regex.
+
+Pure module. Literal substring search is the DEFAULT and carries no
+line-length cap: `str.__contains__` is linear and cannot backtrack. Regex
+is opt-in and scan-bounded, because Python's `re` has no match timeout and
+`agent_service._call_with_timeout` abandons rather than kills its worker
+thread -- the same reasoning behind `grep_files`' own 500-char window.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .run_log_format import RunLogRecord, iter_records
+
+#: Per-record scan window for opt-in regex mode; mirrors
+#: `file_operation_tools._MAX_GREP_LINE_SEARCH_CHARS`.
+MAX_REGEX_SCAN_CHARS = 500
+
+
+def load_records(log_dir: Path) -> list[RunLogRecord]:
+    """Load every complete record from every segment, in order.
+
+    Segment discovery is glob + sort, never the MANIFEST: a crashed run
+    writes no manifest, and those are exactly the runs worth inspecting.
+
+    Args:
+        log_dir: The run's log directory.
+
+    Returns:
+        All records in record-number order; empty when unreadable.
+    """
+    records: list[RunLogRecord] = []
+    try:
+        for segment in sorted(log_dir.glob("logs.*.txt")):
+            records.extend(iter_records(segment.read_bytes()))
+    except OSError:
+        return records
+    return sorted(records, key=lambda r: r.number)
+
+
+def search_records(
+    records: list[RunLogRecord],
+    *,
+    contains: str = "",
+    pattern: str = "",
+    tool: str = "",
+    type: str = "",
+    status: str = "",
+    kind: str = "",
+    from_record: int = 0,
+    to_record: int = 0,
+    context: int = 0,
+    limit: int = 50,
+) -> list[RunLogRecord]:
+    """Filter ``records``; return hits plus optional neighbouring context.
+
+    Args:
+        records: All loaded records, in order.
+        contains: Literal substring (case-insensitive). Never compiled.
+        pattern: Opt-in regex, searched only over the first
+            ``MAX_REGEX_SCAN_CHARS`` characters of each record.
+        tool: Exact tool-name filter.
+        type: Exact record-type filter.
+        status: Exact status filter.
+        kind: Exact agent-kind filter.
+        from_record: Inclusive lower bound on record number.
+        to_record: Inclusive upper bound on record number.
+        context: Include this many records either side of each hit.
+        limit: Maximum records returned.
+
+    Returns:
+        Matching records in record order, deduplicated, capped at ``limit``.
+    """
+    compiled = None
+    if pattern:
+        try:
+            compiled = re.compile(pattern, re.IGNORECASE)
+        except re.error:
+            return []
+    needle = contains.lower()
+    hit_indexes: list[int] = []
+    for index, record in enumerate(records):
+        if from_record and record.number < from_record:
+            continue
+        if to_record and record.number > to_record:
+            continue
+        if tool and record.tool != tool:
+            continue
+        if type and record.type != type:
+            continue
+        if status and record.status != status:
+            continue
+        if kind and record.kind != kind:
+            continue
+        if needle and needle not in record.content.lower():
+            continue
+        if compiled is not None and not compiled.search(
+            record.content[:MAX_REGEX_SCAN_CHARS]
+        ):
+            continue
+        hit_indexes.append(index)
+    selected: set[int] = set()
+    for index in hit_indexes:
+        low = max(0, index - context)
+        high = min(len(records) - 1, index + context)
+        selected.update(range(low, high + 1))
+    return [records[i] for i in sorted(selected)][:limit]
+
+
+def format_results(records: list[RunLogRecord], *, max_chars: int = 400) -> str:
+    """Render results for the model.
+
+    Args:
+        records: Records to render.
+        max_chars: Per-record content ceiling in the rendering.
+
+    Returns:
+        One block per record, or a plain no-matches line.
+    """
+    if not records:
+        return "No matching records."
+    blocks = []
+    for record in records:
+        body = record.content
+        if len(body) > max_chars:
+            body = body[:max_chars] + f"… (+{len(record.content) - max_chars} chars)"
+        blocks.append(
+            f"record {record.number:06d} [{record.type}"
+            f"{'/' + record.tool if record.tool and record.tool != '-' else ''}"
+            f"{'/' + record.status if record.status and record.status != '-' else ''}]"
+            f"\n{body}"
+        )
+    return "\n\n".join(blocks)

--- a/tldw_chatbook/Agents/run_log_search.py
+++ b/tldw_chatbook/Agents/run_log_search.py
@@ -3,9 +3,13 @@
 
 Pure module. Literal substring search is the DEFAULT and carries no
 line-length cap: `str.__contains__` is linear and cannot backtrack. Regex
-is opt-in and scan-bounded, because Python's `re` has no match timeout and
+is opt-in and scan-bounded: the bound makes catastrophic-backtracking worst
+cases finite, not fast. A sufficiently adversarial pattern can still be
+expensive within the window. Python's `re` has no match timeout, and
 `agent_service._call_with_timeout` abandons rather than kills its worker
-thread -- the same reasoning behind `grep_files`' own 500-char window.
+thread -- bounding the scan to the first 500 characters avoids runaway
+execution, not catastrophe within the bound. See also
+`file_operation_tools._MAX_GREP_LINE_SEARCH_CHARS`.
 """
 
 from __future__ import annotations
@@ -15,7 +19,9 @@ from pathlib import Path
 
 from .run_log_format import RunLogRecord, iter_records
 
-#: Per-record scan window for opt-in regex mode; mirrors
+#: Per-record scan window for opt-in regex mode. This bound makes
+#: catastrophic-backtracking worst cases finite, not fast. Neither bound
+#: makes such a pattern fast — only bounded. Mirrors
 #: `file_operation_tools._MAX_GREP_LINE_SEARCH_CHARS`.
 MAX_REGEX_SCAN_CHARS = 500
 
@@ -69,10 +75,12 @@ def search_records(
         from_record: Inclusive lower bound on record number.
         to_record: Inclusive upper bound on record number.
         context: Include this many records either side of each hit.
-        limit: Maximum records returned.
+        limit: Maximum number of matching records returned; context records
+            are returned in addition to this limit.
 
     Returns:
-        Matching records in record order, deduplicated, capped at ``limit``.
+        Matching records in record order, deduplicated, with context records
+        included (result may exceed ``limit`` when context is used).
     """
     compiled = None
     if pattern:
@@ -102,12 +110,15 @@ def search_records(
         ):
             continue
         hit_indexes.append(index)
+    # Apply limit to hits first, then expand context around the limited hits.
+    # Context records are returned in addition to the limit.
+    limited_hit_indexes = hit_indexes[:limit]
     selected: set[int] = set()
-    for index in hit_indexes:
+    for index in limited_hit_indexes:
         low = max(0, index - context)
         high = min(len(records) - 1, index + context)
         selected.update(range(low, high + 1))
-    return [records[i] for i in sorted(selected)][:limit]
+    return [records[i] for i in sorted(selected)]
 
 
 def format_results(records: list[RunLogRecord], *, max_chars: int = 400) -> str:

--- a/tldw_chatbook/Agents/run_log_search.py
+++ b/tldw_chatbook/Agents/run_log_search.py
@@ -127,27 +127,152 @@ def search_records(
     return [records[i] for i in sorted(selected)]
 
 
-def format_results(records: list[RunLogRecord], *, max_chars: int = 400) -> str:
+def format_results(
+    records: list[RunLogRecord],
+    *,
+    max_chars: int = 400,
+    contains: str = "",
+    pattern: str = "",
+    offset: int = 0,
+) -> str:
     """Render results for the model.
+
+    Each record is rendered as a single block, windowed to at most
+    ``max_chars`` characters of its content. Where that window starts is
+    decided in this order:
+
+    1. ``offset`` > 0 -- explicit paging always wins. This is how a caller
+       reaches content in a record larger than ``max_chars``: the previous
+       call's rendered block states the next ``offset`` to pass.
+    2. ``contains`` or ``pattern`` has a match in this record -- the window
+       is centred on that record's *first* match so the match is always
+       inside the rendered text. Before this, rendering always started at
+       0, so a record that matched a query could still render a body that
+       did not contain the match (TASK-1250).
+    3. Neither applies -- the window starts at 0, same as before.
+
+    When the window does not cover the whole record, the block says so:
+    the character range shown, the record's total size, and the ``offset``
+    to pass to continue reading. Before this, a partial render was silent,
+    which is what let a model conclude matched content did not exist.
 
     Args:
         records: Records to render.
         max_chars: Per-record content ceiling in the rendering.
+        contains: The literal substring the caller searched for, if any.
+            Used only to locate a match to centre the window on here --
+            this never re-filters ``records``.
+        pattern: The caller's opt-in regex, if any. Matched over only the
+            first ``MAX_REGEX_SCAN_CHARS`` characters of a record's
+            content, mirroring ``search_records``'s own match decision. An
+            invalid pattern is treated as "no match" rather than raising.
+        offset: Character offset into each record's content to start
+            rendering from, for deterministic paging. Coerced defensively:
+            a negative value clamps to 0, and an offset at or past a
+            record's end clamps to that record's final window rather than
+            rendering nothing.
 
     Returns:
         One block per record, or a plain no-matches line.
     """
     if not records:
         return "No matching records."
+    # A negative offset (a caller, or a model guessing at search_run_log's
+    # args, could send one) must not raise or flip the window backwards --
+    # clamp at the point of use, same rationale as `context` above.
+    offset = max(0, offset)
+    compiled = None
+    if pattern:
+        try:
+            compiled = re.compile(pattern, re.IGNORECASE)
+        except re.error:
+            compiled = None
     blocks = []
     for record in records:
-        body = record.content
-        if len(body) > max_chars:
-            body = body[:max_chars] + f"… (+{len(record.content) - max_chars} chars)"
-        blocks.append(
+        content = record.content
+        total = len(content)
+        start = _window_start(
+            total=total,
+            max_chars=max_chars,
+            offset=offset,
+            match_pos=_find_match_start(content, contains=contains, compiled=compiled),
+        )
+        end = min(total, start + max_chars) if max_chars > 0 else start
+        body = content[start:end]
+        header = (
             f"record {record.number:06d} [{record.type}"
             f"{'/' + record.tool if record.tool and record.tool != '-' else ''}"
             f"{'/' + record.status if record.status and record.status != '-' else ''}]"
-            f"\n{body}"
         )
+        if start > 0 or end < total:
+            continuation = f" Use offset={end} to continue." if end < total else ""
+            body = f"{body}\n[showing chars {start}-{end} of {total} total.{continuation}]"
+        blocks.append(f"{header}\n{body}")
     return "\n\n".join(blocks)
+
+
+def _find_match_start(
+    content: str, *, contains: str, compiled: re.Pattern[str] | None
+) -> int | None:
+    """Locate a record's first match, to centre its render window on.
+
+    ``contains`` is searched unbounded, over the record's whole content,
+    exactly like ``search_records``' own literal match. ``pattern`` is
+    searched only over the first ``MAX_REGEX_SCAN_CHARS`` characters, also
+    mirroring ``search_records``' match decision -- the render window is a
+    separate concern from that scan bound, so a match found within it is
+    still rendered correctly.
+
+    Args:
+        content: One record's full content.
+        contains: Literal substring (case-insensitive), or empty for none.
+        compiled: Compiled opt-in regex, or ``None`` for none.
+
+    Returns:
+        The character index of the first match, or ``None`` when neither
+        query is set or neither matches this record.
+    """
+    if contains:
+        idx = content.lower().find(contains.lower())
+        if idx != -1:
+            return idx
+    if compiled is not None:
+        match = compiled.search(content[:MAX_REGEX_SCAN_CHARS])
+        if match is not None:
+            return match.start()
+    return None
+
+
+def _window_start(*, total: int, max_chars: int, offset: int, match_pos: int | None) -> int:
+    """Pick the character index a record's rendered window starts at.
+
+    Args:
+        total: The record's total content length.
+        max_chars: The render window's width.
+        offset: Explicit, already-clamped-to-non-negative paging offset.
+            Wins over ``match_pos`` whenever it is set -- see
+            ``format_results``.
+        match_pos: The record's first query match position, or ``None``.
+
+    Returns:
+        A start index in ``[0, max(0, total - max_chars)]`` (when
+        ``max_chars`` <= 0, always 0), so the window never runs past the
+        end of ``content`` and, when a window narrower than the whole
+        record exists, always contains ``match_pos`` if one was given.
+    """
+    max_start = max(0, total - max_chars) if max_chars > 0 else 0
+    if offset > 0:
+        # An offset past the end must still show something rather than an
+        # empty window -- clamp to the record's final window instead.
+        return min(offset, max_start) if total > max_chars else 0
+    if match_pos is None:
+        return 0
+    # Centre the window on the match, then clamp into bounds. Clamping can
+    # only move the window towards the match (see the module docstring's
+    # reasoning mirrored here): if centring would run past either edge,
+    # clamping to `max_start` or 0 still leaves the match inside the
+    # window because max_chars >= max(match_pos - start, 0) + 1 in either
+    # clamped case.
+    half = max_chars // 2
+    start = max(0, match_pos - half)
+    return min(start, max_start)

--- a/tldw_chatbook/Agents/tool_catalog.py
+++ b/tldw_chatbook/Agents/tool_catalog.py
@@ -23,6 +23,7 @@ from .agent_models import (
     LOAD_TOOLS_NAME,
     RUN_SKILL_SCRIPT_TOOL_NAME,
     RunBudget,
+    SEARCH_RUN_LOG_TOOL_NAME,
     SKILL_FILE_TOOL_NAME,
     SPAWN_TOOL_NAME,
     ToolCatalogEntry,
@@ -150,6 +151,46 @@ RUN_SKILL_SCRIPT_TOOL_SCHEMA = ToolSchema(
             },
         },
         "required": ["skill_name", "script_path"],
+    },
+)
+
+
+SEARCH_RUN_LOG_TOOL_SCHEMA = ToolSchema(
+    id="runtime:search_run_log",
+    name=SEARCH_RUN_LOG_TOOL_NAME,
+    description=(
+        "Search this run's own complete log. Your context holds a truncated "
+        "view; the log holds every model turn, tool call, and tool result in "
+        "full. Use it to recover a truncated result or recall an earlier step "
+        "instead of re-running work. Prefer 'contains' (literal substring, "
+        "searches the whole record); 'pattern' is a regular expression and "
+        "only examines each record's first 500 characters."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "contains": {
+                "type": "string",
+                "description": "Literal substring to find (case-insensitive).",
+            },
+            "pattern": {
+                "type": "string",
+                "description": "Regular expression; first 500 chars per record.",
+            },
+            "tool": {"type": "string", "description": "Filter by tool name."},
+            "type": {
+                "type": "string",
+                "description": "Filter by record type: model, tool_call, tool_result.",
+            },
+            "status": {"type": "string", "description": "Filter: ok or error."},
+            "from_record": {"type": "integer", "description": "Lowest record number."},
+            "to_record": {"type": "integer", "description": "Highest record number."},
+            "context": {
+                "type": "integer",
+                "description": "Records to include either side of each hit.",
+            },
+        },
+        "required": [],
     },
 )
 

--- a/tldw_chatbook/Agents/tool_catalog.py
+++ b/tldw_chatbook/Agents/tool_catalog.py
@@ -162,20 +162,27 @@ SEARCH_RUN_LOG_TOOL_SCHEMA = ToolSchema(
         "Search this run's own complete log. Your context holds a truncated "
         "view; the log holds every model turn, tool call, and tool result in "
         "full. Use it to recover a truncated result or recall an earlier step "
-        "instead of re-running work. Prefer 'contains' (literal substring, "
-        "searches the whole record); 'pattern' is a regular expression and "
-        "only examines each record's first 500 characters."
+        "instead of re-running work. 'contains' (literal substring) and "
+        "'pattern' (regular expression, first 500 characters per record "
+        "only) both match a record's CONTENT ONLY -- never its metadata. "
+        "Use 'tool', 'type', 'status', and 'kind' to filter by metadata "
+        "instead -- e.g. to find every call to a specific tool, filter "
+        "with 'tool' rather than 'contains', since the tool's name may "
+        "never appear inside its own arguments or result."
     ),
     parameters={
         "type": "object",
         "properties": {
             "contains": {
                 "type": "string",
-                "description": "Literal substring to find (case-insensitive).",
+                "description": "Literal substring to find in a record's content "
+                "(case-insensitive). Never matches metadata such as the tool "
+                "name -- use 'tool' for that.",
             },
             "pattern": {
                 "type": "string",
-                "description": "Regular expression; first 500 chars per record.",
+                "description": "Regular expression over a record's content "
+                "only; first 500 chars per record.",
             },
             "tool": {"type": "string", "description": "Filter by tool name."},
             "type": {
@@ -183,6 +190,10 @@ SEARCH_RUN_LOG_TOOL_SCHEMA = ToolSchema(
                 "description": "Filter by record type: model, tool_call, tool_result.",
             },
             "status": {"type": "string", "description": "Filter: ok or error."},
+            "kind": {
+                "type": "string",
+                "description": "Filter by agent kind: primary or subagent.",
+            },
             "from_record": {"type": "integer", "description": "Lowest record number."},
             "to_record": {"type": "integer", "description": "Highest record number."},
             "context": {

--- a/tldw_chatbook/Agents/tool_catalog.py
+++ b/tldw_chatbook/Agents/tool_catalog.py
@@ -168,7 +168,12 @@ SEARCH_RUN_LOG_TOOL_SCHEMA = ToolSchema(
         "Use 'tool', 'type', 'status', and 'kind' to filter by metadata "
         "instead -- e.g. to find every call to a specific tool, filter "
         "with 'tool' rather than 'contains', since the tool's name may "
-        "never appear inside its own arguments or result."
+        "never appear inside its own arguments or result. A record's "
+        "rendered content is windowed: when 'contains' or 'pattern' is set, "
+        "the window is centred on that record's first match; otherwise it "
+        "starts at the beginning. When a record is shown only partially, "
+        "the render states the character range and total size, and the "
+        "'offset' to pass next to keep reading."
     ),
     parameters={
         "type": "object",
@@ -199,6 +204,15 @@ SEARCH_RUN_LOG_TOOL_SCHEMA = ToolSchema(
             "context": {
                 "type": "integer",
                 "description": "Records to include either side of each hit.",
+            },
+            "offset": {
+                "type": "integer",
+                "description": "Character offset into each record's rendered "
+                "content to start from. Use this to page through a record "
+                "larger than the render window -- the previous result names "
+                "the offset to pass next. Defaults to 0; ignored in favour "
+                "of a match-centred window when 'contains' or 'pattern' "
+                "matches and no offset is given.",
             },
         },
         "required": [],


### PR DESCRIPTION
## What this does

Adds **programmatic run memory** to the agent runtime: every model turn, tool call and tool result is appended losslessly to a segmented, searchable log, and a `search_run_log` runtime tool lets the primary agent query it. When a tool result is truncated in history, the trailer names the log record holding the full copy so the agent can go and read it.

Ported from PRO-LONG ([arXiv 2607.20064v2](https://arxiv.org/html/2607.20064v2)), whose finding is that an agent doesn't need its history *in context* — it needs history to be *reachable*.

**Design:** `Docs/superpowers/specs/2026-07-27-agent-programmatic-run-memory-design.md`

## Why now

The Console budget already allows 30 model turns over 30 minutes, but every turn re-sends the whole accumulated history, with each tool result admitted at up to `max_tool_result_chars` (16,000). A run that uses that budget can exceed 100k prompt tokens, and a 32k local model never finishes. **The budgets were raised for long-horizon work; the memory architecture never was.**

Three further consequences of the same root cause, all addressed here:

- `agent_runs.steps` was written as one JSON blob *after* the loop ended, so a run killed at round 28 of 30 left no record of the first 27.
- Truncation was permanently lossy — the trailer told the model to re-issue the call, redoing work whose answer was already computed.
- A parent saw only 4,000 chars of a sub-agent's entire run.

## Scope — Phase 1 is deliberately additive

`run_agent_loop`'s `messages` list is **not** touched, so context usage is unchanged and existing runs behave identically. This ships the lossless record and makes truncated content *recoverable*; evicting history from context is Phase 3, and the record format carries `call=<tool_call_id>` specifically so that eviction can later rebuild valid assistant/tool pairs without a rewrite.

## What's in it

| Module | Role |
|---|---|
| `Agents/run_log_format.py` (new) | Byte-exact `#@#` record codec; content sliced by declared length, never scanned |
| `Agents/run_log.py` (new) | Segmented writer, two-phase bind, config, MANIFEST, fsync policy |
| `Agents/run_log_search.py` (new) | Literal-first search, structured filters, bounded regex, match-centred rendering |
| `Agents/agent_runtime.py` | `LoopDeps.on_record` capture hook at the loop's two full-fidelity points |
| `Agents/agent_service.py` | Owns the writer per run tree; `search_run_log` closure |
| `Agents/tool_catalog.py`, `agent_models.py` | `search_run_log` schema and registration |

Config under `[agents]`: `run_log_enabled`, `run_log_dir_name`, `run_log_segment_bytes`, `run_log_max_record_bytes`. **Retention is never-auto-delete** — silently pruning files from a user's project directory is the wrong default.

## Verification

- **`Tests/Agents` + `Tests/Chat`: 3085+ passed, 60 skipped, 0 failed.**
- **Additive guarantee proven against the merge base:** 7 test files added; exactly 2 pre-existing test files touched, **+4 lines total**, zero deletions — all four are `SEARCH_RUN_LOG_TOOL_NAME` inventory entries in set-equality assertions that exist to pin that inventory. No assertion logic was altered anywhere.
- **Live run against a real local model** (llama.cpp / gemma-4-26B on the **fence** protocol, i.e. the small-context local-model path this feature targets): the model read a file, had the result truncated to 500 chars in history, followed the trailer into the log, searched by content, and answered correctly from a match-centred window. It issued `{"contains": "FINAL_VERDICT", "tool": "read_file"}` unprompted — content search plus a metadata filter.

## Review history worth knowing about

Every task was reviewed, and the review loop found **21 Critical/Important defects**, nearly all of them in the implementation plan rather than in the code that executed it. Reviewers repeatedly *mutated* the source to check whether a test would actually notice — which caught a vacuous test, an unpinned sub-agent isolation gate, and a placement invariant that all 426 tests tolerated being inverted.

Two defects were found only by the whole-branch review, because both live in the seams between individually-correct tasks:

- **Recovery returned less than the truncation it repaired.** `format_results` capped renders at 400 chars, so following the trailer for a 16,000-char truncation returned 457 characters.
- **Sub-agent isolation was bypassable.** With no workspace bound (the default), the log landed in the tool sandbox — exactly where `glob_files`/`grep_files` are rooted — and the deliberately undotted directory name meant it wasn't excluded. Reproduced by extracting a planted API key from a parent's log via a spawned child. Fixed by using a dotted directory name in the sandbox-fallback case only.

And one defect was found **only by the live run**: the recovery path still rendered from offset 0, so a `contains=` query could *match* a record and render a body without the match. The model followed the pointer correctly twice and produced an empty answer. Fixed in `43597b732` (match-centred rendering + `offset` paging + visible elision); the same live scenario now answers correctly.

## Follow-ups filed

- **TASK-1251** (medium, security) — binding a workspace folder whose resolved path *is* the sandbox root re-opens the disclosure the dotted fallback name prevents. Requires a deliberate, unusual binding.
- **TASK-870** — the Console shows 160–200 chars of a tool result the model received at up to 16,000, via a cascade of hardcoded constants; this log is what makes "read the full content" answerable.
- **TASK-895** — `glob_files`/`grep_files` ignore workspace folder roots that `read_file` honours. Found while designing this; routed around rather than fixed, since widening two shared tools affects every caller.

TASK-1250 was found by this branch's own review and **fixed here** rather than deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds programmatic run memory via a segmented, searchable run log and a new `search_run_log` runtime tool. Truncated tool results are now recoverable without re-running work; existing context behavior stays the same.

- **New Features**
  - Lossless per-run log: every model turn, tool call (pre-dispatch), and tool result is recorded with byte-exact content; segmentation + MANIFEST; additive-only (messages list untouched).
  - `search_run_log` (primary agent only): literal substring by default; optional bounded regex with a safety screen and per-record scan cap; filters by `tool`, `type`, `status`, and `kind`; deadline between records.
  - Recovery: truncation trailers point to the exact record; results render around the first match with `offset` paging and windows sized to the run’s `max_tool_result_chars`.
  - Config `[agents]`: `run_log_enabled`, `run_log_dir_name`, `run_log_segment_bytes`, `run_log_max_record_bytes` with `TLDW_AGENTS_*` env overrides; system prompt adds a brief “run log” note only when the tool is wired.

- **Bug Fixes**
  - Isolation: sandbox fallback uses a dotted `.agent-runs` directory and `search_run_log` is primary-only, blocking sub-agents from reading parent logs via file tools.
  - Correctness/durability: write `status=error` on failed tool calls; emit `tool_call` records before dispatch; flag records capped by `run_log_max_record_bytes` in renders and trailers.
  - Robustness: defensive config coercion, safe path containment checks, idempotent bind, tolerance of partial trailing records, and clamped non-negative search context.
  - Recovery correctness: searches can return content past `max_tool_result_chars` via match-centered windows and `offset` paging; apply hit limits before context expansion.

<sup>Written for commit 734d0d844e7c36b52c7d55212ce1b72f86f66b02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

