### PR TITLE
feat(packaging): give image generation its own extra [TASK-1262, TASK-1263]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,13 @@ This file provides comprehensive guidance to Claude Code (claude.ai/code) when w
 ```bash
 # Setup
 python3 -m venv .venv && source .venv/bin/activate
-pip install -e ".[dev]"  # Or specific: .[embeddings_rag,websearch,local_vllm,ebook,pdf]
+pip install -e ".[dev]"  # Or specific: .[embeddings_rag,websearch,local_vllm,ebook,pdf,image_generation]
+
+# NOTE: the checked-out .venv here is uv-managed (see .venv/pyvenv.cfg) and ships
+# NO pip, so the line above fails with "No module named pip" against it. Use:
+#   VIRTUAL_ENV=.venv uv pip install -e ".[dev]"
+# Dev deps are often absent from a fresh clone's venv -- if `pytest` is missing,
+# install it before assuming the suite is broken.
 
 # Run
 python3 -m tldw_chatbook.app
@@ -428,7 +434,7 @@ A task is **Done** only when **ALL** of the following are complete:
 | Create with labels      | `backlog task create "Feature" -l auth,backend`                                                                                                               |
 | Create with priority    | `backlog task create "Feature" --priority high`                                                                                                               |
 | Create with plan        | `backlog task create "Feature" --plan "1. Research\n2. Implement"`                                                                                            |
-| Create with AC          | `backlog task create "Feature" --ac "Must work,Must be tested"`                                                                                               |
+| Create with AC          | `backlog task create "Feature" --ac "Must work" --ac "Must be tested"` (repeat the flag; `--ac "a,b"` does NOT split on commas -- it writes one run-on criterion that cannot be ticked off individually) |
 | Create with notes       | `backlog task create "Feature" --notes "Started initial research"`                                                                                            |
 | Create with deps        | `backlog task create "Feature" --dep task-1,task-2`                                                                                                           |
 | Create sub task         | `backlog task create -p 14 "Add Login with Google"`                                                                                                           |

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -185,9 +185,11 @@ therefore cannot see a dependency that is *declared* optional but has become
 
 **What happened.** 2026-07-27: the app died on start with
 `RuntimeError: Unable to resolve default chat screen`. `aiohttp` is optional —
-declared only in the `[websearch]`/`[all-tools]` extras, and registered
-`"aiohttp": False` in `Utils/optional_deps.py` — but the `/generate-image`
-console feature had quietly wired it onto the **default** screen's import chain:
+at the time declared only in the `[websearch]`/`[all-tools]` extras (task-1262
+has since given image generation its own `[image_generation]` extra), and
+registered `"aiohttp": False` in `Utils/optional_deps.py` — but the
+`/generate-image` console feature had quietly wired it onto the **default**
+screen's import chain:
 
 ```
 UI/Screens/chat_screen.py

