### PR TITLE
qa: third Watchlists UAT — journey walks end to end; 2 findings + a correction to 1040

### DIFF
--- a/Docs/superpowers/qa/watchlists-uat-2026-07-27/run3-experienced-user.md
+++ b/Docs/superpowers/qa/watchlists-uat-2026-07-27/run3-experienced-user.md
@@ -1,0 +1,51 @@
+# Watchlists UAT run 3 — experienced-user journey, 2026-07-28
+
+`origin/dev` `e82ac1b18`, clean profile (`uat_wl_r3`, deleted after), 235x52,
+click columns computed by character.
+
+Third attempt. Runs 1 and 2 each stopped at a blocking defect before reaching
+this journey; both are fixed, so this run finally walked it.
+
+## Walked successfully
+
+| Step | Result |
+|---|---|
+| Create two watchlists | Both appear; scope follows the new one |
+| Create three sources through the form | All three created; table and Feeds both update |
+| Switch scope to a watchlist | `Feeds in Morning AI Brief (0)`, staging line narrows with it |
+| Add a source to a watchlist | `Feeds in Morning AI Brief (1)`, source listed |
+| Rename a watchlist | Applied; dialog pre-fills the current name and selects it |
+| Delete a watchlist holding a source | **Orphan prevention holds** — scope moved to `Feeds in Unassigned (3)` and all three sources survived |
+
+The delete confirmation explains the consequence properly before acting: it
+names the watchlist, says its sources are not deleted, and says where they go.
+
+`task-895`'s AC#3 — deleting a watchlist must never orphan a source into
+invisibility — is now verified in the running app, not just in tests.
+
+## Found
+
+- **task-1090 (high)** — `Escape` does not dismiss the dialogs; only clicking
+  `Cancel` does. A keyboard user cannot back out, and because the dialog is
+  modal the app appears to ignore every subsequent click. This bit the UAT
+  itself: a `Delete` click was silently swallowed by a still-open Rename dialog.
+- **task-1091 (medium)** — names are not trimmed, so `" Daily"` is stored with
+  its leading space and the tree row is visibly mis-indented; and the delete
+  confirmation reads "Its **1 source are** not deleted".
+
+## A correction to run 2
+
+Run 2 filed, and shipped, the claim that the rail and the centre disagree —
+`All sources  0` beside `Feeds in All sources (1)`. **That was wrong.**
+`get_watchlist_item_counts` returns *item* counts, not source counts. With
+sources added but nothing scraped, `0` is correct. `task-1040` has been
+corrected on the board; the fix it shipped is still right for the sources
+table, but its AC #6 and #7 assert an equivalence that does not exist.
+
+## Still not covered
+
+- **Tag filtering** — no tags were set on any source, so the rail's tag filters
+  were never exercised.
+- **The Feeds → Items → Content reading path** — nothing has been scraped, and
+  the sources point at `example.com` placeholders. Exercising it needs a real
+  feed or seeded items, and it is the substance of Phase D.

--- a/Docs/superpowers/qa/watchlists-uat-2026-07-27/run3-experienced-user.md
+++ b/Docs/superpowers/qa/watchlists-uat-2026-07-27/run3-experienced-user.md
@@ -25,7 +25,7 @@ invisibility — is now verified in the running app, not just in tests.
 
 ## Found
 
-- **task-1090 (high)** — `Escape` does not dismiss the dialogs; only clicking
+- **task-1300 (high)** — `Escape` does not dismiss the dialogs; only clicking
   `Cancel` does. A keyboard user cannot back out, and because the dialog is
   modal the app appears to ignore every subsequent click. This bit the UAT
   itself: a `Delete` click was silently swallowed by a still-open Rename dialog.

