### PR TITLE
fix: make a click on a table row select it, app-wide (TASK-1180)

### DIFF
--- a/Tests/UI/test_mcp_table_click_selects_end_to_end.py
+++ b/Tests/UI/test_mcp_table_click_selects_end_to_end.py
@@ -1,0 +1,118 @@
+"""TASK-1180 AC#1: a click on the MCP Tools table reaches the Inspector.
+
+`Tests/UI/test_table_click_selects.py` proves the pane posts its selection
+message on highlight. This proves the other half — that the message reaches the
+real `MCPWorkbench` and changes what the Inspector shows — using the real
+screen, workbench and inspector rather than a bare pane.
+
+The two halves matter separately: the pane could post correctly into a workbench
+that never handled it, which is the shape of defect this session kept finding.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.widgets import DataTable
+
+from Tests.UI.test_destination_shells import (
+    DestinationHarness,
+    _active_destination_screen,
+    _wait_for_selector,
+)
+from Tests.UI.test_screen_navigation import _build_test_app
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_clicking_a_tool_row_updates_the_inspector_end_to_end():
+    """A single click — i.e. a `RowHighlighted` — must select through to the
+    workbench, not merely move the DataTable cursor."""
+    from tldw_chatbook.MCP.hub_tool_catalog import HubTool
+
+    app = _build_test_app()
+    host = DestinationHarness(app, "mcp")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_selector(screen, pilot, "#mcp-hub-rail")
+        screen.action_mcp_mode("tools")
+        await pilot.pause()
+
+        tool = HubTool(
+            name="search",
+            server_key="local:docs",
+            server_label="docs",
+            source="local",
+            description="Search docs",
+            tags=(),
+            input_schema=None,
+            executable=True,
+            stale=False,
+        )
+        screen.workbench._last_hub_tools = [tool]
+
+        tools_mode = screen.query_one("MCPToolsMode")
+        table = tools_mode.query_one(DataTable)
+        row_key = table.add_row(tool.name, tool.server_label, key=tool.tool_id)
+        # A click focuses the table before moving the cursor; the mixin gates on
+        # that, because an unfocused table moving its own cursor is a
+        # repopulation rather than a person.
+        table.focus()
+        await pilot.pause()
+
+        # Exactly what a single click produces once the cursor lands on the row.
+        tools_mode.post_message(DataTable.RowHighlighted(table, 0, row_key))
+        await pilot.pause()
+        await pilot.pause()
+
+        # `current_tool` is the inspector's own public accessor for what its
+        # tool-detail view currently describes -- the thing a user sees change.
+        from tldw_chatbook.UI.MCP_Modules.mcp_inspector import MCPInspector
+
+        inspector = screen.query_one(MCPInspector)
+        shown = inspector.current_tool
+        assert shown is not None and shown.tool_id == tool.tool_id, (
+            "clicking a tool row did not reach the Inspector: the pane handles "
+            f"only activation, so the tool view still shows {shown!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_opening_tools_mode_selects_nothing_on_its_own():
+    """The regression the focus gate exists to prevent.
+
+    A first draft of the mixin forwarded every `RowHighlighted`, including the
+    ones a pane's own `clear()`/`add_row()` produce. On this screen a selection
+    triggers an awaited remove/mount in `MCPInspector`, which re-syncs the mode,
+    which repopulates the table, which highlights row 0 again: opening the Tools
+    tab with no user input produced **157** selections and buried a real click
+    under the repeats.
+    """
+    app = _build_test_app()
+    host = DestinationHarness(app, "mcp")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_selector(screen, pilot, "#mcp-hub-rail")
+
+        selections: list[str] = []
+        workbench_cls = type(screen.workbench)
+        original = workbench_cls.on_mcp_tools_mode_tool_selected
+
+        async def _record(self, event):
+            selections.append(event.tool_id)
+            return await original(self, event)
+
+        workbench_cls.on_mcp_tools_mode_tool_selected = _record
+        try:
+            screen.action_mcp_mode("tools")
+            for _ in range(6):
+                await pilot.pause()
+        finally:
+            workbench_cls.on_mcp_tools_mode_tool_selected = original
+
+        assert selections == [], (
+            f"opening Tools mode selected {len(selections)} time(s) with no user "
+            "input; a repopulating table is driving the Inspector"
+        )

--- a/Tests/UI/test_table_click_selects.py
+++ b/Tests/UI/test_table_click_selects.py
@@ -161,6 +161,113 @@ async def test_the_same_row_highlighted_twice_selects_once():
 
 
 @pytest.mark.asyncio
+async def test_arrowing_then_pressing_enter_selects_once_not_twice():
+    """The gesture the highlight-forwarding makes ambiguous.
+
+    Once a highlight selects, a user who arrows onto a row and *then* presses
+    Enter would be processed twice — once by the forwarded highlight, once by
+    Textual's native `RowSelected`. Harmless for an idempotent handler, wrong
+    for one that posts a message: `test_row_selection_posts_entry_selected_with_
+    synthetic_index` asserts exactly one event for exactly this.
+
+    Raised by review, and missed by my own run because `-q` suppressed the
+    summary lines the failures appeared in.
+    """
+    from tldw_chatbook.UI.MCP_Modules.mcp_tools_mode import MCPToolsMode
+
+    pane = MCPToolsMode()
+    app = _Harness(pane)
+    async with app.run_test(size=(120, 40)) as pilot:
+        table = pane.query_one(DataTable)
+        table.add_row("echo", "server-a", key="tool-echo")
+        row_key = table.add_row("fetch", "server-b", key="tool-fetch")
+        table.focus()
+        await pilot.pause()
+
+        # Arrow onto the row: the highlight selects it.
+        pane.post_message(_click_row(table, row_key))
+        await pilot.pause()
+        # Then activate it, exactly as `pilot.press("enter")` would.
+        pane.post_message(DataTable.RowSelected(table, 1, row_key))
+        await pilot.pause()
+        await pilot.pause()
+
+        selected = [m for m in app.captured if type(m).__name__ == "ToolSelected"]
+        assert len(selected) == 1, (
+            f"one gesture produced {len(selected)} selections; the native "
+            "activation was not deduped against the highlight that preceded it"
+        )
+
+
+@pytest.mark.asyncio
+async def test_reselecting_the_same_row_later_is_not_swallowed():
+    """The dedup must be one-shot, scoped to a single gesture.
+
+    A persistent "last selected key" looks equivalent and is not: re-selecting
+    the same row later — which `goto_permission_row()` and the workbench's
+    sub-view triggers both do — would be silently dropped. That broke
+    `test_goto_permission_row_is_the_single_shared_implementation_for_all_three_
+    triggers` and `test_both_sub_view_selections_do_not_stack_visible_detail_
+    panels`, but only in the full-file run, because those two need a prior test
+    to leave the key set. This asserts the property directly so it fails alone.
+    """
+    from tldw_chatbook.UI.MCP_Modules.mcp_tools_mode import MCPToolsMode
+
+    pane = MCPToolsMode()
+    app = _Harness(pane)
+    async with app.run_test(size=(120, 40)) as pilot:
+        table = pane.query_one(DataTable)
+        row_key = table.add_row("echo", "server-a", key="tool-echo")
+        table.focus()
+        await pilot.pause()
+
+        # Gesture one: highlight selects, the activation completing it is
+        # swallowed.
+        pane.post_message(_click_row(table, row_key))
+        await pilot.pause()
+        pane.post_message(DataTable.RowSelected(table, 0, row_key))
+        await pilot.pause()
+
+        # Later, something re-selects the same row outright. That is a new
+        # gesture and must reach the pane.
+        pane.post_message(DataTable.RowSelected(table, 0, row_key))
+        await pilot.pause()
+        await pilot.pause()
+
+        selected = [m for m in app.captured if type(m).__name__ == "ToolSelected"]
+        assert len(selected) == 2, (
+            f"expected the gesture plus the later re-selection, got "
+            f"{len(selected)}; the dedup is persistent rather than one-shot"
+        )
+
+
+@pytest.mark.asyncio
+async def test_pressing_enter_without_a_preceding_highlight_still_selects():
+    """The dedup must not swallow a genuine activation.
+
+    Guards the obvious over-correction: a `RowSelected` for a row the mixin did
+    not just forward has to reach the pane.
+    """
+    from tldw_chatbook.UI.MCP_Modules.mcp_tools_mode import MCPToolsMode
+
+    pane = MCPToolsMode()
+    app = _Harness(pane)
+    async with app.run_test(size=(120, 40)) as pilot:
+        table = pane.query_one(DataTable)
+        row_key = table.add_row("echo", "server-a", key="tool-echo")
+        await pilot.pause()
+
+        pane.post_message(DataTable.RowSelected(table, 0, row_key))
+        await pilot.pause()
+        await pilot.pause()
+
+        selected = [m for m in app.captured if type(m).__name__ == "ToolSelected"]
+        assert len(selected) == 1, (
+            "a native activation with no preceding highlight was swallowed"
+        )
+
+
+@pytest.mark.asyncio
 async def test_keyboard_cursor_movement_selects_the_same_way(monkeypatch):
     """AC#3: arrow keys and a click must agree.
 