--- a/backlog/tasks/task-1262 - Give-SwarmUI-image-generation-a-declaring-extra-for-aiohttp.md
+++ b/backlog/tasks/task-1262 - Give-SwarmUI-image-generation-a-declaring-extra-for-aiohttp.md
@@ -1,0 +1,58 @@
+---
+id: TASK-1262
+title: Give SwarmUI image generation a declaring extra for aiohttp
+status: Done
+assignee: []
+created_date: '2026-07-28 19:13'
+labels:
+  - packaging
+  - imagegen
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+aiohttp is required by SwarmUI image generation but is declared in no extra that names image generation: it ships only in [websearch] (for the article scraper) and [all-tools]. A user who wants image generation is therefore told to install the web-search extra, pulling ten unrelated packages (lxml, beautifulsoup4, pandas, playwright, trafilatura, langdetect, nltk, scikit-learn, defusedxml, tqdm) to obtain one HTTP client. This also forced a workaround in task-1261's sibling fix: the optional_deps guard cannot pass feature_name='websearch' without clobbering the DEPENDENCIES_AVAILABLE key that check_websearch_deps() owns, so the install hint had to be hand-written.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 An extra exists that names image generation and provides aiohttp
+- [x] #2 The install hint raised by swarmui_client._require_aiohttp() names that extra rather than [websearch]
+- [x] #3 The new extra is included in all-tools
+- [x] #4 Existing aiohttp consumers keep working: the article scraper via [websearch], the web server via [web] -> textual-serve
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Confirm which aiohttp consumers actually lack a declaring extra.
+2. Add an `image_generation` extra; keep aiohttp in `[websearch]` for the scraper.
+3. Point `_require_aiohttp()`'s hint at the new extra.
+4. Add the matching `OPTIONAL_FEATURES` metadata entry (a test enforces coverage).
+5. Prove the resolution with a dry-run install into a throwaway venv.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Scope check first.** aiohttp has three consumers, not one, and only one was actually unserved:
+
+| Consumer | Declaring extra |
+|---|---|
+| `Web_Scraping/Article_Scraper/crawler.py` | `[websearch]` — correct, left alone |
+| `Web_Server/serve.py` | `[web]` → `textual-serve`, which requires `aiohttp>=3.9.5` and `aiohttp-jinja2>=1.6` — covered transitively |
+| `Media_Creation/swarmui_client.py` | none — the gap |
+
+So this adds `image_generation = ["aiohttp"]` rather than moving anything. aiohttp stays in `[websearch]`; `all-tools` enumerates packages rather than extras and already listed it, now with a comment noting it serves both.
+
+**Measured effect.** Dry-run resolve into a throwaway uv venv: `[image_generation]` → 59 packages, `[websearch]` → 86. A user who wants image generation no longer installs playwright, trafilatura, pandas, nltk and scikit-learn to obtain one HTTP client.
+
+**Metadata.** `Tests/Utils/test_optional_deps.py::test_optional_feature_metadata_covers_pyproject_extras` asserts every pyproject extra has recovery metadata, and correctly failed on the new extra. Added an `OPTIONAL_FEATURES` entry under a new `AREA_MEDIA_CREATION` — `AREA_MEDIA` is "Media ingestion and transcription", which is the wrong side of the ingest/create line. Recovery action is `Console > /generate-image`: no settings screen owns `media_creation`, so pointing at one would have been invented.
+
+**Not done:** the guard still keys `DEPENDENCIES_AVAILABLE` on `"aiohttp"` rather than switching to `require_dependency("aiohttp", "image_generation")`, which the new extra would now make collision-free. Keying on the package keeps one accurate entry across all three consumers instead of one per feature; the reasoning is recorded in `_safe_import_aiohttp()`'s docstring.
+
+**Modified files.** `pyproject.toml`, `tldw_chatbook/Media_Creation/swarmui_client.py`, `tldw_chatbook/Utils/optional_deps.py`, `backlog/docs/lessons-testing-evidence.md` (dated the now-superseded "[websearch] only" claim).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-1263 - Correct-CLAUDE.md-instructions-that-do-not-work-in-this-repo.md
+++ b/backlog/tasks/task-1263 - Correct-CLAUDE.md-instructions-that-do-not-work-in-this-repo.md
@@ -1,0 +1,38 @@
+---
+id: TASK-1263
+title: Correct CLAUDE.md instructions that do not work in this repo
+status: Done
+assignee: []
+created_date: '2026-07-28 19:13'
+labels:
+  - docs
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Two commands CLAUDE.md gives as canonical fail when run. The setup section says 'pip install -e ".[dev]"', but the project venv is uv-managed and ships no pip module, so both 'pip' and 'python3 -m pip' fail; the working form is 'VIRTUAL_ENV=.venv uv pip install'. Separately, the Backlog.md section documents '--ac "Must work,Must be tested"' as producing two criteria; CLI v1.44.0 does not split on commas and writes a single run-on criterion, which cannot be checked off independently and so breaks the Definition of Done's per-item completion. Both cost time in the 2026-07-27 aiohttp startup investigation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The setup section documents the uv-based install command that actually works in this venv
+- [x] #2 The Backlog.md --ac example shows a form that produces separate criteria (repeated --ac flags, verified working on CLI v1.44.0)
+- [x] #3 No other CLAUDE.md guidance is altered
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Two documented commands failed when run; both are corrected in place rather than deleted, since the canonical form is still right for a normal pip venv.
+
+**Setup.** `pip install -e ".[dev]"` fails against the checked-out `.venv`, which is uv-managed (`.venv/pyvenv.cfg`: `uv = 0.11.7`) and ships no `pip` module — both `pip` and `python3 -m pip` error. Added the working `VIRTUAL_ENV=.venv uv pip install -e ".[dev]"` form plus a note that dev deps are often absent entirely, so a missing `pytest` is not evidence the suite is broken. Also added `image_generation` to the example extras list (task-1262).
+
+**Backlog CLI.** The `--ac "Must work,Must be tested"` example does not produce two criteria on CLI v1.44.0 — it writes one run-on criterion that cannot be ticked off individually, which quietly breaks the DoD's per-item completion. Verified the working form (repeat the flag) while filing task-1262: four `--ac` flags produced four separate criteria.
+
+Both traps are already recorded with their incidents in `lessons-backlog-hygiene.md`; this fixes the source that produced them.
+
+**Modified files.** `CLAUDE.md` (two passages; no other guidance touched).
+<!-- SECTION:NOTES:END -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,13 @@ local_transformers = ["transformers"]
 mcp = [
     "mcp[cli]>=1.0.0",
 ]
