### PR TITLE
test: disable the Hypothesis deadline suite-wide (TASK-1260); correct TASK-1240's diagnosis

### DIFF
--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -57,6 +57,34 @@ PROJECT_ROOT = Path(__file__).parent.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+# Hypothesis: no per-example deadline (TASK-1260).
+#
+# Several property tests do real work per example -- `test_safe_paths_always_validate`
+# creates a TemporaryDirectory plus up to four directories, and the DB property
+# suites open SQLite connections. Hypothesis' default deadline is 200ms per
+# example, which a loaded machine crosses on work that is not actually slow:
+# this repo routinely runs 10+ concurrent pytest processes from parallel agents.
+#
+# The resulting failure is indistinguishable from a real regression at the moment
+# it appears, and attributing one instance cost five runs across two worktrees.
+# A deadline that fails a property which *holds* is measuring the machine, not
+# the code -- so it is disabled rather than merely raised. Do not "tighten this
+# back up" as an apparent improvement; timing belongs in benchmarks, not in
+# correctness properties.
+try:  # pragma: no cover - hypothesis is a test-only dependency
+    from hypothesis import HealthCheck, settings as _hypothesis_settings
+
+    _hypothesis_settings.register_profile(
+        "tldw",
+        deadline=None,
+        # `too_slow` fires for the same reason the deadline does: machine load,
+        # not a slow strategy.
+        suppress_health_check=[HealthCheck.too_slow],
+    )
+    _hypothesis_settings.load_profile("tldw")
+except ImportError:
+    pass
+
 # Protect against stdout/stderr being closed during testing
 # This can happen with certain test runners or when tests manipulate file descriptors
 if hasattr(sys.stdout, "fileno"):

