### PR TITLE
fix(settings): clear the hub suite's 22 dev-tip regressions [TASK-1310]

### DIFF
--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -385,35 +385,41 @@ async def _wait_for_settings_search_focus(
     raise AssertionError("Timed out waiting for Settings category search focus")
 
 
+# TASK-1310: task-648 (d15882398, "own provider selection by lifetime") changed
+# resolve_effective_provider_model's contract from an app-instance carrying
+# reactive chat_api_provider_value/chat_api_model_value/chat_model_value
+# attributes to a plain `persisted_defaults: Mapping` argument, and dropped the
+# "ignore the default-OpenAI reactive value" special case entirely (nothing
+# reactive is consulted any more). The tests below were never migrated off the
+# old app-instance shape; they are updated here to the current contract rather
+# than reintroducing the removed app-reactive coupling. See
+# Tests/Provider/test_provider_model_resolution.py for the canonical coverage
+# of the new contract, including test_explicit_api_has_no_application_parameter
+# which guards against regressing back to an app_instance parameter.
+
+
 def test_effective_provider_model_prefers_console_overrides():
-    app = _app(
-        provider="OpenAI",
-        api_model="gpt-4.1",
-        model=None,
-        defaults={"provider": "llama_cpp", "model": "qwen"},
-    )
+    persisted_defaults = {"provider": "llama_cpp", "model": "qwen"}
 
     result = resolve_effective_provider_model(
-        app,
+        persisted_defaults,
         console_provider="Anthropic",
         console_model="claude",
     )
 
     assert result.provider == "Anthropic"
     assert result.model == "claude"
-    assert result.provider_source == "console_control"
-    assert result.model_source == "console_control"
+    assert result.provider_source == "console_session"
+    assert result.model_source == "console_session"
 
 
 def test_effective_provider_model_preserves_configured_provider_when_reactive_is_default_openai():
-    app = _app(
-        provider="OpenAI",
-        api_model=None,
-        model=None,
-        defaults={"provider": "llama_cpp", "model": "qwen"},
-    )
+    """Task-648 removed the app-reactive fallback; assert the current
+    persisted-defaults-only fallback still preserves a non-OpenAI configured
+    provider (no OpenAI-default special case exists to override it any more)."""
+    persisted_defaults = {"provider": "llama_cpp", "model": "qwen"}
 
-    result = resolve_effective_provider_model(app)
+    result = resolve_effective_provider_model(persisted_defaults)
 
     assert result.provider == "llama_cpp"
     assert result.provider_source == "chat_defaults"
@@ -421,15 +427,10 @@ def test_effective_provider_model_preserves_configured_provider_when_reactive_is
 
 
 def test_effective_provider_model_prefers_settings_draft_values():
-    app = _app(
-        provider="OpenAI",
-        api_model="gpt-4.1",
-        model=None,
-        defaults={"provider": "llama_cpp", "model": "qwen"},
-    )
+    persisted_defaults = {"provider": "llama_cpp", "model": "qwen"}
 
     result = resolve_effective_provider_model(
-        app,
+        persisted_defaults,
         settings_provider="Ollama",
         settings_model="llama3.1",
     )
@@ -441,15 +442,10 @@ def test_effective_provider_model_prefers_settings_draft_values():
 
 
 def test_effective_provider_model_ignores_blank_provider_overrides_for_default_fallback():
-    app = _app(
-        provider="OpenAI",
-        api_model=None,
-        model=None,
-        defaults={"provider": "llama_cpp", "model": "qwen"},
-    )
+    persisted_defaults = {"provider": "llama_cpp", "model": "qwen"}
 
     result = resolve_effective_provider_model(
-        app,
+        persisted_defaults,
         settings_provider=" ",
         console_provider="None",
     )
@@ -459,45 +455,36 @@ def test_effective_provider_model_ignores_blank_provider_overrides_for_default_f
 
 
 def test_effective_provider_model_ignores_blank_reactive_provider_for_default_fallback():
-    for reactive_provider in ("", " ", "None"):
-        app = _app(
-            provider=reactive_provider,
-            api_model=None,
-            model=None,
-            defaults={"provider": "llama_cpp", "model": "qwen"},
-        )
+    """Task-648 dropped the app-reactive provider signal entirely; the closest
+    surviving edge case is a blank/placeholder *configured* provider value,
+    which passes straight through as the chat_defaults fallback (only the
+    settings/console override paths run blank-text filtering)."""
+    for configured_provider in ("", " ", "None"):
+        persisted_defaults = {"provider": configured_provider, "model": "qwen"}
 
-        result = resolve_effective_provider_model(app)
+        result = resolve_effective_provider_model(persisted_defaults)
 
-        assert result.provider == "llama_cpp"
+        assert result.provider == configured_provider
         assert result.provider_source == "chat_defaults"
 
 
 def test_effective_provider_model_ignores_textual_blank_select_provider_for_default_fallback():
-    app = _app(
-        provider="OpenAI",
-        api_model=None,
-        model=None,
-        defaults={"provider": "llama_cpp", "model": "qwen"},
-    )
+    persisted_defaults = {"provider": "llama_cpp", "model": "qwen"}
 
-    result = resolve_effective_provider_model(app, settings_provider=Select.BLANK)
+    result = resolve_effective_provider_model(
+        persisted_defaults, settings_provider=Select.BLANK
+    )
 
     assert result.provider == "llama_cpp"
     assert result.provider_source == "chat_defaults"
 
 
 def test_effective_provider_model_ignores_blank_model_overrides_for_default_fallback():
-    app = _app(
-        provider="OpenAI",
-        api_model=None,
-        model=None,
-        defaults={"provider": "llama_cpp", "model": "qwen"},
-    )
+    persisted_defaults = {"provider": "llama_cpp", "model": "qwen"}
 
     for blank_model in ("", " ", "None", Select.BLANK):
         result = resolve_effective_provider_model(
-            app,
+            persisted_defaults,
             settings_model=blank_model,
             console_model=" ",
         )
@@ -507,17 +494,11 @@ def test_effective_provider_model_ignores_blank_model_overrides_for_default_fall
 
 
 def test_effective_provider_model_handles_non_mapping_app_config():
-    app = SimpleNamespace(
-        app_config=[],
-        chat_api_provider_value=None,
-        chat_api_model_value=None,
-        chat_model_value=None,
-    )
-
-    result = resolve_effective_provider_model(app)
-
-    assert result.provider is None
-    assert result.model is None
+    """resolve_effective_provider_model now requires persisted_defaults itself
+    to be a Mapping (it no longer unwraps an app-instance's app_config), so a
+    non-mapping argument raises instead of silently resolving to None values."""
+    with pytest.raises(TypeError, match="mapping"):
+        resolve_effective_provider_model([])
 
 
 def test_settings_draft_tracks_dirty_values():
@@ -3311,8 +3292,13 @@ async def test_settings_category_search_escape_clears_filter():
 async def test_settings_overview_paste_summary_updates_after_toggle(monkeypatch):
     app = _build_test_app()
     app.app_config["console"] = {"collapse_large_pastes": True}
+    # TASK-1310: 1df0c4cb4 ("reconcile privacy lifecycle eval and packaging
+    # hardening") removed settings_screen's import of the per-key
+    # save_setting_to_cli_config helper; the Console Behavior category now
+    # saves exclusively through settings_config_adapter's batched
+    # save_settings_to_cli_config (see test_settings_console_behavior_uses_batched_save_adapter).
     monkeypatch.setattr(
-        "tldw_chatbook.UI.Screens.settings_screen.save_setting_to_cli_config",
+        "tldw_chatbook.UI.Screens.settings_config_adapter.save_settings_to_cli_config",
         lambda *_args, **_kwargs: True,
     )
     host = DestinationHarness(app, "settings")
@@ -3334,8 +3320,13 @@ async def test_settings_overview_paste_summary_updates_after_toggle(monkeypatch)
 async def test_settings_paste_toggle_keeps_keyboard_focus_after_refresh(monkeypatch):
     app = _build_test_app()
     app.app_config["console"] = {"collapse_large_pastes": True}
+    # TASK-1310: 1df0c4cb4 ("reconcile privacy lifecycle eval and packaging
+    # hardening") removed settings_screen's import of the per-key
+    # save_setting_to_cli_config helper; the Console Behavior category now
+    # saves exclusively through settings_config_adapter's batched
+    # save_settings_to_cli_config (see test_settings_console_behavior_uses_batched_save_adapter).
     monkeypatch.setattr(
-        "tldw_chatbook.UI.Screens.settings_screen.save_setting_to_cli_config",
+        "tldw_chatbook.UI.Screens.settings_config_adapter.save_settings_to_cli_config",
         lambda *_args, **_kwargs: True,
     )
     host = DestinationHarness(app, "settings")
@@ -4156,7 +4147,6 @@ async def test_settings_console_behavior_uses_batched_save_adapter(monkeypatch):
         "temperature": 0.7,
         "top_p": 0.95,
     }
