### PR TITLE
perf: move screen mount I/O off the App message pump (TASK-1320)

### DIFF
--- a/Tests/UI/test_destination_shells.py
+++ b/Tests/UI/test_destination_shells.py
@@ -2799,13 +2799,21 @@ async def test_mcp_destination_mode_chip_syncs_to_restored_mode():
         screen = _active_destination_screen(host)
         workbench = screen.query_one(MCPWorkbench)
 
+        tools_chip = screen.query_one("#mcp-mode-tools", Button)
+        servers_chip = screen.query_one("#mcp-mode-servers", Button)
+
+        # Wait on the chip, not just on `active_mode`. The mode is applied by
+        # the workbench and the chip is synced by the screen's `ModeChanged`
+        # handler, so the highlight necessarily lands one pump cycle after the
+        # mode itself. Polling the mode and asserting the chip made the test
+        # depend on the load happening to finish before the test body resumed
+        # (TASK-1320 moved that load into a worker). The end state asserted is
+        # unchanged -- this still fails if the chip never syncs.
         deadline = time.monotonic() + 2.0
-        while time.monotonic() < deadline and workbench.active_mode != "tools":
+        while time.monotonic() < deadline and not tools_chip.has_class("is-active"):
             await pilot.pause(0.01)
 
         assert workbench.active_mode == "tools"
-        tools_chip = screen.query_one("#mcp-mode-tools", Button)
-        servers_chip = screen.query_one("#mcp-mode-servers", Button)
         assert tools_chip.has_class("is-active")
         assert not servers_chip.has_class("is-active")
 

--- a/Tests/UI/test_mount_io_off_pump.py
+++ b/Tests/UI/test_mount_io_off_pump.py
@@ -171,3 +171,86 @@ async def test_workbench_data_still_arrives_after_the_deferred_load():
                 break
 
         assert not workbench.is_loading, "the deferred load never completed"
+
+
+# ---------------------------------------------------------------------------
+# Chatbooks: the mount body is SYNCHRONOUS disk work (glob/stat/zipfile) inside
+# an `async def`, so it blocks the event loop itself, not merely the pump.
+# Deferring it to a coroutine worker would not be enough -- it has to leave the
+# loop entirely.
+# ---------------------------------------------------------------------------
+
+
+async def _max_event_loop_stall(during, *, tick: float = 0.02) -> float:
+    """Run `during()` and return the longest the event loop went unserviced.
+
+    A ping counter cannot measure synchronous blocking: while the loop is
+    blocked the *test* cannot post pings either, so everything serializes and
+    the count comes out clean. A heartbeat measures it directly -- each tick
+    records how late it actually woke up, and blocking work shows up as one
+    long gap.
+    """
+    stalls: list[float] = []
+    stop = False
+
+    async def heartbeat() -> None:
+        last = time.perf_counter()
+        while not stop:
+            await asyncio.sleep(tick)
+            now = time.perf_counter()
+            stalls.append(now - last)
+            last = now
+
+    beat = asyncio.create_task(heartbeat())
+    try:
+        await during()
+    finally:
+        stop = True
+        await asyncio.sleep(tick * 2)
+        beat.cancel()
+    return max(stalls) if stalls else 0.0
+
+
+@pytest.mark.asyncio
+async def test_chatbooks_scan_does_not_block_the_event_loop(monkeypatch):
+    """The chatbook directory scan must run off the event loop."""
+    import tldw_chatbook.UI.Chatbooks_Window_Improved as chatbooks_module
+    from tldw_chatbook.UI.Chatbooks_Window_Improved import ChatbooksWindowImproved
+
+    def blocking_secure(path):
+        # Stands in for the real glob/stat/zipfile work: blocking, not awaitable.
+        # If this runs on the event loop, nothing else in the app can run.
+        time.sleep(SERVICE_DELAY)
+        return path
+
+    monkeypatch.setattr(chatbooks_module, "secure_chatbook_directory", blocking_secure)
+
+    class ChatbooksHostApp(App):
+        def __init__(self) -> None:
+            super().__init__()
+            self.pings_handled = 0
+
+        def compose(self) -> ComposeResult:
+            yield from ()
+
+        async def on_navigate(self, _message: Navigate) -> None:
+            await self.mount(ChatbooksWindowImproved(self))
+
+        async def on_ping(self, _message: Ping) -> None:
+            self.pings_handled += 1
+
+    app = ChatbooksHostApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        async def mount_it() -> None:
+            app.post_message(Navigate())
+            await asyncio.sleep(SERVICE_DELAY + 0.5)
+
+        stall = await _max_event_loop_stall(mount_it)
+
+        assert stall < SERVICE_DELAY / 2, (
+            f"event loop stalled {stall:.2f}s during the chatbook scan "
+            f"(blocking work takes {SERVICE_DELAY}s): the scan is running on "
+            "the loop, so the whole app is frozen for its duration"
+        )

--- a/Tests/UI/test_mount_io_off_pump.py
+++ b/Tests/UI/test_mount_io_off_pump.py
@@ -254,3 +254,46 @@ async def test_chatbooks_scan_does_not_block_the_event_loop(monkeypatch):
             f"(blocking work takes {SERVICE_DELAY}s): the scan is running on "
             "the loop, so the whole app is frozen for its duration"
         )
+
+
+# ---------------------------------------------------------------------------
+# Personas: `on_mount` awaited `refresh_character_list()`, whose own body calls
+# the synchronous `fetch_all_characters()` -- a full read of every character in
+# the library, on the event loop, while the app awaits the mount.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_personas_mount_does_not_block_on_the_character_library(monkeypatch):
+    """Opening Personas must not freeze the app while characters load."""
+    import sys
+
+    sys.path.insert(0, "Tests/UI")
+    from test_destination_shells import DestinationHarness, _build_test_app
+
+    import tldw_chatbook.UI.CCP_Modules.ccp_character_handler as handler_module
+
+    def blocking_fetch_all_characters():
+        # Stands in for a large character library or a server-backed scope.
+        time.sleep(SERVICE_DELAY)
+        return []
+
+    monkeypatch.setattr(
+        handler_module, "fetch_all_characters", blocking_fetch_all_characters
+    )
+
+    app = _build_test_app()
+    host = DestinationHarness(app, "personas")
+
+    async def mount_personas() -> None:
+        async with host.run_test(size=(180, 50)) as pilot:
+            await pilot.pause()
+            await asyncio.sleep(0.2)
+
+    stall = await _max_event_loop_stall(mount_personas)
+
+    assert stall < SERVICE_DELAY / 2, (
+        f"event loop stalled {stall:.2f}s while Personas mounted (character "
+        f"read takes {SERVICE_DELAY}s): the library read is on the loop, so the "
+        "app is frozen for its duration"
+    )

--- a/Tests/UI/test_mount_io_off_pump.py
+++ b/Tests/UI/test_mount_io_off_pump.py
@@ -297,3 +297,69 @@ async def test_personas_mount_does_not_block_on_the_character_library(monkeypatc
         f"read takes {SERVICE_DELAY}s): the library read is on the loop, so the "
         "app is frozen for its duration"
     )
