### PR TITLE
Polish File Notes prepare-session-for-commit UX [TASK-1235]

### DIFF
--- a/.impeccable/critique/2026-07-28T15-38-30Z__ok-widgets-library-library-file-notes-git-panel-py.md
+++ b/.impeccable/critique/2026-07-28T15-38-30Z__ok-widgets-library-library-file-notes-git-panel-py.md
@@ -1,0 +1,197 @@
+---
+score: 25
+p0: 0
+p1: 4
+p2: 1
+verdict: functional-pass-ux-conditional
+timestamp: 2026-07-28T15-38-30Z
+slug: ok-widgets-library-library-file-notes-git-panel-py
+---
+Method: dual-agent (A: Wegener the 2nd · B: Harvey the 2nd)
+
+# File Notes Session Git — senior UX/HCI acceptance critique
+
+## Verdict
+
+**Functional acceptance: PASS. UX acceptance: CONDITIONAL.**
+
+The feature safely completes its promised core loop: Chatbook edits are written to disk, only current-process File Notes paths are offered, selected and bulk staging work, and unrelated index state survives both Stage all and Unstage all. It is safe enough to use now by a Git-literate user.
+
+It is not yet polished enough to feel like the primary notes-management surface for a mixed-audience user base. The largest gaps are authority-state presentation, focused-control legibility, status visibility at small terminal heights, and translation from Git internals into note-centered language.
+
+Design-specificity verdict: **behaviorally bespoke; visually generic.** The safety policy is distinctly Chatbook. The presentation still reads like a raw Git sidebar.
+
+## Acceptance journeys exercised
+
+| Journey | Result | Evidence |
+|---|---|---|
+| Open a tracked Markdown note and edit only its body | Pass | Body edit autosaved; `Saved` returned without a manual save action. |
+| Preserve YAML frontmatter byte-for-byte while editing the body | Pass | Git diff contained one appended body line; frontmatter had no diff. |
+| Reflect session changes near real time | Pass | `Session Git (0)` advanced to `(1)` and `(2)` after autosaves. |
+| Cancel repository trust safely | Pass | Cancel received initial focus; no status/staging ran. |
+| Accept process-scoped trust | Pass | Canonical repository and branch appeared; status populated. |
+| Stage and unstage a selected path | Pass | Git index changed only for `notes/inbox.md`, then returned to unstaged. |
+| Stage all and unstage all session paths | Pass | Both edited notes moved into and out of the index as a group. |
+| Preserve unrelated external index state | Pass | Externally staged `unrelated.md` remained staged after Chatbook Unstage all. |
+| Exclude repository dirt from a prior/fresh Chatbook process | Pass | A new process over the dirty repo showed `Session Git (0)` and “No current-session Git changes.” |
+| Retain search state across Session Git | Pass | Query `recognition` and its single result returned intact after Back. |
+| Explain a non-Git notes root | Pass with UX issue | “Selected File Notes root is not in a Git worktree” appeared, but the focused Back control lost its visible label. |
+| Adapt across terminal sizes | Mixed | 150, 70, and 48 columns remained usable; at 40×20 the final status line clipped and the editor toolbar clipped `Protect` to `P`. |
+| Keyboard Back from the change list | Inconclusive | Real tmux ignored Escape twice; an exact mounted Textual probe returned to Files and restored focus. Treat as a physical-terminal regression-test gap, not a confirmed defect. |
+
+## Nielsen heuristic score
+
+| # | Heuristic | Score (0–4) | Evidence |
+|---|---|---:|---|
+| 1 | Visibility of system status | 2 | Many states exist, but the sole status line is muted, can retain an obsolete action summary, and clips at 40×20. |
+| 2 | Match between system and real world | 2 | Repository authority is explicit; `HEAD`, index ownership, lineage, and “Stage update” are not translated for note-centric users. |
+| 3 | User control and freedom | 3 | Cancel-first trust, exact Unstage, Back, retained context, and safe mutation gates are strong; focused Back legibility is not. |
+| 4 | Consistency and standards | 2 | Behavior is internally consistent, but File Notes bypasses adjacent Library section, toolbar, badge, and status conventions. |
+| 5 | Error prevention | 4 | Trust, repository revalidation, stale gates, autosave flush, path closure, and exact eligibility are excellent. |
+| 6 | Recognition rather than recall | 2 | State is textual, but rows are compound strings, actions appear/disappear, shortcuts are hidden, and change verbs are omitted. |
+| 7 | Flexibility and efficiency | 3 | Selected and bulk actions, stable row identity, keyboard navigation, and retained context are strong; accelerators/filtering are absent. |
+| 8 | Aesthetic and minimalist design | 2 | Clean, but flat hierarchy, large dead zones, wrapped authority copy, and competing editor controls hurt scanability. |
+| 9 | Help users recognize, diagnose, and recover from errors | 3 | Problems are usually named and Refresh/Back exist; recovery copy is sometimes vague or technical, and stale rows can cross authority states. |
+| 10 | Help and documentation | 2 | Scope and trust explanations exist; there is no visible keyboard legend, glossary, or plain-language explanation of staging states. |
+|  | **Total** | **25/40** | **Core-safe, presentation-incomplete.** |
+
+## Cognitive load
+
+**High: 6 of 8 load checks fail.**
+
+- Single focus fails: wide mode keeps an editable note and its toolbar active while Session Git owns the navigator.
+- Chunking fails: path, state, and disabled reason are one wrapping sentence.
+- Hierarchy fails: there is no visible `Session Git` title, and repository, scope, rows, actions, and result feedback have similar weight.
+- One-thing-at-a-time fails: note editing and Git decisions remain equally available.
+- Minimal choices fails: a complex row can expose Back, Refresh, selected Stage/Unstage, and two bulk actions alongside the editor’s actions.
+- Working memory fails: users must remember the meaning of session ownership, external staging, lineage, complete-file staging, and Stage update.
+- Grouping passes structurally: authority, list, selected actions, bulk actions, and status are separate regions.
+- Progressive disclosure passes: Session Git is a separate navigator mode and trust is gated.
+
+## Emotional journey
+
+1. **Entry — confidence:** `Session Git (N)` gives the user a bounded set and makes the session model feel manageable.
+2. **Trust — appropriate anxiety:** The warning correctly explains configured Git-filter risk. Process-only trust, canonical path, safe initial focus, and Escape recovery rebuild confidence.
+3. **Status — comprehension valley:** The user lands in a technically accurate but flat list. A researcher may feel they have left Chatbook and entered a lower-level Git tool.
+4. **Mutation — reassurance:** “in progress,” disabled actions, and exact result counts reduce fear of accidental index changes.
+5. **Completion — mechanically safe:** The actual preservation behavior is excellent, but success copy does not restate the most reassuring promise: unrelated repository state was left untouched.
+
+## What is already strong
+
+- **The safety model is excellent.** Trust is process-scoped; the canonical repository and branch are visible; complete-file staging is disclosed; stale and mutation states gate action; unrelated index state is preserved.
+- **The data loop is trustworthy.** Autosave, exact frontmatter preservation, disk state, session ownership, and Git index behavior aligned during live use.
+- **Context retention is excellent.** Search query/results, expanded folders, open editor, and session rows survive navigator transitions and resize changes.
+- **State coverage is deep.** Ready, empty, checking, stale, unavailable, error, conflict, externally staged, clean, moved, and owned states all have policy support.
+
+## Priority findings
+
+### P1 — Focus can erase the only visible recovery label
+
+**Observed:** In both a fresh-session empty state and a non-Git unavailable state at 70 columns, focus moved to Back as intended, but the control rendered as only `┏━━━━━━━━━━━━━━━┓`; “Back to Files” was not visible. This is the exact state where Back is the primary or only recovery action.
+
+**Cause:** Buttons are forced to one terminal row while the focus treatment uses a heavy outline (`library_file_notes_git_panel.py:160–171`). The workspace intentionally focuses Back when there are no visible rows (`library_file_notes_workspace.py:1955–1967`).
+
+**Improve:** Do not combine a one-cell button with a box-like outline. Use reverse video/background/text style on the same row, or allow three rows where a full outline is required. Add visual assertions for focused Back, Refresh, Stage, and Unstage at 40/70 columns.
+
+### P1 — Repository authority can change while old rows remain visible
+
+**Observed in a mounted state probe:** Ready, untrusted, and unavailable states each retained the same old row in both the model and visible list.
+
+**Cause:** `render_untrusted()` and `render_unavailable()` update authority/status but do not clear or hide `_rows`; only `render_status()` replaces rows (`library_file_notes_git_panel.py:319–401`).
+
+**Why it matters:** Even with actions disabled, paths from repository A can appear under authority text for repository B or “unavailable.” That undermines the feature’s strongest safety concept.
+
+**Improve:** Clear rows and selection whenever repository identity is untrusted, changed, or unavailable. Retain rows only for checking/stale/error states that are proven to belong to the same repository identity.
+
+### P1 — Result and recovery feedback is too easy to miss or misread
+
+**Observed:** After one path was unstaged, a second path was edited. Reopening Session Git correctly showed two rows, but the footer still said `Unstaged 1 · clean 0 · blocked 0`. At 40×20, the final result wrapped below the viewport, leaving `Unstaged 2 · … ·` without its blocked count.
+
+**Cause:** The retained `_git_action_detail` is reapplied after status rehydration (`library_file_notes_workspace.py:1119–1121`, `1234–1243`), and all routine/success/error feedback shares `$text-muted` at the bottom (`library_file_notes_git_panel.py:126–130`).
+
+**Improve:** Give feedback a stable, always-visible strip immediately above actions. Reset or timestamp an action summary when the session/status generation changes. Use explicit text tokens—`READY`, `STAGED`, `STALE`, `BLOCKED`, `FAILED`—plus restrained semantic styling. Replace “settle the draft” with an exact next step.
+
+### P1 — Rows show Git state but omit the note change users care about
+
+**Observed/source evidence:** Each row flattens `path · Git state — disabled reason` into one Static. The model already knows whether the note was created, modified, moved, or deleted, but that change verb is not shown. At narrow widths, technical state/reason strings wrap heavily.
+
+**Improve:** Lead with note intent, then expose Git detail:
+
+`Edited  study/hci.md  [Ready to stage]`
+
+Use a second line or selected-row detail for disabled reasons, middle-elide long paths, and preserve full text on focus. Pair plain language with precise Git language rather than removing the latter.
+
+### P2 — The Git task competes with editor controls and lacks keyboard signposting
+
+**Observed:** Wide mode can display up to 15 actions across Session Git, the editor toolbar, and root selection. At 40 columns the editor’s first toolbar clips `Protect` to `P`. The Git panel exposes no visible keyboard contract. `Back to Files` also returns to search results when search was the prior mode.
+
+**Improve:** Add group labels (`Selected note`, `All eligible (N)`), visually quiet the editor toolbar while Session Git owns focus, stack/wrap the editor toolbar at the same narrow breakpoint, and add `↑↓ Select · Tab Actions · Enter Run · Esc Navigator`. Rename Back dynamically to `Back to search results` or use neutral `Back to navigator`.
+
+## Persona red flags
+
+### Alex — terminal/Git power user
+
+- Likes the exact index preservation, bulk actions, stable selection, and fast retained state.
+- Will miss direct accelerators for refresh/stage/unstage and an actionable-only filter.
+- Will find the variable Tab order and wrapping compound rows slow in a large session.
+
+### Sam — keyboard, low-vision, or screen-reader user
+
+- Benefits from text labels, non-color-only state, safe trust focus, and strong mutation prevention.
+- Is blocked when a focused one-line button loses its label.
+- May not learn that status changed because `Static.update()` has no explicit announcement contract and feedback sits at the bottom.
+- Needs physical-terminal/screen-reader validation; browser ARIA tests do not apply to Textual.
+
+### Priya — researcher/student with modest Git knowledge
+
+- Understands “edited/moved/deleted note” better than `HEAD`, index ownership, or lineage.
+- May overestimate the trust warning’s risk because the dialog does not say that Cancel leaves normal note editing available.
+- Needs success feedback that says the thing she cares about: “2 session notes staged; unrelated repository changes were not touched.”
+
+## Minor observations and upgrades
+
+- `Session Git (N)` counts coalesced session lineages, not necessarily actionable unstaged changes. Prefer `Session paths (N)` or clarify the count.
+- Use sentence case consistently: `Stage all`, `Unstage all`.
+- Split repository and branch across purposeful lines instead of allowing an arbitrary wrap.
+- Empty file trees and zero-result searches need explicit empty copy; search exceptions currently look like zero matches.
+- The trust action is a warning/approval, not a destructive/error action.
+- Detached, unborn, and unavailable HEAD labels lack mounted visual coverage.
+- For large sessions, add an `Actionable only` toggle or filter only after real use shows scanning friction; do not make it part of the immediate fix wave.
+
+## Recommended sequence
+
+1. Fix focused one-line control legibility and add visual assertions.
+2. Clear rows across repository-authority transitions.
+3. Make the status/recovery strip stable, current, visible, and semantic.
+4. Redesign rows around note-change verbs plus state badges.
+5. Reduce action competition and add keyboard signposting/narrow toolbar wrapping.
+
+## Product questions
+
+1. **How should the surface be framed?**
+   - `Prepare this session for commit` — note-centered and outcome-oriented. **Recommended**
+   - `Session Git` — concise and appropriate for expert users.
+   - Dual label: `Prepare session` with `Git staging` as secondary copy.
+
+2. **What should happen to the editor toolbar while Session Git is active in wide mode?**
+   - Keep the note visible but visually quiet or collapse its actions. **Recommended**
+   - Keep the current fully active editor and toolbar.
+   - Hide the editor entirely until the user returns to the navigator.
+
+3. **What should successful bulk feedback emphasize?**
+   - Promise plus count: `2 session notes staged; unrelated repository changes untouched.` **Recommended**
+   - Compact counts only.
+   - A detailed per-path activity log.
+
+## Run notes
+
+- Resolved target: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/file-notes-move-tombstone/tldw_chatbook/Widgets/Library/library_file_notes_git_panel.py`
+- Target slug: `ok-widgets-library-library-file-notes-git-panel-py`
+- Ignore list: `.impeccable/critique/ignore.md` absent; no ignored findings.
+- Assessment independence: Assessment A remained isolated from detector/Assessment B. Synthesis waited for A to complete.
+- Detector: exact output `[]` (0 findings). This is non-probative because Impeccable’s detector does not scan Python/Textual semantics.
+- Browser applicability: not applicable. This is a native Textual TUI with no DOM, browser route, or overlay target. No live web server, visibility mutation, or overlay injection was used.
+- Runtime method: real Textual surface in an isolated tmux server, disposable real Git repository, 150×42, 70×28/24, 48×24, and 40×20 viewports; one exact mounted keyboard probe.
+- Automated fallback evidence: Assessment B ran `Tests/UI/test_library_file_notes_git.py` — 49 passed in 10.78 seconds.
+- Cleanup: all three TUI processes exited, the dedicated tmux server closed, and both disposable `/private/tmp` fixture roots were removed.
+- Accessibility boundary: keyboard completion and visible text/focus were exercised; terminal screen-reader announcement behavior and theme-specific contrast remain unverified.

--- a/Docs/superpowers/plans/2026-07-28-file-notes-prepare-session-ux.md
+++ b/Docs/superpowers/plans/2026-07-28-file-notes-prepare-session-ux.md
@@ -1,0 +1,711 @@
+# File Notes Prepare Session UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn File Notes Session Git into a legible, note-centered `Prepare session for commit` workflow without changing its session-only Git safety behavior.
+
+**Architecture:** Keep `LibraryFileNotesGitPanel` presentation-only and derive every new label, status, count, and recovery instruction from existing immutable row/status models. Keep `FileNotesSessionOwner` as the sole root/repository/session authority; `LibraryFileNotesWorkspace` adds only a keyed last-action presentation record and responsive CSS classes. No Git service, owner, database, schema, or command behavior changes.
+
+**Tech Stack:** Python 3.11+, Textual 8.2.7, Rich cell measurement, pytest 8.4.2, existing real mounted Textual harnesses.
+
+**Backlog:** [TASK-1235](../../../backlog/tasks/task-1235%20-%20Polish-File-Notes-prepare-session-for-commit-UX.md)
+
+**Specification:** [File Notes Prepare Session UX Design](../specs/2026-07-28-file-notes-prepare-session-ux-design.md)
+
+**Source UAT:** [File Notes Session Git acceptance critique](../../../.impeccable/critique/2026-07-28T15-38-30Z__ok-widgets-library-library-file-notes-git-panel-py.md)
+
+**Depends on:** TASK-1213
+
+**ADR required:** no
+
+**ADR path:** N/A
+
+**Reason:** This is a presentation-only repair conforming to ADR-035, ADR-033, ADR-011, and the File Notes disk-authority decision in `backlog/decisions/029-file-notes-disk-authority.md`. It changes no persistence, ownership, Git service contract, security boundary, dependency, or long-lived application structure.
+
+---
+
+## Execution Environment and Scope
+
+Run every command from:
+
+```text
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/file-notes-move-tombstone
+```
+
+Use the main checkout's environment explicitly:
+
+```bash
+../../.venv/bin/python -c "import pathlib, tldw_chatbook, textual, pytest; print(pathlib.Path(tldw_chatbook.__file__).resolve()); print(textual.__version__, pytest.__version__)"
+../../.venv/bin/python -m ruff --version
+git --version
+```
+
+Expected package path: this worktree. Verified baseline versions are Python
+3.12.11, Textual 8.2.7, pytest 8.4.2, Ruff 0.15.22, and Git 2.39.5.
+
+The pre-change focused baseline is:
+
+```bash
+../../.venv/bin/python -m pytest -q Tests/UI/test_library_file_notes_git.py
+```
+
+Expected: `49 passed`.
+
+Use strict red/green TDD. Run each named test immediately after writing it and
+confirm it fails because the approved behavior is absent before modifying
+production code.
+
+Per the approved task boundary, do not run full CI, the multi-hour full pytest
+suite, network/remotes, or a broad soak/performance harness. Run the complete
+focused UI file plus targeted Ruff, compile, and diff checks before completion.
+
+## File Structure
+
+- Modify `tldw_chatbook/Widgets/Library/library_file_notes_git_panel.py`:
+  note-intent rows, semantic/recovery copy, title/help hierarchy, independent
+  current/last-action surfaces, authority clearing, counts, bounded geometry,
+  and non-obscuring focus.
+- Modify `tldw_chatbook/Widgets/Library/library_file_notes_workspace.py`:
+  owner-snapshot-keyed last-action presentation, contract-true summaries,
+  authority transition projection, quiet wide editor actions, and narrow
+  toolbar layout.
+- Modify `Tests/UI/test_library_file_notes_git.py`: all new automated coverage;
+  reuse its existing real panel/workspace harnesses and complete fake service.
+- Modify
+  `backlog/tasks/task-1235 - Polish-File-Notes-prepare-session-for-commit-UX.md`
+  before implementation to link this plan, then after verification to check
+  acceptance criteria and add concise implementation notes.
+
+Do not modify `file_notes_session_owner.py`, `file_notes_git_service.py`,
+`file_notes_service.py`, SQLite code, application navigation, global CSS, or
+Git configuration.
+
+## Planning Checkpoint
+
+Before Task 1, link this plan from TASK-1235, record the ADR determination in
+the task's `## Implementation Plan`, and commit the plan, task update, and
+approved-spec wording correction together. Production implementation begins
+from that clean documentation checkpoint.
+
+## Task 1: Make the Git Panel Note-Centered and Authority-Safe
+
+**Files:**
+
+- Modify:
+  `tldw_chatbook/Widgets/Library/library_file_notes_git_panel.py:1-614`
+- Modify: `Tests/UI/test_library_file_notes_git.py:320-806`
+
+- [ ] **Step 1: Write failing note-intent, semantic-state, hierarchy, and authority tests**
+
+Extend the existing `_row()` helper with optional `latest_action`,
+`source_path`, and `destination_path` arguments. Reuse `_PanelHarness`,
+`_status`, `_text`, and `_wait_until`; do not add another harness or fake.
+
+Add a parametrized row projection test:
+
+```python
+@pytest.mark.parametrize(
+    ("latest_action", "verb"),
+    [
+        ("created", "CREATED"),
+        ("modified", "EDITED"),
+        ("moved", "MOVED"),
+        ("deleted", "DELETED"),
+        ("restored", "RESTORED"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_rows_project_note_intent_on_a_separate_primary_line(
+    latest_action: str,
+    verb: str,
+) -> None:
+    row = _row(
+        "unstaged",
+        latest_action=latest_action,
+        source_path="folder/before.md",
+        destination_path=(
+            "folder/after.md" if latest_action == "moved" else None
+        ),
+        stage_action="stage",
+    )
+    panel = LibraryFileNotesGitPanel()
+    async with _PanelHarness(panel).run_test() as pilot:
+        panel.render_status(_status(row))
+        await pilot.pause()
+        primary = _text(
+            panel.query_one(".file-notes-git-row-primary", Static)
+        )
+        semantic = _text(
+            panel.query_one(".file-notes-git-row-secondary", Static)
+        )
+        assert primary.startswith(verb)
+        assert "folder/before.md" in primary
+        if latest_action == "moved":
+            assert "-> folder/after.md" in primary
+        assert semantic == "READY TO STAGE · Git: unstaged"
+```
+
+Add real `coalesce_session_changes()` cases for create→delete,
+delete→restore, edit→clean, and chained move. Assert `DELETED`, `RESTORED`,
+`EDITED · NO ACTION`, and original-source→final-destination respectively.
+
+Extend `test_row_action_table_is_driven_by_row_policy` with the exact semantic
+token and recovery fragment for every existing row state. Its second rendered
+line must contain:
+
+| State | Required copy |
+| --- | --- |
+| `unstaged` | `READY TO STAGE · Git: unstaged` |
+| `owned` | `STAGED · by Chatbook` |
+| `owned_newer_edits` | `UPDATE AVAILABLE · newer note edits are not staged` |
+| `owned_topology_changed` | `UPDATE REQUIRED · stage the moved note before unstaging` |
+| `external_staged`, `external_partial` | `BLOCKED · already staged outside Chatbook` and `Refresh` |
+| `clean` | `NO ACTION · matches HEAD` |
+| `ignored`, `conflict`, unsafe/unsupported variants | `BLOCKED`, the specific reason, external next step, and `Refresh` |
+| `unavailable` | `BLOCKED`, restore-Git next step, and `Refresh` |
+| `error` | `FAILED`, reason, retry, and `Refresh` |
+
+Extend `test_panel_renders_repository_scope_and_complete_file_state` to assert:
+
+```text
+Prepare session for commit
+Session paths only · stages complete file state
+Up/Down Select | Tab Actions | Enter Run | Esc Back
+Status: CURRENT · READY
+```
+
+Add
+`test_selected_and_bulk_labels_report_selection_and_independent_counts`.
+With two stage-eligible rows and one unstage-eligible row, assert:
+
+```python
+assert _text(
+    panel.query_one("#file-notes-git-selected-note", Static)
+).startswith("Selected note: ")
+assert str(
+    panel.query_one("#file-notes-git-stage-all", Button).label
+) == "Stage all (2)"
+assert str(
+    panel.query_one("#file-notes-git-unstage-all", Button).label
+) == "Unstage all (1)"
+```
+
+Add a parametrized authority-loss test. Render two ready rows, select the
+second, then call `render_untrusted()` or `render_unavailable()`. Assert
+`panel.rows == ()`, `selected_group_id is None`, no rendered row widgets remain,
+and no selected/bulk mutation is usable. Keep the existing stale/error test and
+change it to assert rows remain while
+`#file-notes-git-status` contains `STALE` or `STALE · ERROR` and
+`#file-notes-git-action-status` remains independent.
+
+- [ ] **Step 2: Run the new panel semantics tests and verify RED**
+
+```bash
+../../.venv/bin/python -m pytest -q Tests/UI/test_library_file_notes_git.py -k "rows_project or coalesced or row_action_table or panel_renders_repository or selected_and_bulk_labels or authority_loss or stale_and_error"
+```
+
+Expected: FAIL because rows are one Git-first line, title/help/current status
+do not exist, bulk labels have no counts, and authority-loss renderers retain
+old rows.
+
+- [ ] **Step 3: Implement the minimal panel projections**
+
+Replace `_ROW_STATE_LABELS` with local view copy and add:
+
+```python
+_CHANGE_VERBS = {
+    "created": "CREATED",
+    "modified": "EDITED",
+    "moved": "MOVED",
+    "deleted": "DELETED",
+    "restored": "RESTORED",
+}
+```
+
+Keep raw model paths untouched. Build display-only move text with ASCII `->`
+from `source_path` and `destination_path`, passed through the existing
+control-character sanitizer.
+
+Render `_SessionGitListItem` as exactly two `Static` children:
+
+```python
+yield Static(primary, classes="file-notes-git-row-primary", markup=False)
+yield Static(
+    semantic_and_recovery,
+    classes="file-notes-git-row-secondary",
+    markup=False,
+)
+```
+
+Use the existing `disabled_reason` only as bounded detail; append the
+state-specific next action from the approved table. Reserve cells for the
+semantic token and complete recovery phrase first, then middle-elide only the
+diagnostic detail to the remaining width. Never allow a long reason to hide
+`Refresh`, `Return to the editor`, or the other exact next action. Do not alter
+row policy, eligibility, grouping, or stable IDs.
+
+Change `compose()` to mount, in order:
+
+```text
+Back/Refresh/Trust
+Prepare session for commit
+Repository/branch
+Session paths only · stages complete file state
+Up/Down Select | Tab Actions | Enter Run | Esc Back
+scrollable rows or empty state
+current status
+last action
+selected-note detail
+selected actions
+bulk actions
+```
+
+Use `#file-notes-git-status` for current freshness/recovery. Keep
+`#file-notes-git-action-status` only for the latest action, hidden when empty.
+Add `set_current_status()`, `set_last_action()`, and `clear_last_action()`.
+Every `render_*`, `mark_stale()`, and `set_mutating()` path updates only current
+status.
+
+`render_status()` computes independent stage/unstage counts and uses:
+
+```python
+stage_count = sum(row.stage_eligible for row in self._rows)
+unstage_count = sum(row.unstage_eligible for row in self._rows)
+current = (
+    "Status: CURRENT · READY — "
+    f"{stage_count} can be staged · {unstage_count} can be unstaged."
+)
+```
+
+Use `Status: STALE`, `Status: STALE · ERROR`,
+`Status: TRUST REQUIRED`, `Status: UNAVAILABLE`, and
+`Status: UPDATING INDEX` for the corresponding existing states.
+
+Add one `_clear_rows()` helper that empties `_rows`, selection, and the real
+`ListView` through the existing row-render generation. Call it from untrusted,
+discovery-unavailable, non-repository, and unavailable-status paths. Checking
+may retain rows only when the workspace explicitly passes
+`retain_rows=True`; the panel never infers authority.
+
+In `_update_actions()`, use `Stage`, `Stage update`, and `Unstage` for selected
+buttons and set `Stage all (S)` / `Unstage all (U)` independently. Update the
+two-line selected-note detail from the current row.
+
+- [ ] **Step 4: Run the panel semantics tests and verify GREEN**
+
+Run the Step 2 command.
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing focus, elision, and fixed-region geometry tests**
+
+Strengthen `test_panel_action_controls_fit_with_focus_at_24_cells` and
+parameterize the supported sizes `(150, 42)`, `(70, 28)`, `(70, 24)`, and
+`(40, 20)`. Exercise both untrusted and ready/update states. After focusing
+each visible button, assert its complete `render().plain` label, content width,
+and region remain inside the panel.
+
+Add `test_prepare_session_fixed_regions_remain_visible_at_40_by_20`. Render a
+long moved path, enough rows to overflow, a long row failure reason, a long
+current-status diagnostic, and a long failed last-action result. Assert
+repository, selected-note, current-status, and last-action widgets are visible,
+at most two rows high, and end within the panel. Assert Back and eligible
+actions remain visible, both ends of the elided path remain, every exact
+recovery action is still visible, and the list is the only flexible-height
+region.
+
+Add one helper-level test for cell-aware middle elision, including a wide-cell
+path, proving the result never exceeds the requested Rich cell width and keeps
+both ends.
+
+- [ ] **Step 6: Run the geometry tests and verify RED**
+
+```bash
+../../.venv/bin/python -m pytest -q Tests/UI/test_library_file_notes_git.py -k "focused_controls or action_controls_fit or fixed_regions or middle_elide"
+```
+
+Expected: FAIL because heavy outlines replace focused labels, paths are not
+middle-elided, and fixed status/action regions can fall below `40×20`.
+
+- [ ] **Step 7: Implement bounded cell geometry and non-obscuring focus**
+
+Use `rich.cells.cell_len` and `split_graphemes` in a small local
+`_middle_elide_cells(text, width)` helper. Reserve three cells for `...`, take
+whole graphemes from both ends within the remaining cell budgets, and return
+the original string when it already fits.
+
+On list-item mount/resize, update the primary line against the real row width.
+Use the same helper for selected-note detail. Keep each row exactly two cells
+high.
+
+In panel-local `DEFAULT_CSS`:
+
+```css
+.file-notes-git-row:focus,
+.file-notes-git-row.-highlight,
+LibraryFileNotesGitPanel Button:focus {
+    background: $ds-focus-bg;
+    color: $ds-focus-fg;
+    text-style: bold underline;
+    outline: none;
+}
+```
+
+Repository, selected-note, current-status, and last-action regions get
+`max-height: 2` and hidden overflow. The list gets `height: 1fr`,
+`min-height: 1`, and no vertical margin that can push fixed regions below the
+viewport. Before updating any bounded semantic/current/last-action widget,
+fit its diagnostic portion to the widget's real cell budget while reserving
+the semantic prefix and complete recovery suffix. Keep the unabridged result
+in `_GitLastAction`; truncation is display-only and recomputed after resize.
+
+Replace the fixed `width <= 48` action-stack guess. Sum the Rich cell width
+plus existing button chrome for the currently visible labels in each header,
+selected, and bulk row; set `-stack-actions` only when a row does not fit.
+Recompute after resize and after `_update_actions()` changes visibility/labels.
+
+- [ ] **Step 8: Run the complete panel slice and verify GREEN**
+
+```bash
+../../.venv/bin/python -m pytest -q Tests/UI/test_library_file_notes_git.py -k "panel or row_action_table or rows_project or coalesced or selected_and_bulk or authority_loss or stale_and_error or focused_controls or action_controls_fit or fixed_regions or middle_elide"
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit the panel slice**
+
+```bash
+git add tldw_chatbook/Widgets/Library/library_file_notes_git_panel.py Tests/UI/test_library_file_notes_git.py
+git commit -m "fix(notes): clarify prepare-session Git panel [TASK-1235]"
+```
+
+## Task 2: Keep Feedback Current and Quiet Competing Editor Actions
+
+**Files:**
+
+- Modify:
+  `tldw_chatbook/Widgets/Library/library_file_notes_workspace.py:45-100, 186-215, 270-305, 560-780, 890-925, 999-1245, 2020-2197`
+- Modify: `Tests/UI/test_library_file_notes_git.py:822-2022`
+
+- [ ] **Step 1: Write failing last-action ownership and summary tests**
+
+Use the existing complete `_FakeGitService`; do not assert on the fake itself.
+Assert real workspace/panel behavior.
+
+Add direct `_git_action_summary()` cases for:
+
+- successful Stage and Unstage with one and two coalesced groups;
+- one moved group with two endpoints counting as one session note;
+- zero-effect success;
+- blocked, stale, error, and uncertain results;
+- a `result.message` plus clean/blocked counts.
+- a nominal success with a deliberately mismatched captured action key.
+
+Only certain success with at least one affected group may contain:
+
+```text
+1 session note staged; Chatbook targeted only eligible session paths.
+2 session notes unstaged; Chatbook restored only its owned session entries.
+```
+
+Every other state omits both promises, retains material counts, and includes an
+exact recovery ending in Refresh. Existing bulk tests continue to assert
+nonzero already-staged, skipped, clean, and blocked counts.
+
+The mismatched-success case must not be retained or presented by the workspace
+and must never produce promise copy.
+
+Add `test_session_change_invalidates_last_action_before_refresh`:
+
+1. complete a successful action and its normal refresh;
+2. block the next status;
+3. record `late.md`;
+4. call `_refresh_session_changes()`;
+5. assert the last-action static clears immediately and current status becomes
+   stale before refresh finishes.
+
+Update `test_hidden_action_summary_is_presented_after_reopen` to prove a
+same-binding/repository/change-snapshot result survives hiding, reopening, and
+its normal status-generation change.
+
+Add `test_selected_root_change_clears_rows_and_last_action`: after ready rows
+and a successful last action, call the real `set_root()` for another temporary
+root and assert rows, selection, and last action clear.
+
+Extend the repository-retrust test to assert old rows and last action are gone
+before the replacement trust prompt is accepted.
+
+Add `test_refresh_failure_keeps_stale_error_separate_from_last_action`: after a
+proven action, make the next status task raise and assert the old result remains
+under last action while current status becomes `STALE · ERROR`, rows remain,
+and mutations are disabled.
+
+- [ ] **Step 2: Run the feedback tests and verify RED**
+
+```bash
+../../.venv/bin/python -m pytest -q Tests/UI/test_library_file_notes_git.py -k "action_summary or summary_counts or hidden_action_summary or session_change_invalidates or selected_root_change or repository_retrust or refresh_failure"
+```
+
+Expected: FAIL because one unkeyed string overwrites freshness, survives
+authority/session changes, and lacks checked promise/recovery rules.
+
+- [ ] **Step 3: Implement owner-snapshot-keyed last-action presentation**
+
+Add one local immutable view record beside `_GitActionSummaryContext`:
+
+```python
+@dataclass(frozen=True, slots=True)
+class _GitLastAction:
+    binding: SessionBinding
+    repository: RepositoryIdentity
+    changes: tuple[SequencedSessionChange, ...]
+    text: str
+```
+
+Replace `_git_action_detail` with `_git_last_action: _GitLastAction | None`.
+Add helpers that derive the current key only from the owner's immutable
+snapshot and compare all three fields. Do not include Git status generation or
+staging ownership because the action and automatic postflight refresh
+legitimately change them.
+
+Capture binding, complete trusted `RepositoryIdentity`, and exact
+`snapshot.changes` after draft flush/save/transition checks and immediately
+around synchronous Stage/Unstage admission. Clear the prior presentation only
+after a newer action is admitted. Pass the captured key into
+`_render_git_action()`.
+
+Retain/display a result only when the captured key still equals a fresh owner
+snapshot. Validate/clear it from `_refresh_session_changes()`,
+`_rehydrate_git_presentation()`, `_render_git_status()`, root publication, and
+untrusted/unavailable discovery. A status-generation-only change must not
+clear it.
+
+Route Git blockers, trust loss, and discovery recovery through the panel's
+current-status API. Route only checked action results through
+`set_last_action()`. Replace `settle the draft` with the exact editor recovery
+from the specification.
+
+Change `_git_action_summary()` so a promise is emitted only when:
+
+```python
+service_reported_checked_success
+and affected_group_count > 0
+and action_key_still_matches
+```
+
+`service_reported_checked_success` is exactly
+`result.state == "success"` under the existing `GitActionResult`/ADR-035
+contract: the Git service is the sole authority and emits `success` only after
+repository/`HEAD` postflight and Stage ownership publication or owned-baseline
+Unstage restoration have all verified. Do not duplicate those Git/index safety
+checks in the presentation layer. The workspace-owned proof is the fresh
+binding, complete `RepositoryIdentity`, and exact session-change-key match; a
+mismatch suppresses the entire obsolete result, not just its promise.
+
+Use coalesced staged/unstaged group counts, correct singular/plural nouns, and
+append only material nonzero bulk counts. Do not return `result.message` early;
+preserve it beside counts and add state-specific recovery for blocked, stale,
+error, uncertain, and zero-effect results. Keep the unabridged summary in the
+workspace record; the panel's bounded display projection protects the complete
+recovery phrase when diagnostic text is long.
+
+When a different root binding is atomically published, clear the panel rows
+and last-action presentation on the UI thread. Repository change already
+passes through untrusted/unavailable rendering, which performs the same clear.
+
+For checking, pass `retain_rows=True` only when the current owner snapshot
+contains a prior status with the same binding generation and complete trusted
+repository identity. The panel remains presentation-only.
+
+- [ ] **Step 4: Run the feedback tests and verify GREEN**
+
+Run the Step 2 command.
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing wide-editor quieting and narrow-toolbar tests**
+
+Extend `test_workspace_retains_files_search_and_git_modes_with_back_focus` or
+add
+`test_wide_prepare_session_quiets_and_restores_editor_toolbars_without_remount`.
+At `150×42`, open a note and retain the `TextArea` identity, body, cursor, and
+selection. Enter Prepare session mode and assert:
+
+- both `.file-notes-toolbar` rows are hidden;
+- breadcrumb, save state, and the same editable `TextArea` remain visible;
+- typing still changes the retained editor;
+- Back restores both toolbars immediately without remount or draft loss.
+
+Add `test_narrow_editor_actions_keep_complete_labels_at_40_by_20`. At `40×20`,
+open a note so Editor is visible. For every visible editor action, assert its
+region is inside the editor pane and its rendered label is complete. Explicitly
+assert `Protect`, then toggle protected state and assert `Unprotect`.
+
+- [ ] **Step 6: Run the editor layout tests and verify RED**
+
+```bash
+../../.venv/bin/python -m pytest -q Tests/UI/test_library_file_notes_git.py -k "quiets_and_restores or narrow_editor_actions or retains_files_search_and_git_modes"
+```
+
+Expected: FAIL because wide Git mode leaves both editor toolbars active and
+the first toolbar clips `Protect` at `40×20`.
+
+- [ ] **Step 7: Implement retained toolbar quieting and three-column narrow layout**
+
+In workspace-local `DEFAULT_CSS`:
+
+```css
+LibraryFileNotesWorkspace.-prepare-session-wide .file-notes-toolbar {
+    display: none;
+}
+
+LibraryFileNotesWorkspace.-stack-editor-actions .file-notes-toolbar {
+    layout: grid;
+    grid-size: 3;
+    grid-columns: 1fr 1fr 1fr;
+    height: auto;
+}
+
+LibraryFileNotesWorkspace.-stack-editor-actions .file-notes-toolbar Button {
+    width: 1fr;
+}
+```
+
+At the end of responsive/navigator synchronization, toggle
+`-prepare-session-wide` only when Git mode is visible and the workspace is not
+narrow. Do not hide the path breadcrumb, save state, editor, or editor status,
+and never recompose `_editor_widget`.
+
+After responsive layout and after `_update_controls()` changes
+`Protect`/`Unprotect`, schedule one `_sync_editor_action_layout()` call after
+refresh. Compare the editor pane's real content width with each toolbar's
+natural label-cell total (`cell_len(label) + 4` existing chrome per button).
+Toggle `-stack-editor-actions` only when a row cannot fit. The deterministic
+three-column grid yields two rows plus one row at `40×20`; do not fully stack
+eight buttons vertically.
+
+- [ ] **Step 8: Run the complete focused UI file and verify GREEN**
+
+```bash
+../../.venv/bin/python -m pytest -q Tests/UI/test_library_file_notes_git.py
+```
+
+Expected: all 49 baseline tests plus the new TASK-1235 tests pass.
+
+- [ ] **Step 9: Commit the workspace slice**
+
+```bash
+git add tldw_chatbook/Widgets/Library/library_file_notes_workspace.py Tests/UI/test_library_file_notes_git.py
+git commit -m "fix(notes): keep prepare-session feedback current [TASK-1235]"
+```
+
+## Task 3: Focused Verification, Live UAT, Review, and Backlog Closeout
+
+**Files:**
+
+- Verify:
+  `tldw_chatbook/Widgets/Library/library_file_notes_git_panel.py`
+- Verify:
+  `tldw_chatbook/Widgets/Library/library_file_notes_workspace.py`
+- Verify: `Tests/UI/test_library_file_notes_git.py`
+- Modify:
+  `backlog/tasks/task-1235 - Polish-File-Notes-prepare-session-for-commit-UX.md`
+
+- [ ] **Step 1: Run focused automated verification**
+
+```bash
+../../.venv/bin/python -m pytest -q Tests/UI/test_library_file_notes_git.py
+../../.venv/bin/python -m compileall -q tldw_chatbook/Widgets/Library/library_file_notes_git_panel.py tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+../../.venv/bin/python -m ruff check tldw_chatbook/Widgets/Library/library_file_notes_git_panel.py tldw_chatbook/Widgets/Library/library_file_notes_workspace.py Tests/UI/test_library_file_notes_git.py
+../../.venv/bin/python -m ruff format --check tldw_chatbook/Widgets/Library/library_file_notes_git_panel.py tldw_chatbook/Widgets/Library/library_file_notes_workspace.py Tests/UI/test_library_file_notes_git.py
+git diff --check origin/dev...HEAD
+```
+
+Expected: every command exits 0 with no warnings introduced by TASK-1235.
+
+- [ ] **Step 2: Run the bounded live terminal acceptance pass**
+
+Create a disposable local Git repository outside the worktree with two tracked
+Markdown notes and one unrelated tracked file. Stage an edit to the unrelated
+file before launching Chatbook. Use a temporary, untracked Textual harness that
+mounts the real `LibraryFileNotesWorkspace`, an in-memory
+`FileNotesReplica`, and `build_file_notes_session_owner()` against the
+disposable notes root. Do not add this harness to the repository.
+
+Launch it in an isolated tmux server:
+
+```bash
+tmux -L task1235-uat new-session -d -s chatbook-uat -x 150 -y 42 "../../.venv/bin/python tmp/task1235_uat.py /private/tmp/<exact-created-repository>/notes"
+tmux -L task1235-uat capture-pane -p -t chatbook-uat -S -200
+```
+
+Exercise only:
+
+1. edit two note bodies and wait for `Saved`;
+2. open `Prepare session for commit`, decline trust once, then accept;
+3. verify the title, note verbs, separate current/last-action lines, and
+   selected/bulk count labels;
+4. Stage all and confirm the checked promise copy;
+5. verify with `git diff --cached --name-only` that both session notes and the
+   previously staged unrelated file are staged;
+6. Unstage all and verify only the unrelated file remains staged;
+7. resize/capture at `70×28`, `70×24`, and `40×20`;
+8. at `40×20`, verify focused labels, fixed feedback, Escape focus restoration,
+   and complete `Protect`/`Unprotect`;
+9. at `150×42`, verify editor toolbars quiet during preparation, typing remains
+   active, and Back restores the same editor/toolbars.
+
+Resize and capture with:
+
+```bash
+tmux -L task1235-uat resize-window -t chatbook-uat -x 70 -y 28
+tmux -L task1235-uat resize-window -t chatbook-uat -x 70 -y 24
+tmux -L task1235-uat resize-window -t chatbook-uat -x 40 -y 20
+tmux -L task1235-uat capture-pane -p -t chatbook-uat -S -200
+```
+
+Record concise observed results in TASK-1235 implementation notes. Stop the
+isolated tmux server and delete only the exact temporary harness/repository
+created for this pass.
+
+- [ ] **Step 3: Request focused code and specification review**
+
+Use `superpowers:requesting-code-review` with:
+
+- TASK-1235 acceptance criteria;
+- the approved design and this plan;
+- `origin/dev...HEAD`;
+- focused test/lint/compile/UAT evidence.
+
+Address only concrete in-scope findings. Any behavior fix follows a new
+red/green cycle. Re-run Step 1 and the affected UAT slice after corrections.
+
+- [ ] **Step 4: Reconcile TASK-1235**
+
+Check all eight acceptance criteria, add concise `## Implementation Notes`,
+and set the task to Done through the Backlog CLI only after:
+
+- focused tests, compile, Ruff, and diff checks pass;
+- live UAT passes;
+- review findings are resolved;
+- no production changes remain uncommitted.
+
+Implementation notes must name the two production widgets, focused test file,
+promise truth condition, exact viewport coverage, unrelated-index preservation,
+review result, and the existing ADRs. Reaffirm:
+
+```text
+ADR required: no
+ADR path: N/A
+Reason: presentation-only repair conforming to ADR-035/033/011/029.
+```
+
+- [ ] **Step 5: Commit closeout documentation**
+
+```bash
+git add 'backlog/tasks/task-1235 - Polish-File-Notes-prepare-session-for-commit-UX.md'
+git commit -m "docs(notes): complete prepare-session UX [TASK-1235]"
+git status --short --branch
+```
+
+Expected: the branch is clean and TASK-1235 is Done.