--- a/Tests/test_hypothesis_profile.py
+++ b/Tests/test_hypothesis_profile.py
@@ -1,0 +1,49 @@
+"""TASK-1260: the suite-wide Hypothesis profile must stay loaded.
+
+`test_safe_paths_always_validate` failed once inside a three-suite run, passed
+alone, passed on re-run, and passed on a clean pre-change baseline with the
+identical command. It is a property that creates a `TemporaryDirectory` plus up
+to four directories per example, and Hypothesis' default per-example deadline is
+200ms -- which a machine running 10+ concurrent pytest processes crosses on work
+that is not actually slow.
+
+A deadline that fails a property which *holds* is measuring the machine, not the
+code. The cost is in attribution, not the failure: establishing that one instance
+was not a regression took five runs across two worktrees.
+
+These tests exist so the profile cannot be quietly dropped or "tightened back
+up" as an apparent improvement.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+hypothesis = pytest.importorskip("hypothesis")
+
+
+def test_per_example_deadline_is_disabled() -> None:
+    """A loaded machine must not be able to fail a property that holds."""
+    assert hypothesis.settings.default.deadline is None, (
+        "Hypothesis' per-example deadline is active again; property tests doing "
+        "filesystem or database work will fail intermittently under load and "
+        "read as regressions (TASK-1260)"
+    )
+
+
+def test_too_slow_health_check_is_suppressed() -> None:
+    """`too_slow` fires for the same reason the deadline does: load."""
+    suppressed = hypothesis.settings.default.suppress_health_check
+    assert hypothesis.HealthCheck.too_slow in suppressed, (
+        f"HealthCheck.too_slow is no longer suppressed, got {list(suppressed)}"
+    )
+
+
+def test_the_profile_is_the_one_this_repo_registered() -> None:
+    """Guard the guard: a default-settings object would satisfy neither check
+    by accident, but naming the profile makes the intent explicit if someone
+    later registers a different one."""
+    assert "tldw" in hypothesis.settings._profiles, (
+        "the 'tldw' Hypothesis profile is not registered; Tests/conftest.py "
+        "should register and load it"
+    )

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -344,6 +344,40 @@ not a per-file patch — other property files carry the same exposure.
 
 ---
 
+## A filter with no admitted callers is an off switch
+
+**TASK-1240, 2026-07-28.** The persistent app log wrote zero bytes. The handler
+was attached, the path resolved, the directory existed, the level was INFO.
+
+`PersistentDiagnosticFilter` admits a record only if it carries a marker set
+exclusively by `log_persistent_metadata()`. That function has **zero production
+call sites**. Every ordinary `logger.info(...)` is rejected, so the sink is
+correctly enforcing a boundary that nothing was ever migrated to cross.
+
+The privacy work that introduced it is sound and has its own ADR. The gap is
+between decision and implementation: ADR-029 requires logs be metadata-only
+*with respect to user and model content*, and the design's stated goal was to
+"keep persistent diagnostics **useful** without retaining private payload
+values". Admitting nothing satisfies the letter of the exclusion list and defeats
+the goal.
+
+**What to do.** When a sink produces nothing, check the **admission predicate
+before the plumbing**. Handler attached, path correct and level correct are all
+consistent with a filter that rejects everything. Then ask the question that
+distinguishes the two failures: *how many callers does the admitted path have?*
+Zero is the tell.
+
+And when the answer implicates a deliberate security boundary, record the gap
+and hand the decision to that work's owner. Loosening a privacy filter to make
+your own diagnostics visible is not a fix you get to make alone.
+
+This is the fourth instance of one shape in a single session: a closed import
+cycle, a flag gating the only executor, a prompt surface with no consumer, and
+now a log sink with no admitted caller. Each was built, wired, and given nothing
+to carry — and each read as live to a grep.
+
+---
+
 ## Related
 
 - `lessons-live-verification.md` — why the suite could not see seven of these defects

--- a/backlog/tasks/task-1240 - A-fresh-profile-writes-a-zero-byte-app-log.md
+++ b/backlog/tasks/task-1240 - A-fresh-profile-writes-a-zero-byte-app-log.md
@@ -1,47 +1,74 @@
 ---
 id: TASK-1240
-title: A fresh profile writes a zero-byte app log
+title: The persistent app log admits nothing, so every profile writes a zero-byte log
 status: To Do
 assignee: []
 created_date: '2026-07-28 10:20'
 labels:
   - logging
   - observability
+  - privacy
 priority: high
 ---
 
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Running the app under a fresh profile produces a `tldw_cli_app.log` of **zero bytes** — after a full
-boot, a minute of real work (a scheduled watchlist check that fetched and persisted 5 items from a
-live feed), and a clean `Ctrl+Q` shutdown. The path resolves correctly:
-`get_cli_log_file_path()` returns `~/.local/share/tldw_cli/<user>/tldw_cli_app.log`, the file is
-created, and nothing is ever written to it.
+**Corrected diagnosis (2026-07-28).** This was filed as "a fresh profile writes a zero-byte app
+log", on the evidence that a new profile produced 0 bytes while long-lived `default_user` held
+8.4 MB. That framing was wrong in two ways: it is not specific to fresh profiles, and the cause is
+not a missing handler.
 
-The long-lived `default_user` profile has an 8.4 MB log, so file logging works somewhere. Whatever
-attaches the file handler does not happen for a new profile, or happens after the records it should
-capture.
+`PersistentDiagnosticFilter` is attached to the one persistent file sink
+(`PrivateRotatingFileHandler`) and admits a record only when it carries the
+`_tldw_metadata_only_record` marker, which is set exclusively by
+`Utils/persistent_diagnostics.log_persistent_metadata()`:
 
-Reproduced with two different scratch configs, one of which set `[logging] log_filename` and
-`file_log_level = "INFO"` explicitly.
+```python
+def filter(self, record):
+    if _is_chatbook_record(record):
+        return getattr(record, _PERSISTENT_METADATA_MARKER, False) is True
+    return False          # third-party records are rejected outright
+```
 
-**Why this matters beyond logging.** It is the second half of the failure TASK-1212 exists to fix.
-Watchlist checks silently did nothing for the life of the feature because a working scheduler and an
-unwired one were indistinguishable by observation. TASK-1212 adds structured startup reporting, but
-a user on a fresh install has nowhere to read it: the file log is empty, and the in-app Logs screen
-only starts buffering once its persistent handler is installed, which is after early startup work
-has already logged.
+**`log_persistent_metadata` has zero production call sites.** Every operational diagnostic in the
+app goes through `logger.info(...)` / loguru and is therefore rejected. The sink is correctly
+enforcing a boundary that nothing has been migrated to cross.
 
-Diagnosing the original scheduling defect required a runtime import trace and a seeded database
-probe. It should have required reading a log line.
+`Metrics/logger_config.py` deliberately disables the alternate Loguru file sinks, so there is no
+second path. Terminal and in-app UI handlers are unaffected and remain descriptive, which is why the
+Logs screen still works and made the file log look like the anomaly.
+
+**It affects every profile, not new ones.** The filter reached the file handler in `1df0c4cb4`
+(2026-07-27). `default_user`'s log looks healthy only because its last entry is 2026-07-26 — it is
+a historical file that stopped growing when the filter landed. Any profile, old or new, has written
+nothing since.
+
+**Where the gap is.** ADR-029 requires that "persistent application logs are metadata-only **with
+respect to user and model content**", listing prompts, message bodies, provider payloads, key
+fragments and tool values. It does not call for excluding operational diagnostics. The privacy
+design's own goals include "keep persistent diagnostics **useful** without retaining private payload
+values" and "disable only unsafe persistent file sinks while retaining terminal/UI logs". The
+implementation is stricter than the decision: it admits nothing at all, so "useful" is not met.
+
+**Why this is not a unilateral fix.** Changing what reaches this sink means changing a deliberate
+security boundary with its own ADR (029), design spec, inventory
+(`Docs/security/production-diagnostic-inventory.json`) and task series (489-494). The decision of
+which operational diagnostics may be persisted, and in what shape, belongs to that work's owner.
+This task records the gap and the evidence; it should not be closed by loosening the filter.
+
+**Why it matters.** Watchlist checks did nothing for the entire life of the feature and it went
+unnoticed because a working scheduler and an unwired one were indistinguishable by observation
+(TASK-1210, TASK-1212). Diagnosing it needed a runtime import trace and a seeded database probe.
+With an operational log it would have needed one line. TASK-1212 added structured scheduler startup
+reporting that currently has nowhere to land.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A fresh profile's tldw_cli_app.log contains startup records after a normal boot
-- [ ] #2 Records emitted before the in-app Logs screen's persistent handler is installed still reach the file log
-- [ ] #3 The behaviour is identical for a brand-new profile and a long-lived one
-- [ ] #4 A test asserts the file handler is attached, by running a boot path and checking the log is non-empty rather than by asserting the handler exists
-- [ ] #5 If file logging is intentionally deferred or disabled under some condition, that condition is documented where the log path is resolved
+- [ ] #1 A decision is recorded on which operational diagnostics may be persisted, consistent with ADR-029's scope (user and model content) rather than the current admit-nothing behaviour
+- [ ] #2 If operational diagnostics are to be persisted, representative ones - scheduler startup and handler registration, background worker failures, unhandled exceptions - reach the file log through the metadata-only API
+- [ ] #3 The boundary continues to reject prompts, message bodies, provider payloads, key fragments and tool values, with the existing sentinel matrices still passing
+- [ ] #4 A test asserts the log is non-empty after a boot path, rather than asserting a handler is attached
+- [ ] #5 If admitting nothing is the intended end state, ADR-029 and the privacy design's "keep persistent diagnostics useful" goal are amended to say so, and the app documents where operational diagnostics can be read instead
 <!-- AC:END -->

--- a/backlog/tasks/task-1260 - Path-validation-property-tests-fail-under-machine-load.md
+++ b/backlog/tasks/task-1260 - Path-validation-property-tests-fail-under-machine-load.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1260
 title: Path-validation property tests fail under machine load, producing false regression signals
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-28 10:55'
 labels:
@@ -46,9 +46,32 @@ rather than a one-line patch to this file.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A Hypothesis settings profile is registered in Tests/conftest.py and applied to the suite, rather than each property file setting its own deadline
-- [ ] #2 The profile disables or substantially raises the per-example deadline, so a loaded machine cannot fail a property that holds
-- [ ] #3 Property tests that do real filesystem or database work are identified, and the profile covers them
-- [ ] #4 test_safe_paths_always_validate passes when its suite runs concurrently with at least two other large suites under load
-- [ ] #5 The reason the deadline is relaxed is recorded next to the profile, so it is not "tightened back up" later as an apparent improvement
+- [x] #1 A Hypothesis settings profile is registered in Tests/conftest.py and applied to the suite, rather than each property file setting its own deadline
+- [x] #2 The profile disables or substantially raises the per-example deadline, so a loaded machine cannot fail a property that holds
+- [x] #3 Property tests that do real filesystem or database work are identified, and the profile covers them
+- [x] #4 test_safe_paths_always_validate passes when its suite runs concurrently with at least two other large suites under load
+- [x] #5 The reason the deadline is relaxed is recorded next to the profile, so it is not "tightened back up" later as an apparent improvement
 <!-- AC:END -->
+
+## Implementation Notes
+
+A `tldw` Hypothesis profile is registered and loaded in `Tests/conftest.py` with `deadline=None` and
+`HealthCheck.too_slow` suppressed. Registering it once in the root conftest covers every property
+file rather than patching the one that happened to fail; the other property suites (DB, path,
+validation) carry the same exposure.
+
+**The deadline is disabled rather than raised.** A larger number only moves the threshold a loaded
+machine will eventually cross, and the failure it produces is indistinguishable from a real
+regression. A deadline that fails a property which *holds* is measuring the machine, not the code.
+Timing belongs in benchmarks, not correctness properties. The comment beside the profile says this
+explicitly, per AC#5, so it is not "tightened back up" later as an apparent improvement.
+
+**Mutation-checked twice.** A throwaway property sleeping 250ms per example fails with
+`DeadlineExceeded` when the profile is not loaded and passes when it is -- confirming the diagnosed
+mechanism directly rather than by inference. And setting `deadline=200` in the profile fails
+`test_per_example_deadline_is_disabled`, so the permanent guard is not vacuous.
+
+`Tests/test_hypothesis_profile.py` asserts the deadline is disabled, `too_slow` is suppressed, and
+the profile is the one this repo registered.
+
+Modified: `Tests/conftest.py`. Added: `Tests/test_hypothesis_profile.py`.


### PR DESCRIPTION
Closes TASK-1260. **Corrects** TASK-1240's diagnosis without fixing it — deliberately, see below.

## TASK-1240: I filed it wrong, and the real answer is a decision that isn't mine

I filed 1240 as *"a fresh profile writes a zero-byte app log"*, on the evidence that a new profile produced 0 bytes while long-lived `default_user` held 8.4 MB. **Both halves of that framing were wrong.**

`PersistentDiagnosticFilter` is attached to the one persistent file sink and admits a record only if it carries a marker set exclusively by `log_persistent_metadata()`:

```python
def filter(self, record):
    if _is_chatbook_record(record):
        return getattr(record, _PERSISTENT_METADATA_MARKER, False) is True
    return False          # third-party records rejected outright
```

**`log_persistent_metadata` has zero production call sites.** Every operational diagnostic goes through `logger.info(...)` and is rejected. `Metrics/logger_config.py` deliberately disables the alternate Loguru sinks, so there is no second path. The sink is correctly enforcing a boundary that nothing was ever migrated to cross.

**And it is not fresh-profile-specific.** The filter reached the file handler in `1df0c4cb4` (2026-07-27); `default_user`'s last entry is 2026-07-26. That 8.4 MB file is a historical artifact that stopped growing, not a working log. Every profile — old or new — has written nothing since.

### Why this PR does not fix it

ADR-029 requires persistent logs be metadata-only **with respect to user and model content** — prompts, message bodies, provider payloads, key fragments, tool values. It does not call for excluding operational diagnostics. The privacy design's own goals include *"keep persistent diagnostics **useful** without retaining private payload values"* and *"disable only unsafe persistent file sinks while retaining terminal/UI logs"*. The implementation is stricter than the decision: it admits nothing, so "useful" is not met.

That gap is real, but closing it means changing a deliberate security boundary with its own ADR, design spec, checked inventory (`Docs/security/production-diagnostic-inventory.json`) and task series (489-494). **Which operational diagnostics may be persisted, and in what shape, is that work's decision to make.** Loosening a privacy filter so my own diagnostics become visible is not a call I should make alone.

So the task now carries the corrected diagnosis, the evidence, and both possible resolutions — including "if admitting nothing is the intended end state, amend ADR-029 and document where operational diagnostics can be read instead." The 28 privacy-boundary tests are untouched and passing.

## TASK-1260: fixed

A `tldw` Hypothesis profile registered and loaded in `Tests/conftest.py` — `deadline=None`, `HealthCheck.too_slow` suppressed. Registered once in the root conftest rather than patched into the one file that happened to fail; the DB, path and validation property suites carry the same exposure.

**Disabled rather than raised.** A larger number only moves the threshold a loaded machine eventually crosses, and the failure it produces is indistinguishable from a real regression — attributing one instance cost five runs across two worktrees. A deadline that fails a property which *holds* is measuring the machine, not the code. The comment beside the profile says so explicitly (AC#5), so it isn't "tightened back up" later as an apparent improvement.

**Mutation-checked twice:**
- A throwaway property sleeping 250 ms per example fails with `DeadlineExceeded` without the profile and passes with it — confirming the diagnosed mechanism directly rather than by inference.
- Setting `deadline=200` in the profile fails `test_per_example_deadline_is_disabled`, so the permanent guard is not vacuous.

## The pattern worth naming

This is the **fourth instance of one shape in a single session**: a closed import cycle (#1058), a flag gating the only executor (#1054), a prompt surface with no consumer (#1061), and now a log sink with no admitted caller. Each was built, wired, and given nothing to carry — and each read as live to a grep.

`lessons-testing-evidence.md` gains the diagnostic: when a sink produces nothing, check the **admission predicate before the plumbing** — handler attached, path correct and level correct are all consistent with a filter that rejects everything. Then ask how many callers the admitted path has. Zero is the tell.

## Tests

924 passed, 0 failed across `Tests/Subscriptions/`, `Tests/Scheduling/`, `Tests/Utils/`, the new profile guard, and the three privacy-boundary suites.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled the suite-wide `hypothesis` per-example deadline and suppressed the too_slow health check to stop flaky property test failures under load (TASK-1260). Also corrected TASK-1240’s scope: the persistent app log admits nothing for all profiles due to `PersistentDiagnosticFilter`; no logging behavior is changed here and the decision is deferred to the privacy work.

- **Bug Fixes**
  - Registered and loaded a `hypothesis` profile in `Tests/conftest.py` with `deadline=None` and `HealthCheck.too_slow` suppressed; added `Tests/test_hypothesis_profile.py` to guard it (TASK-1260).
  - Updated TASK-1240 docs/backlog to reflect the correct diagnosis and link it to ADR-029; logging stays unchanged pending a policy decision.

<sup>Written for commit 3e3cad0b8b0e8500198c69906a5094fe0edc5fca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