--- a/Tests/UI/test_table_click_selects.py
+++ b/Tests/UI/test_table_click_selects.py
@@ -1,0 +1,189 @@
+"""TASK-1180: a single click on a table row must select it, not just move the cursor.
+
+Textual fires `RowSelected` on **activation** — Enter, or a second click — while a
+single click produces `RowHighlighted`. A pane that handles only `RowSelected`
+therefore highlights on click and selects nothing: the Inspector stays empty and
+row actions stay disabled.
+
+TASK-1105 fixed this for the Watchlists Sources pane, where it had made
+`Preview` / `Check now` / `Delete` unreachable by mouse and ultimately hid a dead
+scrape path (TASK-1100). Every other table pane still had it.
+
+These tests drive the panes the way a mouse user does — post a
+`RowHighlighted`, which is what a click produces — and assert the pane's own
+selection message comes back out.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import DataTable
+
+pytestmark = pytest.mark.unit
+
+
+class _Harness(App):
+    """Mount one pane and capture every message it posts."""
+
+    def __init__(self, pane) -> None:
+        super().__init__()
+        self._pane = pane
+        self.captured: list[object] = []
+
+    def compose(self) -> ComposeResult:
+        yield self._pane
+
+    async def _on_message(self, message) -> None:  # noqa: D401 - Textual hook
+        # Capture rather than intercept: the message still reaches its normal
+        # handlers, so this observes the pane instead of standing in for it.
+        self.captured.append(message)
+        await super()._on_message(message)
+
+
+def _click_row(table: DataTable, row_key) -> DataTable.RowHighlighted:
+    """The event a single click produces once the cursor lands on a row."""
+    return DataTable.RowHighlighted(table, 0, row_key)
+
+
+@pytest.mark.asyncio
+async def test_clicking_a_tool_row_selects_it():
+    """MCP Tools: confirmed affected in the task report."""
+    from tldw_chatbook.UI.MCP_Modules.mcp_tools_mode import MCPToolsMode
+
+    pane = MCPToolsMode()
+    app = _Harness(pane)
+    async with app.run_test(size=(120, 40)) as pilot:
+        table = pane.query_one(DataTable)
+        row_key = table.add_row("echo", "server-a", key="tool-echo")
+        table.focus()
+        await pilot.pause()
+
+        pane.post_message(_click_row(table, row_key))
+        await pilot.pause()
+        await pilot.pause()
+
+        selected = [m for m in app.captured if type(m).__name__ == "ToolSelected"]
+        assert selected, (
+            "clicking a tool row posted no ToolSelected: the pane handles only "
+            "RowSelected, which a single click does not produce"
+        )
+
+
+@pytest.mark.asyncio
+async def test_clicking_a_permission_row_selects_it():
+    """MCP Permissions: the other confirmed pane."""
+    from tldw_chatbook.UI.MCP_Modules.mcp_permissions_mode import MCPPermissionsMode
+
+    pane = MCPPermissionsMode()
+    app = _Harness(pane)
+    async with app.run_test(size=(120, 40)) as pilot:
+        table = pane.query_one(DataTable)
+        row_key = table.add_row("server", "srv", "ask", key="perm-1")
+        table.focus()
+        # The pane resolves a click back through the map update_matrix() builds.
+        pane._rows_by_key["perm-1"] = type(
+            "PermRow", (), {"kind": "server", "server_key": "srv", "tool_name": None}
+        )()
+        await pilot.pause()
+
+        pane.post_message(_click_row(table, row_key))
+        await pilot.pause()
+        await pilot.pause()
+
+        selected = [m for m in app.captured if type(m).__name__ == "RowSelected"]
+        assert selected, (
+            "clicking a permission row posted no RowSelected identity message"
+        )
+
+
+@pytest.mark.asyncio
+async def test_an_unfocused_table_moving_its_own_cursor_selects_nothing():
+    """The focus gate, tested on its own.
+
+    `clear()`/`add_row()` move the cursor back to row 0 and emit
+    `RowHighlighted` exactly as a click does. The distinguishing fact — measured
+    on the real MCP screen — is that a repopulating table is not focused, while
+    a click focuses it before the cursor moves.
+
+    Without this gate, opening the MCP Tools tab produced 157 selections from no
+    user input, because each one remounted the Inspector, which re-synced the
+    mode, which repopulated the table.
+    """
+    from tldw_chatbook.UI.MCP_Modules.mcp_tools_mode import MCPToolsMode
+
+    pane = MCPToolsMode()
+    app = _Harness(pane)
+    async with app.run_test(size=(120, 40)) as pilot:
+        table = pane.query_one(DataTable)
+        row_key = table.add_row("echo", "server-a", key="tool-echo")
+        # Deliberately NOT focused: this is a repopulation, not a person.
+        await pilot.pause()
+
+        pane.post_message(_click_row(table, row_key))
+        await pilot.pause()
+        await pilot.pause()
+
+        selected = [m for m in app.captured if type(m).__name__ == "ToolSelected"]
+        assert not selected, (
+            "an unfocused table's cursor movement selected a row; a pane "
+            "rebuilding its own rows will drive the inspector"
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_same_row_highlighted_twice_selects_once():
+    """The dedup guard, tested on its own.
+
+    Belt to the focus gate's braces: a background refresh landing on the row the
+    user is already sitting in must not re-post.
+    """
+    from tldw_chatbook.UI.MCP_Modules.mcp_tools_mode import MCPToolsMode
+
+    pane = MCPToolsMode()
+    app = _Harness(pane)
+    async with app.run_test(size=(120, 40)) as pilot:
+        table = pane.query_one(DataTable)
+        row_key = table.add_row("echo", "server-a", key="tool-echo")
+        table.focus()
+        await pilot.pause()
+
+        for _ in range(4):
+            pane.post_message(_click_row(table, row_key))
+            await pilot.pause()
+        await pilot.pause()
+
+        selected = [m for m in app.captured if type(m).__name__ == "ToolSelected"]
+        assert len(selected) == 1, (
+            f"the same row selected {len(selected)} times; repeated highlights "
+            "of the current row should be ignored"
+        )
+
+
+@pytest.mark.asyncio
+async def test_keyboard_cursor_movement_selects_the_same_way(monkeypatch):
+    """AC#3: arrow keys and a click must agree.
+
+    Both produce `RowHighlighted`, so this asserts the shared mechanism does not
+    special-case pointer input.
+    """
+    from tldw_chatbook.UI.MCP_Modules.mcp_tools_mode import MCPToolsMode
+
+    pane = MCPToolsMode()
+    app = _Harness(pane)
+    async with app.run_test(size=(120, 40)) as pilot:
+        table = pane.query_one(DataTable)
+        table.add_row("echo", "server-a", key="tool-echo")
+        second = table.add_row("fetch", "server-b", key="tool-fetch")
+        table.focus()
+        await pilot.pause()
+
+        pane.post_message(_click_row(table, second))
+        await pilot.pause()
+        await pilot.pause()
+
+        selected = [m for m in app.captured if type(m).__name__ == "ToolSelected"]
+        assert selected, "cursor movement posted no selection"
+        assert selected[-1].tool_id == "tool-fetch", (
+            "the selection did not follow the cursor onto the second row"
+        )

--- a/backlog/tasks/task-1180 - Table-panes-outside-Watchlists-select-on-activation-not-on-click.md
+++ b/backlog/tasks/task-1180 - Table-panes-outside-Watchlists-select-on-activation-not-on-click.md
@@ -3,7 +3,7 @@ id: TASK-1180
 title: >-
   Table panes outside Watchlists select on activation, so a click moves the
   cursor but selects nothing
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-28 14:00'
 labels:
@@ -32,9 +32,70 @@ Note the two are independent: TASK-1160 was about clicks not *landing*, this is 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Clicking a row in the MCP Permissions and MCP Tools tables selects it, and the Inspector reflects the selection
-- [ ] #2 Every table pane under `tldw_chatbook/UI` is audited, and the affected ones listed here or fixed
-- [ ] #3 Keyboard cursor movement selects the same way as a click
-- [ ] #4 A shared mechanism is preferred over per-pane handlers, so the next table added does not need to remember
-- [ ] #5 A test clicks a row and asserts the selection, proven to fail against current code
+- [x] #1 Clicking a row in the MCP Permissions and MCP Tools tables selects it, and the Inspector reflects the selection
+- [x] #2 Every table pane under `tldw_chatbook/UI` is audited, and the affected ones listed here or fixed
+- [x] #3 Keyboard cursor movement selects the same way as a click
+- [x] #4 A shared mechanism is preferred over per-pane handlers, so the next table added does not need to remember
+- [x] #5 A test clicks a row and asserts the selection, proven to fail against current code
 <!-- AC:END -->
+
+## Implementation Notes
+
+`DataTableClickSelectMixin` (`UI/Widgets/table_click_select.py`) forwards user-driven cursor
+movement to a pane's existing `on_data_table_row_selected`, so each pane keeps its own row-key
+resolution and only declares that a click should reach it.
+
+**Audit (AC#2).** An AST pass over the 14 panes under `UI/` that handle either event found **7**
+selecting on activation only: `mcp_audit_mode`, `mcp_permissions_mode`, `mcp_servers_mode`,
+`mcp_tools_mode`, `Voice_Cloning_Window`, `stts_profile_library`, and — a **false positive** —
+`mcp_workbench`, whose handlers take the panes' own custom messages rather than `DataTable` events,
+so it works once the panes post. The five Watchlists panes were already fixed by TASK-1105;
+`Evals/results_grid` and `schedules_workbench` correctly use highlight-only.
+
+`stts_profile_library` cannot use the mixin: its handler is bound by `@on(DataTable.RowSelected,
+"#stts-profile-table")`, and the mixin dispatches by conventional method name. It gets an explicit
+paired handler with the same focus gate spelled out.
+
+**The naive version of this fix is a feedback loop, and I shipped it into my own branch first.**
+`RowHighlighted` is not a user-input event — a pane rebuilding its table emits it too, because
+`clear()` resets the cursor to row 0. On the MCP workbench a selection triggers an awaited
+remove/mount in `MCPInspector`, which re-syncs the mode, which repopulates the table, which
+highlights row 0 again. Opening the Tools tab with **zero user input produced 157 selections**, and
+buried a genuine click under the repeats. Three layers now prevent it, each earning its place from
+an observed failure:
+
+- **Focus gate.** Measured on the real screen: a repopulating table is not focused, while a click
+  focuses it before the cursor moves and keyboard navigation requires focus by definition.
+- **`repopulating_table()`**, declared by the pane before `clear()`/`add_row()`. Focus alone was not
+  enough — switching the selected server rebuilds the tools table *while it still has focus*, and
+  the row-0 transient then re-selected a tool and defeated the clear that triggered the rebuild.
+  The existing `test_switching_selected_server_clears_tool_detail` caught that. Suppression releases
+  after the next refresh rather than at the end of a `with` block, because Textual delivers a
+  rebuild's highlight messages *after* the producing code returns; the obvious context-manager shape
+  would have looked right and covered nothing.
+- **Dedup** on the last forwarded row key, bounding the damage if a future pane forgets to declare.
+
+**Two panes already knew about this hazard.** `mcp_permissions_mode` and `mcp_audit_mode` carry
+comments explaining that `DataTable.clear()` resets `cursor_coordinate` to (0, 0), and they restore
+the cursor by row key afterwards. The first version of this fix would have silently defeated that
+careful existing work by treating the transient as a selection. Reading their comments turned the
+fix from "add a guard" into "declare the rebuild so the existing restore still wins."
+
+**The Watchlists panes do not have the storm** (measured: 0 spurious calls). `select_source_by_id`
+sets local state without the inspector-remount feedback cycle, so their hand-written handlers are
+left alone rather than churned. That does leave two patterns in the tree; the mixin is the one to
+use for new tables.
+
+**Mutation testing corrected itself.** The first check passed with the focus gate removed, because
+the dedup guard independently suppressed the storm — a test that survives removing either guard
+proves neither. Isolating gave 0 / 0 / **162** (focus-only / dedup-only / neither), and each guard
+now has a test that fails when exactly that guard is removed.
+
+**Baseline.** Identical command on `6577c67cf` and on this branch: the same **7** failures both
+sides — 4 `PrivatePathError: link_or_non_regular` (environment) and 3 audit-redaction, all
+pre-existing. `test_switching_selected_server_clears_tool_detail` passes on baseline, failed on the
+first draft, and passes now.
+
+Added: `tldw_chatbook/UI/Widgets/table_click_select.py`,
+`Tests/UI/test_table_click_selects.py`, `Tests/UI/test_mcp_table_click_selects_end_to_end.py`.
+Modified: the four `MCP_Modules` panes, `Voice_Cloning_Window.py`, `stts_profile_library.py`.

--- a/tldw_chatbook/UI/MCP_Modules/mcp_audit_mode.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_audit_mode.py
@@ -25,6 +25,7 @@ from textual.widgets import Button, DataTable, Input, Select, Static
 from tldw_chatbook.MCP.readiness import HubAction
 from tldw_chatbook.UI.MCP_Modules.mcp_inspector import format_duration_ms
 from tldw_chatbook.UI.MCP_Modules.mcp_permissions_mode import state_text
+from tldw_chatbook.UI.Widgets.table_click_select import DataTableClickSelectMixin
 
 _TABLE_COLUMNS = ("When", "Tool", "Initiator", "Decision", "Duration", "Outcome")
 
@@ -248,7 +249,7 @@ def _outcome_text(entry: dict[str, Any]) -> str:
     return "OK" if entry.get("ok") else "Failed"
 
 
-class MCPAuditMode(Vertical):
+class MCPAuditMode(DataTableClickSelectMixin, Vertical):
     """Canvas for the Audit mode: execution-log table, filters, empty state."""
 
     DEFAULT_CSS = """
