### PR TITLE
fix: stop two folder-open buttons blocking the app, and guard the bug class (TASK-1373)

### DIFF
--- a/Tests/Architecture/test_no_blocking_io_on_message_pump.py
+++ b/Tests/Architecture/test_no_blocking_io_on_message_pump.py
@@ -1,0 +1,352 @@
+"""Repo-wide guard: blocking I/O must not be reachable from a message handler.
+
+Textual runs message handlers on a serialized pump. Anything blocking that a
+handler reaches -- directly, or through the functions it calls -- stops the app
+processing clicks, keys and navigation for the whole duration.
+
+TASK-1320 fixed four mount-path instances, with measured stalls of 1030ms
+(chatbook directory scan), 1140ms (character library read) and up to 300s
+(unreachable server). TASK-1373 added this guard plus two more instances it
+found outside the mount path: `subprocess.run(["xdg-open", ...])` from a button
+handler in the Chatbook wizard and in the export-management window.
+
+**This guard walks the call graph, and that is the whole point.** The blocking
+call is almost always a level or more below the handler --
+`on_mount -> _refresh_chatbooks -> .glob(` -- so a scan that reads only each
+handler's own body reports a clean result against code known to be broken. That
+is not hypothetical: the first draft of this scan returned zero findings against
+the pre-TASK-1320 chatbooks source. ``test_guard_detects_a_known_blocking_shape``
+below exists so this can never silently regress into a scan that always passes.
+
+Scope is deliberately narrow. Only calls whose cost is user-visible are flagged.
+Small local filesystem operations are not: `mkdir(exist_ok=True)` plus a small
+JSON write measures 0.049ms and `read_text` of a config file 0.014ms, four
+orders of magnitude below the cases above. Flagging them would produce a large
+noisy baseline, and "fixing" them would be churn with real risk -- deferring work
+into a worker has its own failure modes (`run_worker` defaults to
+`exit_on_error=True`, which turns a load error into an app exit).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+PACKAGE_ROOT = Path(__file__).resolve().parent.parent.parent / "tldw_chatbook"
+SCANNED_SUBDIRS = ("UI", "Widgets")
+
+#: Handlers Textual invokes on a message pump.
+HANDLER_PREFIXES = ("on_", "watch_", "action_")
+
+#: Attribute calls that walk the filesystem. Deliberately excludes `mkdir`,
+#: `stat`, `read_text` and `write_text` -- see the module docstring.
+BLOCKING_ATTRS = frozenset({"glob", "iterdir"})
+
+#: Bare names whose call blocks.
+BLOCKING_NAMES = frozenset(
+    {"fetch_all_characters", "fetch_character_names", "ZipFile", "urlopen"}
+)
+
+#: Dotted calls whose cost is a network round trip or a child process.
+BLOCKING_QUALIFIED = frozenset(
+    {
+        "requests.get",
+        "requests.post",
+        "requests.put",
+        "requests.delete",
+        "httpx.get",
+        "httpx.post",
+        "subprocess.run",
+        "subprocess.call",
+        "subprocess.check_output",
+        "time.sleep",
+    }
+)
+
+#: A hop that moves work off the pump ends the walk -- everything below it is
+#: already someone else's thread or worker.
+HANDOFFS = frozenset(
+    {
+        "to_thread",
+        "run_worker",
+        "call_from_thread",
+        "set_timer",
+        "call_after_refresh",
+        "call_later",
+    }
+)
+
+# Accepted pre-existing paths, each with its own reason. Never a blanket
+# suppression: a new entry here is a decision that has to be argued.
+#
+# Keyed on the BLOCKING CALL as well as the file and handler. Keying only on
+# (file, handler) left a hole exactly where it mattered: this window's
+# `on_button_pressed` is baselined for a cheap glob, and under the coarser key a
+# newly added `subprocess.run` reachable from that same handler -- the very bug
+# TASK-1373 fixed here -- would have been silently accepted.
+BASELINE: dict[tuple[str, str, str], str] = {
+    # Dead file: nothing imports `Chatbooks_Window` (the pre-"Improved" copy).
+    # Verified by grep for `Chatbooks_Window import` across the package --
+    # only `Chatbooks_Window_Improved` has importers. Left flagged rather than
+    # deleted because retiring the file is a separate decision.
+    (
+        "UI/Chatbooks_Window.py",
+        "on_mount",
+        "self._export_path.glob",
+    ): "dead file, no importers",
+    (
+        "UI/Chatbooks_Window.py",
+        "on_button_pressed",
+        "self._export_path.glob",
+    ): "dead file, no importers",
+    (
+        "UI/Chatbooks_Window.py",
+        "action_refresh",
+        "self._export_path.glob",
+    ): "dead file, no importers",
+    # `glob("*.zip")` plus one `stat` per entry -- no per-file archive open or
+    # parse, unlike the pre-TASK-1320 scan that measured 1030ms. A stat per
+    # chatbook is sub-millisecond for any realistic export directory.
+    (
+        "UI/ChatbookExportManagementWindow.py",
+        "on_mount",
+        "self.chatbooks_dir.glob",
+    ): "glob + one stat per entry, no archive read",
+    (
+        "UI/ChatbookExportManagementWindow.py",
+        "on_button_pressed",
+        "self.chatbooks_dir.glob",
+    ): "glob + one stat per entry, no archive read",
+    # `glob("*.toml")` plus a `toml.load` per user-created theme, when the theme
+    # editor is shown. Bounded by how many themes the user has authored by hand,
+    # realistically single digits.
+    (
+        "Widgets/settings_theme_editor.py",
+        "on_show",
+        "self.custom_themes_path.glob",
+    ): "one toml parse per hand-authored user theme",
+}
+
+
+def _qualified(node: ast.AST) -> str:
+    """Render a call target as a dotted string (`subprocess.run`, `x.y.glob`)."""
+    if isinstance(node, ast.Attribute):
+        base = _qualified(node.value)
+        return f"{base}.{node.attr}" if base else node.attr
+    if isinstance(node, ast.Name):
+        return node.id
+    return ""
+
+
+class _Function:
+    """One function: what it calls, what it blocks on, whether it hands off."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.calls: set[str] = set()
+        #: Callees passed INTO a hand-off (`run_worker(self._refresh())`). They
+        #: run on a worker or thread, so they are not on the pump and must not
+        #: be walked -- tracked separately rather than by a blanket "this
+        #: function hands off somewhere" flag, which would also excuse blocking
+        #: work the handler still does directly.
+        self.deferred: set[str] = set()
+        self.blocking: list[str] = []
+
+
+def _is_worker(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """Whether Textual's ``@work`` runs this function off the message pump.
+
+    Matches both ``@work`` and ``@work(thread=True)``. Without this the guard
+    reports a false positive for every handler that calls a decorated worker:
+    `HuggingFace/local_models_widget.on_button_pressed -> _delete_model ->
+    iterdir` was flagged even though `_delete_model` is `@work(thread=True)` and
+    never touches the pump. A hand-off is a property of the CALLEE as much as of
+    the call site.
+    """
+    for decorator in node.decorator_list:
+        target = decorator.func if isinstance(decorator, ast.Call) else decorator
+        if _qualified(target).rsplit(".", 1)[-1] == "work":
+            return True
+    return False
+
+
+def _analyse(source: str) -> tuple[dict[str, _Function], list[str]]:
+    """Build the intra-module call graph and list the handler entry points."""
+    tree = ast.parse(source)
+    functions: dict[str, _Function] = {}
+    handlers: list[str] = []
+    workers: set[str] = set()
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if _is_worker(node):
+            workers.add(node.name)
+        info = _Function(node.name)
+        for sub in ast.walk(node):
+            if not isinstance(sub, ast.Call):
+                continue
+            qualified = _qualified(sub.func)
+            leaf = qualified.rsplit(".", 1)[-1] if qualified else ""
+            if leaf in HANDOFFS:
+                for arg in sub.args:
+                    for inner in ast.walk(arg):
+                        if isinstance(inner, (ast.Call, ast.Attribute, ast.Name)):
+                            target = _qualified(
+                                inner.func if isinstance(inner, ast.Call) else inner
+                            )
+                            if target:
+                                info.deferred.add(target.rsplit(".", 1)[-1])
+            if (
+                qualified in BLOCKING_QUALIFIED
+                or leaf in BLOCKING_NAMES
+                or leaf in BLOCKING_ATTRS
+            ):
+                info.blocking.append(qualified or leaf)
+            if leaf:
+                info.calls.add(leaf)
+        functions[node.name] = info
+        if node.name.startswith(HANDLER_PREFIXES):
+            handlers.append(node.name)
+
+    # A call to a `@work`-decorated function is a hand-off wherever it appears.
+    for info in functions.values():
+        info.deferred |= workers
+    return functions, handlers
+
+
+def _paths_to_blocking(functions: dict[str, _Function], entry: str) -> list[list[str]]:
+    """Every path from `entry` down to a blocking call, stopping at a hand-off."""
+    found: list[list[str]] = []
+
+    def walk(name: str, path: list[str], seen: frozenset[str]) -> None:
+        info = functions.get(name)
+        if info is None or name in seen:
+            return
+        if info.blocking:
+            found.append(path + [f"<{info.blocking[0]}>"])
+            return
+        # Anything handed to a worker/thread is no longer on the pump.
+        for callee in sorted(info.calls - info.deferred):
+            if callee in functions:
+                walk(callee, path + [callee], seen | {name})
+
+    walk(entry, [entry], frozenset())
+    return found
+
+
+def _scan_package() -> dict[tuple[str, str, str], list[str]]:
+    """Map (relative path, handler, blocking call) -> the chain that reaches it."""
+    findings: dict[tuple[str, str, str], list[str]] = {}
+    for subdir in SCANNED_SUBDIRS:
+        for path in sorted((PACKAGE_ROOT / subdir).rglob("*.py")):
+            try:
+                functions, handlers = _analyse(path.read_text())
+            except (SyntaxError, UnicodeDecodeError):  # pragma: no cover
+                continue
+            relative = path.relative_to(PACKAGE_ROOT).as_posix()
+            for handler in handlers:
+                for chain in _paths_to_blocking(functions, handler):
+                    call = chain[-1].strip("<>")
+                    findings[(relative, handler, call)] = chain
+    return findings
+
+
+@pytest.mark.unit
+def test_guard_detects_a_known_blocking_shape():
+    """The guard must catch a handler that reaches blocking I/O one level down.
+
+    Load-bearing. A body-only scan of this exact shape reports nothing, and that
+    is how the first draft of this guard came to pass against the real
+    pre-TASK-1320 chatbooks code. Without this test, a future refactor could
+    quietly reduce the guard to something that always succeeds.
+    """
+    source = """
+class Thing:
+    def on_mount(self):
+        self._refresh()
+
+    def _refresh(self):
+        for item in self._dir.glob("*.zip"):
+            pass
+"""
+    functions, handlers = _analyse(source)
+    assert handlers == ["on_mount"]
+    chains = _paths_to_blocking(functions, "on_mount")
+    assert chains, "guard is blind to blocking I/O one call below the handler"
+    assert chains[0] == ["on_mount", "_refresh", "<self._dir.glob>"]
+
+
+@pytest.mark.unit
+def test_guard_respects_a_handoff():
+    """Work moved off the pump must not be reported."""
+    source = """
+class Thing:
+    def on_mount(self):
+        self.run_worker(self._refresh())
+
+    async def _refresh(self):
+        for item in self._dir.glob("*.zip"):
+            pass
+"""
+    functions, _ = _analyse(source)
+    assert not _paths_to_blocking(functions, "on_mount"), (
+        "a handler that hands the work to a worker is not blocking the pump"
+    )
+
+
+@pytest.mark.unit
+def test_no_new_blocking_io_is_reachable_from_a_message_handler():
+    """No handler may reach blocking I/O unless it is baselined with a reason."""
+    findings = _scan_package()
+    unexpected = {key: chain for key, chain in findings.items() if key not in BASELINE}
+
+    assert not unexpected, "blocking I/O is reachable from a message handler:\n" + "\n".join(
+        f"  {path}::{handler}\n      {' -> '.join(chain)}"
+        for (path, handler, _call), chain in sorted(unexpected.items())
+    ) + (
+        "\n\nTextual runs handlers on a serialized pump, so this freezes the whole "
+        "app for the duration. Move the work off the pump (a thread for blocking "
+        "calls, a worker for awaited ones) -- and if you defer into a worker, pass "
+        "exit_on_error=False so a failure cannot exit the app. If the cost is "
+        "genuinely negligible, add it to BASELINE with the measurement."
+    )
+
+
+@pytest.mark.unit
+def test_baseline_has_no_stale_entries():
+    """A baselined path that is now clean must be removed, not left to rot."""
+    findings = _scan_package()
+    stale = sorted(key for key in BASELINE if key not in findings)
+
+    assert not stale, (
+        "these BASELINE entries no longer report anything and should be deleted:\n"
+        + "\n".join(f"  {path}::{handler} ({call})" for path, handler, call in stale)
+    )
+
+
+@pytest.mark.unit
+def test_guard_respects_a_work_decorated_callee():
+    """Calling a `@work` function is a hand-off, even without run_worker.
+
+    A hand-off is a property of the callee as much as of the call site. Missing
+    this reported a false positive against
+    `HuggingFace/local_models_widget.on_button_pressed`, whose `_delete_model`
+    is `@work(thread=True)` and never touches the pump.
+    """
+    source = """
+class Thing:
+    def on_button_pressed(self, event):
+        self._delete(event.path)
+
+    @work(thread=True)
+    def _delete(self, path):
+        if not any(path.parent.iterdir()):
+            pass
+"""
+    functions, _ = _analyse(source)
+    assert not _paths_to_blocking(functions, "on_button_pressed"), (
+        "a @work-decorated callee runs off the pump and must not be reported"
+    )

--- a/Tests/Architecture/test_no_blocking_io_on_message_pump.py
+++ b/Tests/Architecture/test_no_blocking_io_on_message_pump.py
@@ -106,6 +106,24 @@ BASELINE: dict[tuple[str, str, str], str] = {
         "action_refresh",
         "self._export_path.glob",
     ): "dead file, no importers",
+    # The archive opens in the same function, previously hidden behind the glob
+    # above -- surfaced only once the walk started reporting every blocking call
+    # per function rather than the first.
+    (
+        "UI/Chatbooks_Window.py",
+        "on_mount",
+        "zipfile.ZipFile",
+    ): "dead file, no importers",
+    (
+        "UI/Chatbooks_Window.py",
+        "on_button_pressed",
+        "zipfile.ZipFile",
+    ): "dead file, no importers",
+    (
+        "UI/Chatbooks_Window.py",
+        "action_refresh",
+        "zipfile.ZipFile",
+    ): "dead file, no importers",
     # `glob("*.zip")` plus one `stat` per entry -- no per-file archive open or
     # parse, unlike the pre-TASK-1320 scan that measured 1030ms. A stat per
     # chatbook is sub-millisecond for any realistic export directory.
@@ -226,7 +244,12 @@ def _paths_to_blocking(functions: dict[str, _Function], entry: str) -> list[list
         if info is None or name in seen:
             return
         if info.blocking:
-            found.append(path + [f"<{info.blocking[0]}>"])
+            # EVERY blocking call, not just the first. Reporting one per function
+            # would let a newly added expensive call hide behind an
+            # already-baselined cheap one in the same function -- reopening the
+            # hole that keying the baseline on the call was meant to close.
+            for call in dict.fromkeys(info.blocking):
+                found.append(path + [f"<{call}>"])
             return
         # Anything handed to a worker/thread is no longer on the pump.
         for callee in sorted(info.calls - info.deferred):
@@ -349,4 +372,34 @@ class Thing:
     functions, _ = _analyse(source)
     assert not _paths_to_blocking(functions, "on_button_pressed"), (
         "a @work-decorated callee runs off the pump and must not be reported"
+    )
+
+
+@pytest.mark.unit
+def test_guard_reports_every_blocking_call_in_a_function():
+    """One function with two blockers must report both, not just the first.
+
+    This is what makes the per-call baseline key mean anything. Reporting only
+    the first blocking call in a function lets a newly added expensive call hide
+    behind an already-baselined cheap one in the same function -- reintroducing
+    exactly the hole that keying on the call was meant to close. The shape is
+    real: the pre-TASK-1320 chatbook scan held a `glob` and a `ZipFile` open in
+    one function.
+    """
+    source = """
+class Thing:
+    def on_mount(self):
+        self._scan()
+
+    def _scan(self):
+        for item in self._dir.glob("*.zip"):
+            with ZipFile(item) as archive:
+                pass
+"""
+    functions, _ = _analyse(source)
+    calls = {chain[-1].strip("<>") for chain in _paths_to_blocking(functions, "on_mount")}
+
+    assert calls == {"self._dir.glob", "ZipFile"}, (
+        f"expected both blocking calls to be reported, got {sorted(calls)}: a new "
+        "expensive call can hide behind a baselined cheap one in the same function"
     )

--- a/Tests/UI/test_chatbook_wizard_open_folder.py
+++ b/Tests/UI/test_chatbook_wizard_open_folder.py
@@ -14,6 +14,7 @@ opening a folder is fire-and-forget.
 
 from __future__ import annotations
 
+import ast
 import io
 import textwrap
 import tokenize
@@ -60,18 +61,35 @@ def test_open_folder_does_not_wait_on_the_child_process():
 
 @pytest.mark.unit
 def test_open_folder_still_launches_the_platform_handler():
-    """Not blocking must not mean not working."""
-    source = _handler_source()
+    """Not blocking must not mean not working.
 
-    # The launcher names are string literals, so this half reads the raw source.
+    The launcher names are read from actual string LITERALS in the parsed
+    handler, not from its raw text. Searching the raw source let the assertions
+    be satisfied by the explanatory comment -- which names `open` and `xdg-open`
+    while explaining why `subprocess.run` was wrong -- so a dropped platform
+    branch would still have passed. Same trap as the check above, opposite
+    direction.
+    """
+    literals = _string_literals(_handler_source())
+
     for expected in ("open", "xdg-open", "explorer"):
-        assert expected in source, (
-            f"the {expected!r} platform branch disappeared: the handler must "
-            "still open the folder, just without waiting for it"
+        assert expected in literals, (
+            f"the {expected!r} platform branch disappeared from the executable "
+            "code: the handler must still open the folder, just without waiting"
         )
-    assert "Popen" in _code_only(source), (
+    assert "Popen" in _code_only(_handler_source()), (
         "expected a non-waiting launch (Popen) after dropping subprocess.run"
     )
+
+
+def _string_literals(source: str) -> set[str]:
+    """Every string literal in the parsed source, ignoring comments and prose."""
+    tree = ast.parse(textwrap.dedent(source))
+    return {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    }
 
 
 def _handler_source() -> str:

--- a/Tests/UI/test_chatbook_wizard_open_folder.py
+++ b/Tests/UI/test_chatbook_wizard_open_folder.py
@@ -1,0 +1,81 @@
+"""Opening the export folder must not block the app (TASK-1373).
+
+`ProgressStep.on_button_pressed` shelled out with `subprocess.run(["open"/
+"xdg-open"/"explorer", folder])` and no timeout. Textual runs message handlers on
+a serialized pump, so for as long as that child process ran, the app processed no
+clicks, keys or navigation.
+
+On macOS `open` returns promptly, which is why this was never noticed here. But
+`xdg-open` is a shell script that in several desktop environments does not return
+until the launched file manager exits -- so on Linux a button press could freeze
+the app for the rest of the session. The fix must not wait on the child at all:
+opening a folder is fire-and-forget.
+"""
+
+from __future__ import annotations
+
+import io
+import textwrap
+import tokenize
+
+import pytest
+
+from tldw_chatbook.UI.Wizards import ChatbookCreationWizard as wizard_module
+
+
+def _code_only(source: str) -> str:
+    """Strip comments and string literals, leaving executable tokens.
+
+    Load-bearing, not tidiness: the fix's own comment *explains* that
+    ``subprocess.run`` waits for the child, so a plain substring check matched
+    the explanation and reported the bug as unfixed. The same trap is documented
+    in ``Tests/test_call_from_thread_guard.py`` -- a guard that reads prose is a
+    guard that can be fooled in both directions.
+    """
+    ignored = {tokenize.COMMENT, tokenize.STRING}
+    readline = io.StringIO(textwrap.dedent(source)).readline
+    return " ".join(
+        tok.string
+        for tok in tokenize.generate_tokens(readline)
+        if tok.type not in ignored
+    )
+
+
+@pytest.mark.unit
+def test_open_folder_does_not_wait_on_the_child_process():
+    """The folder-open path must never call a blocking `subprocess.run`.
+
+    Asserted against the module source rather than by driving the widget,
+    because the defect is precisely that the call blocks: a behavioural test
+    would have to actually launch a file manager to observe it.
+    """
+    source = _code_only(_handler_source())
+
+    assert "subprocess . run" not in source, (
+        "the folder-open handler still calls subprocess.run, which waits for the "
+        "child process on Textual's message pump -- xdg-open does not always "
+        "return promptly, so this can freeze the whole app on a button press"
+    )
+
+
+@pytest.mark.unit
+def test_open_folder_still_launches_the_platform_handler():
+    """Not blocking must not mean not working."""
+    source = _handler_source()
+
+    # The launcher names are string literals, so this half reads the raw source.
+    for expected in ("open", "xdg-open", "explorer"):
+        assert expected in source, (
+            f"the {expected!r} platform branch disappeared: the handler must "
+            "still open the folder, just without waiting for it"
+        )
+    assert "Popen" in _code_only(source), (
+        "expected a non-waiting launch (Popen) after dropping subprocess.run"
+    )
+
+
+def _handler_source() -> str:
+    """Return the source of the completion-button handler."""
+    import inspect
+
+    return inspect.getsource(wizard_module.ProgressStep.on_button_pressed)

--- a/backlog/tasks/task-1373 - Guard-against-blocking-IO-reachable-from-a-Textual-message-handler.md
+++ b/backlog/tasks/task-1373 - Guard-against-blocking-IO-reachable-from-a-Textual-message-handler.md
@@ -1,0 +1,70 @@
+---
+id: TASK-1373
+title: Guard against blocking I/O reachable from a Textual message handler
+status: In Progress
+assignee: []
+labels:
+  - performance
+  - testing
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Stop the freeze bug class fixed by TASK-1320 from reappearing, and fix the one
+live instance a call-graph sweep found outside the mount path.
+
+Textual runs message handlers on a serialized pump. Anything blocking that a
+handler reaches — directly or through the functions it calls — stops the app
+from processing clicks, keys and navigation for the duration. TASK-1320 fixed
+four mount-path instances (measured stalls of 1030ms, 1140ms, and up to 300s
+against an unreachable server), but nothing prevents a new one being written,
+and the class was never limited to `on_mount`: a button handler that blocks
+freezes the app identically.
+
+A sweep for this found a live instance: `ChatbookCreationWizard.on_button_pressed`
+calls `subprocess.run(["open"/"xdg-open"/"explorer", folder])` with no timeout,
+on the pump. On macOS `open` returns promptly, but `xdg-open` is a shell script
+that in several desktop environments does not return until the launched handler
+exits — an unbounded block triggered by a button press.
+
+The guard has to walk the call graph, not just each handler's body. The blocking
+call is almost always a level or more down (`on_mount` -> `_refresh_chatbooks` ->
+`.glob(`), and a body-only scan reports a clean result against code known to be
+broken — verified: an early draft of this scan returned zero against the
+pre-TASK-1320 chatbooks file.
+
+Scope is deliberately limited to calls whose cost is user-visible. Small local
+filesystem operations (`mkdir(exist_ok=True)`, `read_text` of a config file)
+measure 0.049ms and 0.014ms respectively; flagging them would produce a large
+noisy baseline for no benefit and invite churn with real risk, since deferring
+work into a worker introduces its own failure modes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Opening the export folder from the Chatbook wizard cannot block the app, on any platform
+- [ ] #2 A repo-wide test fails when a new blocking call becomes reachable from a message handler
+- [ ] #3 The guard is proven to catch a known instance, not just to report a clean result
+- [ ] #4 Pre-existing accepted paths are baselined individually with a stated reason, not silenced wholesale
+- [ ] #5 The guard cannot be fooled by the same call name appearing in a comment or string
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Fix the wizard's `subprocess.run` so opening a folder cannot block the pump,
+   with a test that fails against the current call.
+2. Build the guard as an AST call-graph walk from handler entry points
+   (`on_*`/`watch_*`/`action_*`) to blocking leaves, terminating at any hop that
+   hands work off (`to_thread`, `run_worker`, `call_from_thread`, `set_timer`,
+   `call_after_refresh`).
+3. Prove the guard fails against the pre-TASK-1320 chatbooks source before
+   trusting any clean result from it.
+4. Baseline the remaining accepted paths one by one with reasons.
+
+ADR required: no
+Reason: adds a test-suite guard and one localized fix; no policy, framework or
+storage contract changes.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-1373 - Guard-against-blocking-IO-reachable-from-a-Textual-message-handler.md
+++ b/backlog/tasks/task-1373 - Guard-against-blocking-IO-reachable-from-a-Textual-message-handler.md
@@ -44,11 +44,11 @@ work into a worker introduces its own failure modes.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Opening the export folder from the Chatbook wizard cannot block the app, on any platform
-- [ ] #2 A repo-wide test fails when a new blocking call becomes reachable from a message handler
-- [ ] #3 The guard is proven to catch a known instance, not just to report a clean result
-- [ ] #4 Pre-existing accepted paths are baselined individually with a stated reason, not silenced wholesale
-- [ ] #5 The guard cannot be fooled by the same call name appearing in a comment or string
+- [x] #1 Opening the export folder from the Chatbook wizard cannot block the app, on any platform
+- [x] #2 A repo-wide test fails when a new blocking call becomes reachable from a message handler
+- [x] #3 The guard is proven to catch a known instance, not just to report a clean result
+- [x] #4 Pre-existing accepted paths are baselined individually with a stated reason, not silenced wholesale
+- [x] #5 The guard cannot be fooled by the same call name appearing in a comment or string
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -68,3 +68,50 @@ ADR required: no
 Reason: adds a test-suite guard and one localized fix; no policy, framework or
 storage contract changes.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed two live instances and added the repo-wide guard.
+
+**The fixes.** `ProgressStep.on_button_pressed` (Chatbook wizard) and
+`ChatbookExportManagementWindow._open_location` both called `subprocess.run` with
+no timeout on the message pump. Both now use `Popen` and never wait. The wizard
+also notifies on a missing launcher rather than failing silently.
+
+**The guard** (`Tests/Architecture/test_no_blocking_io_on_message_pump.py`) walks
+the intra-module call graph from each handler to a blocking leaf. Three
+correctness problems surfaced by testing the guard itself:
+
+1. A body-only scan returned **zero findings against the real pre-TASK-1320
+   chatbooks source** — the blocking call is a level below the handler. There is
+   now a self-test asserting the guard catches that shape, so it cannot decay
+   into a scan that always passes.
+2. Recognising hand-offs only at the call site produced a false positive for
+   `local_models_widget.on_button_pressed`, whose `_delete_model` is
+   `@work(thread=True)`. A hand-off is a property of the callee as well.
+3. Keying the baseline on `(file, handler)` left a hole precisely where it
+   mattered: the export window's `on_button_pressed` is baselined for a cheap
+   glob, so a re-introduced `subprocess.run` from that same handler would have
+   been accepted. The key now includes the blocking call; verified by mutation.
+
+**Scope.** Only user-visible costs are flagged. `mkdir`/`stat`/`read_text`/
+`write_text` are excluded on measurement — 0.049ms and 0.014ms against the
+1030ms/1140ms/300s cases TASK-1320 fixed. Flagging them would produce a noisy
+baseline and invite churn with real risk (deferring into a worker re-creates the
+`exit_on_error=True` crash path).
+
+**Baselined, each with a reason:** three handlers in the dead `Chatbooks_Window.py`
+(no importers); two in `ChatbookExportManagementWindow` (glob plus one stat per
+entry, no archive read); one in `settings_theme_editor` (one toml parse per
+hand-authored theme). A companion test fails if any baselined entry stops
+reporting, so the list cannot rot.
+
+Pre-existing and unrelated: `test_persistent_diagnostic_inventory` fails on clean
+dev too — isolated by removing this change's only new `logger` call and observing
+the same exit code.
+
+Modified: `ChatbookCreationWizard.py`, `ChatbookExportManagementWindow.py`,
+`Tests/Architecture/test_no_blocking_io_on_message_pump.py` (new),
+`Tests/UI/test_chatbook_wizard_open_folder.py` (new).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/ChatbookExportManagementWindow.py
+++ b/tldw_chatbook/UI/ChatbookExportManagementWindow.py
@@ -1128,17 +1128,27 @@ class ChatbookExportManagementWindow(ModalScreen):
         chatbook = self.chatbook_files[self.selected_chatbook]
 
         try:
-            import subprocess
+            # Launched, never awaited (TASK-1373) -- same reasoning as the
+            # Chatbook wizard's open-folder button. This runs on Textual's
+            # serialized message pump, and `subprocess.run` waits for the child:
+            # `xdg-open` does not always return until the launched file manager
+            # exits, so a button press could freeze the app indefinitely.
             import platform
+            import subprocess
 
             folder = str(chatbook["path"].parent)
-
-            if platform.system() == "Darwin":  # macOS
-                subprocess.run(["open", folder])
-            elif platform.system() == "Linux":
-                subprocess.run(["xdg-open", folder])
-            elif platform.system() == "Windows":
-                subprocess.run(["explorer", folder])
+            launchers = {
+                "Darwin": ["open", folder],
+                "Linux": ["xdg-open", folder],
+                "Windows": ["explorer", folder],
+            }
+            command = launchers.get(platform.system())
+            if command is not None:
+                subprocess.Popen(
+                    command,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
 
         except Exception as e:
             logger.error(f"Error opening folder: {e}")

--- a/tldw_chatbook/UI/Wizards/ChatbookCreationWizard.py
+++ b/tldw_chatbook/UI/Wizards/ChatbookCreationWizard.py
@@ -1036,17 +1036,44 @@ class ProgressStep(WizardStep):
         button_id = event.button.id
 
         if button_id == "open-folder" and self.export_path:
-            # Open the folder containing the export
-            import subprocess
+            # Open the folder containing the export.
+            #
+            # Launched, never awaited (TASK-1373). This runs on Textual's
+            # serialized message pump, so `subprocess.run` -- which waits for the
+            # child -- froze the app for as long as the file manager took to
+            # return. `open` on macOS returns promptly, which is why this went
+            # unnoticed, but `xdg-open` is a shell script that in several desktop
+            # environments does not return until the launched handler exits: an
+            # unbounded freeze from a button press.
             import platform
+            import subprocess
 
             folder = str(self.export_path.parent)
-            if platform.system() == "Darwin":  # macOS
-                subprocess.run(["open", folder])
-            elif platform.system() == "Linux":
-                subprocess.run(["xdg-open", folder])
-            elif platform.system() == "Windows":
-                subprocess.run(["explorer", folder])
+            launchers = {
+                "Darwin": ["open", folder],
+                "Linux": ["xdg-open", folder],
+                "Windows": ["explorer", folder],
+            }
+            command = launchers.get(platform.system())
+            if command is not None:
+                try:
+                    subprocess.Popen(
+                        command,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                    )
+                except Exception as exc:
+                    # A missing launcher must not take down the wizard.
+                    logger.warning(
+                        "Could not open export folder "
+                        "(platform={}, exception_category={}).",
+                        platform.system(),
+                        type(exc).__name__,
+                    )
+                    self.app.notify(
+                        "Couldn't open the folder. The export is still saved.",
+                        severity="warning",
+                    )
 
         elif button_id == "create-another":
             # Dismiss wizard to create another


### PR DESCRIPTION
Follow-on from #1089. That PR moved mount I/O off the App's message pump; this one fixes two live instances **outside** the mount path and adds a guard so the class cannot come back.

## The fixes

`ProgressStep.on_button_pressed` (Chatbook wizard) and `ChatbookExportManagementWindow._open_location` both called `subprocess.run(["open"/"xdg-open"/"explorer", folder])` with **no timeout**, on Textual's serialized message pump. `subprocess.run` waits for the child, so the app processed no clicks, keys or navigation until the file manager returned.

`open` on macOS returns promptly — which is why this went unnoticed here. But `xdg-open` is a shell script that in several desktop environments does not return until the launched handler exits, so on Linux a button press could freeze the app indefinitely. Both now launch via `Popen` and never wait.

## The guard is the substance

`Tests/Architecture/test_no_blocking_io_on_message_pump.py` walks the intra-module call graph from every handler entry point (`on_*`/`watch_*`/`action_*`) to a blocking leaf, stopping at any hand-off.

Three correctness problems surfaced — every one by testing the guard itself, not by reading it:

**1. Call-graph, not body.** The blocking call is nearly always a level or more below the handler (`on_mount → _refresh_chatbooks → .glob(`). My first draft read only each handler's own body and returned **zero findings against the real pre-TASK-1320 chatbooks source** — a clean result that meant nothing. `test_guard_detects_a_known_blocking_shape` now exists so this cannot decay into a scan that always passes.

**2. A hand-off is a property of the callee too.** Recognising only `run_worker`/`to_thread` *call sites* produced a false positive against `local_models_widget.on_button_pressed`, whose `_delete_model` is `@work(thread=True)` and never touches the pump.

**3. Baseline on the blocking call, not just the handler.** Under a `(file, handler)` key, re-introducing the very `subprocess.run` fixed here would have been **silently accepted**, because that same handler is baselined for a cheap glob. The key now includes the blocking call — verified by mutation.

## Scope is deliberately narrow

Only calls whose cost is user-visible. `mkdir`, `stat`, `read_text`, `write_text` are excluded on **measurement**:

| | Cost |
|---|---|
| `mkdir(exist_ok=True)` + small JSON write | 0.049ms |
| `read_text` of a config file | 0.014ms |
| chatbook directory scan (fixed in #1089) | 1,030ms |
| character library read (fixed in #1089) | 1,140ms |
| unreachable server (fixed in #1077) | up to 300,000ms |

Four orders of magnitude apart. Flagging the cheap ones would mean a large noisy baseline and invite churn with real risk — deferring work into a worker re-creates the `exit_on_error=True` crash path #1089 had to guard against.

## Baseline

Each entry carries its own reason, never a blanket suppression: three handlers in the **dead** `Chatbooks_Window.py` (no importers); two in `ChatbookExportManagementWindow` (glob plus one stat per entry, no archive read); one in `settings_theme_editor` (one toml parse per hand-authored theme). A companion test fails if a baselined entry stops reporting, so the list cannot rot.

## Verification

- TDD throughout; the wizard test was watched failing first, and its own first version was fooled by the fix's explanatory comment mentioning `subprocess.run` — it now tokenizes and strips comments/strings, the same trap documented in `Tests/test_call_from_thread_guard.py`.
- 7 passed across the guard and wizard suites; 26 passed across the chatbook suites.
- Mutation-checked in three places: re-introduce `subprocess.run` (caught), bypass the guard's call-graph walk (self-test fails), re-introduce under a baselined handler (caught).
- `ruff` clean.

Pre-existing and unrelated: `test_persistent_diagnostic_inventory` fails on clean dev too — isolated by removing this change's only new `logger` call and observing the same exit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops app freezes when opening export folders and strengthens a repo-wide guard to catch blocking I/O reachable from Textual message handlers. Implements TASK-1373 and prevents this bug class from coming back.

- **Bug Fixes**
  - Replaced `subprocess.run` with `subprocess.Popen` in `ProgressStep.on_button_pressed` and `ChatbookExportManagementWindow._open_location` so the UI never waits.
  - Suppressed child output and, in the wizard, show a warning if the platform launcher is missing.

- **New Features**
  - Added an AST call-graph guard (`Tests/Architecture/test_no_blocking_io_on_message_pump.py`) that walks from `on_*`/`watch_*`/`action_*` to blocking leaves, stopping at hand-offs; now reports every blocking call per function, and tests parse code to ignore comments/strings.
  - Baselined accepted cases by `(file, handler, blocking call)` with reasons; scope excludes cheap local FS ops by measurement; newly surfaced and baselined `zipfile.ZipFile` calls in the dead `Chatbooks_Window.py`.

<sup>Written for commit cba7c5d4ee82b2d91fa6d37a26fc68cfe6f012ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

