### PR TITLE
feat(watchlists): give content_kind a producer, and the change path a real diff (TASK-1343)

### DIFF
--- a/Tests/Subscriptions/test_watchlist_content_kind_producer.py
+++ b/Tests/Subscriptions/test_watchlist_content_kind_producer.py
@@ -55,8 +55,15 @@ def _response(text: str, *, content_type: str = "text/html") -> SimpleNamespace:
 def _serve(monkeypatch, pages: list[str], *, content_type: str = "text/html") -> None:
     """Serve `pages` in order from the monitoring engine's guarded fetch.
 
-    The last page is repeated once the list is exhausted, so a test can do any
-    number of extra checks without the fetch running out.
+    Args:
+        pages: One body per fetch, in order. The last entry is repeated once
+            the list is exhausted, so a test can make extra checks (e.g. a
+            third one that must detect nothing) without the fetch running out.
+        content_type: Returned as the `content-type` header, which
+            `_fetch_and_parse_feed` branches on to choose its parser.
+
+    (`monkeypatch` is a bare pytest fixture and is deliberately not documented
+    here -- see the report on this file's `Args:` policy.)
     """
     remaining = list(pages)
 
@@ -131,16 +138,30 @@ _RSS = """<?xml version="1.0" encoding="utf-8"?>
 
 
 async def _site_source(
-    tmp_path, monkeypatch, pages: list[str], *, change_threshold: float | None = None
+    monkeypatch, pages: list[str], *, change_threshold: float | None = None
 ):
     """A real `url` source, its DB and service, with `pages` served in order.
 