-    legacy_calls = []
     batched_calls = []
 
     class FakeAdapter:
@@ -4165,11 +4155,11 @@ async def test_settings_console_behavior_uses_batched_save_adapter(monkeypatch):
             return True
 
     monkeypatch.setattr(settings_screen_module, "SettingsConfigAdapter", FakeAdapter)
-    monkeypatch.setattr(
-        settings_screen_module,
-        "save_setting_to_cli_config",
-        lambda *args, **kwargs: legacy_calls.append(args) or True,
-    )
+    # TASK-1310: 1df0c4cb4 removed settings_screen's import of the per-key
+    # save_setting_to_cli_config helper entirely, so there is no longer an
+    # attribute here to monkeypatch as a "legacy call" tripwire -- the module
+    # cannot call it (it isn't imported); doing so would raise NameError, a
+    # stronger guarantee than the old runtime mock provided.
     host = DestinationHarness(app, "settings")
 
     async with host.run_test(size=(180, 50)) as pilot:
@@ -4192,7 +4182,6 @@ async def test_settings_console_behavior_uses_batched_save_adapter(monkeypatch):
         await pilot.click("#settings-save-category")
         await _wait_for_settings_text(screen, pilot, "Console behavior settings saved.")
 
-    assert legacy_calls == []
     assert batched_calls == [
         {
             "console": {"paste_collapse_threshold": 120},
@@ -4260,9 +4249,12 @@ async def test_settings_console_behavior_rejects_invalid_global_defaults(
         "max_tokens": 2048,
     }
     saved = []
+    # TASK-1310: 1df0c4cb4 removed settings_screen's import of the per-key
+    # save_setting_to_cli_config helper; Console Behavior saves exclusively
+    # through settings_config_adapter's batched save_settings_to_cli_config.
     monkeypatch.setattr(
-        "tldw_chatbook.UI.Screens.settings_screen.save_setting_to_cli_config",
-        lambda section, key, value: saved.append((section, key, value)) or True,
+        "tldw_chatbook.UI.Screens.settings_config_adapter.save_settings_to_cli_config",
+        lambda section_values: saved.append(section_values) or True,
     )
     host = DestinationHarness(app, "settings")
 
@@ -4296,9 +4288,12 @@ async def test_settings_console_behavior_revert_restores_global_defaults(monkeyp
         "max_tokens": 2048,
     }
     saved = []
+    # TASK-1310: 1df0c4cb4 removed settings_screen's import of the per-key
+    # save_setting_to_cli_config helper; Console Behavior saves exclusively
+    # through settings_config_adapter's batched save_settings_to_cli_config.
     monkeypatch.setattr(
-        "tldw_chatbook.UI.Screens.settings_screen.save_setting_to_cli_config",
-        lambda section, key, value: saved.append((section, key, value)) or True,
+        "tldw_chatbook.UI.Screens.settings_config_adapter.save_settings_to_cli_config",
+        lambda section_values: saved.append(section_values) or True,
     )
     host = DestinationHarness(app, "settings")
 
@@ -4350,9 +4345,12 @@ async def test_settings_console_behavior_revert_button_works_with_input_focus(
         "max_tokens": 2048,
     }
     saved = []
+    # TASK-1310: 1df0c4cb4 removed settings_screen's import of the per-key
+    # save_setting_to_cli_config helper; Console Behavior saves exclusively
+    # through settings_config_adapter's batched save_settings_to_cli_config.
     monkeypatch.setattr(
-        "tldw_chatbook.UI.Screens.settings_screen.save_setting_to_cli_config",
-        lambda section, key, value: saved.append((section, key, value)) or True,
+        "tldw_chatbook.UI.Screens.settings_config_adapter.save_settings_to_cli_config",
+        lambda section_values: saved.append(section_values) or True,
     )
     host = DestinationHarness(app, "settings")
 
@@ -4388,9 +4386,12 @@ async def test_settings_console_behavior_revert_discards_draft(monkeypatch):
     app.app_config["console"] = {"collapse_large_pastes": True}
     saved = []
 
+    # TASK-1310: 1df0c4cb4 removed settings_screen's import of the per-key
+    # save_setting_to_cli_config helper; Console Behavior saves exclusively
+    # through settings_config_adapter's batched save_settings_to_cli_config.
     monkeypatch.setattr(
-        "tldw_chatbook.UI.Screens.settings_screen.save_setting_to_cli_config",
-        lambda section, key, value: saved.append((section, key, value)) or True,
+        "tldw_chatbook.UI.Screens.settings_config_adapter.save_settings_to_cli_config",
+        lambda section_values: saved.append(section_values) or True,
     )
     host = DestinationHarness(app, "settings")
 
@@ -4819,7 +4820,11 @@ async def test_settings_provider_category_saves_provider_defaults_without_sampli
         "streaming": True,
         "temperature": 0.7,
     }
-    assert app.chat_api_provider_value == "OpenAI"
+    # TASK-1310: task-648 (d15882398) removed the chat_api_provider_value
+    # reactive from TldwCli entirely (provider resolution now reads
+    # persisted chat_defaults directly, not an app-instance reactive), so
+    # this asserts against app_config instead of the removed attribute.
+    assert app.app_config["chat_defaults"]["provider"] == "OpenAI"
     saved = []
 
     monkeypatch.setattr(
@@ -4848,7 +4853,7 @@ async def test_settings_provider_category_saves_provider_defaults_without_sampli
         "streaming": True,
         "temperature": 0.7,
     }
-    assert app.chat_api_provider_value == "llama_cpp"
+    assert app.app_config["chat_defaults"]["provider"] == "llama_cpp"
 
 
 @pytest.mark.asyncio
@@ -6870,6 +6875,13 @@ def test_settings_privacy_secret_count_ignores_non_secret_numeric_token_limits()
 @pytest.mark.asyncio
 async def test_settings_storage_test_shortcut_runs_safety_check(monkeypatch, tmp_path):
     config_path = tmp_path / "config" / "config.toml"
+    # TASK-1310: 1df0c4cb4 made application_owned_config_directory() return
+    # None whenever TLDW_CONFIG_PATH is set (custom config parents are never
+    # auto-created -- see config.py's docstring "never a custom parent"), so
+    # the config bootstrap no longer recovers from a missing parent directory
+    # for a test-overridden path. Pre-create it, matching real deployments
+    # where the parent always exists before TLDW_CONFIG_PATH points at it.
+    config_path.parent.mkdir(parents=True, exist_ok=True)
     data_dir = tmp_path / "data"
     data_dir.mkdir()
     monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -7364,3 +7364,15 @@ async def test_settings_mount_triggers_at_most_one_post_mount_recompose():
         f"Settings composed {compose_calls} times after mount -- the sync-rows "
         "refresh storm is no longer coalesced (task-290)."
     )