+image_generation = [
+    # SwarmUI API client (Media_Creation/swarmui_client.py). aiohttp previously
+    # shipped only in [websearch] -- for the article scraper -- so wanting image
+    # generation meant installing the web-search stack (playwright, trafilatura,
+    # pandas, nltk, scikit-learn, ...) to obtain one HTTP client (task-1262).
+    "aiohttp",
+]
 svg = [
     "cairosvg",  # SVG rasterization for image attachments; needs the cairo C library (e.g. `brew install cairo`)
 ]
@@ -325,6 +332,8 @@ all-tools = [
     "pandas",
     "playwright",
     "trafilatura",
+    # Serves both [websearch] (article scraper) and [image_generation]
+    # (SwarmUI client); listed once here since all-tools enumerates packages.
     "aiohttp",
     "defusedxml",
     

--- a/tldw_chatbook/Media_Creation/swarmui_client.py
+++ b/tldw_chatbook/Media_Creation/swarmui_client.py
@@ -16,9 +16,10 @@ if TYPE_CHECKING:  # pragma: no cover - typing only, never imported at runtime
 def _require_aiohttp():
     """Import `aiohttp` on demand, with an actionable message when absent.
 
-    `aiohttp` is an OPTIONAL dependency -- it is declared only in the
-    ``[websearch]``/``[all-tools]`` extras and registered ``"aiohttp": False``
-    in ``Utils/optional_deps.py``. Importing it at module scope put it on the
+    `aiohttp` is an OPTIONAL dependency -- it ships in the
+    ``[image_generation]``/``[all-tools]`` extras and is registered
+    ``"aiohttp": False`` in ``Utils/optional_deps.py``. Importing it at
+    module scope put it on the
     mandatory startup path (this module <- ImageGenerationService <-
     console_generate_image <- the default chat screen), so a plain install
     without an extra died on boot with ``RuntimeError: Unable to resolve
@@ -37,7 +38,7 @@ def _require_aiohttp():
     if aiohttp is None:
         raise ImportError(
             "SwarmUI image generation requires the optional 'aiohttp' package. "
-            "Install it with: pip install 'tldw_chatbook[websearch]'"
+            "Install it with: pip install 'tldw_chatbook[image_generation]'"
         )
     return aiohttp
 
@@ -52,14 +53,17 @@ def _safe_import_aiohttp():
     module's own import cost unchanged.
 
     Note the deliberate ``feature_name`` choice: the default keys the result
-    as ``"aiohttp"``, which is the existing entry in ``DEPENDENCIES_AVAILABLE``.
-    Passing ``"websearch"`` -- the extra that actually ships aiohttp -- would
-    be wrong, because ``check_websearch_deps()`` owns that key and derives it
-    from lxml/bs4/trafilatura/langdetect; clobbering it from here would report
-    web search as available on an aiohttp-only install. The correct extra is
-    named in `_require_aiohttp()`'s error message instead, since
-    `require_dependency()`'s generated hint (``[aiohttp]``) is not a real
-    extra.
+    as ``"aiohttp"``, the existing entry in ``DEPENDENCIES_AVAILABLE``. It must
+    not be keyed as ``"websearch"`` -- aiohttp also ships in that extra for the
+    article scraper, but ``check_websearch_deps()`` owns that key and derives
+    it from lxml/bs4/trafilatura/langdetect, so writing it here would report
+    web search as available on an aiohttp-only install.
+
+    ``"image_generation"`` (added in task-1262) would be collision-free, but
+    keying on the package rather than the feature keeps one entry accurate for
+    every consumer of aiohttp instead of one per feature. Nothing currently
+    reads either key; the extra a user should install is named in
+    `_require_aiohttp()`'s message.
 
     Returns:
         The ``aiohttp`` module, or ``None`` when it is not installed.

--- a/tldw_chatbook/Utils/optional_deps.py
+++ b/tldw_chatbook/Utils/optional_deps.py
@@ -153,6 +153,7 @@ class OptionalFeatureInfo:
 
 AREA_RAG = "RAG and retrieval"
 AREA_MEDIA = "Media ingestion and transcription"
+AREA_MEDIA_CREATION = "Media creation"
 AREA_MCP = "MCP integration"
 AREA_LOCAL_INFERENCE = "Local inference"
 AREA_WEB = "Web access"
@@ -294,6 +295,18 @@ OPTIONAL_FEATURES: dict[str, OptionalFeatureInfo] = {
         "STTS",
         "Higgs Audio TTS",
         OWNER_LIBRARY_MEDIA,
+    ),
+    "image_generation": _feature(
+        "image_generation",
+        "SwarmUI image generation",
+        AREA_MEDIA_CREATION,
+        ("aiohttp",),
+        # No settings screen owns media_creation; `/generate-image` in the
+        # Console is the real entry point, and SwarmUI is configured under
+        # [media_creation.swarmui] in config.toml.
+        "Console > /generate-image",
+        "Image generation",
+        OWNER_CONSOLE_PROVIDER,
     ),
     "local_mlx": _feature(
         "local_mlx",


### PR DESCRIPTION
Closes TASK-1262 and TASK-1263.

## The gap

`aiohttp` is required by SwarmUI image generation but was declared in **no extra that names image generation** — only `[websearch]` (for the article scraper) and `[all-tools]`. So the install hint added with the boot-crash fix (#1051) told a user who wanted *image generation* to install *web search*.

## Scope was checked before changing anything

aiohttp has three consumers, and only one was actually unserved:

| Consumer | Declaring extra | Verdict |
|---|---|---|
| `Web_Scraping/Article_Scraper/crawler.py` | `[websearch]` | correct — left alone |
| `Web_Server/serve.py` | `[web]` → `textual-serve`, which requires `aiohttp>=3.9.5` + `aiohttp-jinja2>=1.6` | covered transitively |
| `Media_Creation/swarmui_client.py` | **none** | the gap |

So this **adds** `image_generation = ["aiohttp"]` rather than moving anything. `[websearch]` keeps aiohttp for the scraper, and `all-tools` (which enumerates packages, not extras) already listed it — now with a comment noting it serves both.

## Measured effect

Dry-run resolve into a throwaway uv venv:

| Extra | Packages installed |
|---|---|
| `[image_generation]` | **59** |
| `[websearch]` (the old instruction) | 86 |

27 fewer packages — no playwright, trafilatura, pandas, nltk or scikit-learn to obtain one HTTP client.

Runtime hint verified with aiohttp blocked:
```
SwarmUI image generation requires the optional 'aiohttp' package.
Install it with: pip install 'tldw_chatbook[image_generation]'
```

## Metadata (caught by an existing test)

`Tests/Utils/test_optional_deps.py::test_optional_feature_metadata_covers_pyproject_extras` asserts every pyproject extra carries recovery metadata, and correctly failed on the new extra — a good guard.

Added the `OPTIONAL_FEATURES` entry under a **new** `AREA_MEDIA_CREATION`: the existing `AREA_MEDIA` is "Media ingestion and transcription", which is the wrong side of the ingest/create line. Recovery action is `Console > /generate-image` — no settings screen owns `media_creation`, so pointing at one would have been invented.

## TASK-1263: CLAUDE.md instructions that don't work

Both cost time during the original investigation, and both already have lessons entries with their incidents; this fixes the source that produced them.

- **`pip install -e ".[dev]"`** — the checked-out `.venv` is uv-managed (`pyvenv.cfg`: `uv = 0.11.7`) and ships no `pip`, so this fails with `No module named pip`. Added the working `VIRTUAL_ENV=.venv uv pip install` form, plus a note that dev deps are often absent entirely, so a missing `pytest` isn't evidence the suite is broken.
- **`--ac "Must work,Must be tested"`** — does not split on commas in CLI v1.44.0; it writes one run-on criterion that can't be ticked off individually, quietly breaking the DoD's per-item completion. Corrected to repeated flags, which I verified while filing TASK-1262 (four flags → four criteria).

## Also

Dated the now-superseded "declared only in `[websearch]`" claim in the `lessons-testing-evidence.md` entry from #1064, so it reads as the state at the time rather than current fact.

## Deliberately not done

The guard still keys `DEPENDENCIES_AVAILABLE` on `"aiohttp"` rather than switching to `require_dependency("aiohttp", "image_generation")`, which the new extra would now make collision-free. Keying on the package keeps one accurate entry across all three consumers instead of one per feature; the reasoning is recorded in `_safe_import_aiohttp()`'s docstring.

## Verification

`318 passed, 9 skipped` across `Tests/Utils/test_optional_deps.py`, `Tests/Media_Creation`, `Tests/Image_Generation`, and `Tests/Utils/test_optional_import_deferral.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a dedicated `image_generation` extra that installs `aiohttp` for SwarmUI image generation, so users don’t have to install the web-search stack. Also fixes broken setup and Backlog CLI examples in `CLAUDE.md`. Addresses TASK-1262 and TASK-1263.

- **Dependencies**
  - Added `[image_generation] = ["aiohttp"]` in `pyproject.toml`; kept `aiohttp` in `[websearch]`; `all-tools` still lists `aiohttp`.
  - Updated `swarmui_client.py` to hint: `pip install 'tldw_chatbook[image_generation]'`.
  - Added optional feature metadata for `image_generation` under new `AREA_MEDIA_CREATION` in `optional_deps.py`.
  - Impact: `[image_generation]` installs ~59 packages vs ~86 with `[websearch]` (≈27 fewer).

- **Bug Fixes**
  - `CLAUDE.md`: replace failing `pip install -e ".[dev]"` with `VIRTUAL_ENV=.venv uv pip install -e ".[dev]"` for the repo’s uv-managed `.venv`.
  - `CLAUDE.md`: correct Backlog example to use repeated `--ac` flags (not comma-separated).

<sup>Written for commit 5d6a515cc9116a925f234e0f4c1760f4ef48882f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

