### PR TITLE
chore: close the merged watchlist tasks and the duplicate they re-derived

### DIFF
--- a/backlog/docs/lessons-backlog-hygiene.md
+++ b/backlog/docs/lessons-backlog-hygiene.md
@@ -153,6 +153,30 @@ alternative is a task that reaches an implementer, consumes a full cycle, and cl
 
 ---
 
+## Search the board for the defect before investigating it
+
+**TASK-1022 / TASK-1210, 2026-07-28.** A runtime import trace established that
+scheduled watchlist checks never ran: the feature flag had no `else` branch, the
+old scheduler had no construction path, and the flag shipped false. That was
+filed as TASK-1210 and fixed.
+
+TASK-1022 already said all of it — filed a day earlier, from a plain reading of
+the code, with the same four load-bearing facts and the same conclusion. The
+investigation was duplicated because nobody grepped `backlog/tasks/` first.
+
+**What to do.** Before investigating a defect, grep the board for its subject —
+here, `grep -il "watchlist.*schedul" backlog/tasks/` would have surfaced it in
+one command. Do it even when the finding feels new, and *especially* when it
+feels like a discovery: a confident diagnosis is exactly the state in which you
+skip the check.
+
+Closing the duplicate is not enough on its own. Say in the surviving task which
+one was first and what it already knew, so the board records that the second
+investigation was avoidable rather than quietly implying two independent
+confirmations.
+
+---
+
 ## Related
 
 - `lessons-testing-evidence.md`

--- a/backlog/tasks/task-1022 - ADR-019-rollback-path-does-not-exist-and-scheduled-watchlist-checks-are-off.md
+++ b/backlog/tasks/task-1022 - ADR-019-rollback-path-does-not-exist-and-scheduled-watchlist-checks-are-off.md
@@ -2,7 +2,7 @@
 id: TASK-1022
 title: >-
   ADR-019's rollback path does not exist and scheduled watchlist checks are off by default
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-27 14:00'
 labels:
@@ -63,3 +63,30 @@ So this is not an ADR that was authored against code that never worked; it is a 
 Handed to the **watchlists workstream** (2026-07-27). This was found incidentally while deleting dead worker components under TASK-1010, and the investigation deliberately stopped at establishing the facts: the decision — restore the rollback path, or amend ADR-019 and retire the old scheduler chain — belongs with whoever owns the watchlist migration, not with a cleanup task.
 
 Everything needed to make that call is in the description above: the missing `else` branch, the absent construction path, the default-false flag, what still works (manual "Check now"), and the twelve-hour window in which the rollback path was severed. No code was changed.