@@ -543,6 +544,10 @@ class MCPAuditMode(Vertical):
             if row_key is not None and row_key.value is not None:
                 cursor_key = str(row_key.value)
 
+        # Rebuilding moves the cursor to row 0 before the key-based restore
+        # below puts it back; declaring the rebuild keeps that transient from
+        # being read as a selection (DataTableClickSelectMixin).
+        self.repopulating_table()
         table.clear(columns=True)
         table.add_columns(*_TABLE_COLUMNS)
         restored_index: int | None = None

--- a/tldw_chatbook/UI/MCP_Modules/mcp_permissions_mode.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_permissions_mode.py
@@ -32,6 +32,7 @@ from tldw_chatbook.MCP.permission_store import (
     cycle_global,
     cycle_ui_state,
 )
+from tldw_chatbook.UI.Widgets.table_click_select import DataTableClickSelectMixin
 
 _TABLE_COLUMNS = ("Tool", "State", "Tags")
 # UX batch item 11: the Tags column is omitted entirely when no row in the
@@ -314,7 +315,7 @@ def _tool_column_text(row: PermRow) -> str:
     return f"{_TOOL_ROW_INDENT}{row.tool_name or ''}"
 
 
-class MCPPermissionsMode(Vertical):
+class MCPPermissionsMode(DataTableClickSelectMixin, Vertical):
     """Canvas for the Permissions mode: kill switch, matrix, policy preview."""
 
     DEFAULT_CSS = """
@@ -673,6 +674,10 @@ class MCPPermissionsMode(Vertical):
         # (`clear(columns=True)`), mirroring `mcp_servers_mode.py`'s own
         # per-source Scope-column precedent (Task 11 there).
         show_tags = self._has_tags
+        # Rebuilding moves the cursor to row 0 before the key-based restore
+        # below puts it back; declaring the rebuild keeps that transient from
+        # being read as a selection (DataTableClickSelectMixin).
+        self.repopulating_table()
         table.clear(columns=True)
         table.add_columns(*(_TABLE_COLUMNS if show_tags else _TABLE_COLUMNS_NO_TAGS))
         for row in rows:

--- a/tldw_chatbook/UI/MCP_Modules/mcp_servers_mode.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_servers_mode.py
@@ -28,6 +28,7 @@ from tldw_chatbook.UI.MCP_Modules.mcp_inspector import MCPInspector
 from tldw_chatbook.UI.MCP_Modules.mcp_permissions_mode import state_text
 from tldw_chatbook.UI.MCP_Modules.mcp_profile_form import MCPImportPanel, MCPProfileForm
 from tldw_chatbook.UI.MCP_Modules.mcp_server_mutations import MCPServerMutationsPanel
+from tldw_chatbook.UI.Widgets.table_click_select import DataTableClickSelectMixin
 
 _MUTATIONS_GATED_TOOLTIP = "Requires team, org, or system-admin scope."
 # I3: Import always writes to the LOCAL profile store (`_apply_import()` in
@@ -116,7 +117,7 @@ _BUILTIN_CHECKBOX_KEYS: dict[str, str] = {
 }
 
 
-class MCPServersMode(Vertical):
+class MCPServersMode(DataTableClickSelectMixin, Vertical):
     """Canvas for the Servers mode."""
 
     DEFAULT_CSS = """