+
+
+def test_settings_source_labels_cover_every_resolvable_source():
+    """TASK-1310 review follow-up: the source-label map must cover exactly the
+    source keys `resolve_effective_provider_model` can return, so the
+    Providers category never renders a raw `key.replace("_", " ")` fallback
+    (the stale `console_control`/`app_reactive` keys did exactly that for
+    `console_session` after task-648's rename)."""
+    from tldw_chatbook.UI.Screens.settings_screen import SETTINGS_SOURCE_LABELS
+
+    resolvable = {"settings_draft", "console_session", "chat_defaults", "default"}
+    assert set(SETTINGS_SOURCE_LABELS) == resolvable

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -414,9 +414,12 @@ def test_effective_provider_model_prefers_console_overrides():
 
 
 def test_effective_provider_model_preserves_configured_provider_when_reactive_is_default_openai():
-    """Task-648 removed the app-reactive fallback; assert the current
-    persisted-defaults-only fallback still preserves a non-OpenAI configured
-    provider (no OpenAI-default special case exists to override it any more)."""
+    """Preserve a non-OpenAI configured provider under the current fallback.
+
+    Task-648 removed the app-reactive fallback; the persisted-defaults-only
+    fallback must still preserve a non-OpenAI configured provider (no
+    OpenAI-default special case exists to override it any more).
+    """
     persisted_defaults = {"provider": "llama_cpp", "model": "qwen"}
 
     result = resolve_effective_provider_model(persisted_defaults)
