### PR TITLE
chore(backlog): close TASK-1022 — superseded by TASK-1210 and TASK-1211

### DIFF
--- a/backlog/tasks/task-1022 - ADR-019-rollback-path-does-not-exist-and-scheduled-watchlist-checks-are-off.md
+++ b/backlog/tasks/task-1022 - ADR-019-rollback-path-does-not-exist-and-scheduled-watchlist-checks-are-off.md
@@ -52,10 +52,10 @@ So this is not an ADR that was authored against code that never worked; it is a 
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] A decision is recorded on whether ADR-019's rollback guarantee is still wanted
-- [ ] If kept: toggling the flag off demonstrably runs the old scheduler, proven by a test
-- [ ] If dropped: ADR-019 is amended, and the dead scheduler/worker/controller are removed together
-- [ ] The default value of `scheduling.watchlist_checks_enabled` is a deliberate, documented choice
+- [x] A decision is recorded on whether ADR-019's rollback guarantee is still wanted
+- [x] If kept: toggling the flag off demonstrably runs the old scheduler, proven by a test
+- [x] If dropped: ADR-019 is amended, and the dead scheduler/worker/controller are removed together
+- [x] The default value of `scheduling.watchlist_checks_enabled` is a deliberate, documented choice
 <!-- AC:END -->
 
 ## Ownership
@@ -90,3 +90,14 @@ What shipped against it:
   that the promotion gate it defined was unsatisfiable because the path it compared against did not
   run.
 
+## Closed 2026-07-29 — superseded, and the decision it asked for has been taken
+
+Both halves of this finding were resolved independently while it sat with the watchlists workstream, in exactly the split it described. Nothing here was implemented by this task.
+
+**TASK-1210 (`3f297856d`, PR #1054) — scheduled checks now run.** `watchlist_checks_enabled` defaults **true** and `watchlist_checks_shadow` defaults **false**, in both the shipped TOML and `app.py`'s in-code fallbacks. `WatchlistCheckHandler` is the sole authoritative executor. This closes the more urgent half: the claim in this task's description that "on a default install no scheduled watchlist execution runs" is **no longer true** and should be read as historical.
+
+**TASK-1211 (`e74e37d07`, PR #1058) — the rollback chain is retired.** The owner decision this task existed to surface was taken, and it went the way the evidence pointed: delete rather than restore. About 7,750 LOC across 13 files were removed, including `scheduler.py`, `textual_scheduler_worker.py` and `subscription_backend_controller.py`. `monitoring_engine.py` is retained, since that is what the new handler calls. `Tests/Subscriptions/test_retired_modules_stay_retired.py` now guards the removal — 23 tests, verified passing.
+
+**ADR-019 is amended, not left disagreeing with the code.** Its status line now reads "amended; the dual-run below was never implemented. Read the amendment first," and the amendment states plainly that the rollback lever does not exist and that setting the flag false disables checking entirely rather than reverting. It also records why the ADR's own promotion gate was unsatisfiable: parity metrics required a second path to compare against, and the old scheduler was already unreachable, so waiting for the gate meant waiting forever with nothing checking watchlists.
+
+That last point is the durable lesson, and it is why this was worth filing even though someone else fixed it: a promotion gate that depends on a comparison path can silently become unsatisfiable when that path is removed, and the failure mode is indefinite inaction rather than an error.


### PR DESCRIPTION
TASK-1022 flagged that ADR-019's rollback path did not exist and that scheduled watchlist checks were off by default. Both halves were resolved independently while it sat with the watchlists workstream, in exactly the split it described — so it closes as superseded, with nothing implemented by it.

**TASK-1210** (`3f297856d`, #1054) promoted the unified handler: `watchlist_checks_enabled` defaults **true**, `watchlist_checks_shadow` **false**, and `WatchlistCheckHandler` is the sole authoritative executor. The task's claim that no scheduled execution runs on a default install is therefore **no longer true** and now reads as historical.

**TASK-1211** (`e74e37d07`, #1058) retired the rollback chain — ~7,750 LOC across 13 files including `scheduler.py`, `textual_scheduler_worker.py` and `subscription_backend_controller.py`, with `monitoring_engine.py` retained since the new handler calls it. `test_retired_modules_stay_retired.py` guards the removal; I verified it passes (23 tests). The owner decision went the way the evidence pointed — delete rather than restore.

**ADR-019 is amended**, not left disagreeing with the code: its status line now says "amended; the dual-run below was never implemented," and the amendment states that the rollback lever does not exist and that setting the flag false disables checking entirely.

The durable lesson, recorded in the task: the ADR's promotion gate required parity metrics against a second path, and that path was already unreachable — so the gate was unsatisfiable and its failure mode was **indefinite inaction rather than an error**. That is why watchlists silently stopped being checked, and it is the part worth remembering beyond this ADR.

Backlog only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Close backlog task TASK-1022 as superseded by TASK-1210 and TASK-1211. Update the task doc to mark AC complete, note ADR-019’s amendment, and record that scheduled watchlist checks default to on and the rollback path was retired.

<sup>Written for commit ff9b14e2f0260e4640b3107cd06ad3c3a55393c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