+
+
+# ---------------------------------------------------------------------------
+# Study: `on_mount` awaited the scope refresh, which ends in a scoped study-data
+# reload. (Its `load_saved_sessions`/`initialize` awaits are dead: `StudyWindow`
+# defines neither, so those `hasattr` guards never fire.)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_study_mount_does_not_block_on_scoped_data(monkeypatch):
+    """Opening Study must not hold the App pump while its scoped data loads.
+
+    Study's mount work is genuinely awaited (async DB helpers), not synchronous
+    like the chatbook scan, so the failure mode is a held message pump rather
+    than a stalled event loop -- and the right instrument is whether the app
+    still handles messages, not whether the loop ticks on time.
+    """
+    import sys
+
+    sys.path.insert(0, "Tests/UI")
+    from test_destination_shells import _build_test_app
+
+    from tldw_chatbook.UI.Screens.study_screen import StudyScreen
+
+    reached = []
+
+    async def slow_scope_refresh(self, scope_context, **kwargs):
+        # Patched at the seam `on_mount` awaits directly: on a fresh mount
+        # `_apply_scope_context` early-returns before the scoped read (the scope
+        # key is unchanged), so patching the read itself exercises nothing.
+        reached.append("scope_refresh")
+        await asyncio.sleep(SERVICE_DELAY)
+
+    monkeypatch.setattr(
+        StudyScreen, "_apply_scope_context_and_refresh", slow_scope_refresh
+    )
+
+    app_instance = _build_test_app()
+
+    class StudyHost(App):
+        def __init__(self) -> None:
+            super().__init__()
+            self.pings_handled = 0
+
+        async def on_navigate(self, _message: Navigate) -> None:
+            await self.push_screen(StudyScreen(app_instance))
+
+        async def on_ping(self, _message: Ping) -> None:
+            self.pings_handled += 1
+
+    host = StudyHost()
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause()
+
+        host.post_message(Navigate())
+        await asyncio.sleep(0.05)
+        for _ in range(5):
+            host.post_message(Ping())
+        await asyncio.sleep(0.3)
+
+        assert reached, "the scope refresh was never awaited; the test proves nothing"
+        assert host.pings_handled == 5, (
+            f"app handled {host.pings_handled}/5 messages while Study mounted: "
+            "the scoped load is holding the App message pump, which is a frozen app"
+        )

--- a/Tests/UI/test_mount_io_off_pump.py
+++ b/Tests/UI/test_mount_io_off_pump.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import time
 from dataclasses import replace
+from typing import Any
 
 import pytest
 from textual.app import App, ComposeResult
@@ -45,29 +46,38 @@ class SlowHubService:
             selected_source="local", selected_section="overview"
         )
 
-    async def load_context(self):
+    async def load_context(self) -> UnifiedMCPContext:
+        """Return the stored context, slowly."""
         await asyncio.sleep(SERVICE_DELAY)
         return self.context
 
-    async def select_source(self, source):
+    async def select_source(self, source: str) -> UnifiedMCPContext:
+        """Record the selected source and return the updated context."""
         self.context = replace(self.context, selected_source=source)
         return self.context
 
-    async def select_scope(self, scope, scope_ref=None):
+    async def select_scope(
+        self, scope: str | None, scope_ref: str | None = None
+    ) -> UnifiedMCPContext:
+        """Return the context unchanged; scope is irrelevant to these tests."""
         return self.context
 
-    async def select_section(self, section):
+    async def select_section(self, section: str) -> UnifiedMCPContext:
+        """Return the context unchanged; section is irrelevant to these tests."""
         return self.context
 
-    async def load_section(self, section=None):
+    async def load_section(self, section: str | None = None) -> list[Any]:
+        """Return no rows, slowly."""
         await asyncio.sleep(SERVICE_DELAY)
         return []
 
-    async def local_external_catalog(self):
+    async def local_external_catalog(self) -> list[Any]:
+        """Return an empty local catalog, slowly."""
         await asyncio.sleep(SERVICE_DELAY)
         return []
 
-    def available_actions(self):
+    def available_actions(self) -> list[Any]:
+        """Offer no hub actions."""
         return []
 
 
@@ -266,9 +276,10 @@ async def test_chatbooks_scan_does_not_block_the_event_loop(monkeypatch):
 @pytest.mark.asyncio
 async def test_personas_mount_does_not_block_on_the_character_library(monkeypatch):
     """Opening Personas must not freeze the app while characters load."""
-    import sys
-
-    sys.path.insert(0, "Tests/UI")
+    # `syspath_prepend`, not a bare `sys.path.insert`: monkeypatch restores it
+    # after the test, so sibling test modules are not left shadowable for the
+    # rest of the session.
+    monkeypatch.syspath_prepend("Tests/UI")
     from test_destination_shells import DestinationHarness, _build_test_app
 
     import tldw_chatbook.UI.CCP_Modules.ccp_character_handler as handler_module