--- a/backlog/tasks/task-1040 - Creating-a-source-does-not-refresh-the-sources-table.md
+++ b/backlog/tasks/task-1040 - Creating-a-source-does-not-refresh-the-sources-table.md
@@ -54,3 +54,13 @@ The tree-write flows added in TASK-895 already did exactly this — every user-i
 
 Test asserts both reloads happen after a create, and was proven red first: it failed on the sources reload before the fix.
 <!-- SECTION:NOTES:END -->
+
+## Correction — the tree-count half of this task was wrong
+
+The description above claimed the rail and the centre were "describing the same thing, disagreeing", citing `All sources  0` beside `Feeds in All sources (1)`.
+
+**That is not a contradiction.** `get_watchlist_item_counts` returns *item* totals and unread counts, not source counts — its own docstring says so. The number beside a tree node is how many **items** have been scraped; the number in the Feeds heading is how many **sources** the scope covers. With three sources and nothing yet scraped, `All sources  0` and `Feeds in All sources (3)` are both correct, which is exactly what the third UAT observed on `e82ac1b18`.
+
+The fix that shipped is still right — `_create_source` genuinely did leave `#sources-table` stale, and reloading the tree alongside it is correct and harmless — but AC #6 and #7 assert an equivalence that does not exist and should not be treated as a contract.
+
+What is *actually* worth addressing is milder and different: a bare `0` next to `All sources` gives no clue it counts items, so a user who has just added three sources reads it as "nothing was added". That is a labelling question, filed separately if it is worth doing at all.

--- a/backlog/tasks/task-1090 - Escape-does-not-dismiss-the-watchlist-dialogs.md
+++ b/backlog/tasks/task-1090 - Escape-does-not-dismiss-the-watchlist-dialogs.md
@@ -1,0 +1,39 @@
+---
+id: TASK-1090
+title: >-
+  Escape does not dismiss the watchlist dialogs — only clicking Cancel does
+status: To Do
+assignee: []
+created_date: '2026-07-28 04:00'
+labels:
+  - watchlists
+  - bug
+  - ui
+  - a11y
+  - uat
+priority: high
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Pressing `Escape` in the Rename-watchlist dialog leaves it open. Verified in the third Watchlists UAT on `origin/dev` `e82ac1b18`: `Escape` sent twice, the dialog still present both times; clicking `Cancel` dismissed it immediately.
+
+```
+dialog present after Escape: 1
+dialog present after Cancel: 0
+```
+
+So a keyboard user cannot back out of a modal, and — because it is modal — cannot do anything else either. Every click goes to the dialog until the mouse finds `Cancel`. During the UAT a `Delete` click was silently swallowed by the still-open Rename dialog, which is exactly how this presents in normal use: the app appears to ignore you.
+
+`Escape`-to-dismiss is the standard expectation for a modal, and the other dialogs on this screen (New watchlist, Add source, Delete confirmation) should be checked for the same gap rather than fixed one at a time.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 `Escape` dismisses the Rename dialog without applying the change
+- [ ] #2 The same holds for New watchlist, Add source, and the Delete confirmation
+- [ ] #3 Dismissing by `Escape` leaves the watchlist untouched, exactly as `Cancel` does
+- [ ] #4 A test presses `Escape` on each dialog and asserts it closed, proven to fail against current code
+<!-- AC:END -->