--- a/Docs/superpowers/specs/2026-07-28-file-notes-prepare-session-ux-design.md
+++ b/Docs/superpowers/specs/2026-07-28-file-notes-prepare-session-ux-design.md
@@ -225,7 +225,7 @@ with an old action summary.
 The promise appears only after the existing service reports a certain,
 successful checked postflight under the unchanged selected-root binding,
 repository and `HEAD` identity, ownership contract, and action snapshot, with
-at least one confirmed affected coalesced group. Nonzero, uncertain, mismatched,
+at least one confirmed affected coalesced group. Non-success, uncertain, mismatched,
 or zero-effect outcomes show counts plus failure/recovery text and no promise.
 The promise describes Chatbook's proven Git target/entry boundary; it does not
 supersede the existing configured-filter and concurrent-external-index

--- a/Docs/superpowers/specs/2026-07-28-file-notes-prepare-session-ux-design.md
+++ b/Docs/superpowers/specs/2026-07-28-file-notes-prepare-session-ux-design.md
@@ -1,0 +1,393 @@
+# File Notes Prepare Session UX Design
+
+Date: 2026-07-28
+Task: [TASK-1235](../../../backlog/tasks/task-1235%20-%20Polish-File-Notes-prepare-session-for-commit-UX.md)
+Source critique: [File Notes Session Git acceptance critique](../../../.impeccable/critique/2026-07-28T15-38-30Z__ok-widgets-library-library-file-notes-git-panel-py.md)
+Primary decision: [ADR-035](../../../backlog/decisions/035-file-notes-session-git-index-controls.md)
+Conforms to: [ADR-033](../../../backlog/decisions/033-application-session-state-ownership.md), [ADR-011](../../../backlog/decisions/011-chatbook-workbench-ui-system.md), and [File Notes disk authority](../../../backlog/decisions/029-file-notes-disk-authority.md)
+
+## Summary
+
+Refine the shipped File Notes Session Git view into a note-centered
+`Prepare session for commit` workflow. The change fixes five observed usability
+problems: focused controls losing their labels, rows surviving an authority
+change, stale or clipped result feedback, Git-first row language, and competing
+editor actions.
+
+This is presentation and interaction-state repair. It does not change which
+paths Chatbook records, trusts, stages, or unstages; how Git ownership is
+proved; or where note and recovery data live.
+
+## User outcome
+
+A user can finish a work or study session, open one bounded preparation view,
+understand which notes were created, edited, moved, deleted, or restored, and
+stage only eligible session notes. The view clearly reports what happened and
+reassures the user that Chatbook targeted only eligible session paths. The same
+workflow remains legible and keyboard-operable in a 40-column terminal.
+
+## Approved product choices
+
+- The visible workflow title is `Prepare session for commit`.
+- In a wide two-pane layout, the open note remains visible and editable while
+  its action toolbars are collapsed or visually quiet.
+- Successful feedback keeps the approved promise-plus-count form while
+  limiting the promise to what Chatbook proves:
+  `2 session notes staged; Chatbook targeted only eligible session paths.`
+- The fix remains staging-only. Commit, push, remote, credential, branch,
+  hunk, and full-repository controls remain outside Chatbook.
+
+## Scope
+
+The work covers the existing File Notes Git panel, its workspace presentation
+state, the incumbent Library/editor styling needed for responsive action
+layout, and focused tests. It preserves the existing process-session owner and
+Git service contracts.
+
+The work does not add direct Git accelerators, an actionable-only filter, a
+general activity log, new shared UI infrastructure, polling, persistence, or
+support for additional repository states. Those are not needed to correct the
+observed acceptance failures.
+
+## Approach
+
+Repair the current stable panel and workspace composition using existing
+Chatbook focus, two-line list-row, semantic-status, and responsive-layout
+patterns.
+
+Two broader alternatives are rejected:
+
+- Replacing the File Notes navigator with a new workbench framework would
+  broaden a focused usability repair and duplicate incumbent primitives.
+- Hiding the editor pane entirely would remove useful session context and make
+  switching back to edit feel like a route change. The editor stays mounted;
+  only competing structural actions become quiet.
+
+## Information hierarchy
+
+The preparation view is ordered as:
+
+1. a one-line return control and the title `Prepare session for commit`;
+2. repository authority and branch;
+3. the persistent scope statement `Session paths only · stages complete file
+   state`;
+4. a compact keyboard guide;
+5. the scrollable session-note list;
+6. an always-visible current-status and last-action strip;
+7. selected-note and bulk actions.
+
+Only the session-note list scrolls. The title, scope, feedback, and action
+regions remain outside that scroll area so the latest result and recovery
+control cannot fall below the viewport.
+
+The existing compact navigator entry may remain `Session Git (N)`. `N`
+continues to mean coalesced current-process session groups, not all repository
+changes and not necessarily all actionable notes.
+
+## Return and keyboard behavior
+
+Use the neutral label `Back to navigator` because the preserved destination may
+be the file tree or search results. It retains the existing behavior: return to
+the prior navigator mode, restore focus to the Session Git entry, and leave the
+editor mounted.
+
+The visible guide reads:
+
+`Up/Down Select | Tab Actions | Enter Run | Esc Back`
+
+The existing key contract remains unchanged. `Up` and `Down` change the
+selected row, `Tab` and `Shift+Tab` traverse visible actions, `Enter` activates
+only the focused action, and `Escape` returns to the prior navigator.
+
+Every one-line control uses a same-row focus treatment: contrasting background
+and foreground plus bold or underline. It uses no outline or border that can
+replace the label glyphs. Focused Back, Refresh, Stage, Stage update, Unstage,
+Stage all, and Unstage all labels must remain readable at 40 and 70 columns.
+
+## Session-note rows
+
+Rows lead with the note change rather than the Git implementation state:
+
+```text
+EDITED   study/hci.md
+READY TO STAGE · Git: unstaged
+```
+
+```text
+MOVED    inbox/topic.md -> study/topic.md
+UPDATE REQUIRED · stage the moved note before Chatbook can unstage it
+```
+
+The primary line contains an uppercase text verb and the display path or move.
+The verb comes from the coalesced session group:
+
+| Session change | Verb |
+| --- | --- |
+| Create | `CREATED` |
+| Modify | `EDITED` |
+| Move or chained move | `MOVED` |
+| Delete | `DELETED` |
+| Restore | `RESTORED` |
+
+Compound histories project the existing coalesced group's latest note intent:
+
+- create then delete renders `DELETED`;
+- delete then restore renders `RESTORED`;
+- edit then revert to `HEAD` renders `EDITED` with
+  `NO ACTION · matches HEAD`;
+- chained moves render `MOVED` from the original source to the final
+  destination.
+
+These labels derive from existing group history and do not alter coalescing,
+stable identity, topology, eligibility, or ownership.
+
+The second line contains a plain-language semantic token followed, when useful,
+by the precise Git state. Color may reinforce but never replace the token.
+
+| Existing row state | User-facing token and explanation |
+| --- | --- |
+| Unstaged | `READY TO STAGE · Git: unstaged` |
+| Staged by Chatbook | `STAGED · by Chatbook` |
+| Staged with newer unstaged edits | `UPDATE AVAILABLE · newer note edits are not staged` |
+| Staged with changed path lineage | `UPDATE REQUIRED · stage the moved note before unstaging` |
+| Staged or partially staged externally | `BLOCKED · already staged outside Chatbook; manage this path in Git, then Refresh` |
+| Clean | `NO ACTION · matches HEAD` |
+| Ignored | `BLOCKED · ignored by Git; change the ignore rule or stage outside Chatbook, then Refresh` |
+| Conflict | `BLOCKED · resolve the Git conflict outside Chatbook, then Refresh` |
+| Unsupported index or repository state | `BLOCKED · <specific reason>; resolve it outside Chatbook, then Refresh` |
+| Row-specific Git failure | `FAILED · <specific reason>; <exact retry or external recovery>, then Refresh` |
+
+Long primary labels middle-elide within the row rather than forcing the Git
+state and actions out of view. At widths that fit, the selected-note label
+exposes the complete path or move; at the bounded `40×20` layout it retains
+enough leading and trailing context to identify the note. The selected detail
+also gives a concise blocking reason and recovery. This view does not add a
+pointer-only disclosure.
+
+Rows retain their existing stable identity and selection rules. This design
+changes formatting only; it does not change grouping, eligibility, ownership,
+or action mapping.
+
+## Repository-authority transitions
+
+Rows are displayable only under the repository authority that produced them.
+
+- Rendering untrusted, changed-repository, unavailable, or non-repository
+  states immediately clears visible rows, selected-row presentation, and
+  action eligibility.
+- Checking, stale, or failed refresh may retain prior rows only when the
+  process owner still binds them to the same selected root and repository
+  identity.
+- A later successful status replaces the list and restores selection only when
+  the same stable session group remains.
+
+The process-session owner remains the sole authority. Its existing immutable
+snapshot supplies the current selected-root binding, trusted repository
+identity, exact session-change tuple, and Git status generation. The workspace
+only compares and render-projects those owner-supplied values; it keeps no
+independent repository identity, authority generation, or validity state. The
+panel receives and renders the resulting state. The existing snapshot contract
+already supplies every token needed by this repair, so no owner API extension
+is required.
+
+## Current status and last action
+
+One fixed strip immediately above the actions separates current repository
+freshness from the most recent action result. The first line is always current:
+
+- `Status: CURRENT · READY — 2 can be staged · 1 can be unstaged.`
+- `Status: CHECKING — Checking current session notes...`
+- `Status: STALE — Session notes changed; refresh status before staging.`
+- `Status: CURRENT · BLOCKED — Save conflict must be resolved before staging. Return to the editor.`
+- `Status: STALE · ERROR — Git status failed. Retry Refresh.`
+- `Status: TRUST REQUIRED`, `Status: UNAVAILABLE`, or
+  `Status: UPDATING INDEX` for the existing authority and mutation states.
+
+When an action has completed under the same authority and exact session-change
+snapshot, a separate second line reports it:
+
+- `Last action: STAGED — 2 session notes staged; Chatbook targeted only eligible session paths.`
+- `Last action: UNSTAGED — 2 session notes unstaged; Chatbook restored only its owned session entries.`
+
+Singular and plural forms are correct. A count means successfully affected
+coalesced session-note rows, not endpoint paths or all repository files.
+Existing clean, already-staged, skipped, and blocked counts remain available
+after the promise when they materially explain a bulk result.
+
+The last-action line is associated with the selected-root binding, repository
+authority, and exact session-change snapshot already known by the workspace. It
+survives the action's automatic postflight status refresh so users can read the
+result. A later session mutation, root change, repository identity change, or
+newer action invalidates it before the next render. A manual or automatic
+refresh updates the independent current-status line and never overwrites it
+with an old action summary.
+
+The promise appears only after the existing service reports a certain,
+successful checked postflight under the unchanged selected-root binding,
+repository and `HEAD` identity, ownership contract, and action snapshot, with
+at least one confirmed affected coalesced group. Nonzero, uncertain, mismatched,
+or zero-effect outcomes show counts plus failure/recovery text and no promise.
+The promise describes Chatbook's proven Git target/entry boundary; it does not
+supersede the existing configured-filter and concurrent-external-index
+disclosures.
+
+Repository freshness and blocking/error outcome are orthogonal. A
+same-authority refresh failure retains the prior row semantics as stale,
+disables mutation, and puts `STALE · ERROR` plus recovery in this strip.
+`FAILED` inside a row remains reserved for an existing row-specific failure.
+
+Routine, success, stale, blocked, and error states use restrained semantic
+styling, but the text token is authoritative. Recovery text names the next
+action; vague instructions such as `settle the draft` are not used.
+
+## Actions
+
+Actions remain the exact ADR-035 set and action mapping. Presentation groups
+them as:
+
+- `Selected note: <path or move>`: Stage, Stage update, or Unstage when
+  eligible;
+- bulk controls with independent counts: `Stage all (S)` and `Unstage all (U)`.
+
+`S` and `U` are separately derived from the existing stage-eligible and
+unstage-eligible row sets; one shared eligible count is never shown. Labels use
+sentence case. Hidden or disabled actions keep the existing eligibility rules.
+Checking and mutation continue to disable index mutations without disabling
+Back or editor input.
+
+## Editor quieting and responsive layout
+
+When Prepare session for commit is visible beside the editor in a wide layout:
+
+- the path breadcrumb, save state, note body, cursor, and selection remain
+  visible;
+- editor typing and debounced autosave remain active;
+- competing structural/action toolbars collapse;
+- a compact muted note may explain that editor actions return with the
+  navigator, without presenting a new action.
+
+Returning to the file tree or search results restores the toolbar immediately.
+The editor widget is never remounted solely for this mode change.
+
+In a narrow one-pane layout, Navigator and Editor continue to alternate. The
+preparation view does not compete with an off-screen editor. When Editor is the
+visible pane, its normal actions use the existing responsive grouping and wrap
+to additional rows when needed; labels such as `Protect` are never shortened or
+clipped to one character.
+
+At `40×20`, fixed-region text has a strict height budget: repository authority,
+selected-note detail, current status, and last action each use at most two
+lines and middle-elide bounded path/detail text. Recovery instructions are
+written to fit that bound; arbitrary diagnostic detail remains sanitized and
+bounded. Action rows stay horizontal while their full labels fit and stack only
+when the actual panel width requires it. If vertical space tightens, only the
+scrollable session list loses height. The current-status line, any last-action
+line, Back, and currently eligible actions remain visible.
+
+The workspace uses a presentation class on the existing stable composition. It
+does not add a second mode authority, a generic collapse helper, or editor
+recomposition.
+
+## Empty, trust, and failure states
+
+Each non-list state owns the list region and shows no stale rows:
+
+- no session changes: `No notes changed in this Chatbook session.`;
+- trust required: the existing process-only warning and `Trust and check
+  status`, with Cancel initially focused;
+- not a repository: `This notes folder is not in a Git worktree. Notes remain
+  fully usable.`;
+- Git unavailable or unsupported: the specific reason plus an exact next step;
+  when Chatbook cannot recover it, name the required external action and the
+  subsequent Refresh;
+- error under the same authority: retained rows are visibly stale and all
+  mutation actions remain disabled.
+
+Back remains readable and available in every state. Trust wording continues to
+disclose configured-filter execution and makes clear that declining does not
+disable normal note editing.
+
+## State and data boundaries
+
+No database, filesystem, Git command, staging signature, trust, session
+coalescing, service lifecycle, or mutation-gate behavior changes.
+
+The only additional presentation information is:
+
+- a note-change verb derived from the existing coalesced group;
+- a semantic display token derived from the existing row state;
+- whether an action result still matches the current root binding, repository,
+  and exact session-change snapshot;
+- whether the existing editor toolbar should render quietly for the current
+  responsive mode.
+
+These are view projections. They are not persisted and do not become new
+authorities.
+
+The production change stays local to
+`library_file_notes_git_panel.py` and
+`library_file_notes_workspace.py`. The Git panel reuses Chatbook's existing
+height-one background/foreground plus bold-underline focus contract, two-line
+Library row structure, semantic status badges, and its incumbent
+`-stack-actions` resize class. Workspace toolbar quieting and narrow stacking
+use local presentation classes in the widget's existing `DEFAULT_CSS`. No Git
+service, owner, schema, global design-system CSS, or ADR changes are needed.
+
+## Focused verification
+
+Per the approved task boundary, verification for this repair is focused. It
+adds no broad CI, network, long-soak, or performance gate and does not run the
+repository's multi-hour full suite. Targeted lint/format checks still cover
+every changed production and test file.
+
+Focused model/widget tests cover:
+
+- every coalesced change kind renders the correct note verb;
+- every existing Git state renders a non-color semantic token and the existing
+  action eligibility;
+- untrusted, repository-changed, unavailable, and non-repository transitions
+  clear rows and selection;
+- stale/error retention is allowed only for the same authority;
+- a later session-change snapshot replaces an obsolete action result, while
+  the action's postflight refresh preserves it beside an independently current
+  status line;
+- success messages use correct singular/plural counts and the checked
+  Chatbook-target/ownership promise;
+- focused one-line controls retain their complete labels.
+
+Mounted Textual tests at `150×42`, `70×28`, `70×24`, and specifically `40×20`
+cover:
+
+- title, hierarchy, fixed feedback, selected/bulk groups, and keyboard guide;
+- keyboard selection, action traversal, activation, Escape, and focus restore;
+- editor actions quieting and restoration without editor remount or draft loss;
+- narrow editor action wrapping with no clipped labels;
+- checking, trust, empty, stale, blocked, failed, and non-repository states;
+- wrapped authority, selected-path, recovery, and postflight copy leaving the
+  current-status/action regions visible while only the list loses height.
+
+One compact disposable-repository acceptance flow edits at least two session
+notes, stages them in bulk, and confirms both the promise-plus-count feedback
+and preservation of an unrelated externally staged path. It then unstages the
+session notes and confirms the unrelated path remains staged.
+
+The live terminal acceptance pass uses the same `150×42`, `70×28/24`, and
+`40×20` sizes. At `40×20` it explicitly verifies visible postflight feedback,
+the complete `Protect` label in Editor, and Escape returning to the retained
+navigator entry with focus restored.
+
+## ADR check
+
+ADR required: no
+
+ADR path: N/A; this task conforms to
+`backlog/decisions/035-file-notes-session-git-index-controls.md`,
+`backlog/decisions/033-application-session-state-ownership.md`,
+`backlog/decisions/011-chatbook-workbench-ui-system.md`, and
+`backlog/decisions/029-file-notes-disk-authority.md`.
+
+Reason: this is a focused correction to presentation, focus, responsive
+layout, and display-state invalidation under already accepted ownership and Git
+safety contracts. It introduces no storage/schema, sync, data ownership,
+service boundary, security, dependency, or long-lived application-structure
+decision.