@@ -315,9 +326,7 @@ async def test_study_mount_does_not_block_on_scoped_data(monkeypatch):
     than a stalled event loop -- and the right instrument is whether the app
     still handles messages, not whether the loop ticks on time.
     """
-    import sys
-
-    sys.path.insert(0, "Tests/UI")
+    monkeypatch.syspath_prepend("Tests/UI")
     from test_destination_shells import _build_test_app
 
     from tldw_chatbook.UI.Screens.study_screen import StudyScreen
@@ -374,13 +383,18 @@ async def test_study_mount_does_not_block_on_scoped_data(monkeypatch):
 
 
 class FailingHubService(SlowHubService):
-    async def load_context(self):
+    """A hub service whose every read raises, like a service that is down."""
+
+    async def load_context(self) -> UnifiedMCPContext:
+        """Raise instead of answering."""
         raise RuntimeError("backing service is down")
 
-    async def load_section(self, section=None):
+    async def load_section(self, section: str | None = None) -> list[Any]:
+        """Raise instead of answering."""
         raise RuntimeError("backing service is down")
 
-    async def local_external_catalog(self):
+    async def local_external_catalog(self) -> list[Any]:
+        """Raise instead of answering."""
         raise RuntimeError("backing service is down")
 
 
@@ -450,3 +464,36 @@ async def test_an_unhandled_deferred_load_error_does_not_kill_the_app(monkeypatc
         assert app.is_running, (
             "an unhandled error in the deferred mount load exited the app"
         )
+
+
+@pytest.mark.asyncio
+async def test_a_direct_reload_also_shows_the_loading_state():
+    """`reload()` must own the loading state, not just the mount path.
+
+    `is_loading` is the UI-facing "a reload is in flight" flag, and `reload()`
+    always clears it in its `finally` -- but it was only ever SET by `on_mount`.
+    `MCPScreen.action_mcp_refresh()` calls `workbench.reload()` directly, so a
+    manual refresh ran with no spinner at all and then cleared a flag it never
+    raised.
+    """
+    app = SlowWorkbenchApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        workbench = app.query_one(MCPWorkbench)
+
+        # Let the mount-time load settle so we observe `reload()` on its own.
+        deadline = time.perf_counter() + SERVICE_DELAY * 6
+        while time.perf_counter() < deadline and workbench.is_loading:
+            await pilot.pause()
+            await asyncio.sleep(0.05)
+        assert not workbench.is_loading, "mount-time load never settled"
+
+        reload_task = asyncio.create_task(workbench.reload())
+        await asyncio.sleep(0.1)
+        try:
+            assert workbench.is_loading, (
+                "a direct reload() ran without raising the loading state, so a "
+                "manual refresh shows no spinner while it fetches"
+            )
+        finally:
+            await reload_task

--- a/Tests/UI/test_mount_io_off_pump.py
+++ b/Tests/UI/test_mount_io_off_pump.py
@@ -1,0 +1,173 @@
+"""Screen mount work must not run on the App's message pump (TASK-1320).
+
+Textual awaits a screen's mount inside `switch_screen`, and a widget's
+`on_mount` is awaited as part of that mount. `handle_screen_navigation` is an
+`@on` handler on the App, so anything awaited during mount is awaited ON the
+App's message pump: while it runs the app handles no clicks, no bindings and no
+further navigation.
+
+Measured on the pre-fix code: during a 3s mount the App handled 0 of 5 posted
+messages. With a backing service that is merely unreachable rather than slow,
+that window was minutes.
+
+These tests pin the contract: mounting returns promptly and the pump keeps
+draining, with the data arriving afterwards.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import replace
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.message import Message
+
+from tldw_chatbook.MCP.unified_control_models import UnifiedMCPContext
+from tldw_chatbook.UI.MCP_Modules.mcp_workbench import MCPWorkbench
+
+# How long the fake backing service takes to answer. Long enough that a mount
+# which waits for it is unmistakable, short enough to keep the suite quick.
+SERVICE_DELAY = 1.0
+
+
+class Ping(Message):
+    """Stands in for any app-level input while a destination is mounting."""
+
+
+class SlowHubService:
+    """A hub service whose every read is slow, like an unreachable server."""
+
+    def __init__(self) -> None:
+        self.target_store = None
+        self.context = UnifiedMCPContext(
+            selected_source="local", selected_section="overview"
+        )
+
+    async def load_context(self):
+        await asyncio.sleep(SERVICE_DELAY)
+        return self.context
+
+    async def select_source(self, source):
+        self.context = replace(self.context, selected_source=source)
+        return self.context
+
+    async def select_scope(self, scope, scope_ref=None):
+        return self.context
+
+    async def select_section(self, section):
+        return self.context
+
+    async def load_section(self, section=None):
+        await asyncio.sleep(SERVICE_DELAY)
+        return []
+
+    async def local_external_catalog(self):
+        await asyncio.sleep(SERVICE_DELAY)
+        return []
+
+    def available_actions(self):
+        return []
+
+
+class SlowWorkbenchApp(App):
+    def __init__(self) -> None:
+        super().__init__()
+        self.unified_mcp_service = SlowHubService()
+        self.pings_handled = 0
+
+    def compose(self) -> ComposeResult:
+        yield MCPWorkbench(app_instance=self, id="mcp-workbench")
+
+    async def _on_ping(self, _message: Ping) -> None:  # pragma: no cover - see on_ping
+        self.pings_handled += 1
+
+    async def on_ping(self, _message: Ping) -> None:
+        self.pings_handled += 1
+
+
+@pytest.mark.asyncio
+async def test_workbench_mount_does_not_wait_for_its_backing_service():
+    """Mounting must return promptly instead of awaiting the service."""
+    app = SlowWorkbenchApp()
+    started = time.perf_counter()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        mounted_after = time.perf_counter() - started
+
+        assert mounted_after < SERVICE_DELAY, (
+            f"mount took {mounted_after:.2f}s with a {SERVICE_DELAY}s service: "
+            "the mount is waiting for I/O, so the App pump is blocked for that "
+            "whole window and the app is frozen"
+        )
+
+
+class Navigate(Message):
+    """Stands in for NavigateToScreen."""
+
+
+class NavigatingApp(App):
+    """Mirrors the real freeze path: an App-level handler that AWAITS the mount.
+
+    This is the shape that matters. `handle_screen_navigation` is an `@on`
+    handler on the App and it awaits `switch_screen`, which awaits the incoming
+    screen's mount. Mounting from a plain task instead would not reproduce the
+    bug at all, because then nothing on the App's pump is waiting.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.unified_mcp_service = SlowHubService()
+        self.pings_handled = 0
+        self.mount_finished = False
+
+    def compose(self) -> ComposeResult:
+        yield from ()
+
+    async def on_navigate(self, _message: Navigate) -> None:
+        await self.mount(MCPWorkbench(app_instance=self, id="mcp-workbench"))
+        self.mount_finished = True
+
+    async def on_ping(self, _message: Ping) -> None:
+        self.pings_handled += 1
+
+
+@pytest.mark.asyncio
+async def test_app_pump_keeps_draining_while_a_destination_loads():
+    """The app must keep handling messages while mount work is in flight."""
+    app = NavigatingApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        app.post_message(Navigate())
+        await asyncio.sleep(0.05)
+
+        # Everything below lands while the destination is still loading.
+        for _ in range(5):
+            app.post_message(Ping())
+        await asyncio.sleep(0.3)
+
+        assert app.pings_handled == 5, (
+            f"app handled {app.pings_handled}/5 messages while the destination "
+            "was loading: the message pump is blocked, which is a frozen app"
+        )
+
+
+@pytest.mark.asyncio
+async def test_workbench_data_still_arrives_after_the_deferred_load():
+    """Deferring the load must not lose it -- the data still lands."""
+    app = SlowWorkbenchApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        workbench = app.query_one(MCPWorkbench)
+
+        # Let the deferred load finish on its own.
+        deadline = time.perf_counter() + SERVICE_DELAY * 6
+        while time.perf_counter() < deadline:
+            await pilot.pause()
+            await asyncio.sleep(0.1)
+            if not workbench.is_loading:
+                break
+
+        assert not workbench.is_loading, "the deferred load never completed"

--- a/Tests/UI/test_mount_io_off_pump.py
+++ b/Tests/UI/test_mount_io_off_pump.py
@@ -363,3 +363,90 @@ async def test_study_mount_does_not_block_on_scoped_data(monkeypatch):
             f"app handled {host.pings_handled}/5 messages while Study mounted: "
             "the scoped load is holding the App message pump, which is a frozen app"
         )
+
+
+# ---------------------------------------------------------------------------
+# Deferring mount work into a worker introduces a new failure path: Textual's
+# `run_worker` defaults to `exit_on_error=True`, so an exception that used to
+# surface inside `on_mount` now kills the app instead. A destination whose
+# backing service is down must degrade, not take the process with it.
+# ---------------------------------------------------------------------------
+
+
+class FailingHubService(SlowHubService):
+    async def load_context(self):
+        raise RuntimeError("backing service is down")
+
+    async def load_section(self, section=None):
+        raise RuntimeError("backing service is down")
+
+    async def local_external_catalog(self):
+        raise RuntimeError("backing service is down")
+
+
+class FailingWorkbenchApp(App):
+    def __init__(self) -> None:
+        super().__init__()
+        self.unified_mcp_service = FailingHubService()
+
+    def compose(self) -> ComposeResult:
+        yield MCPWorkbench(app_instance=self, id="mcp-workbench")
+
+
+@pytest.mark.asyncio
+async def test_a_failing_mount_load_does_not_kill_the_app():
+    """A destination whose service fails must stay open, not exit the app."""
+    app = FailingWorkbenchApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await asyncio.sleep(0.3)
+        await pilot.pause()
+
+        assert app.is_running, (
+            "the app exited when a deferred mount load raised: run_worker "
+            "defaults to exit_on_error=True, so moving mount I/O into a worker "
+            "turned a recoverable load failure into a dead app"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_failing_mount_load_clears_the_loading_state():
+    """A failed load must not leave the destination spinning forever."""
+    app = FailingWorkbenchApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await asyncio.sleep(0.3)
+        await pilot.pause()
+
+        workbench = app.query_one(MCPWorkbench)
+        assert not workbench.is_loading, (
+            "the spinner is still showing after the load failed: the user is "
+            "told the destination is loading when nothing is coming"
+        )
+
+
+@pytest.mark.asyncio
+async def test_an_unhandled_deferred_load_error_does_not_kill_the_app(monkeypatch):
+    """The deferred load must be fail-safe, not merely usually-safe.
+
+    Moving mount work into a worker is not free: Textual's `run_worker` defaults
+    to `exit_on_error=True`, so any exception the load does not catch itself now
+    takes the whole app down -- where before it surfaced inside `on_mount`.
+    `reload()` catches the failures it anticipates, which is exactly why this
+    has to be tested against one it does not.
+    """
+
+    async def exploding_reload(self):
+        raise RuntimeError("an error reload() does not anticipate")
+
+    monkeypatch.setattr(MCPWorkbench, "reload", exploding_reload)
+
+    app = SlowWorkbenchApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await asyncio.sleep(0.3)
+        await pilot.pause()
+
+        assert app.is_running, (
+            "an unhandled error in the deferred mount load exited the app"
+        )

--- a/backlog/tasks/task-1320 - Move-screen-mount-IO-off-the-App-message-pump.md
+++ b/backlog/tasks/task-1320 - Move-screen-mount-IO-off-the-App-message-pump.md
@@ -43,11 +43,11 @@ depend on.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Opening a destination whose backing service is unreachable leaves the app responsive to clicks, keys and further navigation throughout
-- [ ] #2 `MCPWorkbench` mounts immediately and shows a loading state while its readiness data is fetched
-- [ ] #3 A regression test proves the App pump keeps handling messages while a screen's mount work is in flight
-- [ ] #4 Mount-path fetch failures surface in the destination as a recoverable error, not a silent empty view
-- [ ] #5 An inventory records every `on_mount` that still awaits I/O, with each either converted or explicitly justified
+- [x] #1 Opening a destination whose backing service is unreachable leaves the app responsive to clicks, keys and further navigation throughout
+- [x] #2 `MCPWorkbench` mounts immediately and shows a loading state while its readiness data is fetched
+- [x] #3 A regression test proves the App pump keeps handling messages while a screen's mount work is in flight
+- [x] #4 Mount-path fetch failures surface in the destination as a recoverable error, not a silent empty view
+- [x] #5 An inventory records every `on_mount` that still awaits I/O, with each either converted or explicitly justified
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -75,3 +75,65 @@ ADR required: no
 Reason: no policy, framework or storage contract changes -- this moves existing
 work off the message pump behind the existing worker seam.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Moved every navigation-reachable mount load off the App's message pump. `on_mount`
+is now synchronous in each case and schedules the work; the destination paints
+immediately and the data arrives after.
+
+**Why this mattered.** `handle_screen_navigation` is an `@on` handler on the App,
+and Textual awaits a screen's mount (and its children's `on_mount`) inside
+`switch_screen`. Anything awaited during mount was therefore awaited on the App's
+own pump: no clicks, no keys, no further navigation. Measured against the real
+MCP workbench with a 1s service, the app handled **0 of 5** posted messages.
+
+**Inventory (AC #5).** Ten `on_mount` handlers await I/O-shaped work. Four are
+reachable while a destination mounts, and all four are converted:
+
+| Handler | Reached via | Failure mode | Fix |
+|---|---|---|---|
+| `mcp_workbench` | MCPScreen | awaited service reads | defer + loading state |
+| `personas_screen` | Personas | awaited read, blocking `fetch_all_characters()` | defer + thread |
+| `study_screen` | Study | awaited scope refresh | defer |
+| `Chatbooks_Window_Improved` | chatbooks_screen | **synchronous** glob/stat/zipfile | thread + defer |
+
+Not converted, with reasons: `Voice_Cloning_Window` and
+`console_session_switcher_modal` are `push_screen` surfaces opened on demand, not
+navigation mounts (the same pump concern applies to opening a modal, which is a
+separate question); `ChatbookCreationWindow`, `SmartContentTree` and
+`voice_input_widget` are mounted by no Screen at all; `Chatbooks_Window.py` (the
+pre-"Improved" copy) has **no importers** and is dead.
+
+**Two failure modes, two instruments.** Await-based mount work holds the pump but
+leaves the loop ticking; synchronous work (the chatbook scan, `fetch_all_characters`)
+blocks the loop outright. A message counter cannot see the latter -- while the loop
+is blocked the test cannot post messages either, so everything serializes and the
+count comes out clean. An earlier version of the chatbooks test passed against
+unfixed code for exactly that reason. Loop-blocking is measured with a heartbeat
+that records how late each tick wakes (1.03s stall against the old scan); pump-holding
+is measured with the message counter. Using the wrong one silently proves nothing.
+
+**Deferring is not free.** `run_worker` defaults to `exit_on_error=True`, so moving
+mount work into a worker turned any error the load did not catch itself into an app
+exit -- a failure mode that did not exist while the load ran inline. All four sites
+now pass `exit_on_error=False` and guard their body, clearing the loading state and
+surfacing a recoverable error (AC #4). Verified by test: without it the app exits.
+
+**Orderings that had to be preserved**, both found by tests rather than by reading:
+a widget's `on_mount` fires before the children its `compose()` yielded have
+mounted (so the load is deferred one `call_after_refresh`, else `_sync_children()`
+fails to mount into a canvas that does not exist yet); and `set_initial_view_state()`
+treats `_reloading` as "a reload owns the restore", so that flag is now claimed
+synchronously in `on_mount` to keep the restore stashed and applied at the end of
+`reload()`.
+
+`StudyWindow` defines neither `load_saved_sessions` nor `initialize`, so both
+`hasattr` guards in `study_screen.on_mount` are dead as written. Left in place and
+commented; removing them is a separate decision.
+
+Modified: `mcp_workbench.py`, `personas_screen.py`, `study_screen.py`,
+`Chatbooks_Window_Improved.py`, `ccp_character_handler.py`,
+`Tests/UI/test_mount_io_off_pump.py` (new), `Tests/UI/test_destination_shells.py`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-1320 - Move-screen-mount-IO-off-the-App-message-pump.md
+++ b/backlog/tasks/task-1320 - Move-screen-mount-IO-off-the-App-message-pump.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1320
 title: Move screen mount I/O off the App message pump
-status: To Do
+status: In Progress
 assignee: []
 labels:
   - performance
@@ -49,3 +49,29 @@ depend on.
 - [ ] #4 Mount-path fetch failures surface in the destination as a recoverable error, not a silent empty view
 - [ ] #5 An inventory records every `on_mount` that still awaits I/O, with each either converted or explicitly justified
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inventory every `on_mount` awaiting I/O and classify by navigation reachability
+   (AC #5). Result: 10 handlers await I/O-shaped work; 4 are reachable while a
+   destination mounts -- `mcp_workbench`, `personas_screen`, `study_screen`,
+   `Chatbooks_Window_Improved`. The rest are modals/on-demand `push_screen`
+   surfaces or have no Screen mounting them at all; `Chatbooks_Window.py` (the
+   pre-"Improved" copy) has no importers and is dead.
+2. Write the load-bearing regression test first (AC #3): a destination whose
+   backing service is slow must not stop the App pump handling messages. Prove
+   it fails against current code.
+3. Convert `MCPWorkbench` (AC #2): `on_mount` becomes synchronous and schedules
+   `reload()` in a worker; the canvas mounts immediately in a loading state.
+   Follow the three-state precedent set by TASK-1020 (loading / empty /
+   populated) so an in-flight load is never rendered as "empty".
+4. Convert the remaining three navigation-reachable handlers the same way.
+5. Make mount-path fetch failures resolve to a visible, recoverable error rather
+   than a silent empty view (AC #4).
+6. Record the inventory and the justification for each unconverted handler.
+
+ADR required: no
+Reason: no policy, framework or storage contract changes -- this moves existing
+work off the message pump behind the existing worker seam.
+<!-- SECTION:PLAN:END -->

--- a/tldw_chatbook/UI/CCP_Modules/ccp_character_handler.py
+++ b/tldw_chatbook/UI/CCP_Modules/ccp_character_handler.py
@@ -1,5 +1,5 @@
 """Handler for character-related operations in the Personas screen."""
-
+import asyncio
 from functools import partial
 from typing import TYPE_CHECKING, Optional, Dict, Any, List, Union
 
@@ -355,7 +355,11 @@ class CCPCharacterHandler:
     async def refresh_character_list(self) -> None:
         """Refresh the character select dropdown."""
         try:
-            self.character_list = fetch_all_characters()
+            # Off the loop (TASK-1320): `fetch_all_characters()` is a blocking
+            # read of the entire character library. Awaited from a screen mount
+            # it froze the whole app; every other caller of this method was
+            # stalling the loop for the same read.
+            self.character_list = await asyncio.to_thread(fetch_all_characters)
             options = [
                 (char.get("name", "Unnamed"), str(char.get("id")))
                 for char in self.character_list

--- a/tldw_chatbook/UI/Chatbooks_Window_Improved.py
+++ b/tldw_chatbook/UI/Chatbooks_Window_Improved.py
@@ -486,6 +486,11 @@ class ChatbooksWindowImproved(RecomposeCaptureGuard, Screen):
         self.run_worker(
             self._refresh_chatbooks(),
             group="chatbooks_refresh",
+            # A failed scan is an empty list with an error toast (see
+            # `_refresh_chatbooks`), never a dead app. Textual defaults this to
+            # True, so deferring the scan into a worker would otherwise turn any
+            # error the scan does not catch itself into an app exit.
+            exit_on_error=False,
             exclusive=True,
         )
 

--- a/tldw_chatbook/UI/Chatbooks_Window_Improved.py
+++ b/tldw_chatbook/UI/Chatbooks_Window_Improved.py
@@ -9,6 +9,7 @@ Improved UI for the chatbooks feature with better visual hierarchy,
 more features, and enhanced user experience.
 """
 
