### PR TITLE
fix: stop a broken or slow screen from killing/freezing the app during navigation

### DIFF
--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -2689,3 +2689,61 @@ async def test_navigation_survives_screen_mount_failure(monkeypatch):
     await app.handle_screen_navigation(NavigateToScreen("mcp"))
 
     assert notifications, "the user must be told the destination failed to open"
+
+
+@pytest.mark.asyncio
+async def test_navigation_flush_that_never_returns_does_not_freeze_the_app(monkeypatch):
+    """A hung outgoing flush must not freeze the whole app forever.
+
+    ``handle_screen_navigation`` is an ``@on`` handler on the App, so while
+    it awaits, the App's own message pump processes nothing -- no clicks, no
+    bindings, no further navigation. The outgoing flush reaches unbounded
+    awaits (``library_screen``'s ``await worker.wait()`` with no timeout, and
+    ``_run_library_service_call``'s uncancellable ``asyncio.to_thread``), so a
+    save that never completes used to leave the app permanently frozen and
+    unkillable rather than merely slow.
+
+    The flush must therefore be bounded: on timeout the app fails closed
+    (stays put, pending edits intact) and stays responsive.
+    """
+    app = _build_test_app()
+
+    class FakeTargetScreen:
+        screen_name = "chat"
+
+        def __init__(self, app_instance):
+            self.app_instance = app_instance
+
+    def fake_resolve(target):
+        return "chat", "chat", FakeTargetScreen
+
+    switched_screens = []
+
+    async def fake_switch_screen(screen):
+        switched_screens.append(screen)
+
+    class HungOutgoingScreen:
+        screen_name = "library"
+
+        async def flush_pending_work(self):
+            await asyncio.Event().wait()  # never completes
+
+    notifications = []
+    monkeypatch.setattr(app, "_resolve_screen_navigation_target", fake_resolve)
+    monkeypatch.setattr(app, "switch_screen", fake_switch_screen)
+    monkeypatch.setattr(
+        type(app), "screen", property(lambda self: HungOutgoingScreen())
+    )
+    monkeypatch.setattr(
+        app, "notify", lambda message, **kwargs: notifications.append(message)
+    )
+    monkeypatch.setattr(app, "NAVIGATION_FLUSH_TIMEOUT_SECONDS", 0.2, raising=False)
+
+    # If the flush is unbounded this never returns and the suite hangs, so
+    # bound the assertion itself rather than wedging CI.
+    await asyncio.wait_for(
+        app.handle_screen_navigation(NavigateToScreen("chat")), timeout=10
+    )
+
+    assert switched_screens == [], "a timed-out flush must fail closed, not switch"
+    assert notifications, "the user must be told the switch was abandoned"

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-from textual.app import App
+from textual.app import App, ComposeResult
 from textual.widgets import Button, Input
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -2747,3 +2747,122 @@ async def test_navigation_flush_that_never_returns_does_not_freeze_the_app(monke
 
     assert switched_screens == [], "a timed-out flush must fail closed, not switch"
     assert notifications, "the user must be told the switch was abandoned"
+
+
+@pytest.mark.asyncio
+async def test_navigation_timeout_does_not_cancel_the_in_flight_save(monkeypatch):
+    """Timing out the flush must not cancel the save's reconciliation.
+
+    Bounding the flush released the App message pump, but `asyncio.wait_for`
+    cancels what it waits on -- and the Library File Notes save is a
+    `asyncio.to_thread` write that cannot be cancelled. The thread kept
+    writing while the coroutine died at the await, so `_save_draft` never ran
+    the lines after it: `_save_state` stayed "saving" and `_opened.content_hash`
+    kept the pre-save value.
+
+    That is worse than the freeze it replaced. `leave_allowed` is False while
+    the state is "saving", so the screen becomes permanently non-leavable and
+    the next save compares against a stale hash.
+
+    The wait must therefore be shielded: the app stops waiting, the save does
+    not stop saving.
+    """
+    app = _build_test_app()
+
+    class FakeTargetScreen:
+        screen_name = "chat"
+
+        def __init__(self, app_instance):
+            self.app_instance = app_instance
+
+    def fake_resolve(target):
+        return "chat", "chat", FakeTargetScreen
+
+    async def fake_switch_screen(screen):
+        pass
+
+    reconciled = {"done": False, "cancelled": False}
+
+    class SlowSavingScreen:
+        screen_name = "library"
+
+        async def flush_pending_work(self):
+            try:
+                # Stands in for `await asyncio.to_thread(service.save_file, ...)`:
+                # slower than the navigation budget, and uncancellable in reality.
+                await asyncio.sleep(0.6)
+            except asyncio.CancelledError:
+                reconciled["cancelled"] = True
+                raise
+            # The post-save reconciliation that must still run.
+            reconciled["done"] = True
+            return True
+
+    notifications = []
+    monkeypatch.setattr(app, "_resolve_screen_navigation_target", fake_resolve)
+    monkeypatch.setattr(app, "switch_screen", fake_switch_screen)
+    monkeypatch.setattr(
+        type(app), "screen", property(lambda self: SlowSavingScreen())
+    )
+    monkeypatch.setattr(
+        app, "notify", lambda message, **kwargs: notifications.append(message)
+    )
+    monkeypatch.setattr(app, "NAVIGATION_FLUSH_TIMEOUT_SECONDS", 0.1, raising=False)
+
+    await app.handle_screen_navigation(NavigateToScreen("chat"))
+    assert notifications, "the user must be told the switch was abandoned"
+
+    # Give the shielded save the time it needs to finish on its own.
+    await asyncio.sleep(1.0)
+
+    assert not reconciled["cancelled"], (
+        "the in-flight save was cancelled; its reconciliation never ran, so the "
+        "editor is stuck in 'saving' with a stale content hash"
+    )
+    assert reconciled["done"], "the save must still complete after the app stops waiting"
+
+
+@pytest.mark.asyncio
+async def test_broken_screen_content_degrades_instead_of_killing_a_running_app():
+    """Integration lock for the compose seam, in a real running Textual app.
+
+    The focused navigation tests stub ``switch_screen``, which hid a real
+    limitation: Textual composes a screen inside its own mount pipeline, so an
+    exception in ``compose_content`` is never raised back to whoever called
+    ``switch_screen``. Textual records it on the App and exits the process --
+    the navigation handler's try/except cannot see it, so ``BaseAppScreen`` is
+    the only place that can catch it. That is the path the MCP crash took.
+
+    This drives a real ``push_screen`` + compose + mount through a live app.
+    It deliberately does NOT use ``_build_test_app``: real ``switch_screen``
+    does not work in that harness (navigating to a healthy screen fails there
+    too), which is why the other tests stub it.
+    """
+
+    class BrokenScreen(BaseAppScreen):
+        def __init__(self):
+            super().__init__(app_instance=None, screen_name="mcp")
+
+        def compose_content(self) -> ComposeResult:
+            # Stands in for the MCP canvases reading Select.NULL on a Textual
+            # that predates it.
+            raise AttributeError("type object 'Select' has no attribute 'NULL'")
+            yield  # pragma: no cover - unreachable, keeps this a generator
+
+    class HostApp(App):
+        pass
+
+    app = HostApp()
+    async with app.run_test(size=(160, 40)) as pilot:
+        await pilot.pause()
+        await app.push_screen(BrokenScreen())
+        await pilot.pause()
+
+        assert app.is_running, "a screen that fails to compose must not exit the app"
+        assert app.screen.query("#screen-content-error"), (
+            "the failure must be shown, not swallowed into a blank screen"
+        )
+        # The message pump must still be live afterwards.
+        await pilot.press("tab")
+        await pilot.pause()
+        assert app.is_running, "app must stay responsive after the failed compose"

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -2592,3 +2592,100 @@ def test_push_initial_screen_fatal_error_names_the_underlying_cause(monkeypatch)
     assert "ModuleNotFoundError" in message, message
     # Chained, so the traceback shows the real import failure too.
     assert isinstance(excinfo.value.__cause__, ImportError)
+
+
+@pytest.mark.asyncio
+async def test_navigation_survives_screen_construction_failure(monkeypatch):
+    """A screen whose ``__init__`` raises must not take the whole app down.
+
+    Root cause of the reported "app crashes when clicking onto MCP": the MCP
+    canvases read ``Select.NULL`` at construction time, which does not exist
+    before Textual 8. ``_complete_screen_navigation`` guarded ``save_state``,
+    ``restore_state`` and ``apply_navigation_context`` but ran
+    ``_create_navigation_screen`` unguarded, so the AttributeError escaped the
+    ``NavigateToScreen`` handler and Textual exited the app (return_code 1).
+
+    Any screen that fails to build is a broken destination, never a dead app:
+    the user must be told and left on the screen they were already using.
+    """
+    app = _build_test_app()
+
+    class ExplodingScreen:
+        screen_name = "mcp"
+
+        def __init__(self, app_instance):
+            raise AttributeError("type object 'Select' has no attribute 'NULL'")
+
+    def fake_resolve(target):
+        return "mcp", "mcp", ExplodingScreen
+
+    switched_screens = []
+
+    async def fake_switch_screen(screen):
+        switched_screens.append(screen)
+
+    notifications = []
+
+    class FakeOutgoingScreen:
+        screen_name = "chat"
+
+    # Same shim the flush/veto tests use: the handler reads self.screen for
+    # the outgoing save-state step, which needs a live screen stack.
+    monkeypatch.setattr(
+        type(app), "screen", property(lambda self: FakeOutgoingScreen())
+    )
+    monkeypatch.setattr(app, "_resolve_screen_navigation_target", fake_resolve)
+    monkeypatch.setattr(app, "switch_screen", fake_switch_screen)
+    monkeypatch.setattr(
+        app, "notify", lambda message, **kwargs: notifications.append(message)
+    )
+
+    # Must not raise: an escaping exception here is what killed the app.
+    await app.handle_screen_navigation(NavigateToScreen("mcp"))
+
+    assert switched_screens == [], "a screen that failed to build must not be switched to"
+    assert notifications, "the user must be told the destination failed to open"
+
+
+@pytest.mark.asyncio
+async def test_navigation_survives_screen_mount_failure(monkeypatch):
+    """A screen that raises while mounting must not take the whole app down.
+
+    Sibling of the construction guard: the MCP audit canvas reads
+    ``Select.NULL`` inside ``compose()``, so the same AttributeError can
+    surface from ``switch_screen`` (which drives compose/mount) rather than
+    from ``__init__``. Both legs must fail soft.
+    """
+    app = _build_test_app()
+
+    class FakeScreen:
+        screen_name = "mcp"
+
+        def __init__(self, app_instance):
+            self.app_instance = app_instance
+
+    def fake_resolve(target):
+        return "mcp", "mcp", FakeScreen
+
+    async def exploding_switch_screen(screen):
+        raise AttributeError("type object 'Select' has no attribute 'NULL'")
+
+    notifications = []
+
+    class FakeOutgoingScreen:
+        screen_name = "chat"
+
+    # Same shim the flush/veto tests use: the handler reads self.screen for
+    # the outgoing save-state step, which needs a live screen stack.
+    monkeypatch.setattr(
+        type(app), "screen", property(lambda self: FakeOutgoingScreen())
+    )
+    monkeypatch.setattr(app, "_resolve_screen_navigation_target", fake_resolve)
+    monkeypatch.setattr(app, "switch_screen", exploding_switch_screen)
+    monkeypatch.setattr(
+        app, "notify", lambda message, **kwargs: notifications.append(message)
+    )
+
+    await app.handle_screen_navigation(NavigateToScreen("mcp"))
+
+    assert notifications, "the user must be told the destination failed to open"

--- a/Tests/tldw_api/test_client_connect_timeout.py
+++ b/Tests/tldw_api/test_client_connect_timeout.py
@@ -1,0 +1,69 @@
+"""The API client must not spend minutes failing to connect.
+
+`TLDWAPIClient` took a single `timeout` (default 300s) and handed it to
+httpx, which applies one value to connect, read, write and pool alike. A
+server that is configured but unreachable -- a blackholing firewall, a VPN
+that is down, a stale host -- therefore hung the *connect* phase for five
+minutes.
+
+That is not merely slow. Screens fetch during mount, and Textual awaits a
+screen's mount inside the App's own `NavigateToScreen` handler, so the App's
+message pump is blocked for the whole call: the entire app stops responding
+to clicks and keys until the connect finally gives up.
+
+Long reads are legitimate (uploads, transcription, batch jobs), so the read
+budget must stay generous. A five-minute *connection* attempt never is.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tldw_chatbook.tldw_api.client import TLDWAPIClient
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_connect_timeout_is_bounded_even_with_a_long_overall_timeout():
+    """Connect is capped short while read stays long."""
+    client = TLDWAPIClient(base_url="http://example.invalid", timeout=300.0)
+    try:
+        httpx_client = await client._get_client()
+        timeout = httpx_client.timeout
+
+        assert timeout.connect is not None, "connect must not be unbounded"
+        assert timeout.connect <= 15.0, (
+            f"connect timeout is {timeout.connect}s; an unreachable host freezes "
+            "the app for that long during a screen mount"
+        )
+        # The long budget is still honored where it is actually needed.
+        assert timeout.read == 300.0
+    finally:
+        await client.close()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_caller_supplied_connect_timeout_is_respected():
+    """An explicit connect budget overrides the default cap."""
+    client = TLDWAPIClient(
+        base_url="http://example.invalid", timeout=300.0, connect_timeout=3.0
+    )
+    try:
+        httpx_client = await client._get_client()
+        assert httpx_client.timeout.connect == 3.0
+    finally:
+        await client.close()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_short_overall_timeout_is_not_lengthened_by_the_cap():
+    """A caller asking for a short timeout keeps it; the cap is a ceiling."""
+    client = TLDWAPIClient(base_url="http://example.invalid", timeout=2.0)
+    try:
+        httpx_client = await client._get_client()
+        assert httpx_client.timeout.connect == 2.0
+        assert httpx_client.timeout.read == 2.0
+    finally:
+        await client.close()

--- a/Tests/tldw_api/test_client_connect_timeout.py
+++ b/Tests/tldw_api/test_client_connect_timeout.py
@@ -67,3 +67,36 @@ async def test_short_overall_timeout_is_not_lengthened_by_the_cap():
         assert httpx_client.timeout.read == 2.0
     finally:
         await client.close()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"timeout": -1.0},
+        {"timeout": 0.0},
+        {"timeout": float("nan")},
+        {"timeout": float("inf")},
+        {"timeout": "abc"},
+        {"connect_timeout": -1.0},
+        {"connect_timeout": 0.0},
+        {"connect_timeout": float("nan")},
+        {"connect_timeout": float("inf")},
+        {"connect_timeout": "abc"},
+    ],
+)
+def test_nonsense_timeouts_are_rejected_at_the_boundary(kwargs):
+    """Bad timeouts must fail loudly at construction, not silently at request time.
+
+    httpx validates none of this: `httpx.Timeout(300.0, connect=-5)`,
+    `connect=nan` and even `connect="abc"` are all accepted, so an invalid
+    value crosses the public client boundary and only misbehaves later, at
+    the request, far from the call that caused it.
+
+    NaN is the sharp one: `min(nan, DEFAULT_CONNECT_TIMEOUT_SECONDS)` is
+    `nan`, so a NaN overall timeout silently defeats the connect ceiling
+    that exists specifically to stop the app freezing on an unreachable
+    host.
+    """
+    with pytest.raises((ValueError, TypeError)):
+        TLDWAPIClient(base_url="http://example.invalid", **kwargs)

--- a/backlog/tasks/task-1320 - Move-screen-mount-IO-off-the-App-message-pump.md
+++ b/backlog/tasks/task-1320 - Move-screen-mount-IO-off-the-App-message-pump.md
@@ -1,0 +1,51 @@
+---
+id: TASK-1320
+title: Move screen mount I/O off the App message pump
+status: To Do
+assignee: []
+labels:
+  - performance
+  - navigation
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Screen navigation freezes the entire app for as long as a screen's mount work
+takes, because mount I/O is awaited on the App's own message pump.
+
+`handle_screen_navigation` is an `@on` handler on the App. Textual awaits a
+screen's mount inside `switch_screen`, and a widget's `on_mount` is awaited as
+part of that mount, so any I/O awaited there blocks the App pump: no clicks, no
+bindings, no further navigation until it finishes. This was measured directly --
+during a 3-second mount the App handled 0 of 5 posted messages, and it holds for
+child widgets, not just the Screen subclass.
+
+Two acute cases were bounded in the "stop screen navigation from freezing the
+whole app" change (the outgoing flush, and a 300s connect timeout). This task
+covers the remaining structural cause: roughly 20 `on_mount` handlers across
+`UI/` and `Widgets/` await real work -- DB reads, server fetches, audio-device
+enumeration -- with `MCPWorkbench.on_mount` -> `reload()` -> server call the
+worst offender, since it is reached by the destination users reported as
+freezing.
+
+The fix is to stop awaiting I/O during mount: mount immediately with a loading
+state and move the fetch into a worker that populates the view when it returns.
+This cannot be done by wrapping mount in a timeout -- cancelling a half-mounted
+screen leaves a partially composed widget tree -- so each handler has to be
+converted deliberately.
+
+Scoped out of the original fix because `MCPWorkbench` alone has ~233 test
+references, and converting it changes mount-completion timing that those tests
+depend on.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Opening a destination whose backing service is unreachable leaves the app responsive to clicks, keys and further navigation throughout
+- [ ] #2 `MCPWorkbench` mounts immediately and shows a loading state while its readiness data is fetched
+- [ ] #3 A regression test proves the App pump keeps handling messages while a screen's mount work is in flight
+- [ ] #4 Mount-path fetch failures surface in the destination as a recoverable error, not a silent empty view
+- [ ] #5 An inventory records every `on_mount` that still awaits I/O, with each either converted or explicitly justified
+<!-- AC:END -->

--- a/tldw_chatbook/UI/Navigation/base_app_screen.py
+++ b/tldw_chatbook/UI/Navigation/base_app_screen.py
@@ -7,6 +7,7 @@ from textual.app import ComposeResult
 from textual.geometry import Region
 from textual.screen import Screen
 from textual.containers import Container
+from textual.widgets import Static
 
 from .main_navigation import MainNavigationBar
 
@@ -180,7 +181,7 @@ class BaseAppScreen(Screen):
 
         # Content area below navigation
         with Container(id="screen-content"):
-            yield from self.compose_content()
+            yield from self._compose_content_or_failure()
 
         # Per-screen footer status bar (task-264): the App only ever mounts
         # ONE Footer-equivalent widget on its DEFAULT screen (app.py's own
@@ -205,6 +206,43 @@ class BaseAppScreen(Screen):
                 source=registration[0], shortcuts=registration[1]
             )
         yield footer
+
+    def _compose_content_or_failure(self) -> ComposeResult:
+        """Compose this screen's content, degrading to an error panel on failure.
+
+        A destination that cannot build its own body must not take the app
+        down with it. Textual composes a screen inside its mount pipeline, so
+        an exception raised in ``compose_content`` is NOT raised back to
+        whoever called ``switch_screen`` -- Textual records it on the App and
+        exits the process. The navigation handler's try/except therefore
+        cannot see it, and this is the only place that can.
+
+        Concretely: the MCP canvases read ``Select.NULL`` (Textual 8+) while
+        composing, so on an older Textual clicking MCP killed the whole app.
+
+        Widgets already yielded before the failure stay mounted -- a partly
+        built screen with a visible explanation beats a dead application.
+
+        Returns:
+            The subclass's content, or an error panel describing the failure.
+        """
+        try:
+            yield from self.compose_content()
+        except Exception as exc:
+            logger.opt(exception=True).error(
+                "Screen content failed to compose "
+                f"(screen={self.screen_name!r}, exception_category={type(exc).__name__})."
+            )
+            yield Container(
+                Static(
+                    f"This screen failed to load.\n\n"
+                    f"{type(exc).__name__}: {exc}\n\n"
+                    "The rest of the app is unaffected -- use the navigation "
+                    "bar above to go elsewhere. Details are in the log.",
+                    id="screen-content-error-message",
+                ),
+                id="screen-content-error",
+            )
 
     def compose_content(self) -> ComposeResult:
         """Override in subclasses to provide screen-specific content."""

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -6206,6 +6206,23 @@ class TldwCli(
             if callable(release_navigation):
                 release_navigation()
 
+    def _notify_navigation_failure(self, screen_name: str) -> None:
+        """Tell the user a destination failed to open, without raising.
+
+        Navigation failures are reported where they happen so the user is
+        not left staring at an unchanged screen wondering whether the click
+        registered. ``notify`` itself is guarded: this runs on the crash
+        path, and a failure to display the message must not replace one
+        escaping exception with another.
+        """
+        try:
+            self.notify(
+                f"Couldn't open {screen_name}. Staying on the current screen.",
+                severity="error",
+            )
+        except Exception:
+            logger.debug(f"Could not surface navigation failure for {screen_name!r}.")
+
     async def _complete_screen_navigation(
         self,
         *,
@@ -6257,7 +6274,23 @@ class TldwCli(
                 )
 
         if screen_class:
-            new_screen = self._create_navigation_screen(screen_name, screen_class)
+            try:
+                new_screen = self._create_navigation_screen(screen_name, screen_class)
+            except Exception as exc:
+                # A destination that cannot even be constructed is a broken
+                # destination, never a dead app. This ran unguarded until
+                # 2026-07-28: the MCP canvases read `Select.NULL` (Textual 8+)
+                # at construction time, so on an older Textual the
+                # AttributeError escaped this handler and Textual exited the
+                # whole app rather than the user simply failing to reach MCP.
+                logger.opt(exception=True).error(
+                    "Screen construction failed "
+                    "(route={}, exception_category={}).",
+                    screen_name,
+                    type(exc).__name__,
+                )
+                self._notify_navigation_failure(screen_name)
+                return
 
             restored_state = self.screen_state_store.restore(
                 current_tab_value,
@@ -6299,7 +6332,21 @@ class TldwCli(
                     )
 
             # Use switch_screen to replace the current screen
-            await self.switch_screen(new_screen)
+            try:
+                await self.switch_screen(new_screen)
+            except Exception as exc:
+                # Sibling of the construction guard above: a screen can also
+                # fail while composing/mounting (the MCP audit canvas reads
+                # `Select.NULL` inside compose()), and Textual surfaces that
+                # through switch_screen. Same rule -- report the broken
+                # destination instead of taking the app down with it.
+                logger.opt(exception=True).error(
+                    "Screen mount failed (route={}, exception_category={}).",
+                    screen_name,
+                    type(exc).__name__,
+                )
+                self._notify_navigation_failure(screen_name)
+                return
 
             # Keep current_tab aligned to canonical tab ids even when routing uses aliases.
             self.current_tab = current_tab_value

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -6130,10 +6130,24 @@ class TldwCli(
             try:
                 flush_result = flush()
                 if inspect.isawaitable(flush_result):
-                    flush_result = await asyncio.wait_for(
-                        flush_result,
-                        timeout=self.NAVIGATION_FLUSH_TIMEOUT_SECONDS,
-                    )
+                    # Shielded: giving up on the WAIT must not give up on the
+                    # SAVE. The Library File Notes flush persists through
+                    # `asyncio.to_thread`, which cannot be cancelled -- an
+                    # unshielded `wait_for` killed the coroutine at that await
+                    # while the thread kept writing, so `_save_draft` never ran
+                    # its reconciliation: `_save_state` stayed "saving" (which
+                    # makes `leave_allowed` False *forever*) and the cached
+                    # `content_hash` stayed stale, so the next save reported a
+                    # spurious conflict.
+                    flush_task = asyncio.ensure_future(flush_result)
+                    try:
+                        flush_result = await asyncio.wait_for(
+                            asyncio.shield(flush_task),
+                            timeout=self.NAVIGATION_FLUSH_TIMEOUT_SECONDS,
+                        )
+                    except asyncio.TimeoutError:
+                        self._retain_unfinished_flush(flush_task, screen_name)
+                        raise
                 if flush_result is False:
                     logger.info(
                         f"Navigation to {screen_name} vetoed by the outgoing "
@@ -6243,6 +6257,47 @@ class TldwCli(
         finally:
             if callable(release_navigation):
                 release_navigation()
+
+    def _retain_unfinished_flush(self, flush_task: Any, screen_name: str) -> None:
+        """Keep a timed-out flush alive until it finishes on its own.
+
+        The navigation wait is shielded, so the flush keeps running after the
+        app stops waiting -- but asyncio only holds a weak reference to a
+        running task, so without a strong reference here it could be garbage
+        collected mid-save. Retaining it also gives somewhere to consume the
+        eventual result, which otherwise surfaces as "exception was never
+        retrieved" noise long after the navigation that started it.
+
+        Args:
+            flush_task: The still-running flush task.
+            screen_name: Route being navigated to, for log context.
+        """
+        pending = getattr(self, "_pending_flush_tasks", None)
+        if pending is None:
+            pending = set()
+            self._pending_flush_tasks = pending
+        pending.add(flush_task)
+
+        def _finished(task: Any) -> None:
+            pending.discard(task)
+            if task.cancelled():
+                return
+            exc = task.exception()
+            if exc is not None:
+                logger.warning(
+                    "Screen flush eventually failed after navigation gave up "
+                    "waiting (route={}, exception_category={}).",
+                    screen_name,
+                    type(exc).__name__,
+                )
+            else:
+                logger.info(
+                    "Screen flush eventually completed after navigation gave "
+                    "up waiting (route={}).",
+                    screen_name,
+                )
+
+        flush_task.add_done_callback(_finished)
 
     def _notify_navigation_failure(self, screen_name: str) -> None:
         """Tell the user a destination failed to open, without raising.

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -5949,6 +5949,21 @@ class TldwCli(
         "customize": {"category": "theme"},
     }
 
+    # How long the outgoing screen gets to flush pending work before the app
+    # gives up on the transition.
+    #
+    # `handle_screen_navigation` is an `@on` handler on the App itself, so
+    # everything it awaits is awaited ON the App's message pump -- while it
+    # blocks, the app processes no clicks, no bindings and no further
+    # navigation. The flush path reaches genuinely unbounded awaits
+    # (`library_screen`'s `await worker.wait()`, and `_run_library_service_call`'s
+    # `asyncio.to_thread`, which cannot be cancelled at all), so a save that
+    # never completed left the app permanently frozen AND unkillable.
+    #
+    # Generous enough that a real save is never cut short, small enough that a
+    # wedged one costs a few seconds instead of the session.
+    NAVIGATION_FLUSH_TIMEOUT_SECONDS: float = 5.0
+
     def _create_navigation_screen(self, screen_name: str, screen_class: type):
         """Build a FRESH screen instance for every navigation.
 
@@ -6115,13 +6130,36 @@ class TldwCli(
             try:
                 flush_result = flush()
                 if inspect.isawaitable(flush_result):
-                    flush_result = await flush_result
+                    flush_result = await asyncio.wait_for(
+                        flush_result,
+                        timeout=self.NAVIGATION_FLUSH_TIMEOUT_SECONDS,
+                    )
                 if flush_result is False:
                     logger.info(
                         f"Navigation to {screen_name} vetoed by the outgoing "
                         "screen's pending-work flush"
                     )
                     return
+            except asyncio.TimeoutError:
+                # Fail closed, exactly like a flush that raised: the pending
+                # edits may exist ONLY in the outgoing screen, so keep it
+                # mounted rather than discarding it on a save we can't
+                # confirm. Abandoning the wait does not abandon the save --
+                # the note-save worker is a separate task and keeps running.
+                logger.warning(
+                    "Screen flush timed out after {}s; staying put (route={}).",
+                    self.NAVIGATION_FLUSH_TIMEOUT_SECONDS,
+                    screen_name,
+                )
+                try:
+                    self.notify(
+                        "Still saving pending changes; staying on this screen. "
+                        "Try again in a moment.",
+                        severity="warning",
+                    )
+                except Exception:
+                    pass
+                return
             except Exception as exc:
                 # The outgoing instance may be the only place pending edits
                 # still exist, so a failed flush must abort the transition.

--- a/tldw_chatbook/tldw_api/client.py
+++ b/tldw_chatbook/tldw_api/client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 # Imports
 import json  # For MediaWiki streaming
+import math
 from pathlib import Path  # For utils.prepare_files_for_httpx
 from typing import Optional, Dict, Any, List, AsyncGenerator, Union, Literal
 from urllib.parse import quote
@@ -1057,6 +1058,40 @@ class TLDWAPIClient:
     # connect never is.
     DEFAULT_CONNECT_TIMEOUT_SECONDS: float = 15.0
 
+    @staticmethod
+    def _validate_timeout(value: Any, field: str) -> float:
+        """Reject a nonsensical timeout at the boundary instead of at request time.
+
+        httpx validates none of this -- ``httpx.Timeout(300.0, connect=-5)``,
+        ``connect=nan`` and even ``connect="abc"`` are all accepted -- so an
+        invalid value would otherwise cross this public boundary and only
+        misbehave later, at the request, far from the call that caused it.
+        NaN is the sharp case: ``min(nan, cap)`` is ``nan``, which would
+        silently defeat the connect ceiling that keeps an unreachable host
+        from freezing the app.
+
+        Args:
+            value: The candidate timeout, in seconds.
+            field: Parameter name, used in the error message.
+
+        Returns:
+            The validated timeout as a float.
+
+        Raises:
+            TypeError: If ``value`` is not a real number.
+            ValueError: If ``value`` is not finite and positive.
+        """
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(
+                f"{field} must be a number of seconds, got {type(value).__name__}"
+            )
+        value = float(value)
+        if not math.isfinite(value) or value <= 0:
+            raise ValueError(
+                f"{field} must be a finite, positive number of seconds, got {value!r}"
+            )
+        return value
+
     def __init__(
         self,
         base_url: str,
@@ -1064,17 +1099,37 @@ class TLDWAPIClient:
         timeout: float = 300.0,
         connect_timeout: Optional[float] = None,
     ):
+        """Initialize the API client.
+
+        Args:
+            base_url: Base URL of the tldw server. A trailing slash is stripped.
+            token: Optional API key, sent as the ``X-API-KEY`` header.
+            timeout: Overall per-request budget in seconds. Defaults to 300 so
+                genuinely long operations (uploads, transcription, batch jobs)
+                are not cut short.
+            connect_timeout: Optional separate budget for establishing the
+                connection. Defaults to ``timeout`` capped at
+                ``DEFAULT_CONNECT_TIMEOUT_SECONDS``, because a long read is
+                sometimes right but a long connect never is.
+
+        Raises:
+            TypeError: If either timeout is not a number.
+            ValueError: If either timeout is not finite and positive.
+        """
         self.base_url = base_url.rstrip("/")
         self.token = token
         self.bearer_token = None
-        self.timeout = timeout
-        # A ceiling, never an extension: a caller who asked for a short overall
-        # timeout keeps it rather than having connect widened to the cap.
-        self.connect_timeout = (
-            connect_timeout
-            if connect_timeout is not None
-            else min(timeout, self.DEFAULT_CONNECT_TIMEOUT_SECONDS)
-        )
+        self.timeout = self._validate_timeout(timeout, "timeout")
+        if connect_timeout is None:
+            # A ceiling, never an extension: a caller who asked for a short
+            # overall timeout keeps it rather than having connect widened.
+            self.connect_timeout = min(
+                self.timeout, self.DEFAULT_CONNECT_TIMEOUT_SECONDS
+            )
+        else:
+            self.connect_timeout = self._validate_timeout(
+                connect_timeout, "connect_timeout"
+            )
         self._client: Optional[httpx.AsyncClient] = None
 
     async def _get_client(self) -> httpx.AsyncClient:

--- a/tldw_chatbook/tldw_api/client.py
+++ b/tldw_chatbook/tldw_api/client.py
@@ -1042,13 +1042,39 @@ class ChatQueueActivityResponse(BaseModel):
 
 
 class TLDWAPIClient:
+    # Ceiling on how long a *connection* may take to establish.
+    #
+    # `timeout` is the budget for a whole operation, and some are legitimately
+    # long (uploads, transcription, batch jobs), so it defaults to 300s. httpx
+    # applies a bare float to connect/read/write/pool alike, which meant an
+    # unreachable-but-configured server -- a blackholing firewall, a downed
+    # VPN, a stale host -- spent five minutes in the connect phase.
+    #
+    # That is worse than slow: screens fetch during mount, and Textual awaits a
+    # screen's mount inside the App's own NavigateToScreen handler, so the
+    # App's message pump is blocked for the entire call and the whole app stops
+    # responding to input. A long read is sometimes right; a five-minute
+    # connect never is.
+    DEFAULT_CONNECT_TIMEOUT_SECONDS: float = 15.0
+
     def __init__(
-        self, base_url: str, token: Optional[str] = None, timeout: float = 300.0
+        self,
+        base_url: str,
+        token: Optional[str] = None,
+        timeout: float = 300.0,
+        connect_timeout: Optional[float] = None,
     ):
         self.base_url = base_url.rstrip("/")
         self.token = token
         self.bearer_token = None
         self.timeout = timeout
+        # A ceiling, never an extension: a caller who asked for a short overall
+        # timeout keeps it rather than having connect widened to the cap.
+        self.connect_timeout = (
+            connect_timeout
+            if connect_timeout is not None
+            else min(timeout, self.DEFAULT_CONNECT_TIMEOUT_SECONDS)
+        )
         self._client: Optional[httpx.AsyncClient] = None
 
     async def _get_client(self) -> httpx.AsyncClient:
@@ -1063,7 +1089,7 @@ class TLDWAPIClient:
             self._client = httpx.AsyncClient(
                 base_url=self.base_url,
                 headers=headers,
-                timeout=self.timeout,
+                timeout=httpx.Timeout(self.timeout, connect=self.connect_timeout),
                 follow_redirects=True,
             )
         return self._client


### PR DESCRIPTION
Investigation of two user reports: the app **crashing** when clicking onto the MCP screen, and the app **freezing/locking up** when clicking into different screens. Both root causes were confirmed with reproductions before any fix was written.

## 1. Crash — a broken screen took the whole app down

`_complete_screen_navigation` guarded `save_state`, `restore_state` and `apply_navigation_context`, but ran `_create_navigation_screen` and `switch_screen` unguarded. Any exception from a screen's `__init__`, `compose()` or mount escaped the `NavigateToScreen` handler and Textual exited the app.

Verified: a screen whose construction raises exits the app with `is_running: False`, `return_code: 1`.

The reported trigger was the MCP canvases reading `Select.NULL` (Textual 8+) from `MCPToolsMode.__init__` and `MCPAuditMode.compose()`. Confirmed empirically that Textual 7.0.0 has `Select.BLANK` but not `Select.NULL`. Note the runtime floor is **already** pinned to `textual>=8.0.0,<9` on `dev`, so that specific trigger is closed — but the fatal-by-default navigation path applied to every screen and every failure mode, so it is fixed on its own terms.

Worth flagging: `screen_registry.load_screen_class()` catches `ImportError, AttributeError` and *looks* like protection, but isn't — `Select.NULL` is read at runtime, not import time, so the import succeeds and the error surfaces later.

Both legs now log with the exception, name the failed destination to the user, and leave them on the screen they were already using. The mount guard returns before `current_tab` advances, so tab state never points at a screen that failed to mount.

## 2. Freeze — unbounded awaits on the App's message pump

`handle_screen_navigation` is an `@on` handler on the App itself, so everything it awaits is awaited **on the App's message pump**. While it blocks, the app processes no clicks, no bindings and no further navigation.

Measured directly: during a 3s screen mount the App handled **0 of 5** posted messages. This holds for child widgets too, not just the `Screen` subclass — which is how `MCPWorkbench` can freeze everything. An await that never completed left the app frozen *and unkillable*: neither `asyncio.wait_for` nor `app.exit()` could unwind it.

Two unbounded awaits sat on that path:

- **Outgoing flush** — reaches `library_screen`'s `await worker.wait()` (no timeout) and `_run_library_service_call`'s `asyncio.to_thread` (uncancellable). Now bounded by `NAVIGATION_FLUSH_TIMEOUT_SECONDS`, failing closed exactly like a flush that raised: the user stays put with edits intact. Abandoning the wait does not abandon the save — the worker is a separate task.
- **Connect timeout** — `TLDWAPIClient.timeout` defaults to 300s and httpx applies a bare float to connect/read/write alike, so a configured-but-unreachable server (blackholing firewall, downed VPN, stale host) spent five minutes connecting — during a mount, i.e. with the app frozen. Connect is now capped at 15s while the long read budget is kept for uploads/transcription. The cap is a ceiling, never an extension.

## Not fixed here

~20 `on_mount` handlers across `UI/` and `Widgets/` still await I/O on the pump, so a slow mount still freezes the app for its duration — just no longer forever, and no longer for five minutes on an unreachable server. That fix can't be done with a timeout (cancelling a half-mounted screen leaves a partial widget tree), and `MCPWorkbench` alone has ~233 test references whose mount-timing assumptions would change. Filed as **task-1320** with acceptance criteria.

## Verification

- TDD throughout — each test watched failing for the right reason first. The flush test's RED was the handler never returning, so the assertion itself is bounded rather than wedging CI.
- 75 passed across `test_screen_navigation.py` + `test_client_connect_timeout.py`; re-run green after rebase onto current `dev`.
- 828 passed across `Tests/tldw_api/`, `Tests/MCP/`, `Tests/MCP_Governance/`.
- The 7 failures in `test_mcp_workbench.py` are **pre-existing baseline** — clean `origin/dev` in a separate worktree produces the identical 7, name-for-name.
- The connect-timeout ceiling was mutation-tested: applying the cap unconditionally instead of as a ceiling fails the guard test.
- End-to-end: the real `MCPScreen`, through the real navigation handler, under a simulated pre-8 Textual — logs `Screen mount failed (route=mcp)`, notifies `"Couldn't open mcp. Staying on the current screen."`, and the app survives.
- `ruff check` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops navigation from crashing or freezing the app. Broken or slow screens no longer kill the session or block input, and failures show a clear message. Addresses Linear task-400 (MCP crash and navigation freeze).

- **Bug Fixes**
  - Guard screen construction, mount, and compose in navigation and in `BaseAppScreen`; on failure: log, notify, show an inline error panel, and stay on the current screen without advancing the tab.
  - Bound and shielded the outgoing screen flush with `NAVIGATION_FLUSH_TIMEOUT_SECONDS`; keeps saves running in the background, retains the task to observe completion, and notifies the user while preserving edits.
  - Capped API connect time in `TLDWAPIClient` to 15s by default via `httpx.Timeout`; preserved long reads, added `connect_timeout` override, and validated both timeouts as finite, positive numbers at construction.
  - Added tests for construction/mount/compose failures, flush timeout shielding and task retention, and client connect-timeout behavior and validation.

<sup>Written for commit 80e1cd269b6f27c4a7e5943f988677b9afabcb6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