+
+## Implementation Notes
+
+Resolved by TASK-1210 (#1054), TASK-1211 (#1058) and the ADR-019 amendment they carried. Closing
+against that work rather than doing it twice.
+
+**This task was right, and it was here first.** Filed 2026-07-27 from a reading of the code, it had
+already established every load-bearing fact: the flag has no `else` branch, `SubscriptionScheduler`
+has no construction path from the app, the flag defaults false, and manual "Check now" is
+unaffected because it bypasses the scheduler entirely.
+
+A day later TASK-1210 re-derived the same conclusion from a runtime import trace, without checking
+whether the board already held it. The duplicated effort was mine; this file was the better
+starting point and I should have found it. The repo's own hygiene note — *audit the board, do not
+trust your own summary* — exists for exactly this.
+
+What shipped against it:
+
+- `watchlist_checks_enabled` now defaults **true** and `watchlist_checks_shadow` **false**, in the
+  shipped TOML and in `app.py`'s in-code fallbacks, so scheduled checks actually run. Verified live:
+  a seeded overdue source fetched 5 real items with no user interaction.
+- The unreachable `SubscriptionScheduler` / `SubscriptionSchedulerWorker` and the briefing island
+  they anchored were removed — ~8,150 LOC.
+- ADR-019 is amended to record that the dual-run and its rollback lever were never implemented, and
+  that the promotion gate it defined was unsatisfiable because the path it compared against did not
+  run.
+

--- a/backlog/tasks/task-1180 - Table-panes-outside-Watchlists-select-on-activation-not-on-click.md
+++ b/backlog/tasks/task-1180 - Table-panes-outside-Watchlists-select-on-activation-not-on-click.md
@@ -3,7 +3,7 @@ id: TASK-1180
 title: >-
   Table panes outside Watchlists select on activation, so a click moves the
   cursor but selects nothing
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-28 14:00'
 labels:

--- a/backlog/tasks/task-1210 - Watchlists-never-check-on-a-schedule.md
+++ b/backlog/tasks/task-1210 - Watchlists-never-check-on-a-schedule.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1210
 title: Watchlists never check on a schedule - promote the unified handler out of shadow mode
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-27 22:15'
 labels:

--- a/backlog/tasks/task-1211 - Retire-the-unreachable-subscription-scheduler-and-briefing-island.md
+++ b/backlog/tasks/task-1211 - Retire-the-unreachable-subscription-scheduler-and-briefing-island.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1211
 title: Retire the unreachable subscription scheduler and briefing island
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-27 22:15'
 labels:

--- a/backlog/tasks/task-1212 - Scheduler-should-not-silently-drop-tasks-with-no-handler.md
+++ b/backlog/tasks/task-1212 - Scheduler-should-not-silently-drop-tasks-with-no-handler.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1212
 title: Scheduler should not silently drop tasks whose type has no registered handler
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-27 23:05'
 labels:

--- a/backlog/tasks/task-1220 - Decide-content_processor-fate-now-that-its-last-caller-is-gone.md
+++ b/backlog/tasks/task-1220 - Decide-content_processor-fate-now-that-its-last-caller-is-gone.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1220
 title: Decide content_processor's fate now that its last caller is gone
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-28 00:20'
 labels:

--- a/backlog/tasks/task-1221 - Watchlists-is-gated-on-three-packages-nothing-imports.md
+++ b/backlog/tasks/task-1221 - Watchlists-is-gated-on-three-packages-nothing-imports.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1221
 title: Watchlists is gated on three packages nothing imports
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-28 00:35'
 labels:

--- a/backlog/tasks/task-1260 - Path-validation-property-tests-fail-under-machine-load.md
+++ b/backlog/tasks/task-1260 - Path-validation-property-tests-fail-under-machine-load.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1260
 title: Path-validation property tests fail under machine load, producing false regression signals
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-28 10:55'
 labels:


### PR DESCRIPTION
Backlog hygiene, docs only. Two problems, both mine.

## Seven tasks were left In Progress after merging

DoD item 7 requires status set to Done. These were marked In Progress when I picked them up, had their ACs checked and implementation notes written, and then never flipped when their PRs landed:

| Task | Merged in |
|---|---|
| 1180 | #1070 |
| 1210 | #1054 |
| 1211 | #1058 |
| 1212, 1221 | #1060 |
| 1220 | #1061 |
| 1260 | #1067 |

All now Done. **TASK-1240 stays To Do deliberately** — it needs a decision from the privacy work's owner about what may cross a security boundary, not a patch from me.

## TASK-1022 was here first, and I duplicated it

TASK-1022 — *"ADR-019's rollback path does not exist and scheduled watchlist checks are off by default"* — was filed **2026-07-27**, a day before my audit, from a plain reading of the code. It already contained every load-bearing fact:

- the flag has no `else` branch
- `SubscriptionScheduler` has no construction path from the app
- the flag defaults false
- manual "Check now" is unaffected, because it bypasses the scheduler entirely

TASK-1210 re-derived exactly that from a runtime import trace without checking whether the board already held it. The work still needed doing and #1054/#1058 did it — but the investigation was avoidable, and 1022 was the better starting point.

It's closed as superseded, with that stated plainly in its notes rather than quietly implying two independent confirmations.

## Lesson recorded

`lessons-backlog-hygiene.md` gains: grep `backlog/tasks/` for the subject **before** investigating a defect — here `grep -il "watchlist.*schedul" backlog/tasks/` would have surfaced it in one command. Do it especially when the finding feels like a discovery, because that's exactly the state in which the check gets skipped.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closed seven backlog tasks left In Progress after their PRs merged (1180, 1210, 1211, 1212, 1220, 1221, 1260), and closed TASK-1022 as superseded while noting it predated and informed the work in TASK-1210/1211. Added a backlog hygiene note to grep `backlog/tasks/` before investigating; TASK-1240 stays To Do pending a privacy decision.

<sup>Written for commit ea7b2358a6da7b78184b560803bfdd38d5617f66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