+import asyncio
 from typing import List, Dict, Any, TYPE_CHECKING
 from datetime import datetime
 
@@ -475,9 +476,18 @@ class ChatbooksWindowImproved(RecomposeCaptureGuard, Screen):
                 "0 chatbooks • 0 MB total", id="stats-text", classes="stats-text"
             )
 
-    async def on_mount(self) -> None:
-        """Called when screen is mounted."""
-        await self._refresh_chatbooks()
+    def on_mount(self) -> None:
+        """Mount now, scan after (TASK-1320).
+
+        Synchronous by design: mounting is awaited by the app's own navigation
+        handler, so awaiting the directory scan here held the App's message
+        pump for the length of the scan on top of blocking the event loop.
+        """
+        self.run_worker(
+            self._refresh_chatbooks(),
+            group="chatbooks_refresh",
+            exclusive=True,
+        )
 
     def watch_chatbooks(self, old_value: List[Dict], new_value: List[Dict]) -> None:
         """React to chatbooks list changes."""
@@ -569,68 +579,82 @@ class ChatbooksWindowImproved(RecomposeCaptureGuard, Screen):
         self.query_one("#stats-text", Static).update(stats_text)
 
     async def _refresh_chatbooks(self) -> None:
-        """Load chatbooks from export directory."""
+        """Load chatbooks from the export directory, off the event loop.
+
+        The scan itself is blocking (`glob`, `stat`, and a `ZipFile` open plus
+        manifest read per chatbook) and used to run directly here. Being inside
+        an `async def` bought nothing: with no await around the blocking calls
+        the whole event loop stopped for the duration, so the app froze while a
+        directory of chatbooks was read. Measured at ~1s per second of scan.
+
+        The scan now runs in a thread and only the reactive assignment happens
+        back on the loop (TASK-1320).
+        """
         try:
-            self._export_path = secure_chatbook_directory(self._export_path)
-
-            chatbooks = []
-
-            # Scan for .zip files
-            for zip_file in self._export_path.glob("*.zip"):
-                try:
-                    # Get basic info
-                    cb_info = {
-                        "name": zip_file.stem,
-                        "path": str(zip_file),
-                        "size_mb": zip_file.stat().st_size / (1024 * 1024),
-                        "created_at": datetime.fromtimestamp(
-                            zip_file.stat().st_ctime
-                        ).isoformat(),
-                    }
-
-                    # Try to read manifest for more info
-                    import zipfile
-                    import json
-
-                    try:
-                        with zipfile.ZipFile(zip_file, "r") as zf:
-                            if "manifest.json" in zf.namelist():
-                                manifest_data = json.loads(zf.read("manifest.json"))
-                                cb_info.update(
-                                    {
-                                        "name": manifest_data.get(
-                                            "name", cb_info["name"]
-                                        ),
-                                        "description": manifest_data.get(
-                                            "description", ""
-                                        ),
-                                        "tags": manifest_data.get("tags", []),
-                                        "statistics": manifest_data.get(
-                                            "statistics",
-                                            {
-                                                "conversations": 0,
-                                                "notes": 0,
-                                                "characters": 0,
-                                            },
-                                        ),
-                                    }
-                                )
-                    except Exception:
-                        pass
-
-                    chatbooks.append(cb_info)
-                except Exception as e:
-                    logger.error(f"Error reading chatbook {zip_file}: {e}")
-
-            # Sort by created date, newest first
-            chatbooks.sort(key=lambda x: x["created_at"], reverse=True)
+            chatbooks = await asyncio.to_thread(self._scan_chatbooks)
             self.chatbooks = chatbooks
-
         except Exception as e:
             logger.error(f"Error refreshing chatbooks: {e}")
             self.app_instance.notify(
                 f"Error loading chatbooks: {str(e)}", severity="error"
             )
+
+    def _scan_chatbooks(self) -> List[Dict[str, Any]]:
+        """Read the export directory. Blocking -- always call via a thread."""
+        self._export_path = secure_chatbook_directory(self._export_path)
+
+        chatbooks = []
+
+        # Scan for .zip files
+        for zip_file in self._export_path.glob("*.zip"):
+            try:
+                # Get basic info
+                cb_info = {
+                    "name": zip_file.stem,
+                    "path": str(zip_file),
+                    "size_mb": zip_file.stat().st_size / (1024 * 1024),
+                    "created_at": datetime.fromtimestamp(
+                        zip_file.stat().st_ctime
+                    ).isoformat(),
+                }
+
+                # Try to read manifest for more info
+                import zipfile
+                import json
+
+                try:
+                    with zipfile.ZipFile(zip_file, "r") as zf:
+                        if "manifest.json" in zf.namelist():
+                            manifest_data = json.loads(zf.read("manifest.json"))
+                            cb_info.update(
+                                {
+                                    "name": manifest_data.get(
+                                        "name", cb_info["name"]
+                                    ),
+                                    "description": manifest_data.get(
+                                        "description", ""
+                                    ),
+                                    "tags": manifest_data.get("tags", []),
+                                    "statistics": manifest_data.get(
+                                        "statistics",
+                                        {
+                                            "conversations": 0,
+                                            "notes": 0,
+                                            "characters": 0,
+                                        },
+                                    ),
+                                }
+                            )
+                except Exception:
+                    pass
+
+                chatbooks.append(cb_info)
+            except Exception as e:
+                logger.error(f"Error reading chatbook {zip_file}: {e}")
+
+        # Sort by created date, newest first
+        chatbooks.sort(key=lambda x: x["created_at"], reverse=True)
+        return chatbooks
 
     async def on_button_pressed(self, event: Button.Pressed) -> None:
         """Handle button presses."""