--- a/Tests/UI/test_library_file_notes_git.py
+++ b/Tests/UI/test_library_file_notes_git.py
@@ -10,7 +10,9 @@ from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 
 import pytest
+from rich.cells import cell_len
 from textual.app import App, ComposeResult
+from textual.color import Color
 from textual.containers import Vertical
 from textual.widgets import Button, Input, Label, ListView, Static, TextArea, Tree
 
@@ -22,6 +24,7 @@ from tldw_chatbook.Notes.file_notes_git_service import (  # noqa: E402
     GitActionResult,
     GitCommandResult,
     GitMutationAdmissionError,
+    coalesce_session_changes,
 )
 from tldw_chatbook.Notes.file_notes_replica import FileNotesReplica  # noqa: E402
 from tldw_chatbook.Notes.file_notes_session_owner import (  # noqa: E402
@@ -32,6 +35,7 @@ from tldw_chatbook.Notes.file_notes_session_owner import (  # noqa: E402
     SequencedSessionChange,
     SessionBinding,
     SessionChange,
+    SessionChangeAction,
     SessionChangeGroup,
     SessionGitRow,
     SessionGitRowState,
@@ -41,6 +45,7 @@ from tldw_chatbook.Notes.file_notes_session_owner import (  # noqa: E402
 from tldw_chatbook.Widgets.Library.library_file_notes_git_panel import (  # noqa: E402
     LibraryFileNotesGitPanel,
     SessionGitTrustDialog,
+    _middle_elide_cells,
 )
 from tldw_chatbook.Widgets.Library.library_file_notes_workspace import (  # noqa: E402
     LibraryFileNotesWorkspace,
@@ -337,16 +342,26 @@ def _row(
     stage_action: SessionGitStageAction | None = None,
     unstage_eligible: bool = False,
     disabled_reason: str | None = None,
+    latest_action: SessionChangeAction = "modified",
+    source_path: str | None = None,
+    destination_path: str | None = None,
 ) -> SessionGitRow:
+    source = source_path or f"note-{group_id}.md"
+    current = destination_path or source
     return SessionGitRow(
         SessionChangeGroup(
             group_id=group_id,
-            endpoints=(f"note-{group_id}.md",),
-            source_path=f"note-{group_id}.md",
-            destination_path=None,
-            current_path=f"note-{group_id}.md",
-            latest_action="modified",
+            endpoints=(
+                (source,) if destination_path is None else (source, destination_path)
+            ),
+            source_path=source,
+            destination_path=destination_path,
+            current_path=current,
+            latest_action=latest_action,
             latest_sequence=group_id,
+            move_edges=(
+                () if destination_path is None else ((source, destination_path),)
+            ),
         ),
         state,
         stage_action=stage_action,
@@ -447,8 +462,17 @@ async def _assert_visible_panel_buttons_fit(panel, pilot) -> None:
         button.focus()
         await pilot.pause()
         assert button.has_focus
+        label = str(button.label)
+        assert button.render().plain == label
+        assert cell_len(label) <= button.content_region.width
         assert button.region.x >= bounds.x
         assert button.region.right <= bounds.right
+        assert button.region.y >= bounds.y
+        assert button.region.bottom <= bounds.bottom
+        assert not button.styles.outline
+        assert button.styles.background == Color.parse("#51677e")
+        assert button.styles.text_style.bold
+        assert button.styles.text_style.underline
 
 
 @pytest.mark.asyncio
@@ -458,6 +482,10 @@ async def test_panel_renders_repository_scope_and_complete_file_state() -> None:
         panel.render_status(_status(_row("unstaged", stage_action="stage")))
         await pilot.pause()
 
+        assert (
+            _text(panel.query_one("#file-notes-git-title", Static))
+            == "Prepare session for commit"
+        )
         assert "/canonical/repository" in _text(
             panel.query_one("#file-notes-git-repository", Static)
         )
@@ -466,10 +494,120 @@ async def test_panel_renders_repository_scope_and_complete_file_state() -> None:
         )
         assert (
             _text(panel.query_one("#file-notes-git-scope", Static))
-            == "Session paths only"
+            == "Session paths only · stages complete file state"
         )
-        assert "content, deletion, and mode" in _text(
-            panel.query_one("#file-notes-git-complete-state", Static)
+        assert _text(panel.query_one("#file-notes-git-guide", Static)) == (
+            "Up/Down Select | Tab Actions | Enter Run | Esc Back"
+        )
+        assert _text(panel.query_one("#file-notes-git-status", Static)).startswith(
+            "Status: CURRENT · READY"
+        )
+
+
+@pytest.mark.parametrize(
+    ("latest_action", "verb"),
+    [
+        ("created", "CREATED"),
+        ("modified", "EDITED"),
+        ("moved", "MOVED"),
+        ("deleted", "DELETED"),
+        ("restored", "RESTORED"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_rows_project_note_intent_on_a_separate_primary_line(
+    latest_action: SessionChangeAction,
+    verb: str,
+) -> None:
+    row = _row(
+        "unstaged",
+        latest_action=latest_action,
+        source_path="folder/before.md",
+        destination_path=("folder/after.md" if latest_action == "moved" else None),
+        stage_action="stage",
+    )
+    panel = LibraryFileNotesGitPanel()
+    async with _PanelHarness(panel).run_test() as pilot:
+        panel.render_status(_status(row))
+        await pilot.pause()
+
+        primary = _text(panel.query_one(".file-notes-git-row-primary", Static))
+        semantic = _text(panel.query_one(".file-notes-git-row-secondary", Static))
+        assert primary.startswith(verb)
+        assert "folder/before.md" in primary
+        if latest_action == "moved":
+            assert "-> folder/after.md" in primary
+        assert semantic == "READY TO STAGE · Git: unstaged"
+
+
+@pytest.mark.parametrize(
+    ("changes", "state", "expected_primary", "expected_secondary"),
+    [
+        (
+            (
+                SessionChange("created", "draft.md"),
+                SessionChange("deleted", "draft.md"),
+            ),
+            "unstaged",
+            "DELETED   draft.md",
+            "READY TO STAGE · Git: unstaged",
+        ),
+        (
+            (
+                SessionChange("deleted", "restored.md"),
+                SessionChange("restored", "restored.md"),
+            ),
+            "unstaged",
+            "RESTORED  restored.md",
+            "READY TO STAGE · Git: unstaged",
+        ),
+        (
+            (SessionChange("modified", "unchanged.md"),),
+            "clean",
+            "EDITED    unchanged.md",
+            "NO ACTION · matches HEAD",
+        ),
+        (
+            (
+                SessionChange("moved", "original.md", "middle.md"),
+                SessionChange("moved", "middle.md", "final.md"),
+            ),
+            "unstaged",
+            "MOVED     original.md -> final.md",
+            "READY TO STAGE · Git: unstaged",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_coalesced_histories_project_latest_note_intent(
+    changes: tuple[SessionChange, ...],
+    state: SessionGitRowState,
+    expected_primary: str,
+    expected_secondary: str,
+) -> None:
+    (group,) = coalesce_session_changes(
+        tuple(
+            SequencedSessionChange(sequence, change)
+            for sequence, change in enumerate(changes, 1)
+        )
+    )
+    row = SessionGitRow(
+        group,
+        state,
+        stage_action="stage" if state == "unstaged" else None,
+    )
+    panel = LibraryFileNotesGitPanel()
+    async with _PanelHarness(panel).run_test() as pilot:
+        panel.render_status(_status(row))
+        await pilot.pause()
+
+        assert (
+            _text(panel.query_one(".file-notes-git-row-primary", Static))
+            == expected_primary
+        )
+        assert (
+            _text(panel.query_one(".file-notes-git-row-secondary", Static))
+            == expected_secondary
         )
 
 
@@ -520,11 +658,17 @@ async def test_trust_dialog_escapes_repository_path_controls_and_markup() -> Non
         assert "\x1b" not in rendered
 
 
+@pytest.mark.parametrize(
+    "size",
+    [(150, 42), (70, 28), (70, 24), (40, 20)],
+)
 @pytest.mark.asyncio
-async def test_panel_action_controls_fit_with_focus_at_24_cells() -> None:
+async def test_focused_controls_keep_complete_labels_and_fit(
+    size: tuple[int, int],
+) -> None:
     panel = LibraryFileNotesGitPanel()
     panel.styles.display = "block"
-    async with _PanelHarness(panel).run_test(size=(24, 40)) as pilot:
+    async with _PanelHarness(panel).run_test(size=size) as pilot:
         panel.render_untrusted("/repo")
         await pilot.pause()
         await _assert_visible_panel_buttons_fit(panel, pilot)
@@ -543,6 +687,205 @@ async def test_panel_action_controls_fit_with_focus_at_24_cells() -> None:
 
 
 @pytest.mark.asyncio
+async def test_action_controls_fit_from_visible_label_cells_and_recompute() -> None:
+    panel = LibraryFileNotesGitPanel()
+    panel.styles.display = "block"
+    async with _PanelHarness(panel).run_test(size=(70, 28)) as pilot:
+        panel.render_untrusted("/repo")
+        await pilot.pause()
+        assert not panel.has_class("-stack-actions")
+
+        await pilot.resize_terminal(40, 20)
+        await pilot.pause()
+        assert panel.has_class("-stack-actions")
+        await _assert_visible_panel_buttons_fit(panel, pilot)
+
+        panel.render_status(
+            _status(
+                _row(
+                    "owned_newer_edits",
+                    stage_action="stage_update",
+                    unstage_eligible=True,
+                )
+            )
+        )
+        await pilot.pause()
+        assert not panel.has_class("-stack-actions")
+        await _assert_visible_panel_buttons_fit(panel, pilot)
+
+
+def test_middle_elide_cells_preserves_graphemes_width_and_path_ends() -> None:
+    text = "notes/资料/emoji-👩‍💻-very-long-folder/final.md"
+
+    result = _middle_elide_cells(text, 24)
+
+    assert cell_len(result) <= 24
+    assert result.startswith("notes/")
+    assert result.endswith("final.md")
+    assert "..." in result
+    assert "👩" not in result or "👩‍💻" in result
+    assert "💻" not in result or "👩‍💻" in result
+    assert "\u200d" not in result or "👩‍💻" in result
+
+
+@pytest.mark.asyncio
+async def test_middle_elide_recomputes_mounted_path_labels_after_resize() -> None:
+    source = "source/" + "before-folder/" * 2 + "before-note.md"
+    destination = "destination/" + "after-folder/" * 2 + "final-note.md"
+    row = _row(
+        "unstaged",
+        stage_action="stage",
+        latest_action="moved",
+        source_path=source,
+        destination_path=destination,
+    )
+    panel = LibraryFileNotesGitPanel()
+    panel.styles.display = "block"
+    async with _PanelHarness(panel).run_test(size=(150, 42)) as pilot:
+        panel.render_status(_status(row))
+        await pilot.pause()
+        primary = panel.query_one(".file-notes-git-row-primary", Static)
+        selected = panel.query_one("#file-notes-git-selected-note", Static)
+        assert _text(primary) == f"MOVED     {source} -> {destination}"
+        assert _text(selected) == f"Selected note: {source} -> {destination}"
+
+        await pilot.resize_terminal(40, 20)
+        await pilot.pause()
+        assert "..." in _text(primary)
+        assert _text(primary).startswith("MOVED")
+        assert _text(primary).endswith("final-note.md")
+        assert "..." in _text(selected)
+        assert _text(selected).startswith("Selected note: ")
+        assert _text(selected).endswith("final-note.md")
+
+        await pilot.resize_terminal(150, 42)
+        await pilot.pause()
+        assert _text(primary) == f"MOVED     {source} -> {destination}"
+        assert _text(selected) == f"Selected note: {source} -> {destination}"
+
+
+@pytest.mark.asyncio
+async def test_prepare_session_fixed_regions_remain_visible_at_40_by_20() -> None:
+    long_source = "source-leading/" + "deep-session-folder/" * 8 + "before-note.md"
+    long_destination = (
+        "destination-leading/" + "another-deep-folder/" * 8 + "final-note.md"
+    )
+    long_reason = "index diagnostic " * 18
+    rows = (
+        _row(
+            "owned_newer_edits",
+            group_id=1,
+            stage_action="stage_update",
+            unstage_eligible=True,
+            latest_action="moved",
+            source_path=long_source,
+            destination_path=long_destination,
+        ),
+        _row(
+            "error",
+            group_id=2,
+            disabled_reason=long_reason,
+        ),
+        *tuple(
+            _row(
+                "unstaged",
+                group_id=group_id,
+                stage_action="stage",
+            )
+            for group_id in range(3, 10)
+        ),
+    )
+    repository = _repository(
+        "/repository/" + "very-long-authority-path/" * 10 + "notes"
+    )
+    status = SessionGitStatus(
+        binding_generation=1,
+        status_generation=1,
+        state="ready",
+        rows=rows,
+        repository=repository,
+        head=HeadIdentity.attached(
+            "feature/a-very-long-prepare-session-branch",
+            "a" * 40,
+        ),
+    )
+    panel = LibraryFileNotesGitPanel()
+    panel.styles.display = "block"
+    async with _PanelHarness(panel).run_test(size=(40, 20)) as pilot:
+        panel.render_status(status)
+        panel.set_current_status(
+            "Status: STALE · ERROR — " + long_reason + "Retry Refresh."
+        )
+        panel.set_last_action(
+            "Last action: FAILED — " + long_reason + "retry the action, then Refresh"
+        )
+        await pilot.pause()
+
+        bounds = panel.content_region
+        fixed_selectors = (
+            "#file-notes-git-repository",
+            "#file-notes-git-status",
+            "#file-notes-git-action-status",
+            "#file-notes-git-selected-note",
+        )
+        for selector in fixed_selectors:
+            widget = panel.query_one(selector, Static)
+            assert widget.display
+            assert 0 < widget.region.height <= 2
+            assert widget.region.y >= bounds.y
+            assert widget.region.bottom <= bounds.bottom
+            assert cell_len(_text(widget)) <= (
+                widget.content_region.width * widget.region.height
+            )
+
+        list_view = panel.query_one("#file-notes-git-rows", ListView)
+        assert list_view.region.height >= 1
+        assert (
+            list_view.region.bottom
+            <= panel.query_one(
+                "#file-notes-git-status",
+                Static,
+            ).region.y
+        )
+        for item in panel.query(".file-notes-git-row"):
+            assert item.region.height == 2
+
+        primary = _text(panel.query_one(".file-notes-git-row-primary", Static))
+        assert primary.startswith("MOVED")
+        assert "source-" in primary
+        assert primary.endswith("final-note.md")
+        assert "..." in primary
+        primary_widget = panel.query_one(
+            ".file-notes-git-row-primary",
+            Static,
+        )
+        assert cell_len(primary) <= primary_widget.content_region.width
+
+        selected = panel.query_one("#file-notes-git-selected-note", Static)
+        selected_text = _text(selected)
+        assert selected_text.startswith("Selected note: ")
+        assert selected_text.endswith("final-note.md")
+        assert "..." in selected_text
+
+        failure = next(
+            widget
+            for widget in panel.query(".file-notes-git-row-secondary")
+            if _text(widget).startswith("FAILED")
+        )
+        failure_text = _text(failure)
+        assert failure_text.endswith("; retry, Refresh")
+        assert cell_len(failure_text) <= failure.content_region.width
+
+        assert _text(panel.query_one("#file-notes-git-status", Static)).endswith(
+            "Retry Refresh."
+        )
+        assert _text(panel.query_one("#file-notes-git-action-status", Static)).endswith(
+            "then Refresh"
+        )
+        await _assert_visible_panel_buttons_fit(panel, pilot)
+
+
+@pytest.mark.asyncio
 async def test_ready_status_without_rows_renders_explicit_empty_state() -> None:
     panel = LibraryFileNotesGitPanel()
     panel.styles.display = "block"
@@ -554,85 +897,105 @@ async def test_ready_status_without_rows_renders_explicit_empty_state() -> None:
         assert _text(empty) == "No current-session Git changes."
 
 
-@pytest.mark.parametrize(
-    (
-        "row",
-        "stage_label",
-        "unstage_enabled",
-        "stage_all",
-        "unstage_all",
-        "reason",
+_ROW_REASONS: dict[SessionGitRowState, str] = {
+    "conflict": "conflict",
+    "unsupported": "skip-worktree",
+    "nested_repository": "nested repository",
+    "unsafe_closure": "outside session lineage",
+    "ambiguous_lineage": "ambiguous lineage",
+    "unavailable": "Git unavailable",
+    "error": "status failed",
+}
+_ROW_SEMANTICS: dict[SessionGitRowState, tuple[str, ...]] = {
+    "unstaged": ("READY TO STAGE", "Git: unstaged"),
+    "owned": ("STAGED", "by Chatbook"),
+    "owned_newer_edits": ("UPDATE AVAILABLE", "newer note edits are not staged"),
+    "owned_topology_changed": (
+        "UPDATE REQUIRED",
+        "stage the moved note before unstaging",
     ),
+    "external_staged": ("BLOCKED", "already staged outside Chatbook", "Refresh"),
+    "external_partial": ("BLOCKED", "already staged outside Chatbook", "Refresh"),
+    "clean": ("NO ACTION", "matches HEAD"),
+    "ignored": ("BLOCKED", "ignored by Git", "ignore rule", "Refresh"),
+    "conflict": ("BLOCKED", "conflict", "outside Chatbook", "Refresh"),
+    "unsupported": ("BLOCKED", "skip-worktree", "outside Chatbook", "Refresh"),
+    "nested_repository": (
+        "BLOCKED",
+        "nested repository",
+        "outside Chatbook",
+        "Refresh",
+    ),
+    "unsafe_closure": (
+        "BLOCKED",
+        "outside session lineage",
+        "outside Chatbook",
+        "Refresh",
+    ),
+    "ambiguous_lineage": (
+        "BLOCKED",
+        "ambiguous lineage",
+        "outside Chatbook",
+        "Refresh",
+    ),
+    "unavailable": ("BLOCKED", "Git unavailable", "restore Git", "Refresh"),
+    "error": ("FAILED", "status failed", "retry", "Refresh"),
+}
+
+
+@pytest.mark.parametrize(
+    ("state", "stage_action", "unstage_eligible"),
     [
-        (_row("unstaged", stage_action="stage"), "Stage selected", False, True, False, None),
-        (_row("owned", unstage_eligible=True), None, True, False, True, None),
-        (
-            _row(
-                "owned_newer_edits",
-                stage_action="stage_update",
-                unstage_eligible=True,
-            ),
-            "Stage update",
-            True,
-            True,
-            True,
-            None,
-        ),
-        (
-            _row(
-                "owned_topology_changed",
-                stage_action="stage_update",
-                disabled_reason="Unstage requires Stage update",
-            ),
-            "Stage update",
-            False,
-            True,
-            False,
-            "Unstage requires Stage update",
-        ),
-        (_row("external_staged", disabled_reason="external index state"), None, False, False, False, "external index state"),
-        (_row("external_partial", disabled_reason="external index state"), None, False, False, False, "external index state"),
-        (_row("clean"), None, False, False, False, None),
-        (_row("ignored", disabled_reason="ignored"), None, False, False, False, "ignored"),
-        (_row("conflict", disabled_reason="conflict"), None, False, False, False, "conflict"),
-        (_row("unsupported", disabled_reason="skip-worktree"), None, False, False, False, "skip-worktree"),
-        (_row("nested_repository", disabled_reason="nested repository"), None, False, False, False, "nested repository"),
-        (_row("unsafe_closure", disabled_reason="outside session lineage"), None, False, False, False, "outside session lineage"),
-        (_row("ambiguous_lineage", disabled_reason="ambiguous lineage"), None, False, False, False, "ambiguous lineage"),
-        (_row("unavailable", disabled_reason="Git unavailable"), None, False, False, False, "Git unavailable"),
-        (_row("error", disabled_reason="status failed"), None, False, False, False, "status failed"),
+        ("unstaged", "stage", False),
+        ("owned", None, True),
+        ("owned_newer_edits", "stage_update", True),
+        ("owned_topology_changed", "stage_update", False),
+        ("external_staged", None, False),
+        ("external_partial", None, False),
+        ("clean", None, False),
+        ("ignored", None, False),
+        ("conflict", None, False),
+        ("unsupported", None, False),
+        ("nested_repository", None, False),
+        ("unsafe_closure", None, False),
+        ("ambiguous_lineage", None, False),
+        ("unavailable", None, False),
+        ("error", None, False),
     ],
 )
 @pytest.mark.asyncio
 async def test_row_action_table_is_driven_by_row_policy(
-    row: SessionGitRow,
-    stage_label: str | None,
-    unstage_enabled: bool,
-    stage_all: bool,
-    unstage_all: bool,
-    reason: str | None,
+    state: SessionGitRowState,
+    stage_action: SessionGitStageAction | None,
+    unstage_eligible: bool,
 ) -> None:
+    row = _row(
+        state,
+        stage_action=stage_action,
+        unstage_eligible=unstage_eligible,
+        disabled_reason=_ROW_REASONS.get(state),
+    )
     panel = LibraryFileNotesGitPanel()
-    async with _PanelHarness(panel).run_test() as pilot:
+    async with _PanelHarness(panel).run_test(size=(150, 42)) as pilot:
         panel.render_status(_status(row))
         await pilot.pause()
 
         stage = panel.query_one("#file-notes-git-stage-selected", Button)
         unstage = panel.query_one("#file-notes-git-unstage-selected", Button)
-        assert stage.display is (stage_label is not None)
-        if stage_label is not None:
-            assert str(stage.label) == stage_label
+        assert stage.display is (stage_action is not None)
+        if stage_action is not None:
+            expected = "Stage update" if stage_action == "stage_update" else "Stage"
+            assert str(stage.label) == expected
             assert not stage.disabled
-        assert unstage.display is unstage_enabled
+        assert unstage.display is unstage_eligible
         assert panel.query_one("#file-notes-git-stage-all", Button).disabled is (
-            not stage_all
+            stage_action is None
         )
         assert panel.query_one("#file-notes-git-unstage-all", Button).disabled is (
-            not unstage_all
+            not unstage_eligible
         )
-        row_text = _text(panel.query_one(".file-notes-git-row-copy", Static))
-        if reason is not None:
-            assert reason in row_text
+        row_text = _text(panel.query_one(".file-notes-git-row-secondary", Static))
+        assert all(fragment in row_text for fragment in _ROW_SEMANTICS[state])
 
 
 @pytest.mark.asyncio
@@ -673,6 +1036,55 @@ async def test_selection_uses_stable_group_id_across_refresh() -> None:
         assert rows.index == 0
 
 
+@pytest.mark.asyncio
+async def test_selected_and_bulk_labels_report_selection_and_independent_counts() -> None:
+    first = _row(
+        "unstaged",
+        group_id=11,
+        stage_action="stage",
+        source_path="folder/first.md",
+    )
+    selected = _row(
+        "owned_newer_edits",
+        group_id=22,
+        stage_action="stage_update",
+        unstage_eligible=True,
+        source_path="folder/second.md",
+    )
+    panel = LibraryFileNotesGitPanel()
+    async with _PanelHarness(panel).run_test() as pilot:
+        panel.render_status(_status(first, selected))
+        await pilot.pause()
+
+        selected_note = panel.query_one("#file-notes-git-selected-note", Static)
+        stage_selected = panel.query_one(
+            "#file-notes-git-stage-selected",
+            Button,
+        )
+        unstage_selected = panel.query_one(
+            "#file-notes-git-unstage-selected",
+            Button,
+        )
+        assert _text(selected_note).startswith("Selected note: ")
+        assert "folder/first.md" in _text(selected_note)
+        assert str(stage_selected.label) == "Stage"
+        assert (
+            str(panel.query_one("#file-notes-git-stage-all", Button).label)
+            == "Stage all (2)"
+        )
+        assert (
+            str(panel.query_one("#file-notes-git-unstage-all", Button).label)
+            == "Unstage all (1)"
+        )
+
+        rows = panel.query_one("#file-notes-git-rows", ListView)
+        rows.index = 1
+        await pilot.pause()
+        assert "folder/second.md" in _text(selected_note)
+        assert str(stage_selected.label) == "Stage update"
+        assert str(unstage_selected.label) == "Unstage"
+
+
 @pytest.mark.parametrize("state", ["stale", "error"])
 @pytest.mark.asyncio
 async def test_stale_and_error_retain_rows_but_only_refresh_is_available(
@@ -680,12 +1092,14 @@ async def test_stale_and_error_retain_rows_but_only_refresh_is_available(
 ) -> None:
     panel = LibraryFileNotesGitPanel()
     async with _PanelHarness(panel).run_test() as pilot:
+        panel.set_last_action("Last action: STAGED — 1 session note staged.")
         panel.render_status(
             _status(
                 _row("unstaged", stage_action="stage"),
                 state=state,
                 message="status failed; retry",
-            )
+            ),
+            retain_rows=True,
         )
         await pilot.pause()
 
@@ -693,9 +1107,72 @@ async def test_stale_and_error_retain_rows_but_only_refresh_is_available(
         assert not panel.query_one("#file-notes-git-refresh", Button).disabled
         assert panel.query_one("#file-notes-git-stage-selected", Button).disabled
         assert panel.query_one("#file-notes-git-stage-all", Button).disabled
+        expected = "STALE" if state == "stale" else "STALE · ERROR"
+        assert expected in _text(panel.query_one("#file-notes-git-status", Static))
         assert "status failed; retry" in _text(
-            panel.query_one("#file-notes-git-action-status", Static)
+            panel.query_one("#file-notes-git-status", Static)
         )
+        assert (
+            _text(panel.query_one("#file-notes-git-action-status", Static))
+            == "Last action: STAGED — 1 session note staged."
+        )
+
+
+@pytest.mark.parametrize(
+    "authority_loss",
+    [
+        lambda panel: panel.render_untrusted("/different/repository"),
+        lambda panel: panel.render_unavailable(
+            "This notes folder is not in a Git worktree."
+        ),
+        lambda panel: panel.render_status(
+            _status(
+                state="unavailable",
+                message="Git is unavailable; restore Git, then Refresh.",
+            )
+        ),
+    ],
+    ids=("untrusted", "discovery-unavailable", "status-unavailable"),
+)
+@pytest.mark.asyncio
+async def test_authority_loss_clears_rows_selection_and_mutation_actions(
+    authority_loss: Callable[[LibraryFileNotesGitPanel], None],
+) -> None:
+    panel = LibraryFileNotesGitPanel()
+    async with _PanelHarness(panel).run_test() as pilot:
+        panel.render_status(
+            _status(
+                _row("unstaged", group_id=11, stage_action="stage"),
+                _row(
+                    "owned",
+                    group_id=22,
+                    unstage_eligible=True,
+                ),
+            )
+        )
+        await pilot.pause()
+        rows = panel.query_one("#file-notes-git-rows", ListView)
+        rows.index = 1
+        await pilot.pause()
+        assert panel.selected_group_id == 22
+
+        authority_loss(panel)
+        await _wait_until(
+            pilot,
+            lambda: len(panel.query(".file-notes-git-row")) == 0,
+            "authority loss did not clear rendered rows",
+        )
+
+        assert panel.rows == ()
+        assert panel.selected_group_id is None
+        for selector in (
+            "#file-notes-git-stage-selected",
+            "#file-notes-git-unstage-selected",
+            "#file-notes-git-stage-all",
+            "#file-notes-git-unstage-all",
+        ):
+            button = panel.query_one(selector, Button)
+            assert not button.display
 
 
 @pytest.mark.asyncio
@@ -719,7 +1196,7 @@ async def test_untrusted_shows_only_trust_action_and_checking_keeps_back_enabled
         assert not panel.query_one("#file-notes-git-back", Button).disabled
         assert panel.query_one("#file-notes-git-stage-all", Button).disabled
         assert "Checking" in _text(
-            panel.query_one("#file-notes-git-action-status", Static)
+            panel.query_one("#file-notes-git-status", Static)
         )
 
 

--- a/Tests/UI/test_library_file_notes_git.py
+++ b/Tests/UI/test_library_file_notes_git.py
@@ -536,14 +536,19 @@ def _assert_visible_editor_actions_fit(
     pane = workspace.query_one("#file-notes-editor-pane")
     visible_actions = tuple(button for button in pane.query(Button) if button.display)
     assert visible_actions
+    clipped_labels: dict[str | None, tuple[str, str]] = {}
     for button in visible_actions:
         label = str(button.label)
+        rendered_label = button.render_line(0).text.strip()
+        if rendered_label != label:
+            clipped_labels[button.id] = (label, rendered_label)
         assert button.render().plain == label
         assert cell_len(label) <= button.content_region.width
         assert button.region.x >= pane.region.x
         assert button.region.right <= pane.region.right
         assert button.region.y >= pane.region.y
         assert button.region.bottom <= pane.region.bottom
+    assert not clipped_labels, f"clipped editor action labels: {clipped_labels}"
 
 
 async def _assert_visible_panel_buttons_fit(panel, pilot) -> None:

--- a/Tests/UI/test_library_file_notes_git.py
+++ b/Tests/UI/test_library_file_notes_git.py
@@ -94,6 +94,14 @@ class _PanelHarness(App[None]):
         self.messages.append(message)
 
 
+class _PanelWithOutsideControlHarness(_PanelHarness):
+    """Mount one unrelated focus target beside the panel."""
+
+    def compose(self) -> ComposeResult:
+        yield Button("Outside panel", id="outside-panel-control")
+        yield self.panel
+
+
 class _DialogHarness(App[None]):
     """Open a Session Git trust dialog at mount."""
 
@@ -430,6 +438,14 @@ def _text(widget: Static | Label) -> str:
     return getattr(renderable, "plain", str(renderable))
 
 
+def _rendered_text(widget: Static) -> str:
+    """Return only the strips that are actually visible inside one Static."""
+    return "\n".join(
+        widget.render_line(y).text.rstrip()
+        for y in range(widget.content_region.height)
+    ).rstrip()
+
+
 def _assert_git_mutations_disabled(
     workspace: LibraryFileNotesWorkspace,
 ) -> None:
@@ -727,6 +743,10 @@ def test_middle_elide_cells_preserves_graphemes_width_and_path_ends() -> None:
     assert "💻" not in result or "👩‍💻" in result
     assert "\u200d" not in result or "👩‍💻" in result
 
+    flag_result = _middle_elide_cells("A🇺🇸BBBB", 6)
+    assert cell_len(flag_result) <= 6
+    assert ("🇺" in flag_result) == ("🇸" in flag_result)
+
 
 @pytest.mark.asyncio
 async def test_middle_elide_recomputes_mounted_path_labels_after_resize() -> None:
@@ -815,7 +835,7 @@ async def test_prepare_session_fixed_regions_remain_visible_at_40_by_20() -> Non
         rows=rows,
         repository=repository,
         head=HeadIdentity.attached(
-            "feature/a-very-long-prepare-session-branch",
+            "feature/very-long-prepare-session-branch/final-note.md",
             "a" * 40,
         ),
     )
@@ -829,6 +849,7 @@ async def test_prepare_session_fixed_regions_remain_visible_at_40_by_20() -> Non
         panel.set_last_action(
             "Last action: FAILED — " + long_reason + "retry the action, then Refresh"
         )
+        await pilot.pause()
         await pilot.pause()
 
         bounds = panel.content_region
@@ -905,6 +926,50 @@ async def test_prepare_session_fixed_regions_remain_visible_at_40_by_20() -> Non
         assert _text(panel.query_one("#file-notes-git-action-status", Static)).endswith(
             "then Refresh"
         )
+
+        repository_rendered = _rendered_text(
+            panel.query_one("#file-notes-git-repository", Static)
+        )
+        assert repository_rendered.startswith("Repository:")
+        assert repository_rendered.endswith("final-note.md")
+
+        selected_rendered = _rendered_text(selected)
+        assert selected_rendered.startswith("Selected note:")
+        assert selected_rendered.endswith("final-note.md")
+
+        status_rendered = _rendered_text(
+            panel.query_one("#file-notes-git-status", Static)
+        )
+        assert status_rendered.startswith("Status: STALE · ERROR")
+        assert status_rendered.endswith("Retry Refresh.")
+
+        action_rendered = _rendered_text(
+            panel.query_one("#file-notes-git-action-status", Static)
+        )
+        assert action_rendered.startswith("Last action: FAILED")
+        assert action_rendered.endswith("then Refresh")
+
+        panel.set_current_status(
+            "Status: STALE · ERROR\nstatus detail\nRetry Refresh."
+        )
+        panel.set_last_action(
+            "Last action: FAILED\naction detail\nthen Refresh"
+        )
+        await pilot.pause()
+        multiline_status = _rendered_text(
+            panel.query_one("#file-notes-git-status", Static)
+        )
+        assert multiline_status.startswith("Status: STALE · ERROR")
+        assert multiline_status.endswith("Retry Refresh.")
+        assert len(multiline_status.splitlines()) <= 2
+
+        multiline_action = _rendered_text(
+            panel.query_one("#file-notes-git-action-status", Static)
+        )
+        assert multiline_action.startswith("Last action: FAILED")
+        assert multiline_action.endswith("then Refresh")
+        assert len(multiline_action.splitlines()) <= 2
+
         await _assert_visible_panel_buttons_fit(panel, pilot)
 
 
@@ -1180,6 +1245,8 @@ async def test_authority_loss_clears_rows_selection_and_mutation_actions(
         assert panel.selected_group_id == 22
 
         authority_loss(panel)
+        assert len(panel.query(".file-notes-git-row")) == 2
+        assert not rows.display
         await _wait_until(
             pilot,
             lambda: len(panel.query(".file-notes-git-row")) == 0,
@@ -1196,6 +1263,80 @@ async def test_authority_loss_clears_rows_selection_and_mutation_actions(
         ):
             button = panel.query_one(selector, Button)
             assert not button.display
+
+
+@pytest.mark.parametrize(
+    ("transition", "safe_selector"),
+    [
+        (
+            lambda panel: panel.render_untrusted("/replacement/repository"),
+            "#file-notes-git-trust",
+        ),
+        (
+            lambda panel: panel.render_unavailable("Git discovery failed."),
+            "#file-notes-git-back",
+        ),
+    ],
+    ids=("untrusted-prefers-trust", "unavailable-prefers-back"),
+)
+@pytest.mark.asyncio
+async def test_disappearing_mutation_focus_repairs_without_stealing_external_focus(
+    transition: Callable[[LibraryFileNotesGitPanel], None],
+    safe_selector: str,
+) -> None:
+    panel = LibraryFileNotesGitPanel()
+    panel.styles.display = "block"
+    app = _PanelWithOutsideControlHarness(panel)
+    ready = _status(_row("unstaged", stage_action="stage"))
+    async with app.run_test() as pilot:
+        panel.render_status(ready)
+        await pilot.pause()
+        stage = panel.query_one("#file-notes-git-stage-selected", Button)
+        stage.focus()
+        await pilot.pause()
+        assert stage.has_focus
+
+        transition(panel)
+        await pilot.pause()
+        assert panel.query_one(safe_selector, Button).has_focus
+        await pilot.press("escape")
+        await _wait_until(
+            pilot,
+            lambda: len(app.messages) == 1,
+            "Escape did not emit Back after focus repair",
+        )
+        assert isinstance(app.messages[0], LibraryFileNotesGitPanel.BackRequested)
+
+        panel.render_status(ready)
+        await pilot.pause()
+        outside = app.query_one("#outside-panel-control", Button)
+        outside.focus()
+        await pilot.pause()
+        assert outside.has_focus
+        transition(panel)
+        await pilot.pause()
+        assert outside.has_focus
+
+
+@pytest.mark.asyncio
+async def test_row_render_worker_is_registered_lazily(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    panel = LibraryFileNotesGitPanel()
+    observed_work: list[object] = []
+
+    def capture_worker(work: object, **_kwargs: object) -> None:
+        observed_work.append(work)
+        if not callable(work):
+            getattr(work, "close")()
+
+    async with _PanelHarness(panel).run_test():
+        monkeypatch.setattr(panel, "run_worker", capture_worker)
+        panel.render_status(_status(_row("unstaged", stage_action="stage")))
+        panel.render_unavailable("Git discovery failed.")
+
+        assert len(observed_work) == 2
+        assert all(callable(work) for work in observed_work)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_file_notes_git.py
+++ b/Tests/UI/test_library_file_notes_git.py
@@ -479,6 +479,21 @@ async def _wait_until(
     raise AssertionError(message)
 
 
+async def _settle_current_git_row_render(
+    workspace: LibraryFileNotesWorkspace,
+) -> None:
+    """Await the current non-cancelled panel row replacement, if any."""
+    row_workers = tuple(
+        worker
+        for worker in workspace.app.workers
+        if worker.node is workspace._git_panel_widget
+        and worker.group == "file-notes-git-render-rows"
+        and not worker.is_cancelled
+    )
+    if row_workers:
+        await workspace.app.workers.wait_for_complete(row_workers)
+
+
 async def _open_git_and_stage_one(
     workspace: LibraryFileNotesWorkspace,
     git_service: _FakeGitService,
@@ -502,6 +517,13 @@ async def _open_git_and_stage_one(
         ).display,
         "Stage result did not render",
     )
+    action_worker = workspace._git_action_worker
+    if action_worker is not None:
+        await action_worker.wait()
+    status_worker = workspace._git_status_worker
+    if status_worker is not None:
+        await status_worker.wait()
+    await _settle_current_git_row_render(workspace)
 
 
 async def _assert_visible_panel_buttons_fit(panel, pilot) -> None:
@@ -2071,23 +2093,36 @@ async def test_session_change_invalidates_last_action_before_refresh(
             await _open_git_and_stage_one(workspace, git_service, pilot)
 
             git_service.status_release = release
-            assert owner.record_change(
-                binding,
-                SessionChange("modified", "late.md"),
-            )
-            workspace._refresh_session_changes()
+            try:
+                assert owner.record_change(
+                    binding,
+                    SessionChange("modified", "late.md"),
+                )
+                workspace._refresh_session_changes()
 
-            last_action = workspace.query_one(
-                "#file-notes-git-action-status",
-                Static,
-            )
-            assert not last_action.display
-            assert _text(last_action) == ""
-            assert "Status: STALE" in _text(
-                workspace.query_one("#file-notes-git-status", Static)
-            )
+                last_action = workspace.query_one(
+                    "#file-notes-git-action-status",
+                    Static,
+                )
+                assert not last_action.display
+                assert _text(last_action) == ""
+                assert "Status: STALE" in _text(
+                    workspace.query_one("#file-notes-git-status", Static)
+                )
+            finally:
+                scheduled_refresh = workspace._git_refresh_timer
+                if scheduled_refresh is not None:
+                    scheduled_task = scheduled_refresh._task
+                    scheduled_refresh.stop()
+                    if scheduled_task is not None:
+                        await asyncio.gather(
+                            scheduled_task,
+                            return_exceptions=True,
+                        )
+                    workspace._git_refresh_timer = None
+                release.set()
+                await _settle_current_git_row_render(workspace)
     finally:
-        release.set()
         await workspace.shutdown()
         owner.shutdown()
         replica.close()
@@ -2124,6 +2159,7 @@ async def test_selected_root_change_clears_rows_and_last_action(
             Static,
         ).display
         assert workspace._git_last_action is None
+        await _settle_current_git_row_render(workspace)
     await workspace.shutdown()
     owner.shutdown()
     replica.close()
@@ -2168,6 +2204,7 @@ async def test_repository_retrust_clears_old_rows_and_action_before_prompt(
             Static,
         ).display
         assert workspace._git_last_action is None
+        await _settle_current_git_row_render(workspace)
         await pilot.press("escape")
     await workspace.shutdown()
     owner.shutdown()
@@ -3109,8 +3146,18 @@ async def test_wide_prepare_session_quiets_and_restores_editor_toolbars_without_
         await _wait_until(
             pilot,
             lambda: len(git_service.status_calls) == 1
+            and len(workspace._git_panel_widget.rows) == 2
             and all(not toolbar.display for toolbar in toolbars),
             "Prepare session did not quiet both editor toolbars",
+        )
+        await _settle_current_git_row_render(workspace)
+        await pilot.pause()
+        git_back = workspace.query_one("#file-notes-git-back", Button)
+        git_rows = workspace.query_one("#file-notes-git-rows", ListView)
+        await _wait_until(
+            pilot,
+            lambda: git_back.has_focus or git_rows.has_focus,
+            "Prepare session focus transfer did not settle",
         )
         assert workspace.query_one("#file-notes-breadcrumb", Static).display
         assert workspace.query_one("#file-notes-save-status", Static).display

--- a/Tests/UI/test_library_file_notes_git.py
+++ b/Tests/UI/test_library_file_notes_git.py
@@ -160,6 +160,7 @@ class _FakeGitService:
         self.revalidate_result = True
         self.discovery_result: DiscoveryResult | None = None
         self.status_release: asyncio.Event | None = None
+        self.status_error: Exception | None = None
         self.action_release: asyncio.Event | None = None
         self._status_binding: SessionBinding | None = None
         self._status_task: asyncio.Task[SessionGitStatus] | None = None
@@ -197,6 +198,7 @@ class _FakeGitService:
     ) -> asyncio.Task[SessionGitStatus]:
         self.status_calls.append(tuple(changes))
         release = self.status_release
+        error = self.status_error
         repository = self.repository
         head = self.head
         rows = self.rows
@@ -204,6 +206,8 @@ class _FakeGitService:
         async def finish() -> SessionGitStatus:
             if release is not None:
                 await release.wait()
+            if error is not None:
+                raise error
             generation = self.owner.next_status_generation(binding)
             assert generation is not None
             status = SessionGitStatus(
@@ -438,6 +442,11 @@ def _text(widget: Static | Label) -> str:
     return getattr(renderable, "plain", str(renderable))
 
 
+def _flat_text(widget: Static | Label) -> str:
+    """Flatten intentional two-line fitting without changing word spacing."""
+    return " ".join(_text(widget).split())
+
+
 def _rendered_text(widget: Static) -> str:
     """Return only the strips that are actually visible inside one Static."""
     return "\n".join(
@@ -468,6 +477,31 @@ async def _wait_until(
             return
         await pilot.pause(0.02)
     raise AssertionError(message)
+
+
+async def _open_git_and_stage_one(
+    workspace: LibraryFileNotesWorkspace,
+    git_service: _FakeGitService,
+    pilot,
+) -> None:
+    """Reach one proven mounted Stage result for lifetime regressions."""
+    workspace.query_one("#file-notes-session-changes", Button).press()
+    await _wait_until(
+        pilot,
+        lambda: len(git_service.status_calls) == 1
+        and len(workspace._git_panel_widget.rows) == 2,
+        "initial status did not finish",
+    )
+    workspace.query_one("#file-notes-git-stage-selected", Button).press()
+    await _wait_until(
+        pilot,
+        lambda: len(git_service.status_calls) == 2
+        and workspace.query_one(
+            "#file-notes-git-action-status",
+            Static,
+        ).display,
+        "Stage result did not render",
+    )
 
 
 async def _assert_visible_panel_buttons_fit(panel, pilot) -> None:
@@ -1674,6 +1708,8 @@ async def test_reopening_cached_status_keeps_mutation_controls_disabled(
             lambda: len(workspace._git_panel_widget.rows) == 2,
             "initial status did not finish",
         )
+        initial_status = owner.snapshot(binding).git_status
+        assert initial_status is not None
         workspace.query_one("#file-notes-git-stage-selected", Button).press()
         await _wait_until(
             pilot,
@@ -1807,10 +1843,10 @@ async def test_fresh_workspace_attaches_retained_status_before_cached_ready_stat
             workspace.query_one("#file-notes-session-changes", Button).press()
             await _wait_until(
                 pilot,
-                lambda: "Checking Session Git status"
+                lambda: "Status: CHECKING"
                 in _text(
                     workspace.query_one(
-                        "#file-notes-git-action-status",
+                        "#file-notes-git-status",
                         Static,
                     )
                 ),
@@ -1878,8 +1914,23 @@ async def test_repository_retrust_consumes_rejected_status_before_fresh_refresh(
             git_service.repository = replacement_repository
             original_release.set()
             await asyncio.shield(rejected_task)
-            await pilot.pause()
+            await _wait_until(
+                pilot,
+                lambda: "Status: UNAVAILABLE"
+                in _text(
+                    workspace.query_one(
+                        "#file-notes-git-status",
+                        Static,
+                    )
+                ),
+                "rejected status did not clear the checking presentation",
+            )
             assert owner.snapshot(binding).git_status is None
+            assert workspace._git_panel_widget.rows == ()
+            assert not workspace.query_one(
+                "#file-notes-git-action-status",
+                Static,
+            ).display
 
             workspace.query_one("#file-notes-git-back", Button).press()
             await _wait_until(
@@ -1913,10 +1964,10 @@ async def test_repository_retrust_consumes_rejected_status_before_fresh_refresh(
                 lambda: owner.snapshot(binding).git_status is not None
                 and owner.snapshot(binding).git_status.repository
                 == replacement_repository
-                and "Status ready"
+                and "Status: CURRENT · READY"
                 in _text(
                     workspace.query_one(
-                        "#file-notes-git-action-status",
+                        "#file-notes-git-status",
                         Static,
                     )
                 ),
@@ -1951,6 +2002,8 @@ async def test_hidden_action_summary_is_presented_after_reopen(
             lambda: len(workspace._git_panel_widget.rows) == 2,
             "initial status did not finish",
         )
+        initial_status = owner.snapshot(binding).git_status
+        assert initial_status is not None
         workspace.query_one("#file-notes-git-stage-selected", Button).press()
         await _wait_until(
             pilot,
@@ -1979,12 +2032,186 @@ async def test_hidden_action_summary_is_presented_after_reopen(
         )
         await _wait_until(
             pilot,
-            lambda: "Staged 1 · clean 0 · blocked 0"
-            in _text(
-                workspace.query_one("#file-notes-git-action-status", Static)
-            ),
+            lambda: workspace._git_last_action is not None
+            and workspace.query_one(
+                "#file-notes-git-action-status",
+                Static,
+            ).display,
             "reopen did not present the retained action summary",
         )
+        assert workspace._git_last_action is not None
+        assert workspace._git_last_action.text == (
+            "Last action: STAGED — 1 session note staged; "
+            "Chatbook targeted only eligible session paths."
+        )
+        refreshed_status = owner.snapshot(binding).git_status
+        assert refreshed_status is not None
+        assert (
+            refreshed_status.status_generation
+            > initial_status.status_generation
+        )
+    await workspace.shutdown()
+    owner.shutdown()
+    replica.close()
+
+
+@pytest.mark.asyncio
+async def test_session_change_invalidates_last_action_before_refresh(
+    tmp_path: Path,
+) -> None:
+    _root, owner, binding, replica, git_service, workspace = _workspace_fixture(
+        tmp_path
+    )
+    release = asyncio.Event()
+    try:
+        async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
+            await _wait_until(
+                pilot,
+                lambda: workspace.initialized,
+                "scan did not finish",
+            )
+            await _open_git_and_stage_one(workspace, git_service, pilot)
+
+            git_service.status_release = release
+            assert owner.record_change(
+                binding,
+                SessionChange("modified", "late.md"),
+            )
+            workspace._refresh_session_changes()
+
+            last_action = workspace.query_one(
+                "#file-notes-git-action-status",
+                Static,
+            )
+            assert not last_action.display
+            assert _text(last_action) == ""
+            assert "Status: STALE" in _text(
+                workspace.query_one("#file-notes-git-status", Static)
+            )
+    finally:
+        release.set()
+        await workspace.shutdown()
+        owner.shutdown()
+        replica.close()
+
+
+@pytest.mark.asyncio
+async def test_selected_root_change_clears_rows_and_last_action(
+    tmp_path: Path,
+) -> None:
+    root, owner, _binding, replica, git_service, workspace = _workspace_fixture(
+        tmp_path
+    )
+    replacement = tmp_path / "replacement-notes"
+    replacement.mkdir()
+    (replacement / "new-root.md").write_text("replacement", encoding="utf-8")
+    async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        await _open_git_and_stage_one(workspace, git_service, pilot)
+
+        retained_rows = workspace._git_panel_widget.rows
+        retained_selection = workspace._git_panel_widget.selected_group_id
+        retained_action = workspace._git_last_action
+        assert await workspace.set_root(root, persist=False)
+        assert workspace._git_panel_widget.rows == retained_rows
+        assert workspace._git_panel_widget.selected_group_id == retained_selection
+        assert workspace._git_last_action == retained_action
+
+        assert await workspace.set_root(replacement, persist=False)
+
+        assert workspace._git_panel_widget.rows == ()
+        assert workspace._git_panel_widget.selected_group_id is None
+        assert not workspace.query_one(
+            "#file-notes-git-action-status",
+            Static,
+        ).display
+        assert workspace._git_last_action is None
+    await workspace.shutdown()
+    owner.shutdown()
+    replica.close()
+
+
+@pytest.mark.asyncio
+async def test_repository_retrust_clears_old_rows_and_action_before_prompt(
+    tmp_path: Path,
+) -> None:
+    _root, owner, binding, replica, git_service, workspace = _workspace_fixture(
+        tmp_path
+    )
+    original_repository = git_service.repository
+    replacement_repository = _repository(
+        "/canonical/retrusted",
+        identity=FileSystemIdentity(7, 8),
+    )
+    async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        entry = workspace.query_one("#file-notes-session-changes", Button)
+        await _open_git_and_stage_one(workspace, git_service, pilot)
+
+        assert owner.clear_trust_if_matches(binding, original_repository)
+        git_service.repository = replacement_repository
+        workspace.query_one("#file-notes-git-back", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace._navigator_mode != "git",
+            "Back did not hide Session Git",
+        )
+        entry.press()
+        await _wait_until(
+            pilot,
+            lambda: isinstance(workspace.app.screen, SessionGitTrustDialog),
+            "replacement repository prompt did not open",
+        )
+
+        assert workspace._git_panel_widget.rows == ()
+        assert workspace._git_panel_widget.selected_group_id is None
+        assert not workspace.query_one(
+            "#file-notes-git-action-status",
+            Static,
+        ).display
+        assert workspace._git_last_action is None
+        await pilot.press("escape")
+    await workspace.shutdown()
+    owner.shutdown()
+    replica.close()
+
+
+@pytest.mark.asyncio
+async def test_refresh_failure_keeps_stale_error_separate_from_last_action(
+    tmp_path: Path,
+) -> None:
+    _root, owner, _binding, replica, git_service, workspace = _workspace_fixture(
+        tmp_path
+    )
+    async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        await _open_git_and_stage_one(workspace, git_service, pilot)
+        last_action = _flat_text(
+            workspace.query_one("#file-notes-git-action-status", Static)
+        )
+
+        release = asyncio.Event()
+        git_service.status_release = release
+        git_service.status_error = RuntimeError("simulated status failure")
+        try:
+            workspace._start_git_refresh()
+            assert len(git_service.status_calls) == 3
+            assert len(workspace._git_panel_widget.rows) == 2
+            _assert_git_mutations_disabled(workspace)
+        finally:
+            release.set()
+        await _wait_until(
+            pilot,
+            lambda: "Status: STALE · ERROR"
+            in _text(workspace.query_one("#file-notes-git-status", Static)),
+            "refresh failure did not render separately",
+        )
+
+        assert _flat_text(
+            workspace.query_one("#file-notes-git-action-status", Static)
+        ) == last_action
+        assert len(workspace._git_panel_widget.rows) == 2
+        _assert_git_mutations_disabled(workspace)
     await workspace.shutdown()
     owner.shutdown()
     replica.close()
@@ -2007,8 +2234,8 @@ async def test_remount_rehydrates_status_that_finished_while_unmounted(
             lambda: len(git_service.status_calls) == 1,
             "retained status did not start",
         )
-        assert "Checking Session Git status" in _text(
-            workspace.query_one("#file-notes-git-action-status", Static)
+        assert "Status: CHECKING" in _text(
+            workspace.query_one("#file-notes-git-status", Static)
         )
 
         host = app.query_one("#remount-workspace-host", Vertical)
@@ -2033,8 +2260,8 @@ async def test_remount_rehydrates_status_that_finished_while_unmounted(
         await pilot.pause()
 
         assert len(workspace._git_panel_widget.rows) == 2
-        assert "Status ready" in _text(
-            workspace.query_one("#file-notes-git-action-status", Static)
+        assert "Status: CURRENT · READY" in _text(
+            workspace.query_one("#file-notes-git-status", Static)
         )
         assert len(git_service.status_calls) == 1
     await workspace.shutdown()
@@ -2204,9 +2431,10 @@ async def test_stage_flushes_then_gate_keeps_editor_back_and_one_latest_refresh(
         await pilot.pause(0.1)
         assert len(git_service.status_calls) == 2
         assert git_service.status_calls[-1][-1].change.relative_path == "latest.md"
-        assert "Staged 1 · clean 0 · blocked 0" in _text(
-            workspace.query_one("#file-notes-git-action-status", Static)
-        )
+        assert not workspace.query_one(
+            "#file-notes-git-action-status",
+            Static,
+        ).display
     await workspace.shutdown()
     owner.shutdown()
     replica.close()
@@ -2221,9 +2449,10 @@ async def test_stage_all_summary_counts_the_complete_displayed_snapshot(
     )
     git_service.rows = (
         _row("unstaged", group_id=1, stage_action="stage"),
-        _row("owned", group_id=2, unstage_eligible=True),
-        _row("clean", group_id=3),
-        _row("conflict", group_id=4, disabled_reason="conflict"),
+        _row("unstaged", group_id=2, stage_action="stage"),
+        _row("owned", group_id=3, unstage_eligible=True),
+        _row("clean", group_id=4),
+        _row("conflict", group_id=5, disabled_reason="conflict"),
     )
     async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
@@ -2237,14 +2466,16 @@ async def test_stage_all_summary_counts_the_complete_displayed_snapshot(
         workspace.query_one("#file-notes-git-stage-all", Button).press()
         await _wait_until(
             pilot,
-            lambda: git_service.stage_calls == [(1,)]
+            lambda: git_service.stage_calls == [(1, 2)]
             and len(git_service.status_calls) == 2,
             "Stage All did not settle and refresh",
         )
 
-        assert (
-            _text(workspace.query_one("#file-notes-git-action-status", Static))
-            == "Staged 1 · already staged 1 · clean 1 · blocked 1"
+        assert workspace._git_last_action is not None
+        assert workspace._git_last_action.text == (
+            "Last action: STAGED — 2 session notes staged; "
+            "Chatbook targeted only eligible session paths. "
+            "Counts: already staged 1; clean 1; blocked 1."
         )
     await workspace.shutdown()
     owner.shutdown()
@@ -2260,9 +2491,10 @@ async def test_unstage_all_summary_counts_the_complete_displayed_snapshot(
     )
     git_service.rows = (
         _row("owned", group_id=1, unstage_eligible=True),
-        _row("unstaged", group_id=2, stage_action="stage"),
-        _row("clean", group_id=3),
-        _row("conflict", group_id=4, disabled_reason="conflict"),
+        _row("owned", group_id=2, unstage_eligible=True),
+        _row("unstaged", group_id=3, stage_action="stage"),
+        _row("clean", group_id=4),
+        _row("conflict", group_id=5, disabled_reason="conflict"),
     )
     async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
@@ -2276,22 +2508,132 @@ async def test_unstage_all_summary_counts_the_complete_displayed_snapshot(
         workspace.query_one("#file-notes-git-unstage-all", Button).press()
         await _wait_until(
             pilot,
-            lambda: git_service.unstage_calls == [(1,)]
+            lambda: git_service.unstage_calls == [(1, 2)]
             and len(git_service.status_calls) == 2,
             "Unstage All did not settle and refresh",
         )
 
-        assert (
-            _text(workspace.query_one("#file-notes-git-action-status", Static))
-            == "Unstaged 1 · skipped 1 · clean 1 · blocked 1"
+        assert workspace._git_last_action is not None
+        assert workspace._git_last_action.text == (
+            "Last action: UNSTAGED — 2 session notes unstaged; "
+            "Chatbook restored only its owned session entries. "
+            "Counts: skipped 1; clean 1; blocked 1."
         )
-        selected_context = workspace._git_action_summary_context(
+    await workspace.shutdown()
+    owner.shutdown()
+    replica.close()
+
+
+def test_action_summary_contract_matrix(tmp_path: Path) -> None:
+    _root, owner, binding, replica, _git_service, workspace = _workspace_fixture(
+        tmp_path
+    )
+    try:
+        assert owner.record_change(
+            binding,
+            SessionChange(
+                "moved",
+                "folder/one.md",
+                "folder/moved.md",
+            ),
+        )
+        action_key = workspace._capture_git_action_key(binding)
+        assert action_key is not None
+        stage_context = workspace._git_action_summary_context(
             "stage",
             (1,),
             bulk=False,
         )
-        assert (
-            workspace._git_action_summary(
+        unstage_context = workspace._git_action_summary_context(
+            "unstage",
+            (1,),
+            bulk=False,
+        )
+        cases = (
+            (
+                GitActionResult(
+                    "stage",
+                    "success",
+                    (1,),
+                    staged_group_ids=(1,),
+                ),
+                stage_context,
+                "1 session note staged; "
+                "Chatbook targeted only eligible session paths.",
+            ),
+            (
+                GitActionResult(
+                    "stage",
+                    "success",
+                    (1, 2),
+                    staged_group_ids=(1, 2),
+                ),
+                stage_context,
+                "2 session notes staged; "
+                "Chatbook targeted only eligible session paths.",
+            ),
+            (
+                GitActionResult(
+                    "unstage",
+                    "success",
+                    (1,),
+                    unstaged_group_ids=(1,),
+                ),
+                unstage_context,
+                "1 session note unstaged; "
+                "Chatbook restored only its owned session entry.",
+            ),
+            (
+                GitActionResult(
+                    "unstage",
+                    "success",
+                    (1, 2),
+                    unstaged_group_ids=(1, 2),
+                ),
+                unstage_context,
+                "2 session notes unstaged; "
+                "Chatbook restored only its owned session entries.",
+            ),
+            (
+                GitActionResult(
+                    "unstage",
+                    "success",
+                    (1,),
+                    clean_group_ids=(1,),
+                    blocked_group_ids=(2,),
+                    message="Nothing required an index update",
+                ),
+                unstage_context,
+                "No session notes unstaged. Nothing required an index update. "
+                "Counts: clean 1; blocked 1. "
+                "Review current eligibility, then Refresh.",
+            ),
+            (
+                GitActionResult(
+                    "stage",
+                    "blocked",
+                    (1,),
+                    clean_group_ids=(2,),
+                    blocked_group_ids=(1,),
+                    message="Service supplied detail",
+                ),
+                stage_context,
+                "Service supplied detail. Counts: clean 1; blocked 1. "
+                "Resolve the reported Git state outside Chatbook, then Refresh.",
+            ),
+            (
+                GitActionResult("stage", "stale", (1,)),
+                stage_context,
+                "Stage status became stale. "
+                "Review the changed repository or session state, then Refresh.",
+            ),
+            (
+                GitActionResult("stage", "error", (1,)),
+                stage_context,
+                "Stage failed. "
+                "Fix the reported Git error outside Chatbook, then Refresh.",
+            ),
+            (
                 GitActionResult(
                     "stage",
                     "uncertain",
@@ -2299,24 +2641,30 @@ async def test_unstage_all_summary_counts_the_complete_displayed_snapshot(
                     blocked_group_ids=(1,),
                     message="Git Stage outcome is uncertain",
                 ),
-                selected_context,
-            )
-            == "Git Stage outcome is uncertain"
-        )
-        uncertain = workspace._git_action_summary(
-            GitActionResult(
-                "stage",
-                "uncertain",
-                (1,),
-                blocked_group_ids=(1,),
+                stage_context,
+                "Git Stage outcome is uncertain. Counts: blocked 1. "
+                "Inspect the repository index outside Chatbook, then Refresh.",
             ),
-            selected_context,
         )
-        assert uncertain == "Stage uncertain · clean 0 · blocked 1"
-        assert "Staged" not in uncertain
-    await workspace.shutdown()
-    owner.shutdown()
-    replica.close()
+        for result, context, expected in cases:
+            assert workspace._git_action_summary(
+                result,
+                context,
+                action_key,
+            ) == expected
+
+        assert owner.record_change(
+            binding,
+            SessionChange("modified", "late.md"),
+        )
+        assert workspace._git_action_summary(
+            cases[0][0],
+            stage_context,
+            action_key,
+        ) is None
+    finally:
+        owner.shutdown()
+        replica.close()
 
 
 @pytest.mark.asyncio
@@ -2341,7 +2689,7 @@ async def test_unavailable_discovery_exposes_no_trust_or_mutation_action(
         await _wait_until(
             pilot,
             lambda: "Git is not installed"
-            in _text(panel.query_one("#file-notes-git-action-status", Static)),
+            in _text(panel.query_one("#file-notes-git-status", Static)),
             "Git discovery failure was not rendered",
         )
         visible_actions = {
@@ -2422,8 +2770,10 @@ async def test_identity_change_after_trust_runs_no_status(
         await pilot.pause(0.1)
         assert git_service.status_calls == []
         assert owner.snapshot(binding).trusted_repository is None
-        assert "identity changed" in _text(
-            workspace.query_one("#file-notes-git-action-status", Static)
+        assert (
+            workspace._git_panel_widget._current_status_text
+            == "Status: TRUST REQUIRED — Repository identity changed; "
+            "retry Trust and check status."
         )
     await workspace.shutdown()
     owner.shutdown()
@@ -2453,8 +2803,10 @@ async def test_unstage_selected_reports_counts_and_refreshes_once(
             and len(git_service.status_calls) == 2,
             "Unstage did not settle and refresh once",
         )
-        assert "Unstaged 1 · clean 0 · blocked 0" in _text(
-            workspace.query_one("#file-notes-git-action-status", Static)
+        assert workspace._git_last_action is not None
+        assert workspace._git_last_action.text == (
+            "Last action: UNSTAGED — 1 session note unstaged; "
+            "Chatbook restored only its owned session entry."
         )
     await workspace.shutdown()
     owner.shutdown()
@@ -2601,11 +2953,51 @@ async def test_stage_rechecks_transition_admission_after_flush_await(
         workspace.query_one("#file-notes-git-stage-selected", Button).press()
         await pilot.pause(0.1)
         assert git_service.stage_calls == []
-        assert "blocked" in _text(
-            workspace.query_one("#file-notes-git-action-status", Static)
+        assert (
+            workspace._git_panel_widget._current_status_text
+            == "Status: CURRENT · BLOCKED — Stage could not start: "
+            "mutation refused. Finish the active File Notes action, then "
+            "Refresh."
         )
+        assert not workspace.query_one(
+            "#file-notes-git-action-status",
+            Static,
+        ).display
         assert lease is not None
         lease.release()
+    await workspace.shutdown()
+    owner.shutdown()
+    replica.close()
+
+
+@pytest.mark.asyncio
+async def test_stage_draft_conflict_names_save_and_editor_recovery(
+    tmp_path: Path,
+) -> None:
+    _root, owner, _binding, replica, git_service, workspace = _workspace_fixture(
+        tmp_path
+    )
+    async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        workspace.query_one("#file-notes-session-changes", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: len(git_service.status_calls) == 1,
+            "initial status did not finish",
+        )
+        workspace._set_save_state("conflict", "file changed on disk")
+        workspace.query_one("#file-notes-git-stage-selected", Button).press()
+        await pilot.pause()
+
+        assert git_service.stage_calls == []
+        assert workspace._git_panel_widget._current_status_text == (
+            "Status: CURRENT · BLOCKED — Save conflict must be resolved "
+            "before staging. Return to the editor."
+        )
+        assert not workspace.query_one(
+            "#file-notes-git-action-status",
+            Static,
+        ).display
     await workspace.shutdown()
     owner.shutdown()
     replica.close()
@@ -2658,6 +3050,113 @@ async def test_narrow_git_navigation_retains_editor_search_tree_and_row_selectio
         assert search.value == "needle"
         assert folder.is_expanded
         assert panel.selected_group_id == 2
+    await workspace.shutdown()
+    owner.shutdown()
+    replica.close()
+
+
+@pytest.mark.asyncio
+async def test_wide_prepare_session_quiets_and_restores_editor_toolbars_without_remount(
+    tmp_path: Path,
+) -> None:
+    _root, owner, _binding, replica, git_service, workspace = _workspace_fixture(
+        tmp_path
+    )
+    async with _WorkspaceHarness(workspace).run_test(size=(150, 42)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        assert await workspace.open_path("folder/one.md")
+        editor = workspace.query_one("#file-notes-editor", TextArea)
+        editor.cursor_location = (0, 3)
+        editor.selection = editor.selection.__class__((0, 1), (0, 5))
+        toolbars = tuple(workspace.query(".file-notes-toolbar"))
+        assert len(toolbars) == 2
+        assert all(toolbar.display for toolbar in toolbars)
+
+        workspace.query_one("#file-notes-session-changes", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: len(git_service.status_calls) == 1
+            and all(not toolbar.display for toolbar in toolbars),
+            "Prepare session did not quiet both editor toolbars",
+        )
+        assert workspace.query_one("#file-notes-breadcrumb", Static).display
+        assert workspace.query_one("#file-notes-save-status", Static).display
+        assert workspace.query_one("#file-notes-action-status", Static).display
+        assert workspace.query_one("#file-notes-editor", TextArea) is editor
+        assert not editor.read_only
+
+        editor.focus()
+        await pilot.press("x")
+        await _wait_until(
+            pilot,
+            lambda: workspace.save_state == "dirty",
+            "typing beside Prepare session did not retain an editable draft",
+        )
+        body = editor.text
+        cursor = editor.cursor_location
+        selection = editor.selection
+        workspace.query_one("#file-notes-git-back", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: all(toolbar.display for toolbar in toolbars),
+            "Back did not restore both editor toolbars",
+        )
+
+        assert workspace.query_one("#file-notes-editor", TextArea) is editor
+        assert editor.text == body
+        assert editor.cursor_location == cursor
+        assert editor.selection == selection
+        assert workspace.save_state == "dirty"
+    await workspace.shutdown()
+    owner.shutdown()
+    replica.close()
+
+
+@pytest.mark.asyncio
+async def test_narrow_editor_actions_keep_complete_labels_at_40_by_20(
+    tmp_path: Path,
+) -> None:
+    _root, owner, _binding, replica, _git_service, workspace = _workspace_fixture(
+        tmp_path
+    )
+    async with _WorkspaceHarness(workspace).run_test(size=(40, 20)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        assert await workspace.open_path("folder/one.md")
+        await _wait_until(
+            pilot,
+            lambda: workspace.has_class("-stack-editor-actions"),
+            "narrow editor actions did not switch to the three-column grid",
+        )
+        pane = workspace.query_one("#file-notes-editor-pane")
+
+        def assert_editor_actions_fit() -> None:
+            visible_actions = tuple(
+                button
+                for button in pane.query(Button)
+                if button.display
+            )
+            assert visible_actions
+            for button in visible_actions:
+                label = str(button.label)
+                assert button.render().plain == label
+                assert cell_len(label) <= button.content_region.width
+                assert button.region.x >= pane.region.x
+                assert button.region.right <= pane.region.right
+                assert button.region.y >= pane.region.y
+                assert button.region.bottom <= pane.region.bottom
+
+        assert_editor_actions_fit()
+        protect = workspace.query_one("#file-notes-protect", Button)
+        assert str(protect.label) == "Protect"
+        protect.press()
+        await _wait_until(
+            pilot,
+            lambda: str(protect.label) == "Unprotect",
+            "Protect did not expose the complete Unprotect label",
+        )
+        await pilot.pause()
+        assert workspace.has_class("-stack-editor-actions")
+        assert_editor_actions_fit()
     await workspace.shutdown()
     owner.shutdown()
     replica.close()

--- a/Tests/UI/test_library_file_notes_git.py
+++ b/Tests/UI/test_library_file_notes_git.py
@@ -2158,6 +2158,96 @@ async def test_unexpected_action_failure_survives_postflight_refresh(
 
 
 @pytest.mark.asyncio
+async def test_hidden_unexpected_action_failure_refreshes_on_reopen(
+    tmp_path: Path,
+) -> None:
+    _root, owner, binding, replica, git_service, workspace = _workspace_fixture(
+        tmp_path
+    )
+    git_service.action_release = asyncio.Event()
+    git_service.action_error = RuntimeError("simulated hidden action failure")
+    async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        entry = workspace.query_one("#file-notes-session-changes", Button)
+        entry.press()
+        await _wait_until(
+            pilot,
+            lambda: len(git_service.status_calls) == 1
+            and len(workspace._git_panel_widget.rows) == 2,
+            "initial status did not finish",
+        )
+        initial_status = owner.snapshot(binding).git_status
+        assert initial_status is not None
+
+        workspace.query_one("#file-notes-git-stage-selected", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: git_service.stage_calls == [(1,)]
+            and owner.mutation_active(binding),
+            "Stage did not retain the mutation gate",
+        )
+        workspace.query_one("#file-notes-git-back", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace._navigator_mode != "git" and entry.has_focus,
+            "Back did not hide Session Git and restore entry focus",
+        )
+
+        git_service.action_release.set()
+        await _wait_until(
+            pilot,
+            lambda: not owner.mutation_active(binding)
+            and workspace._git_last_action is not None,
+            "hidden Stage failure did not settle",
+        )
+        await pilot.pause(0.1)
+        assert len(git_service.status_calls) == 1
+        retained_action = workspace._git_last_action
+        assert retained_action is not None
+        assert workspace._git_refresh_after_mutation
+        assert retained_action.binding == binding
+        assert retained_action.repository == git_service.repository
+        assert retained_action.changes == owner.snapshot(binding).changes
+        assert retained_action.text == (
+            "Last action: FAILED — Git action failed: simulated hidden action "
+            "failure. Inspect the repository index outside Chatbook, then Refresh."
+        )
+
+        entry.press()
+        await _wait_until(
+            pilot,
+            lambda: len(git_service.status_calls) == 2
+            and owner.snapshot(binding).git_status is not None
+            and owner.snapshot(binding).git_status.status_generation
+            > initial_status.status_generation
+            and "Status: CURRENT · READY"
+            in _text(workspace.query_one("#file-notes-git-status", Static)),
+            "reopen did not refresh the hidden action failure",
+        )
+        await _wait_for_current_git_row_projection(workspace)
+        assert not workspace._git_refresh_after_mutation
+        git_rows = workspace.query_one("#file-notes-git-rows", ListView)
+        await _wait_until(
+            pilot,
+            lambda: git_rows.has_focus,
+            "reopen did not restore focus to the refreshed rows",
+        )
+        assert workspace._git_last_action == retained_action
+        action_status = workspace.query_one(
+            "#file-notes-git-action-status",
+            Static,
+        )
+        assert action_status.display
+        assert _flat_text(action_status).startswith("Last action: FAILED")
+        assert _flat_text(action_status).endswith(
+            "outside Chatbook, then Refresh."
+        )
+    await workspace.shutdown()
+    owner.shutdown()
+    replica.close()
+
+
+@pytest.mark.asyncio
 async def test_session_change_invalidates_last_action_before_refresh(
     tmp_path: Path,
 ) -> None:

--- a/Tests/UI/test_library_file_notes_git.py
+++ b/Tests/UI/test_library_file_notes_git.py
@@ -786,13 +786,23 @@ async def test_prepare_session_fixed_regions_remain_visible_at_40_by_20() -> Non
             group_id=2,
             disabled_reason=long_reason,
         ),
+        _row(
+            "conflict",
+            group_id=3,
+            disabled_reason=long_reason,
+        ),
+        _row(
+            "unavailable",
+            group_id=4,
+            disabled_reason=long_reason,
+        ),
         *tuple(
             _row(
                 "unstaged",
                 group_id=group_id,
                 stage_action="stage",
             )
-            for group_id in range(3, 10)
+            for group_id in range(5, 12)
         ),
     )
     repository = _repository(
@@ -875,6 +885,19 @@ async def test_prepare_session_fixed_regions_remain_visible_at_40_by_20() -> Non
         failure_text = _text(failure)
         assert failure_text.endswith("; retry, Refresh")
         assert cell_len(failure_text) <= failure.content_region.width
+
+        conflict, unavailable = tuple(
+            widget
+            for widget in panel.query(".file-notes-git-row-secondary")
+            if _text(widget).startswith("BLOCKED")
+        )
+        conflict_text = _text(conflict)
+        assert conflict_text == "BLOCKED · Conflict: use Git; Refresh"
+        assert cell_len(conflict_text) <= conflict.content_region.width
+
+        unavailable_text = _text(unavailable)
+        assert unavailable_text == "BLOCKED · Restore Git first; Refresh"
+        assert cell_len(unavailable_text) <= unavailable.content_region.width
 
         assert _text(panel.query_one("#file-notes-git-status", Static)).endswith(
             "Retry Refresh."

--- a/Tests/UI/test_library_file_notes_git.py
+++ b/Tests/UI/test_library_file_notes_git.py
@@ -162,6 +162,7 @@ class _FakeGitService:
         self.status_release: asyncio.Event | None = None
         self.status_error: Exception | None = None
         self.action_release: asyncio.Event | None = None
+        self.action_error: Exception | None = None
         self._status_binding: SessionBinding | None = None
         self._status_task: asyncio.Task[SessionGitStatus] | None = None
 
@@ -257,11 +258,14 @@ class _FakeGitService:
             self.stage_calls.append(requested)
         else:
             self.unstage_calls.append(requested)
+        error = self.action_error
 
         async def finish() -> GitActionResult:
             try:
                 if self.action_release is not None:
                     await self.action_release.wait()
+                if error is not None:
+                    raise error
                 self.owner.clear_status(binding)
                 return GitActionResult(
                     action,  # type: ignore[arg-type]
@@ -2095,6 +2099,59 @@ async def test_hidden_action_summary_is_presented_after_reopen(
             refreshed_status.status_generation
             > initial_status.status_generation
         )
+    await workspace.shutdown()
+    owner.shutdown()
+    replica.close()
+
+
+@pytest.mark.asyncio
+async def test_unexpected_action_failure_survives_postflight_refresh(
+    tmp_path: Path,
+) -> None:
+    _root, owner, binding, replica, git_service, workspace = _workspace_fixture(
+        tmp_path
+    )
+    git_service.action_error = RuntimeError("simulated action failure")
+    async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        workspace.query_one("#file-notes-session-changes", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: len(git_service.status_calls) == 1
+            and len(workspace._git_panel_widget.rows) == 2,
+            "initial status did not finish",
+        )
+        admission = owner.snapshot(binding)
+
+        workspace.query_one("#file-notes-git-stage-selected", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: git_service.stage_calls == [(1,)]
+            and len(git_service.status_calls) == 2
+            and not owner.mutation_active(binding)
+            and "Status: CURRENT · READY"
+            in _text(workspace.query_one("#file-notes-git-status", Static)),
+            "failed Stage did not settle through its postflight refresh",
+        )
+
+        last_action = workspace._git_last_action
+        assert last_action is not None
+        expected = (
+            "Last action: FAILED — Git action failed: simulated action failure. "
+            "Inspect the repository index outside Chatbook, then Refresh."
+        )
+        assert last_action.binding == admission.binding == binding
+        assert last_action.repository == admission.trusted_repository
+        assert last_action.changes == admission.changes
+        assert last_action.text == expected
+        action_status = workspace.query_one(
+            "#file-notes-git-action-status",
+            Static,
+        )
+        assert action_status.display
+        rendered_action = _flat_text(action_status)
+        assert rendered_action.startswith("Last action: FAILED")
+        assert rendered_action.endswith("outside Chatbook, then Refresh.")
     await workspace.shutdown()
     owner.shutdown()
     replica.close()

--- a/Tests/UI/test_library_file_notes_git.py
+++ b/Tests/UI/test_library_file_notes_git.py
@@ -1708,8 +1708,6 @@ async def test_reopening_cached_status_keeps_mutation_controls_disabled(
             lambda: len(workspace._git_panel_widget.rows) == 2,
             "initial status did not finish",
         )
-        initial_status = owner.snapshot(binding).git_status
-        assert initial_status is not None
         workspace.query_one("#file-notes-git-stage-selected", Button).press()
         await _wait_until(
             pilot,
@@ -2539,6 +2537,16 @@ def test_action_summary_contract_matrix(tmp_path: Path) -> None:
         )
         action_key = workspace._capture_git_action_key(binding)
         assert action_key is not None
+        moved_group = next(
+            group
+            for group in coalesce_session_changes(action_key.changes)
+            if group.latest_action == "moved"
+        )
+        assert set(moved_group.endpoints) == {
+            "folder/one.md",
+            "folder/moved.md",
+        }
+        assert len(moved_group.endpoints) == 2
         stage_context = workspace._git_action_summary_context(
             "stage",
             (1,),
@@ -2554,8 +2562,8 @@ def test_action_summary_contract_matrix(tmp_path: Path) -> None:
                 GitActionResult(
                     "stage",
                     "success",
-                    (1,),
-                    staged_group_ids=(1,),
+                    (moved_group.group_id,),
+                    staged_group_ids=(moved_group.group_id,),
                 ),
                 stage_context,
                 "1 session note staged; "
@@ -2667,19 +2675,43 @@ def test_action_summary_contract_matrix(tmp_path: Path) -> None:
         replica.close()
 
 
+@pytest.mark.parametrize(
+    ("discovery", "expected_status", "visible_recovery"),
+    [
+        (
+            DiscoveryResult(
+                "unavailable",
+                message="Git is not installed",
+            ),
+            "Status: UNAVAILABLE — Git is not installed. Install or restore "
+            "Git, then reopen Prepare session for commit.",
+            "Install or restore Git, then reopen Prepare session for commit.",
+        ),
+        (
+            DiscoveryResult(
+                "not_repository",
+                message="Selected File Notes root is not in a Git worktree",
+            ),
+            "Status: UNAVAILABLE — This notes folder is not in a Git "
+            "worktree. Notes remain fully usable.",
+            "Notes remain fully usable.",
+        ),
+    ],
+    ids=("git-unavailable", "not-repository"),
+)
 @pytest.mark.asyncio
 async def test_unavailable_discovery_exposes_no_trust_or_mutation_action(
     tmp_path: Path,
+    discovery: DiscoveryResult,
+    expected_status: str,
+    visible_recovery: str,
 ) -> None:
     _root, owner, _binding, replica, git_service, workspace = _workspace_fixture(
         tmp_path,
         trusted=False,
     )
-    git_service.discovery_result = DiscoveryResult(
-        "unavailable",
-        message="Git is not installed",
-    )
-    async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
+    git_service.discovery_result = discovery
+    async with _WorkspaceHarness(workspace).run_test(size=(220, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
         workspace.query_one("#file-notes-session-changes", Button).press()
         panel = workspace.query_one(
@@ -2688,10 +2720,11 @@ async def test_unavailable_discovery_exposes_no_trust_or_mutation_action(
         )
         await _wait_until(
             pilot,
-            lambda: "Git is not installed"
-            in _text(panel.query_one("#file-notes-git-status", Static)),
-            "Git discovery failure was not rendered",
+            lambda: visible_recovery
+            in _flat_text(panel.query_one("#file-notes-git-status", Static)),
+            "Git discovery recovery was not visibly rendered",
         )
+        assert panel._current_status_text == expected_status
         visible_actions = {
             button.id
             for button in panel.query(Button)

--- a/Tests/UI/test_library_file_notes_git.py
+++ b/Tests/UI/test_library_file_notes_git.py
@@ -479,19 +479,22 @@ async def _wait_until(
     raise AssertionError(message)
 
 
-async def _settle_current_git_row_render(
+async def _wait_for_current_git_row_projection(
     workspace: LibraryFileNotesWorkspace,
 ) -> None:
-    """Await the current non-cancelled panel row replacement, if any."""
-    row_workers = tuple(
-        worker
-        for worker in workspace.app.workers
-        if worker.node is workspace._git_panel_widget
-        and worker.group == "file-notes-git-render-rows"
-        and not worker.is_cancelled
+    """Wait until the panel model and mounted row projection agree."""
+    panel = workspace._git_panel_widget
+    row_list = panel.query_one("#file-notes-git-rows", ListView)
+    for _ in range(200):
+        mounted_count = len(panel.query(".file-notes-git-row"))
+        if mounted_count == len(panel.rows) and row_list.display is bool(panel.rows):
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError(
+        "Git row projection did not settle: "
+        f"model={len(panel.rows)}, mounted={mounted_count}, "
+        f"display={row_list.display}"
     )
-    if row_workers:
-        await workspace.app.workers.wait_for_complete(row_workers)
 
 
 async def _open_git_and_stage_one(
@@ -523,7 +526,24 @@ async def _open_git_and_stage_one(
     status_worker = workspace._git_status_worker
     if status_worker is not None:
         await status_worker.wait()
-    await _settle_current_git_row_render(workspace)
+    await _wait_for_current_git_row_projection(workspace)
+
+
+def _assert_visible_editor_actions_fit(
+    workspace: LibraryFileNotesWorkspace,
+) -> None:
+    """Assert visible editor actions keep complete labels inside their pane."""
+    pane = workspace.query_one("#file-notes-editor-pane")
+    visible_actions = tuple(button for button in pane.query(Button) if button.display)
+    assert visible_actions
+    for button in visible_actions:
+        label = str(button.label)
+        assert button.render().plain == label
+        assert cell_len(label) <= button.content_region.width
+        assert button.region.x >= pane.region.x
+        assert button.region.right <= pane.region.right
+        assert button.region.y >= pane.region.y
+        assert button.region.bottom <= pane.region.bottom
 
 
 async def _assert_visible_panel_buttons_fit(panel, pilot) -> None:
@@ -2112,16 +2132,14 @@ async def test_session_change_invalidates_last_action_before_refresh(
             finally:
                 scheduled_refresh = workspace._git_refresh_timer
                 if scheduled_refresh is not None:
-                    scheduled_task = scheduled_refresh._task
                     scheduled_refresh.stop()
-                    if scheduled_task is not None:
-                        await asyncio.gather(
-                            scheduled_task,
-                            return_exceptions=True,
-                        )
                     workspace._git_refresh_timer = None
                 release.set()
-                await _settle_current_git_row_render(workspace)
+                await pilot.pause()
+                status_worker = workspace._git_status_worker
+                if status_worker is not None:
+                    await status_worker.wait()
+                await _wait_for_current_git_row_projection(workspace)
     finally:
         await workspace.shutdown()
         owner.shutdown()
@@ -2159,7 +2177,7 @@ async def test_selected_root_change_clears_rows_and_last_action(
             Static,
         ).display
         assert workspace._git_last_action is None
-        await _settle_current_git_row_render(workspace)
+        await _wait_for_current_git_row_projection(workspace)
     await workspace.shutdown()
     owner.shutdown()
     replica.close()
@@ -2204,7 +2222,7 @@ async def test_repository_retrust_clears_old_rows_and_action_before_prompt(
             Static,
         ).display
         assert workspace._git_last_action is None
-        await _settle_current_git_row_render(workspace)
+        await _wait_for_current_git_row_projection(workspace)
         await pilot.press("escape")
     await workspace.shutdown()
     owner.shutdown()
@@ -2665,6 +2683,16 @@ def test_action_summary_contract_matrix(tmp_path: Path) -> None:
                 stage_context,
                 "Service supplied detail. Counts: clean 1; blocked 1. "
                 "Resolve the reported Git state outside Chatbook, then Refresh.",
+            ),
+            (
+                GitActionResult(
+                    "stage",
+                    "blocked",
+                    (1,),
+                    clean_group_ids=(1,),
+                ),
+                stage_context,
+                "Counts: clean 1. No eligible note changes remain; Refresh status.",
             ),
             (
                 GitActionResult("stage", "stale", (1,)),
@@ -3142,7 +3170,14 @@ async def test_wide_prepare_session_quiets_and_restores_editor_toolbars_without_
         assert len(toolbars) == 2
         assert all(toolbar.display for toolbar in toolbars)
 
-        workspace.query_one("#file-notes-session-changes", Button).press()
+        entry = workspace.query_one("#file-notes-session-changes", Button)
+        entry.focus()
+        await _wait_until(
+            pilot,
+            lambda: entry.has_focus,
+            "Prepare session entry did not receive focus",
+        )
+        entry.press()
         await _wait_until(
             pilot,
             lambda: len(git_service.status_calls) == 1
@@ -3150,7 +3185,7 @@ async def test_wide_prepare_session_quiets_and_restores_editor_toolbars_without_
             and all(not toolbar.display for toolbar in toolbars),
             "Prepare session did not quiet both editor toolbars",
         )
-        await _settle_current_git_row_render(workspace)
+        await _wait_for_current_git_row_projection(workspace)
         await pilot.pause()
         git_back = workspace.query_one("#file-notes-git-back", Button)
         git_rows = workspace.query_one("#file-notes-git-rows", ListView)
@@ -3193,6 +3228,122 @@ async def test_wide_prepare_session_quiets_and_restores_editor_toolbars_without_
 
 
 @pytest.mark.asyncio
+async def test_deferred_git_row_focus_does_not_steal_retained_editor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _root, owner, _binding, replica, git_service, workspace = _workspace_fixture(
+        tmp_path
+    )
+    panel = workspace._git_panel_widget
+    render_rows = panel._render_rows
+    render_started = asyncio.Event()
+    release_rows = asyncio.Event()
+
+    async def blocked_render_rows(generation, group_id, rows) -> None:
+        render_started.set()
+        await release_rows.wait()
+        await render_rows(generation, group_id, rows)
+
+    monkeypatch.setattr(panel, "_render_rows", blocked_render_rows)
+    try:
+        async with _WorkspaceHarness(workspace).run_test(size=(150, 42)) as pilot:
+            await _wait_until(
+                pilot,
+                lambda: workspace.initialized,
+                "scan did not finish",
+            )
+            assert await workspace.open_path("folder/one.md")
+            editor = workspace.query_one("#file-notes-editor", TextArea)
+            original_body = editor.text
+            entry = workspace.query_one("#file-notes-session-changes", Button)
+            entry.focus()
+            await _wait_until(
+                pilot,
+                lambda: entry.has_focus,
+                "Prepare session entry did not receive focus",
+            )
+            entry.press()
+            await _wait_until(
+                pilot,
+                lambda: (
+                    render_started.is_set()
+                    and len(git_service.status_calls) == 1
+                    and len(panel.rows) == 2
+                ),
+                "Git row replacement did not enter its pending state",
+            )
+
+            workspace.query_one("#file-notes-git-back", Button).focus()
+            workspace._focus_session_git_panel(retries_remaining=1)
+            assert not editor.read_only
+            editor.focus()
+            release_rows.set()
+            await _wait_for_current_git_row_projection(workspace)
+            await pilot.pause()
+
+            assert editor.has_focus, repr(workspace.app.focused)
+            await pilot.press("x")
+            await _wait_until(
+                pilot,
+                lambda: workspace.save_state == "dirty",
+                "typing after the Git focus retry did not retain the draft",
+            )
+            assert editor.text != original_body
+            assert editor.has_focus
+    finally:
+        release_rows.set()
+        await workspace.shutdown()
+        owner.shutdown()
+        replica.close()
+
+
+@pytest.mark.asyncio
+async def test_narrow_delete_confirmation_keeps_complete_action_labels(
+    tmp_path: Path,
+) -> None:
+    _root, owner, _binding, replica, _git_service, workspace = _workspace_fixture(
+        tmp_path
+    )
+    async with _WorkspaceHarness(workspace).run_test(size=(40, 20)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        assert await workspace.open_path("folder/one.md")
+        await _wait_until(
+            pilot,
+            lambda: workspace.has_class("-stack-editor-actions"),
+            "narrow editor actions did not switch to the three-column grid",
+        )
+        delete = workspace.query_one("#file-notes-delete", Button)
+        delete.press()
+        await _wait_until(
+            pilot,
+            lambda: workspace._delete_confirmation_path == "folder/one.md",
+            "Delete did not enter its confirmation state",
+        )
+        await pilot.pause()
+
+        assert str(delete.label) == "Confirm delete"
+        assert delete.has_class("-confirm-delete")
+        assert delete.styles.column_span == 2
+        _assert_visible_editor_actions_fit(workspace)
+
+        editor = workspace.query_one("#file-notes-editor", TextArea)
+        editor.focus()
+        await pilot.press("x")
+        await _wait_until(
+            pilot,
+            lambda: str(delete.label) == "Delete",
+            "editing did not leave Delete confirmation",
+        )
+        await pilot.pause()
+        assert not delete.has_class("-confirm-delete")
+        _assert_visible_editor_actions_fit(workspace)
+    await workspace.shutdown()
+    owner.shutdown()
+    replica.close()
+
+
+@pytest.mark.asyncio
 async def test_narrow_editor_actions_keep_complete_labels_at_40_by_20(
     tmp_path: Path,
 ) -> None:
@@ -3207,25 +3358,7 @@ async def test_narrow_editor_actions_keep_complete_labels_at_40_by_20(
             lambda: workspace.has_class("-stack-editor-actions"),
             "narrow editor actions did not switch to the three-column grid",
         )
-        pane = workspace.query_one("#file-notes-editor-pane")
-
-        def assert_editor_actions_fit() -> None:
-            visible_actions = tuple(
-                button
-                for button in pane.query(Button)
-                if button.display
-            )
-            assert visible_actions
-            for button in visible_actions:
-                label = str(button.label)
-                assert button.render().plain == label
-                assert cell_len(label) <= button.content_region.width
-                assert button.region.x >= pane.region.x
-                assert button.region.right <= pane.region.right
-                assert button.region.y >= pane.region.y
-                assert button.region.bottom <= pane.region.bottom
-
-        assert_editor_actions_fit()
+        _assert_visible_editor_actions_fit(workspace)
         protect = workspace.query_one("#file-notes-protect", Button)
         assert str(protect.label) == "Protect"
         protect.press()
@@ -3236,7 +3369,7 @@ async def test_narrow_editor_actions_keep_complete_labels_at_40_by_20(
         )
         await pilot.pause()
         assert workspace.has_class("-stack-editor-actions")
-        assert_editor_actions_fit()
+        _assert_visible_editor_actions_fit(workspace)
     await workspace.shutdown()
     owner.shutdown()
     replica.close()

--- a/backlog/tasks/task-1235 - Polish-File-Notes-prepare-session-for-commit-UX.md
+++ b/backlog/tasks/task-1235 - Polish-File-Notes-prepare-session-for-commit-UX.md
@@ -4,7 +4,7 @@ title: Polish File Notes prepare-session-for-commit UX
 status: Done
 assignee: []
 created_date: '2026-07-28 15:51'
-updated_date: '2026-07-28 20:41'
+updated_date: '2026-07-29 00:35'
 labels:
   - notes
   - git
@@ -72,4 +72,12 @@ Implemented the approved prepare-session UX polish without changing Git ownershi
 - ADR required: no. This is a presentation/lifecycle repair within ADR-035, ADR-033, ADR-011, and ADR-029; no storage, sync, ownership, service-contract, or long-lived architectural boundary changed.
 
 Primary modified files: tldw_chatbook/Widgets/Library/library_file_notes_git_panel.py, tldw_chatbook/Widgets/Library/library_file_notes_workspace.py, and Tests/UI/test_library_file_notes_git.py.
+
+PR #1076 review follow-up:
+
+- Addressed Qodo inline comment 3670053454 by documenting `render_checking` parameters in the required Google-style `Args:` format.
+- Addressed inline comment 3670053457 with a RED/GREEN mounted regression: unexpected admitted Git action exceptions now survive the automatic postflight refresh in the independent `Last action: FAILED` surface only while the admission-captured binding, complete repository identity, and exact session changes remain current.
+- Focused review exposed the corresponding hidden-completion case before push. A second RED/GREEN regression now proves reopening consumes the deferred refresh before cached status rehydration, preserves keyed failure feedback, and restores current rows/focus.
+- Follow-up verification: 85 focused tests passed; adjacent real-service delete/restore tests passed; compileall, Ruff lint, and diff checks passed. Focused fix re-review approved with no open issues.
+- ADR decision remains unchanged: no new ADR; the fixes enforce the existing ADR-035/033 status and authority contracts.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-1235 - Polish-File-Notes-prepare-session-for-commit-UX.md
+++ b/backlog/tasks/task-1235 - Polish-File-Notes-prepare-session-for-commit-UX.md
@@ -1,0 +1,44 @@
+---
+id: TASK-1235
+title: Polish File Notes prepare-session-for-commit UX
+status: In Progress
+assignee: []
+created_date: '2026-07-28 15:51'
+updated_date: '2026-07-28 15:57'
+labels:
+  - notes
+  - git
+  - library
+  - ux
+  - accessibility
+dependencies:
+  - TASK-1213
+references:
+  - >-
+    .impeccable/critique/2026-07-28T15-38-30Z__ok-widgets-library-library-file-notes-git-panel-py.md
+documentation:
+  - Docs/superpowers/specs/2026-07-28-file-notes-prepare-session-ux-design.md
+  - backlog/decisions/035-file-notes-session-git-index-controls.md
+  - backlog/decisions/033-application-session-state-ownership.md
+  - backlog/decisions/011-chatbook-workbench-ui-system.md
+  - backlog/decisions/029-file-notes-disk-authority.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make the shipped File Notes session-staging surface legible, current, note-centered, and usable at narrow terminal sizes while preserving the exact session-only Git safety and ownership behavior delivered by TASK-1213.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The staging surface is titled Prepare session for commit, clearly retains its session-path and complete-file-state scope, and introduces no commit, push, remote, full-repository, or hunk-staging controls.
+- [ ] #2 Every session row leads with the note change intent such as Created, Edited, Moved, Deleted, or Restored and separately communicates its actionable Git state and any blocking reason without relying on color alone.
+- [ ] #3 Focused Back, Refresh, selected-note, and bulk controls retain readable labels at supported narrow and wide terminal widths, and the visible keyboard guidance accurately describes selection, action, activation, and return behavior.
+- [ ] #4 Untrusted, selected-root-changed, repository-changed, unavailable, and non-repository states clear prior rows; checking, stale, or error rows are retained only when the process owner proves the same selected root and complete repository identity.
+- [ ] #5 Current repository freshness remains visible independently from the latest action result; a later session or authority generation removes an obsolete action summary, while the action postflight refresh preserves a still-current result and every blocked or error state gives an exact recovery action.
+- [ ] #6 A certain successful Stage or Unstage combines the affected session-note count with the checked promise that Chatbook targeted only eligible session paths or restored only its owned session entries; Stage all and Unstage all show their own eligible counts, while nonzero, uncertain, mismatched, or zero-effect results omit the promise and retain accurate skipped, clean, or blocked counts.
+- [ ] #7 While Prepare session for commit is active beside the editor, editor actions are visually quiet or collapsed and restore on return; narrow editor layouts keep every action label legible without clipping.
+- [ ] #8 Focused Textual tests and live acceptance checks at 150×42, 70×28/24, and 40×20 cover authority transitions, focus labels, keyboard return, row semantics, fixed feedback visibility, editor-action quieting, unclipped editor labels, and unrelated-index preservation without adding a full-suite or broad CI gate.
+<!-- AC:END -->

--- a/backlog/tasks/task-1235 - Polish-File-Notes-prepare-session-for-commit-UX.md
+++ b/backlog/tasks/task-1235 - Polish-File-Notes-prepare-session-for-commit-UX.md
@@ -4,7 +4,7 @@ title: Polish File Notes prepare-session-for-commit UX
 status: In Progress
 assignee: []
 created_date: '2026-07-28 15:51'
-updated_date: '2026-07-28 15:57'
+updated_date: '2026-07-28 16:34'
 labels:
   - notes
   - git
@@ -18,6 +18,7 @@ references:
     .impeccable/critique/2026-07-28T15-38-30Z__ok-widgets-library-library-file-notes-git-panel-py.md
 documentation:
   - Docs/superpowers/specs/2026-07-28-file-notes-prepare-session-ux-design.md
+  - Docs/superpowers/plans/2026-07-28-file-notes-prepare-session-ux.md
   - backlog/decisions/035-file-notes-session-git-index-controls.md
   - backlog/decisions/033-application-session-state-ownership.md
   - backlog/decisions/011-chatbook-workbench-ui-system.md
@@ -38,7 +39,21 @@ Make the shipped File Notes session-staging surface legible, current, note-cente
 - [ ] #3 Focused Back, Refresh, selected-note, and bulk controls retain readable labels at supported narrow and wide terminal widths, and the visible keyboard guidance accurately describes selection, action, activation, and return behavior.
 - [ ] #4 Untrusted, selected-root-changed, repository-changed, unavailable, and non-repository states clear prior rows; checking, stale, or error rows are retained only when the process owner proves the same selected root and complete repository identity.
 - [ ] #5 Current repository freshness remains visible independently from the latest action result; a later session or authority generation removes an obsolete action summary, while the action postflight refresh preserves a still-current result and every blocked or error state gives an exact recovery action.
-- [ ] #6 A certain successful Stage or Unstage combines the affected session-note count with the checked promise that Chatbook targeted only eligible session paths or restored only its owned session entries; Stage all and Unstage all show their own eligible counts, while nonzero, uncertain, mismatched, or zero-effect results omit the promise and retain accurate skipped, clean, or blocked counts.
+- [ ] #6 A certain successful Stage or Unstage combines the affected session-note count with the checked promise that Chatbook targeted only eligible session paths or restored only its owned session entries; Stage all and Unstage all show their own eligible counts, while non-success, uncertain, mismatched, or zero-effect results omit the promise and retain accurate skipped, clean, or blocked counts.
 - [ ] #7 While Prepare session for commit is active beside the editor, editor actions are visually quiet or collapsed and restore on return; narrow editor layouts keep every action label legible without clipping.
 - [ ] #8 Focused Textual tests and live acceptance checks at 150×42, 70×28/24, and 40×20 cover authority transitions, focus labels, keyboard return, row semantics, fixed feedback visibility, editor-action quieting, unclipped editor labels, and unrelated-index preservation without adding a full-suite or broad CI gate.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: N/A
+Reason: presentation-only repair conforming to ADR-035, ADR-033, ADR-011, and ADR-029.
+
+1. Add failing focused tests for note-intent rows, semantic/recovery copy, authority clearing, focus, elision, counts, and fixed-region geometry; implement the minimal panel projections and verify green.
+2. Add failing focused tests for keyed last-action feedback, promise/count truthfulness, root/repository/session invalidation, wide editor-action quieting, and narrow label fit; implement the minimal workspace presentation changes and verify green.
+3. Run the focused UI file, compile, Ruff lint/format checks, bounded live terminal UAT at the approved sizes, and focused review; resolve concrete findings before closeout.
+
+Detailed plan: Docs/superpowers/plans/2026-07-28-file-notes-prepare-session-ux.md
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-1235 - Polish-File-Notes-prepare-session-for-commit-UX.md
+++ b/backlog/tasks/task-1235 - Polish-File-Notes-prepare-session-for-commit-UX.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-1235
 title: Polish File Notes prepare-session-for-commit UX
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-28 15:51'
-updated_date: '2026-07-28 16:34'
+updated_date: '2026-07-28 20:41'
 labels:
   - notes
   - git
@@ -34,14 +34,14 @@ Make the shipped File Notes session-staging surface legible, current, note-cente
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The staging surface is titled Prepare session for commit, clearly retains its session-path and complete-file-state scope, and introduces no commit, push, remote, full-repository, or hunk-staging controls.
-- [ ] #2 Every session row leads with the note change intent such as Created, Edited, Moved, Deleted, or Restored and separately communicates its actionable Git state and any blocking reason without relying on color alone.
-- [ ] #3 Focused Back, Refresh, selected-note, and bulk controls retain readable labels at supported narrow and wide terminal widths, and the visible keyboard guidance accurately describes selection, action, activation, and return behavior.
-- [ ] #4 Untrusted, selected-root-changed, repository-changed, unavailable, and non-repository states clear prior rows; checking, stale, or error rows are retained only when the process owner proves the same selected root and complete repository identity.
-- [ ] #5 Current repository freshness remains visible independently from the latest action result; a later session or authority generation removes an obsolete action summary, while the action postflight refresh preserves a still-current result and every blocked or error state gives an exact recovery action.
-- [ ] #6 A certain successful Stage or Unstage combines the affected session-note count with the checked promise that Chatbook targeted only eligible session paths or restored only its owned session entries; Stage all and Unstage all show their own eligible counts, while non-success, uncertain, mismatched, or zero-effect results omit the promise and retain accurate skipped, clean, or blocked counts.
-- [ ] #7 While Prepare session for commit is active beside the editor, editor actions are visually quiet or collapsed and restore on return; narrow editor layouts keep every action label legible without clipping.
-- [ ] #8 Focused Textual tests and live acceptance checks at 150×42, 70×28/24, and 40×20 cover authority transitions, focus labels, keyboard return, row semantics, fixed feedback visibility, editor-action quieting, unclipped editor labels, and unrelated-index preservation without adding a full-suite or broad CI gate.
+- [x] #1 The staging surface is titled Prepare session for commit, clearly retains its session-path and complete-file-state scope, and introduces no commit, push, remote, full-repository, or hunk-staging controls.
+- [x] #2 Every session row leads with the note change intent such as Created, Edited, Moved, Deleted, or Restored and separately communicates its actionable Git state and any blocking reason without relying on color alone.
+- [x] #3 Focused Back, Refresh, selected-note, and bulk controls retain readable labels at supported narrow and wide terminal widths, and the visible keyboard guidance accurately describes selection, action, activation, and return behavior.
+- [x] #4 Untrusted, selected-root-changed, repository-changed, unavailable, and non-repository states clear prior rows; checking, stale, or error rows are retained only when the process owner proves the same selected root and complete repository identity.
+- [x] #5 Current repository freshness remains visible independently from the latest action result; a later session or authority generation removes an obsolete action summary, while the action postflight refresh preserves a still-current result and every blocked or error state gives an exact recovery action.
+- [x] #6 A certain successful Stage or Unstage combines the affected session-note count with the checked promise that Chatbook targeted only eligible session paths or restored only its owned session entries; Stage all and Unstage all show their own eligible counts, while non-success, uncertain, mismatched, or zero-effect results omit the promise and retain accurate skipped, clean, or blocked counts.
+- [x] #7 While Prepare session for commit is active beside the editor, editor actions are visually quiet or collapsed and restore on return; narrow editor layouts keep every action label legible without clipping.
+- [x] #8 Focused Textual tests and live acceptance checks at 150×42, 70×28/24, and 40×20 cover authority transitions, focus labels, keyboard return, row semantics, fixed feedback visibility, editor-action quieting, unclipped editor labels, and unrelated-index preservation without adding a full-suite or broad CI gate.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -57,3 +57,19 @@ Reason: presentation-only repair conforming to ADR-035, ADR-033, ADR-011, and AD
 
 Detailed plan: Docs/superpowers/plans/2026-07-28-file-notes-prepare-session-ux.md
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the approved prepare-session UX polish without changing Git ownership or repository scope.
+
+- Reworked the Git panel around note intent, explicit actionable Git state/recovery, independent current-status and last-action surfaces, complete repository/session authority keying, and truthful per-note/bulk eligibility counts. Successful actions now pair the affected-note count with the checked session-only promise; uncertain, blocked, clean, and stale results do not.
+- Kept the mounted editor usable while Prepare session for commit is open, quieted both editor toolbars in wide mode, restored the same editor/body/toolbars/focus on Back, and made narrow controls and confirmation geometry render complete labels.
+- Added focused Textual coverage for authority transitions, stale-action invalidation, actual rendered-line fit, focus return, feedback retention, promise/count truth, and delete-confirmation lifecycle. Live UAT found Restore/Protect clipping at 40x20; a RED render-line regression reproduced it, and a confirmation-toolbar-only padding correction fixed it.
+- Real-service UAT used a disposable Git repository: two notes saved; trust decline/reopen/accept passed; Stage All staged both session notes while preserving an unrelated staged file; Unstage All removed only Chatbook-owned entries. Viewports 150x42, 70x28, 70x24, and 40x20 passed, including post-fix confirmation labels and wide editor/Back restoration.
+- Verification: 83 focused Git-panel/workspace tests passed; 2 adjacent real-service delete/restore tests passed; compileall, Ruff lint, and git diff --check passed. Ruff whole-file format check remains the same pre-existing origin/dev baseline for the three legacy files, so no unrelated bulk reformat was introduced.
+- Final reviews: spec compliant; code quality approved with no open issues.
+- ADR required: no. This is a presentation/lifecycle repair within ADR-035, ADR-033, ADR-011, and ADR-029; no storage, sync, ownership, service-contract, or long-lived architectural boundary changed.
+
+Primary modified files: tldw_chatbook/Widgets/Library/library_file_notes_git_panel.py, tldw_chatbook/Widgets/Library/library_file_notes_workspace.py, and Tests/UI/test_library_file_notes_git.py.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Widgets/Library/library_file_notes_git_panel.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_git_panel.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import unicodedata
 from collections.abc import Iterable
+from functools import partial
 
 from rich.cells import cell_len, split_graphemes
 from rich.markup import escape as escape_markup
@@ -13,6 +14,7 @@ from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.events import Resize
 from textual.message import Message
+from textual.widget import Widget
 from textual.widgets import Button, ListItem, ListView, Static
 
 from tldw_chatbook.Notes.file_notes_session_owner import (
@@ -58,6 +60,32 @@ def _repository_path_for_display(path: str, *, markup: bool = False) -> str:
     return escape_markup(display) if markup else display
 
 
+def _grapheme_spans(text: str) -> list[tuple[int, int, int]]:
+    """Return Rich spans with regional-indicator pairs kept together."""
+    spans, _ = split_graphemes(text)
+    grouped: list[tuple[int, int, int]] = []
+    index = 0
+    while index < len(spans):
+        start, end, width = spans[index]
+        if index + 1 < len(spans):
+            next_start, next_end, next_width = spans[index + 1]
+            current_is_indicator = (
+                end == start + 1
+                and 0x1F1E6 <= ord(text[start]) <= 0x1F1FF
+            )
+            next_is_indicator = (
+                next_end == next_start + 1
+                and 0x1F1E6 <= ord(text[next_start]) <= 0x1F1FF
+            )
+            if current_is_indicator and next_is_indicator:
+                grouped.append((start, next_end, width + next_width))
+                index += 2
+                continue
+        grouped.append((start, end, width))
+        index += 1
+    return grouped
+
+
 def _middle_elide_cells(text: str, width: int) -> str:
     """Middle-elide on grapheme boundaries without exceeding cell width."""
     if width <= 0:
@@ -67,7 +95,7 @@ def _middle_elide_cells(text: str, width: int) -> str:
     if width <= 3:
         return "." * width
 
-    graphemes, _ = split_graphemes(text)
+    graphemes = _grapheme_spans(text)
     remaining = width - 3
     left_budget = (remaining + 1) // 2
     right_budget = remaining - left_budget
@@ -97,6 +125,45 @@ def _middle_elide_cells(text: str, width: int) -> str:
         used += grapheme_width
 
     return f"{text[:left_end]}...{text[right_start:]}"
+
+
+def _fit_two_line_copy(text: str, width: int) -> str:
+    """Fit copy to explicit lines so word wrapping cannot create a third."""
+    text = (
+        text.replace("\r\n", r"\n")
+        .replace("\r", r"\r")
+        .replace("\n", r"\n")
+    )
+    if width <= 0 or cell_len(text) <= width:
+        return text
+
+    fitted = _middle_elide_cells(text, max(width, width * 2 - 3))
+    if cell_len(fitted) <= width:
+        return fitted
+
+    graphemes = _grapheme_spans(fitted)
+    total_width = sum(grapheme_width for _, _, grapheme_width in graphemes)
+    first_width = 0
+    split_end = 0
+    split_key = (2, total_width)
+    ellipsis_start = fitted.find("...")
+    for _start, end, grapheme_width in graphemes:
+        first_width += grapheme_width
+        if first_width > width:
+            break
+        if total_width - first_width <= width:
+            if ellipsis_start >= 0 and ellipsis_start < end < ellipsis_start + 3:
+                continue
+            key = (
+                0 if fitted[end - 1].isspace() else 1,
+                abs(total_width - first_width * 2),
+            )
+            if key < split_key:
+                split_key = key
+                split_end = end
+    if split_end:
+        return f"{fitted[:split_end]}\n{fitted[split_end:]}"
+    return _middle_elide_cells(fitted, width)
 
 
 def _group_path_for_display(row: SessionGitRow) -> str:
@@ -302,6 +369,7 @@ class LibraryFileNotesGitPanel(Vertical):
     #file-notes-git-action-status {
         max-height: 2;
         overflow: hidden hidden;
+        text-wrap: nowrap;
     }
 
     #file-notes-git-repository {
@@ -572,7 +640,7 @@ class LibraryFileNotesGitPanel(Vertical):
         ):
             widget = self.query_one(selector, Static)
             width = widget.content_region.width or self.content_region.width
-            fitted = text if width <= 0 else _middle_elide_cells(text, width * 2)
+            fitted = text if width <= 0 else _fit_two_line_copy(text, width)
             widget.update(fitted)
 
     def _set_repository_text(self, text: str) -> None:
@@ -757,12 +825,19 @@ class LibraryFileNotesGitPanel(Vertical):
         self._replace_rows(None)
 
     def _sync_empty_state(self) -> None:
-        ready_empty = self._status_ready and not self._rows
+        ready_empty = (
+            not self._replacing_rows
+            and self._status_ready
+            and not self._rows
+        )
         self.query_one("#file-notes-git-empty", Static).display = ready_empty
-        self.query_one("#file-notes-git-rows", ListView).display = not ready_empty
+        self.query_one("#file-notes-git-rows", ListView).display = (
+            bool(self._rows) and not self._replacing_rows
+        )
 
     def _replace_rows(self, prior_group_id: int | None) -> None:
-        group_ids = tuple(row.group_id for row in self._rows)
+        rows = self._rows
+        group_ids = tuple(row.group_id for row in rows)
         if prior_group_id in group_ids:
             self._selected_group_id = prior_group_id
         elif group_ids:
@@ -770,10 +845,16 @@ class LibraryFileNotesGitPanel(Vertical):
         else:
             self._selected_group_id = None
         self._row_render_generation += 1
+        generation = self._row_render_generation
+        group_id = self._selected_group_id
+        self._replacing_rows = True
+        self.query_one("#file-notes-git-rows", ListView).display = False
         self.run_worker(
-            self._render_rows(
-                self._row_render_generation,
-                self._selected_group_id,
+            partial(
+                self._render_rows,
+                generation,
+                group_id,
+                rows,
             ),
             name="file-notes-git-render-rows",
             group="file-notes-git-render-rows",
@@ -784,15 +865,17 @@ class LibraryFileNotesGitPanel(Vertical):
         self,
         generation: int,
         group_id: int | None,
+        rows: tuple[SessionGitRow, ...],
     ) -> None:
         list_view = self.query_one("#file-notes-git-rows", ListView)
-        self._replacing_rows = True
         try:
             await list_view.clear()
-            await list_view.extend(_SessionGitListItem(row) for row in self._rows)
             if generation != self._row_render_generation:
                 return
-            group_ids = tuple(row.group_id for row in self._rows)
+            await list_view.extend(_SessionGitListItem(row) for row in rows)
+            if generation != self._row_render_generation:
+                return
+            group_ids = tuple(row.group_id for row in rows)
             list_view.index = (
                 group_ids.index(group_id)
                 if group_id is not None and group_id in group_ids
@@ -802,6 +885,7 @@ class LibraryFileNotesGitPanel(Vertical):
         finally:
             if generation == self._row_render_generation:
                 self._replacing_rows = False
+                self._sync_empty_state()
                 self._update_actions()
 
     @staticmethod
@@ -828,6 +912,8 @@ class LibraryFileNotesGitPanel(Vertical):
     def _update_actions(self) -> None:
         if not self.is_mounted:
             return
+        focused = self.screen.focused
+        back = self.query_one("#file-notes-git-back", Button)
         trust = self.query_one("#file-notes-git-trust", Button)
         refresh = self.query_one("#file-notes-git-refresh", Button)
         stage_selected = self.query_one(
@@ -882,6 +968,36 @@ class LibraryFileNotesGitPanel(Vertical):
         stage_all.disabled = not (can_mutate and stage_count > 0)
         unstage_all.disabled = not (can_mutate and unstage_count > 0)
         self._sync_action_layout(self.content_region.width)
+        self._repair_hidden_focus(focused, back, trust, refresh)
+
+    def _repair_hidden_focus(
+        self,
+        focused: Widget | None,
+        back: Button,
+        trust: Button,
+        refresh: Button,
+    ) -> None:
+        """Move hidden panel focus to one safe, visible recovery control."""
+        if focused is None or self not in focused.ancestors:
+            return
+        # Authorized rows are only hidden while their new generation mounts.
+        if self._replacing_rows and self._rows:
+            return
+        if all(
+            not isinstance(node, Widget) or node.display
+            for node in focused.ancestors_with_self
+        ):
+            return
+
+        if self._trust_available and trust.display:
+            target = trust
+        elif not self._trusted:
+            target = back
+        elif refresh.display and not refresh.disabled:
+            target = refresh
+        else:
+            target = back
+        self.screen.set_focus(target, scroll_visible=False)
 
     @on(ListView.Highlighted, "#file-notes-git-rows")
     def _row_highlighted(self, event: ListView.Highlighted) -> None:

--- a/tldw_chatbook/Widgets/Library/library_file_notes_git_panel.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_git_panel.py
@@ -740,7 +740,13 @@ class LibraryFileNotesGitPanel(Vertical):
         *,
         retain_rows: bool = False,
     ) -> None:
-        """Render status checking with only explicitly authorized old rows."""
+        """Render status checking with only explicitly authorized old rows.
+
+        Args:
+            repository_path: Worktree path to display while checking status.
+            retain_rows: Whether the caller has proved previously rendered rows
+                still belong to the current trusted repository authority.
+        """
         self._trusted = True
         self._trust_available = False
         self._status_ready = False

--- a/tldw_chatbook/Widgets/Library/library_file_notes_git_panel.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_git_panel.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import unicodedata
 from collections.abc import Iterable
 
+from rich.cells import cell_len, split_graphemes
 from rich.markup import escape as escape_markup
 from textual import on
 from textual.app import ComposeResult
@@ -21,22 +22,12 @@ from tldw_chatbook.Notes.file_notes_session_owner import (
 )
 from tldw_chatbook.Widgets.confirmation_dialog import ConfirmationDialog
 
-_ROW_STATE_LABELS = {
-    "unstaged": "Unstaged",
-    "owned": "Staged by Chatbook",
-    "owned_newer_edits": "Staged by Chatbook · newer unstaged edits",
-    "owned_topology_changed": "Staged by Chatbook · path lineage changed",
-    "external_staged": "Staged externally",
-    "external_partial": "Partially staged externally",
-    "clean": "Clean · currently matches HEAD",
-    "ignored": "Ignored",
-    "conflict": "Git conflict",
-    "unsupported": "Unsupported Git index state",
-    "nested_repository": "Nested repository unsupported",
-    "unsafe_closure": "Unsafe session path closure",
-    "ambiguous_lineage": "Ambiguous session path lineage",
-    "unavailable": "Git unavailable",
-    "error": "Error",
+_CHANGE_VERBS = {
+    "created": "CREATED",
+    "modified": "EDITED",
+    "moved": "MOVED",
+    "deleted": "DELETED",
+    "restored": "RESTORED",
 }
 
 
@@ -67,6 +58,169 @@ def _repository_path_for_display(path: str, *, markup: bool = False) -> str:
     return escape_markup(display) if markup else display
 
 
+def _middle_elide_cells(text: str, width: int) -> str:
+    """Middle-elide on grapheme boundaries without exceeding cell width."""
+    if width <= 0:
+        return ""
+    if cell_len(text) <= width:
+        return text
+    if width <= 3:
+        return "." * width
+
+    graphemes, _ = split_graphemes(text)
+    remaining = width - 3
+    left_budget = (remaining + 1) // 2
+    right_budget = remaining - left_budget
+    first_width = graphemes[0][2]
+    last_width = graphemes[-1][2]
+    if first_width > left_budget and first_width + last_width <= remaining:
+        left_budget = first_width
+        right_budget = remaining - left_budget
+    if last_width > right_budget and first_width + last_width <= remaining:
+        right_budget = last_width
+        left_budget = remaining - right_budget
+
+    left_end = 0
+    used = 0
+    for _start, end, grapheme_width in graphemes:
+        if used + grapheme_width > left_budget:
+            break
+        left_end = end
+        used += grapheme_width
+
+    right_start = len(text)
+    used = 0
+    for start, _end, grapheme_width in reversed(graphemes):
+        if used + grapheme_width > right_budget:
+            break
+        right_start = start
+        used += grapheme_width
+
+    return f"{text[:left_end]}...{text[right_start:]}"
+
+
+def _group_path_for_display(row: SessionGitRow) -> str:
+    """Project one immutable group to display-only note path copy."""
+    source = _repository_path_for_display(row.group.source_path)
+    destination = row.group.destination_path
+    if destination is None:
+        return source
+    return f"{source} -> {_repository_path_for_display(destination)}"
+
+
+def _row_primary_copy(row: SessionGitRow) -> str:
+    """Lead one row with the note intent represented by its latest change."""
+    verb = _CHANGE_VERBS[row.group.latest_action]
+    return f"{verb:<9} {_group_path_for_display(row)}"
+
+
+def _row_secondary_parts(
+    row: SessionGitRow,
+) -> tuple[str, str, str, str]:
+    """Return semantic prefix, detail, recovery, and narrow recovery."""
+    state = row.state
+    if state == "unstaged":
+        return "READY TO STAGE · Git: unstaged", "", "", ""
+    if state == "owned":
+        return "STAGED · by Chatbook", "", "", ""
+    if state == "owned_newer_edits":
+        return (
+            "UPDATE AVAILABLE · newer note edits are not staged",
+            "",
+            "",
+            "",
+        )
+    if state == "owned_topology_changed":
+        return (
+            "UPDATE REQUIRED · stage the moved note before unstaging",
+            "",
+            "",
+            "",
+        )
+    if state in {"external_staged", "external_partial"}:
+        return (
+            "BLOCKED · ",
+            "already staged outside Chatbook",
+            "; manage this path in Git, then Refresh",
+            "; use Git, then Refresh",
+        )
+    if state == "clean":
+        return "NO ACTION · matches HEAD", "", "", ""
+    if state == "ignored":
+        return (
+            "BLOCKED · ",
+            "ignored by Git",
+            ("; change the ignore rule or stage outside Chatbook, then Refresh"),
+            "; fix ignore, then Refresh",
+        )
+
+    reason = _repository_path_for_display(
+        row.disabled_reason
+        or {
+            "conflict": "Git conflict",
+            "unsupported": "unsupported Git index state",
+            "nested_repository": "nested repository",
+            "unsafe_closure": "unsafe session path closure",
+            "ambiguous_lineage": "ambiguous session path lineage",
+            "unavailable": "Git unavailable",
+            "error": "Git status failed",
+        }[state]
+    )
+    if state == "conflict":
+        return (
+            "BLOCKED · ",
+            reason,
+            "; resolve the Git conflict outside Chatbook, then Refresh",
+            "; resolve conflict, then Refresh",
+        )
+    if state in {
+        "unsupported",
+        "nested_repository",
+        "unsafe_closure",
+        "ambiguous_lineage",
+    }:
+        return (
+            "BLOCKED · ",
+            reason,
+            "; resolve it outside Chatbook, then Refresh",
+            "; use Git, then Refresh",
+        )
+    if state == "unavailable":
+        return (
+            "BLOCKED · ",
+            reason,
+            "; restore Git, then Refresh",
+            "; restore Git, then Refresh",
+        )
+    return (
+        "FAILED · ",
+        reason,
+        "; retry Git status, then Refresh",
+        "; retry, Refresh",
+    )
+
+
+def _row_secondary_copy(row: SessionGitRow, width: int | None = None) -> str:
+    """Project Git state while reserving semantic and recovery cells."""
+    prefix, detail, recovery, narrow_recovery = _row_secondary_parts(row)
+    full = f"{prefix}{detail}{recovery}"
+    if width is None or cell_len(full) <= width:
+        return full
+    if not detail:
+        return _middle_elide_cells(full, width)
+
+    suffix = recovery
+    if narrow_recovery and cell_len(prefix) + cell_len(suffix) > width:
+        suffix = narrow_recovery
+    detail_width = max(
+        0,
+        width - cell_len(prefix) - cell_len(suffix),
+    )
+    fitted_detail = _middle_elide_cells(detail, detail_width)
+    fitted = f"{prefix}{fitted_detail}{suffix}"
+    return fitted if cell_len(fitted) <= width else _middle_elide_cells(fitted, width)
+
+
 class _SessionGitListItem(ListItem):
     """One selectable row whose action policy remains in ``SessionGitRow``."""
 
@@ -75,17 +229,34 @@ class _SessionGitListItem(ListItem):
         self.row = row
 
     def compose(self) -> ComposeResult:
-        label = _ROW_STATE_LABELS[self.row.state]
-        reason = (
-            ""
-            if not self.row.disabled_reason
-            else f" — {self.row.disabled_reason}"
-        )
         yield Static(
-            f"{self.row.group.display_text} · {label}{reason}",
-            classes="file-notes-git-row-copy",
+            _row_primary_copy(self.row),
+            classes="file-notes-git-row-primary",
             markup=False,
         )
+        yield Static(
+            _row_secondary_copy(self.row),
+            classes="file-notes-git-row-secondary",
+            markup=False,
+        )
+
+    def on_mount(self) -> None:
+        self.call_after_refresh(self._fit_copy)
+
+    def on_resize(self, _event: Resize) -> None:
+        """Reproject display-only labels against the mounted row width."""
+        self.call_after_refresh(self._fit_copy)
+
+    def _fit_copy(self) -> None:
+        if not self.is_mounted or not self.children:
+            return
+        primary = self.query_one(".file-notes-git-row-primary", Static)
+        secondary = self.query_one(".file-notes-git-row-secondary", Static)
+        width = primary.content_region.width
+        if width <= 0:
+            return
+        primary.update(_middle_elide_cells(_row_primary_copy(self.row), width))
+        secondary.update(_row_secondary_copy(self.row, width))
 
 
 class LibraryFileNotesGitPanel(Vertical):
@@ -96,6 +267,9 @@ class LibraryFileNotesGitPanel(Vertical):
     ]
 
     DEFAULT_CSS = """
+    $ds-focus-bg: #51677e;
+    $ds-focus-fg: $text;
+
     LibraryFileNotesGitPanel {
         display: none;
         height: 1fr;
@@ -111,50 +285,75 @@ class LibraryFileNotesGitPanel(Vertical):
     }
 
     #file-notes-git-repository,
+    #file-notes-git-title,
     #file-notes-git-scope,
-    #file-notes-git-complete-state,
+    #file-notes-git-guide,
     #file-notes-git-empty,
+    #file-notes-git-status,
+    #file-notes-git-selected-note,
     #file-notes-git-action-status {
         height: auto;
         min-height: 1;
+    }
+
+    #file-notes-git-repository,
+    #file-notes-git-status,
+    #file-notes-git-selected-note,
+    #file-notes-git-action-status {
+        max-height: 2;
+        overflow: hidden hidden;
     }
 
     #file-notes-git-repository {
         text-style: bold;
     }
 
+    #file-notes-git-title {
+        text-style: bold;
+    }
+
     #file-notes-git-scope,
-    #file-notes-git-complete-state,
+    #file-notes-git-guide,
     #file-notes-git-empty,
+    #file-notes-git-status,
+    #file-notes-git-selected-note,
     #file-notes-git-action-status {
         color: $text-muted;
     }
 
+    #file-notes-git-action-status,
+    #file-notes-git-selected-note {
+        display: none;
+    }
+
     #file-notes-git-empty {
         display: none;
-        margin: 1 0;
     }
 
     #file-notes-git-rows {
         height: 1fr;
-        min-height: 3;
-        margin: 1 0;
+        min-height: 1;
     }
 
     .file-notes-git-row {
-        height: auto;
-        min-height: 1;
+        height: 2;
+        min-height: 2;
         padding: 0 1;
     }
 
     .file-notes-git-row:focus,
     .file-notes-git-row.-highlight {
-        outline: heavy $accent;
+        background: $ds-focus-bg;
+        color: $ds-focus-fg;
+        text-style: bold underline;
+        outline: none;
     }
 
-    .file-notes-git-row-copy {
-        height: auto;
+    .file-notes-git-row-primary,
+    .file-notes-git-row-secondary {
+        height: 1;
         min-height: 1;
+        overflow: hidden hidden;
     }
 
     LibraryFileNotesGitPanel Button {
@@ -167,8 +366,11 @@ class LibraryFileNotesGitPanel(Vertical):
         background: transparent;
     }
 
-    LibraryFileNotesGitPanel Button:focus {
-        outline: heavy $accent;
+    LibraryFileNotesGitPanel Button.-style-default:focus {
+        background: $ds-focus-bg;
+        color: $ds-focus-fg;
+        text-style: bold underline;
+        outline: none;
     }
 
     LibraryFileNotesGitPanel.-stack-actions #file-notes-git-header,
@@ -228,6 +430,10 @@ class LibraryFileNotesGitPanel(Vertical):
         self._mutating = False
         self._row_render_generation = 0
         self._replacing_rows = False
+        self._repository_text = "Repository: not checked"
+        self._current_status_text = "Status: NOT CHECKED"
+        self._last_action_text = ""
+        self._selected_note_text = ""
 
     @property
     def selected_group_id(self) -> int | None:
@@ -242,7 +448,7 @@ class LibraryFileNotesGitPanel(Vertical):
     def compose(self) -> ComposeResult:
         with Horizontal(id="file-notes-git-header"):
             yield Button(
-                "Back to Files",
+                "Back to navigator",
                 id="file-notes-git-back",
                 compact=True,
             )
@@ -257,18 +463,23 @@ class LibraryFileNotesGitPanel(Vertical):
                 compact=True,
             )
         yield Static(
+            "Prepare session for commit",
+            id="file-notes-git-title",
+            markup=False,
+        )
+        yield Static(
             "Repository: not checked",
             id="file-notes-git-repository",
             markup=False,
         )
         yield Static(
-            "Session paths only",
+            "Session paths only · stages complete file state",
             id="file-notes-git-scope",
             markup=False,
         )
         yield Static(
-            "Stages complete file state (content, deletion, and mode)",
-            id="file-notes-git-complete-state",
+            "Up/Down Select | Tab Actions | Enter Run | Esc Back",
+            id="file-notes-git-guide",
             markup=False,
         )
         yield ListView(id="file-notes-git-rows")
@@ -277,73 +488,164 @@ class LibraryFileNotesGitPanel(Vertical):
             id="file-notes-git-empty",
             markup=False,
         )
+        yield Static(
+            "Status: NOT CHECKED",
+            id="file-notes-git-status",
+            markup=False,
+        )
+        yield Static(
+            "",
+            id="file-notes-git-action-status",
+            markup=False,
+        )
+        yield Static(
+            "",
+            id="file-notes-git-selected-note",
+            markup=False,
+        )
         with Horizontal(id="file-notes-git-selected-actions"):
             yield Button(
-                "Stage selected",
+                "Stage",
                 id="file-notes-git-stage-selected",
                 compact=True,
             )
             yield Button(
-                "Unstage selected",
+                "Unstage",
                 id="file-notes-git-unstage-selected",
                 compact=True,
             )
         with Horizontal(id="file-notes-git-bulk-actions"):
             yield Button(
-                "Stage All",
+                "Stage all (0)",
                 id="file-notes-git-stage-all",
                 compact=True,
             )
             yield Button(
-                "Unstage All",
+                "Unstage all (0)",
                 id="file-notes-git-unstage-all",
                 compact=True,
             )
-        yield Static(
-            "Open Session Git to check status.",
-            id="file-notes-git-action-status",
-            markup=False,
-        )
 
     def on_mount(self) -> None:
         self._sync_action_layout(self.size.width)
         self._update_actions()
+        self.call_after_refresh(self._fit_fixed_regions)
 
     def on_resize(self, event: Resize) -> None:
-        """Stack action controls before their intrinsic widths can clip."""
+        """Recompute mounted copy and actions from real available geometry."""
         self._sync_action_layout(event.size.width)
+        self.call_after_refresh(self._fit_fixed_regions)
 
     def _sync_action_layout(self, width: int) -> None:
-        self.set_class(width <= 48, "-stack-actions")
+        """Stack only when a visible action row's real labels do not fit."""
+        if not self.is_mounted:
+            return
+        needs_stack = any(
+            self._visible_action_cells(selector)
+            > self._action_row_width(selector, width)
+            for selector in (
+                "#file-notes-git-header",
+                "#file-notes-git-selected-actions",
+                "#file-notes-git-bulk-actions",
+            )
+        )
+        self.set_class(needs_stack, "-stack-actions")
 
-    def render_status(self, status: SessionGitStatus) -> None:
-        """Render one immutable owner-published status result."""
+    def _visible_action_cells(self, selector: str) -> int:
+        row = self.query_one(selector)
+        return sum(
+            cell_len(str(button.label)) + button.styles.padding.width
+            for button in row.query(Button)
+            if button.display
+        )
+
+    def _action_row_width(self, selector: str, fallback: int) -> int:
+        row = self.query_one(selector)
+        return row.content_region.width or fallback
+
+    def _fit_fixed_regions(self) -> None:
+        for selector, text in (
+            ("#file-notes-git-repository", self._repository_text),
+            ("#file-notes-git-status", self._current_status_text),
+            ("#file-notes-git-action-status", self._last_action_text),
+            ("#file-notes-git-selected-note", self._selected_note_text),
+        ):
+            widget = self.query_one(selector, Static)
+            width = widget.content_region.width or self.content_region.width
+            fitted = text if width <= 0 else _middle_elide_cells(text, width * 2)
+            widget.update(fitted)
+
+    def _set_repository_text(self, text: str) -> None:
+        self._repository_text = text
+        self._fit_fixed_regions()
+
+    def render_status(
+        self,
+        status: SessionGitStatus,
+        *,
+        retain_rows: bool = False,
+    ) -> None:
+        """Render one immutable owner-published status result.
+
+        Args:
+            status: Owner-published status to project.
+            retain_rows: Whether the caller has proved that stale or failed
+                status still belongs to the currently trusted authority.
+        """
         prior_group_id = self._selected_group_id
-        self._rows = status.rows
-        self._trusted = status.repository is not None
+        authority_available = status.repository is not None
+        self._trusted = authority_available
         self._trust_available = False
-        self._status_ready = status.state == "ready"
+        self._status_ready = status.state == "ready" and authority_available
         self._mutating = False
-        if status.repository is None:
+        if not authority_available:
             repository_text = "Repository: unavailable"
         else:
+            assert status.repository is not None
             repository_text = (
                 "Repository: "
                 f"{_repository_path_for_display(status.repository.worktree_root)}"
                 f" · {self._head_label(status.head)}"
             )
-        self.query_one("#file-notes-git-repository", Static).update(
-            repository_text
-        )
-        message = status.message or {
-            "ready": "Status ready.",
-            "stale": "Stale — refresh status before staging.",
-            "unavailable": "Git unavailable.",
-            "error": "Git status failed; retry.",
-        }[status.state]
-        self.query_one("#file-notes-git-action-status", Static).update(message)
+        self._set_repository_text(repository_text)
+
+        if self._status_ready:
+            self._rows = status.rows
+            self._replace_rows(prior_group_id)
+            stage_count = sum(row.stage_eligible for row in self._rows)
+            unstage_count = sum(row.unstage_eligible for row in self._rows)
+            self.set_current_status(
+                "Status: CURRENT · READY — "
+                f"{stage_count} can be staged · "
+                f"{unstage_count} can be unstaged."
+            )
+        elif authority_available and status.state in {"stale", "error"} and retain_rows:
+            if status.rows:
+                self._rows = status.rows
+            self._replace_rows(prior_group_id)
+            token = "STALE" if status.state == "stale" else "STALE · ERROR"
+            detail = status.message or (
+                "Session notes changed; Refresh before staging."
+                if status.state == "stale"
+                else "Git status failed. Retry Refresh."
+            )
+            self.set_current_status(f"Status: {token} — {detail}")
+        else:
+            self._clear_rows()
+            if not authority_available or status.state == "unavailable":
+                detail = status.message or "Restore Git, then Refresh."
+                self.set_current_status(f"Status: UNAVAILABLE — {detail}")
+                self.clear_last_action()
+            elif status.state == "stale":
+                detail = (
+                    status.message or "Session notes changed; Refresh before staging."
+                )
+                self.set_current_status(f"Status: STALE — {detail}")
+            elif status.state == "error":
+                detail = status.message or "Git status failed. Retry Refresh."
+                self.set_current_status(f"Status: STALE · ERROR — {detail}")
+
         self._sync_empty_state()
-        self._replace_rows(prior_group_id)
         self._update_actions()
 
     def render_untrusted(self, repository_path: str) -> None:
@@ -352,40 +654,71 @@ class LibraryFileNotesGitPanel(Vertical):
         self._trust_available = True
         self._status_ready = False
         self._mutating = False
-        self.query_one("#file-notes-git-repository", Static).update(
+        self._clear_rows()
+        self.clear_last_action()
+        self._set_repository_text(
             f"Repository: {_repository_path_for_display(repository_path)}"
         )
-        self.query_one("#file-notes-git-action-status", Static).update(
-            "Trust is required before checking Session Git status."
+        self.set_current_status(
+            "Status: TRUST REQUIRED — Trust this repository to check "
+            "current session notes."
         )
         self._sync_empty_state()
         self._update_actions()
 
-    def render_checking(self, repository_path: str) -> None:
-        """Render transient status-checking presentation state."""
+    def render_checking(
+        self,
+        repository_path: str,
+        *,
+        retain_rows: bool = False,
+    ) -> None:
+        """Render status checking with only explicitly authorized old rows."""
         self._trusted = True
         self._trust_available = False
         self._status_ready = False
         self._mutating = False
-        self.query_one("#file-notes-git-repository", Static).update(
+        if not retain_rows:
+            self._clear_rows()
+        self._set_repository_text(
             f"Repository: {_repository_path_for_display(repository_path)}"
         )
-        self.query_one("#file-notes-git-action-status", Static).update(
-            "Checking Session Git status…"
-        )
+        self.set_current_status("Status: CHECKING — Checking current session notes…")
         self._sync_empty_state()
         self._update_actions()
 
     def set_mutating(self, active: bool, detail: str = "") -> None:
         """Render transient mutation state without owning its lifecycle."""
         self._mutating = active
-        if detail:
-            self.query_one("#file-notes-git-action-status", Static).update(detail)
+        if active:
+            self.set_current_status(
+                "Status: UPDATING INDEX" + (f" — {detail}" if detail else "")
+            )
+        elif detail:
+            self.set_current_status(detail)
         self._update_actions()
 
+    def set_current_status(self, detail: str) -> None:
+        """Set repository freshness/recovery without changing last action."""
+        self._current_status_text = detail
+        self._fit_fixed_regions()
+
+    def set_last_action(self, detail: str) -> None:
+        """Set the latest action result independently of current freshness."""
+        widget = self.query_one("#file-notes-git-action-status", Static)
+        self._last_action_text = detail
+        self._fit_fixed_regions()
+        widget.display = bool(detail)
+
+    def clear_last_action(self) -> None:
+        """Clear an obsolete latest-action presentation."""
+        widget = self.query_one("#file-notes-git-action-status", Static)
+        self._last_action_text = ""
+        self._fit_fixed_regions()
+        widget.display = False
+
     def set_action_status(self, detail: str) -> None:
-        """Render the latest workspace-owned action/result description."""
-        self.query_one("#file-notes-git-action-status", Static).update(detail)
+        """Compatibility alias for the latest workspace-owned action result."""
+        self.set_last_action(detail)
 
     def render_unavailable(self, detail: str) -> None:
         """Render a non-trustable discovery failure with Back as recovery."""
@@ -393,22 +726,35 @@ class LibraryFileNotesGitPanel(Vertical):
         self._trust_available = False
         self._status_ready = False
         self._mutating = False
-        self.query_one("#file-notes-git-repository", Static).update(
-            "Repository: unavailable"
-        )
-        self.query_one("#file-notes-git-action-status", Static).update(detail)
+        self._clear_rows()
+        self.clear_last_action()
+        self._set_repository_text("Repository: unavailable")
+        self.set_current_status(f"Status: UNAVAILABLE — {detail}")
         self._sync_empty_state()
         self._update_actions()
 
-    def mark_stale(self, detail: str = "Session paths changed; refresh status.") -> None:
-        """Retain rendered rows while disabling mutations until refresh."""
+    def mark_stale(
+        self,
+        detail: str = "Session notes changed; Refresh before staging.",
+        *,
+        retain_rows: bool = False,
+        error: bool = False,
+    ) -> None:
+        """Disable mutations, retaining rows only under caller-proved authority."""
         self._status_ready = False
         self._mutating = False
-        self.query_one("#file-notes-git-action-status", Static).update(
-            f"Stale — {detail}"
-        )
+        if not retain_rows:
+            self._clear_rows()
+        token = "STALE · ERROR" if error else "STALE"
+        self.set_current_status(f"Status: {token} — {detail}")
         self._sync_empty_state()
         self._update_actions()
+
+    def _clear_rows(self) -> None:
+        """Invalidate row presentation before scheduling the real list clear."""
+        self._rows = ()
+        self._selected_group_id = None
+        self._replace_rows(None)
 
     def _sync_empty_state(self) -> None:
         ready_empty = self._status_ready and not self._rows
@@ -494,36 +840,48 @@ class LibraryFileNotesGitPanel(Vertical):
         )
         stage_all = self.query_one("#file-notes-git-stage-all", Button)
         unstage_all = self.query_one("#file-notes-git-unstage-all", Button)
+        selected_note = self.query_one(
+            "#file-notes-git-selected-note",
+            Static,
+        )
 
         trust.display = self._trust_available and not self._trusted
         refresh.display = self._trusted
         refresh.disabled = self._mutating
         selected = self._selected_row()
+        if selected is None:
+            self._selected_note_text = ""
+            self._fit_fixed_regions()
+            selected_note.display = False
+        else:
+            self._selected_note_text = (
+                f"Selected note: {_group_path_for_display(selected)}"
+            )
+            self._fit_fixed_regions()
+            selected_note.display = True
         can_mutate = self._status_ready and not self._mutating
         stage_selected.display = (
-            self._trusted
-            and selected is not None
-            and selected.stage_action is not None
+            self._trusted and selected is not None and selected.stage_action is not None
         )
         stage_selected.disabled = not can_mutate
         if selected is not None and selected.stage_action == "stage_update":
             stage_selected.label = "Stage update"
         else:
-            stage_selected.label = "Stage selected"
+            stage_selected.label = "Stage"
         unstage_selected.display = (
-            self._trusted
-            and selected is not None
-            and selected.unstage_eligible
+            self._trusted and selected is not None and selected.unstage_eligible
         )
+        unstage_selected.label = "Unstage"
         unstage_selected.disabled = not can_mutate
-        stage_all.display = self._trusted
-        unstage_all.display = self._trusted
-        stage_all.disabled = not (
-            can_mutate and any(row.stage_eligible for row in self._rows)
-        )
-        unstage_all.disabled = not (
-            can_mutate and any(row.unstage_eligible for row in self._rows)
-        )
+        stage_count = sum(row.stage_eligible for row in self._rows)
+        unstage_count = sum(row.unstage_eligible for row in self._rows)
+        stage_all.label = f"Stage all ({stage_count})"
+        unstage_all.label = f"Unstage all ({unstage_count})"
+        stage_all.display = self._trusted and bool(self._rows)
+        unstage_all.display = self._trusted and bool(self._rows)
+        stage_all.disabled = not (can_mutate and stage_count > 0)
+        unstage_all.disabled = not (can_mutate and unstage_count > 0)
+        self._sync_action_layout(self.content_region.width)
 
     @on(ListView.Highlighted, "#file-notes-git-rows")
     def _row_highlighted(self, event: ListView.Highlighted) -> None:

--- a/tldw_chatbook/Widgets/Library/library_file_notes_git_panel.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_git_panel.py
@@ -171,7 +171,7 @@ def _row_secondary_parts(
             "BLOCKED · ",
             reason,
             "; resolve the Git conflict outside Chatbook, then Refresh",
-            "; resolve conflict, then Refresh",
+            "Conflict: use Git; Refresh",
         )
     if state in {
         "unsupported",
@@ -190,7 +190,7 @@ def _row_secondary_parts(
             "BLOCKED · ",
             reason,
             "; restore Git, then Refresh",
-            "; restore Git, then Refresh",
+            "Restore Git first; Refresh",
         )
     return (
         "FAILED · ",

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -247,6 +247,11 @@ class LibraryFileNotesWorkspace(Vertical):
     }
 
     LibraryFileNotesWorkspace.-stack-editor-actions
+    .file-notes-toolbar.-confirm-delete Button {
+        padding: 0;
+    }
+
+    LibraryFileNotesWorkspace.-stack-editor-actions
     #file-notes-delete.-confirm-delete {
         column-span: 2;
     }

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -11,6 +11,7 @@ from threading import Lock, RLock
 from typing import Any, Literal, Protocol, cast
 from uuid import uuid4
 
+from rich.cells import cell_len
 from rich.text import Text
 from textual import on
 from textual.app import ComposeResult
@@ -74,6 +75,16 @@ class _GitActionSummaryContext:
     already_staged: int = 0
     clean: int = 0
     blocked: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class _GitLastAction:
+    """One action presentation bound to exact owner authority and changes."""
+
+    binding: SessionBinding
+    repository: RepositoryIdentity
+    changes: tuple[SequencedSessionChange, ...]
+    text: str
 
 
 class _SessionGitService(Protocol):
@@ -211,6 +222,25 @@ class LibraryFileNotesWorkspace(Vertical):
         border: none;
         background: transparent;
     }
+
+    LibraryFileNotesWorkspace.-prepare-session-wide .file-notes-toolbar {
+        display: none;
+    }
+
+    LibraryFileNotesWorkspace.-stack-editor-actions .file-notes-toolbar {
+        layout: grid;
+        grid-size: 3;
+        grid-columns: 1fr 1fr 1fr;
+        height: auto;
+    }
+
+    LibraryFileNotesWorkspace.-stack-editor-actions .file-notes-toolbar Button {
+        width: 1fr;
+    }
+
+    LibraryFileNotesWorkspace.-stack-editor-actions #file-notes-editor {
+        min-height: 3;
+    }
     """
 
     def __init__(
@@ -294,10 +324,11 @@ class LibraryFileNotesWorkspace(Vertical):
         self._narrow_view: Literal["navigator", "editor"] = "navigator"
         self._navigator_mode: Literal["files", "search", "git"] = "files"
         self._navigator_mode_before_git: Literal["files", "search"] = "files"
+        self._editor_action_layout_sync_scheduled = False
         self._git_observed_changes: tuple[SequencedSessionChange, ...] | None = None
         self._git_refresh_timer: Timer | None = None
         self._git_refresh_after_mutation = False
-        self._git_action_detail = ""
+        self._git_last_action: _GitLastAction | None = None
         self._git_panel_widget = LibraryFileNotesGitPanel()
         # The editor itself is retained across parent Library recompositions.
         # Textual calls ``compose`` again when this same workspace object is
@@ -520,6 +551,7 @@ class LibraryFileNotesWorkspace(Vertical):
         self._save_worker = None
         self._git_status_worker = None
         self._git_action_worker = None
+        self._editor_action_layout_sync_scheduled = False
 
     async def shutdown(self) -> None:
         """Permanently close this workspace's owned replica once."""
@@ -760,6 +792,17 @@ class LibraryFileNotesWorkspace(Vertical):
                     )
 
             def publish(binding: SessionBinding) -> None:
+                binding_changed = binding != self._session_binding
+                if binding_changed:
+                    self._clear_git_last_action()
+                    self._git_observed_changes = None
+                    self._git_status_task = None
+                    self._git_status_task_binding = None
+                    if self._active and self.is_mounted:
+                        self._git_panel_widget.render_unavailable(
+                            "Selected notes root changed. Reopen Prepare "
+                            "session for commit to check the new root."
+                        )
                 service._bind_session_owner(self._session_owner, binding)
                 self._root = root
                 self._session_binding = binding
@@ -904,6 +947,7 @@ class LibraryFileNotesWorkspace(Vertical):
             editor.display = True
             back.display = False
         self._sync_navigator_mode()
+        self._schedule_editor_action_layout()
 
     def _sync_navigator_mode(self) -> None:
         """Show one retained navigator surface without remounting its peers."""
@@ -923,6 +967,44 @@ class LibraryFileNotesWorkspace(Vertical):
         entry.display = not git_visible
         tree.display = not git_visible and self._navigator_mode == "files"
         results.display = not git_visible and self._navigator_mode == "search"
+        self.set_class(
+            git_visible and not self._narrow,
+            "-prepare-session-wide",
+        )
+
+    def _schedule_editor_action_layout(self) -> None:
+        """Coalesce editor-action measurements after Textual refreshes layout."""
+        if (
+            not self._active
+            or not self.is_mounted
+            or self._editor_action_layout_sync_scheduled
+        ):
+            return
+        self._editor_action_layout_sync_scheduled = True
+        self.call_after_refresh(self._sync_editor_action_layout)
+
+    def _sync_editor_action_layout(self) -> None:
+        """Stack current editor actions only when their labels need the space."""
+        self._editor_action_layout_sync_scheduled = False
+        if not self._active or not self.is_mounted:
+            return
+        pane = self.query_one("#file-notes-editor-pane")
+        if not pane.display:
+            return
+        available_width = pane.content_region.width
+        if available_width <= 0:
+            return
+        needs_stack = any(
+            toolbar.display
+            and sum(
+                cell_len(str(button.label)) + 4
+                for button in toolbar.query(Button)
+                if button.display
+            )
+            > available_width
+            for toolbar in pane.query(".file-notes-toolbar")
+        )
+        self.set_class(needs_stack, "-stack-editor-actions")
 
     def _rebuild_tree(self) -> None:
         if not self._active or not self.is_mounted:
@@ -1003,6 +1085,7 @@ class LibraryFileNotesWorkspace(Vertical):
         changes: tuple[SequencedSessionChange, ...] = ()
         if binding is not None:
             changes = self._session_owner.snapshot(binding).changes
+        self._sync_git_last_action()
         count = len(coalesce_session_changes(changes))
         self.query_one("#file-notes-session-changes", Button).label = (
             f"Session Git ({count})"
@@ -1011,7 +1094,9 @@ class LibraryFileNotesWorkspace(Vertical):
         self._git_observed_changes = changes
         if prior is None or prior == changes or binding is None:
             return
-        self._git_panel_widget.mark_stale()
+        self._git_panel_widget.mark_stale(
+            retain_rows=self._git_can_retain_rows(binding),
+        )
         if self._navigator_mode == "git":
             self._schedule_git_refresh()
 
@@ -1046,6 +1131,87 @@ class LibraryFileNotesWorkspace(Vertical):
         return (
             binding == self._session_binding
             and binding == self._session_owner.current_binding()
+        )
+
+    @staticmethod
+    def _repository_identity_is_complete(
+        repository: RepositoryIdentity | None,
+    ) -> bool:
+        """Return whether a repository identity is complete enough to key UI."""
+        return (
+            repository is not None
+            and bool(repository.worktree_root)
+            and bool(repository.git_dir)
+            and bool(repository.git_common_dir)
+            and repository.worktree_identity is not None
+            and repository.git_dir_identity is not None
+            and repository.git_common_dir_identity is not None
+        )
+
+    def _capture_git_action_key(
+        self,
+        binding: SessionBinding,
+    ) -> _GitLastAction | None:
+        """Capture exact owner authority immediately around action admission."""
+        if binding != self._session_owner.current_binding():
+            return None
+        snapshot = self._session_owner.snapshot(binding)
+        repository = snapshot.trusted_repository
+        if not self._repository_identity_is_complete(repository):
+            return None
+        assert repository is not None
+        return _GitLastAction(
+            binding=snapshot.binding,
+            repository=repository,
+            changes=snapshot.changes,
+            text="",
+        )
+
+    def _git_action_key_is_current(self, action: _GitLastAction) -> bool:
+        """Compare one captured key with a fresh immutable owner snapshot."""
+        if action.binding != self._session_owner.current_binding():
+            return False
+        snapshot = self._session_owner.snapshot(action.binding)
+        return (
+            snapshot.binding == action.binding
+            and snapshot.trusted_repository == action.repository
+            and snapshot.changes == action.changes
+            and self._repository_identity_is_complete(
+                snapshot.trusted_repository
+            )
+        )
+
+    def _clear_git_last_action(self) -> None:
+        """Discard obsolete action text in both workspace and mounted panel."""
+        self._git_last_action = None
+        if self._active and self.is_mounted:
+            self._git_panel_widget.clear_last_action()
+
+    def _sync_git_last_action(self) -> bool:
+        """Validate and project the retained action against fresh owner state."""
+        action = self._git_last_action
+        if action is not None and not self._git_action_key_is_current(action):
+            action = None
+            self._git_last_action = None
+        if self._active and self.is_mounted:
+            if action is None:
+                self._git_panel_widget.clear_last_action()
+            else:
+                self._git_panel_widget.set_last_action(action.text)
+        return action is not None
+
+    def _git_can_retain_rows(self, binding: SessionBinding) -> bool:
+        """Prove prior rows belong to the same complete trusted authority."""
+        if binding != self._session_owner.current_binding():
+            return False
+        snapshot = self._session_owner.snapshot(binding)
+        repository = snapshot.trusted_repository
+        status = snapshot.git_status
+        return (
+            self._repository_identity_is_complete(repository)
+            and status is not None
+            and status.binding_generation == binding.generation
+            and status.repository == repository
         )
 
     def _ensure_git_status_waiter(
@@ -1083,14 +1249,19 @@ class LibraryFileNotesWorkspace(Vertical):
             return False
         binding = self._session_binding
         if binding is None or not self._git_binding_matches_session(binding):
+            self._clear_git_last_action()
             return False
         snapshot = self._session_owner.snapshot(binding)
+        self._sync_git_last_action()
         if self._session_owner.mutation_active(binding):
             if snapshot.git_status is not None:
-                self._git_panel_widget.render_status(snapshot.git_status)
+                self._git_panel_widget.render_status(
+                    snapshot.git_status,
+                    retain_rows=self._git_can_retain_rows(binding),
+                )
             self._git_panel_widget.set_mutating(
                 True,
-                self._git_action_detail or "Git mutation in progress…",
+                "Git mutation in progress…",
             )
             self._git_refresh_after_mutation = True
             return True
@@ -1110,16 +1281,17 @@ class LibraryFileNotesWorkspace(Vertical):
             repository = snapshot.trusted_repository
             if repository is not None:
                 self._git_panel_widget.render_checking(
-                    repository.worktree_root
+                    repository.worktree_root,
+                    retain_rows=self._git_can_retain_rows(binding),
                 )
             self._ensure_git_status_waiter(task, binding)
             return True
         if snapshot.git_status is not None:
-            self._git_panel_widget.render_status(snapshot.git_status)
-            if self._git_action_detail:
-                self._git_panel_widget.set_action_status(
-                    self._git_action_detail
-                )
+            self._git_panel_widget.render_status(
+                snapshot.git_status,
+                retain_rows=self._git_can_retain_rows(binding),
+            )
+            self._sync_git_last_action()
             return True
         if (
             task is not None
@@ -1134,8 +1306,10 @@ class LibraryFileNotesWorkspace(Vertical):
         binding = self._session_binding
         service = self._session_git_service()
         if binding is None or service is None:
-            self._git_panel_widget.set_action_status(
-                "Git is unavailable for the selected File Notes root."
+            self._clear_git_last_action()
+            self._git_panel_widget.render_unavailable(
+                "Git is unavailable for the selected File Notes root. "
+                "Restore Git, then reopen Prepare session for commit."
             )
             return
         discovery = await service.discover(binding)
@@ -1143,6 +1317,7 @@ class LibraryFileNotesWorkspace(Vertical):
             return
         repository = discovery.repository
         if discovery.state != "ready" or repository is None:
+            self._clear_git_last_action()
             self._git_panel_widget.render_unavailable(
                 discovery.message or "Git repository status is unavailable."
             )
@@ -1152,6 +1327,7 @@ class LibraryFileNotesWorkspace(Vertical):
             force_prompt or snapshot.trusted_repository != repository
         )
         if needs_trust:
+            self._clear_git_last_action()
             self._git_panel_widget.render_untrusted(repository.worktree_root)
             accepted = await self.app.push_screen_wait(
                 SessionGitTrustDialog(repository.worktree_root)
@@ -1160,17 +1336,21 @@ class LibraryFileNotesWorkspace(Vertical):
                 return
             if not await service.revalidate_repository(binding, repository):
                 if self._git_binding_is_current(binding):
+                    self._clear_git_last_action()
                     self._git_panel_widget.render_untrusted(
                         repository.worktree_root
                     )
-                    self._git_panel_widget.set_action_status(
-                        "Repository identity changed; trust was not granted."
+                    self._git_panel_widget.set_current_status(
+                        "Status: TRUST REQUIRED — Repository identity changed; "
+                        "retry Trust and check status."
                     )
                 return
             if not self._session_owner.publish_trust(binding, repository):
+                self._clear_git_last_action()
                 return
             snapshot = self._session_owner.snapshot(binding)
         if self._rehydrate_git_presentation():
+            self.call_after_refresh(self._focus_session_git_panel)
             return
         self._start_git_refresh()
 
@@ -1181,27 +1361,41 @@ class LibraryFileNotesWorkspace(Vertical):
         binding = self._session_binding
         service = self._session_git_service()
         if binding is None or service is None:
+            self._clear_git_last_action()
+            self._git_panel_widget.render_unavailable(
+                "Git status is unavailable. Restore Git, then reopen "
+                "Prepare session for commit."
+            )
             return
         if self._session_owner.mutation_active(binding):
             self._git_refresh_after_mutation = True
             self._git_panel_widget.mark_stale(
-                "Git mutation in progress; refresh will follow."
+                "Git mutation in progress; refresh will follow.",
+                retain_rows=self._git_can_retain_rows(binding),
             )
             return
         snapshot = self._session_owner.snapshot(binding)
         repository = snapshot.trusted_repository
         if repository is None:
-            self._git_panel_widget.set_action_status(
-                "Trust is required before checking Session Git status."
+            self._clear_git_last_action()
+            self._git_panel_widget.render_unavailable(
+                "Repository trust is unavailable. Return to the navigator, "
+                "reopen Prepare session for commit, and trust the repository."
             )
             return
-        self._git_panel_widget.render_checking(repository.worktree_root)
+        self._git_panel_widget.render_checking(
+            repository.worktree_root,
+            retain_rows=self._git_can_retain_rows(binding),
+        )
         try:
             task = service.start_status(binding, snapshot.changes)
         except GitStatusAdmissionError as error:
             if error.reason == "mutation_active":
                 self._git_refresh_after_mutation = True
-            self._git_panel_widget.mark_stale(str(error))
+            self._git_panel_widget.mark_stale(
+                f"{error}. Retry Refresh.",
+                retain_rows=self._git_can_retain_rows(binding),
+            )
             return
         self._git_status_task = task
         self._git_status_task_binding = binding
@@ -1218,30 +1412,44 @@ class LibraryFileNotesWorkspace(Vertical):
             raise
         except Exception as error:
             if self._git_binding_is_current(binding):
-                self._git_panel_widget.mark_stale(f"Git status failed: {error}")
+                self._sync_git_last_action()
+                self._git_panel_widget.mark_stale(
+                    f"Git status failed: {error}. Retry Refresh.",
+                    retain_rows=self._git_can_retain_rows(binding),
+                    error=True,
+                )
                 if self._git_status_task is task:
                     self._git_status_task = None
                     self._git_status_task_binding = None
             return
+        self._sync_git_last_action()
         if not self._git_binding_is_current(binding):
             return
         snapshot = self._session_owner.snapshot(binding)
         if self._git_status_task is task:
             self._git_status_task = None
             self._git_status_task_binding = None
+        if snapshot.trusted_repository is None:
+            self._clear_git_last_action()
+            self._git_panel_widget.render_unavailable(
+                "Repository trust changed while checking status. Return to "
+                "the navigator, reopen Prepare session for commit, and trust "
+                "the current repository."
+            )
+            return
         if status == snapshot.git_status:
-            self._git_panel_widget.render_status(status)
-            if self._git_action_detail:
-                self._git_panel_widget.set_action_status(
-                    self._git_action_detail
-                )
+            self._git_panel_widget.render_status(
+                status,
+                retain_rows=self._git_can_retain_rows(binding),
+            )
+            self._sync_git_last_action()
             return
         if snapshot.git_status is not None:
-            self._git_panel_widget.render_status(snapshot.git_status)
-            if self._git_action_detail:
-                self._git_panel_widget.set_action_status(
-                    self._git_action_detail
-                )
+            self._git_panel_widget.render_status(
+                snapshot.git_status,
+                retain_rows=self._git_can_retain_rows(binding),
+            )
+            self._sync_git_last_action()
             return
         if (
             snapshot.trusted_repository is not None
@@ -1302,6 +1510,7 @@ class LibraryFileNotesWorkspace(Vertical):
             if self._opened is not None and self._opened.protected
             else "Protect"
         )
+        self._schedule_editor_action_layout()
         self.query_one("#file-notes-search", Input).disabled = transitioning
         self.query_one("#file-notes-path", Input).disabled = (
             transitioning or mutation_active
@@ -1952,7 +2161,7 @@ class LibraryFileNotesWorkspace(Vertical):
             exclusive=True,
         )
 
-    def _focus_session_git_panel(self) -> None:
+    def _focus_session_git_panel(self, retries_remaining: int = 8) -> None:
         """Move focus off the hidden entry into the visible Git surface."""
         if (
             not self._active
@@ -1961,8 +2170,16 @@ class LibraryFileNotesWorkspace(Vertical):
         ):
             return
         rows = self.query_one("#file-notes-git-rows", ListView)
-        if self._git_panel_widget.rows and rows.display:
-            rows.focus()
+        if self._git_panel_widget.rows:
+            if rows.display:
+                rows.focus()
+            elif retries_remaining:
+                self.call_after_refresh(
+                    self._focus_session_git_panel,
+                    retries_remaining - 1,
+                )
+            else:
+                self.query_one("#file-notes-git-back", Button).focus()
             return
         self.query_one("#file-notes-git-back", Button).focus()
 
@@ -2041,10 +2258,23 @@ class LibraryFileNotesWorkspace(Vertical):
             )
         )
         if (action == "stage" or pending_save) and not await self.flush_pending_work():
-            self._git_panel_widget.set_action_status(
-                "Stage blocked: settle the File Notes draft first."
-                if action == "stage"
-                else "Unstage blocked: settle the File Notes draft first."
+            gerund = "staging" if action == "stage" else "unstaging"
+            if self._save_state == "conflict":
+                detail = (
+                    f"Save conflict must be resolved before {gerund}. "
+                    "Return to the editor."
+                )
+            elif self._save_state == "error":
+                detail = (
+                    f"Fix the save error before {gerund}. "
+                    "Return to the editor."
+                )
+            else:
+                detail = (
+                    f"Save the note before {gerund}. Return to the editor."
+                )
+            self._git_panel_widget.set_current_status(
+                f"Status: CURRENT · BLOCKED — {detail}"
             )
             return
         if (
@@ -2053,8 +2283,18 @@ class LibraryFileNotesWorkspace(Vertical):
             or self._path_transitioning
             or self._save_state in {"dirty", "saving", "conflict", "error"}
         ):
-            self._git_panel_widget.set_action_status(
-                f"{action.title()} blocked: File Notes state changed."
+            self._git_panel_widget.set_current_status(
+                "Status: CURRENT · BLOCKED — File Notes changed before "
+                f"{action.title()}. Return to the editor, finish the save or "
+                "transition, then Refresh."
+            )
+            return
+        action_key = self._capture_git_action_key(binding)
+        if action_key is None:
+            self._git_panel_widget.set_current_status(
+                "Status: STALE · BLOCKED — Repository or session authority "
+                "changed before the action. Return to the navigator, reopen "
+                "Prepare session for commit, then Refresh."
             )
             return
         try:
@@ -2064,10 +2304,16 @@ class LibraryFileNotesWorkspace(Vertical):
                 else service.start_unstage(binding, group_ids)
             )
         except GitMutationAdmissionError as error:
-            self._git_panel_widget.set_action_status(
-                f"{action.title()} blocked: {error}"
+            self._git_panel_widget.set_current_status(
+                f"Status: CURRENT · BLOCKED — {action.title()} could not "
+                f"start: {error}. Finish the active File Notes action, then "
+                "Refresh."
             )
             return
+        action_key_after_admission = self._capture_git_action_key(binding)
+        if action_key_after_admission != action_key:
+            action_key = None
+        self._clear_git_last_action()
         self._git_status_task = None
         self._git_status_task_binding = None
         self._git_panel_widget.set_mutating(
@@ -2077,7 +2323,12 @@ class LibraryFileNotesWorkspace(Vertical):
         self._update_root_surface()
         self._update_controls()
         self._git_action_worker = self.run_worker(
-            self._render_git_action(task, binding, summary_context),
+            self._render_git_action(
+                task,
+                binding,
+                summary_context,
+                action_key,
+            ),
             name=f"file-notes-git-{action}",
             group="file-notes-git-action",
             exclusive=True,
@@ -2088,6 +2339,7 @@ class LibraryFileNotesWorkspace(Vertical):
         task: asyncio.Task[GitActionResult],
         binding: SessionBinding,
         summary_context: _GitActionSummaryContext,
+        action_key: _GitLastAction | None,
     ) -> None:
         result: GitActionResult | None = None
         try:
@@ -2095,22 +2347,33 @@ class LibraryFileNotesWorkspace(Vertical):
         except asyncio.CancelledError:
             raise
         except Exception as error:
-            if self._git_binding_matches_session(binding):
-                self._git_action_detail = f"Git action failed: {error}"
-                if self._git_binding_is_current(binding):
-                    self._git_panel_widget.set_action_status(
-                        self._git_action_detail
-                    )
+            if self._git_binding_is_current(binding):
+                self._git_panel_widget.mark_stale(
+                    f"Git action failed: {error}. Inspect the repository "
+                    "index outside Chatbook, then Refresh.",
+                    retain_rows=self._git_can_retain_rows(binding),
+                    error=True,
+                )
         else:
-            if self._git_binding_matches_session(binding):
-                self._git_action_detail = self._git_action_summary(
+            if action_key is not None:
+                summary = self._git_action_summary(
                     result,
                     summary_context,
+                    action_key,
                 )
-                if self._git_binding_is_current(binding):
-                    self._git_panel_widget.set_action_status(
-                        self._git_action_detail
+                if (
+                    summary is not None
+                    and self._git_action_key_is_current(action_key)
+                ):
+                    self._git_last_action = replace(
+                        action_key,
+                        text=(
+                            f"Last action: {self._git_action_label(result)} — "
+                            f"{summary}"
+                        ),
                     )
+                    if self._git_binding_is_current(binding):
+                        self._sync_git_last_action()
         finally:
             binding_changed = (
                 binding != self._session_binding
@@ -2129,7 +2392,9 @@ class LibraryFileNotesWorkspace(Vertical):
                         self._git_refresh_after_mutation = True
                         if self._active and self.is_mounted:
                             self._git_panel_widget.mark_stale(
-                                "Git action finished while Session Git was hidden."
+                                "Git action finished while Prepare session was "
+                                "hidden. Reopen it to Refresh.",
+                                retain_rows=self._git_can_retain_rows(binding),
                             )
 
     def _git_action_summary_context(
@@ -2165,36 +2430,114 @@ class LibraryFileNotesWorkspace(Vertical):
             blocked=len(excluded) - clean - skipped,
         )
 
-    @staticmethod
     def _git_action_summary(
+        self,
         result: GitActionResult,
         context: _GitActionSummaryContext,
-    ) -> str:
-        """Render selected counts or complete pre-action bulk counts."""
-        if result.message:
-            return result.message
-        verb = (
-            ("Staged" if result.action == "stage" else "Unstaged")
-            if result.state == "success"
-            else f"{result.action.title()} {result.state}"
-        )
-        changed = (
-            len(result.staged_group_ids)
+        action_key: _GitLastAction,
+    ) -> str | None:
+        """Render one current checked result without overstating its proof."""
+        if not self._git_action_key_is_current(action_key):
+            return None
+        affected_group_ids = (
+            result.staged_group_ids
             if result.action == "stage"
-            else len(result.unstaged_group_ids)
+            else result.unstaged_group_ids
         )
-        parts = [f"{verb} {changed}" if result.state == "success" else verb]
-        if context.bulk and result.action == "stage":
-            parts.append(f"already staged {context.already_staged}")
-        if context.bulk and result.action == "unstage":
-            parts.append(f"skipped {context.skipped}")
-        parts.extend(
-            (
-                f"clean {len(result.clean_group_ids) + context.clean}",
-                f"blocked {len(result.blocked_group_ids) + context.blocked}",
+        affected = len(tuple(dict.fromkeys(affected_group_ids)))
+        counts: list[str] = []
+        if (
+            context.bulk
+            and result.action == "stage"
+            and context.already_staged
+        ):
+            counts.append(f"already staged {context.already_staged}")
+        if context.bulk and result.action == "unstage" and context.skipped:
+            counts.append(f"skipped {context.skipped}")
+        clean = len(result.clean_group_ids) + context.clean
+        blocked = len(result.blocked_group_ids) + context.blocked
+        if clean:
+            counts.append(f"clean {clean}")
+        if blocked:
+            counts.append(f"blocked {blocked}")
+        counts_text = (
+            f"Counts: {'; '.join(counts)}." if counts else ""
+        )
+
+        message = (result.message or "").strip()
+        if message and message[-1] not in ".!?":
+            message += "."
+
+        if result.state == "success" and affected:
+            note = "session note" if affected == 1 else "session notes"
+            if result.action == "stage":
+                core = (
+                    f"{affected} {note} staged; Chatbook targeted only "
+                    "eligible session paths."
+                )
+            else:
+                entry = "entry" if affected == 1 else "entries"
+                core = (
+                    f"{affected} {note} unstaged; Chatbook restored only its "
+                    f"owned session {entry}."
+                )
+            return " ".join(
+                part for part in (core, message, counts_text) if part
             )
+
+        if result.state == "success":
+            past = "staged" if result.action == "stage" else "unstaged"
+            return " ".join(
+                part
+                for part in (
+                    f"No session notes {past}.",
+                    message,
+                    counts_text,
+                    "Review current eligibility, then Refresh.",
+                )
+                if part
+            )
+
+        fallback = {
+            "blocked": f"{result.action.title()} was blocked.",
+            "stale": f"{result.action.title()} status became stale.",
+            "error": f"{result.action.title()} failed.",
+            "uncertain": f"{result.action.title()} outcome is uncertain.",
+        }[result.state]
+        recovery = {
+            "blocked": (
+                "Resolve the reported Git state outside Chatbook, then Refresh."
+            ),
+            "stale": (
+                "Review the changed repository or session state, then Refresh."
+            ),
+            "error": "Fix the reported Git error outside Chatbook, then Refresh.",
+            "uncertain": (
+                "Inspect the repository index outside Chatbook, then Refresh."
+            ),
+        }[result.state]
+        return " ".join(
+            part for part in (message or fallback, counts_text, recovery) if part
         )
-        return " · ".join(parts)
+
+    @staticmethod
+    def _git_action_label(result: GitActionResult) -> str:
+        """Return the semantic token for one checked action result."""
+        affected = (
+            result.staged_group_ids
+            if result.action == "stage"
+            else result.unstaged_group_ids
+        )
+        if result.state == "success" and affected:
+            return "STAGED" if result.action == "stage" else "UNSTAGED"
+        if result.state == "success":
+            return "NO CHANGE"
+        return {
+            "blocked": "BLOCKED",
+            "stale": "STALE",
+            "error": "FAILED",
+            "uncertain": "UNCERTAIN",
+        }[result.state]
 
     @on(Button.Pressed, "#file-notes-new")
     async def _new_file(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -1302,6 +1302,49 @@ class LibraryFileNotesWorkspace(Vertical):
             return True
         return False
 
+    @staticmethod
+    def _git_discovery_failure_detail(discovery: DiscoveryResult) -> str:
+        """Project one discovery failure to reason plus feasible recovery."""
+        if discovery.state == "not_repository":
+            return (
+                "This notes folder is not in a Git worktree. "
+                "Notes remain fully usable."
+            )
+
+        defaults = {
+            "unavailable": "Git is unavailable",
+            "unsupported": "Git repository compatibility is unsupported",
+            "unsafe_root": "Selected File Notes root is unsafe",
+        }
+        recoveries = {
+            "unavailable": (
+                "Install or restore Git, then reopen Prepare session for "
+                "commit."
+            ),
+            "unsupported": (
+                "Resolve Git compatibility outside Chatbook, then reopen "
+                "Prepare session for commit."
+            ),
+            "unsafe_root": (
+                "Select or fix a safe notes root, then reopen Prepare session "
+                "for commit."
+            ),
+        }
+        reason = (
+            discovery.message
+            or defaults.get(
+                discovery.state,
+                "Git repository discovery is unavailable",
+            )
+        ).strip()
+        if reason and reason[-1] not in ".!?":
+            reason += "."
+        recovery = recoveries.get(
+            discovery.state,
+            "Reopen Prepare session for commit.",
+        )
+        return f"{reason} {recovery}"
+
     async def _open_session_git(self, *, force_prompt: bool = False) -> None:
         binding = self._session_binding
         service = self._session_git_service()
@@ -1319,7 +1362,7 @@ class LibraryFileNotesWorkspace(Vertical):
         if discovery.state != "ready" or repository is None:
             self._clear_git_last_action()
             self._git_panel_widget.render_unavailable(
-                discovery.message or "Git repository status is unavailable."
+                self._git_discovery_failure_detail(discovery)
             )
             return
         snapshot = self._session_owner.snapshot(binding)

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -1422,6 +1422,14 @@ class LibraryFileNotesWorkspace(Vertical):
                 self._clear_git_last_action()
                 return
             snapshot = self._session_owner.snapshot(binding)
+        if (
+            self._git_refresh_after_mutation
+            and not self._session_owner.mutation_active(binding)
+        ):
+            self._git_refresh_after_mutation = False
+            self._start_git_refresh()
+            self.call_after_refresh(self._focus_session_git_panel)
+            return
         if self._rehydrate_git_presentation():
             self.call_after_refresh(self._focus_session_git_panel)
             return

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -238,6 +238,19 @@ class LibraryFileNotesWorkspace(Vertical):
         width: 1fr;
     }
 
+    LibraryFileNotesWorkspace.-stack-editor-actions
+    .file-notes-toolbar.-confirm-delete {
+        grid-size: 4;
+        grid-columns: 1fr 1fr 1fr 1fr;
+        grid-rows: 1 1;
+        height: 2;
+    }
+
+    LibraryFileNotesWorkspace.-stack-editor-actions
+    #file-notes-delete.-confirm-delete {
+        column-span: 2;
+    }
+
     LibraryFileNotesWorkspace.-stack-editor-actions #file-notes-editor {
         min-height: 3;
     }
@@ -982,6 +995,18 @@ class LibraryFileNotesWorkspace(Vertical):
             return
         self._editor_action_layout_sync_scheduled = True
         self.call_after_refresh(self._sync_editor_action_layout)
+
+    def _set_delete_confirmation(self, relative_path: str = "") -> None:
+        """Project one confirmation state into its copy and narrow layout."""
+        confirmed = bool(relative_path)
+        self._delete_confirmation_path = relative_path
+        delete = self.query_one("#file-notes-delete", Button)
+        delete.label = "Confirm delete" if confirmed else "Delete"
+        delete.set_class(confirmed, "-confirm-delete")
+        toolbar = delete.parent
+        if toolbar is not None:
+            toolbar.set_class(confirmed, "-confirm-delete")
+        self._schedule_editor_action_layout()
 
     def _sync_editor_action_layout(self) -> None:
         """Stack current editor actions only when their labels need the space."""
@@ -1743,14 +1768,13 @@ class LibraryFileNotesWorkspace(Vertical):
         self._current_path = opened.relative_path
         self._selected_deleted_path = ""
         self._session_key = uuid4().hex
-        self._delete_confirmation_path = ""
+        self._set_delete_confirmation()
         editor = self.query_one("#file-notes-editor", TextArea)
         with editor.prevent(TextArea.Changed):
             editor.load_text(opened.body)
         editor.read_only = not opened.editable
         self.query_one("#file-notes-path", Input).value = opened.relative_path
         self.query_one("#file-notes-breadcrumb", Static).update(opened.relative_path)
-        self.query_one("#file-notes-delete", Button).label = "Delete"
         if opened.editable:
             self._set_save_state("saved")
         else:
@@ -1782,7 +1806,7 @@ class LibraryFileNotesWorkspace(Vertical):
         if not keep_restore_path:
             self.query_one("#file-notes-path", Input).value = ""
             self.query_one("#file-notes-breadcrumb", Static).update("No file selected")
-        self.query_one("#file-notes-delete", Button).label = "Delete"
+        self._set_delete_confirmation()
         self._set_save_state("idle")
         self._update_controls()
 
@@ -2087,8 +2111,7 @@ class LibraryFileNotesWorkspace(Vertical):
             or not self._opened.editable
         ):
             return
-        self._delete_confirmation_path = ""
-        self.query_one("#file-notes-delete", Button).label = "Delete"
+        self._set_delete_confirmation()
         self._set_save_state("dirty")
         self._arm_autosave()
 
@@ -2188,6 +2211,7 @@ class LibraryFileNotesWorkspace(Vertical):
     @on(Button.Pressed, "#file-notes-session-changes")
     def _session_git_pressed(self, event: Button.Pressed) -> None:
         event.stop()
+        entry_owned_focus = event.button.has_focus
         if self._navigator_mode != "git":
             self._navigator_mode_before_git = (
                 "search"
@@ -2196,6 +2220,11 @@ class LibraryFileNotesWorkspace(Vertical):
             )
         self._navigator_mode = "git"
         self._sync_navigator_mode()
+        if entry_owned_focus:
+            self.screen.set_focus(
+                self.query_one("#file-notes-git-back", Button),
+                scroll_visible=False,
+            )
         self.call_after_refresh(self._focus_session_git_panel)
         self.run_worker(
             self._open_session_git(),
@@ -2212,19 +2241,34 @@ class LibraryFileNotesWorkspace(Vertical):
             or self._navigator_mode != "git"
         ):
             return
+        entry = self.query_one("#file-notes-session-changes", Button)
+        back = self.query_one("#file-notes-git-back", Button)
+        focused = self.app.focused
+        if not (
+            focused is entry
+            or focused is back
+            or (
+                focused is not None
+                and (
+                    focused is self._git_panel_widget
+                    or self._git_panel_widget in focused.ancestors
+                )
+            )
+        ):
+            return
         rows = self.query_one("#file-notes-git-rows", ListView)
         if self._git_panel_widget.rows:
             if rows.display:
-                rows.focus()
+                self.screen.set_focus(rows, scroll_visible=False)
             elif retries_remaining:
                 self.call_after_refresh(
                     self._focus_session_git_panel,
                     retries_remaining - 1,
                 )
             else:
-                self.query_one("#file-notes-git-back", Button).focus()
+                self.screen.set_focus(back, scroll_visible=False)
             return
-        self.query_one("#file-notes-git-back", Button).focus()
+        self.screen.set_focus(back, scroll_visible=False)
 
     @on(LibraryFileNotesGitPanel.BackRequested)
     def _session_git_back(
@@ -2541,6 +2585,17 @@ class LibraryFileNotesWorkspace(Vertical):
                 if part
             )
 
+        if result.state == "blocked" and not affected and clean and not blocked:
+            return " ".join(
+                part
+                for part in (
+                    message,
+                    counts_text,
+                    "No eligible note changes remain; Refresh status.",
+                )
+                if part
+            )
+
         fallback = {
             "blocked": f"{result.action.title()} was blocked.",
             "stale": f"{result.action.title()} status became stale.",
@@ -2627,8 +2682,7 @@ class LibraryFileNotesWorkspace(Vertical):
         if self._service is None or opened is None:
             return
         if self._delete_confirmation_path != opened.relative_path:
-            self._delete_confirmation_path = opened.relative_path
-            event.button.label = "Confirm delete"
+            self._set_delete_confirmation(opened.relative_path)
             self._set_action_status("Click Delete again to confirm.")
             return
         if not await self.flush_pending_work():

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -2439,10 +2439,23 @@ class LibraryFileNotesWorkspace(Vertical):
         except asyncio.CancelledError:
             raise
         except Exception as error:
+            detail = (
+                f"Git action failed: {error}. Inspect the repository "
+                "index outside Chatbook, then Refresh."
+            )
+            if (
+                action_key is not None
+                and self._git_action_key_is_current(action_key)
+            ):
+                self._git_last_action = replace(
+                    action_key,
+                    text=f"Last action: FAILED — {detail}",
+                )
+                if self._git_binding_is_current(binding):
+                    self._sync_git_last_action()
             if self._git_binding_is_current(binding):
                 self._git_panel_widget.mark_stale(
-                    f"Git action failed: {error}. Inspect the repository "
-                    "index outside Chatbook, then Refresh.",
+                    detail,
                     retain_rows=self._git_can_retain_rows(binding),
                     error=True,
                 )


### PR DESCRIPTION
## Summary

- Reframe File Notes staging as **Prepare session for commit**, with note-intent-first rows, explicit actionable Git states, recovery guidance, and independent current-status/last-action surfaces.
- Key action feedback to the selected root, complete repository identity, session generation, exact affected paths, and full result text so stale or mismatched feedback is never shown.
- Keep the mounted editor usable while preparing a session, quiet editor actions in wide mode, restore the same body/toolbars/focus on Back, and preserve complete labels at narrow terminal sizes.

## Git safety

- Retains TASK-1213 session-path and complete-file-state scope.
- Adds no commit, push, remote, full-repository, or hunk-staging controls.
- Successful copy promises only what the checked Git result proves; blocked, uncertain, stale, clean, and zero-effect results omit the promise.

## Acceptance evidence

- Real-service disposable-repository UAT saved two notes, declined/reopened/accepted trust, staged both session notes while preserving an unrelated staged file, then unstaged only Chatbook-owned entries.
- Verified at 150x42, 70x28, 70x24, and 40x20, including Escape/focus return, Protect/Unprotect, editor-action quieting, retained-editor editing, and Back restoration.
- Live UAT exposed 40x20 confirmation-state clipping; a failing actual-render-line regression reproduced `Restore -> Resto` and `Protect -> Protec`. The scoped fix was retested live with full `Confirm delete`, `Restore`, and `Protect` labels and safe cancellation.

## Verification

- `83 passed` — `Tests/UI/test_library_file_notes_git.py`
- `2 passed` — adjacent real-service delete/restore workspace flows
- `compileall`, Ruff lint, and `git diff --check` passed
- Final spec review: compliant
- Final code-quality review: approved, no open issues
- Ruff whole-file formatting remains the existing `origin/dev` baseline for the three legacy files; this PR avoids unrelated bulk formatting churn.

## Architecture

ADR required: no. This presentation/lifecycle repair conforms to ADR-035, ADR-033, ADR-011, and ADR-029 without changing storage, sync, Git ownership, or service boundaries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the File Notes "Prepare session for commit" flow to make staging note changes clearer, safer, and readable on small terminals. Satisfies TASK-1235.

- **New Features**
  - Reframed as "Prepare session for commit" with note-first rows and clear Git states.
  - Separate current status vs last action; feedback bound to root, repository identity, and exact paths.
  - Stage/Unstage all only for session notes; unrelated index state is preserved.
  - Editor remains usable during prepare; Back restores body, toolbars, and focus.
  - Adds recovery guidance and trust flows; keeps session-only Git scope (no commit/push/remote/hunk).

- **Bug Fixes**
  - Scope feedback to exact session changes to prevent stale or mismatched results.
  - Retain unexpected Git action failures and surface them after reopen.
  - Fix small-terminal label clipping via middle elision; keep "Confirm delete", "Restore", and "Protect" intact.
  - Harden panel lifecycle, refresh, and confirmations to avoid blocked or hidden states and preserve narrow recovery copy.

<sup>Written for commit b6c82c14d47ce3acc4afd7546b2fd1665fc6bb74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