@@ -455,10 +458,13 @@ def test_effective_provider_model_ignores_blank_provider_overrides_for_default_f
 
 
 def test_effective_provider_model_ignores_blank_reactive_provider_for_default_fallback():
-    """Task-648 dropped the app-reactive provider signal entirely; the closest
+    """Blank configured providers pass through as the chat_defaults fallback.
+
+    Task-648 dropped the app-reactive provider signal entirely; the closest
     surviving edge case is a blank/placeholder *configured* provider value,
-    which passes straight through as the chat_defaults fallback (only the
-    settings/console override paths run blank-text filtering)."""
+    which passes straight through (only the settings/console override paths
+    run blank-text filtering).
+    """
     for configured_provider in ("", " ", "None"):
         persisted_defaults = {"provider": configured_provider, "model": "qwen"}
 
@@ -4155,11 +4161,19 @@ async def test_settings_console_behavior_uses_batched_save_adapter(monkeypatch):
             return True
 
     monkeypatch.setattr(settings_screen_module, "SettingsConfigAdapter", FakeAdapter)
-    # TASK-1310: 1df0c4cb4 removed settings_screen's import of the per-key
-    # save_setting_to_cli_config helper entirely, so there is no longer an
-    # attribute here to monkeypatch as a "legacy call" tripwire -- the module
-    # cannot call it (it isn't imported); doing so would raise NameError, a
-    # stronger guarantee than the old runtime mock provided.
+    # TASK-1310 + Qodo #1081: 1df0c4cb4 removed settings_screen's import of
+    # the per-key save_setting_to_cli_config helper, but a future change
+    # could re-import it and quietly reintroduce per-key writes ALONGSIDE the
+    # batched save -- the positive assertion below would still pass. Plant a
+    # tripwire on the (absent) legacy name so any reintroduced call fails
+    # loudly instead.
+    legacy_calls = []
+    monkeypatch.setattr(
+        settings_screen_module,
+        "save_setting_to_cli_config",
+        lambda *a, **k: legacy_calls.append((a, k)),
+        raising=False,
+    )
     host = DestinationHarness(app, "settings")
 
     async with host.run_test(size=(180, 50)) as pilot:
@@ -4190,6 +4204,10 @@ async def test_settings_console_behavior_uses_batched_save_adapter(monkeypatch):
     ]
     assert app.app_config["console"]["paste_collapse_threshold"] == 120
     assert app.app_config["chat_defaults"]["streaming"] is False
+    assert legacy_calls == [], (
+        "Console Behavior must save atomically through the batched adapter; "
+        "a legacy per-key save_setting_to_cli_config call was reintroduced"
+    )
 
 
 @pytest.mark.asyncio
@@ -7367,11 +7385,14 @@ async def test_settings_mount_triggers_at_most_one_post_mount_recompose():
 
 
 def test_settings_source_labels_cover_every_resolvable_source():
-    """TASK-1310 review follow-up: the source-label map must cover exactly the
-    source keys `resolve_effective_provider_model` can return, so the
-    Providers category never renders a raw `key.replace("_", " ")` fallback
-    (the stale `console_control`/`app_reactive` keys did exactly that for
-    `console_session` after task-648's rename)."""
+    """Pin the source-label map to exactly the resolvable source keys.
+
+    TASK-1310 review follow-up: the map must cover exactly the source keys
+    `resolve_effective_provider_model` can return, so the Providers category
+    never renders a raw `key.replace("_", " ")` fallback (the stale
+    `console_control`/`app_reactive` keys did exactly that for
+    `console_session` after task-648's rename).
+    """
     from tldw_chatbook.UI.Screens.settings_screen import SETTINGS_SOURCE_LABELS
 
     resolvable = {"settings_draft", "console_session", "chat_defaults", "default"}

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -380,6 +380,38 @@ to carry — and each read as live to a grep.
 
 ---
 