--- a/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
@@ -16,6 +16,7 @@ from rich.markup import escape as escape_markup
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal
 from textual.message import Message
+from textual.reactive import reactive
 from textual.widgets import ContentSwitcher
 from textual.worker import Worker
 
@@ -386,6 +387,12 @@ class _AdvancedSectionShim:
 class MCPWorkbench(Container):
     """Assembles the MCP Hub. Read-only over the control-plane service."""
 
+    #: Whether a `reload()` is in flight. Distinct from `_reloading`, which is
+    #: internal write-ordering state: this one is the UI-facing third state
+    #: (loading / empty / populated) so an in-flight load is never rendered as
+    #: "nothing here" -- the same distinction TASK-1020 drew for Watchlists.
+    is_loading: reactive[bool] = reactive(False)
+
     class ModeChanged(Message, namespace="mcp_workbench"):
         """Posted by `set_mode()` whenever the active mode actually changes,
         so the hosting screen can keep its mode-chip highlight in sync.
@@ -661,8 +668,59 @@ class MCPWorkbench(Container):
                 yield MCPAuditMode(id="mcp-mode-canvas-audit")
             yield MCPInspector(id="mcp-hub-inspector", classes="destination-workbench-pane")
 
-    async def on_mount(self) -> None:
-        await self.reload()
+    def on_mount(self) -> None:
+        """Mount now, load after (TASK-1320).
+
+        This is deliberately SYNCHRONOUS. Textual awaits a widget's `on_mount`
+        as part of mounting, and the app awaits the whole mount inside its own
+        `NavigateToScreen` handler -- so awaiting the service here awaited it on
+        the App's message pump, and the entire app stopped handling clicks,
+        keys and further navigation until it answered. Against a configured but
+        unreachable server that window was minutes, which users reported as the
+        app freezing when they clicked into a screen.
+
+        Scheduling `reload()` instead lets the canvas mount immediately in a
+        loading state. `_reloading` already existed to guard a restore racing an
+        in-flight reload, so a reload outliving mount is a case this widget was
+        already built for -- it is simply the normal case now.
+        """
+        self.is_loading = True
+        # Claim the reload SYNCHRONOUSLY, before yielding to the event loop.
+        # `set_initial_view_state()` treats `_reloading` as "a reload owns the
+        # restore, stash it for the end" -- and it is called by the destination
+        # screen during this same mount. When `reload()` was awaited inline the
+        # flag was already set by the time that happened; deferring the load
+        # left it False, so the screen started its own restore worker and
+        # applied the saved mode before the mode chips existed to hear
+        # `ModeChanged`. Setting it here preserves the original ordering: the
+        # restore is stashed and consumed at the end of `reload()`.
+        self._reloading = True
+        # `call_after_refresh`, not a bare `run_worker`: a widget's `on_mount`
+        # fires once IT is mounted, before the children `compose()` yielded have
+        # finished mounting. The old `await reload()` happened to be safe
+        # because each await let the pending child mounts drain first; a worker
+        # started here does not, and `_sync_children()` then tries to mount into
+        # a canvas that does not exist yet ("Can't mount widget(s) before
+        # Vertical(id='mcp-perm-server-profiles') is mounted"). Deferring one
+        # refresh puts the load after the subtree has settled.
+        self.call_after_refresh(self._start_initial_load)
+
+    def _start_initial_load(self) -> None:
+        """Kick off the mount-time reload once the subtree is mounted."""
+        self.run_worker(
+            self.reload(),
+            group="mcp_workbench_reload",
+            exclusive=True,
+        )
+
+    def watch_is_loading(self, loading: bool) -> None:
+        """Show the spinner over the canvas only, leaving the rail usable."""
+        try:
+            self.query_one("#mcp-hub-canvas").loading = loading
+        except Exception:
+            # Called before the canvas exists (the reactive is set in
+            # `on_mount`, ahead of the first refresh) -- nothing to show yet.
+            pass
 
     # -- data loading ---------------------------------------------------------
 
@@ -691,6 +749,7 @@ class MCPWorkbench(Container):
             self._rebind_inspector_advanced_context(service)
         finally:
             self._reloading = False
+            self.is_loading = False
         # Consume any view state that arrived while this reload was in
         # flight (see `set_initial_view_state()`), so it is applied exactly
         # once and always after this reload's own `_sync_children()`.

--- a/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
@@ -708,10 +708,38 @@ class MCPWorkbench(Container):
     def _start_initial_load(self) -> None:
         """Kick off the mount-time reload once the subtree is mounted."""
         self.run_worker(
-            self.reload(),
+            self._reload_guarded(),
             group="mcp_workbench_reload",
+            # A load failure is a broken destination, never a dead app. Textual
+            # defaults this to True, so moving mount work into a worker would
+            # otherwise turn any error `reload()` does not itself catch into an
+            # app exit -- a failure mode that did not exist while the load ran
+            # inside `on_mount`.
+            exit_on_error=False,
             exclusive=True,
         )
+
+    async def _reload_guarded(self) -> None:
+        """Run the mount-time reload without letting a failure strand the UI."""
+        try:
+            await self.reload()
+        except Exception as exc:
+            # `reload()` clears `is_loading` in its own `finally`, but only for
+            # paths that reach it; anything raised earlier would otherwise leave
+            # the canvas spinning forever, telling the user data is coming when
+            # nothing is.
+            self.is_loading = False
+            self._reloading = False
+            logger.opt(exception=True).error(
+                f"MCP workbench initial load failed: {exc}"
+            )
+            try:
+                self.app.notify(
+                    "Couldn't load MCP data. Use Refresh to try again.",
+                    severity="error",
+                )
+            except Exception:
+                pass
 
     def watch_is_loading(self, loading: bool) -> None:
         """Show the spinner over the canvas only, leaving the rail usable."""

--- a/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
@@ -707,6 +707,12 @@ class MCPWorkbench(Container):
 
     def _start_initial_load(self) -> None:
         """Kick off the mount-time reload once the subtree is mounted."""
+        # Re-assert the spinner now that the subtree has definitely settled.
+        # `watch_is_loading` runs when `on_mount` sets the flag, and the canvas
+        # happens to be queryable by then -- but that watcher tolerates a miss
+        # rather than retrying, so re-applying here keeps a future change to
+        # mount ordering from silently costing the loading state.
+        self.watch_is_loading(self.is_loading)
         self.run_worker(
             self._reload_guarded(),
             group="mcp_workbench_reload",
@@ -731,7 +737,15 @@ class MCPWorkbench(Container):
             self.is_loading = False
             self._reloading = False
             logger.opt(exception=True).error(
-                f"MCP workbench initial load failed: {exc}"
+                "MCP workbench initial load failed "
+                "(source={}, scope={}, scope_ref={}, server_key={}, mode={}, "
+                "exception_category={}).",
+                self._source,
+                self._scope,
+                self._scope_ref,
+                self._selected_server_key,
+                self.active_mode,
+                type(exc).__name__,
             )
             try:
                 self.app.notify(
@@ -754,6 +768,11 @@ class MCPWorkbench(Container):
 
     async def reload(self) -> None:
         self._reloading = True
+        # Raised here, not only in `on_mount`: `reload()` always CLEARS this in
+        # its `finally`, so every caller must also raise it or a direct reload
+        # (MCPScreen's manual refresh calls this straight) would fetch with no
+        # spinner and then clear a flag it never set.
+        self.is_loading = True
         try:
             service = self._service()
             if service is not None:

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -957,18 +957,33 @@ class PersonasScreen(BaseAppScreen):
         self.run_worker(
             self._load_after_mount(),
             group="personas_initial_load",
+            # A load failure is a broken screen, never a dead app. Textual
+            # defaults this to True, so deferring mount work into a worker would
+            # otherwise turn a failed library read into an app exit.
+            exit_on_error=False,
             exclusive=True,
         )
 
     async def _load_after_mount(self) -> None:
         """Load the character library once the screen is already on screen."""
-        loading_manager = getattr(self, "loading_manager", None)
-        setup_loading = getattr(loading_manager, "setup", None)
-        if callable(setup_loading):
-            await setup_loading()
-        await self.character_handler.refresh_character_list()
-        self._sync_title_and_console_actions()
-        await self._apply_pending_restore()
+        try:
+            loading_manager = getattr(self, "loading_manager", None)
+            setup_loading = getattr(loading_manager, "setup", None)
+            if callable(setup_loading):
+                await setup_loading()
+            await self.character_handler.refresh_character_list()
+            self._sync_title_and_console_actions()
+            await self._apply_pending_restore()
+        except Exception as exc:
+            logger.opt(exception=True).error(
+                f"Personas initial load failed: {exc}"
+            )
+            try:
+                self.notify(
+                    "Couldn't load the character library.", severity="error"
+                )
+            except Exception:
+                pass
 
     def _set_persona_editor_runtime_source(self, runtime_source: str) -> None:
         """Synchronize the screen state and mounted Persona editor source."""

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -929,17 +929,43 @@ class PersonasScreen(BaseAppScreen):
             self._show_center(None)
             self._sync_title_and_console_actions()
 
-    async def on_mount(self) -> None:
+    def on_mount(self) -> None:
+        """Paint the shell now, load the library after (TASK-1320).
+
+        Synchronous by design. Mounting is awaited by the app's own navigation
+        handler, so awaiting the character read here ran it on the App's message
+        pump -- and `refresh_character_list()` reads every character through the
+        blocking `fetch_all_characters()`, so the app stopped responding
+        entirely until the library came back.
+
+        Everything that only arranges already-composed widgets stays here, so
+        the screen is laid out and readable immediately. Only the library read
+        and what genuinely depends on it is deferred, in its original order.
+        """
         super().on_mount()
-        loading_manager = getattr(self, "loading_manager", None)
-        setup_loading = getattr(loading_manager, "setup", None)
-        if callable(setup_loading):
-            await setup_loading()
         self._sync_responsive_workbench()
         self._sync_personas_rails()
         self._set_persona_editor_runtime_source(self.persona_handler.current_mode())
         self.query_one(PersonasLibraryPane).set_mode(self.state.active_mode)
         self._show_center(None)
+        # Reflect a "my name" pointer persisted from a previous session
+        # immediately, before any selection happens (task-442 T3) -- now
+        # genuinely immediate, rather than behind the library read.
+        self.query_one(PersonasInspectorPane).set_active_profile_name(
+            get_active_user_profile_pointer()
+        )
+        self.run_worker(
+            self._load_after_mount(),
+            group="personas_initial_load",
+            exclusive=True,
+        )
+
+    async def _load_after_mount(self) -> None:
+        """Load the character library once the screen is already on screen."""
+        loading_manager = getattr(self, "loading_manager", None)
+        setup_loading = getattr(loading_manager, "setup", None)
+        if callable(setup_loading):
+            await setup_loading()
         await self.character_handler.refresh_character_list()
         self._sync_title_and_console_actions()
         await self._apply_pending_restore()

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -940,7 +940,8 @@ class PersonasScreen(BaseAppScreen):
 
         Everything that only arranges already-composed widgets stays here, so
         the screen is laid out and readable immediately. Only the library read
-        and what genuinely depends on it is deferred, in its original order.
+        and what genuinely depends on it is deferred, in its original order --
+        including the loading-manager setup, which the library read follows.
         """
         super().on_mount()
         self._sync_responsive_workbench()