@@ -515,6 +516,10 @@ class MCPServersMode(Vertical):
         # rendered column set, and this only runs on an actual overview
         # resync, not per keystroke.
         show_scope = source != "local"
+        # Rebuilding moves the cursor to row 0 before the key-based restore
+        # below puts it back; declaring the rebuild keeps that transient from
+        # being read as a selection (DataTableClickSelectMixin).
+        self.repopulating_table()
         table.clear(columns=True)
         table.add_columns(*(_TABLE_COLUMNS if show_scope else _TABLE_COLUMNS_NO_SCOPE))
         seen_keys: set[str] = set()

--- a/tldw_chatbook/UI/MCP_Modules/mcp_tools_mode.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_tools_mode.py
@@ -29,6 +29,7 @@ from tldw_chatbook.UI.MCP_Modules.mcp_permissions_mode import (
     tool_state_kind,
 )
 from tldw_chatbook.UI.MCP_Modules.mcp_schema_form import parse_schema
+from tldw_chatbook.UI.Widgets.table_click_select import DataTableClickSelectMixin
 
 _TABLE_COLUMNS = ("Tool", "State", "Server", "Tags", "Schema")
 # UX batch item 11: the Tags column is omitted entirely when no tool in the
@@ -74,7 +75,7 @@ _EMPTY_ACTION_TOOLTIPS: dict[str, str] = {
 _ECHO_CONSUMED = object()
 
 
-class MCPToolsMode(Vertical):
+class MCPToolsMode(DataTableClickSelectMixin, Vertical):
     """Canvas for the Tools mode: cross-server catalog, filters, empty state."""
 
     DEFAULT_CSS = """
@@ -349,6 +350,10 @@ class MCPToolsMode(Vertical):
         # (the filtered subset) -- a text/server filter that happens to
         # narrow the visible rows to an all-tagless subset must not make
         # the column flicker away mid-typing.
+        # Rebuilding the rows moves the cursor back to row 0, which emits the
+        # same RowHighlighted a click does. Declaring the rebuild stops that
+        # being read as a selection -- see DataTableClickSelectMixin.
+        self.repopulating_table()
         table.clear(columns=True)
         table.add_columns(*(_TABLE_COLUMNS if self._has_tags else _TABLE_COLUMNS_NO_TAGS))
         seen_keys: set[str] = set()

--- a/tldw_chatbook/UI/Voice_Cloning_Window.py
+++ b/tldw_chatbook/UI/Voice_Cloning_Window.py
@@ -41,6 +41,7 @@ from ..Widgets.enhanced_file_picker import (
 from ..Third_Party.textual_fspicker import Filters
 from ..Event_Handlers.STTS_Events.stts_events import STTSPlaygroundGenerateEvent
 from ..TTS import STTSPlaygroundRequest
+from tldw_chatbook.UI.Widgets.table_click_select import DataTableClickSelectMixin
 
 #######################################################################################################################
 #
@@ -48,7 +49,7 @@ from ..TTS import STTSPlaygroundRequest
 #
 
 
-class VoiceCloningWindow(Screen):
+class VoiceCloningWindow(DataTableClickSelectMixin, Screen):
     """
     Voice Cloning management window supporting multiple TTS backends.
 
@@ -338,6 +339,10 @@ class VoiceCloningWindow(Screen):
 
         # Update table
         table = self.query_one("#profile-table", DataTable)
+        # Rebuilding moves the cursor to row 0 before the key-based restore
+        # below puts it back; declaring the rebuild keeps that transient from
+        # being read as a selection (DataTableClickSelectMixin).
+        self.repopulating_table()
         table.clear()
 
         # Update test profile selector

--- a/tldw_chatbook/UI/Widgets/table_click_select.py
+++ b/tldw_chatbook/UI/Widgets/table_click_select.py
@@ -59,6 +59,57 @@ class DataTableClickSelectMixin:
     #: Set while the pane is rebuilding its own rows. See `repopulating_table`.
     _suppress_row_selection: bool = False
 
+    #: True only while the mixin is invoking the pane's own handler, so the
+    #: dedup wrapper can tell its own call from a native activation.
+    _forwarding_highlight: bool = False
+
+    #: Row key a forwarded highlight just selected, consumed by the *next*
+    #: native activation and then cleared. One-shot on purpose: it must
+    #: suppress the Enter that completes an arrow-then-Enter gesture, and must
+    #: NOT suppress a later, genuine re-selection of the same row -- which is
+    #: what `goto_permission_row()` and the sub-view triggers do.
+    _pending_activation_key: Any = None
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        """Make the pane's own `RowSelected` handler idempotent per row.
+
+        Highlighting a row now selects it, so a user who arrows onto a row and
+        *then* presses Enter would otherwise be processed twice: once by the
+        forwarded highlight, once by Textual's native `RowSelected`. That is
+        redundant work for an idempotent handler and a wrong count for anything
+        that posts a message -- `test_row_selection_posts_entry_selected_with_
+        synthetic_index` asserts exactly one event for exactly that gesture.
+
+        The mixin cannot intercept by defining `on_data_table_row_selected`
+        itself: a method on the subclass shadows one on a base class, and the
+        subclass is where every pane defines its handler. Wrapping at class
+        creation gets in front of that without any pane having to remember.
+        """
+        super().__init_subclass__(**kwargs)
+        handler = cls.__dict__.get("on_data_table_row_selected")
+        if handler is None or getattr(handler, "_tldw_dedup_wrapped", False):
+            return
+
+        def _deduped(self, event, _handler=handler):
+            if self._forwarding_highlight:
+                # This IS the mixin's forwarded call; let it through.
+                return _handler(self, event)
+            row_key = getattr(event, "row_key", None)
+            value = getattr(row_key, "value", None)
+            pending = self._pending_activation_key
+            self._pending_activation_key = None
+            if value is not None and value == pending:
+                # The activation completing the gesture whose highlight already
+                # selected this row; swallow it rather than re-posting.
+                event.stop()
+                return None
+            return _handler(self, event)
+
+        _deduped._tldw_dedup_wrapped = True  # type: ignore[attr-defined]
+        _deduped.__name__ = handler.__name__
+        _deduped.__doc__ = handler.__doc__
+        cls.on_data_table_row_selected = _deduped  # type: ignore[assignment]
+
     def repopulating_table(self) -> None:
         """Declare that this pane is about to rebuild a table's rows.
 
@@ -113,9 +164,14 @@ class DataTableClickSelectMixin:
         if not self._should_forward(table, row_key):
             return
         event.stop()
-        handler(
-            DataTable.RowSelected(table, getattr(event, "cursor_row", 0), row_key)
-        )
+        self._forwarding_highlight = True
+        try:
+            handler(
+                DataTable.RowSelected(table, getattr(event, "cursor_row", 0), row_key)
+            )
+        finally:
+            self._forwarding_highlight = False
+            self._pending_activation_key = row_key.value
 
     def on_data_table_cell_highlighted(
         self, event: DataTable.CellHighlighted
@@ -129,24 +185,32 @@ class DataTableClickSelectMixin:
         cell_handler: Any = getattr(self, "on_data_table_cell_selected", None)
         if cell_handler is not None:
             event.stop()
-            cell_handler(
-                DataTable.CellSelected(
-                    table,
-                    getattr(event, "value", None),
-                    getattr(event, "coordinate", None),
-                    event.cell_key,
+            self._forwarding_highlight = True
+            try:
+                cell_handler(
+                    DataTable.CellSelected(
+                        table,
+                        getattr(event, "value", None),
+                        getattr(event, "coordinate", None),
+                        event.cell_key,
+                    )
                 )
-            )
+            finally:
+                self._forwarding_highlight = False
             return
 
         row_handler = getattr(self, "on_data_table_row_selected", None)
         if row_handler is None:
             return
         event.stop()
-        row_handler(
-            DataTable.RowSelected(
-                table,
-                getattr(getattr(event, "coordinate", None), "row", 0) or 0,
-                row_key,
+        self._forwarding_highlight = True
+        try:
+            row_handler(
+                DataTable.RowSelected(
+                    table,
+                    getattr(getattr(event, "coordinate", None), "row", 0) or 0,
+                    row_key,
+                )
             )
-        )
+        finally:
+            self._forwarding_highlight = False

--- a/tldw_chatbook/UI/Widgets/table_click_select.py
+++ b/tldw_chatbook/UI/Widgets/table_click_select.py
@@ -1,0 +1,152 @@
+"""Make a single click on a `DataTable` row select it, not just move the cursor.
+
+Textual fires `DataTable.RowSelected` on **activation** — Enter, or a second
+click — while a single click produces `DataTable.RowHighlighted`. A pane that
+handles only `RowSelected` therefore highlights on click and selects nothing:
+the inspector stays empty and row actions stay disabled.
+
+That defect made `Preview` / `Check now` / `Delete` unreachable by mouse in the
+Watchlists Sources pane and ultimately hid a dead scrape path (TASK-1100,
+TASK-1105). Every other table pane in the app still had it (TASK-1180).
+
+**Why this gates on focus.** `RowHighlighted` is not a user-input event. It also
+fires when a pane rebuilds its own table — `clear()` then `add_row()` moves the
+cursor back to row 0 — and forwarding those turns a repopulation into a
+selection. On the MCP workbench that is not merely noisy: a selection triggers
+an awaited remove/mount in `MCPInspector`, which re-syncs the mode, which
+repopulates the table, which highlights row 0 again. A first draft of this mixin
+without the gate produced **157 selections from opening the Tools tab with no
+user input at all**, and buried a genuine click under the repeats.
+
+Focus separates the two cleanly, as measured on the real screen: a repopulating
+table is not focused, while a click focuses the table before the cursor moves
+and keyboard navigation requires focus by definition. So "the cursor moved on a
+focused table" means a person moved it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from textual.widgets import DataTable
+
+__all__ = ["DataTableClickSelectMixin"]
+
+
+class DataTableClickSelectMixin:
+    """Forward user-driven `DataTable` cursor movement to the selection handler.
+
+    List this **before** the widget base class so its handlers are found::
+
+        class MyPane(DataTableClickSelectMixin, Vertical):
+            def on_data_table_row_selected(self, event): ...
+
+    The mixin re-dispatches to the pane's existing handler rather than defining
+    its own selection hook: each pane resolves a row key back to its own domain
+    object and posts its own message, and duplicating that in a second method is
+    how the two drift apart.
+    """
+
+    #: Set False on a pane where cursor movement genuinely should not select --
+    #: a multi-select table being marked up, for example. Prefer leaving the
+    #: mixin off entirely; this exists so an opt-out is greppable.
+    select_on_highlight: bool = True
+
+    #: Last row key forwarded, so a table that re-highlights the same row does
+    #: not re-post.
+    _last_forwarded_row_key: Any = None
+
+    #: Set while the pane is rebuilding its own rows. See `repopulating_table`.
+    _suppress_row_selection: bool = False
+
+    def repopulating_table(self) -> None:
+        """Declare that this pane is about to rebuild a table's rows.
+
+        Call immediately before `clear()`/`add_row()`. Focus alone is not
+        enough: a pane can rebuild a table the user is currently sitting in --
+        switching the selected server repopulates the tools table while it
+        still has focus -- and the resulting row-0 highlight then re-selects a
+        tool, defeating the very clear that triggered the rebuild. An existing
+        workbench test (`test_switching_selected_server_clears_tool_detail`)
+        catches exactly that.
+
+        Suppression is released after the next refresh rather than at the end of
+        a `with` block, because Textual delivers the highlight messages a
+        rebuild produces *after* the code that produced them has returned.
+        """
+        self._suppress_row_selection = True
+        self._last_forwarded_row_key = None
+        call_after_refresh = getattr(self, "call_after_refresh", None)
+        if call_after_refresh is None:  # not mounted (unit-constructed pane)
+            self._suppress_row_selection = False
+            return
+        call_after_refresh(self._resume_row_selection)
+
+    def _resume_row_selection(self) -> None:
+        self._suppress_row_selection = False
+
+    def _should_forward(self, table: DataTable | None, row_key: Any) -> bool:
+        if not self.select_on_highlight:
+            return False
+        if self._suppress_row_selection:
+            return False
+        if row_key is None or getattr(row_key, "value", None) is None:
+            return False
+        # A repopulating table is usually not focused; a clicked or arrowed one
+        # always is. `repopulating_table()` covers the case where it is.
+        if table is None or not table.has_focus:
+            return False
+        if row_key.value == self._last_forwarded_row_key:
+            return False
+        self._last_forwarded_row_key = row_key.value
+        return True
+
+    def on_data_table_row_highlighted(
+        self, event: DataTable.RowHighlighted
+    ) -> None:
+        """A click, or an arrow key, landing on a row."""
+        handler = getattr(self, "on_data_table_row_selected", None)
+        if handler is None:
+            return
+        table = getattr(event, "data_table", None)
+        row_key = getattr(event, "row_key", None)
+        if not self._should_forward(table, row_key):
+            return
+        event.stop()
+        handler(
+            DataTable.RowSelected(table, getattr(event, "cursor_row", 0), row_key)
+        )
+
+    def on_data_table_cell_highlighted(
+        self, event: DataTable.CellHighlighted
+    ) -> None:
+        """The same, for a table whose cursor is cell-shaped rather than row-shaped."""
+        table = getattr(event, "data_table", None)
+        row_key = getattr(getattr(event, "cell_key", None), "row_key", None)
+        if not self._should_forward(table, row_key):
+            return
+
+        cell_handler: Any = getattr(self, "on_data_table_cell_selected", None)
+        if cell_handler is not None:
+            event.stop()
+            cell_handler(
+                DataTable.CellSelected(
+                    table,
+                    getattr(event, "value", None),
+                    getattr(event, "coordinate", None),
+                    event.cell_key,
+                )
+            )
+            return
+
+        row_handler = getattr(self, "on_data_table_row_selected", None)
+        if row_handler is None:
+            return
+        event.stop()
+        row_handler(
+            DataTable.RowSelected(
+                table,
+                getattr(getattr(event, "coordinate", None), "row", 0) or 0,
+                row_key,
+            )
+        )

--- a/tldw_chatbook/UI/stts_profile_library.py
+++ b/tldw_chatbook/UI/stts_profile_library.py
@@ -1233,6 +1233,33 @@ class STTSProfileLibrary(Widget):
             rendered_offset + len(self._loaded_rows) >= self._total
         )
 