-    `change_threshold` defaults to the DB's own 0.1 (a 10% character-level
-    difference). Pass 0.0 when the point of the test is a *small* edit to a long
-    page, which is otherwise discarded by `check_url` before it ever produces an
-    item -- as happened while writing the rule-scope tests below.
+    The database is `:memory:` per CLAUDE.md. It is safe here specifically
+    because these tests are single-threaded: `SubscriptionsDB` keeps a
+    *thread-local* connection and builds the schema on the constructing
+    thread's, so an in-memory instance touched from a second thread would find
+    zero tables (documented in `SubscriptionsDB._initialize_schema`). Nothing
+    below crosses a thread -- the service is awaited directly, with no worker.
+
+    Args:
+        pages: Passed straight to `_serve`.
+        change_threshold: The source's `change_threshold`, or `None` to keep the
+            DB default of 0.1 -- a 10% *character-level* difference over the
+            whole page. Pass 0.0 when the point of a test is a *small* edit to a
+            long page: `check_url` otherwise discards it before producing any
+            item at all, which is what silently emptied the rule-scope tests
+            below on their first run.
+
+    Returns:
+        `(db, service, source_id)`.
     """
-    db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
+    db = SubscriptionsDB(":memory:", "test")
     service = LocalWatchlistsService(db_factory=lambda: db)
     _serve(monkeypatch, pages)
     payload = {
@@ -158,9 +179,7 @@ async def _site_source(
 
 
 @pytest.mark.asyncio
-async def test_a_real_site_change_is_dispatched_to_the_change_renderer(
-    tmp_path, monkeypatch
-):
+async def test_a_real_site_change_is_dispatched_to_the_change_renderer(monkeypatch):
     """AC#3, driven end to end: fetch, detect, persist, normalize, dispatch.
 
     The first check only stores a baseline (`check_url` returns `None` with no
@@ -174,7 +193,7 @@ async def test_a_real_site_change_is_dispatched_to_the_change_renderer(
     assignment in `check_url` reddens this test.
     """
     db, service, source_id = await _site_source(
-        tmp_path, monkeypatch, [_PAGE_BEFORE, _PAGE_AFTER]
+        monkeypatch, [_PAGE_BEFORE, _PAGE_AFTER]
     )
 
     first = await _check(service, source_id)
@@ -201,9 +220,7 @@ async def test_a_real_site_change_is_dispatched_to_the_change_renderer(
 
 
 @pytest.mark.asyncio
-async def test_the_stored_change_content_is_a_diff_not_the_whole_new_page(
-    tmp_path, monkeypatch
-):
+async def test_the_stored_change_content_is_a_diff_not_the_whole_new_page(monkeypatch):
     """`content` used to be `current_content["text"]` -- the entire new page.
 
     So the reader could see what the page says now but never what changed,
@@ -213,7 +230,7 @@ async def test_the_stored_change_content_is_a_diff_not_the_whole_new_page(
     twice, and that `render_change` actually colours those lines.
     """
     db, service, source_id = await _site_source(
-        tmp_path, monkeypatch, [_PAGE_BEFORE, _PAGE_AFTER]
+        monkeypatch, [_PAGE_BEFORE, _PAGE_AFTER]
     )
     await _check(service, source_id)
     await _check(service, source_id)
@@ -250,9 +267,7 @@ async def test_the_stored_change_content_is_a_diff_not_the_whole_new_page(
 
 
 @pytest.mark.asyncio
-async def test_the_change_headline_carries_a_diff_summary_and_a_real_percentage(
-    tmp_path, monkeypatch
-):
+async def test_the_change_headline_carries_a_diff_summary_and_a_real_percentage(monkeypatch):
     """AC#4, plus the scale of `change_percentage`.
 
     `diff_summary` is rendered by `render_change` and had no producer at all.
@@ -262,7 +277,7 @@ async def test_the_change_headline_carries_a_diff_summary_and_a_real_percentage(
     unscaled 25% change would have printed "0% changed".
     """
     db, service, source_id = await _site_source(
-        tmp_path, monkeypatch, [_PAGE_BEFORE, _PAGE_AFTER]
+        monkeypatch, [_PAGE_BEFORE, _PAGE_AFTER]
     )
     await _check(service, source_id)
     await _check(service, source_id)
@@ -288,9 +303,7 @@ async def test_the_change_headline_carries_a_diff_summary_and_a_real_percentage(
 
 
 @pytest.mark.asyncio
-async def test_change_type_is_derived_from_the_snapshots_not_hardcoded(
-    tmp_path, monkeypatch
-):
+async def test_change_type_is_derived_from_the_snapshots_not_hardcoded(monkeypatch):
     """`change_type` was the literal `"content"` for every change ever.
 
     Only the distinctions the two snapshots actually support are claimed:
@@ -307,7 +320,6 @@ async def test_change_type_is_derived_from_the_snapshots_not_hardcoded(
 
     # And it reaches the DB from a real check: this page loses all of its text.
     db, service, source_id = await _site_source(
-        tmp_path,
         monkeypatch,
         [_PAGE_BEFORE, "<html><body><script>x=1</script></body></html>"],
     )
@@ -326,9 +338,7 @@ async def test_change_type_is_derived_from_the_snapshots_not_hardcoded(
 
 
 @pytest.mark.asyncio
-async def test_a_feed_item_is_stored_as_an_article_with_a_legal_format(
-    tmp_path, monkeypatch
-):
+async def test_a_feed_item_is_stored_as_an_article_with_a_legal_format(monkeypatch):
     """AC#2. The RSS path wrote neither field, so it relied on `render_for`'s
     fallback -- which is what made the dispatch untestable in the first place.
 
@@ -336,7 +346,7 @@ async def test_a_feed_item_is_stored_as_an_article_with_a_legal_format(
     plain text or HTML and nothing on this path converts it to markdown.
     Claiming `"markdown"` would hand publisher HTML to a CommonMark parser.
     """
-    db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
+    db = SubscriptionsDB(":memory:", "test")
     service = LocalWatchlistsService(db_factory=lambda: db)
     _serve(monkeypatch, [_RSS], content_type="application/rss+xml")
 
@@ -364,9 +374,7 @@ async def test_a_feed_item_is_stored_as_an_article_with_a_legal_format(
 
 
 @pytest.mark.asyncio
-async def test_an_api_item_is_stored_as_an_article_with_a_legal_format(
-    tmp_path, monkeypatch
-):
+async def test_an_api_item_is_stored_as_an_article_with_a_legal_format(monkeypatch):
     """The API path is normalized in the service, not the monitoring engine,
     and had the same gap. Its body is whatever JSON field the source's
     `field_map` points at, in whatever format the API chose and unconverted,
@@ -397,7 +405,7 @@ async def test_an_api_item_is_stored_as_an_article_with_a_legal_format(
         fake_guarded,
     )
 
-    db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
+    db = SubscriptionsDB(":memory:", "test")
     service = LocalWatchlistsService(db_factory=lambda: db)
     source = await service.create_source(
         {
@@ -421,7 +429,7 @@ async def test_an_api_item_is_stored_as_an_article_with_a_legal_format(
 
 
 @pytest.mark.asyncio
-async def test_an_oversized_change_is_truncated_and_says_so(tmp_path, monkeypatch):
+async def test_an_oversized_change_is_truncated_and_says_so(monkeypatch):
     """A large page can produce an enormous diff, and this goes into a TEXT
     column and a pane about nine rows tall.
 
@@ -468,7 +476,6 @@ async def test_an_oversized_change_is_truncated_and_says_so(tmp_path, monkeypatc
     # truncation must be visible to a reader who never scrolls: the summary is
     # in `render_change`'s headline.
     db, service, source_id = await _site_source(
-        tmp_path,
         monkeypatch,
         [f"<html><body><p>{before}</p></body></html>",
          f"<html><body><p>{after}</p></body></html>"],
@@ -485,6 +492,122 @@ async def test_an_oversized_change_is_truncated_and_says_so(tmp_path, monkeypatc
     head = "\n".join(plain.splitlines()[:4])
     assert "truncated" in head, (
         "a reader who never scrolls must still be told the diff was cut"
+    )
+
+
+def test_a_diff_far_larger_than_the_cap_is_bounded_with_accurate_counts():
+    """PR #1092 review, Bug #1: the caps bound the body, the counters do not.
+
+    `build_change_diff` consumes `unified_diff` as a generator and stops
+    *appending* once a cap is hit, but deliberately keeps *iterating* so
+    `total_lines`, `added` and `removed` describe the whole change rather than
+    the retained slice. That is the behavioural half of the streaming fix, and
+    it is what this test pins: a diff twenty times the line cap still yields a
+    capped body whose headline and notice tell the truth about what was cut.
+
+    What this test does NOT prove is the memory property itself -- see
+    `test_the_diff_generator_is_not_materialised` for that, and the report for
+    what is and is not achievable.
+    """
+    import re
+
+    from tldw_chatbook.Subscriptions.monitoring_engine import (
+        _MAX_DIFF_CHARS,
+        _MAX_DIFF_LINES,
+        build_change_diff,
+    )
+
+    segments = 4000
+    before = " ".join(f"Paragraph {i} says the old thing." for i in range(segments))
+    after = " ".join(
+        f"Paragraph {i} says the new thing instead." for i in range(segments)
+    )
+
+    body, summary = build_change_diff(before, after)
+    lines = body.splitlines()
+
+    # Bounded: the notice is the single line allowed past the line cap.
+    assert len(lines) == _MAX_DIFF_LINES + 1
+    assert len(body) <= _MAX_DIFF_CHARS + len(lines[0]) + 1
+
+    # Accurate: every one of the 4000 removals and 4000 additions is counted,
+    # though only ~400 lines were retained.
+    assert summary == f"{segments} line(s) added, {segments} removed (diff truncated)"
+
+    retained_additions = sum(1 for line in lines if line.startswith("+"))
+    assert retained_additions < segments / 4, (
+        "the precondition: the body holds far fewer additions than the count "
+        f"reports ({retained_additions} retained vs {segments} counted), so the "
+        "counters cannot have come from the retained slice"
+    )
+
+    # The notice's own total must be the whole diff too.
+    match = re.search(r"first (\d+) of (\d+) diff lines", lines[0])
+    assert match, lines[0]
+    kept_count, total = int(match.group(1)), int(match.group(2))
+    assert kept_count == _MAX_DIFF_LINES
+    # 4000 `-` + 4000 `+` + the one `@@` hunk header these disjoint inputs
+    # produce. Asserted relative to the counts rather than hardcoded, so this
+    # states the relationship rather than a magic number.
+    assert total == segments * 2 + 1
+
+
+def test_the_diff_generator_is_not_materialised():
+    """PR #1092 review, Bug #1: peak memory, measured differentially.
+
+    `list(unified_diff(...))` bounded what was *stored* while leaving peak
+    memory proportional to the whole diff -- inside a scheduled fetch, over
+    pages the egress layer admits up to 10 MB. This measures the real
+    allocation peak of the shipped implementation against the same input run
+    through a materialising stand-in, in the same process.
+
+    It is a DIFFERENTIAL check, not an absolute budget: an absolute threshold
+    would be a machine-specific magic number, and peak does still grow with the
+    input, because `_segment_for_diff` must build both segment lists in full
+    (`difflib.SequenceMatcher` needs random access to both sequences). What the
+    streaming change removes is the diff-output term on top of that -- measured
+    at a stable ~33% of peak across input sizes -- and what it guarantees is
+    that the term bounded by `_MAX_DIFF_LINES`/`_MAX_DIFF_CHARS` is the only
+    one that scales with the diff. The threshold below leaves wide headroom
+    (asserting 0.85 against a measured 0.65) precisely so it does not become a
+    flaky allocation assertion.
+    """
+    import tracemalloc
+
+    from tldw_chatbook.Subscriptions import monitoring_engine
+
+    segments = 4000
+    before = " ".join(f"Paragraph {i} says the old thing." for i in range(segments))
+    after = " ".join(
+        f"Paragraph {i} says the new thing instead." for i in range(segments)
+    )
+
+    tracemalloc.start()
+    streamed_body, streamed_summary = monitoring_engine.build_change_diff(before, after)
+    _current, peak_streamed = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    real_unified_diff = monitoring_engine.unified_diff
+    try:
+        monitoring_engine.unified_diff = (
+            lambda *args, **kwargs: iter(list(real_unified_diff(*args, **kwargs)))
+        )
+        tracemalloc.start()
+        listed_body, listed_summary = monitoring_engine.build_change_diff(before, after)
+        _current, peak_listed = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+    finally:
+        monitoring_engine.unified_diff = real_unified_diff
+
+    # The refactor must be output-preserving: the only intended difference
+    # between the two runs is what was held in memory.
+    assert streamed_body == listed_body
+    assert streamed_summary == listed_summary
+
+    assert peak_streamed < peak_listed * 0.85, (
+        f"streaming peak {peak_streamed / 1024:.0f} KiB is not meaningfully "
+        f"below the materialising peak {peak_listed / 1024:.0f} KiB -- the "
+        "generator is being held somewhere"
     )
 
 
@@ -531,7 +654,7 @@ def test_a_removed_line_that_looks_like_a_diff_header_is_not_deleted():
 
 
 @pytest.mark.asyncio
-async def test_the_whole_stored_diff_body_is_exactly_this(tmp_path, monkeypatch):
+async def test_the_whole_stored_diff_body_is_exactly_this(monkeypatch):
     """Pin the body a real check produces, in full.
 
     The individual `in content` assertions above cannot show that the result is
@@ -540,7 +663,7 @@ async def test_the_whole_stored_diff_body_is_exactly_this(tmp_path, monkeypatch)
     diff's shape has to come through here and be looked at.
     """
     db, service, source_id = await _site_source(
-        tmp_path, monkeypatch, [_PAGE_BEFORE, _PAGE_AFTER]
+        monkeypatch, [_PAGE_BEFORE, _PAGE_AFTER]
     )
     await _check(service, source_id)
     await _check(service, source_id)
@@ -609,9 +732,7 @@ def test_the_diff_is_readable_in_a_narrow_pane():
 
 
 @pytest.mark.asyncio
-async def test_a_site_alert_still_fires_on_text_the_change_did_not_touch(
-    tmp_path, monkeypatch
-):
+async def test_a_site_alert_still_fires_on_text_the_change_did_not_touch(monkeypatch):
     """Fix round 1, Important #3. An undeclared narrowing of every site rule.
 
     `WatchlistFilterService` and `WatchlistContentAlertService` build their
@@ -628,7 +749,6 @@ async def test_a_site_alert_still_fires_on_text_the_change_did_not_touch(
     one line of context `n=1` happens to include.
     """
     db, service, source_id = await _site_source(
-        tmp_path,
         monkeypatch,
         # The unchanged sentence is moved far enough from the change that `n=1`
         # context cannot reach it.
@@ -666,16 +786,13 @@ async def test_a_site_alert_still_fires_on_text_the_change_did_not_touch(
 
 
 @pytest.mark.asyncio
-async def test_an_exclude_filter_on_unchanged_page_text_still_excludes(
-    tmp_path, monkeypatch
-):
+async def test_an_exclude_filter_on_unchanged_page_text_still_excludes(monkeypatch):
     """The same narrowing, on the other service.
 
     A filter is the destructive half: narrowing it does not merely fail to
     notify, it lets through items the user had told the app to drop.
     """
     db, service, source_id = await _site_source(
-        tmp_path,
         monkeypatch,
         [
             "<html><body><p>Sponsored placement.</p>"
@@ -736,7 +853,7 @@ def test_the_rule_haystack_is_the_page_when_content_is_a_diff():
     )
 
 
-def test_the_rule_match_text_is_not_persisted_as_a_column(tmp_path):
+def test_the_rule_match_text_is_not_persisted_as_a_column():
     """It is a matching-time field, not a second copy of every page in the DB.
 
     The full text is already durable in `url_snapshots`; storing it on the item
@@ -744,7 +861,7 @@ def test_the_rule_match_text_is_not_persisted_as_a_column(tmp_path):
     """
     from tldw_chatbook.Subscriptions.watchlist_rule_matching import RULE_MATCH_TEXT_KEY
 
-    db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
+    db = SubscriptionsDB(":memory:", "test")
     columns = {
         row[1] for row in db.conn.execute("PRAGMA table_info(subscription_items)")
     }
@@ -756,9 +873,7 @@ def test_the_rule_match_text_is_not_persisted_as_a_column(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_no_producer_emits_a_pairing_persistence_would_reject(
-    tmp_path, monkeypatch
-):
+async def test_no_producer_emits_a_pairing_persistence_would_reject(monkeypatch):
     """`persist_subscription_item` RAISES on an invalid pairing, and that raise
     lands inside a scheduled fetch, where `execute_run` converts it into a
     failed run and drops every item the run collected.
@@ -794,7 +909,7 @@ async def test_no_producer_emits_a_pairing_persistence_would_reject(
     produced.append((api_item.get("content_kind"), api_item.get("content_format")))
 
     db, service, source_id = await _site_source(
-        tmp_path, monkeypatch, [_PAGE_BEFORE, _PAGE_AFTER]
+        monkeypatch, [_PAGE_BEFORE, _PAGE_AFTER]
     )
     await _check(service, source_id)
     await _check(service, source_id)

--- a/Tests/Subscriptions/test_watchlist_content_kind_producer.py
+++ b/Tests/Subscriptions/test_watchlist_content_kind_producer.py
@@ -17,6 +17,7 @@ renderer thoroughly and every one of its fixtures sets `content_kind` itself.
 from __future__ import annotations
 
 import ast
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -129,18 +130,27 @@ _RSS = """<?xml version="1.0" encoding="utf-8"?>
 </channel></rss>"""
 
 
-async def _site_source(tmp_path, monkeypatch, pages: list[str]):
-    """A real `url` source, its DB and service, with `pages` served in order."""
+async def _site_source(
+    tmp_path, monkeypatch, pages: list[str], *, change_threshold: float | None = None
+):
+    """A real `url` source, its DB and service, with `pages` served in order.
+
+    `change_threshold` defaults to the DB's own 0.1 (a 10% character-level
+    difference). Pass 0.0 when the point of the test is a *small* edit to a long
+    page, which is otherwise discarded by `check_url` before it ever produces an
+    item -- as happened while writing the rule-scope tests below.
+    """
     db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
     service = LocalWatchlistsService(db_factory=lambda: db)
     _serve(monkeypatch, pages)
-    source = await service.create_source(
-        {
-            "name": "Anthropic status",
-            "url": "https://example.com/page",
-            "source_type": "site",
-        }
-    )
+    payload = {
+        "name": "Anthropic status",
+        "url": "https://example.com/page",
+        "source_type": "site",
+    }
+    if change_threshold is not None:
+        payload["change_threshold"] = change_threshold
+    source = await service.create_source(payload)
     return db, service, int(source["source_id"])
 
 
@@ -418,6 +428,11 @@ async def test_an_oversized_change_is_truncated_and_says_so(tmp_path, monkeypatc
     The bound must hold, and the body must SAY it was cut -- a silently
     partial diff is a change presented as complete. The summary counts the
     whole diff, not the retained slice, so the headline stays true.
+
+    Fix round 1, Important #2: the notice must be the FIRST line, and must also
+    reach `diff_summary`. As line 401 of 401, in a pane about nine rows tall, it
+    was unreachable in exactly the case it exists for -- the reader saw the head
+    of a cut-down diff with nothing at all to say it had been cut.
     """
     from tldw_chatbook.Subscriptions.monitoring_engine import (
         _MAX_DIFF_CHARS,
@@ -433,18 +448,25 @@ async def test_an_oversized_change_is_truncated_and_says_so(tmp_path, monkeypatc
 
     assert "diff truncated" in body, "truncation must be stated in the content"
     assert "partial view" in body
-    # The notice is appended after the cap, so it is the one line allowed past
-    # it -- and it must not itself be coloured as a change.
+    # First line, where nine visible rows can actually reach it -- and not
+    # coloured as though the notice were itself a change.
+    assert "diff truncated" in lines[0], (
+        "the notice must lead the body, not sit past the end of a 400-line diff"
+    )
+    assert not lines[0].startswith(("+", "-"))
+    # It is the one line allowed past the cap.
     assert len(lines) <= _MAX_DIFF_LINES + 1
-    assert not lines[-1].startswith(("+", "-"))
-    assert len(body) <= _MAX_DIFF_CHARS + len(lines[-1]) + 1
+    assert len(body) <= _MAX_DIFF_CHARS + len(lines[0]) + 1
 
     # 900 removals and 900 additions really were produced; the summary must
-    # report those, not the ~400 lines that fit inside the cap.
-    assert summary == "900 line(s) added, 900 removed", summary
+    # report those, not the ~400 lines that fit inside the cap -- and it must
+    # say it was truncated, because the headline needs no scrolling at all.
+    assert summary == "900 line(s) added, 900 removed (diff truncated)", summary
     assert f"{len(lines)} line" not in summary
 
-    # And the same bound holds on the live path, not just in this helper.
+    # And the same bound holds on the live path, not just in this helper. The
+    # truncation must be visible to a reader who never scrolls: the summary is
+    # in `render_change`'s headline.
     db, service, source_id = await _site_source(
         tmp_path,
         monkeypatch,
@@ -453,9 +475,59 @@ async def test_an_oversized_change_is_truncated_and_says_so(tmp_path, monkeypatc
     )
     await _check(service, source_id)
     await _check(service, source_id)
-    stored = _stored_items(db, source_id)[0]["content"]
-    assert "diff truncated" in stored
+    item = _stored_items(db, source_id)[0]
+    stored = item["content"]
+    assert "diff truncated" in stored.splitlines()[0]
     assert len(stored.splitlines()) <= _MAX_DIFF_LINES + 1
+    assert item["diff_summary"].endswith("(diff truncated)")
+
+    plain, _ansi = _rendered(item)
+    head = "\n".join(plain.splitlines()[:4])
+    assert "truncated" in head, (
+        "a reader who never scrolls must still be told the diff was cut"
+    )
+
+
+def test_a_removed_line_that_looks_like_a_diff_header_is_not_deleted():
+    """Fix round 1, Important #1. The header filter ate real content.
+
+    The first implementation dropped any line matching `("---", "+++")`. A
+    REMOVED segment beginning `--` becomes `---...` and an ADDED one beginning
+    `++` becomes `+++...`, so a page dropping a literal `--- Deprecated notice`
+    banner produced a persisted change whose body showed nothing removed and
+    whose headline read "0 line(s) added, 0 removed". The stored record
+    misrepresented the change -- worse than a rendering glitch.
+
+    The headers are dropped by position instead: `unified_diff` yields both of
+    them together before the first hunk, or yields nothing at all.
+    """
+    from tldw_chatbook.Subscriptions.monitoring_engine import build_change_diff
+
+    # The exact case from the review.
+    body, summary = build_change_diff(
+        "Alpha stays. --- Deprecated notice text. Gamma end.",
+        "Alpha stays. Gamma end.",
+    )
+    assert any(
+        line.startswith("-") and "Deprecated notice text." in line
+        for line in body.splitlines()
+    ), f"the removed banner line was deleted as if it were a header: {body!r}"
+    assert summary == "0 line(s) added, 1 removed", summary
+    assert body.splitlines()[0].startswith("@@"), (
+        "the real file headers must still be gone -- the body starts at a hunk"
+    )
+
+    # And the `+++` half: an ADDED segment starting `++`.
+    body, summary = build_change_diff(
+        "Alpha stays. Gamma end.",
+        "Alpha stays. ++ Added banner text. Gamma end.",
+    )
+    assert any(
+        line.startswith("+") and "Added banner text." in line
+        for line in body.splitlines()
+    ), f"the added banner line was deleted as if it were a header: {body!r}"
+    assert summary == "1 line(s) added, 0 removed", summary
+    assert body.splitlines()[0].startswith("@@")
 
 
 @pytest.mark.asyncio
@@ -531,6 +603,153 @@ def test_the_diff_is_readable_in_a_narrow_pane():
     # The unified-diff file headers would be painted red and green by
     # `render_change` as though the header were the change.
     assert not any(line.startswith(("---", "+++")) for line in lines)
+
+
+# --- rules must still see the page, not the diff ---------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_site_alert_still_fires_on_text_the_change_did_not_touch(
+    tmp_path, monkeypatch
+):
+    """Fix round 1, Important #3. An undeclared narrowing of every site rule.
+
+    `WatchlistFilterService` and `WatchlistContentAlertService` build their
+    haystack from `item["content"]`, and `_apply_filters_and_alerts` runs
+    BEFORE persistence. So making `content` a diff silently narrowed every
+    site rule from "matches anywhere on the page" to "matches a changed segment
+    plus one line of context" -- a user's alert that had been firing for months
+    would just stop, with nothing on screen to explain it.
+
+    The phrase here ("All systems operational") sits in the UNCHANGED part of
+    the page and appears nowhere in the diff except as context; the assertion
+    below is deliberately stronger than that, checking the phrase really is
+    absent from the diff body, so the test cannot pass by accident through the
+    one line of context `n=1` happens to include.
+    """
+    db, service, source_id = await _site_source(
+        tmp_path,
+        monkeypatch,
+        # The unchanged sentence is moved far enough from the change that `n=1`
+        # context cannot reach it.
+        [
+            "<html><body><p>All systems operational.</p>"
+            "<p>Filler one. Filler two. Filler three.</p>"
+            "<p>Latest release: Opus 4.1 is available.</p></body></html>",
+            "<html><body><p>All systems operational.</p>"
+            "<p>Filler one. Filler two. Filler three.</p>"
+            "<p>Latest release: Opus 4.5 is available.</p></body></html>",
+        ],
+        change_threshold=0.0,
+    )
+    db.add_filter(
+        name="Status alert",
+        conditions={"type": "keyword", "pattern": "all systems operational"},
+        action="notify",
+        action_params={"severity": "warning"},
+        subscription_id=source_id,
+    )
+
+    await _check(service, source_id)
+    await _check(service, source_id)
+
+    item = _stored_items(db, source_id)[0]
+    assert "All systems operational" not in item["content"], (
+        "the precondition: the phrase is NOT in the stored diff, so a "
+        "diff-scoped haystack genuinely cannot match it"
+    )
+    assert item["alert_matches"] is not None, (
+        "a rule matching unchanged page text must still fire"
+    )
+    matches = json.loads(item["alert_matches"])
+    assert [match["rule_name"] for match in matches] == ["Status alert"]
+
+
+@pytest.mark.asyncio
+async def test_an_exclude_filter_on_unchanged_page_text_still_excludes(
+    tmp_path, monkeypatch
+):
+    """The same narrowing, on the other service.
+
+    A filter is the destructive half: narrowing it does not merely fail to
+    notify, it lets through items the user had told the app to drop.
+    """
+    db, service, source_id = await _site_source(
+        tmp_path,
+        monkeypatch,
+        [
+            "<html><body><p>Sponsored placement.</p>"
+            "<p>Filler one. Filler two. Filler three.</p>"
+            "<p>Latest release: Opus 4.1 is available.</p></body></html>",
+            "<html><body><p>Sponsored placement.</p>"
+            "<p>Filler one. Filler two. Filler three.</p>"
+            "<p>Latest release: Opus 4.5 is available.</p></body></html>",
+        ],
+        change_threshold=0.0,
+    )
+    db.add_filter(
+        name="Drop sponsored",
+        conditions={"type": "keyword", "pattern": "sponsored placement"},
+        action="exclude",
+        subscription_id=source_id,
+    )
+
+    await _check(service, source_id)
+    completed = await _check(service, source_id)
+
+    assert completed["stats"]["items_found"] == 1, "the change really was detected"
+    assert completed["stats"]["items_ingested"] == 0, (
+        "an exclude filter matching unchanged page text must still exclude"
+    )
+    assert _stored_items(db, source_id) == []
+
+
+def test_the_rule_haystack_is_the_page_when_content_is_a_diff():
+    """The shared helper, isolated -- and the drift guard.
+
+    Both services now build their haystack here, so a future edit to one cannot
+    silently diverge from the other. The full text REPLACES `content` rather
+    than being appended to it: a phrase that exists only in the text the change
+    removed must not start matching, which is the mirror-image regression.
+    """
+    from tldw_chatbook.Subscriptions.watchlist_rule_matching import (
+        RULE_MATCH_TEXT_KEY,
+        build_rule_haystack,
+    )
+
+    haystack = build_rule_haystack({
+        "title": "Change detected: Status",
+        "content": "@@ -1,2 +1,2 @@\n-Opus 4.1 available\n+Opus 4.5 available",
+        RULE_MATCH_TEXT_KEY: "All systems operational. Opus 4.5 available.",
+        "author": None,
+    })
+
+    assert "all systems operational" in haystack
+    assert "change detected: status" in haystack
+    assert "opus 4.1" not in haystack, (
+        "removed text must not become matchable -- it is not on the page"
+    )
+
+    # Feed and API items set no `rule_match_text`; `content` IS their body.
+    assert "the model is available" in build_rule_haystack(
+        {"title": "Opus 4.5", "content": "The model is available in the API today."}
+    )
+
+
+def test_the_rule_match_text_is_not_persisted_as_a_column(tmp_path):
+    """It is a matching-time field, not a second copy of every page in the DB.
+
+    The full text is already durable in `url_snapshots`; storing it on the item
+    row as well would undo the whole point of storing a diff.
+    """
+    from tldw_chatbook.Subscriptions.watchlist_rule_matching import RULE_MATCH_TEXT_KEY
+
+    db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
+    columns = {
+        row[1] for row in db.conn.execute("PRAGMA table_info(subscription_items)")
+    }
+    assert "content_kind" in columns, "the table must have been introspected"
+    assert RULE_MATCH_TEXT_KEY not in columns
 
 
 # --- no path may emit an invalid pairing -----------------------------------

--- a/Tests/Subscriptions/test_watchlist_content_kind_producer.py
+++ b/Tests/Subscriptions/test_watchlist_content_kind_producer.py
@@ -1,0 +1,674 @@
+"""TASK-1343: the producers of `content_kind` / `content_format` / `diff_summary`.
+
+Phase D built two reader renderers and dispatches between them on
+`content_kind` (`UI/Watchlists_Modules/content_pane.py`, `render_for`), but
+nothing in the repo wrote the field. So every item -- including every site
+change -- fell through to the article renderer, `render_change` was unreachable
+in production, and `diff_summary` had no producer at all.
+
+These tests drive the REAL producers (`URLMonitor.check_url`,
+`FeedMonitor.check_feed`, `LocalWatchlistsService._normalize_api_item`) through
+the real persistence path and then through the real renderer. Hand-built item
+dicts would pass whether or not any producer writes anything, which is exactly
+how this shipped: `Tests/UI/test_watchlists_content_pane.py` covers the
+renderer thoroughly and every one of its fixtures sets `content_kind` itself.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
+from tldw_chatbook.Subscriptions import LocalWatchlistsService
+from tldw_chatbook.Subscriptions.item_persist import (
+    _VALID_PAIRINGS,
+    _validate_content_pairing,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# --- harness ---------------------------------------------------------------
+
+
+def _response(text: str, *, content_type: str = "text/html") -> SimpleNamespace:
+    """A stand-in for the `httpx.Response` `guarded_fetch_httpx_async` returns.
+
+    `_fetch_url_content` reads `.text`, `.headers` (as a dict) and
+    `.status_code`; `_fetch_and_parse_feed` also reads
+    `.headers.get("content-type")` and calls `.raise_for_status()`.
+    """
+    return SimpleNamespace(
+        status_code=200,
+        headers={"content-type": content_type},
+        text=text,
+        final_url="https://example.com/page",
+        raise_for_status=lambda: None,
+    )
+
+
+def _serve(monkeypatch, pages: list[str], *, content_type: str = "text/html") -> None:
+    """Serve `pages` in order from the monitoring engine's guarded fetch.
+
+    The last page is repeated once the list is exhausted, so a test can do any
+    number of extra checks without the fetch running out.
+    """
+    remaining = list(pages)
+
+    async def fake_guarded(url, *, client, max_bytes, **kwargs):
+        page = remaining.pop(0) if len(remaining) > 1 else remaining[0]
+        return _response(page, content_type=content_type)
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Subscriptions.monitoring_engine.guarded_fetch_httpx_async",
+        fake_guarded,
+    )
+
+
+async def _check(service: LocalWatchlistsService, source_id: int) -> dict:
+    """Launch and execute one real run for `source_id`."""
+    launched = await service.launch_run(source_id=source_id)
+    return await service.execute_run(launched["run_id"])
+
+
+def _stored_items(db: SubscriptionsDB, source_id: int) -> list[dict]:
+    rows = db.conn.execute(
+        "SELECT * FROM subscription_items WHERE subscription_id = ? ORDER BY id ASC",
+        (source_id,),
+    ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def _rendered(item_row: dict) -> tuple[str, str]:
+    """Normalize a stored row and render it exactly as the reader does.
+
+    Goes through `normalize_watchlist_item` (the dict the screen actually hands
+    `ContentPane`) and `render_for` (the dispatch under test), then through a
+    real `rich.console.Console` so the returned pair is (painted characters,
+    characters plus style codes).
+    """
+    from rich.console import Console
+
+    from tldw_chatbook.Subscriptions.watchlist_normalizers import (
+        normalize_watchlist_item,
+    )
+    from tldw_chatbook.UI.Watchlists_Modules.content_pane import render_for
+
+    item = normalize_watchlist_item("local", item_row)
+    console = Console(width=80, record=True, color_system="standard", force_terminal=True)
+    console.print(render_for(item))
+    return console.export_text(clear=False), console.export_text(styles=True)
+
+
+_PAGE_BEFORE = """<html><body>
+<h1>Anthropic status</h1>
+<p>All systems operational.</p>
+<p>Latest release: Opus 4.1 is available.</p>
+</body></html>"""
+
+_PAGE_AFTER = """<html><body>
+<h1>Anthropic status</h1>
+<p>All systems operational.</p>
+<p>Latest release: Opus 4.5 is available.</p>
+<p>Scheduled maintenance on Friday at 02:00 UTC.</p>
+</body></html>"""
+
+_RSS = """<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0"><channel>
+  <title>Anthropic News</title>
+  <item>
+    <title>Opus 4.5 is now available</title>
+    <link>https://example.com/news/opus-45</link>
+    <description>The model is available in the API today.</description>
+    <pubDate>Tue, 28 Jul 2026 09:00:00 +0000</pubDate>
+  </item>
+</channel></rss>"""
+
+
+async def _site_source(tmp_path, monkeypatch, pages: list[str]):
+    """A real `url` source, its DB and service, with `pages` served in order."""
+    db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
+    service = LocalWatchlistsService(db_factory=lambda: db)
+    _serve(monkeypatch, pages)
+    source = await service.create_source(
+        {
+            "name": "Anthropic status",
+            "url": "https://example.com/page",
+            "source_type": "site",
+        }
+    )
+    return db, service, int(source["source_id"])
+
+
+# --- AC#1 / AC#3: the change path reaches `render_change` ------------------
+
+
+@pytest.mark.asyncio
+async def test_a_real_site_change_is_dispatched_to_the_change_renderer(
+    tmp_path, monkeypatch
+):
+    """AC#3, driven end to end: fetch, detect, persist, normalize, dispatch.
+
+    The first check only stores a baseline (`check_url` returns `None` with no
+    previous snapshot), so it must produce no item at all; the second must
+    produce one whose `content_kind` sends `render_for` to `render_change`.
+
+    The discriminator is the one `Tests/UI/test_watchlists_content_pane.py`
+    had to adopt for the same reason: `render_article`'s meta line emits
+    `"<n> words"` and `render_change` emits it under no input, so asserting on
+    it pins the dispatch in both directions. Deleting the `content_kind`
+    assignment in `check_url` reddens this test.
+    """
+    db, service, source_id = await _site_source(
+        tmp_path, monkeypatch, [_PAGE_BEFORE, _PAGE_AFTER]
+    )
+
+    first = await _check(service, source_id)
+    assert first["status"] == "completed"
+    assert _stored_items(db, source_id) == [], (
+        "the first check only stores a baseline snapshot -- the precondition"
+    )
+
+    second = await _check(service, source_id)
+    assert second["status"] == "completed"
+    items = _stored_items(db, source_id)
+    assert len(items) == 1
+
+    item = items[0]
+    assert item["content_kind"] == "change"
+    assert item["content_format"] == "diff"
+
+    plain, _ansi = _rendered(item)
+    assert "words" not in plain, (
+        "a site change must NOT render through render_article -- 'words' comes "
+        "from its meta line and render_change never emits it"
+    )
+    assert "% changed" in plain, "the change headline must be present"
+
+
+@pytest.mark.asyncio
+async def test_the_stored_change_content_is_a_diff_not_the_whole_new_page(
+    tmp_path, monkeypatch
+):
+    """`content` used to be `current_content["text"]` -- the entire new page.
+
+    So the reader could see what the page says now but never what changed,
+    while the full page was ALSO already stored in `url_snapshots`. Asserts
+    the real before/after shows up as `-`/`+` lines, that the unchanged
+    sentence appears once (as context) rather than the whole page being dumped
+    twice, and that `render_change` actually colours those lines.
+    """
+    db, service, source_id = await _site_source(
+        tmp_path, monkeypatch, [_PAGE_BEFORE, _PAGE_AFTER]
+    )
+    await _check(service, source_id)
+    await _check(service, source_id)
+
+    item = _stored_items(db, source_id)[0]
+    content = item["content"]
+
+    assert "-Latest release: Opus 4.1 is available." in content, (
+        "the removed line must be present, prefixed for the renderer to colour"
+    )
+    assert "+Latest release: Opus 4.5 is available." in content
+    assert "+Scheduled maintenance on Friday at 02:00 UTC." in content
+    # The unchanged sentence survives once, as diff context -- not as part of a
+    # second full copy of the page.
+    assert content.count("All systems operational.") == 1
+
+    # The full page is still recoverable, from the snapshot table that already
+    # held it -- nothing was lost by storing the diff instead. Ordered by `id`,
+    # not `created_at`: `url_snapshots.created_at` has one-second resolution, so
+    # two checks in the same second are indistinguishable by it (see the report
+    # -- `check_url`'s own "previous snapshot" query has the same weakness).
+    snapshot = db.conn.execute(
+        "SELECT extracted_content FROM url_snapshots WHERE subscription_id = ?"
+        " ORDER BY id DESC LIMIT 1",
+        (source_id,),
+    ).fetchone()
+    assert "Scheduled maintenance on Friday" in snapshot["extracted_content"]
+    assert "Latest release: Opus 4.5" in snapshot["extracted_content"]
+
+    plain, ansi = _rendered(item)
+    assert "Opus 4.1" in plain and "Opus 4.5" in plain
+    assert "\x1b[32m" in ansi, "an added (`+`) diff line must be painted green"
+    assert "\x1b[31m" in ansi, "a removed (`-`) diff line must be painted red"
+
+
+@pytest.mark.asyncio
+async def test_the_change_headline_carries_a_diff_summary_and_a_real_percentage(
+    tmp_path, monkeypatch
+):
+    """AC#4, plus the scale of `change_percentage`.
+
+    `diff_summary` is rendered by `render_change` and had no producer at all.
+    `change_percentage` is now stored on the 0-100 scale its column name, the
+    renderer's `f"{float(pct):.0f}% changed"` and every renderer fixture read
+    it on; `calculate_change_percentage` returns a 0.0-1.0 ratio, so an
+    unscaled 25% change would have printed "0% changed".
+    """
+    db, service, source_id = await _site_source(
+        tmp_path, monkeypatch, [_PAGE_BEFORE, _PAGE_AFTER]
+    )
+    await _check(service, source_id)
+    await _check(service, source_id)
+
+    item = _stored_items(db, source_id)[0]
+
+    assert item["diff_summary"], "diff_summary must have a producer now"
+    assert "\n" not in item["diff_summary"], "it is a one-line headline field"
+    assert "added" in item["diff_summary"] and "removed" in item["diff_summary"]
+
+    pct = item["change_percentage"]
+    assert isinstance(pct, float)
+    assert 1.0 < pct <= 100.0, (
+        f"change_percentage must be a percentage, not a 0-1 ratio (got {pct!r})"
+    )
+
+    plain, _ansi = _rendered(item)
+    assert f"{pct:.0f}% changed" in plain
+    assert "0% changed" not in plain, (
+        "a real change must never print as 0% -- the ratio/percent mismatch"
+    )
+    assert item["diff_summary"] in plain
+
+
+@pytest.mark.asyncio
+async def test_change_type_is_derived_from_the_snapshots_not_hardcoded(
+    tmp_path, monkeypatch
+):
+    """`change_type` was the literal `"content"` for every change ever.
+
+    Only the distinctions the two snapshots actually support are claimed:
+    text appearing where there was none is `"new"`, text disappearing entirely
+    is `"removed"`, anything else is `"content"`. A page whose text goes away
+    used to be reported to the user as an ordinary content edit.
+    """
+    from tldw_chatbook.Subscriptions.monitoring_engine import classify_change_type
+
+    assert classify_change_type("", "hello") == "new"
+    assert classify_change_type("hello", "") == "removed"
+    assert classify_change_type("   ", "hello") == "new"
+    assert classify_change_type("hello", "goodbye") == "content"
+
+    # And it reaches the DB from a real check: this page loses all of its text.
+    db, service, source_id = await _site_source(
+        tmp_path,
+        monkeypatch,
+        [_PAGE_BEFORE, "<html><body><script>x=1</script></body></html>"],
+    )
+    await _check(service, source_id)
+    await _check(service, source_id)
+
+    item = _stored_items(db, source_id)[0]
+    assert item["change_type"] == "removed", (
+        "a page that lost all of its text is not a 'content' edit"
+    )
+    plain, _ansi = _rendered(item)
+    assert "removed" in plain
+
+
+# --- AC#2: the feed and API paths ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_feed_item_is_stored_as_an_article_with_a_legal_format(
+    tmp_path, monkeypatch
+):
+    """AC#2. The RSS path wrote neither field, so it relied on `render_for`'s
+    fallback -- which is what made the dispatch untestable in the first place.
+
+    `"text"` is the honest format: `description` arrives as the publisher's
+    plain text or HTML and nothing on this path converts it to markdown.
+    Claiming `"markdown"` would hand publisher HTML to a CommonMark parser.
+    """
+    db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
+    service = LocalWatchlistsService(db_factory=lambda: db)
+    _serve(monkeypatch, [_RSS], content_type="application/rss+xml")
+
+    source = await service.create_source(
+        {
+            "name": "Anthropic News",
+            "url": "https://example.com/feed.xml",
+            "source_type": "rss",
+        }
+    )
+    source_id = int(source["source_id"])
+    completed = await _check(service, source_id)
+    assert completed["status"] == "completed"
+
+    items = _stored_items(db, source_id)
+    assert len(items) == 1
+    item = items[0]
+    assert item["content_kind"] == "article"
+    assert item["content_format"] == "text"
+    assert item["content"] == "The model is available in the API today."
+
+    plain, _ansi = _rendered(item)
+    assert "words" in plain, "an article must render through render_article"
+    assert "% changed" not in plain
+
+
+@pytest.mark.asyncio
+async def test_an_api_item_is_stored_as_an_article_with_a_legal_format(
+    tmp_path, monkeypatch
+):
+    """The API path is normalized in the service, not the monitoring engine,
+    and had the same gap. Its body is whatever JSON field the source's
+    `field_map` points at, in whatever format the API chose and unconverted,
+    so `"text"` is what was captured.
+    """
+    payload = {
+        "items": [
+            {
+                "title": "Alpha update",
+                "url": "https://api.example.com/a",
+                "summary": "First item body.",
+            }
+        ]
+    }
+
+    async def fake_guarded(url, *, client, max_bytes, **kwargs):
+        return SimpleNamespace(
+            status_code=200,
+            headers={"content-type": "application/json"},
+            final_url=url,
+            raise_for_status=lambda: None,
+            json=lambda: payload,
+        )
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Subscriptions.local_watchlists_service."
+        "guarded_fetch_httpx_async",
+        fake_guarded,
+    )
+
+    db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
+    service = LocalWatchlistsService(db_factory=lambda: db)
+    source = await service.create_source(
+        {
+            "name": "API changelog",
+            "url": "https://api.example.com/changes",
+            "source_type": "api",
+        }
+    )
+    source_id = int(source["source_id"])
+    await _check(service, source_id)
+
+    item = _stored_items(db, source_id)[0]
+    assert item["content_kind"] == "article"
+    assert item["content_format"] == "text"
+
+    plain, _ansi = _rendered(item)
+    assert "words" in plain
+
+
+# --- the size bound --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_oversized_change_is_truncated_and_says_so(tmp_path, monkeypatch):
+    """A large page can produce an enormous diff, and this goes into a TEXT
+    column and a pane about nine rows tall.
+
+    The bound must hold, and the body must SAY it was cut -- a silently
+    partial diff is a change presented as complete. The summary counts the
+    whole diff, not the retained slice, so the headline stays true.
+    """
+    from tldw_chatbook.Subscriptions.monitoring_engine import (
+        _MAX_DIFF_CHARS,
+        _MAX_DIFF_LINES,
+        build_change_diff,
+    )
+
+    before = " ".join(f"Paragraph {i} says the old thing." for i in range(900))
+    after = " ".join(f"Paragraph {i} says the new thing instead." for i in range(900))
+
+    body, summary = build_change_diff(before, after)
+    lines = body.splitlines()
+
+    assert "diff truncated" in body, "truncation must be stated in the content"
+    assert "partial view" in body
+    # The notice is appended after the cap, so it is the one line allowed past
+    # it -- and it must not itself be coloured as a change.
+    assert len(lines) <= _MAX_DIFF_LINES + 1
+    assert not lines[-1].startswith(("+", "-"))
+    assert len(body) <= _MAX_DIFF_CHARS + len(lines[-1]) + 1
+
+    # 900 removals and 900 additions really were produced; the summary must
+    # report those, not the ~400 lines that fit inside the cap.
+    assert summary == "900 line(s) added, 900 removed", summary
+    assert f"{len(lines)} line" not in summary
+
+    # And the same bound holds on the live path, not just in this helper.
+    db, service, source_id = await _site_source(
+        tmp_path,
+        monkeypatch,
+        [f"<html><body><p>{before}</p></body></html>",
+         f"<html><body><p>{after}</p></body></html>"],
+    )
+    await _check(service, source_id)
+    await _check(service, source_id)
+    stored = _stored_items(db, source_id)[0]["content"]
+    assert "diff truncated" in stored
+    assert len(stored.splitlines()) <= _MAX_DIFF_LINES + 1
+
+
+@pytest.mark.asyncio
+async def test_the_whole_stored_diff_body_is_exactly_this(tmp_path, monkeypatch):
+    """Pin the body a real check produces, in full.
+
+    The individual `in content` assertions above cannot show that the result is
+    *readable*: four short lines with a hunk header, not a wall of text. This
+    is what a reader sees in a pane about nine rows tall, and any change to the
+    diff's shape has to come through here and be looked at.
+    """
+    db, service, source_id = await _site_source(
+        tmp_path, monkeypatch, [_PAGE_BEFORE, _PAGE_AFTER]
+    )
+    await _check(service, source_id)
+    await _check(service, source_id)
+
+    assert _stored_items(db, source_id)[0]["content"] == (
+        "@@ -1,2 +1,3 @@\n"
+        " Anthropic status All systems operational.\n"
+        "-Latest release: Opus 4.1 is available.\n"
+        "+Latest release: Opus 4.5 is available.\n"
+        "+Scheduled maintenance on Friday at 02:00 UTC."
+    )
+
+
+def test_a_change_with_no_textual_difference_says_so_rather_than_nothing():
+    """The content hash is taken over the raw extracted text while
+    segmentation trims whitespace, so a whitespace-only change hashes
+    differently and diffs to nothing.
+
+    An empty body would make `render_change` print "no body captured for this
+    item -- re-check this source to fetch it": a claim that nothing was
+    captured, when in fact it was captured and it matched.
+    """
+    from tldw_chatbook.Subscriptions.monitoring_engine import build_change_diff
+
+    body, summary = build_change_diff("One sentence.  Two.", "One sentence. Two.")
+
+    assert body, "never return an empty body -- the renderer would misreport it"
+    assert "identical" in body
+    assert not body.startswith(("+", "-")), "the notice must not read as a change"
+    assert summary == "no textual change after normalization"
+
+
+def test_the_diff_is_readable_in_a_narrow_pane():
+    """`extract_text_from_html` joins every chunk of a page with a single
+    space, so extracted page text is ONE line with no newlines in it.
+
+    A line-based diff of two such snapshots is therefore always exactly
+    `-<the entire old page>` / `+<the entire new page>` -- the full text twice.
+    Both sides are re-segmented before diffing, and no emitted line may be
+    wider than the reader pane can show.
+    """
+    from tldw_chatbook.Subscriptions.monitoring_engine import (
+        _MAX_DIFF_SEGMENT_CHARS,
+        build_change_diff,
+    )
+
+    before = "Alpha holds. " + "Beta " * 200 + "stays. Gamma was here."
+    after = "Alpha holds. " + "Beta " * 200 + "stays. Delta is here now."
+
+    body, _summary = build_change_diff(before, after)
+    lines = body.splitlines()
+
+    assert len(lines) > 2, "a single-line page must still produce a real diff"
+    for line in lines:
+        assert len(line) <= _MAX_DIFF_SEGMENT_CHARS + 2, (
+            f"a diff line wider than the pane: {line[:60]!r}... ({len(line)} chars)"
+        )
+    assert any(line.startswith("-") and "Gamma was here." in line for line in lines)
+    assert any(line.startswith("+") and "Delta is here now." in line for line in lines)
+    # The unified-diff file headers would be painted red and green by
+    # `render_change` as though the header were the change.
+    assert not any(line.startswith(("---", "+++")) for line in lines)
+
+
+# --- no path may emit an invalid pairing -----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_producer_emits_a_pairing_persistence_would_reject(
+    tmp_path, monkeypatch
+):
+    """`persist_subscription_item` RAISES on an invalid pairing, and that raise
+    lands inside a scheduled fetch, where `execute_run` converts it into a
+    failed run and drops every item the run collected.
+
+    So every producer's output is collected here and checked against
+    `_VALID_PAIRINGS` itself -- not against a copy of the list.
+    """
+    from tldw_chatbook.Subscriptions.local_watchlists_service import (
+        LocalWatchlistsService as Service,
+    )
+    from tldw_chatbook.Subscriptions.monitoring_engine import FeedMonitor
+
+    produced: list[tuple] = []
+
+    monitor = FeedMonitor()
+    produced.extend(
+        (item.get("content_kind"), item.get("content_format"))
+        for item in monitor._parse_xml_feed(_RSS, "rss")
+    )
+    produced.extend(
+        (item.get("content_kind"), item.get("content_format"))
+        for item in monitor._parse_xml_feed(_ATOM, "atom")
+    )
+    produced.extend(
+        (item.get("content_kind"), item.get("content_format"))
+        for item in monitor._parse_json_feed(_JSON_FEED)
+    )
+    api_item = Service._normalize_api_item(
+        {"title": "t", "url": "https://example.com/x", "content": "body"},
+        {},
+        "https://example.com/api",
+    )
+    produced.append((api_item.get("content_kind"), api_item.get("content_format")))
+
+    db, service, source_id = await _site_source(
+        tmp_path, monkeypatch, [_PAGE_BEFORE, _PAGE_AFTER]
+    )
+    await _check(service, source_id)
+    await _check(service, source_id)
+    change = _stored_items(db, source_id)[0]
+    produced.append((change["content_kind"], change["content_format"]))
+
+    assert len(produced) == 4 + 1, f"a producer stopped emitting: {produced}"
+    for pairing in produced:
+        assert pairing in _VALID_PAIRINGS, f"{pairing} would be rejected on write"
+        _validate_content_pairing(*pairing)
+
+
+def test_every_content_kind_literal_in_the_package_is_from_the_vocabulary():
+    """The typo guard, structurally.
+
+    A producer that writes `"changed"` or `"plain"` instead of the real value
+    does not fail at the write boundary (`_validate_content_pairing` raises,
+    but only when that code path runs -- inside a scheduled fetch, on someone
+    else's machine). Every `content_kind`/`content_format` value written as a
+    dict-literal in the subscriptions/watchlists code must therefore be either
+    one of `item_persist`'s named constants or a member of the vocabulary.
+    Values that are expressions (e.g. `row.get("content_kind")` in
+    `watchlist_normalizers`, which READS the field) are not producers and are
+    skipped.
+
+    Scoped to the trees that own this vocabulary: `content_format` is an
+    unrelated, differently-valued key in the media-reading services
+    (`Media/local_media_reading_service.py` and friends), and sweeping the
+    whole package would be asserting something false about them.
+    """
+    kinds = {kind for kind, _fmt in _VALID_PAIRINGS}
+    formats = {fmt for _kind, fmt in _VALID_PAIRINGS}
+    allowed_names = {
+        "CONTENT_KIND_ARTICLE",
+        "CONTENT_KIND_CHANGE",
+        "CONTENT_FORMAT_TEXT",
+        "CONTENT_FORMAT_MARKDOWN",
+        "CONTENT_FORMAT_DIFF",
+    }
+    package_root = Path(__file__).resolve().parents[2] / "tldw_chatbook"
+    scanned = [
+        *(package_root / "Subscriptions").rglob("*.py"),
+        *(package_root / "UI" / "Watchlists_Modules").rglob("*.py"),
+        package_root / "DB" / "Subscriptions_DB.py",
+    ]
+    assert len(scanned) > 20, "the scan lost its files"
+
+    offenders: list[str] = []
+    for path in scanned:
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except (SyntaxError, UnicodeDecodeError):  # pragma: no cover - defensive
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Dict):
+                continue
+            for key, value in zip(node.keys, node.values):
+                if not isinstance(key, ast.Constant) or key.value not in (
+                    "content_kind",
+                    "content_format",
+                ):
+                    continue
+                allowed = kinds if key.value == "content_kind" else formats
+                if isinstance(value, ast.Name):
+                    if value.id not in allowed_names:
+                        offenders.append(f"{path}:{value.lineno} {value.id}")
+                elif isinstance(value, ast.Constant) and isinstance(value.value, str):
+                    if value.value not in allowed:
+                        offenders.append(f"{path}:{value.lineno} {value.value!r}")
+
+    assert not offenders, f"values outside the vocabulary: {offenders}"
+
+
+_ATOM = """<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Anthropic News</title>
+  <entry>
+    <title>Opus 4.5 is now available</title>
+    <link rel="alternate" href="https://example.com/news/opus-45"/>
+    <summary>The model is available in the API today.</summary>
+    <published>2026-07-28T09:00:00Z</published>
+  </entry>
+</feed>"""
+
+_JSON_FEED = """{
+  "version": "https://jsonfeed.org/version/1.1",
+  "items": [
+    {
+      "id": "1",
+      "title": "Opus 4.5 is now available",
+      "url": "https://example.com/news/opus-45",
+      "content_html": "<p>The model is available in the API today.</p>",
+      "date_published": "2026-07-28T09:00:00Z"
+    }
+  ]
+}"""

--- a/backlog/tasks/task-1343 - Nothing-writes-content_kind-so-the-Watchlists-change-renderer-is-unreachable.md
+++ b/backlog/tasks/task-1343 - Nothing-writes-content_kind-so-the-Watchlists-change-renderer-is-unreachable.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-1343
-title: Nothing writes content_kind, so the Watchlists change renderer is unreachable
-status: To Do
-assignee: []
+title: 'Nothing writes content_kind, so the Watchlists change renderer is unreachable'
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-29 05:30'
+updated_date: '2026-07-29 23:04'
 labels:
   - watchlists
   - dead-code
@@ -39,8 +41,41 @@ reading as live to a grep.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The site-change detection path writes content_kind="change" and content_format="diff" when it persists an item, alongside the change_percentage and change_type it already writes
-- [ ] #2 The feed path writes content_kind="article" with a content_format matching what it actually captured
-- [ ] #3 A test asserts a real site check produces an item that render_for dispatches to render_change, failing if content_kind is absent
-- [ ] #4 diff_summary is populated by the change path, or removed from the renderer if nothing will produce it
+- [x] #1 The site-change detection path writes content_kind="change" and content_format="diff" when it persists an item, alongside the change_percentage and change_type it already writes
+- [x] #2 The feed path writes content_kind="article" with a content_format matching what it actually captured
+- [x] #3 A test asserts a real site check produces an item that render_for dispatches to render_change, failing if content_kind is absent
+- [x] #4 diff_summary is populated by the change path, or removed from the renderer if nothing will produce it
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Establish where each source type's item dict is built and confirm it reaches persist_subscription_item unchanged.
+2. Give the site-change path a real diff: re-segment both snapshots (extracted page text is ONE line), build a bounded unified-diff body, and emit content_kind/content_format/diff_summary/change_type.
+3. Emit content_kind=article + content_format=text on the RSS, Atom, JSON Feed and API paths.
+4. Name the vocabulary once, in item_persist, so no producer can typo a pairing.
+5. Correct content_pane's stale change_percentage producer comment.
+6. Tests driving the real producers end to end, plus mutation checks on every assignment.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Gave the reader's `content_kind` dispatch its missing producer, on every live path.
+
+**The change path now emits a real diff, not the whole page.** `URLMonitor.check_url` stored `current_content["text"]` — the entire new page — as the item body, so a reader could see what a page says now but never what changed, while the same full text was ALSO already in `url_snapshots`. It now stores a bounded unified-diff body (`content_kind="change"`, `content_format="diff"`), plus `diff_summary` ("N line(s) added, M removed", counted over the whole diff so it stays true when the body is capped) and a derived `change_type`.
+
+**Segmentation was the load-bearing detail.** `ContentExtractor.extract_text_from_html` joins every chunk of a page with a single space, so extracted page text is ONE line with no newlines. A line-based diff of two snapshots is therefore always exactly `-<entire old page>` / `+<entire new page>`: the full text twice. Both sides are re-segmented before diffing — real line breaks when present, otherwise sentence boundaries (which stay aligned under a local edit; fixed-width chunking does not) — and over-long segments are word-wrapped at 110 chars so no diff line is wider than the pane.
+
+**Bounds:** 400 lines / 20,000 chars, whichever is hit first, with the truncation stated IN the body so a partial change never reads as complete. Losing the tail loses nothing recoverable — the full page is still in `url_snapshots`. Two notices (truncation, and "hash changed but text is identical after normalization") deliberately start with `[` so `render_change` does not colour them as changes; an empty body would otherwise make the renderer claim "no body captured", which would be false.
+
+**`change_type`** was the hardcoded literal `"content"`. Now `new`/`removed`/`content`, the only three distinctions two snapshots support. `baseline_manager.ChangeReport`'s `structural`/`semantic` need DOM and embedding analysis `check_url` does not do; `baseline_manager` was not touched (TASK-1360).
+
+**Feed and API paths** emit `article`/`text`. `text` is the honest answer: RSS `description`, `atom:content`, JSON Feed `content_html` and an API's mapped JSON field all arrive as the publisher's plain text or HTML and nothing converts them; claiming `markdown` would hand publisher HTML to a CommonMark parser.
+
+**Two adjacent corrections.** (1) `change_percentage` is now scaled to 0-100 at the point it is handed to the reader, matching the column name, `render_change`'s `f"{float(pct):.0f}% changed"` and every renderer fixture; the threshold comparison still uses the 0-1 ratio. Unscaled, making the renderer reachable would have printed "0% changed" for a real 35% change. (2) `content_pane.py`'s comment claiming `baseline_manager.py` writes `change_percentage` now names only the real producer.
+
+The kind/format vocabulary is named once in `item_persist.py` (where `_VALID_PAIRINGS` already lived) and imported by both producers, because an invalid pairing raises inside a scheduled fetch and `execute_run` converts that into a failed run that drops every item it collected.
+
+Modified: `Subscriptions/monitoring_engine.py`, `Subscriptions/local_watchlists_service.py`, `Subscriptions/item_persist.py`, `UI/Watchlists_Modules/content_pane.py`. Added: `Tests/Subscriptions/test_watchlist_content_kind_producer.py` (12 tests, all driving the real producers through real persistence and the real renderer; 9 mutation checks confirmed each assignment is load-bearing).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-1345 - Select-Input-mount-race-makes-the-Watchlists-create-form-tests-order-dependent.md
+++ b/backlog/tasks/task-1345 - Select-Input-mount-race-makes-the-Watchlists-create-form-tests-order-dependent.md
@@ -22,6 +22,16 @@ Symptoms are a `Select`/`Input` mount race — `NoMatches` on `SelectCurrent`, a
 (`'orning' == 'Morning'`) indicating the input was read while still mounting.
 
 The failures are intermittent across runs, so a green CI run is not evidence the race is gone.
+
+**Corrected 2026-07-30 (TASK-1343):** the race is **not confined to a named test**. Three
+consecutive runs of `Tests/UI/ -k watchlist` produced three different failing sets: it moved among
+three tests in `test_watchlists_source_create_form.py` and surfaced once in
+`test_watchlists_source_frequency_control.py`. Both files pass in isolation (15/15 and 19/19,
+reproduced). Only the two tree-chevron failures are constant.
+
+Consequence for anyone reading a test run: **do not quote a fixed test name as the expected
+baseline** for this race. Doing so generates false regression reports when it moves, and false
+all-clear when it lands somewhere unlisted. Characterise it by file and by ordering instead.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria

--- a/backlog/tasks/task-1360 - Decide-the-fate-of-baseline_manager-a-697-line-change-detector-nothing-imports.md
+++ b/backlog/tasks/task-1360 - Decide-the-fate-of-baseline_manager-a-697-line-change-detector-nothing-imports.md
@@ -1,0 +1,46 @@
+---
+id: TASK-1360
+title: Decide the fate of baseline_manager, a 697-line change detector nothing imports
+status: To Do
+assignee: []
+created_date: '2026-07-29 23:10'
+labels:
+  - watchlists
+  - dead-code
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`tldw_chatbook/Subscriptions/baseline_manager.py` is 697 lines and 20 methods of change-detection
+machinery with **no importers anywhere in the repo and no tests**. The only reference to it is a
+comment in `content_pane.py`. Verified: a grep for `baseline_manager`/`BaselineManager` across every
+`.py` under `tldw_chatbook/` returns only that comment, and an import statement must name the module.
+
+It matters because it is **better than the code actually in use**. `ChangeReport` carries a
+`change_type` vocabulary of `'content'/'structural'/'semantic'/'new'/'removed'` — the spec's site
+mockup shows `structural` — plus a `summary` field that is precisely what the `diff_summary` column
+wants, and it compares key elements structurally rather than only by text ratio.
+
+The live path (`monitoring_engine.py`) instead computes `change_percentage` from
+`difflib.SequenceMatcher` and hardcodes `change_type: "content"`. TASK-1343 extends that live path
+rather than adopting this module, deliberately, because pulling 697 untested lines into the fetch
+path is its own risk and deserves its own decision.
+
+This is the sixth instance in this codebase of a construct that is built, wired and carrying
+nothing while reading as live to a grep — see TASK-1220 (`content_processor` orphaned) and
+TASK-1221 (Watchlists gated on three packages nothing imports).
+
+Note also: a comment at `content_pane.py:160-161` cites "`baseline_manager.py`/`monitoring_engine.py`"
+as the producers of `change_percentage`. Half of that is false and is corrected by TASK-1343.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A decision is recorded on whether baseline_manager is adopted into the live change-detection path, kept as a documented future component, or deleted
+- [ ] #2 If adopted, it has test coverage before it enters the fetch path, and monitoring_engine's duplicate detection is retired rather than left as a second implementation
+- [ ] #3 If deleted, the change_type vocabulary and structural comparison worth keeping are named in the task notes so the capability is not silently lost
+- [ ] #4 A liveness check is run from both ends (what imports it, and what it imports) rather than a single outward grep
+<!-- AC:END -->

--- a/backlog/tasks/task-1361 - Two-URL-checks-in-the-same-second-diff-against-a-stale-snapshot.md
+++ b/backlog/tasks/task-1361 - Two-URL-checks-in-the-same-second-diff-against-a-stale-snapshot.md
@@ -1,0 +1,35 @@
+---
+id: TASK-1361
+title: Two URL checks in the same second diff against a stale snapshot
+status: To Do
+assignee: []
+created_date: '2026-07-29 23:40'
+labels:
+  - watchlists
+  - correctness
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`URLMonitor.check_url` selects the baseline to compare against with
+`ORDER BY created_at DESC LIMIT 1` over `url_snapshots`, and `created_at` has one-second resolution.
+If two checks for the same source land within the same second, the ordering between the snapshot just
+written and the one before it is undefined, so a check can diff against a **stale** baseline.
+
+Found while implementing TASK-1343 — it broke the first draft of a test that performed two checks in
+quick succession, which is exactly the shape a retry, a manual "Check now" during a scheduled run, or
+a tight test loop produces.
+
+The consequence is a wrong `change_percentage`, a wrong diff, and possibly a spurious item: the
+change is measured against the wrong "before".
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Baseline selection is deterministic regardless of how many snapshots share a created_at value, for example by tie-breaking on the row id
+- [ ] #2 A test performs two checks for one source within the same second and asserts the second diffs against the first, not against an older snapshot
+- [ ] #3 The test fails if the tie-break is removed
+<!-- AC:END -->

--- a/backlog/tasks/task-1362 - A-small-edit-to-a-long-page-never-clears-the-change-threshold.md
+++ b/backlog/tasks/task-1362 - A-small-edit-to-a-long-page-never-clears-the-change-threshold.md
@@ -1,0 +1,40 @@
+---
+id: TASK-1362
+title: A small edit to a long page never clears the change threshold
+status: To Do
+assignee: []
+created_date: '2026-07-29 23:55'
+labels:
+  - watchlists
+  - correctness
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`change_threshold` defaults to `0.1` and is compared against `calculate_change_percentage`, which is
+whole-page character similarity via `difflib.SequenceMatcher`. On a long page, a genuinely important
+small edit — a price, a version number, a single added paragraph — moves that ratio by far less than
+0.1, so **no item is ever created and the user is never told**.
+
+The failure is silent and indistinguishable from "nothing changed", which is the same class of
+problem as the watchlists that never checked at all (TASK-1210): the machinery works, and the user
+concludes the feature does nothing.
+
+Found while implementing TASK-1343, which made the change body renderable and therefore made the
+threshold's behaviour visible for the first time.
+
+Worth considering together: a per-region or per-element comparison, an absolute floor alongside the
+ratio (e.g. "N characters changed"), or surfacing the computed percentage in the UI so a user can see
+why nothing fired and tune the threshold. `baseline_manager.py` already contains structural and
+key-element comparison that would help here, but it is orphaned — see TASK-1360.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A small but meaningful edit to a long page produces an item under the default configuration
+- [ ] #2 The rule that decides "significant" is stated in the UI or docs, so a user can tell why a change did or did not fire
+- [ ] #3 A test pins a realistic long-page-small-edit case and fails under the old whole-page ratio alone
+<!-- AC:END -->

--- a/backlog/tasks/task-1363 - Offer-appeared-disappeared-semantics-for-content-alerts.md
+++ b/backlog/tasks/task-1363 - Offer-appeared-disappeared-semantics-for-content-alerts.md
@@ -1,0 +1,35 @@
+---
+id: TASK-1363
+title: Offer appeared/disappeared semantics for content alerts
+status: To Do
+assignee: []
+created_date: '2026-07-29 23:55'
+labels:
+  - watchlists
+  - enhancement
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Content alerts and filters match against the **full page text**, which TASK-1343 deliberately
+preserved: a rule that has matched a phrase for months must not silently stop firing because the
+phrase happens to sit in an unchanged part of the page, and a narrowed *exclude* filter would admit
+items the user told the app to drop.
+
+But "tell me when this phrase **appears**" — matching only newly-added text — is a genuinely useful
+thing to want from a site watcher, and the diff now makes it cheap to compute. The same applies to
+"tell me when it **disappears**".
+
+This should be a per-rule opt-in with its own affordance, not a change to the default. Filed because
+the capability arrived as a side effect of TASK-1343's diff and would otherwise be forgotten.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A content alert rule can be set to match on newly-added text, on removed text, or anywhere on the page, with anywhere remaining the default
+- [ ] #2 Exclude filters continue to match the whole page regardless of the setting, so a narrowed scope can never admit an excluded item
+- [ ] #3 Tests cover each scope, including that an existing rule with no explicit scope keeps its current page-wide behaviour
+<!-- AC:END -->

--- a/task-1343-report.md
+++ b/task-1343-report.md
@@ -1,0 +1,224 @@
+# TASK-1343 — `content_kind` / `content_format` / `diff_summary` now have producers
+
+Branch `feat/task-1343-content-kind-producer`, worktree `/private/tmp/tldw-1343`.
+
+## What was built
+
+### 1. The change path emits a real diff, not the full page
+
+`URLMonitor.check_url` (`tldw_chatbook/Subscriptions/monitoring_engine.py`) previously put
+`current_content["text"]` — the **entire new page** — into the item's `content`, and wrote no
+`content_kind`. It now writes:
+
+| field | before | after |
+|---|---|---|
+| `content` | the whole new page text | a bounded unified-diff body |
+| `content_kind` | *(absent)* | `"change"` |
+| `content_format` | *(absent)* | `"diff"` |
+| `diff_summary` | *(absent — no producer anywhere)* | `"2 line(s) added, 1 removed"` |
+| `change_type` | hardcoded `"content"` | `"new"` / `"removed"` / `"content"`, derived |
+| `change_percentage` | 0.0–1.0 ratio | the same value × 100 (see §6) |
+
+The full page continues to live in `url_snapshots` — `_store_snapshot` is still called on the very
+next line — so nothing was lost by storing the diff instead. A test asserts the snapshot still
+holds the whole new text.
+
+### 2. Format choice: a unified-diff body, headers stripped, sentence-segmented
+
+`render_change` colours a line by its leading `+`/`-` (`content_pane.py:190`), so the body is a
+`difflib.unified_diff` body with `n=1` context. The `---`/`+++` **file headers are dropped**:
+they begin with `-` and `+`, so the renderer would paint them red and green as though the header
+itself were the change. `@@` hunk headers are kept — they carry position and colour as ordinary
+text.
+
+**The load-bearing finding, and the reason a naive diff would have been useless.**
+`ContentExtractor.extract_text_from_html` ends with
+
+```python
+text = " ".join(chunk for chunk in chunks if chunk)
+```
+
+so **the extracted text of an entire page is ONE line, with no newlines in it at all.** A
+line-based diff of two such snapshots is therefore always exactly
+
+```
+-<the entire old page>
++<the entire new page>
+```
+
+— the full text twice: simultaneously the least readable and the largest possible thing to store.
+So both sides are re-segmented before diffing (`_segment_for_diff`):
+
+* real line breaks when the text has any (`extraction_method` other than `full`/`auto`);
+* otherwise sentence boundaries, `(?<=[.!?])\s+`. Sentences stay aligned under a local edit;
+  fixed-width chunking does not (inserting one word early shifts every boundary and makes every
+  chunk differ).
+* any segment over **110 characters** is word-wrapped, so no emitted diff line is wider than the
+  narrow reader pane. A test asserts this for every line.
+
+The result, from a real check driven through the real producer (pinned in full by
+`test_the_whole_stored_diff_body_is_exactly_this`):
+
+```
+@@ -1,2 +1,3 @@
+ Anthropic status All systems operational.
+-Latest release: Opus 4.1 is available.
++Latest release: Opus 4.5 is available.
++Scheduled maintenance on Friday at 02:00 UTC.
+```
+
+Four short lines. Readable in a nine-row pane.
+
+### 3. Size cap: **400 lines / 20,000 characters, whichever is hit first**
+
+Why those numbers: the body goes into a `TEXT` column *and* into a pane about nine rows tall, and
+the page it was computed from is already archived in `url_snapshots` — so the diff is a summary,
+not an archive, and losing its tail loses nothing recoverable. 400 lines is ~40× the pane height
+and far more than a reader scrolls; 20,000 characters keeps the item row small next to the
+snapshot.
+
+Truncation is stated **in the content**, as the one line allowed past the cap:
+
+```
+[diff truncated: showing the first 400 of 1800 diff lines (cap 400 lines / 20000 characters).
+This is a partial view of the change; the full page is in this source's snapshot history.]
+```
+
+It starts with `[`, not `+`/`-`, so the renderer does not colour it as a change — a test asserts
+that. `diff_summary` counts the **whole** diff, not the retained slice, so the headline stays true
+when the body is cut.
+
+### 4. `diff_summary`
+
+`"N line(s) added, M removed"` — one line, which is what `render_change`'s `·`-joined headline
+needs. A real change renders as e.g. `25% changed · content · 2 line(s) added, 1 removed`.
+
+### 5. `change_type` — improved, not left hardcoded
+
+It was the literal `"content"` for every change ever detected. `classify_change_type` now returns:
+
+* `"new"` — the previous snapshot had no text and the new one does;
+* `"removed"` — the page's text disappeared entirely (previously reported to the user as an
+  ordinary content edit);
+* `"content"` — otherwise.
+
+Those are the only three distinctions two text snapshots can honestly support.
+`baseline_manager.ChangeReport`'s richer vocabulary also has `'structural'` and `'semantic'`, but
+those need DOM-shape and embedding analysis that `check_url` does not do, so claiming them would
+be a guess. **`baseline_manager.py` was not touched** (TASK-1360).
+
+### 6. Feed and API paths → `("article", "text")`
+
+* `FeedMonitor._parse_rss_item`, `_parse_atom_entry`, `_parse_json_feed`
+* `LocalWatchlistsService._normalize_api_item`
+
+`"text"` is the honest format, not `"markdown"`: RSS `description`, `atom:content`/`atom:summary`,
+JSON Feed `content_html`/`content_text` and an API's mapped JSON field all arrive as the
+publisher's plain text or HTML, and **nothing on any of these paths converts anything to
+markdown**. Claiming `"markdown"` would make `render_article` hand publisher HTML to a CommonMark
+parser. The API path is written unconditionally, even when the source supplied no body: the kind
+is still `article` (`render_article` then explains the missing body), and both values are non-`None`
+so they survive `_normalize_api_item`'s `if value is not None` filter.
+
+### 7. The vocabulary is named once
+
+`CONTENT_KIND_ARTICLE` / `CONTENT_KIND_CHANGE` / `CONTENT_FORMAT_TEXT` /
+`CONTENT_FORMAT_MARKDOWN` / `CONTENT_FORMAT_DIFF` now live in `item_persist.py`, which already
+owned `_VALID_PAIRINGS` (now built from them), and both producers import from there. Reason: an
+invalid pairing **raises** out of `persist_subscription_item`, `execute_run` catches it into
+`record_run_failure`, and **every item the run collected is dropped**. Mutation 6 below
+demonstrates exactly that. `item_persist` has no heavy imports, so this is safe at module scope
+and does not disturb `monitoring_engine`'s deliberately lazy import in
+`_default_run_executor`.
+
+### 8. The stale comment (point 6 of the brief)
+
+`content_pane.py:160-161` claimed `change_percentage` "is always written as a Python float by
+`baseline_manager.py`/`monitoring_engine.py`". It now names the single real producer,
+`monitoring_engine.URLMonitor.check_url`, states the 0–100 scale, and records that
+`baseline_manager` writes nothing because nothing imports it (TASK-1360).
+
+## Findings
+
+**F1 — `change_percentage` was stored as a 0–1 ratio and printed as a percentage.**
+`calculate_change_percentage` returns 0.0–1.0. `render_change` prints
+`f"{float(pct):.0f}% changed"`. The column is named `change_percentage`. Every fixture in
+`Tests/UI/test_watchlists_content_pane.py` passes 12.0 and asserts `"12"` and `"%"`. So the moment
+this task made `render_change` reachable, **a real 35% change would have displayed as "0% changed"**
+and a total rewrite as "1% changed".
+
+I scaled it at the point the value is handed to the reader (`change_percentage * 100.0` in the
+`change_info` dict), and left the threshold comparison on the ratio, where
+`change_threshold`'s 0.1 default and `config.py:3609`'s `change_threshold = 0.05  # 5% change
+threshold` both live. This is the one change I made that the AC does not name — it is one line
+and a comment, and it is reverted by deleting `* 100.0`. Consequence to be aware of: any
+`subscription_items` rows written before this branch hold ratios and will render as `0% changed`.
+Those rows have never been displayed by anything (the renderer was unreachable), and I did not
+migrate them.
+
+**F2 — `check_url`'s "previous snapshot" query orders by a one-second-resolution column.**
+`monitoring_engine.py` selects the previous snapshot with
+`ORDER BY created_at DESC LIMIT 1`, and `url_snapshots.created_at` has one-second resolution. My
+first draft of the diff test failed for exactly this reason: two snapshots written in the same
+second, and the query returned the *older* one. In production this means two checks inside one
+second can compare the new page against a stale baseline and report a change that already
+happened. `ORDER BY id DESC` would fix it. Out of scope here — not filed; my test uses
+`ORDER BY id DESC` and says why.
+
+**F3 — the whitespace-only-change hole, closed.** The content hash is taken over the raw extracted
+text while segmentation trims and normalizes whitespace, so a whitespace-only or markup-only
+change hashes differently and diffs to **nothing**. An empty `content` would make `render_change`
+print "no body captured for this item — re-check this source to fetch it": a claim that nothing
+was captured, when it was captured and it matched. `build_change_diff` returns an explicit notice
+instead.
+
+**F4 — a second live persistence path exists and is now covered.**
+`Scheduling/scheduler/handlers/watchlist_check_handler.py` calls the same `check_feed`/`check_url`
+and persists via `record_check_result(items=...)` → `_add_subscription_item` →
+`persist_subscription_item`. That is the *scheduled* path, i.e. the one that actually runs
+unattended. Both paths carry the new fields because the producers changed, not the persisters.
+`Tests/Scheduling/` is green (189 passed).
+
+## Verification
+
+```
+Tests/Subscriptions/                12 new, 145 passed
+Tests/Watchlists/                   189 passed
+Tests/DB/ -k subscription           47 passed, 563 deselected
+Tests/UI/ -k watchlist              232 passed, 3 failed  (all three pre-existing)
+Tests/Scheduling/                   189 passed  (the scheduled persist path, F4)
+```
+
+The three `Tests/UI` failures are the known baseline ones named in the brief: two tree-chevron
+assertions in `test_destination_visual_parity_correction.py` and the order-dependent
+`Select`/`Input` mount race in `test_watchlists_source_create_form.py` (TASK-1345). No new
+failures.
+
+New file: `Tests/Subscriptions/test_watchlist_content_kind_producer.py`, 12 tests. All of the
+end-to-end ones drive the **real** producers (`URLMonitor.check_url`, `FeedMonitor.check_feed`,
+`_normalize_api_item`) through the real service run, the real `persist_subscription_item`, the
+real `normalize_watchlist_item`, and the real `render_for` — plus a real `rich.console.Console`,
+so ANSI colour is read back rather than assumed. Hand-built item dicts would pass whether or not
+any producer writes anything, which is exactly how this shipped: the existing renderer tests are
+thorough and every one of their fixtures sets `content_kind` itself.
+
+### Mutation outcomes
+
+| # | Mutation | Result |
+|---|---|---|
+| 1 | delete `"content_kind": CONTENT_KIND_CHANGE` from `check_url` | **7 failed** |
+| 2 | `content` back to `current_content["text"]` | **3 failed** |
+| 3 | delete the RSS `content_kind`/`content_format` | **2 failed** |
+| 4 | never append the truncation notice (`if False:`) | **1 failed** |
+| 5 | `classify_change_type` returns `"content"` always | **1 failed** |
+| 6 | change path emits the invalid `("change", "text")` | **7 failed**, run status `failed` |
+| 7 | drop the `* 100.0` scaling | **1 failed** |
+| 8 | delete the API path's `content_kind`/`content_format` | **2 failed** |
+| 9 | typo a literal: `"articl"` instead of `CONTENT_KIND_ARTICLE` | **1 failed** (the AST vocabulary guard) |
+
+Every assignment this task adds is load-bearing. After each mutation the source was diffed back
+against a pre-mutation copy and confirmed byte-identical before continuing.
+
+Mutation 6 is worth reading as the production consequence, not just a red test: the run's status
+became `failed` and every item it had collected was dropped. That is why the vocabulary is named
+constants imported from the module that owns the rule.

--- a/task-1343-report.md
+++ b/task-1343-report.md
@@ -222,3 +222,138 @@ against a pre-mutation copy and confirmed byte-identical before continuing.
 Mutation 6 is worth reading as the production consequence, not just a red test: the run's status
 became `failed` and every item it had collected was dropped. That is why the vocabulary is named
 constants imported from the module that owns the rule.
+
+---
+
+# Fix round 1
+
+All five points addressed. Baseline before this round: `ff4c10c50`.
+
+## 1. Important — the header filter deleted real change lines (fixed)
+
+Confirmed and reproduced exactly as reported. `line.startswith(("---", "+++"))` cannot distinguish
+a file header from content, because a **removed** segment beginning `--` becomes `---…` and an
+**added** one beginning `++` becomes `+++…`. A page dropping a literal `--- Deprecated notice`
+banner therefore persisted a change whose body showed nothing removed and whose headline read
+`0 line(s) added, 0 removed`. The reviewer is right that this is the worst class of the five: the
+stored record misrepresented the change, and nothing downstream could tell.
+
+Now dropped **positionally**: `_HEADER_LINES = 2`, applied as `emitted[_HEADER_LINES:]` on the
+materialized generator. `difflib.unified_diff` yields `--- <fromfile>` and `+++ <tofile>` together
+immediately before the first hunk, or yields nothing at all, so they are always exactly positions 0
+and 1 — there is no case where slicing removes content or leaves a header behind.
+
+`test_a_removed_line_that_looks_like_a_diff_header_is_not_deleted` covers both halves (a `--`
+removal and a `++` addition), asserts the summary counts are right (`0 added, 1 removed` /
+`1 added, 0 removed`), and asserts the body still starts at a `@@` hunk so the real headers are
+genuinely gone.
+
+## 2. Important — the truncation notice was unreachable (fixed)
+
+Correct, and a good catch: as line 401 of 401 in a pane about nine rows tall, the notice existed
+only for someone who scrolled a diff they did not know had been cut. **Both** remedies applied:
+
+* the notice is now `kept.insert(0, …)` — the **first** line of the body;
+* `diff_summary` gains `" (diff truncated)"`, so it appears in `render_change`'s headline, which
+  needs no scrolling at all.
+
+The `[`-prefix is unchanged. The test now asserts `"diff truncated" in lines[0]`, that line 0 is
+not `+`/`-` prefixed, that the stored `diff_summary` ends with `(diff truncated)`, and — through
+the real renderer — that the word "truncated" appears within the **first four rendered rows**.
+
+## 3. Important — rule scope: page-scoped behaviour preserved (fixed)
+
+Confirmed: `_apply_filters_and_alerts` runs before persistence on the raw item, and both services
+built their haystack from `item["content"]`, so this branch had silently narrowed every site rule
+from "matches anywhere on the page" to "matches a changed segment plus one line of `n=1` context".
+Shipping that as a side effect would have looked, to a user, like an alert that had worked for
+months just stopping.
+
+Fixed by separating the two concerns rather than choosing between them. `URLMonitor.check_url` now
+also carries the full page text as `rule_match_text`, and a new module
+`tldw_chatbook/Subscriptions/watchlist_rule_matching.py` owns the single haystack builder that
+**both** services now call:
+
+* the body used for matching is `rule_match_text` when present, else `content` (feed and API items
+  never set it — their `content` *is* the captured body, so nothing changes for them);
+* it **replaces** `content` rather than being appended to it. Appending would have introduced the
+  mirror-image bug: text that the change *removed* is in the diff but is no longer on the page, and
+  it must not start matching. A test pins that (`"opus 4.1" not in haystack`);
+* `rule_match_text` is deliberately **not** a persisted column — a test asserts it is absent from
+  `subscription_items` — because that would put a second copy of every page back in the item row
+  and undo the point of storing a diff. The full text is already durable in `url_snapshots`.
+
+The two services previously each held their own copy of the same key tuple, which is precisely how
+this drifted; the shared module removes that. Three tests cover it: an alert on unchanged page text
+still firing (with an explicit precondition that the phrase is *absent* from the stored diff, so it
+cannot pass via the context line), an **exclude** filter on unchanged page text still excluding
+(the destructive half — a narrowed filter admits items the user told the app to drop), and the
+helper in isolation.
+
+**My position, asked for explicitly.** Page-scoped is right as the default and I would not change
+it. For *filters* it is not even a close call: include/exclude classifies the item, a site item
+represents the page, and a narrowed exclude filter silently admits content. For *content alerts*
+there is a real argument that "tell me when this phrase appears" is the more useful semantic — but
+that is `changed_to`/`appeared` semantics, which needs to be a **per-rule opt-in with its own UI
+affordance** (and probably a distinction between "appeared" and "disappeared", both of which the
+diff can support and neither of which a keyword match expresses). It is a feature, not a default,
+and it should not arrive as a consequence of a storage change. Worth filing; not worth shipping
+silently.
+
+While writing these tests I hit a related detail worth recording: a *small* edit to a *long* page
+does not clear the default `change_threshold` of 0.1 at all — `calculate_change_percentage` is
+character-level over the whole page, so the filler text alone suppressed the item. The helper now
+takes an explicit `change_threshold`, and it is a reminder that the threshold is a whole-page
+similarity measure, not a per-region one.
+
+## 4. Minor — `_segment_for_diff` docstring (fixed)
+
+It cited `extraction_method` (full/auto), which the function never reads. It now describes the
+actual condition — whether the text already contains newlines — and notes that the extraction
+method is a *consequence* of that, not the switch. The module comment above `_SENTENCE_BOUNDARY`
+was corrected the same way.
+
+## 5. Minor — mutation table row 9 was wrong (corrected)
+
+Row 9 said "1 failed". Re-run on the full file: **3 failed**
+(`test_a_feed_item_is_stored_as_an_article_with_a_legal_format`,
+`test_no_producer_emits_a_pairing_persistence_would_reject`,
+`test_every_content_kind_literal_in_the_package_is_from_the_vocabulary`). The round-1 number came
+from a run I had narrowed with `-k "vocabulary"`, which deselected the other eleven tests — the
+number was real for that command and useless as a table row. All mutation runs in this round were
+made on the **whole file** with no `-k`, so every row is reproducible as written.
+
+## Round-1 verification
+
+```
+Tests/Subscriptions/ + Tests/Scheduling/   339 passed  (17 in the new file, up from 12)
+Tests/Watchlists/                          189 passed
+Tests/DB/ -k subscription                   47 passed, 563 deselected
+Tests/UI/ -k watchlist                     232 passed, 3 failed  (the same three as before)
+```
+
+The three `Tests/UI` failures are unchanged in identity and count from the pre-round-1 run: two
+tree-chevron assertions in `test_destination_visual_parity_correction.py` and the order-dependent
+`Select`/`Input` mount race in `test_watchlists_source_create_form.py` (TASK-1345).
+
+### Round-1 mutation outcomes
+
+| Mutation | Result |
+|---|---|
+| A — restore the pattern-match header filter | **1 failed** (`test_a_removed_line_that_looks_like_a_diff_header_is_not_deleted`) |
+| B — truncation notice back to last line, no summary suffix | **1 failed** (`test_an_oversized_change_is_truncated_and_says_so`) |
+| C — haystack body back to `content` (the diff) | **3 failed** (both rule-scope tests + the helper test) |
+| D — filter service drifts back to its own local haystack | **1 failed** (the exclude-filter test) |
+| 9 (re-run, whole file) — typo `"articl"` literal | **3 failed**, correcting the round-1 table |
+
+Each source file was restored from a pre-mutation copy and `diff`-verified byte-identical before
+the next mutation.
+
+### Files changed in this round
+
+* `tldw_chatbook/Subscriptions/monitoring_engine.py` — positional header slice, notice-first +
+  summary suffix, docstring/comment corrections, `rule_match_text` on the change item.
+* `tldw_chatbook/Subscriptions/watchlist_rule_matching.py` — **new**, the shared haystack.
+* `tldw_chatbook/Subscriptions/watchlist_filter_service.py`,
+  `watchlist_content_alert_service.py` — both call the shared haystack.
+* `Tests/Subscriptions/test_watchlist_content_kind_producer.py` — 12 → 17 tests.

--- a/task-1343-report.md
+++ b/task-1343-report.md
@@ -357,3 +357,145 @@ the next mutation.
 * `tldw_chatbook/Subscriptions/watchlist_filter_service.py`,
   `watchlist_content_alert_service.py` — both call the shared haystack.
 * `Tests/Subscriptions/test_watchlist_content_kind_producer.py` — 12 → 17 tests.
+
+---
+
+# Fix round 2 (PR #1092 / Qodo)
+
+Baseline before this round: `3c3fec30e`.
+
+## 1. Bug — the diff bound protected storage but not memory (fixed)
+
+Correct, and the mechanism is exactly as described: `emitted = list(unified_diff(...))` bounded what
+was *stored* while leaving peak allocation proportional to the whole diff, on a path that runs
+inside a scheduled fetch over pages the egress layer admits up to `MAX_FETCH_BYTES_PAGE` (10 MB).
+
+`build_change_diff` now consumes the generator **once**, in a single pass:
+
+* the first `_HEADER_LINES` yielded items are skipped by index (the positional header rule from
+  round 1 is unchanged, just applied during iteration instead of by slicing);
+* `total_lines`, `added` and `removed` accumulate as lines go past;
+* `kept` grows only while both caps hold; when a cap is hit, a `truncated` flag is set and
+  iteration **continues** so the counters keep describing the whole change rather than the retained
+  slice;
+* the post-processing (no-textual-change notice, notice-first, summary suffix) is unchanged, and
+  `total` in the notice now comes from `total_lines`.
+
+Verified output-preserving: the same input through the shipped code and through a materialising
+stand-in produces byte-identical body and summary (asserted in the test, not just observed).
+
+**Measured, differentially, in-process** (4,000 segments per side → 8,001 diff lines):
+
+| | peak allocation |
+|---|---|
+| streaming (shipped) | 1,289 KiB |
+| `list(...)` materialised | 1,945 KiB |
+| ratio | **1.51×**, stable at 1.50–1.55× across 4k/12k/20k segments and repeat runs |
+
+### What the tests do and do not prove
+
+Two tests, deliberately separated because they prove different things.
+
+`test_a_diff_far_larger_than_the_cap_is_bounded_with_accurate_counts` — the **behavioural** half.
+On a diff twenty times the line cap it proves: the body is exactly `_MAX_DIFF_LINES + 1` lines, the
+char bound holds, the summary reports all 4,000 additions and 4,000 removals, the notice's own
+total equals `added + removed + 1` (the single `@@` header these disjoint inputs produce), and the
+retained body contains **far fewer** `+` lines than the count reports — which is what shows the
+counters cannot have come from the retained slice, i.e. that iteration really continued past the
+cap. **It proves nothing about memory**; it passes identically under the materialising mutation.
+
+`test_the_diff_generator_is_not_materialised` — the **memory** half, and the honest limits of it:
+
+* it is a **differential** measurement (shipped vs a materialising stand-in, same input, same
+  process), not an absolute budget — an absolute threshold would be a machine-specific magic
+  number;
+* it asserts `peak_streamed < peak_listed * 0.85` against a measured 0.65, deliberately wide so it
+  does not become a flaky allocation assertion;
+* it does **not** prove "peak memory is proportional to the caps, not the input", and I want to be
+  explicit that the stronger claim is **not achievable here**: `_segment_for_diff` must build both
+  segment lists in full, because `difflib.SequenceMatcher` needs random access to both sequences,
+  and its internal `b2j` index is O(len(b)) as well. Those terms remain proportional to the page.
+  What the change removes is the diff-output term *on top* of them — about a third of peak — and
+  what it guarantees is that the only term scaling with the **diff** is now the one bounded by
+  `_MAX_DIFF_LINES`/`_MAX_DIFF_CHARS`. Making the whole function O(caps) would mean not using
+  `difflib`, which is a different task.
+
+## 2. Rule violation — file-backed test DB (fixed)
+
+All four `SubscriptionsDB(tmp_path / "subscriptions.db", "test")` sites are now
+`SubscriptionsDB(":memory:", "test")`. The whole file passes (19/19), so nothing depended on the DB
+being on disk. `tmp_path` became unused in twelve signatures and the `_site_source` helper, and was
+removed rather than left as a dead parameter — which, incidentally, disposes of most of item 3.
+
+Worth recording *why* `:memory:` is safe here rather than leaving it as a compliance change:
+`SubscriptionsDB` keeps a **thread-local** connection and builds the schema on the constructing
+thread's connection only — `SubscriptionsDB._initialize_schema` documents this, because every
+`sqlite3.connect(":memory:")` opens a fresh empty database, so an in-memory instance touched from a
+second thread finds zero tables. These tests are single-threaded (the service is awaited directly;
+no worker, no `call_from_thread`), so the caveat does not apply. It is now stated in the helper's
+docstring, so a future test that adds a thread has the trap in front of it.
+
+## 3. `Args:` in test docstrings — judgment applied, not blanket compliance
+
+I measured the precedent independently and reproduce the coordinator's figure exactly: **50 of
+1,392** `.py` files under `Tests/` contain an `Args:` section — 3.6%. (Narrowed to `test_*.py`
+files only it is 43 of 1,315, 3.3%.) So the convention exists but is a small minority, and Qodo
+itself rates the item "unclear" for tests.
+
+Decision: **`Args:` only where a parameter is genuinely non-obvious; bare pytest fixtures stay
+undocumented.** Applied as:
+
+* `_serve` — documented. `pages` has real semantics a reader cannot guess (one body per fetch, in
+  order, last entry repeated on exhaustion), and `content_type` selects which parser
+  `_fetch_and_parse_feed` uses.
+* `_site_source` — documented, and this is the case that justifies the policy: `change_threshold`
+  is not merely non-obvious, it is a **trap**. It is a whole-page character-level similarity
+  measure, so a small edit to a long page never clears the 0.1 default and the test silently gets
+  zero items — which is exactly what happened to the round-1 rule-scope tests on their first run.
+  That belongs in an `Args:` entry; "tmp_path: the pytest temporary directory fixture" does not.
+* every test function — not documented. After item 2 they take at most `monkeypatch`, and several
+  take nothing at all. Twenty repetitions of a boilerplate fixture description would dilute
+  docstrings whose value is explaining *why the test exists*.
+
+## Round-2 verification
+
+```
+Tests/Subscriptions/ + Tests/Scheduling/   341 passed  (19 in the new file, up from 17)
+Tests/Watchlists/                          189 passed
+Tests/DB/ -k subscription                   47 passed, 563 deselected
+Tests/UI/ -k watchlist                       3 failed, 232 passed   (see below)
+```
+
+### A note on the `Tests/UI/ -k watchlist` baseline — it is wider than one test
+
+Three runs of the identical command in this round produced three different failing sets:
+
+| run | failures |
+|---|---|
+| 1 | 2 × chevron, `test_watchlists_source_create_form::test_clicking_any_row_of_the_name_input_focuses_it[size0]`, `test_watchlists_source_frequency_control::test_frequency_options_are_reachable_when_expanded[size1]` (**4**) |
+| 2 | 2 × chevron, `test_watchlists_source_create_form::test_a_source_can_be_created_end_to_end_through_the_form[size1]` (**3**) |
+| pre-round-2 | 2 × chevron, `test_watchlists_source_create_form::test_typing_straight_after_opening_the_form_lands_in_name[size1]` (**3**) |
+
+The two chevron failures are constant. The rest is the TASK-1345 order-dependent mount race, and
+the finding worth recording is that **it is not confined to one named test**: it moves between tests
+within `test_watchlists_source_create_form.py` and has also surfaced once in
+`test_watchlists_source_frequency_control.py`. Both files pass **19/19 in isolation**, and neither
+can be reached by anything in this round (the source change is confined to `build_change_diff`,
+which no UI test in this selection exercises; the test-file change is under `Tests/Subscriptions/`,
+which `-k watchlist` over `Tests/UI/` does not collect). Quoting a fixed name for this baseline will
+keep producing false regressions.
+
+### Round-2 mutation outcome
+
+| Mutation | Result |
+|---|---|
+| E — restore `list(unified_diff(...))` materialisation | **1 failed** (`test_the_diff_generator_is_not_materialised`); the other 18 stayed green, which is the point: the behavioural test correctly does not claim to cover memory |
+
+Source restored from a pre-mutation copy and `diff`-verified byte-identical afterwards.
+
+### Files changed in this round
+
+* `tldw_chatbook/Subscriptions/monitoring_engine.py` — single-pass streaming diff with
+  continue-past-cap counters.
+* `Tests/Subscriptions/test_watchlist_content_kind_producer.py` — 17 → 19 tests; `:memory:` DB;
+  `tmp_path` removed throughout; `Args:` added to the two helpers that earn it.

--- a/tldw_chatbook/Subscriptions/item_persist.py
+++ b/tldw_chatbook/Subscriptions/item_persist.py
@@ -15,10 +15,26 @@ from collections.abc import Mapping
 from typing import Any
 
 
+#: The vocabulary of ``content_kind``/``content_format``, named once.
+#:
+#: TASK-1343: producers used to write neither field, so
+#: ``content_pane.render_for`` fell through to the article renderer for every
+#: item including site changes. They now write both -- and since an invalid
+#: pairing *raises* out of ``persist_subscription_item``, inside a scheduled
+#: fetch, the producers import these names from here (the module that owns the
+#: rule) rather than repeat string literals that a typo would turn into a
+#: run-time failure. This module has no heavy imports of its own, so it is safe
+#: for any producer to import at module scope.
+CONTENT_KIND_ARTICLE = "article"
+CONTENT_KIND_CHANGE = "change"
+CONTENT_FORMAT_TEXT = "text"
+CONTENT_FORMAT_MARKDOWN = "markdown"
+CONTENT_FORMAT_DIFF = "diff"
+
 _VALID_PAIRINGS = {
-    ("article", "text"),
-    ("article", "markdown"),
-    ("change", "diff"),
+    (CONTENT_KIND_ARTICLE, CONTENT_FORMAT_TEXT),
+    (CONTENT_KIND_ARTICLE, CONTENT_FORMAT_MARKDOWN),
+    (CONTENT_KIND_CHANGE, CONTENT_FORMAT_DIFF),
 }
 
 

--- a/tldw_chatbook/Subscriptions/local_watchlists_service.py
+++ b/tldw_chatbook/Subscriptions/local_watchlists_service.py
@@ -18,7 +18,11 @@ from ..Utils.egress import (
     guarded_fetch_httpx_async,
     origin_set,
 )
-from .item_persist import persist_subscription_item
+from .item_persist import (
+    CONTENT_FORMAT_TEXT,
+    CONTENT_KIND_ARTICLE,
+    persist_subscription_item,
+)
 from .watchlist_content_alert_service import WatchlistContentAlertService
 from .watchlist_filter_service import WatchlistFilterService
 from .watchlist_normalizers import (
@@ -1015,6 +1019,19 @@ class LocalWatchlistsService:
             "published_date": published_date,
             "author": author,
             "extracted_data": item if isinstance(item, Mapping) else {"value": item},
+            # TASK-1343. An API source produces articles, not site changes, so
+            # it must dispatch to `render_article` explicitly rather than rely
+            # on `render_for`'s fallback -- which is what silently rendered
+            # every kind the same way. `content` here is whatever JSON field
+            # the source's `field_map` points at, in whatever format the API
+            # chose; nothing converts it, and `_VALID_PAIRINGS` permits only
+            # "text" or "markdown" for an article, so "text" is the honest
+            # answer. Written even when the API supplied no content at all:
+            # the kind is still `article` (`render_article` then explains the
+            # missing body), and both values are non-None so they survive the
+            # filter below.
+            "content_kind": CONTENT_KIND_ARTICLE,
+            "content_format": CONTENT_FORMAT_TEXT,
         }
         return {key: value for key, value in normalized.items() if value is not None}
 

--- a/tldw_chatbook/Subscriptions/monitoring_engine.py
+++ b/tldw_chatbook/Subscriptions/monitoring_engine.py
@@ -50,6 +50,7 @@ from .item_persist import (
     CONTENT_KIND_ARTICLE,
     CONTENT_KIND_CHANGE,
 )
+from .watchlist_rule_matching import RULE_MATCH_TEXT_KEY
 from ..Utils.egress import (
     EgressBlockedError,
     EgressFetchError,
@@ -255,17 +256,31 @@ class ContentExtractor:
 # `---`/`+++` file headers `difflib.unified_diff` emits first are dropped
 # deliberately -- they begin with `-` and `+`, so the renderer would paint them
 # red and green as if the header itself were part of the change.
+#
+# They are dropped POSITIONALLY (see `_HEADER_LINES`), never by pattern. Fix
+# round 1, Important #1: filtering `line.startswith(("---", "+++"))` also
+# deletes real content, because a removed segment beginning `--` becomes
+# `---...` and an added one beginning `++` becomes `+++...`. A page dropping a
+# literal `--- Deprecated notice ---` banner produced a persisted change whose
+# body showed nothing removed and whose headline said "0 line(s) added, 0
+# removed": the stored record misrepresented the change, which is worse than a
+# rendering glitch.
 _DIFF_CONTEXT_SEGMENTS = 1
+
+# `difflib.unified_diff` yields `--- <fromfile>` and `+++ <tofile>` together,
+# immediately before the first hunk, or yields nothing at all -- so when there
+# is any output at all they are exactly positions 0 and 1.
+_HEADER_LINES = 2
 
 # `ContentExtractor.extract_text_from_html` joins every chunk of a page with a
 # single space, so the extracted text of a whole page is ONE line containing no
 # newlines at all. A line-based diff of two such snapshots is therefore always
 # exactly `-<the entire old page>` / `+<the entire new page>`: the full text
 # twice, which is simultaneously the least readable and the largest possible
-# thing to store. Both sides are re-segmented before diffing -- on real line
-# breaks when the text has any (`extraction_method` other than full/auto),
-# otherwise on sentence boundaries, which stay aligned under a local edit in a
-# way fixed-width chunking does not.
+# thing to store. Both sides are re-segmented before diffing -- see
+# `_segment_for_diff`, which splits on real line breaks when the text has any
+# and on sentence boundaries when it does not (sentences stay aligned under a
+# local edit in a way fixed-width chunking does not).
 _SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?])\s+")
 
 # A segment longer than this is wrapped at word boundaries, so no single diff
@@ -286,11 +301,18 @@ _MAX_DIFF_CHARS = 20_000
 
 # Both notices are worded to start with `[` rather than `+`/`-`, so the
 # renderer does not colour them as though they were themselves a change.
+#
+# The truncation notice goes FIRST, not last (fix round 1, Important #2): as
+# the 401st line of 401 in a pane about nine rows tall it was unreachable
+# exactly when it mattered, so a reader saw the head of a cut-down diff with
+# nothing to say it had been cut. `_DIFF_TRUNCATION_SUMMARY_SUFFIX` puts it in
+# the headline too, which is on screen without any scrolling at all.
 _DIFF_TRUNCATION_NOTICE = (
     "[diff truncated: showing the first {kept} of {total} diff lines "
     "(cap {max_lines} lines / {max_chars} characters). This is a partial "
     "view of the change; the full page is in this source's snapshot history.]"
 )
+_DIFF_TRUNCATION_SUMMARY_SUFFIX = " (diff truncated)"
 _NO_TEXTUAL_CHANGE_NOTICE = (
     "[the page changed, but its extracted text is identical once whitespace "
     "is normalized -- the difference was in markup or spacing only]"
@@ -299,6 +321,18 @@ _NO_TEXTUAL_CHANGE_NOTICE = (
 
 def _segment_for_diff(text: str) -> List[str]:
     """Split one side of a comparison into diffable, pane-width segments.
+
+    Splits on real line breaks when ``text`` contains any, and on sentence
+    boundaries when it does not -- which is the case for a whole page captured
+    through ``extract_text_from_html``, since that collapses everything onto
+    one line. Segments longer than ``_MAX_DIFF_SEGMENT_CHARS`` are then wrapped
+    at word boundaries, and blank segments are dropped.
+
+    (Fix round 1, Minor #4: this used to be described in terms of the
+    subscription's ``extraction_method``, which it never reads -- the only
+    switch is whether the text already has newlines in it. A raw-extraction
+    page usually does and a text-extracted one never does, but that is a
+    consequence, not the condition.)
 
     Args:
         text: Extracted page text, which may be a single very long line.
@@ -338,21 +372,23 @@ def build_change_diff(previous_text: str, current_text: str) -> tuple[str, str]:
         body whose changed lines start with ``+``/``-`` for
         ``content_pane.render_change`` to colour; ``diff_summary`` is a single
         line naming how many lines were added and removed, counted over the
-        *whole* diff so it stays true even when the body is truncated.
+        *whole* diff so it stays true even when the body is truncated, and
+        saying so when it was.
     """
     old_segments = _segment_for_diff(previous_text)
     new_segments = _segment_for_diff(current_text)
-    lines = [
-        line
-        for line in unified_diff(
+    emitted = list(
+        unified_diff(
             old_segments,
             new_segments,
             n=_DIFF_CONTEXT_SEGMENTS,
             lineterm="",
         )
-        # See `_DIFF_CONTEXT_SEGMENTS`: the file headers would be coloured.
-        if not line.startswith(("---", "+++"))
-    ]
+    )
+    # Drop the two file headers by POSITION, never by pattern -- see
+    # `_HEADER_LINES` and `_DIFF_CONTEXT_SEGMENTS` for what a pattern match
+    # deletes along with them.
+    lines = emitted[_HEADER_LINES:]
     if not lines:
         # Reachable: the content hash is taken over the raw extracted text,
         # while segmentation trims and normalizes whitespace, so a
@@ -374,14 +410,18 @@ def build_change_diff(previous_text: str, current_text: str) -> tuple[str, str]:
         kept.append(line)
         chars += len(line) + 1
     if len(kept) < len(lines):
-        kept.append(
+        # First line, not last -- see `_DIFF_TRUNCATION_NOTICE`. And in the
+        # headline as well, which needs no scrolling to reach.
+        kept.insert(
+            0,
             _DIFF_TRUNCATION_NOTICE.format(
                 kept=len(kept),
                 total=len(lines),
                 max_lines=_MAX_DIFF_LINES,
                 max_chars=_MAX_DIFF_CHARS,
-            )
+            ),
         )
+        summary += _DIFF_TRUNCATION_SUMMARY_SUFFIX
     return "\n".join(kept), summary
 
 
@@ -985,6 +1025,16 @@ class URLMonitor:
                 ),
                 "diff_summary": diff_summary,
                 "published_date": datetime.now(timezone.utc).isoformat(),
+                # Filters and content-alert rules are evaluated on the raw
+                # fetched item, BEFORE persistence, and their haystack was
+                # built from `content`. With `content` now a diff, a rule that
+                # had matched a phrase anywhere on the page would silently have
+                # narrowed to "matches a changed segment" -- a user's alert
+                # quietly stopping after months, with nothing on screen to
+                # explain it. So the full page text travels alongside the diff
+                # for matching only; it is not a persisted column (see
+                # `watchlist_rule_matching`).
+                RULE_MATCH_TEXT_KEY: current_content["text"],
             }
 
             # Store new snapshot

--- a/tldw_chatbook/Subscriptions/monitoring_engine.py
+++ b/tldw_chatbook/Subscriptions/monitoring_engine.py
@@ -11,11 +11,13 @@
 # Imports
 import hashlib
 import json
+import re
+import textwrap
 import time
 from datetime import datetime, timezone
 from typing import List, Dict, Any, Optional
 from urllib.parse import urlparse
-from difflib import SequenceMatcher
+from difflib import SequenceMatcher, unified_diff
 
 #
 # Third-Party Imports
@@ -42,6 +44,12 @@ from ..DB.Subscriptions_DB import (
     SubscriptionError,
 )
 from ..Metrics.metrics_logger import log_histogram, log_counter
+from .item_persist import (
+    CONTENT_FORMAT_DIFF,
+    CONTENT_FORMAT_TEXT,
+    CONTENT_KIND_ARTICLE,
+    CONTENT_KIND_CHANGE,
+)
 from ..Utils.egress import (
     EgressBlockedError,
     EgressFetchError,
@@ -233,6 +241,176 @@ class ContentExtractor:
         matcher = SequenceMatcher(None, old_content, new_content)
         similarity = matcher.ratio()
         return 1.0 - similarity
+
+
+########################################################################################################################
+#
+# content_kind / content_format production (TASK-1343)
+#
+########################################################################################################################
+
+# `content_pane.render_change` styles a diff line by its leading `+` or `-`, so
+# what `check_url` writes to `content` is a unified-diff *body*: `+`/`-` for
+# changed segments, a leading space for context, `@@` for position. The
+# `---`/`+++` file headers `difflib.unified_diff` emits first are dropped
+# deliberately -- they begin with `-` and `+`, so the renderer would paint them
+# red and green as if the header itself were part of the change.
+_DIFF_CONTEXT_SEGMENTS = 1
+
+# `ContentExtractor.extract_text_from_html` joins every chunk of a page with a
+# single space, so the extracted text of a whole page is ONE line containing no
+# newlines at all. A line-based diff of two such snapshots is therefore always
+# exactly `-<the entire old page>` / `+<the entire new page>`: the full text
+# twice, which is simultaneously the least readable and the largest possible
+# thing to store. Both sides are re-segmented before diffing -- on real line
+# breaks when the text has any (`extraction_method` other than full/auto),
+# otherwise on sentence boundaries, which stay aligned under a local edit in a
+# way fixed-width chunking does not.
+_SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?])\s+")
+
+# A segment longer than this is wrapped at word boundaries, so no single diff
+# line is wider than the narrow reader pane can show without wrapping mid-word.
+_MAX_DIFF_SEGMENT_CHARS = 110
+
+# Bounds on the stored diff. The body goes into a TEXT column and into a pane
+# roughly nine rows tall, and the full page it was computed from is already
+# kept in `url_snapshots` (`_store_snapshot`) -- so the diff is a summary, not
+# an archive, and losing its tail loses nothing recoverable. 400 lines is far
+# more than a reader scrolls and ~40x the pane's height; 20,000 characters
+# keeps the item row small beside the snapshot. Whichever bound is reached
+# first wins, and the truncation is stated IN the body (see
+# `_DIFF_TRUNCATION_NOTICE`) so a partial change is never presented as a
+# complete one.
+_MAX_DIFF_LINES = 400
+_MAX_DIFF_CHARS = 20_000
+
+# Both notices are worded to start with `[` rather than `+`/`-`, so the
+# renderer does not colour them as though they were themselves a change.
+_DIFF_TRUNCATION_NOTICE = (
+    "[diff truncated: showing the first {kept} of {total} diff lines "
+    "(cap {max_lines} lines / {max_chars} characters). This is a partial "
+    "view of the change; the full page is in this source's snapshot history.]"
+)
+_NO_TEXTUAL_CHANGE_NOTICE = (
+    "[the page changed, but its extracted text is identical once whitespace "
+    "is normalized -- the difference was in markup or spacing only]"
+)
+
+
+def _segment_for_diff(text: str) -> List[str]:
+    """Split one side of a comparison into diffable, pane-width segments.
+
+    Args:
+        text: Extracted page text, which may be a single very long line.
+
+    Returns:
+        Non-empty, whitespace-trimmed segments, none longer than
+        ``_MAX_DIFF_SEGMENT_CHARS``.
+    """
+    source = text or ""
+    units = source.splitlines() if "\n" in source else _SENTENCE_BOUNDARY.split(source)
+    segments: List[str] = []
+    for unit in units:
+        stripped = unit.strip()
+        if not stripped:
+            continue
+        if len(stripped) <= _MAX_DIFF_SEGMENT_CHARS:
+            segments.append(stripped)
+            continue
+        segments.extend(textwrap.wrap(stripped, _MAX_DIFF_SEGMENT_CHARS) or [stripped])
+    return segments
+
+
+def build_change_diff(previous_text: str, current_text: str) -> tuple[str, str]:
+    """Produce the stored diff body and its one-line summary for a site change.
+
+    Before TASK-1343 the site-change path stored the *entire new page text* as
+    the item's ``content``, which meant the reader could see what the page says
+    now but never what actually changed, and the change renderer it was written
+    for was never even dispatched to (nothing wrote ``content_kind``).
+
+    Args:
+        previous_text: The previous snapshot's ``extracted_content``.
+        current_text: The freshly fetched extracted text.
+
+    Returns:
+        ``(diff_body, diff_summary)``. ``diff_body`` is a bounded unified-diff
+        body whose changed lines start with ``+``/``-`` for
+        ``content_pane.render_change`` to colour; ``diff_summary`` is a single
+        line naming how many lines were added and removed, counted over the
+        *whole* diff so it stays true even when the body is truncated.
+    """
+    old_segments = _segment_for_diff(previous_text)
+    new_segments = _segment_for_diff(current_text)
+    lines = [
+        line
+        for line in unified_diff(
+            old_segments,
+            new_segments,
+            n=_DIFF_CONTEXT_SEGMENTS,
+            lineterm="",
+        )
+        # See `_DIFF_CONTEXT_SEGMENTS`: the file headers would be coloured.
+        if not line.startswith(("---", "+++"))
+    ]
+    if not lines:
+        # Reachable: the content hash is taken over the raw extracted text,
+        # while segmentation trims and normalizes whitespace, so a
+        # whitespace-only or markup-only change hashes differently and diffs
+        # to nothing. Saying so beats an empty body, which `render_change`
+        # would replace with "no body captured for this item" -- a claim that
+        # content was never captured, when in fact it was and it matched.
+        return _NO_TEXTUAL_CHANGE_NOTICE, "no textual change after normalization"
+
+    added = sum(1 for line in lines if line.startswith("+"))
+    removed = sum(1 for line in lines if line.startswith("-"))
+    summary = f"{added} line(s) added, {removed} removed"
+
+    kept: List[str] = []
+    chars = 0
+    for line in lines:
+        if len(kept) >= _MAX_DIFF_LINES or chars + len(line) + 1 > _MAX_DIFF_CHARS:
+            break
+        kept.append(line)
+        chars += len(line) + 1
+    if len(kept) < len(lines):
+        kept.append(
+            _DIFF_TRUNCATION_NOTICE.format(
+                kept=len(kept),
+                total=len(lines),
+                max_lines=_MAX_DIFF_LINES,
+                max_chars=_MAX_DIFF_CHARS,
+            )
+        )
+    return "\n".join(kept), summary
+
+
+def classify_change_type(previous_text: str, current_text: str) -> str:
+    """Name what kind of change this is, from what ``check_url`` already has.
+
+    This replaces a hardcoded ``"content"`` literal. Only the three cases the
+    two snapshots can actually distinguish are reported: the richer vocabulary
+    in ``baseline_manager.ChangeReport`` also carries ``'structural'`` and
+    ``'semantic'``, but those need DOM-shape and embedding analysis that
+    ``check_url`` does not do, so claiming them here would be a guess. (That
+    module has no importers at all and its fate is TASK-1360; it is
+    deliberately not extended from here.)
+
+    Args:
+        previous_text: The previous snapshot's extracted text.
+        current_text: The freshly fetched extracted text.
+
+    Returns:
+        ``"new"`` when text appeared where there was none, ``"removed"`` when
+        it disappeared entirely, otherwise ``"content"``.
+    """
+    had_text = bool((previous_text or "").strip())
+    has_text = bool((current_text or "").strip())
+    if not had_text and has_text:
+        return "new"
+    if had_text and not has_text:
+        return "removed"
+    return "content"
 
 
 class FeedMonitor:
@@ -494,6 +672,15 @@ class FeedMonitor:
                     cat.text for cat in item_elem.findall("category") if cat.text
                 ],
                 "enclosures": [],
+                # TASK-1343. Every feed item is an article, and `description`
+                # is whatever the publisher wrote -- plain text or HTML.
+                # Nothing on this path converts it to markdown, and
+                # `_VALID_PAIRINGS` allows only "text" or "markdown" for an
+                # article, so "text" is what was honestly captured; claiming
+                # "markdown" would make `render_article` hand publisher HTML
+                # to a CommonMark parser.
+                "content_kind": CONTENT_KIND_ARTICLE,
+                "content_format": CONTENT_FORMAT_TEXT,
             }
 
             # Get enclosures
@@ -535,6 +722,10 @@ class FeedMonitor:
                 ),
                 "categories": [],
                 "enclosures": [],
+                # TASK-1343, same reasoning as `_parse_rss_item`: `atom:content`
+                # arrives as the publisher's text or HTML, unconverted.
+                "content_kind": CONTENT_KIND_ARTICLE,
+                "content_format": CONTENT_FORMAT_TEXT,
             }
 
             # Get link
@@ -583,6 +774,12 @@ class FeedMonitor:
                     "published_date": self._parse_date(feed_item.get("date_published")),
                     "categories": feed_item.get("tags", []),
                     "enclosures": [],
+                    # TASK-1343. JSON Feed's `content_html` is HTML by
+                    # definition and `content_text` is plain; neither is
+                    # markdown and nothing converts them, so "text" is the
+                    # honest format for both.
+                    "content_kind": CONTENT_KIND_ARTICLE,
+                    "content_format": CONTENT_FORMAT_TEXT,
                 }
 
                 # Get author
@@ -739,27 +936,54 @@ class URLMonitor:
                 return None
 
             # Calculate change details
+            previous_text = previous["extracted_content"] or ""
             change_percentage = ContentExtractor.calculate_change_percentage(
-                previous["extracted_content"] or "", current_content["text"]
+                previous_text, current_content["text"]
             )
 
-            # Check if change exceeds threshold
+            # Check if change exceeds threshold. Both sides of this comparison
+            # are 0.0-1.0 ratios (`change_threshold` defaults to 0.1, i.e. 10%)
+            # -- the scaling to a percentage happens only where the value is
+            # handed to the reader, below.
             threshold = subscription.get("change_threshold", 0.1)
             if change_percentage < threshold:
                 # Change too small
                 breaker.record_success()
                 return None
 
-            # Significant change detected
+            # Significant change detected. TASK-1343: `content` is the DIFF, not
+            # the new page. The full page continues to live in `url_snapshots`
+            # (`_store_snapshot`, immediately below), which is where the
+            # reader's `[full page]` / `[previous snapshot]` affordances read
+            # from; storing it a second time here bought nothing and left the
+            # reader unable to see what had actually changed.
+            diff_body, diff_summary = build_change_diff(
+                previous_text, current_content["text"]
+            )
             change_info = {
                 "type": "url_change",
                 "url": url,
                 "title": f"Change detected: {subscription['name']}",
-                "content": current_content["text"],
+                "content": diff_body,
+                # Without these two, `content_pane.render_for` fell through to
+                # the article renderer for every site change ever detected, and
+                # `render_change` was unreachable in production.
+                "content_kind": CONTENT_KIND_CHANGE,
+                "content_format": CONTENT_FORMAT_DIFF,
                 "content_hash": current_hash,
                 "previous_hash": previous["content_hash"],
-                "change_percentage": change_percentage,
-                "change_type": "content",
+                # Scaled to a percentage, as the column name
+                # (`change_percentage`), the reader's headline
+                # (`f"{float(pct):.0f}% changed"`) and every renderer test
+                # fixture all read it. `calculate_change_percentage` returns a
+                # 0.0-1.0 ratio, so before TASK-1343 made the change renderer
+                # reachable at all, a real 35% change would have displayed as
+                # "0% changed" and a total rewrite as "1% changed".
+                "change_percentage": change_percentage * 100.0,
+                "change_type": classify_change_type(
+                    previous_text, current_content["text"]
+                ),
+                "diff_summary": diff_summary,
                 "published_date": datetime.now(timezone.utc).isoformat(),
             }
 

--- a/tldw_chatbook/Subscriptions/monitoring_engine.py
+++ b/tldw_chatbook/Subscriptions/monitoring_engine.py
@@ -377,19 +377,50 @@ def build_change_diff(previous_text: str, current_text: str) -> tuple[str, str]:
     """
     old_segments = _segment_for_diff(previous_text)
     new_segments = _segment_for_diff(current_text)
-    emitted = list(
+
+    # The generator is consumed ONCE and never materialized (PR #1092 review,
+    # Bug #1): `list(unified_diff(...))` bounded what was *stored* but left peak
+    # memory proportional to the whole diff. The fetch layer admits pages up to
+    # `MAX_FETCH_BYTES_PAGE` (10 MB) and 110-char segmentation turns one of
+    # those into a very long segment list, so the intermediate diff of two of
+    # them can be enormous -- and this runs inside a scheduled fetch, where
+    # memory pressure is both least visible and least welcome. Counters are
+    # accumulated as the lines go past, and iteration DELIBERATELY continues
+    # after a cap is hit so `total_lines`, `added` and `removed` still describe
+    # the whole change rather than the retained slice.
+    kept: List[str] = []
+    chars = 0
+    total_lines = 0
+    added = 0
+    removed = 0
+    truncated = False
+    for index, line in enumerate(
         unified_diff(
             old_segments,
             new_segments,
             n=_DIFF_CONTEXT_SEGMENTS,
             lineterm="",
         )
-    )
-    # Drop the two file headers by POSITION, never by pattern -- see
-    # `_HEADER_LINES` and `_DIFF_CONTEXT_SEGMENTS` for what a pattern match
-    # deletes along with them.
-    lines = emitted[_HEADER_LINES:]
-    if not lines:
+    ):
+        # Drop the two file headers by POSITION, never by pattern -- see
+        # `_HEADER_LINES` and `_DIFF_CONTEXT_SEGMENTS` for what a pattern match
+        # deletes along with them.
+        if index < _HEADER_LINES:
+            continue
+        total_lines += 1
+        if line.startswith("+"):
+            added += 1
+        elif line.startswith("-"):
+            removed += 1
+        if truncated:
+            continue
+        if len(kept) >= _MAX_DIFF_LINES or chars + len(line) + 1 > _MAX_DIFF_CHARS:
+            truncated = True
+            continue
+        kept.append(line)
+        chars += len(line) + 1
+
+    if not total_lines:
         # Reachable: the content hash is taken over the raw extracted text,
         # while segmentation trims and normalizes whitespace, so a
         # whitespace-only or markup-only change hashes differently and diffs
@@ -398,25 +429,15 @@ def build_change_diff(previous_text: str, current_text: str) -> tuple[str, str]:
         # content was never captured, when in fact it was and it matched.
         return _NO_TEXTUAL_CHANGE_NOTICE, "no textual change after normalization"
 
-    added = sum(1 for line in lines if line.startswith("+"))
-    removed = sum(1 for line in lines if line.startswith("-"))
     summary = f"{added} line(s) added, {removed} removed"
-
-    kept: List[str] = []
-    chars = 0
-    for line in lines:
-        if len(kept) >= _MAX_DIFF_LINES or chars + len(line) + 1 > _MAX_DIFF_CHARS:
-            break
-        kept.append(line)
-        chars += len(line) + 1
-    if len(kept) < len(lines):
+    if truncated:
         # First line, not last -- see `_DIFF_TRUNCATION_NOTICE`. And in the
         # headline as well, which needs no scrolling to reach.
         kept.insert(
             0,
             _DIFF_TRUNCATION_NOTICE.format(
                 kept=len(kept),
-                total=len(lines),
+                total=total_lines,
                 max_lines=_MAX_DIFF_LINES,
                 max_chars=_MAX_DIFF_CHARS,
             ),

--- a/tldw_chatbook/Subscriptions/watchlist_content_alert_service.py
+++ b/tldw_chatbook/Subscriptions/watchlist_content_alert_service.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import re
 from typing import Any, Mapping
 
+from .watchlist_rule_matching import build_rule_haystack
+
 
 class WatchlistContentAlertService:
     """Evaluate per-item content-alert rules."""
@@ -13,9 +15,10 @@ class WatchlistContentAlertService:
         rules: list[Mapping[str, Any]],
     ) -> list[dict[str, Any]]:
         matched: list[dict[str, Any]] = []
-        haystack = " ".join(
-            str(item.get(key) or "") for key in ("title", "summary", "content", "author")
-        ).lower()
+        # Shared with `WatchlistFilterService` so the two cannot drift, and
+        # page-scoped rather than diff-scoped for a site change -- see
+        # `watchlist_rule_matching`.
+        haystack = build_rule_haystack(item)
         for rule in rules:
             conditions = dict(rule.get("conditions") or {})
             pattern = str(conditions.get("pattern") or "")

--- a/tldw_chatbook/Subscriptions/watchlist_filter_service.py
+++ b/tldw_chatbook/Subscriptions/watchlist_filter_service.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import re
 from typing import Any, Mapping
 
+from .watchlist_rule_matching import build_rule_haystack
+
 
 class WatchlistFilterService:
     """Evaluate source-level include/exclude/flag filters against candidate items."""
@@ -48,9 +50,10 @@ class WatchlistFilterService:
         if not pattern:
             return False
 
-        haystack = " ".join(
-            str(item.get(key) or "") for key in ("title", "summary", "content", "author")
-        ).lower()
+        # Shared with `WatchlistContentAlertService` so the two cannot drift,
+        # and page-scoped rather than diff-scoped for a site change -- see
+        # `watchlist_rule_matching`.
+        haystack = build_rule_haystack(item)
 
         if rule_type == "keyword":
             needle = pattern.lower()

--- a/tldw_chatbook/Subscriptions/watchlist_rule_matching.py
+++ b/tldw_chatbook/Subscriptions/watchlist_rule_matching.py
@@ -1,0 +1,55 @@
+"""The one haystack watchlist filters and content-alert rules match against.
+
+Fix round 1, Important #3. ``WatchlistFilterService`` and
+``WatchlistContentAlertService`` each built their own copy of the same
+``" ".join(...)`` over ``("title", "summary", "content", "author")``, and
+``_apply_filters_and_alerts`` runs *before* persistence -- so when TASK-1343
+made a site change's ``content`` a diff rather than the whole page, both
+services silently narrowed from "matches anywhere on the page" to "matches a
+changed segment plus one line of context".
+
+That is a behaviour change a user would experience as an alert that had been
+firing for months quietly stopping, with nothing in the UI to explain it. So
+the producer keeps the full page text on the item under
+:data:`RULE_MATCH_TEXT_KEY` -- a display-and-storage concern (the diff) and a
+matching concern (the page) are simply not the same text -- and the haystack
+lives here once, so the two services cannot drift apart again.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+#: Full captured text for rule matching, when ``content`` is not it.
+#:
+#: Set by ``URLMonitor.check_url``, whose ``content`` is a diff. Deliberately
+#: NOT a persisted column: ``persist_subscription_item`` reads a fixed key set
+#: and ignores this one, and the same text is already durable in
+#: ``url_snapshots``. Feed and API items do not set it -- their ``content``
+#: *is* the captured body -- so the fallback below is the common path.
+RULE_MATCH_TEXT_KEY = "rule_match_text"
+
+
+def build_rule_haystack(item: Mapping[str, Any]) -> str:
+    """Build the lowercased text a filter or alert rule is matched against.
+
+    Args:
+        item: A raw fetched item, before persistence.
+
+    Returns:
+        ``title``, ``summary``, the item's body and ``author`` joined by single
+        spaces and lowercased. The body is :data:`RULE_MATCH_TEXT_KEY` when the
+        producer supplied it, otherwise ``content``; it *replaces* ``content``
+        rather than adding to it, so that a phrase which was only ever in the
+        text the previous check removed does not start matching.
+    """
+    body = item.get(RULE_MATCH_TEXT_KEY)
+    if body is None:
+        body = item.get("content")
+    parts = [
+        str(item.get("title") or ""),
+        str(item.get("summary") or ""),
+        str(body or ""),
+        str(item.get("author") or ""),
+    ]
+    return " ".join(parts).lower()

--- a/tldw_chatbook/UI/Watchlists_Modules/content_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/content_pane.py
@@ -157,12 +157,15 @@ def render_change(item: dict[str, Any]) -> Text:
     headline: list[str] = []
     pct = item.get("change_percentage")
     if pct is not None:
-        # `change_percentage` is always written as a Python float by
-        # `baseline_manager.py`/`monitoring_engine.py`, never parsed from raw
-        # remote text, so this cast is not currently reachable with a
-        # non-numeric value. Guard it anyway: a raise here would escape
-        # `compose()` and exit the whole application over a single headline
-        # field, so degrade by omitting the percent rather than raising.
+        # `change_percentage` has exactly one producer:
+        # `monitoring_engine.URLMonitor.check_url`, which writes a Python
+        # float on a 0-100 scale, never text parsed from a remote page, so
+        # this cast is not currently reachable with a non-numeric value.
+        # (This comment used to name `baseline_manager.py` as a producer too.
+        # It writes nothing -- nothing in the repo imports it; see TASK-1360.)
+        # Guard the cast anyway: a raise here would escape `compose()` and
+        # exit the whole application over a single headline field, so degrade
+        # by omitting the percent rather than raising.
         try:
             headline.append(f"{float(pct):.0f}% changed")
         except (TypeError, ValueError):


### PR DESCRIPTION
## What this does

Phase D shipped the Watchlists reader with two renderers dispatched on `content_kind` — and **nothing in the repo wrote `content_kind`**, so `render_change` was unreachable in production, every item fell through to the article renderer, and `diff_summary` had no producer at all. This gives them producers on the live path.

- **Site changes** now emit `content_kind="change"`, `content_format="diff"`, a real unified diff as `content`, and a one-line `diff_summary`. The full page continues to live in `url_snapshots`, which is what the spec's `[full page]` / `[previous snapshot]` read.
- **Feeds and the API path** emit `content_kind="article"` with an honest `content_format`.
- **`change_type`** is no longer the hardcoded literal `"content"` — it distinguishes `new` / `removed` / `content`, the only distinctions two snapshots support.

`baseline_manager.py` is deliberately untouched — see the orphan note below.

## Two things worth knowing

**Extracted page text is a single line.** `monitoring_engine.py:215` is literally `" ".join(chunk for chunk in chunks if chunk)`, so a naive line diff degenerates to `-<entire old page>` / `+<entire new page>` — a technically valid `("change","diff")` that is useless in a narrow pane. Both sides are re-segmented (line breaks, else sentence boundaries, 110-char wrap). Real output is four short readable lines, pinned verbatim by a test.

**`change_percentage` is now scaled at emission.** It was stored as a ratio, so the moment the renderer became reachable a real 35% change would have printed **"0% changed"**. The threshold comparison still uses the unscaled ratio (`:949`), so detection sensitivity is unchanged — verified by a full consumer sweep. Legacy rows keep ratios and were not migrated, and cannot display one: they have `content_kind` NULL, so `render_for` sends them to `render_article`, which never reads the field.

## Review found three Importants, all fixed

- **The diff's header filter deleted real change lines.** It dropped any line starting with `---`/`+++`, so a removed segment beginning `--` swallowed silently: a detected, persisted change whose body showed nothing removed and whose headline read "0 line(s) added, 0 removed". Now dropped **positionally** — verified against CPython's `unified_diff`, which yields both headers as a pair before the first hunk or nothing at all.
- **The truncation notice was line 401 of 401**, invisible in a ~9-row pane. Now first, plus a `(diff truncated)` suffix on `diff_summary` so it shows in the headline.
- **Keyword alerts and filters had silently narrowed to the diff.** Both rule services build their haystack from `item["content"]`, and `_apply_filters_and_alerts` runs before persist — so a site rule matching text in an *unchanged* part of the page would have stopped firing, with no error and no failing test. A new `watchlist_rule_matching.py` owns one haystack both services call; `check_url` carries the page as `rule_match_text`, which **replaces** `content` in the haystack (appending would make *removed* text matchable) and is never persisted. Exclude filters still match the whole page — that is the case where narrowing would admit an item the user told the app to drop.

## Testing

`Tests/Subscriptions/` + `Tests/Scheduling/` 339 passed · `Tests/Watchlists/` 189 · `Tests/DB/ -k subscription` 47 · `Tests/UI/ -k watchlist` 232 passed, 3 failed.

The 3 are pre-existing: two tree-chevron assertions and one order-dependent `Select`/`Input` mount race (TASK-1345).

Tests drive the real chain — `create_source` → `launch_run` → `execute_run` → real `URLMonitor.check_url` → real `persist_subscription_item` → real `normalize_watchlist_item` → real `render_for` — with only the HTTP fetch faked. Every fix carries a mutation check; the diff body is pinned verbatim and ANSI is read back from a real `Console`.

## Follow-ups filed from this work

**1360** `baseline_manager.py` — 697 lines, 20 methods, **no importers and no tests**, and *better* than the code in use: its `ChangeReport` has the spec's `change_type` vocabulary including `structural`, plus a `summary` matching `diff_summary`. Extending the live path was chosen deliberately over pulling untested code into the fetch path; its fate is now its own decision.

**1361** `check_url` picks its baseline with `ORDER BY created_at DESC` on a one-second-resolution column, so two checks in the same second can diff against a stale snapshot.

**1362** `change_threshold` 0.1 is whole-page character similarity, so a small but meaningful edit to a long page never fires — silent, and reads to a user as "the feature does nothing".

**1363** appeared/disappeared alert scoping, now cheap to compute from the diff, as a per-rule opt-in rather than a default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Watchlists render site changes correctly by producing `content_kind` and a bounded unified diff, so change items reach `render_change` with accurate summaries. Also streams diff generation to cut peak memory during checks. Addresses Linear TASK-1343 (AC#1–#4).

- **New Features**
  - Site changes emit `content_kind="change"`, `content_format="diff"`, a unified diff body, `diff_summary`, derived `change_type` (`new`/`removed`/`content`), and `change_percentage` scaled to 0–100. (AC#1, AC#4)
  - Feeds (RSS/Atom/JSON Feed) and API emit `content_kind="article"` with `content_format="text"`. (AC#2)
  - Kind/format vocabulary centralized in `item_persist` with validation; end-to-end tests assert dispatch to `render_change`, legal pairings, and stored diff content. (AC#3)

- **Bug Fixes**
  - Drop unified diff headers positionally to avoid deleting real `---/+++` content.
  - Put truncation notice first and add “(diff truncated)” to `diff_summary`; cap body at 400 lines/20k chars with sentence segmentation and wrapping.
  - Keep alerts and filters page-scoped via a shared haystack (`watchlist_rule_matching`) using `rule_match_text` (not persisted).
  - Stream diff generation instead of materializing the whole diff; output unchanged with lower peak memory.

<sup>Written for commit de7bb1b1165a7af6074f3dc0a7e8792d1d3bd203. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