@@ -948,12 +949,6 @@ class PersonasScreen(BaseAppScreen):
         self._set_persona_editor_runtime_source(self.persona_handler.current_mode())
         self.query_one(PersonasLibraryPane).set_mode(self.state.active_mode)
         self._show_center(None)
-        # Reflect a "my name" pointer persisted from a previous session
-        # immediately, before any selection happens (task-442 T3) -- now
-        # genuinely immediate, rather than behind the library read.
-        self.query_one(PersonasInspectorPane).set_active_profile_name(
-            get_active_user_profile_pointer()
-        )
         self.run_worker(
             self._load_after_mount(),
             group="personas_initial_load",

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -971,7 +971,11 @@ class PersonasScreen(BaseAppScreen):
             await self._apply_pending_restore()
         except Exception as exc:
             logger.opt(exception=True).error(
-                f"Personas initial load failed: {exc}"
+                "Personas initial load failed "
+                "(mode={}, runtime_backend={}, exception_category={}).",
+                getattr(self.state, "active_mode", None),
+                getattr(self.state, "runtime_source", None),
+                type(exc).__name__,
             )
             try:
                 self.notify(

--- a/tldw_chatbook/UI/Screens/study_screen.py
+++ b/tldw_chatbook/UI/Screens/study_screen.py
@@ -1245,7 +1245,14 @@ class StudyScreen(BaseAppScreen):
         try:
             await self._load_after_mount_inner()
         except Exception as exc:
-            logger.opt(exception=True).error(f"Study initial load failed: {exc}")
+            logger.opt(exception=True).error(
+                "Study initial load failed "
+                "(section={}, scope_key={}, backend={}, exception_category={}).",
+                self.current_section,
+                self._effective_scope_key,
+                getattr(self.scope_state, "backend", None),
+                type(exc).__name__,
+            )
             try:
                 self.notify("Couldn't load study data.", severity="error")
             except Exception:

--- a/tldw_chatbook/UI/Screens/study_screen.py
+++ b/tldw_chatbook/UI/Screens/study_screen.py
@@ -1213,11 +1213,31 @@ class StudyScreen(BaseAppScreen):
         else:
             store.acknowledge(claim)
 
-    async def on_mount(self) -> None:
-        """Initialize Study features when screen is mounted."""
+    def on_mount(self) -> None:
+        """Mount now, load the scoped data after (TASK-1320).
+
+        Synchronous by design: mounting is awaited by the app's own navigation
+        handler, so awaiting the scope refresh here ran it on the App's message
+        pump and the app stopped responding until the scoped study data came
+        back.
+
+        Deferred by `call_after_refresh` rather than started directly, because a
+        screen's `on_mount` fires before the children its `compose()` yielded
+        have finished mounting and the deferred work does `query_one(StudyWindow)`.
+        """
         super().on_mount()
         logger.info("Study screen mounted")
+        self.call_after_refresh(self._start_initial_load)
 
+    def _start_initial_load(self) -> None:
+        self.run_worker(
+            self._load_after_mount(),
+            group="study_initial_load",
+            exclusive=True,
+        )
+
+    async def _load_after_mount(self) -> None:
+        """Apply scope and load scoped study data, off the message pump."""
         study_window = self.query_one(StudyWindow)
 
         if not await self._apply_pending_scope_handoff(study_window=study_window):
@@ -1226,6 +1246,10 @@ class StudyScreen(BaseAppScreen):
                 study_window=study_window,
             )
 
+        # `StudyWindow` defines neither of these, so both guards are dead as
+        # written; they are kept as-is rather than silently dropped, since
+        # removing them is a separate decision from moving the mount off the
+        # pump.
         if hasattr(study_window, "load_saved_sessions"):
             await study_window.load_saved_sessions()
 

--- a/tldw_chatbook/UI/Screens/study_screen.py
+++ b/tldw_chatbook/UI/Screens/study_screen.py
@@ -1233,11 +1233,25 @@ class StudyScreen(BaseAppScreen):
         self.run_worker(
             self._load_after_mount(),
             group="study_initial_load",
+            # A load failure is a broken screen, never a dead app. Textual
+            # defaults this to True, so deferring mount work into a worker would
+            # otherwise turn a failed scoped read into an app exit.
+            exit_on_error=False,
             exclusive=True,
         )
 
     async def _load_after_mount(self) -> None:
         """Apply scope and load scoped study data, off the message pump."""
+        try:
+            await self._load_after_mount_inner()
+        except Exception as exc:
+            logger.opt(exception=True).error(f"Study initial load failed: {exc}")
+            try:
+                self.notify("Couldn't load study data.", severity="error")
+            except Exception:
+                pass
+
+    async def _load_after_mount_inner(self) -> None:
         study_window = self.query_one(StudyWindow)
 
         if not await self._apply_pending_scope_handoff(study_window=study_window):


### PR DESCRIPTION
Follow-up to #1077, which bounded the two unbounded waits that made the navigation freeze *permanent*. This removes the structural cause: mount work running on the App's message pump.

## Why this froze the app

`handle_screen_navigation` is an `@on` handler on the App, and Textual awaits a screen's mount — and its children's `on_mount` — inside `switch_screen`. Anything awaited during mount was therefore awaited **on the App's own pump**: no clicks, no keys, no further navigation until it finished. Against the real MCP workbench with a 1s service, the app handled **0 of 5** posted messages.

## Inventory (AC #5)

Ten `on_mount` handlers await I/O-shaped work. Four are reachable while a destination mounts; all four are converted.

| Handler | Reached via | Failure mode | Fix |
|---|---|---|---|
| `mcp_workbench` | MCPScreen | awaited service reads | defer + loading state |
| `personas_screen` | Personas | awaited read, blocking `fetch_all_characters()` | defer + thread |
| `study_screen` | Study | awaited scope refresh | defer |
| `Chatbooks_Window_Improved` | chatbooks_screen | **synchronous** glob/stat/zipfile | thread + defer |

Not converted, with reasons: `Voice_Cloning_Window` and `console_session_switcher_modal` are `push_screen` surfaces opened on demand, not navigation mounts; `ChatbookCreationWindow`, `SmartContentTree` and `voice_input_widget` are mounted by no Screen at all; `Chatbooks_Window.py` (the pre-"Improved" copy) has **no importers** and is dead.

## Two failure modes need two instruments

Await-based mount work *holds the pump* while the loop keeps ticking. Synchronous work — the chatbook scan, `fetch_all_characters` — *blocks the loop outright*.

A message counter cannot see the second one at all: while the loop is blocked the test cannot post messages either, so everything serializes and the count comes out clean. **An earlier version of the chatbooks test passed against unfixed code for exactly that reason.** Loop-blocking is now measured with a heartbeat recording how late each tick wakes (1.03s stall against the old scan); pump-holding with the message counter. Using the wrong one silently proves nothing — which is why the study test asserts its patched seam was actually reached.

## Deferring is not free

`run_worker` defaults to `exit_on_error=True`, so moving mount work into a worker turned any error the load did not catch itself into an **app exit** — a failure mode that did not exist while it ran inline. Confirmed by test that the app did exit. All four sites now pass `exit_on_error=False` and guard their body, clearing the loading state and surfacing a recoverable error (AC #4).

## Orderings that had to be preserved

Both found by tests, not by reading:

- A widget's `on_mount` fires **before** the children its `compose()` yielded have mounted. The old inline `await` was safe only because each await drained those pending mounts; a worker does not, and `_sync_children()` failed with `Can't mount widget(s) before Vertical(id='mcp-perm-server-profiles') is mounted`. Deferred one `call_after_refresh`.
- `set_initial_view_state()` treats `_reloading` as "a reload owns the restore, stash it for the end", and the destination screen calls it during the same mount. `_reloading` is now claimed synchronously in `on_mount` so the restore is still applied at the end of `reload()`.

## Verification

- TDD throughout; every test watched failing first, with the measured number in each assertion message.
- 323 passed post-rebase across mount/MCP/destination/personas/chatbooks suites; 537 passed on the wider sweep.
- Baselines compared **name-by-name** (`comm`), not by count: the study suite's 65→66 was my own still-red test, not a regression. MCP's remaining 3 audit failures are baseline (the 4 `PrivatePathError` ones are tmpdir-symlink dependent and pass intermittently on both sides).
- The study test is mutation-checked: revert the fix and it reports `0/5 messages`.
- `ruff` clean.

## Notes

- `StudyWindow` defines neither `load_saved_sessions` nor `initialize`, so both `hasattr` guards in study's mount are dead as written. Left in place and commented — removing them is a separate decision.
- One commit is a rebase-resolution repair: dev had removed `get_active_user_profile_pointer` and resolving the conflict carried the call back in. Git merged it silently; `ruff`'s F821 caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move all screen mount I/O off the App message pump so navigation stays responsive. Screens now mount instantly, load data in the background, and handle failures without exiting the app (TASK-1320).

- **Bug Fixes**
  - Deferred mount work to workers for `MCPWorkbench`, `personas_screen`, `study_screen`, and `Chatbooks_Window_Improved`; start after the first refresh where needed (`call_after_refresh`).
  - Ran blocking I/O in threads: chatbook scan via `_scan_chatbooks()` + `asyncio.to_thread`, and `fetch_all_characters()` via `asyncio.to_thread`.
  - Guarded workers with `exit_on_error=False`, caught errors, cleared loading states, and showed user notifications; tests ensure the app stays running and spinners clear on failure.
  - Preserved ordering: claim `_reloading` early in `MCPWorkbench.on_mount`; kick the initial load after children mount; updated the test to wait on the mode-chip highlight instead of the mode value.
  - Made `reload()` own `is_loading` so manual refresh shows a spinner.

- **Refactors**
  - Added `is_loading` to `MCPWorkbench` and show a canvas-only spinner; re-asserted after the subtree mounts.
  - Split chatbook scan into sync `_scan_chatbooks()` executed in a thread; deferred Personas library load behind the loading manager.
  - New regression suite `Tests/UI/test_mount_io_off_pump.py` measures pump draining and event-loop stalls; acceptance criteria in the TASK-1320 backlog are now checked off.

<sup>Written for commit eccb07b54abeead92508ea3728f399869cf97924. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