+    @on(DataTable.RowHighlighted, "#stts-profile-table")
+    def _handle_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
+        """A single click, or an arrow key, landing on a profile row.
+
+        Textual fires `RowSelected` on *activation* -- Enter, or a second click
+        -- so handling only that left a clicked profile highlighted but not
+        selected, with the row actions still disabled (TASK-1180).
+
+        This pane cannot use `DataTableClickSelectMixin`: the mixin forwards to
+        a conventionally-named `on_data_table_row_selected`, and this handler is
+        bound by an `@on` selector so it only applies to this one table. The
+        pairing is explicit here instead.
+        """
+        if event.row_key is None or event.row_key.value is None:
+            return
+        # Only a focused table's cursor is being moved by a person; an
+        # unfocused one is rebuilding its own rows, and forwarding that would
+        # let a refresh select on the user's behalf. Same gate the mixin
+        # applies, spelled out here because this pane cannot use it.
+        table = getattr(event, "data_table", None)
+        if table is None or not table.has_focus:
+            return
+        event.stop()
+        self._handle_row_selected(
+            DataTable.RowSelected(table, event.cursor_row, event.row_key)
+        )
+
     @on(DataTable.RowSelected, "#stts-profile-table")
     def _handle_row_selected(self, event: DataTable.RowSelected) -> None:
         event.stop()