+## A suite that no gate runs can rot invisibly for days
+
+**TASK-1310, 2026-07-28.** `Tests/UI/test_settings_configuration_hub.py` carried 22
+failures at dev tip — byte-identical at base and branch, so none were caused by the
+branch that finally surfaced them (TASK-1234's review, the first time this hub ran in
+that review cycle). The suite was last known green before #1050; nothing narrower
+caught the drift for days across two deliberate, well-reasoned refactors
+(`d15882398` "own provider selection by lifetime" and `1df0c4cb4` "reconcile privacy
+lifecycle eval and packaging hardening") that each correctly updated every production
+call site and left this one 253-test file behind.
+
+Both refactors were textbook-good: each shipped its own new, correct test coverage
+(`Tests/Provider/test_provider_model_resolution.py`; the batched-save-adapter test in
+this same file) and left zero live bugs — `grep` across all of `tldw_chatbook/` for the
+removed symbols (`chat_api_provider_value`, `save_setting_to_cli_config` imported into
+`settings_screen`) came back empty on both counts. The damage was entirely to *this*
+suite's ability to say so: 22 tests calling a removed signature/attribute is worse than
+0 tests, because a red suite nobody gates reports exactly as much confidence as a suite
+that does not exist, while still costing the CI minutes of everyone who happens to run
+it directly.
+
+**What to do.** A suite this large (253 tests, a whole product surface) needs a home in
+routine verification, not opportunistic discovery via someone else's PR review. The
+Settings/Console-area verification gate must include
+`Tests/UI/test_settings_configuration_hub.py` going forward — not because it is
+special, but because "carries the hub's tests" is exactly the kind of suite that rots
+silently when nothing runs it: too large to eyeball, too domain-specific for a generic
+CI matrix to catch by accident, and it will not fail loudly for anyone except the next
+person who happens to touch that screen.
+
+---
+
 ## Related
 
 - `lessons-live-verification.md` — why the suite could not see seven of these defects

--- a/backlog/tasks/task-1310 - Settings-hub-suite-carries-22-dev-tip-failures-and-was-ungated.md
+++ b/backlog/tasks/task-1310 - Settings-hub-suite-carries-22-dev-tip-failures-and-was-ungated.md
@@ -1,10 +1,15 @@
 ---
 id: TASK-1310
-title: 'Settings-hub suite carries 22 dev-tip failures and was ungated'
-status: To Do
-assignee: []
+title: Settings-hub suite carries 22 dev-tip failures and was ungated
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-28 13:30'
-labels: [settings, tests, regressions]
+updated_date: '2026-07-29 01:10'
+labels:
+  - settings
+  - tests
+  - regressions
 dependencies: []
 ---
 
@@ -16,7 +21,77 @@ During TASK-1234's review, the first settings-hub gate on the fleet-findings bra
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 All 22 named failures (see TASK-1234 review) pass or are individually dispositioned with root-cause notes.
-- [ ] #2 The originating dev commits are identified (naming drift especially).
-- [ ] #3 The hub suite is listed in the standard Console-area verification gates going forward.
+- [x] #1 All 22 named failures (see TASK-1234 review) pass or are individually dispositioned with root-cause notes.
+- [x] #2 The originating dev commits are identified (naming drift especially).
+- [x] #3 The hub suite is listed in the standard Console-area verification gates going forward.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the 22 failures locally (hub-baseline.log) and bucket by traceback shape: TypeError persisted_defaults (8), module AttributeError save_setting_to_cli_config (12), TldwCli.chat_api_provider_value AttributeError (1), PrivatePathError missing_parent (1).
+2. git blame/git log -S each removed symbol to find the originating commit and read its diff to determine whether the change was deliberate (own tests, docstring intent, all other call sites updated) or accidental drift (dangling stale caller left in production).
+3. For each family, fix the RIGHT side: update stale test expectations to the new deliberate contract, or fix production if a caller was missed.
+4. Grep tldw_chatbook/ for any other stray references to removed symbols to rule out a live production bug (broken real save path).
+5. Run the full hub suite (target 253/0) plus the parallel-runs/per-session regression backstop suites in blocking foreground calls.
+6. Document per-failure dispositions and originating commits in Implementation Notes; append a lessons-testing-evidence.md entry for AC#3.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed all 22 dev-tip failures by tracing each to its originating commit and confirming the intent
+was deliberate on the production side; no production drift remained live for real users (verified
+below). All fixes landed in the test file. `Tests/UI/test_settings_configuration_hub.py` now passes
+253/253; the regression backstop (`Tests/UI/test_console_parallel_runs.py` +
+`Tests/Chat/test_console_run_state_per_session.py`, 46 tests) is green.
+
+**Two originating commits account for all 22 failures:**
+
+- `d15882398` "refactor(console): own provider selection by lifetime (task-648)" — changed
+  `resolve_effective_provider_model(app_instance, ...)` to `resolve_effective_provider_model(persisted_defaults: Mapping, ...)`,
+  dropped the app-reactive fallback branch (and its `console_control` source label, now
+  `console_session`), and deleted the `chat_api_provider_value`/`chat_api_model_value`/`chat_model_value`
+  reactive attributes from `TldwCli` entirely. Deliberate: shipped its own comprehensive test file
+  (`Tests/Provider/test_provider_model_resolution.py`, including a guard test —
+  `test_explicit_api_has_no_application_parameter` — that asserts no `app_instance` parameter exists),
+  and every production caller (`chat_screen.py`, `settings_screen.py`) was updated to the new
+  signature. `grep -rn "chat_api_provider_value|chat_api_model_value|chat_model_value" tldw_chatbook/`
+  returns nothing — no live production bug.
+- `1df0c4cb4` "fix: reconcile privacy lifecycle eval and packaging hardening" — removed
+  `settings_screen.py`'s import/use of the singular `save_setting_to_cli_config` helper (Console
+  Behavior category now saves exclusively through the atomic, batched
+  `SettingsConfigAdapter.save_sections()` -> `save_settings_to_cli_config()`), and made
+  `application_owned_config_directory()` return `None` whenever `TLDW_CONFIG_PATH` is set (custom
+  config parents are fail-closed and never auto-created — "never a custom parent"). Deliberate
+  security/atomicity hardening: `grep -n "save_setting_to_cli_config(\|save_settings_to_cli_config(" tldw_chatbook/UI/Screens/settings_screen.py`
+  shows only the plural, batched call at both real call sites — no live production bug.
+
+**Per-failure disposition (test-file fix in every case; production was correct):**
+
+1. `test_effective_provider_model_prefers_console_overrides` — stale app-instance call shape; updated to pass `persisted_defaults` mapping directly, `provider_source` expectation updated `console_control` → `console_session`. [d15882398]
+2. `test_effective_provider_model_preserves_configured_provider_when_reactive_is_default_openai` — premise (app-reactive OpenAI-default special case) was deliberately removed; rewrote to assert the surviving plain fallback (persisted_defaults wins with no overrides). [d15882398]
+3. `test_effective_provider_model_prefers_settings_draft_values` — stale call shape only; passes `persisted_defaults` mapping directly, assertions unchanged. [d15882398]
+4. `test_effective_provider_model_ignores_blank_provider_overrides_for_default_fallback` — stale call shape only; passes `persisted_defaults` mapping directly. [d15882398]
+5. `test_effective_provider_model_ignores_blank_reactive_provider_for_default_fallback` — app-reactive input no longer exists; repurposed to cover a genuinely new edge case (blank/whitespace *configured* provider values pass through unsanitized as the final fallback, unlike the override paths which do filter blank text). [d15882398]
+6. `test_effective_provider_model_ignores_textual_blank_select_provider_for_default_fallback` — stale call shape only; `Select.BLANK` handling unaffected. [d15882398]
+7. `test_effective_provider_model_ignores_blank_model_overrides_for_default_fallback` — stale call shape only. [d15882398]
+8. `test_effective_provider_model_handles_non_mapping_app_config` — old behavior (tolerate non-mapping, return None) was deliberately replaced by fail-fast `TypeError`; rewrote to assert `pytest.raises(TypeError, match="mapping")`, matching `Tests/Provider/test_provider_model_resolution.py::test_effective_resolver_rejects_non_mapping_defaults`. [d15882398]
+9. `test_settings_console_behavior_rejects_invalid_global_defaults` (6 parametrized cases: max-tokens, min-p, streaming, temperature, thinking-budget-tokens, top-p) — monkeypatch retargeted from the removed `settings_screen.save_setting_to_cli_config` to `settings_config_adapter.save_settings_to_cli_config` (the actual batched call Console Behavior now uses), lambda signature updated to the plural function's single-mapping-arg shape. [1df0c4cb4]
+10. `test_settings_console_behavior_revert_button_works_with_input_focus` — same retarget as #9. [1df0c4cb4]
+11. `test_settings_console_behavior_revert_discards_draft` — same retarget as #9. [1df0c4cb4]
+12. `test_settings_console_behavior_revert_restores_global_defaults` — same retarget as #9. [1df0c4cb4]
+13. `test_settings_console_behavior_uses_batched_save_adapter` — the `legacy_calls` monkeypatch target (`settings_screen_module.save_setting_to_cli_config`) no longer exists as an attribute to patch; removed the dead monkeypatch and the `legacy_calls` tracking/assertion (a NameError would now fire on any attempt to reintroduce a per-key call from that module — a stronger guarantee than the old runtime mock). `batched_calls` assertions (the test's actual purpose) are untouched. [1df0c4cb4]
+14. `test_settings_overview_paste_summary_updates_after_toggle` — monkeypatch retargeted from `settings_screen.save_setting_to_cli_config` to `settings_config_adapter.save_settings_to_cli_config`. [1df0c4cb4]
+15. `test_settings_paste_toggle_keeps_keyboard_focus_after_refresh` — same retarget as #14. [1df0c4cb4]
+16. `test_settings_provider_category_saves_provider_defaults_without_sampling` — asserted on the removed `app.chat_api_provider_value` reactive before and after save; both assertions rewritten to read `app.app_config["chat_defaults"]["provider"]` (the persisted source of truth this reactive used to mirror). [d15882398]
+17. `test_settings_storage_test_shortcut_runs_safety_check` — test-only bug, unrelated to any rename: it set `TLDW_CONFIG_PATH` to `tmp_path/"config"/"config.toml"` but only ever created `tmp_path/"data"`, never `tmp_path/"config"`. Every sibling test in this file uses `tmp_path/"config.toml"` directly (parent = `tmp_path`, always present). Before 1df0c4cb4 a missing parent for the *default* config path was silently recovered by `_load_cli_config_bootstrap_unlocked`'s `missing_parent` handler; that recovery is deliberately gated to `application_owned_config_directory(config_path) is not None`, which returns `None` whenever `TLDW_CONFIG_PATH` is set — custom config parents are never auto-created (fail-closed security hardening). Fixed by adding `config_path.parent.mkdir(parents=True, exist_ok=True)` before setting the env var, matching real deployments where the parent directory always exists first. [1df0c4cb4, test bug predates it by commit 0d314d29f]
+
+**Files modified:**
+- `Tests/UI/test_settings_configuration_hub.py` — all 22 fixes (test-only; no production changes were needed).
+- `backlog/docs/lessons-testing-evidence.md` — new entry: "A suite that no gate runs can rot invisibly for days", citing this task's evidence for AC#3 (route the hub suite through Console-area verification gates going forward).
+
+**Verification:**
+- `Tests/UI/test_settings_configuration_hub.py`: 253 passed, 0 failed (was 231 passed / 22 failed).
+- Regression backstop `Tests/UI/test_console_parallel_runs.py` + `Tests/Chat/test_console_run_state_per_session.py`: 46 passed, 0 failed.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -403,9 +403,13 @@ API_URL_PROVIDER_KEYS = {
     "vllm",
 }
 SETTINGS_SOURCE_LABELS = {
+    # Keys mirror the source values resolve_effective_provider_model can
+    # return (Provider/provider_model_resolution.py) -- task-648 renamed
+    # console_control to console_session and deleted app_reactive; TASK-1310's
+    # review caught the stale keys here rendering a raw "console session"
+    # fallback label in Settings > Providers.
     "settings_draft": "Unsaved Settings draft",
-    "console_control": "Console runtime override",
-    "app_reactive": "Current app selection",
+    "console_session": "Console runtime override",
     "chat_defaults": "Saved chat defaults",
     "default": "Default fallback",
 }


### PR DESCRIPTION
## Summary
Clears all 22 settings-hub failures that had accumulated invisibly at the dev tip (surfaced by the fleet-findings branch's first-ever hub gate, task-1310):

- **8× `resolve_effective_provider_model` TypeErrors** — task-648 (`d15882398`) deliberately changed the resolver's contract (`app_instance` → `persisted_defaults` mapping); tests updated to the new contract with the full precedence/fallback matrix preserved (reviewer-audited byte-for-byte against the resolver).
- **12× save-seam monkeypatch drift** — Console Behavior saves batch through `SettingsConfigAdapter.save_sections` (migrated in `b4cb5e536`; `1df0c4cb4` removed the then-dead import the tests still patched). Monkeypatches retargeted to the boundary production actually traverses — the review found the OLD patches had already been silent no-op decoys, so this strictly strengthens coverage.
- **1× deleted `chat_api_provider_value` reactive** (task-648) — assertions rewritten against the persisted config outcome.
- **1× PrivatePathError** — a pre-existing test bug (fixture never created its config dir), surfaced by `1df0c4cb4`'s deliberate fail-closed hardening; fixed in the fixture.

**Zero test weakening** (independent audit) and **one real production bug found and fixed as a rider**: `SETTINGS_SOURCE_LABELS` still carried task-648's orphaned `console_control`/`app_reactive` keys while missing `console_session`, so the Providers category rendered a raw "console session" fallback label — aligned and pinned by an exact-coverage test.

Also adds a lessons entry: a suite no gate runs can rot invisibly for days — the hub now rides Console-area verification gates.

## Testing
Hub suite 254 passed / 0 failed (was 231/22); regression backstop (parallel-runs + run-state) 46/46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the Settings hub suite to green by updating tests to the current provider resolver and batched save paths, fixes Providers source labels, and adds a tripwire to block legacy per-key saves. Completes TASK-1310 with guards to prevent regressions.

- **Bug Fixes**
  - Resolver tests now call `resolve_effective_provider_model(persisted_defaults: Mapping)`, drop app‑reactive cases, expect `console_session`, and assert `TypeError` for non‑mapping inputs.
  - Console Behavior tests retargeted to `SettingsConfigAdapter.save_sections`/`save_settings_to_cli_config`; added a tripwire on `save_setting_to_cli_config` to fail loudly if per‑key writes return (Qodo #1081).
  - Storage safety test creates the config parent when `TLDW_CONFIG_PATH` is set.
  - Providers UI: corrected `SETTINGS_SOURCE_LABELS` to include `console_session` and removed stale keys; added an exact‑coverage test to match resolver sources.
  - Results: hub suite 253/253; regression backstop 46/46. Docs updated to include the hub suite in Console‑area verification gates.

<sup>Written for commit 9ef52773a8c4134e1c497ceaa924fe0bd0871605. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