--- a/backlog/tasks/task-1091 - Watchlist-names-are-not-trimmed-and-the-delete-copy-mispluralises.md
+++ b/backlog/tasks/task-1091 - Watchlist-names-are-not-trimmed-and-the-delete-copy-mispluralises.md
@@ -1,0 +1,44 @@
+---
+id: TASK-1091
+title: >-
+  Watchlist names keep leading whitespace, and the delete copy says "1 source are"
+status: To Do
+assignee: []
+created_date: '2026-07-28 04:00'
+labels:
+  - watchlists
+  - bug
+  - ui
+  - uat
+priority: medium
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Two small copy/validation defects seen in the third Watchlists UAT (`origin/dev` `e82ac1b18`).
+
+**Names are not trimmed.** Renaming a watchlist to `" Daily"` (leading space) stored it verbatim, and the tree renders the space as extra indentation, so the row no longer lines up with its siblings:
+
+```
+│ ▸     Daily  0           │
+│ ▸  Security Watch  0     │
+```
+
+Create has the same gap. A name that is entirely whitespace is presumably also accepted, which would produce an unclickable, unnameable row.
+
+**The delete confirmation mispluralises.** With one source attached it reads:
+
+> Its **1 source are** not deleted. They stay in Watchlists and appear under Unassigned unless they also belong to another watchlist.
+
+Should be "is" for one. The rest of that copy is genuinely good — it explains the consequence clearly, which is why the grammar stands out.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Leading and trailing whitespace is stripped from a watchlist name on create and on rename
+- [ ] #2 A name that is empty or whitespace-only is rejected with a visible reason, not silently accepted
+- [ ] #3 The delete confirmation reads correctly for one source and for several
+- [ ] #4 Tests cover the whitespace-only name and the single-source wording, proven to fail against current code
+<!-- AC:END -->

--- a/backlog/tasks/task-1300 - Escape-does-not-dismiss-the-watchlist-dialogs.md
+++ b/backlog/tasks/task-1300 - Escape-does-not-dismiss-the-watchlist-dialogs.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-1090
+id: TASK-1300
 title: >-
   Escape does not dismiss the watchlist dialogs — only clicking Cancel does
 status: To Do


### PR DESCRIPTION
Supersedes #1031, which was opened before a different `task-1090` landed on dev and would now fail the backlog guard.

## What's here

The third Watchlists UAT (experienced-user journey), which **walks end to end** — the first run to do so, after the scrape-path and click-selection fixes landed.

**Two findings**, filed:
- **TASK-1300** — Escape does not dismiss the watchlist dialogs
- **TASK-1091** — watchlist names are not trimmed, and the delete copy mispluralises

**A correction to TASK-1040**, which matters more than the findings. That task claimed the rail and the centre were "describing the same thing, disagreeing" — `All sources  0` beside `Feeds in All sources (1)`. That is not a contradiction: `get_watchlist_item_counts` returns *item* totals, not source counts, as its own docstring says. With three sources and nothing scraped yet, `All sources  0` and `Feeds in All sources (3)` are both correct.

The fix that shipped is still right — `_create_source` genuinely left `#sources-table` stale — but AC #6 and #7 assert an equivalence that does not exist and should not be read as a contract. The real issue is milder: a bare `0` gives no clue it counts items, so someone who just added three sources reads it as "nothing was added". That's a labelling question, noted rather than filed.

## The collision

dev already carries a different `task-1090` ("watchlist fetch failures are swallowed into a debug log", since closed). This branch predates it, so rebasing produced two `task-1090` files — failing the guard on both the filename prefix and the frontmatter `id:`. Renumbered to **1300**, past the current global max of 1284 with headroom per the repo's leapfrog rule, with the UAT doc's cross-references updated to match.

Verified after renumbering: no duplicate filename prefixes, no duplicate frontmatter ids, no residual `1090` references to the Escape task.

Docs and backlog only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records the third Watchlists UAT that walked the experienced-user journey end to end. Confirms `TASK-895` AC#3 (deleting a watchlist never orphans sources), files two findings, and corrects `TASK-1040`.

- **Docs and Backlog**
  - `TASK-1300`: Escape does not dismiss watchlist dialogs; keyboard users get trapped. Apply fix across Rename/New/Add/Delete; renumbered from `task-1090` to avoid a collision.
  - `TASK-1091`: Watchlist names aren’t trimmed; delete copy mispluralizes “1 source”.
  - Corrects `TASK-1040`: rail shows item counts, not sources; `All sources 0` beside `Feeds in All sources (3)` is expected. Shipped sources-table refresh remains valid.

<sup>Written for commit 943fd18e481181f0aabc0e0928b578a7e6735991. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