### PR DESCRIPTION
Closes TASK-1180.

Textual fires `RowSelected` on **activation** — Enter, or a second click — while a single click produces `RowHighlighted`. Seven panes handled only the former, so a click moved the cursor and selected nothing: the Inspector stayed empty and row actions stayed disabled. TASK-1105 fixed this for Watchlists by hand, after it made `Preview`/`Check now`/`Delete` unreachable by mouse and ultimately hid a dead scrape path. Everything else still had it.

## The audit (AC#2)

An AST pass over the 14 panes under `UI/` that handle either event:

| Pane | Verdict |
|---|---|
| `mcp_audit_mode`, `mcp_permissions_mode`, `mcp_servers_mode`, `mcp_tools_mode` | affected → mixin |
| `Voice_Cloning_Window` | affected → mixin |
| `stts_profile_library` | affected → explicit paired handler |
| `mcp_workbench` | **false positive** — handles the panes' own messages, not `DataTable` events |
| 5 Watchlists panes | already fixed (TASK-1105) |
| `Evals/results_grid`, `schedules_workbench` | correctly highlight-only |

`stts_profile_library` binds its handler with `@on(DataTable.RowSelected, "#stts-profile-table")`, which the mixin's name-based dispatch cannot reach — hence the explicit pairing.

## The naive fix is a feedback loop, and I built it first

`RowHighlighted` is not a user-input event. A pane rebuilding its own table emits it too, because `clear()` resets the cursor to row 0. On the MCP workbench a selection awaits a remove/mount in `MCPInspector`, which re-syncs the mode, which repopulates the table, which highlights row 0 again.

**Opening the Tools tab with zero user input produced 157 selections**, and buried a genuine click under the repeats. That's why the first live check showed nothing happening — not a harness artifact this time, a real regression I'd introduced.

Three layers now, each earning its place from an observed failure:

1. **Focus gate.** Measured on the real screen: a repopulating table is not focused, while a click focuses it before the cursor moves and keyboard navigation requires focus by definition. 157 → 0.
2. **`repopulating_table()`**, declared before `clear()`/`add_row()`. Focus alone was not enough — switching the selected server rebuilds the tools table *while it still has focus*, and the row-0 transient then re-selected a tool, defeating the clear that triggered the rebuild. The existing `test_switching_selected_server_clears_tool_detail` caught it. Suppression releases after the **next refresh**, not at the end of a `with` block, because Textual delivers a rebuild's highlight messages after the producing code returns — the obvious context-manager shape would have looked right and covered nothing.
3. **Dedup** on the last forwarded row key, bounding the damage if a future pane forgets to declare.

## Two panes already knew

`mcp_permissions_mode` and `mcp_audit_mode` carry comments explaining that `DataTable.clear()` resets `cursor_coordinate` to (0, 0), and they already restore the cursor **by row key** afterwards. My first version would have silently defeated that careful existing work by treating the transient as a selection. Reading their comments turned the fix from "add a guard" into "declare the rebuild so the existing restore still wins."

## Watchlists deliberately untouched

Measured: **0** spurious calls. `select_source_by_id` sets local state without the inspector-remount feedback cycle, so the storm is specific to MCP's architecture rather than inherent to highlight-forwarding. Those hand-written handlers stay as they are rather than churning a recently-fixed area. That leaves two patterns in the tree; the mixin is the one to use for new tables.

## Mutation testing corrected itself

My first check **passed with the focus gate removed** — because the dedup guard independently suppressed the storm. A test that survives removing either guard proves neither. Isolating gave **0 / 0 / 162** (focus-only / dedup-only / neither), and each guard now has a test that fails when exactly that guard is removed.

## Verification

- 5 unit tests on the panes + 2 end-to-end through the real `MCPScreen` → `MCPWorkbench` → `MCPInspector`, including one asserting that opening Tools mode selects **nothing** on its own.
- Both new suites failed against pre-change code, per AC#5.
- **Failure sets identical to baseline `6577c67cf`** — the same 7 pre-existing failures on both sides (4 `PrivatePathError: link_or_non_regular`, environment; 3 audit-redaction). `test_switching_selected_server_clears_tool_detail` passes on baseline, failed on my first draft, passes now.

One process note: I twice read "0 failures" that turned out to be `-q` suppressing pytest's summary lines rather than a clean run. The numbers above come from plain output on both sides.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make a single click on any `DataTable` row actually select it (not just move the cursor), app-wide, and prevent double-firing when users arrow then press Enter (TASK-1180). Also stops selection storms during table rebuilds and keeps keyboard and mouse selection consistent.

- **Bug Fixes**
  - Added `DataTableClickSelectMixin` (`UI/Widgets/table_click_select.py`) to forward `DataTable.RowHighlighted` to existing `on_data_table_row_selected`, with a focus gate, `repopulating_table()` suppression (released after next refresh), per-row-key dedup, and a new one-shot activation dedup that wraps `on_data_table_row_selected` to swallow the Enter that completes the same gesture.
  - Applied mixin to `mcp_audit_mode`, `mcp_permissions_mode`, `mcp_servers_mode`, `mcp_tools_mode`, and `Voice_Cloning_Window`; added an explicit paired handler in `stts_profile_library` due to `@on(..., "#selector")`. Audited remaining panes; Watchlists were already fixed.
  - Added tests (`Tests/UI/test_table_click_selects.py`, `Tests/UI/test_mcp_table_click_selects_end_to_end.py`) covering click and keyboard selection, prevention of rebuild-triggered auto-selections, end-to-end inspector updates, and the one-shot arrow+Enter dedup.

<sup>Written for commit 4d81f2ebee2a61bbb784265e4408828cd519b03f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

